### PR TITLE
Hotfix/fix md it toc

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,6 @@
     "xhook": "~1.3.0",
     "osf-panel": "https://github.com/caneruguz/osf-panel.git#fda8e05d9f3ba8ed7bd43b46ceffe265b3d73b39",
     "markdown-it-sanitizer": "~0.2.0",
-    "markdown-it-toc": "https://github.com/samchrisinger/markdown-it-toc.git#82c0c364d8e756c6ee00085f8f9069f937243dd7",
     "styles": "https://github.com/lyndsysimon/styles.git#4db9c8e2f5932cad9f23ad3579d1a82c691faf12",
     "locales": "https://github.com/citation-style-language/locales.git#d2b612f8a6f764cbd66e67238636fac3888a7736",
     "jsTimezoneDetect": "https://cdnjs.cloudflare.com/ajax/libs/jstimezonedetect/1.0.4/jstz.js",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "livedb-mongo": "~0.4.1",
     "markdown-it": "~3.0.5",
     "markdown-it-video": "~0.1.6",
+    "markdown-it-toc": "~1.0.4",
     "morgan": "^1.5.1",
     "object-assign": "^2.0.0",
     "raven": "^0.7.2",


### PR DESCRIPTION
## Purpose

markdown-it-toc was allowing special characters in anchor hrefs and ids. This broke javascript event binders. 

## Changes

Strip special chars from hrefs and ids

## Side effects
none