### PR TITLE
Fix box logging

### DIFF
--- a/website/addons/box/model.py
+++ b/website/addons/box/model.py
@@ -329,6 +329,10 @@ class BoxNodeSettings(AddonNodeSettingsBase):
 
     def create_waterbutler_log(self, auth, action, metadata):
         path = metadata['path']
+        try:
+            full_path = metadata['extra']['fullPath']
+        except KeyError:
+            full_path = None
         self.owner.add_log(
             'box_{0}'.format(action),
             auth=auth,
@@ -336,11 +340,13 @@ class BoxNodeSettings(AddonNodeSettingsBase):
                 'project': self.owner.parent_id,
                 'node': self.owner._id,
                 'path': os.path.join(self.folder_id, path),
+                'name': metadata['path'].split('/')[-1],
                 'folder': self.folder_id,
                 'urls': {
                     'view': self.owner.web_url_for('addon_view_or_download_file', provider='box', action='view', path=path),
                     'download': self.owner.web_url_for('addon_view_or_download_file', provider='box', action='download', path=path),
                 },
+                'fullPath': full_path
             },
         )
 

--- a/website/addons/box/templates/log_templates.mako
+++ b/website/addons/box/templates/log_templates.mako
@@ -1,6 +1,6 @@
 <script type="text/html" id="box_file_added">
 added file
-<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect">{{ params.path }}</a> to
+<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect">{{ params.fullPath }}</a> to
 Box in {{ nodeType }}
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
@@ -8,14 +8,14 @@ Box in {{ nodeType }}
 
 <script type="text/html" id="box_file_updated">
 updated file
-<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect">{{ params.path }}</a> to
+<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect">{{ params.fullPath }}</a> to
 Box in {{ nodeType }}
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 
 
 <script type="text/html" id="box_file_removed">
-removed file <span class="overflow">{{ params.path }}</span> from
+removed file <span class="overflow">'{{ params.name }}'</span> from
 Box in {{ nodeType }}
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>


### PR DESCRIPTION
Purpose
=======
Improve logging behavior for Box
Accompanies PR: https://github.com/CenterForOpenScience/waterbutler/pull/23

Changes
=======
Upload/update logs include human-readable path/link to file
Delete logs read: `{User} removed file '{filename}' from Box in project {project}`

Side Effects
=========