### PR TITLE
[hotfix] Show correct dates in file revision widget.

### DIFF
--- a/website/addons/osfstorage/tests/test_utils.py
+++ b/website/addons/osfstorage/tests/test_utils.py
@@ -212,7 +212,7 @@ class TestGetDownloadUrl(StorageTestCase):
         filename = utils.get_filename(2, self.record.versions[-2], self.record)
         expected = ''.join([
             'reviews-',
-            self.record.versions[-2].date_modified.isoformat(),
+            self.record.versions[-2].date_created.isoformat(),
             '.gif',
         ])
         assert_equal(filename, expected)
@@ -246,10 +246,7 @@ class TestSerializeRevision(StorageTestCase):
         self.path = 'kind/of/magic.mp3'
         self.record = model.OsfStorageFileRecord.get_or_create(self.path, self.node_settings)
         self.versions = [
-             factories.FileVersionFactory(
-                creator=self.user,
-                date_modified=datetime.datetime.utcnow(),
-            )
+             factories.FileVersionFactory(creator=self.user)
             for _ in range(3)
         ]
         self.record.versions = self.versions
@@ -277,7 +274,7 @@ class TestSerializeRevision(StorageTestCase):
                 'name': self.user.fullname,
                 'url': self.user.url,
             },
-            'date': self.versions[0].date_modified.isoformat(),
+            'date': self.versions[0].date_created.isoformat(),
             'downloads': 2,
             'urls': {
                 'view': self.project.web_url_for(
@@ -302,10 +299,7 @@ class TestSerializeRevision(StorageTestCase):
         assert_equal(expected, observed)
 
     def test_serialize_revision_uploading(self):
-        version = factories.FileVersionFactory(
-            status=model.status_map['UPLOADING'],
-            date_modified=None,
-        )
+        version = factories.FileVersionFactory(status=model.status_map['UPLOADING'])
         self.record.versions.append(version)
         self.record.save()
         serialized = utils.serialize_revision(

--- a/website/addons/osfstorage/utils.py
+++ b/website/addons/osfstorage/utils.py
@@ -123,8 +123,8 @@ def serialize_revision(node, record, version, index):
             'url': version.creator.url,
         },
         'date': (
-            version.date_modified.isoformat()
-            if version.date_modified
+            version.date_created.isoformat()
+            if not version.pending
             else None
         ),
         'downloads': record.get_download_count(version=index),
@@ -259,7 +259,7 @@ def get_filename(version_idx, file_version, file_record):
     name, ext = os.path.splitext(file_record.name)
     return u'{name}-{date}{ext}'.format(
         name=name,
-        date=file_version.date_modified.isoformat(),
+        date=file_version.date_created.isoformat(),
         ext=ext,
     )
 


### PR DESCRIPTION
# Purpose

We currently show the date created metadata from Rackspace, which will
be different from the date the user uploaded the file when the same file
is uploaded to different nodes at different dates. This patch shows the
date at which the user uploaded the file instead. Thanks @caileyfitz for
reporting.
# Changes
- Use `date_created` rather than `date_modified` in revision table and file name
- Update dates
# Side effects

None expected
