### PR TITLE
Ensure tokens not stale.

### DIFF
--- a/website/addons/box/model.py
+++ b/website/addons/box/model.py
@@ -93,6 +93,10 @@ class BoxOAuthSettings(StoredObject):
         )
 
     def refresh_access_token(self, force=False):
+        # Ensure that most recent tokens are loaded from the database. Needed
+        # in case another concurrent request has already changed the tokens.
+        if self._is_loaded:
+            self.refresh()
         if self._needs_refresh() or force:
             token = refresh_v2_token(settings.BOX_KEY, settings.BOX_SECRET, self.refresh_token)
 


### PR DESCRIPTION
# Purpose
Temporary workaround to ensure that token checker has most current tokens from database.