### PR TITLE
Hotifx/disable making public registrations private

### DIFF
--- a/scripts/email_public_registration_contributors.py
+++ b/scripts/email_public_registration_contributors.py
@@ -1,0 +1,35 @@
+"""Script for sending OSF email to all users who contribute to public registrations."""
+
+import datetime
+
+from modularodm import Q
+
+from website import models
+from website.app import init_app
+from website.mails import Mail, send_mail
+
+
+def main():
+    public_registrations = models.Node.find(Q('is_registration', 'eq', True) & Q('is_public', 'eq', True))
+    contributors = []
+    for node in public_registrations:
+        contributors.extend([contrib for contrib in node.contributors if contrib not in contributors])
+
+    # FIXME: need cutoff date from Brian or Sara
+    cutoff_date = datetime.date.today() + datetime.timedelta(days=14)
+
+    # FIXME: subject line needs to be revised by Brian or Sara
+    mailer = Mail('email_contributors_of_public_registrations', 'SUBJECT LINE -- Sara and BrianN please advice')
+
+    for contrib in contributors:
+        send_mail(
+            contrib.username,
+            mailer,
+            user=contrib,
+            cutoff_date=cutoff_date
+        )
+
+
+if __name__ == '__main__':
+    init_app(routes=False, mfr=False)
+    main()

--- a/tests/test_elastic.py
+++ b/tests/test_elastic.py
@@ -216,9 +216,6 @@ class TestPublicNodes(SearchTestCase):
         self.component.set_privacy('private')
         docs = query('category:component AND ' + self.title)['results']
         assert_equal(len(docs), 0)
-        self.registration.set_privacy('private')
-        docs = query('category:registration AND ' + self.title)['results']
-        assert_equal(len(docs), 0)
 
     def test_public_parent_title(self):
         self.project.set_title('hello &amp; world', self.consolidate_auth)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2946,6 +2946,7 @@ class TestRegisterNode(OsfTestCase):
         registration = RegistrationFactory(project=self.project)
         assert_true(registration.is_public)
 
+    # TODO(hrybacki): Re-work once no public registrations can be made private
     def test_public_registration_made_after_cutoff_date_cannot_be_made_private(self):
         self.registration.is_public = True
         self.registration.registered_date = settings.REGISTRATION_CUTOFF_DATE + datetime.timedelta(days=1)
@@ -2955,6 +2956,7 @@ class TestRegisterNode(OsfTestCase):
             self.registration.set_privacy('private', auth=self.consolidate_auth)
         assert_true(self.registration.is_public)
 
+    # TODO(hrybacki): Re-work once no public registrations can be made private
     def test_public_registration_made_before_cutoff_date_can_be_made_private(self):
         self.registration.is_public = True
         self.registration.registered_date = settings.REGISTRATION_CUTOFF_DATE - datetime.timedelta(days=1)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1594,6 +1594,15 @@ class TestNode(OsfTestCase):
         self.node.collapse(user=self.user)
         assert_equal(self.node.is_expanded(user=self.user), False)
 
+    def test_set_privacy_private_for_public_registration_raises_NodeStateError(self):
+        self.node.is_registration = True
+        self.node.is_public = True
+        self.node.save()
+        with assert_raises(NodeStateError):
+            self.node.set_privacy('private', auth=self.consolidate_auth)
+        assert_true(self.node.is_public)
+
+
 class TestNodeTraversals(OsfTestCase):
 
     def setUp(self):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -408,15 +408,27 @@ class TestProjectViews(OsfTestCase):
         assert_false(self.project.is_public)
         assert_equal(res.json['status'], 'success')
 
-    def test_make_registration_private_raises_HTTPBad_Request(self):
-        self.project.is_public = True
-        self.project.is_registration = True
-        self.project.save()
-        url = self.project.api_url_for('project_set_privacy', permissions='private')
+    def test_make_registration_private_created_after_cutoff_raises_HTTPBad_Request(self):
+        registration = RegistrationFactory(creator=self.user1, is_public=True)
+        registration.registered_date = settings.REGISTRATION_CUTOFF_DATE + dt.timedelta(days=1)
+        registration.save()
+
+        url = registration.api_url_for('project_set_privacy', permissions='private')
         res = self.app.post_json(url, {}, auth=self.auth, expect_errors=True)
-        self.project.reload()
-        assert_true(self.project.is_public)
+        registration.reload()
+        assert_true(registration.is_public)
         assert_equal(res.status_code, 400)
+
+    def test_make_registration_private_created_before_cutoff_returns_HTTPOK(self):
+        registration = RegistrationFactory(creator=self.user1, is_public=True)
+        registration.registered_date = settings.REGISTRATION_CUTOFF_DATE - dt.timedelta(days=1)
+        registration.save()
+
+        url = registration.api_url_for('project_set_privacy', permissions='private')
+        res = self.app.post_json(url, {}, auth=self.auth)
+        registration.reload()
+        assert_false(registration.is_public)
+        assert_equal(res.status_code, 200)
 
     def test_cant_make_public_if_not_admin(self):
         non_admin = AuthUserFactory()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -408,6 +408,7 @@ class TestProjectViews(OsfTestCase):
         assert_false(self.project.is_public)
         assert_equal(res.json['status'], 'success')
 
+    # TODO(hrybacki): Re-work once no public registrations can be made private
     def test_make_registration_private_created_after_cutoff_raises_HTTPBad_Request(self):
         registration = RegistrationFactory(creator=self.user1, is_public=True)
         registration.registered_date = settings.REGISTRATION_CUTOFF_DATE + dt.timedelta(days=1)
@@ -419,6 +420,7 @@ class TestProjectViews(OsfTestCase):
         assert_true(registration.is_public)
         assert_equal(res.status_code, 400)
 
+    # TODO(hrybacki): Re-work once no public registrations can be made private
     def test_make_registration_private_created_before_cutoff_returns_HTTPOK(self):
         registration = RegistrationFactory(creator=self.user1, is_public=True)
         registration.registered_date = settings.REGISTRATION_CUTOFF_DATE - dt.timedelta(days=1)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -408,6 +408,16 @@ class TestProjectViews(OsfTestCase):
         assert_false(self.project.is_public)
         assert_equal(res.json['status'], 'success')
 
+    def test_make_registration_private_raises_HTTPBad_Request(self):
+        self.project.is_public = True
+        self.project.is_registration = True
+        self.project.save()
+        url = self.project.api_url_for('project_set_privacy', permissions='private')
+        res = self.app.post_json(url, {}, auth=self.auth, expect_errors=True)
+        self.project.reload()
+        assert_true(self.project.is_public)
+        assert_equal(res.status_code, 400)
+
     def test_cant_make_public_if_not_admin(self):
         non_admin = AuthUserFactory()
         self.project.add_contributor(non_admin, permissions=['read', 'write'])

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -687,6 +687,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
         parents = self.parents
         return {p._id for p in parents}
 
+    # TODO(hrybacki): Remove once no public registrations can be made private
     @property
     def registered_before_cutoff_date(self):
         if self.is_registration:
@@ -2307,6 +2308,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
         if permissions == 'public' and not self.is_public:
             self.is_public = True
         elif permissions == 'private' and self.is_public:
+            # TODO(hrybacki): Remove 2nd antecedent once no public registrations can be made private
             if self.is_registration and not self.registered_before_cutoff_date:
                 raise NodeStateError('Cannot make a public registration private')
             self.is_public = False

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2296,11 +2296,13 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
         """Set the permissions for this node.
 
         :param permissions: A string, either 'public' or 'private'
-        :param auth: All the auth informtion including user, API key.
+        :param auth: All the auth information including user, API key.
         """
         if permissions == 'public' and not self.is_public:
             self.is_public = True
         elif permissions == 'private' and self.is_public:
+            if self.is_registration:
+                raise NodeStateError('Cannot make a public registration private')
             self.is_public = False
         else:
             return False

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -687,6 +687,12 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
         parents = self.parents
         return {p._id for p in parents}
 
+    @property
+    def registered_before_cutoff_date(self):
+        if self.is_registration:
+            return self.registered_date < settings.REGISTRATION_CUTOFF_DATE
+        return False
+
     def can_edit(self, auth=None, user=None):
         """Return if a user is authorized to edit this node.
         Must specify one of (`auth`, `user`).
@@ -2301,7 +2307,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
         if permissions == 'public' and not self.is_public:
             self.is_public = True
         elif permissions == 'private' and self.is_public:
-            if self.is_registration:
+            if self.is_registration and not self.registered_before_cutoff_date:
                 raise NodeStateError('Cannot make a public registration private')
             self.is_public = False
         else:

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -475,6 +475,7 @@ def project_set_privacy(auth, node, **kwargs):
     if permissions is None:
         raise HTTPError(http.BAD_REQUEST)
 
+    # TODO(hrybacki): Remove third antecedent once no public registrations can be made private
     if permissions == 'private' and node.is_registration and not node.registered_before_cutoff_date:
         raise HTTPError(http.BAD_REQUEST)
 
@@ -731,6 +732,7 @@ def _view_project(node, auth, primary=False):
                 for meta in node.registered_meta or []
             ],
             'registration_count': len(node.node__registrations),
+            # TODO(hrybacki): Remove once no public registrations can be made private
             'registered_before_cutoff_date': node.registered_before_cutoff_date,
             'is_fork': node.is_fork,
             'forked_from_id': node.forked_from._primary_key if node.is_fork else '',
@@ -906,6 +908,7 @@ def _get_summary(node, auth, rescale_ratio, primary=True, link_id=None):
             'category': node.category,
             'node_type': node.project_or_component,
             'is_registration': node.is_registration,
+            # TODO(hrybacki): Remove once no public registrations can be made private
             'registered_before_cutoff_date': node.registered_before_cutoff_date,
             'anonymous': has_anonymous_link(node, auth),
             'registered_date': node.registered_date.strftime('%Y-%m-%d %H:%M UTC')

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -475,7 +475,7 @@ def project_set_privacy(auth, node, **kwargs):
     if permissions is None:
         raise HTTPError(http.BAD_REQUEST)
 
-    if permissions == 'private' and node.is_registration:
+    if permissions == 'private' and node.is_registration and not node.registered_before_cutoff_date:
         raise HTTPError(http.BAD_REQUEST)
 
     node.set_privacy(permissions, auth)
@@ -731,6 +731,7 @@ def _view_project(node, auth, primary=False):
                 for meta in node.registered_meta or []
             ],
             'registration_count': len(node.node__registrations),
+            'registered_before_cutoff_date': node.registered_before_cutoff_date,
             'is_fork': node.is_fork,
             'forked_from_id': node.forked_from._primary_key if node.is_fork else '',
             'forked_from_display_absolute_url': node.forked_from.display_absolute_url if node.is_fork else '',
@@ -905,6 +906,7 @@ def _get_summary(node, auth, rescale_ratio, primary=True, link_id=None):
             'category': node.category,
             'node_type': node.project_or_component,
             'is_registration': node.is_registration,
+            'registered_before_cutoff_date': node.registered_before_cutoff_date,
             'anonymous': has_anonymous_link(node, auth),
             'registered_date': node.registered_date.strftime('%Y-%m-%d %H:%M UTC')
             if node.is_registration

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -475,6 +475,9 @@ def project_set_privacy(auth, node, **kwargs):
     if permissions is None:
         raise HTTPError(http.BAD_REQUEST)
 
+    if permissions == 'private' and node.is_registration:
+        raise HTTPError(http.BAD_REQUEST)
+
     node.set_privacy(permissions, auth)
 
     return {

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -4,6 +4,7 @@ Base settings file, common to all environments.
 These settings can be overridden in local.py.
 """
 
+import datetime
 import os
 import json
 import hashlib
@@ -250,3 +251,6 @@ EZID_FORMAT = '{namespace}osf.io/{guid}'
 
 SHARE_REGISTRATION_URL = ''
 SHARE_API_DOCS_URL = ''
+
+# Date which registrations created after cannot be made public
+REGISTRATION_CUTOFF_DATE = datetime.datetime(2015, 5, 10)

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -253,4 +253,4 @@ SHARE_REGISTRATION_URL = ''
 SHARE_API_DOCS_URL = ''
 
 # Date which registrations created after cannot be made public
-REGISTRATION_CUTOFF_DATE = datetime.datetime(2015, 5, 10)
+REGISTRATION_CUTOFF_DATE = datetime.datetime(2015, 5, 22)

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -252,5 +252,6 @@ EZID_FORMAT = '{namespace}osf.io/{guid}'
 SHARE_REGISTRATION_URL = ''
 SHARE_API_DOCS_URL = ''
 
+# TODO(hrybacki): Remove this and datetime import once no public registrations can be made private
 # Date which registrations created after cannot be made public
 REGISTRATION_CUTOFF_DATE = datetime.datetime(2015, 5, 22)

--- a/website/static/js/nodeControl.js
+++ b/website/static/js/nodeControl.js
@@ -35,7 +35,15 @@ var MESSAGES = {
 
     makeComponentPrivateWarning: 'Making a component private will prevent users from viewing it on this site, ' +
                         'but will have no impact on external sites, including Google\'s cache. ' +
-                        'Would you like to continue?'
+                        'Would you like to continue?',
+
+    // TODO(hrybacki): Remove once the hotifx is taken out
+    makePostCutoffRegistrationPublicWarning: 'Once a project is made public, there is no way to guarantee that ' +
+                        'access to the data it contains can be completely prevented. Users ' +
+                        'should assume that once a project is made public, it will always ' +
+                        'be public. Please note that his action is irreversible. Once this ' +
+                        'registration is made public, it cannot be made private. Are you ' +
+                        'absolutely sure you would like to continue?',
 };
 
 // TODO(sloria): Fix this external dependency on nodeApiUrl
@@ -48,12 +56,16 @@ var PRIVATE = 'private';
 var PROJECT = 'project';
 var COMPONENT = 'component';
 
-
 function setPermissions(permissions, nodeType) {
+
+    // TODO(hrybacki): Remove once the hotifx is taken out
+    var isRegistration = window.contextVars.node.isRegistration;
+    var registeredBeforeCutoffDate = window.contextVars.node.registeredBeforeCutoffDate;
 
     var msgKey;
 
-    if (permissions === PUBLIC && nodeType === PROJECT) { msgKey = 'makeProjectPublicWarning'; }
+    if (permissions === PUBLIC && isRegistration && !registeredBeforeCutoffDate) { msgKey = 'makePostCutoffRegistrationPublicWarning'; }
+    else if (permissions === PUBLIC && nodeType === PROJECT) { msgKey = 'makeProjectPublicWarning'; }
     else if(permissions === PUBLIC && nodeType === COMPONENT) { msgKey = 'makeComponentPublicWarning'; }
     else if(permissions === PRIVATE && nodeType === PROJECT) { msgKey = 'makeProjectPrivateWarning'; }
     else { msgKey = 'makeComponentPrivateWarning'; }

--- a/website/templates/emails/email_contributors_of_public_registrations.txt.mako
+++ b/website/templates/emails/email_contributors_of_public_registrations.txt.mako
@@ -1,0 +1,12 @@
+Hello ${user.fullname},
+
+Sara and Brian N., please revise below.
+
+I am writing to inform you that a policy change will be going to affect on ${cutoff_date} that affects one or more
+registrations to which you contribute. Effective as of ${cutoff_date}, administrators will no longer to convert
+public registrations private. If you have a public registration that you would like to be private, please do
+so, or contact an adminstrator that can, before ${cutoff_date}.
+
+Sincerely yours,
+
+The OSF Robot

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -33,7 +33,7 @@
                             <a class="btn btn-default" data-bind="click: makePublic">Make Public</a>
                         % endif
                     % else:
-                        % if 'admin' in user['permissions']:
+                        % if 'admin' in user['permissions'] and not node['is_registration']:
                             <a class="btn btn-default" data-bind="click: makePrivate">Make Private</a>
                         % endif
                         <button class="btn btn-default disabled">Public</button>

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -33,7 +33,7 @@
                             <a class="btn btn-default" data-bind="click: makePublic">Make Public</a>
                         % endif
                     % else:
-                        % if 'admin' in user['permissions'] and not node['is_registration']:
+                        % if 'admin' in user['permissions'] and (not node['is_registration'] or node['registered_before_cutoff_date']):
                             <a class="btn btn-default" data-bind="click: makePrivate">Make Private</a>
                         % endif
                         <button class="btn btn-default disabled">Public</button>

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -33,6 +33,8 @@
                             <a class="btn btn-default" data-bind="click: makePublic">Make Public</a>
                         % endif
                     % else:
+                        ## TODO(hrybacki): Convert once no public registrations can be made private
+                        ## % if 'admin' in user['permissions'] and not node['is_registration']
                         % if 'admin' in user['permissions'] and (not node['is_registration'] or node['registered_before_cutoff_date']):
                             <a class="btn btn-default" data-bind="click: makePrivate">Make Private</a>
                         % endif

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -328,7 +328,9 @@ ${parent.javascript_bottom()}
         node: {
             hasChildren: ${json.dumps(node['has_children'])},
             isRegistration: ${json.dumps(node['is_registration'])},
-            tags: ${json.dumps(node['tags'])}
+            tags: ${json.dumps(node['tags'])},
+            // TODO(hrybacki): Remove once the hotifx is taken out
+            registeredBeforeCutoffDate: ${json.dumps(node['registered_before_cutoff_date'])}
         }
     });
 </script>


### PR DESCRIPTION
## Purpose
Registrations now have the ability to obtain DOIs and ARK IDs. With this and upcoming behavior changes with Retractions and Embargoes, public registrations should not be able to be made private unless they were created before a predetermined cutoff date.

## Changes
Registrations created before the cutoff date will have no behavioral changes.

Registrations created after the cutoff date will no longer be able to be made private **after** they have been made public. That cutoff date, **REGISTRATION_CUTOFF_DATE**, is set in `defaults.py`

## Side Effects
None

## Notes
Closes-issue: #2670
Old-pr: #2682 