### PR TITLE
[hotfix] disable make public registrations private

### DIFF
--- a/tests/test_elastic.py
+++ b/tests/test_elastic.py
@@ -216,9 +216,6 @@ class TestPublicNodes(SearchTestCase):
         self.component.set_privacy('private')
         docs = query('category:component AND ' + self.title)['results']
         assert_equal(len(docs), 0)
-        self.registration.set_privacy('private')
-        docs = query('category:registration AND ' + self.title)['results']
-        assert_equal(len(docs), 0)
 
     def test_public_parent_title(self):
         self.project.set_title('hello &amp; world', self.consolidate_auth)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1594,6 +1594,15 @@ class TestNode(OsfTestCase):
         self.node.collapse(user=self.user)
         assert_equal(self.node.is_expanded(user=self.user), False)
 
+    def test_set_privacy_private_for_public_registration_raises_NodeStateError(self):
+        self.node.is_registration = True
+        self.node.is_public = True
+        self.node.save()
+        with assert_raises(NodeStateError):
+            self.node.set_privacy('private', auth=self.consolidate_auth)
+        assert_true(self.node.is_public)
+
+
 class TestNodeTraversals(OsfTestCase):
 
     def setUp(self):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -408,15 +408,27 @@ class TestProjectViews(OsfTestCase):
         assert_false(self.project.is_public)
         assert_equal(res.json['status'], 'success')
 
-    def test_make_registration_private_raises_HTTPBad_Request(self):
-        self.project.is_public = True
-        self.project.is_registration = True
-        self.project.save()
-        url = self.project.api_url_for('project_set_privacy', permissions='private')
+    def test_make_registration_private_created_after_cutoff_raises_HTTPBad_Request(self):
+        registration = RegistrationFactory(creator=self.user1, is_public=True)
+        registration.registered_date = settings.REGISTRATION_CUTOFF_DATE + dt.timedelta(days=1)
+        registration.save()
+
+        url = registration.api_url_for('project_set_privacy', permissions='private')
         res = self.app.post_json(url, {}, auth=self.auth, expect_errors=True)
-        self.project.reload()
-        assert_true(self.project.is_public)
+        registration.reload()
+        assert_true(registration.is_public)
         assert_equal(res.status_code, 400)
+
+    def test_make_registration_private_created_before_cutoff_returns_HTTPOK(self):
+        registration = RegistrationFactory(creator=self.user1, is_public=True)
+        registration.registered_date = settings.REGISTRATION_CUTOFF_DATE - dt.timedelta(days=1)
+        registration.save()
+
+        url = registration.api_url_for('project_set_privacy', permissions='private')
+        res = self.app.post_json(url, {}, auth=self.auth)
+        registration.reload()
+        assert_false(registration.is_public)
+        assert_equal(res.status_code, 200)
 
     def test_cant_make_public_if_not_admin(self):
         non_admin = AuthUserFactory()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -408,6 +408,16 @@ class TestProjectViews(OsfTestCase):
         assert_false(self.project.is_public)
         assert_equal(res.json['status'], 'success')
 
+    def test_make_registration_private_raises_HTTPBad_Request(self):
+        self.project.is_public = True
+        self.project.is_registration = True
+        self.project.save()
+        url = self.project.api_url_for('project_set_privacy', permissions='private')
+        res = self.app.post_json(url, {}, auth=self.auth, expect_errors=True)
+        self.project.reload()
+        assert_true(self.project.is_public)
+        assert_equal(res.status_code, 400)
+
     def test_cant_make_public_if_not_admin(self):
         non_admin = AuthUserFactory()
         self.project.add_contributor(non_admin, permissions=['read', 'write'])

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2296,11 +2296,13 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
         """Set the permissions for this node.
 
         :param permissions: A string, either 'public' or 'private'
-        :param auth: All the auth informtion including user, API key.
+        :param auth: All the auth information including user, API key.
         """
         if permissions == 'public' and not self.is_public:
             self.is_public = True
         elif permissions == 'private' and self.is_public:
+            if self.is_registration:
+                raise NodeStateError('Cannot make a public registration private')
             self.is_public = False
         else:
             return False

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -687,6 +687,12 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
         parents = self.parents
         return {p._id for p in parents}
 
+    @property
+    def registered_before_cutoff_date(self):
+        if self.is_registration:
+            return self.registered_date < settings.REGISTRATION_CUTOFF_DATE
+        return False
+
     def can_edit(self, auth=None, user=None):
         """Return if a user is authorized to edit this node.
         Must specify one of (`auth`, `user`).
@@ -2301,7 +2307,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
         if permissions == 'public' and not self.is_public:
             self.is_public = True
         elif permissions == 'private' and self.is_public:
-            if self.is_registration:
+            if self.is_registration and not self.registered_before_cutoff_date:
                 raise NodeStateError('Cannot make a public registration private')
             self.is_public = False
         else:

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -475,7 +475,7 @@ def project_set_privacy(auth, node, **kwargs):
     if permissions is None:
         raise HTTPError(http.BAD_REQUEST)
 
-    if permissions == 'private' and node.is_registration:
+    if permissions == 'private' and node.is_registration and not node.registered_before_cutoff_date:
         raise HTTPError(http.BAD_REQUEST)
 
     node.set_privacy(permissions, auth)
@@ -731,6 +731,7 @@ def _view_project(node, auth, primary=False):
                 for meta in node.registered_meta or []
             ],
             'registration_count': len(node.node__registrations),
+            'registered_before_cutoff_date': node.registered_before_cutoff_date,
             'is_fork': node.is_fork,
             'forked_from_id': node.forked_from._primary_key if node.is_fork else '',
             'forked_from_display_absolute_url': node.forked_from.display_absolute_url if node.is_fork else '',
@@ -905,6 +906,7 @@ def _get_summary(node, auth, rescale_ratio, primary=True, link_id=None):
             'category': node.category,
             'node_type': node.project_or_component,
             'is_registration': node.is_registration,
+            'registered_before_cutoff_date': node.registered_before_cutoff_date,
             'anonymous': has_anonymous_link(node, auth),
             'registered_date': node.registered_date.strftime('%Y-%m-%d %H:%M UTC')
             if node.is_registration

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -475,6 +475,9 @@ def project_set_privacy(auth, node, **kwargs):
     if permissions is None:
         raise HTTPError(http.BAD_REQUEST)
 
+    if permissions == 'private' and node.is_registration:
+        raise HTTPError(http.BAD_REQUEST)
+
     node.set_privacy(permissions, auth)
 
     return {

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -4,6 +4,7 @@ Base settings file, common to all environments.
 These settings can be overridden in local.py.
 """
 
+import datetime
 import os
 import json
 import hashlib
@@ -250,3 +251,6 @@ EZID_FORMAT = '{namespace}osf.io/{guid}'
 
 SHARE_REGISTRATION_URL = ''
 SHARE_API_DOCS_URL = ''
+
+# Date which registrations created after cannot be made public
+REGISTRATION_CUTOFF_DATE = datetime.datetime(2015, 5, 10)

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -253,4 +253,4 @@ SHARE_REGISTRATION_URL = ''
 SHARE_API_DOCS_URL = ''
 
 # Date which registrations created after cannot be made public
-REGISTRATION_CUTOFF_DATE = datetime.datetime(2015, 5, 10)
+REGISTRATION_CUTOFF_DATE = datetime.datetime(2015, 5, 22)

--- a/website/templates/log_templates.mako
+++ b/website/templates/log_templates.mako
@@ -16,7 +16,7 @@ deleted
 
 <script type="text/html" id="created_from">
 created 
-<a class="log-node-title-link overflow" data-bind="text: nodeTitle, attr: {href: nodeUrl}"></a> based on <a class="log-node-title-link overflow" data-bind="attr: {href: params.template_node.url}">another </a>
+<a class="log-node-title-link overflow" data-bind="text: nodeTitle, attr: {href: nodeUrl}"></a> based on <a class="log-node-title-link overflow" data-bind="attr: {href: params.template_node.url}">another</a>
 </script>
 
 <script type="text/html" id="node_created">
@@ -98,7 +98,7 @@ edited description of  <a class="log-node-title-link" data-bind="attr: {href: no
   changed the <span data-bind="listing: {
                                  data: params.updated_fields,
                                  map: mapUpdates
-                               }"></span> of 
+                               }"></span> for
   <a class="log-node-title-link" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -33,7 +33,7 @@
                             <a class="btn btn-default" data-bind="click: makePublic">Make Public</a>
                         % endif
                     % else:
-                        % if 'admin' in user['permissions']:
+                        % if 'admin' in user['permissions'] and not node['is_registration']:
                             <a class="btn btn-default" data-bind="click: makePrivate">Make Private</a>
                         % endif
                         <button class="btn btn-default disabled">Public</button>

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -33,7 +33,7 @@
                             <a class="btn btn-default" data-bind="click: makePublic">Make Public</a>
                         % endif
                     % else:
-                        % if 'admin' in user['permissions'] and not node['is_registration']:
+                        % if 'admin' in user['permissions'] and (not node['is_registration'] or node['registered_before_cutoff_date']):
                             <a class="btn btn-default" data-bind="click: makePrivate">Make Private</a>
                         % endif
                         <button class="btn btn-default disabled">Public</button>


### PR DESCRIPTION
## Purpose
Registrations now have the ability to obtain DOIs and ARK IDs. With this and upcoming behavior changes with Retractions and Embargoes, public registrations should not be able to be made private unless they were created before a predetermined cutoff date.

## Changes
Registrations created before the cutoff date will have no behavioral changes.

Registrations created after the cutoff date will no longer be able to be made private **after** they have been made public. That cutoff date, **REGISTRATION_CUTOFF_DATE**, is set in `defaults.py`

## Side Effects
None

## Notes
Closes-issue: #2670 