### PR TITLE
Remove duplicates if same file is uploaded

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -338,6 +338,16 @@ function _fangornDropzoneSuccess(treebeard, file, response) {
         item.data = response;
         inheritFromParent(item, item.parent());
     }
+    // Check and remove duplicates
+    if(parent.children.length  > 0 ) {
+        for (var j = 0; j < parent.children.length; j++){
+            var o = parent.children[j]; 
+            if(o.data.name === item.data.name && o.id !== item.id){
+                o.removeSelf(); 
+            }
+        }
+    }
+
     treebeard.redraw();
 }
 


### PR DESCRIPTION
## Purpose
When a file was uploaded that already existed in the folder the view showed both. With this update the most recent one (just uploaded) will remain, other copies will be removed from view. 

Trello card: https://trello.com/c/R7htu5Em

## Changes
Add a check to see if duplicates exist by name (which are not the currently uploaded item itself)

## Side Effects

Unless there is a corruption in the data structure this should not have side effect. The current behavior will remove ALL duplicates by name, but name has to be exactly the same. 