### PR TITLE
Remove test_to_json from Zendeley test_models.py

### DIFF
--- a/website/addons/mendeley/tests/test_models.py
+++ b/website/addons/mendeley/tests/test_models.py
@@ -316,22 +316,6 @@ class MendeleyNodeSettingsTestCase(OsfTestCase):
 
 
 class MendeleyUserSettingsTestCase(OsfTestCase):
-    def test_to_json(self):
-        # All values are passed to the user settings view
-        user_accounts = [MendeleyAccountFactory(), MendeleyAccountFactory()]
-        user = UserFactory(external_accounts=user_accounts)
-        user_addon = MendeleyUserSettingsFactory(owner=user)
-        res = user_addon.to_json(user)
-        for account in user_accounts:
-            assert_in(
-                {
-                    'id': account._id,
-                    'provider_id': account.provider_id,
-                    'display_name': account.display_name,
-                    'nodes': [],
-                },
-                res['accounts'],
-            )
 
     def _prep_oauth_case(self):
         self.node = ProjectFactory()

--- a/website/addons/zotero/tests/test_models.py
+++ b/website/addons/zotero/tests/test_models.py
@@ -248,23 +248,6 @@ class ZoteroNodeSettingsTestCase(OsfTestCase):
 
 class ZoteroUserSettingsTestCase(OsfTestCase):
 
-    def test_to_json(self):
-        # All values are passed to the user settings view
-        user_accounts = [ZoteroAccountFactory(), ZoteroAccountFactory()]
-        user = UserFactory(external_accounts=user_accounts)
-        user_addon = ZoteroUserSettingsFactory(owner=user)
-        res = user_addon.to_json(user)
-        for account in user_accounts:
-            assert_in(
-                {
-                    'id': account._id,
-                    'provider_id': account.provider_id,
-                    'display_name': account.display_name,
-                    'nodes': [],
-                },
-                res['accounts'],
-            )
-
     def _prep_oauth_case(self):
         self.node = ProjectFactory()
         self.user = self.node.creator


### PR DESCRIPTION
## Purpose 

Atm to_json is handled in the superclass and testing on a per-addon basis is
unnecessary. Also these test were failing and breaking builds on develop.

## Changes

Remove test_to_json from Zendeley test_models

## Side effects

Broken builds should now pass. :beers: 