### PR TITLE
[Hotfix] IE Search bar (again) (should work this time)

### DIFF
--- a/website/static/js/search.js
+++ b/website/static/js/search.js
@@ -182,7 +182,7 @@
 
         self.submit = function() {
             //Forces the query value to update in IE
-            $('#searchBar').blur().focus();
+            $('#searchPageFullBar').blur().focus();
 
             self.searchStarted(false);
             self.totalResults(0);

--- a/website/templates/search.mako
+++ b/website/templates/search.mako
@@ -9,7 +9,7 @@
         <div class="row">
             <div class="col-md-12">
                 <form class="input-group" data-bind="submit: submit">
-                    <input name="searchBar" type="text" class="form-control" placeholder="Search" data-bind="value: query, hasFocus: true">
+                    <input id="searchPageFullBar" type="text" class="form-control" placeholder="Search" data-bind="value: query, hasFocus: true">
                     <span class="input-group-btn">
                         <button type=button class="btn btn-default" data-bind="click: help"><i class="icon-question"></i></button>
                         <button type=button class="btn btn-default" data-bind="click: submit"><i class="icon-search"></i></button>


### PR DESCRIPTION
Properly reference the main search bar
Previous was attempting to refernce by name but using the id selector
Now the searchbar has a longer/more unqiue id, not name.