### PR TITLE
Fix firefox search text

### DIFF
--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -2008,7 +2008,7 @@ span#profileFullname{
     box-shadow: none;
     border-bottom: 1px dotted #FFF;
     border-radius: 0;
-    padding: 15px 0;
+    padding: 0 0;
     font-size: 20px;
     color: #214762;
     font-weight: 300;


### PR DESCRIPTION
Purpose
-----------
Keep firefox from cutting off most of the search bar text

Change
-----------
Remove 15px of padding from the search bar

Side effects
---------------
No readily apparent side effects

Fixes https://trello.com/c/pdDUUtrN