### PR TITLE
[Ready for Review] Prevent Mendeley 500s

### DIFF
--- a/website/addons/base/serializer.py
+++ b/website/addons/base/serializer.py
@@ -67,7 +67,8 @@ class OAuthAddonSerializer(AddonSerializer):
     def serialized_user_settings(self):
         retval = super(OAuthAddonSerializer, self).serialized_user_settings
 
-        retval['accounts'] = self.serialized_accounts
+        if self.user_settings:
+            retval['accounts'] = self.serialized_accounts
 
         return retval
 

--- a/website/addons/base/serializer.py
+++ b/website/addons/base/serializer.py
@@ -67,6 +67,7 @@ class OAuthAddonSerializer(AddonSerializer):
     def serialized_user_settings(self):
         retval = super(OAuthAddonSerializer, self).serialized_user_settings
 
+        retval['accounts'] = []
         if self.user_settings:
             retval['accounts'] = self.serialized_accounts
 


### PR DESCRIPTION
## Purpose

Under some circumstances user's were getting 500s when creating Mendeley credentials

## Changes
Check to make sure user_settings is not None before attempting serialization

## Side effects

None