### PR TITLE
hotfix/do not count deleted children

### DIFF
--- a/website/util/rubeus.py
+++ b/website/util/rubeus.py
@@ -296,7 +296,7 @@ class NodeProjectCollector(object):
         readable_children = []
         for child in child_nodes:
             if child is not None:
-                if child.resolve().can_view(auth=self.auth):
+                if child.resolve().can_view(auth=self.auth) and not child.resolve().is_deleted:
                     readable_children.append(child)
         children_count = len(readable_children)
         is_pointer = not node.primary


### PR DESCRIPTION
Purpose
-----------
Ensure deleted children aren't added to children count to save future developers trouble and also to reduce unnecessary AJAX calls. Currently, the end user doesn't see this, because lazy loading fetches the children, finds out there are none, and corrects the number. This will keep some items from being lazy loaded at all.

Changes
-----------
In rubeus.py, check the pointers of a project and verify that the children aren't deleted before adding them to the child count.

Side effects
----------------
None anticipated

Closes #1410 