### PR TITLE
Fix long file names not breaking in Activity log dashboard page

### DIFF
--- a/website/templates/log_list.mako
+++ b/website/templates/log_list.mako
@@ -35,7 +35,7 @@
 
                 <dl class="dl-horizontal activity-log" data-bind="foreach: {data: logs, as: 'log'}">
                     <dt><span class="date log-date" data-bind="text: log.date.local, tooltip: {title: log.date.utc}"></span></dt>
-                    <dd class="log-content">
+                    <dd class="log-content break-word">
 
                         <!-- ko if: log.hasTemplate() -->
                         <span data-bind="if:log.anonymous">


### PR DESCRIPTION
## Purpose
Fixes issue #1676 

## Changes
Adds css class to break words

## Side effects
Shouldn't be any, I can't imagine a scenario where the word break should not be requested. Tested in IE 10 in Win 7 so future versions of IE should work, also tested in Chrome, Safari and Firefox for regression. 