### PR TITLE
Fix Dataverse error messages

### DIFF
--- a/website/addons/dataverse/static/dataverseNodeConfig.js
+++ b/website/addons/dataverse/static/dataverseNodeConfig.js
@@ -211,7 +211,7 @@ ViewModel.prototype.updateFromData = function(data) {
         self.savedDataverseAlias(data.savedDataverse.alias);
         self.savedDataverseTitle(data.savedDataverse.title);
         self.selectedDataverseAlias(data.savedDataverse.alias);
-        self.savendStudyHdl(data.savedStudy.hdl);
+        self.savedStudyHdl(data.savedStudy.hdl);
         self.savedStudyTitle(data.savedStudy.title);
         self.connected(data.connected);
         if (self.userIsOwner()) {


### PR DESCRIPTION
## Purpose

Users were always getting error messages when connecting a dataverse account (even with success).

## Changes

Fix the typo that was causing this.

## Side effects

None