### PR TITLE
Fix resetting of original row for multiselect

### DIFF
--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -841,7 +841,7 @@ function filterRowsNotInParent(rows) {
         return this.multiselected;
     }
     var i, newRows = [],
-        originalRow = this.find(this.selected),
+        originalRow = this.find(this.multiselected[0].id),
         originalParent,
         currentItem;
     if (typeof originalRow !== "undefined") {


### PR DESCRIPTION
## Purpose
Fixes the problem where multiselect original row was reset during shift selects. Originalrow is important for selecting multiple rows using shift key. 
Trello card:  https://trello.com/c/kWRti0nr

## Changes
Projectorganizer.js was using treebeard.selected for the purpose of originalrow which is a problem because selected gets updated on every click on the row. Returned that value to be the first item in multiselect. 

## Side effects
This only runs if multiselect has more than 1 item so there will always be a multiselected[0] in this scenario. Should not have any side effects. 
