### PR TITLE
Feature/deprecate citation properties

### DIFF
--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -489,10 +489,17 @@ class User(GuidStoredObject, AddonModelMixin):
         return check_password_hash(self.password, raw_password)
 
     @property
+    def csl_given_name(self):
+        parts = [self.given_name]
+        if self.middle_names:
+            parts.extend(each[0] for each in re.split(r'\s+', self.middle_names))
+        return ' '.join(parts)
+
+    @property
     def csl_name(self):
         return {
             'family': self.family_name,
-            'given': ' '.join(part for part in [self.given_name, self.middle_names] if part),
+            'given': self.csl_given_name,
         }
 
     def change_password(self, raw_old_password, raw_new_password, raw_confirm_password):

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -1983,7 +1983,7 @@ class Node(GuidStoredObject, AddonModelMixin):
         """
         csl = {
             'id': self._id,
-            'title': self.title,
+            'title': html_parser.unescape(self.title),
             'author': [
                 contributor.csl_name  # method in auth/model.py which parses the names of authors
                 for contributor in self.contributors


### PR DESCRIPTION
# Purpose
Add hacks to fix CSL rendering

# Changes
* Append middle initials (rather than middle names) to given name
* Unescape title text server-side (since we're storing escaped text in mongo)