### PR TITLE
Add suffix to researcherID base URL object

### DIFF
--- a/website/static/js/profile.js
+++ b/website/static/js/profile.js
@@ -490,7 +490,7 @@
         );
         self.researcherId = extendLink(
             ko.observable().extend({cleanup: cleanByRule(socialRules.researcherId)}),
-            self, 'researcherId', 'http://researcherId.com/'
+            self, 'researcherId', 'http://researcherId.com/rid/'
         );
         self.twitter = extendLink(
             ko.observable().extend({cleanup: cleanByRule(socialRules.twitter)}),


### PR DESCRIPTION
I stumbled upon this myself but realized it was already raised in #1470.

This one line fix corrects wrong base URL for researcher ID (it was lacking the "/rid/" suffix).
Otherwise, this line in malformed links from the social tab of the user's profile page.

I'm not sure of your policy for hotfixing bugs in production. I'm targeting the master branch now (because that's what I branched off) but am happy to redirect to whatever you like if the pull request looks good to the dev team.