### PR TITLE
Move Google Drive settings for app credentials into local-dist.py.

### DIFF
--- a/website/addons/googledrive/settings/defaults.py
+++ b/website/addons/googledrive/settings/defaults.py
@@ -1,8 +1,3 @@
-
-# Drive credentials
-CLIENT_ID = 'chaneme'
-CLIENT_SECRET = 'changeme'
-
 REFRESH_TIME = 5 * 60  # 5 minutes
 
 # Check https://developers.google.com/drive/scopes for all available scopes

--- a/website/addons/googledrive/settings/local-dist.py
+++ b/website/addons/googledrive/settings/local-dist.py
@@ -1,0 +1,3 @@
+# Drive credentials
+CLIENT_ID = 'changeme'
+CLIENT_SECRET = 'changeme'


### PR DESCRIPTION
## Purpose

Google Drive was not following the convention of leaving placeholders for app credentials in local-dist.py. This is changed to reflect other addons.

## Changes

^

## Side Effects

None