### PR TITLE
[feature] Fixes for Public Activity page

### DIFF
--- a/framework/analytics/piwik.py
+++ b/framework/analytics/piwik.py
@@ -208,6 +208,11 @@ class PiwikClient(object):
             idSubtable=v.subtable_id,
             period=self.period,
             date=self.date,
+            # Get all results (defaults to a limit of 100)
+            # NOTE: This appears to have an actual limit of 1,000 - the Piwik
+            #       documentation does not specify this.
+            #       http://developer.piwik.org/api-reference/reporting-api
+            filter_limit=-1,
         )
 
     def __call_api(self, method, **kwargs):

--- a/website/discovery/views.py
+++ b/website/discovery/views.py
@@ -1,3 +1,5 @@
+import datetime
+
 from website import settings
 from website.project import Node
 
@@ -5,11 +7,15 @@ from modularodm.query.querydialect import DefaultQueryDialect as Q
 
 from framework.analytics.piwik import PiwikClient
 
+
 def activity():
 
     popular_public_projects = []
     popular_public_registrations = []
     hits = {}
+
+    # get the date for exactly one week ago
+    target_date = datetime.date.today() - datetime.timedelta(weeks=1)
 
     if settings.PIWIK_HOST:
         client = PiwikClient(
@@ -17,8 +23,9 @@ def activity():
             auth_token=settings.PIWIK_ADMIN_TOKEN,
             site_id=settings.PIWIK_SITE_ID,
             period='week',
-            date='today',
+            date=target_date.strftime('%Y-%m-%d'),
         )
+
         popular_project_ids = [
             x for x in client.custom_variables if x.label == 'Project ID'
         ][0].values

--- a/website/discovery/views.py
+++ b/website/discovery/views.py
@@ -51,10 +51,6 @@ def activity():
         Q('is_deleted', 'eq', False)
     )
 
-    # Temporary bug fix: Skip projects with empty contributor lists
-    # Todo: Fix underlying bug and remove this selector
-    recent_query = recent_query & Q('contributors', 'ne', [])
-
     recent_public_projects = Node.find(
         recent_query &
         Q('is_registration', 'eq', False)

--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -760,10 +760,13 @@ li.list-group-item-node {
 
 li .project-meta {
     position: absolute;
-    top: 10px;
     right: 10px;
     font-weight: normal;
     font-style: italic;
+}
+
+li .project-meta.pull-right {
+    text-align:right;
 }
 
 /*****************************************************/

--- a/website/templates/public/pages/active_nodes.mako
+++ b/website/templates/public/pages/active_nodes.mako
@@ -73,7 +73,7 @@
                     <div class="col-md-2">
                         % if metric == 'hits':
                             <span class="project-meta pull-right text-primary" rel='tooltip' data-original-title='${ hits[node._id].get('hits') } views (${ hits[node._id].get('visits') } visits)'>
-                                ${ hits[node._id].get('hits') } views (in the past week)
+                                ${ hits[node._id].get('hits') }&nbsp;views (last&nbsp;week)
                             </span>
                         % elif metric == 'date_created':
                             <span class="project-meta pull-right text-primary" rel='tooltip' data-original-title='Created: ${explicit_date}'>


### PR DESCRIPTION
Changes:
 
* Returns more results from Piwik, extending the list of popular registrations (closes #2002)
* Changes the date range from the current week (Sunday-Saturday) to the previous week. This prevents displaying very few hits (or no active projects/registrations) early in the week.
* Removes some dead code filtering out projects with no contributors - that issue has long been fixed.