### PR TITLE
Set Figshare files to uneditable by default to avoid accidental deletes.

### DIFF
--- a/website/addons/figshare/static/figshareFangornConfig.js
+++ b/website/addons/figshare/static/figshareFangornConfig.js
@@ -28,23 +28,26 @@ function _fangornActionColumn (item, col) {
         });
     }
 
-    if (item.kind === 'file' && item.data.extra && item.data.extra.status !== 'public' && item.data.permissions.edit) {
+    // Files can be deleted if private or if parent contains more than one child
+    var privateOrSiblings = (item.data.extra && item.data.extra.status !== 'public') ||
+        item.parent().children.length > 1;
+    if (item.kind === 'file' && privateOrSiblings) {
         buttons.push({
-            'name' : '',
-            'icon' : 'icon-remove',
-            'tooltip' : 'Delete',
-            'css' : 'm-l-lg text-danger fg-hover-hide',
-            'style' : 'display:none',
-            'onclick' : Fangorn.ButtonEvents._removeEvent
+            name: '',
+            icon: 'icon-remove',
+            tooltip: 'Delete',
+            css: 'm-l-lg text-danger fg-hover-hide',
+            style: 'display:none',
+            onclick: Fangorn.ButtonEvents._removeEvent
         });
     }
 
     return buttons.map(function(btn) {
-        return m('span', { 'data-col' : item.id }, [ m('i',{ 
-        	'class' : btn.css, 
-        	style : btn.style, 
+        return m('span', { 'data-col' : item.id }, [ m('i',{
+        	'class' : btn.css,
+        	style : btn.style,
             'data-toggle' : 'tooltip', title : btn.tooltip, 'data-placement': 'bottom',
-        	'onclick' : function(event){ btn.onclick.call(self, event, item, col); } 
+        	'onclick' : function(event){ btn.onclick.call(self, event, item, col); }
         },
             [ m('span', { 'class' : btn.icon}, btn.name) ])
         ]);

--- a/website/static/js/fileRevisions.js
+++ b/website/static/js/fileRevisions.js
@@ -67,7 +67,9 @@ var RevisionsViewModel = function(node, file, editable) {
         file.path.split('/') :
         file.path.split('/').map(decodeURIComponent);
 
-    self.editable = ko.observable(editable);
+    // Hack: Set Figshare files to uneditable by default, then update after
+    // fetching file metadata after revisions request fails
+    self.editable = ko.observable(editable && file.provider !== 'figshare');
     self.urls = {
         delete: waterbutler.buildDeleteUrl(file.path, file.provider, node.id, fileExtra),
         download: waterbutler.buildDownloadUrl(file.path, file.provider, node.id, fileExtra),
@@ -120,12 +122,8 @@ RevisionsViewModel.prototype.fetch = function() {
             $.ajax({
                 method: 'GET',
                 url: self.urls.metadata,
-            }).done(function(data) {
-                if (data.data.extra.status === 'drafts') {
-                    self.editable(true);
-                } else {
-                    self.editable(false);
-                }
+            }).done(function(resp) {
+                self.editable(resp.data.extra.status === 'drafts');
             }).fail(function(xhr) {
                 self.editable(false);
             });

--- a/website/static/js/fileRevisions.js
+++ b/website/static/js/fileRevisions.js
@@ -121,9 +121,9 @@ RevisionsViewModel.prototype.fetch = function() {
             // so dont allow downloads and set a fake current version
             $.ajax({
                 method: 'GET',
-                url: self.urls.metadata,
+                url: self.urls.metadata
             }).done(function(resp) {
-                self.editable(resp.data.extra.status === 'drafts');
+                self.editable(resp.data.extra.canDelete);
             }).fail(function(xhr) {
                 self.editable(false);
             });


### PR DESCRIPTION
# Purpose
Hide the delete button on the file detail page for Figshare files until we know whether the file is editable or not.

# Changes
* Default `editable` to `false` for Figshare files

# Side effects
None expected

[Resolves #2101]