### PR TITLE
Fix bug in footer to allow Safari to save dismissed state

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,4 +6,4 @@ from website.app import init_app
 app = init_app('website.settings', set_backends=True, routes=True)
 
 if __name__ == '__main__':
-    app.run(host='127.0.0.1', port=5000)
+    app.run(host='0.0.0.0', port=5000)

--- a/website/static/js/site.js
+++ b/website/static/js/site.js
@@ -303,15 +303,14 @@
             var self = this;
             self.elem = $(sliderSelector);
 
-            // Detect if localStorage is available.
-            // TODO: We should be using a library like Modernizr for this
-            var useLocalStorage = typeof(localStorage) !== 'undefined';
+            var dismissed = false;
 
-            if (useLocalStorage) {
-                var dismissed = localStorage.getItem("slide") === "0";
-            } else {
-                var dismissed = $.cookie("slide") === "0";
-            }
+            try {
+                dismissed = dismissed || localStorage.getItem("slide") === "0"
+            } catch (e) {}
+
+            dismissed = dismissed || $.cookie("slide") === "0";
+
             if (this.elem.length > 0 && !dismissed) {
                 setTimeout(function () {
                     self.elem.slideDown(1000);
@@ -319,9 +318,9 @@
             }
             self.dismiss = function() {
                 self.elem.slideUp(1000);
-                if (useLocalStorage) {
+                try {
                     localStorage.setItem("slide", "0");
-                } else {
+                } catch (e) {
                     $.cookie('slide', '0', { expires: 1});
                 }
             };


### PR DESCRIPTION
# Issue

In Safari on OSX, the footer slidein's dismissal would (usually) not persist between page loads. While inspection in the development console showed that the cookie was indeed set, approximately 75% of the time the cookie would not be set the next time any OSF page was loaded.

This seems to have unlikely been a problem with the library used `[jquery.cookie](/carhartl/jquery-cookie)`, as the page's `document.cookie` propery did in fact reflect that the cookie was set... at least, until the user reloaded the page.
# Changes

The footer slide-in now uses HTML5 local storage to store the user's dismissal of the modal. If the `localStorage` object isn't available - for instance, if the user has it turned off, or if they're using a very old browser - then I'm falling back to using the cookie.
# Side Effects

None known. This should only impact the footer code.
# Notes

In theory, this does not completely resolve the problem. It's possible that a user might be using a version of Safari that doesn't support local storage, in which case the defective behavior will likely still be present. Safari 4 was the first version to support it and it was released in 2008, so the chances of this occurring seem to be very small. That said, the worst that could happen with this particular issue is that the slide-in would show on every page when the user is logged out.

I've tested the slider, including this hotfix, in IE 11 on Win8.1. I found no issues.
