### PR TITLE
Feature/gravatar view

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -790,7 +790,7 @@ class TestUserProfile(OsfTestCase):
 
     def test_sanitization_of_edit_profile(self):
         url = api_url_for('edit_profile', uid=self.user._id)
-        post_data = {'name': 'fullname',  'value': 'new<b> name</b>'}
+        post_data = {'name': 'fullname', 'value': 'new<b> name</b>'}
         request = self.app.post(url, post_data, auth=self.user.auth)
         assert_equal('new name', request.json['name'])
 
@@ -1007,6 +1007,48 @@ class TestUserProfile(OsfTestCase):
         url = api_url_for('unserialize_jobs')
         res = self.app.put_json(url, payload, auth=self.user.auth)
         assert_equal(res.status_code, 200)
+
+    def test_get_current_user_gravatar_default_size(self):
+        url = api_url_for('current_user_gravatar')
+        res = self.app.get(url, auth=self.user.auth)
+        current_user_gravatar = res.json['gravatar_url']
+        assert_true(current_user_gravatar is not None)
+        url = api_url_for('get_gravatar', uid=self.user._id)
+        res = self.app.get(url, auth=self.user.auth)
+        my_user_gravatar = res.json['gravatar_url']
+        assert_equal(current_user_gravatar, my_user_gravatar)
+
+    def test_get_other_user_gravatar_default_size(self):
+        user2 = AuthUserFactory()
+        url = api_url_for('current_user_gravatar')
+        res = self.app.get(url, auth=self.user.auth)
+        current_user_gravatar = res.json['gravatar_url']
+        url = api_url_for('get_gravatar', uid=user2._id)
+        res = self.app.get(url, auth=self.user.auth)
+        user2_gravatar = res.json['gravatar_url']
+        assert_true(user2_gravatar is not None)
+        assert_not_equal(current_user_gravatar, user2_gravatar)
+
+    def test_get_current_user_gravatar_specific_size(self):
+        url = api_url_for('current_user_gravatar')
+        res = self.app.get(url, auth=self.user.auth)
+        current_user_default_gravatar = res.json['gravatar_url']
+        url = api_url_for('current_user_gravatar', size=11)
+        res = self.app.get(url, auth=self.user.auth)
+        current_user_small_gravatar = res.json['gravatar_url']
+        assert_true(current_user_small_gravatar is not None)
+        assert_not_equal(current_user_default_gravatar, current_user_small_gravatar)
+
+    def test_get_other_user_gravatar_specific_size(self):
+        user2 = AuthUserFactory()
+        url = api_url_for('get_gravatar', uid=user2._id)
+        res = self.app.get(url, auth=self.user.auth)
+        gravatar_default_size = res.json['gravatar_url']
+        url = api_url_for('get_gravatar', uid=user2._id, size=11)
+        res = self.app.get(url, auth=self.user.auth)
+        gravatar_small = res.json['gravatar_url']
+        assert_true(gravatar_small is not None)
+        assert_not_equal(gravatar_default_size, gravatar_small)
 
 
 class TestUserAccount(OsfTestCase):

--- a/website/profile/utils.py
+++ b/website/profile/utils.py
@@ -22,6 +22,15 @@ def get_public_projects(user):
     return [p for p in get_projects(user) if p.is_public]
 
 
+def get_gravatar(user, size=None):
+    if size is None:
+        size = settings.GRAVATAR_SIZE_PROFILE
+    return gravatar(
+        user, use_ssl=True,
+        size=size
+    )
+
+
 def serialize_user(user, node=None, full=False):
     """Return a dictionary representation of a registered user.
 

--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -58,6 +58,16 @@ def get_public_components(uid=None, user=None):
     ])
 
 
+@must_be_logged_in
+def current_user_gravatar(size=None, **kwargs):
+    user_id = kwargs['auth'].user._id
+    return get_gravatar(user_id, size=size)
+
+
+def get_gravatar(uid, size=None):
+    return {'gravatar_url': profile_utils.get_gravatar(User.load(uid), size=size)}
+
+
 def date_or_none(date):
     try:
         return parse_date(date)

--- a/website/routes.py
+++ b/website/routes.py
@@ -497,6 +497,31 @@ def make_url_map(app):
         Rule('/user/<uid>/<pid>/claim/email/', 'post',
              project_views.contributor.claim_user_post, json_renderer),
 
+        Rule(
+            [
+                '/profile/gravatar/',
+                '/users/gravatar/',
+                '/profile/gravatar/<size>',
+                '/users/gravatar/<size>',
+            ],
+            'get',
+            profile_views.current_user_gravatar,
+            json_renderer,
+        ),
+
+        Rule(
+            [
+                '/profile/<uid>/gravatar/',
+                '/users/<uid>/gravatar/',
+                '/profile/<uid>/gravatar/<size>',
+                '/users/<uid>/gravatar/<size>',
+            ],
+            'get',
+            profile_views.get_gravatar,
+            json_renderer,
+        ),
+
+
         # Rules for user profile configuration
         Rule('/settings/names/', 'get', profile_views.serialize_names, json_renderer),
         Rule('/settings/names/', 'put', profile_views.unserialize_names, json_renderer),

--- a/website/routes.py
+++ b/website/routes.py
@@ -118,6 +118,8 @@ def make_url_map(app):
              OsfWebRenderer('', render_mako_string)),
         Rule('/api/v1/<path:_>', ['get', 'post'],
              HTTPError(http.NOT_FOUND), json_renderer),
+        Rule('/api/v1a/<path:_>', ['get', 'post'],
+             HTTPError(http.NOT_FOUND), json_renderer),
     ])
 
     ### GUID ###
@@ -500,9 +502,7 @@ def make_url_map(app):
         Rule(
             [
                 '/profile/gravatar/',
-                '/users/gravatar/',
                 '/profile/gravatar/<size>',
-                '/users/gravatar/<size>',
             ],
             'get',
             profile_views.current_user_gravatar,
@@ -512,9 +512,7 @@ def make_url_map(app):
         Rule(
             [
                 '/profile/<uid>/gravatar/',
-                '/users/<uid>/gravatar/',
                 '/profile/<uid>/gravatar/<size>',
-                '/users/<uid>/gravatar/<size>',
             ],
             'get',
             profile_views.get_gravatar,
@@ -1148,6 +1146,29 @@ def make_url_map(app):
             json_renderer
         ),
     ], prefix='/api/v1')
+
+    process_rules(app, [
+        Rule(
+            [
+                '/users/gravatar/',
+                '/users/gravatar/<size>',
+            ],
+            'get',
+            profile_views.current_user_gravatar,
+            json_renderer, endpoint_suffix='__dord',
+
+        ),
+
+        Rule(
+            [
+                '/users/<uid>/gravatar/',
+                '/users/<uid>/gravatar/<size>',
+            ],
+            'get',
+            profile_views.get_gravatar,
+            json_renderer, endpoint_suffix='__dord',
+        ),
+    ], prefix='/api/v1a')
 
     # Set up static routing for addons
     # NOTE: We use nginx to serve static addon assets in production

--- a/website/routes.py
+++ b/website/routes.py
@@ -82,6 +82,7 @@ def favicon():
         mimetype='image/vnd.microsoft.icon'
     )
 
+
 def robots():
     """Serves the robots.txt file."""
     # Allow local robots.txt
@@ -97,7 +98,7 @@ def robots():
     )
 
 
-def goodbye(**kwargs):
+def goodbye():
     # Redirect to dashboard if logged in
     if _get_current_user():
         return redirect(util.web_url_for('dashboard'))
@@ -156,7 +157,7 @@ def make_url_map(app):
 
         Rule('/dashboard/', 'get', website_views.dashboard, OsfWebRenderer('dashboard.mako')),
         Rule('/reproducibility/', 'get',
-            website_views.reproducibility, OsfWebRenderer('', render_mako_string)),
+             website_views.reproducibility, OsfWebRenderer('', render_mako_string)),
 
         Rule('/about/', 'get', {}, OsfWebRenderer('public/pages/about.mako')),
         Rule('/howosfworks/', 'get', {}, OsfWebRenderer('public/pages/howosfworks.mako')),
@@ -344,7 +345,7 @@ def make_url_map(app):
     process_rules(app, [
 
         Rule('/explore/activity/', 'get', discovery_views.activity,
-            OsfWebRenderer('public/pages/active_nodes.mako')),
+             OsfWebRenderer('public/pages/active_nodes.mako')),
 
     ])
 
@@ -378,21 +379,21 @@ def make_url_map(app):
 
         # TODO: Remove `auth_register_post`
         Rule('/register/', 'post', auth_views.auth_register_post,
-            OsfWebRenderer('public/login.mako')),
+             OsfWebRenderer('public/login.mako')),
         Rule('/api/v1/register/', 'post', auth_views.register_user, json_renderer),
 
         Rule(['/login/', '/account/'], 'get',
-            auth_views.auth_login, OsfWebRenderer('public/login.mako')),
+             auth_views.auth_login, OsfWebRenderer('public/login.mako')),
         Rule('/login/', 'post', auth_views.auth_login,
-            OsfWebRenderer('public/login.mako'), endpoint_suffix='__post'),
+             OsfWebRenderer('public/login.mako'), endpoint_suffix='__post'),
         Rule('/login/first/', 'get', auth_views.auth_login,
-            OsfWebRenderer('public/login.mako'),
-            endpoint_suffix='__first', view_kwargs={'first': True}),
+             OsfWebRenderer('public/login.mako'),
+             endpoint_suffix='__first', view_kwargs={'first': True}),
 
         Rule('/logout/', 'get', auth_views.auth_logout, notemplate),
 
         Rule('/forgotpassword/', 'post', auth_views.forgot_password,
-            OsfWebRenderer('public/login.mako')),
+             OsfWebRenderer('public/login.mako')),
 
         Rule([
             '/midas/', '/summit/', '/accountbeta/', '/decline/'
@@ -417,22 +418,22 @@ def make_url_map(app):
     process_rules(app, [
         Rule('/profile/', 'get', profile_views.profile_view, OsfWebRenderer('profile.mako')),
         Rule('/profile/<uid>/', 'get', profile_views.profile_view_id,
-            OsfWebRenderer('profile.mako')),
+             OsfWebRenderer('profile.mako')),
         Rule('/settings/key_history/<kid>/', 'get', profile_views.user_key_history,
-            OsfWebRenderer('profile/key_history.mako')),
+             OsfWebRenderer('profile/key_history.mako')),
         Rule('/addons/', 'get', profile_views.profile_addons,
-            OsfWebRenderer('profile/addons.mako')),
+             OsfWebRenderer('profile/addons.mako')),
         Rule(["/user/merge/"], 'get', auth_views.merge_user_get,
-            OsfWebRenderer("merge_accounts.mako")),
+             OsfWebRenderer("merge_accounts.mako")),
         Rule(["/user/merge/"], 'post', auth_views.merge_user_post,
-            OsfWebRenderer("merge_accounts.mako")),
+             OsfWebRenderer("merge_accounts.mako")),
         # Route for claiming and setting email and password.
         # Verification token must be querystring argument
         Rule(['/user/<uid>/<pid>/claim/'], ['get', 'post'],
-            project_views.contributor.claim_user_form, OsfWebRenderer('claim_account.mako')),
+             project_views.contributor.claim_user_form, OsfWebRenderer('claim_account.mako')),
         Rule(['/user/<uid>/<pid>/claim/verify/<token>/'], ['get', 'post'],
-            project_views.contributor.claim_user_registered,
-            OsfWebRenderer('claim_account_registered.mako')),
+             project_views.contributor.claim_user_registered,
+             OsfWebRenderer('claim_account_registered.mako')),
 
 
         Rule(
@@ -482,9 +483,9 @@ def make_url_map(app):
         # Used by profile.html
         Rule('/profile/<uid>/edit/', 'post', profile_views.edit_profile, json_renderer),
         Rule('/profile/<uid>/public_projects/', 'get',
-            profile_views.get_public_projects, json_renderer),
+             profile_views.get_public_projects, json_renderer),
         Rule('/profile/<uid>/public_components/', 'get',
-            profile_views.get_public_components, json_renderer),
+             profile_views.get_public_components, json_renderer),
 
         Rule('/settings/keys/', 'get', profile_views.get_keys, json_renderer),
         Rule('/settings/create_key/', 'post', profile_views.create_user_key, json_renderer),
@@ -492,9 +493,9 @@ def make_url_map(app):
         Rule('/settings/key_history/<kid>/', 'get', profile_views.user_key_history, json_renderer),
 
         Rule('/profile/<user_id>/summary/', 'get',
-            profile_views.get_profile_summary, json_renderer),
+             profile_views.get_profile_summary, json_renderer),
         Rule('/user/<uid>/<pid>/claim/email/', 'post',
-            project_views.contributor.claim_user_post, json_renderer),
+             project_views.contributor.claim_user_post, json_renderer),
 
         # Rules for user profile configuration
         Rule('/settings/names/', 'get', profile_views.serialize_names, json_renderer),
@@ -607,7 +608,7 @@ def make_url_map(app):
 
         # Create a new subproject/component
         Rule('/project/<pid>/newnode/', 'post', project_views.node.project_new_node,
-            OsfWebRenderer('', render_mako_string)),
+             OsfWebRenderer('', render_mako_string)),
 
         Rule([
             '/project/<pid>/key_history/<kid>/',
@@ -618,10 +619,10 @@ def make_url_map(app):
         # Rule('/tags/<tag>/', 'get', project_views.tag.project_tag, OsfWebRenderer('tags.mako')),
 
         Rule('/folder/<nid>', 'get', project_views.node.folder_new,
-            OsfWebRenderer('project/new_folder.mako')),
+             OsfWebRenderer('project/new_folder.mako')),
         Rule('/api/v1/folder/<nid>', 'post', project_views.node.folder_new_post, json_renderer),
         Rule('/project/new/<pid>/beforeTemplate/', 'get',
-            project_views.node.project_before_template, json_renderer),
+             project_views.node.project_before_template, json_renderer),
 
         Rule(
             [
@@ -929,7 +930,7 @@ def make_url_map(app):
 
         # Reorder components
         Rule('/project/<pid>/reorder_components/', 'post',
-                project_views.node.project_reorder_components, json_renderer),
+             project_views.node.project_reorder_components, json_renderer),
 
         # Edit node
         Rule([

--- a/website/routes.py
+++ b/website/routes.py
@@ -42,6 +42,7 @@ def get_globals():
         'user_full_name': user.fullname if user else '',
         'user_id': user._primary_key if user else '',
         'user_url': user.url if user else '',
+        'user_gravatar': profile_views.current_user_gravatar()['gravatar_url'] if user else '',
         'user_api_url': user.api_url if user else '',
         'display_name': get_display_name(user.fullname) if user else '',
         'use_cdn': settings.USE_CDN_FOR_CLIENT_LIBS,
@@ -58,7 +59,7 @@ def get_globals():
         'web_url_for': util.web_url_for,
         'api_url_for': util.api_url_for,
         'sanitize': sanitize,
-        'js_str': lambda x: x.replace("'", r"\'").replace('"', r'\"')
+        'js_str': lambda x: x.replace("'", r"\'").replace('"', r'\"'),
 
     }
 


### PR DESCRIPTION
This is mostly for review rather than to merge, though it's not a bad thing to merge. I had to work around an issue related to this with search, and so others might have a use for this, but mostly it's for API stuff (See side effects).

Purpose
-----------
Add views and routes to allow a user to get their (or another user's) gravatar without needing access to their email address.

Changes
------------
Routes, utility, views, and view tests to allow get either the current user's gravatar or any gravatar from a user's ID. You can also pass in a size to allow you to get a custom size, rather than the default which is settings.GRAVATAR_SIZE_PROFILE (currently 40).

Valid routes to get the current user's gravatar are:
/api/v1/profile/gravatar/
/api/v1/profile/gravatar/\<size\>*
/api/v1a/users/gravatar/
/api/v1a/users/gravatar/\<size\>*

To get another user's gravatar, it's the same as above, but put /\<uid\>* in before /gravatar

I also added a user_gravatar variable to the global mako context. This is partly for the purpose of a redesign that @caneruguz is working on, and it's also the most likely default case, so it makes it less overhead on the AJAX front. 

*-where \<size\> is an integer and \<uid\> is a user's id.

Side effects
---------------
I put in the initial /api/v1a/ route section. Woo! We could put all the v1a routes here, and it gives an example of how to use an existing view function in the new routes (with the suffix). As it seems to be non-user facing, I used the metasyntactic suffix of [dord](http://www.qwantz.com/index.php?comic=2739).  