### PR TITLE
[feature] presentation service link

### DIFF
--- a/website/templates/nav.mako
+++ b/website/templates/nav.mako
@@ -27,8 +27,8 @@
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">Explore <b class="caret"></b></a>
                     <ul class="dropdown-menu">
                         <li><a href="/search/?q=*&filter=registration">Registry</a></li>
-                        <li><a href="/presentations">Presentations</a></li>
-                        <li><a href="/explore/activity">Public Activity</a></li>
+                        <li><a href="/presentations/">Presentations</a></li>
+                        <li><a href="/explore/activity/">Public Activity</a></li>
                     </ul><!-- end dropdown-menu -->
                 </li><!-- end dropdown -->
                 <li class="dropdown">

--- a/website/templates/nav.mako
+++ b/website/templates/nav.mako
@@ -27,6 +27,7 @@
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">Explore <b class="caret"></b></a>
                     <ul class="dropdown-menu">
                         <li><a href="/search/?q=*&filter=registration">Registry</a></li>
+                        <li><a href="/presentations">Presentations</a></li>
                         <li><a href="/explore/activity">Public Activity</a></li>
                     </ul><!-- end dropdown-menu -->
                 </li><!-- end dropdown -->


### PR DESCRIPTION
### Purpose
- Allows the presentation service to be accessed by users directly from the OSF.
- Addresses [#1418](https://github.com/CenterForOpenScience/osf.io/issues/1418) and [#2115](https://github.com/CenterForOpenScience/osf.io/issues/2115#issuecomment-85587127)

### Changes
- Adds the link to the presentation service to the Explore tab in the navbar.

![screen shot 2015-03-24 at 11 57 44 am](https://cloud.githubusercontent.com/assets/7913604/6806084/0cfe5754-d21d-11e4-802a-dc5a6b93b9c2.png)
