### PR TITLE
Feature/wiki permission change

### DIFF
--- a/website/addons/wiki/model.py
+++ b/website/addons/wiki/model.py
@@ -15,7 +15,6 @@ from modularodm import fields
 
 from framework.forms.utils import sanitize
 from framework.guid.model import GuidStoredObject
-from framework.mongo.utils import to_mongo_key
 
 from website import settings
 from website.addons.base import AddonNodeSettingsBase
@@ -35,9 +34,8 @@ class AddonWikiNodeSettings(AddonNodeSettingsBase):
 
     def after_remove_contributor(self, node, removed):
         # Migrate every page on the node
-        for wiki_name in node.wiki_pages_current:
-            wiki_page = node.get_wiki_page(wiki_name)
-            wiki_page.migrate_uuid(node)
+        for wiki_name in node.wiki_private_uuids:
+            wiki_utils.migrate_uuid(node, wiki_name)
 
     def to_json(self, user):
         return {}
@@ -122,52 +120,6 @@ class NodeWikiPage(GuidStoredObject):
         """ The raw text of the page, suitable for using in a test search"""
 
         return sanitize(self.html(node), tags=[], strip=True)
-
-    def delete_share_doc(self, node, save=True):
-        """Deletes share document and removes namespace from model."""
-
-        db = wiki_utils.share_db()
-        sharejs_uuid = wiki_utils.get_sharejs_uuid(node, self.page_name)
-
-        db['docs'].remove({'_id': sharejs_uuid})
-        db['docs_ops'].remove({'name': sharejs_uuid})
-
-        wiki_key = to_mongo_key(self.page_name)
-        del node.wiki_private_uuids[wiki_key]
-        node.save()
-
-        if save:
-            self.save()
-
-    def migrate_uuid(self, node, save=True):
-        """Migrates uuid to new namespace."""
-
-        db = wiki_utils.share_db()
-        old_sharejs_uuid = wiki_utils.get_sharejs_uuid(node, self.page_name)
-
-        wiki_utils.broadcast_to_sharejs('lock', old_sharejs_uuid)
-
-        wiki_utils.generate_private_uuid(node, self.page_name)
-        new_sharejs_uuid = wiki_utils.get_sharejs_uuid(node, self.page_name)
-
-        doc_item = db['docs'].find_one({'_id': old_sharejs_uuid})
-        if doc_item:
-            doc_item['_id'] = new_sharejs_uuid
-            db['docs'].insert(doc_item)
-            db['docs'].remove({'_id': old_sharejs_uuid})
-
-        ops_items = [item for item in db['docs_ops'].find({'name': old_sharejs_uuid})]
-        if ops_items:
-            for item in ops_items:
-                item['_id'] = item['_id'].replace(old_sharejs_uuid, new_sharejs_uuid)
-                item['name'] = new_sharejs_uuid
-            db['docs_ops'].insert(ops_items)
-            db['docs_ops'].remove({'name': old_sharejs_uuid})
-
-        wiki_utils.broadcast_to_sharejs('unlock', old_sharejs_uuid)
-
-        if save:
-            self.save()
 
     def get_draft(self, node):
         """

--- a/website/addons/wiki/tests/test_wiki.py
+++ b/website/addons/wiki/tests/test_wiki.py
@@ -12,15 +12,17 @@ from modularodm.exceptions import ValidationValueError
 
 from tests.base import OsfTestCase, fake
 from tests.factories import (
-    UserFactory, NodeFactory, PointerFactory, ProjectFactory, ApiKeyFactory,
+    UserFactory, NodeFactory, ProjectFactory, ApiKeyFactory,
     AuthUserFactory, NodeWikiFactory,
 )
 
-from framework.forms.utils import sanitize
 from website.addons.wiki import settings
 from website.addons.wiki.views import _serialize_wiki_toc, _get_wiki_web_urls, _get_wiki_api_urls
 from website.addons.wiki.model import NodeWikiPage, render_content
-from website.addons.wiki.utils import get_sharejs_uuid, generate_private_uuid, share_db
+from website.addons.wiki.utils import (
+    get_sharejs_uuid, generate_private_uuid, share_db, delete_share_doc,
+    migrate_uuid,
+)
 from website.addons.wiki.tests.config import EXAMPLE_DOCS, EXAMPLE_OPS
 from framework.auth import Auth
 from framework.mongo.utils import to_mongo_key
@@ -696,8 +698,7 @@ class TestWikiUuid(OsfTestCase):
         fork = self.project.fork_node(Auth(self.user))
         assert_equal(original_uuid, fork.wiki_private_uuids.get(self.wkey))
 
-        wiki_page = self.project.get_wiki_page(self.wkey)
-        wiki_page.migrate_uuid(self.project)
+        migrate_uuid(self.project, self.wname)
 
         assert_not_equal(original_uuid, self.project.wiki_private_uuids.get(self.wkey))
         assert_equal(original_uuid, fork.wiki_private_uuids.get(self.wkey))
@@ -805,7 +806,7 @@ class TestWikiShareJSMongo(OsfTestCase):
 
     @mock.patch('website.addons.wiki.utils.broadcast_to_sharejs')
     def test_migrate_uuid(self, mock_sharejs):
-        self.wiki_page.migrate_uuid(self.project)
+        migrate_uuid(self.project, self.wname)
         assert_is_none(self.db.docs.find_one({'_id': self.sharejs_uuid}))
         assert_is_none(self.db.docs_ops.find_one({'name': self.sharejs_uuid}))
 
@@ -829,7 +830,7 @@ class TestWikiShareJSMongo(OsfTestCase):
 
         self.project.update_node_wiki(wname, 'Hello world', Auth(self.user))
         wiki_page = self.project.get_wiki_page(wname)
-        wiki_page.migrate_uuid(self.project)
+        migrate_uuid(self.project, wname)
 
         assert_not_equal(share_uuid, self.project.wiki_private_uuids.get(wkey))
         assert_is_none(self.db.docs.find_one({'_id': sharejs_uuid}))
@@ -837,20 +838,51 @@ class TestWikiShareJSMongo(OsfTestCase):
 
     @mock.patch('website.addons.wiki.utils.broadcast_to_sharejs')
     def test_migrate_uuid_updates_node(self, mock_sharejs):
-        assert_equal(self.private_uuid, self.project.wiki_private_uuids[self.wkey])
-        self.wiki_page.migrate_uuid(self.project)
+        migrate_uuid(self.project, self.wname)
         assert_not_equal(self.private_uuid, self.project.wiki_private_uuids[self.wkey])
 
     @mock.patch('website.addons.wiki.utils.broadcast_to_sharejs')
+    def test_manage_contributors_updates_uuid(self, mock_sharejs):
+        user = UserFactory()
+        self.project.add_contributor(
+            contributor=user,
+            permissions=['read', 'write', 'admin'],
+            auth=Auth(user=self.user),
+        )
+        self.project.save()
+        assert_equal(self.private_uuid, self.project.wiki_private_uuids[self.wkey])
+        # Removing admin permission does nothing
+        self.project.manage_contributors(
+            user_dicts=[
+                {'id': user._id, 'permission': 'write', 'visible': True},
+                {'id': self.user._id, 'permission': 'admin', 'visible': True},
+            ],
+            auth=Auth(user=self.user),
+            save=True,
+        )
+        assert_equal(self.private_uuid, self.project.wiki_private_uuids[self.wkey])
+        # Removing write permission migrates uuid
+        self.project.manage_contributors(
+            user_dicts=[
+                {'id': user._id, 'permission': 'read', 'visible': True},
+                {'id': self.user._id, 'permission': 'admin', 'visible': True},
+            ],
+            auth=Auth(user=self.user),
+            save=True,
+        )
+        assert_not_equal(self.private_uuid, self.project.wiki_private_uuids[self.wkey])
+
+
+    @mock.patch('website.addons.wiki.utils.broadcast_to_sharejs')
     def test_delete_share_doc(self, mock_sharejs):
-        self.wiki_page.delete_share_doc(self.project, self.wname)
+        delete_share_doc(self.project, self.wname)
         assert_is_none(self.db.docs.find_one({'_id': self.sharejs_uuid}))
         assert_is_none(self.db.docs_ops.find_one({'name': self.sharejs_uuid}))
 
     @mock.patch('website.addons.wiki.utils.broadcast_to_sharejs')
     def test_delete_share_doc_updates_node(self, mock_sharejs):
         assert_equal(self.private_uuid, self.project.wiki_private_uuids[self.wkey])
-        self.wiki_page.delete_share_doc(self.project)
+        delete_share_doc(self.project, self.wname)
         assert_not_in(self.wkey, self.project.wiki_private_uuids)
 
     def test_get_draft(self):

--- a/website/addons/wiki/utils.py
+++ b/website/addons/wiki/utils.py
@@ -35,6 +35,48 @@ def get_sharejs_uuid(node, wname):
     )) if private_uuid else None
 
 
+def delete_share_doc(node, wname):
+    """Deletes share document and removes namespace from model."""
+
+    db = share_db()
+    sharejs_uuid = get_sharejs_uuid(node, wname)
+
+    db['docs'].remove({'_id': sharejs_uuid})
+    db['docs_ops'].remove({'name': sharejs_uuid})
+
+    wiki_key = to_mongo_key(wname)
+    del node.wiki_private_uuids[wiki_key]
+    node.save()
+
+
+def migrate_uuid(node, wname):
+    """Migrates uuid to new namespace."""
+
+    db = share_db()
+    old_sharejs_uuid = get_sharejs_uuid(node, wname)
+
+    broadcast_to_sharejs('lock', old_sharejs_uuid)
+
+    generate_private_uuid(node, wname)
+    new_sharejs_uuid = get_sharejs_uuid(node, wname)
+
+    doc_item = db['docs'].find_one({'_id': old_sharejs_uuid})
+    if doc_item:
+        doc_item['_id'] = new_sharejs_uuid
+        db['docs'].insert(doc_item)
+        db['docs'].remove({'_id': old_sharejs_uuid})
+
+    ops_items = [item for item in db['docs_ops'].find({'name': old_sharejs_uuid})]
+    if ops_items:
+        for item in ops_items:
+            item['_id'] = item['_id'].replace(old_sharejs_uuid, new_sharejs_uuid)
+            item['name'] = new_sharejs_uuid
+        db['docs_ops'].insert(ops_items)
+        db['docs_ops'].remove({'name': old_sharejs_uuid})
+
+    broadcast_to_sharejs('unlock', old_sharejs_uuid)
+
+
 def share_db():
     """Generate db client for sharejs db"""
     client = MongoClient(settings.DB_HOST, settings.DB_PORT)

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2342,9 +2342,9 @@ class Node(GuidStoredObject, AddonModelMixin):
 
         if permissions_changed:
             if ['read'] in permissions_changed.values():
-                for wiki_name in self.wiki_pages_current:
-                    wiki_page = self.get_wiki_page(wiki_name)
-                    wiki_page.migrate_uuid(self)
+                from website.addons.wiki.utils import migrate_uuid
+                for wiki_name in self.wiki_private_uuids:
+                    migrate_uuid(self, wiki_name)
 
             self.add_log(
                 action=NodeLog.PERMISSIONS_UPDATED,

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2341,6 +2341,11 @@ class Node(GuidStoredObject, AddonModelMixin):
         self.contributors = users
 
         if permissions_changed:
+            if ['read'] in permissions_changed.values():
+                for wiki_name in self.wiki_pages_current:
+                    wiki_page = self.get_wiki_page(wiki_name)
+                    wiki_page.migrate_uuid(self)
+
             self.add_log(
                 action=NodeLog.PERMISSIONS_UPDATED,
                 params={


### PR DESCRIPTION
This improves the cases in which wikis' sharejs uuids will be migrated, barring users who no longer should have access from accessing these pages. This includes a permission change to read-only, as well as migrations on wiki pages that have not yet been saved.