### PR TITLE
[hotfix] Prevent unnecessary FS access when building log templates

### DIFF
--- a/website/addons/base/__init__.py
+++ b/website/addons/base/__init__.py
@@ -439,11 +439,15 @@ class AddonNodeSettingsBase(AddonSettingsBase):
 
 
 # TODO: No more magicks
-def init_addon(app, addon_name, routes=True):
-    """Load addon module and create configuration object.
+def init_addon(app, addon_name, log_fp=None, routes=True):
+    """Load addon module return its create configuration object.
+
+    If `log_fp` is provided, the addon's log templates will be appended
+    to the file.
 
     :param app: Flask app object
     :param addon_name: Name of addon directory
+    :param file log_fp: File pointer for the built logs file.
     :param bool routes: Add routes
     :return AddonConfig: AddonConfig configuration object if module found,
         else None
@@ -461,9 +465,8 @@ def init_addon(app, addon_name, routes=True):
     log_templates = os.path.join(
         addon_path, 'templates', 'log_templates.mako'
     )
-    if os.path.exists(log_templates):
-        with open(settings.BUILT_TEMPLATES, 'a') as fp:
-            fp.write(open(log_templates, 'r').read())
+    if os.path.exists(log_templates) and log_fp:
+        log_fp.write(open(log_templates, 'r').read())
 
     # Add routes
     if routes:

--- a/website/app.py
+++ b/website/app.py
@@ -21,10 +21,16 @@ from website.addons.base import init_addon
 from website.project.model import ensure_schemas
 
 
-def init_addons(settings, routes=True):
+def init_addons(settings, routes=True, log_fp=None):
+    """Initialize each addon in settings.ADDONS_REQUESTED.
+
+    :param module settings: The settings module.
+    :param bool routes: Add each addon's routing rules to the URL map.
+    :param file log_fp: File pointer for the built logs file.
+    """
     ADDONS_AVAILABLE = []
     for addon_name in settings.ADDONS_REQUESTED:
-        addon = init_addon(app, addon_name, routes)
+        addon = init_addon(app, addon_name, routes=True, log_fp=log_fp)
         if addon:
             ADDONS_AVAILABLE.append(addon)
     settings.ADDONS_AVAILABLE = ADDONS_AVAILABLE
@@ -83,10 +89,10 @@ def init_app(settings_module='website.settings', set_backends=True, routes=True)
     with open(settings.BUILT_TEMPLATES, 'w') as build_fp:
         init_log_file(build_fp, settings)
 
-    try:
-        init_addons(settings, routes)
-    except AssertionError as error:  # Addon Route map has already been created
-        logger.error(error)
+        try:
+            init_addons(settings, routes, log_fp=build_fp)
+        except AssertionError as error:  # Addon Route map has already been created
+            logger.error(error)
 
     app.debug = settings.DEBUG_MODE
     if set_backends:


### PR DESCRIPTION
Previously, each addon was opening the _log_templates.mako in
append mode. This may have resulted in a race condition that
caused the file to be written in an incomplete state.

This patch ensures that _log_templates.mako is only opened
once at run time.

Attempt to fix #1341

thanks @lyndsysimon for looking this over with me
