### PR TITLE
Show first non-deleted file in conference table.

### DIFF
--- a/website/conferences/views.py
+++ b/website/conferences/views.py
@@ -112,15 +112,19 @@ def add_poster_by_email(conference, message):
 
 def _render_conference_node(node, idx):
     storage_settings = node.get_addon('osfstorage')
-    if storage_settings.file_tree and storage_settings.file_tree.children:
-        record = storage_settings.file_tree.children[0]
+    records = storage_settings.file_tree.children if storage_settings.file_tree else []
+    try:
+        record = next(
+            each for each in records
+            if not each.is_deleted,
+        )
         download_count = record.get_download_count()
         download_url = node.web_url_for(
             'osf_storage_view_file',
             path=record.path,
             action='download',
         )
-    else:
+    except StopIteration:
         download_url = ''
         download_count = 0
 


### PR DESCRIPTION
# Purpose
Fix bug reported by @KatyCain526: no download link or count is displayed in the conference table for nodes whose first file has been deleted. This patch shows the first non-deleted file in the conference table.

# Changes
* Show the first non-deleted file rather than the first file

# Side effects
None expected