### PR TITLE
Hotfix: Fix message shown when there are no registrations on a component

### DIFF
--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -767,6 +767,7 @@ def _view_project(node, auth, primary=False):
         },
         'user': {
             'is_contributor': node.is_contributor(user),
+            'is_admin_parent': parent.is_admin_parent(user) if parent else False,
             'can_edit': (node.can_edit(auth)
                          and not node.is_registration),
             'has_read_permissions': node.has_permission(user, 'read'),

--- a/website/templates/project/registrations.mako
+++ b/website/templates/project/registrations.mako
@@ -8,14 +8,18 @@
 
 <div class="row">
   <div class="col-sm-9">
-      % if node["registration_count"]:
+    % if node["registration_count"]:
         <div mod-meta='{
             "tpl": "util/render_nodes.mako",
             "uri": "${node["api_url"]}get_registrations/",
             "replace": true
             }'></div>
     % elif node['node_type'] != 'project':
-        To register this component, you must <a href="${parent_node['url']}registrations"><b>register its parent project</b></a> (<a href="${parent_node['url']}">${parent_node['title']}</a>).
+          %if user['is_admin_parent']:
+              To register this component, you must <a href="${parent_node['url']}registrations"><b>register its parent project</b></a> (<a href="${parent_node['url']}">${parent_node['title']}</a>).
+          %else:
+              There have been no registrations of the parent project (<a href="${parent_node['url']}">${parent_node['title']}</a>).
+          %endif
     % else:
         There have been no registrations of this ${node['node_type']}.
         For a list of the most viewed and most recent public registrations on the


### PR DESCRIPTION
<h3>Purpose</h3>
Closes issue #1628 where the message "To register this component you must register the parent project" is currently shown to the public and to contributors who do not have permission to register the parent project.

<h3>Changes</h3>
Only show the message to users who are admin on the parent project, since they are able to register it. For everyone else, show the message, "There have been no registrations of the parent project ([parent project title])."