### PR TITLE
Hotfix/No wiki links on debounce

### DIFF
--- a/website/static/js/markdown.js
+++ b/website/static/js/markdown.js
@@ -32,6 +32,7 @@ var markdownQuick = new MarkdownIt(('commonmark'), {
      highlight: highlighter
 })
     .use(require('markdown-it-sanitizer'))
+    .disable('link')
     .disable('image');
 
 module.exports = {


### PR DESCRIPTION
Purpose
-----------
Ensures that there aren't fake links caused by plugins that are disabled during debounced rendering

Changes
-------------
Disable links during quick render

Side effects
----------------
No other links will work during that time. I don't think that offering people a link target that appears for only a half-second or during active editing. I think it makes the most sense not to have links at all during that time, though arguments could be made.

Fixes #2022 