### PR TITLE
[feature] API v2 node serializer counts

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -15,15 +15,18 @@ class NodeSerializer(JSONAPISerializer):
     date_modified = ser.DateTimeField(read_only=True)
 
     links = LinksField({
-        'html': 'absolute_url',
+        'html': 'get_absolute_url',
         'children': {
-            'related': Link('nodes:node-children', kwargs={'pk': '<pk>'})
+            'related': Link('nodes:node-children', kwargs={'pk': '<pk>'}),
+            'count': 'get_node_count'
         },
         'contributors': {
-            'related': Link('nodes:node-contributors', kwargs={'pk': '<pk>'})
+            'related': Link('nodes:node-contributors', kwargs={'pk': '<pk>'}),
+            'count': 'get_contrib_count'
         },
         'registrations': {
-            'related': Link('nodes:node-registrations', kwargs={'pk': '<pk>'})
+            'related': Link('nodes:node-registrations', kwargs={'pk': '<pk>'}),
+            'count': 'get_registration_count'
         },
     })
     properties = ser.SerializerMethodField()
@@ -32,6 +35,18 @@ class NodeSerializer(JSONAPISerializer):
 
     class Meta:
         type_ = 'nodes'
+
+    def get_absolute_url(self, obj):
+        return obj.absolute_url
+
+    def get_node_count(self, obj):
+        return len(obj.nodes)
+
+    def get_contrib_count(self, obj):
+        return len(obj.contributors)
+
+    def get_registration_count(self, obj):
+        return len(obj.node__registrations)
 
     def get_properties(self, obj):
         ret = {

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -19,6 +19,9 @@ class UserSerializer(JSONAPISerializer):
     class Meta:
         type_ = 'users'
 
+    def absolute_url(self, obj):
+        return obj.absolute_url
+
     def update(self, instance, validated_data):
         # TODO
         pass


### PR DESCRIPTION
Purpose: 
Add counts to `NodeSerializer` links field

Changes: 
- Change `_url_val` to take strings as functions of the serializer instead of attributes of the object being serialized.
- Add serializer methods for getting counts for node children, contributors and registrations.
- Add counts in links dict passed to `LinksField`