### PR TITLE
[Hotfix] Fixes #1598 Sorting depth not to include major folders in files page

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
     "x-editable": "~1.5.1",
     "slickgrid": "~2.1.0",
     "dropzone": "https://github.com/sloria/dropzone.git#accept-directory",
-    "treebeard": "https://github.com/caneruguz/treebeard.git#46cec1fedf806c85a25172ef0205d3405152b2a4",
+    "treebeard": "https://github.com/caneruguz/treebeard.git#f331389796e2c2cdb2623a30ac46b97b3cebd015",
     "jquery.cookie": "~1.4.1",
     "hgrid": "~0.2.10",
     "uri.js": "~1.14.1",

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -560,7 +560,10 @@ function _fangornLazyLoadOnLoad (tree) {
     });
     resolveconfigOption.call(this, tree, 'lazyLoadOnLoad', [tree]);
     $('[data-toggle="tooltip"]').tooltip();
-    _fangornOrderFolder.call(this, tree);
+
+    if (tree.depth > 1) {
+        _fangornOrderFolder.call(this, tree);
+    }
 }
 
 /**
@@ -571,10 +574,8 @@ function _fangornLazyLoadOnLoad (tree) {
  */
 function _fangornOrderFolder(tree) {
     var sortDirection = this.isSorted[0].desc ? 'desc' : 'asc';
-    if (tree.depth > 1) {
-        tree.sortChildren(this, sortDirection, 'text', 0);
-        this.redraw();
-    }
+    tree.sortChildren(this, sortDirection, 'text', 0);
+    this.redraw();
 }
 
 /**
@@ -900,6 +901,7 @@ tbOptions = {
     },
     filterPlaceholder : 'Search',
     onmouseoverrow : _fangornMouseOverRow,
+    sortDepth : 2,
     dropzone : {                                           // All dropzone options.
         url: function(files) {return files[0].url;},
         clickable : '#treeGrid',


### PR DESCRIPTION
## Purpose 
Fixes #1598 and uses the new treebeard option to add depth to sorting. 

## Changes
Major changes are in Treebeard. **needs a treebeard update** new commit SHA is in the bower.json file. Adds sorting depth level so folders below that level (parents) will not be sorted.

## Side effects
Default sort level is 0, so if it's not defined it will not harm the behavior of other sort instances. This treebeard update will bring the production to this commit including previous commits. No foreseable effect though. 