### PR TITLE
Feature/folderpicker none

### DIFF
--- a/website/addons/figshare/static/node-cfg.js
+++ b/website/addons/figshare/static/node-cfg.js
@@ -3,7 +3,7 @@
 var AddonNodeConfig = require('js/addonNodeConfig').AddonNodeConfig;
 
 var url = window.contextVars.node.urls.api + 'figshare/config/';
-new AddonNodeConfig('FigShare', '#figshareScope', url, '#figshareGrid', {
+new AddonNodeConfig('figshare', '#figshareScope', url, '#figshareGrid', {
     onPickFolder: function (evt, item) {
         evt.preventDefault();
         this.selected({name: item.data.name, type: item.data.type, id: item.data.id});

--- a/website/static/js/folderPickerNodeConfig.js
+++ b/website/static/js/folderPickerNodeConfig.js
@@ -161,7 +161,7 @@ var FolderPickerViewModel = oop.defclass({
         self.folderName = ko.pureComputed(function() {
             var nodeHasAuth = self.nodeHasAuth();
             var folder = self.folder();
-            return (nodeHasAuth && folder) ? folder.name : '';
+            return (nodeHasAuth && folder) ? folder.name : 'None';
         });
 
         self.selectedFolderName = ko.pureComputed(function() {

--- a/website/static/js/folderPickerNodeConfig.js
+++ b/website/static/js/folderPickerNodeConfig.js
@@ -161,7 +161,7 @@ var FolderPickerViewModel = oop.defclass({
         self.folderName = ko.pureComputed(function() {
             var nodeHasAuth = self.nodeHasAuth();
             var folder = self.folder();
-            return (nodeHasAuth && folder) ? folder.name : 'None';
+            return (nodeHasAuth && folder) ? folder.name : '';
         });
 
         self.selectedFolderName = ko.pureComputed(function() {

--- a/website/templates/project/addon/node_settings_default.mako
+++ b/website/templates/project/addon/node_settings_default.mako
@@ -36,7 +36,7 @@
                     <a data-bind="attr.href: urls().files">
                         {{folderName}}
                     </a>
-                    <span data-bind="if: folder().path === null" class="text-muted">
+                    <span data-bind="if: folder().path == null" class="text-muted">
                         None
                     </span>
                 </p>


### PR DESCRIPTION
## Purpose

For some addons when no folder is linked the UI shows 
![image](https://cloud.githubusercontent.com/assets/2207561/7091171/fab2b9e4-df75-11e4-9370-1b2497291dad.png)
Where is should say 'Current Folder: None'

## Changes

- Let the folderName fall back to 'None'
- Let the check for folder().path == null be truthy for null and undefined

## Side Effects

None