### PR TITLE
[hotfix] sharejs debug environment

### DIFF
--- a/website/addons/wiki/shareServer.js
+++ b/website/addons/wiki/shareServer.js
@@ -11,7 +11,7 @@ var morgan = require('morgan');
 var async = require('async');
 
 var settings = {
-    debug: process.env.SHAREJS_DEBUG ? Boolean(process.env.SHAREJS_DEBUG) : true,
+    debug: process.env.SHAREJS_DEBUG ? process.env.SHAREJS_DEBUG === 'true' : true,
     // Server Options
     host: process.env.SHAREJS_SERVER_HOST || 'localhost',
     port: process.env.SHAREJS_SERVER_PORT || 7007,
@@ -24,6 +24,7 @@ var settings = {
     sentryDSN: process.env.SHAREJS_SENTRY_DSN
 };
 
+debugger;
 var client = new raven.Client(settings.sentryDSN);
 
 if (!settings.debug) {

--- a/website/addons/wiki/shareServer.js
+++ b/website/addons/wiki/shareServer.js
@@ -24,7 +24,6 @@ var settings = {
     sentryDSN: process.env.SHAREJS_SENTRY_DSN
 };
 
-debugger;
 var client = new raven.Client(settings.sentryDSN);
 
 if (!settings.debug) {


### PR DESCRIPTION
Properly set the sharejs server's debug environment flag.