### PR TITLE
Ensure Box folder IDs are strings.

### DIFF
--- a/website/addons/box/model.py
+++ b/website/addons/box/model.py
@@ -228,7 +228,7 @@ class BoxNodeSettings(AddonNodeSettingsBase):
     user_settings = fields.ForeignField(
         'boxusersettings', backref='authorized'
     )
-    folder_id = fields.IntegerField(default=None)
+    folder_id = fields.StringField(default=None)
     folder_name = fields.StringField()
     folder_path = fields.StringField()
 
@@ -270,7 +270,7 @@ class BoxNodeSettings(AddonNodeSettingsBase):
             self.save()
 
     def set_folder(self, folder_id, auth):
-        self.folder_id = folder_id
+        self.folder_id = str(folder_id)
         self.save()
         # Add log to node
         nodelogger = BoxNodeLogger(node=self.owner, auth=auth)

--- a/website/addons/box/views/config.py
+++ b/website/addons/box/views/config.py
@@ -196,7 +196,6 @@ def box_get_share_emails(auth, user_addon, node_addon, **kwargs):
                 if contrib != auth.user
             ],
         }
-        #'url': utils.get_share_folder_uri(node_addon.folder)
     }
 
 
@@ -212,7 +211,7 @@ def box_list_folders(node_addon, **kwargs):
 
     if folder_id is None:
         return [{
-            'id': 0,
+            'id': '0',
             'path': 'All Files',
             'addon': 'box',
             'kind': 'folder',


### PR DESCRIPTION
Previously had a combination of string and int IDs, which was breaking
the logging callback when uploading files to the Box root folder.