### PR TITLE
fix the redirecting issue

### DIFF
--- a/website/addons/dropbox/views/auth.py
+++ b/website/addons/dropbox/views/auth.py
@@ -42,7 +42,7 @@ def get_auth_flow():
 
 AuthResult = namedtuple('AuthResult', ['access_token', 'dropbox_id', 'url_state'])
 
-def finish_auth():
+def finish_auth(node):
     """View helper for finishing the Dropbox Oauth2 flow. Returns the
     access_token, dropbox_id, and url_state.
 
@@ -59,6 +59,8 @@ def finish_auth():
         raise HTTPError(http.FORBIDDEN)
     except DropboxOAuth2Flow.NotApprovedException:  # User canceled flow
         flash('Did not approve token.', 'info')
+        if node:
+            return redirect(node.web_url_for('node_setting'))
         return redirect(web_url_for('user_addons'))
     except DropboxOAuth2Flow.ProviderException:
         raise HTTPError(http.FORBIDDEN)
@@ -95,7 +97,7 @@ def dropbox_oauth_finish(auth, **kwargs):
     user = auth.user
 
     node = Node.load(session.data.get('dropbox_auth_nid'))
-    result = finish_auth()
+    result = finish_auth(node)
     # If result is a redirect response, follow the redirect
     if isinstance(result, BaseResponse):
         return result


### PR DESCRIPTION
resolve issue https://github.com/CenterForOpenScience/osf.io/issues/2177

<b>Purpose</b>
Fix the problem that when cancel the authorization on dropdox while you author it will always return you to user settings page instead of node settings page

<b>Changes</b>
if now you authorization starts from node settings page. It will return you back to there instead of return you to user settings page.

![screen shot 2015-03-16 at 10 49 12 am](https://cloud.githubusercontent.com/assets/4974056/6668560/1b9c4018-cbca-11e4-9594-b7079fbc6647.png)
