### PR TITLE
Hotfix/download count

### DIFF
--- a/framework/analytics/__init__.py
+++ b/framework/analytics/__init__.py
@@ -45,14 +45,6 @@ def get_total_activity_count(user_id, db=None):
     return 0
 
 
-def clean_page(page):
-    return page.replace(
-        '.', '_'
-    ).replace(
-        '$', '_'
-    )
-
-
 def build_page(rex, kwargs):
     """Build page key from format pattern and request data.
 
@@ -83,8 +75,6 @@ def update_counter(page, db=None):
 
     date = datetime.utcnow()
     date = date.strftime('%Y/%m/%d')
-
-    page = clean_page(page)
 
     d = {'$inc': {}}
 
@@ -143,7 +133,7 @@ def get_basic_counters(page, db=None):
     total = 0
     collection = database['pagecounters']
     result = collection.find_one(
-        {'_id': clean_page(page)},
+        {'_id': page},
         {'total': 1, 'unique': 1}
     )
     if result:


### PR DESCRIPTION
Problem
------------------
Upload two files to the osf storage with file1 including underscores and file2 has the same name as file1 but changes all underscores to dots. Such as "ginny_huang.txt" and "ginny.huang.txt"
There download counts will synchronize. Downloading one of them will cause the other download count to increase too.

Cause
------------------
Before we have waterbutler, there are restrictions to filenames, so osf would change "ginny.huang.txt" into "ginny_huang.txt" when uploading that file. 60f430a9ae1f36ba0edd16879508e07bb2f1447f is commited for consistency.

Solution
-------------------
Since now we can have "ginny_huang.txt" and "ginny.huang.txt" in the osf storage together, we do not need that fix anymore.

Side effects
____________
If you have files with names including dots(.) or dollar signs($) before, this change will revert their download counts to zero.