### PR TITLE
[Ready for Review] More NodeRefactor Cleanup

### DIFF
--- a/website/addons/box/templates/log_templates.mako
+++ b/website/addons/box/templates/log_templates.mako
@@ -1,28 +1,28 @@
 <script type="text/html" id="box_file_added">
 added file
 <a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect">{{ params.fullPath }}</a> to
-Box in {{ nodeType }}
+Box in
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 
 <script type="text/html" id="box_folder_created">
 created folder
 <span class="overflow log-folder">{{ params.fullPath }}</span> in
-Box in {{ nodeType }}
+Box in
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 
 <script type="text/html" id="box_file_updated">
 updated file
 <a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect">{{ params.fullPath }}</a> to
-Box in {{ nodeType }}
+Box in
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 
 
 <script type="text/html" id="box_file_removed">
 removed {{ params.path.endsWith('/') ? 'folder' : 'file' }} <span class="overflow">{{ params.name }}</span> from
-Box in {{ nodeType }}
+Box in
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 
@@ -31,20 +31,20 @@ Box in {{ nodeType }}
 linked Box folder
 <span class="overflow">
     {{ params.folder === 'All Files' ? '/ (Full Box)' : params.folder.replace('All Files','')}}
-</span> to {{ nodeType }}
+</span> to
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 
 
 <script type="text/html" id="box_node_deauthorized">
-deauthorized the Box addon for {{ nodeType }}
+deauthorized the Box addon for
 <a class="log-node-title-link overflow"
     data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 
 
 <script type="text/html" id="box_node_authorized">
-authorized the Box addon for {{ nodeType }}
+authorized the Box addon for
 <a class="log-node-title-link overflow"
     data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>

--- a/website/addons/dataverse/templates/log_templates.mako
+++ b/website/addons/dataverse/templates/log_templates.mako
@@ -2,53 +2,53 @@
 added file
 <a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect, text: params.filename"></a> to
 Dataverse dataset <span class="overflow">{{ params.dataset }}</span>
-in {{ nodeType }}
+in
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 
 <script type="text/html" id="dataverse_file_removed">
 removed file <span class="overflow">{{ params.filename }}</span> from
 Dataverse dataset <span class="overflow">{{ params.dataset }}</span>
-in {{ nodeType }}
+in
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 
 <script type="text/html" id="dataverse_dataset_linked">
 linked Dataverse dataset
-<span class="overflow">{{ params.dataset }}</span> to {{ nodeType }}
+<span class="overflow">{{ params.dataset }}</span> to
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 
 <!-- Legacy version -->
 <script type="text/html" id="dataverse_study_linked">
 linked Dataverse dataset
-<span class="overflow">{{ params.study }}</span> to {{ nodeType }}
+<span class="overflow">{{ params.study }}</span> to
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 
 <script type="text/html" id="dataverse_dataset_published">
 published a new version of Dataverse dataset
-<span class="overflow">{{ params.dataset }}</span> to {{ nodeType }}
-for {{ nodeType }}
+<span class="overflow">{{ params.dataset }}</span> to
+for
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 
 <!-- Legacy version -->
 <script type="text/html" id="dataverse_study_released">
 published a new version of Dataverse dataset
-<span class="overflow">{{ params.study }}</span> to {{ nodeType }}
-for {{ nodeType }}
+<span class="overflow">{{ params.study }}</span> to
+for
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 
 <script type="text/html" id="dataverse_node_authorized">
-authorized the Dataverse addon for {{ nodeType }}
+authorized the Dataverse addon for
 <a class="log-node-title-link overflow"
     data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 
 <script type="text/html" id="dataverse_node_deauthorized">
-deauthorized the Dataverse addon for {{ nodeType }}
+deauthorized the Dataverse addon for
 <a class="log-node-title-link overflow"
     data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>

--- a/website/addons/dropbox/templates/log_templates.mako
+++ b/website/addons/dropbox/templates/log_templates.mako
@@ -1,47 +1,47 @@
 <script type="text/html" id="dropbox_file_added">
 added file
 <a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect">{{ params.path }}</a> to
-Dropbox in {{ nodeType }}
+Dropbox in
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 
 <script type="text/html" id="dropbox_folder_created">
 created folder
 <span class="overflow log-folder">{{ params.path }}</span> in
-Dropbox in {{ nodeType }}
+Dropbox in
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 
 <script type="text/html" id="dropbox_file_updated">
 updated file
 <a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect">{{ params.path }}</a> to
-Dropbox in {{ nodeType }}
+Dropbox in
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 
 
 <script type="text/html" id="dropbox_file_removed">
 removed {{ params.path.endsWith('/') ? 'folder' : 'file' }} <span class="overflow">{{ params.path }}</span> from
-Dropbox in {{ nodeType }}
+Dropbox in
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 
 
 <script type="text/html" id="dropbox_folder_selected">
-linked Dropbox folder <span class="overflow">{{ params.folder === '/' ? '/ (Full Dropbox)' : params.folder }}</span> to {{ nodeType }}
+linked Dropbox folder <span class="overflow">{{ params.folder === '/' ? '/ (Full Dropbox)' : params.folder }}</span> to
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 
 
 <script type="text/html" id="dropbox_node_deauthorized">
-deauthorized the Dropbox addon for {{ nodeType }}
+deauthorized the Dropbox addon for
 <a class="log-node-title-link overflow"
     data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 
 
 <script type="text/html" id="dropbox_node_authorized">
-authorized the Dropbox addon for {{ nodeType }}
+authorized the Dropbox addon for
 <a class="log-node-title-link overflow"
     data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>

--- a/website/addons/figshare/templates/log_templates.mako
+++ b/website/addons/figshare/templates/log_templates.mako
@@ -7,30 +7,28 @@ figshare <span data-bind="text: params.figshare.title"></span> in
 
 <script type="text/html" id="figshare_file_removed">
 removed file <span class="overflow">{{ params.path }}</span> from
-figshare in {{ nodeType }}
+figshare in
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 
 <script type="text/html" id="figshare_content_linked">
 linked figshare project /<span data-bind="text: params.figshare.title"></span> to
-<span data-bind="text: nodeType"></span>
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="figshare_content_unlinked">
 unlinked figshare project /<span data-bind="text: params.figshare.title"></span> from
-<span data-bind="text: nodeType"></span>
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="figshare_node_authorized">
-authorized the figshare addon for {{ nodeType }}
+authorized the figshare addon for
 <a class="log-node-title-link overflow"
     data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 
 <script type="text/html" id="figshare_node_deauthorized">
-deauthorized the figshare addon for {{ nodeType }}
+deauthorized the figshare addon for
 <a class="log-node-title-link overflow"
     data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>

--- a/website/addons/forward/templates/log_templates.mako
+++ b/website/addons/forward/templates/log_templates.mako
@@ -1,6 +1,6 @@
 <script type="text/html" id="forward_url_changed">
 changed forward URL to
 <a target="_blank" class="overflow log-file-link" data-bind="attr.href: params.forward_url">{{ params.forward_url }}</a>
-in {{ nodeType }}
+in
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>

--- a/website/addons/github/templates/log_templates.mako
+++ b/website/addons/github/templates/log_templates.mako
@@ -4,7 +4,6 @@ added file
 GitHub repo
 <span data-bind="text: params.github.user"></span> /
 <span data-bind="text: params.github.repo"></span> to
-<span data-bind="text: nodeType"></span>
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
@@ -14,7 +13,6 @@ created folder
 GitHub repo
 <span data-bind="text: params.github.user"></span> /
 <span data-bind="text: params.github.repo"></span> in
-<span data-bind="text: nodeType"></span>
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 
@@ -24,7 +22,6 @@ updated file
 GitHub repo
 <span data-bind="text: params.github.user"></span> /
 <span data-bind="text: params.github.repo"></span> in
-<span data-bind="text: nodeType"></span>
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
@@ -33,7 +30,6 @@ removed file <span class="overflow" data-bind="text: params.path"></span> from
 GitHub repo
 <span data-bind="text: params.github.user"></span> /
 <span data-bind="text: params.github.repo"></span> from
-<span data-bind="text: nodeType"></span>
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
@@ -41,7 +37,6 @@ GitHub repo
 linked GitHub repo
 <span data-bind="text: params.github.user"></span> /
 <span data-bind="text: params.github.repo"></span> to
-<span data-bind="text: nodeType"></span>
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
@@ -49,18 +44,17 @@ linked GitHub repo
 unlinked GitHub repo
 <span data-bind="text: params.github.user"></span> /
 <span data-bind="text: params.github.repo"></span> from
-<span data-bind="text: nodeType"></span>
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="github_node_authorized">
-authorized the GitHub addon for {{ nodeType }}
+authorized the GitHub addon for
 <a class="log-node-title-link overflow"
     data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 
 <script type="text/html" id="github_node_deauthorized">
-deauthorized the GitHub addon for {{ nodeType }}
+deauthorized the GitHub addon for
 <a class="log-node-title-link overflow"
     data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>

--- a/website/addons/googledrive/templates/log_templates.mako
+++ b/website/addons/googledrive/templates/log_templates.mako
@@ -1,47 +1,47 @@
 <script type="text/html" id="googledrive_file_added">
 added file
 <a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect">{{ decodeURIComponent(params.path) }}</a> to
-Google Drive in {{ nodeType }}
+Google Drive in
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 
 <script type="text/html" id="googledrive_folder_created">
 created folder
 <span class="overflow log-folder">{{ decodeURIComponent(params.path) }}</span> in
-Google Drive in {{ nodeType }}
+Google Drive in
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 
 <script type="text/html" id="googledrive_file_updated">
 updated file
 <a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect">{{ decodeURIComponent(params.path) }}</a> to
-Google Drive in {{ nodeType }}
+Google Drive in
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 
 
 <script type="text/html" id="googledrive_file_removed">
 removed {{ params.path.endsWith('/') ? 'folder' : 'file' }} <span class="overflow ">{{ decodeURIComponent(params.path) }}</span> from
-Google Drive in {{ nodeType }}
+Google Drive in
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 
 
 <script type="text/html" id="googledrive_folder_selected">
-linked Google Drive folder /<span class="overflow">{{ params.folder === '/' ? '(Full Google Drive)' : decodeURIComponent(params.folder) }}</span> to {{ nodeType }}
+linked Google Drive folder /<span class="overflow">{{ params.folder === '/' ? '(Full Google Drive)' : decodeURIComponent(params.folder) }}</span> to
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 
 
 <script type="text/html" id="googledrive_node_deauthorized">
-deauthorized the Google Drive addon for {{ nodeType }}
+deauthorized the Google Drive addon for
 <a class="log-node-title-link overflow"
     data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 
 
 <script type="text/html" id="googledrive_node_authorized">
-authorized the Google Drive addon for {{ nodeType }}
+authorized the Google Drive addon for
 <a class="log-node-title-link overflow"
     data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>

--- a/website/addons/mendeley/templates/log_templates.mako
+++ b/website/addons/mendeley/templates/log_templates.mako
@@ -1,4 +1,4 @@
 <script type="text/html" id="mendeley_folder_selected">
-linked Mendeley folder /<span class="overflow">{{ params.folder_name }}</span> to {{ nodeType }}
+linked Mendeley folder /<span class="overflow">{{ params.folder_name }}</span> to
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>

--- a/website/addons/osfstorage/templates/log_templates.mako
+++ b/website/addons/osfstorage/templates/log_templates.mako
@@ -1,23 +1,23 @@
 <script type="text/html" id="osf_storage_file_added">
 added file
-<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect">{{ params.path }}</a> in {{ nodeType }}
+<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect">{{ params.path }}</a> in
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 
 <script type="text/html" id="osf_storage_folder_created">
 created folder
-<span class="overflow log-folder">{{ params.path }}</span> in {{ nodeType }}
+<span class="overflow log-folder">{{ params.path }}</span> in
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 
 <script type="text/html" id="osf_storage_file_updated">
 updated file
-<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect">{{ params.path }}</a> in {{ nodeType }}
+<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect">{{ params.path }}</a> in
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 
 <script type="text/html" id="osf_storage_file_removed">
-  removed {{ params.path.endsWith('/') ? 'folder' : 'file' }} <span class="overflow">{{ params.path }}</span> in {{ nodeType }}
+  removed {{ params.path.endsWith('/') ? 'folder' : 'file' }} <span class="overflow">{{ params.path }}</span> in
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 
@@ -25,18 +25,15 @@ updated file
 ## Legacy log templates for previous OSF Files
 <script type="text/html" id="file_added">
 added file <a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect, text: params.path"></a> to
-<span data-bind="text: nodeType"></span>
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="file_updated">
 updated file <a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect, text: params.path"></a> in
-<span data-bind="text: nodeType"></span>
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="file_removed">
 removed file <span data-bind="text: params.path"></span> from
-<span data-bind="text: nodeType"></span>
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>

--- a/website/addons/s3/templates/log_templates.mako
+++ b/website/addons/s3/templates/log_templates.mako
@@ -3,14 +3,13 @@ added file
 <a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect, text: params.path"></a> to
 bucket
 <span data-bind="text: params.bucket"></span> in
-<span data-bind="text: nodeType"></span>
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="s3_folder_created">
 created folder
 <span class="overflow log-folder">{{ params.path }}</span> in
-bucket {{ params.bucket }} in {{ nodeType }}
+bucket {{ params.bucket }} in 
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 
@@ -19,7 +18,6 @@ updated file
 <a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect, text: params.path"></a> in
 bucket
 <span data-bind="text: params.bucket"></span> in
-<span data-bind="text: nodeType"></span>
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
@@ -27,32 +25,29 @@ bucket
 removed {{ params.path.endsWith('/') ? 'folder' : 'file' }} <span class="overflow" data-bind="text: params.path"></span> from
 bucket
 <span data-bind="text: params.bucket"></span> in
-<span data-bind="text: nodeType"></span>
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="s3_bucket_linked">
 linked the Amazon S3 bucket /
 <span data-bind="text: params.bucket"></span> to
-<span data-bind="text: nodeType"></span>
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="s3_bucket_unlinked">
 un-selected bucket
 <span data-bind="text: params.bucket"></span> in
-<span data-bind="text: nodeType"></span>
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="s3_node_authorized">
-authorized the Amazon S3 addon for {{ nodeType }}
+authorized the Amazon S3 addon for 
 <a class="log-node-title-link overflow"
     data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 
 <script type="text/html" id="s3_node_deauthorized">
-deauthorized the Amazon S3 addon for {{ nodeType }}
+deauthorized the Amazon S3 addon for 
 <a class="log-node-title-link overflow"
     data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>

--- a/website/addons/zotero/templates/log_templates.mako
+++ b/website/addons/zotero/templates/log_templates.mako
@@ -1,4 +1,4 @@
 <script type="text/html" id="zotero_folder_selected">
-linked Zotero folder /<span class="overflow">{{ params.folder_name }}</span> to {{ nodeType }}
+linked Zotero folder /<span class="overflow">{{ params.folder_name }}</span> to 
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -1044,10 +1044,12 @@ def _serialize_node_search(node):
     if node.is_registration:
         title += ' (registration)'
 
+    first_author = node.visible_contributors[0]
+
     return {
         'id': node._id,
         'title': title,
-        'firstAuthor': node.visible_contributors[0].family_name,
+        'firstAuthor': first_author.family_name or first_author.given_name or first_author.full_name,
         'etal': len(node.visible_contributors) > 1,
     }
 

--- a/website/static/js/pages/project-settings-page.js
+++ b/website/static/js/pages/project-settings-page.js
@@ -50,10 +50,12 @@ $(document).ready(function() {
             value: keys[i]
         });
     }
+    var disableCategory = !window.contextVars.node.parentExists;
     var categorySettingsVM = new ProjectSettings.NodeCategorySettings(
         window.contextVars.node.category,
         categories,
-        window.contextVars.node.urls.update
+        window.contextVars.node.urls.update,
+        disableCategory
     );
     ko.applyBindings(categorySettingsVM, $('#nodeCategorySettings')[0]);
 

--- a/website/static/js/projectSettings.js
+++ b/website/static/js/projectSettings.js
@@ -11,10 +11,12 @@ var ChangeMessageMixin = require('js/changeMessage');
 var NodeCategorySettings = oop.extend(
     ChangeMessageMixin,
     {
-        constructor: function(category, categories, updateUrl) {
+        constructor: function(category, categories, updateUrl, disabled) {
             this.super.constructor.call(this);
 
             var self = this;
+
+            self.disabled = disabled || false;
 
             self.UPDATE_SUCCESS_MESSAGE = 'Category updated successfully';
             self.UPDATE_ERROR_MESSAGE = 'Error updating category, please try again. If the problem persists, email ' +

--- a/website/templates/log_templates.mako
+++ b/website/templates/log_templates.mako
@@ -5,27 +5,27 @@
 ## website/addons/<addon_name>/templates/log_templates.mako.
 
 <script type="text/html" id="project_created">
-created <span data-bind="text: nodeType"></span>
+created 
 <a class="log-node-title-link overflow" data-bind="text: nodeTitle, attr: {href: nodeUrl}"></a>
 </script>
 
 <script type="text/html" id="project_deleted">
-deleted <span data-bind="text: nodeType"></span>
+deleted 
 <span class="log-node-title-link overflow" data-bind="text: nodeTitle"></span>
 </script>
 
 <script type="text/html" id="created_from">
-created <span data-bind="text: nodeType"></span>
-<a class="log-node-title-link overflow" data-bind="text: nodeTitle, attr: {href: nodeUrl}"></a> based on <a class="log-node-title-link overflow" data-bind="attr: {href: params.template_node.url}">another <span data-bind="text: nodeType"></span></a>
+created 
+<a class="log-node-title-link overflow" data-bind="text: nodeTitle, attr: {href: nodeUrl}"></a> based on <a class="log-node-title-link overflow" data-bind="attr: {href: params.template_node.url}">another </a>
 </script>
 
 <script type="text/html" id="node_created">
-created <span data-bind="text: nodeType"></span>
+created 
 <a class="log-node-title-link overflow" data-bind="text: nodeTitle, attr: {href: nodeUrl}"></a>
 </script>
 
 <script type="text/html" id="node_removed">
-removed <span data-bind="text: nodeType"></span>
+removed 
 <span class="log-node-title-link overflow" data-bind="text: nodeTitle"></span>
 </script>
 
@@ -33,7 +33,6 @@ removed <span data-bind="text: nodeType"></span>
 added
 <span data-bind="html: displayContributors"></span>
 as contributor(s) to
-<span data-bind="text: nodeType"></span>
 <a class="log-node-title-link overflow" data-bind="attr: {href: $parent.nodeUrl}, text: $parent.nodeTitle"></a>
 </script>
 
@@ -41,67 +40,63 @@ as contributor(s) to
 removed
 <span data-bind="html: displayContributors"></span>
 as contributor(s) from
-<span data-bind="text: nodeType"></span>
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="contributors_reordered">
 reordered contributors for
-<span data-bind="text: nodeType"></span>
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="permissions_updated">
 changed permissions for
-<span data-bind="text: nodeType"></span>
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="made_public">
-made <span data-bind="text: nodeType"></span>
+made 
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a> public
 </script>
 
 <script type="text/html" id="made_private">
-made <span data-bind="text: nodeType"></span>
+made 
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a> private
 </script>
 
 <script type="text/html" id="tag_added">
 tagged
-<span data-bind="text: nodeType"></span>
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a> as <a class='tag' data-bind="attr: {href: '/search/?q=%22' + params.tag + '%22'}, text: params.tag"></a>
 </script>
 
 <script type="text/html" id="tag_removed">
 removed tag <a class='tag' data-bind="attr: {href: '/search/?q=%22' + params.tag + '%22'}, text: params.tag"></a>
-from <span data-bind="text: nodeType"></span>
+from 
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="edit_title">
 changed the title from <span class="overflow" data-bind="text: params.title_original"></span>
-to <span data-bind="text: nodeType"></span>
+to 
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: params.title_new"></a>
 </script>
 
 <script type="text/html" id="project_registered">
-registered <span data-bind="text: nodeType"></span>
+registered 
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="node_forked">
-created fork from <span data-bind="text: nodeType"></span>
+created fork from 
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="edit_description">
-edited description of <span data-bind="text: nodeType"></span> <a class="log-node-title-link" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
+edited description of  <a class="log-node-title-link" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="updated_fields">
-  updated the <span data-bind="listing: params.updated_fields"></span>  of <span data-bind="text: nodeType"></span>
-  <a class="log-node-title-link" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
+updated the <span data-bind="listing: params.updated_fields"></span> of 
+<a class="log-node-title-link" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="pointer_created">
@@ -121,45 +116,45 @@ forked a link to <span data-bind="text: params.pointer.category"></span>
 
 <script type="text/html" id="addon_added">
 added addon <span data-bind="text: params.addon"></span>
-to <span data-bind="text: nodeType"></span>
+to 
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="addon_removed">
 removed addon <span data-bind="text: params.addon"></span>
-from <span data-bind="text: nodeType"></span>
+from 
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="comment_added">
 added a comment
-to <span data-bind="text: nodeType"></span>
+to 
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="comment_updated">
 updated a comment
-on <span data-bind="text: nodeType"></span>
+on 
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="comment_removed">
 deleted a comment
-on <span data-bind="text: nodeType"></span>
+on 
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="made_contributor_visible">
 made contributor
 <span data-bind="html: displayContributors"></span>
-visible on <span data-bind="text: nodeType"></span>
+visible on 
 <a class="log-node-title-link overflow" data-bind="attr: {href: $parent.nodeUrl}, text: $parent.nodeTitle"></a>
 </script>
 
 <script type="text/html" id="made_contributor_invisible">
 made contributor
 <span data-bind="html: displayContributors"></span>
-invisible on <span data-bind="text: nodeType"></span>
+invisible on 
 <a class="log-node-title-link overflow" data-bind="attr: {href: $parent.nodeUrl}, text: $parent.nodeTitle"></a>
 </script>
 
@@ -167,6 +162,6 @@ invisible on <span data-bind="text: nodeType"></span>
 created external identifiers
 <a data-bind="attr.href: 'http://ezid.cdlib.org/id/doi:' + params.identifiers.doi, text: 'doi:' + params.identifiers.doi"></a> and
 <a data-bind="attr.href: 'http://ezid.cdlib.org/id/doi:' + params.identifiers.doi, text: 'ark:' + params.identifiers.ark"></a>
-on <span data-bind="text: nodeType"></span>
+on 
 <a class="log-node-title-link overflow" data-bind="attr: {href: $parent.nodeUrl}, text: $parent.nodeTitle"></a>
 </script>

--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -50,8 +50,10 @@
                     <h3 id="configureNode" class="panel-title">Configure ${node['node_type'].capitalize()}</h3>
                 </div>
                 <div id="nodeCategorySettings" class="panel-body">
+                  <div data-bind="css: {disabled: disabled}">
                   <h5>
-                    Category: <select data-bind="options: categories,
+                    Category: <select data-bind="attr.disabled: disabled,
+                                                 options: categories,
                                                  optionsValue: 'value',
                                                  optionsText: 'label',
                                                  value: selectedCategory"></select>
@@ -65,6 +67,10 @@
                             class="btn btn-default">Cancel</button>                
                   </p>
                   <span data-bind="css: messageClass, html: message"></span>
+                  </div>
+                  <span data-bind="if: disabled" class="help-block">
+                    A top-level project's category cannot be changed
+                  </span>
                 </div>
                 <hr />
                 <div class="panel-body">


### PR DESCRIPTION
# Purpose
- Address some language concerns in logs
- Fix broken contrib. listing in Add Links modal
- Prevent top-level projects' categories from changing (UI only)

# Changes
- Remove nodeType from log_templates and addons' log_templates
- Let firstAuthor fall back on given name and then full name
- Disable category selector when ```window.contextVars.node.parentExists``` is false 

# Side effects
Log formatting may be broken in some places 