### PR TITLE
[Ready for Review] Hotfix/folderpicker dom destroy

### DIFF
--- a/website/addons/box/templates/box_node_settings.mako
+++ b/website/addons/box/templates/box_node_settings.mako
@@ -33,7 +33,7 @@
 
 
     <!-- Settings Pane -->
-    <div class="box-settings" data-bind='if: showSettings'>
+    <div class="box-settings" data-bind='visible: showSettings'>
         <div class="row">
             <div class="col-md-12">
                 <p>

--- a/website/addons/dropbox/templates/dropbox_node_settings.mako
+++ b/website/addons/dropbox/templates/dropbox_node_settings.mako
@@ -32,7 +32,7 @@
 
 
     <!-- Settings Pane -->
-    <div class="dropbox-settings" data-bind='if: showSettings'>
+    <div class="dropbox-settings" data-bind='visible: showSettings'>
         <div class="row">
             <div class="col-md-12">
                 <p>

--- a/website/addons/figshare/templates/figshare_node_settings.mako
+++ b/website/addons/figshare/templates/figshare_node_settings.mako
@@ -33,7 +33,7 @@
     </h4>
 
     <!-- Settings Pane -->
-    <div class="figshare-settings" data-bind='if: showSettings'>
+    <div class="figshare-settings" data-bind='visible: showSettings'>
         <div class="row">
             <div class="col-md-12">
                 <p>

--- a/website/addons/googledrive/templates/googledrive_node_settings.mako
+++ b/website/addons/googledrive/templates/googledrive_node_settings.mako
@@ -29,7 +29,7 @@
     </small>
     </h4>
 
-    <div id="currentFolder" data-bind="if:showFolders()">
+    <div id="currentFolder" data-bind="visible: showFolders()">
        <p>
         <strong> Current folder:</strong>
         <a href="{{ urls().files }}" data-bind="if: currentFolder">{{ currentFolder }}</a>

--- a/website/addons/mendeley/templates/mendeley_node_settings.mako
+++ b/website/addons/mendeley/templates/mendeley_node_settings.mako
@@ -27,7 +27,7 @@
     </h4>
 
     <!-- Settings Pane -->
-    <div class="mendeley-settings" data-bind='if: showSettings'>
+    <div class="mendeley-settings" data-bind='visible: showSettings'>
         <div class="row">
             <div class="col-md-12">
                 <p>

--- a/website/addons/zotero/templates/zotero_node_settings.mako
+++ b/website/addons/zotero/templates/zotero_node_settings.mako
@@ -27,7 +27,7 @@
     </h4>
 
     <!-- Settings Pane -->
-    <div class="zotero-settings" data-bind='if: showSettings'>
+    <div class="zotero-settings" data-bind='visible: showSettings'>
         <div class="row">
             <div class="col-md-12">
                 <p>


### PR DESCRIPTION
## Purpose

When users imported/deauthorized multiple times on the node settings page the folderpicker would not show on the second load and onward. This PR fixes that.

## Changes

The KO 'if' binding was causing the DOM containing the folderpicker to be destroyed. This binding was switched to 'visible' and now the folderpicker persists.

## Side effects

None