### PR TITLE
Hotfix/oauth addon callbacks

### DIFF
--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -70,7 +70,6 @@ def _prepare_mock_500_error():
     )
 
 
-
 class TestExternalAccount(OsfTestCase):
     # Test the ExternalAccount object and associated views.
     #
@@ -225,17 +224,19 @@ class TestExternalProviderOAuth1(OsfTestCase):
         responses.add(
             responses.POST,
             'http://mock1a.com/callback',
-             body='oauth_token=perm_token'
-                  '&oauth_token_secret=perm_secret'
-                  '&oauth_callback_confirmed=true',
+            body=(
+                'oauth_token=perm_token'
+                '&oauth_token_secret=perm_secret'
+                '&oauth_callback_confirmed=true',
+            ),
         )
 
         user = UserFactory()
 
         # Fake a request context for the callback
         with self.app.app.test_request_context(
-                path='/oauth/callback/mock1a/',
-                query_string='oauth_token=temp_key&oauth_verifier=mock_verifier'
+            path='/oauth/callback/mock1a/',
+            query_string='oauth_token=temp_key&oauth_verifier=mock_verifier',
         ):
 
             # make sure the user is logged in

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -227,17 +227,18 @@ class TestExternalProviderOAuth1(OsfTestCase):
             body=(
                 'oauth_token=perm_token'
                 '&oauth_token_secret=perm_secret'
-                '&oauth_callback_confirmed=true',
+                '&oauth_callback_confirmed=true'
             ),
         )
 
         user = UserFactory()
 
         # Fake a request context for the callback
-        with self.app.app.test_request_context(
+        ctx = self.app.app.test_request_context(
             path='/oauth/callback/mock1a/',
             query_string='oauth_token=temp_key&oauth_verifier=mock_verifier',
-        ):
+        )
+        with ctx:
 
             # make sure the user is logged in
             authenticate(user=user, response=None)

--- a/website/addons/base/__init__.py
+++ b/website/addons/base/__init__.py
@@ -730,7 +730,6 @@ class AddonOAuthNodeSettingsBase(AddonNodeSettingsBase):
 
     def clear_auth(self):
         """Disconnect the node settings from the user settings"""
-
         self.external_account = None
         self.user_settings = None
         self.save()
@@ -742,7 +741,7 @@ class AddonOAuthNodeSettingsBase(AddonNodeSettingsBase):
         if self.has_auth and self.user_settings.owner == removed:
             return (
                 u'The {addon} add-on for this {category} is authenticated by {name}. '
-                u'Removing this user will also remove write access to Dropbox '
+                u'Removing this user will also remove write access to {addon} '
                 u'unless another contributor re-authenticates the add-on.'
             ).format(
                 addon=self.config.full_name,

--- a/website/addons/mendeley/tests/test_models.py
+++ b/website/addons/mendeley/tests/test_models.py
@@ -263,6 +263,8 @@ class MendeleyNodeSettingsTestCase(OsfTestCase):
             'Fake Folder'
         )
 
+    # TODO: Make these tests generic and move to core
+
     @mock.patch('framework.status.push_status_message')
     def test_remove_contributor_authorizer(self, mock_push_status):
         external_account = ExternalAccountFactory()
@@ -287,6 +289,30 @@ class MendeleyNodeSettingsTestCase(OsfTestCase):
 
         assert_true(self.node_settings.has_auth)
         assert_true(self.user_settings.verify_oauth_access(self.node, external_account))
+
+    @mock.patch('framework.status.push_status_message')
+    def test_fork_by_authorizer(self, mock_push_status):
+        external_account = ExternalAccountFactory()
+        self.user.external_accounts.append(external_account)
+        self.node_settings.set_auth(external_account, self.user)
+
+        fork = self.node.fork_node(auth=Auth(user=self.node.creator))
+
+        assert_true(fork.get_addon('mendeley').has_auth)
+        assert_true(self.user_settings.verify_oauth_access(fork, external_account))
+
+    @mock.patch('framework.status.push_status_message')
+    def test_fork_not_by_authorizer(self, mock_push_status):
+        external_account = ExternalAccountFactory()
+        self.user.external_accounts.append(external_account)
+        self.node_settings.set_auth(external_account, self.user)
+
+        contributor = UserFactory()
+        self.node.add_contributor(contributor)
+        fork = self.node.fork_node(auth=Auth(user=contributor))
+
+        assert_false(fork.get_addon('mendeley').has_auth)
+        assert_false(self.user_settings.verify_oauth_access(fork, external_account))
 
 
 class MendeleyUserSettingsTestCase(OsfTestCase):

--- a/website/addons/mendeley/tests/test_models.py
+++ b/website/addons/mendeley/tests/test_models.py
@@ -3,14 +3,15 @@
 import mock
 from nose.tools import *  # noqa
 
+from framework.auth.core import Auth
 from framework.exceptions import PermissionsError
 
 from tests.base import OsfTestCase
 from tests.factories import UserFactory, ProjectFactory
 from website.addons.mendeley.tests.factories import (
-    MendeleyAccountFactory, MendeleyUserSettingsFactory,
+    MendeleyAccountFactory,
+    MendeleyUserSettingsFactory,
     ExternalAccountFactory,
-    MendeleyNodeSettingsFactory
 )
 from website.addons.mendeley.provider import MendeleyCitationsProvider
 
@@ -261,6 +262,31 @@ class MendeleyNodeSettingsTestCase(OsfTestCase):
             self.node_settings.selected_folder_name,
             'Fake Folder'
         )
+
+    @mock.patch('framework.status.push_status_message')
+    def test_remove_contributor_authorizer(self, mock_push_status):
+        external_account = ExternalAccountFactory()
+        self.user.external_accounts.append(external_account)
+        self.node_settings.set_auth(external_account, self.user)
+
+        contributor = UserFactory()
+        self.node.add_contributor(contributor)
+        self.node.remove_contributor(self.node.creator, auth=Auth(user=contributor))
+
+        assert_false(self.node_settings.has_auth)
+        assert_false(self.user_settings.verify_oauth_access(self.node, external_account))
+
+    def test_remove_contributor_not_authorizer(self):
+        external_account = ExternalAccountFactory()
+        self.user.external_accounts.append(external_account)
+        self.node_settings.set_auth(external_account, self.user)
+
+        contributor = UserFactory()
+        self.node.add_contributor(contributor)
+        self.node.remove_contributor(contributor, auth=Auth(user=self.node.creator))
+
+        assert_true(self.node_settings.has_auth)
+        assert_true(self.user_settings.verify_oauth_access(self.node, external_account))
 
 
 class MendeleyUserSettingsTestCase(OsfTestCase):


### PR DESCRIPTION
# Purpose
Add callbacks to `AddonOAuthNodeSettings` base class to preserve behavior of existing addons

# Changes
* Remove authorization on removing the authorizing contributor
* Copy authorization on forking by the authorizing contributor
* Add tests

# Side effects
Zotero and Mendeley addons will behave like previous addons for removing contributors and forking