### PR TITLE
hotfix/wiki-optimization

### DIFF
--- a/website/static/js/markdown.js
+++ b/website/static/js/markdown.js
@@ -28,9 +28,7 @@ var markdown = new MarkdownIt('commonmark', {
 
 
 // Fast markdown renderer for active editing to prevent slow loading/rendering tasks
-var markdownQuick = new MarkdownIt(('commonmark'), {
-     highlight: highlighter
-})
+var markdownQuick = new MarkdownIt(('commonmark'), {})
     .use(require('markdown-it-sanitizer'))
     .disable('link')
     .disable('image');

--- a/website/static/js/markdown.js
+++ b/website/static/js/markdown.js
@@ -28,7 +28,7 @@ var markdown = new MarkdownIt('commonmark', {
 
 
 // Fast markdown renderer for active editing to prevent slow loading/rendering tasks
-var markdownQuick = new MarkdownIt(('commonmark'), {})
+var markdownQuick = new MarkdownIt(('commonmark'), { })
     .use(require('markdown-it-sanitizer'))
     .disable('link')
     .disable('image');


### PR DESCRIPTION
Purpose
-----------
Make wiki much faster for blocks of highlighted code on quick render

Changes
------------
Remove the highlighting on quick render

Side effects
----------------
This was unnecessary for quick rendering. Editing is now much faster in these circumstances. There may still be other optimizations that can be made for other issues, but for what @fabianvf showed me as far as slow editing, this does the trick

Closes #2053 