### PR TITLE
Browser check and labels, closes #1703 and closes #1483

### DIFF
--- a/website/static/js/pages/base-page.js
+++ b/website/static/js/pages/base-page.js
@@ -73,6 +73,12 @@ $(document).on('click', '.project-toggle', function() {
     return false;
 });
 
+$(function() {
+  if(/MSIE 9.0/.test(navigator.userAgent) || /MSIE 8.0/.test(navigator.userAgent) ||/MSIE 7.0/.test(navigator.userAgent) ||/MSIE 6.0/.test(navigator.userAgent)) {
+    $('.placeholder-replace').show();
+  }
+});
+
 var NO_FOOTER_PATHS = ['/login/', '/getting-started/', '/register/'];
 $(function() {
     if ($(sliderSelector).length > 0 &&

--- a/website/templates/index.mako
+++ b/website/templates/index.mako
@@ -12,6 +12,7 @@
         <div id="signUpScope" class="col-sm-4 col-md-offset-1 img-rounded hpSignUp">
             <form data-bind="submit: submit, css: {hideValidation: !showValidation()}">
                 <div class="form-group" data-bind="css: {'has-error': fullName() && !fullName.isValid()}">
+                    <label class="placeholder-replace" style="display:none">Full Name</label>
                     <input class="form-control" placeholder="Full Name" data-bind="
                         value: fullName,
                         valueUpdate: 'input',
@@ -22,6 +23,7 @@
                         }"/>
                 </div>
                 <div class="form-group" data-bind="css: {'has-error': email1() && !email1.isValid()}">
+                    <label class="placeholder-replace" style="display:none">Contact Email</label>
                     <input class="form-control" placeholder="Contact Email" data-bind="
                         value: email1,
                         valueUpdate: 'input',
@@ -32,6 +34,7 @@
                         }"/>
                 </div>
                 <div class="form-group" data-bind="css: {'has-error': email2() && !email2.isValid()}">
+                    <label class="placeholder-replace" style="display:none">Confirm Email</label>
                     <input class="form-control" placeholder="Confirm Email" data-bind="
                         value: email2,
                         valueUpdate: 'input',
@@ -42,6 +45,7 @@
                         }"/>
                 </div>
                 <div class="form-group" data-bind="css: {'has-error': password() && !password.isValid()}">
+                    <label class="placeholder-replace" style="display:none">Password</label>
                     <input type="password" class="form-control" placeholder="Password" data-bind="
                         value: password,
                         valueUpdate: 'input',


### PR DESCRIPTION
## Purpose
The signup page has placeholders that do not work in MSIE 9 or less. The PR uses navigator.userAgent to see which browser the page is open on and if it claims to be MSIE 9, 8, 7, or 6 for good measure.

closes: #1703 and #1483

## Changes
Ugly UI for IE9 or worse, UX much improved. 

## Suggestions
Suggest using modernizr for future feature detects rather than browser detecting which is often spoofed. 