### PR TITLE
[hotfix] DropboxNodeLogger must account for deleted node settings records

### DIFF
--- a/website/addons/dropbox/model.py
+++ b/website/addons/dropbox/model.py
@@ -186,6 +186,7 @@ class DropboxNodeSettings(AddonNodeSettingsBase):
         nodelogger = DropboxNodeLogger(node=self.owner, auth=Auth(user_settings.owner))
         nodelogger.log(action="node_authorized", save=True)
 
+    # TODO: Is this used? If not, remove this and perhaps remove the 'deleted' field
     def delete(self, save=True):
         self.deauthorize(add_log=False)
         super(DropboxNodeSettings, self).delete(save)

--- a/website/addons/dropbox/tests/test_utils.py
+++ b/website/addons/dropbox/tests/test_utils.py
@@ -33,6 +33,21 @@ class TestNodeLogger(DropboxAddonTestCase):
 
         assert_equal(last_log.action, "dropbox_{0}".format(NodeLog.FILE_ADDED))
 
+    # Regression test for https://github.com/CenterForOpenScience/osf.io/issues/1557
+    def test_log_deauthorized_when_node_settings_are_deleted(self):
+        project = ProjectFactory()
+        project.add_addon('dropbox', auth=Auth(project.creator))
+        dbox_settings = project.get_addon('dropbox')
+        dbox_settings.delete(save=True)
+        # sanity check
+        assert_true(dbox_settings.deleted)
+
+        logger = utils.DropboxNodeLogger(node=project, auth=Auth(self.user))
+        logger.log(action='node_deauthorized', save=True)
+
+        last_log = project.logs[-1]
+        assert_equal(last_log.action, 'dropbox_node_deauthorized')
+
 
 def test_get_file_name():
     assert_equal(utils.get_file_name('foo/bar/baz.txt'), 'baz.txt')

--- a/website/addons/dropbox/utils.py
+++ b/website/addons/dropbox/utils.py
@@ -52,7 +52,7 @@ class DropboxNodeLogger(object):
         params = {
             'project': self.node.parent_id,
             'node': self.node._primary_key,
-            'folder': self.node.get_addon('dropbox').folder
+            'folder': self.node.get_addon('dropbox', deleted=True).folder
         }
         # If logging a file-related action, add the file's view and download URLs
         if self.file_obj or self.path:


### PR DESCRIPTION
Otherwise, get_addon will return `None`, which leads to the
AttributeError that caused #1557.

[fix #1557]