### PR TITLE
Hotfix/remove contributor network

### DIFF
--- a/website/templates/nav.mako
+++ b/website/templates/nav.mako
@@ -28,7 +28,6 @@
                 <li class="dropdown">
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">Explore <b class="caret"></b></a>
                     <ul class="dropdown-menu">
-                        <li><a href="/explore">Collaborator Network</a></li>
                         <li><a href="/explore/activity">Public Activity</a></li>
                     </ul><!-- end dropdown-menu -->
                 </li><!-- end dropdown -->


### PR DESCRIPTION
Purpose
-----------
Collaborator network is out of date. This removes that link until we can make it better.

Changes
-------------
Remove the link to the collaborator network.

Side effects
----------------
There is only one item in the Explore menu. Combining this with #1343 will fix that problem.

Closes #2044 