### PR TITLE
[hotfix] addon-cached-file-lookup-download-path-to-url

### DIFF
--- a/website/addons/dataverse/views/crud.py
+++ b/website/addons/dataverse/views/crud.py
@@ -181,7 +181,7 @@ def dataverse_view_file(node_addon, auth, **kwargs):
             start_render=True,
             remote_path=file_obj.path,
             file_content=content,
-            download_path=download_url,
+            download_url=download_url,
         )
     else:
         filename, _ = scrape_dataverse(file_id, name_only=True)

--- a/website/addons/dropbox/utils.py
+++ b/website/addons/dropbox/utils.py
@@ -163,7 +163,7 @@ def render_dropbox_file(file_obj, client=None, rev=None):
             start_render=True,
             remote_path=file_obj.path,
             file_content=file_response.read(),
-            download_path=file_obj.download_url(guid=True, rev=rev),
+            download_url=file_obj.download_url(guid=True, rev=rev),
         )
     return rendered
 


### PR DESCRIPTION
Corrects error preventing the user from viewing dropbox/dataverse files.

```
Stacktrace (most recent call last):

  File "framework/routing/__init__.py", line 96, in wrapped
    data = fn(*args, **kwargs)
  File "website/project/decorators.py", line 138, in wrapped
    return response or func(*args, **kwargs)
  File "website/project/decorators.py", line 181, in wrapped
    return func(*args, **kwargs)
  File "website/addons/dropbox/views/crud.py", line 174, in dropbox_view_file
    rendered = render_dropbox_file(file_obj, client=client, rev=rev)
  File "website/addons/dropbox/utils.py", line 166, in render_dropbox_file
    download_path=file_obj.download_url(guid=True, rev=rev),
```
