### PR TITLE
Feature/inaccessible grandchildren

### DIFF
--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -814,6 +814,7 @@ def _get_children(node, auth, indent=0):
                 'title': child.title,
                 'indent': indent,
                 'is_public': child.is_public,
+                'parent_id': child.parent_id,
             })
             children.extend(_get_children(child, auth, indent + 1))
 
@@ -845,7 +846,7 @@ def get_editable_children(auth, **kwargs):
     children = _get_children(node, auth)
 
     return {
-        'node': {'title': node.title, 'is_public': node.is_public},
+        'node': {'id': node._id, 'title': node.title, 'is_public': node.is_public},
         'children': children,
     }
 

--- a/website/static/js/privateLinkManager.js
+++ b/website/static/js/privateLinkManager.js
@@ -20,6 +20,9 @@ var PrivateLinkViewModel = function(url) {
     self.disableSubmit = ko.observable(false);
     self.submitText = ko.observable('Submit');
 
+    self.isChildVisible = function(data) {
+        return (self.nodesToChange().indexOf(data.parent_id) !== -1 ||  data.parent_id === self.id());
+    };
 
     self.changingNodesCleaner = ko.computed(function(){
         self.nodesToChange();

--- a/website/static/js/privateLinkManager.js
+++ b/website/static/js/privateLinkManager.js
@@ -31,11 +31,11 @@ var PrivateLinkViewModel = function(url) {
         self.nodes(response['children']);
     }
 
-        function onFetchError() {
-            $osf.growl('Could not retrieve projects.', 'Please refresh the page or ' +
-                    'contact <a href="mailto: support@cos.io">support@cos.io</a> if the ' +
-                    'problem persists.');
-        }
+    function onFetchError() {
+        $osf.growl('Could not retrieve projects.', 'Please refresh the page or ' +
+                'contact <a href="mailto: support@cos.io">support@cos.io</a> if the ' +
+                'problem persists.');
+    }
 
     function fetch() {
         $.ajax({

--- a/website/static/js/privateLinkManager.js
+++ b/website/static/js/privateLinkManager.js
@@ -35,7 +35,7 @@ var PrivateLinkViewModel = function(url) {
             }
         }
     });
-    
+
     /**
         * Fetches the node info from the server and updates the viewmodel.
         */

--- a/website/static/js/privateLinkManager.js
+++ b/website/static/js/privateLinkManager.js
@@ -13,11 +13,29 @@ var PrivateLinkViewModel = function(url) {
     self.anonymous = ko.observable(false);
     self.pageTitle = 'Generate New Link to Share Project';
     self.errorMsg = ko.observable('');
+    self.id = ko.observable('');
 
     self.nodes = ko.observableArray([]);
     self.nodesToChange = ko.observableArray();
     self.disableSubmit = ko.observable(false);
     self.submitText = ko.observable('Submit');
+
+
+    self.changingNodesCleaner = ko.computed(function(){
+        self.nodesToChange();
+        var unchecked = [];
+        var index;
+        for (index = 0; index < self.nodes().length; ++index) {
+            var currentNode = self.nodes()[index];
+            if(unchecked.indexOf(currentNode.parent_id) !== -1 && currentNode.parent_id !== self.id()){
+                self.nodesToChange.remove(currentNode.id);
+            }
+            if(self.nodesToChange.indexOf(currentNode.id) === -1){
+                unchecked.push(currentNode.id);
+            }
+        }
+    });
+    
     /**
         * Fetches the node info from the server and updates the viewmodel.
         */
@@ -25,6 +43,7 @@ var PrivateLinkViewModel = function(url) {
     function onFetchSuccess(response) {
         self.title(response.node.title);
         self.isPublic(response.node.is_public);
+        self.id(response.node.id);
         $.each(response['children'], function(idx, child) {
             child['margin'] = NODE_OFFSET + child['indent'] * NODE_OFFSET + 'px';
         });

--- a/website/static/js/privateLinkTable.js
+++ b/website/static/js/privateLinkTable.js
@@ -21,7 +21,7 @@ var setupEditable = function(elm, data) {
         ajaxOptions: {
             type: 'PUT',
             dataType: 'json',
-            contentType: 'application/json',
+            contentType: 'application/json'
         },
         send: 'always',
         title: 'Edit Link Name',
@@ -33,7 +33,7 @@ var setupEditable = function(elm, data) {
         success: function(response, value) {
             data.name(value);
         },
-        error: $osf.handleEditableError,
+        error: $osf.handleEditableError
     });
 };
 
@@ -116,7 +116,7 @@ function ViewModel(url, nodeIsPublic) {
         $.ajax({
             url: url,
             type: 'GET',
-            dataType: 'json',
+            dataType: 'json'
         }).done(
             onFetchSuccess
         ).fail(

--- a/website/templates/project/modal_generate_private_link.mako
+++ b/website/templates/project/modal_generate_private_link.mako
@@ -41,15 +41,21 @@
 
 
                     <div class="row">
-
                         <div class="col-md-6" >
                             <div class="list-overflow">
                             <input type="checkbox" checked disabled />
+
                             <span data-bind="text:title"></span> (current component
                                 <span data-bind="if: isPublic">, public</span>)
+
                             <div data-bind="foreach:nodes">
                                 <div data-bind="style:{'marginLeft': margin}">
+                                    <!-- ko if: ($parent.nodesToChange().indexOf($data.parent_id) !== -1 ||  $data.parent_id === $parent.id())-->
                                     <input type="checkbox" data-bind="checked:$parent.nodesToChange, value:id" />
+                                    <!-- /ko -->
+                                    <!-- ko if: ($parent.nodesToChange().indexOf($data.parent_id) === -1 &&  $data.parent_id !== $parent.id()) -->
+                                        <i class="icon-question-sign" data-bind="tooltip: {title: 'Parent needs to be checked'}"></i>
+                                    <!-- /ko -->
                                     <span data-bind="text:$data.title"></span>
                                     <span data-bind="if: $data.is_public">(public)</span>
                                 </div>

--- a/website/templates/project/modal_generate_private_link.mako
+++ b/website/templates/project/modal_generate_private_link.mako
@@ -50,10 +50,10 @@
 
                             <div data-bind="foreach:nodes">
                                 <div data-bind="style:{'marginLeft': margin}">
-                                    <!-- ko if: ($parent.nodesToChange().indexOf($data.parent_id) !== -1 ||  $data.parent_id === $parent.id())-->
+                                    <!-- ko if: $root.isChildVisible($data) -->
                                     <input type="checkbox" data-bind="checked:$parent.nodesToChange, value:id" />
                                     <!-- /ko -->
-                                    <!-- ko if: ($parent.nodesToChange().indexOf($data.parent_id) === -1 &&  $data.parent_id !== $parent.id()) -->
+                                    <!-- ko ifnot: $root.isChildVisible($data) -->
                                         <i class="icon-question-sign" data-bind="tooltip: {title: 'Parent needs to be checked'}"></i>
                                     <!-- /ko -->
                                     <span data-bind="text:$data.title"></span>


### PR DESCRIPTION
Purpose
-----------
Prevent users from creating new View Only Links that include components that non-contributors wouldn't be able to get to. The specific situation is that a user would give a link to, say, the parent project and a grandchild, but not the child, so the user couldn't get to the grandchild.

This will not fix existing links.

Changes
------------
The link sharing widget will now prevent users from having access to a checkbox if the parent of the component is not checked. The checkbox is replaced with a question mark that has a tooltip to let the user know that the parent has to be checked. When an ancestor is unchecked, it clears out the descendant checks as well.

![private link grandchildren](https://cloud.githubusercontent.com/assets/6599111/6495825/83e35770-c29b-11e4-973d-a553875195ab.gif)

Side effects
----------------
I added a little information to the view for getting information about the ancestry, and the get_editable_children view is now tested.

Closes #1514 