### PR TITLE
Fixes multiselect hover class clearing when drag starts in PO

### DIFF
--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -895,7 +895,7 @@ function _poOver(event, ui) {
     var items = this.multiselected.length === 0 ? [this.find(this.selected)] : this.multiselected,
         folder = this.find($(event.target).attr('data-id')),
         dragState = dragLogic.call(this, event, items, ui);
-    $('.tb-row').removeClass('tb-h-success po-hover po-hover-multiselect');
+    $('.tb-row').removeClass('tb-h-success po-hover');
     if (dragState !== 'forbidden') {
         $('.tb-row[data-id="' + folder.id + '"]').addClass('tb-h-success');
     } else {


### PR DESCRIPTION
## Purpose
Fixes this Trello card: https://trello.com/c/pe7OS5Ty; where starting drag clears multiselect hover class so the user doesn't know they are still selected. 

## Changes
Remove code that removes multiselect hover class

## Side effects
None. Tested in Chrome, Safari, Firefox, IE 11
