### PR TITLE
[feature fix] add-to-dashboard-button public projects

### DIFF
--- a/website/static/js/nodeControl.js
+++ b/website/static/js/nodeControl.js
@@ -115,7 +115,7 @@
         self.category = data.node.category;
         self.isRegistration = data.node.is_registration;
         self.user = data.user;
-        self.nodeIsPublic = data.node.nodeType === PUBLIC;
+        self.nodeIsPublic = data.node.is_public;
         self.nodeType = data.node.node_type;
         // The button text to display (e.g. "Watch" if not watching)
         self.watchButtonDisplay = ko.computed(function() {


### PR DESCRIPTION
Fix checking for public projects. Now the button should show in public projects even if you are not a contributor.
