### PR TITLE
Change implementation for fetching citations for Mendeley folder

### DIFF
--- a/website/addons/mendeley/model.py
+++ b/website/addons/mendeley/model.py
@@ -273,14 +273,6 @@ class Mendeley(ExternalProvider):
         folder = self.client.folders.get(folder_id)
         return folder
 
-    def _get_citations(self, src):
-
-        documents = src.documents.iter(page_size=500)
-        return [
-            self._citation_for_mendeley_document(document)
-            for document in documents
-        ]
-
     def _citations_for_mendeley_folder(self, folder):
 
         document_ids = [
@@ -295,7 +287,11 @@ class Mendeley(ExternalProvider):
 
     def _citations_for_mendeley_user(self):
 
-        return self._get_citations(self.client)
+        documents = self.client.documents.iter(page_size=500)
+        return [
+            self._citation_for_mendeley_document(document)
+            for document in documents
+        ]
 
     def _citation_for_mendeley_document(self, document):
         """Mendeley document to ``website.citations.models.Citation``

--- a/website/addons/mendeley/model.py
+++ b/website/addons/mendeley/model.py
@@ -253,7 +253,7 @@ class Mendeley(ExternalProvider):
             extract_folder(each)
             for each in folders
         ]
-        return ([all_documents] + serialized_folders)
+        return [all_documents] + serialized_folders
 
     def get_list(self, list_id='ROOT'):
         """Get a single CitationList
@@ -276,14 +276,22 @@ class Mendeley(ExternalProvider):
     def _get_citations(self, src):
 
         documents = src.documents.iter(page_size=500)
-        return (
+        return [
             self._citation_for_mendeley_document(document)
             for document in documents
-        )
+        ]
 
     def _citations_for_mendeley_folder(self, folder):
 
-        return self._get_citations(folder)
+        document_ids = [
+            document.id
+            for document in folder.documents.iter(page_size=500)
+        ]
+        citations = {
+            citation['id']: citation
+            for citation in self._citations_for_mendeley_user()
+        }
+        return map(lambda id: citations[id], document_ids)
 
     def _citations_for_mendeley_user(self):
 


### PR DESCRIPTION
## Purpose

Dramatically reduces API calls to Mendeley. In particular before we had to make 1 request per citation in a folder. Now we make only 2 requests.

## Changes

Before me made an API call to fetch a list of citation ids. Citation attributes were then lazily evaluated (part of the mendeley-python-sdk), which required an API call. 

Now me make 2 requests: One to get the list of citation ids for a folder, and one to fetch the metadata for all of a user's citations. These results are filtered by the list of ids.

## Side Effects

none