### PR TITLE
Fix issue where long filenames wrapping in project overview

### DIFF
--- a/website/static/css/fangorn.css
+++ b/website/static/css/fangorn.css
@@ -46,7 +46,7 @@ text-align: center;
 	line-height: 14px;
 	background: url('/static/img/hgrid/header-columns-bg.gif');
 	padding: 3px 0px 7px 5px;
-font-size: 13px
+	font-size: 13px
 }
 
 .tb-td {
@@ -66,4 +66,7 @@ font-size: 13px
 }
 .tb-row .icon-remove {
 	cursor : pointer;
+}
+.tb-notify {
+	white-space: nowrap;
 }

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -206,7 +206,7 @@ function _fangornUploadProgress(treebeard, file, progress) {
 
     if(treebeard.options.placement === 'dashboard'){
         column = null;
-        msgText += file.name + '  : ';
+        msgText += file.name.slice(0,25) + '... : ';
     } else {
         column = 1;
     }


### PR DESCRIPTION
## Purpose
Fixes error reported in flowdock where when uploading a file with a long name in project overview page the file name wraps to other rows. 

## Changes
Truncated the file name in project overview upload notification and added nowrap style so there is no wrapping in any case. 

## Side effects
This doesn't change the behavior in other upload situations or treebeard instances. Should not have any side effects.  