### PR TITLE
Fix dropping components or links into itself and other scenarios where t...

### DIFF
--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -1026,7 +1026,7 @@ function dropLogic(event, items, folder) {
         itemParent,
         itemParentNodeID,
         getAction;
-    if (typeof folder !== 'undefined' && folder !== null) {
+    if (typeof folder !== 'undefined' && folder !== null && folder.data.isFolder) {
         theFolderNodeID = folder.data.node_id;
         getChildrenURL = folder.data.apiURL + 'get_folder_pointers/';
         sampleItem = items[0];


### PR DESCRIPTION
## Purpose

Fix a bug where dropping a components or link on something that is not a folder results in a bad json call.
https://trello.com/c/Wq6JS7UZ

## Changes
This call shouldn't even be made, so the change was to put a check to see if the drop target is in fact a folder.

## Side effects
There shouldn't be any since is target is not a proper folder drops should not be happening anyway, dropping to project is not allowed. 