### PR TITLE
Now account for index numbers with multiple digits

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -50,6 +50,7 @@ SILENT_LOGGERS = [
     'website.search.elastic_search',
     'framework.auth.core',
     'website.mails',
+    'website.search_migration.migrate',
 ]
 for logger_name in SILENT_LOGGERS:
     logging.getLogger(logger_name).setLevel(logging.CRITICAL)

--- a/tests/test_elastic.py
+++ b/tests/test_elastic.py
@@ -509,14 +509,10 @@ class TestSearchMigration(SearchTestCase):
         assert_equal(var[settings.ELASTIC_INDEX + '_v1']['aliases'].keys()[0], settings.ELASTIC_INDEX)
 
     def test_multiple_migrations_no_delete(self):
-        migrate(delete=False, index=settings.ELASTIC_INDEX)
-        var = self.es.indices.get_aliases()
-        assert_equal(var[settings.ELASTIC_INDEX + '_v1']['aliases'].keys()[0], settings.ELASTIC_INDEX)
-
-        migrate(delete=False, index=settings.ELASTIC_INDEX)
-        var = self.es.indices.get_aliases()
-        assert_equal(var[settings.ELASTIC_INDEX + '_v2']['aliases'].keys()[0], settings.ELASTIC_INDEX)
-
+        for n in xrange(1, 21):
+            migrate(delete=False, index=settings.ELASTIC_INDEX)
+            var = self.es.indices.get_aliases()
+            assert_equal(var[settings.ELASTIC_INDEX + '_v{}'.format(n)]['aliases'].keys()[0], settings.ELASTIC_INDEX)
 
     def test_first_migration_with_delete(self):
         migrate(delete=True, index=settings.ELASTIC_INDEX)
@@ -524,11 +520,12 @@ class TestSearchMigration(SearchTestCase):
         assert_equal(var[settings.ELASTIC_INDEX + '_v1']['aliases'].keys()[0], settings.ELASTIC_INDEX)
 
     def test_multiple_migrations_with_delete(self):
-        migrate(delete=True, index=settings.ELASTIC_INDEX)
-        var = self.es.indices.get_aliases()
-        assert_equal(var[settings.ELASTIC_INDEX + '_v1']['aliases'].keys()[0], settings.ELASTIC_INDEX)
+        for n in xrange(1, 21, 2):
+            migrate(delete=True, index=settings.ELASTIC_INDEX)
+            var = self.es.indices.get_aliases()
+            assert_equal(var[settings.ELASTIC_INDEX + '_v{}'.format(n)]['aliases'].keys()[0], settings.ELASTIC_INDEX)
 
-        migrate(delete=True, index=settings.ELASTIC_INDEX)
-        var = self.es.indices.get_aliases()
-        assert_equal(var[settings.ELASTIC_INDEX + '_v2']['aliases'].keys()[0], settings.ELASTIC_INDEX)
-        assert not var.get(settings.ELASTIC_INDEX + '_v1')
+            migrate(delete=True, index=settings.ELASTIC_INDEX)
+            var = self.es.indices.get_aliases()
+            assert_equal(var[settings.ELASTIC_INDEX + '_v{}'.format(n + 1)]['aliases'].keys()[0], settings.ELASTIC_INDEX)
+            assert not var.get(settings.ELASTIC_INDEX + '_v{}'.format(n))

--- a/website/search_migration/migrate.py
+++ b/website/search_migration/migrate.py
@@ -97,12 +97,12 @@ def set_up_alias(old_index, index):
 
 
 def delete_old(index):
-    old_version = int(index[-1]) - 1
+    old_version = int(index.split('_v')[1]) - 1
     if old_version < 1:
         logger.info("No index before {} to delete".format(index))
         pass
     else:
-        old_index = index[:-1] + str(old_version)
+        old_index = index.split('_v')[0] + '_v' + str(old_version)
         logger.info("Deleting {}".format(old_index))
         es.indices.delete(index=old_index, ignore=404)
 

--- a/website/search_migration/migrate.py
+++ b/website/search_migration/migrate.py
@@ -79,7 +79,7 @@ def set_up_index(idx):
         es.indices.put_alias(idx, index)
     else:
         # Increment version
-        version = int(alias.keys()[0][-1]) + 1
+        version = int(alias.keys()[0].split('_v')[1]) + 1
         logger.info("Incrementing index version to {}".format(version))
         index = '{0}_v{1}'.format(idx, version)
         search.create_index(index=index)


### PR DESCRIPTION
Purpose
-----------
Account for index numbers with multiple digits during migrations

Changes
------------
Now account for index numbers with multiple digits during migrations

Side Effects
----------------
Migrations made on indices with multi-digit version numbers will now not loop back to the second digit +1

TODO
---------
- [x] add tests