### PR TITLE
Add unload event to force browsers not to use bfcache

### DIFF
--- a/website/static/js/pages/project-base-page.js
+++ b/website/static/js/pages/project-base-page.js
@@ -37,6 +37,10 @@ function replaceAnchorScroll (buffer){
     });
 }
 
+// Used for clearing backward/forward cache issues 
+$(window).unload(function(){ 
+    return "Unload";
+});
 $(document).ready(function(){
     replaceAnchorScroll();
 });


### PR DESCRIPTION
## Purpose
Fixes this bug reported in Trello: https://trello.com/c/Rcit6oVh. When browser goes back to files page "view file" tooltips do not clear

![screen_shot_2015-03-17_at_3 39 11_pm](https://cloud.githubusercontent.com/assets/1314003/6716011/dc14b6ae-cd78-11e4-9243-dab567a8c716.png)
 

This issue is caused by backward/forward cache: https://developer.mozilla.org/en-US/docs/Using_Firefox_1.5_caching

## Changes
Added a dummy unload event which doesn't do anything but existence of an unload event forces the browser to reload the page when it goes back in history, therefore not maintaining state. 

## Side effects
I added this to project base page so that it applies to other places this tooltip may appear with files, i.e. Files page, future single file view page or others as they may come up. Navigating to other project pages isn't causing any issues. 
* Tested in Chrome, Safari, Firefox, IE 11
