### PR TITLE
Convert file icons in fangorn to classes with background images 

### DIFF
--- a/website/static/css/fangorn.css
+++ b/website/static/css/fangorn.css
@@ -74,6 +74,7 @@ text-align: center;
 .tb-expand-icon-holder > i {
   font-size: 16px;
   padding-left: 2px;
+  cursor: default;
 }
 
 /* File icons */

--- a/website/static/css/fangorn.css
+++ b/website/static/css/fangorn.css
@@ -70,3 +70,108 @@ text-align: center;
 .tb-notify {
 	white-space: nowrap;
 }
+
+/* File icons */
+.file-extension {
+
+}
+.file-extension._3gp {background: url('/static/img/hgrid/fatcowicons/file_extension_3gp.png');	}
+.file-extension._7z  {background: url('/static/img/hgrid/fatcowicons/file_extension_7z.png'); 	}
+.file-extension._ace {background: url('/static/img/hgrid/fatcowicons/file_extension_ace.png');	}
+.file-extension._ai  {background: url('/static/img/hgrid/fatcowicons/file_extension_ai.png');	}
+.file-extension._aif {background: url('/static/img/hgrid/fatcowicons/file_extension_aif.png');	}
+.file-extension._aiff{background: url('/static/img/hgrid/fatcowicons/file_extension_aiff.png');	}
+.file-extension._amr {background: url('/static/img/hgrid/fatcowicons/file_extension_amr.png');	}
+.file-extension._asf {background: url('/static/img/hgrid/fatcowicons/file_extension_asf.png');	}
+.file-extension._asx {background: url('/static/img/hgrid/fatcowicons/file_extension_asx.png');	}
+.file-extension._bin {background: url('/static/img/hgrid/fatcowicons/file_extension_bin.png');	}
+.file-extension._bmp {background: url('/static/img/hgrid/fatcowicons/file_extension_bmp.png');	}
+
+.file-extension._bup {background: url('/static/img/hgrid/fatcowicons/file_extension_bup.png');	}
+
+.file-extension._cab {background: url('/static/img/hgrid/fatcowicons/file_extension_cab.png');	}
+
+.file-extension._cbr {background: url('/static/img/hgrid/fatcowicons/file_extension_cbr.png');	}
+
+.file-extension._cda {background: url('/static/img/hgrid/fatcowicons/file_extension_bmp.cda');	}
+
+.file-extension._cdl {background: url('/static/img/hgrid/fatcowicons/file_extension_cdl.png');	}
+
+.file-extension._cdr {background: url('/static/img/hgrid/fatcowicons/file_extension_cdr.png');	}
+
+.file-extension._chm {background: url('/static/img/hgrid/fatcowicons/file_extension_chm.png');	}
+
+.file-extension._dat {background: url('/static/img/hgrid/fatcowicons/file_extension_dat.png');	}
+
+.file-extension._divx{background: url('/static/img/hgrid/fatcowicons/file_extension_divx.png');	}
+
+.file-extension._dll {background: url('/static/img/hgrid/fatcowicons/file_extension_dll.png');	}
+
+.file-extension._dmg {background: url('/static/img/hgrid/fatcowicons/file_extension_dmg.png');	}
+
+.file-extension._doc {background: url('/static/img/hgrid/fatcowicons/file_extension_doc.png');	}
+
+.file-extension._docx{background: url('/static/img/hgrid/fatcowicons/file_extension_docx.png');	}
+
+.file-extension._dss {background: url('/static/img/hgrid/fatcowicons/file_extension_dss.png');	}
+
+.file-extension._dvf {background: url('/static/img/hgrid/fatcowicons/file_extension_dvf.png');	}
+
+.file-extension._dwg {background: url('/static/img/hgrid/fatcowicons/file_extension_dwg.png');	}
+
+.file-extension._eml {background: url('/static/img/hgrid/fatcowicons/file_extension_eml.png');	}
+
+.file-extension._eps {background: url('/static/img/hgrid/fatcowicons/file_extension_eps.png');	}
+
+.file-extension._exe {background: url('/static/img/hgrid/fatcowicons/file_extension_exe.png');	}
+
+.file-extension._fla {background: url('/static/img/hgrid/fatcowicons/file_extension_fla.png');	}
+
+.file-extension._flv {background: url('/static/img/hgrid/fatcowicons/file_extension_flv.png');	}
+
+.file-extension._gif {background: url('/static/img/hgrid/fatcowicons/file_extension_gif.png');	}
+
+.file-extension._gz  {background: url('/static/img/hgrid/fatcowicons/file_extension_gz.png');	}
+
+.file-extension._hqx {background: url('/static/img/hgrid/fatcowicons/file_extension_hqx.png');	}
+
+.file-extension._htm {background: url('/static/img/hgrid/fatcowicons/file_extension_htm.png');	}
+
+.file-extension._ifo {background: url('/static/img/hgrid/fatcowicons/file_extension_ifo.png');	}
+
+.file-extension._indd{background: url('/static/img/hgrid/fatcowicons/file_extension_indd.png');	}
+
+.file-extension._iso {background: url('/static/img/hgrid/fatcowicons/file_extension_iso.png');	}
+
+.file-extension._jar {background: url('/static/img/hgrid/fatcowicons/file_extension_jar.png');	}
+
+.file-extension._jpeg{background: url('/static/img/hgrid/fatcowicons/file_extension_jpeg.png');	}
+
+.file-extension._jpg {background: url('/static/img/hgrid/fatcowicons/file_extension_jpg.png');	}
+
+.file-extension._lnk {background: url('/static/img/hgrid/fatcowicons/file_extension_lnk.png');	}
+
+.file-extension._log {background: url('/static/img/hgrid/fatcowicons/file_extension_log.png');	}
+
+.file-extension._m4a {background: url('/static/img/hgrid/fatcowicons/file_extension_m4a.png');	}
+
+.file-extension._m4b {background: url('/static/img/hgrid/fatcowicons/file_extension_m4b.png');	}
+
+.file-extension._m4p {background: url('/static/img/hgrid/fatcowicons/file_extension_m4p.png');	}
+
+.file-extension._m4v {background: url('/static/img/hgrid/fatcowicons/file_extension_m4v.png');	}
+
+.file-extension._mcd {background: url('/static/img/hgrid/fatcowicons/file_extension_mcd.png');	}
+
+.file-extension._mdb {background: url('/static/img/hgrid/fatcowicons/file_extension_mdb.png');	}
+
+.file-extension._mid {background: url('/static/img/hgrid/fatcowicons/file_extension_mid.png');	}
+
+.file-extension._mov {background: url('/static/img/hgrid/fatcowicons/file_extension_mov.png');	}
+
+
+
+
+
+
+

--- a/website/static/css/fangorn.css
+++ b/website/static/css/fangorn.css
@@ -84,94 +84,100 @@ text-align: center;
 .file-extension._amr {background: url('/static/img/hgrid/fatcowicons/file_extension_amr.png');	}
 .file-extension._asf {background: url('/static/img/hgrid/fatcowicons/file_extension_asf.png');	}
 .file-extension._asx {background: url('/static/img/hgrid/fatcowicons/file_extension_asx.png');	}
+.file-extension._bat {background: url('/static/img/hgrid/fatcowicons/file_extension_bat.png');	}
 .file-extension._bin {background: url('/static/img/hgrid/fatcowicons/file_extension_bin.png');	}
 .file-extension._bmp {background: url('/static/img/hgrid/fatcowicons/file_extension_bmp.png');	}
-
 .file-extension._bup {background: url('/static/img/hgrid/fatcowicons/file_extension_bup.png');	}
-
 .file-extension._cab {background: url('/static/img/hgrid/fatcowicons/file_extension_cab.png');	}
-
 .file-extension._cbr {background: url('/static/img/hgrid/fatcowicons/file_extension_cbr.png');	}
-
-.file-extension._cda {background: url('/static/img/hgrid/fatcowicons/file_extension_bmp.cda');	}
-
+.file-extension._cda {background: url('/static/img/hgrid/fatcowicons/file_extension_cda.png');	}
 .file-extension._cdl {background: url('/static/img/hgrid/fatcowicons/file_extension_cdl.png');	}
-
 .file-extension._cdr {background: url('/static/img/hgrid/fatcowicons/file_extension_cdr.png');	}
-
 .file-extension._chm {background: url('/static/img/hgrid/fatcowicons/file_extension_chm.png');	}
-
 .file-extension._dat {background: url('/static/img/hgrid/fatcowicons/file_extension_dat.png');	}
-
 .file-extension._divx{background: url('/static/img/hgrid/fatcowicons/file_extension_divx.png');	}
-
 .file-extension._dll {background: url('/static/img/hgrid/fatcowicons/file_extension_dll.png');	}
-
 .file-extension._dmg {background: url('/static/img/hgrid/fatcowicons/file_extension_dmg.png');	}
-
 .file-extension._doc {background: url('/static/img/hgrid/fatcowicons/file_extension_doc.png');	}
-
 .file-extension._docx{background: url('/static/img/hgrid/fatcowicons/file_extension_docx.png');	}
-
 .file-extension._dss {background: url('/static/img/hgrid/fatcowicons/file_extension_dss.png');	}
-
 .file-extension._dvf {background: url('/static/img/hgrid/fatcowicons/file_extension_dvf.png');	}
-
 .file-extension._dwg {background: url('/static/img/hgrid/fatcowicons/file_extension_dwg.png');	}
-
 .file-extension._eml {background: url('/static/img/hgrid/fatcowicons/file_extension_eml.png');	}
-
 .file-extension._eps {background: url('/static/img/hgrid/fatcowicons/file_extension_eps.png');	}
-
 .file-extension._exe {background: url('/static/img/hgrid/fatcowicons/file_extension_exe.png');	}
-
 .file-extension._fla {background: url('/static/img/hgrid/fatcowicons/file_extension_fla.png');	}
-
 .file-extension._flv {background: url('/static/img/hgrid/fatcowicons/file_extension_flv.png');	}
-
 .file-extension._gif {background: url('/static/img/hgrid/fatcowicons/file_extension_gif.png');	}
-
 .file-extension._gz  {background: url('/static/img/hgrid/fatcowicons/file_extension_gz.png');	}
-
 .file-extension._hqx {background: url('/static/img/hgrid/fatcowicons/file_extension_hqx.png');	}
-
 .file-extension._htm {background: url('/static/img/hgrid/fatcowicons/file_extension_htm.png');	}
-
+.file-extension._html{background: url('/static/img/hgrid/fatcowicons/file_extension_html.png');	}
 .file-extension._ifo {background: url('/static/img/hgrid/fatcowicons/file_extension_ifo.png');	}
-
 .file-extension._indd{background: url('/static/img/hgrid/fatcowicons/file_extension_indd.png');	}
-
 .file-extension._iso {background: url('/static/img/hgrid/fatcowicons/file_extension_iso.png');	}
-
 .file-extension._jar {background: url('/static/img/hgrid/fatcowicons/file_extension_jar.png');	}
-
 .file-extension._jpeg{background: url('/static/img/hgrid/fatcowicons/file_extension_jpeg.png');	}
-
 .file-extension._jpg {background: url('/static/img/hgrid/fatcowicons/file_extension_jpg.png');	}
-
 .file-extension._lnk {background: url('/static/img/hgrid/fatcowicons/file_extension_lnk.png');	}
-
 .file-extension._log {background: url('/static/img/hgrid/fatcowicons/file_extension_log.png');	}
-
 .file-extension._m4a {background: url('/static/img/hgrid/fatcowicons/file_extension_m4a.png');	}
-
 .file-extension._m4b {background: url('/static/img/hgrid/fatcowicons/file_extension_m4b.png');	}
-
 .file-extension._m4p {background: url('/static/img/hgrid/fatcowicons/file_extension_m4p.png');	}
-
 .file-extension._m4v {background: url('/static/img/hgrid/fatcowicons/file_extension_m4v.png');	}
-
 .file-extension._mcd {background: url('/static/img/hgrid/fatcowicons/file_extension_mcd.png');	}
-
 .file-extension._mdb {background: url('/static/img/hgrid/fatcowicons/file_extension_mdb.png');	}
-
 .file-extension._mid {background: url('/static/img/hgrid/fatcowicons/file_extension_mid.png');	}
-
 .file-extension._mov {background: url('/static/img/hgrid/fatcowicons/file_extension_mov.png');	}
-
-
-
-
-
-
-
+.file-extension._mp2 {background: url('/static/img/hgrid/fatcowicons/file_extension_mp2.png');	}
+.file-extension._mp3 {background: url('/static/img/hgrid/fatcowicons/file_extension_mp3.png');	}
+.file-extension._mp4 {background: url('/static/img/hgrid/fatcowicons/file_extension_mp4.png');	}
+.file-extension._mpeg {background: url('/static/img/hgrid/fatcowicons/file_extension_mpeg.png');	}
+.file-extension._mpg {background: url('/static/img/hgrid/fatcowicons/file_extension_mpg.png');	}
+.file-extension._msi {background: url('/static/img/hgrid/fatcowicons/file_extension_msi.png');	}
+.file-extension._mswmm {background: url('/static/img/hgrid/fatcowicons/file_extension_mswmm.png');	}
+.file-extension._ogg {background: url('/static/img/hgrid/fatcowicons/file_extension_ogg.png');	}
+.file-extension._pdf {background: url('/static/img/hgrid/fatcowicons/file_extension_pdf.png');	}
+.file-extension._png {background: url('/static/img/hgrid/fatcowicons/file_extension_png.png');	}
+.file-extension._pps {background: url('/static/img/hgrid/fatcowicons/file_extension_pps.png');	}
+.file-extension._ps {background: url('/static/img/hgrid/fatcowicons/file_extension_ps.png');	}
+.file-extension._psd {background: url('/static/img/hgrid/fatcowicons/file_extension_psd.png');	}
+.file-extension._pst {background: url('/static/img/hgrid/fatcowicons/file_extension_pst.png');	}
+.file-extension._ptb {background: url('/static/img/hgrid/fatcowicons/file_extension_ptb.png');	}
+.file-extension._pub {background: url('/static/img/hgrid/fatcowicons/file_extension_pub.png');	}
+.file-extension._py {background: url('/static/img/hgrid/fatcowicons/file_extension_py.png');	}
+.file-extension._qbb {background: url('/static/img/hgrid/fatcowicons/file_extension_qbb.png');	}
+.file-extension._qbw {background: url('/static/img/hgrid/fatcowicons/file_extension_qbw.png');	}
+.file-extension._qxd {background: url('/static/img/hgrid/fatcowicons/file_extension_qxd.png');	}
+.file-extension._ram {background: url('/static/img/hgrid/fatcowicons/file_extension_ram.png');	}
+.file-extension._rar {background: url('/static/img/hgrid/fatcowicons/file_extension_rar.png');	}
+.file-extension._rm {background: url('/static/img/hgrid/fatcowicons/file_extension_rm.png');	}
+.file-extension._rmvb {background: url('/static/img/hgrid/fatcowicons/file_extension_rmvb.png');	}
+.file-extension._rtf {background: url('/static/img/hgrid/fatcowicons/file_extension_rtf.png');	}
+.file-extension._sea {background: url('/static/img/hgrid/fatcowicons/file_extension_sea.png');	}
+.file-extension._ses {background: url('/static/img/hgrid/fatcowicons/file_extension_ses.png');	}
+.file-extension._sit {background: url('/static/img/hgrid/fatcowicons/file_extension_sit.png');	}
+.file-extension._sitx {background: url('/static/img/hgrid/fatcowicons/file_extension_sitx.png');	}
+.file-extension._ss {background: url('/static/img/hgrid/fatcowicons/file_extension_ss.png');	}
+.file-extension._swf {background: url('/static/img/hgrid/fatcowicons/file_extension_swf.png');	}
+.file-extension._tgz {background: url('/static/img/hgrid/fatcowicons/file_extension_tgz.png');	}
+.file-extension._thm {background: url('/static/img/hgrid/fatcowicons/file_extension_thm.png');	}
+.file-extension._tif {background: url('/static/img/hgrid/fatcowicons/file_extension_tif.png');	}
+.file-extension._tmp {background: url('/static/img/hgrid/fatcowicons/file_extension_tmp.png');	}
+.file-extension._torrent {background: url('/static/img/hgrid/fatcowicons/file_extension_torrent.png');	}
+.file-extension._ttf {background: url('/static/img/hgrid/fatcowicons/file_extension_ttf.png');	}
+.file-extension._txt {background: url('/static/img/hgrid/fatcowicons/file_extension_txt.png');	}
+.file-extension._vcd {background: url('/static/img/hgrid/fatcowicons/file_extension_vcd.png');	}
+.file-extension._vob {background: url('/static/img/hgrid/fatcowicons/file_extension_vob.png');	}
+.file-extension._wav {background: url('/static/img/hgrid/fatcowicons/file_extension_wav.png');	}
+.file-extension._wma {background: url('/static/img/hgrid/fatcowicons/file_extension_wma.png');	}
+.file-extension._wmv {background: url('/static/img/hgrid/fatcowicons/file_extension_wmv.png');	}
+.file-extension._wps {background: url('/static/img/hgrid/fatcowicons/file_extension_wps.png');	}
+.file-extension._xls {background: url('/static/img/hgrid/fatcowicons/file_extension_xls.png');	}
+.file-extension._xlsx {background: url('/static/img/hgrid/fatcowicons/file_extension_xlsx.png');	}
+.file-extension._xpi {background: url('/static/img/hgrid/fatcowicons/file_extension_xpi.png');	}
+.file-extension._zip {background: url('/static/img/hgrid/fatcowicons/file_extension_zip.png');	}
+.file-extension._folder {background: url('/static/img/hgrid/fatcowicons/folder.png');	}
+.file-extension._folder_delete {background: url('/static/img/hgrid/fatcowicons/folder_delete.png');	}
+.file-extension._folder_horizontal_closed {background: url('/static/img/hgrid/fatcowicons/folder_horizontal_closed.png');	}
+.file-extension._delete {background: url('/static/img/hgrid/fatcowicons/delete.png');	}

--- a/website/static/css/fangorn.css
+++ b/website/static/css/fangorn.css
@@ -71,9 +71,15 @@ text-align: center;
 	white-space: nowrap;
 }
 
+.tb-expand-icon-holder > i {
+  font-size: 16px;
+  padding-left: 2px;
+}
+
 /* File icons */
 .file-extension {
-
+	width: 16px;
+	height: 16px;
 }
 .file-extension._3gp {background: url('/static/img/hgrid/fatcowicons/file_extension_3gp.png');	}
 .file-extension._7z  {background: url('/static/img/hgrid/fatcowicons/file_extension_7z.png'); 	}
@@ -127,6 +133,7 @@ text-align: center;
 .file-extension._m4v {background: url('/static/img/hgrid/fatcowicons/file_extension_m4v.png');	}
 .file-extension._mcd {background: url('/static/img/hgrid/fatcowicons/file_extension_mcd.png');	}
 .file-extension._mdb {background: url('/static/img/hgrid/fatcowicons/file_extension_mdb.png');	}
+.file-extension._md {background: url('/static/img/hgrid/fatcowicons/file_extension_txt.png');	}
 .file-extension._mid {background: url('/static/img/hgrid/fatcowicons/file_extension_mid.png');	}
 .file-extension._mov {background: url('/static/img/hgrid/fatcowicons/file_extension_mov.png');	}
 .file-extension._mp2 {background: url('/static/img/hgrid/fatcowicons/file_extension_mp2.png');	}

--- a/website/static/css/fangorn.css
+++ b/website/static/css/fangorn.css
@@ -71,10 +71,13 @@ text-align: center;
 	white-space: nowrap;
 }
 
+.tb-expand-icon-holder {
+	cursor: default;	
+}
+
 .tb-expand-icon-holder > i {
-  font-size: 16px;
-  padding-left: 2px;
-  cursor: default;
+	font-size: 16px;
+	padding-left: 2px;
 }
 
 /* File icons */

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -40,14 +40,13 @@ $.extend(EXTENSION_MAP, {
 
 var ICON_PATH = '/static/img/hgrid/fatcowicons/';
 
-var getExtensionIcon = function(name) {
+var getExtensionIconClass = function(name) {
     var extension = name.split('.').pop().toLowerCase();
     var icon = EXTENSION_MAP[extension];
     if (icon) {
-        return ICON_PATH + 'file_extension_' + icon + '.png';
-    } else {
-        return null;
+        return '_' + icon;
     }
+    return null;
 };
 
 /**
@@ -84,12 +83,11 @@ function _fangornResolveIcon(item) {
         return m('i.fa.' + item.data.icon, ' ');
     }
 
-    icon = getExtensionIcon(item.data.name);
+    icon = getExtensionIconClass(item.data.name);
     if (icon) {
-        return m('img', {src: icon});
-    } else {
-        return m('i.icon-file-alt');
+        return m('div.file-extension', { 'class': icon });
     }
+    return m('i.icon-file-alt');
 }
 
 // Addon config registry. this will be populated with add on specific items if any.

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -23,7 +23,7 @@ var tempCounter = 1;
 var EXTENSIONS = ['3gp', '7z', 'ace', 'ai', 'aif', 'aiff', 'amr', 'asf', 'asx', 'bat', 'bin', 'bmp', 'bup',
     'cab', 'cbr', 'cda', 'cdl', 'cdr', 'chm', 'dat', 'divx', 'dll', 'dmg', 'doc', 'docx', 'dss', 'dvf', 'dwg',
     'eml', 'eps', 'exe', 'fla', 'flv', 'gif', 'gz', 'hqx', 'htm', 'html', 'ifo', 'indd', 'iso', 'jar',
-    'jpeg', 'jpg', 'lnk', 'log', 'm4a', 'm4b', 'm4p', 'm4v', 'mcd', 'mdb', 'mid', 'mov', 'mp2', 'mp3', 'mp4',
+    'jpeg', 'jpg', 'lnk', 'log', 'm4a', 'm4b', 'm4p', 'm4v', 'mcd', 'md', 'mdb', 'mid', 'mov', 'mp2', 'mp3', 'mp4',
     'mpeg', 'mpg', 'msi', 'mswmm', 'ogg', 'pdf', 'png', 'pps', 'ps', 'psd', 'pst', 'ptb', 'pub', 'qbb',
     'qbw', 'qxd', 'ram', 'rar', 'rm', 'rmvb', 'rtf', 'sea', 'ses', 'sit', 'sitx', 'ss', 'swf', 'tgz', 'thm',
     'tif', 'tmp', 'torrent', 'ttf', 'txt', 'vcd', 'vob', 'wav', 'wma', 'wmv', 'wps', 'xls', 'xpi', 'zip',
@@ -57,7 +57,7 @@ var getExtensionIconClass = function(name) {
  * @private
  */
 function _fangornResolveIcon(item) {
-    var privateFolder = m('img', {src: '/static/img/hgrid/fatcowicons/folder_delete.png'}),
+    var privateFolder =  m('div.file-extension._folder_delete', ' '),
         pointerFolder = m('i.icon-link', ' '),
         openFolder  = m('i.icon-folder-open', ' '),
         closedFolder = m('i.icon-folder-close', ' '),


### PR DESCRIPTION
## Purpose 

A solution to issue #1680; with suggestion from @brianjgeiger . This fix turns the img tag file icons into classes with backgrounds to avoid dragging of those files. I think this is a semantically correct way to handle this problem and it's less error prone. 

## Changes
- Create file-extension class and file names classes starting with _
- Change fangorn.js ResolveIcon and related methods to generate proper classes instead of path
- Add md file extension to use .txt icon for the moment
- Minor adjustments to alt icon css

# Side effects
None. Only affects fangorn, (not project organizer or other uses of Treebeard since they don't actually have files). Tested in Chrome, Safari, Firefox. The css used here is very old so should be compatible with IE. 