### PR TITLE
improve the public project registration page redirect

### DIFF
--- a/website/templates/project/registrations.mako
+++ b/website/templates/project/registrations.mako
@@ -23,7 +23,7 @@
     % else:
         There have been no registrations of this ${node['node_type']}.
         For a list of the most viewed and most recent public registrations on the
-        Open Science Framework, click <a href="/explore/activity/">here</a>.
+        Open Science Framework, click <a href="/explore/activity/#newPublicRegistrations">here</a>.
 
     % endif
 


### PR DESCRIPTION
<b>Purpose</b>
Fix the problem that the public project registration page's redirect link direct you to top of public activity page instead of newest public registration part. Solves https://github.com/CenterForOpenScience/osf.io/issues/2461.


<b>Changes</b>
Now the redirect link direct you to the Newest public registration part of the public activity instead of top of the public activity page.