### PR TITLE
[Ready for Review] More noderefactor cleanup

### DIFF
--- a/website/addons/osfstorage/model.py
+++ b/website/addons/osfstorage/model.py
@@ -55,14 +55,14 @@ class OsfStorageNodeSettings(AddonNodeSettingsBase):
         return OsfStorageGuidFile.get_or_create(self.owner, path)
 
     def after_fork(self, node, fork, user, save=True):
-        clone, message = super(OsfStorageNodeSettings, self).after_fork(
-            node=node, fork=fork, user=user, save=False
-        )
+        clone = self.clone()
+        clone.owner = fork
         clone.save()
+
         clone.root_node = utils.copy_files(self.root_node, clone)
         clone.save()
 
-        return clone, message
+        return clone, None
 
     def after_register(self, node, registration, user, save=True):
         clone = self.clone()

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -593,7 +593,8 @@ def component_remove(auth, node, **kwargs):
         node.project_or_component.capitalize()
     )
     status.push_status_message(message)
-    if node.node__parent:
+    parent = node.parent_node
+    if parent and parent.can_view(auth):
         redirect_url = node.node__parent[0].url
     else:
         redirect_url = '/dashboard/'

--- a/website/static/css/iconmap.css
+++ b/website/static/css/iconmap.css
@@ -1,0 +1,6 @@
+.iconmap-smaller {
+    font-size: 75%;
+}
+.iconmap-clickable {
+    cursor: pointer;
+}

--- a/website/static/js/iconmap.js
+++ b/website/static/js/iconmap.js
@@ -1,6 +1,4 @@
-// TODO Remove when @caneruguz's updates are in
-require('css/projectorganizer.css');
-///////////////////////////////////////////////
+require('css/iconmap.css');
 
 module.exports = {
     componentIcons: {
@@ -23,5 +21,7 @@ module.exports = {
         registeredComponent:  'fa fa-th-large text-muted',
         link:  'fa fa-link'
     },
-    info: 'fa fa-info-circle'
+    info: 'fa fa-info-circle',
+    smaller: 'iconmap-smaller',
+    clickable: 'iconmap-clickable'
 };

--- a/website/static/js/nodeControl.js
+++ b/website/static/js/nodeControl.js
@@ -141,16 +141,14 @@ var ProjectViewModel = function(data) {
     });
 
     // Add icon to title
-    var icon = '';
+    self.icon = '';
     var category = data.node.category_short;
     if (Object.keys(iconmap.componentIcons).indexOf(category) >=0 ){
-        icon = iconmap.componentIcons[category];        
+        self.icon = iconmap.componentIcons[category];        
     }
     else {
-        icon = iconmap.projectIcons[category];
+        self.icon = iconmap.projectIcons[category];
     }
-    icon = $('<span>').addClass(icon);
-    $('#nodeTitleEditable').parent().prepend(icon);
 
     // Editable Title and Description
     if (self.userCanEdit) {

--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -53,7 +53,6 @@ var projectOrganizerCategories = $.extend({}, {
     folder: 'Folder',
     smartFolder: 'Smart Folder',
     project: 'Project',
-    registration:  'Registration',
     link:  'Link'
 }, nodeCategories);
 
@@ -644,13 +643,17 @@ function _poToggleCheck(item) {
 function _poResolveIcon(item) {
     var icons = iconmap.projectIcons;
     var componentIcons = iconmap.componentIcons;
+    var projectIcons = iconmap.projectIcons;
     var viewLink = item.data.urls.fetch;
     function returnView(type, category) {
         var iconType = icons[type];
         if (type === 'component' || type === 'registeredComponent') {
             iconType = componentIcons[category];
         }
-        if (type === 'registeredComponent') {
+        else if (type === 'project' || type === 'registeredProject') {
+            iconType = projectIcons[category];
+        }
+        if (type === 'registeredComponent' || type === 'registeredProject') {
             iconType += ' po-icon-registered';
         }
         else {
@@ -674,7 +677,7 @@ function _poResolveIcon(item) {
     }
     if (item.data.isProject) {
         if (item.data.isRegistration) {
-            return returnView('registration');
+            return returnView('registeredProject', item.data.category);
         } else {
             return returnView('project');
         }

--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -1331,7 +1331,7 @@ ProjectOrganizer.prototype = {
         return m.render(
             domNode,
             m('span', {
-                className: iconmap.info + ' smaller',
+                className: [iconmap.info, iconmap.smaller, iconmap.clickable].join(' '),
                 click: showLegend
             })
         );

--- a/website/static/js/registerNode.js
+++ b/website/static/js/registerNode.js
@@ -9,7 +9,7 @@ var preRegisterMessage =  function(title, parentTitle, parentUrl) {
     return 'You are about to Register the component "' + title +
         '" and everything that is inside it. This will not register' +
         ' your larger project "' + parentTitle + '" and its other components.' +
-        ' If you want to register the parent project, please go <a href="' +
+        ' If you want to register the entire project, please go <a href="' +
         parentUrl + '">here.</a>';
 };
 

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -135,6 +135,8 @@
                   <!-- /ko -->
                 </span>
                 <br />Category: <span class="node-category">${node['category']}</span>
+                &nbsp;
+                <span data-bind="css: icon"></span>
                 % if node['description'] or 'write' in user['permissions']:
                     <br /><span id="description">Description:</span> <span id="nodeDescriptionEditable" class="node-description overflow" data-type="textarea">${node['description']}</span>
                 % endif

--- a/website/templates/project/registrations.mako
+++ b/website/templates/project/registrations.mako
@@ -29,7 +29,7 @@
     %if parent_node['exists'] and parent_node['can_view']:
         <br />
         <br />
-        To register the parent project "${parent_node['title']}" instead, click <a href="${parent_node['registrations_url']}">here.</a>
+        To register the entire project "${parent_node['title']}" instead, click <a href="${parent_node['registrations_url']}">here.</a>
     %endif 
 
   </div>


### PR DESCRIPTION
# Purpose 

- Clean up some stylistic issues with iconography.
- Bugfix an issue when deleting subprojects
- Update PO icons to make registrations grayed-out versions (even for projects)

# Changes
- Move icon from project title to next to category
- Make PO info icon smaller and have cursor: pointer
- Check if can_view parent before redirect when deleting
- Change registration language as per @lbanner's request

# Side effects
None

