### PR TITLE
[feature] bower zeroclipboard ie10 fix

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "history.js": "~1.8.0",
     "bootstrap.growl": "~2.0.0",
     "bootbox": "~4.3.0",
-    "zeroclipboard": "~2.2.0",
+    "zeroclipboard": "~2.1.6",
     "jquery.tagsinput": "~1.3.2",
     "jquery-autosize": "~1.18.15",
     "x-editable": "~1.5.1",


### PR DESCRIPTION
set zeroclipboard to 2.1.6, could not use in ie10