### PR TITLE
0.24.0/make-registration-icons-grey

### DIFF
--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -632,17 +632,21 @@ function _poResolveIcon(item) {
         return returnView('link');
     }
     if (item.data.isProject) {
-        return returnView('project');
+        if (item.data.isRegistration) {
+            return returnView('registration');
+        } else {
+            return returnView('project');
+        }
     }
-    if (item.data.isRegistration) {
-        return returnView('registration');
-    }
+
     if (item.data.isComponent) {
-        return returnView('component');
+        if (item.data.isRegistration) {
+            return returnView('registeredComponent');
+        }else {
+            return returnView('component');
+        }
     }
-    if (item.data.isRegistration && item.data.isComponent) {
-        return returnView('registeredComponent');
-    }
+
     if (item.data.isPointer) {
         return returnView('link');
     }


### PR DESCRIPTION
Purpose
-----------
Make the icons for registered projects and components show properly

Changes
------------
Previously, the code checking the type of icon it should use was exiting out before checking if it was a registration. This fixes that

Side effects
---------------
There should be no side effects

Fixes https://trello.com/c/UjHCsl52