### PR TITLE
[hotfix] ga object should be mocked if no ID present

### DIFF
--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -125,6 +125,18 @@
             ga('linker:autoLink', ['centerforopenscience.org'] );
             ga('send', 'pageview');
             </script>
+        % else:
+            <script>
+                window.ga = function(source) {
+                        console.error('=== Mock ga event called: ===');
+                        console.log('event: ga(' +
+                                    arguments[0] + ', ' +
+                                    arguments[1] + ', ' +
+                                    arguments[2] + ', ' +
+                                    arguments[3] + ')'
+                        );
+                };
+          </script>
         % endif
 
         % if piwik_host:


### PR DESCRIPTION
## Purpose
Google Analytics objects should be mocked in the event that no GOOGLE_ANALYTICS_ID is set.

## Changes
ga object is mocked if GOOGLE_ANALYTICS_ID is not set

## Side Effects
Cleaner console error messages.

Closes-Issue: #2027