### PR TITLE
[feature] Don't cachebust webpack assets in DEBUG_MODE

### DIFF
--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -144,7 +144,7 @@ var externals = {
 
 var plugins = [
     // Bundle common code between modules
-    new webpack.optimize.CommonsChunkPlugin('vendor', 'vendor.[hash].js'),
+    new webpack.optimize.CommonsChunkPlugin('vendor', 'vendor.js'),
     // Bower support
     new webpack.ResolverPlugin(
         new webpack.ResolverPlugin.DirectoryDescriptionFilePlugin('bower.json', ['main'])
@@ -158,14 +158,13 @@ var plugins = [
     new webpack.DefinePlugin({
         'define.amd': false
     }),
-    new SaveAssetsJson()
 ];
 
 
 var output = {
     path: './website/static/public/js/',
     // publicPath: '/static/', // used to generate urls to e.g. images
-    filename: '[name].[chunkhash].js',
+    filename: '[name].js',
     sourcePrefix: ''
 };
 
@@ -183,7 +182,7 @@ module.exports = {
             {test: /\.png$/, loader: 'url-loader?limit=100000&mimetype=image/ng'},
             {test: /\.gif$/, loader: 'url-loader?limit=10000&mimetype=image/gif'},
             {test: /\.jpg$/, loader: 'url-loader?limit=10000&mimetype=image/jpg'},
-            {test: /\.woff(2)?(\?v=[0-9]\.[0-9]\.[0-9])?$/, loader: "url-loader?minetype=application/font-woff" },
+            {test: /\.woff(2)?(\?v=[0-9]\.[0-9]\.[0-9])?$/, loader: 'url-loader?mimetype=application/font-woff'},
             {test: /\.svg/, loader: 'file-loader'},
             {test: /\.eot/, loader: 'file-loader'},
             {test: /\.ttf/, loader: 'file-loader'}

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -3,5 +3,5 @@ var assign = require('object-assign');
 
 module.exports = assign(common, {
     debug: true,
-    devtool: 'source-map',
+    devtool: 'source-map'
 });

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -1,6 +1,7 @@
 var webpack = require('webpack');
 var common = require('./webpack.common.config.js');
 var assign = require('object-assign');
+var SaveAssetsJson = require('assets-webpack-plugin');
 
 module.exports = assign(common, {
     debug: false,
@@ -20,6 +21,20 @@ module.exports = assign(common, {
         new webpack.optimize.UglifyJsPlugin({
             exclude: /conference.*?\.js$/,
             compress: {warnings: false}
-        })
-    ])
+        }),
+        // Save a webpack-assets.json file that maps base filename to filename with
+        // hash. This file is used by the webpack_asset mako filter to expand
+        // base filenames to full filename with hash.
+        new SaveAssetsJson(),
+        // Append hash to commons chunk for cachebusting
+        new webpack.optimize.CommonsChunkPlugin('vendor', 'vendor.[hash].js'),
+    ]),
+    output: {
+        path: './website/static/public/js/',
+        // publicPath: '/static/', // used to generate urls to e.g. images
+
+        // Append hash to filenames for cachebusting
+        filename: '[name].[chunkhash].js',
+        sourcePrefix: ''
+    }
 });

--- a/website/util/paths.py
+++ b/website/util/paths.py
@@ -24,9 +24,12 @@ def webpack_asset(path, asset_paths=asset_paths):
     """Mako filter that resolves a human-readable asset path to its name on disk
     (which may include the hash of the file).
     """
-    key = path.replace(base_static_path, '').replace('.js', '')
-    hash_path = asset_paths[key]
-    return os.path.join(base_static_path, hash_path)
+    if not settings.DEBUG_MODE:
+        key = path.replace(base_static_path, '').replace('.js', '')
+        hash_path = asset_paths[key]
+        return os.path.join(base_static_path, hash_path)
+    else:  # We don't cachebust in debug mode, so just return modified path
+        return path
 
 
 def resolve_addon_path(config, file_name):

--- a/website/util/paths.py
+++ b/website/util/paths.py
@@ -28,7 +28,7 @@ def webpack_asset(path, asset_paths=asset_paths):
         key = path.replace(base_static_path, '').replace('.js', '')
         hash_path = asset_paths[key]
         return os.path.join(base_static_path, hash_path)
-    else:  # We don't cachebust in debug mode, so just return modified path
+    else:  # We don't cachebust in debug mode, so just return unmodified path
         return path
 
 


### PR DESCRIPTION
### Purpose

Prevent extra app reload every time assets are built during development.

### Changes

- webpack will no longer append hashes to built files when in debug mode
- [assets-webpack-plugin](https://github.com/sporto/assets-webpack-plugin) is no longer used in dev environments

### Side effects

None. Devs can now safely remove old assets with `inv clean_assets` the rerun webpack with `inv assets -dw`.