### PR TITLE
Use absolute URLs in conference emails.

### DIFF
--- a/tests/test_conferences.py
+++ b/tests/test_conferences.py
@@ -3,12 +3,13 @@
 import mock
 from nose.tools import *  # noqa (PEP8 asserts)
 
-from modularodm import Q
-from modularodm.exceptions import ValidationError
-
 import hmac
 import hashlib
 from StringIO import StringIO
+
+import furl
+from modularodm import Q
+from modularodm.exceptions import ValidationError
 
 from framework.auth.core import Auth
 
@@ -22,6 +23,12 @@ from website.util import api_url_for, web_url_for
 from tests.base import OsfTestCase, fake
 from tests.factories import ModularOdmFactory, FakerAttribute, ProjectFactory, UserFactory
 from factory import Sequence, post_generation
+
+
+def assert_absolute(url):
+    parsed_domain = furl.furl(settings.DOMAIN)
+    parsed_url = furl.furl(url)
+    assert_equal(parsed_domain.host, parsed_url.host)
 
 
 class ConferenceFactory(ModularOdmFactory):
@@ -421,8 +428,9 @@ class TestConferenceModel(OsfTestCase):
 
 class TestConferenceIntegration(ContextTestCase):
 
+    @mock.patch('website.conferences.views.send_mail')
     @mock.patch('website.conferences.utils.upload_attachments')
-    def test_integration(self, mock_upload):
+    def test_integration(self, mock_upload, mock_send_mail):
         fullname = 'John Deacon'
         username = 'deacon@queen.com'
         title = 'good songs'
@@ -462,3 +470,10 @@ class TestConferenceIntegration(ContextTestCase):
         assert_equal(nodes.count(), 1)
         node = nodes[0]
         assert_equal(node.get_wiki_page('home').content, body)
+        assert_true(mock_send_mail.called)
+        call_args, call_kwargs = mock_send_mail.call_args
+        assert_absolute(call_kwargs['conf_view_url'])
+        assert_absolute(call_kwargs['set_password_url'])
+        assert_absolute(call_kwargs['profile_url'])
+        assert_absolute(call_kwargs['file_url'])
+        assert_absolute(call_kwargs['node_url'])

--- a/website/conferences/views.py
+++ b/website/conferences/views.py
@@ -70,6 +70,7 @@ def add_poster_by_email(conference, message):
         set_password_url = web_url_for(
             'reset_password',
             verification_key=user.verification_key,
+            _absolute=True,
         )
     else:
         set_password_url = None
@@ -96,6 +97,7 @@ def add_poster_by_email(conference, message):
         conf_view_url=web_url_for(
             'conference_results',
             meeting=message.conference_name,
+            _absolute=True,
         ),
         fullname=message.sender_display,
         user_created=user_created,


### PR DESCRIPTION
Ensure absolute URLs in conference emails; add regression tests.