### PR TITLE
fix the read permission contributor can't comment

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3598,6 +3598,15 @@ class TestComments(OsfTestCase):
         with assert_raises(ValidationValueError):
             self.comment.save()
 
+    def test_read_permission_contributor_can_comment(self):
+        project = ProjectFactory()
+        user = UserFactory()
+        project.set_privacy('private')
+        project.add_contributor(user, 'read')
+        project.save()
+
+        assert_true(project.can_comment(Auth(user=user)))
+
 
 class TestPrivateLink(OsfTestCase):
 

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -948,7 +948,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
                 self.is_public or
                 (auth.user and self.has_permission(auth.user, 'read'))
             )
-        return self.can_edit(auth)
+        return self.is_contributor(auth.user)
 
     def update(self, fields, auth=None, save=True):
         if self.is_registration:


### PR DESCRIPTION
<b>Purpose</b>
Fix the problem that read permission contributor can't comment on a project. Solves https://github.com/CenterForOpenScience/osf.io/issues/2684