### PR TITLE
[hotfix] Build log templates separately from importing addons.

### DIFF
--- a/website/addons/base/__init__.py
+++ b/website/addons/base/__init__.py
@@ -439,7 +439,7 @@ class AddonNodeSettingsBase(AddonSettingsBase):
 
 
 # TODO: No more magicks
-def init_addon(app, addon_name, log_fp=None, routes=True):
+def init_addon(app, addon_name, routes=True):
     """Load addon module return its create configuration object.
 
     If `log_fp` is provided, the addon's log templates will be appended
@@ -453,20 +453,12 @@ def init_addon(app, addon_name, log_fp=None, routes=True):
         else None
 
     """
-    addon_path = os.path.join('website', 'addons', addon_name)
     import_path = 'website.addons.{0}'.format(addon_name)
 
     # Import addon module
     addon_module = importlib.import_module(import_path)
 
     data = vars(addon_module)
-
-    # Append add-on log templates to main log templates
-    log_templates = os.path.join(
-        addon_path, 'templates', 'log_templates.mako'
-    )
-    if os.path.exists(log_templates) and log_fp:
-        log_fp.write(open(log_templates, 'r').read())
 
     # Add routes
     if routes:

--- a/website/app.py
+++ b/website/app.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import os
 import importlib
 
 from modularodm import storage
@@ -21,25 +22,24 @@ from website.addons.base import init_addon
 from website.project.model import ensure_schemas
 
 
-def init_addons(settings, routes=True, log_fp=None):
+def init_addons(settings, routes=True):
     """Initialize each addon in settings.ADDONS_REQUESTED.
 
     :param module settings: The settings module.
     :param bool routes: Add each addon's routing rules to the URL map.
-    :param file log_fp: File pointer for the built logs file.
     """
-    ADDONS_AVAILABLE = []
+    settings.ADDONS_AVAILABLE = getattr(settings, 'ADDONS_AVAILABLE', [])
+    settings.ADDONS_AVAILABLE_DICT = getattr(settings, 'ADDONS_AVAILABLE_DICT', {})
     for addon_name in settings.ADDONS_REQUESTED:
-        addon = init_addon(app, addon_name, routes=True, log_fp=log_fp)
+        try:
+            addon = init_addon(app, addon_name, routes=routes)
+        except AssertionError as error:
+            logger.exception(error)
+            continue
         if addon:
-            ADDONS_AVAILABLE.append(addon)
-    settings.ADDONS_AVAILABLE = ADDONS_AVAILABLE
-
-    settings.ADDONS_AVAILABLE_DICT = {
-        addon.short_name: addon
-        for addon in settings.ADDONS_AVAILABLE
-    }
-
+            if addon not in settings.ADDONS_AVAILABLE:
+                settings.ADDONS_AVAILABLE.append(addon)
+            settings.ADDONS_AVAILABLE_DICT[addon.short_name] = addon
     settings.ADDON_CAPABILITIES = render_addon_capabilities(settings.ADDONS_AVAILABLE)
 
 
@@ -61,16 +61,28 @@ def attach_handlers(app, settings):
     add_handlers(app, {'before_request': framework.sessions.before_request})
     return app
 
-def init_log_file(build_fp, settings):
+
+def build_addon_log_templates(build_fp, settings):
+    for addon in settings.ADDONS_REQUESTED:
+        log_path = os.path.join(settings.ADDON_PATH, addon, 'templates', 'log_templates.mako')
+        try:
+            with open(log_path) as addon_fp:
+                build_fp.write(addon_fp.read())
+        except IOError:
+            pass
+
+
+def build_log_templates(settings):
     """Write header and core templates to the built log templates file."""
-    build_fp.write('## Built templates file. DO NOT MODIFY.\n')
-    with open(settings.CORE_TEMPLATES) as core_fp:
-        # Exclude comments in core templates mako file
-        content = '\n'.join([line.rstrip() for line in
-            core_fp.readlines() if not line.strip().startswith('##')])
-        build_fp.write(content)
-    build_fp.write('\n')
-    return None
+    with open(settings.BUILT_TEMPLATES, 'w') as build_fp:
+        build_fp.write('## Built templates file. DO NOT MODIFY.\n')
+        with open(settings.CORE_TEMPLATES) as core_fp:
+            # Exclude comments in core templates mako file
+            content = '\n'.join([line.rstrip() for line in
+                core_fp.readlines() if not line.strip().startswith('##')])
+            build_fp.write(content)
+        build_fp.write('\n')
+        build_addon_log_templates(build_fp, settings)
 
 
 def init_app(settings_module='website.settings', set_backends=True, routes=True):
@@ -86,13 +98,8 @@ def init_app(settings_module='website.settings', set_backends=True, routes=True)
     # The settings module
     settings = importlib.import_module(settings_module)
 
-    with open(settings.BUILT_TEMPLATES, 'w') as build_fp:
-        init_log_file(build_fp, settings)
-
-        try:
-            init_addons(settings, routes, log_fp=build_fp)
-        except AssertionError as error:  # Addon Route map has already been created
-            logger.error(error)
+    build_log_templates(settings)
+    init_addons(settings, routes)
 
     app.debug = settings.DEBUG_MODE
     if set_backends:
@@ -120,6 +127,7 @@ def init_app(settings_module='website.settings', set_backends=True, routes=True)
         ensure_schemas()
     apply_middlewares(app, settings)
     return app
+
 
 def apply_middlewares(flask_app, settings):
     # Use ProxyFix to respect X-Forwarded-Proto header


### PR DESCRIPTION
# Purpose

Separate building log templates from importing addons so that errors in the latter don't break the former.
# Changes
- Build log templates in separate function
# Side effects

None expected
