### PR TITLE
Fix illegal-for-xml unicode chars in Atom feed

### DIFF
--- a/tests/test_share.py
+++ b/tests/test_share.py
@@ -1,8 +1,10 @@
-from nose.tools import *  # PEP8 asserts
-from mock import patch
-from tests.base import OsfTestCase
 import xml
 
+from mock import patch
+from nose.tools import *  # PEP8 asserts
+from tests.base import OsfTestCase
+
+from website.search import util
 from website.search import share_search
 
 STANDARD_RETURN_VALUE = {
@@ -196,3 +198,10 @@ class TestShareAtom(OsfTestCase):
         })
         title = response.xml.find('{http://www.w3.org/2005/Atom}title')
         assert_equal(title.text, 'SHARE: Atom Feed for query: "cats"')
+
+    def test_illegal_unicode_sub(self):
+        illegal_str = u'\u0000\u0008\u000b\u000c\u000e\u001f\ufffe\uffffHello'
+        illegal_str += unichr(0xd800) + unichr(0xdbff) + ' World'
+        assert_equal(util.illegal_unicode_replace(illegal_str), 'Hello World')
+        assert_equal(util.illegal_unicode_replace(''), '')
+        assert_equal(util.illegal_unicode_replace('WOOOooooOOo'), 'WOOOooooOOo')

--- a/tests/test_share.py
+++ b/tests/test_share.py
@@ -204,4 +204,5 @@ class TestShareAtom(OsfTestCase):
         illegal_str += unichr(0xd800) + unichr(0xdbff) + ' World'
         assert_equal(util.illegal_unicode_replace(illegal_str), 'Hello World')
         assert_equal(util.illegal_unicode_replace(''), '')
+        assert_equal(util.illegal_unicode_replace(None), None)
         assert_equal(util.illegal_unicode_replace('WOOOooooOOo'), 'WOOOooooOOo')

--- a/website/search/share_search.py
+++ b/website/search/share_search.py
@@ -13,7 +13,7 @@ from elasticsearch import Elasticsearch
 
 from website import settings
 
-from util import generate_color
+from util import generate_color, illegal_unicode_replace
 
 share_es = Elasticsearch(
     settings.SHARE_ELASTIC_URI,
@@ -252,15 +252,15 @@ def data_for_charts(elastic_results):
 
 def to_atom(result):
     return {
-        'title': result.get('title') or 'No title provided.',
-        'summary': result.get('description') or 'No summary provided.',
+        'title': illegal_unicode_replace(result.get('title')) or 'No title provided.',
+        'summary': illegal_unicode_replace(result.get('description')) or 'No summary provided.',
         'id': result['id']['url'],
         'updated': get_date_updated(result),
         'links': [
             {'href': result['id']['url'], 'rel': 'alternate'}
         ],
         'author': format_contributors_for_atom(result['contributors']),
-        'categories': [{"term": tag} for tag in result.get('tags')],
+        'categories': [{"term": illegal_unicode_replace(tag)} for tag in result.get('tags')],
         'published': parse(result.get('dateUpdated'))
     }
 
@@ -268,7 +268,10 @@ def to_atom(result):
 def format_contributors_for_atom(contributors_list):
     return [
         {
-            'name': '{} {}'.format(entry['given'], entry['family'])
+            'name': '{} {}'.format(
+                illegal_unicode_replace(entry['given']),
+                illegal_unicode_replace(entry['family'])
+            )
         }
         for entry in contributors_list
     ]

--- a/website/search/util.py
+++ b/website/search/util.py
@@ -2,6 +2,9 @@ import re
 import copy
 import webcolors
 
+from werkzeug.contrib.atom import AtomFeed
+
+
 COLORBREWER_COLORS = [(166, 206, 227), (31, 120, 180), (178, 223, 138), (51, 160, 44), (251, 154, 153), (227, 26, 28), (253, 191, 111), (255, 127, 0), (202, 178, 214), (106, 61, 154), (255, 255, 153), (177, 89, 40)]
 
 RE_XML_ILLEGAL = u'([\u0000-\u0008\u000b-\u000c\u000e-\u001f\ufffe-\uffff])' + \
@@ -12,8 +15,6 @@ RE_XML_ILLEGAL = u'([\u0000-\u0008\u000b-\u000c\u000e-\u001f\ufffe-\uffff])' + \
                  unichr(0xd800), unichr(0xdbff), unichr(0xdc00), unichr(0xdfff))
 
 RE_XML_ILLEGAL_COMPILED = re.compile(RE_XML_ILLEGAL)
-
-from werkzeug.contrib.atom import AtomFeed
 
 
 def build_query(q='*', start=0, size=10, sort=None):
@@ -109,5 +110,6 @@ def illegal_unicode_replace(atom_element):
     This fix thanks to Matt Harper from his blog post:
     https://maxharp3r.wordpress.com/2008/05/15/pythons-minidom-xml-and-illegal-unicode-characters/
     """
-
-    return RE_XML_ILLEGAL_COMPILED.sub('', atom_element)
+    if atom_element:
+        return re.sub(RE_XML_ILLEGAL_COMPILED, '', atom_element)
+    return atom_element

--- a/website/search/util.py
+++ b/website/search/util.py
@@ -111,5 +111,5 @@ def illegal_unicode_replace(atom_element):
     https://maxharp3r.wordpress.com/2008/05/15/pythons-minidom-xml-and-illegal-unicode-characters/
     """
     if atom_element:
-        return re.sub(RE_XML_ILLEGAL_COMPILED, '', atom_element)
+        return RE_XML_ILLEGAL_COMPILED.sub('', atom_element)
     return atom_element

--- a/website/search/util.py
+++ b/website/search/util.py
@@ -4,6 +4,14 @@ import webcolors
 
 COLORBREWER_COLORS = [(166, 206, 227), (31, 120, 180), (178, 223, 138), (51, 160, 44), (251, 154, 153), (227, 26, 28), (253, 191, 111), (255, 127, 0), (202, 178, 214), (106, 61, 154), (255, 255, 153), (177, 89, 40)]
 
+RE_XML_ILLEGAL = u'([\u0000-\u0008\u000b-\u000c\u000e-\u001f\ufffe-\uffff])' + \
+                 u'|' + \
+                 u'([%s-%s][^%s-%s])|([^%s-%s][%s-%s])|([%s-%s]$)|(^[%s-%s])' % \
+                 (unichr(0xd800), unichr(0xdbff), unichr(0xdc00), unichr(0xdfff),
+                 unichr(0xd800), unichr(0xdbff), unichr(0xdc00), unichr(0xdfff),
+                 unichr(0xd800), unichr(0xdbff), unichr(0xdc00), unichr(0xdfff))
+
+RE_XML_ILLEGAL_COMPILED = re.compile(RE_XML_ILLEGAL)
 
 from werkzeug.contrib.atom import AtomFeed
 
@@ -101,10 +109,5 @@ def illegal_unicode_replace(atom_element):
     This fix thanks to Matt Harper from his blog post:
     https://maxharp3r.wordpress.com/2008/05/15/pythons-minidom-xml-and-illegal-unicode-characters/
     """
-    RE_XML_ILLEGAL = u'([\u0000-\u0008\u000b-\u000c\u000e-\u001f\ufffe-\uffff])' + \
-                     u'|' + \
-                     u'([%s-%s][^%s-%s])|([^%s-%s][%s-%s])|([%s-%s]$)|(^[%s-%s])' % \
-                     (unichr(0xd800), unichr(0xdbff), unichr(0xdc00), unichr(0xdfff),
-                     unichr(0xd800), unichr(0xdbff), unichr(0xdc00), unichr(0xdfff),
-                     unichr(0xd800), unichr(0xdbff), unichr(0xdc00), unichr(0xdfff))
-    return re.sub(RE_XML_ILLEGAL, "", atom_element)
+
+    return RE_XML_ILLEGAL_COMPILED.sub('', atom_element)

--- a/website/search/util.py
+++ b/website/search/util.py
@@ -1,3 +1,4 @@
+import re
 import copy
 import webcolors
 
@@ -93,3 +94,17 @@ def create_atom_feed(name, data, query, size, start, url, to_atom):
         feed.add(**to_atom(doc))
 
     return feed
+
+
+def illegal_unicode_replace(atom_element):
+    """ Replace an illegal for XML unicode character with nothing.
+    This fix thanks to Matt Harper from his blog post:
+    https://maxharp3r.wordpress.com/2008/05/15/pythons-minidom-xml-and-illegal-unicode-characters/
+    """
+    RE_XML_ILLEGAL = u'([\u0000-\u0008\u000b-\u000c\u000e-\u001f\ufffe-\uffff])' + \
+                     u'|' + \
+                     u'([%s-%s][^%s-%s])|([^%s-%s][%s-%s])|([%s-%s]$)|(^[%s-%s])' % \
+                     (unichr(0xd800), unichr(0xdbff), unichr(0xdc00), unichr(0xdfff),
+                     unichr(0xd800), unichr(0xdbff), unichr(0xdc00), unichr(0xdfff),
+                     unichr(0xd800), unichr(0xdbff), unichr(0xdc00), unichr(0xdfff))
+    return re.sub(RE_XML_ILLEGAL, "", atom_element)


### PR DESCRIPTION
## Purpose
SHARE atom feed at http://osf.io/share/atom was displaying errors in chrome and firefox because of an illegal-for-xml unicode character that had gotten through the atom feed parser.  This fix screens any title, description, tags, or contributors for any more of the unicode characters that are illegal for XML, and replaces them with an empty string. 

## Changes
Add a function to utils that scans for unicode chars illegal in XML. Fix found at https://maxharp3r.wordpress.com/2008/05/15/pythons-minidom-xml-and-illegal-unicode-characters/ . Use that function when generating the title, summary, tags and contributors for the atom feed in share_search.py

## Side Effects
Shouldn't be any! Only used in a small part of the share atom feed. Possible that some titles will display strangely if the character that gets through is a non-empty whitespace character. 