### PR TITLE
Add proper word breaking to contributor cell in project contributors page

### DIFF
--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -2175,6 +2175,11 @@ span#profileFullname{
 .break-word {
     word-wrap: break-word;
 }
+.table-fixed {
+    table-layout: fixed;
+    width: 100%;
+    word-wrap: break-word;
+}
 .modal-backdrop {
     position: fixed;
 }

--- a/website/templates/project/modal_add_contributor.mako
+++ b/website/templates/project/modal_add_contributor.mako
@@ -1,5 +1,5 @@
 <div id="addContributors" class="modal fade">
-    <div class="modal-dialog">
+    <div class="modal-dialog modal-lg">
         <div class="modal-content">
             <div class="modal-header">
                 <h3 data-bind="text:pageTitle"></h3>
@@ -130,12 +130,12 @@
                             </div>
 
                             <!-- TODO: Duplication here: Put this in a KO template -->
-                            <table>
+                            <table class="table-fixed">
                                 <thead data-bind="visible: selection().length">
-                                    <th></th>
-                                    <th></th>
-                                    <th>Name</th>
-                                    <th>
+                                    <th width="10%"></th>
+                                    <th width="15%"></th>
+                                    <th width="45%">Name</th>
+                                    <th width="30%">
                                         Permissions
                                         <i class="icon-question-sign permission-info"
                                                 data-toggle="popover"


### PR DESCRIPTION
## Purpose
This is an attempt at a different fix to issue #1778 compared to Nan's fix here: #2077 

## Changes
Takes a CSS/HTML approach to fixing the width. 
- Adds table-fixed helper class for tables that need word wrapping done.
- Changes modal to a larger modal so more of the available window space is used.
- Adds widths to the table columns as percentages that work in different window sizes
- adds word-wrap to table cells

## Side Effects
The effects are limited to the contributor adding table and seems to work fine in Chrome, Safari, Firefox. Didn't check Internet Explorer but the css property is has good cross-browser compatibility. 
- **Someone should check this with long username data from server, I changed names after page load. Since the css class still applies this shouldn't be an issue but better test it again.** 