### PR TITLE
Feature/googledrive

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
     "slickgrid": "~2.1.0",
     "reconnectingWebsocket": "#07669519f8",
     "dropzone": "https://github.com/sloria/dropzone.git#accept-directory",
-    "treebeard": "https://github.com/caneruguz/treebeard.git#4112b22be4333c9fce35249131632b6b2a37bb87",
+    "treebeard": "https://github.com/caneruguz/treebeard.git#ae7451090de14e82f77bb1550b4abdc2cd21d404",
     "jquery.cookie": "~1.4.1",
     "hgrid": "~0.2.10",
     "uri.js": "~1.14.1",

--- a/framework/render/core.py
+++ b/framework/render/core.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import os
-import re
 import time
 
 import mfr
@@ -28,21 +27,6 @@ def init_mfr(app):
         'ASSETS_FOLDER': os.path.join(app.static_folder, 'mfr'),
     })
     mfr.collect_static(dest=mfr.config['ASSETS_FOLDER'])
-
-
-mime_map = {
-    'application/pdf': mfr.ext.pdf.Handler,
-}
-
-def detect_by_mimetype(content_type):
-    """Detect MFR handler by content type.
-    :param str content_type: File content type
-    :return: Instance of `Handler` subclass or `None`
-    """
-    # Remove trailing text, e.g. "; charset=utf-8"
-    content_type = re.sub(r';.*', '', content_type).lower()
-    handler_class = mime_map.get(content_type)
-    return handler_class() if handler_class else None
 
 
 def render_is_done_or_happening(cache_path, temp_path):

--- a/framework/render/tasks.py
+++ b/framework/render/tasks.py
@@ -13,7 +13,6 @@ from website.language import ERROR_PREFIX
 
 from framework.tasks import app
 from framework.render import exceptions
-from framework.render.core import detect_by_mimetype
 from framework.render.core import save_to_file_or_error
 from framework.render.core import render_is_done_or_happening
 
@@ -65,7 +64,7 @@ def _build_rendered_html(download_url, cache_path, temp_path, public_download_ur
 
     rendered = None
     try:
-        response = save_to_file_or_error(download_url, temp_path)
+        save_to_file_or_error(download_url, temp_path)
     except exceptions.RenderNotPossibleException as e:
         # Write out unavoidable errors
         rendered = e.renderable_error
@@ -73,8 +72,7 @@ def _build_rendered_html(download_url, cache_path, temp_path, public_download_ur
         with codecs.open(temp_path) as temp_file:
             # Try to render file
             try:
-                handler = detect_by_mimetype(response.headers['content-type'])
-                render_result = mfr.render(temp_file, src=public_download_url, handler=handler)
+                render_result = mfr.render(temp_file, src=public_download_url)
                 # Rendered result
                 rendered = _build_html(render_result)
             except MFRError as err:

--- a/website/addons/googledrive/client.py
+++ b/website/addons/googledrive/client.py
@@ -1,0 +1,146 @@
+import os
+import itertools
+
+import furl
+import requests
+
+from requests_oauthlib import OAuth2Session
+
+from framework import exceptions
+
+from website.util import api_url_for
+from website.addons.googledrive import settings
+
+
+class BaseClient(object):
+
+    def __init__(self, base):
+        self.base = base
+
+    @property
+    def default_headers(self):
+        return {}
+
+    def _make_request(self, method, segments, **kwargs):
+        query = kwargs.pop('query', {})
+        expects = kwargs.pop('expects', None)
+        throws = kwargs.pop('throws', exceptions.HTTPError)
+
+        url = self._build_url(*segments, **query)
+        kwargs['headers'] = self._build_headers(**kwargs.get('headers', {}))
+
+        response = requests.request(method, url, **kwargs)
+        if expects and response.status_code not in expects:
+            raise throws
+
+        return response
+
+    def _build_headers(self, **kwargs):
+        headers = self.default_headers
+        headers.update(kwargs)
+        return {
+            key: value
+            for key, value in headers.items()
+            if value is not None
+        }
+
+    def _build_url(self, *segments, **query):
+        url = furl.furl(self.base)
+        segments = filter(
+            lambda segment: segment,
+            map(
+                lambda segment: segment.strip('/'),
+                itertools.chain(url.path.segments, segments)
+            )
+        )
+        url.path = os.path.join(*segments)
+        url.args = query
+        return url.url
+
+
+class GoogleAuthClient(BaseClient):
+
+    def __init__(self, token=None):
+        super(GoogleAuthClient, self).__init__(settings.OAUTH_BASE_URL)
+
+    def start(self):
+        client = OAuth2Session(
+            settings.CLIENT_ID,
+            redirect_uri=api_url_for('googledrive_oauth_finish', _absolute=True),
+            scope=settings.OAUTH_SCOPE
+        )
+        return client.authorization_url(
+            self._build_url('auth'),
+            access_type='offline',
+            approval_prompt='force'
+        )
+
+    def finish(self, code):
+        client = OAuth2Session(
+            settings.CLIENT_ID,
+            redirect_uri=api_url_for('googledrive_oauth_finish', _absolute=True),
+        )
+        return client.fetch_token(
+            self._build_url('token'),
+            client_secret=settings.CLIENT_SECRET,
+            code=code
+        )
+
+    def refresh(self, token):
+        client = OAuth2Session(
+            settings.CLIENT_ID,
+            token=token
+        )
+        extra = {
+            'client_id': settings.CLIENT_ID,
+            'client_secret': settings.CLIENT_SECRET,
+        }
+        return client.refresh_token(
+            self._build_url('token'),
+            **extra
+        )
+
+    def revoke(self, token):
+        return self._make_request(
+            'GET',
+            ('revoke', ),
+            query={'token': token},
+            expects=(200, 400, ),
+            throws=Exception
+        )
+
+
+class GoogleDriveClient(BaseClient):
+
+    def __init__(self, token=None):
+        super(GoogleDriveClient, self).__init__(settings.DRIVE_BASE_URL)
+        self.token = token
+
+    @property
+    def default_headers(self):
+        if self.token:
+            return {'authorization': 'Bearer {}'.format(self.token)}
+        return {}
+
+    def about(self):
+        return self._make_request(
+            'GET',
+            ('about', ),
+            expects=(200, ),
+            throws=Exception
+        ).json()
+
+    def folders(self, folder_id='root'):
+        query = ' and '.join([
+            "'{0}' in parents".format(folder_id),
+            'trashed = false',
+            "mimeType = 'application/vnd.google-apps.folder'",
+        ])
+        res = self._make_request(
+            'GET',
+            ('files', ),
+            query={'q': query},
+            expects=(200, ),
+            throws=Exception
+        )
+        return res.json()['items']

--- a/website/addons/googledrive/client.py
+++ b/website/addons/googledrive/client.py
@@ -86,10 +86,15 @@ class GoogleAuthClient(BaseClient):
             code=code
         )
 
-    def refresh(self, token):
+    def refresh(self, access_token, refresh_token):
         client = OAuth2Session(
             settings.CLIENT_ID,
-            token=token
+            token={
+                'access_token': access_token,
+                'refresh_token': refresh_token,
+                'token_type': 'Bearer',
+                'expires_in': '-30',
+            }
         )
         extra = {
             'client_id': settings.CLIENT_ID,

--- a/website/addons/googledrive/exceptions.py
+++ b/website/addons/googledrive/exceptions.py
@@ -1,4 +1,4 @@
-from website.addons.base import AddonError
+from website.addons.base.exceptions import AddonError
 
 
 class GoogleDriveError(AddonError):

--- a/website/addons/googledrive/exceptions.py
+++ b/website/addons/googledrive/exceptions.py
@@ -1,0 +1,9 @@
+from website.addons.base import AddonError
+
+
+class GoogleDriveError(AddonError):
+    pass
+
+
+class ExpiredAuthError(GoogleDriveError):
+    pass

--- a/website/addons/googledrive/model.py
+++ b/website/addons/googledrive/model.py
@@ -23,7 +23,6 @@ class GoogleDriveGuidFile(GuidFile):
     @property
     def waterbutler_path(self):
         return self.path.replace(self.folder, '', 1)
-        # return '/' + self.path.replace(self.folder, '', 1).lstrip('/')
 
     @property
     def provider(self):

--- a/website/addons/googledrive/model.py
+++ b/website/addons/googledrive/model.py
@@ -2,11 +2,8 @@
 """Persistence layer for the google drive addon.
 """
 import os
-import time
 import base64
 from datetime import datetime
-
-import requests
 
 from modularodm import fields, Q
 from modularodm.exceptions import ModularOdmException

--- a/website/addons/googledrive/model.py
+++ b/website/addons/googledrive/model.py
@@ -108,13 +108,12 @@ class GoogleDriveUserSettings(AddonUserSettingsBase):
     def has_auth(self):
         return bool(self.access_token)
 
-    def clear(self):  # TODO : check for all the nodes (see dropbox)
+    def clear(self):
         self.access_token = None
-
+        self.refresh_token = None
         for node_settings in self.googledrivenodesettings__authorized:
             node_settings.deauthorize(Auth(self.owner))
             node_settings.save()
-        return self
 
     def delete(self, save=True):
         self.clear()
@@ -259,7 +258,7 @@ class GoogleDriveNodeSettings(AddonNodeSettingsBase):
             category = node.project_or_component
             name = removed.fullname
             return (u'The Google Drive add-on for this {category} is authenticated by {name}. '
-                    'Removing this user will also remove write access to Dropbox '
+                    'Removing this user will also remove write access to Google Drive '
                     'unless another contributor re-authenticates the add-on.'
                     ).format(**locals())
 

--- a/website/addons/googledrive/model.py
+++ b/website/addons/googledrive/model.py
@@ -10,11 +10,13 @@ from modularodm.exceptions import ModularOdmException
 
 from framework.auth import Auth
 
+from website import settings
 from website.addons.base import exceptions
-from website.addons.googledrive import settings
-from website.addons.googledrive.client import GoogleAuthClient
-from website.addons.googledrive.utils import GoogleDriveNodeLogger
 from website.addons.base import AddonUserSettingsBase, AddonNodeSettingsBase, GuidFile
+
+from website.addons.googledrive.client import GoogleAuthClient
+from website.addons.googledrive import settings as drive_settings
+from website.addons.googledrive.utils import GoogleDriveNodeLogger
 
 
 class GoogleDriveGuidFile(GuidFile):
@@ -37,6 +39,24 @@ class GoogleDriveGuidFile(GuidFile):
         if self.revision:
             return '{0}_{1}_{2}.html'.format(self._id, self.revision, base64.b64encode(self.folder))
         return '{0}_{1}_{2}.html'.format(self._id, self.unique_identifier, base64.b64encode(self.folder))
+
+    @property
+    def mfr_temp_path(self):
+        """Files names from Google Docs metadata doesn't necessarily correspond
+        to download file names. Use the `downloadExt` field in the Docs metadata
+        to save the temporary file with the appropriate extension.
+        """
+        ext = (
+            self._metadata_cache['extra'].get('downloadExt') or
+            os.path.splitext(self.name)[-1]
+        )
+        return os.path.join(
+            settings.MFR_TEMP_PATH,
+            self.node._id,
+            self.provider,
+            # Attempt to keep the original extension of the file for MFR detection
+            self.file_name + ext,
+        )
 
     @property
     def folder(self):
@@ -99,7 +119,7 @@ class GoogleDriveUserSettings(AddonUserSettingsBase):
     def needs_refresh(self):
         if self.token_expires_at is None:
             return False
-        return (self.token_expires_at - datetime.utcnow()).total_seconds() < settings.REFRESH_TIME
+        return (self.token_expires_at - datetime.utcnow()).total_seconds() < drive_settings.REFRESH_TIME
 
     @property
     def has_auth(self):

--- a/website/addons/googledrive/requirements.txt
+++ b/website/addons/googledrive/requirements.txt
@@ -1,3 +1,0 @@
-# Requirements for the googledrive add-on
-
-google-api-python-client==1.2

--- a/website/addons/googledrive/settings/defaults.py
+++ b/website/addons/googledrive/settings/defaults.py
@@ -6,5 +6,6 @@ CLIENT_SECRET = 'changeme'
 REFRESH_TIME = 5 * 60  # 5 minutes
 
 # Check https://developers.google.com/drive/scopes for all available scopes
+DRIVE_BASE_URL = 'https://www.googleapis.com/drive/v2/'
+OAUTH_BASE_URL = 'https://accounts.google.com/o/oauth2/'
 OAUTH_SCOPE = ['https://www.googleapis.com/auth/drive']
-REFRESH_ENDPOINT = 'https://www.googleapis.com/oauth2/v3/token'

--- a/website/addons/googledrive/settings/defaults.py
+++ b/website/addons/googledrive/settings/defaults.py
@@ -3,5 +3,8 @@
 CLIENT_ID = 'chaneme'
 CLIENT_SECRET = 'changeme'
 
+REFRESH_TIME = 5 * 60  # 5 minutes
+
 # Check https://developers.google.com/drive/scopes for all available scopes
 OAUTH_SCOPE = ['https://www.googleapis.com/auth/drive']
+REFRESH_ENDPOINT = 'https://www.googleapis.com/oauth2/v3/token'

--- a/website/addons/googledrive/static/googleDriveNodeConfig.js
+++ b/website/addons/googledrive/static/googleDriveNodeConfig.js
@@ -227,7 +227,7 @@ var ViewModel = function(url, selector, folderPicker) {
     };
 
     self.showFolders = ko.computed(function(){
-        return self.nodeHasAuth();
+        return self.nodeHasAuth() && self.userIsOwner();
     });
 
     self.selectedFolderName = ko.computed(function() {

--- a/website/addons/googledrive/static/googleDriveNodeConfig.js
+++ b/website/addons/googledrive/static/googleDriveNodeConfig.js
@@ -1,5 +1,5 @@
 /**
- * Module that controls the Dropbox node settings. Includes Knockout view-model
+ * Module that controls the Google Drive node settings. Includes Knockout view-model
  * for syncing data, and HGrid-folderpicker for selecting a folder.
  */
 'use strict';
@@ -177,7 +177,7 @@ var ViewModel = function(url, selector, folderPicker) {
         });
     }
 
-    /** Pop up a confirmation to deauthorize Dropbox from this node.
+    /** Pop up a confirmation to deauthorize Google Drive from this node.
      *  Send DELETE request if confirmed.
      */
     self.deauthorize = function() {

--- a/website/addons/googledrive/static/googleDriveNodeConfig.js
+++ b/website/addons/googledrive/static/googleDriveNodeConfig.js
@@ -28,15 +28,12 @@ var ViewModel = function(url, selector, folderPicker) {
     // whether current user is authorizer of the addon
     self.userIsOwner = ko.observable(false);
 
-    //Api key required for Google picker
-    self.access_token = ko.observable();
-
     self.owner = ko.observable();
     self.ownerName = ko.observable();
     self.urls = ko.observable({});
     self.loadedFolders = ko.observable(false);
     self.loading = ko.observable(false);
-    self.currentFolder = ko.observable('None');
+    self.currentFolder = ko.observable(null);
 
     //Folderpicker specific
     self.folderPicker =  folderPicker;
@@ -59,12 +56,8 @@ var ViewModel = function(url, selector, folderPicker) {
         self.urls(response.result.urls);
         self.ownerName(response.result.ownerName);
         self.owner(response.result.urls.owner);
-        self.access_token (response.result.access_token);
         self.currentFolder(response.result.currentFolder);
 
-        if (self.currentFolder() == null) {
-            self.currentFolder('None');
-        }
         self.loadedSettings(true);
     }
 
@@ -76,10 +69,10 @@ var ViewModel = function(url, selector, folderPicker) {
         $.ajax({
             url: self.url,
             type: 'GET',
-            dataType: 'json',
-            success: onFetchSuccess,
-            error: onFetchError
-        });
+            dataType: 'json'
+        })
+        .done(onFetchSuccess)
+        .fail(onFetchError);
     }
 
     fetch();
@@ -112,7 +105,7 @@ var ViewModel = function(url, selector, folderPicker) {
             self.urls().create
         ).success(function(response){
             window.location.href = response.url;
-            self.changeMessage('Successfully authorized Google Drive account', 'text-primary');
+            self.changeMessage('Successfully authorized Google Drive account', 'text-success');
         }).fail(function() {
             self.changeMessage('Could not authorize at this moment', 'text-danger');
         });
@@ -165,15 +158,12 @@ var ViewModel = function(url, selector, folderPicker) {
         return $.ajax({
             url: self.urls().deauthorize,
             type: 'DELETE',
-            success: function() {
-                // Update observables
-                self.nodeHasAuth(false);
-                self.changeMessage('Deauthorized Google Drive.', 'text-warning', 3000);
-            },
-            error: function() {
-                self.changeMessage('Could not deauthorize Google Drive because of an error. Please try again later.',
-                                   'text-danger');
-            }
+        }).done(function() {
+            // Update observables
+            self.nodeHasAuth(false);
+            self.changeMessage('Deauthorized Google Drive.', 'text-warning', 3000);
+        }).fail(function() {
+            self.changeMessage('Could not deauthorize Google Drive because of an error. Please try again later.', 'text-danger');
         });
     }
 
@@ -200,7 +190,7 @@ var ViewModel = function(url, selector, folderPicker) {
         evt.preventDefault();
         self.selected({
             id: item.data.id,
-            name: 'Google Drive/' + item.data.path,
+            name: 'Google Drive/' + (item.data.path === '/' ? '' : item.data.path),
             path: item.data.path
         });
         return false; // Prevent event propagation

--- a/website/addons/googledrive/static/googleDriveUserConfig.js
+++ b/website/addons/googledrive/static/googleDriveUserConfig.js
@@ -21,30 +21,30 @@ var ViewModel = function(url) {
     self.username = ko.observable();
 
     //Helper-class variables
-    self.message = ko.observable('')
+    self.message = ko.observable('');
     self.messageClass = ko.observable('text-info');
 
     $.ajax({
-        url: url, type: 'GET', dataType: 'json',
-        success: function(response) {
-            var data =response.result;
-            self.userHasAuth(data.userHasAuth);
-            self.username(data.username)
-            self.urls(data.urls);
-            self.loaded(true);
-        },
-        error: function(xhr, textStatus, error){
-            self.changeMessage(
-                'Could not retrieve settings. Please refresh the page or ' +
-                'contact <a href="mailto: support@osf.io">support@osf.io</a> if the ' +
-                'problem persists.', 'text-warning'
-            );
-            Raven.captureMessage('Could not GET Google Drive settings', {
-                url: url,
-                textStatus: textStatus,
-                error: error
-            });
-        }
+        url: url,
+        type: 'GET',
+        dataType: 'json',
+    }).done(function(response) {
+        var data =response.result;
+        self.userHasAuth(data.userHasAuth);
+        self.username(data.username);
+        self.urls(data.urls);
+        self.loaded(true);
+    }).fail(function(xhr, textStatus, error) {
+        self.changeMessage(
+            'Could not retrieve settings. Please refresh the page or ' +
+            'contact <a href="mailto: support@osf.io">support@osf.io</a> if the ' +
+            'problem persists.', 'text-warning'
+        );
+        Raven.captureMessage('Could not GET Google Drive settings', {
+            url: url,
+            textStatus: textStatus,
+            error: error
+        });
     });
 
     /** Change the flashed status message */
@@ -91,20 +91,17 @@ var ViewModel = function(url) {
     function sendDeauth() {
         return $.ajax({
             url: self.urls().delete,
-            type: 'DELETE',
-            success: function() {
-                window.location.reload();
-                self.changeMessage(language.deauthSuccess, 'text-info', 5000);
-
-            },
-            error: function(textStatus, error) {
-                self.changeMessage(language.deauthError, 'text-danger');
-                Raven.captureMessage('Could not deauthorize Google Drive.', {
-                    url: url,
-                    textStatus: textStatus,
-                    error: error
-                });
-            }
+            type: 'DELETE'
+        }).done(function() {
+            window.location.reload();
+            self.changeMessage(language.deauthSuccess, 'text-info', 5000);
+        }).fail(function(textStatus, error) {
+            self.changeMessage(language.deauthError, 'text-danger');
+            Raven.captureMessage('Could not deauthorize Google Drive.', {
+                url: url,
+                textStatus: textStatus,
+                error: error
+            });
         });
     }
 };

--- a/website/addons/googledrive/templates/googledrive_node_settings.mako
+++ b/website/addons/googledrive/templates/googledrive_node_settings.mako
@@ -39,14 +39,14 @@
        </p>
 
         <div class="btn-group" >
-        <button data-bind="click:changeFolder" class="btn btn-sm btn-dropbox"> Change Folder</button>
+        <button data-bind="click:changeFolder" class="btn btn-sm btn-googledrive"> Change Folder</button>
         </div>
 
         <!-- Google Drive Treebeard -->
-        <p class="text-muted text-center dropbox-loading-text" data-bind="visible: loading">
+        <p class="text-muted text-center googledrive-loading-text" data-bind="visible: loading">
                     Loading folders...</p>
         <div id="myGoogleDriveGrid"
-             class="filebrowser hgrid dropbox-folder-picker">
+             class="filebrowser hgrid googledrive-folder-picker">
 
 
         </div>
@@ -56,7 +56,7 @@
             data-bind="visible:selected">
             <form data-bind="submit: submitSettings">
 
-                <h4 data-bind="if: selected" class="dropbox-confirm-dlg">
+                <h4 data-bind="if: selected" class="googledrive-confirm-dlg">
                     Connect &ldquo;{{ selectedFolderName }}&rdquo;?
                 </h4>
                 <div class="pull-right">

--- a/website/addons/googledrive/templates/googledrive_node_settings.mako
+++ b/website/addons/googledrive/templates/googledrive_node_settings.mako
@@ -33,13 +33,12 @@
        <p>
 
         <strong> Current folder:</strong>
-        <a data-bind="attr.href: urls().files">
-            <span data-bind = "text:currentFolder"> None </span>
-        </a>
+        <a href="{{ urls().files }}" data-bind="if: currentFolder">{{ currentFolder }}</a>
+        <span class="text-muted" data-bind="ifnot: currentFolder">None</span>
        </p>
 
         <div class="btn-group" >
-        <button data-bind="click:changeFolder" class="btn btn-sm btn-googledrive"> Change Folder</button>
+          <button data-bind="click:changeFolder" class="btn btn-sm btn-default"> Change Folder</button>
         </div>
 
         <!-- Google Drive Treebeard -->

--- a/website/addons/googledrive/tests/factories.py
+++ b/website/addons/googledrive/tests/factories.py
@@ -25,13 +25,8 @@ class GoogleDriveNodeSettingsFactory(ModularOdmFactory):
 
     owner = SubFactory(ProjectFactory)
     user_settings = SubFactory(GoogleDriveUserSettingsFactory)
-    folder = 'Camera Uploads'
-    waterbutler_folder = {
-        'id': '12345',
-        'name': 'Camera Uploads',
-        'path':'Drive/Camera Uploads'
-    }
-
+    folder_id = '12345'
+    folder_path = 'Drive/Camera Uploads'
 
 
 class GoogleDriveFileFactory(ModularOdmFactory):

--- a/website/addons/googledrive/utils.py
+++ b/website/addons/googledrive/utils.py
@@ -46,7 +46,7 @@ class GoogleDriveNodeLogger(object):
         params = {
             'project': self.node.parent_id,
             'node': self.node._primary_key,
-            'folder': self.node.get_addon('googledrive', deleted=True).folder_name
+            'folder': self.node.get_addon('googledrive', deleted=True).folder_path
         }
         if extra:
             params.update(extra)
@@ -91,7 +91,6 @@ def serialize_settings(node_settings, current_user):
     if node_settings.has_auth:
         # Add owner's profile URL
         ret['ownerName'] = user_settings.owner.fullname
-        ret['access_token'] = user_settings.access_token
         ret['currentFolder'] = node_settings.folder_name  # if node_settings.folder else None
         ret['urls']['owner'] = web_url_for('profile_view_id', uid=user_settings.owner._id)
 

--- a/website/addons/googledrive/utils.py
+++ b/website/addons/googledrive/utils.py
@@ -2,15 +2,9 @@
 """Utility functions for the Google Drive add-on.
 """
 import os
-import time
 import logging
-import datetime
-
-import requests
 
 from website.util import web_url_for
-
-from . import settings
 
 
 logger = logging.getLogger(__name__)
@@ -69,12 +63,12 @@ class GoogleDriveNodeLogger(object):
 def serialize_urls(node_settings):
     node = node_settings.owner
     return {
-        'create': node.api_url_for('googledrive_oauth_start'),
-        'importAuth': node.api_url_for('googledrive_import_user_auth'),
-        'deauthorize': node.api_url_for('googledrive_deauthorize'),
-        'get_folders': node.api_url_for('googledrive_folders', includeRoot=1),
-        'config': node.api_url_for('googledrive_config_put'),
         'files': node.web_url_for('collect_file_trees'),
+        'config': node.api_url_for('googledrive_config_put'),
+        'create': node.api_url_for('googledrive_oauth_start'),
+        'deauthorize': node.api_url_for('googledrive_deauthorize'),
+        'importAuth': node.api_url_for('googledrive_import_user_auth'),
+        'get_folders': node.api_url_for('googledrive_folders', includeRoot=1),
     }
 
 
@@ -84,9 +78,8 @@ def serialize_settings(node_settings, current_user):
     Provides the return value for the googledrive config endpoints.
     """
     user_settings = node_settings.user_settings
-    user_is_owner = user_settings is not None and (
-        user_settings.owner._primary_key == current_user._primary_key
-    )
+    user_is_owner = user_settings is not None and user_settings.owner == current_user
+
     current_user_settings = current_user.get_addon('googledrive')
     ret = {
         'nodeHasAuth': node_settings.has_auth,
@@ -94,31 +87,21 @@ def serialize_settings(node_settings, current_user):
         'userHasAuth': current_user_settings is not None and current_user_settings.has_auth,
         'urls': serialize_urls(node_settings)
     }
+
     if node_settings.has_auth:
         # Add owner's profile URL
-        ret['urls']['owner'] = web_url_for('profile_view_id', uid=user_settings.owner._id)
         ret['ownerName'] = user_settings.owner.fullname
         ret['access_token'] = user_settings.access_token
         ret['currentFolder'] = node_settings.folder  # if node_settings.folder else None
+        ret['urls']['owner'] = web_url_for('profile_view_id', uid=user_settings.owner._id)
+
     return ret
-
-
-def clean_path(path):
-    """Ensure a path is formatted correctly for url_for."""
-    if path is None:
-        return ''
-    parts = path.strip('/').split('/')
-    if len(parts) <= 1:
-        cleaned_path = '/' + parts[len(parts) - 1]
-    cleaned_path = parts[len(parts) - 1]
-
-    return cleaned_path
 
 
 def build_googledrive_urls(item, node, path):
     return {
-        'get_folders': node.api_url_for('googledrive_folders', folderId=item['id'], path=path),
         'fetch': node.api_url_for('googledrive_folders', folderId=item['id']),
+        'get_folders': node.api_url_for('googledrive_folders', folderId=item['id'], path=path),
     }
 
 
@@ -137,34 +120,3 @@ def to_hgrid(item, node, path):
         'path': path,
     }
     return serialized
-
-
-def check_access_token(user_settings):
-    cur_time_in_millis = time.mktime(datetime.datetime.utcnow().timetuple())
-    if user_settings.token_expiry <= cur_time_in_millis:
-        refresh_access_token(user_settings)
-        # return{'status': 'token_expired'}
-    return {'status': 'token_valid'}
-
-
-def refresh_access_token(user_settings):
-    try:
-        params = {
-            'client_id': settings.CLIENT_ID,
-            'client_secret': settings.CLIENT_SECRET,
-            'refresh_token': user_settings.refresh_token,
-            'grant_type': 'refresh_token',
-        }
-        url = 'https://www.googleapis.com/oauth2/v3/token'
-        response = requests.post(url, params=params)
-        json_response = response.json()
-        refreshed_access_token = json_response['access_token']
-        user_settings.access_token = refreshed_access_token
-        # shadow cur_time_in_millis because of time lapse from post request
-        cur_time_in_millis = time.mktime(datetime.datetime.utcnow().timetuple())
-        user_settings.token_expiry = cur_time_in_millis + json_response['expires_in']
-        user_settings.save()
-        return {'status': 'token_refreshed'}
-    # TODO: Don't catch generic exception @jmcarp
-    except:
-        return {'status': 'token cannot be refreshed at this moment'}

--- a/website/addons/googledrive/utils.py
+++ b/website/addons/googledrive/utils.py
@@ -46,7 +46,7 @@ class GoogleDriveNodeLogger(object):
         params = {
             'project': self.node.parent_id,
             'node': self.node._primary_key,
-            'folder': self.node.get_addon('googledrive', deleted=True).folder
+            'folder': self.node.get_addon('googledrive', deleted=True).folder_name
         }
         if extra:
             params.update(extra)
@@ -92,7 +92,7 @@ def serialize_settings(node_settings, current_user):
         # Add owner's profile URL
         ret['ownerName'] = user_settings.owner.fullname
         ret['access_token'] = user_settings.access_token
-        ret['currentFolder'] = node_settings.folder  # if node_settings.folder else None
+        ret['currentFolder'] = node_settings.folder_name  # if node_settings.folder else None
         ret['urls']['owner'] = web_url_for('profile_view_id', uid=user_settings.owner._id)
 
     return ret

--- a/website/addons/googledrive/views/auth.py
+++ b/website/addons/googledrive/views/auth.py
@@ -103,7 +103,7 @@ def googledrive_oauth_finish(auth, **kwargs):
 @must_have_addon('googledrive', 'user')
 def googledrive_oauth_delete_user(user_addon, **kwargs):
     client = GoogleAuthClient()
-    client.revoke(user_addon.access_token)
+    client.revoke(user_addon._access_token)
     user_addon.clear()
     user_addon.save()
 

--- a/website/addons/googledrive/views/auth.py
+++ b/website/addons/googledrive/views/auth.py
@@ -13,8 +13,10 @@ from website import models
 from website.util import permissions
 from website.util import web_url_for
 from website.project.model import Node
-from website.project.decorators import must_have_addon
-from website.project.decorators import must_have_permission
+from website.project.decorators import (
+    must_have_addon,
+    must_have_permission
+)
 
 from website.addons.googledrive.client import GoogleAuthClient
 from website.addons.googledrive.client import GoogleDriveClient

--- a/website/addons/googledrive/views/auth.py
+++ b/website/addons/googledrive/views/auth.py
@@ -1,4 +1,3 @@
-import time
 import httplib2
 import httplib as http
 
@@ -30,7 +29,7 @@ def googledrive_oauth_start(auth, **kwargs):
     # Run through the OAuth flow and retrieve credentials
     # Store the node ID on the session in order to get the correct redirect URL
     # upon finishing the flow
-    nid = kwargs.get('nid') or kwargs['pid']
+    nid = kwargs.get('nid') or kwargs.get('pid')
     node_addon = auth.user.get_addon('googledrive')
 
     if nid:
@@ -83,7 +82,7 @@ def googledrive_oauth_finish(auth, **kwargs):
     user_settings.access_token = credentials.access_token
     user_settings.refresh_token = credentials.refresh_token
     # Add No. of seconds left for token to expire into current utc time
-    user_settings.token_expiry = time.mktime(credentials.token_expiry.timetuple())
+    user_settings.token_expires_at = credentials.token_expiry
 
     # Retrieves username for authorized google drive
     service = build('drive', 'v2', http_service)

--- a/website/addons/googledrive/views/auth.py
+++ b/website/addons/googledrive/views/auth.py
@@ -1,4 +1,3 @@
-import httplib2
 import httplib as http
 from datetime import datetime
 

--- a/website/addons/googledrive/views/auth.py
+++ b/website/addons/googledrive/views/auth.py
@@ -3,38 +3,41 @@ import httplib2
 import httplib as http
 
 from flask import request
-from oauth2client.client import OAuth2WebServerFlow
 from apiclient.discovery import build
+from oauth2client.client import OAuth2WebServerFlow
 
-from framework.exceptions import HTTPError
-from framework.auth.decorators import must_be_logged_in, collect_auth
 from framework.flask import redirect  # VOL-aware redirect
-from framework.status import push_status_message as flash
 from framework.sessions import session
+from framework.exceptions import HTTPError
+from framework.auth.decorators import must_be_logged_in
+from framework.status import push_status_message as flash
 
 from website.util import api_url_for
-from website.project.model import Node
+from website.util import permissions
 from website.util import web_url_for
-from website.project.decorators import (must_have_addon, must_have_permission)
+from website.project.model import Node
+from website.project.decorators import must_have_addon
+from website.project.decorators import must_have_permission
 
-from ..import settings
-from ..utils import serialize_settings
+from website.addons.googledrive import settings
+from website.addons.googledrive.utils import serialize_settings
+
 
 @must_be_logged_in
 def googledrive_oauth_start(auth, **kwargs):
     """View function that does OAuth Authorization
     and returns access token"""
     # Run through the OAuth flow and retrieve credentials
-    user = auth.user
-    if not user:
-        raise HTTPError(http.FORBIDDEN)
     # Store the node ID on the session in order to get the correct redirect URL
     # upon finishing the flow
-    nid = kwargs.get('nid') or kwargs.get('pid')
+    nid = kwargs.get('nid') or kwargs['pid']
+    node_addon = auth.user.get_addon('googledrive')
+
     if nid:
         session.data['googledrive_auth_nid'] = nid
-    # If user has already authorized dropbox, flash error message
-    if user.has_addon('googledrive') and user.get_addon('googledrive').has_auth:
+
+    # If user has already authorized google drive, flash error message
+    if node_addon and node_addon.has_auth:
         flash('You have already authorized Google Drive for this account', 'warning')
         return redirect(web_url_for('user_addons'))
 
@@ -47,22 +50,22 @@ def googledrive_oauth_start(auth, **kwargs):
     )
     flow.params['approval_prompt'] = 'force'
     authorize_url = flow.step1_get_authorize_url()
-    return{'url': authorize_url}
+    return {'url': authorize_url}
 
 
-@collect_auth
+@must_be_logged_in
 def googledrive_oauth_finish(auth, **kwargs):
     """View called when the Oauth flow is completed. Adds a new GoogleDriveUserSettings
     record to the user and saves the user's access token and account info.
     """
-    if not auth.logged_in:
-        raise HTTPError(http.FORBIDDEN)
     user = auth.user
     user.add_addon('googledrive')
     user.save()
+
+    code = request.args.get('code')
     user_settings = user.get_addon('googledrive')
     node = Node.load(session.data.get('googledrive_auth_nid'))
-    code = request.args.get('code')
+
     if code is None:
         raise HTTPError(http.BAD_REQUEST)
 
@@ -76,11 +79,12 @@ def googledrive_oauth_finish(auth, **kwargs):
     credentials = flow.step2_exchange(code)
     http_service = httplib2.Http()
     http_service = credentials.authorize(http_service)
+
     user_settings.access_token = credentials.access_token
     user_settings.refresh_token = credentials.refresh_token
-    token_expiry_in_millis = time.mktime(credentials.token_expiry.timetuple())
     # Add No. of seconds left for token to expire into current utc time
-    user_settings.token_expiry = token_expiry_in_millis
+    user_settings.token_expiry = time.mktime(credentials.token_expiry.timetuple())
+
     # Retrieves username for authorized google drive
     service = build('drive', 'v2', http_service)
     about = service.about().get().execute()
@@ -100,28 +104,29 @@ def googledrive_oauth_finish(auth, **kwargs):
 
 @must_be_logged_in
 @must_have_addon('googledrive', 'user')
-def googledrive_oauth_delete_user(user_addon, auth, **kwargs):
+def googledrive_oauth_delete_user(user_addon, **kwargs):
     user_addon.clear()
     user_addon.save()
 
 
-@must_have_permission('write')
+@must_have_permission(permissions.WRITE)
 @must_have_addon('googledrive', 'node')
 def googledrive_deauthorize(auth, node_addon, **kwargs):
     node_addon.deauthorize(auth=auth)
     node_addon.save()
-    return None
 
 
-@must_have_permission('write')
+@must_have_permission(permissions.WRITE)
 @must_have_addon('googledrive', 'node')
 def googledrive_import_user_auth(auth, node_addon, **kwargs):
     """Import googledrive credentials from the currently logged-in user to a node.
     """
     user = auth.user
     user_addon = user.get_addon('googledrive')
-    if user_addon is None or node_addon is None:
+
+    if user_addon is None:
         raise HTTPError(http.BAD_REQUEST)
+
     node_addon.set_user_auth(user_addon)
     node_addon.save()
     return {

--- a/website/addons/googledrive/views/auth.py
+++ b/website/addons/googledrive/views/auth.py
@@ -75,13 +75,13 @@ def googledrive_oauth_finish(auth, **kwargs):
         raise HTTPError(http.BAD_REQUEST)
 
     auth_client = GoogleAuthClient()
-    credentials = auth_client.finish(code)
+    token = auth_client.finish(code)
 
-    user_settings.access_token = credentials['access_token']
-    user_settings.refresh_token = credentials['refresh_token']
-    user_settings.token_expires_at = datetime.fromtimestamp(credentials['expires_at'])
+    user_settings.access_token = token['access_token']
+    user_settings.refresh_token = token['refresh_token']
+    user_settings.token_expires_at = datetime.utcfromtimestamp(token['expires_at'])
 
-    drive_client = GoogleDriveClient(user_settings.access_token)
+    drive_client = GoogleDriveClient(token['access_token'])
     about = drive_client.about()
 
     user_settings.username = about['name']

--- a/website/addons/googledrive/views/config.py
+++ b/website/addons/googledrive/views/config.py
@@ -3,39 +3,39 @@ import httplib as http
 
 from flask import request
 
-from framework.auth.core import _get_current_user
 from framework.auth.decorators import must_be_logged_in
 
+from website.util import api_url_for
+from website.util import permissions
 from website.project.decorators import (
     must_have_permission,
     must_have_addon,
     must_not_be_registration,
     must_be_addon_authorizer,
 )
-from website.util import api_url_for
-from website.util import permissions
 
-from ..utils import serialize_settings, serialize_urls
+from website.addons.googledrive.utils import serialize_urls
+from website.addons.googledrive.utils import serialize_settings
 
 
+@must_be_logged_in
 @must_have_addon('googledrive', 'node')
 @must_have_permission(permissions.WRITE)
-def googledrive_config_get(node_addon, **kwargs):
+def googledrive_config_get(node_addon, auth, **kwargs):
     """API that returns the serialized node settings."""
-    user = _get_current_user()
     return {
-        'result': serialize_settings(node_addon, user),
+        'result': serialize_settings(node_addon, auth.user),
     }, http.OK
 
 
-@must_have_permission(permissions.WRITE)
 @must_not_be_registration
 @must_have_addon('googledrive', 'user')
 @must_have_addon('googledrive', 'node')
 @must_be_addon_authorizer('googledrive')
-def googledrive_config_put(node_addon, user_addon, auth, **kwargs):
+@must_have_permission(permissions.WRITE)
+def googledrive_config_put(node_addon, auth, **kwargs):
     """View for changing a node's linked Google Drive folder/file."""
-    selected = request.json.get('selected')
+    selected = request.get_json().get('selected')
     node_addon.set_folder(selected, auth=auth)
     node_addon.save()
     return {
@@ -51,7 +51,7 @@ def googledrive_config_put(node_addon, user_addon, auth, **kwargs):
 
 @must_be_logged_in
 @must_have_addon('googledrive', 'user')
-def googledrive_user_config_get(user_addon, auth, **kwargs):
+def googledrive_user_config_get(user_addon, **kwargs):
     """View for getting a JSON representation of the logged-in user's
     Google Drive user settings.
     """
@@ -62,8 +62,8 @@ def googledrive_user_config_get(user_addon, auth, **kwargs):
 
     return {
         'result': {
-            'userHasAuth': user_addon.has_auth,
             'urls': urls,
-            'username': user_addon.username
+            'username': user_addon.username,
+            'userHasAuth': user_addon.has_auth,
         },
     }, http.OK

--- a/website/addons/googledrive/views/config.py
+++ b/website/addons/googledrive/views/config.py
@@ -25,7 +25,7 @@ def googledrive_config_get(node_addon, auth, **kwargs):
     """API that returns the serialized node settings."""
     return {
         'result': serialize_settings(node_addon, auth.user),
-    }, http.OK
+    }
 
 
 @must_not_be_registration
@@ -46,7 +46,7 @@ def googledrive_config_put(node_addon, auth, **kwargs):
             'urls': serialize_urls(node_addon),
         },
         'message': 'Successfully updated settings.',
-    }, http.OK
+    }
 
 
 @must_be_logged_in
@@ -66,4 +66,4 @@ def googledrive_user_config_get(user_addon, **kwargs):
             'username': user_addon.username,
             'userHasAuth': user_addon.has_auth,
         },
-    }, http.OK
+    }

--- a/website/addons/googledrive/views/config.py
+++ b/website/addons/googledrive/views/config.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import httplib as http
-
 from flask import request
 
 from framework.auth.decorators import must_be_logged_in

--- a/website/addons/googledrive/views/hgrid.py
+++ b/website/addons/googledrive/views/hgrid.py
@@ -3,22 +3,15 @@
 from flask import request
 
 from website.util import rubeus
-from website.util import permissions
-from website.project.decorators import (
-    must_have_addon,
-    must_have_permission,
-    must_not_be_registration,
-    must_be_addon_authorizer,
-)
+from website.project.decorators import must_have_addon
+from website.project.decorators import must_be_addon_authorizer
 
 from website.addons.googledrive.utils import to_hgrid
 from website.addons.googledrive.client import GoogleDriveClient
 
 
-@must_not_be_registration
 @must_have_addon('googledrive', 'user')
 @must_have_addon('googledrive', 'node')
-@must_have_permission(permissions.WRITE)
 @must_be_addon_authorizer('googledrive')
 def googledrive_folders(node_addon, user_addon, **kwargs):
     """ Returns all the subsequent folders under the folder id passed """


### PR DESCRIPTION
Contains code cleanup for google drive as well as a couple bug fixes.

Notable changes:
* Schema for node settings changed
    - the actual OAuth access token is now stored in `_access_token`
        - It can still be set via assigning to `access_token`
* Schema for user settings changed
    - The display name of a folder is now `folder_name`
    - The full path of a folder is now stored in `folder_path`
    - The id of a folder is now stored in `folder_id`
        - If the `folder_id` is used for null checks rather than `folder_path`
* The data stored in fileguid has changed
* Fileguids now behave like dropbox
    - if change your folder and the file is still in scope it will retain the original guid
* Accessing the `access_token` field on user settings will transparently attempt to refresh the token if required
    - Tokens are refreshed if they are within 5 minutes of expiring
* Update to the latest version of treebeard to fix multigrid issues on the settings page
* Drive no longer attempts to register itself