### PR TITLE
[hotfix] Fix for IE

### DIFF
--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -479,24 +479,24 @@ var AddContributorViewModel = function(title, parentId, parentTitle) {
         return names.join(', ');
     });
 
-        self.submit = function() {
-            $osf.block();
+    self.submit = function() {
+        $osf.block();
+        $osf.postJSON(
+            nodeApiUrl + 'contributors/',
+            {
+                users: self.selection().map(function(user) {
+                    return ko.toJS(user);
+                }),
+                node_ids: self.nodesToChange()
+            }
+        ).done(function() {
+            window.location.reload();
+        }).fail(function() {
             $('.modal').modal('hide');
-            $osf.postJSON(
-                nodeApiUrl + 'contributors/',
-                {
-                    users: self.selection().map(function(user) {
-                        return ko.toJS(user);
-                    }),
-                    node_ids: self.nodesToChange()
-                }
-            ).done(function() {
-                window.location.reload();
-            }).fail(function() {
-                $osf.unblock();
-                $osf.growl('Error','Add contributor failed.');
-            });
-        };
+            $osf.unblock();
+            $osf.growl('Error','Add contributor failed.');
+        });
+    };
 
     self.clear = function() {
         self.page('whom');


### PR DESCRIPTION
Fixes #1907 

Problem
------------------
In IE 9, the admin cannot add more contributors on hitting "submit" on the add contributor modal

Cause
-------------------
When the modal is dismissed, the javascript <code>clear</code> function is called, so all selections are cleared. Since the modal is dismissed prior to the selections are passed to python, python actually gets a list of 0 users to be added.

Fix
--------------------
Since the page is going to reload anyways if adding contributors is successful, now the modal is dismissed AFTER the selections are passed to python, a value is returned, and only when python fails to add a contributor.

Side effects
---------------------
None

And btw...
---------------------
I un-indented the js code for submit just for clarity...


ping @sloria @lbanner 