### PR TITLE
Fix wiki anchor scrolls not working in registration or private modes

### DIFF
--- a/website/addons/wiki/templates/edit.mako
+++ b/website/addons/wiki/templates/edit.mako
@@ -157,7 +157,7 @@
                 </div>
 
                 <div id="wikiViewPanel"  class="wiki-panel-body" data-bind="css: { 'wiki-panel-body-flex': $root.singleVis() !== 'view' }">
-                  <div id="wikiViewRender" data-bind="html: renderedView, mathjaxify: renderedView, anchorScroll : { buffer: 215, elem : '#wikiViewPanel'}" class=" markdown-it-view">
+                  <div id="wikiViewRender" data-bind="html: renderedView, mathjaxify: renderedView, anchorScroll : { buffer: 50, elem : '#wikiViewPanel'}" class=" markdown-it-view">
                       % if wiki_content:
                           ${wiki_content | n}
                       % else:

--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -307,19 +307,21 @@ ko.bindingHandlers.anchorScroll = {
     init: function(elem, valueAccessor) {
         var buffer = valueAccessor().buffer || 100;
         var element = valueAccessor().elem || elem;
+        var offset;
         $(element).on('click', 'a[href^="#"]', function (event) {
             var $item = $(this);
             var $element = $(element);
             if(!$item.attr('data-model') && $item.attr('href') !== "#") {
                 event.preventDefault();
                 // get location of the target
-                var target = $item.attr('href'),
-                    offset = $(target).offset();
+                var target = $item.attr('href');
                 // if target has a scrollbar scroll it, otherwise scroll the page
                 if ( $element.get(0).scrollHeight > $element.height() ) {
+                    offset = $(target).position();
                     $element.scrollTop(offset.top - buffer);
                 } else {
-                    $(window).scrollTop(offset.top - 100);
+                    offset = $(target).offset();
+                    $(window).scrollTop(offset.top - 100); // This is fixed to 100 because of the fixed navigation menus on the page
                 }
             }
         });


### PR DESCRIPTION
## Purpose
Fixes Trello card: https://trello.com/c/mGfhI0ii

## Changes
Was used wrong position offset information, for closed components used position rather than offset to correctly get parent element offset. 

## Side effects
None. Tested with regular projects as well. 