### PR TITLE
[Feature] cookieName made available to javascript for waterbutler integration

### DIFF
--- a/website/routes.py
+++ b/website/routes.py
@@ -52,6 +52,7 @@ def get_globals():
         'sentry_dsn_js': settings.SENTRY_DSN_JS if sentry.enabled else None,
         'dev_mode': settings.DEV_MODE,
         'allow_login': settings.ALLOW_LOGIN,
+        'cookie_name': settings.COOKIE_NAME,
         'status': status.pop_status_messages(),
         'css_all': assets_env['css'].urls(),
         'domain': settings.DOMAIN,

--- a/website/static/js/waterbutler.js
+++ b/website/static/js/waterbutler.js
@@ -4,7 +4,8 @@ var settings = require('settings');
 
 
 function getCookie() {
-    match = document.cookie.match(/osf=(.*?)(;|$)/);
+    cookieName =  window.contextVars.cookieName;
+    match = document.cookie.match(new RegExp(cookieName + '=(.*?)(;|$)'));
     return match ? match[1] : null;
 }
 

--- a/website/templates/project/project_base.mako
+++ b/website/templates/project/project_base.mako
@@ -42,6 +42,7 @@ ${next.body()}
     var nodeApiUrl = '${node['api_url']}';
     // Mako variables accessible globally
     window.contextVars = $.extend(true, {}, window.contextVars, {
+        cookieName: '${cookie_name}',
         currentUser: {
             ## TODO: Abstract me
             username: ${json.dumps(user['username']) | n},


### PR DESCRIPTION
Allows waterbutler.js to use global context cookieName from website/settings, fixes IE9 subdomain issue.

local.py on staging will need to be updated to COOKIE_NAME = 'osf_staging'