### PR TITLE
[Hotfix] Fix meetings plain page to match meetings.mako

### DIFF
--- a/website/static/js/conference.js
+++ b/website/static/js/conference.js
@@ -23,7 +23,7 @@ function Meeting(data) {
                 },
                 {
                     title: "Author",
-                    width : "25%",
+                    width : "20%",
                     sortType : "text",
                     sort : true
 
@@ -35,7 +35,7 @@ function Meeting(data) {
                 },
                 {
                     title: "Downloads",
-                    width : "10%",
+                    width : "15%",
                     sort : false
                 }
             ]},            

--- a/website/templates/public/pages/meeting_plain.mako
+++ b/website/templates/public/pages/meeting_plain.mako
@@ -89,6 +89,9 @@
     <script type="text/javascript">
         window.contextVars = window.contextVars || {};
         window.contextVars.meetingData = ${data};
+        % if meeting['active'] and meeting['info_url']: 
+            window.contextVars.tbInstructionsLink =  '${ meeting['info_url'] }'; 
+        % endif 
     </script>
     <script src=${"/static/public/js/conference-page.js" | webpack_asset}></script>
 </body>

--- a/website/templates/public/pages/meeting_plain.mako
+++ b/website/templates/public/pages/meeting_plain.mako
@@ -5,7 +5,7 @@
     <title>${ meeting['name'] } Presentations</title>
 
     <%namespace name="globals" file="base.mako" />
-    ${globals.includes_top()}}
+    ${globals.includes_top()}
 
     % if sentry_dsn_js:
     <script src="/static/vendor/bower_components/raven-js/dist/raven.min.js"></script>
@@ -44,20 +44,10 @@
         <h2 style="padding-bottom: 30px;">${ meeting['name'] } Posters & Talks</h2>
 
         % if meeting['logo_url']:
-            <img src="${ meeting['logo_url'] }" class="image-responsive" />
+            <img src="${ meeting['logo_url'] }" class="image-responsive" style="width:100%"/>
             <br /><br />
         % endif
 
-        % if meeting['info_url']:
-            <div><a href="${ meeting['info_url'] }" target="_blank">Add your poster or talk</a></div>
-        % else:
-            <div><a href="#submit">Add your poster or talk</a></div>
-        % endif
-
-        <div style="padding-bottom: 30px;">
-            Search results by title or author:
-            <input id="gridSearch" />
-        </div>
         <div id="grid" style="width: 100%;"></div>
 
         % if not meeting.get('info_url'):


### PR DESCRIPTION
## Purpose 
Fix errors reported in email by Jeff and Brian on the plain version of the presentations mako page. 

## Changes
- Change column widths so that in the narrow version that their iframe uses; the downloads column has more space
- Remove the extra "}" 
- Remove the extra search bar
- Change image being used to width:100% so that the image always fits the screen on different sizes. 

## Side effects
The changes should not bring any side effects. 

Someone should double check this section though, it's supposed to add a special link if the meeting is actve and there is a info_url. In this case (SPSP 2015), meeting[active] is True, meeting['info_url'] is None. Is the data or the logic here correct? There is no reason to assume it's not but good to double check. 

```mako
% if meeting['active'] and meeting['info_url']: 
    window.contextVars.tbInstructionsLink =  '${ meeting['info_url'] }'; 
 % endif  
```