### PR TITLE
[Hotfix] unauthed addon files

### DIFF
--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
+import time
 import mock
 import unittest
-import time
 from nose.tools import *  # noqa
 
 import webtest
@@ -391,8 +391,27 @@ class TestAddonFileViews(OsfTestCase):
         super(TestAddonFileViews, self).setUp()
         self.user = AuthUserFactory()
         self.project = ProjectFactory(creator=self.user)
+
+        self.user.add_addon('github')
         self.project.add_addon('github', auth=Auth(self.user))
+
+        self.user_addon = self.user.get_addon('github')
         self.node_addon = self.project.get_addon('github')
+        self.oauth = AddonGitHubOauthSettings(
+            github_user_id='denbarell',
+            oauth_access_token='Truthy'
+        )
+
+        self.oauth.save()
+
+        self.user_addon.oauth_settings = self.oauth
+        self.user_addon.save()
+
+        self.node_addon.user_settings = self.user_addon
+        self.node_addon.save()
+
+        # self.node_addon.user_settings = 'Truthy'
+        # setattr(self.node_addon, 'has_auth', True)
 
     def get_mako_return(self):
         ret = serialize_node(self.project, Auth(self.user), primary=True)
@@ -486,6 +505,24 @@ class TestAddonFileViews(OsfTestCase):
         assert_true(guid)
         assert_false(created)
         assert_equals(guid.waterbutler_path, '/' + path)
+
+    def test_unauthorized_addons_raise(self):
+        path = 'cloudfiles'
+        self.node_addon.user_settings = None
+        self.node_addon.save()
+
+        resp = self.app.get(
+            self.project.web_url_for(
+                'addon_view_or_download_file',
+                path=path,
+                provider='github',
+                action='download'
+            ),
+            auth=self.user.auth,
+            expect_errors=True
+        )
+
+        assert_equals(resp.status_code, 403)
 
     @mock.patch('website.addons.base.views.request')
     @mock.patch('website.addons.base.views.requests.get')

--- a/website/addons/base/__init__.py
+++ b/website/addons/base/__init__.py
@@ -447,6 +447,11 @@ class AddonNodeSettingsBase(AddonSettingsBase):
         'abstract': True,
     }
 
+    @property
+    def has_auth(self):
+        """Whether the node has added credentials for this addon."""
+        return False
+
     def to_json(self, user):
         ret = super(AddonNodeSettingsBase, self).to_json(user)
         ret.update({

--- a/website/addons/base/views.py
+++ b/website/addons/base/views.py
@@ -274,6 +274,9 @@ def addon_view_or_download_file(auth, path, provider, **kwargs):
     if not path or not node_addon:
         raise HTTPError(httplib.BAD_REQUEST)
 
+    if not node_addon.has_auth:
+        raise HTTPError(httplib.FORBIDDEN)
+
     if not path.startswith('/'):
         path = '/' + path
 
@@ -331,6 +334,9 @@ def addon_render_file(auth, path, provider, **kwargs):
 
     if not path or not node_addon:
         raise HTTPError(httplib.BAD_REQUEST)
+
+    if not node_addon.has_auth:
+        raise HTTPError(httplib.UNAUTHORIZED)
 
     if not path.startswith('/'):
         path = '/' + path

--- a/website/addons/github/model.py
+++ b/website/addons/github/model.py
@@ -200,6 +200,10 @@ class AddonGitHubNodeSettings(AddonNodeSettingsBase):
 
     registration_data = fields.DictionaryField()
 
+    @property
+    def has_auth(self):
+        return bool(self.user_settings and self.user_settings.has_auth)
+
     def find_or_create_file_guid(self, path):
         try:
             return GithubGuidFile.find_one(

--- a/website/addons/osfstorage/model.py
+++ b/website/addons/osfstorage/model.py
@@ -71,6 +71,10 @@ class OsfStorageNodeSettings(AddonNodeSettingsBase):
 
     file_tree = fields.ForeignField('OsfStorageFileTree')
 
+    @property
+    def has_auth(self):
+        return True
+
     def find_or_create_file_guid(self, path):
         return OsfStorageGuidFile.get_or_create(self.owner, path.lstrip('/'))
 

--- a/website/addons/s3/model.py
+++ b/website/addons/s3/model.py
@@ -203,7 +203,7 @@ class AddonS3NodeSettings(AddonNodeSettingsBase):
 
     @property
     def has_auth(self):
-        return self.user_settings and self.user_settings.has_auth
+        return bool(self.user_settings and self.user_settings.has_auth)
         #TODO Update callbacks
 
     def before_register(self, node, user):


### PR DESCRIPTION
Fixes #1819

In some cases when attempting to view a file that was no longer authorized an uncaught exception when attempting to retrieve the authorization from osf as `user_settings` was `None`.

Fixed by adding in a check of `has_auth` and adding `has_auth` to all addons that don't have it.

Side effects:

All waterbutler/Crud addons now need to implement `has_auth` ping @mfraezz @kushG 