### PR TITLE
[hotfix] Prevent creation of invalid OsfStorageFileGuids

### DIFF
--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -22,6 +22,7 @@ from website.addons.base import exceptions, GuidFile
 from website.project import new_private_link
 from website.project.utils import serialize_node
 from website.addons.base import AddonConfig, AddonNodeSettingsBase, views
+from website.addons.osfstorage.model import OsfStorageFileRecord
 from website.addons.github.model import AddonGitHubOauthSettings
 from tests.base import OsfTestCase
 from tests.factories import AuthUserFactory, ProjectFactory
@@ -641,6 +642,11 @@ class TestLegacyViews(OsfTestCase):
         self.path = 'mercury.png'
         self.user = AuthUserFactory()
         self.project = ProjectFactory(creator=self.user)
+        self.node_addon = self.project.get_addon('osfstorage')
+        file_record, _ = OsfStorageFileRecord.get_or_create(path=self.path,
+                                                            node_settings=self.node_addon)
+        self.node_addon.save()
+        file_record.save()
 
     def test_view_file_redirect(self):
         url = '/{0}/osffiles/{1}/'.format(self.project._id, self.path)

--- a/website/addons/base/views.py
+++ b/website/addons/base/views.py
@@ -255,6 +255,16 @@ def addon_view_or_download_file_legacy(**kwargs):
     if kwargs.get('vid'):
         query_params['version'] = kwargs['vid']
 
+    # If provider is OSFstorage, check existence of requested file in the filetree
+    # This prevents invalid GUIDs from being created
+    if provider == 'osfstorage':
+        file_tree = node.get_addon('osfstorage').file_tree
+        if not file_tree or (file_tree and not file_tree.find_by_path(path)):
+            raise HTTPError(
+                404, data=dict(message_short='File not found',
+                               message_long='You requested a file that does not exist.')
+            )
+
     return redirect(
         node.web_url_for(
             'addon_view_or_download_file',

--- a/website/addons/base/views.py
+++ b/website/addons/base/views.py
@@ -258,12 +258,18 @@ def addon_view_or_download_file_legacy(**kwargs):
     # If provider is OSFstorage, check existence of requested file in the filetree
     # This prevents invalid GUIDs from being created
     if provider == 'osfstorage':
-        file_tree = node.get_addon('osfstorage').file_tree
-        if not file_tree or (file_tree and not file_tree.find_by_path(path)):
-            raise HTTPError(
-                404, data=dict(message_short='File not found',
-                               message_long='You requested a file that does not exist.')
-            )
+        node_settings = node.get_addon('osfstorage')
+        file_tree = node_settings.file_tree
+        error = HTTPError(
+            404, data=dict(message_short='File not found',
+                           message_long='You requested a file that does not exist.')
+        )
+        if not file_tree:
+            raise error
+        else:
+            children_paths = [child.path for child in file_tree.children]
+            if path not in children_paths:
+                raise error
 
     return redirect(
         node.web_url_for(

--- a/website/routes.py
+++ b/website/routes.py
@@ -844,7 +844,13 @@ def make_url_map(app):
                 '/project/<pid>/node/<nid>/files/<fid>/version/<vid>/',
                 '/project/<pid>/files/download/<fid>/version/<vid>/',
                 '/project/<pid>/node/<nid>/files/download/<fid>/version/<vid>/',
-
+            ],
+            'get',
+            addon_views.addon_view_or_download_file_legacy,
+            OsfWebRenderer('project/view_file.mako'),
+        ),
+        Rule(
+            [
                 # api/v1 Legacy routes for `download_file`
                 '/api/v1/project/<pid>/osffiles/<fid>/',
                 '/api/v1/project/<pid>/node/<nid>/osffiles/<fid>/',


### PR DESCRIPTION
by checking the existence of the requested path in the node's
file tree

Using legacy routes in https://github.com/CenterForOpenScience/osf.io/blob/77e84f6ba8a5f05d06384d735e5d3ed851a8aa0d/website/routes.py#L807-863 with invalid file paths should no longer generate invalid GUIDs.