### PR TITLE
Hotfix/wiki route cleanup

### DIFF
--- a/website/addons/wiki/routes.py
+++ b/website/addons/wiki/routes.py
@@ -81,12 +81,6 @@ api_routes = {
             '/project/<pid>/node/<nid>/wiki/',
         ], 'get', views.project_wiki_home, json_renderer),
 
-        # View (Name) : GET
-        Rule([
-            '/project/<pid>/wiki/<wname>/',
-            '/project/<pid>/node/<nid>/wiki/<wname>/',
-        ], 'get', views.project_wiki_view, json_renderer),
-
         # Draft : GET
         Rule([
             '/project/<pid>/wiki/<wname>/draft/',

--- a/website/addons/wiki/static/wikiPage.js
+++ b/website/addons/wiki/static/wikiPage.js
@@ -241,8 +241,6 @@ function ViewModel(options){
             url += paramPrefix + 'menu';
         }
 
-        console.log('state is..');
-        console.log(window.history.state);
         window.history.replaceState({}, self.pageTitle, url);
     });
 

--- a/website/addons/wiki/templates/edit.mako
+++ b/website/addons/wiki/templates/edit.mako
@@ -101,7 +101,7 @@
                                    data-bind="ace: currentText">Loading. . .</div>
                           </div>
                         </div>
-                      </div>                    
+                      </div>
                   </div>
                   <div class="wiki-panel-footer">
                       <div class="row">
@@ -153,7 +153,7 @@
                         </div>
                     </div>
                 </div>
-                <div id = "wikiViewRender" data-bind="html: renderedView, mathjaxify: renderedView" class="wiki-panel-body markdown-it-view wiki-panel-body-flex">
+                <div id="wikiViewRender" data-bind="html: renderedView, mathjaxify: renderedView" class="wiki-panel-body markdown-it-view wiki-panel-body-flex">
 
                 </div>
               </div>
@@ -166,7 +166,6 @@
                   <div class="row">
                       <div class="col-xs-12">
                           <i class="icon-exchange"> </i>  Compare
-                      
                             <!-- Version Picker -->
                           <span class="compare-version-text"><i> <span data-bind="text: viewVersionDisplay"></span></i> to
                             <select data-bind="value: compareVersion" id="compareVersionSelect">
@@ -192,7 +191,7 @@
   </div>
 </div><!-- end wiki -->
 
-<!-- Wiki modals should also be placed here! --> 
+<!-- Wiki modals should also be placed here! -->
   <%include file="wiki/templates/add_wiki_page.mako"/>
 % if wiki_id and wiki_name != 'home':
   <%include file="wiki/templates/delete_wiki_page.mako"/>

--- a/website/addons/wiki/views.py
+++ b/website/addons/wiki/views.py
@@ -80,7 +80,7 @@ def _get_wiki_versions(node, name, anonymous=False):
         {
             'version': version.version,
             'user_fullname': privacy_info_handle(version.user.fullname, anonymous, name=True),
-            'date': version.date.replace(microsecond=0),
+            'date': version.date.replace(microsecond=0).isoformat(),
         }
         for version in reversed(versions)
     ]


### PR DESCRIPTION
# Purpose
We currently expose an API route for wiki content that isn't used anywhere. That route currently throws a 500 in production, since it's trying to JSON-serialize `datetime` objects. This patch removes the unused route and stringifies the offending date, in case we decide to expose through the API later on.

# Changes
* Delete unused wiki route
* Stringify wiki version dates for JSON safety

# Side effects
None expected

[Resolves https://sentry.osf.io/osf/production/group/2196/]
Verified with @rliebz and @brianjgeiger that this route isn't used--actually, it's not clear that it ever was.