### PR TITLE
Fixes error in firefox where dashboard toolbar edits did not return to o...

### DIFF
--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -133,7 +133,7 @@ function createBlankProjectDetail(message) {
 }
 
 function triggerClickOnItem(item) {
-    var row = $('.tb-row[data-id="'+ item.id+'"');
+    var row = $('.tb-row[data-id="'+ item.id+'"]');
     if(row.hasClass(this.options.hoverClassMultiselect)){
         row.trigger('click');
     }


### PR DESCRIPTION
## Purpose

Fixes an error Steve found where in Firefox the editing of content on Project Organizer does not return the toolbar back.

## Changes

This error was due to a wrong syntax in jquery selector. MAking the fix below too care of it. 

## Side Effects
I'm quite sure there is none. 