### PR TITLE
[Hotfix] Add webkit specific scrollbar css for treebeard

### DIFF
--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -2340,11 +2340,20 @@ span#profileFullname{
     background: #D9E8D9;
 }
 
-
+/* scroll fix for wherever treebeard is used */
+#tb-tbody::-webkit-scrollbar  {
+    z-index: 9;
+    background-color: #f5f5f5;
+    width: 10px;
+}
+#tb-tbody::-webkit-scrollbar-thumb { 
+    background-color: #999;
+    border-radius: 5px;
+    width: 6px;
+ }
 
 .container-xxl {
   width : 100%;
   padding-left: 20px;
   padding-right: 20px;
-
 }


### PR DESCRIPTION
## Purpose
This change is designed to fix this issue: #2017, without using css transform related hacks so that we have a more reliable solution.

## Change
Scrollbars specific to webkit (Chrome and Safari) were added to the treebeard body elements only with a generic looking grey design. 

## Side effects
There shouldn't be any, the scope is under control so it shouldn't apply to anything other than treebeard grids in webkit browser
- Tested in Chrome : shows custom bars as expected
- Tested in Safari: shows custom bars as expected
- Tested in Firefox: doesn't show custom bars as expected
- Tested in IE9, 10, 11: doesn't show custom bars as expected

Also tested fangorn, folderpicker and presentations, everything seems to work fine with the custom scrollbars. 