### PR TITLE
[hotfix] Requirements install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,18 +22,13 @@ install:
     - travis_retry pip install flake8 --force-reinstall --upgrade
     - travis_retry invoke wheelhouse --repo https://github.com/CenterForOpenScience/wheelhouse --path $WHEELHOUSE
     - travis_retry invoke travis_addon_settings
-    - travis_retry invoke requirements
-    - travis_retry invoke addon_requirements
-    - travis_retry mfr -r install all
-    - travis_retry npm install
-    - travis_retry npm install -g bower
-    - travis_retry bower install
-    - inv webpack
-
+    - travis_retry invoke requirements --dev --addons
+    - travis_retry invoke assets
 before_script:
     - flake8 .
 
-script: invoke test_all
+# Run Python tests (core and addon) and JS tests
+script: invoke test --all
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ install:
     - travis_retry invoke wheelhouse --repo https://github.com/CenterForOpenScience/wheelhouse --path $WHEELHOUSE
     - travis_retry invoke travis_addon_settings
     - travis_retry invoke requirements --dev --addons
-    - travis_retry invoke assets
+    - travis_retry invoke assets --dev
 before_script:
     - flake8 .
 

--- a/README.md
+++ b/README.md
@@ -316,6 +316,8 @@ Use the following command to update your requirements and build the asset bundle
 $ inv assets -dw
 ```
 
+The -w option puts you in "watch": assets will be built when a file changes.
+
 ## Downloading citation styles (optional)
 
 To download citation styles, run:
@@ -330,7 +332,7 @@ $ invoke update_citation_styles
 To install the python libraries needed to support the enabled addons, run:
 
 ```bash
-$ invoke addon_requirements
+$ invoke requirements --addons
 ```
 
 ### Getting application credentials

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,8 @@
+# Base requirements for running the OSF.
+# NOTE: This does not include addon requirements or development requirements.
+# To install addon requirements: inv requirements --addons
+# To install dev requirements: inv requirements --dev
+
 invoke==0.9.0
 Flask==0.10.1
 Mako==1.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,14 +1,16 @@
--r requirements.txt
+-r ../requirements.txt
 # Requirements that are used in the development environment only
+
+# Testing
 nose
 factory-boy==2.2.1
 webtest-plus==0.3.3
 mock
 fake-factory
-
-flake8==2.4.0
-
 responses
-
 # Fork of HTTPretty with pymongo fix
 git+https://github.com/jmcarp/HTTPretty@fix-tests-for-208
+
+# Syntax checking
+flake8==2.4.0
+

--- a/requirements/metrics.txt
+++ b/requirements/metrics.txt
@@ -1,3 +1,4 @@
+# Requirements for generating user metrics
 numpy==1.8.0
 scipy==0.14.0
 matplotlib==1.3.1

--- a/requirements/release.txt
+++ b/requirements/release.txt
@@ -1,0 +1,3 @@
+# Requirements to be installed on server deployments
+-r ../requirements.txt
+-r metrics.txt

--- a/tasks.py
+++ b/tasks.py
@@ -553,7 +553,7 @@ def setup():
     packages()
     requirements(all=True)
     encryption()
-    assets(develop=True, watch=False)
+    assets(dev=True, watch=False)
 
 
 @task
@@ -734,34 +734,34 @@ def clean_assets():
 
 
 @task(aliases=['pack'])
-def webpack(clean=False, watch=False, develop=False):
+def webpack(clean=False, watch=False, dev=False):
     """Build static assets with webpack."""
     if clean:
         clean_assets()
     webpack_bin = os.path.join(HERE, 'node_modules', 'webpack', 'bin', 'webpack.js')
     args = [webpack_bin]
-    if settings.DEBUG_MODE and develop:
+    if settings.DEBUG_MODE and dev:
         args += ['--colors']
     else:
         args += ['--progress']
     if watch:
         args += ['--watch']
-    config_file = 'webpack.dev.config.js' if develop else 'webpack.prod.config.js'
+    config_file = 'webpack.dev.config.js' if dev else 'webpack.prod.config.js'
     args += ['--config {0}'.format(config_file)]
     command = ' '.join(args)
     run(command, echo=True)
 
 @task()
-def assets(develop=False, watch=False):
+def assets(dev=False, watch=False):
     """Install and build static assets."""
     npm = 'npm install'
-    if not develop:
+    if not dev:
         npm += ' --production'
     run(npm, echo=True)
     bower_install()
     # Always set clean=False to prevent possible mistakes
     # on prod
-    webpack(clean=False, watch=watch, develop=develop)
+    webpack(clean=False, watch=watch, dev=dev)
 
 @task
 def generate_self_signed(domain):

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -3,6 +3,5 @@ var assign = require('object-assign');
 
 module.exports = assign(common, {
     debug: true,
-    watch: true,
     devtool: 'source-map',
 });


### PR DESCRIPTION
### Purpose

Currently, OSF requirements and user metrics requirements are installed in separate virtuaenvs. If we forget to install metrics requirements after deploying a release, our user metrics scripts break. This PR makes it easier to install all deployment requirements into a single virtualenv.

### Changes

- Put environment-specific requirements files in`requireements` directory
- Modify `requirements` invoke task for the following interface

```
inv requirements --dev
inv requirements --addons
inv requirements --release
```

- Add `req` alias to invoke task
- Don't install all mfr renderer dependencies on travis--they aren't necessary for the tests
- `inv assets -d` will *not* put you in watch mode. You must pass `-w` or `--watch`. This allows us to build dev assets on Travis

### Side effects

- To update dev environments, run: `inv req --dev --addons`
- For deployments: `inv req --release`