### PR TITLE
Hotfix/box share

### DIFF
--- a/website/addons/box/static/boxNodeConfig.js
+++ b/website/addons/box/static/boxNodeConfig.js
@@ -67,6 +67,10 @@ var ViewModel = function(url, selector, folderPicker) {
         return !self.urls().emails;
     });
 
+    self.showShare = ko.computed(function(){
+        return self.validCredentials() && self.folder().path !== 'All Files' && (typeof self.folder().path !== 'undefined');
+    });
+
     /**
     *  Update the view model from data returned from the server.
     */

--- a/website/addons/box/templates/box_node_settings.mako
+++ b/website/addons/box/templates/box_node_settings.mako
@@ -53,7 +53,7 @@
                                         css: {active: currentDisplay() === PICKER}"
                             class="btn btn-sm btn-box"><i class="icon-edit"></i> Change</button>
                     <button data-bind="attr.disabled: disableShare,
-                                        visible: validCredentials,
+                                        visible: showShare,
                                         click: toggleShare,
                                         css: {active: currentDisplay() === SHARE}"
                         class="btn btn-sm btn-box"><i class="icon-share-alt"></i> Share on Box

--- a/website/addons/box/views/config.py
+++ b/website/addons/box/views/config.py
@@ -19,8 +19,6 @@ from website.project.decorators import (
 from website.addons.box.client import get_node_client
 from website.addons.box.client import get_client_from_user_settings
 
-from website.addons.box import settings
-
 BOX_SHARE_URL_TEMPLATE = 'https://app.box.com/files/0/f/{0}'
 
 @must_have_addon('box', 'node')

--- a/website/addons/box/views/config.py
+++ b/website/addons/box/views/config.py
@@ -144,7 +144,7 @@ def box_config_put(node_addon, user_addon, auth, **kwargs):
     return {
         'result': {
             'folder': {
-                'name': path if path != 'All Files'  else '/ (Full Box)',
+                'name': path if path != 'All Files' else '/ (Full Box)',
                 'path': path,
             },
             'urls': serialize_urls(node_addon),

--- a/website/addons/box/views/config.py
+++ b/website/addons/box/views/config.py
@@ -36,7 +36,7 @@ def serialize_folder(metadata):
     """
     # if path is root
     if metadata['path'] == '' or metadata['path'] == '/':
-        name = 'All Files'
+        name = '/ (Full Box)'
     else:
         name = 'Box' + metadata['path']
     return {
@@ -52,7 +52,7 @@ def get_folders(client):
     metadata = client.metadata('/', list=True)
     # List each folder, including the root
     root = {
-        'name': 'All Files',
+        'name': '/ (Full Box)',
         'path': '',
     }
     folders = [root] + [
@@ -144,7 +144,7 @@ def box_config_put(node_addon, user_addon, auth, **kwargs):
     return {
         'result': {
             'folder': {
-                'name': path,
+                'name': path if path != 'All Files'  else '/ (Full Box)',
                 'path': path,
             },
             'urls': serialize_urls(node_addon),


### PR DESCRIPTION
## Purpose

The 'Share on Box' button should be hidden when no Box folder is configured or the '/ (Full Box)' folder is set. This fixes this. 

Also there was some inconsistencies between the usage of 'All Files' and '/ (Full Box)' that are now resolved.

## Changes

- Change some references to 'All Files' to '/ (Full Box)' when appropriate
- Update Box Knockout model to hide 'Share on Box' when appropriate
- Remove unused settings.py import

## Side Effects

none