### PR TITLE
Fix sign in form overlapping with search at certain width intervals

### DIFF
--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -2098,6 +2098,11 @@ span#profileFullname{
         max-width: 400px;
     }
 }
+@media (max-width: 992px) {
+    #signInForm input {
+        width: 110px;
+    }    
+}
 
 /* Search bar */
 .osf-search {

--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -1851,9 +1851,11 @@ span#profileFullname{
     padding:13px 15px;
 }
 
-.navbar-form {
+.osf-navbar .navbar-form {
     margin-top: 5px;
     margin-bottom: 2px;
+    margin-left: 0;
+    margin-right: 0;
 }
 
 .navbar-toggle {
@@ -2098,9 +2100,14 @@ span#profileFullname{
         max-width: 400px;
     }
 }
-@media (max-width: 992px) {
+@media (min-width: 768px) and (max-width: 991px)  {
     #signInForm input {
         width: 110px;
+    }    
+}
+@media (min-width: 1600px) {
+    #signInForm input {
+        width: 220px;
     }    
 }
 

--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -2052,7 +2052,7 @@ span#profileFullname{
     }
     .osf-xs-search {
         text-decoration: none !important;
-        padding: 8px;
+        padding: 14px;
     }
 }
 


### PR DESCRIPTION
## Purpose 
Fixes issue reported at : #2363 

## Changes
- Added media tag for shortening the input element for signin form at certain intervals. 
- Adjusted spacing in XS to fix a horizontal scroll bar
- Adjusted padding in search bar in XS to fix apparent misalignment. 

## Side effects
None.
Tested in Chrome, Firefox, Safari
Checked other sign in forms, since this change is using id specificity it shouldn't effect other elements. 
