### PR TITLE
Feature/add breadcrumb to public components

### DIFF
--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -54,7 +54,7 @@ def get_public_components(uid=None, user=None):
         and node.is_public
         and not node.is_registration
         and not node.is_deleted
-    ])
+    ], show_path=True)
 
 
 @must_be_logged_in

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -891,7 +891,7 @@ def get_recent_logs(**kwargs):
     return {'logs': logs}
 
 
-def _get_summary(node, auth, rescale_ratio, primary=True, link_id=None):
+def _get_summary(node, auth, rescale_ratio, primary=True, link_id=None, show_path=False):
     # TODO(sloria): Refactor this or remove (lots of duplication with _view_project)
     summary = {
         'id': link_id if link_id else node._id,
@@ -921,7 +921,10 @@ def _get_summary(node, auth, rescale_ratio, primary=True, link_id=None):
             'ua': None,
             'non_ua': None,
             'addons_enabled': node.get_addon_names(),
-            'is_public': node.is_public
+            'is_public': node.is_public,
+            'parent_title': node.parent_node.title if node.parent_node else None,
+            'parent_is_public': node.parent_node.is_public if node.parent_node else False,
+            'show_path': show_path
         })
         if rescale_ratio:
             ua_count, ua, non_ua = _get_user_activity(node, auth, rescale_ratio)
@@ -952,9 +955,10 @@ def get_summary(auth, **kwargs):
             raise HTTPError(http.BAD_REQUEST)
     primary = kwargs.get('primary')
     link_id = kwargs.get('link_id')
+    show_path = kwargs.get('show_path', False)
 
     return _get_summary(
-        node, auth, rescale_ratio, primary=primary, link_id=link_id
+        node, auth, rescale_ratio, primary=primary, link_id=link_id, show_path=show_path
     )
 
 

--- a/website/templates/util/render_node.mako
+++ b/website/templates/util/render_node.mako
@@ -32,6 +32,13 @@
                 <i id="icon-${summary['id']}" class="pointer fa fa-plus" onclick="NodeActions.openCloseNode('${summary['id']}');" data-toggle="tooltip" title="More"></i>
             </div>
         </h4>
+
+        % if summary['show_path'] and summary['node_type'] == 'component':
+            <div style="padding-bottom: 10px">
+                ${summary['parent_title'] if summary['parent_is_public'] else "<em>-- private project --</em>"} / <b>${summary['title']}</b>
+            </div>
+        % endif
+
         <div class="list-group-item-text"></div>
 
         % if not summary['anonymous']:

--- a/website/templates/util/render_nodes.mako
+++ b/website/templates/util/render_nodes.mako
@@ -7,7 +7,8 @@
                     "rescale_ratio": ${rescale_ratio},
                     "primary": ${int(each['primary'])},
                     "link_id": "${each['id']}",
-                    "uid": "${user_id}"
+                    "uid": "${user_id}",
+                    "show_path": ${"true" if show_path else "false"}
                 },
                 "replace": true
             }'></div>

--- a/website/views.py
+++ b/website/views.py
@@ -79,7 +79,7 @@ def _render_node(node, auth=None):
     }
 
 
-def _render_nodes(nodes, auth=None):
+def _render_nodes(nodes, auth=None, show_path=False):
     """
 
     :param nodes:
@@ -91,6 +91,7 @@ def _render_nodes(nodes, auth=None):
             for node in nodes
         ],
         'rescale_ratio': _rescale_ratio(auth, nodes),
+        'show_path': show_path
     }
     return ret
 


### PR DESCRIPTION
Purpose
--------------------
Closes #1249 
Often, components from different projects have the same title (e.g. "Study Materials" or "Data"). They are listed in your public profile without providing the project title for context, so components with the same name are indistinguishable from each other.

Changes
---------------------
- Before
![Original](https://cloud.githubusercontent.com/assets/4965832/5034679/f2354c7e-6b3e-11e4-87a3-c4d8e54f08b6.png)

- After
![screen shot 2015-03-25 at 3 27 43 pm](https://cloud.githubusercontent.com/assets/8628591/6833704/70847572-d305-11e4-8aa0-af65162697fb.png)

Side effects
----------------------
I refactored <code>get_public_components</code> in <code>website/profile/views.py</code> so that when this method is called, the summary of node that is rendered always have the path underneath.