### PR TITLE
[hotfix] Handle queued tasks when working outside request context.

### DIFF
--- a/framework/tasks/handlers.py
+++ b/framework/tasks/handlers.py
@@ -28,8 +28,15 @@ def celery_teardown_request(error=None):
 
 
 def enqueue_task(signature):
-    if signature not in g._celery_tasks:
-        g._celery_tasks.append(signature)
+    """If working in a request context, push task signature to ``g`` to run
+    after request is complete; else run signature immediately.
+    :param signature: Celery task signature
+    """
+    try:
+        if signature not in g._celery_tasks:
+            g._celery_tasks.append(signature)
+    except RuntimeError:
+        signature()
 
 
 handlers = {


### PR DESCRIPTION
# Purpose

Don't crash when a post-request Celery task is queued outside a request context. This happens, for example, when saving a `Node` from the shell.
# Changes
- If a task signature is queued outside a request context, execute the task immediately rather than waiting for the request to finish (since there is no request to wait for)
# Side effects

None expected
