### PR TITLE
check_parent fix

### DIFF
--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -842,8 +842,11 @@ class TestSendEmails(OsfTestCase):
             "comments" email template.
         """
         user = factories.UserFactory()
-        sent_subscribers = emails.notify(self.node._id, 'comments', user=user, node=self.node, timestamp=datetime.datetime.utcnow(), target_user=user)
-        mock_send.assert_called_with([self.project.creator._id], 'email_transactional', self.node._id, 'comments', target_user=user)
+        time_now = datetime.datetime.utcnow()
+        sent_subscribers = emails.notify(self.node._id, 'comments', user, self.node,
+                                         time_now, target_user=user)
+        mock_send.assert_called_with([self.project.creator._id], 'email_transactional', self.node._id, 'comments',
+                                     user, self.node, time_now, target_user=user)
 
     # @mock.patch('website.notifications.emails.notify')
     @mock.patch('website.project.views.comment.notify')
@@ -901,7 +904,7 @@ class TestSendEmails(OsfTestCase):
         project_subscription.none.append(project.creator)
         project_subscription.save()
         node = factories.NodeFactory(project=project)
-        emails.check_parent(node._id, 'comments', [])
+        emails.check_parent(node._id, 'comments', [], self.user, project, datetime.datetime.utcnow())
         assert_false(mock_send.called)
 
     @mock.patch('website.notifications.emails.send')
@@ -928,7 +931,7 @@ class TestSendEmails(OsfTestCase):
         node_subscription.save()
 
         # Assert that user receives an email when someone comments on the component
-        emails.check_parent(node._id, 'comments', [])
+        emails.check_parent(node._id, 'comments', [], self.user, node, datetime.datetime.utcnow())
         assert_true(mock_send.called)
 
     @mock.patch('website.notifications.emails.send')
@@ -956,7 +959,7 @@ class TestSendEmails(OsfTestCase):
         node_subscription.save()
 
         # Assert that user does not receive an email when someone comments on the component
-        emails.check_parent(node._id, 'comments', [])
+        emails.check_parent(node._id, 'comments', [], user, node, datetime.datetime.utcnow())
         assert_false(mock_send.called)
 
     # @mock.patch('website.notifications.emails.email_transactional')

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -882,9 +882,12 @@ class TestSendEmails(OsfTestCase):
 
     @mock.patch('website.notifications.emails.send')
     def test_check_parent(self, send):
-        emails.check_parent(self.node._id, 'comments', [])
+        time_now = datetime.datetime.utcnow()
+        project = factories.ProjectFactory()
+        emails.check_parent(self.node._id, 'comments', [], self.user, project, time_now)
         assert_true(send.called)
-        send.assert_called_with([self.project.creator._id], 'email_transactional', self.node._id, 'comments')
+        send.assert_called_with([self.project.creator._id], 'email_transactional', self.node._id, 'comments',
+                                self.user, project, time_now)
 
     @mock.patch('website.notifications.emails.send')
     def test_check_parent_does_not_send_if_notification_type_is_none(self, mock_send):

--- a/website/notifications/emails.py
+++ b/website/notifications/emails.py
@@ -108,7 +108,7 @@ def notify(uid, event, user, node, timestamp, **context):
     return check_parent(uid, event, node_subscribers, user, node, timestamp, **context)
 
 
-def check_parent(uid, event, node_subscribers, user, node, timestamp, **context):
+def check_parent(uid, event, node_subscribers, user, orig_node, timestamp, **context):
     """ Check subscription object for the event on the parent project
         and send transactional email to indirect subscribers.
     """
@@ -120,7 +120,7 @@ def check_parent(uid, event, node_subscribers, user, node, timestamp, **context)
         subscription = NotificationSubscription.load(key)
 
         if not subscription:
-            return check_parent(node.parent_id, event, node_subscribers, user, node, timestamp, **context)
+            return check_parent(node.parent_id, event, node_subscribers, user, orig_node, timestamp, **context)
 
         for notification_type in constants.NOTIFICATION_TYPES:
             subscribed_users = getattr(subscription, notification_type, [])
@@ -129,10 +129,10 @@ def check_parent(uid, event, node_subscribers, user, node, timestamp, **context)
                 if u not in node_subscribers and node.has_permission(u, 'read'):
                     if notification_type != 'none':
                         event = 'comment_replies' if target_user == u else event
-                        send([u._id], notification_type, uid, event, user, node, timestamp, **context)
+                        send([u._id], notification_type, uid, event, user, orig_node, timestamp, **context)
                     node_subscribers.append(u)
 
-        return check_parent(node.parent_id, event, node_subscribers, user, node, timestamp, **context)
+        return check_parent(node.parent_id, event, node_subscribers, user, orig_node, timestamp, **context)
 
     return node_subscribers
 

--- a/website/notifications/emails.py
+++ b/website/notifications/emails.py
@@ -105,10 +105,10 @@ def notify(uid, event, user, node, timestamp, **context):
                     event = 'comment_replies' if context.get('target_user') == recipient else event
                     send([recipient._id], notification_type, uid, event, user, node, timestamp, **context)
 
-    return check_parent(uid, event, node_subscribers, **context)
+    return check_parent(uid, event, node_subscribers, user, node, timestamp, **context)
 
 
-def check_parent(uid, event, node_subscribers, **context):
+def check_parent(uid, event, node_subscribers, user, node, timestamp, **context):
     """ Check subscription object for the event on the parent project
         and send transactional email to indirect subscribers.
     """
@@ -120,7 +120,7 @@ def check_parent(uid, event, node_subscribers, **context):
         subscription = NotificationSubscription.load(key)
 
         if not subscription:
-            return check_parent(node.parent_id, event, node_subscribers, **context)
+            return check_parent(node.parent_id, event, node_subscribers, user, node, timestamp, **context)
 
         for notification_type in constants.NOTIFICATION_TYPES:
             subscribed_users = getattr(subscription, notification_type, [])
@@ -129,10 +129,10 @@ def check_parent(uid, event, node_subscribers, **context):
                 if u not in node_subscribers and node.has_permission(u, 'read'):
                     if notification_type != 'none':
                         event = 'comment_replies' if target_user == u else event
-                        send([u._id], notification_type, uid, event, **context)
+                        send([u._id], notification_type, uid, event, user, node, timestamp, **context)
                     node_subscribers.append(u)
 
-        return check_parent(node.parent_id, event, node_subscribers, **context)
+        return check_parent(node.parent_id, event, node_subscribers, user, node, timestamp, **context)
 
     return node_subscribers
 


### PR DESCRIPTION
The signature for check_parent was not updated along with the rest of emails.py. This fixes it.

Tests need to be fixed.