### PR TITLE
Hotfix: Fix "Share on Box"

### DIFF
--- a/website/addons/box/settings/defaults.py
+++ b/website/addons/box/settings/defaults.py
@@ -6,3 +6,5 @@ REFRESH_TIME = 5 * 60  # 5 minutes
 
 BOX_OAUTH_TOKEN_ENDPOINT = 'https://www.box.com/api/oauth2/token'
 BOX_OAUTH_AUTH_ENDPOINT = 'https://www.box.com/api/oauth2/authorize'
+
+BOX_SHARE_URL_TEMPLATE = 'https://app.box.com/files/0/f/{0}'

--- a/website/addons/box/views/config.py
+++ b/website/addons/box/views/config.py
@@ -19,6 +19,7 @@ from website.project.decorators import (
 from website.addons.box.client import get_node_client
 from website.addons.box.client import get_client_from_user_settings
 
+from website.addons.box import settings
 
 @must_have_addon('box', 'node')
 @must_have_permission(permissions.WRITE)
@@ -70,6 +71,7 @@ def serialize_urls(node_settings):
         'config': node.api_url_for('box_config_put'),
         'files': node.web_url_for('collect_file_trees'),
         'emails': node.api_url_for('box_get_share_emails'),
+        'share': settings.BOX_SHARE_URL_TEMPLATE.format(node_settings.folder_id),
         'deauthorize': node.api_url_for('box_deauthorize'),
         'importAuth': node.api_url_for('box_import_user_auth'),
         # Endpoint for fetching only folders (including root)


### PR DESCRIPTION
## Purpose

Currently clicking "Share on Box" from the folderpicker UI does nothing.This allows the folderpicker to work as expected.

## Changes

- Add a share URL template to Box settings
- Add a share url to serialized Box settings

## Side Effects

None