### PR TITLE
Handle 401 errors from GitHub.

### DIFF
--- a/website/addons/github/model.py
+++ b/website/addons/github/model.py
@@ -13,9 +13,10 @@ from framework.auth import Auth
 from framework.mongo import StoredObject
 
 from website import settings
+from website.util import web_url_for
+from website.addons.base import GuidFile
 from website.addons.base import exceptions
 from website.addons.base import AddonUserSettingsBase, AddonNodeSettingsBase
-from website.addons.base import GuidFile
 
 from website.addons.github import utils
 from website.addons.github.api import GitHub
@@ -145,13 +146,13 @@ class AddonGitHubUserSettings(AddonUserSettingsBase):
         return super(AddonGitHubUserSettings, self).save(*args, **kwargs)
 
     def to_json(self, user):
-        rv = super(AddonGitHubUserSettings, self).to_json(user)
-        rv.update({
+        ret = super(AddonGitHubUserSettings, self).to_json(user)
+        ret.update({
             'authorized': self.has_auth,
             'authorized_github_user': self.github_user_name if self.github_user_name else '',
             'show_submit': False,
         })
-        return rv
+        return ret
 
     def revoke_token(self):
         connection = GitHub.from_settings(self)
@@ -164,8 +165,7 @@ class AddonGitHubUserSettings(AddonUserSettingsBase):
                     'were unable to revoke your access token from GitHub. Your '
                     'GitHub credentials may no longer be valid.'
                 )
-            else:
-                raise
+            raise
 
     def clear_auth(self, auth=None, save=False):
         for node_settings in self.addongithubnodesettings__authorized:
@@ -174,7 +174,7 @@ class AddonGitHubUserSettings(AddonUserSettingsBase):
         # if there is only one osf user linked to this github user oauth, revoke the token,
         # otherwise, disconnect the osf user from the addongithuboauthsettings
         if self.oauth_settings:
-            if len(self.oauth_settings.addongithubusersettings__accessed) < 2:
+            if len(self.oauth_settings.addongithubusersettings__accessed) <= 1:
                 self.revoke_token()
 
         # Clear tokens on oauth_settings
@@ -278,9 +278,9 @@ class AddonGitHubNodeSettings(AddonNodeSettingsBase):
 
     # TODO: Delete me and replace with serialize_settings / Knockout
     def to_json(self, user):
-        rv = super(AddonGitHubNodeSettings, self).to_json(user)
+        ret = super(AddonGitHubNodeSettings, self).to_json(user)
         user_settings = user.get_addon('github')
-        rv.update({
+        ret.update({
             'user_has_auth': user_settings and user_settings.has_auth,
             'is_registration': self.owner.is_registration,
         })
@@ -292,15 +292,19 @@ class AddonGitHubNodeSettings(AddonNodeSettingsBase):
                 # Since /user/repos excludes organization repos to which the
                 # current user has push access, we have to make extra requests to
                 # find them
-                repos = itertools.chain.from_iterable((connection.repos(), connection.my_org_repos()))
-                repo_names = [
-                    '{0} / {1}'.format(repo.owner.login, repo.name)
-                    for repo in repos
-                ]
-                rv.update({
-                    'repo_names': repo_names,
-                })
-            rv.update({
+                valid_credentials = True
+                try:
+                    repos = itertools.chain.from_iterable((connection.repos(), connection.my_org_repos()))
+                    repo_names = [
+                        '{0} / {1}'.format(repo.owner.login, repo.name)
+                        for repo in repos
+                    ]
+                except GitHubError as error:
+                    if error.code == http.UNAUTHORIZED:
+                        repo_names = []
+                        valid_credentials = False
+                ret.update({'repo_names': repo_names})
+            ret.update({
                 'node_has_auth': True,
                 'github_user': self.user or '',
                 'github_repo': self.repo or '',
@@ -311,8 +315,10 @@ class AddonGitHubNodeSettings(AddonNodeSettingsBase):
                 'github_user_name': self.user_settings.github_user_name,
                 'github_user_url': 'https://github.com/{0}'.format(self.user_settings.github_user_name),
                 'is_owner': owner == user,
+                'valid_credentials': valid_credentials,
+                'addons_url': web_url_for('user_addons'),
             })
-        return rv
+        return ret
 
     def serialize_waterbutler_credentials(self):
         if not self.complete or not self.repo:
@@ -368,7 +374,6 @@ class AddonGitHubNodeSettings(AddonNodeSettingsBase):
         :param Node node:
         :param User user:
         :return str: Alert message
-
         """
         messages = []
 
@@ -388,7 +393,7 @@ class AddonGitHubNodeSettings(AddonNodeSettingsBase):
 
         try:
             repo = connect.repo(self.user, self.repo)
-        except ApiError:
+        except (ApiError, GitHubError):
             return
 
         node_permissions = 'public' if node.is_public else 'private'
@@ -633,15 +638,13 @@ class AddonGitHubNodeSettings(AddonNodeSettingsBase):
 
     def delete_hook(self, save=True):
         """
-
         :return bool: Hook was deleted
-
         """
         if self.user_settings and self.hook_id:
             connection = GitHub.from_settings(self.user_settings)
             try:
                 response = connection.delete_hook(self.user, self.repo, self.hook_id)
-            except NotFoundError:
+            except (GitHubError, NotFoundError):
                 return False
             if response:
                 self.hook_id = None

--- a/website/addons/github/templates/github_node_settings.mako
+++ b/website/addons/github/templates/github_node_settings.mako
@@ -27,12 +27,12 @@
         </h4>
     </div>
 
-    % if node_has_auth:
+    % if node_has_auth and valid_credentials:
 
         <input type="hidden" id="githubUser" name="github_user" value="${github_user}" />
         <input type="hidden" id="githubRepo" name="github_repo" value="${github_repo}" />
 
-        <p> <strong>Current Repo:</strong></p>
+        <p><strong>Current Repo:</strong></p>
 
         <div class="row">
 
@@ -52,13 +52,10 @@
             % if is_owner and not is_registration:
                 <div class="col-md-6">
                     <a id="githubCreateRepo" class="btn btn-default">Create Repo</a>
-
                     <button class="btn btn-primary addon-settings-submit pull-right">
                         Submit
                     </button>
                 </div>
-
-
             % endif
 
         </div>
@@ -67,7 +64,20 @@
 
     ${self.on_submit()}
 
-    <div class="addon-settings-message" style="display: none; padding-top: 10px;"></div>
+    % if node_has_auth and not valid_credentials:
+        <div class="addon-settings-message text-danger" style="padding-top: 10px;">
+            % if is_owner:
+                Could not retrieve GitHub settings at this time. The GitHub addon credentials
+                may no longer be valid. Try deauthorizing and reauthorizing GitHub on your
+                <a href="${addons_url}">account settings page</a>.
+            % else:
+                Could not retrieve GitHub settings at this time. The GitHuh addon credentials
+                may no longer be valid. Contact ${auth_osf_name} to verify.
+            % endif
+        </div>
+    % else:
+        <div class="addon-settings-message" style="display: none; padding-top: 10px;"></div>
+    % endif
 
 </form>
 

--- a/website/addons/github/tests/test_models.py
+++ b/website/addons/github/tests/test_models.py
@@ -1,17 +1,25 @@
+# -*- coding: utf-8 -*-
+
 import mock
 import unittest
-from nose.tools import *
+from nose.tools import *  # noqa
 
+from github3 import GitHubError
 from github3.repos import Repository
 
 from tests.base import OsfTestCase
 from tests.factories import UserFactory, ProjectFactory
 
 from framework.auth import Auth
+
+from website.addons.github.exceptions import NotFoundError
 from website.addons.github import settings as github_settings
 from website.addons.github.exceptions import NotFoundError, TooBigToRenderError
 from website.addons.github.tests.factories import GitHubOauthSettingsFactory
-from website.addons.github.model import AddonGitHubUserSettings, AddonGitHubOauthSettings, GithubGuidFile
+from website.addons.github.model import AddonGitHubUserSettings
+from website.addons.github.model import AddonGitHubNodeSettings
+from website.addons.github.model import AddonGitHubOauthSettings
+from website.addons.github.model import GithubGuidFile
 
 from .utils import create_mock_github
 mock_github = create_mock_github()
@@ -323,3 +331,68 @@ class TestAddonGithubUserSettings(OsfTestCase):
         assert_false(self.user_settings.oauth_token_type)
         assert_false(self.user_settings.oauth_access_token)
         assert_false(self.user_settings.oauth_settings)
+
+
+class TestAddonGithubNodeSettings(OsfTestCase):
+
+    def setUp(self):
+        OsfTestCase.setUp(self)
+        self.user_settings = AddonGitHubUserSettings()
+        self.oauth_settings = AddonGitHubOauthSettings()
+        self.oauth_settings.github_user_id = 'testuser'
+        self.oauth_settings.save()
+        self.user_settings.oauth_settings = self.oauth_settings
+        self.user_settings.save()
+        self.node_settings = AddonGitHubNodeSettings(
+            user='chrisseto',
+            repo='openpokemon',
+            user_settings=self.user_settings,
+        )
+        self.node_settings.save()
+
+    @mock.patch('website.addons.github.api.GitHub.delete_hook')
+    def test_delete_hook(self, mock_delete_hook):
+        self.node_settings.hook_id = 'hook'
+        self.node_settings.save()
+        args = (
+            self.node_settings.user,
+            self.node_settings.repo,
+            self.node_settings.hook_id,
+        )
+        res = self.node_settings.delete_hook()
+        assert_true(res)
+        mock_delete_hook.assert_called_with(*args)
+
+    @mock.patch('website.addons.github.api.GitHub.delete_hook')
+    def test_delete_hook_no_hook(self, mock_delete_hook):
+        res = self.node_settings.delete_hook()
+        assert_false(res)
+        assert_false(mock_delete_hook.called)
+
+    @mock.patch('website.addons.github.api.GitHub.delete_hook')
+    def test_delete_hook_not_found(self, mock_delete_hook):
+        self.node_settings.hook_id = 'hook'
+        self.node_settings.save()
+        mock_delete_hook.side_effect = NotFoundError
+        args = (
+            self.node_settings.user,
+            self.node_settings.repo,
+            self.node_settings.hook_id,
+        )
+        res = self.node_settings.delete_hook()
+        assert_false(res)
+        mock_delete_hook.assert_called_with(*args)
+
+    @mock.patch('website.addons.github.api.GitHub.delete_hook')
+    def test_delete_hook_error(self, mock_delete_hook):
+        self.node_settings.hook_id = 'hook'
+        self.node_settings.save()
+        mock_delete_hook.side_effect = GitHubError(mock.Mock())
+        args = (
+            self.node_settings.user,
+            self.node_settings.repo,
+            self.node_settings.hook_id,
+        )
+        res = self.node_settings.delete_hook()
+        assert_false(res)
+        mock_delete_hook.assert_called_with(*args)

--- a/website/addons/github/views/hgrid.py
+++ b/website/addons/github/views/hgrid.py
@@ -4,6 +4,7 @@ import logging
 import httplib as http
 
 from flask import request
+from github3 import GitHubError
 
 from framework.exceptions import HTTPError
 
@@ -118,7 +119,7 @@ def github_hgrid_data(node_settings, auth, **kwargs):
             sha=kwargs.get('sha'),
             connection=connection,
         )
-    except NotFoundError:
+    except (NotFoundError, GitHubError):
         # TODO: Show an alert or change GitHub configuration?
         logger.error('GitHub repo not found')
         return

--- a/website/routes.py
+++ b/website/routes.py
@@ -64,7 +64,7 @@ def get_globals():
         'sanitize': sanitize,
         'js_str': lambda x: x.replace("'", r"\'").replace('"', r'\"'),
         'webpack_asset': paths.webpack_asset,
-        'waterbutler_url': settings.WATERBUTLER_URL
+        'waterbutler_url': settings.WATERBUTLER_URL,
     }
 
 


### PR DESCRIPTION
# Purpose
Handle 401 errors from GitHub API in various points in the code, borrowing language from Dropbox addon.

# Changes
* Add `valid_credentials` field to serialized GitHub settings
* Show appropriate error message on invalid credentials
* Catch other 401s and add regression tests

# Side effects
None expected

[Resolves #2103]

Note: Most of the frontend changes in this patch will be replaced by an
upcoming refactor of the GitHub UI by @harrismendell.