### PR TITLE
[feature fix] Fix notification message for comment replies on components

### DIFF
--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -833,6 +833,14 @@ class TestSendEmails(OsfTestCase):
         mock_send.assert_called_with([self.project.creator._id], 'email_transactional', self.project._id, 'comment_replies', commenter=self.project.creator, target_user=self.project.creator)
         assert_false(mock_send_mail.called)
 
+    @mock.patch('website.notifications.emails.send')
+    def test_notify_sends_comment_event_if_comment_reply_is_not_direct_reply_on_component(self, mock_send):
+        """ Test that comment replies on components that are not direct replies to the subscriber use the
+            "comments" email template.
+        """
+        user = factories.UserFactory()
+        sent_subscribers = emails.notify(self.node._id, 'comments', target_user=user)
+        mock_send.assert_called_with([self.project.creator._id], 'email_transactional', self.node._id, 'comments', target_user=user)
 
     # @mock.patch('website.notifications.emails.notify')
     @mock.patch('website.project.views.comment.notify')

--- a/website/notifications/emails.py
+++ b/website/notifications/emails.py
@@ -116,7 +116,7 @@ def check_parent(uid, event, node_subscribers, **context):
             for u in subscribed_users:
                 if u not in node_subscribers and node.has_permission(u, 'read'):
                     if notification_type != 'none':
-                        event = 'comment_replies' if target_user else event
+                        event = 'comment_replies' if target_user == u else event
                         send([u._id], notification_type, uid, event, **context)
                     node_subscribers.append(u)
 


### PR DESCRIPTION
<h3>Purpose</h3>
Fixes https://trello.com/c/gydQs38q/40-replying-to-a-comment-sends-email-with-misleading-incorrect-information.

<h3>Changes</h3>
Extension of PR https://github.com/CenterForOpenScience/osf.io/pull/2130, that accounts for users who receive notifications on components that are set to the default "adopt settings from parent component." 