### PR TITLE
feature/file_version

### DIFF
--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -22,7 +22,7 @@ from website.addons.base import exceptions, GuidFile
 from website.project import new_private_link
 from website.project.utils import serialize_node
 from website.addons.base import AddonConfig, AddonNodeSettingsBase, views
-from website.addons.osfstorage.model import OsfStorageFileRecord
+from website.addons.osfstorage.oldels import OsfStorageFileRecord
 from website.addons.github.model import AddonGitHubOauthSettings
 from tests.base import OsfTestCase
 from tests.factories import AuthUserFactory, ProjectFactory

--- a/website/addons/osfstorage/oldels.py
+++ b/website/addons/osfstorage/oldels.py
@@ -17,7 +17,6 @@ from website.models import NodeLog
 
 from website.addons.osfstorage import logs
 from website.addons.osfstorage import errors
-from website.addons.osfstorage import settings
 from website.addons.osfstorage.model import OsfStorageFileVersion
 
 
@@ -174,7 +173,7 @@ class OsfStorageFileRecord(BaseFileObject):
                 raise errors.VersionNotFoundError
             return None
 
-    def get_versions(self, page, size=settings.REVISIONS_PAGE_SIZE):
+    def get_versions(self, page, size):
         start = len(self.versions) - (page * size)
         stop = max(0, start - size)
         indices = range(start, stop, -1)

--- a/website/addons/osfstorage/settings/defaults.py
+++ b/website/addons/osfstorage/settings/defaults.py
@@ -5,8 +5,6 @@ import os
 from website import settings
 
 
-REVISIONS_PAGE_SIZE = 10
-
 WATERBUTLER_CREDENTIALS = {
     'storage': {}
 }

--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -1493,6 +1493,20 @@ dl.activity-log dd {
     padding:5px;
 }
 
+/*#fileRevisions{*/
+    /*margin-bottom: 625px;*/
+/*}*/
+thead.file-version-thread{
+    display: inline-block;
+}
+
+tbody.file-version{
+    max-height: 580px;
+    overflow-y: auto;
+    display: inline-block;
+    /*position: absolute;*/
+}
+
 /** The project and wiki name editable inputs should be larger
  * than the editable inputs elsewhere on the site.
  */

--- a/website/static/js/fileRevisions.js
+++ b/website/static/js/fileRevisions.js
@@ -131,6 +131,8 @@ RevisionsViewModel.prototype.fetch = function() {
         if (Object.keys(self.currentVersion()).length === 0) {
             self.currentVersion(self.revisions()[0]);
         }
+
+        $osf.tableResize('#fileRevisions', 4);
     });
 
     request.fail(function(response) {

--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -390,6 +390,37 @@ var htmlEscape = function(text) {
     return $('<div/>').text(text).html();
 };
 
+/**
++ * Resize table to match thead and tbody column
++ */
+
+var tableResize = function(selector, checker) {
+    // Change the selector if needed
+    var $table = $(selector);
+    var $bodyCells = $table.find('tbody tr:first').children();
+    var colWidth;
+
+    // Adjust the width of thead cells when window resizes
+    $(window).resize(function() {
+        // Get the tbody columns width array
+        colWidth = $bodyCells.map(function() {
+            return $(this).width();
+        }).get();
+        // Set the width of thead columns
+        $table.find('thead tr').children().each(function(i, v) {
+            if(i === 0 && $(v).width() > colWidth[i]){
+                $($bodyCells[i]).width($(v).width());
+            }
+            if(checker && i === checker) {
+                $(v).width(colWidth[i] + colWidth[i + 1]);
+            }else{
+                $(v).width(colWidth[i]);
+            }
+        });
+    }).resize(); // Trigger resize handler
+};
+
+
 // Also export these to the global namespace so that these can be used in inline
 // JS. This is used on the /goodbye page at the moment.
 module.exports = window.$.osf = {
@@ -409,5 +440,6 @@ module.exports = window.$.osf = {
     FormattableDate: FormattableDate,
     throttle: throttle,
     debounce: debounce,
-    htmlEscape: htmlEscape
+    htmlEscape: htmlEscape,
+    tableResize: tableResize
 };

--- a/website/templates/project/view_file.mako
+++ b/website/templates/project/view_file.mako
@@ -77,16 +77,17 @@
 
 
           <table class="table" data-bind="if: versioningSupported && revisions().length">
-            <thead>
+            <thead class="file-version-thread">
               <tr>
-                <th>Version ID</th>
+                <th width="10%">Version ID</th>
                 <th>Date</th>
                 <th data-bind="if: userColumn">User</th>
                 <th colspan="2">Download</th>
+                <th></th>
               </tr>
             </thead>
 
-            <tbody data-bind="foreach: {data: revisions, as: 'revision'}">
+            <tbody class="file-version" data-bind="foreach: {data: revisions, as: 'revision'}">
               <tr data-bind="css: $parent.isActive(revision)">
                 <td>
                   <a href="{{ revision.osfViewUrl }}" data-bind="if: revision !== $parent.currentVersion()">
@@ -132,7 +133,6 @@
       </div>
     </div>
 
-  </div>
 
 <%def name="javascript_bottom()">
     ${parent.javascript_bottom()}


### PR DESCRIPTION
Purpose
Fix the problem the osfstorge only provide the 10 latest version of files to user and add the scroll bar to make interface more readable for all file storage addon. Solve issue #2059

Changes
the old file versions:
screen shot 2015-03-30 at 5 26 00 pm
![image](https://cloud.githubusercontent.com/assets/4974056/7376585/c65b8eb8-edae-11e4-9081-fdaba8a3b76c.png)


the new file versions:
screen shot 2015-03-30 at 5 26 37 pm
![image](https://cloud.githubusercontent.com/assets/4974056/7376587/cd089c56-edae-11e4-81b6-76e536770a2a.png)


Facts
the current file addons on OSF:
1. S3: S3 supports versions only if you enable the version for the bucket
2. Box: Box's version function is only available for premium user 
3. Dataverse: Doesn't support versioning
4. Dropbox: Dropbox currently only return 10 versions since the controller is defaulted to be 10. @chrisseto is going to change the waterbulter to make dropbox return more versions for osf users.
5. Github: Github currently returns 30 latest versions.
6. GoogleDrive: Google drive returns all versions.
7. Osfstorage: After this patch, it will returns all the versions.
8. figshare: figshare doesn't support versions.