### PR TITLE
Correctly apply "scripted" class to log list.

### DIFF
--- a/website/templates/log_list.mako
+++ b/website/templates/log_list.mako
@@ -1,3 +1,5 @@
+<%page args="scripted" />
+
 ### Included where the LogsViewModel is used ###
 <div id="logProgressBar" class="progress progress-striped active">
     <div class="progress-bar"  role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="width: 100%">

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -234,7 +234,7 @@
         %endif
 
 
-        <%include file="log_list.mako"/>
+        <%include file="log_list.mako" args="scripted=True" />
 
     </div>
 


### PR DESCRIPTION
# Purpose
Hide potentially misleading placeholders (e.g. "A user could not render log") while project log list is loading

# Change
* Pass `scripted` argument to `log_list.mako`
* Use `%page` tag to read `scripted` argument

# Side effects
None expected