### PR TITLE
[WIP] import livereload class only in live mode

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -44,10 +44,10 @@ except Failure:
 def server(host=None, port=5000, debug=True, live=False):
     """Run the app server."""
     from website.app import init_app
-    from livereload import Server
     app = init_app(set_backends=True, routes=True, mfr=True)
 
     if live:
+        from livereload import Server
         server = Server(app.wsgi_app)
         server.watch(os.path.join(HERE, 'website', 'static', 'public'))
         server.serve(port=port)


### PR DESCRIPTION
This is a fix for https://github.com/CenterForOpenScience/osf.io/issues/2309
Of course, now email logging doesn't work with `invoke server --live`, hence the WIP tag.
I don't really understand what's happening and I am not familiar with livereload, but maybe this can give some inspiration for a better fix.