### PR TITLE
[WIP] Add scripts to add bash completion for invoke tasks

### DIFF
--- a/.invoke_completion_template
+++ b/.invoke_completion_template
@@ -1,0 +1,12 @@
+#!/bin/bash
+_invoke ()
+{       
+  local cur prev opts
+  cur="${COMP_WORDS[COMP_CWORD]}"
+  prev="${COMP_WORDS[COMP_CWORD-1]}"
+  opts="__OPTS__"
+  
+  COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+  return 0
+}
+complete -F _invoke invoke

--- a/generate_invoke_completion.py
+++ b/generate_invoke_completion.py
@@ -1,0 +1,18 @@
+def main():
+    f = open('tasks.py', 'r')
+    tasks = []
+    lines = f.read().split('\n')
+    f.close()
+    for i in range(len(lines)):
+        line = lines[i]
+        if '@task' in line:
+            opt = lines[i + 1].replace('def ', '').split('(')[0]
+            tasks.append(opt)
+    templ = open('.invoke_completion_template', 'r').read()
+    templ = templ.replace('__OPTS__', ' '.join(tasks))
+    out = open('.invoke_completion.sh', 'wb')
+    out.write(templ)
+    out.close()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Purpose

ATM there' s no bash completion for invoke tasks. These scripts add this.

## Changes

- Add a template file for bash completion for invoke. 
- Add a script to parse tasks.py and generation a bash completion script

Use this script like
```
python generate_invoke_completion.py
source .invoke_completion.sh
```
or add to $VIRTUALENV_HOME/{osf virtualenv}/bin/postactivate:
```
cd $OSF_HOME
python generate_invoke_completion.py
source ./.invoke_completion.sh
```
to have autocompletion regenerated every time you workon osf

## Side Effects

None