### PR TITLE
Block pointer auto-expansion frontend

### DIFF
--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -1,4 +1,4 @@
-/**
+**
  * Handles Project Organizer on dashboard page of OSF.
  * For Treebeard and _item API's check: https://github.com/caneruguz/treebeard/wiki
  */
@@ -742,7 +742,11 @@ function expandStateLoad(item) {
         item.data.childrenCount = 0;
         tb.updateFolder(null, item);
     }
-    if (item.children.length > 0 && item.depth > 0) {
+    if (item.data.isPointer) {
+        item.data.expand = false;
+    }
+
+    if ((!item.data.isPointer) && (item.children.length > 0 && item.depth > 0)) {
         for (i = 0; i < item.children.length; i++) {
             if (item.children[i].data.expand) {
                 tb.updateFolder(null, item.children[i]);

--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -1,4 +1,4 @@
-**
+/**
  * Handles Project Organizer on dashboard page of OSF.
  * For Treebeard and _item API's check: https://github.com/caneruguz/treebeard/wiki
  */


### PR DESCRIPTION
# Purpose 

Andy found a bug with cyclic pointer auto-expansion in projectorganizer. This PR attempts to prevent that expansion front-end. 

# Changes

Check for item.data.isPointer in _expandStateLoad

# Side Effects

None