### PR TITLE
[hotfix] forgot password should not give unnecessary info

### DIFF
--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -82,9 +82,12 @@ def forgot_password():
                 mail=mails.FORGOT_PASSWORD,
                 reset_link=reset_link
             )
-            status.push_status_message('Reset email sent to {0}'.format(email))
-        else:
-            status.push_status_message('Email {email} not found'.format(email=email))
+        status.push_status_message(
+            'An email with instructions on how to reset the password for the '
+            'account associated with {0} has been sent. If you do not receive '
+            'an email and believe you should have please '
+            'contact OSF Support.'.format(email)
+        )
 
     forms.push_errors_to_status(form.errors)
     return auth_login(forgot_password_form=form)


### PR DESCRIPTION
## Purpose
Requests for password resets of email accounts that had not been registered were informing the requestee that they didn't exist. Generally these should fail silently so we don't inadvertently leak information to a malicious party.

## Changes
Requester shall see the same status message informing them an email has been sent with reset information regarding the account in question regardless of whether that email is registered or not.

## Side Effects
This could confuse legitimate users that type in the wrong email address and don't read the status message.

Closes-Issue: #2355 