### PR TITLE
Fix figshare action buttons checking for permissions to show delete

### DIFF
--- a/website/addons/figshare/static/figshareFangornConfig.js
+++ b/website/addons/figshare/static/figshareFangornConfig.js
@@ -30,7 +30,7 @@ function _fangornActionColumn (item, col) {
         });
     }
 
-    if (item.kind === 'file' && item.data.extra && item.data.extra.status !== 'public') {
+    if (item.kind === 'file' && item.data.extra && item.data.extra.status !== 'public' && item.data.permissions.edit) {
         buttons.push({
             'name' : '',
             'icon' : 'icon-remove',


### PR DESCRIPTION
## Purpose
Adds permissions check to show/hide delete button when user is logged out. 
Trello card: https://trello.com/c/H69pGl31

## Changes
figshare fangorn Checks if user has edit permissions when deciding to show delete button

## Side effects
None. 