### PR TITLE
Fix figshare load

### DIFF
--- a/website/static/js/folderPicker.js
+++ b/website/static/js/folderPicker.js
@@ -155,7 +155,7 @@
                 }
                 tb.options.folderArray = folderArray;
             }
-
+            console.log(tb.treeData);
             for (var i = 0; i < tb.treeData.children.length; i++) {
                 if (tb.treeData.children[i].data.addon !== 'figshare' && tb.treeData.children[i].data.name === folderArray[0]) {
                     tb.updateFolder(null, tb.treeData.children[i]);
@@ -168,6 +168,7 @@
 
     function _treebeardLazyLoadOnLoad  (item) {
         var tb = this; 
+
         for (var i = 0; i < item.children.length; i++) {
             if (item.children[i].data.addon === 'figshare'){
                 return;
@@ -187,12 +188,13 @@
         resolveIcon : _treebeardResolveIcon,
         togglecheck : _treebeardToggleCheck,
         resolveToggle : _treebeardResolveToggle,
-        onload : _treebeardOnload,
+        ondataload : _treebeardOnload,
         lazyLoadOnLoad : _treebeardLazyLoadOnLoad,
         // Disable uploads
         uploads: false,
         showFilter : false,
-        resizeColumns : false
+        resizeColumns : false,
+        rowHeight : 35
     };
 
     function FolderPicker(selector, opts) {


### PR DESCRIPTION
## Purpose

Fixes figshare view not updating on first load.

Trello card: https://trello.com/c/ul6PFxw1 

## Changes
Added a utility hook to Treebeard for ondataload; when all data load and flattening is done.
Added rowHeight value to folderPicker which resolved the view height problem (it turns out this was the main issue) 

Do ```bower treebeard update``` to update treebeard

## Sideeffects 
Should not be any since rowHeight is used in all TB instances and the hook is still optional. 