### PR TITLE
[Rrready for Review] Feature/projectorganizer no last name

### DIFF
--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -7,9 +7,9 @@
 var Treebeard = require('treebeard');
 
 // CSS
-require('../css/typeahead.css');
-require('../css/fangorn.css');
-require('../css/projectorganizer.css');
+require('css/typeahead.css');
+require('css/fangorn.css');
+require('css/projectorganizer.css');
 
 var Handlebars = require('handlebars');
 var $ = require('jquery');
@@ -533,16 +533,16 @@ function _poContributors(item) {
  * @private
  */
 function _poModified(item) {
-    var personString,
-        dateString;
+    var personString = '';
+    var dateString = '';
     if (item.data.modifiedDelta === 0) {
         return m('span');
     }
     dateString = moment.utc(item.data.dateModified).fromNow();
     if (item.data.modifiedBy !== '') {
-        personString = item.data.modifiedBy.toString();
+        personString = ', by ' + item.data.modifiedBy.toString();
     }
-    return m('span', dateString + ', by ' + personString);
+    return m('span', dateString + personString);
 }
 
 /**

--- a/website/views.py
+++ b/website/views.py
@@ -262,7 +262,7 @@ def get_dashboard_nodes(auth):
         if perm not in permissions.PERMISSIONS:
             raise HTTPError(http.BAD_REQUEST, dict(
                 message_short='Invalid query parameter',
-                message_oong='{0} is not in {1}'.format(perm, permissions.PERMISSIONS)
+                message_long='{0} is not in {1}'.format(perm, permissions.PERMISSIONS)
             ))
         response_nodes = [node for node in nodes if node.has_permission(user, permission=perm)]
     else:


### PR DESCRIPTION
## :dolphin: 

When a project's modifiedBy field was empty, projectorganizer was showing a modified 'by undefined'. This PR omits the 'by {name}' string if this is the case.

## :moneybag: 

- Use CSS alias
- Omit name string if empty
- Fix kwarg in website views

## :8ball: 

None