### PR TITLE
0.23.0/onboarder dropzone

### DIFF
--- a/website/static/js/onboarder.js
+++ b/website/static/js/onboarder.js
@@ -5,7 +5,7 @@
 */
 'use strict';
 var Handlebars = require('handlebars');
-var Dropzone = require('../vendor/bower_components/dropzone/downloads/dropzone.js');
+var Dropzone = require('dropzonePatch');
 var Raven = require('raven-js');
 var ko = require('knockout');
 var $ = require('jquery');


### PR DESCRIPTION
Purpose
-----------
Make the dropzone on the onboarder page properly upload files.

Changes
------------
Uses the patched dropzone instead of the regular dropzone.

Side Effects
----------------
Shouldn't be any, though I can't really test this, because I don't have local osfstorage working. However, the change does cause it to use the proper REST verb (post, not put), and the new error is consistent with what I would expect, so it probably works. Still, you'll want to try it first, obviously.

Fixes (hopefully) https://trello.com/c/F6TuUnRd