### PR TITLE
hotfix/Fire Mailchimp Celery tasks after request.

### DIFF
--- a/tests/test_mailchimp.py
+++ b/tests/test_mailchimp.py
@@ -1,7 +1,9 @@
+# -*- coding: utf-8 -*-
+
 import mock
 from website import mailchimp_utils
 from tests.base import OsfTestCase
-from nose.tools import *  # PEP8 asserts
+from nose.tools import *  # noqa; PEP8 asserts
 from tests.factories import UserFactory
 import mailchimp
 
@@ -36,13 +38,17 @@ class TestMailChimpHelpers(OsfTestCase):
         mock_get_mailchimp_api.return_value = mock_client
         mock_client.lists.list.return_value = {'data': [{'id': 1, 'list_name': list_name}]}
         list_id = mailchimp_utils.get_list_id_from_name(list_name)
-        mailchimp_utils.subscribe(list_name, user)
-        mock_client.lists.subscribe.assert_called_with(id=list_id,
-                                                       email={'email': user.username},
-                                                       merge_vars={'fname': user.given_name,
-                                                                   'lname': user.family_name},
-                                                       double_optin=False,
-                                                       update_existing=True)
+        mailchimp_utils.subscribe_mailchimp(list_name, user)
+        mock_client.lists.subscribe.assert_called_with(
+            id=list_id,
+            email={'email': user.username},
+            merge_vars={
+                'fname': user.given_name,
+                'lname': user.family_name,
+            },
+            double_optin=False,
+            update_existing=True,
+        )
 
     @mock.patch('website.mailchimp_utils.get_mailchimp_api')
     def test_subscribe_fake_email_does_not_throw_validation_error(self, mock_get_mailchimp_api):
@@ -52,7 +58,7 @@ class TestMailChimpHelpers(OsfTestCase):
         mock_get_mailchimp_api.return_value = mock_client
         mock_client.lists.list.return_value = {'data': [{'id': 1, 'list_name': list_name}]}
         mock_client.lists.subscribe.side_effect = mailchimp.ValidationError
-        mailchimp_utils.subscribe(list_name, user)
+        mailchimp_utils.subscribe_mailchimp(list_name, user)
         assert_false(user.mailing_lists[list_name])
 
     @mock.patch('website.mailchimp_utils.get_mailchimp_api')
@@ -63,5 +69,5 @@ class TestMailChimpHelpers(OsfTestCase):
         mock_get_mailchimp_api.return_value = mock_client
         mock_client.lists.list.return_value = {'data': [{'id': 2, 'list_name': list_name}]}
         list_id = mailchimp_utils.get_list_id_from_name(list_name)
-        mailchimp_utils.unsubscribe(list_name, user)
+        mailchimp_utils.unsubscribe_mailchimp(list_name, user)
         mock_client.lists.unsubscribe.assert_called_with(id=list_id, email={'email': user.username})


### PR DESCRIPTION
# Purpose 
Fixes race condition on user confirmation in which Celery task can overwrite a user record with stale data.

# Changes
* Add general `queued_task` decorator for Celery tasks to be used in a request context
* Wrap Mailchimp tasks with `queued_task`
* Fix tests

# Side effects
None expected