### PR TITLE
Hotfix/box refresh

### DIFF
--- a/scripts/refresh_box_tokens.py
+++ b/scripts/refresh_box_tokens.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+import sys
+import logging
+import datetime
+
+from modularodm import Q
+from dateutil.relativedelta import relativedelta
+
+from website.addons.box import model
+
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+def get_targets(delta):
+    return model.BoxOAuthSettings.find(
+        Q('expires_at', 'lt', datetime.datetime.utcnow() + delta)
+    )
+
+
+def main(delta, dry_run):
+    for record in get_targets(delta):
+        logger.info(
+            'Refreshing tokens on record {0}; expires at {1}'.format(
+                record.user_id,
+                record.expires_at.strftime('%c')
+            )
+        )
+        if not dry_run:
+            record.refresh_access_token(force=True)
+
+
+if __name__ == '__main__':
+    dry_run = 'dry' in sys.argv
+    try:
+        days = int(sys.argv[2])
+    except (IndexError, ValueError, TypeError):
+        days = 7
+    delta = relativedelta(days=days)
+    main(delta, dry_run=dry_run)

--- a/scripts/tests/test_refresh_box_tokens.py
+++ b/scripts/tests/test_refresh_box_tokens.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+
+import mock
+from nose.tools import *  # noqa
+
+from tests.base import OsfTestCase
+
+from website.addons.box.tests import factories
+
+import datetime
+
+from dateutil.relativedelta import relativedelta
+
+from website.addons.box import model
+
+from scripts.refresh_box_tokens import get_targets, main
+
+
+class TestRefreshTokens(OsfTestCase):
+
+    def tearDown(self):
+        super(TestRefreshTokens, self).tearDown()
+        model.BoxOAuthSettings.remove()
+
+    def test_get_targets(self):
+        now = datetime.datetime.utcnow()
+        records = [
+            factories.BoxOAuthSettingsFactory(expires_at=now + datetime.timedelta(days=8)),
+            factories.BoxOAuthSettingsFactory(expires_at=now + datetime.timedelta(days=6)),
+        ]
+        targets = list(get_targets(delta=relativedelta(days=7)))
+        assert_in(records[1], targets)
+        assert_not_in(records[0], targets)
+
+    @mock.patch('website.addons.box.model.BoxOAuthSettings.refresh_access_token')
+    def test_refresh(self, mock_refresh):
+        factories.BoxOAuthSettingsFactory(expires_at=datetime.datetime.utcnow())
+        main(delta=relativedelta(days=7), dry_run=False)
+        mock_refresh.assert_called_once_with(force=True)


### PR DESCRIPTION
# Purpose
Add script to force-refresh Box OAuth tokens on authorizations that will expire soon. Should be run periodically on a cron job.

# Changes
Add migration script

# Side effects
None

Note: This will need to be updated once @mfraezz is done porting the Box addon to @lyndsysimon's abstracted OAuth.