### PR TITLE
[feature] Minor changes to page header for registration

### DIFF
--- a/website/static/js/nodeControl.js
+++ b/website/static/js/nodeControl.js
@@ -105,6 +105,7 @@
         self.dateCreated = new FormattableDate(data.node.date_created);
         self.dateModified = new FormattableDate(data.node.date_modified);
         self.dateForked = new FormattableDate(data.node.forked_date);
+        self.dateRegistered = new FormattableDate(data.node.registered_date);
         self.watchedCount = ko.observable(data.node.watched_count);
         self.userIsWatching = ko.observable(data.user.is_watching);
         self.inDashboard = ko.observable(data.node.in_dashboard);

--- a/website/templates/project/project_header.mako
+++ b/website/templates/project/project_header.mako
@@ -122,6 +122,10 @@
                     <br />Forked from <a class="node-forked-from" href="/${node['forked_from_id']}/">${node['forked_from_display_absolute_url']}</a> on
                     <span data-bind="text: dateForked.local, tooltip: {title: dateForked.utc}"></span>
                 % endif
+                % if node['is_registration']:
+                    <br />Registration Date:
+                    <span data-bind="text: dateRegistered.local, tooltip: {title: dateRegistered.utc}" class="date node-registered-date"></span>
+                % endif
                 % if node['is_registration'] and node['registered_meta']:
                     <br />Registration Supplement:
                     % for meta in node['registered_meta']:

--- a/website/templates/project/project_header.mako
+++ b/website/templates/project/project_header.mako
@@ -139,7 +139,12 @@
                 % if parent_node['id']:
                     <br />Category: <span class="node-category">${node['category']}</span>
                 % elif node['description'] or 'write' in user['permissions']:
-                    <br /><span id="description">Description:</span> <span id="nodeDescriptionEditable" class="node-description overflow" data-type="textarea">${node['description']}</span>
+                    <br /><span id="description">Description:</span>
+                    % if node['is_registration']:
+                        <span class="node-description overflow${'' if node['description'] else ' text-muted'}" data-type="textarea">${node['description'] or "No description"}</span>
+                    % else:
+                        <span id="nodeDescriptionEditable" class="node-description overflow" data-type="textarea">${node['description']}</span>
+                    % endif
                 % endif
             </div>
         </div>


### PR DESCRIPTION
Adds a line for "Registration Date", per #1342.
Add placeholder text ("No description") for projects without descriptions, styled to align with how it appears for contributors.