### PR TITLE
SHARE: Change hovertext for pubmed to pubmed central

### DIFF
--- a/website/static/js/share/stats.js
+++ b/website/static/js/share/stats.js
@@ -36,14 +36,14 @@ function donutGraph (data, vm) {
             show: false
         },
         tooltip: {
-          format: {
-            name: function (name, ratio, id, index) {
-                if (name == 'pubmed') {
-                    name = 'pubmed central'
+            format: {
+                name: function (name, ratio, id, index) {
+                    if (name == 'pubmed') {
+                        name = 'pubmed central'
+                    }
+                    return name; 
                 }
-                return name; 
             }
-          }
         }
     });
 }
@@ -74,7 +74,15 @@ function timeGraph (data) {
             show: false
         },
         tooltip: {
-          grouped: false
+            grouped: false,
+            format: {
+              name: function (name, ratio, id, index) {
+                  if (name == 'pubmed') {
+                      name = 'pubmed central'
+                  }
+                  return name; 
+              }
+            }
         }
     });
 }

--- a/website/static/js/share/stats.js
+++ b/website/static/js/share/stats.js
@@ -34,6 +34,16 @@ function donutGraph (data, vm) {
         },
         legend: {
             show: false
+        },
+        tooltip: {
+          format: {
+            name: function (name, ratio, id, index) {
+                if (name == 'pubmed') {
+                    name = 'pubmed central'
+                }
+                return name; 
+            }
+          }
         }
     });
 }


### PR DESCRIPTION
# Purpose
Pubmed should instead be displayed as pubmed central. As we've never changed a provider name before, we still need to figure out the best way to do this. As a temporary fix to the front end of the graph, I've changed the text for pubmed to pubmed central using the c3 tooltip function. Once we've done a proper assessment and come up with a fix for this, this custom tooltip code can be removed.

# Changed
Add custom tooltip formatting in c3 code for generating the donut and time graphs that changes the display "pubmed" to "pubmed central."

# Side effects
Should only effect tooltip of pubmed entries. 