### PR TITLE
Feature/deprecate citation properties

### DIFF
--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -492,7 +492,7 @@ class User(GuidStoredObject, AddonModelMixin):
     def csl_name(self):
         return {
             'family': self.family_name,
-            'given': self.given_name,
+            'given': ' '.join(part for part in [self.given_name, self.middle_names] if part),
         }
 
     def change_password(self, raw_old_password, raw_new_password, raw_confirm_password):

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -48,7 +48,8 @@ var entry = {
         'dropzone',
         'knockout-sortable',
         'treebeard',
-        'jquery.cookie'
+        'jquery.cookie',
+        'citations'
     ]
 };
 
@@ -106,7 +107,8 @@ var resolve = {
         'addonHelper': staticPath('js/addonHelper.js'),
         'koHelpers': staticPath('js/koHelpers.js'),
         'addonPermissions': staticPath('js/addonPermissions.js'),
-        'navbar-control': staticPath('js/navbarControl.js')
+        'navbar-control': staticPath('js/navbarControl.js'),
+        'citations': staticPath('js/citations.js')
     }
 };
 

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2025,36 +2025,6 @@ class Node(GuidStoredObject, AddonModelMixin):
         ]
 
     @property
-    def citation_apa(self):
-        return u'{authors} ({year}). {title}. Retrieved from Open Science Framework, <a href="{url}">{display_url}</a>'.format(
-            authors=self.author_list(and_delim='&'),
-            year=self.logs[-1].date.year if self.logs else '?',
-            title=self.title,
-            url=self.url,
-            display_url=self.display_absolute_url,
-        )
-
-    @property
-    def citation_mla(self):
-        return u'{authors} "{title}." Open Science Framework, {year}. <a href="{url}">{display_url}</a>'.format(
-            authors=self.author_list(and_delim='and'),
-            year=self.logs[-1].date.year if self.logs else '?',
-            title=self.title,
-            url=self.url,
-            display_url=self.display_absolute_url,
-        )
-
-    @property
-    def citation_chicago(self):
-        return u'{authors} "{title}." Open Science Framework ({year}). <a href="{url}">{display_url}</a>'.format(
-            authors=self.author_list(and_delim='and'),
-            year=self.logs[-1].date.year if self.logs else '?',
-            title=self.title,
-            url=self.url,
-            display_url=self.display_absolute_url,
-        )
-
-    @property
     def parent_node(self):
         """The parent node, if it exists, otherwise ``None``. Note: this
         property is named `parent_node` rather than `parent` to avoid a

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -723,11 +723,6 @@ def _view_project(node, auth, primary=False):
             'redirect_url': redirect_url,
             'display_absolute_url': node.display_absolute_url,
             'in_dashboard': in_dashboard,
-            'citations': {
-                'apa': node.citation_apa,
-                'mla': node.citation_mla,
-                'chicago': node.citation_chicago,
-            } if not anonymous else '',
             'is_public': node.is_public,
             'date_created': iso8601format(node.date_created),
             'date_modified': iso8601format(node.logs[-1].date) if node.logs else '',

--- a/website/static/js/citationList.js
+++ b/website/static/js/citationList.js
@@ -1,0 +1,52 @@
+'use strict';
+
+var $ = require('jquery');
+var ko = require('knockout');
+var $osf = require('osfHelpers');
+var citations = require('citations');
+
+var BASE_URL = '/static/vendor/bower_components/styles/';
+var STYLES = {
+    apa: 'apa.csl',
+    mla: 'modern-language-association.csl',
+    chicago: 'chicago-author-date.csl'
+};
+
+var ctx = window.contextVars;
+
+var formatCitation = function(style, data, format) {
+    var citeproc = citations.makeCiteproc(style, data, format);
+    return citeproc.makeBibliography()[1];
+};
+
+var ViewModel = function() {
+    this.apa = ko.observable();
+    this.mla = ko.observable();
+    this.chicago = ko.observable();
+};
+
+ViewModel.prototype.fetch = function() {
+    var self = this;
+    var citationRequest = $.ajax(ctx.node.urls.api + 'citation/');
+    var styleRequests = [
+        $.ajax(BASE_URL + STYLES.apa),
+        $.ajax(BASE_URL + STYLES.mla),
+        $.ajax(BASE_URL + STYLES.chicago)
+    ];
+    var requests = [citationRequest].concat(styleRequests);
+    $.when.apply(self, requests).done(function(data, apa, mla, chicago) {
+        self.apa(formatCitation(apa[0], data[0], 'text'));
+        self.mla(formatCitation(mla[0], data[0], 'text'));
+        self.chicago(formatCitation(chicago[0], data[0], 'text'));
+    }).fail(function() {
+        console.log('Could not load citations');
+    });
+};
+
+var CitationList = function(selector) {
+    this.viewModel = new ViewModel();
+    $osf.applyBindings(this.viewModel, selector);
+    this.viewModel.fetch();
+};
+
+module.exports = CitationList;

--- a/website/static/js/citationWidget.js
+++ b/website/static/js/citationWidget.js
@@ -1,0 +1,81 @@
+/**
+ * Controller for the rich citation widget on the project overview page.
+ */
+'use strict';
+
+var $ = require('jquery');
+var Raven = require('raven-js');
+var $osf = require('osfHelpers');
+var citations = require('citations');
+
+require('select2');
+require('../css/citations.css');
+
+var ctx = window.contextVars;
+
+var formatResult = function(state) {
+    return '<div class="citation-result-title">' + state.title + '</div>';
+};
+
+var formatSelection = function(state) {
+    return state.title;
+};
+
+// Public API
+
+function CitationWidget(inputSelector, displaySelector) {
+    this.$input = $(inputSelector || '#citationStyleInput');
+    this.$citationElement = $(displaySelector || '#citationText');
+    this.init();
+}
+
+CitationWidget.prototype.init = function() {
+    var self = this;
+    // Initialize select2 for selecting citation style
+    self.$input.select2({
+        allowClear: true,
+        formatResult: formatResult,
+        formatSelection: formatSelection,
+        placeholder: 'Citation Style (e.g. "APA")',
+        minimumInputLength: 1,
+        ajax: {
+            url: '/api/v1/citations/styles/',
+            quietMillis: 200,
+            data: function(term, page) {
+                return {
+                    'q': term
+                };
+            },
+            results: function(data, page) {
+                return {results: data.styles};
+            },
+            cache: true
+        }
+    }).on('select2-selecting', function(event) {
+        var styleUrl = '/static/vendor/bower_components/styles/' + event.val + '.csl';
+        var styleRequest = $.get(styleUrl);
+        var citationRequest = $.get(ctx.node.urls.api + 'citation/');
+        $.when(styleRequest, citationRequest).done(function(style, data) {
+            var citeproc = citations.makeCiteproc(style[0], data[0], 'text');
+            var items = citeproc.makeBibliography()[1];
+            self.$citationElement.text(items[0]).slideDown();
+        }).fail(function(jqxhr, status, error) {
+            $osf.growl(
+                'Citation render failed',
+                'The requested citation format generated an error.',
+                'danger'
+            );
+            Raven.captureMessage('Unexpected error when fetching citation', {
+                url: styleUrl,
+                citationStyle: event.val,
+                status: status,
+                error: error
+            });
+        });
+    }).on('select2-removed', function (e) {
+        self.$citationElement.slideUp().text();
+    });
+
+};
+
+module.exports = CitationWidget;

--- a/website/static/js/citations.js
+++ b/website/static/js/citations.js
@@ -1,26 +1,6 @@
-/**
- * Controller for the rich citation widget on the project overview page.
- */
 'use strict';
 
-var $ = require('jquery');
-var Raven = require('raven-js');
-
-var $osf = require('osfHelpers');
-require('select2');
-require('../css/citations.css');
-
 var locale = require('raw!../vendor/bower_components/locales/locales-en-US.xml');
-
-var ctx = window.contextVars;
-
-var formatResult = function(state) {
-    return '<div class="citation-result-title">' + state.title + '</div>';
-};
-
-var formatSelection = function(state) {
-    return state.title;
-};
 
 var makeCiteproc = function(style, citations, format) {
     format = format || 'html';
@@ -45,61 +25,6 @@ var makeCiteproc = function(style, citations, format) {
     return citeproc;
 };
 
-// Public API
-
-function CitationWidget(inputSelector, displaySelector) {
-    this.$input = $(inputSelector || '#citationStyleInput');
-    this.$citationElement = $(displaySelector || '#citationText');
-    this.init();
-}
-
-CitationWidget.prototype.init = function() {
-    var self = this;
-    // Initialize select2 for selecting citation style
-    self.$input.select2({
-        allowClear: true,
-        formatResult: formatResult,
-        formatSelection: formatSelection,
-        placeholder: 'Citation Style (e.g. "APA")',
-        minimumInputLength: 1,
-        ajax: {
-            url: '/api/v1/citations/styles/',
-            quietMillis: 200,
-            data: function(term, page) {
-                return {
-                    'q': term
-                };
-            },
-            results: function(data, page) {
-                return {results: data.styles};
-            },
-            cache: true
-        }
-    }).on('select2-selecting', function(event) {
-        var styleUrl = '/static/vendor/bower_components/styles/' + event.val + '.csl';
-        var styleRequest = $.get(styleUrl);
-        var citationRequest = $.get(ctx.node.urls.api + 'citation/');
-        $.when(styleRequest, citationRequest).done(function(style, citations) {
-            var citeproc = makeCiteproc(style[0], citations[0], 'text');
-            var items = citeproc.makeBibliography()[1];
-            self.$citationElement.text(items[0]).slideDown();
-        }).fail(function(jqxhr, status, error) {
-            $osf.growl(
-                'Citation render failed',
-                'The requested citation format generated an error.',
-                'danger'
-            );
-            Raven.captureMessage('Unexpected error when fetching citation', {
-                url: styleUrl,
-                citationStyle: event.val,
-                status: status,
-                error: error
-            });
-        });
-    }).on('select2-removed', function (e) {
-        self.$citationElement.slideUp().text();
-    });
-
+module.exports = {
+    makeCiteproc: makeCiteproc
 };
-
-module.exports = CitationWidget;

--- a/website/static/js/pages/project-dashboard-page.js
+++ b/website/static/js/pages/project-dashboard-page.js
@@ -16,7 +16,8 @@ var Raven = require('raven-js');
 
 var NodeControl = require('../nodeControl.js');
 
-var CitationWidget = require('../citations.js');
+var CitationList = require('../citationList.js');
+var CitationWidget = require('../citationWidget.js');
 
 var ctx = window.contextVars;
 var nodeApiUrl = ctx.node.urls.api;
@@ -29,9 +30,7 @@ $('body').on('nodeLoad', function(event, data) {
     new LogFeed('#logScope', nodeApiUrl + 'log/');
     // Initialize nodeControl
     new NodeControl('#projectScope', data);
-
 });
-
 
 // Initialize comment pane w/ it's viewmodel
 var $comments = $('#comments');
@@ -44,6 +43,7 @@ if ($comments.length) {
 
 // Initialize CitationWidget if user isn't viewing through an anonymized VOL
 if (!ctx.node.anonymous) {
+    new CitationList('#citationList');
     new CitationWidget('#citationStyleInput', '#citationText');
 }
 

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -201,13 +201,13 @@
                 </div>
             </div>
             <div class="addon-widget-body" style="display:none">
-                <dl class="citation-list">
+                <dl id="citationList" class="citation-list">
                     <dt>APA</dt>
-                        <dd class="citation-text">${node['citations']['apa']}</dd>
+                        <dd class="citation-text" data-bind="text: apa"></dd>
                     <dt>MLA</dt>
-                        <dd class="citation-text">${node['citations']['mla']}</dd>
+                        <dd class="citation-text" data-bind="text: mla"></dd>
                     <dt>Chicago</dt>
-                        <dd class="citation-text">${node['citations']['chicago']}</dd>
+                        <dd class="citation-text" data-bind="text: chicago"></dd>
                 </dl>
                 <p><strong>More</strong></p>
                 <div id="citation-style-panel">


### PR DESCRIPTION
# Purpose
Render APA, MLA, and Chicago using citeproc-js.

# Changes
* Remove deprecated citation properties on `Node`
* Add `CitationList` widget to bind citation text
* Handle middle names in CSL

# Side effects
None expected