### PR TITLE
Feature/api v2 drf - Tests and privacy

### DIFF
--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -78,11 +78,14 @@ class ODMFilterMixin(object):
         raise NotImplementedError('Must define get_default_odm_query')
 
     def get_query_from_request(self):
-        query = self.query_params_to_odm_query(self.request.QUERY_PARAMS)
-        if query:
-            query = query & self.get_default_odm_query()
+        param_query = self.query_params_to_odm_query(self.request.QUERY_PARAMS)
+        default_query = self.get_default_odm_query()
+
+        if param_query:
+            query = param_query & default_query
         else:
-            query = self.get_default_odm_query()
+            query = default_query
+
         return query
 
     def query_params_to_odm_query(self, query_params):

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -79,7 +79,9 @@ class ODMFilterMixin(object):
 
     def get_query_from_request(self):
         query = self.query_params_to_odm_query(self.request.QUERY_PARAMS)
-        if not query:
+        if query:
+            query = query & self.get_default_odm_query()
+        else:
             query = self.get_default_odm_query()
         return query
 
@@ -92,7 +94,7 @@ class ODMFilterMixin(object):
                 Q(self.convert_key(key=key), self.get_comparison_operator(key=key), self.convert_value(value=value))
                 for key, value in fields_dict.items() if self.is_filterable_field(key=key)
             ]
-            # TODO Ensure that if you try to filter on an invalid field, it returns a useful error.
+            # TODO Ensure that if you try to filter on an invalid field, it returns a useful error. Fix related test.
             try:
                 query = functools.reduce(intersect, query_parts)
             except TypeError:

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -40,7 +40,7 @@ class NodeList(generics.ListCreateAPIView, ODMFilterMixin):
         return (
             Q('is_public', 'eq', True) &
             Q('is_deleted', 'ne', True) &
-            Q('is_dashboard', 'ne', True)
+            Q('is_folder', 'ne', True)
         )
 
     # overrides ListCreateAPIView

--- a/tests/api_tests/test_base.py
+++ b/tests/api_tests/test_base.py
@@ -3,7 +3,7 @@ from nose.tools import *  # flake8: noqa
 
 from website.models import Node
 from tests.base import OsfTestCase
-from tests.factories import UserFactory, ProjectFactory
+from tests.factories import UserFactory, ProjectFactory, FolderFactory, DashboardFactory
 
 class TestApiBaseViews(OsfTestCase):
 
@@ -20,6 +20,8 @@ class TestFiltering(OsfTestCase):
         self.project_two = ProjectFactory(title="Project Two", description="One Three", is_public=True)
         self.project_three = ProjectFactory(title="Three", is_public=True)
         self.private_project = ProjectFactory(title="Private Project", is_public=False)
+        self.folder = FolderFactory()
+        self.dashboard = DashboardFactory()
 
     def tearDown(self):
         OsfTestCase.tearDown(self)
@@ -36,6 +38,8 @@ class TestFiltering(OsfTestCase):
         assert_in(self.project_two._id, ids)
         assert_in(self.project_three._id, ids)
         assert_not_in(self.private_project._id, ids)
+        assert_not_in(self.folder._id, ids)
+        assert_not_in(self.dashboard._id, ids)
 
     def test_get_one_project_with_exact_filter(self):
         url = "/api/v2/nodes/?filter[title]=Project%20One"
@@ -48,6 +52,8 @@ class TestFiltering(OsfTestCase):
         assert_not_in(self.project_two._id, ids)
         assert_not_in(self.project_three._id, ids)
         assert_not_in(self.private_project._id, ids)
+        assert_not_in(self.folder._id, ids)
+        assert_not_in(self.dashboard._id, ids)
 
     def test_get_some_projects_with_substring(self):
         url = "/api/v2/nodes/?filter[title]=Two"
@@ -60,6 +66,8 @@ class TestFiltering(OsfTestCase):
         assert_in(self.project_two._id, ids)
         assert_not_in(self.project_three._id, ids)
         assert_not_in(self.private_project._id, ids)
+        assert_not_in(self.folder._id, ids)
+        assert_not_in(self.dashboard._id, ids)
 
     def test_get_only_public_projects_with_filter(self):
         url = "/api/v2/nodes/?filter[title]=Project"
@@ -72,6 +80,8 @@ class TestFiltering(OsfTestCase):
         assert_in(self.project_two._id, ids)
         assert_not_in(self.project_three._id, ids)
         assert_not_in(self.private_project._id, ids)
+        assert_not_in(self.folder._id, ids)
+        assert_not_in(self.dashboard._id, ids)
 
     def test_alternate_filtering_field(self):
         url = "/api/v2/nodes/?filter[description]=Three"
@@ -84,6 +94,8 @@ class TestFiltering(OsfTestCase):
         assert_in(self.project_two._id, ids)
         assert_not_in(self.project_three._id, ids)
         assert_not_in(self.private_project._id, ids)
+        assert_not_in(self.folder._id, ids)
+        assert_not_in(self.dashboard._id, ids)
 
     def test_incorrect_filtering_field(self):
         # TODO Change to check for error when the functionality changes. Currently acts as though it doesn't exist
@@ -97,3 +109,5 @@ class TestFiltering(OsfTestCase):
         assert_in(self.project_two._id, ids)
         assert_in(self.project_three._id, ids)
         assert_not_in(self.private_project._id, ids)
+        assert_not_in(self.folder._id, ids)
+        assert_not_in(self.dashboard._id, ids)

--- a/tests/api_tests/test_base.py
+++ b/tests/api_tests/test_base.py
@@ -1,10 +1,99 @@
 # -*- coding: utf-8 -*-
 from nose.tools import *  # flake8: noqa
-from tests.base import OsfTestCase
 
+from website.models import Node
+from tests.base import OsfTestCase
+from tests.factories import UserFactory, ProjectFactory
 
 class TestApiBaseViews(OsfTestCase):
 
     def test_root_returns_200(self):
         res = self.app.get('/api/v2/')
         assert_equal(res.status_code, 200)
+
+
+class TestFiltering(OsfTestCase):
+
+    def setUp(self):
+        OsfTestCase.setUp(self)
+        self.project_one = ProjectFactory(title="Project One", is_public=True)
+        self.project_two = ProjectFactory(title="Project Two", description="One Three", is_public=True)
+        self.project_three = ProjectFactory(title="Three", is_public=True)
+        self.private_project = ProjectFactory(title="Private Project", is_public=False)
+
+    def tearDown(self):
+        OsfTestCase.tearDown(self)
+        Node.remove()
+
+    def test_get_all_projects_with_no_filter(self):
+        url = "/api/v2/nodes/"
+
+        res = self.app.get(url)
+        node_json = res.json['data']
+
+        ids = [each['id'] for each in node_json]
+        assert_in(self.project_one._id, ids)
+        assert_in(self.project_two._id, ids)
+        assert_in(self.project_three._id, ids)
+        assert_not_in(self.private_project._id, ids)
+
+    def test_get_one_project_with_exact_filter(self):
+        url = "/api/v2/nodes/?filter[title]=Project%20One"
+
+        res = self.app.get(url)
+        node_json = res.json['data']
+
+        ids = [each['id'] for each in node_json]
+        assert_in(self.project_one._id, ids)
+        assert_not_in(self.project_two._id, ids)
+        assert_not_in(self.project_three._id, ids)
+        assert_not_in(self.private_project._id, ids)
+
+    def test_get_some_projects_with_substring(self):
+        url = "/api/v2/nodes/?filter[title]=Two"
+
+        res = self.app.get(url)
+        node_json = res.json['data']
+
+        ids = [each['id'] for each in node_json]
+        assert_not_in(self.project_one._id, ids)
+        assert_in(self.project_two._id, ids)
+        assert_not_in(self.project_three._id, ids)
+        assert_not_in(self.private_project._id, ids)
+
+    def test_get_only_public_projects_with_filter(self):
+        url = "/api/v2/nodes/?filter[title]=Project"
+
+        res = self.app.get(url)
+        node_json = res.json['data']
+
+        ids = [each['id'] for each in node_json]
+        assert_in(self.project_one._id, ids)
+        assert_in(self.project_two._id, ids)
+        assert_not_in(self.project_three._id, ids)
+        assert_not_in(self.private_project._id, ids)
+
+    def test_alternate_filtering_field(self):
+        url = "/api/v2/nodes/?filter[description]=Three"
+
+        res = self.app.get(url)
+        node_json = res.json['data']
+
+        ids = [each['id'] for each in node_json]
+        assert_not_in(self.project_one._id, ids)
+        assert_in(self.project_two._id, ids)
+        assert_not_in(self.project_three._id, ids)
+        assert_not_in(self.private_project._id, ids)
+
+    def test_incorrect_filtering_field(self):
+        # TODO Change to check for error when the functionality changes. Currently acts as though it doesn't exist
+        url = "/api/v2/nodes/?filter[notafield]=bogus"
+
+        res = self.app.get(url)
+        node_json = res.json['data']
+
+        ids = [each['id'] for each in node_json]
+        assert_in(self.project_one._id, ids)
+        assert_in(self.project_two._id, ids)
+        assert_in(self.project_three._id, ids)
+        assert_not_in(self.private_project._id, ids)

--- a/tests/api_tests/test_base.py
+++ b/tests/api_tests/test_base.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 from nose.tools import *  # flake8: noqa
 
-from website.models import Node
 from tests.base import OsfTestCase
-from tests.factories import UserFactory, ProjectFactory, FolderFactory, DashboardFactory
 
 class TestApiBaseViews(OsfTestCase):
 
@@ -12,102 +10,3 @@ class TestApiBaseViews(OsfTestCase):
         assert_equal(res.status_code, 200)
 
 
-class TestFiltering(OsfTestCase):
-
-    def setUp(self):
-        OsfTestCase.setUp(self)
-        self.project_one = ProjectFactory(title="Project One", is_public=True)
-        self.project_two = ProjectFactory(title="Project Two", description="One Three", is_public=True)
-        self.project_three = ProjectFactory(title="Three", is_public=True)
-        self.private_project = ProjectFactory(title="Private Project", is_public=False)
-        self.folder = FolderFactory()
-        self.dashboard = DashboardFactory()
-
-    def tearDown(self):
-        OsfTestCase.tearDown(self)
-        Node.remove()
-
-    def test_get_all_projects_with_no_filter(self):
-        url = "/api/v2/nodes/"
-
-        res = self.app.get(url)
-        node_json = res.json['data']
-
-        ids = [each['id'] for each in node_json]
-        assert_in(self.project_one._id, ids)
-        assert_in(self.project_two._id, ids)
-        assert_in(self.project_three._id, ids)
-        assert_not_in(self.private_project._id, ids)
-        assert_not_in(self.folder._id, ids)
-        assert_not_in(self.dashboard._id, ids)
-
-    def test_get_one_project_with_exact_filter(self):
-        url = "/api/v2/nodes/?filter[title]=Project%20One"
-
-        res = self.app.get(url)
-        node_json = res.json['data']
-
-        ids = [each['id'] for each in node_json]
-        assert_in(self.project_one._id, ids)
-        assert_not_in(self.project_two._id, ids)
-        assert_not_in(self.project_three._id, ids)
-        assert_not_in(self.private_project._id, ids)
-        assert_not_in(self.folder._id, ids)
-        assert_not_in(self.dashboard._id, ids)
-
-    def test_get_some_projects_with_substring(self):
-        url = "/api/v2/nodes/?filter[title]=Two"
-
-        res = self.app.get(url)
-        node_json = res.json['data']
-
-        ids = [each['id'] for each in node_json]
-        assert_not_in(self.project_one._id, ids)
-        assert_in(self.project_two._id, ids)
-        assert_not_in(self.project_three._id, ids)
-        assert_not_in(self.private_project._id, ids)
-        assert_not_in(self.folder._id, ids)
-        assert_not_in(self.dashboard._id, ids)
-
-    def test_get_only_public_projects_with_filter(self):
-        url = "/api/v2/nodes/?filter[title]=Project"
-
-        res = self.app.get(url)
-        node_json = res.json['data']
-
-        ids = [each['id'] for each in node_json]
-        assert_in(self.project_one._id, ids)
-        assert_in(self.project_two._id, ids)
-        assert_not_in(self.project_three._id, ids)
-        assert_not_in(self.private_project._id, ids)
-        assert_not_in(self.folder._id, ids)
-        assert_not_in(self.dashboard._id, ids)
-
-    def test_alternate_filtering_field(self):
-        url = "/api/v2/nodes/?filter[description]=Three"
-
-        res = self.app.get(url)
-        node_json = res.json['data']
-
-        ids = [each['id'] for each in node_json]
-        assert_not_in(self.project_one._id, ids)
-        assert_in(self.project_two._id, ids)
-        assert_not_in(self.project_three._id, ids)
-        assert_not_in(self.private_project._id, ids)
-        assert_not_in(self.folder._id, ids)
-        assert_not_in(self.dashboard._id, ids)
-
-    def test_incorrect_filtering_field(self):
-        # TODO Change to check for error when the functionality changes. Currently acts as though it doesn't exist
-        url = "/api/v2/nodes/?filter[notafield]=bogus"
-
-        res = self.app.get(url)
-        node_json = res.json['data']
-
-        ids = [each['id'] for each in node_json]
-        assert_in(self.project_one._id, ids)
-        assert_in(self.project_two._id, ids)
-        assert_in(self.project_three._id, ids)
-        assert_not_in(self.private_project._id, ids)
-        assert_not_in(self.folder._id, ids)
-        assert_not_in(self.dashboard._id, ids)

--- a/tests/api_tests/test_nodes.py
+++ b/tests/api_tests/test_nodes.py
@@ -4,7 +4,7 @@ from nose.tools import *  # flake8: noqa
 from website.models import Node
 from website.util import api_v2_url_for
 from tests.base import OsfTestCase, fake
-from tests.factories import UserFactory, ProjectFactory
+from tests.factories import UserFactory, ProjectFactory, FolderFactory, DashboardFactory
 
 
 class TestNodeList(OsfTestCase):
@@ -74,3 +74,104 @@ class TestNodeContributorList(OsfTestCase):
         res = self.app.get(url, auth=(self.user.username, self.password))
         assert_equal(res.status_code, 200)
         Node.remove()
+
+
+class TestNodeFiltering(OsfTestCase):
+
+    def setUp(self):
+        OsfTestCase.setUp(self)
+        self.project_one = ProjectFactory(title="Project One", is_public=True)
+        self.project_two = ProjectFactory(title="Project Two", description="One Three", is_public=True)
+        self.project_three = ProjectFactory(title="Three", is_public=True)
+        self.private_project = ProjectFactory(title="Private Project", is_public=False)
+        self.folder = FolderFactory()
+        self.dashboard = DashboardFactory()
+
+    def tearDown(self):
+        OsfTestCase.tearDown(self)
+        Node.remove()
+
+    def test_get_all_projects_with_no_filter(self):
+        url = "/api/v2/nodes/"
+
+        res = self.app.get(url)
+        node_json = res.json['data']
+
+        ids = [each['id'] for each in node_json]
+        assert_in(self.project_one._id, ids)
+        assert_in(self.project_two._id, ids)
+        assert_in(self.project_three._id, ids)
+        assert_not_in(self.private_project._id, ids)
+        assert_not_in(self.folder._id, ids)
+        assert_not_in(self.dashboard._id, ids)
+
+    def test_get_one_project_with_exact_filter(self):
+        url = "/api/v2/nodes/?filter[title]=Project%20One"
+
+        res = self.app.get(url)
+        node_json = res.json['data']
+
+        ids = [each['id'] for each in node_json]
+        assert_in(self.project_one._id, ids)
+        assert_not_in(self.project_two._id, ids)
+        assert_not_in(self.project_three._id, ids)
+        assert_not_in(self.private_project._id, ids)
+        assert_not_in(self.folder._id, ids)
+        assert_not_in(self.dashboard._id, ids)
+
+    def test_get_some_projects_with_substring(self):
+        url = "/api/v2/nodes/?filter[title]=Two"
+
+        res = self.app.get(url)
+        node_json = res.json['data']
+
+        ids = [each['id'] for each in node_json]
+        assert_not_in(self.project_one._id, ids)
+        assert_in(self.project_two._id, ids)
+        assert_not_in(self.project_three._id, ids)
+        assert_not_in(self.private_project._id, ids)
+        assert_not_in(self.folder._id, ids)
+        assert_not_in(self.dashboard._id, ids)
+
+    def test_get_only_public_projects_with_filter(self):
+        url = "/api/v2/nodes/?filter[title]=Project"
+
+        res = self.app.get(url)
+        node_json = res.json['data']
+
+        ids = [each['id'] for each in node_json]
+        assert_in(self.project_one._id, ids)
+        assert_in(self.project_two._id, ids)
+        assert_not_in(self.project_three._id, ids)
+        assert_not_in(self.private_project._id, ids)
+        assert_not_in(self.folder._id, ids)
+        assert_not_in(self.dashboard._id, ids)
+
+    def test_alternate_filtering_field(self):
+        url = "/api/v2/nodes/?filter[description]=Three"
+
+        res = self.app.get(url)
+        node_json = res.json['data']
+
+        ids = [each['id'] for each in node_json]
+        assert_not_in(self.project_one._id, ids)
+        assert_in(self.project_two._id, ids)
+        assert_not_in(self.project_three._id, ids)
+        assert_not_in(self.private_project._id, ids)
+        assert_not_in(self.folder._id, ids)
+        assert_not_in(self.dashboard._id, ids)
+
+    def test_incorrect_filtering_field(self):
+        # TODO Change to check for error when the functionality changes. Currently acts as though it doesn't exist
+        url = "/api/v2/nodes/?filter[notafield]=bogus"
+
+        res = self.app.get(url)
+        node_json = res.json['data']
+
+        ids = [each['id'] for each in node_json]
+        assert_in(self.project_one._id, ids)
+        assert_in(self.project_two._id, ids)
+        assert_in(self.project_three._id, ids)
+        assert_not_in(self.private_project._id, ids)
+        assert_not_in(self.folder._id, ids)
+        assert_not_in(self.dashboard._id, ids)


### PR DESCRIPTION
Purpose
-----------
Filtering tests.

Also fix the problem where filters would ignore privacy settings (and also folders and deleted nodes).

Changes
------------
1) Added tests.
2) ANDing the query filter to the base query rather than replacing it.
3) Changed the node base query to check for folders rather than dashboards, as dashboards are a subset of folders, and you don't want either.

Side effects
----------------
Shouldn't be any.