### PR TITLE
[hotfix] Fix confusing timestamps for registration templates

### DIFF
--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -112,10 +112,18 @@
                         <a href="${node['url']}register/${meta['name_no_ext']}">${meta['name_clean']}</a>
                     % endfor
                 % endif
-                <br />Date Created:
-                <span data-bind="text: dateCreated.local, tooltip: {title: dateCreated.utc}" class="date node-date-created"></span>
-                | Last Updated:
-                <span data-bind="text: dateModified.local, tooltip: {title: dateModified.utc}" class="date node-last-modified-date"></span>
+                % if node['is_registration']:
+                    <br />Date Registered:
+                    <span data-bind="text: dateRegistered.local, tooltip: {title: dateRegistered.utc}" class="date node-date-registered"></span>
+                    <br />Date Parent Project Created:
+                % else:
+                    <br />Date Created:
+                % endif
+                    <span data-bind="text: dateCreated.local, tooltip: {title: dateCreated.utc}" class="date node-date-created"></span>
+                % if not node['is_registration']:
+                    | Last Updated:
+                    <span data-bind="text: dateModified.local, tooltip: {title: dateModified.utc}" class="date node-last-modified-date"></span>
+                % endif
                 <span data-bind="if: hasIdentifiers()" class="scripted">
                   <br />
                     Identifiers:


### PR DESCRIPTION
## Purpose 
At some point `date registered` was removed from the project templates. This lead to some confusion about if parent projects were affecting logs of child registrations (they don't). Changes attempt to resolve any potential confusion for users viewing registrations

## Changes
Re-added `date registered` to template, made `date parent project created`
more explicit, and removed date_modified for registrations per discussion.

## Side Effects
None

## Notes
Closes-issue: #1342 