### PR TITLE
Upgrade markdown-it-toc and move to package.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,6 @@
     "treebeard": "https://github.com/caneruguz/treebeard.git#40af39cb35ac545732b184a3dddc20e37b85159f",
     "xhook": "~1.3.0",
     "osf-panel": "https://github.com/caneruguz/osf-panel.git#fda8e05d9f3ba8ed7bd43b46ceffe265b3d73b39",
-    "markdown-it-toc": "https://github.com/samchrisinger/markdown-it-toc.git#82c0c364d8e756c6ee00085f8f9069f937243dd7",
     "styles": "https://github.com/lyndsysimon/styles.git#4db9c8e2f5932cad9f23ad3579d1a82c691faf12",
     "locales": "https://github.com/citation-style-language/locales.git#d2b612f8a6f764cbd66e67238636fac3888a7736",
     "raven-js": "~1.1.17"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "typeahead.js": "^0.10.5",
     "url-loader": "^0.5.5",
     "webpack": "^1.7.2",
-    "ws": "~0.4.32"
+    "ws": "~0.4.32",
+    "markdown-it-toc": "1.0.4"
   },
   "devDependencies": {
     "chai": "^2.1.1",


### PR DESCRIPTION
## Purpose

markdown-it-toc was allowing special characters in anchor hrefs and ids. This broke javascript event binders. 

## Changes

Strip special chars from hrefs and ids

## Side effects
none