### PR TITLE
Feature/wiki less refreshing

### DIFF
--- a/website/addons/wiki/static/wikiPage.js
+++ b/website/addons/wiki/static/wikiPage.js
@@ -53,10 +53,13 @@ function ViewWidget(visible, version, viewText, rendered, contentURL, allowMathj
 
     if (typeof self.editor !== 'undefined') {
         self.editor.on('change', function () {
-            // Quick render
-            self.allowFullRender(false);
-            // Full render
-            self.debouncedAllowFullRender();
+            if(self.version() === 'preview') {
+                // Quick render
+                self.allowFullRender(false);
+
+                // Full render
+                self.debouncedAllowFullRender();
+            }
         });
     } else {
         self.allowFullRender(true);


### PR DESCRIPTION
Purpose
-----------
Keep refreshing from happening when not previewing live editing

Changes
------------
In debounce, verify that the view version is 'preview'

Side effects
----------------
Shouldn't be any