### PR TITLE
Hotfix/Remove collaborator network

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -842,7 +842,7 @@ tbOptions = {
             if (window.File && window.FileReader) {
                 return m('p', {
                 }, [
-                    m('span', 'To Upload: Drag files into a folder below OR click the '),
+                    m('span', 'To Upload: Drag files into a folder OR click the '),
                     m('i.btn.btn-default.btn-xs', { disabled : 'disabled'}, [ m('span.icon-upload-alt')]),
                     m('span', ' below.')
                 ]);

--- a/website/templates/nav.mako
+++ b/website/templates/nav.mako
@@ -28,7 +28,6 @@
                 <li class="dropdown">
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">Explore <b class="caret"></b></a>
                     <ul class="dropdown-menu">
-                        <li><a href="/explore">Collaborator Network</a></li>
                         <li><a href="/explore/activity">Public Activity</a></li>
                     </ul><!-- end dropdown-menu -->
                 </li><!-- end dropdown -->


### PR DESCRIPTION
Purpose
-----------
Collaborator network is out of date. This removes that link until we can make it better.

Changes
-------------
Remove the link to the collaborator network. Also removed a redundant word from a line in Fangorn.

Side effects
----------------
There is only one item in the Explore menu. Combining this with #1343 will fix that problem.

Closes #2044 