### PR TITLE
move /api/v1/share/ to /api/v1/share/search/

### DIFF
--- a/tests/test_share.py
+++ b/tests/test_share.py
@@ -76,7 +76,7 @@ class TestShareSearch(OsfTestCase):
                 'total': 0
             }
         }
-        self.app.get('/api/v1/share/', params={
+        self.app.get('/api/v1/share/search/', params={
             'q': '*',
             'from': '1',
             'size:': '20',
@@ -87,7 +87,7 @@ class TestShareSearch(OsfTestCase):
     @patch.object(share_search.share_es, 'count')
     def test_share_count(self, mock_count):
         mock_count.return_value = {'count': 0}
-        self.app.get('/api/v1/share/', params={
+        self.app.get('/api/v1/share/search/', params={
             'q': '*',
             'from': '1',
             'size:': '20',

--- a/website/routes.py
+++ b/website/routes.py
@@ -670,7 +670,7 @@ def make_url_map(app):
 
         Rule(['/search/', '/search/<type>/'], ['get', 'post'], search_views.search_search, json_renderer),
         Rule('/search/projects/', 'get', search_views.search_projects_by_title, json_renderer),
-        Rule('/share/', ['get', 'post'], search_views.search_share, json_renderer),
+        Rule('/share/search/', ['get', 'post'], search_views.search_share, json_renderer),
         Rule('/share/stats/', 'get', search_views.search_share_stats, json_renderer),
         Rule('/share/providers/', 'get', search_views.search_share_providers, json_renderer),
 

--- a/website/search/views.py
+++ b/website/search/views.py
@@ -210,8 +210,8 @@ def search_share():
     elif request.method == 'GET':
         query = build_query(
             request.args.get('q', '*'),
-            request.args.get('from'),
-            request.args.get('size'),
+            request.args.get('from', 0),
+            request.args.get('size', 10),
             sort=request.args.get('sort')
         )
 

--- a/website/static/js/search.js
+++ b/website/static/js/search.js
@@ -257,7 +257,7 @@ var ViewModel = function(params) {
             if (!noPush) {
                 self.pushState();
             }
-            $osf.postJSON('/api/v1/share/?count', jsonData).success(function(data) {
+            $osf.postJSON('/api/v1/share/search/?count', jsonData).success(function(data) {
                 self.categories.push(new Category('SHARE', data.count, 'SHARE'));
             });
         }).fail(function(response){

--- a/website/static/js/share/stats.js
+++ b/website/static/js/share/stats.js
@@ -125,7 +125,7 @@ Stats.controller = function(vm) {
     m.request({
         method: 'GET',
         background: true,
-        url: '/api/v1/share/?size=1',
+        url: '/api/v1/share/search/?size=1',
     }).then(function(data) {
         self.vm.totalCount = data.count;
         self.vm.latestDate = new $osf.FormattableDate(data.results[0].dateUpdated).local;

--- a/website/static/js/share/utils.js
+++ b/website/static/js/share/utils.js
@@ -70,7 +70,7 @@ utils.loadMore = function(vm) {
         m.request({
             method: 'get',
             background: true,
-            url: '/api/v1/share/?' + $.param({
+            url: '/api/v1/share/search/?' + $.param({
                 from: page,
                 q: utils.buildQuery(vm),
                 sort: sort


### PR DESCRIPTION
Purpose
-----------
We are ensuring that all non-REST-ful search routes be easily recognizable via the suffix /search/

Changes
-------------
Move the /api/v1/share/ search route to /api/v1/share/search/

Side-effects
--------------
Hopefully none, so long as I successfully found every use of the route in the frontend (which I think I did).