### PR TITLE
Feature Figshare deauth banner

### DIFF
--- a/website/addons/figshare/model.py
+++ b/website/addons/figshare/model.py
@@ -260,7 +260,7 @@ class AddonFigShareNodeSettings(AddonNodeSettingsBase):
             return messages.AFTER_REMOVE_CONTRIBUTOR.format(
                 user=removed.fullname,
                 url=node.url,
-                category=self.figshare_id
+                category=node.project_or_component
             )
 
     def before_fork(self, node, user):

--- a/website/addons/figshare/tests/test_models.py
+++ b/website/addons/figshare/tests/test_models.py
@@ -138,8 +138,13 @@ class TestCallbacks(OsfTestCase):
         assert_false(message)
 
     def test_after_remove_contributor_authenticator(self):
-        self.node_settings.after_remove_contributor(
+        msg = self.node_settings.after_remove_contributor(
             self.project, self.project.creator
+        )
+
+        assert_in(
+                self.project.project_or_component,
+                msg
         )
         assert_equal(
             self.node_settings.user_settings,


### PR DESCRIPTION
# Purpose
- Fixes #1335
# How/Why

Looks to be a typo, category was being set as `figshare_id` rather than `project_or_component` as it was everywhere else
# Possible Side Effect
- Literally none
