### PR TITLE
Hotfix/googledrive log path

### DIFF
--- a/website/addons/googledrive/utils.py
+++ b/website/addons/googledrive/utils.py
@@ -47,7 +47,7 @@ class GoogleDriveNodeLogger(object):
         params = {
             'project': self.node.parent_id,
             'node': self.node._primary_key,
-            'folder': self.node.get_addon('googledrive', deleted=True).folder_name
+            'folder': self.node.get_addon('googledrive', deleted=True).folder_path
         }
         if extra:
             params.update(extra)


### PR DESCRIPTION
<b>Purpose</b>
Fix https://trello.com/c/VJ8Yzweq/76-consistency-of-linked-repo-folder-addon-logs. Refactor googledrive folder name in log part back to folder_path. The space display as %20 problem is actually not addressed in my pr but in https://github.com/CenterForOpenScience/osf.io/pull/2231.