### PR TITLE
Change S3 full name to Amazon S3

### DIFF
--- a/framework/addons/data/addons.json
+++ b/framework/addons/data/addons.json
@@ -27,7 +27,7 @@
                 "text": "GitHub content cannot be registered."
             }
         },
-        "Amazon Simple Storage Service": {
+        "Amazon S3": {
             "Permissions": {
                 "status": "partial",
                 "text": "Making an OSF project public or private is independent of making an S3 bucket public or private. The OSF does not alter the permissions of linked S3 buckets."

--- a/tests/test_rubeus.py
+++ b/tests/test_rubeus.py
@@ -58,7 +58,7 @@ class TestRubeus(OsfTestCase):
             'provider': 's3',
             'addonFullname': node_settings.config.full_name,
             'iconUrl': node_settings.config.icon_url,
-            'name': 'Amazon Simple Storage Service: {0}'.format(
+            'name': 'Amazon S3: {0}'.format(
                 node_settings.bucket
             ),
             'kind': 'folder',
@@ -134,7 +134,7 @@ class TestRubeus(OsfTestCase):
             'addon': 's3',
             'addonFullname': node_settings.config.full_name,
             'iconUrl': node_settings.config.icon_url,
-            'name': 'Amazon Simple Storage Service: {0}'.format(
+            'name': 'Amazon S3: {0}'.format(
                 node_settings.bucket
             ),
             'kind': 'folder',
@@ -171,7 +171,7 @@ class TestRubeus(OsfTestCase):
             'provider': 's3',
             'addonFullname': node_settings.config.full_name,
             'iconUrl': node_settings.config.icon_url,
-            'name': 'Amazon Simple Storage Service: {0}'.format(
+            'name': 'Amazon S3: {0}'.format(
                 node_settings.bucket
             ),
             'kind': 'folder',

--- a/website/addons/s3/__init__.py
+++ b/website/addons/s3/__init__.py
@@ -11,7 +11,7 @@ NODE_SETTINGS_MODEL = model.AddonS3NodeSettings
 ROUTES = [routes.settings_routes]
 
 SHORT_NAME = 's3'
-FULL_NAME = 'Amazon Simple Storage Service'
+FULL_NAME = 'Amazon S3'
 
 
 OWNERS = ['user', 'node']


### PR DESCRIPTION
## Purpose

We've decided to always refer to Amazon Simple Storage Service as Amazon S3. Logs generated using AddonConfig#full_name were still using 'Amazon Simple Storage Service'.

## Changes

Change S3 full_name to Amazon S3

## Side Effects

Wondering if @lbanner and @GaryKriebel are aware of these changes, and those in:
https://github.com/CenterForOpenScience/osf.io/pull/2409

There's a good chance these changes affect our user docs. 