### PR TITLE
Feature/migrate conference admins

### DIFF
--- a/scripts/migrate_conference_admins.py
+++ b/scripts/migrate_conference_admins.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+
+import sys
+import logging
+
+from modularodm import Q
+
+from website import models
+
+from scripts import utils as scripts_utils
+
+
+STAFF_EMAIL = 'presentations@cos.io'
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+def migrate_conference(conference, staff_user, dry_run=True):
+    nodes = models.Node.find(
+        Q('system_tags', 'eq', conference.endpoint) |
+        Q('tags', 'eq', conference.endpoint)
+    )
+    for node in nodes:
+        migrate_node(node, conference, staff_user, dry_run=dry_run)
+
+
+def migrate_node(node, conference, staff_user, dry_run=True):
+    for admin in conference.admins:
+        if admin in node.contributors:
+            logger.info(
+                'Removing admin {0} from node {1}'.format(
+                    admin.fullname,
+                    node.title,
+                )
+            )
+            if not dry_run:
+                node.remove_contributor(admin, log=False, auth=None)
+    if staff_user not in node.contributors:
+        logger.info(
+            'Adding staff email {0} to node {1}'.format(
+                staff_user.fullname,
+                node.title,
+            )
+        )
+        if not dry_run:
+            node.add_contributor(staff_user, log=False)
+    node.save()
+
+
+def main(dry_run=True):
+    staff_user = models.User.find_one(Q('username', 'eq', STAFF_EMAIL))
+    for conference in models.Conference.find():
+        migrate_conference(conference, staff_user, dry_run=dry_run)
+
+
+if __name__ == '__main__':
+    dry_run = 'dry' in sys.argv
+    if not dry_run:
+        scripts_utils.add_file_logger(logger, __file__)
+    main(dry_run=dry_run)

--- a/scripts/populate_conferences.py
+++ b/scripts/populate_conferences.py
@@ -185,7 +185,7 @@ MEETING_DATA = {
         ],
         'public_projects': True,
     },
-    
+
 }
 
 

--- a/scripts/tests/test_migrate_conference_admins.py
+++ b/scripts/tests/test_migrate_conference_admins.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+
+from nose.tools import *  # noqa
+
+from tests.base import OsfTestCase
+from tests.factories import UserFactory
+from tests.factories import NodeFactory
+from tests.test_conferences import ConferenceFactory
+
+from scripts.migrate_conference_admins import migrate_node
+
+
+class TestMigrateAdmins(OsfTestCase):
+
+    def test_migrate_node(self):
+        conference = ConferenceFactory()
+        node = NodeFactory(creator=conference.admins[0])
+        staff_user = UserFactory()
+        migrate_node(node, conference, staff_user, dry_run=False)
+        node.reload()
+        assert_in(staff_user, node.contributors)
+        assert_not_in(conference.admins[0], node.contributors)
+        # Verify that migration is idempotent
+        migrate_node(node, conference, staff_user, dry_run=False)
+        node.reload()
+        assert_in(staff_user, node.contributors)
+        assert_not_in(conference.admins[0], node.contributors)


### PR DESCRIPTION
# Purpose
Add migration script to replace conference administrators with personal addresses (Andrew, Katy) with a staff account (currently configured to be presentations@cos). This will ensure continuity throughout personnel changes on the presentation service.

# Changes
* Add migration script
* Add unit test

# Side effects
None expected

Note @sloria: a `User` with the email address `STAFF_EMAIL` must exist before running this script.