### PR TITLE
Fix typo from last commit for the SHARE UI changes

### DIFF
--- a/website/static/js/share/index.js
+++ b/website/static/js/share/index.js
@@ -23,9 +23,9 @@ ShareApp.ViewModel = function() {
     self.count = 0;
     self.results = null;
     self.query = m.prop($osf.urlParams().q || '');
-    self.vm.sort = m.prop($osf.urlParams().sort || 'Relevance');
-    self.vm.requiredFilters = $osf.urlParams().required ? $osf.urlParams().required.split('|') : [];
-    self.vm.optionalFilters = $osf.urlParams().optional ? $osf.urlParams().optional.split('|') : [];
+    self.sort = m.prop($osf.urlParams().sort || 'Relevance');
+    self.requiredFilters = $osf.urlParams().required ? $osf.urlParams().required.split('|') : [];
+    self.optionalFilters = $osf.urlParams().optional ? $osf.urlParams().optional.split('|') : [];
 };
 
 


### PR DESCRIPTION
Changes
-----------
self.vm changed to self. in the viewmodel init

Side-effects
---------------
SHARE page shouldn't crash due to js errors.