### PR TITLE
feature/update-markdown-it-video-version

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "markdown-it": "~4.1.0",
     "markdown-it-sanitizer": "~0.3.0",
     "markdown-it-toc": "~1.1.0",
-    "markdown-it-video": "~0.2.0",
+    "markdown-it-video": "~0.2.1",
     "mithril": "^0.1.30",
     "moment": "^2.9.0",
     "morgan": "^1.5.1",


### PR DESCRIPTION
Purpose
-----------
Update the version of Markdown-It-Video plugin being used in the OSF

Changes
------------
Not much is different, but we had a community contribution to change the style of tag closing for the iframe. Functionally, it should be the same. I had an issue from the same user to register the package with bower, so I figured I'd do it all at once.

It's also exporting the function a little differently, but nothing that changes functionally.

Side effects
----------------
None expected. Tests all pass, videos still embed.