### PR TITLE
[Feature] Fix figshare rendering

### DIFF
--- a/website/addons/figshare/templates/figshare_view_file.mako
+++ b/website/addons/figshare/templates/figshare_view_file.mako
@@ -4,7 +4,7 @@
 <%def name="file_versions()">
 <div class="scripted" id="figshareScope">
 <h3>Status: <span class="label label-${'success' if file_status == 'Public' else 'warning'}"> ${file_status}</span></h3>
-% if file_status != 'Public' and parent_type == 'singlefile':
+## % if file_status != 'Public' and parent_type == 'singlefile':
 <!--<a id="figsharePublishArticle" class="btn btn-danger">Publish</a><h3>
 <script type="text/javascript">
 $('#figsharePublishArticle').on('click', function(){
@@ -22,7 +22,7 @@ $('#figsharePublishArticle').on('click', function(){
 });
 </script>
 -->
-% endif
+## % endif
 
     <div class="alert alert-warning" data-bind="visible: deleting">
         Deleting your file…
@@ -58,11 +58,11 @@ $('#figsharePublishArticle').on('click', function(){
             % endif
     </p>
 
-%if file_versions:
-    <p>Versions: ${file_version}
+%if file_version:
+    <p>Version: ${file_version}
     <a href="${urls['version']}">Version History</a></p>
 %endif
-%if figshare_url and not node['anonymous']:
+%if urls.get('figshare') and not node['anonymous']:
     <p><a href="${urls['figshare']}">View on FigShare</a></p>
 %endif
 
@@ -76,7 +76,7 @@ $('#figsharePublishArticle').on('click', function(){
                 urls: {
                     delete_url: '${urls['delete']}',
                     files_page_url: '${urls['files']}'
-                    }
+                }
             }
         });
     </script>

--- a/website/addons/figshare/views/crud.py
+++ b/website/addons/figshare/views/crud.py
@@ -363,9 +363,9 @@ def figshare_view_file(*args, **kwargs):
                 download_url=download_url,
             )
 
-    categories = connect.categories()['items']  # TODO Cache this
-    categories = ''.join(
-        ["<option value='{val}'>{label}</option>".format(val=i['id'], label=i['name']) for i in categories])
+    # categories = connect.categories()['items']  # TODO Cache this
+    # categories = ''.join(
+    #     ["<option value='{val}'>{label}</option>".format(val=i['id'], label=i['name']) for i in categories])
 
     rv = {
         'node': {
@@ -379,9 +379,10 @@ def figshare_view_file(*args, **kwargs):
         'doi': 'http://dx.doi.org/10.6084/m9.figshare.{0}'.format(article['items'][0]['article_id']),
         'parent_type': 'fileset' if article['items'][0]['defined_type'] == 'fileset' else 'singlefile',
         'parent_id': article['items'][0]['article_id'],
-        'figshare_categories': categories,
+        # 'figshare_categories': categories,
         'figshare_title': article['items'][0]['title'],
         'figshare_desc': article['items'][0]['description'],
+        'render_url': render_url,
         'urls': {
             'render': render_url,
             'download': found.get('download_url'),


### PR DESCRIPTION
Parent mako templates required `render_url` figshare was providing `urls.render`.

Also comments out some currently unused code for fetching categories.