### PR TITLE
[Feature] fix removed addon files

### DIFF
--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -546,6 +546,60 @@ class TestAddonFileViews(OsfTestCase):
 
         assert_equals(resp.status_code, 403)
 
+    def test_nonexistant_addons_raise(self):
+        path = 'cloudfiles'
+        self.project.delete_addon('github', Auth(self.user))
+        self.project.save()
+
+        resp = self.app.get(
+            self.project.api_url_for(
+                'addon_render_file',
+                path=path,
+                provider='github',
+                action='download'
+            ),
+            auth=self.user.auth,
+            expect_errors=True
+        )
+
+        assert_equals(resp.status_code, 400)
+
+    def test_unauth_addons_raise(self):
+        path = 'cloudfiles'
+        self.node_addon.user_settings = None
+        self.node_addon.save()
+
+        resp = self.app.get(
+            self.project.api_url_for(
+                'addon_render_file',
+                path=path,
+                provider='github',
+                action='download'
+            ),
+            auth=self.user.auth,
+            expect_errors=True
+        )
+
+        assert_equals(resp.status_code, 401)
+
+    def test_unconfigured_addons_raise(self):
+        path = 'cloudfiles'
+        self.node_addon.repo = None
+        self.node_addon.save()
+
+        resp = self.app.get(
+            self.project.api_url_for(
+                'addon_render_file',
+                path=path,
+                provider='github',
+                action='download'
+            ),
+            auth=self.user.auth,
+            expect_errors=True
+        )
+
+        assert_equals(resp.status_code, 400)
+
     @mock.patch('website.addons.base.views.request')
     @mock.patch('website.addons.base.views.requests.get')
     @mock.patch('website.addons.base.requests.get')

--- a/website/addons/base/__init__.py
+++ b/website/addons/base/__init__.py
@@ -627,6 +627,13 @@ class AddonNodeSettingsBase(AddonSettingsBase):
     }
 
     @property
+    def complete(self):
+        """Whether or not this addon is properly configured
+        :rtype bool:
+        """
+        raise NotImplementedError()
+
+    @property
     def has_auth(self):
         """Whether the node has added credentials for this addon."""
         return False

--- a/website/addons/base/views.py
+++ b/website/addons/base/views.py
@@ -337,11 +337,26 @@ def addon_render_file(auth, path, provider, **kwargs):
 
     node_addon = node.get_addon(provider)
 
-    if not path or not node_addon:
+    if not path:
         raise HTTPError(httplib.BAD_REQUEST)
 
+    if not node_addon:
+        raise HTTPError(httplib.BAD_REQUEST, {
+            'message_short': 'Bad Request',
+            'message_long': 'The add-on containing this file is no longer attached to the {}.'.format(node.project_or_component)
+        })
+
     if not node_addon.has_auth:
-        raise HTTPError(httplib.UNAUTHORIZED)
+        raise HTTPError(httplib.UNAUTHORIZED, {
+            'message_short': 'Unauthorized',
+            'message_long': 'The add-on containing this file is no longer authorized.'
+        })
+
+    if not node_addon.complete:
+        raise HTTPError(httplib.UNAUTHORIZED, {
+            'message_short': 'Unauthorized',
+            'message_long': 'The add-on containing this file is no longer configured.'
+        })
 
     if not path.startswith('/'):
         path = '/' + path

--- a/website/addons/base/views.py
+++ b/website/addons/base/views.py
@@ -353,8 +353,8 @@ def addon_render_file(auth, path, provider, **kwargs):
         })
 
     if not node_addon.complete:
-        raise HTTPError(httplib.UNAUTHORIZED, {
-            'message_short': 'Unauthorized',
+        raise HTTPError(httplib.BAD_REQUEST, {
+            'message_short': 'Bad Request',
             'message_long': 'The add-on containing this file is no longer configured.'
         })
 

--- a/website/addons/box/model.py
+++ b/website/addons/box/model.py
@@ -250,6 +250,10 @@ class BoxNodeSettings(AddonNodeSettingsBase):
         """Whether an access token is associated with this node."""
         return bool(self.user_settings and self.user_settings.has_auth)
 
+    @property
+    def complete(self):
+        return self.has_auth and self.folder_id is not None
+
     def fetch_folder_name(self):
         self._update_folder_data()
         return self.folder_name

--- a/website/addons/dropbox/model.py
+++ b/website/addons/dropbox/model.py
@@ -127,6 +127,10 @@ class DropboxNodeSettings(AddonNodeSettingsBase):
         return '{0}: {1}'.format(self.config.full_name, self.folder)
 
     @property
+    def complete(self):
+        return self.has_auth and self.folder is not None
+
+    @property
     def has_auth(self):
         """Whether an access token is associated with this node."""
         return bool(self.user_settings and self.user_settings.has_auth)

--- a/website/addons/dropbox/tests/test_models.py
+++ b/website/addons/dropbox/tests/test_models.py
@@ -174,6 +174,25 @@ class TestDropboxNodeSettingsModel(OsfTestCase):
             owner=self.project
         )
 
+    def test_complete_true(self):
+        self.node_settings.user_settings.access_token = 'seems legit'
+
+        assert_true(self.node_settings.has_auth)
+        assert_true(self.node_settings.complete)
+
+    def test_complete_false(self):
+        self.node_settings.user_settings.access_token = 'seems legit'
+        self.node_settings.folder = None
+
+        assert_true(self.node_settings.has_auth)
+        assert_false(self.node_settings.complete)
+
+    def test_complete_auth_false(self):
+        self.node_settings.user_settings = None
+
+        assert_false(self.node_settings.has_auth)
+        assert_false(self.node_settings.complete)
+
     def test_fields(self):
         node_settings = DropboxNodeSettings(user_settings=self.user_settings)
         node_settings.save()

--- a/website/addons/figshare/model.py
+++ b/website/addons/figshare/model.py
@@ -135,6 +135,10 @@ class AddonFigShareNodeSettings(AddonNodeSettingsBase):
         return bool(self.user_settings and self.user_settings.has_auth)
 
     @property
+    def complete(self):
+        return self.has_auth and self.figshare_id is not None
+
+    @property
     def linked_content(self):
         return {
             'id': self.figshare_id,

--- a/website/addons/figshare/tests/test_models.py
+++ b/website/addons/figshare/tests/test_models.py
@@ -122,6 +122,41 @@ class TestFileGuid(OsfTestCase):
         assert_false(other_created)
         assert_equal(guid, other)
 
+class TestNodeSettings(OsfTestCase):
+    def setUp(self):
+        super(TestNodeSettings, self).setUp()
+        self.user = AuthUserFactory()
+        self.project = ProjectFactory(creator=self.user)
+
+        self.project.add_addon('figshare', auth=Auth(self.user))
+        self.project.creator.add_addon('figshare')
+        self.node_settings = self.project.get_addon('figshare')
+        self.user_settings = self.project.creator.get_addon('figshare')
+        self.user_settings.oauth_access_token = 'legittoken'
+        self.user_settings.oauth_access_token_secret = 'legittoken'
+        self.user_settings.save()
+        self.node_settings.user_settings = self.user_settings
+        self.node_settings.figshare_id = '123456'
+        self.node_settings.figshare_type = 'project'
+        self.node_settings.figshare_title = 'singlefile'
+        self.node_settings.save()
+
+    def test_complete_true(self):
+        assert_true(self.node_settings.has_auth)
+        assert_true(self.node_settings.complete)
+
+    def test_complete_false(self):
+        self.node_settings.figshare_id = None
+
+        assert_true(self.node_settings.has_auth)
+        assert_false(self.node_settings.complete)
+
+    def test_complete_auth_false(self):
+        self.node_settings.user_settings = None
+
+        assert_false(self.node_settings.has_auth)
+        assert_false(self.node_settings.complete)
+
 class TestCallbacks(OsfTestCase):
 
     def setUp(self):

--- a/website/addons/github/model.py
+++ b/website/addons/github/model.py
@@ -269,13 +269,6 @@ class AddonGitHubNodeSettings(AddonNodeSettingsBase):
             return '/'.join([self.user, self.repo])
 
     @property
-    def complete(self):
-        return (
-            self.user and self.repo and
-            self.user_settings and self.user_settings.has_auth
-        )
-
-    @property
     def is_private(self):
         connection = GitHub.from_settings(self.user_settings)
         return connection.repo(user=self.user, repo=self.repo).private

--- a/website/addons/github/model.py
+++ b/website/addons/github/model.py
@@ -204,6 +204,10 @@ class AddonGitHubNodeSettings(AddonNodeSettingsBase):
     def has_auth(self):
         return bool(self.user_settings and self.user_settings.has_auth)
 
+    @property
+    def complete(self):
+        return self.has_auth and self.repo is not None and self.user is not None
+
     def find_or_create_file_guid(self, path):
         try:
             return GithubGuidFile.find_one(

--- a/website/addons/github/tests/test_models.py
+++ b/website/addons/github/tests/test_models.py
@@ -14,7 +14,7 @@ from framework.auth import Auth
 
 from website.addons.github.exceptions import NotFoundError
 from website.addons.github import settings as github_settings
-from website.addons.github.exceptions import NotFoundError, TooBigToRenderError
+from website.addons.github.exceptions import TooBigToRenderError
 from website.addons.github.tests.factories import GitHubOauthSettingsFactory
 from website.addons.github.model import AddonGitHubUserSettings
 from website.addons.github.model import AddonGitHubNodeSettings
@@ -366,6 +366,28 @@ class TestAddonGithubNodeSettings(OsfTestCase):
             user_settings=self.user_settings,
         )
         self.node_settings.save()
+
+    def test_complete_true(self):
+        assert_true(self.node_settings.has_auth)
+        assert_true(self.node_settings.complete)
+
+    def test_complete_false(self):
+        self.node_settings.user = None
+
+        assert_true(self.node_settings.has_auth)
+        assert_false(self.node_settings.complete)
+
+    def test_complete_repo_false(self):
+        self.node_settings.repo = None
+
+        assert_true(self.node_settings.has_auth)
+        assert_false(self.node_settings.complete)
+
+    def test_complete_auth_false(self):
+        self.node_settings.user_settings = None
+
+        assert_false(self.node_settings.has_auth)
+        assert_false(self.node_settings.complete)
 
     @mock.patch('website.addons.github.api.GitHub.delete_hook')
     def test_delete_hook(self, mock_delete_hook):

--- a/website/addons/googledrive/model.py
+++ b/website/addons/googledrive/model.py
@@ -253,6 +253,10 @@ class GoogleDriveNodeSettings(AddonNodeSettingsBase):
         """Whether an access token is associated with this node."""
         return bool(self.user_settings and self.user_settings.has_auth)
 
+    @property
+    def complete(self):
+        return self.has_auth and self.folder_id is not None
+
     def deauthorize(self, auth=None, add_log=True):
         """Remove user authorization from this node and log the event."""
         if add_log:

--- a/website/addons/googledrive/tests/test_models.py
+++ b/website/addons/googledrive/tests/test_models.py
@@ -278,6 +278,22 @@ class TestGoogleDriveNodeSettingsModel(OsfTestCase):
         assert_true(hasattr(node_settings, 'folder_name'))
         assert_equal(node_settings.user_settings.owner, self.user)
 
+    def test_complete_true(self):
+        assert_true(self.node_settings.has_auth)
+        assert_true(self.node_settings.complete)
+
+    def test_complete_false(self):
+        self.node_settings.folder_id = None
+
+        assert_true(self.node_settings.has_auth)
+        assert_false(self.node_settings.complete)
+
+    def test_complete_auth_false(self):
+        self.node_settings.user_settings = None
+
+        assert_false(self.node_settings.has_auth)
+        assert_false(self.node_settings.complete)
+
     def test_folder_defaults_to_none(self):
         node_settings = GoogleDriveNodeSettings(user_settings=self.user_settings)
         node_settings.save()

--- a/website/addons/osfstorage/model.py
+++ b/website/addons/osfstorage/model.py
@@ -75,6 +75,10 @@ class OsfStorageNodeSettings(AddonNodeSettingsBase):
     def has_auth(self):
         return True
 
+    @property
+    def complete(self):
+        return True
+
     def find_or_create_file_guid(self, path):
         return OsfStorageGuidFile.get_or_create(self.owner, path.lstrip('/'))
 

--- a/website/addons/osfstorage/tests/test_models.py
+++ b/website/addons/osfstorage/tests/test_models.py
@@ -75,6 +75,8 @@ class TestNodeSettingsModel(StorageTestCase):
     def test_fields(self):
         assert_true(self.node_settings._id)
         assert_is(self.node_settings.file_tree, None)
+        assert_is(self.node_settings.has_auth, True)
+        assert_is(self.node_settings.complete, True)
 
     def test_after_fork_copies_versions(self):
         path = 'jazz/dreamers-ball.mp3'

--- a/website/addons/s3/model.py
+++ b/website/addons/s3/model.py
@@ -106,6 +106,10 @@ class AddonS3NodeSettings(AddonNodeSettingsBase):
     def display_name(self):
         return u'{0}: {1}'.format(self.config.full_name, self.bucket)
 
+    @property
+    def complete(self):
+        return self.has_auth and self.bucket is not None
+
     def authorize(self, user_settings, save=False):
         self.user_settings = user_settings
         self.owner.add_log(

--- a/website/addons/s3/tests/test_model.py
+++ b/website/addons/s3/tests/test_model.py
@@ -59,6 +59,42 @@ class TestFileGuid(OsfTestCase):
         assert_false(created2)
         assert_equals(guid1, guid2)
 
+class TestNodeSettings(OsfTestCase):
+    def setUp(self):
+        super(TestNodeSettings, self).setUp()
+        self.user = UserFactory()
+        self.project = ProjectFactory(creator=self.user)
+
+        self.user.add_addon('s3')
+        self.project.add_addon('s3', auth=Auth(self.user))
+
+        self.user_settings = self.user.get_addon('s3')
+        self.node_settings = self.project.get_addon('s3')
+
+        self.user_settings.access_key = 'We-Will-Rock-You'
+        self.user_settings.secret_key = 'Idontknowanyqueensongs'
+        self.user_settings.save()
+
+        self.node_settings.bucket = 'Sheer-Heart-Attack'
+        self.node_settings.user_settings = self.user_settings
+        self.node_settings.save()
+
+    def test_complete_true(self):
+        assert_true(self.node_settings.has_auth)
+        assert_true(self.node_settings.complete)
+
+    def test_complete_false(self):
+        self.node_settings.bucket = None
+
+        assert_true(self.node_settings.has_auth)
+        assert_false(self.node_settings.complete)
+
+    def test_complete_auth_false(self):
+        self.node_settings.user_settings = None
+
+        assert_false(self.node_settings.has_auth)
+        assert_false(self.node_settings.complete)
+
 
 class TestCallbacks(OsfTestCase):
 


### PR DESCRIPTION
# Purpose
* Give slightly better error message to users when attempting to view files that are no longer in scope of their project
* Check if addons are unconfigured when attempting to view files

# The Error
* When attempting to view a file that's containing addon was unconfigured it would cause 500s.

# The Fix
* Adding the `complete` attribute to denote if an addon is completely configured and authorized

# Side Effects
* all addons must now implement a complete property
    * otherwise it will raise a `NotImplementedError` when it is called

# Notes
* mendeley and zotero should not require `complete` currently as they should never be in a view function that requires that property
* Tests on the way