### PR TITLE
Hotfix/previous box log

### DIFF
--- a/website/addons/box/templates/log_templates.mako
+++ b/website/addons/box/templates/log_templates.mako
@@ -24,7 +24,7 @@ Box in {{ nodeType }}
 <script type="text/html" id="box_folder_selected">
 linked Box folder
 <span class="overflow">
-    {{ params.folder_path === 'All Files' ? '/ (Full Box)' : params.folder_path.replace('All Files','')}}
+    {{ params.folder === 'All Files' ? '/ (Full Box)' : params.folder.replace('All Files','')}}
 </span> to {{ nodeType }}
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>

--- a/website/addons/box/utils.py
+++ b/website/addons/box/utils.py
@@ -46,6 +46,9 @@ class BoxNodeLogger(object):
             'project': self.node.parent_id,
             'node': self.node._primary_key,
             'folder_id': self.node.get_addon('box', deleted=True).folder_id,
+            # it used to be "folder": self.node.get_addon('box', deleted=True).folder_name
+            # changed to folder_path to make log show the complete folder path "/folder/subfolder"
+            # instead of just showing the subfolder's name "/subfolder"
             'folder_name': self.node.get_addon('box', deleted=True).folder_name,
             'folder': self.node.get_addon('box', deleted=True).folder_path
         }

--- a/website/addons/box/utils.py
+++ b/website/addons/box/utils.py
@@ -46,8 +46,8 @@ class BoxNodeLogger(object):
             'project': self.node.parent_id,
             'node': self.node._primary_key,
             'folder_id': self.node.get_addon('box', deleted=True).folder_id,
-            'folder': self.node.get_addon('box', deleted=True).folder_name,
-            'folder_path': self.node.get_addon('box', deleted=True).folder_path
+            'folder_name': self.node.get_addon('box', deleted=True).folder_name,
+            'folder': self.node.get_addon('box', deleted=True).folder_path
         }
         # If logging a file-related action, add the file's view and download URLs
         if self.file_obj or self.path:


### PR DESCRIPTION
<b>Purpose</b>
fix https://trello.com/c/zQiQVEii/108-project-log-won-t-render

<b>Changes</b>
change the field in box addon log template back to folder from folder.path and add docs for reason in utils.py