### PR TITLE
Hotfix/filesview 404

### DIFF
--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -384,6 +384,28 @@ class TestAddonFileViewHelpers(OsfFileTestCase):
             views.get_or_start_render(file_guid)
         )
 
+    def test_key_error_raises_attr_error_for_name(self):
+        class TestGuidFile(GuidFile):
+            pass
+
+        with assert_raises(AttributeError):
+            TestGuidFile().name
+
+    def test_getattrname_catches(self):
+        class TestGuidFile(GuidFile):
+            pass
+
+        assert_equals(getattr(TestGuidFile(), 'name', 'foo'), 'foo')
+
+    def test_getattrname(self):
+        class TestGuidFile(GuidFile):
+            pass
+
+        guid = TestGuidFile()
+        guid._metadata_cache = {'name': 'test'}
+
+        assert_equals(getattr(guid, 'name', 'foo'), 'test')
+
 
 class TestAddonFileViews(OsfTestCase):
 

--- a/website/addons/base/__init__.py
+++ b/website/addons/base/__init__.py
@@ -204,7 +204,11 @@ class GuidFile(GuidStoredObject):
 
     @property
     def name(self):
-        return self._metadata_cache['name']
+        try:
+            return self._metadata_cache['name']
+        except (TypeError, KeyError):
+            # If name is not in _metadata_cache or metadata_cache is None
+            raise AttributeError('No attribute name')
 
     @property
     def file_name(self):


### PR DESCRIPTION
When Waterbutler returns a `404` `_metadata_cache` is set to `None` causing a `TypeError` rather than an `AttributeError`.