### PR TITLE
Hotfix/add multiple contributors

### DIFF
--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -265,9 +265,11 @@ var AddContributorViewModel = oop.extend(Paginator, {
         }
         // Make sure that entered email is not already in selection
         for (var i = 0, contrib; contrib = self.selection()[i]; ++i) {
-            var contribEmail = contrib.email.toLowerCase().trim();
-            if (contribEmail === self.inviteEmail().toLowerCase().trim()) {
-                return self.inviteEmail() + ' is already in queue.';
+            if (contrib.email) {
+                var contribEmail = contrib.email.toLowerCase().trim();
+                if (contribEmail === self.inviteEmail().toLowerCase().trim()) {
+                    return self.inviteEmail() + ' is already in queue.';
+                }
             }
         }
         return true;


### PR DESCRIPTION
**Steps to reproduce**
1.Put a name in the search bar of the add contributor modal and click search (do not add anyone from the "recent/frequent collaborators" part)
2.Add someone from the search results
3. Search for an unregistered contributor and add that person as an unregistered contributor
4. "Add" button is not working

**Problem and Solution**
The e-mail of the user is not returned from contributor search. However, when new unregistered contributor is added, the e-mails of previously added users are checked to see whether there are duplicate e-mails to the one of the new contributors.
With this fix we check the contributor's e-mail only when it exists

**Side effects**
None. Originally I am afraid that this would enable adding the same e-mail address for multiple times into the project, but then the program would check whether the e-mail address is in the database when an unregistered user is added.