### PR TITLE
Fix Project organizer bug where some items would load contents twice

### DIFF
--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -1026,7 +1026,6 @@ function dropLogic(event, items, folder) {
         getChildrenURL,
         folderChildren,
         sampleItem,
-        //itemParentID,
         itemParent,
         itemParentNodeID,
         getAction;
@@ -1034,7 +1033,6 @@ function dropLogic(event, items, folder) {
         theFolderNodeID = folder.data.node_id;
         getChildrenURL = folder.data.apiURL + 'get_folder_pointers/';
         sampleItem = items[0];
-        //itemParentID = sampleItem.parentID;
         itemParent = sampleItem.parent();
         itemParentNodeID = itemParent.data.node_id;
         if (itemParentNodeID !== theFolderNodeID) { // This shouldn't happen, but if it does, it's bad
@@ -1085,23 +1083,18 @@ function dropLogic(event, items, folder) {
                             if (copyMode === 'move') {
                                 if (!outerFolder) {
                                     tb.updateFolder(null, itemParent);
+                                    tb.updateFolder(null, folder);
                                 } else {
                                     tb.updateFolder(null, outerFolder);
                                 }
+                            } else {
+                                tb.updateFolder(null, folder);
                             }
-                            // } else {
-                            //     tb.updateFolder(null, folder);
-                            // }
-                            tb.updateFolder(null, folder);
-
                         });
                         postAction.fail(function (jqxhr, textStatus, errorThrown) {
                             $osf.growl('Error:', textStatus + '. ' + errorThrown);
                         });
                     }
-                    // else { // From:  if (itemsToMove.length > 0)
-                    //    tb.updateFolder(null, itemParent);
-                    //}
                 }
             });
             getAction.fail(function (jqxhr, textStatus, errorThrown) {


### PR DESCRIPTION
## Purpose
An earlier fix introduced a bug where some items would load twice, doubling their content. This fix makes sure the appropriate logic is used in Project organizer.

Trello card: https://trello.com/c/O22fwTxe

## Changes 
The logic for when updateFolder runs was changed. 

## Side effects
There might be a very edge scenario where this update may break things but we tested with all scenarios that users may need in this page. 

Thanks to @brianjgeiger for his help on this.  