### PR TITLE
Fix Addon highlighting current item in file view [skip ci]

### DIFF
--- a/website/addons/dataverse/static/dataverseFangornConfig.js
+++ b/website/addons/dataverse/static/dataverseFangornConfig.js
@@ -238,7 +238,8 @@ function _fangornColumns(item) {
     var tb = this;
     var selectClass = '';
     if (item.data.kind === 'file' && tb.currentFileID === item.id) {
-        selectClass = 'fangorn-selected';
+        item.css = 'fangorn-selected';
+        tb.multiselected([item]);
     }
     var columns = [];
     columns.push({

--- a/website/addons/github/static/githubFangornConfig.js
+++ b/website/addons/github/static/githubFangornConfig.js
@@ -284,7 +284,8 @@ function _fangornColumns (item) {
     var selectClass = '';
     var node = item.parent().parent();
     if (item.data.kind === 'file' && tb.currentFileID === item.id) {
-        selectClass = 'fangorn-selected';
+        item.css = 'fangorn-selected';
+        tb.multiselected([item]);
     }
 
     var columns = [];
@@ -293,7 +294,6 @@ function _fangornColumns (item) {
         data : 'name',
         folderIcons : true,
         filter: true,
-        css: selectClass,
         custom : _fangornGithubTitle
     });
 

--- a/website/static/js/fileViewTreebeard.js
+++ b/website/static/js/fileViewTreebeard.js
@@ -83,6 +83,7 @@ function FileViewTreebeard(data) {
             var node = item.parent().parent();
             if (item.data.kind === 'file' && tb.currentFileID === item.id) {
                 item.css = 'fangorn-selected';
+                tb.multiselected([item]);
             }
 
             var defaultColumns = [


### PR DESCRIPTION
## Purpose
Fixes Trello card about add on not maintaining highlight in file detail view page. 
https://trello.com/c/hYinPmmF

## Changes
Add the item to multipleselect to make sure redrawings would occur because of onscroll highlightmultiselect function

## Side effects
None
