### PR TITLE
[feature] API V2 DRF: Make UserList class permission IsAuthenticatedOrReadOnly

### DIFF
--- a/api/users/views.py
+++ b/api/users/views.py
@@ -27,9 +27,8 @@ class UserMixin(object):
 
 class UserList(generics.ListAPIView, ODMFilterMixin):
     """Return a list of registered users."""
-    # TODO: Allow unauthenticated requests?
     permission_classes = (
-        drf_permissions.IsAuthenticated,
+        drf_permissions.IsAuthenticatedOrReadOnly,
     )
     serializer_class = UserSerializer
     ordering = ('-date_registered')


### PR DESCRIPTION
Change permissions of the UserList class to `IsAuthenticatedOrReadOnly` so that GET requests are still allowed for unauthenticated users.