### PR TITLE
Force user to pick account even when 'Create Access Token'

### DIFF
--- a/website/static/js/citationsNodeConfig.js
+++ b/website/static/js/citationsNodeConfig.js
@@ -105,8 +105,7 @@ var CitationsFolderPickerViewModel = oop.extend(FolderPickerViewModel, {
         window.oauthComplete = function(res) {
             // Update view model based on response
             self.changeMessage(self.messages.connectAccountSuccess(), 'text-success', 3000);
-            self.updateAccounts()
-                .done(self.importAuth.bind(self));
+            self.importAuth.call(self);
         };
         window.open(self.urls().auth);
     },

--- a/website/static/js/citationsNodeConfig.js
+++ b/website/static/js/citationsNodeConfig.js
@@ -106,13 +106,7 @@ var CitationsFolderPickerViewModel = oop.extend(FolderPickerViewModel, {
             // Update view model based on response
             self.changeMessage(self.messages.connectAccountSuccess(), 'text-success', 3000);
             self.updateAccounts()
-                .done(function() {
-                    $osf.putJSON(
-                        self.urls().importAuth, {
-                            external_account_id: self.accounts()[0].id
-                        }
-                    ).then(self.onImportSuccess.bind(self), self.onImportError.bind(self));
-                });
+                .done(self.importAuth.bind(self));
         };
         window.open(self.urls().auth);
     },


### PR DESCRIPTION
## Purpose

Addresses the issue defined here: https://trello.com/c/PrkBu8ww/51-cannot-change-user-account-for-mendeley-zotero

## Changes

Before, if a user saw 'Create Access Token', we assumed they had 0 linked accounts (a fallacy). Now we force them to choose from their list of connected accounts every time.

## Side Effects

None