### PR TITLE
Pass file paths to render task instead of file content.

### DIFF
--- a/framework/email/tasks.py
+++ b/framework/email/tasks.py
@@ -2,13 +2,13 @@ import smtplib
 import logging
 from email.mime.text import MIMEText
 
-from framework.tasks import celery
+from framework.tasks import app
 from website import settings
 
 logger = logging.getLogger(__name__)
 
 
-@celery.task
+@app.task
 def send_email(from_addr, to_addr, subject, message, mimetype='html', ttls=True, login=True):
     """Send email to specified destination.
     Email is sent from the email specified in FROM_EMAIL settings in the

--- a/framework/render/tasks.py
+++ b/framework/render/tasks.py
@@ -1,12 +1,14 @@
-import logging
+# -*- coding: utf-8 -*-
+
 import os
+import logging
 import errno
 import codecs
-from framework.tasks import celery
+
+from framework.tasks import app
 from website import settings
 from mfr.renderer import FileRenderer
 import mfr
-import tempfile
 from mfr.renderer.exceptions import MFRError
 from website.language import ERROR_PREFIX, STATA_VERSION_ERROR, BLANK_OR_CORRUPT_TABLE_ERROR
 
@@ -45,29 +47,17 @@ def render_mfr_error(err):
            </div>
         """.format(**locals())
 
-@celery.task(time_limit=settings.MFR_TIMEOUT)
-def _build_rendered_html(file_name, file_content, cache_dir, cache_file_name,
-                         download_path):
+
+@app.task(ignore_result=True, timeout=settings.MFR_TIMEOUT)
+def _build_rendered_html(file_path, cache_dir, cache_file_name, download_url):
     """
 
-    :param str file_name:
-    :param str file_content:
-    :param str cache_dir:
-    :param str cache_file_name:
-    :param str download_path:
-
+    :param str file_path: Full path to raw file on disk
+    :param str cache_dir: Folder to store cached file in
+    :param str cache_file_name: Name of cached file
+    :param str download_url: External download URL
     """
-
-    # Open file pointer if no content provided
-    if file_content is None:
-        file_pointer = codecs.open(file_name)
-    # Else create temporary file with content
-    else:
-        file_pointer = tempfile.NamedTemporaryFile(
-            suffix=os.path.splitext(file_name)[1],
-        )
-        file_pointer.write(file_content)
-        file_pointer.seek(0)
+    file_pointer = codecs.open(file_path)
 
     # Build path to cached content
     # Note: Ensures that cache directories have the same owner as the files
@@ -77,9 +67,9 @@ def _build_rendered_html(file_name, file_content, cache_dir, cache_file_name,
 
     # Render file
     try:
-        rendered = mfr.render(file_pointer, url=download_path)
+        rendered = mfr.render(file_pointer, url=download_url)
     except MFRError as err:
-        rendered = render_mfr_error(err).format(download_path=download_path)
+        rendered = render_mfr_error(err).format(download_path=download_url)
 
     # Close read pointer
     file_pointer.close()
@@ -88,9 +78,23 @@ def _build_rendered_html(file_name, file_content, cache_dir, cache_file_name,
     with codecs.open(cache_file_path, 'w', 'utf-8') as write_file_pointer:
         write_file_pointer.write(rendered)
 
-    return True
+    os.remove(file_path)
 
-# Expose render function
-build_rendered_html = _build_rendered_html
-if settings.USE_CELERY:
-    build_rendered_html = build_rendered_html.delay
+
+def build_rendered_html(file_path, cache_dir, cache_file_name, download_url):
+    """Public wrapper for the rendering task. Override the default Celery ID
+    generation, passing the unique cached path as the `task_id`, to permit
+    checking whether the requested file is already being rendered.
+    """
+    args = (file_path, cache_dir, cache_file_name, download_url)
+    if settings.USE_CELERY:
+        # Call task asynchronously
+        task_id = '{0}/{1}'.format(cache_dir, cache_file_name)
+        # Enqueue task if it hasn't already been sent to Rabbit ("PENDING"
+        # means not published to message queue)
+        result = app.AsyncResult(task_id)
+        if result.status == 'PENDING':
+            _build_rendered_html.apply_async(args, task_id=task_id)
+    else:
+        # Call task synchronously
+        _build_rendered_html(*args)

--- a/framework/tasks/__init__.py
+++ b/framework/tasks/__init__.py
@@ -2,14 +2,33 @@
 '''Asynchronous task queue module.'''
 
 from celery import Celery
+from celery import current_app
 from celery.utils.log import get_task_logger
+from celery.signals import after_task_publish
 
-celery = Celery()
+
+# Adapted from http://stackoverflow.com/questions/9824172/find-out-whether-celery-task-exists
+@after_task_publish.connect
+def update_published_state(sender=None, body=None, **kwargs):
+    """By default, Celery doesn't distinguish between tasks that are pending
+    and tasks that have not been published; both are flagged as "PENDING". This
+    callback sets task status to "PUBLISHED" after being sent to the message
+    broker so that the application can determine which tasks are active.
+    """
+    # the task may not exist if sent using `send_task` which
+    # sends tasks by name, so fall back to the default result backend
+    # if that is the case.
+    task = current_app.tasks.get(sender)
+    backend = task.backend if task else current_app.backend
+    backend.store_result(body['id'], None, 'PUBLISHED')
+
+
+app = Celery()
 
 # TODO: Hardcoded settings module. Should be set using framework's config handler
-celery.config_from_object('website.settings')
+app.config_from_object('website.settings')
 
-@celery.task
+@app.task
 def error_handler(task_id, task_name):
     """logs detailed message about tasks that raise exceptions
 
@@ -19,7 +38,7 @@ def error_handler(task_id, task_name):
     # get the current logger
     logger = get_task_logger(__name__)
     # query the broker for the AsyncResult
-    result = celery.AsyncResult(task_id)
+    result = app.AsyncResult(task_id)
     excep = result.get(propagate=False)
     # log detailed error mesage in error log
     logger.error('#####FAILURE LOG BEGIN#####\n'

--- a/website/addons/dataverse/views/crud.py
+++ b/website/addons/dataverse/views/crud.py
@@ -167,8 +167,8 @@ def dataverse_view_file(node_addon, auth, **kwargs):
         return redirect(redirect_url)
 
     # Get or create rendered file
-    cache_file = '{0}.html'.format(file_id)
-    rendered = get_cache_content(node_addon, cache_file)
+    cache_file_name = '{0}.html'.format(file_id)
+    rendered = get_cache_content(node_addon, cache_file_name)
 
     if rendered is None:
         filename, content = scrape_dataverse(file_id)
@@ -176,8 +176,10 @@ def dataverse_view_file(node_addon, auth, **kwargs):
             'dataverse_download_file_proxy', path=file_id
         )
         rendered = get_cache_content(
-            node_addon, cache_file, start_render=True,
-            file_path=filename, file_content=content,
+            node_addon,
+            cache_file_name,
+            start_render=True,
+            file_content=content,
             download_path=download_url,
         )
     else:

--- a/website/addons/dropbox/utils.py
+++ b/website/addons/dropbox/utils.py
@@ -141,9 +141,9 @@ def render_dropbox_file(file_obj, client=None, rev=None):
     :return: The HTML for the rendered file.
     """
     # Filename for the cached MFR HTML file
-    cache_name = file_obj.get_cache_filename(client=client, rev=rev)
+    cache_file_name = file_obj.get_cache_filename(client=client, rev=rev)
     node_settings = file_obj.node.get_addon('dropbox')
-    rendered = get_cache_content(node_settings, cache_name)
+    rendered = get_cache_content(node_settings, cache_file_name)
     if rendered is None:  # not in MFR cache
         dropbox_client = client or get_node_addon_client(node_settings)
         try:
@@ -159,11 +159,10 @@ def render_dropbox_file(file_obj, client=None, rev=None):
             return ''.join(['<p class="text-danger">', message, '</p>'])
         rendered = get_cache_content(
             node_settings=node_settings,
-            cache_file=cache_name,
+            cache_file_name=cache_file_name,
             start_render=True,
-            file_path=get_file_name(file_obj.path),
             file_content=file_response.read(),
-            download_path=file_obj.download_url(guid=True, rev=rev)
+            download_path=file_obj.download_url(guid=True, rev=rev),
         )
     return rendered
 

--- a/website/addons/figshare/views/crud.py
+++ b/website/addons/figshare/views/crud.py
@@ -340,10 +340,10 @@ def figshare_view_file(*args, **kwargs):
     delete_url = node.api_url + 'figshare/article/{aid}/file/{fid}/'.format(aid=article_id, fid=file_id)
 
     filename = found['name']
-    cache_file = get_cache_file(
+    cache_file_name = get_cache_file(
         article_id, file_id
     )
-    rendered = get_cache_content(node_settings, cache_file)
+    rendered = get_cache_content(node_settings, cache_file_name)
     if private:
         rendered = messages.FIGSHARE_VIEW_FILE_PRIVATE.format(url='http://figshare.com/')
     elif rendered is None:
@@ -355,8 +355,12 @@ def figshare_view_file(*args, **kwargs):
                 url=found.get('download_url'))
         else:
             rendered = get_cache_content(
-                node_settings, cache_file, start_render=True,
-                file_path=filename, file_content=filedata, download_path=download_url)
+                node_settings,
+                cache_file_name,
+                start_render=True,
+                file_content=filedata,
+                download_url=download_url,
+            )
 
     categories = connect.categories()['items']  # TODO Cache this
     categories = ''.join(

--- a/website/addons/github/views/crud.py
+++ b/website/addons/github/views/crud.py
@@ -177,10 +177,10 @@ def github_view_file(auth, **kwargs):
             commit['email'] = ''
 
     # Get or create rendered file
-    cache_file = get_cache_file(
+    cache_file_name = get_cache_file(
         path, current_sha,
     )
-    rendered = get_cache_content(node_settings, cache_file)
+    rendered = get_cache_content(node_settings, cache_file_name)
     if rendered is None:
         try:
             _, data, size = connection.file(
@@ -194,8 +194,11 @@ def github_view_file(auth, **kwargs):
                 rendered = 'File too large to render; download file to view it.'
             else:
                 rendered = get_cache_content(
-                    node_settings, cache_file, start_render=True,
-                    file_path=file_name, file_content=data, download_path=download_url,
+                    node_settings,
+                    cache_file_name,
+                    start_render=True,
+                    file_content=data,
+                    download_url=download_url,
                 )
 
     rv = {

--- a/website/addons/osfstorage/utils.py
+++ b/website/addons/osfstorage/utils.py
@@ -302,18 +302,17 @@ def render_file(version_idx, file_version, file_record):
         Q('node', 'eq', file_record.node) &
         Q('path', 'eq', file_record.path)
     )
-    cache_filename = get_cache_filename(file_version)
+    cache_file_name = get_cache_filename(file_version)
     node_settings = file_obj.node.get_addon('osfstorage')
-    rendered = get_cache_content(node_settings, cache_filename)
+    rendered = get_cache_content(node_settings, cache_file_name)
     if rendered is None:
         download_url = get_download_url(version_idx, file_version, file_record)
         file_response = requests.get(download_url)
         rendered = get_cache_content(
-            node_settings=node_settings,
-            cache_file=cache_filename,
+            node_settings,
+            cache_file_name,
             start_render=True,
-            file_path=file_record.path,
             file_content=file_response.content,
-            download_path=file_obj.get_download_path(version_idx),
+            download_url=file_obj.get_download_path(version_idx),
         )
     return rendered

--- a/website/addons/s3/views/crud.py
+++ b/website/addons/s3/views/crud.py
@@ -113,20 +113,22 @@ def s3_view(**kwargs):
     if redirect_url:
         return redirect(redirect_url)
 
-    cache_name = get_cache_file_name(path, key.etag)
+    cache_file_name = get_cache_file_name(path, key.etag)
     urls = build_urls(node, path, etag=key.etag)
 
     if key.s3Key.size > MAX_RENDER_SIZE:
         render = 'File too large to render; download file to view it'
     else:
         # Check to see if the file has already been rendered.
-        render = get_cache_content(node_settings, cache_name)
+        render = get_cache_content(node_settings, cache_file_name)
         if render is None:
             file_contents = key.s3Key.get_contents_as_string()
             render = get_cache_content(
-                node_settings, cache_name, start_render=True,
-                file_content=file_contents, download_path=urls['download'],
-                file_path=path,
+                node_settings,
+                cache_file_name,
+                start_render=True,
+                file_content=file_contents,
+                download_url=urls['download'],
             )
 
     versions = create_version_list(wrapper, urllib.unquote(path), node)

--- a/website/project/views/file.py
+++ b/website/project/views/file.py
@@ -6,7 +6,7 @@ import codecs
 
 from flask import request
 
-from framework.render.tasks import build_rendered_html
+from framework.render.tasks import ensure_path, build_rendered_html
 
 from website.util import rubeus
 from website.project.decorators import must_be_contributor_or_public
@@ -37,30 +37,43 @@ def grid_data(**kwargs):
     return {'data': rubeus.to_hgrid(node, auth, **data)}
 
 # File rendering
-def get_cache_path(node_settings):
+def get_cache_path(node_settings, cache_type):
+    if cache_type == 'temp':
+        base_path = settings.MFR_TEMP_PATH
+    elif cache_type == 'rendered':
+        base_path = settings.MFR_CACHE_PATH
+    else:
+        raise ValueError('Argument "cache_type" must be "temp" or "rendered"')
     return os.path.join(
-        settings.MFR_CACHE_PATH,
+        base_path,
         node_settings.config.short_name,
         node_settings.owner._id,
     )
 
 
-def get_cache_content(node_settings, cache_file, start_render=False,
-                      file_path=None, file_content=None, download_path=None):
+def get_cache_content(node_settings, cache_file_name, start_render=False,
+                      file_content=None, download_url=None):
     """
-
     """
-    # Get rendered content if present
-    cache_path = get_cache_path(node_settings)
-    cache_file_path = os.path.join(cache_path, cache_file)
+    cache_dir = get_cache_path(node_settings, cache_type='rendered')
+    cache_file_path = os.path.join(cache_dir, cache_file_name)
     try:
         return codecs.open(cache_file_path, 'r', 'utf-8').read()
     except IOError:
         # Start rendering job if requested
         if start_render:
+            if file_content is None:
+                raise ValueError('Must provide "file_content"')
+            temp_file_dir = get_cache_path(node_settings, cache_type='temp')
+            temp_file_path = os.path.join(temp_file_dir, cache_file_name)
+            ensure_path(temp_file_dir)
+            with open(temp_file_path, 'wb') as fp:
+                fp.write(file_content)
             build_rendered_html(
-                file_path, file_content, cache_path, cache_file_path,
-                download_path
+                temp_file_path,
+                cache_dir,
+                cache_file_name,
+                download_url,
             )
         return None
 

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -68,6 +68,7 @@ MAILGUN_API_KEY = None
 # TODO: Override in local.py in production
 UPLOADS_PATH = os.path.join(BASE_PATH, 'uploads')
 MFR_CACHE_PATH = os.path.join(BASE_PATH, 'mfrcache')
+MFR_TEMP_PATH = os.path.join(BASE_PATH, 'mfrtemp')
 
 # Use Celery for file rendering
 USE_CELERY = True


### PR DESCRIPTION
# Purpose

Previously, most add-ons passed file contents to the Celery render task
as a string, which has the potential to flood the message broker with
data. This patch saves files to a temporary directory on disk and passes
the file paths to Celery instead. Temp files are deleted after rendering
is complete.
# Changes
- Render task accepts temp file path rather than content
- Render task deletes temp file after rendering
# Side effects
- Must add `MFR_TEMP_PATH` to settings
- Must ensure permissions on temp path

Thanks @icereval for writing this with me.
