### PR TITLE
[Hotfix] #1696 add links modal

### DIFF
--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -2100,3 +2100,6 @@ span#profileFullname{
 .break-word {
     word-wrap: break-word;
 }
+.modal-backdrop {
+    position: fixed;
+}


### PR DESCRIPTION
## Purpose 

Fixes #1696 temporarily until bootstrap fixes come later. 

## Changes
Added fixed positioning to modal-backdrop

## Side effects
Should not be any, but we need to revisit if Bootstrap updates happen. Tested with Firefox, Chrome, Safari and IE 10 in Win 7. 