### PR TITLE
Update migration to handle dates for pre-migration files.

### DIFF
--- a/website/addons/osfstorage/model.py
+++ b/website/addons/osfstorage/model.py
@@ -352,11 +352,12 @@ class OsfStorageFileVersion(StoredObject):
     _id = oid_primary_key
     creator = fields.ForeignField('user', required=True)
 
+    # Date version record was created. This is the date displayed to the user.
     date_created = fields.DateTimeField(auto_now_add=True)
 
     # Dictionary specifying all information needed to locate file on backend
     # {
-    #     'service': 'buttfiles',  # required
+    #     'service': 'cloudfiles',  # required
     #     'container': 'osf',       # required
     #     'object': '20c53b',       # required
     #     'worker_url': '127.0.0.1',
@@ -375,6 +376,9 @@ class OsfStorageFileVersion(StoredObject):
 
     size = fields.IntegerField()
     content_type = fields.StringField()
+    # Date file modified on third-party backend. Not displayed to user, since
+    # this date may be earlier than the date of upload if the file already
+    # exists on the backend
     date_modified = fields.DateTimeField()
 
     @property


### PR DESCRIPTION
After running this script last time, we changed which fields on the
`OsfStorageFileVersion` model were displayed to the user:
`date_created` now reflects the time the file was uploaded (which is
displayed to the user), and `date_modified` reflects the time the file
reached the backend (which does not always correspond to the upload
time, and is not displayed to the user). The original migration to OSF
Storage didn't copy creation time correctly; this updated migration
copies times from the `nodefile` collection to the `date_created` field
of `OsfStorageFileVersion`.

[Resolves #1885]