### PR TITLE
[hotfix] Match contributors list in search with that on project overview

### DIFF
--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -171,7 +171,6 @@ def format_result(result, parent_id=None):
         'parent_title': parent_info.get('title').replace('&amp;', '&') if parent_info else None,
         'parent_url': parent_info.get('url') if parent_info is not None else None,
         'tags': result['tags'],
-        'contributors_url': result['contributors_url'],
         'is_registration': (result['is_registration'] if parent_info is None
                                                         else parent_info.get('is_registration')),
         'description': result['description'] if parent_info is None else None,
@@ -230,13 +229,12 @@ def update_node(node, index=INDEX):
         elastic_document = {
             'id': elastic_document_id,
             'contributors': [
-                x.fullname for x in node.visible_contributors
+                {
+                    'fullname': x.fullname,
+                    'url': x.profile_url if x.is_active else None
+                }
+                for x in node.visible_contributors
                 if x is not None
-            ],
-            'contributors_url': [
-                x.profile_url for x in node.visible_contributors
-                if x is not None
-                and x.is_active
             ],
             'title': node.title,
             'normalized_title': normalized_title,

--- a/website/templates/search.mako
+++ b/website/templates/search.mako
@@ -182,11 +182,11 @@
         <!-- ko if: contributors.length > 0 -->
         <p>
             <strong>Contributors:</strong> <span data-bind="foreach: contributors">
-                <!-- ko if: $parent.contributors_url[$index()] -->
-                    <a data-bind="attr.href: $parent.contributors_url[$index()]">{{ $data }}</a>
-                <!-- /ko -->
-                <!-- ko ifnot: ($parent.contributors_url[$index()]) -->
-                    {{ $data }}
+                <!-- ko if: url -->
+                    <a data-bind="attr.href: url">{{ fullname }}</a>
+                <!-- /ko-->
+                <!-- ko ifnot: url -->
+                    {{ fullname }}
                 <!-- /ko -->
 
 
@@ -214,11 +214,11 @@
         <!-- ko if: contributors.length > 0 -->
         <p>
             <strong>Contributors:</strong> <span data-bind="foreach: contributors">
-                <!-- ko if: $parent.contributors_url[$index()] -->
-                    <a data-bind="attr.href: $parent.contributors_url[$index()]">{{ $data }}</a>
-                <!-- /ko -->
-                <!-- ko ifnot: ($parent.contributors_url[$index()]) -->
-                    {{ $data }}
+                <!-- ko if: url -->
+                    <a data-bind="attr.href: url">{{ fullname }}</a>
+                <!-- /ko-->
+                <!-- ko ifnot: url -->
+                    {{ fullname }}
                 <!-- /ko -->
 
 
@@ -248,11 +248,11 @@
         <!-- ko if: contributors.length > 0 -->
         <p>
             <strong>Contributors:</strong> <span data-bind="foreach: contributors">
-                <!-- ko if: $parent.contributors_url[$index()] -->
-                    <a data-bind="attr.href: $parent.contributors_url[$index()]">{{ $data }}</a>
-                <!-- /ko -->
-                <!-- ko ifnot: ($parent.contributors_url[$index()]) -->
-                    {{ $data }}
+                <!-- ko if: url -->
+                    <a data-bind="attr.href: url">{{ fullname }}</a>
+                <!-- /ko-->
+                <!-- ko ifnot: url -->
+                    {{ fullname }}
                 <!-- /ko -->
             <!-- ko if: ($index()+1) < ($parent.contributors.length) -->&nbsp;- <!-- /ko -->
             </span>
@@ -278,11 +278,11 @@
         <!-- ko if: contributors.length > 0 -->
         <p>
             <strong>Contributors:</strong> <span data-bind="foreach: contributors">
-                <!-- ko if: $parent.contributors_url[$index()] -->
-                    <a data-bind="attr.href: $parent.contributors_url[$index()]">{{ $data }}</a>
+                <!-- ko if: url -->
+                    <a data-bind="attr.href: url">{{ fullname }}</a>
                 <!-- /ko-->
-                <!-- ko ifnot: ($parent.contributors_url[$index()]) -->
-                    {{ $data }}
+                <!-- ko ifnot: url -->
+                    {{ fullname }}
                 <!-- /ko -->
 
 


### PR DESCRIPTION
**Steps to reproduce**
1. Make sure you have a public project
2. Add an unregistered user to that project
3. Add a registered user to that project
4. Search for this project
In the search result, there is a link for the unregistered user, while there is no link for the registered user. If you click on the unregistered user, it takes you to the profile page of the registered user.

**Cause**
Calling <code>es.search</code> returns a formatted output that is specified in <code>website/search/elasticsearch.py:update_node</code>. That format stores contributor names and contributor urls in separate lists, which results in the bug.

**Fix**
Changes the format of the elasticsearch output to the following:

    {
        'contributors': [
            {
                'url': '/a1b2c',
                'name': 'Ginny Huang'
            },
            {
                'url': None,
                'name': 'Ginny Unregistered'
            },
        ],
        ...
    }

So we can map the correct url to each contributor.

**Side effects**
Has to invoke migrate_search again before use. Nothing else expected.