### PR TITLE
[feature] s3-loading-icon

### DIFF
--- a/website/addons/s3/templates/s3_node_settings.mako
+++ b/website/addons/s3/templates/s3_node_settings.mako
@@ -113,10 +113,10 @@
             }).done(function() {
                 msgElm.text('S3 access keys loading...')
                         .removeClass('text-danger').addClass('text-info')
-                        .fadeOut(200).fadeIn();
+                        .fadeIn(1000);
                 setTimeout(function(){
                     window.location.reload();
-                }, 3000);
+                }, 5000);
             }).fail(function(xhr) {
                 var message = 'Error: ';
                 var response = JSON.parse(xhr.responseText);


### PR DESCRIPTION
**Purpose**
- Addresses [#1187](https://github.com/CenterForOpenScience/openscienceframework.org/issues/1187)
- Currently, if a user authorizes the Amazon S3 addon via a project settings page (i.e. when `node_has_auth` and `user_has_auth` are both `False`) the user is told to wait and refresh the page after importing their access key and secret key.

**Changes**
- This PR adds a timeout to refresh the page 3 seconds after the authorization finishes. It also displays the text `S3 access keys loading...` during the timeout so the user knows to wait. After speaking with @chrisseto, this process should always take between 2 and 3 seconds (no matter the amount of buckets in the user's S3 account) so a three second timeout should be sufficient, and has worked every time I have tested it.

**Side Effects**
- If `bucket_list` is still `None` after the three second timeout, then an error message (`Error loading S3 access keys. Please refresh the page.`) will be displayed. 
