### PR TITLE
Change check for pre-selecting folderPicker selects.

### DIFF
--- a/website/addons/figshare/static/figshareNodeConfig.js
+++ b/website/addons/figshare/static/figshareNodeConfig.js
@@ -266,7 +266,7 @@ var ViewModel = function(url, selector, folderPicker) {
         $(self.folderPicker).folderpicker({
             onPickFolder: onPickFolder,
             initialFolderName : self.folderName(),
-            initialFolderPath : undefined,
+            initialFolderPath : '__NONE__',
             // Fetch Figshare folders with AJAX
             filesData: self.urls().options, // URL for fetching folders
             // Lazy-load each folder's contents

--- a/website/static/js/folderPicker.js
+++ b/website/static/js/folderPicker.js
@@ -75,10 +75,8 @@ function _treebeardSelectView(item) {
         return templateUnchecked;
     }
 
-    if (item.data.addon !== 'figshare'){
-        if (item.data.path === tb.options.folderPath || (tb.options.folderArray && tb.options.folderArray[tb.options.folderArray.length - 1] === item.data.name)) {
-            return templateChecked;
-        }
+    if (item.data.path === tb.options.folderPath || (tb.options.folderArray && tb.options.folderArray[tb.options.folderArray.length - 1] === item.data.name)) {
+        return templateChecked;
     }
 
     return templateUnchecked;

--- a/website/static/js/folderPicker.js
+++ b/website/static/js/folderPicker.js
@@ -75,8 +75,10 @@ function _treebeardSelectView(item) {
         return templateUnchecked;
     }
 
-    if (item.data.path === tb.options.folderPath || (tb.options.folderArray && tb.options.folderArray[tb.options.folderArray.length - 1] === item.data.name)) {
-        return templateChecked;
+    if (item.data.addon !== 'figshare'){
+        if (item.data.path === tb.options.folderPath || (tb.options.folderArray && tb.options.folderArray[tb.options.folderArray.length - 1] === item.data.name)) {
+            return templateChecked;
+        }
     }
 
     return templateUnchecked;


### PR DESCRIPTION
## Purpose

Some of the folderPicker code is oriented towards path-based addon configs (e.g. dropbox, github, box, gdrive) rather than name based (figshare, mendeley, zotero). In particular checks for pre-selecting selects when building the Treebeard rows are incompatible with figshare logic. This fixes the figshareNode config to prevent these checks from evaluating true when inappropriate.

## Changes

Set figshare initialFolderPath to a string that is unlikely to be matched.

## Side Effects

None