### PR TITLE
Feature/hit enter go to project

### DIFF
--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -1325,6 +1325,7 @@ dl.activity-log dd {
 
 .overflow {
     word-wrap: break-word;
+    word-break: break-all;
     max-width: 100%;
 }
 

--- a/website/templates/components/dashboard_templates.mako
+++ b/website/templates/components/dashboard_templates.mako
@@ -35,7 +35,7 @@
                             clearOn: cleared
                         },
                     value: componentInput,
-                    attr: {disabled: hasSelectedComponent(),
+                    attr: {readonly: hasSelectedComponent(),
                             placeholder: componentPlaceholder}"
                 class="typeahead ob-typeahead-input form-control"
                 name="component"

--- a/website/templates/components/dashboard_templates.mako
+++ b/website/templates/components/dashboard_templates.mako
@@ -13,7 +13,7 @@
                             onSelected: onSelectedProject
                         },
                         value: projectInput,
-                        attr: {disabled: hasSelectedProject(),
+                        attr: {readonly: hasSelectedProject(),
                             placeholder: projectPlaceholder}"
                 class="typeahead ob-typeahead-input form-control"
                 name="project"

--- a/website/templates/project/modal_add_pointer.mako
+++ b/website/templates/project/modal_add_pointer.mako
@@ -25,7 +25,7 @@
                 <!-- Choose which to add -->
                 <div class="row">
 
-                    <div class="col-md-6"col-md->
+                    <div class="col-md-6">
                         <div>
                             <span class="modal-subheader">Results</span>
                             <a data-bind="click:addAll">Add all</a>
@@ -42,7 +42,7 @@
                                                 title="Add link"
                                             >+</a>
                                     </td>
-                                    <td data-bind="text:title"></td>
+                                    <td data-bind="text:title" class="overflow"></td>
                                     <td data-bind="text:$root.authorText($data)"></td>
                                 </tr>
                             </tbody>


### PR DESCRIPTION
Purpose
---------------------
Closes #2145
After selecting a project on "Onboarding," you have the option now hit "enter" to go to that project, instead of clicking the "Go" button.
This should be the default behavior for submitting forms. Also, it aligns with users' habits.
Additionally this would increase consistencies in behaviors across browsers: currently, Safari goes to project on enter; Firefox and Chrome do not.

Causes and fixes
----------------------
**Cause**: The field in which you can select a project is "disabled" once a project is selected. In Firefox and Chrome, once a field is disabled, it is automatically out of focus of key events.
**Changes**: I changed it to "readonly," so that it could not be mutated, but still in of focus.