### PR TITLE
CommonJS-fix: Store registration template payload as JS object on contextVars

### DIFF
--- a/website/project/views/register.py
+++ b/website/project/views/register.py
@@ -66,7 +66,7 @@ def node_register_template_page(auth, **kwargs):
         payload = node.registered_meta.get(to_mongo(template_name))
         payload = json.loads(payload)
         payload = unprocess_payload(payload)
-        payload = json.dumps(payload)
+        payload = payload
         if node.registered_schema:
             meta_schema = node.registered_schema
         else:

--- a/website/project/views/register.py
+++ b/website/project/views/register.py
@@ -66,7 +66,7 @@ def node_register_template_page(auth, **kwargs):
         payload = node.registered_meta.get(to_mongo(template_name))
         payload = json.loads(payload)
         payload = unprocess_payload(payload)
-        payload = payload
+
         if node.registered_schema:
             meta_schema = node.registered_schema
         else:

--- a/website/templates/metadata/register_1.mako
+++ b/website/templates/metadata/register_1.mako
@@ -47,6 +47,6 @@
     window.contextVars.node.children = ${[str(each) for each in children_ids]};
     window.contextVars.regTemplate = ${json.dumps(template_name or '')};
     window.contextVars.regSchema = ${schema};
-    window.contextVars.regPayload = ${json.dumps(payload)};
+    window.contextVars.regPayload = $.parseJSON(${json.dumps(payload)});
     window.contextVars.registered = ${json.dumps(int(registered))};
 </script>

--- a/website/templates/metadata/register_1.mako
+++ b/website/templates/metadata/register_1.mako
@@ -47,6 +47,6 @@
     window.contextVars.node.children = ${[str(each) for each in children_ids]};
     window.contextVars.regTemplate = ${json.dumps(template_name or '')};
     window.contextVars.regSchema = ${schema};
-    window.contextVars.regPayload = $.parseJSON(${json.dumps(payload)});
+    window.contextVars.regPayload = ${json.dumps(payload)};
     window.contextVars.registered = ${json.dumps(int(registered))};
 </script>


### PR DESCRIPTION
<h3>Purpose</h3>
Fixes issue where data was not unserializing in the template for OSF Standard Pre-Data Collection Registration.

<h3>Changes</h3>
Make `window.contextVars.regPayload` a JSON object instead of leaving it as a string so that `MetaData.ViewModel.unserialize` does not throw an error. 