### PR TITLE
Repair removed figshare checks for action buttons

### DIFF
--- a/website/addons/figshare/static/figshareFangornConfig.js
+++ b/website/addons/figshare/static/figshareFangornConfig.js
@@ -3,8 +3,57 @@ var m = require('mithril');
 var Fangorn = require('fangorn');
 
 
-// Although this is empty it should stay here. Fangorn is going to look for figshare in it's config file. 
+// Define Fangorn Button Actions
+function _fangornActionColumn (item, col) {
+    var self = this;
+    var buttons = [];
+
+    if (item.kind === 'folder') {
+        buttons.push(
+            {
+                'name' : '',
+                'tooltip' : 'Upload files',
+                'icon' : 'icon-upload-alt',
+                'css' : 'fangorn-clickable btn btn-default btn-xs',
+                'onclick' : Fangorn.ButtonEvents._uploadEvent
+            }
+        );
+    }
+
+    if (item.kind === 'file' && item.data.extra && item.data.extra.status === 'public') {
+        buttons.push({
+            'name' : '',
+            'tooltip' : 'Download file',
+            'icon' : 'icon-download-alt',
+            'css' : 'btn btn-info btn-xs',
+            'onclick' : Fangorn.ButtonEvents._downloadEvent
+        });
+    }
+
+    if (item.kind === 'file' && item.data.extra && item.data.extra.status !== 'public') {
+        buttons.push({
+            'name' : '',
+            'icon' : 'icon-remove',
+            'tooltip' : 'Delete',
+            'css' : 'm-l-lg text-danger fg-hover-hide',
+            'style' : 'display:none',
+            'onclick' : Fangorn.ButtonEvents._removeEvent
+        });
+    }
+
+    return buttons.map(function(btn) {
+        return m('span', { 'data-col' : item.id }, [ m('i',{ 
+        	'class' : btn.css, 
+        	style : btn.style, 
+            'data-toggle' : 'tooltip', title : btn.tooltip, 'data-placement': 'bottom',
+        	'onclick' : function(event){ btn.onclick.call(self, event, item, col); } 
+        },
+            [ m('span', { 'class' : btn.icon}, btn.name) ])
+        ]);
+    });
+}
+
 Fangorn.config.figshare = {
-    
-    
+    // Fangorn options are called if functions, so return a thunk that returns the column builder
+    resolveActionColumn: function() {return _fangornActionColumn;}
 };


### PR DESCRIPTION
## Purpose
A previous fix for tooltips deleted the figshare buttons based on the misunderstanding that they were the same as the fangorn code, but they have checks that are unique to figshare so they need to be replaced and have the proper tooltips applied.
Fixes this Trello card: https://trello.com/c/H69pGl31

## Changes
Previous version of the figshareFangonConfig file was restored with changes that added tooltips to the buttons. 

## Side effects
Should not be any, this was existing working code and the logic applies here. 
