### PR TITLE
Hotfix: Add user's first and last name when subscribing to mailchimp

### DIFF
--- a/scripts/sync_email.py
+++ b/scripts/sync_email.py
@@ -66,7 +66,12 @@ def serialize_user(user):
     """Return the formatted dict expected by the mailchimp batch subscribe endpoint.
     https://apidocs.mailchimp.com/api/2.0/lists/batch-subscribe.php
     """
-    return {'email': {'email': user.username}, 'email_type': 'html'}
+    return {'email': {'email': user.username},
+            'email_type': 'html',
+            'merge_vars': {
+                'fname': user.given_name,
+                'lname': user.family_name}
+            }
 
 
 def subscribe_users(users, dry=True):
@@ -118,7 +123,12 @@ class TestSyncEmail(OsfTestCase):
     def test_serialize_user(self):
         user = UserFactory()
         result = serialize_user(user)
-        assert_equal(result, {'email': {'email': user.username}, 'email_type': 'html'})
+        assert_equal(result, {'email': {'email': user.username},
+                              'email_type': 'html',
+                              'merge_vars': {
+                                  'fname': user.given_name,
+                                  'lname': user.family_name}
+                              })
 
     def test_get_users(self):
         users = list(get_users())

--- a/tests/test_mailchimp.py
+++ b/tests/test_mailchimp.py
@@ -36,7 +36,12 @@ class TestMailChimpHelpers(OsfTestCase):
         mock_client.lists.list.return_value = {'data': [{'id': 1, 'list_name': list_name}]}
         list_id = mailchimp_utils.get_list_id_from_name(list_name)
         mailchimp_utils.subscribe(list_name, user)
-        mock_client.lists.subscribe.assert_called_with(id=list_id, email={'email': user.username}, double_optin=False, update_existing=True)
+        mock_client.lists.subscribe.assert_called_with(id=list_id,
+                                                       email={'email': user.username},
+                                                       merge_vars={'fname': user.given_name,
+                                                                   'lname': user.family_name},
+                                                       double_optin=False,
+                                                       update_existing=True)
 
     @mock.patch('website.mailchimp_utils.get_mailchimp_api')
     def test_unsubscribe_called_with_correct_arguments(self, mock_get_mailchimp_api):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2367,7 +2367,13 @@ class TestConfigureMailingListViews(OsfTestCase):
         )
 
         # check that user is subscribed
-        mock_client.lists.subscribe.assert_called_with(id=list_id, email={'email': user.username}, double_optin=False, update_existing=True)
+        mock_client.lists.subscribe.assert_called_with(id=list_id,
+                                                       email={'email': user.username},
+                                                       merge_vars= {'fname': user.given_name,
+                                                                    'lname': user.family_name,
+                                                       },
+                                                       double_optin=False,
+                                                       update_existing=True)
 
     def test_get_mailchimp_get_endpoint_returns_200(self):
         url = api_url_for('mailchimp_get_endpoint')

--- a/website/mailchimp_utils.py
+++ b/website/mailchimp_utils.py
@@ -27,7 +27,12 @@ def subscribe(list_name, user_id):
     user = User.load(user_id)
     m = get_mailchimp_api()
     list_id = get_list_id_from_name(list_name=list_name)
-    m.lists.subscribe(id=list_id, email={'email': user.username}, double_optin=False, update_existing=True)
+    m.lists.subscribe(id=list_id,
+                      email={'email': user.username},
+                      merge_vars={'fname': user.given_name,
+                                  'lname': user.family_name},
+                      double_optin=False,
+                      update_existing=True)
 
     # Update mailing_list user field
     if user.mailing_lists is None:


### PR DESCRIPTION
Adds a user's first and last name when subscribing them to a mailchimp list, so that it is included in their mailchimp profile. 