### PR TITLE
[Hotfix] Fix select related bug in folderpicker

### DIFF
--- a/website/static/js/folderPicker.js
+++ b/website/static/js/folderPicker.js
@@ -69,32 +69,42 @@
      * Returns the folder select button for a single row.
      */
     function _treebeardSelectView(item) {
+        var tb = this; 
+        var setTempPicked = function () {
+            this.options.tempPicked = item.data.path;
+        } 
+        var templateChecked = m("input", {
+            type:"radio",
+            checked : 'checked',
+            name: "#" + tb.options.divID + INPUT_NAME,
+            value:item.id
+            }, " ");
+        var templateUnchecked = m("input",{
+            type:"radio",
+            onclick : setTempPicked.bind(tb),
+            name: "#" + tb.options.divID + INPUT_NAME,
+            value:item.id
+            }, " ");
 
-        if(item.data.path != undefined){
-            if (item.data.path === this.options.folderPath) {
-                return m("input",{
-                type:"radio",
-                checked : 'checked',
-                name: "#" + this.options.divID + INPUT_NAME,
-                value:item.id
-                }, " ");
+        if(tb.options.tempPicked) {
+            if(tb.options.tempPicked === item.data.path) {
+                return templateChecked;
+            } else {
+                return templateUnchecked;
             }
         }
 
-        if (this.options.folderArray && item.data.name === this.options.folderArray[0]) {
-            return m("input",{
-                type:"radio",
-                checked : 'checked',
-                name: "#" + this.options.divID + INPUT_NAME,
-                value:item.id
-                }, " ");
+        if(item.data.path != undefined){
+            if (item.data.path === tb.options.folderPath) {
+                return templateChecked;
+            }
         }
 
-        return m("input",{
-            type:"radio",
-            name: "#" + this.options.divID + INPUT_NAME,
-            value:item.id
-        }, " ");
+        if (tb.options.folderArray && item.data.name === tb.options.folderArray[0]) {
+            return templateChecked;
+        }
+
+        return templateUnchecked;
     }
 
     function _treebeardColumnTitle(){


### PR DESCRIPTION
## Purpose

@icereval Pointed out a bug where if folderpicker item has enough items to require scrolling and the user selects another folder, the selected folder select goes unchecked with mithril refresh. This is because mithril is redrawing based on its state. This change fixes this bug so that if the user selects another folder the view is consistent despite scrolling. 

## Changes

Added a temporary item to treebeard option to show which item is selected and cleaned up the function. 

## Side effects
Should not break anything else, this also doesn't affect any saved state. 