### PR TITLE
Fail tests mocking incorrectly

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -6,6 +6,7 @@ import logging
 import os
 import shutil
 import unittest
+import mock
 
 from webtest_plus import TestApp
 import blinker
@@ -34,6 +35,8 @@ from website.addons.wiki.model import NodeWikiPage
 import website.models
 from website.signals import ALL_SIGNALS
 from website.app import init_app
+
+from tests.exceptions import UnmockedError
 
 # Just a simple app without routing set up or backends
 test_app = init_app(
@@ -146,7 +149,15 @@ class UploadTestCase(unittest.TestCase):
         settings.UPLOADS_PATH = cls._old_uploads_path
 
 
-class OsfTestCase(DbTestCase, AppTestCase, UploadTestCase):
+class MockTestCase(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(MockTestCase, cls).setUpClass()
+        mock.patch('requests.Session.send', side_effect=UnmockedError).start()
+
+
+class OsfTestCase(DbTestCase, AppTestCase, UploadTestCase, MockTestCase):
     """Base `TestCase` for tests that require both scratch databases and the OSF
     application. Note: superclasses must call `super` in order for all setup and
     teardown methods to be called correctly.

--- a/tests/base.py
+++ b/tests/base.py
@@ -149,15 +149,15 @@ class UploadTestCase(unittest.TestCase):
         settings.UPLOADS_PATH = cls._old_uploads_path
 
 
-class MockTestCase(unittest.TestCase):
+class MockRequestTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        super(MockTestCase, cls).setUpClass()
+        super(MockRequestTestCase, cls).setUpClass()
         mock.patch('requests.Session.send', side_effect=UnmockedError).start()
 
 
-class OsfTestCase(DbTestCase, AppTestCase, UploadTestCase, MockTestCase):
+class OsfTestCase(DbTestCase, AppTestCase, UploadTestCase, MockRequestTestCase):
     """Base `TestCase` for tests that require both scratch databases and the OSF
     application. Note: superclasses must call `super` in order for all setup and
     teardown methods to be called correctly.

--- a/tests/exceptions.py
+++ b/tests/exceptions.py
@@ -1,6 +1,4 @@
 class UnmockedError(Exception):
-    def __init__(self):
-        super(Exception, self).__init__(
-            'No mocking exists, and real connections are '
-            'not allowed.'
-        )
+    def __init__(self, message='No requests mocking exists, \
+real connections are not allowed.'):
+        super(UnmockedError, self).__init__(message)

--- a/tests/exceptions.py
+++ b/tests/exceptions.py
@@ -1,0 +1,6 @@
+class UnmockedError(Exception):
+    def __init__(self):
+        super(Exception, self).__init__(
+            'No mocking exists, and real connections are '
+            'not allowed.'
+        )

--- a/website/addons/dataverse/tests/test_views.py
+++ b/website/addons/dataverse/tests/test_views.py
@@ -641,7 +641,8 @@ class TestDataverseViewsCrud(DataverseAddonTestCase):
     @mock.patch('website.addons.dataverse.views.crud.scrape_dataverse')
     @mock.patch('website.addons.dataverse.views.crud.connect_from_settings_or_403')
     @mock.patch('website.addons.dataverse.views.crud.get_files')
-    def test_dataverse_get_file_info_returns_filename_and_links(self, mock_get_files, mock_connection, mock_scrape):
+    @mock.patch('website.addons.dataverse.views.crud.fail_if_private')
+    def test_dataverse_get_file_info_returns_filename_and_links(self, mock_fail_if_private, mock_get_files, mock_connection, mock_scrape):
         mock_connection.return_value = create_mock_connection()
         mock_get_files.return_value = [create_mock_draft_file('foo')]
         mock_scrape.return_value = ('filename', 'content')

--- a/website/addons/github/tests/webtest_tests.py
+++ b/website/addons/github/tests/webtest_tests.py
@@ -71,7 +71,9 @@ class TestGitHubFileView(OsfTestCase):
     @mock.patch('website.addons.github.api.GitHub.commits')
     @mock.patch('website.addons.github.api.GitHub.file')
     @mock.patch('website.addons.github.api.GitHub.repo')
-    def test_file_view(self, mock_repo, mock_file, mock_commits):
+    @mock.patch('website.addons.github.api.GitHub.contents')
+    def test_file_view(self, mock_contents, mock_repo, mock_file, mock_commits):
+        mock_contents.return_value = None
         mock_commits.return_value = [Commit.from_json({
             "url": "https://api.github.com/repos/octocat/Hello-World/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e",
             "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
@@ -119,7 +121,9 @@ class TestGitHubFileView(OsfTestCase):
     @mock.patch('website.addons.github.api.GitHub.commits')
     @mock.patch('website.addons.github.api.GitHub.file')
     @mock.patch('website.addons.github.api.GitHub.repo')
-    def test_file_view_deleted(self, mock_repo, mock_file, mock_commits):
+    @mock.patch('website.addons.github.api.GitHub.contents')
+    def test_file_view_deleted(self, mock_contents, mock_repo, mock_file, mock_commits):
+        mock_contents.return_value = None
         mock_commits.return_value = [Commit.from_json({
             "url": "https://api.github.com/repos/octocat/Hello-World/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e",
             "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e",
@@ -164,7 +168,9 @@ class TestGitHubFileView(OsfTestCase):
     @mock.patch('website.addons.github.api.GitHub.commits')
     @mock.patch('website.addons.github.api.GitHub.file')
     @mock.patch('website.addons.github.api.GitHub.repo')
-    def test_file_view_with_anonymous_link(self, mock_repo, mock_file, mock_commits):
+    @mock.patch('website.addons.github.api.GitHub.contents')
+    def test_file_view_with_anonymous_link(self, mock_contents, mock_repo, mock_file, mock_commits):
+        mock_contents.return_value = None
         mock_commits.return_value = [Commit.from_json({
             "url": "https://api.github.com/repos/octocat/Hello-World/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e",
             "sha": "6dcb09b5b57875f334f61aebed695e2e4193db5e",


### PR DESCRIPTION
Purpose
======
See https://github.com/CenterForOpenScience/osf.io/issues/1363

Changes
=======
Use "mock" library to patch the sending of http requests. Requests that would be sent now generate the exception "UnmockedError"

Side Effects
==========
Previously passing, improperly mocked tests now fail.