### PR TITLE
Hotfix/mailchimp race condition

### DIFF
--- a/framework/analytics/tasks.py
+++ b/framework/analytics/tasks.py
@@ -2,19 +2,19 @@
 
 from framework.tasks import app
 from framework.tasks.handlers import queued_task
+from framework.transactions.context import transaction
 
 from . import piwik
 
 
 @queued_task
 @app.task(bind=True, max_retries=5, default_retry_delay=60)
+@transaction()
 def update_node(self, node_id, updated_fields=None):
     # Avoid circular imports
-    from framework.transactions.context import TokuTransaction
     from website import models
     node = models.Node.load(node_id)
     try:
-        with TokuTransaction():
-            piwik._update_node_object(node, updated_fields)
+        piwik._update_node_object(node, updated_fields)
     except Exception as error:
         raise self.retry(exc=error)

--- a/framework/tasks/handlers.py
+++ b/framework/tasks/handlers.py
@@ -4,7 +4,7 @@ import logging
 import functools
 
 from flask import g
-from celery import group
+from celery import chain
 
 from website import settings
 
@@ -22,7 +22,7 @@ def celery_teardown_request(error=None):
     try:
         tasks = g._celery_tasks
         if tasks:
-            group(*tasks)()
+            chain(*tasks)()
     except AttributeError:
         if not settings.DEBUG_MODE:
             logger.error('Task queue not initialized')
@@ -49,7 +49,7 @@ def queued_task(task):
     @functools.wraps(task)
     def wrapped(*args, **kwargs):
         if settings.USE_CELERY:
-            signature = task.s(*args, **kwargs)
+            signature = task.si(*args, **kwargs)
             enqueue_task(signature)
         else:
             task(*args, **kwargs)


### PR DESCRIPTION
# Purpose
Update previous hotfix with a few niceties to prevent trouble later on.

# Changes
* Run post-request Celery tasks in series rather than in parallel to avoid potential race conditions
* Wrap post-request Celery tasks in TokuMX transactions

# Side effects
None expected