### PR TITLE
Create guidelines for contributing, especially issue reports

### DIFF
--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -27,4 +27,4 @@ When submitting an issue, be as descriptive as possible:
 
 Include pictures (e.g., in OSX press Cmd+Shift+4 to draw a box to screenshot)
 
-Examples of good issue reporting: #382, #713 
+Examples of good issue reporting: #382, #713

--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -8,6 +8,11 @@ If you find a bug in osf.io or would like to propose a new feature, please file 
 
 If you do this a lot, or you just want to know how to make it easier for us to find and fix the problem, keep reading.
 
+Quick link
+----------
+[Submit an issue](https://github.com/CenterForOpenScience/OSF.io/issues/new?body=Steps%0A-------%0A1.%20%0A%0AExpected%0A------------%0A%0AActual%0A--------%0A)
+using that link and you will have a handy template to save you a little time in your issue reporting.
+
 How to make the best issue
 --------------------------
 

--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -1,0 +1,30 @@
+CONTRIBUTING
+============
+
+REPORTING ISSUES
+----------------
+
+If you find a bug in osf.io or would like to propose a new feature, please file an issue report in CenterForOpenScience/osf.io. Below we have some information on how to best report the issue, but if you’re short on time or new to this, don’t worry! We really want to know about the problem, so go ahead and report it.
+
+If you do this a lot, or you just want to know how to make it easier for us to find and fix the problem, keep reading.
+
+How to make the best issue
+--------------------------
+
+First, please make sure that the issue has not already been reported by searching through the issue archives. 
+
+When submitting an issue, be as descriptive as possible: 
+* What you did (step by step)
+    * Where does this happen on the OSF?
+* What you expected
+* What actually happened 
+    * Check the JavaScript console in the browser (e.g. In Chrome go to View → Developer → JavaScript console) and report errors 
+    * If it's an issue with staging, report whether or not it also occurs on production 
+    * If an error was generated, report what time it occurred, and the specific URL.
+* Potential causes 
+* Suggest a solution
+    * What will it look like when this issue is resolved? 
+
+Include pictures (e.g., in OSX press Cmd+Shift+4 to draw a box to screenshot)
+
+Examples of good issue reporting: #382, #713 


### PR DESCRIPTION
Purpose
------------
Add the Guidelines for Contributing that @samanehsan and I made a long time ago to the OSF repo

Changes
------------
There's a new markdown file with the guidelines

Side effects
----------------
There'll be a new notice at the top of the repo for how to report issues. One day it may also explain the best way to submit code.