### PR TITLE
Fix flickering of the progress message in file upload

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -207,10 +207,10 @@ function _fangornUploadProgress(treebeard, file, progress) {
     } else {
         column = 1;
     }
-    msgText  += 'Uploaded ' + Math.floor(progress) + '%'
+    msgText  += 'Uploaded ' + Math.floor(progress) + '%';
 
     if (progress < 100) {
-        item.notify.update(msgText, 'success', column, 0);
+        item.notify.update(msgText, 'success', column, 1);
     } else {
         item.notify.update(msgText, 'success', column, 2000);
     }


### PR DESCRIPTION
## Purpose

Fix an error where during file upload the progress message times out and flickers between off and on state

Trello card: https://trello.com/c/x2DyPfsO

## Changes
Pass timeout variable as 1 to avoid falsy issue in javascript with 0

## Side effects
As far as I can tell none. 