### PR TITLE
[feature] [fix] Adds jquery-ui-sortable to bower; corrects path for webpack

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,6 +25,7 @@
     "jquery-autosize": "~1.18.15",
     "x-editable": "~1.5.1",
     "slickgrid": "~2.1.0",
-    "jquery.cookie": "~1.4.1"
+    "jquery.cookie": "~1.4.1",
+    "jquery-ui-sortable": "4323c165b8"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -89,7 +89,7 @@ module.exports = {
             'jquery.cookie': staticPath('vendor/bower_components/jquery.cookie/jquery.cookie.js'),
             'history': staticPath('vendor/bower_components/history.js/scripts/bundled/html4+html5/jquery.history.js'),
             // Needed for knockout-sortable
-            'jquery.ui.sortable': staticPath('vendor/bower_components/jquery-ui/ui/jquery.ui.sortable.js'),
+            'jquery.ui.sortable': staticPath('vendor/bower_components/jquery-ui-sortable/jquery-ui-sortable.min.js'),
             // Dropzone doesn't have a proper 'main' entry in its bower.json
             'dropzone': staticPath('vendor/bower_components/dropzone/downloads/dropzone.js'),
             // Also alias some internal libraries for easy access


### PR DESCRIPTION
This PR resolves a problem where Javascript errors were being generated when accessing the user's dashboard page.

h/t @erinspace for bringing this to my attention and helping me work through it.
