### PR TITLE
[feature] ace snippets inline formatting

### DIFF
--- a/website/addons/wiki/static/ace-markdown-snippets.js
+++ b/website/addons/wiki/static/ace-markdown-snippets.js
@@ -10,15 +10,19 @@ snippet font-bold\n\
 	**${1:text}**\n\
 \n\
 snippet heading-1\n\
+	\n\
 	# ${1:title}\n\
 \n\
 snippet heading-2\n\
+	\n\
 	## ${1:title}\n\
 \n\
 snippet heading-3\n\
+	\n\
 	### ${1:title}\n\
 \n\
 snippet heading-4\n\
+	\n\
 	#### ${1:title}\n\
 \n\
 snippet horizontal-rule\n\
@@ -27,9 +31,11 @@ snippet horizontal-rule\n\
 	\n\
 \n\
 snippet blockquote\n\
+	\n\
 	> ${1:quote}\n\
 \n\
 snippet codeblock\n\
+	\n\
 	```\n\
 	${1:snippet}\n\
 	```\n\
@@ -43,9 +49,11 @@ snippet hyperlink\n\
 	[${1:linktext}](${2:url} \"${3:title}\")\n\
 \n\
 snippet numbered-list\n\
+	\n\
 	1. ${1:item}\n\
 \n\
 snippet bulleted-list\n\
+	\n\
 	* ${1:item}\n\
 \n\
 ";


### PR DESCRIPTION
Purpose
---

Adds a new line before snippet code where the snippet is required to start at the beginning of a line for proper formatting.

Cause
---

Selecting snippets like `blockquote` while in the middle of typing a sentence did not move to a separate line and would not render.

Side effects
---

None