### PR TITLE
[bugfix] Misc. bugfixes for user merging

### DIFF
--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -1119,6 +1119,7 @@ class User(GuidStoredObject, AddonModelMixin):
                 self.comments_viewed_timestamp[node_id] = timestamp
 
         self.emails.extend(user.emails)
+        user.emails = []
 
         for k, v in user.email_verifications.iteritems():
             email_to_confirm = v['email']

--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -21,6 +21,7 @@ from framework.auth import exceptions, utils, signals
 from framework.sentry import log_exception
 from framework.addons import AddonModelMixin
 from framework.sessions.model import Session
+from framework.sessions.utils import remove_sessions_for_user
 from framework.exceptions import PermissionsError
 from framework.guid.model import GuidStoredObject
 from framework.bcrypt import generate_password_hash, check_password_hash
@@ -1177,6 +1178,8 @@ class User(GuidStoredObject, AddonModelMixin):
             user_settings.save()
 
         # finalize the merge
+
+        remove_sessions_for_user(user)
 
         # - username is set to None so the resultant user can set it primary
         #   in the future.

--- a/framework/sessions/utils.py
+++ b/framework/sessions/utils.py
@@ -1,0 +1,11 @@
+from modularodm import Q
+
+from .model import Session
+
+
+def remove_sessions_for_user(user):
+    """Permanently remove all stored sessions for the user from the DB.
+
+    :param User user:
+    """
+    Session.remove(Q('data.auth_user_id', 'eq', user._id))

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -19,6 +19,7 @@ from factory import base, Sequence, SubFactory, post_generation, LazyAttribute
 from framework.mongo import StoredObject
 from framework.auth import User, Auth
 from framework.auth.utils import impute_names_model
+from framework.sessions.model import Session
 from website.addons import base as addons_base
 from website.oauth.models import ExternalAccount
 from website.oauth.models import ExternalProvider
@@ -394,6 +395,28 @@ class ExternalAccountFactory(ModularOdmFactory):
     provider_id = Sequence(lambda n: 'user-{0}'.format(n))
     provider_name = 'Fake Provider'
     display_name = Sequence(lambda n: 'user-{0}'.format(n))
+
+
+class SessionFactory(ModularOdmFactory):
+    FACTORY_FOR = Session
+
+    @classmethod
+    def _build(cls, target_class, *args, **kwargs):
+        user = kwargs.pop('user', None)
+        instance = target_class(*args, **kwargs)
+
+        if user:
+            instance.data['auth_user_username'] = user.username
+            instance.data['auth_user_id'] = user._primary_key
+            instance.data['auth_user_fullname'] = user.fullname
+
+        return instance
+
+    @classmethod
+    def _create(cls, target_class, *args, **kwargs):
+        instance = cls._build(target_class, *args, **kwargs)
+        instance.save()
+        return instance
 
 
 class MockOAuth2Provider(ExternalProvider):

--- a/tests/framework_tests/test_sessions.py
+++ b/tests/framework_tests/test_sessions.py
@@ -1,0 +1,36 @@
+from nose.tools import *
+
+from framework.sessions import utils
+from tests import factories
+from tests.base import DbTestCase
+from website.models import User
+from website.models import Session
+
+
+class SessionUtilsTestCase(DbTestCase):
+    def setUp(self, *args, **kwargs):
+        super(SessionUtilsTestCase, self).setUp(*args, **kwargs)
+        self.user = factories.UserFactory()
+
+    def tearDown(self, *args, **kwargs):
+        super(SessionUtilsTestCase, self).tearDown(*args, **kwargs)
+        User.remove()
+        Session.remove()
+
+    def test_remove_session_for_user(self):
+        factories.SessionFactory(user=self.user)
+
+        # sanity check
+        assert_equal(1, Session.find().count())
+
+        utils.remove_sessions_for_user(self.user)
+        assert_equal(0, Session.find().count())
+
+        factories.SessionFactory()
+        factories.SessionFactory(user=self.user)
+
+        # sanity check
+        assert_equal(2, Session.find().count())
+
+        utils.remove_sessions_for_user(self.user)
+        assert_equal(1, Session.find().count())

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -1,5 +1,6 @@
 import datetime
 
+from modularodm import Q
 from nose.tools import *  # flake8: noqa (PEP8 asserts)
 
 from framework import auth
@@ -19,6 +20,7 @@ class TestUser(base.OsfTestCase):
     def tearDown(self):
         models.Node.remove()
         models.User.remove()
+        models.Session.remove()
         super(TestUser, self).tearDown()
 
     # Regression test for https://github.com/CenterForOpenScience/osf.io/issues/2454
@@ -363,6 +365,13 @@ class TestUserMerging(base.OsfTestCase):
 
         # check fields set on merged user
         assert_equal(other_user.merged_by, self.user)
+
+        assert_equal(
+            0,
+            models.Session.find(
+                Q('data.auth_user_id', 'eq', other_user._id)
+            ).count()
+        )
 
     def test_merge_unconfirmed(self):
         self._add_unconfirmed_user()


### PR DESCRIPTION
Fixes the following bugs discovered by the QA team:

* [Alternate email the same for two users](https://trello.com/c/SOjOgLuu/28-alternate-email-the-same-for-two-users) (h/t @caileyfitz)
* [Merged user remains logged in](https://trello.com/c/TcyWVySj/26-merged-user-remains-logged-in) (h/t @caileyfitz)