### PR TITLE
Fix logic for checking if Box folder not set

### DIFF
--- a/website/addons/box/static/boxNodeConfig.js
+++ b/website/addons/box/static/boxNodeConfig.js
@@ -65,7 +65,7 @@ var ViewModel = function(url, selector, folderPicker) {
 
     self.disableShare = ko.pureComputed(function() {       
         var isRoot = self.folder().path === 'All Files';
-        var notSet = (self.folder().path === null);
+        var notSet = (self.folder().path == null);
         return !(self.urls().emails) || !self.validCredentials() || isRoot || notSet;
 
     });

--- a/website/addons/box/static/boxNodeConfig.js
+++ b/website/addons/box/static/boxNodeConfig.js
@@ -65,7 +65,7 @@ var ViewModel = function(url, selector, folderPicker) {
 
     self.disableShare = ko.pureComputed(function() {       
         var isRoot = self.folder().path === 'All Files';
-        var notSet = (typeof self.folder().path === 'undefined');
+        var notSet = (self.folder().path === null);
         return !(self.urls().emails) || !self.validCredentials() || isRoot || notSet;
 
     });


### PR DESCRIPTION
## Purpose

'Share on Box' was still clickable when Box folder was unconfigured.

## Changes

Fix logic to correct this.

## Side Effects

None