### PR TITLE
[Hotfix] Fixes wiki panel headers scrolling and use of space in devices

### DIFF
--- a/website/addons/wiki/templates/edit.mako
+++ b/website/addons/wiki/templates/edit.mako
@@ -164,12 +164,12 @@
             <div class="wiki-panel wiki-panel-flex">
               <div class="wiki-panel-header wiki-panel-header-flex">
                   <div class="row">
-                      <div class="col-sm-6">
+                      <div class="col-xs-12">
                           <i class="icon-exchange"> </i>  Compare
                       </div>
-                      <div class="col-sm-6">
+                      <div class="col-xs-12">
                             <!-- Version Picker -->
-                          <span class="compare-version-text pull-right"><span data-bind="text: viewVersionDisplay"></span> to
+                          <span class="compare-version-text"><span data-bind="text: viewVersionDisplay"></span> to
                             <select data-bind="value: compareVersion" id="compareVersionSelect">
                                 <option value="current" ${'selected' if version_settings['compare'] == 'current' else ''}>Current</option>
                                 % if len(versions) > 1:

--- a/website/addons/wiki/templates/edit.mako
+++ b/website/addons/wiki/templates/edit.mako
@@ -166,10 +166,9 @@
                   <div class="row">
                       <div class="col-xs-12">
                           <i class="icon-exchange"> </i>  Compare
-                      </div>
-                      <div class="col-xs-12">
+                      
                             <!-- Version Picker -->
-                          <span class="compare-version-text"><span data-bind="text: viewVersionDisplay"></span> to
+                          <span class="compare-version-text"><i> <span data-bind="text: viewVersionDisplay"></span></i> to
                             <select data-bind="value: compareVersion" id="compareVersionSelect">
                                 <option value="current" ${'selected' if version_settings['compare'] == 'current' else ''}>Current</option>
                                 % if len(versions) > 1:

--- a/website/addons/wiki/templates/edit.mako
+++ b/website/addons/wiki/templates/edit.mako
@@ -130,8 +130,8 @@
           <div data-osf-panel="View"
                class="${'col-sm-{0}'.format(12 / num_columns) | n}"
                style="${'' if 'view' in panels_used else 'display: none' | n}">
-              <div class="wiki-panel">
-                <div class="wiki-panel-header">
+              <div class="wiki-panel wiki-panel-flex">
+                <div class="wiki-panel-header wiki-panel-header-flex">
                     <div class="row">
                         <div class="col-sm-6">
                             <i class="icon-eye-open"> </i>  View
@@ -153,7 +153,7 @@
                         </div>
                     </div>
                 </div>
-                <div id = "wikiViewRender" data-bind="html: renderedView, mathjaxify: renderedView" class="wiki-panel-body markdown-it-view">
+                <div id = "wikiViewRender" data-bind="html: renderedView, mathjaxify: renderedView" class="wiki-panel-body markdown-it-view wiki-panel-body-flex">
 
                 </div>
               </div>
@@ -161,8 +161,8 @@
           <div data-osf-panel="Compare"
                class="${'col-sm-{0}'.format(12 / num_columns) | n}"
                style="${'' if 'compare' in panels_used else 'display: none' | n}">
-            <div class="wiki-panel">
-              <div class="wiki-panel-header">
+            <div class="wiki-panel wiki-panel-flex">
+              <div class="wiki-panel-header wiki-panel-header-flex">
                   <div class="row">
                       <div class="col-sm-6">
                           <i class="icon-exchange"> </i>  Compare
@@ -182,7 +182,7 @@
                       </div>
                   </div>
               </div>
-              <div data-bind="html: renderedCompare" class="wiki-panel-body wiki-compare-view">
+              <div data-bind="html: renderedCompare" class="wiki-panel-body wiki-compare-view wiki-panel-body-flex">
 
               </div>
             </div>

--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -817,6 +817,7 @@ h1.node-title, h1.node-parent-title {
 
 .compare-version-text{
     margin-right: 5px;
+    margin-left: 5px;
 }
 
 .wiki-title {

--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -855,6 +855,7 @@ h1.node-title, h1.node-parent-title {
 }
 
 
+
 .wiki-panel-body .superlist li {
     display: block;
     font-size: 20px;
@@ -2252,6 +2253,7 @@ span#profileFullname{
     position: relative;
     overflow-x: hidden;
 }
+
 .superlist li.active {
     background: #EFEFEF;
     font-weight: bold;
@@ -2340,6 +2342,46 @@ span#profileFullname{
     background: #D9E8D9;
 }
 
+
+.wiki-panel-flex {
+    width: 100%;
+    display: -webkit-box;
+    display: -ms-flexbox;
+    display: -webkit-flex;
+    display: flex;
+    height: 750px;
+    -webkit-align-content: flex-start;
+    -ms-align-content: flex-start;
+    align-content: flex-start;
+    -webkit-flex-direction: column;
+    -ms-flex-direction: column;
+    flex-direction: column;
+    -webkit-box-align: stretch;
+    -webkit-align-items: stretch;
+    -ms-flex-align: stretch;
+    align-items: stretch;
+    -webkit-flex-wrap: wrap;
+    -ms-flex-wrap: wrap;
+    flex-wrap: wrap;
+}
+
+.wiki-panel-header-flex {
+    width: 100%;
+    margin: auto;
+    -webkit-box-flex: 0 0 auto;
+    -webkit-flex: 0 0 auto;
+    -ms-flex: 0 0 auto;
+    flex: 0 0 auto;
+}
+.wiki-panel-body-flex{
+    width: 100%;
+    margin: auto;
+    -webkit-box-flex: 3 0 auto;
+    -webkit-flex: 3 0 auto;
+    -ms-flex: 3 0 auto;
+    flex: 3 0 auto;
+    height: 500px;
+}
 
 
 .container-xxl {

--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -393,9 +393,9 @@ li.pointer {
     border-width: 1px;
     width: 100%;
     margin: auto;
-    -webkit-box-flex: 0 0 auto;
-    -webkit-flex: 0 0 auto;
-    -ms-flex: 0 0 auto;
+    -webkit-box-flex: 3 0 auto;
+    -webkit-flex: 3 0 auto;
+    -ms-flex: 3 0 auto;
     flex: 3 0 auto;
     height: 500px; /* this will get overwritten by flex box */
 }


### PR DESCRIPTION
## Purpose
This fix introduces flex display style to wiki panels so that their header does not scroll and the height is still equal despite header size differences. It also changes the compare panel header.

## Changes
- Added flex style to view and compare panels
- Change compare header so that everything is in one line, works best across devices.

## Side effects
Shouldn't be any, the styles are compartmentalized. In IE9 the flex style will default to the stated height (500px) for those panel bodies. 