### PR TITLE
[hotfix] fix for file render page download via view_only link

### DIFF
--- a/website/addons/base/views.py
+++ b/website/addons/base/views.py
@@ -135,7 +135,7 @@ def get_auth(**kwargs):
     except KeyError:
         raise HTTPError(httplib.BAD_REQUEST)
 
-    view_only = request.args.get('viewOnly')
+    view_only = request.args.get('view_only')
 
     user = get_user_from_cookie(cookie)
 

--- a/website/addons/osfstorage/tests/test_utils.py
+++ b/website/addons/osfstorage/tests/test_utils.py
@@ -5,6 +5,8 @@ from nose.tools import *  # noqa
 
 from tests.factories import AuthUserFactory
 
+import furl
+
 from framework import sessions
 from framework.flask import request
 
@@ -107,6 +109,27 @@ class TestGetDownloadUrl(StorageTestCase):
             '.gif',
         ])
         assert_equal(filename, expected)
+
+    def test_get_waterbutler_url(self):
+        user = AuthUserFactory()
+        path = ('test', 'endpoint')
+        query = {'some': 'field'}
+        test_url = utils.get_waterbutler_url(user, *path, **query)
+        url = furl.furl(test_url)
+
+        assert_equal(url.path.segments[0], 'test')
+        assert_equal(url.path.segments[1], 'endpoint')
+        assert_equal(url.args['some'], 'field')
+        assert_not_in('view_only', url.args)
+
+    def test_get_waterbutler_url_view_only(self):
+        user = AuthUserFactory()
+        path = ('test', 'endpoint')
+        query = {'view_only': 'secret_key'}
+        test_url = utils.get_waterbutler_url(user, *path, **query)
+        url = furl.furl(test_url)
+
+        assert_equal(url.args['view_only'], 'secret_key')
 
 
 class TestSerializeRevision(StorageTestCase):

--- a/website/addons/osfstorage/utils.py
+++ b/website/addons/osfstorage/utils.py
@@ -184,6 +184,8 @@ def get_waterbutler_url(user, *path, **query):
         'provider': 'osfstorage',
         'cookie': cookie,
     })
+    if 'view_only' in request.args:
+        url.args['view_only'] = request.args['view_only']
     url.args.update(query)
     return url.url
 

--- a/website/addons/osfstorage/utils.py
+++ b/website/addons/osfstorage/utils.py
@@ -180,7 +180,6 @@ def get_waterbutler_url(user, *path, **query):
         else request.cookies.get(site_settings.COOKIE_NAME)
     )
     url.args.update({
-        'token': '',
         'provider': 'osfstorage',
         'cookie': cookie,
     })

--- a/website/static/js/waterbutler.js
+++ b/website/static/js/waterbutler.js
@@ -18,7 +18,7 @@ function getDefaultOptions(path, provider) {
         path: path,
         provider: provider,
         cookie: getCookie(),
-        viewOnly: getViewOnly()
+        view_only: getViewOnly()
     };
 }
 


### PR DESCRIPTION
Purpose:
Corrects view only link file downloads not working.

Resolves #1748

Cause:
View Only file links are not downloading.

Side Effects:
None