### PR TITLE
Pin dataverse client to compatible commit

### DIFF
--- a/website/addons/dataverse/requirements.txt
+++ b/website/addons/dataverse/requirements.txt
@@ -1,2 +1,2 @@
 -e git+https://github.com/rliebz/python-client-sword2.git#egg=sword2
--e git+https://github.com/rliebz/dvn-client-python.git#egg=dataverse
+-e git+https://github.com/rliebz/dvn-client-python.git@0fe9ae12d86a5bee697ae51b094cc47f75d45866#egg=dataverse


### PR DESCRIPTION
This fix reverts all backwards-incompatible changes from 4.0 by locking to an earlier commit.