### PR TITLE
Feature/clarify visibility toggle language

### DIFF
--- a/website/static/js/project.js
+++ b/website/static/js/project.js
@@ -231,12 +231,12 @@ $(document).ready(function() {
         trigger: 'hover'
     });
 
-    var visibilityInfoHtml = 'Only visible contributors will be displayed ' +
-        'in the Contributors list and in project citations. Non-visible ' +
-        'contributors can read and modify the project as normal.';
+    var bibliographicContribInfoHtml = 'Only bibliographic contributors will be displayed ' +
+           'in the Contributors list and in project citations. Non-bibliographic contributors ' +
+            'can read and modify the project as normal.';
 
     $('.visibility-info').attr(
-        'data-content', visibilityInfoHtml
+        'data-content', bibliographicContribInfoHtml
     ).popover({
         trigger: 'hover'
     });

--- a/website/templates/project/contributors.mako
+++ b/website/templates/project/contributors.mako
@@ -37,10 +37,10 @@
                                 ></i>
                         </th>
                         <th class="col-md-3">
-                            Visibility
+                            Bibliographic Contributor
                             <i class="icon-question-sign visibility-info"
                                     data-toggle="popover"
-                                    data-title="Visibility Information"
+                                    data-title="Bibliographic Contributor Information"
                                     data-container="body"
                                     data-placement="right"
                                     data-html="true"


### PR DESCRIPTION
<h2>Purpose</h2>

The language for the visibility popover was unclear. When a project owner checks the visibility toggle for a contributor, it makes them visible in the project citations. It does not change privacy settings. This was unclear. It would be clearer if the toggle name and help information for this feature were changed from "Visibility" to "Bibliographic Contributor"

Addresses: https://github.com/CenterForOpenScience/openscienceframework.org/issues/1167

<h2>Changes</h2>

Changes language to what was suggested in the issue comments ie "Visibility" to "Bibliographic Contributor" both in the mako templates and the js file from where the language is attained.

Did not change the internal python functions associated with this, which are in fact also called "visibility"

<h2>Side Effects</h2>

None.
