### PR TITLE
Fixes UX issues in "jobs" and "education" panels of a user's profile

### DIFF
--- a/website/static/js/profile.js
+++ b/website/static/js/profile.js
@@ -591,6 +591,10 @@
          * Emulates the interface of TrackedMixin.dirty
          * */
         self.dirty = function() {
+            // if the length of the list has changed
+            if (self.originalItems.length !== self.contents().length) {
+                return true;
+            }
             for (var i=0; i<self.contents().length; i++) {
                 if (
                     // object has changed


### PR DESCRIPTION
A fairly simple fix - I didn't check to verify that the current state contained the same number of items as the original state, resulting in an issue where items removed from the end of the list would fail to make the object dirty.
