### PR TITLE
Fixes/row sizing tb headers

### DIFF
--- a/website/static/js/conference.js
+++ b/website/static/js/conference.js
@@ -88,16 +88,16 @@ function Meeting(data) {
         showFilter : true,     // Gives the option to filter by showing the filter box.
         filterStyle : { 'float' : 'right', 'width' : '50%'},
         title : function() {
-            if(window.contextVars.tbInstructions === 'withLink') {
+            if(window.contextVars.tbInstructionsLink) {
                 return m('div', [
                     m('a', { href : window.contextVars.tbInstructionsLink, target : '_blank' }, 'Add your poster or talk')
                 ]);
-            }
-            if(window.contextVars.tbInstructions === 'withAnchor') {
+            } else {
                 return m('div', [
                     m('a', { href : "#submit" }, 'Add your poster or talk')
                 ]);
             }
+                
             return undefined;
         },
         allowMove : false,       // Turn moving on or off.

--- a/website/static/js/conference.js
+++ b/website/static/js/conference.js
@@ -87,7 +87,19 @@ function Meeting(data) {
         },
         showFilter : true,     // Gives the option to filter by showing the filter box.
         filterStyle : { 'float' : 'right', 'width' : '50%'},
-        title : false,          // Title of the grid, boolean, string OR function that returns a string.
+        title : function() {
+            if(window.contextVars.tbInstructions === 'withLink') {
+                return m('div', [
+                    m('a', { href : window.contextVars.tbInstructionsLink, target : '_blank' }, 'Add your poster or talk')
+                ]);
+            }
+            if(window.contextVars.tbInstructions === 'withAnchor') {
+                return m('div', [
+                    m('a', { href : "#submit" }, 'Add your poster or talk')
+                ]);
+            }
+            return undefined;
+        },
         allowMove : false,       // Turn moving on or off.
         hoverClass : 'fangorn-hover'
     };

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -783,9 +783,9 @@ tbOptions = {
     title : function() {
         if(window.contextVars.uploadInstruction) {
             return m('p', [
-                m('span', 'To Upload: Drag files into a folder below OR click the ('),
+                m('span', 'To Upload: Drag files into a folder below OR click the '),
                 m('i.btn.btn-default.btn-xs', { disabled : 'disabled'}, [ m('span.icon-upload-alt')]),
-                m('span', ') below.')
+                m('span', ' below.')
             ]);
         }
         return undefined;

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -783,9 +783,9 @@ tbOptions = {
     title : function() {
         if(window.contextVars.uploadInstruction) {
             return m('p', [
-                m('span', 'To Upload: Drag files from your desktop into a folder below OR click an upload('),
+                m('span', 'To Upload: Drag files into a folder below OR click the ('),
                 m('i.btn.btn-default.btn-xs', { disabled : 'disabled'}, [ m('span.icon-upload-alt')]),
-                m('span', ') button.')
+                m('span', ') below.')
             ]);
         }
         return undefined;

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -780,9 +780,17 @@ tbOptions = {
     uploads : true,         // Turns dropzone on/off.
     columnTitles : _fangornColumnTitles,
     resolveRows : _fangornResolveRows,
+    title : function() {
+        if(window.contextVars.uploadInstruction) {
+            return m('p', [
+                m('span', 'To Upload: Drag files from your desktop into a folder below OR click an upload('),
+                m('i.btn.btn-default.btn-xs', { disabled : 'disabled'}, [ m('span.icon-upload-alt')]),
+                m('span', ') button.')
+            ]);
+        }
+        return undefined;
+    },
     showFilter : true,     // Gives the option to filter by showing the filter box.
-    filterStyle : { 'float' : 'right', 'width' : '50%'},
-    title : false,          // Title of the grid, boolean, string OR function that returns a string.
     allowMove : false,       // Turn moving on or off.
     hoverClass : 'fangorn-hover',
     togglecheck : _fangornToggleCheck,

--- a/website/static/js/pages/project-dashboard-page.js
+++ b/website/static/js/pages/project-dashboard-page.js
@@ -51,8 +51,9 @@ $(document).ready(function() {
             filesData: data.data,
             uploads : true,
             showFilter : true,
-            filterStyle : { 'float' : 'left', width : '100%'},
             placement: 'dashboard',
+            title : undefined,
+            filterFullWidth : true, // Make the filter span the entire row for this view
             columnTitles : function(){
                 return [
                     {

--- a/website/templates/project/files.mako
+++ b/website/templates/project/files.mako
@@ -6,19 +6,8 @@
   <h2 class="text-300">Files</h2>
 </div>
 
-<div class="row">
-<div class="col-md-12">
-    <div class='help-block'>
-        % if 'write' in user['permissions'] and not disk_saving_mode:
-            <p>To Upload: Drag files from your desktop into a folder below OR click an upload (<i class="btn btn-default btn-xs" disabled><span class="icon-upload-alt"></span></i>) button.</p>
-        % endif
-    </div>
-</div><!-- end col-md-->
-
-</div><!--end row -->
-
 <div id="treeGrid">
-<div class="fangorn-loading"> <i class="icon-spinner fangorn-spin"></i> <p class="m-t-sm fg-load-message"> Loading files...  </p> </div>
+	<div class="fangorn-loading"> <i class="icon-spinner fangorn-spin"></i> <p class="m-t-sm fg-load-message"> Loading files...  </p> </div>
 </div>
 
 
@@ -29,10 +18,20 @@ ${parent.stylesheets()}
 % endfor
 </%def>
 
+
+
 <%def name="javascript_bottom()">
+
+
 ${parent.javascript_bottom()}
 % for script in tree_js:
 <script type="text/javascript" src="${script | webpack_asset}"></script>
 % endfor
 <script src=${"/static/public/js/files-page.js" | webpack_asset}></script>
+<script type="text/javascript">
+    window.contextVars = window.contextVars || {}; 
+    % if 'write' in user['permissions'] and not disk_saving_mode:
+        window.contextVars.uploadInstruction = true
+    % endif
+</script>
 </%def>

--- a/website/templates/public/pages/meeting.mako
+++ b/website/templates/public/pages/meeting.mako
@@ -60,10 +60,7 @@
         window.contextVars.meetingData = ${data};
         
         % if meeting['active'] and meeting['info_url']:
-            window.contextVars.tbInstructions =  'withLink';
             window.contextVars.tbInstructionsLink =  '${ meeting['info_url'] }';
-        % else:
-            window.contextVars.tbInstructions =  'withAnchor'; 
         % endif
 
 

--- a/website/templates/public/pages/meeting.mako
+++ b/website/templates/public/pages/meeting.mako
@@ -10,12 +10,6 @@
         <br /><br />
     % endif
 
-    % if meeting['active'] and meeting['info_url']:
-        <div><a href="${ meeting['info_url'] }" target="_blank">Add your poster or talk</a></div>
-    % else:
-        <div><a href="#submit">Add your poster or talk</a></div>
-    % endif
-
     <div id="grid" style="width: 100%;"></div>
 
     % if meeting['active'] and not meeting.get('info_url'):
@@ -64,6 +58,15 @@
     <script type="text/javascript">
         window.contextVars = window.contextVars || {};
         window.contextVars.meetingData = ${data};
+        
+        % if meeting['active'] and meeting['info_url']:
+            window.contextVars.tbInstructions =  'withLink';
+            window.contextVars.tbInstructionsLink =  '${ meeting['info_url'] }';
+        % else:
+            window.contextVars.tbInstructions =  'withAnchor'; 
+        % endif
+
+
     </script>
     <script src=${"/static/public/js/conference-page.js" | webpack_asset}></script>
 </%def>


### PR DESCRIPTION
## Purpose
There is a large amountof space between instructions and search filter where Treebeard instructions take place. This change includes the instructions within treebeard as a title column next to the search bar and adds proper sizing for responsiveness. 
Fixes Trello card: https://trello.com/c/dNZs1X5m

## Change
**This requires treebeard update**
Changes were made to files page, project overview page and conferences/meetings page where TB options were edited to include the instructions row

## Side effects
I checked proper sizing but responsiveness is something to keep an eye on. 
This method also uses mako for what to pass to the title html template and no direct html is being rendered. It would be useful to carefully review the mako file changes in this PR. 