### PR TITLE
Hotfix/Make lines at top of dashboard consistent

### DIFF
--- a/website/static/css/onboarding.css
+++ b/website/static/css/onboarding.css
@@ -104,10 +104,13 @@ ul.ob-widget-list {
 }
 
 .ob-tab-head {
-    padding-bottom: 9px;
-    margin: 20px 0 16px;
+    padding-bottom: 5px;
+    margin: 25px 0 5px;
 }
 
+ul.nav.nav-tabs {
+    border-bottom:1px solid #eee
+}
 
 div.ob-dropzone-filename{
 	margin-top:10px;


### PR DESCRIPTION
Purpose
-----------
There were minor inconsistencies in the dashboard page. This corrects those.

Changes
------------
Align the Project Organizer HR with the onboarder's tab border bottom and make them the same color. 

![screen shot 2015-02-02 at 12 38 45 pm](https://cloud.githubusercontent.com/assets/6599111/6005643/edbb2076-aad9-11e4-9819-4bb837c3102d.png)

Side effects
----------------
Shouldn't be any, unless someone loads the onboarder CSS onto a page that they don't want the tab bar to be lighter on. 


Fixes #1683 