### PR TITLE
Break long file names on file view

### DIFF
--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -2077,3 +2077,6 @@ span#profileFullname{
     font-size: 18px;
     color: #555;
 }
+.break-word {
+    word-wrap: break-word;
+}

--- a/website/templates/project/addon/view_file.mako
+++ b/website/templates/project/addon/view_file.mako
@@ -2,7 +2,7 @@
 <%def name="title()">${file_name}</%def>
 
     <div>
-        <h2>
+        <h2 class="break-word">
             ${file_name | h}
             % if file_revision:
                 <small>&nbsp;${file_revision | h}</small>


### PR DESCRIPTION
## Purpose

Adds breaking word when file name is too long on file view page. 
Trello card: https://trello.com/c/TUJXjBdb

## Changes
Added the break work style to the header

## Side effects
CSS scope might be an issue if the exact class name 'break-word' is being used elsewhere. I did an OSF wide search, did not find it defined anywhere else. 
