### PR TITLE
Fix project organizer items dropping to smart folders and causing growl

### DIFF
--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -1043,7 +1043,7 @@ function dropLogic(event, items, folder) {
         itemParent,
         itemParentNodeID,
         getAction;
-    if (typeof folder !== 'undefined' && folder !== null && folder.data.isFolder) {
+    if (typeof folder !== 'undefined' && !folder.data.isSmartFolder && folder !== null && folder.data.isFolder) {
         theFolderNodeID = folder.data.node_id;
         getChildrenURL = folder.data.apiURL + 'get_folder_pointers/';
         sampleItem = items[0];


### PR DESCRIPTION
## Purpose
Smartfolders in Project organizer should not accept any drops 
Fixes trello card: https://trello.com/c/QTlitNLR

## Changes
Add the check for whether a drop target is smartfolder to droplogic

## Side effects
Since only smartfolders are going to be affected by this change it should not have any side effects. 