### PR TITLE
Fix view and render by version.

### DIFF
--- a/website/addons/osfstorage/tests/test_utils.py
+++ b/website/addons/osfstorage/tests/test_utils.py
@@ -99,12 +99,12 @@ class TestGetDownloadUrl(StorageTestCase):
 
     def test_get_filename_latest_version(self):
         filename = utils.get_filename(3, self.record.versions[-1], self.record)
-        assert_equal(filename, '/' + self.record.name)
+        assert_equal(filename, self.record.name)
 
     def test_get_filename_not_latest_version(self):
         filename = utils.get_filename(2, self.record.versions[-2], self.record)
         expected = ''.join([
-            '/reviews-',
+            'reviews-',
             self.record.versions[-2].date_created.isoformat(),
             '.gif',
         ])

--- a/website/addons/osfstorage/tests/test_views.py
+++ b/website/addons/osfstorage/tests/test_views.py
@@ -243,9 +243,9 @@ class TestViewFile(StorageTestCase):
         assert_equal(redirect_parsed.path.strip('/'), file_obj._id)
 
     def test_view_file_does_not_create_guid_if_exists(self):
-        _ = self.view_file(self.path)
+        self.view_file(self.path)
         n_objs = model.OsfStorageGuidFile.find().count()
-        res = self.view_file(self.path)
+        self.view_file(self.path)
         assert_equal(n_objs, model.OsfStorageGuidFile.find().count())
 
     def test_view_file_deleted_throws_error(self):

--- a/website/addons/osfstorage/utils.py
+++ b/website/addons/osfstorage/utils.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# encoding: utf-8
+# -*- coding: utf-8 -*-
 
 import os
 import httplib
@@ -145,9 +144,9 @@ def get_filename(version_idx, file_version, file_record):
     :param FileRecord file_record: Root file object
     """
     if version_idx == len(file_record.versions):
-        return '/' + file_record.name
+        return file_record.name
     name, ext = os.path.splitext(file_record.name)
-    return u'/{name}-{date}{ext}'.format(
+    return u'{name}-{date}{ext}'.format(
         name=name,
         date=file_version.date_created.isoformat(),
         ext=ext,
@@ -192,8 +191,16 @@ def get_waterbutler_url(user, *path, **query):
 
 def get_waterbutler_download_url(version_idx, file_version, file_record, user=None, **query):
     nid = file_record.node._id
-    path = get_filename(version_idx, file_version, file_record)
-    return get_waterbutler_url(user, 'file', nid=nid, path=path, **query)
+    display_name = get_filename(version_idx, file_version, file_record)
+    return get_waterbutler_url(
+        user,
+        'file',
+        nid=nid,
+        path='/' + file_record.name,
+        displayName=display_name,
+        version=version_idx,
+        **query
+    )
 
 
 def get_waterbutler_upload_url(user, node, path, **query):
@@ -222,7 +229,12 @@ def render_file(version_idx, file_version, file_record):
     node_settings = file_obj.node.get_addon('osfstorage')
     rendered = get_cache_content(node_settings, cache_file_name)
     if rendered is None:
-        download_url = get_waterbutler_download_url(version_idx, file_version, file_record, mode='render')
+        download_url = get_waterbutler_download_url(
+            version_idx,
+            file_version,
+            file_record,
+            mode='render',
+        )
         file_response = requests.get(download_url)
         rendered = get_cache_content(
             node_settings,

--- a/website/addons/osfstorage/views.py
+++ b/website/addons/osfstorage/views.py
@@ -54,7 +54,7 @@ def osf_storage_download_file_hook(node_addon, payload, **kwargs):
     except KeyError:
         raise HTTPError(httplib.BAD_REQUEST)
 
-    version_idx, version, record = get_version(path, node_addon, request.args.get('version'))
+    version_idx, version, record = get_version(path, node_addon, payload.get('version'))
 
     if payload.get('mode') != 'render':
         update_analytics(node_addon.owner, path, version_idx)


### PR DESCRIPTION
Fixes https://trello.com/c/QqViXlNJ/228-unable-to-download-previous-versions-of-files.