### PR TITLE
Hotfix IE search when submitting via enter

### DIFF
--- a/website/static/js/search.js
+++ b/website/static/js/search.js
@@ -181,6 +181,9 @@
         };
 
         self.submit = function() {
+            //Forces the query value to update in IE
+            $('#searchBar').blur().focus();
+
             self.searchStarted(false);
             self.totalResults(0);
             self.currentPage(1);

--- a/website/templates/search.mako
+++ b/website/templates/search.mako
@@ -9,7 +9,7 @@
         <div class="row">
             <div class="col-md-12">
                 <form class="input-group" data-bind="submit: submit">
-                    <input type="text" class="form-control" placeholder="Search" data-bind="value: query, hasFocus: true">
+                    <input name="searchBar" type="text" class="form-control" placeholder="Search" data-bind="value: query, hasFocus: true">
                     <span class="input-group-btn">
                         <button type=button class="btn btn-default" data-bind="click: help"><i class="icon-question"></i></button>
                         <button type=button class="btn btn-default" data-bind="click: submit"><i class="icon-search"></i></button>


### PR DESCRIPTION
Force the knockout value to update in IE when using enter to submit a search, fixes https://github.com/CenterForOpenScience/osf.io/issues/1448

# Cause

IE doesn't update the value of the search field unless the focus is lost

# Fix

Blur and then focus the field before submitting the search

# Notes

I don't have access to an IE browser to test this but running the commands in saucelab's VM seemed to work.