### PR TITLE
Use short version of OSF in navigation for mobile devices

### DIFF
--- a/website/templates/nav.mako
+++ b/website/templates/nav.mako
@@ -16,8 +16,7 @@
             </span>
             <!-- /ko -->
             <a class="navbar-brand visible-lg" href="/"><img src="/static/img/cos-white2.png" class="osf-navbar-logo" width="27" alt="COS logo"/> Open Science Framework <span class="brand-version"> BETA</span></a>
-            <a class="navbar-brand hidden-lg hidden-xs" href="/"><img src="/static/img/cos-white2.png" class="osf-navbar-logo" width="27" alt="COS logo"/> OSF</a>
-            <a class="navbar-brand visible-xs" href="/"><img src="/static/img/cos-white2.png" class="osf-navbar-logo" width="27" alt="COS logo"/> Open Science Framework</a>
+            <a class="navbar-brand hidden-lg" href="/"><img src="/static/img/cos-white2.png" class="osf-navbar-logo" width="27" alt="COS logo"/> OSF</a>
 
         </div><!-- end navbar-header -->
         <div class="collapse navbar-collapse navbar-ex1-collapse">


### PR DESCRIPTION
## Purpose
Fixes #1649 and other issues caused by long OSF name in navigation bar. 

## Changes
Use the short version of OSF in all widths smaller than large

## Side Effects
None. 