### PR TITLE
Add "Registry" to the Explore menu

### DIFF
--- a/website/templates/nav.mako
+++ b/website/templates/nav.mako
@@ -19,8 +19,9 @@
                 <li class="dropdown">
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">Explore <b class="caret"></b></a>
                     <ul class="dropdown-menu">
-                        <li><a href="/explore">Collaborator Network</a></li>
+                        <li><a href="/search/?q=*&filter=registration">Registry</a></li>
                         <li><a href="/explore/activity">Public Activity</a></li>
+                        <li><a href="/explore">Collaborator Network</a></li>
                     </ul><!-- end dropdown-menu -->
                 </li><!-- end dropdown -->
                 <li class="dropdown">


### PR DESCRIPTION
Purpose
-----------
OSF is a registry. People do not understand this. Having a registry link is a quick first step to making that clear. 

Changes
------------
Adds a menu item to the Explore menu called Registry that takes the user to a Search page of all of the OSF registrations.

![screen shot 2014-12-04 at 10 50 29 am](https://cloud.githubusercontent.com/assets/6599111/5301104/efe659d4-7ba3-11e4-87d5-621463d00839.png)


Side effects
----------------
Rearranged the Explore menu to put registry at the top and Collaborator Network, which becomes increasingly out of date, at the bottom.

Closes #1331