### PR TITLE
[feature] pip install exists-action wipe

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -326,7 +326,7 @@ def pip_install(req_file):
     """Return the proper 'pip install' command for installing the dependencies
     defined in ``req_file``.
     """
-    cmd = bin_prefix('pip install --upgrade -r {} '.format(req_file))
+    cmd = bin_prefix('pip install --exists-action w --upgrade -r {} '.format(req_file))
     if WHEELHOUSE_PATH:
         cmd += ' --no-index --find-links={}'.format(WHEELHOUSE_PATH)
     return cmd
@@ -450,7 +450,7 @@ def addon_requirements():
                 requirements_file = os.path.join(path, 'requirements.txt')
                 open(requirements_file)
                 print('Installing requirements for {0}'.format(directory))
-                cmd = 'pip install --upgrade -r {0}'.format(requirements_file)
+                cmd = 'pip install --exists-action w --upgrade -r {0}'.format(requirements_file)
                 if WHEELHOUSE_PATH:
                     cmd += ' --no-index --find-links={}'.format(WHEELHOUSE_PATH)
                 run(bin_prefix(cmd))


### PR DESCRIPTION
Default action for exists during pip install.

Prevents the invoke requirements task from freezing w/o prompt while waiting on input during pip installs.

**Issue**

```bash
Installing requirements for dataverse
Obtaining dataverse from git+https://github.com/IQSS/dataverse-client-python.git@b6aec5bc3fd1cc3199e3c97ac9c71705b54c3d11#egg=dataverse (from -r /Users/michael/Projects/cos/osf/website/addons/dataverse/requirements.txt (line 1))
  git clone in /Users/michael/.virtualenvs/osf/src/dataverse exists with URL https://github.com/rliebz/dvn-client-python.git
  The plan is to install the git repository https://github.com/IQSS/dataverse-client-python.git
```

**Actual Problem**
```bash
Obtaining dataverse from git+https://github.com/IQSS/dataverse-client-python.git@b6aec5bc3fd1cc3199e3c97ac9c71705b54c3d11#egg=dataverse (from -r requirements.txt (line 1))
  git clone in /Users/michael/.virtualenvs/osf/src/dataverse exists with URL https://github.com/rliebz/dvn-client-python.git
  The plan is to install the git repository https://github.com/IQSS/dataverse-client-python.git
What to do?  (s)witch, (i)gnore, (w)ipe, (b)ackup w
```
