### PR TITLE
Overrides some Treebeard style to disable pointer-style cursor

### DIFF
--- a/website/static/css/citations_widget.css
+++ b/website/static/css/citations_widget.css
@@ -1,3 +1,13 @@
+/*
+Override treebeard styles
+*/
+.citation-widget .title-text {
+    cursor: initial;
+}
+.citation-widget .tb-expand-icon-holder {
+    cursor: initial;
+}
+/* ---------------- */
 .citation-picker {
     padding-bottom: 6px;
 }


### PR DESCRIPTION
## Purpose

Disable pointer-style mouse when inappropriate in citations widget

## Changes

Overrides some Treebeard imposed styles for descendants of .citations-widget

## Side Effects

None -- we may consider applying this to aspects of the files widget as well.  