### PR TITLE
Hotifx: Catch 'subscribe' events sent via mailchimp webhooks

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2383,7 +2383,7 @@ class TestConfigureMailingListViews(OsfTestCase):
     @mock.patch('website.mailchimp_utils.get_mailchimp_api')
     def test_mailchimp_webhook_subscribe_action_does_not_change_user(self, mock_get_mailchimp_api):
         """ Test that 'subscribe' actions sent to the OSF via mailchimp
-            webhooks do not cause any database changes.
+            webhooks update the OSF database.
         """
         list_id = '12345'
         list_name = 'OSF General'
@@ -2396,8 +2396,7 @@ class TestConfigureMailingListViews(OsfTestCase):
         user.mailing_lists = {'OSF General': False}
         user.save()
 
-        # user subscribes and webhook sends request (when configured
-        # to update on changes made through the API)
+        # user subscribes and webhook sends request to OSF
         data = {'type': 'subscribe',
                 'data[list_id]': list_id,
                 'data[email]': user.username
@@ -2408,9 +2407,9 @@ class TestConfigureMailingListViews(OsfTestCase):
                             content_type="application/x-www-form-urlencoded",
                             auth=user.auth)
 
-        # user field does not change
+        # user field is updated on the OSF
         user.reload()
-        assert_false(user.mailing_lists[list_name])
+        assert_true(user.mailing_lists[list_name])
 
     @mock.patch('website.mailchimp_utils.get_mailchimp_api')
     def test_mailchimp_webhook_profile_action_does_not_change_user(self, mock_get_mailchimp_api):

--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -284,17 +284,21 @@ def sync_data_from_mailchimp(**kwargs):
         action = r.values['type']
         list_name = mailchimp_utils.get_list_name_from_id(list_id=r.values['data[list_id]'])
         username = r.values['data[email]']
+
+        try:
+            user = User.find_one(Q('username', 'eq', username))
+        except NoResultsFound:
+            sentry.log_exception()
+            sentry.log_message("A user with this username does not exist.")
+            raise HTTPError(404, data=dict(message_short='User not found',
+                                        message_long='A user with this username does not exist'))
         if action == 'unsubscribe':
-            try:
-                user = User.find_one(Q('username', 'eq', username))
-            except NoResultsFound:
-                sentry.log_exception()
-                sentry.log_message("A user with this username does not exist.")
-                raise HTTPError(404, data=dict(message_short='User not found',
-                                            message_long='A user with this username does not exist'))
-            else:
-                user.mailing_lists[list_name] = False
-                user.save()
+            user.mailing_lists[list_name] = False
+            user.save()
+
+        elif action == 'subscribe':
+            user.mailing_lists[list_name] = True
+            user.save()
 
     else:
         # TODO: get tests to pass with sentry logging


### PR DESCRIPTION
Since we enabled unsubscribe confirmations and the email gives users the option to re-subscribe to the mailing list, the OSF needs to catch these subscribe events and update user records in our database. 