### PR TITLE
Fixes/sending multiple

### DIFF
--- a/website/static/js/pages/project-dashboard-page.js
+++ b/website/static/js/pages/project-dashboard-page.js
@@ -64,7 +64,19 @@ $(document).ready(function() {
                     }
                 ];
                 },
-            resolveRows : function(){
+            resolveRows : function(item){
+                
+                if(item.data.tmpID){
+                    return [ 
+                        {
+                            data : 'name',  // Data field name
+                            folderIcons : true,
+                            filter : true,
+                            custom : function(){ return m('span.text-muted', 'Uploading ' + item.data.name + '...'); }
+                        }
+                    ];
+                }
+
                 return  [{
                     data: 'name',
                     folderIcons: true,


### PR DESCRIPTION
## Purpose
Treebeard needed to copy the existing behavior where list of files to be uploaded needed to appear first. This change makes sure that all files pending uploaded are shown. 

Fixes this Trello card: https://trello.com/c/Bj13p1Uo

## Changes
- There was no need to alter treebeard core functionality. The main change was to move the blankitem creation from fangornsending to _fangornAddedFile so that all files would show a row on drop or upload. 
- These changes were applied to the overview page as well. 

## Side effects
- Currently there is a flickering where "Upload pending" view reappears after 100% upload, but this is due to another bug fixed separately. Need to test this before final push to production