### PR TITLE
Update SHARE search graph

### DIFF
--- a/website/search/share_search.py
+++ b/website/search/share_search.py
@@ -64,6 +64,7 @@ def providers():
         }
     }
 
+
 @requires_search
 def stats(query=None):
     query = query or {"query": {"match_all": {}}}
@@ -231,6 +232,10 @@ def data_for_charts(elastic_results):
         'date_numbers': numbers,
         'group_names': names
     }
+
+    if date_totals.get('date_numbers') == [[u'x']]:
+        for name in date_totals.get('group_names'):
+            date_totals.get('date_numbers').append([name, 0])
 
     for_charts['date_totals'] = date_totals
 

--- a/website/static/js/share/stats.js
+++ b/website/static/js/share/stats.js
@@ -62,6 +62,9 @@ function timeGraph (data) {
         },
         legend: {
             show: false
+        },
+        tooltip: {
+          grouped: false
         }
     });
 }

--- a/website/static/js/share/utils.js
+++ b/website/static/js/share/utils.js
@@ -212,12 +212,9 @@ utils.loadStats = function(vm){
             if(type === 'shareDonutGraph') {
                 var count = data.charts.shareDonutGraph.columns.filter(function(val){return val[1] > 0;}).length;
                 $('.c3-chart-arcs-title').text(count + ' Provider' + (count !== 1 ? 's' : ''));
-                vm.statsData.charts.shareDonutGraph.columns = vm.statsData.charts[type].columns.filter(function(datum) {
-                    return (datum[1] > 0);
-                });
             }
-            vm.statsData.charts[type].unload = unload;
             vm.graphs[type].load(vm.statsData.charts[type]);
+            vm.graphs[type].flush();
         }, utils.errorState.bind(this, vm));
         vm.statsLoaded(true);
     }).then(m.redraw);

--- a/website/static/js/share/utils.js
+++ b/website/static/js/share/utils.js
@@ -199,14 +199,6 @@ utils.loadStats = function(vm){
         url: '/api/v1/share/stats/?' + $.param({q: utils.buildQuery(vm)}),
         background: true
     }).then(function(data) {
-        var unload;
-        if (vm.statsData){
-            unload = $.map(vm.statsData.charts.shareDonutGraph.columns, function(datum) {
-                return datum[0];
-            });
-        } else {
-            unload = [];
-        }
         vm.statsData = data;
         $.map(Object.keys(vm.graphs), function(type) {
             if(type === 'shareDonutGraph') {

--- a/website/static/js/share/utils.js
+++ b/website/static/js/share/utils.js
@@ -214,7 +214,6 @@ utils.loadStats = function(vm){
                 $('.c3-chart-arcs-title').text(count + ' Provider' + (count !== 1 ? 's' : ''));
             }
             vm.graphs[type].load(vm.statsData.charts[type]);
-            vm.graphs[type].flush();
         }, utils.errorState.bind(this, vm));
         vm.statsLoaded(true);
     }).then(m.redraw);


### PR DESCRIPTION
## Purpose
Update the SHARE search page graph, specifically fixing:
- Graph now differently redraws to 0 when there are no results
- Re-searching from the beginning no longer renders blank pie slices
- Time series tooltip no longer shows ALL providers, only one per data point

## Changes
- Remove redraw from share utils, causing weird blank pie slices
- Make the tooltip no longer grouped, but individual
- Add columns with 0 results per provider for 0 search results

## Side effects
None anticipated