### PR TITLE
Fixes/navbar overlap xs fixes

### DIFF
--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -1947,12 +1947,16 @@ span#profileFullname{
         overflow: hidden;
     }
     .osf-search {
-        margin-top: 195px;
-        z-index: 1033;
+        margin-top: -30px;
+        z-index: 1028;
     }
     #searchControls > .osf-search {
         margin-top: -30px;
         z-index: 99;
+    }
+    .osf-xs-search {
+        text-decoration: none !important;
+        padding: 8px;
     }
 }
 

--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -1973,7 +1973,7 @@ span#profileFullname{
     }
     .osf-search {
         margin-top: -30px;
-        z-index: 1033; 
+        z-index: 1028; /* should be less than 1030 to not cover navbar */
     }
     #searchControls > .osf-search {
         margin-top: -30px;

--- a/website/templates/nav.mako
+++ b/website/templates/nav.mako
@@ -8,6 +8,13 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
+            <!-- ko ifnot: onSearchPage -->
+            <span class="visible-xs" data-bind="click : toggleSearch, css: searchCSS">
+                <a class="osf-xs-search pull-right" >
+                    <span rel="tooltip" data-placement="bottom" title="Search OSF" class="icon-search icon-lg" ></span>
+                </a>
+            </span>
+            <!-- /ko -->
             <a class="navbar-brand visible-lg" href="/"><img src="/static/img/cos-white2.png" class="osf-navbar-logo" width="27" alt="COS logo"/> Open Science Framework <span class="brand-version"> BETA</span></a>
             <a class="navbar-brand hidden-lg hidden-xs" href="/"><img src="/static/img/cos-white2.png" class="osf-navbar-logo" width="27" alt="COS logo"/> OSF</a>
             <a class="navbar-brand visible-xs" href="/"><img src="/static/img/cos-white2.png" class="osf-navbar-logo" width="27" alt="COS logo"/> Open Science Framework</a>
@@ -39,7 +46,7 @@
             </ul><!-- end nav navbar-nav -->
             <ul class="nav navbar-nav navbar-right">
                 <!-- ko ifnot: onSearchPage -->
-                <li data-bind="click : toggleSearch, css: searchCSS">
+                <li class="hidden-xs" data-bind="click : toggleSearch, css: searchCSS">
                     <a class="" >
                         <span rel="tooltip" data-placement="bottom" title="Search OSF" class="icon-search icon-lg" ></span>
                     </a>


### PR DESCRIPTION
## Purpose
Improve search bar overlay views in search page and navbar XS mode
Fixes Trello card: https://trello.com/c/xe91Vh9A

## Changes
- fix z-index for search page so that the search bar does not cover up the navigation
- Add the above fix to al instances of search bar as well
- Fix XS mode so that there is a search icon at the top, insteaf of within the list of items 

## Side effects
The z-index change may cause other overlap issues but this is not very likely. Search bar is designed to overlap so users may see it covering up other things, much of this behvior is normal and should not be a problem in regulr use. 