### PR TITLE
Fix user migrations

### DIFF
--- a/website/search_migration/migrate.py
+++ b/website/search_migration/migrate.py
@@ -21,15 +21,17 @@ def migrate_nodes():
     for i, node in enumerate(nodes):
         node.update_search()
 
-    return i + 1  # Started counting from 0
+    logger.info('Nodes migrated: {}'.format(i + 1))
 
 
 def migrate_users():
+    n_iter = 0
     for i, user in enumerate(User.find()):
         if user.is_active:
             user.update_search()
+            n_iter += 1
 
-    return i + 1  # Started counting from 0
+    logger.info('Users iterated: {0}\nUsers migrated: {1}'.format(i + 1, n_iter))
 
 
 def main():
@@ -39,8 +41,8 @@ def main():
 
     search.delete_all()
     search.create_index()
-    logger.info("Nodes migrated: {}".format(migrate_nodes()))
-    logger.info("Users migrated: {}".format(migrate_users()))
+    migrate_nodes()
+    migrate_users()
 
     ctx.pop()
 

--- a/website/search_migration/migrate.py
+++ b/website/search_migration/migrate.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 
 import logging
 from modularodm.query.querydialect import DefaultQueryDialect as Q
+from scripts import utils as script_utils
 from website.models import Node
 from framework.auth import User
 import website.search.search as search
@@ -17,25 +18,30 @@ app = init_app("website.settings", set_backends=True, routes=True)
 
 
 def migrate_nodes():
+    n_iter = 0
     nodes = Node.find(Q('is_public', 'eq', True) & Q('is_deleted', 'eq', False))
-    for i, node in enumerate(nodes):
+    for node in nodes:
         node.update_search()
+        n_iter += 1
 
-    logger.info('Nodes migrated: {}'.format(i + 1))
+    logger.info('Nodes migrated: {}'.format(n_iter))
 
 
 def migrate_users():
+    n_migr = 0
     n_iter = 0
-    for i, user in enumerate(User.find()):
+    for user in User.find():
         if user.is_active:
             user.update_search()
-            n_iter += 1
+            n_migr += 1
+        n_iter += 1
 
-    logger.info('Users iterated: {0}\nUsers migrated: {1}'.format(i + 1, n_iter))
+    logger.info('Users iterated: {0}\nUsers migrated: {1}'.format(n_iter, n_migr))
 
 
 def main():
 
+    script_utils.add_file_logger(logger, __file__)
     ctx = app.test_request_context()
     ctx.push()
 

--- a/website/search_migration/migrate.py
+++ b/website/search_migration/migrate.py
@@ -17,21 +17,19 @@ app = init_app("website.settings", set_backends=True, routes=True)
 
 
 def migrate_nodes():
-    count = 0
     nodes = Node.find(Q('is_public', 'eq', True) & Q('is_deleted', 'eq', False))
-    for node in nodes:
+    for i, node in enumerate(nodes):
         node.update_search()
-        count += 1
-    return count
+
+    return i + 1  # Started counting from 0
 
 
 def migrate_users():
-    count = 0
-    for user in User.find():
+    for i, user in enumerate(User.find()):
         if user.is_active:
             user.update_search()
-            count += 1
-    return count
+
+    return i + 1  # Started counting from 0
 
 
 def main():


### PR DESCRIPTION
Purpose
--------------
This PR ensures that all active users are added to the search index when ```inv migrate_search``` is called.

Changes
--------------
There is some logging added to the end of the migration script, so that we can know how many users/nodes were iterated over and how many should be in the search index. I also iterate over all users and add them if they are active, rather than manually checking a few properties like the previous script did

Side-effects
--------------
Hopefully all users will show up in search after a migration. Other than that, none.