### PR TITLE
Feature/030 zenedely fixes

### DIFF
--- a/website/addons/base/__init__.py
+++ b/website/addons/base/__init__.py
@@ -24,6 +24,8 @@ from website.addons.base import exceptions
 from website.addons.base import serializer
 from website.project.model import Node
 
+from website.oauth.signals import oauth_complete
+
 lookup = TemplateLookup(
     directories=[
         settings.TEMPLATES_PATH
@@ -526,6 +528,15 @@ class AddonOAuthUserSettingsBase(AddonUserSettingsBase):
             x for x in self.owner.external_accounts
             if x.provider == self.oauth_provider.short_name
         ]
+
+    @oauth_complete.connect
+    def oauth_complete(args):
+        external_account = args.get('external_account')
+        user = args.get('user')
+        if not user or not external_account:
+            return
+
+        user.get_or_add_addon(external_account.provider)
 
     def grant_oauth_access(self, node, external_account, metadata=None):
         """Give a node permission to use an ``ExternalAccount`` instance."""

--- a/website/addons/base/__init__.py
+++ b/website/addons/base/__init__.py
@@ -530,13 +530,10 @@ class AddonOAuthUserSettingsBase(AddonUserSettingsBase):
         ]
 
     @oauth_complete.connect
-    def oauth_complete(args):
-        external_account = args.get('external_account')
-        user = args.get('user')
-        if not user or not external_account:
+    def oauth_complete(provider, account, user):
+        if not user or not account:
             return
-
-        user.get_or_add_addon(external_account.provider)
+        user.get_or_add_addon(account.provider)
 
     def grant_oauth_access(self, node, external_account, metadata=None):
         """Give a node permission to use an ``ExternalAccount`` instance."""

--- a/website/addons/base/serializer.py
+++ b/website/addons/base/serializer.py
@@ -66,7 +66,6 @@ class OAuthAddonSerializer(AddonSerializer):
     @property
     def serialized_user_settings(self):
         retval = super(OAuthAddonSerializer, self).serialized_user_settings
-
         retval['accounts'] = []
         if self.user_settings:
             retval['accounts'] = self.serialized_accounts

--- a/website/addons/mendeley/routes.py
+++ b/website/addons/mendeley/routes.py
@@ -11,7 +11,7 @@ api_routes = {
                 '/settings/mendeley/accounts/',
             ],
             'get',
-            views.mendeley_get_user_settings,
+            views.mendeley_get_user_accounts,
             json_renderer,
         ),
         Rule(

--- a/website/addons/mendeley/serializer.py
+++ b/website/addons/mendeley/serializer.py
@@ -25,5 +25,5 @@ class MendeleySerializer(CitationsAddonSerializer):
             'folders': node.api_url_for('mendeley_citation_list'),
             'config': node.api_url_for('mendeley_set_config'),
             'deauthorize': node.api_url_for('mendeley_remove_user_auth'),
-            'accounts': node.api_url_for('mendeley_get_user_settings'),
+            'accounts': node.api_url_for('mendeley_get_user_accounts'),
         }

--- a/website/addons/mendeley/views.py
+++ b/website/addons/mendeley/views.py
@@ -15,7 +15,7 @@ from .provider import MendeleyCitationsProvider
 
 
 @must_be_logged_in
-def mendeley_get_user_settings(auth):
+def mendeley_get_user_accounts(auth):
     """ Returns the list of all of the current user's authorized Mendeley accounts """
 
     provider = MendeleyCitationsProvider()

--- a/website/oauth/signals.py
+++ b/website/oauth/signals.py
@@ -1,0 +1,4 @@
+import blinker
+
+oauth_signals = blinker.Namespace()
+oauth_complete = oauth_signals.signal('oauth-complete')

--- a/website/oauth/views.py
+++ b/website/oauth/views.py
@@ -49,5 +49,6 @@ def oauth_callback(service_name, auth):
     if provider.account not in user.external_accounts:
         user.external_accounts.append(provider.account)
         user.save()
+    user.get_or_add_addon(service_name)
 
     return {}

--- a/website/oauth/views.py
+++ b/website/oauth/views.py
@@ -8,7 +8,7 @@ from framework.auth.decorators import must_be_logged_in
 from framework.exceptions import HTTPError
 from website.oauth.models import ExternalAccount
 from website.oauth.utils import get_service
-
+from website.oauth.signals import oauth_complete
 
 @must_be_logged_in
 def oauth_disconnect(external_account_id, auth):
@@ -49,6 +49,9 @@ def oauth_callback(service_name, auth):
     if provider.account not in user.external_accounts:
         user.external_accounts.append(provider.account)
         user.save()
-    user.get_or_add_addon(service_name)
 
+    oauth_complete.send({
+        'account': provider.account,
+        'user': user
+    })
     return {}

--- a/website/oauth/views.py
+++ b/website/oauth/views.py
@@ -50,8 +50,6 @@ def oauth_callback(service_name, auth):
         user.external_accounts.append(provider.account)
         user.save()
 
-    oauth_complete.send({
-        'account': provider.account,
-        'user': user
-    })
+    oauth_complete.send(provider, account=provider.account, user=user)
+
     return {}


### PR DESCRIPTION
## Purpose

Zendeley users went through the OAuth dance but were still unable to see their content from the node settings panel. This PR fixes this.

## Changes

At no point was the AddonUserSettings instance getting created, which prevented the ExternalAccount from being listed as one of the available ones. This broke the chain of ExternalAccount events and never linked the external account to the user settings instance.

## Side Effects

@lyndsysimon should review this change before merge