### PR TITLE
[hotfix] Remove custom task IDs and state.

### DIFF
--- a/framework/render/tasks.py
+++ b/framework/render/tasks.py
@@ -82,19 +82,11 @@ def _build_rendered_html(file_path, cache_dir, cache_file_name, download_url):
 
 
 def build_rendered_html(file_path, cache_dir, cache_file_name, download_url):
-    """Public wrapper for the rendering task. Override the default Celery ID
-    generation, passing the unique cached path as the `task_id`, to permit
-    checking whether the requested file is already being rendered.
+    """Public wrapper for the rendering task.
     """
     args = (file_path, cache_dir, cache_file_name, download_url)
     if settings.USE_CELERY:
-        # Call task asynchronously
-        task_id = '{0}/{1}'.format(cache_dir, cache_file_name)
-        # Enqueue task if it hasn't already been sent to Rabbit ("PENDING"
-        # means not published to message queue)
-        result = app.AsyncResult(task_id)
-        if result.status == 'PENDING':
-            _build_rendered_html.apply_async(args, task_id=task_id)
+        _build_rendered_html.apply_async(args)
     else:
         # Call task synchronously
         _build_rendered_html(*args)

--- a/framework/tasks/__init__.py
+++ b/framework/tasks/__init__.py
@@ -1,27 +1,13 @@
 # -*- coding: utf-8 -*-
 """Asynchronous task queue module."""
 
-from celery import Celery, current_app
+from celery import Celery
 from celery.utils.log import get_task_logger
-from celery.signals import after_task_publish
 
 from raven import Client
 from raven.contrib.celery import register_signal
 
 from website import settings
-
-
-# Adapted from http://stackoverflow.com/questions/9824172/find-out-whether-celery-task-exists
-@after_task_publish.connect
-def update_published_state(sender=None, body=None, **kwargs):
-    """By default, Celery doesn't distinguish between tasks that are pending
-    and tasks that have not been published; both are flagged as "PENDING". This
-    callback sets task status to "PUBLISHED" after being sent to the message
-    broker so that the application can determine which tasks are active.
-    """
-    task = current_app.tasks.get(sender)
-    backend = task.backend if task else current_app.backend
-    backend.store_result(body['id'], None, 'PUBLISHED')
 
 
 app = Celery()


### PR DESCRIPTION
# Purpose

Don't use custom task IDs or `PUBLISHED` state for file rendering task. @icereval and I discussed this and figured out that we don't actually need to prevent multiple render tasks from firing for the same file--the user sees the correctly rendered file even if multiple tasks run at once. This resolves #1356.
# Changes
- Remove custom task ID
- Remove custom task state
# Side effects

None expected
