### PR TITLE
[Hotfix] #1950 comment covering project links

### DIFF
--- a/website/static/css/commentpane.css
+++ b/website/static/css/commentpane.css
@@ -1,6 +1,6 @@
 #commentPane {
     position: fixed;
-    z-index: 999; /* Note: Must be lower than Bootstrap modals, BlockUI */
+    z-index: 98; /* Note: Must be lower than Bootstrap modals, BlockUI */
     width: 0;
     top: 0;
     right: 0;


### PR DESCRIPTION
## Purpose
Fixes comment pane covering the project navigation links when they overlap. As reported in this issue: #1950 

## Changes
- Z-index for the comment pane div is reduced
Solution provided by @sambrady3 

## Side effects
Doesn't seem to be any. Checked these scenarios
- XS size (because navigation changes significantly there), works correctly, opens above comment pane
- Search bar opening, works correctly opens above comment pane 
- Modals opening (work correctly, opens above comment pane)