### PR TITLE
[feature] getting-started page scrollspy too big

### DIFF
--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -45,10 +45,21 @@ body {
     font-size: 12px;
     padding: 4px 0 4px 15px;
     opacity: 0.8;
+}/* nested navs */
+.gs-sidebar .nav .nav {
+    display: none;
+}
+/* nested active navs */
+.gs-sidebar .nav .active .nav {
+    display: block;
 }
 /* nested link icons */
 .gs-sidebar .nav .nav>li>a i {
     display: none;
+}
+/* nested active link icons */
+.gs-sidebar .nav .nav>.active>a i {
+    display: inline-block;
 }
 /* active & hover links */
 .gs-sidebar .nav>.active>a,
@@ -61,10 +72,6 @@ body {
 .gs-sidebar .nav .nav>.active:hover>a,
 .gs-sidebar .nav .nav>.active:focus>a {
     font-weight: bold;
-}
-/* nested active link icons */
-.gs-sidebar .nav .nav>.active>a i {
-    display: inline-block;
 }
 /* affixed sidebar */
 .gs-sidebar,


### PR DESCRIPTION
## Purpose
As a result, users could scroll passed the nav menu and it wouldn't
correct itself until the user would hit the bottom of the page
and affix would become affix-bottom.
![screen shot 2015-02-19 at 4 35 40 pm](https://cloud.githubusercontent.com/assets/2614670/6276543/9feca9b2-b855-11e4-91a2-5dd76415a13a.png)

## Changes
Hide sub nav elements (list items) until they become **active**.
![screen shot 2015-02-19 at 4 36 08 pm](https://cloud.githubusercontent.com/assets/2614670/6276567/c1b9147c-b855-11e4-9174-e1bd9d060dc6.png)

## Side Effects
None.


Closes-issue: #1843