### PR TITLE
[Fix] Fix for scrolling to file 

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1004,10 +1004,8 @@ function scrollToFile(fileID) {
     if (fileID !== undefined) {
         var index = tb.returnIndex(fileID);
         var visibleIndex = tb.visibleIndexes.indexOf(index);
-        if (visibleIndex !== -1 && visibleIndex > tb.showRange.length - 2) {
-            var scrollTo = visibleIndex * tb.options.rowHeight;
-            this.select('#tb-tbody').scrollTop(scrollTo);
-        }
+        var scrollTo = visibleIndex * tb.options.rowHeight;
+        this.select('#tb-tbody').scrollTop(scrollTo);
     }
 }
 


### PR DESCRIPTION
## Purpose 
Following scrolling changes the go to file was broken. This fixes to make sure single file view; detail page works. 

## Changes
Remove unnecessary code from before scrollign changes

## Side effects.
Doesn't seem to be any. 