### PR TITLE
fix the apmersand being rendered as html in search results

### DIFF
--- a/tests/test_elastic.py
+++ b/tests/test_elastic.py
@@ -95,8 +95,6 @@ class TestUserUpdate(SearchTestCase):
         # Ensure user is not in search index
         assert_equal(len(query_user(user.fullname)['results']), 0)
 
-
-
     def test_merged_user(self):
         user = UserFactory(fullname='Annie Lennox')
         merged_user = UserFactory(fullname='Lisa Stansfield')
@@ -222,6 +220,14 @@ class TestPublicNodes(SearchTestCase):
         self.registration.set_privacy('private')
         docs = query('category:registration AND ' + self.title)['results']
         assert_equal(len(docs), 0)
+
+    def test_public_parent_title(self):
+        self.project.set_title('hello &amp; world',self.consolidate_auth)
+        self.project.save()
+        docs = query('category:component AND ' + self.title)['results']
+        assert_equal(len(docs), 1)
+        assert_equal(docs[0]['parent_title'], 'hello & world')
+        assert_true(docs[0]['parent_url'])
 
     def test_make_parent_private(self):
         """Make parent of component, public, then private, and verify that the

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -168,7 +168,7 @@ def format_result(result, parent_id=None):
         'title': result['title'].replace('&amp;', '&'),
         'url': result['url'],
         'is_component': False if parent_info is None else True,
-        'parent_title': parent_info.get('title') if parent_info is not None else None,
+        'parent_title': parent_info.get('title').replace('&amp;', '&') if parent_info else None,
         'parent_url': parent_info.get('url') if parent_info is not None else None,
         'tags': result['tags'],
         'contributors_url': result['contributors_url'],


### PR DESCRIPTION
<b>Purpose</b>
Fix the problem that the ampersand is still being rendered as html in search results in some instances but not others (appears to be for component search results, but not project results in this case)
![image](https://cloud.githubusercontent.com/assets/4974056/6304833/0d40eb5a-b8f5-11e4-9370-5ca0a3d6ac70.png)


<b>Changes</b>
Now the ampersand is displayed as "&" in search results.
![screen shot 2015-02-20 at 11 39 32 am](https://cloud.githubusercontent.com/assets/4974056/6304842/2eed6d0a-b8f5-11e4-87ac-402d93551087.png)

resolves 
https://github.com/CenterForOpenScience/osf.io/issues/1832