### PR TITLE
Fix the css shift for the project organizer typeahead

### DIFF
--- a/website/static/css/projectorganizer.css
+++ b/website/static/css/projectorganizer.css
@@ -297,6 +297,8 @@ height: 32px ;
 */
 .tt-hint {
     color: #999;
+    padding-top: 9px;
+    padding-left: 13px;
 }
 h3.category {
     font-size: 18px;


### PR DESCRIPTION
## Purpose 

Fix the shift that happens in project organizer when typeahead hint is initialized.
 
![e71a5c24-a1cd-11e4-83c0-433b8efa4d0e](https://cloud.githubusercontent.com/assets/1314003/5858117/bd5e9fe8-a21e-11e4-8d00-08f715206d2a.png)

Trello issue: https://trello.com/c/T2rDZyqk 

## Changes

Changes CSS values for padding towards this shift. 

## Side effects

I checked if this class effects anyone else or any other typeaheads in the project organizer, doesn't seem to, but we may want to scope it better in future. 