### PR TITLE
Hotfix to update hard-coded SHARE provider number in search bar

### DIFF
--- a/website/static/js/share/searchBar.js
+++ b/website/static/js/share/searchBar.js
@@ -55,7 +55,7 @@ SearchBar.controller = function(vm) {
     self.vm = vm;
 
     self.vm.totalCount = 0;
-    self.vm.providers = 26;
+    self.vm.providers = 28;
     self.vm.latestDate = undefined;
     self.vm.showStats = true;
 

--- a/website/static/js/share/stats.js
+++ b/website/static/js/share/stats.js
@@ -97,7 +97,6 @@ Stats.controller = function(vm) {
     var self = this;
 
     self.vm = vm;
-    self.vm.providers = 26;
 
     self.graphs = {};
 


### PR DESCRIPTION
Once migration goes though, this number will match the one on the SHARE donut. Also, removed redundant variable setting in stats page.