### PR TITLE
Turn off AJAX caching

### DIFF
--- a/website/static/js/nodeControl.js
+++ b/website/static/js/nodeControl.js
@@ -10,6 +10,9 @@
     }
 }(this, function($, ko) {
     'use strict';
+    
+    // Don't cache AJAX requests, IE. Just… stop.
+    jQuery.ajaxSetup({ cache: false });
 
     // Modal language
     var MESSAGES = {


### PR DESCRIPTION
As usual, AJAX caching made IE behave strangely. This turns off AJAX caching.

Fixes https://trello.com/c/0E0cxxCc
