### PR TITLE
[Ready for Review] Let modifiedBy fall back for user's first name

### DIFF
--- a/website/util/rubeus.py
+++ b/website/util/rubeus.py
@@ -287,7 +287,7 @@ class NodeProjectCollector(object):
                 })
         try:
             user = node.logs[-1].user
-            modified_by = user.family_name
+            modified_by = user.family_name or user.given_name
         except AttributeError:
             modified_by = ''
         # test_children = self._collect_addons(node)


### PR DESCRIPTION
## Purpose

Projectorganizer was ommitting the person who last modified the project when their last name is empty or undefined. This lets that value fall back to the modifier's first name.

## Changes

Let modifiedBy fall back to given_name

## Side effects

None