### PR TITLE
hotfix: Add SPSP 2015; disable old conferences.

### DIFF
--- a/scripts/populate_conferences.py
+++ b/scripts/populate_conferences.py
@@ -65,7 +65,7 @@ MEETING_DATA = {
         'info_url': None,
         'logo_url': 'https://science.nrao.edu/science/meetings/2014/'
                     'filamentary-structure/images/filaments2014_660x178.png',
-        'active': True,
+        'active': False,
         'admins': [
             'lvonschi@nrao.edu',
             'sara.d.bowman@gmail.com',
@@ -82,7 +82,7 @@ MEETING_DATA = {
             'conferences',
             'bitss.jpg',
         ),
-        'active': True,
+        'active': False,
         'admins': [
             'gkroll@berkeley.edu',
             'andrew@cos.io',
@@ -90,13 +90,16 @@ MEETING_DATA = {
         ],
         'public_projects': True,
     },
-    # TODO: Uncomment on 2015/02/01
-    # 'spsp2015': {
-    #     'name': 'SPSP 2015',
-    #     'info_url': None,
-    #     'logo_url': None,
-    #     'active': False,
-    # },
+    'spsp2015': {
+        'name': 'SPSP 2015',
+        'info_url': 'http://spspmeeting.org/2015/General-Info.aspx',
+        'logo_url': 'http://spspmeeting.org/CMSPages/SPSPimages/spsp2015banner.jpg',
+        'active': True,
+        'admins': [
+            'meetings@spsp.org',
+            'andrew@cos.io',
+        ],
+    },
 }
 
 


### PR DESCRIPTION
# Purpose
Add SPSP conference and disable old conferences.

# Changes
See above

# Side effects
None expected

@sloria: The requested admin user for SPSP2015 didn't exist on production as of this morning, so @KatyCain526 did/will talk to her/him and confirm when the account exists. At that point, we can run `populate_conferences`.

Resolves #1444
Resolves #1456