### PR TITLE
Fix "examples of good issue reporting" links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,4 +32,4 @@ When submitting an issue, be as descriptive as possible:
 
 Include pictures (e.g., in OSX press Cmd+Shift+4 to draw a box to screenshot)
 
-Examples of good issue reporting: #382, #713
+Examples of good issue reporting: [#382](https://github.com/CenterForOpenScience/osf.io/issues/384), [#713](https://github.com/CenterForOpenScience/osf.io/issues/713).


### PR DESCRIPTION
github doesn't auto-link issues in Markdown documents in the repository; fixed links by inserting appropriate markdown linkage fu.