### PR TITLE
Hotfix/GitHub deleted files

### DIFF
--- a/website/addons/github/tests/webtest_tests.py
+++ b/website/addons/github/tests/webtest_tests.py
@@ -119,6 +119,51 @@ class TestGitHubFileView(OsfTestCase):
     @mock.patch('website.addons.github.api.GitHub.commits')
     @mock.patch('website.addons.github.api.GitHub.file')
     @mock.patch('website.addons.github.api.GitHub.repo')
+    def test_file_view_deleted(self, mock_repo, mock_file, mock_commits):
+        mock_commits.return_value = [Commit.from_json({
+            "url": "https://api.github.com/repos/octocat/Hello-World/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+            "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+            "commit": {
+                "url": "https://api.github.com/repos/octocat/Hello-World/git/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e",
+                "author": {
+                    "name": "Monalisa Octocat",
+                    "email": "support@github.com",
+                   "date": "2011-04-14T16:00:49Z"
+                }
+            }
+        })]
+
+        mock_repo.return_value = Repository.from_json({
+            "default_branch": "dev",
+            'url': u'https://api.github.com/repos/{user}/mock-repo/git/trees/dev'.format(user=self.user),
+            'sha': 'dev',
+            'private': False,
+            'tree': [
+                {u'mode': u'100644',
+                 u'path': u'coveragerc',
+                 u'sha': u'92029ff5ce192425d346b598d7e7dd25f5f05185',
+                 u'size': 245,
+                 u'type': u'file',
+                 u'url': u'https://api.github.com/repos/{user}/mock-repo/git/blobs/92029ff5ce192425d346b598d7e7dd25f5f05185'.format(user=self.user)}]
+        })
+
+        mock_file.return_value = (None, None, None)
+
+        url = "/project/{0}/github/file/{1}/".format(
+            self.project._id,
+            "coveragerc"
+        )
+        self.app.auth = self.user.auth
+        res = self.app.get(url).maybe_follow()
+
+        assert_in("icon-download-alt", res)
+        assert_in("Thu Apr 14 16:00:49 2011", res)
+        assert_in("This file does not exist at this commit", res)
+        assert_in("6dcb09b5b57875f334f61aebed695e2e4193db5e", res)
+
+    @mock.patch('website.addons.github.api.GitHub.commits')
+    @mock.patch('website.addons.github.api.GitHub.file')
+    @mock.patch('website.addons.github.api.GitHub.repo')
     def test_file_view_with_anonymous_link(self, mock_repo, mock_file, mock_commits):
         mock_commits.return_value = [Commit.from_json({
             "url": "https://api.github.com/repos/octocat/Hello-World/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e",

--- a/website/addons/github/views/crud.py
+++ b/website/addons/github/views/crud.py
@@ -186,8 +186,14 @@ def github_view_file(auth, **kwargs):
             _, data, size = connection.file(
                 node_settings.user, node_settings.repo, path, ref=sha,
             )
+
+            if data is None:
+                # The file was deleted in this commit
+                rendered = 'This file does not exist at this commit.'
+
         except TooBigError:
             rendered = 'File too large to download.'
+
         if rendered is None:
             # Skip if too large to be rendered.
             if github_settings.MAX_RENDER_SIZE is not None and size > github_settings.MAX_RENDER_SIZE:


### PR DESCRIPTION
# Issue
When viewing a github file's revisions, if the file was deleted in that commit that commit will show up as a version of the file even though it does not exist. [Example](https://staging.osf.io/kuj73/?sha=cac34591e098ed35f9196cd36aade86a79c176fe&branch=master)

# Solution
The file API will return `None` values, as opposed to an empty file `''`.
If the file is `None` return a proper message to the user.

Currently the message is `This file does not exist at this commit.`