### PR TITLE
[hotfix] Show conference external link

### DIFF
--- a/website/templates/public/pages/meeting.mako
+++ b/website/templates/public/pages/meeting.mako
@@ -2,54 +2,7 @@
 <%def name="title()">${ meeting['name'] } Presentations</%def>
 
 <%def name="content()">
-
-    <h2 style="padding-bottom: 30px;">${ meeting['name'] } Posters & Talks</h2>
-
-    % if meeting['logo_url']:
-        <img src="${ meeting['logo_url'] }" class="image-responsive" />
-        <br /><br />
-    % endif
-
-
-    % if meeting['active']:
-        % if meeting['info_url']:
-            <div><a href="${ meeting['info_url'] }" target="_blank">Add your poster or talk</a></div>
-        % else:
-          <div ><a id="addLink" onclick="" href="#">Add your poster or talk</a></div>
-              <div style="display: none" id="submit">
-                  <h3>Add your poster or talk</h3>
-                  <p>
-                      Send an email to one of the following addresses from the email
-                      account you would like used on the OSF:
-                  </p>
-                  <ul>
-                      <li>For posters, email <a href="mailto:${ label }-poster@osf.io">${ label }-poster@osf.io</a></li>
-                      <li>For talks, email <a href="mailto:${ label }-talk@osf.io">${ label }-talk@osf.io</a></li>
-                  </ul>
-                  <p>The format of the email should be as follows:</p>
-                  <div>
-                      <dl style="padding-left: 25px">
-                          <dt>Subject</dt>
-                          <dd>Presentation title</dd>
-                          <dt>Message body</dt>
-                          <dd>Presentation abstract (if any)</dd>
-                          <dt>Attachment</dt>
-                          <dd>Your presentation file (e.g., PowerPoint, PDF, etc.)</dd>
-                      </dl>
-                  </div>
-                  <p>
-                      Once sent, we will follow-up by sending you the permanent identifier
-                      that others can use to cite your work; you can also login and make changes,
-                      such as uploading additional files, to your project at that URL. If you
-                      didn't have an OSF account, one will be created automatically and a link
-                      to set your password will be emailed to you; if you do, we will simply create
-                      a new project in your account.
-                  </p>
-              </div>
-        % endif
-    % endif
-
-    <div id="grid" style="width: 100%;"></div>
+    <%include file="public/pages/meeting_body.mako" />
 </%def>
 
 <%def name="stylesheets()">

--- a/website/templates/public/pages/meeting_body.mako
+++ b/website/templates/public/pages/meeting_body.mako
@@ -1,0 +1,48 @@
+<h2 style="padding-bottom: 30px;">${ meeting['name'] } Posters & Talks</h2>
+
+% if meeting['logo_url']:
+    <img src="${ meeting['logo_url'] }" class="image-responsive" />
+    <br /><br />
+  % endif
+
+% if meeting['active']:
+    <div>
+        <a id="addLink" onclick="" href="#">Add your poster or talk</a>
+        % if meeting['info_url']:
+          | <a href="${ meeting['info_url'] }" target="_blank">Conference homepage <i class="icon-sm icon-external-link"></i></a>
+        % endif
+    </div>
+
+    <div style="display: none" id="submit">
+        <h3>Add your poster or talk</h3>
+        <p>
+            Send an email to one of the following addresses from the email
+            account you would like used on the OSF:
+        </p>
+        <ul>
+            <li>For posters, email <a href="mailto:${ label }-poster@osf.io">${ label }-poster@osf.io</a></li>
+            <li>For talks, email <a href="mailto:${ label }-talk@osf.io">${ label }-talk@osf.io</a></li>
+        </ul>
+        <p>The format of the email should be as follows:</p>
+        <div>
+            <dl style="padding-left: 25px">
+                <dt>Subject</dt>
+                <dd>Presentation title</dd>
+                <dt>Message body</dt>
+                <dd>Presentation abstract (if any)</dd>
+                <dt>Attachment</dt>
+                <dd>Your presentation file (e.g., PowerPoint, PDF, etc.)</dd>
+            </dl>
+        </div>
+        <p>
+            Once sent, we will follow-up by sending you the permanent identifier
+            that others can use to cite your work; you can also login and make changes,
+            such as uploading additional files, to your project at that URL. If you
+            didn't have an OSF account, one will be created automatically and a link
+            to set your password will be emailed to you; if you do, we will simply create
+            a new project in your account.
+        </p>
+    </div>
+% endif
+
+<div id="grid" style="width: 100%;"></div>

--- a/website/templates/public/pages/meeting_plain.mako
+++ b/website/templates/public/pages/meeting_plain.mako
@@ -40,54 +40,7 @@
 <body>
 
     <div class="container">
-
-        <h2 style="padding-bottom: 30px;">${ meeting['name'] } Posters & Talks</h2>
-
-        % if meeting['logo_url']:
-            <img src="${ meeting['logo_url'] }" class="image-responsive" style="width:100%"/>
-            <br /><br />
-        % endif
-
-        % if meeting['active']:
-            % if meeting['info_url']:
-                <div><a href="${ meeting['info_url'] }" target="_blank">Add your poster or talk</a></div>
-            % else:
-              <div ><a id="addLink" onclick="" href="#">Add your poster or talk</a></div>
-                  <div style="display: none" id="submit">
-                      <h3>Add your poster or talk</h3>
-                      <p>
-                          Send an email to one of the following addresses from the email
-                          account you would like used on the OSF:
-                      </p>
-                      <ul>
-                          <li>For posters, email <a href="mailto:${ label }-poster@osf.io">${ label }-poster@osf.io</a></li>
-                          <li>For talks, email <a href="mailto:${ label }-talk@osf.io">${ label }-talk@osf.io</a></li>
-                      </ul>
-                      <p>The format of the email should be as follows:</p>
-                      <div>
-                          <dl style="padding-left: 25px">
-                              <dt>Subject</dt>
-                              <dd>Presentation title</dd>
-                              <dt>Message body</dt>
-                              <dd>Presentation abstract (if any)</dd>
-                              <dt>Attachment</dt>
-                              <dd>Your presentation file (e.g., PowerPoint, PDF, etc.)</dd>
-                          </dl>
-                      </div>
-                      <p>
-                          Once sent, we will follow-up by sending you the permanent identifier
-                          that others can use to cite your work; you can also login and make changes,
-                          such as uploading additional files, to your project at that URL. If you
-                          didn't have an OSF account, one will be created automatically and a link
-                          to set your password will be emailed to you; if you do, we will simply create
-                          a new project in your account.
-                      </p>
-                  </div>
-            % endif
-        % endif
-        <div id="grid" style="width: 100%;"></div>
-
-
+        <%include file="public/pages/meeting_body.mako" />
     </div>
 
     <script type="text/javascript">


### PR DESCRIPTION
# Purpose
Show external link to conference (if provided) as well as submission info

# Changes
* Show external link if provided
* Move duplicated mako code into included file

# Side effects
None expected

Requested by / discussed with @saradbowman 