### PR TITLE
Override more Treebeard styles in citations widget

### DIFF
--- a/website/static/css/citations_widget.css
+++ b/website/static/css/citations_widget.css
@@ -7,6 +7,9 @@ Override treebeard styles
 .citation-widget .tb-expand-icon-holder {
     cursor: initial;
 }
+.citation-widget .tb-multiselect {
+    background-color: white;
+}
 /* ---------------- */
 .citation-picker {
     padding-bottom: 6px;


### PR DESCRIPTION
## Purpose

Prevent rows from turing red

## Changes

Overrides Treebeard .tb-multiselect background color for descendants of .citation-widget

## Side Effects

None