### PR TITLE
Hotfix: catch mailchimp validation error

### DIFF
--- a/tests/framework_tests/test_sentry.py
+++ b/tests/framework_tests/test_sentry.py
@@ -19,11 +19,8 @@ def set_sentry(status):
         @functools.wraps(func)
         def wrapped(*args, **kwargs):
             enabled, sentry.enabled = sentry.enabled, status
-            try:
-                return func(*args, **kwargs)
-            except:
-                sentry.enabled = enabled
-                raise
+            func(*args, **kwargs)
+            sentry.enabled = enabled
         return wrapped
     return wrapper
 

--- a/tests/test_mailchimp.py
+++ b/tests/test_mailchimp.py
@@ -3,6 +3,7 @@ from website import mailchimp_utils
 from tests.base import OsfTestCase
 from nose.tools import *  # PEP8 asserts
 from tests.factories import UserFactory
+import mailchimp
 
 
 class TestMailChimpHelpers(OsfTestCase):
@@ -42,6 +43,17 @@ class TestMailChimpHelpers(OsfTestCase):
                                                                    'lname': user.family_name},
                                                        double_optin=False,
                                                        update_existing=True)
+
+    @mock.patch('website.mailchimp_utils.get_mailchimp_api')
+    def test_subscribe_fake_email_does_not_throw_validation_error(self, mock_get_mailchimp_api):
+        list_name = 'foo'
+        user = UserFactory(username='fake@fake.com')
+        mock_client = mock.MagicMock()
+        mock_get_mailchimp_api.return_value = mock_client
+        mock_client.lists.list.return_value = {'data': [{'id': 1, 'list_name': list_name}]}
+        mock_client.lists.subscribe.side_effect = mailchimp.ValidationError
+        mailchimp_utils.subscribe(list_name, user)
+        assert_not_in(list_name, user.mailing_lists)
 
     @mock.patch('website.mailchimp_utils.get_mailchimp_api')
     def test_unsubscribe_called_with_correct_arguments(self, mock_get_mailchimp_api):

--- a/tests/test_mailchimp.py
+++ b/tests/test_mailchimp.py
@@ -53,7 +53,7 @@ class TestMailChimpHelpers(OsfTestCase):
         mock_client.lists.list.return_value = {'data': [{'id': 1, 'list_name': list_name}]}
         mock_client.lists.subscribe.side_effect = mailchimp.ValidationError
         mailchimp_utils.subscribe(list_name, user)
-        assert_not_in(list_name, user.mailing_lists)
+        assert_false(user.mailing_lists[list_name])
 
     @mock.patch('website.mailchimp_utils.get_mailchimp_api')
     def test_unsubscribe_called_with_correct_arguments(self, mock_get_mailchimp_api):

--- a/website/mailchimp_utils.py
+++ b/website/mailchimp_utils.py
@@ -36,17 +36,18 @@ def subscribe(list_name, user_id):
                           double_optin=False,
                           update_existing=True)
 
+        # Update mailing_list user field
+        if user.mailing_lists is None:
+            user.mailing_lists = {}
+            user.save()
+
+        user.mailing_lists[list_name] = True
+        user.save()
+
     except mailchimp.ValidationError as error:
         sentry.log_exception()
         sentry.log_message(error.message)
 
-    # Update mailing_list user field
-    if user.mailing_lists is None:
-        user.mailing_lists = {}
-        user.save()
-
-    user.mailing_lists[list_name] = True
-    user.save()
 
 @app.task
 def unsubscribe(list_name, user_id):


### PR DESCRIPTION
<h3>Purpose</h3>
Mailchimp validates emails before subscribing to a mailing list, but the OSF does not. As a result, if a user registers with a fake-looking email their account confirmation will fail. 

<h3>Changes</h3>
Catch `mailchimp.ValidationError`