### PR TITLE
Track whether users were created as unregistered.

### DIFF
--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -210,18 +210,14 @@ class User(GuidStoredObject, AddonModelMixin):
     username = fields.StringField(required=False, unique=True, index=True)
     password = fields.StringField()
     fullname = fields.StringField(required=True, validate=string_required)
-    is_registered = fields.BooleanField()
+    is_registered = fields.BooleanField(index=True)
 
-    # TODO: Migrate unclaimed users to the new style, then remove this attribute
-    # Note: No new users should be created where is_claimed is False.
-    #   As of 9 Sep 2014, there were 331 legacy unclaimed users in the system.
-    #   When those users are migrated to the new style, this attribute should be
-    #   removed.
-    is_claimed = fields.BooleanField()
+    is_claimed = fields.BooleanField(default=False, index=True)
 
     # Tags for internal use
     system_tags = fields.StringField(list=True)
     security_messages = fields.DictionaryField()
+    is_invited = fields.BooleanField(default=False, index=True)
 
     # Per-project unclaimed user data:
     # Format: {
@@ -237,7 +233,7 @@ class User(GuidStoredObject, AddonModelMixin):
     # TODO: add validation
     unclaimed_records = fields.DictionaryField(required=False)
     # The user who merged this account
-    merged_by = fields.ForeignField('user', default=None, backref="merged")
+    merged_by = fields.ForeignField('user', default=None, backref='merged', index=True)
     #: Verification key used for resetting password
     verification_key = fields.StringField()
     emails = fields.StringField(list=True)
@@ -256,7 +252,7 @@ class User(GuidStoredObject, AddonModelMixin):
     mailing_lists = fields.DictionaryField()
 
     aka = fields.StringField(list=True)
-    date_registered = fields.DateTimeField(auto_now_add=dt.datetime.utcnow)
+    date_registered = fields.DateTimeField(auto_now_add=dt.datetime.utcnow, index=True)
     # Watched nodes are stored via a list of WatchConfigs
     watched = fields.ForeignField("WatchConfig", list=True, backref="watched")
 
@@ -315,10 +311,10 @@ class User(GuidStoredObject, AddonModelMixin):
 
     date_last_login = fields.DateTimeField()
 
-    date_confirmed = fields.DateTimeField()
+    date_confirmed = fields.DateTimeField(index=True)
 
     # When the user was disabled.
-    date_disabled = fields.DateTimeField()
+    date_disabled = fields.DateTimeField(index=True)
 
     # Format: {
     #   'node_id': 'timestamp'
@@ -338,19 +334,17 @@ class User(GuidStoredObject, AddonModelMixin):
 
     @classmethod
     def create_unregistered(cls, fullname, email=None):
-        """Creates a new unregistered user.
-
-        :raises: DuplicateEmailError if a user with the given email address
-            is already in the database.
+        """Create a new unregistered user.
         """
         user = cls(
             username=email,
             fullname=fullname,
+            is_invited=True,
+            is_registered=False,
         )
         user.update_guessed_names()
         if email:
             user.emails.append(email)
-        user.is_registered = False
         return user
 
     @classmethod

--- a/scripts/analytics/folders.py
+++ b/scripts/analytics/folders.py
@@ -9,7 +9,7 @@ from website import settings
 from utils import plot_dates, mkdirp
 
 
-comment_collection = database['comment']
+node_collection = database['node']
 
 FIG_PATH = os.path.join(settings.ANALYTICS_PATH, 'figs', 'features')
 mkdirp(FIG_PATH)
@@ -18,11 +18,17 @@ mkdirp(FIG_PATH)
 def main():
     dates = [
         record['date_created']
-        for record in comment_collection.find({}, {'date_created': True})
+        for record in node_collection.find(
+            {
+                'is_folder': True,
+                'is_dashboard': {'$ne': True},
+            },
+            {'date_created': True},
+        )
     ]
     plot_dates(dates)
-    plt.title('comments ({0} total)'.format(len(dates)))
-    plt.savefig(os.path.join(FIG_PATH, 'comment-actions.png'))
+    plt.title('folders ({0} total)'.format(len(dates)))
+    plt.savefig(os.path.join(FIG_PATH, 'folder-actions.png'))
     plt.close()
 
 

--- a/scripts/migrate_was_invited.py
+++ b/scripts/migrate_was_invited.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+import sys
+import logging
+
+from modularodm import Q
+
+from website import models
+
+from scripts import utils as scripts_utils
+
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+def is_invited(user):
+    query = (
+        Q('action', 'eq', 'contributor_added') &
+        Q('params.contributors', 'eq', user._id)
+    )
+    if user.date_confirmed:
+        query = (
+            query &
+            Q('date', 'ne', None) &
+            Q('date', 'lt', user.date_confirmed)
+        )
+    logs = models.NodeLog.find(query)
+    return bool(logs)
+
+
+def main(dry_run=True):
+    users = models.User.find(Q('is_invited', 'eq', None))
+    for user in users:
+        invited = is_invited(user)
+        logger.info('Setting `is_invited` field of user {0} to {1}'.format(user._id, invited))
+        if not dry_run:
+            user.is_invited = invited
+            user.save()
+
+
+if __name__ == '__main__':
+    dry_run = 'dry' in sys.argv
+    if not dry_run:
+        scripts_utils.add_file_logger(logger, __file__)
+    main(dry_run=dry_run)

--- a/scripts/tests/test_migrate_was_invited.py
+++ b/scripts/tests/test_migrate_was_invited.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+
+from nose.tools import *  # noqa
+
+from tests.base import fake
+from tests.base import OsfTestCase
+from tests.factories import UserFactory
+from tests.factories import NodeFactory
+from tests.factories import UnconfirmedUserFactory
+
+from framework.auth.core import Auth
+
+from scripts.migrate_was_invited import main
+from scripts.migrate_was_invited import is_invited
+
+
+class TestWasInvited(OsfTestCase):
+
+    def test_was_invited(self):
+        referrer = UserFactory()
+        node = NodeFactory(creator=referrer)
+        name = fake.name()
+        email = fake.email()
+        user = node.add_unregistered_contributor(
+            fullname=name,
+            email=email,
+            auth=Auth(user=referrer),
+        )
+        user.register(email, 'secret')
+        assert_true(is_invited(user))
+        user.is_invited = None
+        user.save()
+        main(dry_run=False)
+        user.reload()
+        assert_true(user.is_invited)
+
+    def test_was_not_invited(self):
+        referrer = UserFactory()
+        node = NodeFactory(creator=referrer)
+        user = UserFactory()
+        node.add_contributor(user, auth=Auth(referrer))
+        assert_false(is_invited(user))
+        user.is_invited = None
+        user.save()
+        main(dry_run=False)
+        user.reload()
+        assert_false(user.is_invited)
+
+    def test_was_not_invited_unconfirmed(self):
+        user = UnconfirmedUserFactory()
+        assert_false(is_invited(user))
+        user.is_invited = None
+        user.save()
+        main(dry_run=False)
+        user.reload()
+        assert_false(user.is_invited)

--- a/tasks.py
+++ b/tasks.py
@@ -543,11 +543,11 @@ def analytics():
     init_app()
     from scripts import metrics
     from scripts.analytics import (
-        logs, addons, comments, links, watch, email_invites,
+        logs, addons, comments, folders, links, watch, email_invites,
         permissions, profile, benchmarks
     )
     modules = (
-        metrics, logs, addons, comments, links, watch, email_invites,
+        metrics, logs, addons, comments, folders, links, watch, email_invites,
         permissions, profile, benchmarks
     )
     for module in modules:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -224,6 +224,8 @@ class TestUser(OsfTestCase):
         u.save()
         assert_equal(u.username, email)
         assert_false(u.is_registered)
+        assert_false(u.is_claimed)
+        assert_true(u.is_invited)
         assert_true(email in u.emails)
         parsed = impute_names_model(name)
         assert_equal(u.given_name, parsed['given_name'])

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -545,18 +545,18 @@ class Node(GuidStoredObject, AddonModelMixin):
 
     _id = fields.StringField(primary=True)
 
-    date_created = fields.DateTimeField(auto_now_add=datetime.datetime.utcnow)
+    date_created = fields.DateTimeField(auto_now_add=datetime.datetime.utcnow, index=True)
 
     # Privacy
-    is_public = fields.BooleanField(default=False)
+    is_public = fields.BooleanField(default=False, index=True)
 
     # User mappings
     permissions = fields.DictionaryField()
     visible_contributor_ids = fields.StringField(list=True)
 
     # Project Organization
-    is_dashboard = fields.BooleanField(default=False)
-    is_folder = fields.BooleanField(default=False)
+    is_dashboard = fields.BooleanField(default=False, index=True)
+    is_folder = fields.BooleanField(default=False, index=True)
 
     # Expanded: Dictionary field mapping user IDs to expand state of this node:
     # {
@@ -565,21 +565,21 @@ class Node(GuidStoredObject, AddonModelMixin):
     # }
     expanded = fields.DictionaryField(default={}, validate=validate_user)
 
-    is_deleted = fields.BooleanField(default=False)
-    deleted_date = fields.DateTimeField()
+    is_deleted = fields.BooleanField(default=False, index=True)
+    deleted_date = fields.DateTimeField(index=True)
 
-    is_registration = fields.BooleanField(default=False)
-    registered_date = fields.DateTimeField()
+    is_registration = fields.BooleanField(default=False, index=True)
+    registered_date = fields.DateTimeField(index=True)
     registered_user = fields.ForeignField('user', backref='registered')
     registered_schema = fields.ForeignField('metaschema', backref='registered')
     registered_meta = fields.DictionaryField()
 
-    is_fork = fields.BooleanField(default=False)
-    forked_date = fields.DateTimeField()
+    is_fork = fields.BooleanField(default=False, index=True)
+    forked_date = fields.DateTimeField(index=True)
 
     title = fields.StringField(validate=validate_title)
     description = fields.StringField()
-    category = fields.StringField(validate=validate_category)
+    category = fields.StringField(validate=validate_category, index=True)
 
     # One of 'public', 'private'
     # TODO: Add validator
@@ -602,11 +602,11 @@ class Node(GuidStoredObject, AddonModelMixin):
     system_tags = fields.StringField(list=True)
 
     nodes = fields.AbstractForeignField(list=True, backref='parent')
-    forked_from = fields.ForeignField('node', backref='forked')
-    registered_from = fields.ForeignField('node', backref='registrations')
+    forked_from = fields.ForeignField('node', backref='forked', index=True)
+    registered_from = fields.ForeignField('node', backref='registrations', index=True)
 
     # The node (if any) used as a template for this node's creation
-    template_node = fields.ForeignField('node', backref='template_node')
+    template_node = fields.ForeignField('node', backref='template_node', index=True)
 
     api_keys = fields.ForeignField('apikey', list=True, backref='keyed')
 

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -285,8 +285,8 @@ class NodeLog(StoredObject):
 
     _id = fields.StringField(primary=True, default=lambda: str(ObjectId()))
 
-    date = fields.DateTimeField(default=datetime.datetime.utcnow)
-    action = fields.StringField()
+    date = fields.DateTimeField(default=datetime.datetime.utcnow, index=True)
+    action = fields.StringField(index=True)
     params = fields.DictionaryField()
 
     user = fields.ForeignField('user', backref='created')


### PR DESCRIPTION
# Purpose
We don't currently have a practical (i.e. using a single, tolerably fast query) way to figure out whether an active user was originally created as an unregistered user or not. This isn't ideal for metrics or provenance tracking. This patch adds an `is_invited` field to `User` to track user provenance, and adds a migration script to backfill the new field for existing users--thanks @lyndsysimon for suggesting the method for this.

# Changes
* Add `is_invited` field to `User`
* Add migration to backfill `is_invited` for existing users
* Add indices on queried fields

# Side effects
None expected