### PR TITLE
Feature/wiki delay migration

### DIFF
--- a/website/addons/wiki/model.py
+++ b/website/addons/wiki/model.py
@@ -19,6 +19,7 @@ from framework.guid.model import GuidStoredObject
 from website import settings
 from website.addons.base import AddonNodeSettingsBase
 from website.addons.wiki import utils as wiki_utils
+from website.project.model import write_permissions_revoked
 
 from .exceptions import (
     NameEmptyError,
@@ -32,13 +33,15 @@ logger = logging.getLogger(__name__)
 
 class AddonWikiNodeSettings(AddonNodeSettingsBase):
 
-    def after_remove_contributor(self, node, removed):
-        # Migrate every page on the node
-        for wiki_name in node.wiki_private_uuids:
-            wiki_utils.migrate_uuid(node, wiki_name)
-
     def to_json(self, user):
         return {}
+
+
+@write_permissions_revoked.connect
+def subscribe_on_write_permissions_revoked(node):
+    # Migrate every page on the node
+    for wiki_name in node.wiki_private_uuids:
+        wiki_utils.migrate_uuid(node, wiki_name)
 
 
 def build_wiki_url(node, label, base, end):

--- a/website/addons/wiki/static/ShareJSDoc.js
+++ b/website/addons/wiki/static/ShareJSDoc.js
@@ -55,6 +55,8 @@ var ShareJSDoc = function(selector, url, metadata) {
     var sjs = new sharejs.Connection(socket);
     var doc = sjs.get('docs', metadata.docId);
     var madeConnection = false;
+    var allowRefresh = true;
+    var refreshTriggered = false;
 
     function whenReady() {
 
@@ -88,6 +90,12 @@ var ShareJSDoc = function(selector, url, metadata) {
         socket.send(JSON.stringify(metadata));
     }
 
+    function refreshMaybe() {
+        if (allowRefresh && refreshTriggered) {
+            window.location.reload();
+        }
+    }
+
     // Handle our custom messages separately
     var onmessage = socket.onmessage;
     socket.onmessage = function (message) {
@@ -105,15 +113,20 @@ var ShareJSDoc = function(selector, url, metadata) {
                 viewModel.activeUsers(activeUsers);
                 break;
             case 'lock':
+                allowRefresh = false;
                 editor.setReadOnly(true);
                 permissionsModal.modal({
                     backdrop: 'static',
                     keyboard: false
                 });
+                setTimeout(function() {
+                    allowRefresh = true;
+                    refreshMaybe();
+                }, 3000);
                 break;
             case 'unlock':
-                // TODO: Wait a certain number of seconds so they can read it?
-                window.location.reload();
+                refreshTriggered = true;
+                refreshMaybe();
                 break;
             case 'redirect':
                 editor.setReadOnly(true);

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -39,6 +39,7 @@ from framework.analytics import (
     get_basic_counters, increment_user_activity_counters
 )
 from framework.sentry import log_exception
+from framework.transactions.context import TokuTransaction
 
 from website import language
 from website import settings
@@ -2283,82 +2284,84 @@ class Node(GuidStoredObject, AddonModelMixin):
             no admin contributors remaining
 
         """
-        users = []
-        user_ids = []
-        permissions_changed = {}
-        to_retain = []
-        to_remove = []
-        for user_dict in user_dicts:
-            user = User.load(user_dict['id'])
-            if user is None:
-                raise ValueError('User not found')
-            if user not in self.contributors:
+        with TokuTransaction():
+            users = []
+            user_ids = []
+            permissions_changed = {}
+            to_retain = []
+            to_remove = []
+            for user_dict in user_dicts:
+                user = User.load(user_dict['id'])
+                if user is None:
+                    raise ValueError('User not found')
+                if user not in self.contributors:
+                    raise ValueError(
+                        'User {0} not in contributors'.format(user.fullname)
+                    )
+                permissions = expand_permissions(user_dict['permission'])
+                if set(permissions) != set(self.get_permissions(user)):
+                    self.set_permissions(user, permissions, save=False)
+                    permissions_changed[user._id] = permissions
+                self.set_visible(user, user_dict['visible'], auth=auth)
+                users.append(user)
+                user_ids.append(user_dict['id'])
+
+            for user in self.contributors:
+                if user._id in user_ids:
+                    to_retain.append(user)
+                else:
+                    to_remove.append(user)
+
+            # TODO: Move to validator or helper @jmcarp
+            admins = [
+                user for user in users
+                if self.has_permission(user, 'admin')
+                and user.is_registered
+            ]
+            if users is None or not admins:
                 raise ValueError(
-                    'User {0} not in contributors'.format(user.fullname)
+                    'Must have at least one registered admin contributor'
                 )
-            permissions = expand_permissions(user_dict['permission'])
-            if set(permissions) != set(self.get_permissions(user)):
-                self.set_permissions(user, permissions, save=False)
-                permissions_changed[user._id] = permissions
-            self.set_visible(user, user_dict['visible'], auth=auth)
-            users.append(user)
-            user_ids.append(user_dict['id'])
 
-        for user in self.contributors:
-            if user._id in user_ids:
-                to_retain.append(user)
-            else:
-                to_remove.append(user)
+            if to_retain != users:
+                self.add_log(
+                    action=NodeLog.CONTRIB_REORDERED,
+                    params={
+                        'project': self.parent_id,
+                        'node': self._id,
+                        'contributors': [
+                            user._id
+                            for user in users
+                        ],
+                    },
+                    auth=auth,
+                    save=False,
+                )
 
-        # TODO: Move to validator or helper @jmcarp
-        admins = [
-            user for user in users
-            if self.has_permission(user, 'admin')
-            and user.is_registered
-        ]
-        if users is None or not admins:
-            raise ValueError(
-                'Must have at least one registered admin contributor'
-            )
+            if to_remove:
+                self.remove_contributors(to_remove, auth=auth, save=False)
 
-        if to_retain != users:
-            self.add_log(
-                action=NodeLog.CONTRIB_REORDERED,
-                params={
-                    'project': self.parent_id,
-                    'node': self._id,
-                    'contributors': [
-                        user._id
-                        for user in users
-                    ],
-                },
-                auth=auth,
-                save=False,
-            )
+            self.contributors = users
 
-        if to_remove:
-            self.remove_contributors(to_remove, auth=auth, save=False)
+            if permissions_changed:
+                self.add_log(
+                    action=NodeLog.PERMISSIONS_UPDATED,
+                    params={
+                        'project': self.parent_id,
+                        'node': self._id,
+                        'contributors': permissions_changed,
+                    },
+                    auth=auth,
+                    save=False,
+                )
+            # Update list of visible IDs
+            self.update_visible_ids()
+            if save:
+                self.save()
 
-        self.contributors = users
-
-        if permissions_changed:
-            self.add_log(
-                action=NodeLog.PERMISSIONS_UPDATED,
-                params={
-                    'project': self.parent_id,
-                    'node': self._id,
-                    'contributors': permissions_changed,
-                },
-                auth=auth,
-                save=False,
-            )
-        # Update list of visible IDs
-        self.update_visible_ids()
-        if save:
-            self.save()
-
-        if to_remove or permissions_changed and ['read'] in permissions_changed.values():
-            write_permissions_revoked.send(self)
+        with TokuTransaction():
+            if to_remove or permissions_changed and ['read'] in permissions_changed.values():
+                write_permissions_revoked.send(self)
 
     def add_contributor(self, contributor, permissions=None, visible=True,
                         auth=None, log=True, save=False):

--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -17,6 +17,7 @@ from framework.exceptions import HTTPError
 from framework.auth.signals import user_registered
 from framework.auth.decorators import collect_auth, must_be_logged_in
 from framework.auth.forms import PasswordForm, SetEmailAndPasswordForm
+from framework.transactions.handlers import no_auto_transaction
 
 from website import mails
 from website import language
@@ -360,6 +361,7 @@ def project_contributors_post(**kwargs):
     return {'status': 'success'}, 201
 
 
+@no_auto_transaction
 @must_be_valid_project  # injects project
 @must_have_permission(ADMIN)
 @must_not_be_registration


### PR DESCRIPTION
Fixes for staging.

 - Separates migration of uuids into its own toku transaction to occur after contributor permission changes. 
    - This should guarantee page refreshes occur after permission change is complete.
 - Guarantees permission-change modal will persist on screen for at least 3 seconds before refresh.

It would be prudent to double check how toku transactions are being handled during review.