### PR TITLE
Fix Trello issue with scroll not happening on single page.

### DIFF
--- a/website/addons/wiki/templates/edit.mako
+++ b/website/addons/wiki/templates/edit.mako
@@ -156,7 +156,7 @@
                     </div>
                 </div>
 
-                <div id="wikiViewPanel"  class="wiki-panel-body wiki-panel-body-flex">
+                <div id="wikiViewPanel"  class="wiki-panel-body" data-bind"css: { 'wiki-panel-body-flex': $root.singleVis() !== 'view' }">
                   <div id="wikiViewRender" data-bind="html: renderedView, mathjaxify: renderedView, anchorScroll : { buffer: 215, elem : '#wikiViewPanel'}" class=" markdown-it-view">
                       % if wiki_content:
                           ${wiki_content | n}


### PR DESCRIPTION
## Purpose
Fixes this issue: https://trello.com/c/Vix4YLTL/31-single-page-wiki-does-not-have-page-scroll

## Changes
Added back the flex css knockout binding for View wiki-panel-body

## Side effects
None