### PR TITLE
fix route regression

### DIFF
--- a/tests/test_share.py
+++ b/tests/test_share.py
@@ -76,7 +76,7 @@ class TestShareSearch(OsfTestCase):
                 'total': 0
             }
         }
-        self.app.get('/api/v1/share/', params={
+        self.app.get('/api/v1/share/search/', params={
             'q': '*',
             'from': '1',
             'size:': '20',
@@ -88,7 +88,7 @@ class TestShareSearch(OsfTestCase):
     @patch.object(share_search.share_es, 'count')
     def test_share_count(self, mock_count):
         mock_count.return_value = {'count': 0}
-        self.app.get('/api/v1/share/', params={
+        self.app.get('/api/v1/share/search/', params={
             'q': '*',
             'from': '1',
             'size:': '20',

--- a/website/routes.py
+++ b/website/routes.py
@@ -670,7 +670,7 @@ def make_url_map(app):
 
         Rule(['/search/', '/search/<type>/'], ['get', 'post'], search_views.search_search, json_renderer),
         Rule('/search/projects/', 'get', search_views.search_projects_by_title, json_renderer),
-        Rule('/share/', ['get', 'post'], search_views.search_share, json_renderer),
+        Rule('/share/search/', ['get', 'post'], search_views.search_share, json_renderer),
         Rule('/share/stats/', 'get', search_views.search_share_stats, json_renderer),
         Rule('/share/providers/', 'get', search_views.search_share_providers, json_renderer),
 

--- a/website/static/js/share/utils.js
+++ b/website/static/js/share/utils.js
@@ -70,7 +70,7 @@ utils.loadMore = function(vm) {
         m.request({
             method: 'get',
             background: true,
-            url: '/api/v1/share/?' + $.param({
+            url: '/api/v1/share/search/?' + $.param({
                 from: page,
                 q: utils.buildQuery(vm),
                 sort: sort,


### PR DESCRIPTION
Purpose
------------
Get SHARE search routes working again 
(/api/v1/share/search changed to /api/v1/share for ......some reason)

Changes
------------
Updated all references to /api/v1/share to /api/v1/share/search