### PR TITLE
feature/localize-wiki-version-dates

### DIFF
--- a/website/addons/wiki/templates/history.mako
+++ b/website/addons/wiki/templates/history.mako
@@ -7,7 +7,12 @@
             % if not node['anonymous']:
                 by ${version['user_fullname']}
             % endif
-            on ${version['date']}
+            on <span id="version-${version['version']}"></span>
+
+            <script type="application/javascript">
+                var versionDate = new $.osf.FormattableDate("${version['date']}");
+                $("#version-${version['version']}").text(versionDate.local);
+            </script>
         </a>
 	</p>
 % endfor

--- a/website/addons/wiki/views.py
+++ b/website/addons/wiki/views.py
@@ -74,7 +74,7 @@ def _get_wiki_versions(node, name, anonymous=False):
         {
             'version': version.version,
             'user_fullname': privacy_info_handle(version.user.fullname, anonymous, name=True),
-            'date': version.date.replace(microsecond=0),
+            'date': version.date.replace(microsecond=0).isoformat(),
             'compare_web_url': node.web_url_for('project_wiki_compare', wname=name, wver=version.version, _guid=True),
         }
         for version in reversed(versions)


### PR DESCRIPTION
Purpose
-----------
Convert dates on wiki page history to viewer's local time. 
![screen shot 2014-12-01 at 1 35 16 pm](https://cloud.githubusercontent.com/assets/6599111/5250949/541b60ee-795f-11e4-958b-222c22349091.png)


Changes
------------
Modified the view function in python to output the ISO format of the date, then created a quick bit of JS on the wiki's history.mako to use the OSF's FormattableDate and put in the localized version of the date.

Side Effects
----------------
Should be fairly side-effect free. If anything else was using that view serialization code, then the dates are going to be formatted differently, but it doesn't look like the dates were being shown on the other pages. There's an API Route that uses the same data, but I didn't find anything using that date. Otherwise it's the view and edit pages for the wiki, neither of which seem to show the date.

Fixes #1065 