### PR TITLE
[feature] osfstorage support for direct provider downloads and default to filesytemprovider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ website/cache/*
 website/settings/uploads/*
 website/uploads/*
 website/mfrcache/*
+website/osfstoragecache/*
 website/gpg/*
 webpack-assets.json
 

--- a/website/addons/osfstorage/settings/defaults.py
+++ b/website/addons/osfstorage/settings/defaults.py
@@ -34,7 +34,7 @@ WATERBUTLER_CREDENTIALS = {
 WATERBUTLER_SETTINGS = {
     'storage': {
         'provider': 'filesystem',
-        'folder': os.path.join(os.getcwd(), 'osfstoragecache'),
+        'folder': os.path.join(settings.BASE_PATH, 'osfstoragecache'),
     }
 }
 

--- a/website/addons/osfstorage/settings/defaults.py
+++ b/website/addons/osfstorage/settings/defaults.py
@@ -1,31 +1,11 @@
 # encoding: utf-8
 
 import os
-import hashlib
 
 from website import settings
 
 
-DOMAIN = settings.DOMAIN
-UPLOAD_SERVICE_URLS = ['changeme']
-PING_TIMEOUT = 5 * 60
-
-SIGNED_REQUEST_KWARGS = {}
-
-# HMAC options
-SIGNATURE_HEADER_KEY = 'X-Signature'
-URLS_HMAC_SECRET = 'changeme'
-URLS_HMAC_DIGEST = hashlib.sha1
-WEBHOOK_HMAC_SECRET = 'changeme'
-WEBHOOK_HMAC_DIGEST = hashlib.sha1
-
 REVISIONS_PAGE_SIZE = 10
-
-# IDENTITY = {
-#     'provider': 's3',
-#     'access_key': '',
-#     'secret_key': ''
-# }
 
 WATERBUTLER_CREDENTIALS = {
     'storage': {}

--- a/website/addons/osfstorage/settings/defaults.py
+++ b/website/addons/osfstorage/settings/defaults.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 
+import os
 import hashlib
 
 from website import settings
@@ -27,14 +28,14 @@ REVISIONS_PAGE_SIZE = 10
 # }
 
 WATERBUTLER_CREDENTIALS = {
-    'username': 'changeme',
-    'token': 'changeme',
-    'region': 'changeme'
+    'storage': {}
 }
 
 WATERBUTLER_SETTINGS = {
-    'provider': 'cloudfiles',
-    'container': 'changeme',
+    'storage': {
+        'provider': 'filesystem',
+        'folder': os.path.join(os.getcwd(), 'osfstoragecache'),
+    }
 }
 
-WATERBUTLER_RESOURCE = 'container'
+WATERBUTLER_RESOURCE = 'folder'

--- a/website/addons/osfstorage/utils.py
+++ b/website/addons/osfstorage/utils.py
@@ -117,7 +117,7 @@ def patch_url(url, **kwargs):
 
 
 def ensure_domain(url):
-    return patch_url(url, host=settings.DOMAIN)
+    return patch_url(url, host=site_settings.DOMAIN)
 
 
 def build_callback_urls(node, path):


### PR DESCRIPTION
Purpose
====

Allow non-signed url's to be downloaded and rendered from osfstorage.
FileSystemProvider is now the default for WaterButler/OSF, this will allow for easier system setup on development machines.

Changes
===

When calling osfstorage's download_file check for a 301 or 302 status, if found send back the redirect location (current behavior), otherwise send the full request contents directly to the renderer or client browser.

Side effects
===

None