### PR TITLE
Fix GoogleDrive file naming bug

### DIFF
--- a/website/static/js/fileRevisions.js
+++ b/website/static/js/fileRevisions.js
@@ -75,10 +75,6 @@ var RevisionsViewModel = function(node, file, editable) {
         revisions: waterbutler.buildRevisionsUrl(file.path, file.provider, node.id, revisionsOptions)
     };
 
-    // This is only because of for Google Drive
-    if((self.file.path.split('/').length) > 2)
-        self.path = '/' + self.file.path.split('/')[(self.file.path.split('/').length) -1]
-
     self.errorMessage = ko.observable('');
     self.currentVersion = ko.observable({});
     self.revisions = ko.observableArray([]);


### PR DESCRIPTION
Purpose
=======
When viewing files within nested folders with google drive, the breadcrumb area displays the project name and the root folder, omits the subfolder(s), and the file name has a '/' separating each character.

Changes
=======
The breadcrumbs now display `{project} / {root} / {subfolder(/s)} / {filename.ext}` for GDrive

Side Effects
=========
Box will display `{project} / {root} / {file_id} / {filename.ext}`