### PR TITLE
Remove small highlight after clicking gravatar

### DIFF
--- a/website/templates/profile.mako
+++ b/website/templates/profile.mako
@@ -19,10 +19,8 @@
 <div class="page-header">
     <div class="profile-fullname">
         % if user['is_profile']:
-            <a href="#changeAvatarModal" data-toggle="modal">
-            <img id='profile-gravatar' src="${profile['gravatar_url']}"
-                    rel="tooltip" title="Click to change avatar"/>
-            </a>
+            <a href="#changeAvatarModal" data-toggle="modal"><img id='profile-gravatar' src="${profile['gravatar_url']}"
+                    rel="tooltip" title="Click to change avatar"/></a>
         % else:
             <img id='profile-gravatar' src="${profile['gravatar_url']}"/>
         % endif


### PR DESCRIPTION
Purpose
-----------
On the gravatar page, if you click on the gravatar, after dismissing the dialog box, you would get a highlight around the gravatar and a little more on the side (looks like a briefcase).

Change
----------
Remove the whitespace between the a tag and the img tag, thus removing the briefcase highlight

Side effects
----------------
The code doesn't look as pretty, but nothing functional.

Fixes one of the issues in https://trello.com/c/7DbaUxsZ/37-various-tooltips-broken