### PR TITLE
Upgrade requests to latest version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,6 @@ git+https://github.com/CenterForOpenScience/modular-odm.git@develop
 # Development version of modular file renderer
 git+https://github.com/CenterForOpenScience/modular-file-renderer.git@dev
 
-requests==2.4.1
+requests==2.5.3
 requests-oauthlib>=0.4.1
 raven==5.1.1


### PR DESCRIPTION
# Purpose
Resolves issue https://sentry.osf.io/osf/staging/group/2832/. We were
using the `json` parameter in `requests.Request`, which was added in
requests 2.4.2, but pinning to requests 2.4.1.

# Changes
* Upgrade requests version

# Side effects
None expected

As it turns out, this was breaking on staging but not on production, since production is currently using a newer version of requests than the version in `requirements.txt`.