### PR TITLE
[hotfix] Ignore case in conference endpoints.

### DIFF
--- a/tests/test_conferences.py
+++ b/tests/test_conferences.py
@@ -392,7 +392,7 @@ class TestConferenceEmailViews(OsfTestCase):
 
         # Create conference nodes
         n_conference_nodes = 3
-        conf_nodes = create_fake_conference_nodes(
+        create_fake_conference_nodes(
             n_conference_nodes,
             conference.endpoint,
         )
@@ -402,8 +402,41 @@ class TestConferenceEmailViews(OsfTestCase):
         url = api_url_for('conference_data', meeting=conference.endpoint)
         res = self.app.get(url)
         assert_equal(res.status_code, 200)
-        json = res.json
-        assert_equal(len(json), n_conference_nodes)
+        assert_equal(len(res.json), n_conference_nodes)
+
+    def test_conference_data_url_upper(self):
+        conference = ConferenceFactory()
+
+        # Create conference nodes
+        n_conference_nodes = 3
+        create_fake_conference_nodes(
+            n_conference_nodes,
+            conference.endpoint,
+        )
+        # Create a non-conference node
+        ProjectFactory()
+
+        url = api_url_for('conference_data', meeting=conference.endpoint.upper())
+        res = self.app.get(url)
+        assert_equal(res.status_code, 200)
+        assert_equal(len(res.json), n_conference_nodes)
+
+    def test_conference_data_tag_upper(self):
+        conference = ConferenceFactory()
+
+        # Create conference nodes
+        n_conference_nodes = 3
+        create_fake_conference_nodes(
+            n_conference_nodes,
+            conference.endpoint.upper(),
+        )
+        # Create a non-conference node
+        ProjectFactory()
+
+        url = api_url_for('conference_data', meeting=conference.endpoint)
+        res = self.app.get(url)
+        assert_equal(res.status_code, 200)
+        assert_equal(len(res.json), n_conference_nodes)
 
     def test_conference_results(self):
         conference = ConferenceFactory()
@@ -437,7 +470,7 @@ class TestConferenceIntegration(ContextTestCase):
             'test-' if settings.DEV_MODE else '',
             conference.endpoint,
         )
-        res = self.app.post(
+        self.app.post(
             api_url_for('meeting_hook'),
             {
                 'X-Mailgun-Sscore': 0,
@@ -481,7 +514,6 @@ class TestConferenceIntegration(ContextTestCase):
         username = 'deacon@queen.com'
         title = 'good songs'
         body = 'dragon on my back'
-        content = 'dragon attack'
         recipient = '{0}{1}-poster@osf.io'.format(
             'test-' if settings.DEV_MODE else '',
             conference.endpoint,

--- a/website/conferences/views.py
+++ b/website/conferences/views.py
@@ -122,7 +122,7 @@ def add_poster_by_email(conference, message):
         profile_url=user.absolute_url,
         node_url=node.absolute_url,
         file_url=download_url,
-        presentation_type=message.conference_category,
+        presentation_type=message.conference_category.lower(),
         is_spam=message.is_spam,
     )
 
@@ -169,7 +169,7 @@ def conference_data(meeting):
         raise HTTPError(httplib.NOT_FOUND)
 
     nodes = Node.find(
-        Q('tags', 'eq', meeting) &
+        Q('tags', 'iexact', meeting) &
         Q('is_public', 'eq', True) &
         Q('is_deleted', 'eq', False)
     )
@@ -205,7 +205,7 @@ def conference_view(**kwargs):
     meetings = []
     for conf in Conference.find():
         query = (
-            Q('tags', 'eq', conf.endpoint)
+            Q('tags', 'iexact', conf.endpoint)
             & Q('is_public', 'eq', True)
             & Q('is_deleted', 'eq', False)
         )


### PR DESCRIPTION
# Purpose
Make conference lookups case-insensitive.

# Changes
* Change `eq` operator to `iexact` as needed
* Add regression tests

# Side effects
None expected