### PR TITLE
Fixes #1369 unreg changing E-mails

### DIFF
--- a/framework/auth/forms.py
+++ b/framework/auth/forms.py
@@ -126,7 +126,6 @@ class ResetPasswordForm(Form):
 
 
 class SetEmailAndPasswordForm(ResetPasswordForm):
-    username = unique_email_field
     token = HiddenField()
 
 # TODO: use unique email field and remove redundant status message and

--- a/tests/webtest_tests.py
+++ b/tests/webtest_tests.py
@@ -903,7 +903,7 @@ class TestClaiming(OsfTestCase):
         self.project.reload()
         assert_in('Set Password', res)
         form = res.forms['setPasswordForm']
-        form['username'] = new_user.username
+        #form['username'] = new_user.username #Removed as long as E-mail can't be updated.
         form['password'] = 'killerqueen'
         form['password2'] = 'killerqueen'
         res = form.submit().maybe_follow()
@@ -985,7 +985,7 @@ class TestClaiming(OsfTestCase):
         self.project.reload()
         assert_in('Set Password', res)
         form = res.forms['setPasswordForm']
-        form['username'] = new_user.username
+        #form['username'] = new_user.username #Removed as long as the E-mail can't be changed
         form['password'] = 'killerqueen'
         form['password2'] = 'killerqueen'
         res = form.submit().maybe_follow()
@@ -1013,7 +1013,7 @@ class TestClaiming(OsfTestCase):
         assert_in('Set Password', res)
         form = res.forms['setPasswordForm']
         # Fills out an email that is the username of another user
-        form['username'] = reg_user.username
+        #form['username'] = reg_user.username #Removed as long as E-mails cannot be changed
         form['password'] = 'killerqueen'
         form['password2'] = 'killerqueen'
         res = form.submit().maybe_follow(expect_errors=True)

--- a/tests/webtest_tests.py
+++ b/tests/webtest_tests.py
@@ -997,6 +997,7 @@ class TestClaiming(OsfTestCase):
         assert_equal(res.status_code, 400)
         assert_in('already been claimed', res)
 
+    @unittest.skip("as long as E-mails cannot be changed")
     def test_cannot_set_email_to_a_user_that_already_exists(self):
         reg_user = UserFactory()
         name, email = fake.name(), fake.email()
@@ -1013,7 +1014,7 @@ class TestClaiming(OsfTestCase):
         assert_in('Set Password', res)
         form = res.forms['setPasswordForm']
         # Fills out an email that is the username of another user
-        #form['username'] = reg_user.username #Removed as long as E-mails cannot be changed
+        form['username'] = reg_user.username
         form['password'] = 'killerqueen'
         form['password2'] = 'killerqueen'
         res = form.submit().maybe_follow(expect_errors=True)

--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -627,7 +627,7 @@ def claim_user_form(auth, **kwargs):
     form = SetEmailAndPasswordForm(request.form, token=token)
     if request.method == 'POST':
         if form.validate():
-            username, password = form.username.data, form.password.data
+            username, password = email, form.password.data
             user.register(username=username, password=password)
             # Clear unclaimed records
             user.unclaimed_records = {}

--- a/website/templates/claim_account.mako
+++ b/website/templates/claim_account.mako
@@ -7,11 +7,9 @@
     ## Center the form
     <div class="col-md-6 col-md-offset-3">
     <p>Hello ${firstname}! Please set a password to claim your account.</p>
+    <p>E-mail: ${email}</p>
 
         <form method="POST" id='setPasswordForm' role='form'>
-            <div class='form-group'>
-                ${form.username(placeholder='Email', value=email)}
-            </div>
             <div class='form-group'>
                 ${form.password(placeholder='New password')}
             </div>
@@ -32,4 +30,3 @@
     </div>
 </div>
 </%def>
-


### PR DESCRIPTION
## Proposed
Addresses #1369 by removing text input field and replacing with text about what the E-mail is. This effectively disables the ability to change the E-mail without confirmation.

## Repercussions
Users are unable to update E-mails via unregistered account claims.

## Suggestions
This is merely a security plug and does not address the issue of the user wanting to change the E-mail.

Also this looks ugly and should probably be reformatted if it is going to be kept.