### PR TITLE
[Ready] Hotfix fork_node failure for osfstorage

### DIFF
--- a/website/addons/osfstorage/model.py
+++ b/website/addons/osfstorage/model.py
@@ -55,14 +55,14 @@ class OsfStorageNodeSettings(AddonNodeSettingsBase):
         return OsfStorageGuidFile.get_or_create(self.owner, path)
 
     def after_fork(self, node, fork, user, save=True):
-        clone, message = super(OsfStorageNodeSettings, self).after_fork(
-            node=node, fork=fork, user=user, save=False
-        )
+        clone = self.clone()
+        clone.owner = fork
         clone.save()
+
         clone.root_node = utils.copy_files(self.root_node, clone)
         clone.save()
 
-        return clone, message
+        return clone, None
 
     def after_register(self, node, registration, user, save=True):
         clone = self.clone()


### PR DESCRIPTION
# Purpose

User's were getting 500s when trying to fork nodes

# Changes

Modify the after_fork logic for the osfstorage model to call self.clone(). This runs the model's on_add, which adds the root_node property. @chrisseto has reviewed and approves of this fix.

# Side Effects

None