### PR TITLE
[Fix] Add node type to rubeus to omit components from multi delete [skip ci]

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1250,7 +1250,7 @@ var FGToolbar = {
             // Only show delete button if user has edit permissions on at least one selected file
             for (var i = 0, len = items.length; i < len; i++) {
                 var each = items[i];
-                if (each.data.permissions.edit && !each.data.isAddonRoot) {
+                if (each.data.permissions.edit && !each.data.isAddonRoot && !each.data.nodeType) {
                     showDelete = true;
                     break;
                 }

--- a/website/util/rubeus.py
+++ b/website/util/rubeus.py
@@ -458,6 +458,7 @@ class NodeFileCollector(object):
             'children': children,
             'isPointer': not node.primary,
             'isSmartFolder': False,
+            'nodeType': node.project_or_component,
             'nodeID': node.resolve()._id,
         }
 


### PR DESCRIPTION
## Purpose
Fixes the Trello card : https://trello.com/c/BkwPYEsL

## Changes
Added to rubeus ndoeType value
Check against this value in fangorn to see if delete multiple button should be shown.

## Side effects
None. 