### PR TITLE
Hide the graph if there are no results

### DIFF
--- a/website/static/js/share/stats.js
+++ b/website/static/js/share/stats.js
@@ -81,7 +81,7 @@ Stats.view = function(ctrl) {
         m('.row', ctrl.vm.showStats ? [
             m('.col-md-12', [
                 m('.row', m('.col-md-12', [
-                    m('.row', ctrl.vm.statsData ? [
+                    m('.row', (ctrl.vm.statsData && ctrl.vm.count > 0) ? [
                         m('.col-sm-3', ctrl.drawGraph('shareDonutGraph', donutGraph)),
                         m('.col-sm-9', ctrl.drawGraph('shareTimeGraph', timeGraph))
                     ] : [])


### PR DESCRIPTION
Purpose
------------
When there are no results, nearly empty graphs are displayed (with a small sliver for all the sources with 0 results). This is confusing and ugly.

Changes
------------
Now, if your search yields no results, the graphs are hidden

Side-effects
-----------------
Possible performance issues? I would love if someone who had some experience with c3 could look at this change.