### PR TITLE
Feature/truncate zotero

### DIFF
--- a/website/addons/zotero/model.py
+++ b/website/addons/zotero/model.py
@@ -78,7 +78,8 @@ class Zotero(ExternalProvider):
             citations = []
             more = True
             offset = 0
-            while more:
+            # TODO don't cap at 200 responses
+            while more and len(citations) <= 200:
                 page = self.client.collection_items(list_id, content='csljson', size=100, start=offset)
                 citations = citations + page
                 if len(page) == 0 or len(page) < 100:
@@ -102,7 +103,8 @@ class Zotero(ExternalProvider):
         citations = []
         more = True
         offset = 0
-        while more:
+        # TODO don't cap at 200
+        while more and len(citations) <= 200:
             page = self.client.items(content='csljson', limit=100, start=offset)
             citations = citations + page
             if len(page) == 0 or len(page) < 100:

--- a/website/static/citations_load_error.html
+++ b/website/static/citations_load_error.html
@@ -1,0 +1,1 @@
+<div class="citation-loading"> <p class="m-t-sm text-error"> Error loading citations. Please try refreshing the page.   </p> </div>

--- a/website/static/js/citationGrid.js
+++ b/website/static/js/citationGrid.js
@@ -278,7 +278,7 @@ CitationGrid.prototype.initTreebeard = function() {
             resolveRows: function() {
                 return self.resolveRowAux.call(self, arguments);
             },
-            ondataloadError: function(err) {
+            ondataloaderror: function(err) {
                 $(self.gridSelector).html(errorPage);
             }
         },

--- a/website/static/js/citationGrid.js
+++ b/website/static/js/citationGrid.js
@@ -33,6 +33,8 @@ function resolveIcon(item) {
 
     if (item.kind === 'folder') {
         return item.open ? openFolder : closedFolder;
+    } else if (item.kind === 'message'){
+        return '';
     } else if (item.data.icon) {
         return m('i.fa.' + item.data.icon, ' ');
     } else {
@@ -284,6 +286,20 @@ CitationGrid.prototype.initTreebeard = function() {
         },
         treebeardOptions
     );
+    var preprocess = options.lazyLoadPreprocess;
+    options.lazyLoadPreprocess = function(data){
+        data = preprocess(data);
+        // TODO remove special case for Zotero
+        if (self.provider === 'Zotero') {
+            if (data.length >= 200) {
+		data.push({
+                    name: 'We can only load 200 citations; some citations may not be shown.',
+                    kind: 'message'
+                });
+            }
+        }        
+        return data;
+    };
     self.treebeard = new Treebeard(options);
 };
 
@@ -378,7 +394,15 @@ CitationGrid.prototype.resolveRowAux = function(item) {
         data: 'csl',
         folderIcons: true,
         custom: function(item) {
-            return item.kind === 'folder' ? item.data.name : self.getCitation(item);
+            if (item.kind === 'folder'){
+                return item.data.name;
+            }
+            else if (item.kind === 'message'){
+                return item.data.name;
+            }
+            else {
+                return self.getCitation(item);
+            }
         }
     }, {
         // Wrap callback in closure to preserve intended `this`

--- a/website/templates/project/addon/citations_widget.mako
+++ b/website/templates/project/addon/citations_widget.mako
@@ -10,5 +10,5 @@ window.contextVars = $.extend(true, {}, window.contextVars, {
     <input id="${short_name}StyleSelect" type="hidden" />
 </div>
 <div id="${short_name}Widget" class="citation-widget">
-	<div class="citation-loading"> <i class="icon-spinner citation-spin"></i> <p class="m-t-sm fg-load-message"> Loading files...  </p> </div>
+	<div class="citation-loading"> <i class="icon-spinner citation-spin"></i> <p class="m-t-sm fg-load-message"> Loading citations...  </p> </div>
 </div>


### PR DESCRIPTION
## Purpose

Truncates Zotero citations at 200 to prevent slow page loads. Also adds error handling if data load request should fail.

## Changes

- Backend logic to cap Zotero results
- Frontend logic to check if Zotero results may have been truncated
- Minor fixes to language in citations_widget

## Side Effects

None