### PR TITLE
Add redraw based on height of container in notifications/treebeard

### DIFF
--- a/website/static/js/notificationsTreebeard.js
+++ b/website/static/js/notificationsTreebeard.js
@@ -133,6 +133,11 @@ function ProjectNotifications(data) {
                 }
             ];
         },
+        ontogglefolder : function (item){
+            var containerHeight = this.select('#tb-tbody').height();
+            this.options.showTotal = Math.floor(containerHeight / this.options.rowHeight) + 1;
+            this.redraw();
+        },
         resolveRows : function notificationResolveRows(item){
             var columns = [];
             var iconcss = '';


### PR DESCRIPTION
## Purpose
Fix a regression bug where the toggle and retoggle of folder does not show all children. This was a regression bug caused by not setting height on load, so Treebeard was setting it's showTotal to be whatever the container happened to be at the time, in this case limiting it to 3 because that was all that could fit. 

## Changes
In order to not have to roll back the height fix, what this change does is add another step towards checking the height of container after toggle because loading the items in fact does increase the height. 

## Side effects
The changes are limited to the notifications treebeard instance. There shouldn't be side effects but this is not an elegant solution for the long term, I'll look into how Treebeard is doing its redraws and maybe do a better fluid height solution for this. Although most libraries that deal with such issues usually set fixed heights. 