### PR TITLE
0.24.0/Figshare-message-concatenation

### DIFF
--- a/website/addons/figshare/messages.py
+++ b/website/addons/figshare/messages.py
@@ -1,33 +1,33 @@
 FIGSHARE = 'FigShare'
 
 # MODEL MESSAGES :model.py
-BEFORE_PAGE_LOAD_PRIVATE_NODE_MIXED_FS = 'Warnings: This OSF {category} is private but ' + FIGSHARE + ' project {project_id} may contain some public files or filesets'
+BEFORE_PAGE_LOAD_PRIVATE_NODE_MIXED_FS = 'Warnings: This OSF {category} is private but ' + FIGSHARE + ' project {project_id} may contain some public files or filesets. '
 
-BEFORE_PAGE_LOAD_PUBLIC_NODE_MIXED_FS = 'Warnings: This OSF {category} is public but ' + FIGSHARE + ' project {project_id} may contain some private files or filesets'
+BEFORE_PAGE_LOAD_PUBLIC_NODE_MIXED_FS = 'Warnings: This OSF {category} is public but ' + FIGSHARE + ' project {project_id} may contain some private files or filesets. '
 
-BEFORE_PAGE_LOAD_PERM_MISMATCH = 'Warnings: This OSF {category} is {node_perm}, but the ' + FIGSHARE + ' article {figshare_id} is {figshare_perm}'
+BEFORE_PAGE_LOAD_PERM_MISMATCH = 'Warnings: This OSF {category} is {node_perm}, but the ' + FIGSHARE + ' article {figshare_id} is {figshare_perm}. '
 
-BEFORE_PAGE_LOAD_PUBLIC_NODE_PRIVATE_FS = 'Users can view the contents of this private ' + FIGSHARE + ' article.'
+BEFORE_PAGE_LOAD_PUBLIC_NODE_PRIVATE_FS = 'Users can view the contents of this private ' + FIGSHARE + ' article. '
 
 BEFORE_REMOVE_CONTRIBUTOR = 'The ' + FIGSHARE + ' add-on for this {category} is authenticated by {user}. Removing this user will also remove write access to the {category} unless another contributor re-authenticates. '
 
-AFTER_REMOVE_CONTRIBUTOR = 'Because the ' + FIGSHARE + ' add-on for this {category} was authenticated by {user}, authentication information has been deleted. You can re-authenticate on the <a href="{url}settings/">Settings</a> page.'
+AFTER_REMOVE_CONTRIBUTOR = 'Because the ' + FIGSHARE + ' add-on for this {category} was authenticated by {user}, authentication information has been deleted. You can re-authenticate on the <a href="{url}settings/">Settings</a> page. '
 
-BEFORE_FORK_OWNER = 'Because you have authenticated the ' + FIGSHARE + ' add-on for this {category}, forking it will also transfer your authorization to the forked {category}.'
+BEFORE_FORK_OWNER = 'Because you have authenticated the ' + FIGSHARE + ' add-on for this {category}, forking it will also transfer your authorization to the forked {category}. '
 
-BEFORE_FORK_NOT_OWNER = 'Because this ' + FIGSHARE + ' add-on has been authenticated by a different user, forking it will not transfer authentication to the forked {category}.'
+BEFORE_FORK_NOT_OWNER = 'Because this ' + FIGSHARE + ' add-on has been authenticated by a different user, forking it will not transfer authentication to the forked {category}. '
 
-AFTER_FORK_OWNER = '' + FIGSHARE + ' authorization copied to forked {category}.'
+AFTER_FORK_OWNER = '' + FIGSHARE + ' authorization copied to forked {category}. '
 
-AFTER_FORK_NOT_OWNER = '' + FIGSHARE + ' authorization not copied to forked {category}. You may authorize this fork on the <a href={url}>Settings</a> page.'
+AFTER_FORK_NOT_OWNER = '' + FIGSHARE + ' authorization not copied to forked {category}. You may authorize this fork on the <a href={url}>Settings</a> page. '
 
-BEFORE_REGISTER = 'The contents of ' + FIGSHARE + ' projects cannot be registered at this time. The ' + FIGSHARE + ' data associated with this {category} will not be included as part of this registration.'
+BEFORE_REGISTER = 'The contents of ' + FIGSHARE + ' projects cannot be registered at this time. The ' + FIGSHARE + ' data associated with this {category} will not be included as part of this registration. '
 # END MODEL MESSAGES
 
 # MFR MESSAGES :views/crud.py
-FIGSHARE_VIEW_FILE_PRIVATE = 'Since this ' + FIGSHARE + ' file is unpublished we cannot render it. In order to access this content you will need to log into the <a href="{url}">' + FIGSHARE + ' page</a> and view it there.'
+FIGSHARE_VIEW_FILE_PRIVATE = 'Since this ' + FIGSHARE + ' file is unpublished we cannot render it. In order to access this content you will need to log into the <a href="{url}">' + FIGSHARE + ' page</a> and view it there. '
 
-FIGSHARE_VIEW_FILE_OVERSIZED = 'This ' + FIGSHARE + ' file is too large to render; <a href="{url}">download file</a> to view it.'
+FIGSHARE_VIEW_FILE_OVERSIZED = 'This ' + FIGSHARE + ' file is too large to render; <a href="{url}">download file</a> to view it. '
 
 '''
 Publishing this article is an irreversible operation. Once a FigShare article is published it can never be deleted. Proceed with caution.
@@ -45,6 +45,6 @@ Also, FigShare requires some additional info before this article can be publishe
 </form>
 '''
 
-OAUTH_INVALID = 'Your OAuth key for FigSahre is no longer valid. Please re-authenticate.'
+OAUTH_INVALID = 'Your OAuth key for FigSahre is no longer valid. Please re-authenticate. '
 
 # END MFR MESSAGES


### PR DESCRIPTION
Purpose
-----------
Ensure concatenated messages are properly spaced. Found by Jeff and/or Caner.

Changes
-----------
Figshare messages are sometimes concatenated. One of these was found with no period or space after it. I added a period and/or space to all the messages to make sure they can be concatenated in any order.

Side effects
---------------
Someone could be relying on bad formatting somewhere. It won't be worse than what we have now as a problem, and if it is reported, then this will be closer to a proper fix than what would be there.