### PR TITLE
[feature] Escape special characters when searching for contributors

### DIFF
--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -376,7 +376,7 @@ def search_contributor(query, page=0, size=10, exclude=[], current_user=None):
     items = re.split(r'[\s-]+', query)
     query = ''
 
-    query = "  AND ".join('{}*~'.format(item) for item in items) + \
+    query = "  AND ".join('{}*~'.format(re.escape(item)) for item in items) + \
             "".join(' NOT "{}"'.format(excluded) for excluded in exclude)
 
     results = search(build_query(query, start=start, size=size), index='website', search_type='user')


### PR DESCRIPTION
From CenterForOpenScience/osf#1250 hopefully I've done the right thing!

**Purpose**
If you put quotes when searching for contributors, it returns A LOT OF results (that is, including those results that are not related to the search query)

**Cause**
Special characters are not html escaped properly, causing confusions whether they are parts of the search query or belong to lucene search syntax

**Changes**
Uses <code>re.escape(item)</code> to escape every special character in the query, except whitespaces. <code>item</code> do not contain whitespaces, since it is any element in the list "<code>items</code>" that is returned by splitting the query by whitespaces.
