### PR TITLE
Fixes/po switch on column resizing

### DIFF
--- a/website/assets.py
+++ b/website/assets.py
@@ -17,6 +17,8 @@ css = Bundle(
         'vendor/bower_components/x-editable/dist/bootstrap3-editable/css/bootstrap-editable.css',
         'vendor/bower_components/treebeard/dist/treebeard.css',
         'vendor/bower_components/bootstrap/dist/css/bootstrap-theme.css',
+        'vendor/bower_components/jquery-ui/themes/base/minified/jquery.ui.resizable.min.css',
+
         filters='cssmin'),
     # Site-specific CSS
     Bundle(

--- a/website/templates/project/files.mako
+++ b/website/templates/project/files.mako
@@ -1,6 +1,5 @@
 <%inherit file="project/project_base.mako"/>
 <%def name="title()">${node['title']} Files</%def>
-<link rel="stylesheet" href="/static/vendor/bower_components/jquery-ui/themes/base/minified/jquery.ui.resizable.min.css">
 
 <div class="page-header  visible-xs">
   <h2 class="text-300">Files</h2>


### PR DESCRIPTION
## Purpose 
Turn on column resizing for Project organizer
Trello card: https://trello.com/c/EGbWOH29

## Changes
Add jquery ui theme css so that the handle can be visible. The resizing itself was turned on before. 
The real changes are in Treebeard, will need a treebeard update.

## Side effects
There is a known issue in Firefox and Safari only and only in files page which drags down the resizing column title down a bit and restores it when dragging is complete. This is related to padding and box-sizing in these browser. Needs some work to find out. I'll add to this commit when that's fixed. 