### PR TITLE
Fix Firefox padding on typeahead

### DIFF
--- a/website/static/css/projectorganizer.css
+++ b/website/static/css/projectorganizer.css
@@ -297,12 +297,11 @@ height: 32px ;
 */
 .tt-hint {
     color: #999;
-    padding-top: 9px;
-    padding-left: 13px;
+    padding: 2px 12px 0px 13px;
 }
 h3.category {
     font-size: 18px;
-    margin-top: 5px;
+    margin-top: 4px;
     margin-left: 5px;
 }
 .tt-dropdown-menu {
@@ -372,6 +371,9 @@ h3.category {
     margin-right: 4px;
 }
 
+.tt-input {
+    padding: 0 12px;
+}
 
 
 


### PR DESCRIPTION
## Purpose

Fixes the problem of typeahead padding. Refer to this Trello card: https://trello.com/c/PGUBPXzB

## Changes
CSS Adjustments that give proper padding to the elements involved.

## Side effects
Shouldn't be any.
I tested in Safar, Chrome and Firefox, and check if any other typeahead element on the page has problems. Also fixed one other typehead use on dashboard on onboarder, which is a desired fix. 