### PR TITLE
0.23.0/remove briefcase highlight on profile gravatar

### DIFF
--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -662,8 +662,10 @@ h4 {
 
 /* Profile gravatar
 -------------------------------------------------- */
-#profile-gravatar{
+.profile-avatar{
     margin-right:.5em;
+}
+#profile-gravatar{
     width:70px;
     height:70px;
 }

--- a/website/templates/profile.mako
+++ b/website/templates/profile.mako
@@ -18,13 +18,14 @@
 
 <div class="page-header">
     <div class="profile-fullname">
+        <span class="profile-avatar">
         % if user['is_profile']:
             <a href="#changeAvatarModal" data-toggle="modal"><img id='profile-gravatar' src="${profile['gravatar_url']}"
                     rel="tooltip" title="Click to change avatar"/></a>
         % else:
             <img id='profile-gravatar' src="${profile['gravatar_url']}"/>
         % endif
-
+        </span>
     <span id="profileFullname" class="h1 overflow ">${profile["fullname"]}</span>
         <span class="edit-profile-settings">
         % if user['is_profile']:


### PR DESCRIPTION
Purpose
-----------
On the gravatar page, if you click on the gravatar, after dismissing the dialog box, you would get a highlight around the gravatar and a little more on the side (looks like a briefcase).

Change
----------
Move the padding for the gravatar into a containing span rather than on the anchor element.

Side effects
----------------
None that I can think of. It still has a highlight, but not an oddly shaped highlight.

Fixes one of the issues in https://trello.com/c/7DbaUxsZ/37-various-tooltips-broken - hopefully properly this time.