### PR TITLE
Handle text overflow of email tooltip in navbar

### DIFF
--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -1674,3 +1674,8 @@ div.pydocx-center{
     padding-left: 40px;
     list-style-type: disc;
 }
+
+.tooltip-inner {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}


### PR DESCRIPTION
Closes #1347
