### PR TITLE
update all fa-question-sign to fa-question-circle 

### DIFF
--- a/website/templates/project/contributors.mako
+++ b/website/templates/project/contributors.mako
@@ -66,7 +66,7 @@
                 <div data-bind="if: adminContributors.length">
                     <h4>
                       Admins on Parent Projects
-                      <i class="fa fa-question-sign admin-info"
+                      <i class="fa fa-question-circle admin-info"
                               data-content="These users are not contributors on
                               this component but can view and register it because they
                                 are administrators on a parent project."
@@ -161,7 +161,7 @@
                         <td class="col-sm-1">
                             <span data-bind="html: anonymousDisplay"></span>
                             <!-- ko if: $root.nodeIsPublic && anonymous -->
-                            <i data-bind="tooltip: {title: 'Public projects are not anonymized.'}" class="fa fa-question-sign fa fa-sm"></i>
+                            <i data-bind="tooltip: {title: 'Public projects are not anonymized.'}" class="fa fa-question-circle fa-sm"></i>
                             <!-- /ko -->
                         </td>
                         <td class="col-sm-0">

--- a/website/templates/project/modal_add_contributor.mako
+++ b/website/templates/project/modal_add_contributor.mako
@@ -137,7 +137,7 @@
                                     <th width="45%">Name</th>
                                     <th width="30%">
                                         Permissions
-                                        <i class="fa fa-question-sign permission-info"
+                                        <i class="fa fa-question-circle permission-info"
                                                 data-toggle="popover"
                                                 data-title="Permission Information"
                                                 data-container="#addContributors"

--- a/website/templates/project/modal_generate_private_link.mako
+++ b/website/templates/project/modal_generate_private_link.mako
@@ -54,7 +54,7 @@
                                     <input type="checkbox" data-bind="checked:$parent.nodesToChange, value:id" />
                                     <!-- /ko -->
                                     <!-- ko ifnot: $root.isChildVisible($data) -->
-                                        <i class="fa fa-question-sign" data-bind="tooltip: {title: 'Parent needs to be checked'}"></i>
+                                        <i class="fa fa-question-circle" data-bind="tooltip: {title: 'Parent needs to be checked'}"></i>
                                     <!-- /ko -->
                                     <span data-bind="text:$data.title"></span>
                                     <span data-bind="if: $data.is_public">(public)</span>


### PR DESCRIPTION
<b>Purpose</b>
Update all fa-question-sign to fa-question-circle according to the update from font-awesome 3.2 to font-awesome 4. fix issue https://github.com/CenterForOpenScience/osf.io/issues/2395

<b>Changes</b>
for public project's anonymous link in view-only link table in sharing page
before change
![image](https://cloud.githubusercontent.com/assets/4974056/7029604/c428f96a-dd2c-11e4-8ca0-1f97675d6e6b.png)
after
![screen shot 2015-04-07 at 1 49 37 pm](https://cloud.githubusercontent.com/assets/4974056/7029624/f63b9e6c-dd2c-11e4-9fbc-e21cf83a0917.png)

admin on parent project
before change
![screen shot 2015-04-07 at 1 51 19 pm](https://cloud.githubusercontent.com/assets/4974056/7029653/35c166ac-dd2d-11e4-82cc-c6c136ca64ba.png)
after change
![screen shot 2015-04-07 at 1 50 12 pm](https://cloud.githubusercontent.com/assets/4974056/7029663/47d6ad7a-dd2d-11e4-9779-cd7229b9ed15.png)

add contributor permission
before change
![screen shot 2015-04-07 at 1 52 34 pm](https://cloud.githubusercontent.com/assets/4974056/7029677/5f5a82aa-dd2d-11e4-9d07-fe5dd54454c7.png)
after change
![screen shot 2015-04-07 at 1 53 10 pm](https://cloud.githubusercontent.com/assets/4974056/7029687/742465fc-dd2d-11e4-878a-becf66d004f7.png)

add view-only link
before change
![screen shot 2015-04-07 at 1 53 53 pm](https://cloud.githubusercontent.com/assets/4974056/7029708/9c577834-dd2d-11e4-974e-f13d7f68b25e.png)
after change
![screen shot 2015-04-07 at 1 54 18 pm](https://cloud.githubusercontent.com/assets/4974056/7029711/a44b6f0a-dd2d-11e4-8cc0-f85c3a33a905.png)

<b>Others</b>
Perhaps need someone to inspect any missing font-awesome icon missing upgrade from 3.2 to 4.0 throughout osf
