### PR TITLE
[WIP] Update SHARE Atom Feed - html tags and cutting off first result

### DIFF
--- a/tests/test_share.py
+++ b/tests/test_share.py
@@ -210,3 +210,10 @@ class TestShareAtom(OsfTestCase):
     def test_html_tag_sub(self):
         html_str = "<p><b>RKO</b> outta <i>NOWHERE</i>!!!</p>"
         assert_equal(util.html_and_illegal_unicode_replace(html_str), 'RKO outta NOWHERE!!!')
+
+    @patch.object(share_search.share_es, 'search')
+    def test_atom_returns_correct_number(self, mock_search):
+        mock_search.return_value = STANDARD_RETURN_VALUE
+        response = self.app.get('/share/atom/')
+        entries = response.xml.findall('{http://www.w3.org/2005/Atom}entry')
+        assert_equal(len(entries), STANDARD_RETURN_VALUE['hits']['total'])

--- a/tests/test_share.py
+++ b/tests/test_share.py
@@ -202,7 +202,11 @@ class TestShareAtom(OsfTestCase):
     def test_illegal_unicode_sub(self):
         illegal_str = u'\u0000\u0008\u000b\u000c\u000e\u001f\ufffe\uffffHello'
         illegal_str += unichr(0xd800) + unichr(0xdbff) + ' World'
-        assert_equal(util.illegal_unicode_replace(illegal_str), 'Hello World')
-        assert_equal(util.illegal_unicode_replace(''), '')
-        assert_equal(util.illegal_unicode_replace(None), None)
-        assert_equal(util.illegal_unicode_replace('WOOOooooOOo'), 'WOOOooooOOo')
+        assert_equal(util.html_and_illegal_unicode_replace(illegal_str), 'Hello World')
+        assert_equal(util.html_and_illegal_unicode_replace(''), '')
+        assert_equal(util.html_and_illegal_unicode_replace(None), None)
+        assert_equal(util.html_and_illegal_unicode_replace('WOOOooooOOo'), 'WOOOooooOOo')
+
+    def test_html_tag_sub(self):
+        html_str = "<p><b>RKO</b> outta <i>NOWHERE</i>!!!</p>"
+        assert_equal(util.html_and_illegal_unicode_replace(html_str), 'RKO outta NOWHERE!!!')

--- a/tests/test_share.py
+++ b/tests/test_share.py
@@ -217,3 +217,21 @@ class TestShareAtom(OsfTestCase):
         response = self.app.get('/share/atom/')
         entries = response.xml.findall('{http://www.w3.org/2005/Atom}entry')
         assert_equal(len(entries), STANDARD_RETURN_VALUE['hits']['total'])
+
+    def test_compute_start_non_number(self):
+        page = 'cow'
+        size = 250
+        result = util.compute_start(page, size)
+        assert_equal(result, 0)
+
+    def test_compute_start_negative(self):
+        page = -10
+        size = 250
+        result = util.compute_start(page, size)
+        assert_equal(result, 0)
+
+    def test_compute_start_normal(self):
+        page = 50
+        size = 10
+        result = util.compute_start(page, size)
+        assert_equal(result, 490)

--- a/website/search/share_search.py
+++ b/website/search/share_search.py
@@ -13,7 +13,7 @@ from elasticsearch import Elasticsearch
 
 from website import settings
 
-from util import generate_color, illegal_unicode_replace
+from util import generate_color, html_and_illegal_unicode_replace
 
 share_es = Elasticsearch(
     settings.SHARE_ELASTIC_URI,
@@ -59,6 +59,7 @@ def providers():
             hit['_source']['short_name']: hit['_source'] for hit in provider_map['hits']['hits']
         }
     }
+
 
 def stats(query=None):
     query = query or {"query": {"match_all": {}}}
@@ -252,15 +253,15 @@ def data_for_charts(elastic_results):
 
 def to_atom(result):
     return {
-        'title': illegal_unicode_replace(result.get('title')) or 'No title provided.',
-        'summary': illegal_unicode_replace(result.get('description')) or 'No summary provided.',
+        'title': html_and_illegal_unicode_replace(result.get('title')) or 'No title provided.',
+        'summary': html_and_illegal_unicode_replace(result.get('description')) or 'No summary provided.',
         'id': result['id']['url'],
         'updated': get_date_updated(result),
         'links': [
             {'href': result['id']['url'], 'rel': 'alternate'}
         ],
         'author': format_contributors_for_atom(result['contributors']),
-        'categories': [{"term": illegal_unicode_replace(tag)} for tag in result.get('tags')],
+        'categories': [{"term": html_and_illegal_unicode_replace(tag)} for tag in result.get('tags')],
         'published': parse(result.get('dateUpdated'))
     }
 
@@ -269,8 +270,8 @@ def format_contributors_for_atom(contributors_list):
     return [
         {
             'name': '{} {}'.format(
-                illegal_unicode_replace(entry['given']),
-                illegal_unicode_replace(entry['family'])
+                html_and_illegal_unicode_replace(entry['given']),
+                html_and_illegal_unicode_replace(entry['family'])
             )
         }
         for entry in contributors_list

--- a/website/search/util.py
+++ b/website/search/util.py
@@ -47,6 +47,18 @@ def build_query_string(q):
     }
 
 
+def compute_start(page, size):
+    try:
+        start = (int(page) - 1) * size
+    except ValueError:
+        start = 0
+
+    if start < 0:
+        start = 0
+
+    return start
+
+
 def generate_color():
     # TODO - this might not be the optimal way - copy is expensive
     colors_to_generate = copy.copy(COLORBREWER_COLORS)

--- a/website/search/util.py
+++ b/website/search/util.py
@@ -16,6 +16,8 @@ RE_XML_ILLEGAL = u'([\u0000-\u0008\u000b-\u000c\u000e-\u001f\ufffe-\uffff])' + \
 
 RE_XML_ILLEGAL_COMPILED = re.compile(RE_XML_ILLEGAL)
 
+RE_HTML_TAG_COMPILED = re.compile(r'<[^>]+>')
+
 
 def build_query(q='*', start=0, size=10, sort=None):
     query = {
@@ -105,11 +107,12 @@ def create_atom_feed(name, data, query, size, start, url, to_atom):
     return feed
 
 
-def illegal_unicode_replace(atom_element):
+def html_and_illegal_unicode_replace(atom_element):
     """ Replace an illegal for XML unicode character with nothing.
     This fix thanks to Matt Harper from his blog post:
     https://maxharp3r.wordpress.com/2008/05/15/pythons-minidom-xml-and-illegal-unicode-characters/
     """
     if atom_element:
-        return RE_XML_ILLEGAL_COMPILED.sub('', atom_element)
+        new_element = RE_XML_ILLEGAL_COMPILED.sub('', atom_element)
+        return RE_HTML_TAG_COMPILED.sub('', new_element)
     return atom_element

--- a/website/search/util.py
+++ b/website/search/util.py
@@ -4,6 +4,8 @@ import webcolors
 
 from werkzeug.contrib.atom import AtomFeed
 
+from website.util.sanitize import strip_html
+
 
 COLORBREWER_COLORS = [(166, 206, 227), (31, 120, 180), (178, 223, 138), (51, 160, 44), (251, 154, 153), (227, 26, 28), (253, 191, 111), (255, 127, 0), (202, 178, 214), (106, 61, 154), (255, 255, 153), (177, 89, 40)]
 
@@ -15,8 +17,6 @@ RE_XML_ILLEGAL = u'([\u0000-\u0008\u000b-\u000c\u000e-\u001f\ufffe-\uffff])' + \
                  unichr(0xd800), unichr(0xdbff), unichr(0xdc00), unichr(0xdfff))
 
 RE_XML_ILLEGAL_COMPILED = re.compile(RE_XML_ILLEGAL)
-
-RE_HTML_TAG_COMPILED = re.compile(r'<[^>]+>')
 
 
 def build_query(q='*', start=0, size=10, sort=None):
@@ -114,5 +114,5 @@ def html_and_illegal_unicode_replace(atom_element):
     """
     if atom_element:
         new_element = RE_XML_ILLEGAL_COMPILED.sub('', atom_element)
-        return RE_HTML_TAG_COMPILED.sub('', new_element)
+        return strip_html(new_element)
     return atom_element

--- a/website/search/views.py
+++ b/website/search/views.py
@@ -231,20 +231,25 @@ def search_share_stats():
     return search.share_stats(query=query)
 
 
+def compute_start(page, size):
+    try:
+        start = (int(page) - 1) * size
+    except ValueError:
+        start = 0
+
+    if start < 0:
+        start = 0
+
+    return start
+
+
 def search_share_atom(**kwargs):
     q = request.args.get('q', '*')
     sort = request.args.get('sort', 'dateUpdated')
 
     # we want the results per page to be constant between pages
     # TODO -  move this functionality into build_query in util
-
-    try:
-        start = (int(request.args.get('page', 1)) - 1) * RESULTS_PER_PAGE
-    except ValueError:
-        start = 0
-
-    if start < 0:
-        start = 0
+    start = compute_start(request.args.get('page', 1), RESULTS_PER_PAGE)
 
     query = build_query(q, size=RESULTS_PER_PAGE, start=start, sort=sort)
 

--- a/website/search/views.py
+++ b/website/search/views.py
@@ -231,25 +231,13 @@ def search_share_stats():
     return search.share_stats(query=query)
 
 
-def compute_start(page, size):
-    try:
-        start = (int(page) - 1) * size
-    except ValueError:
-        start = 0
-
-    if start < 0:
-        start = 0
-
-    return start
-
-
 def search_share_atom(**kwargs):
     q = request.args.get('q', '*')
     sort = request.args.get('sort', 'dateUpdated')
 
     # we want the results per page to be constant between pages
     # TODO -  move this functionality into build_query in util
-    start = compute_start(request.args.get('page', 1), RESULTS_PER_PAGE)
+    start = util.compute_start(request.args.get('page', 1), RESULTS_PER_PAGE)
 
     query = build_query(q, size=RESULTS_PER_PAGE, start=start, sort=sort)
 

--- a/website/search/views.py
+++ b/website/search/views.py
@@ -239,14 +239,14 @@ def search_share_atom(**kwargs):
     # TODO -  move this functionality into build_query in util
 
     try:
-        page = (int(request.args.get('page', 1)) - 1) * RESULTS_PER_PAGE
+        start = (int(request.args.get('page', 1)) - 1) * RESULTS_PER_PAGE
     except ValueError:
-        page = 1
+        start = 0
 
-    if page < 1:
-        page = 1
+    if start < 0:
+        start = 0
 
-    query = build_query(q, size=RESULTS_PER_PAGE, start=page, sort=sort)
+    query = build_query(q, size=RESULTS_PER_PAGE, start=start, sort=sort)
 
     try:
         search_results = search.search_share(query)
@@ -265,7 +265,7 @@ def search_share_atom(**kwargs):
         data=search_results['results'],
         query=q,
         size=RESULTS_PER_PAGE,
-        start=page,
+        start=start,
         url=atom_url,
         to_atom=share_search.to_atom
     )


### PR DESCRIPTION
# Purpose
XML was letting html tags through in title, description and tags. This hotfix updates the already existing remove illegal unicode chars function to also strip out html tags from the fields that were already getting checked for inappropriate characters for the xml atom feed.

Also, the atom feed was cutting off the first result, because I was starting the feed based on "page" instead of "start." Thanks for catching that @fabianvf!

# Changes
- add re to find elements enclosed in <> tags signifying html tags
- replace found tags with nothing in illegal unicode function that before just removed illegal unicode characters
- Rename illegal_unicode_replace to html_and_illegal_unicode_replace to reflect change
- In search_share_atom in search views, update query to be based on "start" instead of "page" - was starting on result 1 instead of 0.

# Side effects
Shouldn't be any, as this only affects one function only used on the atom feed elements