### PR TITLE
[wip] Feature: DOI metadata/multiple creators

### DIFF
--- a/tests/webtest_tests.py
+++ b/tests/webtest_tests.py
@@ -8,12 +8,10 @@ import mock
 
 from nose.tools import *  # noqa (PEP8 asserts)
 
-from modularodm import Q
-
 from framework.mongo.utils import to_mongo_key
 
 from framework.auth import exceptions as auth_exc
-from framework.auth.core import User, Auth
+from framework.auth.core import Auth
 from tests.base import OsfTestCase, fake
 from tests.factories import (UserFactory, AuthUserFactory, ProjectFactory,
                              WatchConfigFactory, ApiKeyFactory,
@@ -28,7 +26,6 @@ from website.security import random_string
 from website.project.metadata.schemas import OSF_META_SCHEMAS
 from website.project.model import ensure_schemas
 from website.util import web_url_for
-from website.addons.twofactor.tests import _valid_code
 
 
 class TestDisabledUser(OsfTestCase):

--- a/website/identifiers/metadata.py
+++ b/website/identifiers/metadata.py
@@ -2,10 +2,11 @@
 import lxml.etree
 import lxml.builder
 
+NAMESPACE = 'http://datacite.org/schema/kernel-3'
 XSI = 'http://www.w3.org/2001/XMLSchema-instance'
 SCHEMA_LOCATION = 'http://datacite.org/schema/kernel-3 http://schema.datacite.org/meta/kernel-3/metadata.xsd'
 E = lxml.builder.ElementMaker(nsmap={
-    None: "http://datacite.org/schema/kernel-3",
+    None: NAMESPACE,
     'xsi': XSI},
 )
 
@@ -15,7 +16,7 @@ CREATOR_NAME = E.creatorName
 def datacite_metadata_for_node(node, doi, pretty_print=False):
     """Return the datacite metadata XML document for a given node as a string."""
     def format_contrib(contributor):
-        return '{}, {}'.format(contributor.family_name, contributor.given_name)
+        return u'{}, {}'.format(contributor.family_name, contributor.given_name)
     creators = [CREATOR(CREATOR_NAME(format_contrib(each)))
                         for each in node.visible_contributors]
     root = E.resource(

--- a/website/identifiers/metadata.py
+++ b/website/identifiers/metadata.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+import lxml.etree
+import lxml.builder
+
+XSI = 'http://www.w3.org/2001/XMLSchema-instance'
+SCHEMA_LOCATION = 'http://datacite.org/schema/kernel-3 http://schema.datacite.org/meta/kernel-3/metadata.xsd'
+E = lxml.builder.ElementMaker(nsmap={
+    None: "http://datacite.org/schema/kernel-3",
+    'xsi': XSI},
+)
+
+CREATOR = E.creator
+CREATOR_NAME = E.creatorName
+
+def datacite_metadata_for_node(node, doi, pretty_print=False):
+    """Return the datacite metadata XML document for a given node as a string."""
+    def format_contrib(contributor):
+        return '{}, {}'.format(contributor.family_name, contributor.given_name)
+    creators = [CREATOR(CREATOR_NAME(format_contrib(each)))
+                        for each in node.visible_contributors]
+    root = E.resource(
+        E.identifier(doi, identifierType='DOI'),
+        E.creators(*creators),
+        E.titles(E.title(node.title)),
+        E.publisher('OSF'),
+        E.publicationYear(str(node.registered_date.year)),
+    )
+    root.attrib["{" + XSI + "}schemaLocation"] = SCHEMA_LOCATION
+    return lxml.etree.tostring(root, pretty_print=pretty_print)

--- a/website/project/views/register.py
+++ b/website/project/views/register.py
@@ -17,6 +17,7 @@ from website.project.decorators import (
     must_have_permission, must_not_be_registration
 )
 from website.identifiers.model import Identifier
+from website.identifiers.metadata import datacite_metadata_for_node
 from website.project.metadata.schemas import OSF_META_SCHEMAS
 from website.util.permissions import ADMIN
 from website.models import MetaSchema
@@ -167,10 +168,7 @@ def _build_ezid_metadata(node):
     doi = '{0}{1}'.format(settings.DOI_NAMESPACE, node._id)
     metadata = {
         '_target': node.absolute_url,
-        'datacite.creator': node.creator.fullname,
-        'datacite.title': node.title,
-        'datacite.publisher': 'Open Science Framework',
-        'datacite.publicationyear': str(node.registered_date.year),
+        'datacite': datacite_metadata_for_node(node=node, doi=doi)
     }
     return doi, metadata
 


### PR DESCRIPTION
Adds a function `datacite_metadata_for_node` for building the [datacite metadata XML](http://schema.datacite.org/meta/kernel-3/index.html) for a given node. Allows all contributors of a Node to be listed as a creator for the DOI.