### PR TITLE
Fix dashboard row selection icons not working

### DIFF
--- a/website/templates/projectGridTemplates.html
+++ b/website/templates/projectGridTemplates.html
@@ -91,20 +91,78 @@
         {{/if}}
         
         {{#unless theItem.parentIsFolder}}
-            <div class="col-xs-12">
-                <span class = "title">
-                    <span class = "name-container" id="nc-{{theItem.node_id}}">
-                          {{#if theItem.isFolder}}{{{ theItem.name }}}{{/if}}
-                          {{#unless theItem.isFolder}}<a href="{{ theItem.urls.fetch }}">{{{ theItem.name }}}</a>{{#if theItem.isRegistration}} (Registration){{/if}}
-                          {{/unless}}
-                          {{#unless theItem.isDashboard}}{{#unless theItem.isRegistration}}{{#if theItem.permissions.edit}}
-                              <button id="rename-node-{{theItem.node_id}}" class="editableControl dker btn btn-xs">
-                                <i class="icon icon-pencil" style="font-size: 11px;"></i> Edit</button>
-                          {{/if}}{{/unless}}{{/unless}}
+            {{#unless theItem.isDashboard}}
+                <div class="col-xs-12">
+                    <span class = "title">
+                        <span class = "name-container" id="nc-{{theItem.node_id}}">
+                              {{#if theItem.isFolder}}{{{ theItem.name }}}{{/if}}
+                              {{#unless theItem.isFolder}}<a href="{{ theItem.urls.fetch }}">{{{ theItem.name }}}</a>{{#if theItem.isRegistration}} (Registration){{/if}}
+                              {{/unless}}
+                              {{#unless theItem.isDashboard}}{{#unless theItem.isRegistration}}{{#if theItem.permissions.edit}}
+                                  <button id="rename-node-{{theItem.node_id}}" class="editableControl dker btn btn-xs">
+                                    <i class="icon icon-pencil" style="font-size: 11px;"></i> Edit</button>
+                              {{/if}}{{/unless}}{{/unless}}
+                        </span>
                     </span>
-                    
-                </span>
-            </div>
+                </div>
+            {{/unless}}
+            {{#if theItem.isDashboard}}
+                <div class="col-xs-4">
+                    <span class = "title">
+                        <span class = "name-container" id="nc-{{theItem.node_id}}">
+                              {{#if theItem.isFolder}}{{{ theItem.name }}}{{/if}}
+                              {{#unless theItem.isFolder}}<a href="{{ theItem.urls.fetch }}">{{{ theItem.name }}}</a>{{#if theItem.isRegistration}} (Registration){{/if}}
+                              {{/unless}}
+                              {{#unless theItem.isDashboard}}{{#unless theItem.isRegistration}}{{#if theItem.permissions.edit}}
+                                  <button id="rename-node-{{theItem.node_id}}" class="editableControl dker btn btn-xs">
+                                    <i class="icon icon-pencil" style="font-size: 11px;"></i> Edit</button>
+                              {{/if}}{{/unless}}{{/unless}}
+                        </span>
+                    </span>
+                </div>
+                <div class="col-xs-8"> 
+                    <div class = "organize-project-controls pull-right">
+                        <div id = "buttons{{theItem.node_id}}">
+                            <div class = "orgnaize-btn btn btn-sm btn-default" id="add-item-{{theItem.node_id}}">Add Existing Project</div>
+                            <div id="add-folder-{{theItem.node_id}}" class = "orgnaize-btn btn btn-sm btn-default">New Folder</div>
+                        </div>
+                        <div id="findNode{{theItem.node_id}}">
+                            <form action="">
+                            <fieldset class="project-detail-fields">
+                                <div class="row">
+                                    <div class="col-xs-8">
+                                        <input class="typeahead" id="input{{theItem.node_id}}" type="text" placeholder="Name of project to find" autofocus>
+                                        <span class="add-link-warning" id="add-link-warn-{{theItem.node_id}}"></span>
+                                    </div>
+                                    <div class="col-xs-4">
+                                    <input type="submit" class = "findBtn btn btn-sm btn-default" id="add-link-{{theItem.node_id}}" disabled="disabled" value="Add">
+                                        <input type="reset" class = "btn btn-sm btn-default cancel-button-{{ theItem.node_id }}" value="Cancel">
+                                    </div>
+                                </div>
+                            </fieldset>
+                                </form>
+                        </div>
+                        <div class="add-folder-container" id="afc-{{theItem.node_id}}">
+                            <form action="">
+                            <fieldset class="project-detail-fields">
+
+                            <div class="row">
+                                <div class="col-xs-8">
+                                     <input class = "typeahead" id="add-folder-input{{theItem.node_id}}" type="text" placeholder="Folder Name" autofocus>
+                                </div>
+                                <div class="col-xs-4">
+                                    <input type="submit" class = "addFolderBtn btn btn-sm btn-default submit-button-{{ theItem.node_id }}" id="add-folder-button{{theItem.node_id}}" disabled="disabled" value="Add">
+                                    <input type="reset" class = "btn btn-sm btn-default cancel-button-{{ theItem.node_id }}" value="Cancel">
+                                </div>
+                            </div>                            
+                            </fieldset>
+                                </form>
+                        </div>
+                    </div>
+                </div>
+            {{/if}}
+
+
         {{/unless}}
        
     </div>


### PR DESCRIPTION
## Purpose 
A previosu fix broke the view for the template on what dashboard is showing. Trello issue: https://trello.com/c/KmV63Bo0

## Changes
The template includes now a section only for dashboard that has Add Existing Project and Add Folder buttons. 

## Side Effects
The logic added checks for whether the item is dashboard. If any it would have side effects on the dashboard toolbar displays. 