### PR TITLE
Fix incorrect tests

### DIFF
--- a/tests/test_mailchimp.py
+++ b/tests/test_mailchimp.py
@@ -38,7 +38,7 @@ class TestMailChimpHelpers(OsfTestCase):
         mock_get_mailchimp_api.return_value = mock_client
         mock_client.lists.list.return_value = {'data': [{'id': 1, 'list_name': list_name}]}
         list_id = mailchimp_utils.get_list_id_from_name(list_name)
-        mailchimp_utils.subscribe_mailchimp(list_name, user)
+        mailchimp_utils.subscribe_mailchimp(list_name, user._id)
         mock_client.lists.subscribe.assert_called_with(
             id=list_id,
             email={'email': user.username},
@@ -58,7 +58,7 @@ class TestMailChimpHelpers(OsfTestCase):
         mock_get_mailchimp_api.return_value = mock_client
         mock_client.lists.list.return_value = {'data': [{'id': 1, 'list_name': list_name}]}
         mock_client.lists.subscribe.side_effect = mailchimp.ValidationError
-        mailchimp_utils.subscribe_mailchimp(list_name, user)
+        mailchimp_utils.subscribe_mailchimp(list_name, user._id)
         assert_false(user.mailing_lists[list_name])
 
     @mock.patch('website.mailchimp_utils.get_mailchimp_api')
@@ -69,5 +69,5 @@ class TestMailChimpHelpers(OsfTestCase):
         mock_get_mailchimp_api.return_value = mock_client
         mock_client.lists.list.return_value = {'data': [{'id': 2, 'list_name': list_name}]}
         list_id = mailchimp_utils.get_list_id_from_name(list_name)
-        mailchimp_utils.unsubscribe_mailchimp(list_name, user)
+        mailchimp_utils.unsubscribe_mailchimp(list_name, user._id)
         mock_client.lists.unsubscribe.assert_called_with(id=list_id, email={'email': user.username})

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1027,7 +1027,7 @@ class TestSendEmails(OsfTestCase):
         )
 
     def test_send_email_digest_creates_digest_notification(self):
-        subscribed_users = [factories.UserFactory()]
+        subscribed_users = [factories.UserFactory()._id]
         digest_count_before = NotificationDigest.find().count()
         emails.email_digest(subscribed_users, self.project._id, 'comments',
                             user=self.user,
@@ -1043,7 +1043,7 @@ class TestSendEmails(OsfTestCase):
         assert_equal((digest_count - digest_count_before), 1)
 
     def test_send_email_digest_not_created_for_user_performed_actions(self):
-        subscribed_users = [self.user]
+        subscribed_users = [self.user._id]
         digest_count_before = NotificationDigest.find().count()
         emails.email_digest(subscribed_users, self.project._id, 'comments',
                             user=self.user,


### PR DESCRIPTION
Fix tests in `test_mailchimp.py` and `test_notifications.py` that pass in a user object instead of `user_id`. 