### PR TITLE
[Hotfix] Issue fixes related to private top project icons

### DIFF
--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -16,7 +16,7 @@
                         </h2>
                     % else:
                         <h2 class="node-parent-title unavailable">
-                            <span>Private Project</span>&nbsp;/
+                            <span>Private Project</span> <i class="fa fa-level-down fa fa-dark-lg"> </i>
                         </h2>
                     % endif
                 % endif

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -12,11 +12,11 @@
                 % if parent_node['id']:
                     % if parent_node['can_view'] or parent_node['is_public'] or parent_node['is_contributor']:
                         <h2 class="node-parent-title">
-                            <a href="${parent_node['url']}">${parent_node['title']}</a> <i class="fa fa-level-down fa fa-dark-lg"> </i>
+                            <a href="${parent_node['url']}">${parent_node['title']}</a> &nbsp;/
                         </h2>
                     % else:
                         <h2 class="node-parent-title unavailable">
-                            <span>Private Project</span> <i class="fa fa-level-down fa fa-dark-lg"> </i>
+                            <span>Private Project</span>&nbsp;/
                         </h2>
                     % endif
                 % endif

--- a/website/templates/project/project_header.mako
+++ b/website/templates/project/project_header.mako
@@ -23,7 +23,7 @@
                         % if parent_node['can_view'] or parent_node['is_public'] or parent_node['is_contributor']:
                             <li><a href="${parent_node['url']}" data-toggle="tooltip" title="${parent_node['title']}" data-placement="bottom" style="padding: 13px 17px;"> <i class="fa fa-level-down fa-rotate-180"></i>  </a></li>
                         % else:
-                            <li><a href="#"> <i class="fa fa-level-up text-muted"></i>  </a></li>
+                            <li><a href="#" data-toggle="tooltip" title="Parent project is private" data-placement="bottom" style="cursor: default"> <i class="fa fa-level-down fa-rotate-180 text-muted"></i>  </a></li>
                         % endif
                     % endif
                         <li><a href="${node['url']}"  class="project-title"> ${node['title'] | n}  </a></li>


### PR DESCRIPTION
## Purpose

Fixes these two issues: 
#2184 
#2293 

## Changes
- The icons and methods for a parent that is not a private project were the correct ones, these were not accurately transferred to the scenario where the parent is private. These have changed to have the same behaviors
- If there is no link to parent component the cursor is not a link and the tooltip says the parent is private. 

## Side effects
None, very tiny code change. 


![screen shot 2015-03-24 at 10 26 11 am](https://cloud.githubusercontent.com/assets/1314003/6803938/40570828-d211-11e4-9c18-177317e9eaaa.png)
