### PR TITLE
[feature] forward-slashes-in-wiki-names

### DIFF
--- a/website/addons/wiki/templates/add_wiki_page.mako
+++ b/website/addons/wiki/templates/add_wiki_page.mako
@@ -51,7 +51,6 @@
                     .text('OK');
 
             } else if ($data.val().indexOf('/') != -1) {
-                console.log('SLASHES');
                 $alert.text('The new wiki page name cannot contain forward slashes.');
                 $submitForm
                     .removeAttr('disabled', 'disabled')
@@ -65,7 +64,6 @@
                     url: '${urls['api']['base']}' + encodeURIComponent(wikiName) + '/validate/',
                     dataType: 'json'
                 });
-
                 request.done(function (response) {
                     window.location.href = '${urls['web']['base']}' + encodeURIComponent(wikiName) + '/edit/';
                 });


### PR DESCRIPTION
**Purpose**
- Addresses [#1194](https://github.com/CenterForOpenScience/osf.io/issues/1194)
- Currently, a user can create a wiki page with forward slashes in the name, but those forward slashes will be replaced with spaces when the wiki page is created without giving any warning to the user. 

**Changes**
- This PR adds an alert if the user tries to create a wiki page with forward slashes in the page name.
  ![screen shot 2014-11-21 at 12 24 23 pm](https://cloud.githubusercontent.com/assets/7913604/5146332/5c2e2138-7179-11e4-9508-3994870006db.png)

**Side Effects**
- None expected
