### PR TITLE
Add force_throw argument to ensure pre-request rollback fails as expected

### DIFF
--- a/framework/transactions/commands.py
+++ b/framework/transactions/commands.py
@@ -11,7 +11,11 @@ def begin(database=None):
     database.command('beginTransaction')
 
 
-def rollback(database=None):
+def rollback(database=None, force_throw=True):
+    """
+    :param bool force_throw: Always reraise ``OperationFailure``; used to ensure
+        that pre-request rollback fails as expected
+    """
     database = database or proxy_database
     try:
         # This method is called by various request teardown handlers, and can
@@ -33,7 +37,7 @@ def rollback(database=None):
         #   exceptions on staging to be handled in the same way as those on
         #   production, while also allowing tests to be run without this
         #   exception being raised
-        if not settings.DEBUG_MODE:
+        if not settings.DEBUG_MODE or force_throw:
             raise
 
 

--- a/framework/transactions/handlers.py
+++ b/framework/transactions/handlers.py
@@ -37,7 +37,7 @@ def transaction_before_request():
     if view_has_annotation(NO_AUTO_TRANSACTION_ATTR):
         return None
     try:
-        commands.rollback()
+        commands.rollback(force_throw=True)
         logger.error('Transaction already in progress; rolling back.')
     except OperationFailure as error:
         message = utils.get_error_message(error)


### PR DESCRIPTION
### Purpose
While doing some debugging, I noticed a lot of logged ERROR statements when refreshing a page, that referred to a Transaction already in progress: 
![screen shot 2015-02-26 at 5 13 57 pm](https://cloud.githubusercontent.com/assets/801594/6403632/9be8ccc2-bdde-11e4-874b-fb8a057a4a04.png)

@jmcarp figured out that it was because a deliberate rollback command before a transaction started was not failing as intended, and so was making it to the logging an error stage. This fix adds an argument to the rollback function that ensures the rollback will fail before a transaction where it's supposed to, and then not log the "ERROR: Transaction already in progress; rolling back" message.

### Changes
Add a force_throw parameter in the rollback function, and call the rollback function with the force_throw parameter set to True in the pre-request transaction function. 

### Side Effects
None anticipated!