### PR TITLE
Allow for user to be None when constructing addon_serializer.

### DIFF
--- a/website/addons/citations/provider.py
+++ b/website/addons/citations/provider.py
@@ -126,11 +126,12 @@ class CitationsProvider(object):
         if list_id is None:
             contents = [node_addon.root_folder]
         else:
+            user_settings = user.get_addon(self.provider_name) if user else None
             if show in ('all', 'folders'):
                 contents += [
                     self.serializer(
                         node_settings=node_addon,
-                        user_settings=user.get_addon(self.provider_name),
+                        user_settings=user_settings,
                     ).serialize_folder(each)
                     for each in account_folders
                     if each.get('parent_list_id') == list_id
@@ -140,7 +141,7 @@ class CitationsProvider(object):
                 contents += [
                     self.serializer(
                         node_settings=node_addon,
-                        user_settings=user.get_addon(self.provider_name),
+                        user_settings=user_settings,
                     ).serialize_citation(each)
                     for each in node_addon.api.get_list(list_id)
                 ]


### PR DESCRIPTION
## Purpose
Users were getting 500s when trying to load Mendeley or Zotero content
when not logged in.

## Changes
We were making an explict call to user.get_addon(...) even when user is
possibly a None. This fix allows user to be None.

## Side Effects
None