### PR TITLE
[Hotfix] GitHub nodesettings auth battle

### DIFF
--- a/website/addons/github/model.py
+++ b/website/addons/github/model.py
@@ -285,6 +285,7 @@ class AddonGitHubNodeSettings(AddonNodeSettingsBase):
             'is_registration': self.owner.is_registration,
         })
         if self.user_settings and self.user_settings.has_auth:
+            valid_credentials = False
             owner = self.user_settings.owner
             if user_settings and user_settings.owner == owner:
                 connection = GitHub.from_settings(user_settings)

--- a/website/addons/github/tests/test_models.py
+++ b/website/addons/github/tests/test_models.py
@@ -337,13 +337,16 @@ class TestAddonGithubNodeSettings(OsfTestCase):
 
     def setUp(self):
         OsfTestCase.setUp(self)
-        self.user_settings = AddonGitHubUserSettings()
-        self.oauth_settings = AddonGitHubOauthSettings()
+        self.user = UserFactory()
+        self.user.add_addon('github')
+        self.user_settings = self.user.get_addon('github')
+        self.oauth_settings = AddonGitHubOauthSettings(oauth_access_token='foobar')
         self.oauth_settings.github_user_id = 'testuser'
         self.oauth_settings.save()
         self.user_settings.oauth_settings = self.oauth_settings
         self.user_settings.save()
         self.node_settings = AddonGitHubNodeSettings(
+            owner=ProjectFactory(),
             user='chrisseto',
             repo='openpokemon',
             user_settings=self.user_settings,
@@ -396,3 +399,17 @@ class TestAddonGithubNodeSettings(OsfTestCase):
         res = self.node_settings.delete_hook()
         assert_false(res)
         mock_delete_hook.assert_called_with(*args)
+
+    def test_to_json_noauthorizing_authed_user(self):
+        user = UserFactory()
+        user.add_addon('github')
+        user_settings = user.get_addon('github')
+
+        oauth_settings = AddonGitHubOauthSettings(oauth_access_token='foobar')
+        oauth_settings.github_user_id = 'testuser'
+        oauth_settings.save()
+
+        user_settings.oauth_settings = self.oauth_settings
+        user_settings.save()
+
+        self.node_settings.to_json(user)


### PR DESCRIPTION
Steps (requires 2 users):
* User 1 creates a project,links a github repo, and adds User 2 as a admin
* User 2 authorizes github
* User 2 attempts to view the settings of User 1's project

The fix:
* Default `valid_creditials` to `False`

Side effects:
* The following snippet will no longer raise an error but just return that a user is unauthorized
```python
                except GitHubError as error:
                    if error.code == http.UNAUTHORIZED:
                        repo_names = []
                        valid_credentials = False
```
