### PR TITLE
Hotfix/presentation service

### DIFF
--- a/scripts/migrate_presentation_service.py
+++ b/scripts/migrate_presentation_service.py
@@ -1,0 +1,62 @@
+import sys
+import logging
+
+from framework.auth.core import get_user
+from website.project.model import Node
+from website.app import init_app
+from scripts import utils as script_utils
+
+
+logger = logging.getLogger(__name__)
+
+
+def do_migration(records, dry=False):
+    for user in records:
+        logger.info('Deleting user - {}'.format(user._id))
+        if not dry:
+            migrate_project_contributed(user)
+            user.is_disabled = True
+            user.save()
+    logger.info('{}Deleted {} users'.format('[dry]'if dry else '', len(records)))
+
+
+def migrate_project_contributed(user):
+    count = 0
+    for node_id in user.node__contributed:
+        node = Node.load(node_id)
+        if node._primary_key in user.unclaimed_records:
+            del user.unclaimed_records[node._primary_key]
+
+        node.contributors.remove(user._id)
+
+        node.clear_permission(user)
+        if user._id in node.visible_contributor_ids:
+            node.visible_contributor_ids.remove(user._id)
+
+        node.save()
+        count += 1
+        logger.info('Removed user - {} as a contributor from project - {}'.format(user._id, node._id))
+    logger.info('Removed user - {} as a contributor from {} projects'.format(user._id, count))
+
+
+def get_targets():
+    users = []
+    user1 = get_user(email='presentations@cos.io')
+    if user1:
+        users.append(user1)
+    user2 = get_user(email='presentations@osf.io')
+    if user2:
+        users.append(user2)
+    return users
+
+
+def main():
+    init_app(routes=False)  # Sets the storage backends on all models
+    dry = 'dry' in sys.argv
+    if not dry:
+        script_utils.add_file_logger(logger, __file__)
+    do_migration(get_targets(), dry)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/populate_conferences.py
+++ b/scripts/populate_conferences.py
@@ -67,7 +67,6 @@ MEETING_DATA = {
         'active': False,
         'admins': [
             'lvonschi@nrao.edu',
-            'presentations@osf.io',
             # 'Dkim@nrao.edu',
         ],
         'public_projects': True,
@@ -84,7 +83,6 @@ MEETING_DATA = {
         'active': False,
         'admins': [
             'gkroll@berkeley.edu',
-            'presentations@osf.io',
             'awais@berkeley.edu',
         ],
         'public_projects': True,
@@ -96,7 +94,6 @@ MEETING_DATA = {
         'active': True,
         'admins': [
             'meetings@spsp.org',
-            'presentations@osf.io',
         ],
     },
     'aps2015': {
@@ -105,7 +102,6 @@ MEETING_DATA = {
         'logo_url': 'http://www.psychologicalscience.org/images/APS_2015_Banner_990x157.jpg',
         'active': True,
         'admins': [
-            'presentations@osf.io',
         ],
         'public_projects': True,
     },
@@ -115,7 +111,6 @@ MEETING_DATA = {
         'logo_url': 'http://icps.psychologicalscience.org/wp-content/themes/deepblue/images/ICPS_Website-header_990px.jpg',
         'active': True,
         'admins': [
-            'presentations@osf.io',
         ],
         'public_projects': True,
     },
@@ -126,7 +121,6 @@ MEETING_DATA = {
         'active': True,
         'admins': [
             'mpa@kent.edu',
-            'presentations@osf.io',
         ],
         'public_projects': True,
     },
@@ -137,7 +131,6 @@ MEETING_DATA = {
         'active': True,
         'admins': [
             'aoverman@elon.edu',
-            'presentations@osf.io',
         ],
         'public_projects': True,
     },
@@ -148,7 +141,6 @@ MEETING_DATA = {
         'active': True,
         'admins': [
             'director@vprsf.org',
-            'presentations@osf.io',
         ],
         'public_projects': True,
     },
@@ -159,7 +151,6 @@ MEETING_DATA = {
         'active': True,
         'admins': [
             'mhurst@virginia.edu',
-            'presentations@osf.io',
         ],
         'public_projects': True,
     },
@@ -170,7 +161,6 @@ MEETING_DATA = {
         'active': True,
         'admins': [
             'amorris.mtsu@gmail.com',
-            'presentations@osf.io',
         ],
         'public_projects': True,
     },
@@ -180,7 +170,6 @@ MEETING_DATA = {
         'logo_url': None,
         'active': True,
         'admins': [
-            'presentations@osf.io',
         ],
         'public_projects': True,
     },

--- a/scripts/tests/test_migrate_presentation_service.py
+++ b/scripts/tests/test_migrate_presentation_service.py
@@ -1,0 +1,86 @@
+from tests.base import OsfTestCase
+from tests.factories import UserFactory, ProjectFactory, UnconfirmedUserFactory
+from framework.auth import Auth
+from scripts.migrate_presentation_service import (
+    do_migration, get_targets, migrate_project_contributed
+)
+
+
+class TestMigrateManualMergedUser(OsfTestCase):
+
+    def test_get_targets(self):
+        user1 = UserFactory.build(username='presentations@cos.io')
+        user2 = UserFactory()
+        user1.save()
+
+        user_list = get_targets()
+        assert user_list is not None
+        assert len(user_list) is 1
+
+        user3 = UserFactory.build(username='presentations@osf.io')
+        user3.save()
+        user_list = get_targets()
+        assert len(user_list) is 2
+
+    def test_migrate_project_contributed(self):
+        user1 = UserFactory()
+
+        fullname1 = 'hello world'
+        email1 = 'test@example.com'
+        project1 = ProjectFactory(creator=user1)
+        user2 = project1.add_unregistered_contributor(
+            fullname=fullname1, email=email1, auth=Auth(user=user1)
+        )
+        project1.save()
+        assert project1.is_contributor(user2) is True
+        assert len(project1.contributors) is 2
+
+        migrate_project_contributed(user2)
+        assert project1.is_contributor(user2) is False
+        assert len(project1.contributors) is 1
+
+        user3 = UserFactory()
+        project2 = ProjectFactory(creator=user1)
+        project2.add_contributor(user3)
+        project2.save()
+
+        assert project2.is_contributor(user3) is True
+        assert len(project2.contributors) is 2
+
+        migrate_project_contributed(user3)
+        assert project2.is_contributor(user3) is False
+        assert len(project2.contributors) is 1
+
+    def test_do_migration(self):
+        user1 = UserFactory()
+
+        fullname1 = 'Presentation Service'
+        email1 = 'presentations@cos.io'
+        project1 = ProjectFactory(creator=user1)
+        user2 = project1.add_unregistered_contributor(
+            fullname=fullname1, email=email1, auth=Auth(user=user1)
+        )
+        project1.save()
+
+        user3 = UserFactory.build(username='presentations@osf.io', fullname=fullname1)
+        user3.save()
+        project2 = ProjectFactory(creator=user1)
+        project2.add_contributor(user3)
+        project2.save()
+
+        assert project1.is_contributor(user2) is True
+        assert len(project1.contributors) is 2
+        assert project2.is_contributor(user3) is True
+        assert len(project2.contributors) is 2
+
+        user_list = get_targets()
+        do_migration(user_list)
+
+        assert project2.is_contributor(user3) is False
+        assert len(project2.contributors) is 1
+
+        assert project1.is_contributor(user2) is False
+        assert len(project1.contributors) is 1
+
+        assert user2.is_disabled is True
+        assert user3.is_disabled is True

--- a/website/conferences/utils.py
+++ b/website/conferences/utils.py
@@ -7,6 +7,7 @@ from modularodm import Q
 from modularodm.exceptions import ModularOdmException
 
 from framework.auth import Auth
+from framework.auth.core import get_user
 
 from website import util
 from website import security
@@ -31,10 +32,10 @@ def get_or_create_user(fullname, address, is_spam):
     :param bool is_spam: User flagged as potential spam
     :return: Tuple of (user, created)
     """
-    try:
-        user = User.find_one(Q('username', 'iexact', address))
+    user = get_user(email=address)
+    if user:
         return user, False
-    except ModularOdmException:
+    else:
         password = str(uuid.uuid4())
         user = User.create_confirmed(address, password, fullname)
         user.verification_key = security.random_string(20)

--- a/website/conferences/views.py
+++ b/website/conferences/views.py
@@ -78,9 +78,6 @@ def add_poster_by_email(conference, message):
         )
         if user_created:
             created.append(user)
-
-        if user_created:
-            created.append(user)
             set_password_url = web_url_for(
                 'reset_password',
                 verification_key=user.verification_key,


### PR DESCRIPTION
<b>Purpose</b>
Update presentation service's get_user for merging user feature.
Solves https://github.com/CenterForOpenScience/osf.io/issues/2447.
Deactivate both 'presentations@cos.io' and 'presentations@osf.io' and remove them from all the nodes.
