### PR TITLE
Hotfix/addon log consistency

### DIFF
--- a/website/addons/figshare/templates/log_templates.mako
+++ b/website/addons/figshare/templates/log_templates.mako
@@ -12,13 +12,13 @@ figshare in {{ nodeType }}
 </script>
 
 <script type="text/html" id="figshare_content_linked">
-linked figshare project <span data-bind="text: params.figshare.title"></span> to
+linked figshare project /<span data-bind="text: params.figshare.title"></span> to
 <span data-bind="text: nodeType"></span>
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="figshare_content_unlinked">
-unlinked figshare project <span data-bind="text: params.figshare.title"></span> from
+unlinked figshare project /<span data-bind="text: params.figshare.title"></span> from
 <span data-bind="text: nodeType"></span>
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>

--- a/website/addons/googledrive/templates/log_templates.mako
+++ b/website/addons/googledrive/templates/log_templates.mako
@@ -22,7 +22,7 @@ Google Drive in {{ nodeType }}
 
 
 <script type="text/html" id="googledrive_folder_selected">
-linked Google Drive folder <span class="overflow">{{ params.folder }}</span> to {{ nodeType }}
+linked Google Drive folder /<span class="overflow">{{ params.folder === '/ (Full Google Drive)' ? ' (Full Google Drive)' : params.folder}}</span> to {{ nodeType }}
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 

--- a/website/addons/mendeley/templates/log_templates.mako
+++ b/website/addons/mendeley/templates/log_templates.mako
@@ -1,4 +1,4 @@
 <script type="text/html" id="mendeley_folder_selected">
-linked Mendeley folder <span class="overflow">{{ params.folder_name }}</span> to {{ nodeType }}
+linked Mendeley folder /<span class="overflow">{{ params.folder_name }}</span> to {{ nodeType }}
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>

--- a/website/addons/zotero/templates/log_templates.mako
+++ b/website/addons/zotero/templates/log_templates.mako
@@ -1,4 +1,4 @@
 <script type="text/html" id="zotero_folder_selected">
-linked Zotero folder <span class="overflow">{{ params.folder_name }}</span> to {{ nodeType }}
+linked Zotero folder /<span class="overflow">{{ params.folder_name }}</span> to {{ nodeType }}
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>


### PR DESCRIPTION
<b>Purpose</b>
Make all addons repo show up in log as "addon / folder". Fix https://github.com/CenterForOpenScience/osf.io/issues/2415

<b> Changes</b>
add '/ ' between addon and repo name in logs for zetero, mendelay, figshare, googledrive