### PR TITLE
Fix 1682, project name column uses more of the available width

### DIFF
--- a/website/templates/projectGridTemplates.html
+++ b/website/templates/projectGridTemplates.html
@@ -19,20 +19,21 @@
                     </form>
                 </span>
             </div>
-            <div class="col-sm-4">
-                <span class = "title">
-                    <span class = "name-container" id="nc-{{theItem.node_id}}">
-                          {{#if theItem.isFolder}}{{{ theItem.name }}}{{/if}}
-                          {{#unless theItem.isFolder}}<a href="{{ theItem.urls.fetch }}">{{{ theItem.name }}}</a>{{#if theItem.isRegistration}} (Registration){{/if}}
-                          {{/unless}}
-                          {{#unless theItem.isDashboard}}{{#unless theItem.isRegistration}}{{#if theItem.permissions.edit}}
-                              <button id="rename-node-{{theItem.node_id}}" class="editableControl dker btn btn-xs">
-                                <i class="icon icon-pencil" style="font-size: 11px;"></i> Edit</button>
-                          {{/if}}{{/unless}}{{/unless}}
-                    </span>
-
-                </span>
-            </div>
+            {{#if theItem.isFolder}}
+                        <div class="col-sm-4">
+                            <span class = "title">
+                                <span class = "name-container" id="nc-{{theItem.node_id}}">
+                                      {{#if theItem.isFolder}}{{{ theItem.name }}}{{/if}}
+                                      {{#unless theItem.isFolder}}<a href="{{ theItem.urls.fetch }}">{{{ theItem.name }}}</a>{{#if theItem.isRegistration}} (Registration){{/if}}
+                                      {{/unless}}
+                                      {{#unless theItem.isDashboard}}{{#unless theItem.isRegistration}}{{#if theItem.permissions.edit}}
+                                          <button id="rename-node-{{theItem.node_id}}" class="editableControl dker btn btn-xs">
+                                            <i class="icon icon-pencil" style="font-size: 11px;"></i> Edit</button>
+                                      {{/if}}{{/unless}}{{/unless}}
+                                </span>
+                            </span>
+                        </div>
+            {{/if}}
             <div class="col-sm-8">
                 {{#if theItem.isFolder}}
                     <div class = "organize-project-controls pull-right">
@@ -77,19 +78,36 @@
                         </div>
                     </div>
                 {{/if}}
-                {{#unless theItem.isFolder}}
-                    {{#if theItem.parentIsFolder}}
-                        {{#unless parentIsSmartFolder}}
-                            <div class = "organize-project-controls pull-right">
-                                <div id = "buttons{{theItem.node_id}}">
-                                    <div class="orgnaize-btn btn btn-sm btn-default" id="remove-link-{{theItem.node_id}}">Remove from folder</div>
-                                </div>
-                            </div>
-                        {{/unless}}
-                    {{/if}}
-                {{/unless}}
             </div>
         {{/if}}
+
+        {{#unless theItem.isFolder}}
+            {{#if theItem.parentIsFolder}}
+                {{#unless parentIsSmartFolder}}
+                    <div class="col-sm-8">
+                        <span class = "title">
+                            <span class = "name-container" id="nc-{{theItem.node_id}}">
+                                  {{#if theItem.isFolder}}{{{ theItem.name }}}{{/if}}
+                                  {{#unless theItem.isFolder}}<a href="{{ theItem.urls.fetch }}">{{{ theItem.name }}}</a>{{#if theItem.isRegistration}} (Registration){{/if}}
+                                  {{/unless}}
+                                  {{#unless theItem.isDashboard}}{{#unless theItem.isRegistration}}{{#if theItem.permissions.edit}}
+                                      <button id="rename-node-{{theItem.node_id}}" class="editableControl dker btn btn-xs">
+                                        <i class="icon icon-pencil" style="font-size: 11px;"></i> Edit</button>
+                                  {{/if}}{{/unless}}{{/unless}}
+                            </span>
+                        </span>
+                    </div>
+                    <div class="col-sm-4">
+                        <div class = "organize-project-controls pull-right">
+                            <div id = "buttons{{theItem.node_id}}">
+                                <div class="orgnaize-btn btn btn-sm btn-default" id="remove-link-{{theItem.node_id}}">Remove from folder</div>
+                            </div>
+                        </div>
+                    </div>
+                {{/unless}}
+            {{/if}}
+        {{/unless}}
+
 
         {{#unless theItem.parentIsFolder}}
             {{#unless theItem.isDashboard}}

--- a/website/templates/projectGridTemplates.html
+++ b/website/templates/projectGridTemplates.html
@@ -20,7 +20,7 @@
                 </span>
             </div>
             {{#if theItem.isFolder}}
-                        <div class="col-sm-4">
+                        <div class="col-md-5">
                             <span class = "title">
                                 <span class = "name-container" id="nc-{{theItem.node_id}}">
                                       {{#if theItem.isFolder}}{{{ theItem.name }}}{{/if}}
@@ -34,7 +34,7 @@
                             </span>
                         </div>
             {{/if}}
-            <div class="col-sm-8">
+            <div class="col-md-7 ">
                 {{#if theItem.isFolder}}
                     <div class = "organize-project-controls pull-right">
                         <div id = "buttons{{theItem.node_id}}">
@@ -84,7 +84,7 @@
         {{#unless theItem.isFolder}}
             {{#if theItem.parentIsFolder}}
                 {{#unless parentIsSmartFolder}}
-                    <div class="col-sm-8">
+                    <div class="col-sm-7 col-md-8">
                         <span class = "title">
                             <span class = "name-container" id="nc-{{theItem.node_id}}">
                                   {{#if theItem.isFolder}}{{{ theItem.name }}}{{/if}}
@@ -97,7 +97,7 @@
                             </span>
                         </span>
                     </div>
-                    <div class="col-sm-4">
+                    <div class="col-sm-5 col-md-4">
                         <div class = "organize-project-controls pull-right">
                             <div id = "buttons{{theItem.node_id}}">
                                 <div class="orgnaize-btn btn btn-sm btn-default" id="remove-link-{{theItem.node_id}}">Remove from folder</div>


### PR DESCRIPTION
## Purpose
Fixes #1682 , and allows the project name to be wider and use more of the available space

## Change
- The condition where an item is next to only Remove from folder button was added so that their column placement can be individually adjusted
- Further minor changes were made to improve the responsiveness 

## Side effects
- The conditions for cases can potentially be touching undesired cases but I ran through some tests to make sure all file/folder combinations show the appropriate content and width. 
- Tested in Chrome, Firefox, Safari and IE 10 in Win 7