### PR TITLE
fix the Confirmed emails show up in Unconfirmed emails list

### DIFF
--- a/website/static/js/accountSettings.js
+++ b/website/static/js/accountSettings.js
@@ -129,7 +129,7 @@ var UserProfileClient = oop.defclass({
                 var email = new UserEmail({
                     address: emailData.address,
                     isPrimary: emailData.primary,
-                    isConfirmed: emailData.isConfirmed,
+                    isConfirmed: emailData.confirmed
                 });
                 return email;
             })


### PR DESCRIPTION
<b>Purpose</b>
fix https://trello.com/c/v6C5qJqy/90-confirmed-emails-show-up-in-unconfirmed-emails-list