### PR TITLE
[feature] Add auth argument to render node

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -453,29 +453,29 @@ class TestProjectViews(OsfTestCase):
         # register a project
         self.project.register_node(None, Auth(user=self.project.creator), '', None)
         # get the first registered project of a project
-        url = "/api/v1/project/{0}/get_registrations/".format(self.project._primary_key)
+        url = self.project.api_url_for('get_registrations')
         res = self.app.get(url, auth=self.auth)
         data = res.json
-        api_url = data['nodes'][0]['api_url']
-        url2 = api_url + 'get_summary/'
+        pid = data['nodes'][0]['id']
+        url2 = api_url_for('get_summary', pid=pid)
         # count contributions
         res2 = self.app.get(url2, {'rescale_ratio': data['rescale_ratio']}, auth=self.auth)
         data = res2.json
-        assert_false(data['summary']['nlogs'] is None)
+        assert_is_not_none(data['summary']['nlogs'])
 
     def test_forks_contributions(self):
         # fork a project
         self.project.fork_node(Auth(user=self.project.creator))
         # get the first forked project of a project
-        url = "/api/v1/project/{0}/get_forks/".format(self.project._primary_key)
+        url = self.project.api_url_for('get_forks')
         res = self.app.get(url, auth=self.auth)
         data = res.json
-        api_url = data['nodes'][0]['api_url']
-        url2 = api_url + 'get_summary/'
+        pid = data['nodes'][0]['id']
+        url2 = api_url_for('get_summary', pid=pid)
         # count contributions
         res2 = self.app.get(url2, {'rescale_ratio': data['rescale_ratio']}, auth=self.auth)
         data = res2.json
-        assert_false(data['summary']['nlogs'] is None)
+        assert_is_not_none(data['summary']['nlogs'])
 
     @mock.patch('framework.transactions.commands.begin')
     @mock.patch('framework.transactions.commands.rollback')

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -456,7 +456,6 @@ class TestProjectViews(OsfTestCase):
         url = "/api/v1/project/{0}/get_registrations/".format(self.project._primary_key)
         res = self.app.get(url, auth=self.auth)
         data = res.json
-        registration = data['nodes'][0]
         api_url = data['nodes'][0]['api_url']
         url2 = api_url + 'get_summary/'
         # count contributions
@@ -465,7 +464,18 @@ class TestProjectViews(OsfTestCase):
         assert_false(data['summary']['nlogs'] is None)
 
     def test_forks_contributions(self):
-        assert_true(False) #todo
+        # fork a project
+        self.project.fork_node(Auth(user=self.project.creator))
+        # get the first forked project of a project
+        url = "/api/v1/project/{0}/get_forks/".format(self.project._primary_key)
+        res = self.app.get(url, auth=self.auth)
+        data = res.json
+        api_url = data['nodes'][0]['api_url']
+        url2 = api_url + 'get_summary/'
+        # count contributions
+        res2 = self.app.get(url2, {'rescale_ratio': data['rescale_ratio']}, auth=self.auth)
+        data = res2.json
+        assert_false(data['summary']['nlogs'] is None)
 
     @mock.patch('framework.transactions.commands.begin')
     @mock.patch('framework.transactions.commands.rollback')

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -448,6 +448,25 @@ class TestProjectViews(OsfTestCase):
         assert_equal(res.status_code, 404)
         assert_in('Template not found', res)
 
+    # Regression test for https://github.com/CenterForOpenScience/osf.io/issues/1478
+    def test_registered_projects_contributions(self):
+        # register a project
+        self.project.register_node(None, Auth(user=self.project.creator), '', None)
+        # get the first registered project of a project
+        url = "/api/v1/project/{0}/get_registrations/".format(self.project._primary_key)
+        res = self.app.get(url, auth=self.auth)
+        data = res.json
+        registration = data['nodes'][0]
+        api_url = data['nodes'][0]['api_url']
+        url2 = api_url + 'get_summary/'
+        # count contributions
+        res2 = self.app.get(url2, {'rescale_ratio': data['rescale_ratio']}, auth=self.auth)
+        data = res2.json
+        assert_false(data['summary']['nlogs'] is None)
+
+    def test_forks_contributions(self):
+        assert_true(False) #todo
+
     @mock.patch('framework.transactions.commands.begin')
     @mock.patch('framework.transactions.commands.rollback')
     @mock.patch('framework.transactions.commands.commit')

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -1018,9 +1018,10 @@ def get_forks(**kwargs):
 
 @must_be_contributor_or_public
 def get_registrations(**kwargs):
+    auth = kwargs['auth']
     node_to_use = kwargs['node'] or kwargs['project']
     registrations = node_to_use.node__registrations
-    return _render_nodes(registrations)
+    return _render_nodes(registrations, auth)
 
 
 @must_be_valid_project  # returns project

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -1008,12 +1008,13 @@ def get_folder_pointers(**kwargs):
 
 @must_be_contributor_or_public
 def get_forks(**kwargs):
+    auth = kwargs['auth']
     node_to_use = kwargs['node'] or kwargs['project']
     forks = node_to_use.node__forked.find(
         Q('is_deleted', 'eq', False) &
         Q('is_registration', 'eq', False)
     )
-    return _render_nodes(forks)
+    return _render_nodes(forks, auth)
 
 
 @must_be_contributor_or_public

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -953,7 +953,10 @@ def get_summary(**kwargs):
     node = kwargs['node'] or kwargs['project']
     rescale_ratio = kwargs.get('rescale_ratio')
     if rescale_ratio is None and request.args.get('rescale_ratio'):
-        rescale_ratio = float(request.args.get('rescale_ratio'))
+        try:
+            rescale_ratio = float(request.args.get('rescale_ratio'))
+        except:
+            raise HTTPError(http.BAD_REQUEST)
     primary = kwargs.get('primary')
     link_id = kwargs.get('link_id')
 

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -969,7 +969,9 @@ def get_summary(**kwargs):
 
     auth = kwargs['auth']
     node = kwargs['node'] or kwargs['project']
-    rescale_ratio = kwargs.get('rescale_ratio') or float(request.args.get('rescale_ratio'))
+    rescale_ratio = kwargs.get('rescale_ratio')
+    if rescale_ratio is None and request.args.get('rescale_ratio'):
+        rescale_ratio = float(request.args.get('rescale_ratio'))
     primary = kwargs.get('primary')
     link_id = kwargs.get('link_id')
 

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -969,7 +969,7 @@ def get_summary(**kwargs):
 
     auth = kwargs['auth']
     node = kwargs['node'] or kwargs['project']
-    rescale_ratio = kwargs.get('rescale_ratio')
+    rescale_ratio = kwargs.get('rescale_ratio') or float(request.args.get('rescale_ratio'))
     primary = kwargs.get('primary')
     link_id = kwargs.get('link_id')
 
@@ -1007,8 +1007,7 @@ def get_folder_pointers(**kwargs):
 
 
 @must_be_contributor_or_public
-def get_forks(**kwargs):
-    auth = kwargs['auth']
+def get_forks(auth, **kwargs):
     node_to_use = kwargs['node'] or kwargs['project']
     forks = node_to_use.node__forked.find(
         Q('is_deleted', 'eq', False) &
@@ -1018,8 +1017,7 @@ def get_forks(**kwargs):
 
 
 @must_be_contributor_or_public
-def get_registrations(**kwargs):
-    auth = kwargs['auth']
+def get_registrations(auth, **kwargs):
     node_to_use = kwargs['node'] or kwargs['project']
     registrations = node_to_use.node__registrations
     return _render_nodes(registrations, auth)


### PR DESCRIPTION
Closes #1478 

**Problem**
Registration widget shows None Contributions: 
![nonecontribs](https://cloud.githubusercontent.com/assets/5975444/5723523/9995e53e-9b12-11e4-9519-c4d2e61e6b69.png)
despite there being contributions listed on the project overview page
![somelogs](https://cloud.githubusercontent.com/assets/5975444/5723536/b416e606-9b12-11e4-9069-969025f03b92.png)

**Cause**
The nodes are not rendered correctly in the function "get_registrations" and "get_forks." The "user" argument is not passed in.

**Solution**
Gets "auth" from keyword arguments in "get_registrations" and "get_forks" and pass into _render_nodes

**Side effects**
Not that I can think of