### PR TITLE
Fix add folder padding issue in Firefox

### DIFF
--- a/website/static/css/projectorganizer.css
+++ b/website/static/css/projectorganizer.css
@@ -297,7 +297,7 @@ height: 32px ;
 */
 .tt-hint {
     color: #999;
-    padding: 2px 12px 0px 13px;
+    padding: 2px 12px 0px 12px;
 }
 h3.category {
     font-size: 18px;
@@ -371,7 +371,7 @@ h3.category {
     margin-right: 4px;
 }
 
-.tt-input {
+.tt-input, .typeahead {
     padding: 0 12px;
 }
 

--- a/website/static/css/projectorganizer.css
+++ b/website/static/css/projectorganizer.css
@@ -295,9 +295,13 @@ height: 32px ;
 }
 /* rgb of glow 106 176 232
 */
+.tt-input, .typeahead {
+    padding: 0 12px;
+}
+
 .tt-hint {
     color: #999;
-    padding: 2px 12px 0px 12px;
+    padding: 2px 12px 0px 13px;
 }
 h3.category {
     font-size: 18px;
@@ -371,9 +375,7 @@ h3.category {
     margin-right: 4px;
 }
 
-.tt-input, .typeahead {
-    padding: 0 12px;
-}
+
 
 
 


### PR DESCRIPTION
## Purpose

Fixes Trello issue: https://trello.com/c/ftClJtwf 
Where Firefox input padding for adding a new folder was restricting text height. 

## Changes
The padding style was adjusted for the effected input

## Side effects
This was a general change for '.typeahead' class scoped within places that load projectorganizer.css. I checked that
- It didn't have adverse effects on other inputs in this page related to typeahead
- it didn't break chrome and safari views