### PR TITLE
[Fix] Run reset filter only when returning from search [skip ci]

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1157,8 +1157,10 @@ var FGItemButtons = {
 
 var _dismissToolbar = function(){
     var tb = this;
+    if (tb.toolbarMode === toolbarModes.SEARCH){
+        tb.resetFilter();
+    }
     tb.toolbarMode(toolbarModes.DEFAULT);
-    tb.resetFilter();
     tb.filterText('');
     m.redraw();
 };

--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -1163,8 +1163,10 @@ var POItemButtons = {
 
 var _dismissToolbar = function () {
     var tb = this;
+    if (tb.toolbarMode === Fangorn.Components.toolbarModes.SEARCH){
+        tb.resetFilter();
+    }
     tb.toolbarMode(Fangorn.Components.toolbarModes.DEFAULT);
-    tb.resetFilter();
     tb.filterText('');
     tb.select('.tb-header-row .twitter-typeahead').remove();
     m.redraw();


### PR DESCRIPTION
## Purpose
Fixes this Trello issue: https://trello.com/c/WmZHjGcP

## Changes
Only run resetfilter when toolbar is returning from Search

## Side effects
None. 