### PR TITLE
[Hotfix] Add sorting to the download count column on presentations page

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "reconnectingWebsocket": "#07669519f8",
     "truncate": "https://github.com/pathable/truncate.git#5da408e2325dd965e0c94c354622ad54645824b9",
     "dropzone": "https://github.com/sloria/dropzone.git#accept-directory",
-    "treebeard": "https://github.com/caneruguz/treebeard.git#d946a283afe3ef426d1b465b2df8322171a5624f",
+    "treebeard": "https://github.com/caneruguz/treebeard.git#429317f7fefc5936e7dea9370622d01b6411f92b",
     "jquery.cookie": "~1.4.1",
     "xhook": "~1.3.0",
     "osf-panel": "https://github.com/caneruguz/osf-panel.git#fda8e05d9f3ba8ed7bd43b46ceffe265b3d73b39",

--- a/website/static/js/conference.js
+++ b/website/static/js/conference.js
@@ -35,7 +35,8 @@ function Meeting(data) {
                 {
                     title: "Downloads",
                     width : "15%",
-                    sort : false
+                    sortType : "number",
+                    sort : true
                 }
             ];
         },


### PR DESCRIPTION
## Purpose

Add sorting to download column for presentations

## Changes
This required a fix in treebeard, the fixed a bug related to number sorting. It's tested to work. Commit is here:
https://github.com/caneruguz/treebeard/commit/429317f7fefc5936e7dea9370622d01b6411f92b

## Side effects
The number sorting does not affect any existing treebeard instance in OSF (if it did, this bug would have come up earlier).