### PR TITLE
[Hotfix] #1679 - Add focus to project organizer input elements when pertinent

### DIFF
--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -374,6 +374,7 @@ function _showProjectDetails(event, item, col) {
             $('#rnc-' + theItem.node_id).hide();
             $('#findNode' + theItem.node_id).hide();
             $('#afc-' + theItem.node_id).show();
+            $('#add-folder-input' + theItem.node_id).focus();
         });
         $('#add-folder-input' + theItem.node_id).bind('keyup', function () {
             var contents = $.trim($(this).val());
@@ -411,6 +412,7 @@ function _showProjectDetails(event, item, col) {
             $('#findNode' + theItem.node_id).hide();
             $('#nc-' + theItem.node_id).hide();
             $('#rnc-' + theItem.node_id).css({'display':'inline-block', 'width' : '100%'});
+            $('#rename-node-input' + theItem.node_id).focus();
         });
         $('#rename-node-input' + theItem.node_id).bind('keyup', function () {
             var contents = $.trim($(this).val());
@@ -446,6 +448,7 @@ function _showProjectDetails(event, item, col) {
             $('#afc-' + theItem.node_id).hide();
             $('#rnc-' + theItem.node_id).hide();
             $('#findNode' + theItem.node_id).show();
+            $('#input' + theItem.node_id).focus();
         });
     } else {
         createBlankProjectDetail(theItem.name);


### PR DESCRIPTION
## Purpose
Fixes #1679 and the other two cases where the inputs didn't get immediate focus and needed one more click. 

## Changes
Adds the focus trigger to inputs when they become visible

## Side effects
None. Only applies to the inputs that are relevant and trigger focus does not leave any permanent UI changes. 