### PR TITLE
[hotfix] Pass original file name to preserve file extensions.

### DIFF
--- a/website/addons/dataverse/views/crud.py
+++ b/website/addons/dataverse/views/crud.py
@@ -179,6 +179,7 @@ def dataverse_view_file(node_addon, auth, **kwargs):
             node_addon,
             cache_file_name,
             start_render=True,
+            remote_path=file_obj.path,
             file_content=content,
             download_path=download_url,
         )

--- a/website/addons/dropbox/utils.py
+++ b/website/addons/dropbox/utils.py
@@ -161,6 +161,7 @@ def render_dropbox_file(file_obj, client=None, rev=None):
             node_settings=node_settings,
             cache_file_name=cache_file_name,
             start_render=True,
+            remote_path=file_obj.path,
             file_content=file_response.read(),
             download_path=file_obj.download_url(guid=True, rev=rev),
         )

--- a/website/addons/figshare/views/crud.py
+++ b/website/addons/figshare/views/crud.py
@@ -358,6 +358,7 @@ def figshare_view_file(*args, **kwargs):
                 node_settings,
                 cache_file_name,
                 start_render=True,
+                remote_path=filename,
                 file_content=filedata,
                 download_url=download_url,
             )

--- a/website/addons/github/views/crud.py
+++ b/website/addons/github/views/crud.py
@@ -197,6 +197,7 @@ def github_view_file(auth, **kwargs):
                     node_settings,
                     cache_file_name,
                     start_render=True,
+                    remote_path=guid.path,
                     file_content=data,
                     download_url=download_url,
                 )

--- a/website/addons/osfstorage/utils.py
+++ b/website/addons/osfstorage/utils.py
@@ -312,6 +312,7 @@ def render_file(version_idx, file_version, file_record):
             node_settings,
             cache_file_name,
             start_render=True,
+            remote_path=file_obj.path,
             file_content=file_response.content,
             download_url=file_obj.get_download_path(version_idx),
         )

--- a/website/addons/s3/views/crud.py
+++ b/website/addons/s3/views/crud.py
@@ -127,6 +127,7 @@ def s3_view(**kwargs):
                 node_settings,
                 cache_file_name,
                 start_render=True,
+                remote_path=path,
                 file_content=file_contents,
                 download_url=urls['download'],
             )

--- a/website/project/views/file.py
+++ b/website/project/views/file.py
@@ -52,8 +52,14 @@ def get_cache_path(node_settings, cache_type):
 
 
 def get_cache_content(node_settings, cache_file_name, start_render=False,
-                      file_content=None, download_url=None):
+                      remote_path=None, file_content=None, download_url=None):
     """
+    :param node_settings: Node settings record
+    :param str cache_file_name: Name of cached rendered file
+    :param bool start_render: Start rendering job if cached file not present
+    :param str remote_path: Path or name of file on remote service
+    :param str file_content: File contents
+    :param str download_url: External download URL
     """
     cache_dir = get_cache_path(node_settings, cache_type='rendered')
     cache_file_path = os.path.join(cache_dir, cache_file_name)
@@ -64,8 +70,14 @@ def get_cache_content(node_settings, cache_file_name, start_render=False,
         if start_render:
             if file_content is None:
                 raise ValueError('Must provide "file_content"')
+            if remote_path is None:
+                raise ValueError('Must provide "remote_path"')
             temp_file_dir = get_cache_path(node_settings, cache_type='temp')
-            temp_file_path = os.path.join(temp_file_dir, cache_file_name)
+            _, temp_file_ext = os.path.splitext(remote_path)
+            temp_file_path = os.path.join(
+                temp_file_dir,
+                '{0}{1}'.format(cache_file_name, temp_file_ext),
+            )
             ensure_path(temp_file_dir)
             with open(temp_file_path, 'wb') as fp:
                 fp.write(file_content)


### PR DESCRIPTION
# Purpose

Fix file extension detection in file rendering
# Changes
- Add `remote_path` parameter to render function to preserve original file extension
- Pass `remote_path` from each addon's render method
# Side effects

Rendering files that aren't code will work
