### PR TITLE
Update markdown-it-toc version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
     "xhook": "~1.3.0",
     "osf-panel": "https://github.com/caneruguz/osf-panel.git#fda8e05d9f3ba8ed7bd43b46ceffe265b3d73b39",
     "markdown-it-sanitizer": "~0.2.0",
-    "markdown-it-toc": "https://github.com/samchrisinger/markdown-it-toc.git#3f573a2c595cad2d702956147a23c0ae442a6dbb",
+    "markdown-it-toc": "https://github.com/samchrisinger/markdown-it-toc.git#82c0c364d8e756c6ee00085f8f9069f937243dd7",
     "styles": "https://github.com/lyndsysimon/styles.git#4db9c8e2f5932cad9f23ad3579d1a82c691faf12",
     "locales": "https://github.com/citation-style-language/locales.git#d2b612f8a6f764cbd66e67238636fac3888a7736",
     "c3": "~0.4.9"


### PR DESCRIPTION
## Purpose

Update markdown-it-toc, which had a bug with parsing tokens beginning with newlines.

## Changes

^

## Side Effects

Wiki's getting too cool for its own good. 