### PR TITLE
Bugfixes to folderName logic and tests

### DIFF
--- a/website/static/js/folderPickerNodeConfig.js
+++ b/website/static/js/folderPickerNodeConfig.js
@@ -157,12 +157,12 @@ var FolderPickerViewModel = oop.defclass({
             var loaded = self.loadedSettings();
             return loaded && !userHasAuth && !nodeHasAuth;
         });
-
+        
         /** Computed functions for the linked and selected folders' display text.*/
         self.folderName = ko.pureComputed(function() {
             var nodeHasAuth = self.nodeHasAuth();
             var folder = self.folder();
-            return (nodeHasAuth && folder) ? folder.name : '';
+            return (nodeHasAuth && folder && folder.name) ? folder.name.trim() : '';
         });
 
         self.selectedFolderName = ko.pureComputed(function() {

--- a/website/static/js/folderPickerNodeConfig.js
+++ b/website/static/js/folderPickerNodeConfig.js
@@ -157,7 +157,7 @@ var FolderPickerViewModel = oop.defclass({
             var loaded = self.loadedSettings();
             return loaded && !userHasAuth && !nodeHasAuth;
         });
-        
+
         /** Computed functions for the linked and selected folders' display text.*/
         self.folderName = ko.pureComputed(function() {
             var nodeHasAuth = self.nodeHasAuth();

--- a/website/static/js/tests/addons/folderPickerNodeConfig.test.js
+++ b/website/static/js/tests/addons/folderPickerNodeConfig.test.js
@@ -152,7 +152,7 @@ describe('FolderPickerNodeConfigViewModel', () => {
                     name: null,
                     id: null
                 });
-                assert.isNull(vm.folderName());
+                assert.equal(vm.folderName(), '');
                 var name = faker.hacker.noun();
                 vm.folder({
                     name: name,

--- a/website/templates/project/addon/node_settings_default.mako
+++ b/website/templates/project/addon/node_settings_default.mako
@@ -33,10 +33,10 @@
             <div class="col-md-12">
                 <p>
                     <strong>Current Folder:</strong>
-                    <a data-bind="attr.href: urls().files">
+                    <a data-bind="ifnot: folderName() === '', attr.href: urls().files">
                         {{folderName}}
                     </a>
-                    <span data-bind="if: folder().path == null" class="text-muted">
+                    <span data-bind="if: folderName() === ''" class="text-muted">
                         None
                     </span>
                 </p>


### PR DESCRIPTION
## Purpose

Node config for addons was rendering 'None' inappropriately:
https://trello.com/c/LcxG8dAD/120-zotero-mendeley-folder-picker-none-option

## Changes

Fix bugs in logic for checking whether no folder is linked.

## Side Effects

None