### PR TITLE
[Ready for Review] Mendeley folderPicker bugfix

### DIFF
--- a/website/addons/mendeley/templates/mendeley_node_settings.mako
+++ b/website/addons/mendeley/templates/mendeley_node_settings.mako
@@ -41,9 +41,8 @@
 
                 <!-- Folder buttons -->
                 <div class="btn-group" data-bind="visible: userIsOwner()">
-                    <button data-bind="visible: validCredentials,
-                                        click: togglePicker,
-                                        css: {active: currentDisplay() === PICKER}"
+                    <button data-bind="click: togglePicker,
+                                       css: {active: currentDisplay() === PICKER}"
                             class="btn btn-sm btn-addon"><i class="fa fa-pencil-square-o"></i> Change</button>
                             <span data-bind="visible: folder().path === '/'">(Cannot share root folder)</span>
                         </button>


### PR DESCRIPTION
## Purpose

Obsolete references to validCredentials was breaking the KO template.

## Change 

Remove binding to validCredentials.

## Side effects

Template doesn't break.