### PR TITLE
Add active class to Files when individual file is viewed

### DIFF
--- a/website/templates/project/addon/view_file.mako
+++ b/website/templates/project/addon/view_file.mako
@@ -45,6 +45,9 @@
         <script type="text/javascript">
             window.contextVars = window.contextVars || {};
             window.contextVars.renderURL = '${render_url}';
+            $(document).ready(function(){
+                $('.osf-project-navbar li:contains("Files")').addClass('active');
+            }); 
         </script>
         <script src=${"/static/public/js/view-file-page.js" | webpack_asset}></script>
     % endif


### PR DESCRIPTION
## Purpose
Temporarily fixes #645 . By temporary I mean it is not a system wide solution to highlighting active fields but for this purpose it works well and is reliable. I suggest we use this until a much bigger change. 

## Changes
Adds to view_file.mako some js that adds the active lcass to Files tab in Project Menu

## Side Effects
None. Limited to view_file.mako file. 