### PR TITLE
[feature] Add helpers for OOP

### DIFF
--- a/website/static/js/growlBox.es6.js
+++ b/website/static/js/growlBox.es6.js
@@ -3,19 +3,21 @@
 var $ = require('jquery');
 require('bootstrap.growl');
 
+var oop = require('js/oop');
+
 /**
 * Show a growl-style notification for messages. Defaults to an error type.
 * @param {String} title Shows in bold at the top of the box. Required or it looks foolish.
 * @param {String} message Shows a line below the title. This could be '' if there's nothing to say.
 * @param {String} type One of 'success', 'info', 'warning', or 'danger'. Defaults to danger.
 */
-class GrowlBox {
+var GrowlBox = oop.defclass({
     constructor(title, message, type='danger') {
         this.title = title;
         this.message = message;
         this.type = type;
         this.show();
-    }
+    },
     show() {
         $.growl({
             title: '<strong>' + this.title + '<strong><br />',
@@ -30,6 +32,6 @@ class GrowlBox {
         });
 
     }
-}
+});
 
 module.exports = GrowlBox;

--- a/website/static/js/oop.js
+++ b/website/static/js/oop.js
@@ -3,6 +3,15 @@
 // Douglas Crockford's protoypical inheritance pattern.
 
 var noop = function() {};
+
+// IE8 shim for Object.create
+if (typeof Object.create !== 'function') {
+    Object.create = function (o) {
+        noop.prototype = o;
+        return new noop();
+    };
+}
+
 /**
  * Usage:
  *

--- a/website/static/js/oop.js
+++ b/website/static/js/oop.js
@@ -15,15 +15,15 @@ if (typeof Object.create !== 'function') {
 /**
  * Usage:
  *
-var Animal = defclass({
-    constructor: function(name) {
-        this.name = name || 'unnamed';
-        this.sleeping = false;
-    },
-    sayHi: function() {
-        console.log('Hi, my name is ' + this.name);
-    }
-});
+ *  var Animal = defclass({
+ *      constructor: function(name) {
+ *          this.name = name || 'unnamed';
+ *          this.sleeping = false;
+ *      },
+ *      sayHi: function() {
+ *          console.log('Hi, my name is ' + this.name);
+ *      }
+ *  });
  */
 function defclass(prototype) {
     var constructor = prototype.hasOwnProperty('constructor') ? prototype.constructor : noop;

--- a/website/static/js/oop.js
+++ b/website/static/js/oop.js
@@ -1,3 +1,6 @@
+// These are mostly a simplification of
+// augment.js (https://github.com/javascript/augment, MIT Licensed) and
+// Douglas Crockford's protoypical inheritance pattern.
 /**
  * Usage:
  *

--- a/website/static/js/oop.js
+++ b/website/static/js/oop.js
@@ -1,21 +1,23 @@
 // These are mostly a simplification of
 // augment.js (https://github.com/javascript/augment, MIT Licensed) and
 // Douglas Crockford's protoypical inheritance pattern.
+
+var noop = function() {};
 /**
  * Usage:
  *
- *  var Animal = defclass({
- *      constructor: function(name) {
- *          this.name = name || 'unnamed';
- *          this.sleeping = false;
- *      },
- *      sayHi: function() {
- *          console.log('Hi, my name is ' + this.name);
- *      }
- *  });
+var Animal = defclass({
+    constructor: function(name) {
+        this.name = name || 'unnamed';
+        this.sleeping = false;
+    },
+    sayHi: function() {
+        console.log('Hi, my name is ' + this.name);
+    }
+});
  */
 function defclass(prototype) {
-    var constructor = prototype.constructor;
+    var constructor = prototype.hasOwnProperty('constructor') ? prototype.constructor : noop;
     constructor.prototype = prototype;
     return constructor;
 }

--- a/website/static/js/oop.js
+++ b/website/static/js/oop.js
@@ -1,0 +1,40 @@
+/**
+ * Usage:
+ *
+ *  var Animal = defclass({
+ *      constructor: function(name) {
+ *          this.name = name || 'unnamed';
+ *          this.sleeping = false;
+ *      },
+ *      sayHi: function() {
+ *          console.log('Hi, my name is ' + this.name);
+ *      }
+ *  });
+ */
+function defclass(prototype) {
+    var constructor = prototype.constructor;
+    constructor.prototype = prototype;
+    return constructor;
+}
+
+/**
+ * Usage:
+ *
+ *     var Person = extend(Animal, {
+ *         constructor: function(name) {
+ *             this.super.constructor(name);
+ *             this.name = name || 'Steve';
+ *         }
+ *     });
+ */
+function extend(constructor, sub) {
+    var prototype = Object.create(constructor.prototype);
+    for (var key in sub) { prototype[key] = sub[key]; }
+    prototype.super = constructor.prototype;
+    return defclass(prototype);
+}
+
+module.exports = {
+    defclass: defclass,
+    extend: extend
+};

--- a/website/static/js/tests/oop.test.js
+++ b/website/static/js/tests/oop.test.js
@@ -1,0 +1,62 @@
+/*global describe, it, expect, example, before, after, beforeEach, afterEach, mocha, sinon*/
+'use strict';
+var assert = require('chai').assert;
+// Add sinon asserts to chai.assert, so we can do assert.calledWith instead of sinon.assert.calledWith
+sinon.assert.expose(assert, {prefix: ''});
+
+var oop = require('js/oop');
+
+
+describe('oop', () => {
+    var constructorSpy = new sinon.spy();
+    var methodSpy = new sinon.spy();
+    var overrideSpy = new sinon.spy();
+
+    var Thing = oop.defclass({
+        constructor: constructorSpy,
+        methodA: methodSpy,
+        override: overrideSpy
+    });
+
+    var suboverrideSpy = new sinon.spy();
+    var SubThing = oop.extend(Thing, {
+        override: function() {
+            this.super.override();
+            suboverrideSpy();
+        }
+    });
+
+    afterEach(() => {
+        constructorSpy.reset();
+        methodSpy.reset();
+        overrideSpy.reset();
+        suboverrideSpy.reset();
+    });
+
+    describe('defclass', () => {
+        it('returns a constructor', () => {
+            new Thing();
+            assert.typeOf(Thing, 'function');
+            assert.calledOnce(constructorSpy);
+        });
+    });
+
+    describe('subclasses', () => {
+        it('inherit from superclasses', () => {
+            var st = new SubThing();
+            assert.instanceOf(st, SubThing);
+            assert.instanceOf(st, Thing);
+        });
+        it('inherit methods', () => {
+            var st = new SubThing();
+            st.methodA();
+            assert.calledOnce(methodSpy);
+        });
+        it('can call super method', () => {
+            var st = new SubThing();
+            st.override();
+            assert.calledOnce(overrideSpy);
+            assert.calledOnce(suboverrideSpy);
+        });
+    });
+});


### PR DESCRIPTION
## Proposal

Addition of two JS functions to use when OOP is needed. 

## Rationale

We have encountered a number of use cases for OOP in the JS codebase (see, for example, the mixins and inheritance used in `profile.js`). We've thus far used Constructor/Prototype (see [COSDev](https://github.com/CenterForOpenScience/osf.io/pull/2134)) for encapsulation and `$.extend` for inheritance. While this pattern is valid, it can be overly verbose and difficult to understand for newcomers to JS.

One alternative is to use ES6 classes, as in https://github.com/CenterForOpenScience/osf.io/pull/2134 . However, the Babel transpiler only supports ES6 classes in IE>=10 (source: http://babeljs.io/docs/usage/caveats/). 

The functions in this PR provide a happy medium--clean type definitions and browser support back to Netscape Navigator. 

Add in ES6's enhanced object literals (which has good browser support in Babel), and we get very close to ES6 classes:

```javascript
var Animal = defclass({
    constructor(name='unnamed') {
        this.name = name;
        this.sleeping = false;
    },
    sayHi() {
        console.log('Hi, my name is ' + this.name);
    }
});
                      
var Person = extend(Animal, {
    constructor(name='Steve') {
        this.super.constructor(name);
    }
});

var p = new Person();
p.sayHi();  // Hi, my name is Steve
```