### PR TITLE
Update c3 to 0.4.10 to fix partial loading issues on SHARE graphs

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "body-parser": "~1.12.0",
     "bootbox": "^4.4.0",
     "bower": "^1.3.12",
-    "c3": "^0.4.9",
+    "c3": "^0.4.10",
     "css-loader": "^0.9.1",
     "diff": "~1.2.2",
     "dropzone": "git://github.com/sloria/dropzone.git#accept-directory",


### PR DESCRIPTION
## Purpose
SHARE graphs were experiencing a strange loading issue with sometimes partially loaded data. This issue was very similar to the recently closed c3 issue here - https://github.com/masayuki0812/c3/issues/975

Updating c3 to 0.4.10 should fix some of the strange graph behavior!

## Changes
- change c3 version from 0.4.9 to 0.4.10 in package.json

## Side Effects
WiIll need to update version of c3 by running ```npm install --update```