### PR TITLE
Feature: Handle unicode encode error in localized datetimes

### DIFF
--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1052,7 +1052,7 @@ class TestSendEmails(OsfTestCase):
         locale = Locale(self.user.locale)
         formatted_date = dates.format_date(timestamp, format='full', locale=locale)
         formatted_time = dates.format_time(timestamp, format='short', tzinfo=tz, locale=locale)
-        formatted_datetime = '{time} on {date}'.format(time=formatted_time, date=formatted_date)
+        formatted_datetime = u'{time} on {date}'.format(time=formatted_time, date=formatted_date)
         assert_equal(emails.localize_timestamp(timestamp, self.user), formatted_datetime)
 
     def test_localize_timestamp_empty_timezone(self):
@@ -1064,7 +1064,7 @@ class TestSendEmails(OsfTestCase):
         locale = Locale(self.user.locale)
         formatted_date = dates.format_date(timestamp, format='full', locale=locale)
         formatted_time = dates.format_time(timestamp, format='short', tzinfo=tz, locale=locale)
-        formatted_datetime = '{time} on {date}'.format(time=formatted_time, date=formatted_date)
+        formatted_datetime = u'{time} on {date}'.format(time=formatted_time, date=formatted_date)
         assert_equal(emails.localize_timestamp(timestamp, self.user), formatted_datetime)
 
     def test_localize_timestamp_empty_locale(self):
@@ -1076,7 +1076,19 @@ class TestSendEmails(OsfTestCase):
         locale = Locale('en')
         formatted_date = dates.format_date(timestamp, format='full', locale=locale)
         formatted_time = dates.format_time(timestamp, format='short', tzinfo=tz, locale=locale)
-        formatted_datetime = '{time} on {date}'.format(time=formatted_time, date=formatted_date)
+        formatted_datetime = u'{time} on {date}'.format(time=formatted_time, date=formatted_date)
+        assert_equal(emails.localize_timestamp(timestamp, self.user), formatted_datetime)
+
+    def test_localize_timestamp_handles_unicode(self):
+        timestamp = datetime.datetime.utcnow().replace(tzinfo=pytz.utc)
+        self.user.timezone = 'Europe/Moscow'
+        self.user.locale = 'ru_RU'
+        self.user.save()
+        tz = dates.get_timezone(self.user.timezone)
+        locale = Locale(self.user.locale)
+        formatted_date = dates.format_date(timestamp, format='full', locale=locale)
+        formatted_time = dates.format_time(timestamp, format='short', tzinfo=tz, locale=locale)
+        formatted_datetime = u'{time} on {date}'.format(time=formatted_time, date=formatted_date)
         assert_equal(emails.localize_timestamp(timestamp, self.user), formatted_datetime)
 
 

--- a/website/notifications/emails.py
+++ b/website/notifications/emails.py
@@ -177,4 +177,4 @@ def localize_timestamp(timestamp, user):
     formatted_date = dates.format_date(timestamp, format='full', locale=user_locale)
     formatted_time = dates.format_time(timestamp, format='short', tzinfo=user_timezone, locale=user_locale)
 
-    return '{time} on {date}'.format(time=formatted_time, date=formatted_date)
+    return u'{time} on {date}'.format(time=formatted_time, date=formatted_date)


### PR DESCRIPTION
<h3> Purpose </h3>
When formatting datetimes by locale for the notification emails, the day and month are translated into the language specified in the locale tag and may cause a unicode encode error. 

<h3>Changes</h3>
Return a unicode string in `localize_timestamp`