### PR TITLE
Remove delete button from Dataverse file view page.

### DIFF
--- a/website/addons/dataverse/templates/dataverse_view_file.mako
+++ b/website/addons/dataverse/templates/dataverse_view_file.mako
@@ -17,9 +17,10 @@
 
      <p>
          <a data-bind="attr: {href: download_url}" class="btn btn-success btn-md">Download <i class="icon-download-alt"></i></a>
-        % if user['can_edit']:
-            <button data-bind="click: deleteFile" class="btn btn-danger btn-md">Delete <i class="icon-trash"></i></button>
-        % endif
+         ## TODO: Disable based on whether file is draft version. Re-evaluate on release of Dataverse 4.0
+##        % if user['can_edit']:
+##            <button data-bind="click: deleteFile" class="btn btn-danger btn-md">Delete <i class="icon-trash"></i></button>
+##        % endif
      </p>
 
 


### PR DESCRIPTION
Resolve #1475 by removing delete button from Dataverse file view page.

While it is currently possible to determine if a file is a draft version (editable/deletable) through a series of API calls, I do not believe it is worth the additional time required to perform those actions to conditionally add a delete button to the file page. This may change with Dataverse 4.0, and is worth re-evaluating at that point.

Draft files remain deletable from the "Files" page. 