### PR TITLE
Make mailchimp settings page CommonJS compatible

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,6 +28,7 @@ var entry = {
     'search-page': staticPath('js/pages/search-page.js'),
     'user-addon-cfg-page': staticPath('js/pages/user-addon-cfg-page.js'),
     'addon-permissions': staticPath('js/addon-permissions.js'),
+    'notifications-config-page': staticPath('js/notifications-config-page.js'),
     // Commons chunk
     'vendor': [
         'knockout',

--- a/website/static/js/notifications-config-page.js
+++ b/website/static/js/notifications-config-page.js
@@ -1,0 +1,4 @@
+NotificationsConfig =  require('./notificationsConfig.js');
+
+new NotificationsConfig(window.contextVars.notificationsSelector, window.contextVars.mailingList);
+

--- a/website/static/js/notifications-config-page.js
+++ b/website/static/js/notifications-config-page.js
@@ -1,4 +1,4 @@
 NotificationsConfig =  require('./notificationsConfig.js');
 
-new NotificationsConfig(window.contextVars.notificationsSelector, window.contextVars.mailingList);
+new NotificationsConfig('#selectLists', window.contextVars.mailingList);
 

--- a/website/static/js/notifications-config-page.js
+++ b/website/static/js/notifications-config-page.js
@@ -1,4 +1,4 @@
-NotificationsConfig =  require('./notificationsConfig.js');
+var NotificationsConfig =  require('./notificationsConfig.js');
 
 new NotificationsConfig('#selectLists', window.contextVars.mailingList);
 

--- a/website/static/js/notificationsConfig.js
+++ b/website/static/js/notificationsConfig.js
@@ -1,77 +1,72 @@
-;(function (global, factory) {
-    if (typeof define === 'function' && define.amd) {
-        define(['knockout', 'jquery', 'osfutils'], factory);
-    } else {
-        global.NotificationsConfig = factory(ko, jQuery);
-        $script.done('NotificationsConfig');
-    }
-}(this, function(ko, $) {
-    'use strict';
-    ko.punches.enableAll();
+'use strict';
 
-    var ViewModel = function(list) {
-        var self = this;
-        self.list = list;
-        self.subscribed = ko.observable();
-        // Flashed messages
-        self.message = ko.observable('');
-        self.messageClass = ko.observable('text-success');
+var ko = require('knockout');
+require('knockout-punches');
+var $ = require('jquery');
+var $osf = require('osfHelpers');
+ko.punches.enableAll();
 
-        self.getListInfo = function() {
-            $.ajax({
-                url: '/api/v1/settings/notifications',
-                type: 'GET',
-                dataType: 'json',
-                success: function(response) {
-                    var isSubscribed = response.mailing_lists ? response.mailing_lists[self.list] : false;
-                    self.subscribed(isSubscribed);
-                },
-                error: function() {
-                    var message = 'Could not retrieve settings information.';
-                    self.changeMessage(message, 'text-danger', 5000);
-                }});
-        };
+var ViewModel = function(list) {
+    var self = this;
+    self.list = list;
+    self.subscribed = ko.observable();
+    // Flashed messages
+    self.message = ko.observable('');
+    self.messageClass = ko.observable('text-success');
 
-        self.getListInfo();
-
-        /** Change the flashed status message */
-        self.changeMessage = function(text, css, timeout) {
-            self.message(text);
-            var cssClass = css || 'text-info';
-            self.messageClass(cssClass);
-            if (timeout) {
-                // Reset message after timeout period
-                setTimeout(function() {
-                    self.message('');
-                    self.messageClass('text-info');
-                }, timeout);
-            }
-        };
-
-        self.submit = function () {
-            var payload = {};
-            payload[self.list] = self.subscribed();
-            var request = $.osf.postJSON('/api/v1/settings/notifications/', payload);
-            request.done(function () {
-                self.changeMessage('Settings updated.', 'text-success', 5000);
-            });
-            request.fail(function (xhr) {
-                if (xhr.responseJSON.error_type !== 'not_subscribed') {
-                    var message = 'Could not update email preferences at this time. If this issue persists, ' +
-                        'please report it to <a href="mailto:support@osf.io">support@osf.io</a>.';
-                    self.changeMessage(message, 'text-danger', 5000);
-                }
-            });
-        };
+    self.getListInfo = function() {
+        $.ajax({
+            url: '/api/v1/settings/notifications',
+            type: 'GET',
+            dataType: 'json',
+            success: function(response) {
+                var isSubscribed = response.mailing_lists ? response.mailing_lists[self.list] : false;
+                self.subscribed(isSubscribed);
+            },
+            error: function() {
+                var message = 'Could not retrieve settings information.';
+                self.changeMessage(message, 'text-danger', 5000);
+            }});
     };
 
-    // API
-    function NotificationsViewModel(selector, list) {
-        var self = this;
-        self.viewModel = new ViewModel(list);
-        $.osf.applyBindings(self.viewModel, selector);
-    }
+    self.getListInfo();
 
-    return NotificationsViewModel;
+    /** Change the flashed status message */
+    self.changeMessage = function(text, css, timeout) {
+        self.message(text);
+        var cssClass = css || 'text-info';
+        self.messageClass(cssClass);
+        if (timeout) {
+            // Reset message after timeout period
+            setTimeout(function() {
+                self.message('');
+                self.messageClass('text-info');
+            }, timeout);
+        }
+    };
 
-}));
+    self.submit = function () {
+        var payload = {};
+        payload[self.list] = self.subscribed();
+        var request = $osf.postJSON('/api/v1/settings/notifications/', payload);
+        request.done(function () {
+            self.changeMessage('Settings updated.', 'text-success', 5000);
+        });
+        request.fail(function (xhr) {
+            if (xhr.responseJSON.error_type !== 'not_subscribed') {
+                var message = 'Could not update email preferences at this time. If this issue persists, ' +
+                    'please report it to <a href="mailto:support@osf.io">support@osf.io</a>.';
+                self.changeMessage(message, 'text-danger', 5000);
+            }
+        });
+    };
+};
+
+// API
+function NotificationsViewModel(selector, list) {
+    var self = this;
+    self.viewModel = new ViewModel(list);
+    $osf.applyBindings(self.viewModel, selector);
+}
+
+module.exports = NotificationsViewModel;

--- a/website/templates/profile/notifications.mako
+++ b/website/templates/profile/notifications.mako
@@ -2,6 +2,7 @@
 <%def name="title()">Notifications</%def>
 <%def name="content()">
 <% import json %>
+<% import website %>
 <h2 class="page-header">Notifications</h2>
 
 <div class="row">
@@ -50,7 +51,6 @@
 </%def>
 
 <%def name="javascript()">
-    <% import website%>
     <script type="text/javascript">
         window.contextVars = $.extend({}, window.contextVars, {'notificationsSelector': '#selectLists',
                                                                 'mailingList': '${website.settings.MAILCHIMP_GENERAL_LIST}'});

--- a/website/templates/profile/notifications.mako
+++ b/website/templates/profile/notifications.mako
@@ -2,7 +2,6 @@
 <%def name="title()">Notifications</%def>
 <%def name="content()">
 <% import json %>
-<% import website%>
 <h2 class="page-header">Notifications</h2>
 
 <div class="row">
@@ -48,13 +47,16 @@
             </div>
     </div>
 </div>
+</%def>
 
-<script type="text/javascript">
+<%def name="javascript()">
+    <% import website%>
+    <script type="text/javascript">
+        window.contextVars = $.extend({}, window.contextVars, {'notificationsSelector': '#selectLists',
+                                                                'mailingList': '${website.settings.MAILCHIMP_GENERAL_LIST}'});
+    </script>
+</%def>
 
-    $script(['/static/js/notificationsConfig.js']);
-    $script.ready('NotificationsConfig', function() {
-        var notifications = new NotificationsConfig('#selectLists', '${website.settings.MAILCHIMP_GENERAL_LIST}');
-    });
-</script>
-
+<%def name="javascript_bottom()">
+    <script src="/static/public/js/notifications-config-page.js"></script>
 </%def>

--- a/website/templates/profile/notifications.mako
+++ b/website/templates/profile/notifications.mako
@@ -52,11 +52,13 @@
 
 <%def name="javascript()">
     <script type="text/javascript">
+        ${parent.javascript()}
         window.contextVars = $.extend({}, window.contextVars, {'notificationsSelector': '#selectLists',
                                                                 'mailingList': '${website.settings.MAILCHIMP_GENERAL_LIST}'});
     </script>
 </%def>
 
 <%def name="javascript_bottom()">
+    ${parent.javascript_bottom()}
     <script src="/static/public/js/notifications-config-page.js"></script>
 </%def>

--- a/website/templates/profile/notifications.mako
+++ b/website/templates/profile/notifications.mako
@@ -51,8 +51,8 @@
 
 <%def name="javascript()">
     <% import website %>
+    ${parent.javascript()}
     <script type="text/javascript">
-        ${parent.javascript()}
         window.contextVars = $.extend({}, window.contextVars, {'mailingList': '${website.settings.MAILCHIMP_GENERAL_LIST}'});
     </script>
 </%def>

--- a/website/templates/profile/notifications.mako
+++ b/website/templates/profile/notifications.mako
@@ -53,8 +53,7 @@
 <%def name="javascript()">
     <script type="text/javascript">
         ${parent.javascript()}
-        window.contextVars = $.extend({}, window.contextVars, {'notificationsSelector': '#selectLists',
-                                                                'mailingList': '${website.settings.MAILCHIMP_GENERAL_LIST}'});
+        window.contextVars = $.extend({}, window.contextVars, {'mailingList': '${website.settings.MAILCHIMP_GENERAL_LIST}'});
     </script>
 </%def>
 

--- a/website/templates/profile/notifications.mako
+++ b/website/templates/profile/notifications.mako
@@ -2,7 +2,6 @@
 <%def name="title()">Notifications</%def>
 <%def name="content()">
 <% import json %>
-<% import website %>
 <h2 class="page-header">Notifications</h2>
 
 <div class="row">
@@ -51,6 +50,7 @@
 </%def>
 
 <%def name="javascript()">
+    <% import website %>
     <script type="text/javascript">
         ${parent.javascript()}
         window.contextVars = $.extend({}, window.contextVars, {'mailingList': '${website.settings.MAILCHIMP_GENERAL_LIST}'});


### PR DESCRIPTION
- Require dependencies in `notificationsConfig.js` and add a webpack entry point for the module
- Initialize `NotificationsViewModel` in separate init
  file instead of in `notifications.mako`