### PR TITLE
Hotfix/registration log

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1594,6 +1594,19 @@ class TestNode(OsfTestCase):
         self.node.collapse(user=self.user)
         assert_equal(self.node.is_expanded(user=self.user), False)
 
+    def test_cannot_register_deleted_node(self):
+        self.node.is_deleted = True
+        self.node.save()
+        with assert_raises(NodeStateError) as err:
+            self.node.register_node(
+                schema=None,
+                auth=self.consolidate_auth,
+                template='the template',
+                data=None
+            )
+        assert_equal(err.exception.message, 'Cannot register deleted node.')
+
+
 class TestNodeTraversals(OsfTestCase):
 
     def setUp(self):

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -1660,6 +1660,9 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
         # database objects to which these dictionaries refer. This means that
         # the cloned node must pass itself to its wiki objects to build the
         # correct URLs to that content.
+        if original.is_deleted:
+            raise NodeStateError("Node has been deleted")
+
         registered = original.clone()
 
         registered.is_registration = True
@@ -1689,11 +1692,12 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
         registered.nodes = []
 
         for node_contained in original.nodes:
-            registered_node = node_contained.register_node(
-                schema, auth, template, data
-            )
-            if registered_node is not None:
-                registered.nodes.append(registered_node)
+            if not node_contained.is_deleted:
+                registered_node = node_contained.register_node(
+                    schema, auth, template, data
+                )
+                if registered_node is not None:
+                    registered.nodes.append(registered_node)
 
         original.add_log(
             action=NodeLog.PROJECT_REGISTERED,

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -1661,7 +1661,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
         # the cloned node must pass itself to its wiki objects to build the
         # correct URLs to that content.
         if original.is_deleted:
-            raise NodeStateError("Node has been deleted")
+            raise NodeStateError('Cannot register deleted node.')
 
         registered = original.clone()
 

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -631,7 +631,7 @@ def delete_folder(auth, node, **kwargs):
 
 
 @must_be_valid_project
-@must_have_permission("admin")
+@must_have_permission(ADMIN)
 def remove_private_link(*args, **kwargs):
     link_id = request.json['private_link_id']
 


### PR DESCRIPTION
<b>Purpose</b>
Fix the problem that the deleted component got registered and shown up as registered in logs.
Solves https://github.com/CenterForOpenScience/osf.io/issues/2656

<b>Changes</b>
before change:
![image](https://cloud.githubusercontent.com/assets/4974056/7653916/4cdbf190-fae7-11e4-91b4-504bb185a3fc.png)

after change:
![screen shot 2015-05-15 at 9 46 55 am](https://cloud.githubusercontent.com/assets/4974056/7653925/5c4e637e-fae7-11e4-8018-4c73aac6ee04.png)
