### PR TITLE
Fixes/po regression fixes

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -124,7 +124,7 @@ function _fangornResolveToggle(item) {
     var toggleMinus = m('i.icon-minus', ' '),
         togglePlus = m('i.icon-plus', ' ');
     // check if folder has children whether it's lazyloaded or not.
-    if (item.kind === 'folder') {
+    if (item.kind === 'folder' && item.depth > 1) {
         if(!item.data.permissions.view){
             return '';
         }
@@ -864,6 +864,8 @@ tbOptions = {
     },
     onscrollcomplete : function(){
         $('[data-toggle="tooltip"]').tooltip();
+    },
+    onselectrow : function(row) {
     },
     filterPlaceholder : 'Search',
     onmouseoverrow : _fangornMouseOverRow,

--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -675,7 +675,7 @@ function _poResolveToggle(item) {
     var toggleMinus = m('i.icon-minus'),
         togglePlus = m('i.icon-plus'),
         childrenCount = item.data.childrenCount || item.children.length;
-    if (item.kind === 'folder' && childrenCount > 0) {
+    if (item.kind === 'folder' && childrenCount > 0 && item.depth > 1) {
         if (item.open) {
             return toggleMinus;
         }


### PR DESCRIPTION
## Purpose
Fix the project organizer toggle so that dashboard toggle does not show and hence does not toggle dashboard, and the project files page. 
Trello card: https://trello.com/c/NpZ5da7d

## Changes
Add a check in toggle resolve to only show it above the root folder

## Side effects
None, these files apply to their respective locations and the depth is quite well set. 