### PR TITLE
[Hotfix] Project organizer dragging does not display the clone

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "reconnectingWebsocket": "#07669519f8",
     "truncate": "https://github.com/pathable/truncate.git#5da408e2325dd965e0c94c354622ad54645824b9",
     "dropzone": "https://github.com/sloria/dropzone.git#accept-directory",
-    "treebeard": "https://github.com/caneruguz/treebeard.git#429317f7fefc5936e7dea9370622d01b6411f92b",
+    "treebeard": "https://github.com/caneruguz/treebeard.git#40af39cb35ac545732b184a3dddc20e37b85159f",
     "jquery.cookie": "~1.4.1",
     "xhook": "~1.3.0",
     "osf-panel": "https://github.com/caneruguz/osf-panel.git#fda8e05d9f3ba8ed7bd43b46ceffe265b3d73b39",

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -945,6 +945,9 @@ tbOptions = {
         error : _fangornDropzoneError,
         dragover : _fangornDragOver,
         addedfile : _fangornAddedFile
+    },
+    removeIcon : function(){
+        return m('i.icon-remove-sign');
     }
 };
 


### PR DESCRIPTION
## Purpose
Fixes a critical issue where Projectorganizer dragging clone did not appear properly.

## Changes
Main changes were in Treebeard. See commit: https://github.com/caneruguz/treebeard/commit/40af39cb35ac545732b184a3dddc20e37b85159f

For OSF
- Bower.json commit hash for Treebeard was changed to latest commit in Treebeard
- a minor option setting that defines the removeIcon (for modal that appears when deleting files) was added to comply with Treebeards new requirement. 

## Side effects
None, the Treebeard changes are minor and low impact. 