### PR TITLE
Only allow OperationFailure to pass if in testing mode

### DIFF
--- a/framework/transactions/commands.py
+++ b/framework/transactions/commands.py
@@ -14,25 +14,7 @@ def begin(database=None):
 
 def rollback(database=None):
     database = database or proxy_database
-    try:
-        # This method is called by various request teardown handlers, and can
-        #   interfere with tests - specifically those which use a test request
-        #   context, as in some cases the handlers used to initiate the TokuMX
-        #   transaction before the request is processed are not called.
-        #
-        # The most common issue with this is an extra traceback in the test
-        #   runner output when a test fails. Less common, tests that use Flask's
-        #   native Flask#test_request_context may fail when they would otherwise
-        #   pass
-        #
-        # ref: http://flask.pocoo.org/docs/0.10/reqcontext/
-        #   "Make sure to write your teardown-request handlers in a way that
-        #    they will never fail."
-        database.command('rollbackTransaction')
-    except OperationFailure:
-        # Re-raise the exception if not in testing mode.
-        if not current_app.testing:
-            raise
+    database.command('rollbackTransaction')
 
 
 def commit(database=None):

--- a/framework/transactions/commands.py
+++ b/framework/transactions/commands.py
@@ -3,6 +3,7 @@
 from pymongo.errors import OperationFailure
 
 from framework.mongo import database as proxy_database
+from flask import current_app
 
 from website import settings
 
@@ -29,11 +30,8 @@ def rollback(database=None):
         #    they will never fail."
         database.command('rollbackTransaction')
     except OperationFailure:
-        # Re-raise the exception if not in debug mode. This allows
-        #   exceptions on staging to be handled in the same way as those on
-        #   production, while also allowing tests to be run without this
-        #   exception being raised
-        if not settings.DEBUG_MODE:
+        # Re-raise the exception if not in testing mode.
+        if not current_app.testing:
             raise
 
 

--- a/framework/transactions/commands.py
+++ b/framework/transactions/commands.py
@@ -1,11 +1,6 @@
 # -*- coding: utf-8 -*-
-
-from pymongo.errors import OperationFailure
-
 from framework.mongo import database as proxy_database
-from flask import current_app
 
-from website import settings
 
 def begin(database=None):
     database = database or proxy_database

--- a/framework/transactions/handlers.py
+++ b/framework/transactions/handlers.py
@@ -78,7 +78,10 @@ def transaction_teardown_request(error=None):
         if not settings.DEBUG_MODE:
             logger.error('Uncaught error in `transaction_teardown_request`; '
                          'this should never happen with `DEBUG_MODE = True`')
-        commands.rollback()
+        # If we're testing, the before_request handlers may not have been executed
+        # e.g. when Flask#test_request_context() is used
+        if not current_app.testing:
+            commands.rollback()
 
 
 handlers = {

--- a/tests/base.py
+++ b/tests/base.py
@@ -42,6 +42,7 @@ from tests.exceptions import UnmockedError
 test_app = init_app(
     settings_module='website.settings', routes=True, set_backends=False
 )
+test_app.testing = True
 
 
 # Silence some 3rd-party logging and some "loud" internal loggers
@@ -92,7 +93,8 @@ class DbTestCase(unittest.TestCase):
         cls._original_enable_email_subscriptions = settings.ENABLE_EMAIL_SUBSCRIPTIONS
         settings.ENABLE_EMAIL_SUBSCRIPTIONS = False
 
-        teardown_database(database=database_proxy._get_current_object())
+        with test_app.test_request_context():
+            teardown_database(database=database_proxy._get_current_object())
         # TODO: With `database` as a `LocalProxy`, we should be able to simply
         # this logic
         set_up_storage(
@@ -105,7 +107,8 @@ class DbTestCase(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         super(DbTestCase, cls).tearDownClass()
-        teardown_database(database=database_proxy._get_current_object())
+        with test_app.test_request_context():
+            teardown_database(database=database_proxy._get_current_object())
         settings.DB_NAME = cls._original_db_name
         settings.PIWIK_HOST = cls._original_piwik_host
         settings.ENABLE_EMAIL_SUBSCRIPTIONS = cls._original_enable_email_subscriptions

--- a/tests/base.py
+++ b/tests/base.py
@@ -93,8 +93,7 @@ class DbTestCase(unittest.TestCase):
         cls._original_enable_email_subscriptions = settings.ENABLE_EMAIL_SUBSCRIPTIONS
         settings.ENABLE_EMAIL_SUBSCRIPTIONS = False
 
-        with test_app.test_request_context():
-            teardown_database(database=database_proxy._get_current_object())
+        teardown_database(database=database_proxy._get_current_object())
         # TODO: With `database` as a `LocalProxy`, we should be able to simply
         # this logic
         set_up_storage(
@@ -107,8 +106,7 @@ class DbTestCase(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         super(DbTestCase, cls).tearDownClass()
-        with test_app.test_request_context():
-            teardown_database(database=database_proxy._get_current_object())
+        teardown_database(database=database_proxy._get_current_object())
         settings.DB_NAME = cls._original_db_name
         settings.PIWIK_HOST = cls._original_piwik_host
         settings.ENABLE_EMAIL_SUBSCRIPTIONS = cls._original_enable_email_subscriptions

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -8,6 +8,7 @@ from nose.tools import *  # noqa
 from framework.auth import authenticate
 from framework.exceptions import PermissionsError, HTTPError
 from framework.sessions import get_session
+from framework.transactions.commands import begin
 from website.oauth.models import (
     ExternalAccount,
     ExternalProvider,
@@ -68,6 +69,7 @@ def _prepare_mock_500_error():
         status=503,
         content_type='application/json',
     )
+
 
 
 class TestExternalAccount(OsfTestCase):

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -8,7 +8,6 @@ from nose.tools import *  # noqa
 from framework.auth import authenticate
 from framework.exceptions import PermissionsError, HTTPError
 from framework.sessions import get_session
-from framework.transactions.commands import begin
 from website.oauth.models import (
     ExternalAccount,
     ExternalProvider,
@@ -197,7 +196,7 @@ class TestExternalProviderOAuth1(OsfTestCase):
                   status=200,
                   content_type='application/json')
 
-        with self.app.app.test_request_context("/oauth/connect/mock1a/") as ctx:
+        with self.app.app.test_request_context('/oauth/connect/mock1a/'):
 
             # make sure the user is logged in
             authenticate(user=self.user, response=None)
@@ -235,9 +234,9 @@ class TestExternalProviderOAuth1(OsfTestCase):
 
         # Fake a request context for the callback
         with self.app.app.test_request_context(
-                path="/oauth/callback/mock1a/",
-                query_string="oauth_token=temp_key&oauth_verifier=mock_verifier"
-        ) as ctx:
+                path='/oauth/callback/mock1a/',
+                query_string='oauth_token=temp_key&oauth_verifier=mock_verifier'
+        ):
 
             # make sure the user is logged in
             authenticate(user=user, response=None)

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -70,7 +70,6 @@ def _prepare_mock_500_error():
     )
 
 
-
 class TestExternalAccount(OsfTestCase):
     # Test the ExternalAccount object and associated views.
     #
@@ -405,7 +404,6 @@ class TestExternalProviderOAuth2(OsfTestCase):
         assert_equal(account.oauth_key, 'mock_access_token')
         assert_equal(account.provider_id, 'mock_provider_id')
 
-
     @responses.activate
     def test_provider_down(self):
 
@@ -413,13 +411,11 @@ class TestExternalProviderOAuth2(OsfTestCase):
         _prepare_mock_500_error()
 
         user = UserFactory()
-
         # Fake a request context for the callback
         with self.app.app.test_request_context(
                 path="/oauth/callback/mock2/",
                 query_string="code=mock_code&state=mock_state"
-        ) as ctx:
-
+        ):
             # make sure the user is logged in
             authenticate(user=user, response=None)
 
@@ -440,8 +436,6 @@ class TestExternalProviderOAuth2(OsfTestCase):
                 error_raised.exception.code,
                 503,
             )
-        print('asdf')
-
 
     @responses.activate
     def test_multiple_users_associated(self):


### PR DESCRIPTION
Addresses the problem @erinspace described in https://github.com/CenterForOpenScience/osf.io/pull/1943 . 

@lyndsysimon made a change recently that allowed the transaction `rollback` command to be run within a test request context without raising an error by checking allowing `OperationFailures` to pass when `settings.DEBUG_MODE` is `True`.  However, this means that we incorrectly get error logs here: https://github.com/CenterForOpenScience/osf.io/blob/f23bc005a30375af00b0314ba54ee3bc95770627/framework/transactions/handlers.py#L40-41 when in `DEBUG_MODE`.

This change only allows the OperationFailure to pass if `rollback` is called within a test.