### PR TITLE
fix the folder_name of box addon in log

### DIFF
--- a/website/addons/box/model.py
+++ b/website/addons/box/model.py
@@ -272,6 +272,7 @@ class BoxNodeSettings(AddonNodeSettingsBase):
 
     def set_folder(self, folder_id, auth):
         self.folder_id = str(folder_id)
+        self._update_folder_data()
         self.save()
         # Add log to node
         nodelogger = BoxNodeLogger(node=self.owner, auth=auth)
@@ -304,6 +305,7 @@ class BoxNodeSettings(AddonNodeSettingsBase):
             nodelogger.log(action="node_deauthorized", extra=extra, save=True)
 
         self.folder_id = None
+        self._update_folder_data()
         self.user_settings = None
 
         self.save()

--- a/website/addons/box/templates/log_templates.mako
+++ b/website/addons/box/templates/log_templates.mako
@@ -22,7 +22,10 @@ Box in {{ nodeType }}
 
 
 <script type="text/html" id="box_folder_selected">
-linked Box folder /<span class="overflow">{{ params.folder }}</span> to {{ nodeType }}
+linked Box folder
+<span class="overflow">
+    {{ params.folder === 'All Files' ? '/(Full Box)' : params.folder.replace('All Files','')}}
+</span> to {{ nodeType }}
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 

--- a/website/addons/box/templates/log_templates.mako
+++ b/website/addons/box/templates/log_templates.mako
@@ -24,7 +24,7 @@ Box in {{ nodeType }}
 <script type="text/html" id="box_folder_selected">
 linked Box folder
 <span class="overflow">
-    {{ params.folder === 'All Files' ? '/(Full Box)' : params.folder.replace('All Files','')}}
+    {{ params.folder_path === 'All Files' ? '/(Full Box)' : params.folder_path.replace('All Files','')}}
 </span> to {{ nodeType }}
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>

--- a/website/addons/box/tests/test_models.py
+++ b/website/addons/box/tests/test_models.py
@@ -280,7 +280,8 @@ class TestBoxNodeSettingsModel(OsfTestCase):
         assert_in('project', params)
         assert_in('folder_id', params)
 
-    def test_set_folder(self):
+    @mock.patch("website.addons.box.model.BoxNodeSettings._update_folder_data")
+    def test_set_folder(self, mock_update_folder):
         folder_id = '1234567890'
         self.node_settings.set_folder(folder_id, auth=Auth(self.user))
         self.node_settings.save()

--- a/website/addons/box/utils.py
+++ b/website/addons/box/utils.py
@@ -46,7 +46,7 @@ class BoxNodeLogger(object):
             'project': self.node.parent_id,
             'node': self.node._primary_key,
             'folder_id': self.node.get_addon('box', deleted=True).folder_id,
-            'folder_name': self.node.get_addon('box', deleted=True).folder_name,
+            'folder': self.node.get_addon('box', deleted=True).folder_name,
             'folder_path': self.node.get_addon('box', deleted=True).folder_path
         }
         # If logging a file-related action, add the file's view and download URLs

--- a/website/addons/box/utils.py
+++ b/website/addons/box/utils.py
@@ -46,7 +46,8 @@ class BoxNodeLogger(object):
             'project': self.node.parent_id,
             'node': self.node._primary_key,
             'folder_id': self.node.get_addon('box', deleted=True).folder_id,
-            'folder': self.node.get_addon('box', deleted=True).folder_path
+            'folder_name': self.node.get_addon('box', deleted=True).folder_name,
+            'folder_path': self.node.get_addon('box', deleted=True).folder_path
         }
         # If logging a file-related action, add the file's view and download URLs
         if self.file_obj or self.path:

--- a/website/addons/box/utils.py
+++ b/website/addons/box/utils.py
@@ -46,7 +46,7 @@ class BoxNodeLogger(object):
             'project': self.node.parent_id,
             'node': self.node._primary_key,
             'folder_id': self.node.get_addon('box', deleted=True).folder_id,
-            'folder': self.node.get_addon('box', deleted=True).folder_name
+            'folder': self.node.get_addon('box', deleted=True).folder_path
         }
         # If logging a file-related action, add the file's view and download URLs
         if self.file_obj or self.path:


### PR DESCRIPTION
<b>Purpose</b>
fix the problem https://trello.com/c/1qyfOSRH/81-staging-box-add-on-linked-folder-logged-incorrectly.


<b>Changes</b>
Now the box folder name in log updated correctly.