### PR TITLE
Fix extraneous text on registration page

### DIFF
--- a/website/templates/project/registrations.mako
+++ b/website/templates/project/registrations.mako
@@ -14,13 +14,13 @@
             "uri": "${node["api_url"]}get_registrations/",
             "replace": true
             }'></div>
-    # Uncomment to disable registering Components      
-    #% elif node['node_type'] != 'project':
-    #      %if user['is_admin_parent']:
-    #          To register this component, you must <a href="${parent_node['url']}registrations"><b>register its parent project</b></a> (<a href="${parent_node['url']}">${parent_node['title']}</a>).
-    #      %else:
-    #          There have been no registrations of the parent project (<a href="${parent_node['url']}">${parent_node['title']}</a>).
-    #      %endif
+    ## Uncomment to disable registering Components
+    ##% elif node['node_type'] != 'project':
+    ##      %if user['is_admin_parent']:
+    ##          To register this component, you must <a href="${parent_node['url']}registrations"><b>register its parent project</b></a> (<a href="${parent_node['url']}">${parent_node['title']}</a>).
+    ##      %else:
+    ##          There have been no registrations of the parent project (<a href="${parent_node['url']}">${parent_node['title']}</a>).
+    ##      %endif
     % else:
         There have been no registrations of this ${node['node_type']}.
         For a list of the most viewed and most recent public registrations on the


### PR DESCRIPTION
This ticket refers to an issue observed in testing the development branch for the upcoming 0.35 release. It does not occur in production.

Projects with known registrations display additional, irrelevant text on the registrations page (see screenshot).

![screen shot 2015-05-01 at 6 21 45 pm](https://cloud.githubusercontent.com/assets/2957073/7442016/1e76b358-f0ce-11e4-8b32-65bade67cef8.png)

This appears to be a vestige of commented-out code in the mako template:
```
    # Uncomment to disable registering Components      
    #% elif node['node_type'] != 'project':
    #      %if user['is_admin_parent']:
    #          To register this component, you must <a href="${parent_node['url']}registrations"><b>register its parent project</b></a> (<a href="${parent_node['url']}">${parent_node['title']}</a>).
    #      %else:
    #          There have been no registrations of the parent project (<a href="${parent_node['url']}">${parent_node['title']}</a>).
    #      %endif
```

Changing this to the double-pound-sign comment syntax [recommended](http://docs.makotemplates.org/en/latest/syntax.html#comments) in the mako docs removes this extraneous text. An alternate and longer-term solution would be to remove the commented out block altogether.