### PR TITLE
[hotfix] wiki widget text overflow

### DIFF
--- a/website/addons/wiki/templates/wiki_widget.mako
+++ b/website/addons/wiki/templates/wiki_widget.mako
@@ -1,7 +1,7 @@
 <%inherit file="project/addon/widget.mako"/>
 <%page expression_filter="h"/>
 
-<div id="markdownRender">
+<div id="markdownRender" class="break-word">
     % if wiki_content:
         ${wiki_content | n}
     % else:


### PR DESCRIPTION
**Purpose**
- Prevent long words and links from overflowing in the wiki widget.
- Resolves [#1373](https://github.com/CenterForOpenScience/osf.io/issues/1373)

**Changes**
- Add ```break-word``` class to wiki widget.
- ***Before***
![screen shot 2015-03-06 at 3 49 09 pm](https://cloud.githubusercontent.com/assets/7913604/6536178/7f2e4152-c419-11e4-8dfd-9532b2cc7eef.png)

- ***After***
![screen shot 2015-03-06 at 3 49 30 pm](https://cloud.githubusercontent.com/assets/7913604/6536184/864e08d2-c419-11e4-80b4-92a751c2d265.png)

**Side Effects**
- None. 