### PR TITLE
Use HTTPretty for test mocking.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,6 +27,8 @@ google-api-python-client==1.2
 git+https://github.com/CenterForOpenScience/modular-odm.git@develop
 # Development version of modular file renderer
 git+https://github.com/CenterForOpenScience/modular-file-renderer.git@dev
+# Fork of HTTPretty with pymongo fix
+git+https://github.com/jmcarp/HTTPretty@fix-tests-for-208
 
 requests==2.4.1
 requests-oauthlib>=0.4.1

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,15 +1,16 @@
 # -*- coding: utf-8 -*-
 '''Base TestCase class for OSF unittests. Uses a temporary MongoDB database.'''
-import datetime as dt
-import functools
-import logging
 import os
+import re
 import shutil
+import logging
 import unittest
-import mock
+import functools
+import datetime as dt
 
-from webtest_plus import TestApp
 import blinker
+import httpretty
+from webtest_plus import TestApp
 
 from faker import Factory
 from nose.tools import *  # noqa (PEP8 asserts)
@@ -35,8 +36,6 @@ from website.addons.wiki.model import NodeWikiPage
 import website.models
 from website.signals import ALL_SIGNALS
 from website.app import init_app
-
-from tests.exceptions import UnmockedError
 
 # Just a simple app without routing set up or backends
 test_app = init_app(
@@ -150,12 +149,36 @@ class UploadTestCase(unittest.TestCase):
         settings.UPLOADS_PATH = cls._old_uploads_path
 
 
+methods = [
+    httpretty.GET,
+    httpretty.PUT,
+    httpretty.HEAD,
+    httpretty.POST,
+    httpretty.PATCH,
+    httpretty.DELETE,
+]
+def kill(*args, **kwargs):
+    raise httpretty.errors.UnmockedError
+
+
 class MockRequestTestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
         super(MockRequestTestCase, cls).setUpClass()
-        mock.patch('requests.Session.send', side_effect=UnmockedError).start()
+        httpretty.enable()
+        for method in methods:
+            httpretty.register_uri(
+                method,
+                re.compile(r'.*'),
+                body=kill,
+            )
+
+    @classmethod
+    def tearDownClass(cls):
+        super(MockRequestTestCase, cls).tearDownClass()
+        httpretty.disable()
+        httpretty.reset()
 
 
 class OsfTestCase(DbTestCase, AppTestCase, UploadTestCase, MockRequestTestCase):

--- a/website/addons/dropbox/tests/test_views.py
+++ b/website/addons/dropbox/tests/test_views.py
@@ -82,7 +82,9 @@ class TestAuthViews(OsfTestCase):
 
 class TestConfigViews(DropboxAddonTestCase):
 
-    def test_dropbox_user_config_get_has_auth_info(self):
+    @mock.patch('website.addons.dropbox.client.DropboxClient.account_info')
+    def test_dropbox_user_config_get_has_auth_info(self, mock_account_info):
+        mock_account_info.return_value = {'display_name': 'Mr. Drop Box'}
         url = api_url_for('dropbox_user_config_get')
         res = self.app.get(url, auth=self.user.auth)
         assert_equal(res.status_code, 200)
@@ -112,7 +114,9 @@ class TestConfigViews(DropboxAddonTestCase):
         result = res.json['result']
         assert_false(result['validCredentials'])
 
-    def test_dropbox_user_config_get_returns_correct_urls(self):
+    @mock.patch('website.addons.dropbox.client.DropboxClient.account_info')
+    def test_dropbox_user_config_get_returns_correct_urls(self, mock_account_info):
+        mock_account_info.return_value = {'display_name': 'Mr. Drop Box'}
         url = api_url_for('dropbox_user_config_get')
         res = self.app.get(url, auth=self.user.auth)
         assert_equal(res.status_code, 200)
@@ -169,21 +173,25 @@ class TestConfigViews(DropboxAddonTestCase):
         assert_equal(folder['name'], self.node_settings.folder)
         assert_equal(folder['path'], self.node_settings.folder)
 
-    def test_dropbox_config_get(self):
+    @mock.patch('website.addons.dropbox.client.DropboxClient.account_info')
+    def test_dropbox_config_get(self, mock_account_info):
+        mock_account_info.return_value = {'display_name': 'Mr. Drop Box'}
         self.user_settings.save()
 
-        url = api_url_for('dropbox_config_get', pid=self.project._primary_key)
+        url = self.project.api_url_for('dropbox_config_get')
 
         res = self.app.get(url, auth=self.user.auth)
         assert_equal(res.status_code, 200)
         result = res.json['result']
         assert_equal(result['ownerName'], self.user_settings.owner.fullname)
 
-        assert_equal(result['urls']['config'],
-            api_url_for('dropbox_config_put', pid=self.project._primary_key))
+        assert_equal(
+            result['urls']['config'],
+            self.project.api_url_for('dropbox_config_put'),
+        )
 
     def test_dropbox_config_put(self):
-        url = api_url_for('dropbox_config_put', pid=self.project._primary_key)
+        url = self.project.api_url_for('dropbox_config_put')
         # Can set folder through API call
         res = self.app.put_json(url, {'selected': {'path': 'My test folder',
             'name': 'Dropbox/My test folder'}},
@@ -201,7 +209,7 @@ class TestConfigViews(DropboxAddonTestCase):
         assert_equal(params['folder'], 'My test folder')
 
     def test_dropbox_deauthorize(self):
-        url = api_url_for('dropbox_deauthorize', pid=self.project._primary_key)
+        url = self.project.api_url_for('dropbox_deauthorize')
         saved_folder = self.node_settings.folder
         self.app.delete(url, auth=self.user.auth)
         self.project.reload()
@@ -224,7 +232,7 @@ class TestConfigViews(DropboxAddonTestCase):
         # Node does not have user settings
         self.node_settings.user_settings = None
         self.node_settings.save()
-        url = api_url_for('dropbox_import_user_auth', pid=self.project._primary_key)
+        url = self.project.api_url_for('dropbox_import_user_auth')
         res = self.app.put(url, auth=self.user.auth)
         self.project.reload()
         self.node_settings.reload()
@@ -234,11 +242,13 @@ class TestConfigViews(DropboxAddonTestCase):
         result = res.json['result']
         assert_equal(result, expected_result)
 
-    def test_dropbox_import_user_auth_adds_a_log(self):
+    @mock.patch('website.addons.dropbox.client.DropboxClient.account_info')
+    def test_dropbox_import_user_auth_adds_a_log(self, mock_account_info):
+        mock_account_info.return_value = {'display_name': 'Mr. Drop Box'}
         # Node does not have user settings
         self.node_settings.user_settings = None
         self.node_settings.save()
-        url = api_url_for('dropbox_import_user_auth', pid=self.project._primary_key)
+        url = self.project.api_url_for('dropbox_import_user_auth')
         self.app.put(url, auth=self.user.auth)
         self.project.reload()
         self.node_settings.reload()
@@ -254,7 +264,7 @@ class TestConfigViews(DropboxAddonTestCase):
         contrib = AuthUserFactory()
         self.project.add_contributor(contrib, auth=Auth(self.user))
         self.project.save()
-        url = api_url_for('dropbox_get_share_emails', pid=self.project._primary_key)
+        url = self.project.api_url_for('dropbox_get_share_emails')
         res = self.app.get(url, auth=self.user.auth)
         result = res.json['result']
         assert_equal(result['emails'], [u.username for u in self.project.contributors
@@ -267,7 +277,7 @@ class TestConfigViews(DropboxAddonTestCase):
         contrib.save()
         self.project.add_contributor(contrib, auth=Auth(self.user))
         self.project.save()
-        url = api_url_for('dropbox_get_share_emails', pid=self.project._primary_key)
+        url = self.project.api_url_for('dropbox_get_share_emails')
         # Non-authorizing contributor sends request
         res = self.app.get(url, auth=contrib.auth, expect_errors=True)
         assert_equal(res.status_code, httplib.FORBIDDEN)
@@ -276,7 +286,7 @@ class TestConfigViews(DropboxAddonTestCase):
         # Node doesn't have auth
         self.node_settings.user_settings = None
         self.node_settings.save()
-        url = api_url_for('dropbox_get_share_emails', pid=self.project._primary_key)
+        url = self.project.api_url_for('dropbox_get_share_emails')
         # Non-authorizing contributor sends request
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
         assert_equal(res.status_code, httplib.BAD_REQUEST)
@@ -286,10 +296,9 @@ class TestFilebrowserViews(DropboxAddonTestCase):
 
     def test_dropbox_hgrid_data_contents(self):
         with patch_client('website.addons.dropbox.views.hgrid.get_node_client'):
-            url = api_url_for(
+            url = self.project.api_url_for(
                 'dropbox_hgrid_data_contents',
                 path=self.node_settings.folder,
-                pid=self.project._primary_key,
             )
             res = self.app.get(url, auth=self.user.auth)
             contents = [x for x in mock_client.metadata('', list=True)['contents'] if x['is_dir']]
@@ -302,8 +311,7 @@ class TestFilebrowserViews(DropboxAddonTestCase):
         with patch_client('website.addons.dropbox.views.hgrid.get_node_client'):
             self.node_settings.folder = None
             self.node_settings.save()
-            url = api_url_for('dropbox_hgrid_data_contents',
-                pid=self.project._primary_key, foldersOnly=True)
+            url = self.project.api_url_for('dropbox_hgrid_data_contents', foldersOnly=True)
             res = self.app.get(url, auth=self.user.auth)
             contents = mock_client.metadata('', list=True)['contents']
             expected = [each for each in contents if each['is_dir']]
@@ -311,8 +319,7 @@ class TestFilebrowserViews(DropboxAddonTestCase):
 
     def test_dropbox_hgrid_data_contents_folders_only(self):
         with patch_client('website.addons.dropbox.views.hgrid.get_node_client'):
-            url = api_url_for('dropbox_hgrid_data_contents',
-                pid=self.project._primary_key, foldersOnly=True)
+            url = self.project.api_url_for('dropbox_hgrid_data_contents', foldersOnly=True)
             res = self.app.get(url, auth=self.user.auth)
             contents = mock_client.metadata('', list=True)['contents']
             expected = [each for each in contents if each['is_dir']]
@@ -321,8 +328,7 @@ class TestFilebrowserViews(DropboxAddonTestCase):
     @mock.patch('website.addons.dropbox.client.DropboxClient.metadata')
     def test_dropbox_hgrid_data_contents_include_root(self, mock_metadata):
         with patch_client('website.addons.dropbox.views.hgrid.get_node_client'):
-            url = api_url_for('dropbox_hgrid_data_contents',
-                pid=self.project._primary_key, root=1)
+            url = self.project.api_url_for('dropbox_hgrid_data_contents', root=1)
 
             res = self.app.get(url, auth=self.user.auth)
             contents = mock_client.metadata('', list=True)['contents']
@@ -413,7 +419,7 @@ class TestRestrictions(DropboxAddonTestCase):
         assert_equal(res.status_code, httplib.FORBIDDEN)
 
     def test_restricted_config_contrib_no_addon(self):
-        url = api_url_for('dropbox_config_put', pid=self.project._primary_key)
+        url = self.project.api_url_for('dropbox_config_put')
         res = self.app.put_json(url, {'selected': {'path': 'foo'}},
             auth=self.contrib.auth, expect_errors=True)
         assert_equal(res.status_code, httplib.BAD_REQUEST)
@@ -423,7 +429,7 @@ class TestRestrictions(DropboxAddonTestCase):
         self.contrib.add_addon('dropbox')
         self.contrib.save()
 
-        url = api_url_for('dropbox_config_put', pid=self.project._primary_key)
+        url = self.project.api_url_for('dropbox_config_put')
         res = self.app.put_json(url, {'selected': {'path': 'foo'}},
             auth=self.contrib.auth, expect_errors=True)
         assert_equal(res.status_code, httplib.FORBIDDEN)

--- a/website/addons/dropbox/views/config.py
+++ b/website/addons/dropbox/views/config.py
@@ -24,9 +24,7 @@ from dropbox.rest import ErrorResponse
 @must_have_addon('dropbox', 'node')
 def dropbox_config_get(node_addon, auth, **kwargs):
     """API that returns the serialized node settings."""
-    return {
-        'result': serialize_settings(node_addon, auth.user),
-    }, http.OK
+    return {'result': serialize_settings(node_addon, auth.user)}
 
 
 def serialize_folder(metadata):
@@ -149,7 +147,7 @@ def dropbox_config_put(node_addon, user_addon, auth, **kwargs):
             'urls': serialize_urls(node_addon),
         },
         'message': 'Successfully updated settings.',
-    }, http.OK
+    }
 
 
 @must_have_permission('write')
@@ -164,7 +162,7 @@ def dropbox_import_user_auth(auth, node_addon, user_addon, **kwargs):
     return {
         'result': serialize_settings(node_addon, user),
         'message': 'Successfully imported access token from profile.',
-    }, http.OK
+    }
 
 @must_have_permission('write')
 @must_have_addon('dropbox', 'node')
@@ -193,4 +191,4 @@ def dropbox_get_share_emails(auth, user_addon, node_addon, **kwargs):
                         if contrib != auth.user],
         'url': utils.get_share_folder_uri(node_addon.folder)
     }
-    return {'result': result}, http.OK
+    return {'result': result}


### PR DESCRIPTION
# Purpose
Use HTTPretty instead of requests for mocking HTTP requests in tests.

# Changes
* Switch from mock to HTTPretty
* Fix breaking Dropbox tests

# Side effects
None expected

Note: This uses my fork of HTTPretty for the moment, but we should be
able to switch back to the PyPI version once my patch gets merged.