### PR TITLE
Remove title sorting on project organizer

### DIFF
--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -569,8 +569,7 @@ function _poColumnTitles() {
     columns.push({
         title: 'Name',
         width : '45%',
-        sort : true,
-        sortType : 'text'
+        sort : false
     }, {
         title : 'Actions',
         width : '10%',


### PR DESCRIPTION
## Purpose
Remove sorting toggle buttons from project organizer title column to bring it to same functionality as production

## Changes
In TBoptions for project organizer remove the option to sort from titles column

## Side effects
None, this is limited to one location. 