### PR TITLE
Add script to email users about permission change.

### DIFF
--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -205,6 +205,7 @@ class User(GuidStoredObject, AddonModelMixin):
 
     # Tags for internal use
     system_tags = fields.StringField(list=True)
+    security_messages = fields.DictionaryField()
 
     # Per-project unclaimed user data:
     # Format: {

--- a/scripts/admin_permission_email.py
+++ b/scripts/admin_permission_email.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+import logging
+import datetime
+
+from modularodm import Q
+
+from framework.email.tasks import send_email
+
+from website import mails
+from website import models
+from website.app import init_app
+
+from scripts import utils as script_utils
+
+
+logger = logging.getLogger(__name__)
+script_utils.add_file_logger(logger, __file__)
+logging.basicConfig(level=logging.INFO)
+
+
+FROM_ADDR = ''  # TODO: Configure this @jmcarp
+MESSAGE_NAME = 'permissions_change'
+SECURITY_MESSAGE = mails.Mail(
+    'security_permissions_change',
+    subject='OSF Permissions Change',
+)
+
+
+def send_security_message(user, label, mail):
+    if label in user.security_messages:
+        return
+    mails.send_mail(
+        user.username,
+        mail,
+        from_addr=FROM_ADDR,
+        mailer=send_email,
+        user=user,
+    )
+    user.security_messages[label] = datetime.datetime.utcnow()
+    user.save()
+
+
+def get_targets():
+    query = Q('security_messages.{0}'.format(MESSAGE_NAME), 'exists', False)
+    return models.User.find(query)
+
+
+def main(dry_run):
+    users = get_targets()
+    for user in users:
+        logger.info('Sending message to user {0!r}'.format(user))
+        if not dry_run:
+            send_security_message(user, MESSAGE_NAME, SECURITY_MESSAGE)
+
+
+if __name__ == '__main__':
+    import sys
+    dry_run = 'dry' in sys.argv
+    init_app(set_backends=True, routes=False)
+    main(dry_run=dry_run)
+
+
+import mock
+from nose.tools import *  # noqa
+
+from tests.base import OsfTestCase
+from tests.factories import UserFactory
+
+
+class TestSendSecurityMessage(OsfTestCase):
+
+    def tearDown(self):
+        super(TestSendSecurityMessage, self).tearDown()
+        models.User.remove()
+
+    def test_get_targets(self):
+        users = [UserFactory() for _ in range(3)]
+        users[0].security_messages[MESSAGE_NAME] = datetime.datetime.utcnow()
+        users[0].save()
+        targets = get_targets()
+        assert_equal(set(targets), set(users[1:]))
+
+    @mock.patch('scripts.admin_permission_email.send_email')
+    def test_send_mail(self, mock_send_mail):
+        user = UserFactory()
+        send_security_message(user, MESSAGE_NAME, SECURITY_MESSAGE)
+        user.reload()
+        assert_in(MESSAGE_NAME, user.security_messages)
+
+    @mock.patch('scripts.admin_permission_email.send_email')
+    def test_main(self, mock_send_mail):
+        [UserFactory() for _ in range(3)]
+        assert_equal(len(get_targets()), 3)
+        main(dry_run=False)
+        assert_true(mock_send_mail.called)
+        assert_equal(len(get_targets()), 0)
+
+    @mock.patch('scripts.admin_permission_email.send_email')
+    def test_main_dry(self, mock_send_mail):
+        [UserFactory() for _ in range(3)]
+        assert_equal(len(get_targets()), 3)
+        main(dry_run=True)
+        assert_false(mock_send_mail.called)
+        assert_equal(len(get_targets()), 3)

--- a/website/mails.py
+++ b/website/mails.py
@@ -75,7 +75,7 @@ def render_message(tpl_name, **context):
     return tpl.render(**context)
 
 
-def send_mail(to_addr, mail, mimetype='plain', **context):
+def send_mail(to_addr, mail, mimetype='plain', from_addr=None, mailer=None, **context):
     """Send an email from the OSF.
     Example: ::
 
@@ -92,19 +92,22 @@ def send_mail(to_addr, mail, mimetype='plain', **context):
          Requires celery worker.
 
     """
+    from_addr = from_addr or settings.FROM_EMAIL
+    mailer = mailer or framework_send_email
     subject = mail.subject(**context)
     message = mail.text(**context) if mimetype in ('plain', 'txt') else mail.html(**context)
     # Don't use ttls and login in DEBUG_MODE
     ttls = login = not settings.DEBUG_MODE
     logger.debug('Sending email...')
-    logger.debug(u'To: {to_addr}\nSubject: {subject}\nMessage: {message}'.format(**locals()))
-    return framework_send_email(
-        from_addr=settings.FROM_EMAIL,
+    logger.debug(u'To: {to_addr}\nFrom: {from_addr}\nSubject: {subject}\nMessage: {message}'.format(**locals()))
+    return mailer(
+        from_addr=from_addr,
         to_addr=to_addr,
         subject=subject,
         message=message,
         mimetype=mimetype,
-        ttls=ttls, login=login
+        ttls=ttls,
+        login=login,
     )
 
 # Predefined Emails

--- a/website/templates/emails/security_permissions_change.txt.mako
+++ b/website/templates/emails/security_permissions_change.txt.mako
@@ -4,7 +4,7 @@ We are writing to let you know of a change to our permission model that may affe
 
 Contributors on Open Science Framework (OSF) projects have one of three permission statuses: administrator, read+write, and read-only. These affect what actions those contributors can perform on the project. Projects can have sub-components that have contributor lists that are distinct from the project contributor list.
 
-Currently, project administrators can view the contents of components in their projectsonly ifthey are listed as contributors on those components. However, two weeks from today, project administrators will have read-only access to sub-components of their projects even if they are not listed as a contributor. This means that administrators can see the component and its contents.
+Currently, project administrators can view the contents of components in their projects only if they are listed as contributors on those components. However, two weeks from today, project administrators will have read-only access to sub-components of their projects even if they are not listed as a contributor. This means that administrators can see the component and its contents.
 
 For example, if Thomas, Nikola, and Angus are administrators on project "AC/DC", but Angus is the sole contributor to a subcomponent "High Voltage" within that project, Thomas and Nikola will now be able to view the contents of "High Voltage".
 

--- a/website/templates/emails/security_permissions_change.txt.mako
+++ b/website/templates/emails/security_permissions_change.txt.mako
@@ -1,0 +1,25 @@
+Dear ${user.given_name},
+
+We are writing to let you know of a change to our permission model that may affect how you choose to organize your projects.
+
+Contributors on Open Science Framework (OSF) projects have one of three permission statuses: administrator, read+write, and read-only. These affect what actions those contributors can perform on the project. Projects can have sub-components that have contributor lists that are distinct from the project contributor list.
+
+Currently, project administrators can view the contents of components in their projectsonly ifthey are listed as contributors on those components. However, two weeks from today, project administrators will have read-only access to sub-components of their projects even if they are not listed as a contributor. This means that administrators can see the component and its contents.
+
+For example, if Thomas, Nikola, and Angus are administrators on project "AC/DC", but Angus is the sole contributor to a subcomponent "High Voltage" within that project, Thomas and Nikola will now be able to view the contents of "High Voltage".
+
+Overall, we expect this to provide a more intuitive experience when thinking about permissions within the OSF. Administrators can view the contents of their projects, even if they are not directly contributing to all components. Also, this is an important change because administrators can register projects (i.e., create permanent, uneditable versions). It is important that administrators know what they are registering.
+
+How will this affect you? If you are a contributor on a component of a project and do not want the administrator of that project to see the content, then you may wish to delete the component and move the content to a new project in which you are the administrator.
+
+Please do let us know if you have any questions or would like help in addressing the organization of your projects:
+
+support@osf.io
+
+Regards,
+
+The OSF Team
+Center for Open Science
+http://osf.io/
+
+Note: You are receiving this message because you have an account on the Open Science Framework. In system-wide security messages, we will not include links or ask you for information - passwords or otherwise.


### PR DESCRIPTION
# Purpose
Add script to email users about upcoming change in admin permissions

# Changes
* Add script
* Add `security_messages` field to `User` to track sent messages
* Add miscellaneous change to email utils

# Side effects
None expected

To test: `py.test scripts/admin_permission_email.py`
To dry run: `python -m scripts.admin_permission_email dry`
To run: `python -m scripts.admin_permission_email`

@JeffSpies: Which address should the message be sent from?