### PR TITLE
Hotfix/s3registration

### DIFF
--- a/website/addons/s3/model.py
+++ b/website/addons/s3/model.py
@@ -97,7 +97,7 @@ class AddonS3NodeSettings(AddonNodeSettingsBase):
             self.save()
 
     def deauthorize(self, auth=None, log=True, save=False):
-        self.registration_data = None
+        self.registration_data = {}
         self.bucket = None
         self.user_settings = None
 
@@ -171,8 +171,10 @@ class AddonS3NodeSettings(AddonNodeSettingsBase):
 
         if self.bucket and self.has_auth:
             clone.user_settings = self.user_settings
-            clone.registration_data['bucket'] = self.bucket
-            clone.registration_data['keys'] = serialize_bucket(S3Wrapper.from_addon(self))
+            clone.registration_data = {
+                'bucket': self.bucket,
+                'keys': serialize_bucket(S3Wrapper.from_addon(self))
+            }
 
         if save:
             clone.save()

--- a/website/addons/s3/tests/test_model.py
+++ b/website/addons/s3/tests/test_model.py
@@ -143,3 +143,32 @@ class TestCallbacks(OsfTestCase):
         self.node_settings.reload()
         assert_true(self.node_settings.user_settings is None)
         assert_true(self.node_settings.bucket is None)
+
+    @mock.patch('website.addons.s3.model.serialize_bucket')
+    @mock.patch('website.addons.s3.model.S3Wrapper.from_addon')
+    def test_after_register_registration_data_none(self, mock_wrapper, mock_bucket):
+        fork = ProjectFactory()
+        mock_wrapper.return_value = None
+        mock_bucket.return_value = {'Not None': 'None'}
+
+        self.node_settings.registration_data = None
+
+        clone, message = self.node_settings.after_register(
+            self.project, fork, self.project.creator,
+        )
+
+        assert_true(isinstance(clone.registration_data, dict))
+
+    @mock.patch('website.addons.s3.model.serialize_bucket')
+    @mock.patch('website.addons.s3.model.S3Wrapper.from_addon')
+    def test_register_and_deauth(self, mock_wrapper, mock_bucket):
+        fork = ProjectFactory()
+        mock_wrapper.return_value = None
+        mock_bucket.return_value = {'Not None': 'None'}
+
+        self.node_settings.deauthorize()
+
+    def test_registration_data_and_deauth(self):
+        self.node_settings.deauthorize()
+        assert_false(self.node_settings.registration_data is None)
+        assert_true(isinstance(self.node_settings.registration_data, dict))


### PR DESCRIPTION
Fixes #1435 

# Why
When deauthorizing S3 the `registration_data` field was being set to `None`.
This was causing `clone.registration_data['bucket'] = self.bucket` to fail due to it being `None`.

# The Fix
deauthorize now sets `registration_data` to an empty dictionary.
And `after_register` now assigns to the entire value rather than assuming it is dictionary like,
ensuring that any existing addon settings will register properly.