### PR TITLE
Change the login placeholder from "Username" to "Email"

### DIFF
--- a/website/templates/nav.mako
+++ b/website/templates/nav.mako
@@ -84,7 +84,7 @@
                             method="POST"
                         >
                         <div class="form-group">
-                            <input type="email" class="input-sm form-control" data-bind="value: username" name="username" placeholder="Username">
+                            <input type="email" class="input-sm form-control" data-bind="value: username" name="username" placeholder="Email">
                         </div>
                         <div class="form-group">
                             <input type="password" class="input input-sm form-control" data-bind="value: password" name="password" placeholder="Password">


### PR DESCRIPTION
While the username is a user's email, the OSF signup refers to "Email" not "Username" as now specified in the placeholder in the nav bar.

This simply changes "Username" to "Email".