### PR TITLE
Feature fix: Require bootbox in search.js

### DIFF
--- a/website/static/js/search.js
+++ b/website/static/js/search.js
@@ -1,5 +1,6 @@
 var ko = require('knockout');
 var $ = require('jquery');
+var bootbox = require('bootbox');
 require('bootstrap.growl');
 var History = require('exports?History!history');
 


### PR DESCRIPTION
Fix the search help button by requiring bootbox in search.js. 
