### PR TITLE
Break long file name titles in the delete modal in files page

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -472,7 +472,7 @@ function _removeEvent (event, item, col) {
 
     if (item.data.permissions.edit) {
         var mithrilContent = m('div', [
-                m('h3', 'Delete "' + item.data.name+ '"?'),
+                m('h3.break-word', 'Delete "' + item.data.name+ '"?'),
                 m('p', 'This action is irreversible.')
             ]);
         var mithrilButtons = m('div', [


### PR DESCRIPTION
## Purpose
Long filenames need to break in the modal for deleting files.

## Changes
Added break class to the title

## Side effects
Added only to the header and the only css added applies to breaking the word so no side effects. Tested in Chrome, Safari, Firefox. this css property is compatible down to IE 5.5 