### PR TITLE
hotfix/responsive presentation banners

### DIFF
--- a/website/templates/public/pages/meeting_body.mako
+++ b/website/templates/public/pages/meeting_body.mako
@@ -1,7 +1,7 @@
 <h2 style="padding-bottom: 30px;">${ meeting['name'] } Posters & Talks</h2>
 
 % if meeting['logo_url']:
-    <img src="${ meeting['logo_url'] }" class="image-responsive" />
+    <img src="${ meeting['logo_url'] }" class="img-responsive" />
     <br /><br />
   % endif
 


### PR DESCRIPTION
Purpose
-----------
Make presentation service banners responsive.

Changes
------------
Modify the class of the image so that it's actually being responsive.

Side effects
----------------
Other presentation banners will also become responsive.

Fixes #2397 