### PR TITLE
Fixes/po folder toggle bug

### DIFF
--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -1099,7 +1099,14 @@ function dropLogic(event, items, folder) {
                                     tb.updateFolder(null, itemParent);
                                     tb.updateFolder(null, folder);
                                 } else {
-                                    tb.updateFolder(null, outerFolder);
+                                    // if item is closed folder save expand state to be open
+                                    if(!folder.data.expand){
+                                        saveExpandState(folder.data, function(){
+                                            tb.updateFolder(null, outerFolder);
+                                        });
+                                    } else {
+                                        tb.updateFolder(null, outerFolder);
+                                    }
                                 }
                             } else {
                                 tb.updateFolder(null, folder);

--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -166,6 +166,7 @@ function saveExpandState(item, callback) {
         collapseUrl = item.apiURL + 'collapse/';
         postAction = $osf.postJSON(collapseUrl, {});
         postAction.done(function () {
+            item.expand = false;
             if (typeof callback !== 'undefined') {
                 callback();
             }
@@ -175,6 +176,7 @@ function saveExpandState(item, callback) {
         expandUrl = item.apiURL + 'expand/';
         postAction = $osf.postJSON(expandUrl, {});
         postAction.done(function () {
+            item.expand = false;
             if (typeof callback !== 'undefined') {
                 callback();
             }


### PR DESCRIPTION
## Purpose 

Fixes the folder toggle in Project organizer when a item is moved into a folder within the same parent the folder does not update view to open. 
Trello card: https://trello.com/c/moxiuUdO

## Changes
Two changes were made
- One corrected that the view should update if the expand state if false.
- The other fixed a related issue where toggling folder was not updating the expand state locally (while every other expand state save was doing that).

## Side effects

These issues related to moving of folders and toggling. They shouldn't affect anything (I checked several move scenarios) but if an error comes up it will be in that area. 
