### PR TITLE
[hotfix]multi_account_add_email

### DIFF
--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -95,18 +95,25 @@ def update_user(auth):
     ##########
 
     if 'emails' in data:
+
+        emails_list = [x['address'].strip().lower() for x in data['emails']]
+
+        if user.username not in emails_list:
+            raise HTTPError(httplib.FORBIDDEN)
+
         # removals
         removed_emails = [
             each
             for each in user.emails + user.unconfirmed_emails
-            if each not in [x['address'].strip().lower()
-                            for x in data['emails']]
+            if each not in emails_list
         ]
 
         if user.username in removed_emails:
             raise HTTPError(httplib.FORBIDDEN)
 
         for address in removed_emails:
+            if address == user.username:
+                raise HTTPError(httplib.FORBIDDEN)
             if address in user.emails:
                 user.remove_email(address)
             user.remove_unconfirmed_email(address)

--- a/website/static/js/accountSettings.js
+++ b/website/static/js/accountSettings.js
@@ -97,7 +97,9 @@ var UserProfileClient = oop.defclass({
         ).done(function (data) {
             ret.resolve(this.unserialize(data, profile));
         }.bind(this)).fail(function(xhr, status, error) {
-            $osf.growl('Error', 'User profile not updated.', 'danger');
+            $osf.growl('Error', 'User profile not updated. Please refresh the page and try ' +
+                'again or contact <a href="mailto: support@cos.io">support@cos.io</a> ' +
+                'if the problem persists.', 'danger');
             Raven.captureMessage('Error fetching user profile', {
                 url: this.urls.update,
                 status: status,


### PR DESCRIPTION
<b>Purpose</b>
fix https://trello.com/c/iuQqlj9Z/88-making-email-primary-while-logged-in-as-another-user-sends-confirmation-email-to-an-already-confirmed-user.