### PR TITLE
Improve sharejs status bar to correct default, update when relevant

### DIFF
--- a/website/addons/wiki/static/WikiEditor.js
+++ b/website/addons/wiki/static/WikiEditor.js
@@ -42,7 +42,7 @@ function ViewModel(url, viewText) {
     self.initText = ko.observable('');
     self.currentText = viewText; //from wikiPage's VM
     self.activeUsers = ko.observableArray([]);
-    self.status = ko.observable('connected');
+    self.status = ko.observable('connecting');
     self.throttledStatus = ko.observable(self.status());
 
     self.displayCollaborators = ko.computed(function() {
@@ -57,7 +57,7 @@ function ViewModel(url, viewText) {
     self.throttledUpdateStatus = $osf.throttle(self.updateStatus, 4000, {leading: false});
 
     self.status.subscribe(function (newValue) {
-        if (newValue === 'disconnected') {
+        if (newValue !== 'connecting') {
             self.updateStatus();
         }
 


### PR DESCRIPTION
Changes
-------
 - This corrects a miscommunication that results from the new "connected" display. Users on incompatible browsers will no longer go from "Connected" to "Unsupported".
 - Status messages will only be throttled when attempting to reconnect. 