### PR TITLE
dropbox authentication error message

### DIFF
--- a/website/addons/dropbox/static/dropboxNodeConfig.js
+++ b/website/addons/dropbox/static/dropboxNodeConfig.js
@@ -95,7 +95,7 @@ var ViewModel = function(url, selector, folderPicker, fetchCallback) {
                     if (self.userIsOwner()) {
                         self.changeMessage('Could not retrieve Dropbox settings at ' +
                         'this time. The Dropbox addon credentials may no longer be valid.' +
-                        ' Try deauthorizing and reauthorizing Dropbox on your <a href="' +
+                        ' Please delete your access token and create a new one on your <a href="' +
                             self.urls().settings + '">account settings page</a>.',
                         'text-warning');
                     } else {

--- a/website/addons/dropbox/static/dropboxUserConfig.js
+++ b/website/addons/dropbox/static/dropboxUserConfig.js
@@ -36,7 +36,7 @@ function ViewModel(url) {
             if (!self.validCredentials()) {
                 self.changeMessage('Could not retrieve Dropbox settings at ' +
                     'this time. The Dropbox addon credentials may no longer be valid.' +
-                    ' Try deauthorizing and reauthorizing Dropbox.',
+                    ' Please delete your access token and create a new one.',
                     'text-warning');
             } else if (self.userHasAuth() && self.nNodesAuthorized === 0) {
                 self.changeMessage('Add-on successfully authorized. To link this add-on to an OSF project, ' +


### PR DESCRIPTION
### Purpose
- Clarifies the language in the dropbox authentication error message as described by @caileyfitz and @samanehsan in [#2201](https://github.com/CenterForOpenScience/osf.io/issues/2201)

### Changes
- Only changes the text of the user-facing error message.