### PR TITLE
Hotfix/dont hide header

### DIFF
--- a/website/static/js/comment.js
+++ b/website/static/js/comment.js
@@ -482,7 +482,7 @@ var init = function(selector, userName, canComment, hasChildren) {
     if (!$elm.length) {
         throw('No results found for selector');
     }
-    osfHelpers.applyBindings(viewModel, $elm[0]);
+    osfHelpers.applyBindings(viewModel, selector);
     viewModel.initListeners();
 
     return viewModel;

--- a/website/static/js/nodeControl.js
+++ b/website/static/js/nodeControl.js
@@ -309,7 +309,7 @@ function NodeControl (selector, data, options) {
 
 NodeControl.prototype.init = function() {
     var self = this;
-    $.osf.applyBindings(self.viewModel, self.$element[0]);
+    osfHelpers.applyBindings(self.viewModel, this.selector);
 };
 
 module.exports = {

--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -330,12 +330,22 @@ ko.bindingHandlers.anchorScroll = {
 
 /**
   * A thin wrapper around ko.applyBindings that ensures that a view model
-  * is bound to the expected element. Also shows the element if it was
-  * previously hidden.
+  * is bound to the expected element. Also shows the element (and child elements) if it was
+  * previously hidden by applying the 'scripted' CSS class.
   *
-  * Takes a ViewModel and a selector (String).
+  * Takes a ViewModel and a selector (string) or a DOM element.
   */
 var applyBindings = function(viewModel, selector) {
+    var elem, cssSelector;
+    var $elem = $(selector);
+    if (typeof(selector.nodeName) === 'string') { // dom element
+        elem = selector;
+        // NOTE: Only works with DOM elements that have an ID
+        cssSelector = '#' + elem.id;
+    } else {
+        elem = $elem[0];
+        cssSelector = selector;
+    }
     var $elem = $(selector);
     if ($elem.length === 0) {
         throw "No elements matching selector '" + selector + "'";  // jshint ignore: line
@@ -348,7 +358,7 @@ var applyBindings = function(viewModel, selector) {
         $elem.show();
     }
     // Also show any child elements that have the scripted class
-    $(selector + ' .scripted').each(function(elm) {
+    $(cssSelector + ' .scripted').each(function(elm) {
         $(this).show();
     })
     ko.applyBindings(viewModel, $elem[0]);

--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -347,6 +347,10 @@ var applyBindings = function(viewModel, selector) {
     if ($elem.hasClass('scripted')){
         $elem.show();
     }
+    // Also show any child elements that have the scripted class
+    $(selector + ' .scripted').each(function(elm) {
+        $(this).show();
+    })
     ko.applyBindings(viewModel, $elem[0]);
 };
 

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -115,13 +115,13 @@
                 <span data-bind="text: dateCreated.local, tooltip: {title: dateCreated.utc}" class="date node-date-created"></span>
                 | Last Updated:
                 <span data-bind="text: dateModified.local, tooltip: {title: dateModified.utc}" class="date node-last-modified-date"></span>
-                <span data-bind="if: hasIdentifiers" class="scripted">
+                <span data-bind="if: hasIdentifiers()" class="scripted">
                   <br />
                     Identifiers:
                     DOI <a href="#" data-bind="text: doi, attr.href: doiUrl"></a> |
                     ARK <a href="#" data-bind="text: ark, attr.href: arkUrl"></a>
                 </span>
-                <span data-bind="if: hasIdentifiers" class="scripted">
+                <span data-bind="if: canCreateIdentifiers()" class="scripted">
                   <br />
                     <a data-bind="click: askCreateIdentifiers">Create DOI / ARK</a>
                 </span>

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -5,7 +5,7 @@
     is_project = node['node_type'] == 'project'
 %>
 
-<div id="projectScope" class="scripted">
+<div id="projectScope">
     <header class="subhead" id="overview">
         <div class="row">
             <div class="col-sm-6 col-md-7 cite-container">
@@ -115,16 +115,16 @@
                 <span data-bind="text: dateCreated.local, tooltip: {title: dateCreated.utc}" class="date node-date-created"></span>
                 | Last Updated:
                 <span data-bind="text: dateModified.local, tooltip: {title: dateModified.utc}" class="date node-last-modified-date"></span>
-                <!-- ko if: hasIdentifiers -->
-                    <br />
+                <span data-bind="if: hasIdentifiers" class="scripted">
+                  <br />
                     Identifiers:
                     DOI <a href="#" data-bind="text: doi, attr.href: doiUrl"></a> |
                     ARK <a href="#" data-bind="text: ark, attr.href: arkUrl"></a>
-                <!-- /ko -->
-                <!-- ko if: canCreateIdentifiers -->
-                    <br />
+                </span>
+                <span data-bind="if: hasIdentifiers" class="scripted">
+                  <br />
                     <a data-bind="click: askCreateIdentifiers">Create DOI / ARK</a>
-                <!-- /ko -->
+                </span>
                 % if parent_node['id']:
                     <br />Category: <span class="node-category">${node['category']}</span>
                 % elif node['description'] or 'write' in user['permissions']:


### PR DESCRIPTION
Purpose

The whole project header was being hidden before the server data was being returned. This patch only hides the necessary parts (dates, DOI info, etc.) on page load.

Changes

- Child elements of the element selected by `$osf.applyBindings` may be styled with `scripted` to hide the elements until a ViewModel is bound.
- A DOM element may be passed to `$osf.applyBindings`