### PR TITLE
Update SHARE searchbar numbers

### DIFF
--- a/website/static/js/share/searchBar.js
+++ b/website/static/js/share/searchBar.js
@@ -55,7 +55,7 @@ SearchBar.controller = function(vm) {
     self.vm = vm;
 
     self.vm.totalCount = 0;
-    self.vm.providers = 26;
+    self.vm.providers = 28;
     self.vm.latestDate = undefined;
     self.vm.showStats = true;
 

--- a/website/static/js/share/stats.js
+++ b/website/static/js/share/stats.js
@@ -97,7 +97,6 @@ Stats.controller = function(vm) {
     var self = this;
 
     self.vm = vm;
-    self.vm.providers = 26;
 
     self.graphs = {};
 


### PR DESCRIPTION
When the migration is complete, this number will match the total number of providers in the SHARE service, and the donut and search bar numbers will be in sync.