### PR TITLE
Don't show wiki widget when disabled

### DIFF
--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -671,12 +671,14 @@ def _render_addon(node):
 
 
 def _should_show_wiki_widget(node, user):
+
+    has_wiki = bool(node.get_addon('wiki'))
+    wiki_page = node.get_wiki_page('home', None)
     if not node.has_permission(user, 'write'):
-        wiki_page = node.get_wiki_page('home', None)
-        return wiki_page and wiki_page.html(node)
+        return has_wiki and wiki_page and wiki_page.html(node)
 
     else:
-        return True
+        return has_wiki
 
 
 def _view_project(node, auth, primary=False):


### PR DESCRIPTION
## Purpose

Mako was still attempting to render wiki widget even when wiki is disabled. This fixes that.

## Changes

Adds a check in _should_show_wiki_widget to make sure the node has the wiki addon enabled.

## Side Effects

None