### PR TITLE
Add option to get raw elasticsearch results from share endpoint (for aggregations and such)

### DIFF
--- a/website/search/search.py
+++ b/website/search/search.py
@@ -52,8 +52,8 @@ def search_contributor(query, page=0, size=10, exclude=[], current_user=None):
                                               exclude=exclude, current_user=current_user)
     return result
 
-def search_share(query):
-    return share_search.search(query)
+def search_share(query, raw=False):
+    return share_search.search(query, raw=raw)
 
 def count_share(query):
     return share_search.count(query)

--- a/website/search/share_search.py
+++ b/website/search/share_search.py
@@ -13,15 +13,15 @@ share_es = Elasticsearch(
     request_timeout=settings.ELASTIC_TIMEOUT
 )
 
-def search(query):
+def search(query, raw=False):
     # Run the real query and get the results
-    raw_results = share_es.search(index='share', doc_type=None, body=query)
+    results = share_es.search(index='share', doc_type=None, body=query)
 
-    results = [hit['_source'] for hit in raw_results['hits']['hits']]
-    return {
-        'results': results,
-        'count': raw_results['hits']['total'],
+    return results if raw else {
+        'results': [hit['_source'] for hit in results['hits']['hits']],
+        'count': results['hits']['total'],
     }
+
 
 def count(query):
     if query.get('from') is not None:

--- a/website/search/views.py
+++ b/website/search/views.py
@@ -195,19 +195,23 @@ def search_share():
     tick = time.time()
     results = {}
 
-    is_count = request.args.get('count') is not None
+    count = request.args.get('count') is not None
     raw = request.args.get('raw') is not None
 
     if request.method == 'POST':
-        results = search.count_share(request.get_json()) if is_count else search.search_share(request.get_json(), raw)
+        query = request.get_json()
     elif request.method == 'GET':
-        q = request.args.get('q', '*')
-        # TODO Match javascript params?
-        start = request.args.get('from', '0')
-        size = request.args.get('size', '10')
-        sort = request.args.get('sort')
-        query = build_query(q, start, size, sort=sort)
-        results = search.count_share(query) if is_count else search.search_share(query, raw)
+        query = build_query(
+            request.args.get('q', '*'),
+            request.args.get('from'),
+            request.args.get('size'),
+            sort=request.args.get('sort')
+        )
+
+    if count:
+        results = search.count_share(query)
+    else:
+        results = search.search_share(query, raw)
 
     results['time'] = round(time.time() - tick, 2)
     return results

--- a/website/search/views.py
+++ b/website/search/views.py
@@ -196,9 +196,10 @@ def search_share():
     results = {}
 
     is_count = request.args.get('count') is not None
+    raw = request.args.get('raw') is not None
 
     if request.method == 'POST':
-        results = search.count_share(request.get_json()) if is_count else search.search_share(request.get_json())
+        results = search.count_share(request.get_json()) if is_count else search.search_share(request.get_json(), raw)
     elif request.method == 'GET':
         q = request.args.get('q', '*')
         # TODO Match javascript params?
@@ -206,7 +207,7 @@ def search_share():
         size = request.args.get('size', '10')
         sort = request.args.get('sort')
         query = build_query(q, start, size, sort=sort)
-        results = search.count_share(query) if is_count else search.search_share(query)
+        results = search.count_share(query) if is_count else search.search_share(query, raw)
 
     results['time'] = round(time.time() - tick, 2)
     return results


### PR DESCRIPTION
Purpose
--------------
Allow people to access the raw, unprocessed elasticsearch results for the SHARE data.

Changes
---------------
Accept a ```?raw``` query parameter in the ```/api/v1/share``` route, which causes the raw elasticsearch results to be returned.

Side effects
-----------------
More data will be available from the elasticsearch route, yay!

@chrisseto  @erinspace 