### PR TITLE
Add backend validation for years entered for profile jobs/schools

### DIFF
--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -76,7 +76,7 @@ def validate_year(item):
         except ValueError:
             raise ValidationValueError('Please enter a valid year.')
         else:
-            if len(item) == 4:
+            if len(item) != 4:
                 raise ValidationValueError('Please enter a valid year.')
 
 

--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -57,6 +57,22 @@ def validate_history_item(item):
     startYear = item.get('startYear')
     endMonth = item.get('endMonth')
     endYear = item.get('endYear')
+
+    if startYear:
+        try:
+            int(startYear)
+        except ValueError:
+            raise ValidationValueError('Please enter a valid year.')
+
+    if endYear:
+        try:
+            int(endYear)
+        except ValueError:
+            raise ValidationValueError('Please enter a valid year.')
+
+    if int(startYear)/10000 == 0 or int(endYear)/10000 == 0:
+            raise ValidationValueError('Please enter a valid year.')
+
     if startYear and endYear:
         if endYear < startYear:
             raise ValidationValueError('End date must be later than start date.')

--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -63,15 +63,18 @@ def validate_history_item(item):
             int(startYear)
         except ValueError:
             raise ValidationValueError('Please enter a valid year.')
+        else:
+            if int(startYear)/10000 != 0:
+                raise ValidationValueError('Please enter a valid year.')
 
     if endYear:
         try:
             int(endYear)
         except ValueError:
             raise ValidationValueError('Please enter a valid year.')
-
-    if int(startYear)/10000 == 0 or int(endYear)/10000 == 0:
-            raise ValidationValueError('Please enter a valid year.')
+        else:
+            if int(startYear)/10000 != 0:
+                raise ValidationValueError('Please enter a valid year.')
 
     if startYear and endYear:
         if endYear < startYear:

--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -58,23 +58,8 @@ def validate_history_item(item):
     endMonth = item.get('endMonth')
     endYear = item.get('endYear')
 
-    if startYear:
-        try:
-            int(startYear)
-        except ValueError:
-            raise ValidationValueError('Please enter a valid year.')
-        else:
-            if int(startYear)/10000 != 0:
-                raise ValidationValueError('Please enter a valid year.')
-
-    if endYear:
-        try:
-            int(endYear)
-        except ValueError:
-            raise ValidationValueError('Please enter a valid year.')
-        else:
-            if int(startYear)/10000 != 0:
-                raise ValidationValueError('Please enter a valid year.')
+    validate_year(startYear)
+    validate_year(endYear)
 
     if startYear and endYear:
         if endYear < startYear:
@@ -82,6 +67,18 @@ def validate_history_item(item):
         elif endYear == startYear:
             if endMonth and startMonth and endMonth < startMonth:
                 raise ValidationValueError('End date must be later than start date.')
+
+
+def validate_year(item):
+    if item:
+        try:
+            int(item)
+        except ValueError:
+            raise ValidationValueError('Please enter a valid year.')
+        else:
+            if len(item) == 4:
+                raise ValidationValueError('Please enter a valid year.')
+
 
 validate_url = URLValidator()
 def validate_personal_site(value):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -117,9 +117,9 @@ class TestUserValidation(OsfTestCase):
             'department': 'Fancy Patter',
             'title': 'Lover Boy',
             'startMonth': 1,
-            'startYear': 1970,
+            'startYear': '1970',
             'endMonth': 1,
-            'endYear': 1980,
+            'endYear': '1980',
         }]
         self.user.save()
 
@@ -135,12 +135,13 @@ class TestUserValidation(OsfTestCase):
             'department': fake.bs(),
             'position': fake.catch_phrase(),
             'startMonth': 1,
-            'startYear': 1970,
+            'startYear': '1970',
             'endMonth': 1,
-            'endYear': 1960,
+            'endYear': '1960',
         }]
         with assert_raises(ValidationValueError):
             self.user.save()
+
 
     def test_validate_schools_bad_end_date(self):
         # end year is < start year
@@ -149,12 +150,42 @@ class TestUserValidation(OsfTestCase):
             'institution': fake.company(),
             'department': fake.bs(),
             'startMonth': 1,
-            'startYear': 1970,
+            'startYear': '1970',
             'endMonth': 1,
-            'endYear': 1960,
+            'endYear': '1960',
         }]
         with assert_raises(ValidationValueError):
             self.user.save()
+
+    def test_validate_jobs_bad_year(self):
+        start_year = ['hi', '20507', '99', '67.34']
+        for year in start_year:
+            self.user.jobs = [{
+                'institution': fake.company(),
+                'department': fake.bs(),
+                'position': fake.catch_phrase(),
+                'startMonth': 1,
+                'startYear': year,
+                'endMonth': 1,
+                'endYear': '1960',
+            }]
+            with assert_raises(ValidationValueError):
+                self.user.save()
+
+    def test_validate_schools_bad_year(self):
+        start_year = ['hi', '20507', '99', '67.34']
+        for year in start_year:
+            self.user.schools = [{
+                'degree': fake.catch_phrase(),
+                'institution': fake.company(),
+                'department': fake.bs(),
+                'startMonth': 1,
+                'startYear': year,
+                'endMonth': 1,
+                'endYear': '1960',
+            }]
+            with assert_raises(ValidationValueError):
+                self.user.save()
 
 
 class TestUser(OsfTestCase):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -920,16 +920,16 @@ class TestUserProfile(OsfTestCase):
             'department': 'a department',
             'degree': 'a degree',
             'startMonth': 1,
-            'startYear': 2001,
+            'startYear': '2001',
             'endMonth': 5,
-            'endYear': 2001,
+            'endYear': '2001',
             'ongoing': False,
         }, {
             'institution': 'another institution',
             'department': None,
             'degree': None,
             'startMonth': 5,
-            'startYear': 2001,
+            'startYear': '2001',
             'endMonth': None,
             'endYear': None,
             'ongoing': True,
@@ -954,9 +954,9 @@ class TestUserProfile(OsfTestCase):
                 'department': fake.catch_phrase(),
                 'title': fake.bs(),
                 'startMonth': 5,
-                'startYear': 2013,
+                'startYear': '2013',
                 'endMonth': 3,
-                'endYear': 2014,
+                'endYear': '2014',
                 'ongoing': False,
             }
         ]
@@ -975,9 +975,9 @@ class TestUserProfile(OsfTestCase):
                 'department': fake.catch_phrase(),
                 'degree': fake.bs(),
                 'startMonth': 5,
-                'startYear': 2013,
+                'startYear': '2013',
                 'endMonth': 3,
-                'endYear': 2014,
+                'endYear': '2014',
                 'ongoing': False,
             }
         ]
@@ -997,9 +997,9 @@ class TestUserProfile(OsfTestCase):
                 'department': fake.catch_phrase(),
                 'title': fake.bs(),
                 'startMonth': 5,
-                'startYear': 2013,
+                'startYear': '2013',
                 'endMonth': 3,
-                'endYear': 2014,
+                'endYear': '2014',
                 'ongoing': False,
             }
         ]


### PR DESCRIPTION
<h5>Purpose</h5>
Knockout validation is used to check that the input for the year field is a four-digit integer, but this check is not done on the backend. 

<h5>Changes</h5>
Add this validation to `validate_history_item()`
