### PR TITLE
[feature-fix] Include addon assets in node overview page.

### DIFF
--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -138,7 +138,10 @@
 <%def name="stylesheets()">
     ${parent.stylesheets()}
     % for style in addon_widget_css:
-        <link rel="stylesheet" href="${style}" />
+    <link rel="stylesheet" href="${style}" />
+    % endfor
+    % for stylesheet in tree_css:
+    <link rel='stylesheet' href='${stylesheet}' type='text/css' />
     % endfor
 </%def>
 
@@ -146,6 +149,10 @@
 <% import json %>
 
 ${parent.javascript_bottom()}
+
+% for script in tree_js:
+<script type="text/javascript" src="${script}"></script>
+% endfor
 
 <script type="text/javascript">
     // Hack to allow mako variables to be accessed to JS modules


### PR DESCRIPTION
# Purpose
For uploads to work correctly on the node overview page, custom addon scripts and styles must be included.

# Changes
* Include custom addon style and script assets in node overview page

# Side effects
None expected