### PR TITLE
Add wiki menu panel to the flex layout so menu headers don't scroll.

### DIFF
--- a/website/addons/wiki/templates/edit.mako
+++ b/website/addons/wiki/templates/edit.mako
@@ -19,11 +19,11 @@
   <div class="row wiki-wrapper">
     <div class="panel-toggle col-sm-${'3' if 'menu' in panels_used else '1' | n}">
         <!-- Menu with toggle normal -->
-        <div class="wiki-panel hidden-xs" style="${'' if 'menu' in panels_used else 'display: none' | n}">
-            <div class="wiki-panel-header"> <i class="icon-list"> </i>  Menu
+        <div class="wiki-panel wiki-panel-flex hidden-xs" style="${'' if 'menu' in panels_used else 'display: none' | n}">
+            <div class="wiki-panel-header wiki-panel-header-flex"> <i class="icon-list"> </i>  Menu
                 <div class="pull-right"> <div class="panel-collapse"> <i class="icon icon-angle-left"> </i> </div></div>
             </div>
-            <div class="wiki-panel-body">
+            <div class="wiki-panel-body wiki-panel-body-flex">
                 <%include file="wiki/templates/toc.mako"/>
             </div>
         </div>


### PR DESCRIPTION
## Purpose
Additional fix for #2041 which takes care of the scenario where Menu panel also needs to scroll.

## Changes
Added the flex classes to the menu panel as well. 

## Side effects
None. 