### PR TITLE
Hotfix/Wiki Initial State

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -212,6 +212,12 @@ class NodeWikiFactory(ModularOdmFactory):
     user = SubFactory(UserFactory)
     node = SubFactory(NodeFactory)
 
+    @post_generation
+    def set_node_keys(self, create, extracted):
+        self.node.wiki_pages_current[self.page_name] = self._id
+        self.node.wiki_pages_versions[self.page_name] = [self._id]
+        self.node.save()
+
 
 class UnregUserFactory(ModularOdmFactory):
     """Factory for an unregistered user. Uses User.create_unregistered()

--- a/tests/webtest_tests.py
+++ b/tests/webtest_tests.py
@@ -283,13 +283,24 @@ class TestAUser(OsfTestCase):
         # Can see log event
         assert_in('created', res)
 
-    @unittest.skip('"No wiki content" replaced with javascript handling')
     def test_no_wiki_content_message(self):
         project = ProjectFactory(creator=self.user)
         # Goes to project's wiki, where there is no content
         res = self.app.get('/{0}/wiki/home/'.format(project._primary_key), auth=self.auth)
         # Sees a message indicating no content
         assert_in('No wiki content', res)
+
+    def test_wiki_content(self):
+        project = ProjectFactory(creator=self.user)
+        wiki_page = 'home'
+        wiki_content = 'Kittens'
+        NodeWikiFactory(user=self.user, node=project, content=wiki_content, page_name=wiki_page)
+        res = self.app.get('/{0}/wiki/{1}/'.format(
+            project._primary_key,
+            wiki_page,
+        ), auth=self.auth)
+        assert_not_in('No wiki content', res)
+        assert_in(wiki_content, res)
 
     def test_wiki_page_name_non_ascii(self):
         project = ProjectFactory(creator=self.user)
@@ -310,7 +321,6 @@ class TestAUser(OsfTestCase):
         # Should not see wiki widget (since non-contributor and no content)
         assert_not_in('No wiki content', res)
 
-    @unittest.skip(reason='¯\_(ツ)_/¯ knockout.')
     def test_wiki_does_not_exist(self):
         project = ProjectFactory(creator=self.user)
         res = self.app.get('/{0}/wiki/{1}/'.format(

--- a/website/addons/wiki/templates/edit.mako
+++ b/website/addons/wiki/templates/edit.mako
@@ -154,7 +154,11 @@
                     </div>
                 </div>
                 <div id = "wikiViewRender" data-bind="html: renderedView, mathjaxify: renderedView" class="wiki-panel-body markdown-it-view wiki-panel-body-flex">
-
+                    % if wiki_content:
+                        ${wiki_content | n}
+                    % else:
+                        <p><em>No wiki content</em></p>
+                    % endif
                 </div>
               </div>
           </div>


### PR DESCRIPTION
Purpose
------------
One of the requirements of the one-page wiki was that the mako contain the wiki content so we don't lose SEO. This happened on the project summary page, but that code was dropped from the edit page. This fixes that.

Changes
------------
* Add the mako code that shows the wiki content back into the page.
* Also add tests.
* When the tests don't work, have @jmcarp fix the wiki factory so the tests run.

Side effects
----------------
Our wiki factory didn't actually do anything by way of adding wiki pages, so that's been corrected. Wiki factories now produce wiki pages. Also, heh, a couple of tests we skipped in the update because we thought we couldn't do were actually tests we needed, so I got rid of the skips.

Closes #2135 