### PR TITLE
[Patch] Add check for order folder to avoid syntax errors

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -607,9 +607,12 @@ function _fangornLazyLoadOnLoad (tree) {
  * @private
  */
 function _fangornOrderFolder(tree) {
-    var sortDirection = this.isSorted[0].desc ? 'desc' : 'asc';
-    tree.sortChildren(this, sortDirection, 'text', 0);
-    this.redraw();
+    // Checking if this column does in fact have sorting
+    if (this.isSorted[0]) {
+        var sortDirection = this.isSorted[0].desc ? 'desc' : 'asc';
+        tree.sortChildren(this, sortDirection, 'text', 0);
+        this.redraw();        
+    }
 }
 
 /**


### PR DESCRIPTION
## Purpose

If an implementation of fangorn didn't want any forced ordering like we are doing in here and set up their options accordingly this function causes an error. This patch makes sure there is no error in that scenario. 

## Changes
Add a check to see if isSorted for that column is set (it gets set by Treebeard.js on draw IF col.sort option is true). 

## Side effects
Requires options to be set correctly, otherwise no side effects. 