### PR TITLE
Hotfix/nested project read permission

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2055,7 +2055,11 @@ class TestProject(OsfTestCase):
 
     def test_is_admin_parent_grandparent_admin(self):
         user = UserFactory()
-        parent_node = NodeFactory(project=self.project, creator=user)
+        parent_node = NodeFactory(
+            project=self.project,
+            category='project',
+            creator=user
+        )
         child_node = NodeFactory(project=parent_node, creator=user)
         assert_true(child_node.is_admin_parent(self.project.creator))
         assert_true(parent_node.is_admin_parent(self.project.creator))
@@ -2074,8 +2078,15 @@ class TestProject(OsfTestCase):
 
     def test_has_permission_read_grandparent_admin(self):
         user = UserFactory()
-        parent_node = NodeFactory(project=self.project, creator=user)
-        child_node = NodeFactory(project=parent_node, creator=user)
+        parent_node = NodeFactory(
+            project=self.project,
+            category='project',
+            creator=user
+        )
+        child_node = NodeFactory(
+            project=parent_node,
+            creator=user
+        )
         assert_true(child_node.has_permission(self.project.creator, 'read'))
         assert_false(child_node.has_permission(self.project.creator, 'admin'))
         assert_true(parent_node.has_permission(self.project.creator, 'read'))
@@ -2089,8 +2100,15 @@ class TestProject(OsfTestCase):
 
     def test_can_view_grandparent_admin(self):
         user = UserFactory()
-        parent_node = NodeFactory(project=self.project, creator=user)
-        child_node = NodeFactory(project=parent_node, creator=user)
+        parent_node = NodeFactory(
+            project=self.project,
+            creator=user,
+            category='project'
+        )
+        child_node = NodeFactory(
+            project=parent_node,
+            creator=user
+        )
         assert_true(parent_node.can_view(Auth(user=self.project.creator)))
         assert_false(parent_node.can_edit(Auth(user=self.project.creator)))
         assert_true(child_node.can_view(Auth(user=self.project.creator)))

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -146,6 +146,26 @@ class TestProjectViews(OsfTestCase):
         self.project.add_contributor(self.user2, auth=Auth(self.user1))
         self.project.save()
 
+    def test_can_view_nested_project_as_admin(self):
+        self.parent_project = NodeFactory(
+            title='parent project',
+            category='project',
+            project=self.project,
+            is_public=False
+        )
+        self.parent_project.save()
+        self.child_project = NodeFactory(
+            title='child project',
+            category='project',
+            project=self.parent_project,
+            is_public=False
+        )
+        self.child_project.save()
+        url = self.child_project.web_url_for('view_project')
+        res = self.app.get(url, auth=self.auth)
+        assert_not_in('Private Project', res.body)
+        assert_in('parent project', res.body)
+
     def test_edit_description(self):
         url = "/api/v1/project/{0}/edit/".format(self.project._id)
         self.app.post_json(url,

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -693,14 +693,6 @@ class Node(GuidStoredObject, AddonModelMixin):
             return self.parent_node.is_admin_parent(user)
         return False
 
-    def is_ancestor_admin(self, user):
-        if self.parent_node:
-            if self.parent_node.has_permission(user, "admin"):
-                return True
-            else:
-                return self.parent_node.is_ancestor_admin(user)
-        return False
-
     def can_view(self, auth):
         if not auth and not self.is_public:
             return False
@@ -709,7 +701,7 @@ class Node(GuidStoredObject, AddonModelMixin):
             self.is_public or
             (auth.user and self.has_permission(auth.user, 'read')) or
             auth.private_key in self.private_link_keys_active or
-            self.is_ancestor_admin(auth.user)
+            self.is_admin_parent(auth.user)
         )
 
     def is_expanded(self, user=None):

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -693,6 +693,14 @@ class Node(GuidStoredObject, AddonModelMixin):
             return self.parent_node.is_admin_parent(user)
         return False
 
+    def is_ancestor_admin(self, user):
+        if self.parent_node:
+            if self.parent_node.has_permission(user, "admin"):
+                return True
+            else:
+                return self.parent_node.is_ancestor_admin(user)
+        return False
+
     def can_view(self, auth):
         if not auth and not self.is_public:
             return False
@@ -700,7 +708,8 @@ class Node(GuidStoredObject, AddonModelMixin):
         return (
             self.is_public or
             (auth.user and self.has_permission(auth.user, 'read')) or
-            auth.private_key in self.private_link_keys_active
+            auth.private_key in self.private_link_keys_active or
+            self.is_ancestor_admin(auth.user)
         )
 
     def is_expanded(self, user=None):

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -765,7 +765,7 @@ def _view_project(node, auth, primary=False):
             'absolute_url': parent.absolute_url if parent else '',
             'is_public': parent.is_public if parent else '',
             'is_contributor': parent.is_contributor(user) if parent else '',
-            'can_view': (auth.private_key in parent.private_link_keys_active) if parent else False
+            'can_view': parent.can_view(auth) if parent else False
         },
         'user': {
             'is_contributor': node.is_contributor(user),


### PR DESCRIPTION
fix https://github.com/CenterForOpenScience/osf.io/issues/2159

<b>Purpose</b>
fix the problem that the 'admin' user lose 'read' permission on nested child project title redirect


<b>Changes</b>
before fix,
The Parent project's name is not displayed in the header - instead, "Private Project" is shown.
The "up to parent project" link in the project navbar is linked to nothing.
![image](https://cloud.githubusercontent.com/assets/4974056/6760241/39f0fae4-cf1d-11e4-8610-cbab13ac3f38.png)

after fix,
the behavior is correct, admin user on grandparent project can view the parent project title redirect on child project page.
![screen shot 2015-03-20 at 4 21 00 pm](https://cloud.githubusercontent.com/assets/4974056/6760232/25fee762-cf1d-11e4-8158-3ae05e8b3cda.png)
