### PR TITLE
Fix jittering in Treebeard with on scroll

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,7 +24,7 @@
     "x-editable": "~1.5.1",
     "slickgrid": "~2.1.0",
     "dropzone": "https://github.com/sloria/dropzone.git#accept-directory",
-    "treebeard": "https://github.com/caneruguz/treebeard.git#46cec1fedf806c85a25172ef0205d3405152b2a4",
+    "treebeard": "https://github.com/caneruguz/treebeard.git#41203cefc41f88f5ced1af8a52f5ca646d91cd9c",
     "jquery.cookie": "~1.4.1",
     "hgrid": "~0.2.10",
     "uri.js": "~1.14.1",


### PR DESCRIPTION
## Purpose
Fixes the issue #1661 . Scrolling by dragging the scrollbar with mouse should not cause jitters

## Changes
Replaces the commit sha reference for treebeard in bower.json so the treebeard changes can be installed. 

## Side effects
Does not effect scrolling otherwise. Tested in Chrome, Safari, Firefox and IE 11.  Safari has still a tiny jitter but that should not hold up the fix. 