### PR TITLE
Send contributor to read-only wiki page when removed from project

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "URIjs": "^1.14.1",
     "assets-webpack-plugin": "^0.1.0",
     "async": "^0.9.0",
+    "body-parser": "~1.12.0",
     "css-loader": "^0.9.1",
     "exports-loader": "^0.6.2",
     "express": "~4.10.0",

--- a/website/addons/wiki/utils.py
+++ b/website/addons/wiki/utils.py
@@ -1,3 +1,4 @@
+import json
 import os
 import urllib
 import uuid
@@ -78,7 +79,11 @@ def migrate_uuid(node, wname):
         db['docs_ops'].insert(ops_items)
         db['docs_ops'].remove({'name': old_sharejs_uuid})
 
-    broadcast_to_sharejs('unlock', old_sharejs_uuid)
+    write_contributors = [
+        user._id for user in node.contributors
+        if node.has_permission(user, 'write')
+    ]
+    broadcast_to_sharejs('unlock', old_sharejs_uuid, data=write_contributors)
 
 
 def share_db():
@@ -95,11 +100,12 @@ def get_sharejs_content(node, wname):
     return doc_item['_data'] if doc_item else ''
 
 
-def broadcast_to_sharejs(action, sharejs_uuid, node=None, wiki_name='home'):
+def broadcast_to_sharejs(action, sharejs_uuid, node=None, wiki_name='home', data=None):
     """
     Broadcast an action to all documents connected to a wiki.
     Actions include 'lock', 'unlock', 'redirect', and 'delete'
     'redirect' and 'delete' both require a node to be specified
+    'unlock' requires data to be a list of contributors with write permission
     """
 
     url = 'http://{host}:{port}/{action}/{id}/'.format(
@@ -117,7 +123,7 @@ def broadcast_to_sharejs(action, sharejs_uuid, node=None, wiki_name='home'):
         url = os.path.join(url, redirect_url)
 
     try:
-        requests.post(url)
+        requests.post(url, json=data)
     except requests.ConnectionError:
         pass    # Assume sharejs is not online
 


### PR DESCRIPTION
Purpose
---
 - Fixes issue where contributors viewing the edit page, when write permission was revoked, would be redirected to a Forbidden page rather than a read-only version of the wiki.

Changes
---
 - Redirects users to default read-only wiki page when write permission is revoked. 

Side effects
---
 - As a necessary consequence of migrating sharejs uuids, contributors who are on the page when permissions change will continue to undergo a forced page refresh, but their panel configuration will be preserved. This is the same as the current behavior
 - The sharejs node.js server now requires the body-parser middleware