### PR TITLE
Clean up Box nodeSettings to consistently hide/show Share and correct

### DIFF
--- a/website/addons/box/static/boxNodeConfig.js
+++ b/website/addons/box/static/boxNodeConfig.js
@@ -63,12 +63,11 @@ var ViewModel = function(url, selector, folderPicker) {
         return self.emails().join([', ']);
     });
 
-    self.disableShare = ko.pureComputed(function() {
-        return !self.urls().emails;
-    });
+    self.disableShare = ko.pureComputed(function() {       
+        var isRoot = self.folder().path === 'All Files';
+        var notSet = (typeof self.folder().path === 'undefined');
+        return !(self.urls().emails) || !self.validCredentials() || isRoot || notSet;
 
-    self.showShare = ko.pureComputed(function(){
-        return self.validCredentials() && self.folder().path !== 'All Files' && (typeof self.folder().path !== 'undefined');
     });
 
     /**

--- a/website/addons/box/templates/box_node_settings.mako
+++ b/website/addons/box/templates/box_node_settings.mako
@@ -53,11 +53,10 @@
                                         css: {active: currentDisplay() === PICKER}"
                             class="btn btn-sm btn-box"><i class="icon-edit"></i> Change</button>
                     <button data-bind="attr.disabled: disableShare,
-                                        visible: showShare,
                                         click: toggleShare,
                                         css: {active: currentDisplay() === SHARE}"
                         class="btn btn-sm btn-box"><i class="icon-share-alt"></i> Share on Box
-                            <span data-bind="visible: folder().path === '/'">(Cannot share root folder)</span>
+                            <span data-bind="visible: folder().path === 'All Files'">(Cannot share root folder)</span>
                         </button>
                 </div>
 

--- a/website/addons/box/views/config.py
+++ b/website/addons/box/views/config.py
@@ -144,7 +144,7 @@ def box_config_put(node_addon, user_addon, auth, **kwargs):
     return {
         'result': {
             'folder': {
-                'name': path if path != 'All Files' else '/ (Full Box)',
+                'name': path.replace('All Files', '') if path != 'All Files' else '/ (Full Box)',
                 'path': path,
             },
             'urls': serialize_urls(node_addon),


### PR DESCRIPTION
## Purpose

Cailey found some bugs in the first hotfix in particular when the Share button was being shown, and All Files getting prepended to folder names.

## Changes

- Strip 'All files' from folder path
- Clean up logic for showing 'Share on Box'

## Side Effects

None