### PR TITLE
0.23.0/project-overview-formatting

### DIFF
--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -1706,8 +1706,9 @@ div.pydocx-center{
 }
 
 #footerSlideIn div > a {
-    margin-right:5px;
-    white-space:nowrap;
+    margin-right: 5px;
+    white-space: nowrap;
+}
 
 /* Necessary to handle lots of text in tooltips */
 .tooltip-inner {


### PR DESCRIPTION
## Purpose

Fix https://trello.com/c/qqGZBAq5 - HGrid rows on project overview were not all displaying properly.

Was:
![screen shot 2014-12-30 at 9 31 02 am](https://cloud.githubusercontent.com/assets/6599111/5579324/a3bbd940-9006-11e4-8ee5-98a64cff3a59.png)

Now:
![screen shot 2014-12-30 at 9 30 31 am](https://cloud.githubusercontent.com/assets/6599111/5579334/ab3e8a46-9006-11e4-8262-fc5d5e31a80d.png)
## Changes

Img elements in the project overview hgrid broke the hgrid display when they had the block format applied to them, so I separated out the wiki and addon-widget-container classes to be slightly different. Wiki images are still block elements, but addon-widget-container images are not.
## Side effects

According to the comment, one of the goals of the wiki img formatting was to make the images more responsive, so possibly I broke that, but I tested with the image above, and it seemed to work at various page widths, so it should be fine. That being said, maybe more complex wiki image views?
