### PR TITLE
[hotfix] Markdown  comments

### DIFF
--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -328,6 +328,10 @@ li.pointer {
     overflow-x: hidden;
 }
 
+.comment-actions i {
+    cursor: pointer;
+}
+
 .comment-container {
     margin-top: 10px;
     margin-bottom: 10px;

--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -347,11 +347,9 @@ li.pointer {
 }
 .edit-comment {
     background-color: #F3F3F3;
-    cursor: pointer;
 }
 
 .comment-body i {
-    cursor: pointer;
     padding-right: 5px;
 }
 
@@ -980,7 +978,7 @@ h1.unavailable {
 .project-page .anchor {
     margin-top: -100px;
     padding-top: 100px;
-    display: block; 
+    display: block;
 }
 
 .anchor {

--- a/website/static/js/comment.js
+++ b/website/static/js/comment.js
@@ -10,9 +10,11 @@ require('knockout-mapping');
 require('knockout-punches');
 require('jquery-autosize');
 ko.punches.enableAll();
+var Raven = require('raven-js');
 
-var osfHelpers = require('osfHelpers');
-var CommentPane = require('./commentpane.js');
+var osfHelpers = require('js/osfHelpers');
+var CommentPane = require('js/commentpane');
+var markdown = require('js/markdown');
 
 var nodeApiUrl = window.contextVars.node.urls.api;
 
@@ -193,9 +195,6 @@ BaseComment.prototype.submitReply = function() {
     });
 };
 
-/*
-    *
-    */
 var CommentModel = function(data, $parent, $root) {
 
     BaseComment.prototype.constructor.call(this);
@@ -205,7 +204,16 @@ var CommentModel = function(data, $parent, $root) {
     self.$parent = $parent;
     self.$root = $root;
 
+    // Note: assigns self.content()
     $.extend(self, ko.mapping.fromJS(data));
+
+    self.contentDisplay = ko.observable(markdown.full.render(self.content()));
+
+    // Update contentDisplay with rednered markdown whenever content changes
+    self.content.subscribe(function(newContent) {
+        self.contentDisplay(markdown.full.render(newContent));
+    });
+
     self.dateCreated(data.dateCreated);
     self.dateModified(data.dateModified);
 

--- a/website/templates/include/comment_template.mako
+++ b/website/templates/include/comment_template.mako
@@ -99,7 +99,8 @@
                             <span data-bind="if: hasChildren">
                                 <i data-bind="css: toggleIcon, click: toggle"></i>
                             </span>
-                            <span class="overflow" data-bind="text: content, css: {'edit-comment': editHighlight}, event: {mouseenter: startHoverContent, mouseleave: stopHoverContent, click: edit}"></span>
+                            <span class="overflow"
+                              data-bind="html: contentDisplay, css: {'edit-comment': editHighlight}, event: {mouseenter: startHoverContent, mouseleave: stopHoverContent}"></span>
                         </div>
 
                         <!--
@@ -127,6 +128,9 @@
 
                         <!-- Action bar -->
                         <div data-bind="ifnot: editing" class="comment-actions pull-right">
+                            <span data-bind="if: canEdit, click: edit">
+                                <i class="fa fa-pencil"></i>
+                            </span>
                             <span data-bind="if: $root.canComment, click: showReply">
                                 <i class="fa fa-reply"></i>
                             </span>


### PR DESCRIPTION
Resolves https://github.com/CenterForOpenScience/osf.io/issues/2267

### Changes

- Renders comment content using the markdown-it renderer
- Adds an edit button which toggles comment input

### Side effects 

The display element for the markdown content now uses the `html` rather than the `text` binding. We rely on `markdown-it-sanitizer` rather than Knockout to sanitize the comment content.