### PR TITLE
[hold] Feature/admin views

### DIFF
--- a/tests/test_contributors_views.py
+++ b/tests/test_contributors_views.py
@@ -1,11 +1,30 @@
 # -*- coding: utf-8 -*-
 
-from nose.tools import *  # PEP8 asserts
+from nose.tools import *  # noqa; PEP8 asserts
 
 from tests.factories import ProjectFactory, NodeFactory, AuthUserFactory
 from tests.base import OsfTestCase, fake
 
 from framework.auth.decorators import Auth
+
+from website.profile import utils
+
+
+class TestContributorUtils(OsfTestCase):
+
+    def setUp(self):
+        super(TestContributorUtils, self).setUp()
+        self.project = ProjectFactory()
+
+    def test_serialize_user(self):
+        serialized = utils.serialize_user(self.project.creator, self.project)
+        assert_true(serialized['visible'])
+        assert_equal(serialized['permission'], 'admin')
+
+    def test_serialize_user_admin(self):
+        serialized = utils.serialize_user(self.project.creator, self.project, admin=True)
+        assert_false(serialized['visible'])
+        assert_equal(serialized['permission'], 'read')
 
 
 class TestContributorViews(OsfTestCase):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2762,30 +2762,26 @@ class TestRegisterNode(OsfTestCase):
             assert_not_in(node, self.project.nodes)
             assert_true(node.is_registration)
 
-    def test_partial_contributor_registration(self):
+    def test_private_contributor_registration(self):
 
         # Create some nodes
         self.component = NodeFactory(
             creator=self.user,
             project=self.project,
-            title='Not Registered',
         )
         self.subproject = ProjectFactory(
             creator=self.user,
             project=self.project,
-            title='Not Registered',
         )
 
         # Create some nodes to share
         self.shared_component = NodeFactory(
             creator=self.user,
             project=self.project,
-            title='Registered',
         )
         self.shared_subproject = ProjectFactory(
             creator=self.user,
             project=self.project,
-            title='Registered',
         )
 
         # Share the project and some nodes
@@ -2798,11 +2794,9 @@ class TestRegisterNode(OsfTestCase):
         registration = RegistrationFactory(project=self.project, user=user2)
 
         # The correct subprojects were registered
-        assert_equal(len(registration.nodes), 2)
-        assert_not_in(
-            'Not Registered',
-            [node.title for node in registration.nodes],
-        )
+        assert_equal(len(registration.nodes), len(self.project.nodes))
+        for idx in range(len(registration.nodes)):
+            assert_true(registration.nodes[idx].is_registration_of(self.project.nodes[idx]))
 
     def test_is_registration(self):
         assert_true(self.registration.is_registration)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2004,6 +2004,39 @@ class TestProject(OsfTestCase):
         other_guy_auth.private_key = link.key
         assert_true(self.project.can_view(other_guy_auth))
 
+    def test_is_admin_parent_target_admin(self):
+        assert_true(self.project.is_admin_parent(self.project.creator))
+
+    def test_is_admin_parent_parent_admin(self):
+        user = UserFactory()
+        node = NodeFactory(project=self.project, creator=user)
+        assert_true(node.is_admin_parent(self.project.creator))
+
+    def test_is_admin_parent_parent_write(self):
+        user = UserFactory()
+        node = NodeFactory(project=self.project, creator=user)
+        self.project.set_permissions(self.project.creator, ['read', 'write'])
+        assert_false(node.is_admin_parent(self.project.creator))
+
+    def test_has_permission_read_parent_admin(self):
+        user = UserFactory()
+        node = NodeFactory(project=self.project, creator=user)
+        assert_true(node.has_permission(self.project.creator, 'read'))
+        assert_false(node.has_permission(self.project.creator, 'admin'))
+
+    def test_can_view_parent_admin(self):
+        user = UserFactory()
+        node = NodeFactory(project=self.project, creator=user)
+        assert_true(node.can_view(Auth(user=self.project.creator)))
+        assert_false(node.can_edit(Auth(user=self.project.creator)))
+
+    def test_can_view_parent_write(self):
+        user = UserFactory()
+        node = NodeFactory(project=self.project, creator=user)
+        self.project.set_permissions(self.project.creator, ['read', 'write'])
+        assert_false(node.can_view(Auth(user=self.project.creator)))
+        assert_false(node.can_edit(Auth(user=self.project.creator)))
+
     def test_creator_cannot_edit_project_if_they_are_removed(self):
         creator = UserFactory()
         project = ProjectFactory(creator=creator)

--- a/tests/test_rubeus.py
+++ b/tests/test_rubeus.py
@@ -255,7 +255,8 @@ class TestRubeus(OsfTestCase):
         user = UserFactory()
         auth = Auth(user=user)
         public = ProjectFactory.build(is_public=True)
-        public.add_contributor(user)
+        # Add contributor with write permissions to avoid admin permission cascade
+        public.add_contributor(user, permissions=['read', 'write'])
         public.save()
         private = ProjectFactory(project=public, is_public=False)
         NodeFactory(project=private)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -15,11 +15,10 @@ from modularodm import Q
 from dateutil.parser import parse as parse_date
 
 from framework import auth
-from framework.exceptions import HTTPError, PermissionsError
+from framework.exceptions import HTTPError
 from framework.auth import User, Auth
 from framework.auth.utils import impute_names_model
 
-import website.app
 from website import mailchimp_utils
 from website.views import _rescale_ratio
 from website.util import permissions
@@ -200,7 +199,6 @@ class TestProjectViews(OsfTestCase):
         my_user.reload()
         dashboard = my_user.node__contributed.find(Q('is_dashboard', 'eq', True))
         assert_equal(dashboard.count(), 1)
-
 
     def test_add_contributor_post(self):
         # Two users are added as a contributor via a POST request

--- a/website/profile/utils.py
+++ b/website/profile/utils.py
@@ -31,7 +31,7 @@ def get_gravatar(user, size=None):
     )
 
 
-def serialize_user(user, node=None, full=False):
+def serialize_user(user, node=None, admin=False, full=False):
     """Return a dictionary representation of a registered user.
 
     :param User user: A User object
@@ -52,10 +52,17 @@ def serialize_user(user, node=None, full=False):
         'active': user.is_active,
     }
     if node is not None:
-        rv.update({
-            'visible': user._id in node.visible_contributor_ids,
-            'permission': reduce_permissions(node.get_permissions(user)),
-        })
+        if admin:
+            flags = {
+                'visible': False,
+                'permission': 'read',
+            }
+        else:
+            flags = {
+                'visible': user._id in node.visible_contributor_ids,
+                'permission': reduce_permissions(node.get_permissions(user)),
+            }
+        rv.update(flags)
     if user.is_registered:
         rv.update({
             'url': user.url,
@@ -89,10 +96,9 @@ def serialize_user(user, node=None, full=False):
     return rv
 
 
-def serialize_contributors(contribs, node):
-
+def serialize_contributors(contribs, node, **kwargs):
     return [
-        serialize_user(contrib, node)
+        serialize_user(contrib, node, **kwargs)
         for contrib in contribs
     ]
 

--- a/website/profile/utils.py
+++ b/website/profile/utils.py
@@ -36,10 +36,9 @@ def serialize_user(user, node=None, admin=False, full=False):
 
     :param User user: A User object
     :param bool full: Include complete user properties
-
     """
     fullname = user.display_full_name(node=node)
-    rv = {
+    ret = {
         'id': str(user._primary_key),
         'registered': user.is_registered,
         'surname': user.family_name,
@@ -62,9 +61,9 @@ def serialize_user(user, node=None, admin=False, full=False):
                 'visible': user._id in node.visible_contributor_ids,
                 'permission': reduce_permissions(node.get_permissions(user)),
             }
-        rv.update(flags)
+        ret.update(flags)
     if user.is_registered:
-        rv.update({
+        ret.update({
             'url': user.url,
             'absolute_url': user.absolute_url,
             'display_absolute_url': user.display_absolute_url,
@@ -81,7 +80,7 @@ def serialize_user(user, node=None, admin=False, full=False):
             }
         else:
             merged_by = None
-        rv.update({
+        ret.update({
             'number_projects': len(get_projects(user)),
             'number_public_projects': len(get_public_projects(user)),
             'activity_points': user.get_activity_points(),
@@ -93,7 +92,7 @@ def serialize_user(user, node=None, admin=False, full=False):
             'merged_by': merged_by,
         })
 
-    return rv
+    return ret
 
 
 def serialize_contributors(contribs, node, **kwargs):

--- a/website/project/decorators.py
+++ b/website/project/decorators.py
@@ -78,7 +78,7 @@ def check_can_access(node, user, key=None, api_node=None):
     """
     if user is None:
         return False
-    if not node.is_contributor(user) and api_node != node:
+    if not node.can_view(Auth(user=user)) and api_node != node:
         if key in node.private_link_keys_deleted:
             status.push_status_message("The view-only links you used are expired.")
         raise HTTPError(http.FORBIDDEN)

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -441,7 +441,6 @@ class Pointer(StoredObject):
     """A link to a Node. The Pointer delegates all but a few methods to its
     contained Node. Forking and registration are overridden such that the
     link is cloned, but its contained Node is not.
-
     """
     #: Whether this is a pointer or not
     primary = False
@@ -696,13 +695,22 @@ class Node(GuidStoredObject, AddonModelMixin):
             or is_api_node
         )
 
+    def is_admin_parent(self, user):
+        if self.has_permission(user, 'admin', check_parent=False):
+            return True
+        if self.parent_node:
+            return self.parent_node.is_admin_parent(user)
+        return False
+
     def can_view(self, auth):
         if not auth and not self.is_public:
             return False
 
-        return self.is_public or auth.user \
-            and self.has_permission(auth.user, 'read') \
-            or auth.private_key in self.private_link_keys_active
+        return (
+            self.is_public or
+            (auth.user and self.has_permission(auth.user, 'read')) or
+            auth.private_key in self.private_link_keys_active
+        )
 
     def is_expanded(self, user=None):
         """Return if a user is has expanded the folder in the dashboard view.
@@ -798,21 +806,21 @@ class Node(GuidStoredObject, AddonModelMixin):
         if save:
             self.save()
 
-    def has_permission(self, user, permission):
+    def has_permission(self, user, permission, check_parent=True):
         """Check whether user has permission.
 
         :param User user: User to test
         :param str permission: Required permission
         :returns: User has required permission
-
         """
         if user is None:
             logger.warn('User is ``None``.')
             return False
-        try:
-            return permission in self.permissions[user._id]
-        except KeyError:
-            return False
+        if permission in self.permissions.get(user._id, []):
+            return True
+        if permission == 'read' and check_parent:
+            return self.is_admin_parent(user)
+        return False
 
     def get_permissions(self, user):
         """Get list of permissions for user.
@@ -820,7 +828,6 @@ class Node(GuidStoredObject, AddonModelMixin):
         :param User user: User to check
         :returns: List of permissions
         :raises: ValueError if user not found in permissions
-
         """
         return self.permissions.get(user._id, [])
 

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -1551,11 +1551,7 @@ class Node(GuidStoredObject, AddonModelMixin):
         :param auth: All the auth information including user, API key.
         :template: Template name
         :data: Form data
-
         """
-        if not self.can_edit(auth):
-            return
-
         if self.is_folder:
             raise NodeStateError("Folders may not be registered")
 

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -946,9 +946,7 @@ def _get_summary(node, auth, rescale_ratio, primary=True, link_id=None):
 
 @collect_auth
 @must_be_valid_project
-def get_summary(**kwargs):
-
-    auth = kwargs['auth']
+def get_summary(auth, **kwargs):
     node = kwargs['node'] or kwargs['project']
     rescale_ratio = kwargs.get('rescale_ratio')
     if rescale_ratio is None and request.args.get('rescale_ratio'):

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -354,14 +354,12 @@ def node_choose_addons(**kwargs):
 
 @must_be_valid_project
 @must_have_permission('read')
-def node_contributors(**kwargs):
-
-    auth = kwargs['auth']
+def node_contributors(auth, **kwargs):
     node = kwargs['node'] or kwargs['project']
-
-    rv = _view_project(node, auth, primary=True)
-    rv['contributors'] = utils.serialize_contributors(node.contributors, node)
-    return rv
+    ret = _view_project(node, auth, primary=True)
+    ret['contributors'] = utils.serialize_contributors(node.contributors, node)
+    ret['adminContributors'] = utils.serialize_contributors(node.admin_contributors, node, admin=True)
+    return ret
 
 
 @must_have_permission('admin')

--- a/website/project/views/register.py
+++ b/website/project/views/register.py
@@ -112,10 +112,9 @@ def node_register_template_page(auth, **kwargs):
 @must_be_valid_project  # returns project
 @must_have_permission(ADMIN)
 @must_not_be_registration
-def project_before_register(**kwargs):
-
+def project_before_register(auth, **kwargs):
     node = kwargs['node'] or kwargs['project']
-    user = kwargs['auth'].user
+    user = auth.user
 
     prompts = node.callback('before_register', user=user)
 
@@ -133,7 +132,6 @@ def project_before_register(**kwargs):
 @must_have_permission(ADMIN)
 @must_not_be_registration
 def node_register_template_page_post(auth, **kwargs):
-
     node = kwargs['node'] or kwargs['project']
     data = request.json
 

--- a/website/static/js/pages/sharing-page.js
+++ b/website/static/js/pages/sharing-page.js
@@ -23,7 +23,7 @@ $('body').on('nodeLoad', function(event, data) {
     }
 });
 
-new ContribManager('#manageContributors', ctx.contributors, ctx.user, ctx.isRegistration);
+new ContribManager('#manageContributors', ctx.contributors, ctx.adminContributors, ctx.user, ctx.isRegistration);
 
 if ($.inArray('admin', ctx.user.permissions) !== -1) {
     // Controls the modal

--- a/website/static/js/project.js
+++ b/website/static/js/project.js
@@ -241,6 +241,14 @@ $(document).ready(function() {
         trigger: 'hover'
     });
 
+    var adminInfoHtml = 'These users are not contributors on this component, ' +
+        'but can view it because they are administrators on a parent project.';
+
+    $('.admin-info').attr(
+        'data-content', adminInfoHtml
+    ).popover({
+        trigger: 'hover'
+    });
 
     ////////////////////
     // Event Handlers //

--- a/website/templates/project/contributors.mako
+++ b/website/templates/project/contributors.mako
@@ -61,7 +61,36 @@
                             }
                         }">
                     </tbody>
-                </table>
+                  </table>
+
+                <div data-bind="if: adminContributors.length">
+                    <h3>
+                      Users with Read Access
+                      <i class="icon-question-sign visibility-info"
+                              data-toggle="popover"
+                              data-title="Visibility Information"
+                              data-container="body"
+                              data-placement="right"
+                              data-html="true"
+                          ></i>
+                    </h3>
+                    <table class="table">
+                        <thead>
+                            <tr>
+                                <th class="col-md-6"></th>
+                                <th class="col-md-2"></th>
+                                <th class="col-md-3"></th>
+                                <th class="col-md-1"></th>
+                            </tr>
+                        </thead>
+                        <tbody data-bind="template: {
+                                name: 'contribTpl',
+                                foreach: adminContributors,
+                                as: 'contributor'
+                            }">
+                        </tbody>
+                    </table>
+                </div>
                 ${buttonGroup()}
             </div>
 
@@ -158,7 +187,7 @@
             </span>
         </td>
         <td>
-            <!-- ko if: $parent.canEdit -->
+            <!-- ko if: contributor.canEdit() -->
                 <span data-bind="visible: notDeleteStaged">
                     <a href="#" class="permission-editable no-sort" data-type="select"></a>
                 </span>
@@ -166,18 +195,18 @@
                     <span data-bind="text: formatPermission"></span>
                 </span>
             <!-- /ko -->
-            <!-- ko ifnot: $parent.canEdit -->
+            <!-- ko ifnot: contributor.canEdit() -->
                 <span data-bind="text: formatPermission"></span>
             <!-- /ko -->
         </td>
         <td>
             <input
                     type="checkbox" class="no-sort"
-                    data-bind="checked: visible, enable: $parent.canEdit"
+                    data-bind="checked: visible, enable: $parent.canEdit() && !contributor.isAdmin"
                 />
         </td>
         <td>
-            <!-- ko if: $parent.canEdit -->
+          <!-- ko if: contributor.canEdit() -->
                 <!-- ko ifnot: deleteStaged -->
                     <!-- Note: Prevent clickBubble so that removing a
                      contributor does not immediately un-remove her. -->
@@ -192,7 +221,7 @@
                 <!-- /ko -->
             <!-- /ko -->
 
-            <!-- ko ifnot: $parent.canEdit -->
+            <!-- ko ifnot: contributor.canEdit() -->
                 <!-- ko if: canRemove -->
                     <a
                             data-bind="click: removeSelf, tooltip: {title: 'Remove contributor'}"
@@ -226,6 +255,7 @@
       window.contextVars.user = ${json.dumps(user)};
       window.contextVars.isRegistration = ${json.dumps(node['is_registration'])};
       window.contextVars.contributors = ${json.dumps(contributors)};
+      window.contextVars.adminContributors = ${json.dumps(adminContributors)};
 
     </script>
     <script src=${"/static/public/js/sharing-page.js" | webpack_asset}></script>

--- a/website/templates/project/contributors.mako
+++ b/website/templates/project/contributors.mako
@@ -66,7 +66,7 @@
                 <div data-bind="if: adminContributors.length">
                     <h3>
                       Users with Read Access
-                      <i class="icon-question-sign visibility-info"
+                      <i class="icon-question-sign admin-info"
                               data-toggle="popover"
                               data-title="Visibility Information"
                               data-container="body"

--- a/website/templates/util/render_node.mako
+++ b/website/templates/util/render_node.mako
@@ -91,6 +91,8 @@
                 Private Registration
             %elif summary['is_fork']:
                 Private Fork
+            %elif not summary['primary']:
+                Private Link
             %else:
                 Private Component
             %endif


### PR DESCRIPTION
# Purpose
Ensure that project administrators have at least read-only access on all child projects and components; allow administrators to register private child nodes on which they are not a contributor.

# Changes
* Add `Node#is_admin_parent` method
* Change `Node#has_permission` such that parent admins always have at least `read` permission
* Add `Node#admin_contributors` property to get parent admins who aren't also contributors
* Update contributors table
* Allow admins to register all project children, even if not contributors

# Side effects
None expected

Resolves #438