### PR TITLE
change all the Amazon S3 name display in logs to 'Amazon S3'

### DIFF
--- a/website/addons/s3/templates/log_templates.mako
+++ b/website/addons/s3/templates/log_templates.mako
@@ -25,7 +25,7 @@ bucket
 </script>
 
 <script type="text/html" id="s3_bucket_linked">
-linked Amazon Simple Storage Service bucket /
+linked the Amazon S3 bucket /
 <span data-bind="text: params.bucket"></span> to
 <span data-bind="text: nodeType"></span>
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
@@ -39,13 +39,13 @@ un-selected bucket
 </script>
 
 <script type="text/html" id="s3_node_authorized">
-authorized the S3 addon for {{ nodeType }}
+authorized the Amazon S3 addon for {{ nodeType }}
 <a class="log-node-title-link overflow"
     data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 
 <script type="text/html" id="s3_node_deauthorized">
-deauthorized the S3 addon for {{ nodeType }}
+deauthorized the Amazon S3 addon for {{ nodeType }}
 <a class="log-node-title-link overflow"
     data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>


### PR DESCRIPTION
<b>Purpose</b>
Fix https://trello.com/c/xZzHugJO/79-s3-amazon-simple-storage-service-which-is-it-exactly.

<b>Changes</b>
Change all the names of Amazon S3 in log parts to Amazon S3
before change it's either called S3 or Amazon Simple Storage Service
![image](https://cloud.githubusercontent.com/assets/4974056/7031544/5896df88-dd3a-11e4-8e13-d3f32d03f90f.png)

after changes,
they are all called Amazon S3