### PR TITLE
[file tree] Fix incorrect highlighting of duplicate figshare files

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -844,15 +844,15 @@ function expandStateLoad(item) {
 function setCurrentFileID(tree, nodeID, file) {
     var tb = this;
     if (file.provider === 'figshare') {
-        for (var j = 0; j < tree.children.length; j++) {
-            var child = tree.children[j];
+        for (var i = 0; i < tree.children.length; i++) {
+            var child = tree.children[i];
             if (nodeID === child.data.nodeId && child.data.provider === file.provider && child.data.path === file.path) {
                 tb.currentFileID = child.id;
             }
         }
     } else if (tb.fangornFolderIndex !== undefined && tb.fangornFolderArray !== undefined && tb.fangornFolderIndex < tb.fangornFolderArray.length) {
-        for (var i = 0; i < tree.children.length; i++) {
-            var child = tree.children[i];
+        for (var j = 0; j < tree.children.length; j++) {
+            var child = tree.children[j];
             if (nodeID === child.data.nodeId && child.data.provider === file.provider && child.data.name === tb.fangornFolderArray[tb.fangornFolderIndex]) {
                 tb.fangornFolderIndex++;
                 if (child.data.kind === 'folder') {

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -843,7 +843,14 @@ function expandStateLoad(item) {
  */
 function setCurrentFileID(tree, nodeID, file) {
     var tb = this;
-    if (tb.fangornFolderIndex !== undefined && tb.fangornFolderArray !== undefined && tb.fangornFolderIndex < tb.fangornFolderArray.length) {
+    if (file.provider === 'figshare') {
+        for (var j = 0; j < tree.children.length; j++) {
+            var child = tree.children[j];
+            if (nodeID === child.data.nodeId && child.data.provider === file.provider && child.data.path === file.path) {
+                tb.currentFileID = child.id;
+            }
+        }
+    } else if (tb.fangornFolderIndex !== undefined && tb.fangornFolderArray !== undefined && tb.fangornFolderIndex < tb.fangornFolderArray.length) {
         for (var i = 0; i < tree.children.length; i++) {
             var child = tree.children[i];
             if (nodeID === child.data.nodeId && child.data.provider === file.provider && child.data.name === tb.fangornFolderArray[tb.fangornFolderIndex]) {

--- a/website/static/js/fileViewTreebeard.js
+++ b/website/static/js/fileViewTreebeard.js
@@ -38,9 +38,7 @@ function FileViewTreebeard(data) {
         ondataload: function () {
             var tb = this;
             tb.fangornFolderIndex = 0;
-            if (window.contextVars.file.provider === 'figshare') {
-                tb.fangornFolderArray = [window.contextVars.file.name]
-            } else if (window.contextVars.file.path) {
+            if (window.contextVars.file.path && window.contextVars.file.provider !== 'figshare') {
                 window.contextVars.file.path = decodeURIComponent(window.contextVars.file.path);
                 tb.fangornFolderArray = window.contextVars.file.path.split("/");
                 if (tb.fangornFolderArray.length > 1) {
@@ -67,7 +65,7 @@ function FileViewTreebeard(data) {
             var tb = this;
             Fangorn.DefaultOptions.lazyLoadOnLoad.call(tb, tree, event);
             Fangorn.Utils.setCurrentFileID.call(tb, tree, window.contextVars.node.id, window.contextVars.file);
-            if(!event) { 
+            if(!event) {
                 Fangorn.Utils.scrollToFile.call(tb, tb.currentFileID);
             }
         },


### PR DESCRIPTION
If there are multiple files with the same name in the linked figshare project, highlight the correct one. Fixes https://trello.com/c/MiVDoL6v/99-highlighting-incorrect-when-there-is-more-than-one-file-of-the-same-name-in-the-same-folder. 