### PR TITLE
Fix error in graph caused by inconsistent data lengths for various providers

### DIFF
--- a/website/search/share_search.py
+++ b/website/search/share_search.py
@@ -161,7 +161,6 @@ def data_for_charts(elastic_results):
 
     default_buckets = []
     for bucket in elastic_results['aggregations']['date_chunks']['buckets']:
-        # if len(bucket['articles_over_time']['buckets']) > len(default_buckets):
         default_buckets = bucket['articles_over_time']['buckets']
         stats[bucket['key']]['articles_over_time'] = bucket['articles_over_time']['buckets']
 

--- a/website/search/share_search.py
+++ b/website/search/share_search.py
@@ -161,9 +161,11 @@ def data_for_charts(elastic_results):
 
     default_buckets = []
     for bucket in elastic_results['aggregations']['date_chunks']['buckets']:
+        # if len(bucket['articles_over_time']['buckets']) > len(default_buckets):
         default_buckets = bucket['articles_over_time']['buckets']
         stats[bucket['key']]['articles_over_time'] = bucket['articles_over_time']['buckets']
 
+    max_len = 0
     for key, value in stats.iteritems():
         if not stats[key].get('earlier_documents'):
             stats[key]['earlier_documents'] = 0
@@ -176,6 +178,8 @@ def data_for_charts(elastic_results):
                 }
                 for item in default_buckets
             ]
+        if len(stats[key]['articles_over_time']) > max_len:
+                max_len = len(stats[key]['articles_over_time'])
 
     names = ['x']
     numbers = [['x']]
@@ -186,6 +190,8 @@ def data_for_charts(elastic_results):
         try:
             names.append(key)
             x = [item['doc_count'] for item in value['articles_over_time']]
+            if len(x) < max_len:
+                x += [0] * (max_len - len(x))
             x[0] += stats[key].get('earlier_documents', 0)
             numbers.append([key] + [sum(x[0:i + 1]) for i in range(len(x[0:]))])
         except IndexError:


### PR DESCRIPTION
Should fix source related graph rendering errors (for example, when you search ["source:pubmed OR source:figshare"](https://osf.io/share/?q=source:figshare%20OR%20source:pubmed))

Should not have any side effects.