### PR TITLE
Release 0.34: Fix osfstorage and box file highlighting

### DIFF
--- a/website/static/js/fileViewTreebeard.js
+++ b/website/static/js/fileViewTreebeard.js
@@ -37,10 +37,15 @@ function FileViewTreebeard(data) {
         },
         ondataload: function () {
             var tb = this;
+            var path = '';
             tb.fangornFolderIndex = 0;
             if (window.contextVars.file.path && window.contextVars.file.provider !== 'figshare') {
-                window.contextVars.file.path = decodeURIComponent(window.contextVars.file.path);
-                tb.fangornFolderArray = window.contextVars.file.path.split("/");
+                if (window.contextVars.file.provider === 'osfstorage' || window.contextVars.file.provider === 'box') {
+                    path = decodeURIComponent(window.contextVars.file.extra.fullPath);
+                } else {
+                    path = decodeURIComponent(window.contextVars.file.path);
+                }
+                tb.fangornFolderArray = path.split("/");
                 if (tb.fangornFolderArray.length > 1) {
                     tb.fangornFolderArray.splice(0, 1);
                 }

--- a/website/static/js/fileViewTreebeard.js
+++ b/website/static/js/fileViewTreebeard.js
@@ -39,6 +39,7 @@ function FileViewTreebeard(data) {
             var tb = this;
             var path = '';
             tb.fangornFolderIndex = 0;
+            tb.fangornFolderArray = [''];
             if (window.contextVars.file.path && window.contextVars.file.provider !== 'figshare') {
                 if (window.contextVars.file.provider === 'osfstorage' || window.contextVars.file.provider === 'box') {
                     path = decodeURIComponent(window.contextVars.file.extra.fullPath);
@@ -49,8 +50,6 @@ function FileViewTreebeard(data) {
                 if (tb.fangornFolderArray.length > 1) {
                     tb.fangornFolderArray.splice(0, 1);
                 }
-            } else {
-                tb.fangornFolderArray = [''];
             }
             m.render($('#filesSearch').get(0), tb.options.filterTemplate.call(tb));
         },


### PR DESCRIPTION
Purpose
------------
With the addition of folders, the paths for osfstorage files are no longer the full path to the file. As a result, those files will not highlight in the files navigation panel on the file detail page. 

Fixes https://trello.com/c/gM5yd99b/33-osf-file-not-highlighted-in-file-tree

Changes
------------
Get file paths from `window.contextVars.file.extras.fullPath` instead of `window.contextVars.file.path` for highlighting osfstorage files. Also do this for box files, since the full path to the file is now available.