### PR TITLE
clarify the warning info for view-only link

### DIFF
--- a/website/templates/project/modal_generate_private_link.mako
+++ b/website/templates/project/modal_generate_private_link.mako
@@ -26,7 +26,7 @@
                             <input type="checkbox" data-bind="checked: anonymous"/>
                             <strong>Anonymize</strong> contributor list for this link (e.g., for blind peer review).
                             <br>
-                            <i>Ensure the files and registration supplements you have created and uploaded do not contain identifying information.</i>
+                            <i>Ensure the wiki pages, files, and registration supplements you have created do not contain identifying information</i>
                         </label>
                     </div>
 


### PR DESCRIPTION
resolve #1413
<b><big>Purpose</big></b>
Clarify the warning message that user will see when they try to create a view-only link

<b><big>Changes</big></b>
The old warning message is 
![screen shot 2015-02-11 at 11 43 06 am](https://cloud.githubusercontent.com/assets/4974056/6151519/655a53e8-b1e4-11e4-94d5-0c95144049b3.png)


Now it is changed to
![screen shot 2015-02-11 at 11 44 07 am](https://cloud.githubusercontent.com/assets/4974056/6151526/6b20107e-b1e4-11e4-8dbe-e958a019dd22.png)


<b><big>Side effects</big></b>
This change only add "wiki pages" into the warning message, but actually all user-created content may have a chance to contain identify information, for example, addons.