### PR TITLE
SHARE - fix inconsistent atom feed, will not display items with no URL

### DIFF
--- a/website/search/share_search.py
+++ b/website/search/share_search.py
@@ -16,6 +16,10 @@ from website.search.elastic_search import requires_search
 
 from util import generate_color, html_and_illegal_unicode_replace
 
+import logging
+
+logger = logging.getLogger(__name__)
+
 share_es = Elasticsearch(
     settings.SHARE_ELASTIC_URI,
     request_timeout=settings.ELASTIC_TIMEOUT
@@ -264,10 +268,12 @@ def data_for_charts(elastic_results):
 
 
 def to_atom(result):
+    if not result['id']['url']:
+        logger.error('ATOM error for {}: Missing id'.format(result['source']))
     return {
         'title': html_and_illegal_unicode_replace(result.get('title')) or 'No title provided.',
         'summary': html_and_illegal_unicode_replace(result.get('description')) or 'No summary provided.',
-        'id': result['id']['url'],
+        'id': result['id']['url'] or 'url_error',
         'updated': get_date_updated(result),
         'links': [
             {'href': result['id']['url'], 'rel': 'alternate'}

--- a/website/search/share_search.py
+++ b/website/search/share_search.py
@@ -273,7 +273,7 @@ def to_atom(result):
     return {
         'title': html_and_illegal_unicode_replace(result.get('title')) or 'No title provided.',
         'summary': html_and_illegal_unicode_replace(result.get('description')) or 'No summary provided.',
-        'id': result['id']['url'] or 'url_error',
+        'id': result['id']['url'],
         'updated': get_date_updated(result),
         'links': [
             {'href': result['id']['url'], 'rel': 'alternate'}

--- a/website/search/util.py
+++ b/website/search/util.py
@@ -1,10 +1,13 @@
 import re
 import copy
+import logging
 import webcolors
 
 from werkzeug.contrib.atom import AtomFeed
 
 from website.util.sanitize import strip_html
+
+logger = logging.getLogger(__name__)
 
 
 COLORBREWER_COLORS = [(166, 206, 227), (31, 120, 180), (178, 223, 138), (51, 160, 44), (251, 154, 153), (227, 26, 28), (253, 191, 111), (255, 127, 0), (202, 178, 214), (106, 61, 154), (255, 255, 153), (177, 89, 40)]
@@ -114,7 +117,10 @@ def create_atom_feed(name, data, query, size, start, url, to_atom):
     )
 
     for doc in data:
-        feed.add(**to_atom(doc))
+        try:
+            feed.add(**to_atom(doc))
+        except ValueError as e:
+            logger.error('Atom feed error for source {}: {}'.format(doc.get('source'), e))
 
     return feed
 


### PR DESCRIPTION
# Purpose
- SHARE atom feed breaks periodically, and though I can't seem to reproduce it locally, this should now not add atom entries without an id, which is the url.

# Changes
- Add logging to catch ID errors
- Add try except for adding individual docs to the atom feed, will skip entries missing a URL

# Side Effects
- None anticipated