### PR TITLE
Fix issues with ProjectOrganizer not auto-expanding

### DIFF
--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -742,11 +742,11 @@ function expandStateLoad(item) {
         item.data.childrenCount = 0;
         tb.updateFolder(null, item);
     }
-    if (item.data.isPointer) {
+
+    if (item.data.isPointer && !item.data.parentIsFolder) {
         item.data.expand = false;
     }
-
-    if ((!item.data.isPointer) && (item.children.length > 0 && item.depth > 0)) {
+    if (item.children.length > 0 && item.depth > 0) {
         for (i = 0; i < item.children.length; i++) {
             if (item.children[i].data.expand) {
                 tb.updateFolder(null, item.children[i]);

--- a/website/util/rubeus.py
+++ b/website/util/rubeus.py
@@ -268,7 +268,7 @@ class NodeProjectCollector(object):
 
     def _serialize_node(self, node, visited=None, parent_is_folder=False):
         """Returns the rubeus representation of a node folder for the project organizer.
-        """        
+        """
         visited = visited or []
         visited.append(node.resolve()._id)
         can_edit = node.can_edit(auth=self.auth) and not node.is_registration

--- a/website/util/rubeus.py
+++ b/website/util/rubeus.py
@@ -268,7 +268,7 @@ class NodeProjectCollector(object):
 
     def _serialize_node(self, node, visited=None, parent_is_folder=False):
         """Returns the rubeus representation of a node folder for the project organizer.
-        """
+        """        
         visited = visited or []
         visited.append(node.resolve()._id)
         can_edit = node.can_edit(auth=self.auth) and not node.is_registration
@@ -318,7 +318,7 @@ class NodeProjectCollector(object):
 
         if node.is_dashboard:
             to_expand = True
-        elif not is_pointer:
+        elif not is_pointer or parent_is_folder:
             to_expand = expanded
         else:
             to_expand = False


### PR DESCRIPTION
# Purpose

PO was not auto expanding due to both server side and JS bugs

# Changes

Fix the bugs. 

If a node is a pointer, but a child of the dashboard node, use the saved expand state. 

In JS, don't check if is Pointer.

# Side Effects

It works now :dancer: 