### PR TITLE
Fixes/renaming related bugs

### DIFF
--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -132,8 +132,12 @@ function createBlankProjectDetail(message) {
     $('.project-details').html('<div class="row"> <div class="col-xs-12"> <i class="text-muted text-center po-placeholder"> ' + text + ' </i> </div> </div>');
 }
 
-function triggerClickOnItem(item) {
+function triggerClickOnItem(item, force) {
     var row = $('.tb-row[data-id="'+ item.id+'"');
+    if (force){
+        row.trigger('click');        
+    }
+
     if(row.hasClass(this.options.hoverClassMultiselect)){
         row.trigger('click');
     }
@@ -418,7 +422,6 @@ function _showProjectDetails(event, item, col) {
             postAction = $osf.postJSON(url, postData);
             postAction.done(function () {
                 treebeard.updateFolder(null, theParentNode);
-                triggerClickOnItem.call(treebeard, item);    
             }).fail($osf.handleJSONError);
             return false;
         });
@@ -679,7 +682,7 @@ function _poResolveToggle(item) {
  * @private
  */
 function _poResolveLazyLoad(item) {
-    console.log("tree", item);
+
     return '/api/v1/dashboard/' + item.data.node_id;
 }
 
@@ -697,8 +700,14 @@ function expandStateLoad(item) {
             if (item.children[i].data.expand) {
                 tb.updateFolder(null, item.children[i]);
             }
+            console.log(tb.multiselected[0].data.node_id, item.children[i].data.node_id);
+            if(tb.multiselected[0] && item.children[i].data.node_id === tb.multiselected[0].data.node_id) {
+                triggerClickOnItem.call(tb, item.children[i], true);            
+            }
         }
     }
+
+
 }
 
 /**
@@ -722,7 +731,7 @@ function _poLoadOpenChildren() {
  * @private
  */
 function _poMultiselect(event, tree) {
-    console.log(this, tree);
+    console.log(tree);
     var tb = this,
         selectedRows = filterRowsNotInParent.call(tb, tb.multiselected),
         someItemsAreFolders,
@@ -777,7 +786,6 @@ function _poMultiselect(event, tree) {
         
     } else {
         _showProjectDetails.call(tb, event, tb.multiselected[0]);
-
     }
 }
 

--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -421,7 +421,8 @@ function _showProjectDetails(event, item, col) {
                 };
             postAction = $osf.postJSON(url, postData);
             postAction.done(function () {
-                treebeard.updateFolder(null, theParentNode);
+                treebeard.updateFolder(null, treebeard.find(1));
+                // Also update every
             }).fail($osf.handleJSONError);
             return false;
         });

--- a/website/templates/projectGridTemplates.html
+++ b/website/templates/projectGridTemplates.html
@@ -104,6 +104,22 @@
                     </span>
                     
                 </span>
+                <span class="rename-container" id="rnc-{{theItem.node_id}}">
+                        <form action="">
+                              <fieldset class="project-detail-fields">
+                                <div class="row">
+                                    <div class="col-xs-8">
+                                        <input class="typeahead" id="rename-node-input{{theItem.node_id}}" type="text" value="{{{theItem.name}}}" autofocus>
+                                    </div>
+                                    <div class="col-xs-4">
+                                        <input type="submit" class = "rename-node-btn btn btn-sm btn-default submit-button-{{ theItem.node_id }}" id="rename-node-button{{theItem.node_id}}" disabled="disabled" value="Rename">
+                                        <input type="reset" class = "btn btn-sm btn-default cancel-button-{{ theItem.node_id }}" value="Cancel">
+                                    </div>                    
+                                </div>
+                              </fieldset>
+                        </form>
+                    </span>
+                    
             </div>
         {{/unless}}
        


### PR DESCRIPTION
## Purpose

Improve renaming on the Project organizer. Fixes three issues:
1. Renaming did not refresh the toolbar name
2. Items whose parent were not folders did not show rename div (broken due to a previous change I made)
3. Renaming did not refresh every instance of that item

https://trello.com/c/7ghezzfW

## Changes

1. Refresh didn't happen because folder was reloading. Moved the click trigger to when lazyloading finishes on that item. 
2. Added the div back to the section for components and links
3. Instead of a folder refresh, renaming does a full refresh

## Side effects
Reloading entire dashboard may have consequences but we save open state so that shouldn't be a problem. There isn't a major observable delay. 