### PR TITLE
[hotfix] Fixes bug in method that checks dropbox subdirectory

### DIFF
--- a/website/addons/dropbox/tests/test_utils.py
+++ b/website/addons/dropbox/tests/test_utils.py
@@ -60,13 +60,14 @@ def test_is_subdir():
     assert_true(utils.is_subdir('foo', 'foo'))
     assert_true(utils.is_subdir('foo/bar baz', 'foo'))
     assert_true(utils.is_subdir('bar baz/foo', 'bar baz'))
-    assert_true(utils.is_subdir('foo', ''))
-    assert_true(utils.is_subdir('', ''))
+    assert_true(utils.is_subdir('foo', '/'))
+    assert_true(utils.is_subdir('/', '/'))
 
     assert_false(utils.is_subdir('foo/bar', 'baz'))
     assert_false(utils.is_subdir('foo/bar', 'bar'))
     assert_false(utils.is_subdir('foo', 'foo/bar'))
     assert_false(utils.is_subdir('', 'foo'))
+    assert_false(utils.is_subdir('foo', ''))
     assert_false(utils.is_subdir('foo', None))
     assert_false(utils.is_subdir(None, 'foo'))
     assert_false(utils.is_subdir(None, None))
@@ -91,7 +92,7 @@ def test_is_subdir():
 
 
 def test_clean_path():
-    assert_equal(utils.clean_path('/'), '')
+    assert_equal(utils.clean_path('/'), '/')
     assert_equal(utils.clean_path('/foo/bar/baz/'), 'foo/bar/baz')
     assert_equal(utils.clean_path(None), '')
 

--- a/website/addons/dropbox/tests/test_utils.py
+++ b/website/addons/dropbox/tests/test_utils.py
@@ -60,16 +60,16 @@ def test_is_subdir():
     assert_true(utils.is_subdir('foo', 'foo'))
     assert_true(utils.is_subdir('foo/bar baz', 'foo'))
     assert_true(utils.is_subdir('bar baz/foo', 'bar baz'))
+    assert_true(utils.is_subdir('foo', ''))
+    assert_true(utils.is_subdir('', ''))
 
     assert_false(utils.is_subdir('foo/bar', 'baz'))
     assert_false(utils.is_subdir('foo/bar', 'bar'))
     assert_false(utils.is_subdir('foo', 'foo/bar'))
     assert_false(utils.is_subdir('', 'foo'))
-    assert_false(utils.is_subdir('foo', ''))
     assert_false(utils.is_subdir('foo', None))
     assert_false(utils.is_subdir(None, 'foo'))
     assert_false(utils.is_subdir(None, None))
-    assert_false(utils.is_subdir('', ''))
 
     assert_true(utils.is_subdir('foo/bar', 'Foo/bar'))
     assert_true(utils.is_subdir('Foo/bar', 'foo/bar'))

--- a/website/addons/dropbox/tests/test_utils.py
+++ b/website/addons/dropbox/tests/test_utils.py
@@ -71,6 +71,7 @@ def test_is_subdir():
     assert_false(utils.is_subdir('foo', None))
     assert_false(utils.is_subdir(None, 'foo'))
     assert_false(utils.is_subdir(None, None))
+    assert_false(utils.is_subdir('', ''))
 
     assert_true(utils.is_subdir('foo/bar', 'Foo/bar'))
     assert_true(utils.is_subdir('Foo/bar', 'foo/bar'))

--- a/website/addons/dropbox/utils.py
+++ b/website/addons/dropbox/utils.py
@@ -79,8 +79,11 @@ class DropboxNodeLogger(object):
 
 
 def is_subdir(path, directory):
-    if not (path and directory):
+    if not path:
         return False
+    # directory is root directory
+    if not directory:
+        return True
     #make both absolute
     abs_directory = os.path.abspath(directory).lower()
     abs_path = os.path.abspath(path).lower()

--- a/website/addons/dropbox/utils.py
+++ b/website/addons/dropbox/utils.py
@@ -79,10 +79,10 @@ class DropboxNodeLogger(object):
 
 
 def is_subdir(path, directory):
-    if path is None or directory is None:
+    if not (path and directory):
         return False
     # directory is root directory
-    if directory == '' or directory == '/':
+    if directory == '/':
         return True
     #make both absolute
     abs_directory = os.path.abspath(directory).lower()
@@ -115,6 +115,8 @@ def clean_path(path):
     """Ensure a path is formatted correctly for url_for."""
     if path is None:
         return ''
+    if path == '/':
+        return path
     return path.strip('/')
 
 

--- a/website/addons/dropbox/utils.py
+++ b/website/addons/dropbox/utils.py
@@ -79,13 +79,11 @@ class DropboxNodeLogger(object):
 
 
 def is_subdir(path, directory):
-    if not path:
+    if path is None or directory is None:
         return False
     # directory is root directory
     if directory == '' or directory == '/':
         return True
-    if not directory:
-        return False
     #make both absolute
     abs_directory = os.path.abspath(directory).lower()
     abs_path = os.path.abspath(path).lower()

--- a/website/addons/dropbox/utils.py
+++ b/website/addons/dropbox/utils.py
@@ -82,8 +82,10 @@ def is_subdir(path, directory):
     if not path:
         return False
     # directory is root directory
-    if not directory:
+    if directory == '' or directory == '/':
         return True
+    if not directory:
+        return False
     #make both absolute
     abs_directory = os.path.abspath(directory).lower()
     abs_path = os.path.abspath(path).lower()


### PR DESCRIPTION
**Problem**
If a user linked his dropbox ROOT folder to a project, his collaborators on this project could not view the dropbox files in the project. Instead, when the collaborators click the file to view details, they get "Forbidden" instead.

**Cause**
The function <code>is_subdir</code> is not handling the case where the parent directory to check is the root directory.

**Side effect**
To be added