### PR TITLE
Add a sidebar to the share search page

### DIFF
--- a/website/static/css/share-search.css
+++ b/website/static/css/share-search.css
@@ -74,11 +74,11 @@
   border-bottom: 1px solid #ddd;
   padding-bottom: 15px;
 }
-.searchContent {
+.search-content {
   margin-top: 30px;
 }
 
-.providerFilter {
+.provider-filter {
   background: #f5f5f5;
   margin: 4px 0;
   padding: 9px 8px;
@@ -86,12 +86,12 @@
   cursor: pointer;
 }
 
-.providerFilter.inFilter {
+.provider-filter.in-filter {
   background: #337ab7;
   color: white;
 }
 
-.sidebarHeader {
+.sidebar-header {
   margin: 12px 0 7px 0;
   font-size: 19px;
   border-bottom: 1px solid #eee;
@@ -99,7 +99,7 @@
   font-weight: 300;
 }
 
-.li.renderFilter {
+.li.render-filter {
   padding: 1px;
   font-size: 15px;
 }

--- a/website/static/css/share-search.css
+++ b/website/static/css/share-search.css
@@ -69,7 +69,7 @@
   /* border-top-color: #e4e4e4 */
 }
 
-.searchHelper {
+.search-helper {
   margin-bottom: 40px;
   border-bottom: 1px solid #ddd;
   padding-bottom: 15px;

--- a/website/static/js/share/index.js
+++ b/website/static/js/share/index.js
@@ -82,7 +82,7 @@ ShareApp.controller = function() {
 };
 
 var renderSort = function(ctrl){
-        return m('.btn-group', {style: {'float': 'right'}}, [
+        return m('.btn-group.pull-right', [
             m('button.btn.btn-default.dropdown-toggle', {
                     'data-toggle': 'dropdown',
                     'aria-expanded': 'false'

--- a/website/static/js/share/index.js
+++ b/website/static/js/share/index.js
@@ -32,7 +32,7 @@ ShareApp.view = function(ctrl) {
             SearchBar.view(ctrl.searchBarController),
             Stats.view(ctrl.statsController),
             ctrl.vm.results !== null ? renderSort(ctrl) : [],
-            m('.row.searchContent', [
+            m('.row.search-content', [
                m('.col-md-2.col-lg-3', [
                     SideBar.view(ctrl.sideBarController)
                 ]),

--- a/website/static/js/share/index.js
+++ b/website/static/js/share/index.js
@@ -5,12 +5,12 @@ require('../../css/share-search.css');
 
 var m = require('mithril');
 var $osf = require('js/osfHelpers');
-var Stats = require('../share/stats.js');
-var utils = require('../share/utils.js');
-var SideBar = require('../share/sideBar.js');
-var Results = require('../share/results.js');
+var Stats = require('../share/stats');
+var utils = require('../share/utils');
+var SideBar = require('../share/sideBar');
+var Results = require('../share/results');
 var History = require('exports?History!history');
-var SearchBar = require('../share/searchBar.js');
+var SearchBar = require('../share/searchBar');
 var MESSAGES = JSON.parse(require('raw!../share/messages.json'));
 
 var ShareApp = {};

--- a/website/static/js/share/index.js
+++ b/website/static/js/share/index.js
@@ -5,13 +5,13 @@ require('../../css/share-search.css');
 
 var m = require('mithril');
 var $osf = require('js/osfHelpers');
-var Stats = require('../share/stats');
-var utils = require('../share/utils');
-var SideBar = require('../share/sideBar');
-var Results = require('../share/results');
+var Stats = require('./stats');
+var utils = require('./utils');
+var SideBar = require('./sideBar');
+var Results = require('./results');
 var History = require('exports?History!history');
-var SearchBar = require('../share/searchBar');
-var MESSAGES = JSON.parse(require('raw!../share/messages.json'));
+var SearchBar = require('./searchBar');
+var MESSAGES = JSON.parse(require('raw!./messages.json'));
 
 var ShareApp = {};
 

--- a/website/static/js/share/index.js
+++ b/website/static/js/share/index.js
@@ -23,6 +23,9 @@ ShareApp.ViewModel = function() {
     self.count = 0;
     self.results = null;
     self.query = m.prop($osf.urlParams().q || '');
+    self.vm.sort = m.prop($osf.urlParams().sort || 'Relevance');
+    self.vm.requiredFilters = $osf.urlParams().required ? $osf.urlParams().required.split('|') : [];
+    self.vm.optionalFilters = $osf.urlParams().optional ? $osf.urlParams().optional.split('|') : [];
 };
 
 
@@ -49,11 +52,6 @@ ShareApp.controller = function() {
     var self = this;
 
     self.vm = new ShareApp.ViewModel(self.vm);
-
-    self.vm.sort = m.prop($osf.urlParams().sort || 'Relevance');
-    self.vm.requiredFilters = $osf.urlParams().required ? $osf.urlParams().required.split('|') : [];
-    self.vm.optionalFilters = $osf.urlParams().optional ? $osf.urlParams().optional.split('|') : [];
-
 
     m.request({
         method: 'get',

--- a/website/static/js/share/index.js
+++ b/website/static/js/share/index.js
@@ -83,7 +83,7 @@ ShareApp.controller = function() {
 
 var renderSort = function(ctrl){
         return m('.btn-group', {style: {'float': 'right'}}, [
-            m('button.btn.btn-default.dropdown-taggle', {
+            m('button.btn.btn-default.dropdown-toggle', {
                     'data-toggle': 'dropdown',
                     'aria-expanded': 'false'
                 }, ['Sort by: ' + ctrl.vm.sort() + ' ', m('span.caret')]

--- a/website/static/js/share/index.js
+++ b/website/static/js/share/index.js
@@ -50,6 +50,11 @@ ShareApp.controller = function() {
 
     self.vm = new ShareApp.ViewModel(self.vm);
 
+    self.vm.sort = m.prop($osf.urlParams().sort || 'Relevance');
+    self.vm.requiredFilters = $osf.urlParams().required ? $osf.urlParams().required.split('|') : [];
+    self.vm.optionalFilters = $osf.urlParams().optional ? $osf.urlParams().optional.split('|') : [];
+
+
     m.request({
         method: 'get',
         background: false,

--- a/website/static/js/share/results.js
+++ b/website/static/js/share/results.js
@@ -3,7 +3,7 @@
 var $ = require('jquery');
 var m = require('mithril');
 var $osf = require('js/osfHelpers');
-var utils = require('./utils.js');
+var utils = require('./utils');
 var Results = {};
 
 

--- a/website/static/js/share/results.js
+++ b/website/static/js/share/results.js
@@ -10,7 +10,7 @@ var Results = {};
 Results.view = function(ctrl) {
     var res = [];
     var len = 0;
-    if (ctrl.vm.results !== null){
+    if (ctrl.vm.results){
         res = $.map(ctrl.vm.results, ctrl.renderResult);
         len = ctrl.vm.results.length;
     }

--- a/website/static/js/share/searchBar.js
+++ b/website/static/js/share/searchBar.js
@@ -3,7 +3,7 @@
 var $ = require('jquery');
 var m = require('mithril');
 var $osf = require('js/osfHelpers');
-var utils = require('./utils.js');
+var utils = require('./utils');
 
 var SearchBar = {};
 

--- a/website/static/js/share/sideBar.js
+++ b/website/static/js/share/sideBar.js
@@ -10,7 +10,7 @@ SideBar.view = function(ctrl){
         return [];
     }
     return m('', [
-            m('.sidebarHeader',  ['Active filters:',
+            m('.sidebar-header',  ['Active filters:',
               (ctrl.vm.optionalFilters.length > 0 || ctrl.vm.requiredFilters.length > 0) ? m('a', {
                   style: {
                       'float': 'right'
@@ -20,8 +20,8 @@ SideBar.view = function(ctrl){
                       utils.search(ctrl.vm);
                     }
               }, ['Clear ', m('i.fa.fa-close')]) : []]),
-            m('ul', {style:{'list-style-type': 'none', 'padding-left': 0}}, ctrl.renderFilters()),
-            m('.sidebarHeader', 'Providers:'),
+            m('ul', {style:{'list-style-type': 'none', 'padding-left': 0}}, ctrl.render-filters()),
+            m('.sidebar-header', 'Providers:'),
             m('ul', {style:{'list-style-type': 'none', 'padding-left': 0}}, ctrl.renderProviders()),
     ]);
 };
@@ -52,9 +52,9 @@ SideBar.controller = function(vm) {
         });
     };
 
-    self.renderFilters = function(){
+    self.render-filters = function(){
         return $.map(self.vm.optionalFilters.concat(self.vm.requiredFilters), function(filter){
-            return m('li.renderFilter', [
+            return m('li.render-filter', [
                 m('a', {
                     onclick: function(event){
                         utils.removeFilter(self.vm, filter);
@@ -71,12 +71,12 @@ SideBar.controller = function(vm) {
         }).sort(function(a,b){
                 return a.long_name > b.long_name ? 1: -1;
         }), function(result, index){
-            var checked = (self.vm.optionalFilters.indexOf('source:' + result.short_name) > -1 || self.vm.requiredFilters.indexOf('source:' + result.short_name) > -1) ? 'inFilter' : '';
+            var checked = (self.vm.optionalFilters.indexOf('source:' + result.short_name) > -1 || self.vm.requiredFilters.indexOf('source:' + result.short_name) > -1) ? 'in-filter' : '';
 
-            return m('li', m('.providerFilter', {
+            return m('li', m('.provider-filter', {
                     'class': checked,
                     onclick: function(cb){
-                        if (checked === 'inFilter') {
+                        if (checked === 'in-filter') {
                             utils.removeFilter(self.vm, 'source:' + result.short_name);
                         } else {
                             utils.updateFilter(self.vm, 'source:' + result.short_name);

--- a/website/static/js/share/sideBar.js
+++ b/website/static/js/share/sideBar.js
@@ -20,7 +20,7 @@ SideBar.view = function(ctrl){
                       utils.search(ctrl.vm);
                     }
               }, ['Clear ', m('i.fa.fa-close')]) : []]),
-            m('ul', {style:{'list-style-type': 'none', 'padding-left': 0}}, ctrl.render-filters()),
+            m('ul', {style:{'list-style-type': 'none', 'padding-left': 0}}, ctrl.renderFilters()),
             m('.sidebar-header', 'Providers:'),
             m('ul', {style:{'list-style-type': 'none', 'padding-left': 0}}, ctrl.renderProviders()),
     ]);
@@ -52,7 +52,7 @@ SideBar.controller = function(vm) {
         });
     };
 
-    self.render-filters = function(){
+    self.renderFilters = function(){
         return $.map(self.vm.optionalFilters.concat(self.vm.requiredFilters), function(filter){
             return m('li.render-filter', [
                 m('a', {
@@ -65,26 +65,33 @@ SideBar.controller = function(vm) {
         });
     };
 
-    self.renderProviders = function () {
-        return $.map($.map(Object.keys(self.vm.ProviderMap), function(result, index){
+    self.renderProvider = function(result, index) {
+        var checked = (self.vm.optionalFilters.indexOf('source:' + result.short_name) > -1 || self.vm.requiredFilters.indexOf('source:' + result.short_name) > -1) ? 'in-filter' : '';
+
+        return m('li', m('.provider-filter', {
+                'class': checked,
+                onclick: function(cb){
+                    if (checked === 'in-filter') {
+                        utils.removeFilter(self.vm, 'source:' + result.short_name);
+                    } else {
+                        utils.updateFilter(self.vm, 'source:' + result.short_name);
+                    }
+                }
+            }, result.long_name
+        ));
+
+    };
+
+    self.sortProviders = function() {
+        return $.map(Object.keys(self.vm.ProviderMap), function(result, index){
             return self.vm.ProviderMap[result];
         }).sort(function(a,b){
                 return a.long_name > b.long_name ? 1: -1;
-        }), function(result, index){
-            var checked = (self.vm.optionalFilters.indexOf('source:' + result.short_name) > -1 || self.vm.requiredFilters.indexOf('source:' + result.short_name) > -1) ? 'in-filter' : '';
-
-            return m('li', m('.provider-filter', {
-                    'class': checked,
-                    onclick: function(cb){
-                        if (checked === 'in-filter') {
-                            utils.removeFilter(self.vm, 'source:' + result.short_name);
-                        } else {
-                            utils.updateFilter(self.vm, 'source:' + result.short_name);
-                        }
-                    }
-                }, result.long_name
-            ));
         });
+    };
+
+    self.renderProviders = function () {
+        return $.map(self.sortProviders(), self.renderProvider);
     };
 };
 

--- a/website/static/js/share/sideBar.js
+++ b/website/static/js/share/sideBar.js
@@ -1,7 +1,7 @@
 var $ = require('jquery');
 var m = require('mithril');
 var $osf = require('js/osfHelpers');
-var utils = require('./utils.js');
+var utils = require('./utils');
 
 var SideBar = {};
 

--- a/website/static/js/share/sideBar.js
+++ b/website/static/js/share/sideBar.js
@@ -30,7 +30,7 @@ SideBar.controller = function(vm) {
     var self = this;
     self.vm = vm;
 
-    self.vm.sort = $osf.urlParams().sort ? m.prop($osf.urlParams().sort) : m.prop('Relevance');
+    self.vm.sort = m.prop($osf.urlParams().sort || 'Relevance');
     self.vm.requiredFilters = $osf.urlParams().required ? $osf.urlParams().required.split('|') : [];
     self.vm.optionalFilters = $osf.urlParams().optional ? $osf.urlParams().optional.split('|') : [];
 

--- a/website/static/js/share/sideBar.js
+++ b/website/static/js/share/sideBar.js
@@ -30,10 +30,6 @@ SideBar.controller = function(vm) {
     var self = this;
     self.vm = vm;
 
-    self.vm.sort = m.prop($osf.urlParams().sort || 'Relevance');
-    self.vm.requiredFilters = $osf.urlParams().required ? $osf.urlParams().required.split('|') : [];
-    self.vm.optionalFilters = $osf.urlParams().optional ? $osf.urlParams().optional.split('|') : [];
-
     self.vm.sortMap = {
         'Date': 'dateUpdated',
         Relevance: null

--- a/website/static/js/share/stats.js
+++ b/website/static/js/share/stats.js
@@ -117,7 +117,7 @@ Stats.controller = function(vm) {
     };
 
     self.loadStats = function(){
-        utils.loadStats(self.vm);
+        return utils.loadStats(self.vm);
     };
 
     utils.onSearch(self.loadStats);

--- a/website/static/js/share/stats.js
+++ b/website/static/js/share/stats.js
@@ -68,7 +68,7 @@ function timeGraph (data) {
 
 Stats.view = function(ctrl) {
     return [
-        m('.row.searchHelper', {style: {color: 'darkgrey'}},
+        m('.row.search-helper', {style: {color: 'darkgrey'}},
             m('.col-xs-12.col-lg-8.col-lg-offset-2', [
                 m('.col-md-4', m('p.text-center', ctrl.vm.latestDate ? utils.formatNumber(ctrl.vm.totalCount) + ' events as of ' + new Date().toDateString() : '')),
                 m('.col-md-4', m('p.text-center', (ctrl.vm.query() && ctrl.vm.query().length > 0) ? 'Found ' + utils.formatNumber(ctrl.vm.count) + ' events in ' + ctrl.vm.time + ' seconds' : '')),

--- a/website/static/js/share/stats.js
+++ b/website/static/js/share/stats.js
@@ -4,7 +4,7 @@ var c3 = require('c3');
 var m = require('mithril');
 var $ = require('jquery');
 var $osf = require('js/osfHelpers');
-var utils = require('./utils.js');
+var utils = require('./utils');
 
 var Stats = {};
 

--- a/website/static/js/share/utils.js
+++ b/website/static/js/share/utils.js
@@ -94,7 +94,7 @@ var search = function(vm) {
         sort: vm.sort()
     }, 'OSF | SHARE', '?'+ buildURLParams(vm));
 
-    loadMore(vm);
+    return loadMore(vm);
 };
 
 var buildURLParams = function(vm){

--- a/website/static/js/share/utils.js
+++ b/website/static/js/share/utils.js
@@ -98,9 +98,10 @@ utils.search = function(vm) {
         History.pushState({}, 'OSF | SHARE', '?');
         ret.resolve(null);
     }
-    if (utils.buildQuery(vm).length === 0) {
+    else if (utils.buildQuery(vm).length === 0) {
         ret.resolve(null);
     }
+    else {
     vm.page = 0;
     vm.results = [];
     History.pushState({
@@ -111,10 +112,11 @@ utils.search = function(vm) {
     }, 'OSF | SHARE', '?'+ utils.buildURLParams(vm));
 
     utils.loadMore(vm)
-        .done(function(data) {
+        .then(function(data) {
             utils.updateVM(vm, data);
             ret.resolve(vm);
         });
+    }
     return ret.promise;
 };
 

--- a/website/static/js/tests/share/utils.test.js
+++ b/website/static/js/tests/share/utils.test.js
@@ -84,7 +84,7 @@ describe('share/utils', () => {
             sort = 'sort';
         });
 
-        it('build url parameters of the form ?q=&required=&optional&sort=', () => {
+        it('builds url parameters of the form ?q=&required=&optional&sort=', () => {
             query = '1';
             vm.requiredFilters.push('2');
             vm.optionalFilters.push('3');
@@ -111,6 +111,35 @@ describe('share/utils', () => {
             assert.deepEqual('required=2&optional=3&sort=4', utils.buildURLParams(vm));
 
         });
+    });
 
+    describe('#buildQuery', () => {
+        before(() => {
+            query = 'toast';
+        });
+        after(() => {
+            query = '';
+        });
+        afterEach(() => {
+            vm.optionalFilters = [];
+            vm.requiredFilters = [];
+        });
+
+
+        it('makes a query like query AND (optional) AND (required)', () => {
+            vm.optionalFilters.push('1');
+            vm.requiredFilters.push('2');
+
+            assert.deepEqual('toast AND (1) AND (2)', utils.buildQuery(vm));
+        });
+
+        it('doesn\'t create invalid queries with empty filters', () => {
+            vm.optionalFilters.push('1');
+            assert.deepEqual('toast AND (1)', utils.buildQuery(vm));
+
+            vm.optionalFilters = [];
+            vm.requiredFilters.push('2');
+            assert.deepEqual('toast AND (2)', utils.buildQuery(vm));
+        });
     });
 });

--- a/website/static/js/tests/share/utils.test.js
+++ b/website/static/js/tests/share/utils.test.js
@@ -89,26 +89,26 @@ describe('share/utils', () => {
             vm.requiredFilters.push('2');
             vm.optionalFilters.push('3');
             sort = '4';
-            assert.deepEqual('q=1&required=2&optional=3&sort=4', utils.buildURLParams(vm));
+            assert.equal('q=1&required=2&optional=3&sort=4', utils.buildURLParams(vm));
         });
 
         it('doesn\'t display parameters unless they have meaningful values', () => {
             query = '1';
             vm.requiredFilters.push('2');
             sort = '4';
-            assert.deepEqual('q=1&required=2&sort=4', utils.buildURLParams(vm));
+            assert.equal('q=1&required=2&sort=4', utils.buildURLParams(vm));
 
             vm.optionalFilters.push('3');
             vm.requiredFilters = [];
-            assert.deepEqual('q=1&optional=3&sort=4', utils.buildURLParams(vm));
+            assert.equal('q=1&optional=3&sort=4', utils.buildURLParams(vm));
 
             vm.requiredFilters.push('2');
             sort = null;
-            assert.deepEqual('q=1&required=2&optional=3', utils.buildURLParams(vm));
+            assert.equal('q=1&required=2&optional=3', utils.buildURLParams(vm));
 
             sort = '4';
             query = null;
-            assert.deepEqual('required=2&optional=3&sort=4', utils.buildURLParams(vm));
+            assert.equal('required=2&optional=3&sort=4', utils.buildURLParams(vm));
 
         });
     });
@@ -130,16 +130,16 @@ describe('share/utils', () => {
             vm.optionalFilters.push('1');
             vm.requiredFilters.push('2');
 
-            assert.deepEqual('toast AND (1) AND (2)', utils.buildQuery(vm));
+            assert.equal('toast AND (1) AND (2)', utils.buildQuery(vm));
         });
 
         it('doesn\'t create invalid queries with empty filters', () => {
             vm.optionalFilters.push('1');
-            assert.deepEqual('toast AND (1)', utils.buildQuery(vm));
+            assert.equal('toast AND (1)', utils.buildQuery(vm));
 
             vm.optionalFilters = [];
             vm.requiredFilters.push('2');
-            assert.deepEqual('toast AND (2)', utils.buildQuery(vm));
+            assert.equal('toast AND (2)', utils.buildQuery(vm));
         });
     });
 

--- a/website/static/js/tests/share/utils.test.js
+++ b/website/static/js/tests/share/utils.test.js
@@ -5,39 +5,112 @@ var assert = require('chai').assert;
 var $osf = require('js/osfHelpers');
 
 var utils = require('js/share/utils');
+var testUtils = require('tests/utils');
 
 var noop = function(){};
 
 var resultsLoadingSpy = new sinon.spy();
 describe('share/utils', () => {
+    var query = '';
+    var sort = 'sort';
+
     var vm = {
         page: 0,
         sort: function(){
-            return 'sort';
+            return sort;
         },
         sortMap: {
             sort: 'sort'
         },
-        resultsLoading: resultsLoadingSpy
+        resultsLoading: resultsLoadingSpy,
+        query: function(){return query;},
+        optionalFilters: [],
+        requiredFilters: []
     };
 
     describe('#loadMore', () => {
+        var server;
         var stub;
+
+        var emptyResponse = {
+            count: 0,
+            time: 0,
+            results: []
+        };
+
+        var endpoints = [{
+            method: 'GET',
+            url: /\/api\/v1\/share\/.*/,
+            response: emptyResponse
+        }];
+
         before(() => {
+            query = '';
+
+            server = testUtils.createServer(sinon, endpoints);
             stub = sinon.stub(utils, 'buildQuery', function(){
-                return '';
+                return query;
             });
         });
         after(() => {
             utils.buildQuery.restore();
+            server.restore();
         });
 
-        it('returns a promise that resolves to null when buildQuery returns and empty query', (done) => {
+        it('returns a promise that resolves to null when buildQuery returns an empty query', (done) => {
             utils.loadMore(vm)
                 .then(function(data){
                     assert.isNull(data);
                     done();
                 });
         });
+
+        it('returns a promise that resolves to new data when called with a query', (done) => {
+            query = 'q=toast';
+            utils.loadMore(vm)
+                .then(function(data){
+                    assert.deepEqual(data, emptyResponse);
+                    done();
+                });
+        });
+    });
+
+    describe('#buildURLParams', () => {
+
+        afterEach(() => {
+            vm.optionalFilters = [];
+            vm.requiredFilters = [];
+            query = '';
+            sort = 'sort';
+        });
+
+        it('build url parameters of the form ?q=&required=&optional&sort=', () => {
+            query = '1';
+            vm.requiredFilters.push('2');
+            vm.optionalFilters.push('3');
+            sort = '4';
+            assert.deepEqual('q=1&required=2&optional=3&sort=4', utils.buildURLParams(vm));
+        });
+
+        it('doesn\'t display parameters unless they have meaningful values', () => {
+            query = '1';
+            vm.requiredFilters.push('2');
+            sort = '4';
+            assert.deepEqual('q=1&required=2&sort=4', utils.buildURLParams(vm));
+
+            vm.optionalFilters.push('3');
+            vm.requiredFilters = [];
+            assert.deepEqual('q=1&optional=3&sort=4', utils.buildURLParams(vm));
+
+            vm.requiredFilters.push('2');
+            sort = null;
+            assert.deepEqual('q=1&required=2&optional=3', utils.buildURLParams(vm));
+
+            sort = '4';
+            query = null;
+            assert.deepEqual('required=2&optional=3&sort=4', utils.buildURLParams(vm));
+
+        });
+
     });
 });

--- a/website/static/js/tests/share/utils.test.js
+++ b/website/static/js/tests/share/utils.test.js
@@ -142,4 +142,69 @@ describe('share/utils', () => {
             assert.deepEqual('toast AND (2)', utils.buildQuery(vm));
         });
     });
+
+
+    describe('#updateFilter', () => {
+        var stub;
+
+        before(() => {
+            stub = sinon.stub(utils, 'search', function(){});
+        });
+
+        after(() => {
+            utils.search.restore();
+            vm.requiredFilters = [];
+            vm.optionalFilters = [];
+        });
+
+        it('adds filters to the optionalFilters unless it is already there or it is required', () => {
+            utils.updateFilter(vm, 'test');
+            assert.deepEqual(['test'], vm.optionalFilters);
+
+            utils.updateFilter(vm, 'test');
+            assert.deepEqual(['test'], vm.optionalFilters);
+
+            utils.updateFilter(vm, 'test', true);
+            assert.deepEqual(['test'], vm.optionalFilters);
+        });
+
+        it('adds filters to the required filters only if required is true and the filter is not already there', () => {
+            utils.updateFilter(vm, 'test', true);
+            assert.deepEqual(['test'], vm.requiredFilters);
+
+            utils.updateFilter(vm, 'test', true);
+            assert.deepEqual(['test'], vm.requiredFilters);
+
+            utils.updateFilter(vm, 'toast');
+            assert.deepEqual(['test'], vm.requiredFilters);
+        });
+
+    });
+
+    describe('#removeFilter', () => {
+        var stub;
+
+        before(() => {
+            stub = sinon.stub(utils, 'search', function(){});
+        });
+
+        after(() => {
+            utils.search.restore();
+        });
+
+        it('removes filters from optional and required', () => {
+            utils.updateFilter(vm, 'test');
+            utils.updateFilter(vm, 'test', true);
+            assert.deepEqual(['test'], vm.optionalFilters);
+            assert.deepEqual(['test'], vm.requiredFilters);
+
+            utils.removeFilter(vm, 'test');
+            assert.deepEqual([], vm.optionalFilters);
+            assert.deepEqual([], vm.requiredFilters);
+            utils.removeFilter(vm, 'test');
+            assert.deepEqual([], vm.optionalFilters);
+            assert.deepEqual([], vm.requiredFilters);
+        });
+
+    });
 });


### PR DESCRIPTION
Purposes
--------------
Update functionality and prettiness of SHARE UI

Changes
-------------
- [x] Add filters to a sidebar that allows filtering out providers
- [x] Adds optional filters (via the providers on the right), as well as required filters (clicking the graph, clicking tags, clicking contributors)
- [x] Add the filter lists and such to the history.js state, to make it easier to recreate state on page load
- [x] Make the checkboxes populate on page load
- [x] Get the sorting working 
  - [x] and make it a query parameter
- [x] Make it pretty
- [x] Graphs should not unload and should always display correct counts
- [x] Stop results from rendering twice when being linked to a page with less than 10 results
- [x] Fix safari setting the number of providers to 30 in the graph every time regardless of results
- [x] Tests


Side effects
----------------
None anticipated