### PR TITLE
[hold] [Feature] [Experimental] Add natural scrolling at certain number of items

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "raw-loader": "^0.5.1",
     "share": "~0.7.3",
     "style-loader": "^0.8.3",
-    "treebeard": "git://github.com/caneruguz/treebeard.git#69a4d60d76ae96e57bc5cdcf0ad6d0a49c0940ac",
+    "treebeard": "git://github.com/caneruguz/treebeard.git#fbec928a0c40dd98de41956cf561bd4749cb46be",
     "typeahead.js": "^0.10.5",
     "url-loader": "^0.5.5",
     "webpack": "^1.7.2",

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1548,7 +1548,8 @@ function _resizeHeight () {
  */
 tbOptions = {
     rowHeight : 35,         // user can override or get from .tb-row height
-    showTotal : 15,         // Actually this is calculated with div height, not needed. NEEDS CHECKING
+    showTotal : 500,
+    naturalScroll: true,
     paginate : false,       // Whether the applet starts with pagination or not.
     paginateToggle : false, // Show the buttons that allow users to switch between scroll and paginate.
     uploads : true,         // Turns dropzone on/off.

--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -1386,7 +1386,8 @@ function _deleteFolder(item) {
  */
 var tbOptions = {
     rowHeight : 35,         // user can override or get from .tb-row height
-    showTotal : 15,         // Actually this is calculated with div height, not needed. NEEDS CHECKING
+    showTotal : 500,
+    naturalScroll : true,
     paginate : false,       // Whether the applet starts with pagination or not.
     paginateToggle : false, // Show the buttons that allow users to switch between scroll and paginate.
     uploads : false,         // Turns dropzone on/off.


### PR DESCRIPTION
In combination of showTotal this allows users to define an option called naturalScroll that avoids running onScroll function.

If showTotal is set to X provided that all items are below X the scrolling will be natural. 

This solution is not dynamic to number of items, so still needs furthe work. ie a logic like following is needed
```js
options.naturalScrollLimit = 500;
options.showTotal = 15;

if (options.naturalScrollLimit && totalItems < options.naturalScrollLimit) {
   self.shouldVirtualScroll = false;    
// don't do onscroll and use naturalScrollLimit instead of showTotal
} else {
    self.sholdVirtualScroll = true;
    // do onscroll and use showTotal instead
}
```