### PR TITLE
[feature] component-long-title-overflow

### DIFF
--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -1200,6 +1200,12 @@ dl.activity-log dd {
     max-width: 100%;
 }
 
+.component-overflow {
+    word-wrap: break-word;
+    max-width: 90%;
+    display: inline-block;
+}
+
 /* Need to use this class with a fixed width */
 .overflow-block {
     display: block;

--- a/website/templates/util/render_node.mako
+++ b/website/templates/util/render_node.mako
@@ -9,7 +9,7 @@
         ">
 
         <h4 class="list-group-item-heading">
-            <span class="overflow" style="display:inline-block;">
+            <span class="component-overflow">
             % if not summary['primary']:
               <i class="icon icon-link" data-toggle="tooltip" title="Linked ${summary['node_type']}"></i>
             % endif


### PR DESCRIPTION
**Purpose**
- Resolves [#1205](https://github.com/CenterForOpenScience/openscienceframework.org/issues/1205)
- Currently, a long component title will wrap within the component widget and forces the `Remove`, `Fork`, and `More` buttons below it. This PR adds a maximum width to the title wrap, which keeps the buttons from moving below the long title.

**Changes**
- Added `.component-overflow` CSS class with a maximum overflow width of 90%.
- **_Before**_
  ![screen shot 2014-11-05 at 9 53 02 am](https://cloud.githubusercontent.com/assets/7913604/4920186/47d91c9a-6500-11e4-93a1-22ec049bc315.png)
- **_After**_
  ![screen shot 2014-11-05 at 10 18 01 am](https://cloud.githubusercontent.com/assets/7913604/4920193/540846f8-6500-11e4-90d9-c340b9c3ee64.png)

**Side Effects**
- None
