### PR TITLE
Feature: Add file tree navigation to file detail page

### DIFF
--- a/website/addons/github/static/githubFangornConfig.js
+++ b/website/addons/github/static/githubFangornConfig.js
@@ -147,7 +147,7 @@ function _fangornLazyLoadOnLoad (tree, event) {
     tree.children.forEach(function(item) {
         Fangorn.Utils.inheritFromParent(item, tree, ['branch']);
     });
-    Fangorn.Utils.findCurrentFileID.call(tb, tree, window.contextVars.node.id, window.contextVars.file);
+    Fangorn.Utils.setCurrentFileID.call(tb, tree, window.contextVars.node.id, window.contextVars.file);
     // Do not scroll if user toggles a folder (mouseclick event)
     if(!event){
         Fangorn.Utils.scrollToFile.call(tb, tb.currentFileID);

--- a/website/addons/github/static/githubFangornConfig.js
+++ b/website/addons/github/static/githubFangornConfig.js
@@ -148,6 +148,7 @@ function _fangornLazyLoadOnLoad (tree, event) {
         Fangorn.Utils.inheritFromParent(item, tree, ['branch']);
     });
     Fangorn.Utils.findCurrentFileID.call(tb, tree, window.contextVars.node.id, window.contextVars.file);
+    // Do not scroll if user toggles a folder (mouseclick event)
     if(!event){
         Fangorn.Utils.scrollToFile.call(tb, tb.currentFileID);
     }

--- a/website/addons/github/static/githubFangornConfig.js
+++ b/website/addons/github/static/githubFangornConfig.js
@@ -147,7 +147,7 @@ function _fangornLazyLoadOnLoad (tree) {
     tree.children.forEach(function(item) {
         Fangorn.Utils.inheritFromParent(item, tree, ['branch']);
     });
-    Fangorn.Utils.findCurrentFileID.call(tb, tree, window.contextVars.node.id, window.contextVars.file);
+    Fangorn.Utils.setCurrentFileID.call(tb, tree, window.contextVars.node.id, window.contextVars.file);
     Fangorn.Utils.scrollToFile.call(tb, tb.currentFileID);
 }
 

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -841,7 +841,7 @@ function expandStateLoad(item) {
  * @param nodeID Current node._id
  * @param file window.contextVars.file object
  */
-function findCurrentFileID(tree, nodeID, file) {
+function setCurrentFileID(tree, nodeID, file) {
     var tb = this;
     if (tb.options.folderIndex !== undefined && tb.options.folderArray !== undefined && tb.options.folderIndex < tb.options.folderArray.length) {
         for (var i = 0; i < tree.children.length; i++) {
@@ -1047,7 +1047,7 @@ Fangorn.Utils = {
     inheritFromParent: inheritFromParent,
     resolveconfigOption: resolveconfigOption,
     reapplyTooltips : reapplyTooltips,
-    findCurrentFileID: findCurrentFileID,
+    setCurrentFileID: setCurrentFileID,
     scrollToFile: scrollToFile
 };
 

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -871,7 +871,7 @@ function scrollToFile(fileID) {
         var visibleIndex = tb.visibleIndexes.indexOf(index);
         if (visibleIndex !== -1 && visibleIndex > tb.showRange.length - 2) {
             var scrollTo = visibleIndex * tb.options.rowHeight;
-            $('#tb-tbody').scrollTop(scrollTo);
+            this.select('#tb-tbody').scrollTop(scrollTo);
         }
     }
 }

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -843,11 +843,11 @@ function expandStateLoad(item) {
  */
 function setCurrentFileID(tree, nodeID, file) {
     var tb = this;
-    if (tb.options.folderIndex !== undefined && tb.options.folderArray !== undefined && tb.options.folderIndex < tb.options.folderArray.length) {
+    if (tb.fangornFolderIndex !== undefined && tb.fangornFolderArray !== undefined && tb.fangornFolderIndex < tb.fangornFolderArray.length) {
         for (var i = 0; i < tree.children.length; i++) {
             var child = tree.children[i];
-            if (nodeID === child.data.nodeId && child.data.provider === file.provider && child.data.name === tb.options.folderArray[tb.options.folderIndex]) {
-                tb.options.folderIndex++;
+            if (nodeID === child.data.nodeId && child.data.provider === file.provider && child.data.name === tb.fangornFolderArray[tb.fangornFolderIndex]) {
+                tb.fangornFolderIndex++;
                 if (child.data.kind === 'folder') {
                     tb.updateFolder(null, child);
                     tree = child;

--- a/website/static/js/fileViewTreebeard.js
+++ b/website/static/js/fileViewTreebeard.js
@@ -67,7 +67,8 @@ function FileViewTreebeard(data) {
             var tb = this;
             Fangorn.DefaultOptions.lazyLoadOnLoad.call(tb, tree, event);
             Fangorn.Utils.findCurrentFileID.call(tb, tree, window.contextVars.node.id, window.contextVars.file);
-            if(!event) { 
+            // Do not scroll if user toggles a folder (mouseclick event)
+            if(!event) {
                 Fangorn.Utils.scrollToFile.call(tb, tb.currentFileID);
             }
         },

--- a/website/static/js/fileViewTreebeard.js
+++ b/website/static/js/fileViewTreebeard.js
@@ -66,7 +66,7 @@ function FileViewTreebeard(data) {
         lazyLoadOnLoad: function(tree, event) {
             var tb = this;
             Fangorn.DefaultOptions.lazyLoadOnLoad.call(tb, tree, event);
-            Fangorn.Utils.findCurrentFileID.call(tb, tree, window.contextVars.node.id, window.contextVars.file);
+            Fangorn.Utils.setCurrentFileID.call(tb, tree, window.contextVars.node.id, window.contextVars.file);
             // Do not scroll if user toggles a folder (mouseclick event)
             if(!event) {
                 Fangorn.Utils.scrollToFile.call(tb, tb.currentFileID);

--- a/website/static/js/fileViewTreebeard.js
+++ b/website/static/js/fileViewTreebeard.js
@@ -66,7 +66,7 @@ function FileViewTreebeard(data) {
         lazyLoadOnLoad: function(tree) {
             var tb = this;
             Fangorn.DefaultOptions.lazyLoadOnLoad.call(tb, tree);
-            Fangorn.Utils.findCurrentFileID.call(tb, tree, window.contextVars.node.id, window.contextVars.file);
+            Fangorn.Utils.setCurrentFileID.call(tb, tree, window.contextVars.node.id, window.contextVars.file);
             Fangorn.Utils.scrollToFile.call(tb, tb.currentFileID);
         },
         resolveRows: function (item) {

--- a/website/static/js/fileViewTreebeard.js
+++ b/website/static/js/fileViewTreebeard.js
@@ -37,17 +37,17 @@ function FileViewTreebeard(data) {
         },
         ondataload: function () {
             var tb = this;
-            tb.options.folderIndex = 0;
+            tb.fangornFolderIndex = 0;
             if (window.contextVars.file.provider === 'figshare') {
-                tb.options.folderArray = [window.contextVars.file.name]
+                tb.fangornFolderArray = [window.contextVars.file.name]
             } else if (window.contextVars.file.path) {
                 window.contextVars.file.path = decodeURIComponent(window.contextVars.file.path);
-                tb.options.folderArray = window.contextVars.file.path.split("/");
-                if (tb.options.folderArray.length > 1) {
-                    tb.options.folderArray.splice(0, 1);
+                tb.fangornFolderArray = window.contextVars.file.path.split("/");
+                if (tb.fangornFolderArray.length > 1) {
+                    tb.fangornFolderArray.splice(0, 1);
                 }
             } else {
-                tb.options.folderArray = [''];
+                tb.fangornFolderArray = [''];
             }
             m.render($('#filesSearch').get(0), tb.options.filterTemplate.call(tb));
         },

--- a/website/static/js/pages/view-file-page.js
+++ b/website/static/js/pages/view-file-page.js
@@ -1,5 +1,3 @@
-var nodeApiUrl = window.contextVars.node.urls.api;
-
 var FileRenderer = require('../filerenderer.js');
 var FileRevisions = require('../fileRevisions.js');
 


### PR DESCRIPTION
<h3>Purpose:</h3> 
Currently, there is no easy way to switch between files from the file detail page. Users must go back to the project dashboard or the file overview page and select the file they wish to view. This PR makes it easier to flip between files by adding the file tree as a toggle-able component on the file detail page. 

<h3>Changes:</h3> 
- Add a file navigation menu to the file detail page:
  - The file currently being viewed is highlighted in the grid** (if it is out of view, the grid scrolls to show it)
  - The panel is collapsable and resizes based on content  
  - Files are searchable 

![screen shot 2015-03-31 at 5 30 59 pm](https://cloud.githubusercontent.com/assets/6414394/6929817/e5c87f02-d7cb-11e4-8cf6-e17fd3535de5.png)

<h3>**Deferred issues:</h3>
- Highlighting selected files in the Box addon (requires building a path that includes folder/file names instead of ids) Related to #2356.
- Showing the dataverse file action button as either "released" or "draft" depending on the state of the file being viewed instead of always showing the "released" files as the default.
- Action buttons for github and dataverse get cut off with long repo/study names (#2369) 