### PR TITLE
Hotfix: Edit mailing list description

### DIFF
--- a/website/templates/profile/notifications.mako
+++ b/website/templates/profile/notifications.mako
@@ -30,7 +30,7 @@
                             <input type="checkbox"
                                    data-bind="checked: subscribed"/>
                             <label data-bind="text: list"></label>
-                            <p class="text-muted" style="padding-left: 15px">Receive general notifications</p>
+                            <p class="text-muted" style="padding-left: 15px">Receive general notifications about the OSF every 2-3 weeks.</p>
                         </div>
                         <div class="padded">
                         <button


### PR DESCRIPTION
<h3>Purpose</h3>
Change description of OSF general mailing list in user settings to make it more informative: 
![screen shot 2015-01-06 at 3 58 22 pm](https://cloud.githubusercontent.com/assets/6414394/5636081/de787640-95bc-11e4-9c5c-e5445d47e710.png) 

Discussed with @AndrewSallans and @KatyCain526. @JeffSpies do you have any suggestions on this language? 
