### PR TITLE
[Fix] Changes link structure to use single clicks

### DIFF
--- a/website/addons/dataverse/static/dataverseFangornConfig.js
+++ b/website/addons/dataverse/static/dataverseFangornConfig.js
@@ -205,7 +205,7 @@ function _fangornDataverseTitle(item, col) {
     } else {
         return m('span', [
             m('dataverse-name.fg-file-links', {
-                ondblclick: function () {
+                onclick: function () {
                     var redir = new URI(item.data.nodeUrl);
                     window.location = redir
                         .segment('files')

--- a/website/addons/github/static/githubFangornConfig.js
+++ b/website/addons/github/static/githubFangornConfig.js
@@ -252,7 +252,7 @@ function _fangornGithubTitle(item, col)  {
         if (item.kind === 'file' && item.data.permissions.view) {
             return m('span',[
                 m('github-name.fg-file-links', {
-                    ondblclick: function() {
+                    onclick: function() {
                         var redir = new URI(item.data.nodeUrl);
                         var fileurl = new URI(item.data.nodeUrl)
                             .segment('files')

--- a/website/static/css/fangorn.css
+++ b/website/static/css/fangorn.css
@@ -83,6 +83,7 @@ text-align: center;
 }
 .tb-row {
 	border-bottom: 1px solid #f5f5f5;
+    line-height: 30px;
 }
 .title-text {
     cursor: default;

--- a/website/static/css/fangorn.css
+++ b/website/static/css/fangorn.css
@@ -88,11 +88,15 @@ text-align: center;
 .title-text {
     cursor: default;
 }
-.title-text:hover {
-    text-decoration: underline;
-}
 .fg-file-links  {
     cursor: pointer !important;
+    color: #333333;
+}
+.fg-file-links:hover {
+    text-decoration: underline;
+}
+.fangorn-selected .fg-file-links {
+    color: #FFFFFF;
 }
 .tb-row-titles {
 	height: 35px;

--- a/website/static/css/fangorn.css
+++ b/website/static/css/fangorn.css
@@ -83,10 +83,13 @@ text-align: center;
 }
 .tb-row {
 	border-bottom: 1px solid #f5f5f5;
-    line-height: 30px;
+    line-height: 27px;
 }
 .title-text {
     cursor: default;
+}
+.title-text:hover {
+    text-decoration: underline;
 }
 .fg-file-links  {
     cursor: pointer !important;

--- a/website/static/css/fangorn.css
+++ b/website/static/css/fangorn.css
@@ -70,9 +70,11 @@ text-align: center;
 	line-height: 23px;
 	padding: 3px 0px 7px 5px;
 	font-size: 14px;
-	border-left: none;
+    border-left: 1px solid #DDD;
 }
-
+.tb-th:first-of-type {
+    border-left: none;
+}
 .tb-td {
     height: inherit;
     padding-top: 6px;

--- a/website/static/css/projectorganizer.css
+++ b/website/static/css/projectorganizer.css
@@ -335,6 +335,7 @@ h3.category {
 }
 .tb-row {
     font-size: 13px;
+    line-height: 30px;
 }
 
 .po-hover {

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1291,9 +1291,10 @@ var FGToolbar = {
                 onclick: function(event){
                     var mithrilContent = m('div', [
                         m('h3.break-word.m-b-lg', 'How to Use the File Browser'),
+                        m('p', [ m('b', 'Select rows:'), m('span', ' Click on a row (outside the name) to show further actions in the toolbar.')]),
                         m('p', [ m('b', 'Select Multiple Files:'), m('span', ' Use command or shift keys to select multiple files.')]),
-                        m('p', [ m('b', 'Open Files:'), m('span', ' Double click a file name to go to the file.')]),
-                        m('p', [ m('b', 'Open Files in New Tab:'), m('span',  ' Press Command (or Ctrl in Windows) and double click a file name to open it in a new tab.')]),
+                        m('p', [ m('b', 'Open Files:'), m('span', ' Click a file name to go to the file.')]),
+                        m('p', [ m('b', 'Open Files in New Tab:'), m('span',  ' Press Command (or Ctrl in Windows) and  click a file name to open it in a new tab.')]),
                     ]);
                     var mithrilButtons = m('div', [
                         m('span.tb-modal-btn', { 'class' : 'text-primary', onclick : function() { ctrl.tb.modal.dismiss(); } }, 'Close'),

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1554,7 +1554,7 @@ function _resizeHeight () {
  * Check Treebeard API for more information
  */
 tbOptions = {
-    rowHeight : 30,         // user can override or get from .tb-row height
+    rowHeight : 35,         // user can override or get from .tb-row height
     showTotal : 15,         // Actually this is calculated with div height, not needed. NEEDS CHECKING
     paginate : false,       // Whether the applet starts with pagination or not.
     paginateToggle : false, // Show the buttons that allow users to switch between scroll and paginate.

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -824,7 +824,7 @@ function _fangornTitleColumn(item, col) {
     var tb = this;
     if (item.kind === 'file' && item.data.permissions.view) {
         return m('span.fg-file-links',{
-            ondblclick: function() {
+            onclick: function() {
                 gotoFileEvent.call(tb, item);
             }
         }, item.data.name);

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -100,7 +100,7 @@ var cancelUploadTemplate = function(row){
                 e.stopImmediatePropagation();
                 cancelUploads.call(treebeard, row);
             }},
-        m('.fa.fa-times-circle.text-warning', {
+        m('.fa.fa-times-circle.text-danger', {
             style : 'display:block;font-size:18px; margin-top: -4px;',
             'data-toggle': 'tooltip',
             'data-placement' : 'bottom',

--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -1406,7 +1406,7 @@ function _deleteFolder(item) {
  * For documentation visit: https://github.com/caneruguz/treebeard/wiki
  */
 var tbOptions = {
-    rowHeight : 27,         // user can override or get from .tb-row height
+    rowHeight : 35,         // user can override or get from .tb-row height
     showTotal : 15,         // Actually this is calculated with div height, not needed. NEEDS CHECKING
     paginate : false,       // Whether the applet starts with pagination or not.
     paginateToggle : false, // Show the buttons that allow users to switch between scroll and paginate.

--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -341,9 +341,6 @@ function _poResolveIcon(item) {
             iconType += ' po-icon';
         }
         var template = m('span', { 'class' : iconType});
-        if (viewLink) {
-            return m('a', { href : viewLink}, template);
-        }
         return template;
     }
     if (item.data.isSmartFolder) {

--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -106,15 +106,11 @@ projectOrganizer.myProjects = new Bloodhound({
 function _poTitleColumn(item) {
     var tb = this;
     var css = item.data.isSmartFolder ? 'project-smart-folder smart-folder' : '';
-    var isLink = item.data.urls.fetch ? '.fg-file-links' : '';
-    return m('span' + isLink, { 'class' : css, ondblclick : function (event) {
-        if (COMMAND_KEYS.indexOf(tb.pressedKey) !== -1) {
-            window.open(item.data.urls.fetch, '_blank');
-        } else {
-            window.open(item.data.urls.fetch, '_self');
-        }
+    if(item.data.urls.fetch){
+        return m('a.fg-file-links', { 'class' : css, href : item.data.urls.fetch}, item.data.name);
+    } else {
+        return  m('span', { 'class' : css}, item.data.name);
     }
-        }, item.data.name);
 }
 
 /**


### PR DESCRIPTION
## Purpose
Following from our community meeting these changes turn links into single clicks and Project Organizer links into actual a tag links; plus some housecleaning around these changes. 

@GaryKriebel these include the changes we talked about.

## Changes
- Increase top bottom padding
- Add underline to file name and 
- Make any other than file name not a link (make it consistent across PO and Files) 
- Single click to go to file or project. 
- Single command click to go to file and project
- Change help text to reflect this change 
- Add borders to columns to denote resize grab location 
- Change cancel upload button color to red

## Side effects
None. 