### PR TITLE
Feature/waterbutler

### DIFF
--- a/website/addons/osfstorage/requirements.txt
+++ b/website/addons/osfstorage/requirements.txt
@@ -1,2 +1,1 @@
 MarkupSafe==0.23
-git+https://github.com/CenterForOpenScience/osf-upload-service

--- a/website/addons/osfstorage/tests/test_utils.py
+++ b/website/addons/osfstorage/tests/test_utils.py
@@ -1,19 +1,11 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-import mock
-import unittest
 from nose.tools import *  # noqa
 
-from tests.factories import AuthUserFactory, ProjectFactory
+from tests.factories import AuthUserFactory
 
-import datetime
-import urlparse
-
-import requests
 import markupsafe
-import simplejson
-from cloudstorm import sign
 
 from framework import sessions
 from framework.flask import request
@@ -23,7 +15,6 @@ from website.addons.osfstorage.tests import factories
 from website.addons.osfstorage import model
 from website.addons.osfstorage import views
 from website.addons.osfstorage import utils
-from website.addons.osfstorage import settings
 
 from website.addons.osfstorage.tests.utils import (
     StorageTestCase, Delta, AssertDeltas
@@ -89,10 +80,10 @@ class TestGetCookie(StorageTestCase):
         user = AuthUserFactory()
         create_delta = Delta(lambda: Session.find().count(), lambda value: value + 1)
         with AssertDeltas(create_delta):
-            cookie = utils.get_cookie_for_user(user)
+            utils.get_cookie_for_user(user)
         get_delta = Delta(lambda: Session.find().count())
         with AssertDeltas(get_delta):
-            cookie = utils.get_cookie_for_user(user)
+            utils.get_cookie_for_user(user)
 
 
 class TestGetDownloadUrl(StorageTestCase):

--- a/website/addons/osfstorage/tests/test_views.py
+++ b/website/addons/osfstorage/tests/test_views.py
@@ -188,7 +188,6 @@ class TestUpdateMetadataHook(HookTestCase):
             'metadata': {'archive': 'glacier'},
             'version_id': self.version._id,
         }
-        _, self.signature = utils.webhook_signer.sign_payload(self.payload)
 
     def send_metadata_hook(self, payload=None, **kwargs):
         return self.send_hook(

--- a/website/addons/osfstorage/utils.py
+++ b/website/addons/osfstorage/utils.py
@@ -200,14 +200,14 @@ def get_waterbutler_url(user, *path, **query):
     return url.url
 
 
-def get_waterbutler_download_url(version_idx, file_version, file_record, user=None):
+def get_waterbutler_download_url(version_idx, file_version, file_record, user=None, **query):
     nid = file_record.node._id
     path = get_filename(version_idx, file_version, file_record)
-    return get_waterbutler_url(user, 'file', nid=nid, path=path)
+    return get_waterbutler_url(user, 'file', nid=nid, path=path, **query)
 
 
-def get_waterbutler_upload_url(user, node, path):
-    return get_waterbutler_url(user, 'file', nid=node._id, path=path)
+def get_waterbutler_upload_url(user, node, path, **query):
+    return get_waterbutler_url(user, 'file', nid=node._id, path=path, **query)
 
 
 def get_cache_filename(file_version):

--- a/website/addons/osfstorage/utils.py
+++ b/website/addons/osfstorage/utils.py
@@ -11,7 +11,6 @@ import markupsafe
 import itsdangerous
 from modularodm import Q
 from flask import request
-from cloudstorm import sign
 
 from framework.exceptions import HTTPError
 
@@ -26,15 +25,6 @@ from website.addons.osfstorage import settings
 
 
 logger = logging.getLogger(__name__)
-
-url_signer = sign.Signer(
-    settings.URLS_HMAC_SECRET,
-    settings.URLS_HMAC_DIGEST,
-)
-webhook_signer = sign.Signer(
-    settings.WEBHOOK_HMAC_SECRET,
-    settings.WEBHOOK_HMAC_DIGEST,
-)
 
 
 def get_permissions(auth, node):

--- a/website/addons/osfstorage/views.py
+++ b/website/addons/osfstorage/views.py
@@ -55,7 +55,8 @@ def osf_storage_download_file_hook(node_addon, payload, **kwargs):
 
     version_idx, version, record = get_version(path, node_addon, request.args.get('version'))
 
-    update_analytics(node_addon.owner, path, version_idx)
+    if payload.get('mode') != 'render':
+        update_analytics(node_addon.owner, path, version_idx)
 
     return {
         'data': {
@@ -213,7 +214,7 @@ def serialize_file(idx, version, record, path, node):
         'file_path': '/' + record.path,
         'rendered': rendered,
         'files_url': node.web_url_for('collect_file_trees'),
-        'download_url': node.web_url_for('osf_storage_view_file', path=path, action='download'),
+        'download_url': node.web_url_for('osf_storage_view_file', path=path, action='download', mode='render'),
         'revisions_url': node.api_url_for(
             'osf_storage_get_revisions',
             path=path,
@@ -229,9 +230,7 @@ def serialize_file(idx, version, record, path, node):
 def download_file(path, node_addon, version_query):
     mode = request.args.get('mode')
     idx, version, record = get_version(path, node_addon, version_query)
-    url = utils.get_waterbutler_download_url(idx, version, record)
-    if mode != 'render':
-        update_analytics(node_addon.owner, path, idx)
+    url = utils.get_waterbutler_download_url(idx, version, record, mode=mode)
     return redirect(url)
 
 


### PR DESCRIPTION
Don't increment download counts on file view / render.

Resolves https://trello.com/c/vl47pGrC/156-download-counts-increase-by-x-where-x-1.
Resolves https://trello.com/c/lLf0gltX/155-download-count-shows-1-immediately-after-upload.