### PR TITLE
Hotfix/latest mfr

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,7 @@ Babel==1.3
 # Development version of modular-odm
 git+https://github.com/CenterForOpenScience/modular-odm.git@develop
 # Development version of modular file renderer
-git+https://github.com/CenterForOpenScience/modular-file-renderer.git@dev
+git+https://github.com/CenterForOpenScience/modular-file-renderer.git@master
 
 requests==2.5.3
 requests-oauthlib>=0.4.1


### PR DESCRIPTION
### Change

- Update master to use the latest version on mfr@master, which includes a fix for https://github.com/CenterForOpenScience/osf.io/issues/2340

### Side effects

Need to run the following for deployment:

```
sudo -u www-data `which pip` install -r requirements.txt
sudo -u www-data `which mfr` install docx -r
```