### PR TITLE
Remove markup escaping from osfstorage

### DIFF
--- a/website/addons/osfstorage/requirements.txt
+++ b/website/addons/osfstorage/requirements.txt
@@ -1,1 +1,0 @@
-MarkupSafe==0.23

--- a/website/addons/osfstorage/tests/test_utils.py
+++ b/website/addons/osfstorage/tests/test_utils.py
@@ -5,8 +5,6 @@ from nose.tools import *  # noqa
 
 from tests.factories import AuthUserFactory
 
-import markupsafe
-
 from framework import sessions
 from framework.flask import request
 
@@ -48,11 +46,11 @@ class TestHGridUtils(StorageTestCase):
         )
         assert_equal(
             serialized['path'],
-            markupsafe.escape('kind/of/<strong>magic.mp3'),
+            'kind/of/<strong>magic.mp3',
         )
         assert_equal(
             serialized['name'],
-            markupsafe.escape('<strong>magic.mp3'),
+            '<strong>magic.mp3',
         )
         assert_equal(serialized['ext'], '.mp3')
         assert_equal(serialized['kind'], 'file')

--- a/website/addons/osfstorage/tests/test_views.py
+++ b/website/addons/osfstorage/tests/test_views.py
@@ -15,7 +15,6 @@ from website.addons.osfstorage.tests import factories
 import urlparse
 
 import furl
-import markupsafe
 
 from framework.auth import signing
 from website import settings
@@ -262,7 +261,7 @@ class TestViewFile(StorageTestCase):
         record.versions.append(version)
         record.save()
         res = self.view_file(path).follow(auth=self.project.creator.auth)
-        assert markupsafe.escape(record.name) in res
+        assert record.name in res
 
 
 class TestGetRevisions(StorageTestCase):

--- a/website/addons/osfstorage/utils.py
+++ b/website/addons/osfstorage/utils.py
@@ -7,7 +7,6 @@ import logging
 
 import furl
 import requests
-import markupsafe
 import itsdangerous
 from modularodm import Q
 from flask import request
@@ -57,8 +56,8 @@ def serialize_metadata_hgrid(item, node):
     """
     return {
         # Must escape names rendered by HGrid
-        'path': markupsafe.escape(item.path),
-        'name': markupsafe.escape(item.name),
+        'path': item.path,
+        'name': item.name,
         'ext': item.extension,
         rubeus.KIND: get_item_kind(item),
         'nodeUrl': node.url,


### PR DESCRIPTION
Fixes https://trello.com/c/O0ECROCL/215-delete-fail-when-trying-to-delete-rtf-file-with-non-ascii-character-in-title.

Osfstorage was escaping file names when returning metadata but as we use mithril this is no longer an issue.