### PR TITLE
[WIP] [Feature] Make footer smaller on project related pages

### DIFF
--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -2662,4 +2662,5 @@ span#profileFullname{
 .alternate-copyright {
     background: #F5F5F5;
     border-top: 1px solid #EEE;
+    margin-top: 30px;
 }

--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -2658,3 +2658,8 @@ span#profileFullname{
         position: relative;
     }
 }
+
+.alternate-copyright {
+    background: #F5F5F5;
+    border-top: 1px solid #EEE;
+}

--- a/website/static/js/pages/base-page.js
+++ b/website/static/js/pages/base-page.js
@@ -100,4 +100,7 @@ $(function() {
         $osf.applyBindings(new SlideInViewModel(), sliderSelector);
     }
     new NavbarControl('.osf-nav-wrapper');
+    $('.js-scrollTop').click(function () {
+        $(window).scrollTop(0);
+    });
 });

--- a/website/static/js/pages/project-base-page.js
+++ b/website/static/js/pages/project-base-page.js
@@ -13,7 +13,6 @@ require('js/registerNode');
 
 var node = window.contextVars.node;
 
-
 new pointers.PointerDisplay('#showLinks');
 
 if (!window.contextVars.currentUser.isContributor) {
@@ -25,11 +24,11 @@ if (node.isPublic && node.piwikSiteID) {
 }
 
 // Used for clearing backward/forward cache issues
-$(window).unload(function(){
+$(window).unload(function () {
     return 'Unload';
 });
-$(document).ready(function() {
-    $.getJSON(node.urls.api, function(data) {    
+$(document).ready(function () {
+    $.getJSON(node.urls.api, function (data) {
         $('body').trigger('nodeLoad', data);
     });
-})
+});

--- a/website/static/js/pages/project-dashboard-page.js
+++ b/website/static/js/pages/project-dashboard-page.js
@@ -49,12 +49,11 @@ if (!ctx.node.anonymous) {
     new CitationWidget('#citationStyleInput', '#citationText');
 }
 
-$(document).ready(function() {
+$(document).ready(function () {
     // Treebeard Files view
     $.ajax({
         url:  nodeApiUrl + 'files/grid/'
-    })
-    .done(function( data ) {
+    }).done(function (data) {
         var fangornOpts = {
             divID: 'treeGrid',
             filesData: data.data,
@@ -63,7 +62,7 @@ $(document).ready(function() {
             placement: 'dashboard',
             title : undefined,
             filterFullWidth : true, // Make the filter span the entire row for this view
-            columnTitles : function(){
+            columnTitles : function () {
                 return [
                     {
                     title: 'Name',
@@ -73,7 +72,7 @@ $(document).ready(function() {
                     }
                 ];
             },
-            resolveRows : function(item){
+            resolveRows : function (item) {
                 var defaultColumns = [{
                     data: 'name',
                     folderIcons: true,
@@ -87,14 +86,13 @@ $(document).ready(function() {
                         item.data.accept = item.data.accept || item.parent().data.accept;
                     }
                 }
-
-                if(item.data.tmpID){
+                if (item.data.tmpID) {
                     defaultColumns = [
                         {
                             data : 'name',  // Data field name
                             folderIcons : true,
                             filter : true,
-                            custom : function(){ return m('span.text-muted', 'Uploading ' + item.data.name + '...'); }
+                            custom : function () { return m('span.text-muted', 'Uploading ' + item.data.name + '...'); }
                         }
                     ];
                 }
@@ -114,20 +112,23 @@ $(document).ready(function() {
         width: '100%',
         interactive: window.contextVars.currentUser.canEdit,
         maxChars: 128,
-        onAddTag: function(tag){
+        onAddTag: function (tag) {
             var url = window.contextVars.node.urls.api + 'addtag/' + tag + '/';
             var request = $.ajax({
                 url: url,
                 type: 'POST',
                 contentType: 'application/json'
             });
-            request.fail(function(xhr, textStatus, error) {
+            request.fail(function (xhr, textStatus, error) {
                 Raven.captureMessage('Failed to add tag', {
-                    tag: tag, url: url, textStatus: textStatus, error: error
+                    tag: tag,
+                    url: url,
+                    textStatus: textStatus,
+                    error: error
                 });
             });
         },
-        onRemoveTag: function(tag){
+        onRemoveTag: function (tag) {
             var url = window.contextVars.node.urls.api + 'removetag/' + tag + '/';
             var request = $.ajax({
                 url: url,
@@ -136,7 +137,10 @@ $(document).ready(function() {
             });
             request.fail(function(xhr, textStatus, error) {
                 Raven.captureMessage('Failed to remove tag', {
-                    tag: tag, url: url, textStatus: textStatus, error: error
+                    tag: tag,
+                    url: url,
+                    textStatus: textStatus,
+                    error: error
                 });
             });
         }
@@ -169,7 +173,7 @@ $(document).ready(function() {
     // Remove delete UI if not contributor
     if (!window.contextVars.currentUser.canEdit || window.contextVars.node.isRegistration) {
         $('a[title="Removing tag"]').remove();
-        $('span.tag span').each(function(idx, elm) {
+        $('span.tag span').each(function (idx, elm) {
             $(elm).text($(elm).text().replace(/\s*$/, ''));
         });
     }

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -215,6 +215,9 @@
     ### Javascript loaded at the bottom of the page ###
 </%def>
 
+<%def name="footer()">
+    ### Footer for the pages ###
+</%def>
 
 <%def name="includes_top()">
 

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -98,8 +98,7 @@
     </div>
 </div>
 % endif
-
-    <%include file="footer.mako"/>
+        ${self.footer()}
         % if settings.PINGDOM_ID:
             <script>
             var _prum = [['id', '${settings.PINGDOM_ID}'],

--- a/website/templates/dashboard.mako
+++ b/website/templates/dashboard.mako
@@ -111,3 +111,7 @@
 <script src=${"/static/public/js/dashboard-page.js" | webpack_asset}></script>
 
 </%def>
+
+<%def name="footer()">
+    <%include file="footer.mako" args="placement='dashboardPage'"/>
+</%def>

--- a/website/templates/footer.mako
+++ b/website/templates/footer.mako
@@ -40,7 +40,13 @@
 </footer><!-- end footer -->
 % endif
 
+%if placement == 'projectPage':
+<div class="container alternate-copyright copyright">
+% endif
+% if placement != 'projectPage':
 <div class="container copyright">
+% endif
+
     <div class="row">
         <div class="col-md-12">
             <p>Copyright &copy; 2011-2015 <a href="http://centerforopenscience.org">Center for Open Science</a> |

--- a/website/templates/footer.mako
+++ b/website/templates/footer.mako
@@ -1,8 +1,10 @@
+<%page args="placement"/>
+%if placement != 'projectPage':
 <footer class="footer">
     <div class="container">
         <div class="row">
             <div class="col-sm-2 col-md-2 col-md-offset-1">
-                <h4>OSF</h4>
+                <h4>OSF ${placement}</h4>
                 <ul>
                     <li><a href="/4znzp/wiki/home">About</a></li>
                     <li><a href="/faq">FAQ</a></li>
@@ -36,6 +38,8 @@
         </div>
     </div>
 </footer><!-- end footer -->
+% endif
+
 <div class="container copyright">
     <div class="row">
         <div class="col-md-12">

--- a/website/templates/footer.mako
+++ b/website/templates/footer.mako
@@ -52,8 +52,9 @@
             <p>Copyright &copy; 2011-2015 <a href="http://centerforopenscience.org">Center for Open Science</a> |
                 <a href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/TERMS_OF_USE.md">Terms of Use</a> |
                 <a href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/PRIVACY_POLICY.md">Privacy Policy</a> |
-                <a href="#" class="js-scrollTop"><i class="fa fa-angle-up"></i> Scroll to Top</a>
+                <a href="#" class="js-scrollTop">Scroll to Top</a>
             </p>
         </div>
     </div>
 </div><!-- end container copyright -->
+

--- a/website/templates/footer.mako
+++ b/website/templates/footer.mako
@@ -45,7 +45,8 @@
         <div class="col-md-12">
             <p>Copyright &copy; 2011-2015 <a href="http://centerforopenscience.org">Center for Open Science</a> |
                 <a href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/TERMS_OF_USE.md">Terms of Use</a> |
-                <a href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/PRIVACY_POLICY.md">Privacy Policy</a>
+                <a href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/PRIVACY_POLICY.md">Privacy Policy</a> |
+                <a href="#" class="js-scrollTop"><i class="fa fa-angle-up"></i> Scroll to Top</a>
             </p>
         </div>
     </div>

--- a/website/templates/profile.mako
+++ b/website/templates/profile.mako
@@ -189,3 +189,7 @@
 </script>
 
 </%def>
+
+<%def name="footer()">
+    <%include file="footer.mako" args="placement='profilePage'"/>
+</%def>

--- a/website/templates/profile/settings.mako
+++ b/website/templates/profile/settings.mako
@@ -102,3 +102,7 @@
 </script>
 <script src=${"/static/public/js/profile-settings-page.js" | webpack_asset}></script>
 </%def>
+
+<%def name="footer()">
+    <%include file="footer.mako" args="placement='settingsPage'"/>
+</%def>

--- a/website/templates/project/project_base.mako
+++ b/website/templates/project/project_base.mako
@@ -16,6 +16,7 @@
 
 <%include file="modal_show_links.mako"/>
 
+
 ${next.body()}
 
 ## % if node['node_type'] == 'project':
@@ -23,6 +24,11 @@ ${next.body()}
 ## % endif
 
 </%def>
+
+<%def name="footer()">
+    <%include file="../footer.mako" args="placement='projectPage'"/>
+</%def>
+
 
 <%def name="javascript_bottom()">
 
@@ -101,3 +107,4 @@ ${next.body()}
 ## NOTE: window.contextVars must be set before loading this script
 <script src=${"/static/public/js/project-base-page.js" | webpack_asset}> </script>
 </%def>
+

--- a/website/templates/public/pages/about.mako
+++ b/website/templates/public/pages/about.mako
@@ -85,3 +85,7 @@ Interested in being a developer?  Contact <a href="mailto:jspies@virginia.edu.ed
 Have ideas to make the OSF useful to you?  <a href="mailto:feedback@openscienceframework.org">Submit them here</a>.
 </p>
 </%def>
+
+<%def name="footer()">
+    <%include file="footer.mako" args="placement=''"/>
+</%def>

--- a/website/templates/public/pages/meeting.mako
+++ b/website/templates/public/pages/meeting.mako
@@ -10,6 +10,10 @@
     <link rel="stylesheet" href="/static/vendor/bower_components/hgrid/dist/hgrid.min.css" />
 </%def>
 
+<%def name="footer()">
+    <%include file="footer.mako" args="placement='presentationsPage'"/>
+</%def>
+
 <%def name="javascript_bottom()">
     ${parent.javascript_bottom()}
     <script type="text/javascript">
@@ -24,3 +28,4 @@
     </script>
     <script src=${"/static/public/js/conference-page.js" | webpack_asset}></script>
 </%def>
+

--- a/website/templates/public/pages/meeting_landing.mako
+++ b/website/templates/public/pages/meeting_landing.mako
@@ -59,3 +59,6 @@
     </div>
 
 </%def>
+<%def name="footer()">
+    <%include file="footer.mako" args="placement='presentationsPage'"/>
+</%def>

--- a/website/templates/search.mako
+++ b/website/templates/search.mako
@@ -262,3 +262,7 @@
 
 
 </%def>
+
+<%def name="footer()">
+    <%include file="footer.mako" args="placement='searchPage'"/>
+</%def>


### PR DESCRIPTION
## Purpose
There was some discussion here about what should happen to the footer  inside project pages because there is less need of a full footer in these cases. 
Discussion (scroll below a few posts: https://github.com/CenterForOpenScience/osf.io/issues/2561 )

This PR is experimenting with a smaller footer in project pages. 

## Changes
- The structure with which we include footer in the mako files is changes and worth a review
- Project pages don't show the main footer links and show the copyright instead

## Side effects
- Because of the change of structure with the footer we need to make sure all pages that needed a footer actually get one. Needs general loading of all osf pages as test or a different method to deal with the footer. 

![5bc639b4-e9bb-11e4-9c48-3d2e675ac0f7](https://cloud.githubusercontent.com/assets/1314003/7522194/a475b750-f4c1-11e4-9eac-3c31ea59eae3.png)
