### PR TITLE
Feature/password tooltip

### DIFF
--- a/website/templates/public/login.mako
+++ b/website/templates/public/login.mako
@@ -87,5 +87,11 @@
             $('#twoFactorHelpText').wrap('<a data-toggle="modal" href="#twoFactor">');
         });
     </script>
+
+<script>
+    $(function(){
+   $('#register-password').tooltip({'trigger':'focus',placement:'right',title:'Must be at least 6 characters'});
+});
+</script>
 </%def>
 

--- a/website/templates/public/login.mako
+++ b/website/templates/public/login.mako
@@ -89,8 +89,12 @@
     </script>
     <script>
         $(function(){
-            $('#register-password').tooltip({'trigger':'focus',placement:'right',title:'Must be at least 6 characters'});
+            $('#register-password').tooltip({'trigger':'focus', placement:whereToPlace,container:'.form-group', title:'Must be at least 6 characters'});
         });
+        function whereToPlace(){
+            if (window.innerWidth<768) return 'top';
+            return 'right';
+        }
     </script>
 </%def>
 

--- a/website/templates/public/login.mako
+++ b/website/templates/public/login.mako
@@ -87,11 +87,10 @@
             $('#twoFactorHelpText').wrap('<a data-toggle="modal" href="#twoFactor">');
         });
     </script>
-
-<script>
-    $(function(){
-   $('#register-password').tooltip({'trigger':'focus',placement:'right',title:'Must be at least 6 characters'});
-});
-</script>
+    <script>
+        $(function(){
+            $('#register-password').tooltip({'trigger':'focus',placement:'right',title:'Must be at least 6 characters'});
+        });
+    </script>
 </%def>
 


### PR DESCRIPTION
Addresses feature in #1753.
Adds a tooltip to the password input field on the 'Create an Account' page.

The tooltip by default is placed to the right of the input (first photo), and moves to the top when the window is small enough (second photo). The tooltip is visible only when the input field is in focus. Sometimes wacky things can happen if you resize the window while the tooltip is visible, but I've tried to account for that (and that shouldn't very often at all). 

I'm pretty new to Javascript so I definitely welcome any and all feedback.

# Tooltip on right
![screen shot 2015-02-27 at 2 24 02 am](https://cloud.githubusercontent.com/assets/1837179/6408717/cb4c47fc-be27-11e4-8dd5-b2e89bc7fb91.png)


# Tooltip on top
![screen shot 2015-02-27 at 3 00 38 am](https://cloud.githubusercontent.com/assets/1837179/6409133/0a0bb90a-be2d-11e4-97d6-93491e2c86a2.png)