### PR TITLE
  [hotfix] FigShare OAuth canellations redirected incorrectly

### DIFF
--- a/website/addons/figshare/tests/test_views.py
+++ b/website/addons/figshare/tests/test_views.py
@@ -10,8 +10,8 @@ from nose.tools import *
 import httplib as http
 
 from tests.base import OsfTestCase
-
 from tests.factories import ProjectFactory, AuthUserFactory
+from tests.test_addons import assert_urls_equal
 
 from website.addons.figshare.tests.utils import create_mock_figshare
 from website.addons.figshare import views
@@ -23,15 +23,6 @@ from framework.auth import Auth
 
 
 figshare_mock = create_mock_figshare(project=436)
-
-
-def assert_urls_equal(url1, url2):
-    furl1 = furl.furl(url1)
-    furl2 = furl.furl(url2)
-    for attr in ['scheme', 'host', 'port']:
-        setattr(furl1, attr, None)
-        setattr(furl2, attr, None)
-    assert_equal(furl1, furl2)
 
 
 class TestViewsConfig(OsfTestCase):
@@ -77,20 +68,12 @@ class TestViewsConfig(OsfTestCase):
         is_not_none = settings.user_settings != None
         assert_true(is_not_none)
 
-    def test_oauth_cancel_from_user_settings_redirect(self):
-        """Ensures user initiated oauth token requests that are cancelled
-        before completion at the user settings page results in a redirect
-        back to the user's settings addon page.
-        """
+    def test_cancelled_oauth_request_from_user_settings_page_redirects_correctly(self):
         res = self.app.get(api_url_for('figshare_oauth_callback', uid=self.user._id), auth=self.user.auth)
         assert_equal(res.status_code, 302)
         assert_urls_equal(res.headers['location'], web_url_for('user_addons'))
 
-    def test_oauth_cancel_from_node_settings_redirect(self):
-        """Ensures user initiated oauth token requests that are cancelled
-        before completion at from a node's settings page results in a redirect
-        back to the node's settings addon page.
-        """
+    def test_cancelled_oauth_request_from_node_settings_page_redirects_correctly(self):
         res = self.app.get(api_url_for('figshare_oauth_callback', uid=self.user._id, nid=self.project._id), auth=self.user.auth)
         assert_equal(res.status_code, 302)
         assert_urls_equal(res.headers['location'], self.project.web_url_for('node_setting'))

--- a/website/addons/figshare/views/auth.py
+++ b/website/addons/figshare/views/auth.py
@@ -14,6 +14,7 @@ from website import models
 from website.util import web_url_for
 from website.project.decorators import must_have_addon
 from website.project.decorators import must_have_permission
+from framework.status import push_status_message
 
 from ..auth import oauth_start_url, oauth_get_token
 
@@ -99,8 +100,12 @@ def figshare_oauth_callback(auth, **kwargs):
         figshare_user.oauth_request_token_secret,
         verifier
     )
+    # Handle request cancellations from FigShare's API
     if not access_token or not access_token_secret:
-        return redirect('/settings/')
+        push_status_message('FigShare authorization request cancelled.')
+        if node:
+            return redirect(node.web_url_for('node_setting'))
+        return redirect(web_url_for('user_addons'))
 
     figshare_user.oauth_request_token = None
     figshare_user.oauth_request_token_secret = None


### PR DESCRIPTION
## Purpose
Ensure redirects for user OAuth requests that are cancelled are handled correctly

## Changes
Cancelled requests from a user's settings page will redirect to their /settings/addons/ and cancelled requests from a projects settings page will be redirected to the project's /settings/ page

## Side Effects
None

Closes-Issue: #1844