### PR TITLE
0.24.0/space above revisions

### DIFF
--- a/website/addons/dataverse/templates/dataverse_view_file.mako
+++ b/website/addons/dataverse/templates/dataverse_view_file.mako
@@ -5,10 +5,6 @@
 <%def name="file_versions()">
 <div class="scripted" id="dataverseScope">
 
-    <div class="alert alert-warning" data-bind="visible: deleting">
-        Deleting your file…
-    </div>
-
     <ol class="breadcrumb">
          <li class="active overflow"><a data-bind="attr: {href: files_url}">{{nodeTitle}}</a></li>
          <li>Dataverse</li>

--- a/website/addons/dropbox/templates/dropbox_view_file.mako
+++ b/website/addons/dropbox/templates/dropbox_view_file.mako
@@ -2,9 +2,6 @@
 
 <%def name="file_versions()">
 <div class="scripted" id="revisionScope">
-    <div id="deletingAlert" class="alert alert-warning fade">
-        Deleting your file…
-    </div>
 
     <ol class="breadcrumb">
         <li><a data-bind="attr: {href: filesUrl()}">{{nodeTitle}}</a></li>

--- a/website/addons/figshare/templates/figshare_view_file.mako
+++ b/website/addons/figshare/templates/figshare_view_file.mako
@@ -24,10 +24,6 @@ $('#figsharePublishArticle').on('click', function(){
 -->
 % endif
 
-    <div class="alert alert-warning" data-bind="visible: deleting">
-        Deleting your file…
-    </div>
-
     <ol class="breadcrumb">
         <li class="active overflow"><a href=${urls['files']}>${node['title']}</a></li>
         <li>Figshare</li>

--- a/website/addons/github/templates/github_view_file.mako
+++ b/website/addons/github/templates/github_view_file.mako
@@ -4,10 +4,6 @@
 <%def name="file_versions()">
 <div class="scripted" id="githubScope">
 
-    <div class="alert alert-warning" data-bind="visible: deleting">
-        Deleting your file…
-    </div>
-
     <ol class="breadcrumb">
         <li class="active overflow"><a href=${files_page_url}>${node['title']}</a></li>
         <li>GitHub</li>

--- a/website/addons/s3/templates/s3_view_file.mako
+++ b/website/addons/s3/templates/s3_view_file.mako
@@ -3,11 +3,6 @@
 
 <%def name="file_versions()">
     <div id='s3Scope' class="scripted">
-
-        <div class="alert alert-warning" data-bind="visible: deleting">
-            Deleting your file…
-        </div>
-
             <p>
                 % if download_url:
                     <!--download button-->


### PR DESCRIPTION
Purpose
-----------
Make the file detail pages for all CRUD addons look correct and without a space above the delete/file revisions section.

Changes
------------
Removed the unused warning div that had already been replaced with growlbox functionality

Side effects
----------------
Shouldn't be any. Best to test both that the file detail page looks right for all addons and that the delete growlbox appears.

Fixes https://trello.com/c/kKF42Gz0