### PR TITLE
Feature fix: Use comment reply email templates only with direct replies

### DIFF
--- a/website/notifications/emails.py
+++ b/website/notifications/emails.py
@@ -89,8 +89,9 @@ def notify(uid, event, **context):
             node_subscribers.extend(subscribed_users)
 
             if subscribed_users and notification_type != 'none':
-                event = 'comment_replies' if context.get('target_user') else event
-                send([u._id for u in subscribed_users], notification_type, uid, event, **context)
+                for user in subscribed_users:
+                    event = 'comment_replies' if context.get('target_user') == user else event
+                    send([user._id], notification_type, uid, event, **context)
 
     return check_parent(uid, event, node_subscribers, **context)
 


### PR DESCRIPTION
<h3>Purpose</h3>
Fixes https://trello.com/c/gydQs38q/40-replying-to-a-comment-sends-email-with-misleading-incorrect-information.

<h3>Changes</h3>
Whenever a comment is a reply to another comment, only use the email template for "replies to your comment" for the user who was responded to. For all other subscribers, use the "comments" email template. 
