### PR TITLE
[feature] footerSlideIn shouldn't show up on these pages

### DIFF
--- a/website/static/js/pages/base-page.js
+++ b/website/static/js/pages/base-page.js
@@ -73,7 +73,7 @@ $(document).on('click', '.project-toggle', function() {
     return false;
 });
 
-var NO_FOOTER_PATHS = ['/login/', '/getting-started/', '/register/'];
+var NO_FOOTER_PATHS = ['/', '/login/', '/getting-started/', '/register/', '/forgotpassword/'];
 $(function() {
     if ($(sliderSelector).length > 0 &&
             $.inArray(window.location.pathname, NO_FOOTER_PATHS) === -1) {


### PR DESCRIPTION
## Purpose
Stop footerSlideIn from showing up on pages where it doesn't need to be.

## Changes
It won't show up on the landing page or forgotpassword page.

## Side Effects
Users won't be annoyed by redundant messages.

Closes-issue: #1844