### PR TITLE
Send warning on submission to inactive conference.

### DIFF
--- a/tests/test_conferences.py
+++ b/tests/test_conferences.py
@@ -15,7 +15,7 @@ from framework.auth.core import Auth
 
 from website import settings
 from website.models import User, Node
-from website.conferences.views import _render_conference_node
+from website.conferences import views
 from website.conferences.model import Conference
 from website.conferences import utils, message
 from website.util import api_url_for, web_url_for
@@ -29,6 +29,14 @@ def assert_absolute(url):
     parsed_domain = furl.furl(settings.DOMAIN)
     parsed_url = furl.furl(url)
     assert_equal(parsed_domain.host, parsed_url.host)
+
+
+def assert_equal_urls(first, second):
+    parsed_first = furl.furl(first)
+    parsed_first.port = None
+    parsed_second = furl.furl(second)
+    parsed_second.port = None
+    assert_equal(parsed_first, parsed_second)
 
 
 class ConferenceFactory(ModularOdmFactory):
@@ -477,3 +485,44 @@ class TestConferenceIntegration(ContextTestCase):
         assert_absolute(call_kwargs['profile_url'])
         assert_absolute(call_kwargs['file_url'])
         assert_absolute(call_kwargs['node_url'])
+
+    @mock.patch('website.conferences.views.send_mail')
+    def test_integration_inactive(self, mock_send_mail):
+        conference = ConferenceFactory(active=False)
+        fullname = 'John Deacon'
+        username = 'deacon@queen.com'
+        title = 'good songs'
+        body = 'dragon on my back'
+        content = 'dragon attack'
+        recipient = '{0}{1}-poster@osf.io'.format(
+            'test-' if settings.DEV_MODE else '',
+            conference.endpoint,
+        )
+        res = self.app.post(
+            api_url_for('meeting_hook'),
+            {
+                'X-Mailgun-Sscore': 0,
+                'timestamp': '123',
+                'token': 'secret',
+                'signature': hmac.new(
+                    key=settings.MAILGUN_API_KEY,
+                    msg='{}{}'.format('123', 'secret'),
+                    digestmod=hashlib.sha256,
+                ).hexdigest(),
+                'attachment-count': '1',
+                'X-Mailgun-Sscore': 0,
+                'from': '{0} <{1}>'.format(fullname, username),
+                'recipient': recipient,
+                'subject': title,
+                'stripped-text': body,
+            },
+            expect_errors=True,
+        )
+        assert_equal(res.status_code, 406)
+        call_args, call_kwargs = mock_send_mail.call_args
+        assert_equal(call_args, (username, views.CONFERENCE_INACTIVE))
+        assert_equal(call_kwargs['fullname'], fullname)
+        assert_equal_urls(
+            call_kwargs['presentations_url'],
+            web_url_for('conference_view', _absolute=True),
+        )

--- a/website/conferences/views.py
+++ b/website/conferences/views.py
@@ -12,7 +12,8 @@ from framework.exceptions import HTTPError
 from website import settings
 from website.models import Node
 from website.util import web_url_for
-from website.mails import send_mail, CONFERENCE_SUBMITTED, CONFERENCE_FAILED
+from website.mails import send_mail
+from website.mails import CONFERENCE_SUBMITTED, CONFERENCE_INACTIVE, CONFERENCE_FAILED
 
 from website.conferences import utils
 from website.conferences.message import ConferenceMessage, ConferenceError
@@ -34,9 +35,18 @@ def meeting_hook():
         raise HTTPError(httplib.NOT_ACCEPTABLE)
 
     try:
-        conference = Conference.get_by_endpoint(message.conference_name)
+        conference = Conference.get_by_endpoint(message.conference_name, active=False)
     except ConferenceError as error:
         logger.error(error)
+        raise HTTPError(httplib.NOT_ACCEPTABLE)
+
+    if not conference.active:
+        send_mail(
+            message.sender_email,
+            CONFERENCE_INACTIVE,
+            fullname=message.sender_display,
+            presentations_url=web_url_for('conference_view', _absolute=True),
+        )
         raise HTTPError(httplib.NOT_ACCEPTABLE)
 
     add_poster_by_email(conference=conference, message=message)

--- a/website/mails.py
+++ b/website/mails.py
@@ -122,9 +122,13 @@ PENDING_VERIFICATION_REGISTERED = Mail('pending_registered', subject='Received r
 
 CONFERENCE_SUBMITTED = Mail(
     'conference_submitted',
-    subject='Project created on Open Science Framework'
+    subject='Project created on Open Science Framework',
+)
+CONFERENCE_INACTIVE = Mail(
+    'conference_inactive',
+    subject='Open Science Framework Error: Conference inactive',
 )
 CONFERENCE_FAILED = Mail(
     'conference_failed',
-    subject='Open Science Framework Error: No files attached'
+    subject='Open Science Framework Error: No files attached',
 )

--- a/website/templates/emails/conference_inactive.txt.mako
+++ b/website/templates/emails/conference_inactive.txt.mako
@@ -1,0 +1,7 @@
+Hello ${fullname},
+
+You recently tried to create a project on the Open Science Framework via email, but the conference you attempted to submit to is not currently accepting new submissions. For a list of conferences, see [ ${presentations_url} ].
+
+Sincerely yours,
+
+The OSF Robot


### PR DESCRIPTION
# Purpose
Send warning email on conference submissions to inactive endpoints. Adds feature requested in https://trello.com/c/iyTo3Ndo/15-presentation-service-new-osf-user.

# Changes
* Add email template for warning message
* Send warning email on submission to inactive conference

# Side effects
None expected