### PR TITLE
Hotfix/write contributor enable addon

### DIFF
--- a/website/static/js/pages/project-settings-page.js
+++ b/website/static/js/pages/project-settings-page.js
@@ -57,7 +57,10 @@ $(document).ready(function() {
         window.contextVars.node.urls.update,
         disableCategory
     );
-    ko.applyBindings(categorySettingsVM, $('#nodeCategorySettings')[0]);
+
+    if ($('#nodeCategorySettings')[0]) {
+        ko.applyBindings(categorySettingsVM, $('#nodeCategorySettings')[0]);
+    }
 
     $(window).resize(function (){ fixAffixWidth(); });
     $('.project-page .panel').on('affixed.bs.affix', function(){ fixAffixWidth(); });

--- a/website/static/js/pages/project-settings-page.js
+++ b/website/static/js/pages/project-settings-page.js
@@ -41,24 +41,24 @@ function fixAffixWidth() {
 
 $(document).ready(function() {
 
-    // Apply KO bindings for Node Category Settings
-    var categories = [];
-    var keys = Object.keys(window.contextVars.nodeCategories);
-    for (var i = 0; i < keys.length; i++) {
-        categories.push({
-            label: window.contextVars.nodeCategories[keys[i]],
-            value: keys[i]
-        });
-    }
-    var disableCategory = !window.contextVars.node.parentExists;
-    var categorySettingsVM = new ProjectSettings.NodeCategorySettings(
-        window.contextVars.node.category,
-        categories,
-        window.contextVars.node.urls.update,
-        disableCategory
-    );
-
     if ($('#nodeCategorySettings')[0]) {
+        // Apply KO bindings for Node Category Settings
+        var categories = [];
+        var keys = Object.keys(window.contextVars.nodeCategories);
+        for (var i = 0; i < keys.length; i++) {
+            categories.push({
+                label: window.contextVars.nodeCategories[keys[i]],
+                value: keys[i]
+            });
+        }
+        var disableCategory = !window.contextVars.node.parentExists;
+        var categorySettingsVM = new ProjectSettings.NodeCategorySettings(
+            window.contextVars.node.category,
+            categories,
+            window.contextVars.node.urls.update,
+            disableCategory
+        );
+
         ko.applyBindings(categorySettingsVM, $('#nodeCategorySettings')[0]);
     }
 


### PR DESCRIPTION
<b>Purpose</b>
Fix the problem that write permission user can't enable addons. Solves https://github.com/CenterForOpenScience/osf.io/issues/2665

<b>Changes</b>
Now write permission user can enable addons.