### PR TITLE
Fix dataverse widget on project dashboard

### DIFF
--- a/website/addons/dataverse/templates/dataverse_widget.mako
+++ b/website/addons/dataverse/templates/dataverse_widget.mako
@@ -1,8 +1,5 @@
 % if complete:
-
-    <h3 class="addon-widget-header">
-        Dataverse
-    </h3>
+<%inherit file="project/addon/widget.mako"/>
 
     <div id="dataverseScope" class="scripted">
 

--- a/website/templates/project/addon/config_error.mako
+++ b/website/templates/project/addon/config_error.mako
@@ -1,4 +1,4 @@
-<div class='addon-config-error'>
+<div class='addon-config-error p-sm'>
     ${full_name} add-on is not configured properly.
     ## Only show settings links if contributor
     % if user['is_contributor']:


### PR DESCRIPTION
## Purpose
Fixes the dataverse widget on the project organizer page. Discussed in this Trello card: https://trello.com/c/SKz0Otpi

## Changes
- Added the widget mako generic template to the top to apply to dataverse
- Removed unnecessary h3 header 
- Added padding around error message

## Side effects
Specific to dataverse and does not seem to have any other side effects. Check in Chrome, Firefox, Safari 