### PR TITLE
Fix project settings page sidebar link positioning

### DIFF
--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -2596,3 +2596,9 @@ span#profileFullname{
 .m-xl {
     margin: 50px;
 }
+
+@media (max-width: 768px) {
+    .affix {
+        position: relative;
+    }
+}

--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -981,6 +981,8 @@ h1.unavailable {
     margin-top: -100px;
     padding-top: 100px;
     display: block;
+  z-index: -1;
+  position: relative;    
 }
 
 .anchor {

--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -80,7 +80,7 @@ body {
     position: fixed;
     top: 70px;
 }
-.gs-sidebar.affix-bottom {
+.affix-bottom {
     position: relative;
 }
 

--- a/website/static/js/pages/profile-settings-page.js
+++ b/website/static/js/pages/profile-settings-page.js
@@ -6,19 +6,3 @@ new profile.Names('#names', ctx.nameUrls, ['edit']);
 new profile.Social('#social', ctx.socialUrls, ['edit']);
 new profile.Jobs('#jobs', ctx.jobsUrls, ['edit']);
 new profile.Schools('#schools', ctx.schoolsUrls, ['edit']);
-
-// Reusable function to fix affix widths to columns.  
-function fixAffixWidth() {
-    $('.affix, .affix-top, .affix-bottom').each(function (){
-        var el = $(this);
-        var colsize = el.parent('.affix-parent').width();
-        el.outerWidth(colsize);
-    });
-}
-
-$(document).ready(function() {
-
-    $(window).resize(function (){ fixAffixWidth(); });
-    $('.profile-settings-page .panel').on('affixed.bs.affix', function(){ fixAffixWidth(); });
-
-});

--- a/website/static/js/pages/profile-settings-page.js
+++ b/website/static/js/pages/profile-settings-page.js
@@ -6,3 +6,19 @@ new profile.Names('#names', ctx.nameUrls, ['edit']);
 new profile.Social('#social', ctx.socialUrls, ['edit']);
 new profile.Jobs('#jobs', ctx.jobsUrls, ['edit']);
 new profile.Schools('#schools', ctx.schoolsUrls, ['edit']);
+
+// Reusable function to fix affix widths to columns.  
+function fixAffixWidth() {
+    $('.affix, .affix-top, .affix-bottom').each(function (){
+        var el = $(this);
+        var colsize = el.parent('.affix-parent').width();
+        el.outerWidth(colsize);
+    });
+}
+
+$(document).ready(function() {
+
+    $(window).resize(function (){ fixAffixWidth(); });
+    $('.profile-settings-page .panel').on('affixed.bs.affix', function(){ fixAffixWidth(); });
+
+});

--- a/website/static/js/pages/project-settings-page.js
+++ b/website/static/js/pages/project-settings-page.js
@@ -41,7 +41,7 @@ function fixAffixWidth() {
 $(document).ready(function() {
 
     $(window).resize(function (){ fixAffixWidth(); });
-    // $('.project-page .panel').on('affixed.bs.affix', function(){ fixAffixWidth(); });
+    $('.project-page .panel').on('affixed.bs.affix', function(){ fixAffixWidth(); });
 
     $('#deleteNode').on('click', function() {
         ProjectSettings.getConfirmationCode(ctx.node.nodeType);

--- a/website/static/js/pages/project-settings-page.js
+++ b/website/static/js/pages/project-settings-page.js
@@ -30,19 +30,18 @@ $.ajax({
 });
 
 // Reusable function to fix affix widths to columns.  
-function fixAffixWidth(parent) {
-    var parent = parent || 'body';
-    $(parent + ' .affix').each(function (){
+function fixAffixWidth() {
+    $('.affix, .affix-top, .affix-bottom').each(function (){
         var el = $(this);
-        var colsize = el.parent('div[class^="col-"]').width();
-        el.width(colsize);
+        var colsize = el.parent('.affix-parent').width();
+        el.outerWidth(colsize);
     });
 }
 
 $(document).ready(function() {
 
     $(window).resize(function (){ fixAffixWidth(); });
-    $('.project-page .panel').on('affixed.bs.affix', function(){ fixAffixWidth(); });
+    // $('.project-page .panel').on('affixed.bs.affix', function(){ fixAffixWidth(); });
 
     $('#deleteNode').on('click', function() {
         ProjectSettings.getConfirmationCode(ctx.node.nodeType);

--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -17,7 +17,7 @@
 
 <div class="row project-page">
     <div class="col-sm-3">
-        <div class="panel panel-default" data-spy="affix" >
+        <div class="panel panel-default" data-spy="affix" data-offset-top="60" data-offset-bottom="268">
             <ul class="nav nav-stacked nav-pills">
                 % if 'admin' in user['permissions'] and not node['is_registration']:
                     <li><a href="#configureNodeAnchor">Configure ${node['node_type'].capitalize()}</a></li>

--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -16,7 +16,7 @@
 </div>
 
 <div class="row project-page">
-    <div class="col-sm-3">
+    <div class="col-sm-3 affix-parent">
         <div class="panel panel-default" data-spy="affix" data-offset-top="60" data-offset-bottom="268">
             <ul class="nav nav-stacked nav-pills">
                 % if 'admin' in user['permissions'] and not node['is_registration']:


### PR DESCRIPTION
## Purpose 

Resolves two bugs related to the positioning of the project settings links: 
#2307 
#2314 

## Changes
- Made affix adjustment on resize more robust
- Added proper css for positioning in XS mode
- Added proper css for positioning when scrolling below the overall footer of OSF

## Side effects
None. Checked in Chrome, Safari, Firefox. 