### PR TITLE
Add base scripts to plain conference view.

### DIFF
--- a/website/templates/public/pages/meeting_plain.mako
+++ b/website/templates/public/pages/meeting_plain.mako
@@ -7,7 +7,33 @@
     <%namespace name="globals" file="base.mako" />
     ${globals.includes_top()}}
 
-    % for url in js_bottom:
+    % if sentry_dsn_js:
+    <script src="/static/vendor/bower_components/raven-js/dist/raven.min.js"></script>
+    <script src="/static/vendor/bower_components/raven-js/plugins/jquery.js"></script>
+    <script>
+        Raven.config('${ sentry_dsn_js }', {}).install();
+    </script>
+    % else:
+    <script>
+        window.Raven = {};
+        Raven.captureMessage = function(msg, context) {
+            console.error('=== Mock Raven.captureMessage called with: ===');
+            console.log('Message: ' + msg);
+            console.log(context);
+        };
+        Raven.captureException = function(err, context) {
+            console.error('=== Mock Raven.captureException called with: ===');
+            console.log('Error: ' + err);
+            console.log(context);
+        };
+    </script>
+    % endif
+
+    <script src="/static/vendor/bower_components/dropzone/downloads/dropzone.min.js"></script>
+    <script src="/static/vendor/bower_components/hgrid/dist/hgrid.js"></script>
+    <script src="${"/static/public/js/vendor.js" | webpack_asset}"></script>
+
+    % for url in globals.javascript_bottom():
         <script src="${url}"></script>
     % endfor
 


### PR DESCRIPTION
# Purpose
Fix 500 on plain conference view page reported by @KatyCain526 (e.g. https://osf.io/view/spsp2014/plain)

# Changes
* Include assets from `base.mako` in plain conference view

# Side effects
None expected

@sloria `meeting_plain.mako` doesn't inherit from `base.mako`, so some assets are included manually for now, which is pretty brittle. Can you think of a better way to handle this?