### PR TITLE
Add logs on folder selection for citation addons.

### DIFF
--- a/website/addons/citations/provider.py
+++ b/website/addons/citations/provider.py
@@ -66,10 +66,9 @@ class CitationsProvider(object):
             ]
         }
 
-    def set_config(self, node_addon, user, external_list_id):
+    def set_config(self, node_addon, user, external_list_id, external_list_name, auth):
         # Ensure request has all required information
-
-        node_addon.set_target_folder(external_list_id)
+        node_addon.set_target_folder(external_list_id, external_list_name, auth)
 
     def add_user_auth(self, node_addon, user, external_account_id):
 

--- a/website/addons/mendeley/model.py
+++ b/website/addons/mendeley/model.py
@@ -245,7 +245,7 @@ class MendeleyNodeSettings(AddonOAuthNodeSettingsBase):
         self.mendeley_list_id = None
         return super(MendeleyNodeSettings, self).set_auth(*args, **kwargs)
 
-    def set_target_folder(self, mendeley_list_id):
+    def set_target_folder(self, mendeley_list_id, mendeley_list_name, auth):
         """Configure this addon to point to a Mendeley folder
 
         :param str mendeley_list_id:
@@ -264,3 +264,14 @@ class MendeleyNodeSettings(AddonOAuthNodeSettingsBase):
         # update this instance
         self.mendeley_list_id = mendeley_list_id
         self.save()
+
+        self.owner.add_log(
+            'mendeley_folder_selected',
+            params={
+                'project': self.owner.parent_id,
+                'node': self.owner._id,
+                'folder_id': mendeley_list_id,
+                'folder_name': mendeley_list_name,
+            },
+            auth=auth,
+        )

--- a/website/addons/mendeley/templates/log_templates.mako
+++ b/website/addons/mendeley/templates/log_templates.mako
@@ -1,0 +1,4 @@
+<script type="text/html" id="mendeley_folder_selected">
+linked Mendeley folder <span class="overflow">{{ params.folder_name }}</span> to {{ nodeType }}
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+</script>

--- a/website/addons/mendeley/tests/test_models.py
+++ b/website/addons/mendeley/tests/test_models.py
@@ -170,18 +170,25 @@ class MendeleyNodeSettingsTestCase(OsfTestCase):
         assert_is_none(self.node_settings.user_settings)
 
     def test_set_target_folder(self):
+        folder_id = 'fake-folder-id'
+        folder_name = 'fake-folder-name'
+
         external_account = ExternalAccountFactory()
         self.user.external_accounts.append(external_account)
         self.user.save()
 
         self.node_settings.set_auth(
             external_account=external_account,
-            user=self.user
+            user=self.user,
         )
 
         assert_is_none(self.node_settings.mendeley_list_id)
 
-        self.node_settings.set_target_folder('fake-folder-id')
+        self.node_settings.set_target_folder(
+            folder_id,
+            folder_name,
+            auth=Auth(user=self.user),
+        )
 
         # instance was updated
         assert_equal(
@@ -198,6 +205,11 @@ class MendeleyNodeSettingsTestCase(OsfTestCase):
                 metadata={'folder': 'fake-folder-id'}
             )
         )
+
+        log = self.node.logs[-1]
+        assert_equal(log.action, 'mendeley_folder_selected')
+        assert_equal(log.params['folder_id'], folder_id)
+        assert_equal(log.params['folder_name'], folder_name)
 
     def test_has_auth_false(self):
         external_account = ExternalAccountFactory()

--- a/website/addons/mendeley/tests/test_views.py
+++ b/website/addons/mendeley/tests/test_views.py
@@ -2,25 +2,25 @@
 
 from nose.tools import *  # noqa
 
-import responses
 import mock
-import unittest
+import responses
 
 from tests.base import OsfTestCase
 from tests.factories import AuthUserFactory, ProjectFactory
 
-import json
 import urlparse
 
+from framework.auth.core import Auth
+
 from website.addons.mendeley.tests.factories import (
-    MendeleyAccountFactory, MendeleyUserSettingsFactory,
+    MendeleyAccountFactory,
+    MendeleyUserSettingsFactory,
     MendeleyNodeSettingsFactory
 )
 
 from website.util import api_url_for
 from website.addons.mendeley import utils
 from website.addons.mendeley import views
-from website.addons.citations.utils import serialize_folder
 
 from utils import mock_responses
 
@@ -207,7 +207,7 @@ class MendeleyViewsTestCase(OsfTestCase):
         # JSON: everything a widget needs
         assert_false(self.node_addon.complete)
         assert_equal(self.node_addon.mendeley_list_id, None)
-        self.node_addon.set_target_folder('ROOT')
+        self.node_addon.set_target_folder('ROOT-ID', 'ROOT', auth=Auth(user=self.user))
         res = views.mendeley_widget(node_addon=self.node_addon,
                                     project=self.project,
                                     node=self.node,
@@ -215,7 +215,7 @@ class MendeleyViewsTestCase(OsfTestCase):
                                     pid=self.project._id,
                                     auth=self.user.auth)
         assert_true(res['complete'])
-        assert_equal(res['list_id'], 'ROOT')
+        assert_equal(res['list_id'], 'ROOT-ID')
 
     def test_widget_view_incomplete(self):
         # JSON: tell the widget when it hasn't been configured

--- a/website/addons/mendeley/views.py
+++ b/website/addons/mendeley/views.py
@@ -40,12 +40,14 @@ def mendeley_set_config(auth, node_addon, **kwargs):
 
     provider = MendeleyCitationsProvider()
     args = request.get_json()
-    #external_account_id = args.get('external_account_id')
     external_list_id = args.get('external_list_id')
+    external_list_name = args.get('external_list_name')
     provider.set_config(
         node_addon,
         auth.user,
         external_list_id,
+        external_list_name,
+        auth,
     )
     # TODO: Return a more useful response body, e.g. the serialized settings
     return {}

--- a/website/addons/zotero/model.py
+++ b/website/addons/zotero/model.py
@@ -190,7 +190,7 @@ class ZoteroNodeSettings(AddonOAuthNodeSettingsBase):
         self.zotero_list_id = None
         return super(ZoteroNodeSettings, self).clear_auth()
 
-    def set_target_folder(self, zotero_list_id):
+    def set_target_folder(self, zotero_list_id, zotero_list_name, auth):
         """Configure this addon to point to a Zotero folder
 
         :param str zotero_list_id:
@@ -209,3 +209,14 @@ class ZoteroNodeSettings(AddonOAuthNodeSettingsBase):
         # update this instance
         self.zotero_list_id = zotero_list_id
         self.save()
+
+        self.owner.add_log(
+            'zotero_folder_selected',
+            params={
+                'project': self.owner.parent_id,
+                'node': self.owner._id,
+                'folder_id': zotero_list_id,
+                'folder_name': zotero_list_name,
+            },
+            auth=auth,
+        )

--- a/website/addons/zotero/templates/log_templates.mako
+++ b/website/addons/zotero/templates/log_templates.mako
@@ -1,0 +1,4 @@
+<script type="text/html" id="zotero_folder_selected">
+linked Zotero folder <span class="overflow">{{ params.folder_name }}</span> to {{ nodeType }}
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+</script>

--- a/website/addons/zotero/tests/test_views.py
+++ b/website/addons/zotero/tests/test_views.py
@@ -2,18 +2,19 @@
 
 from nose.tools import *  # noqa
 
-import responses
 import mock
-import unittest
+import responses
 
 from tests.base import OsfTestCase
 from tests.factories import AuthUserFactory, ProjectFactory
 
-import json
 import urlparse
 
+from framework.auth.core import Auth
+
 from website.addons.zotero.tests.factories import (
-    ZoteroAccountFactory, ZoteroUserSettingsFactory,
+    ZoteroAccountFactory,
+    ZoteroUserSettingsFactory,
     ZoteroNodeSettingsFactory
 )
 
@@ -207,7 +208,7 @@ class ZoteroViewsTestCase(OsfTestCase):
         # JSON: everything a widget needs
         assert_false(self.node_addon.complete)
         assert_equal(self.node_addon.zotero_list_id, None)
-        self.node_addon.set_target_folder('ROOT')
+        self.node_addon.set_target_folder('ROOT-ID', 'ROOT', auth=Auth(user=self.user))
         res = views.zotero_widget(node_addon=self.node_addon,
                                     project=self.project,
                                     node=self.node,
@@ -215,7 +216,7 @@ class ZoteroViewsTestCase(OsfTestCase):
                                     pid=self.project._id,
                                     auth=self.user.auth)
         assert_true(res['complete'])
-        assert_equal(res['list_id'], 'ROOT')
+        assert_equal(res['list_id'], 'ROOT-ID')
 
     def test_widget_view_incomplete(self):
         # JSON: tell the widget when it hasn't been configured

--- a/website/addons/zotero/views.py
+++ b/website/addons/zotero/views.py
@@ -40,12 +40,14 @@ def zotero_set_config(auth, node_addon, **kwargs):
 
     provider = ZoteroCitationsProvider()
     args = request.get_json()
-    #external_account_id = args.get('external_account_id')
     external_list_id = args.get('external_list_id')
+    external_list_name = args.get('external_list_name')
     provider.set_config(
         node_addon,
         auth.user,
         external_list_id,
+        external_list_name,
+        auth,
     )
     return {}
 

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2160,8 +2160,8 @@ class Node(GuidStoredObject, AddonModelMixin):
         :return bool: Add-on was deleted
 
         """
-        rv = super(Node, self).delete_addon(addon_name, auth, _force)
-        if rv:
+        ret = super(Node, self).delete_addon(addon_name, auth, _force)
+        if ret:
             config = settings.ADDONS_AVAILABLE_DICT[addon_name]
             self.add_log(
                 action=NodeLog.ADDON_REMOVED,
@@ -2175,7 +2175,7 @@ class Node(GuidStoredObject, AddonModelMixin):
             )
             self.save()
             # TODO: save here or outside the conditional? @mambocab
-        return rv
+        return ret
 
     def callback(self, callback, recursive=False, *args, **kwargs):
         """Invoke callbacks of attached add-ons and collect messages.

--- a/website/static/js/citationsFolderPickerViewModel.js
+++ b/website/static/js/citationsFolderPickerViewModel.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var ko = require('knockout');
 require('knockout-punches');
 var $ = require('jquery');
@@ -282,10 +284,10 @@ CitationsFolderPickerViewModel.prototype.submitSettings = function() {
         self.changeMessage(self.messages.SUBMIT_SETTINGS_ERROR(), 'text-danger');
     }
 
-
     $osf.putJSON(self.urls().config, {
             external_account_id: self.userAccountId(),
-            external_list_id: self.selected().id
+            external_list_id: self.selected().id,
+            external_list_name: self.selected().name
         })
         .done(onSubmitSuccess)
         .fail(onSubmitError);


### PR DESCRIPTION
# Purpose
Citation addons don't currently have logs for selecting a folder, but they should. This patch adds logs for folder selection for Mendeley and Zotero.

# Changes
* Add logs on `set_target_folder`
* Add Mendeley and Zotero log templates
* Update tests

Side effects
None expected

Note: As discussed with @lyndsysimon, addon logging should be generalized, but this can happen in a future patch.