### PR TITLE
enable write permission contributor to change category of a project

### DIFF
--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -553,8 +553,10 @@ def togglewatch_post(auth, node, **kwargs):
 
 @must_be_valid_project
 @must_not_be_registration
-@must_have_permission(ADMIN)
+@must_have_permission(WRITE)
 def update_node(auth, node, **kwargs):
+    # in node.update() method there is a key list node.WRITABLE_WHITELIST only allow user to modify
+    # category, title, and discription which can be edited by write permission contributor
     try:
         return {
             'updated_fields': {

--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -17,32 +17,32 @@
 
 <div class="row project-page">
     <div class="col-sm-3 affix-parent">
-        <div class="panel panel-default" data-spy="affix" data-offset-top="60" data-offset-bottom="268">
-            <ul class="nav nav-stacked nav-pills">
-                % if 'admin' in user['permissions'] and not node['is_registration']:
+        % if 'write' in user['permissions'] and not node['is_registration']:
+            <div class="panel panel-default" data-spy="affix" data-offset-top="60" data-offset-bottom="268">
+                <ul class="nav nav-stacked nav-pills">
                     <li><a href="#configureNodeAnchor">Configure ${node['node_type'].capitalize()}</a></li>
-                % endif
-                % if 'admin' in user['permissions'] and not node['is_registration']:
-                    <li><a href="#configureCommentingAnchor">Configure Commenting</a></li>
-                % endif
 
-                % if 'write' in user['permissions'] and not node['is_registration']:
-                    <li><a href="#selectAddonsAnchor">Select Add-ons</a></li>
+                    % if 'admin' in user['permissions'] and not node['is_registration']:
+                        <li><a href="#configureCommentingAnchor">Configure Commenting</a></li>
+                    % endif
 
-                % if addon_enabled_settings:
-                    <li><a href="#configureAddonsAnchor">Configure Add-ons</a></li>
-                % endif
+                    % if 'write' in user['permissions'] and not node['is_registration']:
+                        <li><a href="#selectAddonsAnchor">Select Add-ons</a></li>
+    
+                    % if addon_enabled_settings:
+                        <li><a href="#configureAddonsAnchor">Configure Add-ons</a></li>
+                    % endif
 
-                    <li><a href="#configureNotificationsAnchor">Configure Notifications</a></li>
-                %endif
-            </ul>
-        </div><!-- end sidebar -->
+                        <li><a href="#configureNotificationsAnchor">Configure Notifications</a></li>
+                    %endif
+                </ul>
+            </div><!-- end sidebar -->
+        % endif
     </div>
 
     <div class="col-sm-9">
 
-        % if 'admin' in user['permissions'] and not node['is_registration']:
-
+        % if 'write' in user['permissions'] and not node['is_registration']:
             <div class="panel panel-default">
                 <span id="configureNodeAnchor" class="anchor"></span>
 
@@ -70,19 +70,23 @@
                     A top-level project's category cannot be changed
                   </span>
                 </div>
-                <hr />
-                <div class="panel-body">
-                    <div class="help-block">
-                        A project cannot be deleted if it has any components within it.
-                        To delete a parent project, you must first delete all child components
-                        by visiting their settings pages.
+
+                % if 'admin' in user['permissions'] and not node['is_registration']:
+                    <hr />
+                    <div class="panel-body">
+                        <div class="help-block">
+                            A project cannot be deleted if it has any components within it.
+                            To delete a parent project, you must first delete all child components
+                            by visiting their settings pages.
+                        </div>
+                        <button id="deleteNode" class="btn btn-danger btn-delete-node">Delete ${node['node_type']}</button>
+
                     </div>
-                    <button id="deleteNode" class="btn btn-danger btn-delete-node">Delete ${node['node_type']}</button>
-
-                </div>
-
+                % endif
             </div>
+        % endif
 
+        % if 'admin' in user['permissions'] and not node['is_registration']:
             <div class="panel panel-default">
                 <span id="configureCommentingAnchor" class="anchor"></span>
 


### PR DESCRIPTION
<b>Purpose</b>
Give write permission contributor the power to change the category of a project. Also solves https://github.com/CenterForOpenScience/osf.io/issues/2665


<b>Change</b>
What a write permission contributor will see on the settings page:
![screen shot 2015-05-15 at 4 02 14 pm](https://cloud.githubusercontent.com/assets/4974056/7660848/ca2fc4ee-fb1b-11e4-9263-7bb5d6284868.png)
