### PR TITLE
Fix 500 in Gdrive serialize_settings when folder_path is None.

### DIFF
--- a/website/addons/googledrive/utils.py
+++ b/website/addons/googledrive/utils.py
@@ -91,7 +91,7 @@ def serialize_settings(node_settings, current_user):
     if node_settings.has_auth:
         # Add owner's profile URL
         ret['ownerName'] = user_settings.owner.fullname
-        ret['currentPath'] = '/' + node_settings.folder_path.lstrip('/')
+        ret['currentPath'] = '/' + (node_settings.folder_path.lstrip('/') if node_settings.folder_path else '')
         ret['currentFolder'] = node_settings.folder_name  # if node_settings.folder else None
         ret['urls']['owner'] = web_url_for('profile_view_id', uid=user_settings.owner._id)
 


### PR DESCRIPTION
## Purpose 

GDrive was getting a 500 when serializing settings for an unconfigured project; fixes that.

## Changes

node_settings.folder_path is None when first importing auth, so calling lstrip gave an error. This fix allows that value to be None.

## Side Effects

I'm not sure I understand all of the side effects of this. Someone from the gdrive team should review this change.

