### PR TITLE
fix redirect link over the website

### DIFF
--- a/website/static/js/pages/base-page.js
+++ b/website/static/js/pages/base-page.js
@@ -59,7 +59,7 @@ var SlideInViewModel = function (){
     // Google Analytics click event tracking
     self.trackClick = function(source) {
         if (source === 'Create Account') {
-            window.location = '/#signUpScopeTop';
+            window.location = '/#signUp';
         } else if (source === 'Learn More') {
             window.location = '/getting-started/';
         }

--- a/website/static/js/pages/base-page.js
+++ b/website/static/js/pages/base-page.js
@@ -58,12 +58,9 @@ var SlideInViewModel = function (){
     };
     // Google Analytics click event tracking
     self.trackClick = function(source) {
-        if (source === 'Create Account') {
-            window.location = '/#signUp';
-        } else if (source === 'Learn More') {
-            window.location = '/getting-started/';
-        }
         window.ga('send', 'event', 'button', 'click', source);
+        //in order to make the href redirect work under knockout onclick binding
+        return true;
     };
 };
 

--- a/website/static/js/pages/base-page.js
+++ b/website/static/js/pages/base-page.js
@@ -58,6 +58,11 @@ var SlideInViewModel = function (){
     };
     // Google Analytics click event tracking
     self.trackClick = function(source) {
+        if (source === 'Create Account') {
+            window.location = '/#signUpScopeTop';
+        } else if (source === 'Learn More') {
+            window.location = '/getting-started/';
+        }
         window.ga('send', 'event', 'button', 'click', source);
     };
 };

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -80,16 +80,16 @@
 <div id="footerSlideIn">
     <div class="container">
         <div class="row">
-            <div class='col-sm-2 hidden-xs'>
-                <img class="logo" src="/static/img/circle_logo.png"></img>
+            <div class='col-sm-2'>
+                <img class="logo" src="/static/img/circle_logo.png">
             </div>
             <div class='col-sm-10 col-xs-12'>
                 <a data-bind="click: dismiss" class="close" href="#">&times;</a>
                 <h1>Start managing your projects on the OSF today.</h1>
                 <p>Free and easy to use, the Open Science Framework supports the entire research lifecycle: planning, execution, reporting, archiving, and discovery.</p>
                 <div>
-                    <a data-bind="click: trackClick.bind($data, 'Create Account')" class="btn btn-primary" href="/login/">Create an Account</a>
-                    <a data-bind="click: trackClick.bind($data, 'Learn More')" class="btn btn-primary" href="/getting-started/">Learn More</a>
+                    <a data-bind="click: trackClick.bind($data, 'Create Account')" class="btn btn-primary" >Create an Account</a>
+                    <a data-bind="click: trackClick.bind($data, 'Learn More')" class="btn btn-primary" >Learn More</a>
                     <a data-bind="click: dismiss">Hide this message</a>
                 </div>
             </div>

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -88,8 +88,9 @@
                 <h1>Start managing your projects on the OSF today.</h1>
                 <p>Free and easy to use, the Open Science Framework supports the entire research lifecycle: planning, execution, reporting, archiving, and discovery.</p>
                 <div>
-                    <a data-bind="click: trackClick.bind($data, 'Create Account')" class="btn btn-primary" >Create an Account</a>
-                    <a data-bind="click: trackClick.bind($data, 'Learn More')" class="btn btn-primary" >Learn More</a>
+                    <a data-bind="click: trackClick.bind($data, 'Create Account')" class="btn btn-primary" href="${web_url_for('index')}#signUp">Create an Account</a>
+
+                    <a data-bind="click: trackClick.bind($data, 'Learn More')" class="btn btn-primary" href="/getting-started/">Learn More</a>
                     <a data-bind="click: dismiss">Hide this message</a>
                 </div>
             </div>

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -80,7 +80,7 @@
 <div id="footerSlideIn">
     <div class="container">
         <div class="row">
-            <div class='col-sm-2'>
+            <div class='col-sm-2 hidden-xs'>
                 <img class="logo" src="/static/img/circle_logo.png">
             </div>
             <div class='col-sm-10 col-xs-12'>

--- a/website/templates/index.mako
+++ b/website/templates/index.mako
@@ -9,6 +9,7 @@
             <br>
             <p class="hpSubHeadOne">The Open Science Framework (OSF) supports the entire research lifecycle: planning, execution, reporting, archiving, and discovery.</p>
         </div>
+        <div id="signUpScopeTop" class="anchor"></div>
         <div id="signUpScope" class="col-sm-4 col-md-offset-1 img-rounded hpSignUp">
             <form data-bind="submit: submit">
               <div class="form-group"
@@ -104,7 +105,7 @@
     </div>
     <div class="row text-center">
         <div class="col-md-12">
-            <p class="hpSubHeadThree hpSteps"><a class="hpLink" href="/account/">Sign up.</a></p>
+            <p class="hpSubHeadThree hpSteps"><a class="hpLink" href="#signUpScopeTop">Sign up.</a></p>
             <p class="hpSubHeadThree hpSteps"><a class="hpLink" href="/getting-started/">Learn how to build a project.</a></p>
             <p class="hpSubHeadThree hpSteps"><a class="hpLink" href="/explore/activity/">Get inspired.</a></p>
         </div>

--- a/website/templates/index.mako
+++ b/website/templates/index.mako
@@ -9,7 +9,7 @@
             <br>
             <p class="hpSubHeadOne">The Open Science Framework (OSF) supports the entire research lifecycle: planning, execution, reporting, archiving, and discovery.</p>
         </div>
-        <div id="signUpScopeTop" class="anchor"></div>
+        <div id="signUp" class="anchor"></div>
         <div id="signUpScope" class="col-sm-4 col-md-offset-1 img-rounded hpSignUp">
             <form data-bind="submit: submit">
               <div class="form-group"
@@ -105,7 +105,7 @@
     </div>
     <div class="row text-center">
         <div class="col-md-12">
-            <p class="hpSubHeadThree hpSteps"><a class="hpLink" href="#signUpScopeTop">Sign up.</a></p>
+            <p class="hpSubHeadThree hpSteps"><a class="hpLink" href="#signUp">Sign up.</a></p>
             <p class="hpSubHeadThree hpSteps"><a class="hpLink" href="/getting-started/">Learn how to build a project.</a></p>
             <p class="hpSubHeadThree hpSteps"><a class="hpLink" href="/explore/activity/">Get inspired.</a></p>
         </div>

--- a/website/templates/public/forgot_password.mako
+++ b/website/templates/public/forgot_password.mako
@@ -24,7 +24,7 @@
                     </div>
             </div>
             <hr class="m-t-lg m-b-sm"/>
-            <h6 class="text-center text-muted text-300"><a href="${ web_url_for('auth_login') }">Back to OSF</a></h6>
+            <h6 class="text-center text-muted text-300"><a href="${ web_url_for('index') }">Back to OSF</a></h6>
         </form>
     </div>
 

--- a/website/templates/public/two_factor.mako
+++ b/website/templates/public/two_factor.mako
@@ -25,7 +25,7 @@
                     </div>
             </div>
             <hr class="m-t-lg m-b-sm"/>
-            <h6 class="text-center text-muted text-300"><a href="${ web_url_for('auth_login') }">Back to OSF</a></h6>
+            <h6 class="text-center text-muted text-300"><a href="${ web_url_for('index') }">Back to OSF</a></h6>
         </form>
     </div>
 


### PR DESCRIPTION
<b>Purpose</b>
fix the outdated redirect link in website. solves https://github.com/CenterForOpenScience/osf.io/issues/2467.

<b>Changs</b>
Sign up bottom on the main page now redirect you to the correct signup form
![screen shot 2015-04-16 at 2 56 11 pm](https://cloud.githubusercontent.com/assets/4974056/7188871/d1e5175a-e448-11e4-95be-d815837a2331.png)

the bottom on the slide in footer should all work and redirect you to the right place
![screen shot 2015-04-16 at 2 57 47 pm](https://cloud.githubusercontent.com/assets/4974056/7188902/016c7522-e449-11e4-9457-c6b6a8f5f9e9.png)

The back to osf link on two factor page and forget password page now redirect you to main page instead of log in page.
