### PR TITLE
hotfix/Fixes forks contribution count

### DIFF
--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -951,6 +951,11 @@ def get_summary(**kwargs):
     auth = kwargs['auth']
     node = kwargs['node'] or kwargs['project']
     rescale_ratio = kwargs.get('rescale_ratio')
+    if rescale_ratio is None and request.args.get('rescale_ratio'):
+        try:
+            rescale_ratio = float(request.args.get('rescale_ratio'))
+        except (TypeError, ValueError):
+            raise HTTPError(http.BAD_REQUEST)
     primary = kwargs.get('primary')
     link_id = kwargs.get('link_id')
 
@@ -988,20 +993,20 @@ def get_folder_pointers(**kwargs):
 
 
 @must_be_contributor_or_public
-def get_forks(**kwargs):
+def get_forks(auth, **kwargs):
     node_to_use = kwargs['node'] or kwargs['project']
     forks = node_to_use.node__forked.find(
         Q('is_deleted', 'eq', False) &
         Q('is_registration', 'eq', False)
     )
-    return _render_nodes(forks)
+    return _render_nodes(forks, auth)
 
 
 @must_be_contributor_or_public
-def get_registrations(**kwargs):
+def get_registrations(auth, **kwargs):
     node_to_use = kwargs['node'] or kwargs['project']
     registrations = node_to_use.node__registrations
-    return _render_nodes(registrations)
+    return _render_nodes(registrations, auth)
 
 
 @must_be_valid_project  # returns project


### PR DESCRIPTION
Closes #1478 

**Problem**
Registration widget shows None Contributions: 
![nonecontribs](https://cloud.githubusercontent.com/assets/5975444/5723523/9995e53e-9b12-11e4-9519-c4d2e61e6b69.png)
despite there being contributions listed on the project overview page
![somelogs](https://cloud.githubusercontent.com/assets/5975444/5723536/b416e606-9b12-11e4-9069-969025f03b92.png)

**Cause**
The nodes are not rendered correctly in the function "get_registrations" and "get_forks." The "user" argument is not passed in.

**Solution**
Gets "auth" from keyword arguments in "get_registrations" and "get_forks" and pass into _render_nodes

**Side effects**
Not that I can think of