### PR TITLE
[feature] add forgot password page

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2266,6 +2266,11 @@ class TestPublicViews(OsfTestCase):
         res = self.app.get("/explore/").maybe_follow()
         assert_equal(res.status_code, 200)
 
+    def test_forgot_password_get(self):
+        res = self.app.get(web_url_for('_forgot_password'))
+        assert_equal(res.status_code, 200)
+        assert_in("Forgot Password", res.body)
+
 
 class TestAuthViews(OsfTestCase):
 
@@ -2417,6 +2422,10 @@ class TestAuthViews(OsfTestCase):
 
     def test_resend_confirmation_get(self):
         res = self.app.get('/resend/')
+        assert_equal(res.status_code, 200)
+
+    def test_forgot_password_get(self):
+        res = self.app.get(web_url_for('_forgot_password'))
         assert_equal(res.status_code, 200)
 
     def test_confirm_email_clears_unclaimed_records_and_revokes_token(self):

--- a/website/static/js/forgotPassword.js
+++ b/website/static/js/forgotPassword.js
@@ -1,12 +1,12 @@
 /*
  * forgot password view model
  */
-'use srict';
+'use strict';
 
 var ko = require('knockout');
 require('knockout-validation');
 
-var $osf = require('osfHelpers');
+var $osf = require('js/osfHelpers');
 
 var ViewModel = function() {
 

--- a/website/static/js/pages/forgotpassword-page.js
+++ b/website/static/js/pages/forgotpassword-page.js
@@ -2,6 +2,6 @@
  * Forgot Password page
  */
 
-var ForgotPassword = require('../forgotPassword.js');
+var ForgotPassword = require('js/forgotPassword.js');
 
 new ForgotPassword('#forgotPasswordForm', true);

--- a/website/static/js/tests/forgotPassword.test.js
+++ b/website/static/js/tests/forgotPassword.test.js
@@ -3,7 +3,7 @@
 var assert = require('chai').assert;
 var $osf = require('js/osfHelpers');
 
-var forgotPassword = require('../forgotPassword');
+var forgotPassword = require('js/forgotPassword');
 
 // Add sinon asserts to chai.assert, so we can do assert.calledWith instead of sinon.assert.calledWith
 sinon.assert.expose(assert, {prefix: ''});

--- a/website/static/js/tests/forgotPassword.test.js
+++ b/website/static/js/tests/forgotPassword.test.js
@@ -1,0 +1,59 @@
+/*global describe, it, expect, example, before, after, beforeEach, afterEach, mocha, sinon*/
+'use strict';
+var assert = require('chai').assert;
+var $osf = require('js/osfHelpers');
+
+var forgotPassword = require('../forgotPassword');
+
+// Add sinon asserts to chai.assert, so we can do assert.calledWith instead of sinon.assert.calledWith
+sinon.assert.expose(assert, {prefix: ''});
+
+describe('forgotPassword', () => {
+    describe('ViewModels', () => {
+
+        describe('ForgtoPasswordViewModel', () => {
+            var vm;
+
+            var invalidUsername = 'notanemail';
+            var validUsername = 'tim@tom.com';
+
+            beforeEach(() => {
+                vm = new forgotPassword.ViewModel();
+            });
+
+            it('invalid email is not valid', () => {
+                vm.username(invalidUsername);
+                assert.isFalse(vm.username.isValid());
+            });
+
+            it('valid email is valid', () => {
+                vm.username(validUsername);
+                assert.isTrue(vm.username.isValid());
+            });
+
+            describe('submit', () => {
+                var growlSpy;
+
+                beforeEach(() => {
+                    growlSpy = new sinon.stub($osf, 'growl');
+                });
+
+                afterEach(() => {
+                    growlSpy.restore();
+                });
+
+                it('growl called if invalid username submitted', () => {
+                    vm.username(invalidUsername);
+                    vm.submit();
+                    assert.isTrue(growlSpy.calledOnce);
+                });
+                it('growl not called with valid username', () => {
+                    vm.username(validUsername);
+                    vm.submit();
+                    assert.isFalse(growlSpy.called);
+                });
+            });
+        });
+    });
+});
+


### PR DESCRIPTION
## Purpose
Currently, there is no stand alone page where users may request password resets. While this is not an issue if all logins are routed through /login/, it becomes an issue once logins become an option from the navbar in PR #1865. 

## Changes
Users may now use a clean reset password module. Developers can use the viewmodel as either a child component within larger viewmodels or as a standalone.

## Side Effects
webpack.common.config.js has one more line

## Notes
Depends-on-PR: #1728, #1865
Build will fail until dependencies are merged.
Need review