### PR TITLE
[Hotfix] #1698 Change the link icon in Wiki page

### DIFF
--- a/website/addons/wiki/templates/toc.mako
+++ b/website/addons/wiki/templates/toc.mako
@@ -27,7 +27,7 @@
                 <li>
                     <a href="${child['url']}">
                         % if child['is_pointer']:
-                            <i class="icon-hand-right"></i>
+                            <i class="icon icon-link"></i>
                         % endif
 
                         ${child['title'] | n}


### PR DESCRIPTION
## Purpose
Fixes #1698 .

## Changes
Changes the link icon to what project main page is using

## Side effects
None