### PR TITLE
[feature] Fix bug in OAuth addon merging where credentials were not merged

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -446,3 +446,11 @@ class MockAddonUserSettings(addons_base.AddonUserSettingsBase):
 class MockAddonUserSettingsMergeable(addons_base.AddonUserSettingsBase):
     def merge(self):
         pass
+
+
+class MockOAuthAddonUserSettings(addons_base.AddonOAuthUserSettingsBase):
+    oauth_provider = MockOAuth2Provider
+
+
+class MockOAuthAddonNodeSettings(addons_base.AddonOAuthNodeSettingsBase):
+    oauth_provider = MockOAuth2Provider

--- a/tests/models/test_addon_settings.py
+++ b/tests/models/test_addon_settings.py
@@ -1,5 +1,6 @@
 from nose.tools import *
 
+from framework.auth.core import Auth
 from website.addons import base as addons_base
 
 from tests import base
@@ -7,6 +8,8 @@ from tests import factories
 
 
 class AddonUserSettingsTestCase(base.OsfTestCase):
+
+    OAUTH_PROVIDER = factories.MockOAuth2Provider.short_name
 
     ADDONS_UNDER_TEST = {
         'mock': {
@@ -16,7 +19,11 @@ class AddonUserSettingsTestCase(base.OsfTestCase):
         'mock_merging': {
             'user_settings': factories.MockAddonUserSettingsMergeable,
             'node_settings': factories.MockAddonNodeSettings,
-        }
+        },
+        OAUTH_PROVIDER: {
+            'user_settings': factories.MockOAuthAddonUserSettings,
+            'node_settings': factories.MockOAuthAddonNodeSettings,
+        },
     }
 
     def setUp(self):
@@ -24,9 +31,13 @@ class AddonUserSettingsTestCase(base.OsfTestCase):
         self.user = factories.UserFactory()
         self.user.add_addon('mock')
         self.user_settings = self.user.get_addon('mock')
+        self.other_user = factories.UserFactory()
+        self.project = factories.ProjectFactory(creator=self.other_user)
 
     def tearDown(self):
         super(AddonUserSettingsTestCase, self).tearDown()
+        self.project.reload()
+        self.project.remove()
         self.user.remove()
 
     def test_can_be_merged_not_implemented(self):
@@ -35,3 +46,33 @@ class AddonUserSettingsTestCase(base.OsfTestCase):
     def test_can_be_merged_implemented(self):
         user_settings = self.user.get_or_add_addon('mock_merging')
         assert_true(user_settings.can_be_merged)
+
+    def test_merge_user_settings(self):
+
+        # give the other user an external account
+        external_account = factories.ExternalAccountFactory(
+            provider=self.OAUTH_PROVIDER
+        )
+        self.other_user.external_accounts.append(external_account)
+
+        # set up a project, whose addon is authenticated to the other user
+        other_user_settings = self.other_user.get_or_add_addon(self.OAUTH_PROVIDER)
+        node_settings = self.project.get_or_add_addon(self.OAUTH_PROVIDER, auth=Auth(self.other_user))
+        node_settings.set_auth(
+            user=self.other_user,
+            external_account=external_account
+        )
+
+        user_settings = self.user.get_or_add_addon(self.OAUTH_PROVIDER)
+
+        self.user.merge_user(self.other_user)
+        self.user.save()
+
+        self.project.reload()
+        node_settings.reload()
+        user_settings.reload()
+        other_user_settings.reload()
+
+        assert_true(node_settings.has_auth)
+        assert_in(self.project._id, user_settings.oauth_grants)
+        assert_equal(node_settings.user_settings, user_settings)

--- a/website/addons/base/__init__.py
+++ b/website/addons/base/__init__.py
@@ -651,6 +651,20 @@ class AddonOAuthUserSettingsBase(AddonUserSettingsBase):
 
         user_settings.oauth_grants = {}
         user_settings.save()
+
+        try:
+            config = settings.ADDONS_AVAILABLE_DICT[
+                self.oauth_provider.short_name
+            ]
+            Model = config.settings_models['node']
+        except KeyError:
+            pass
+        else:
+            connected = Model.find(Q('user_settings', 'eq', user_settings))
+            for node_settings in connected:
+                node_settings.user_settings = self
+                node_settings.save()
+
         self.save()
 
     def to_json(self, user):


### PR DESCRIPTION
This code is ugly, but it should do the trick for now.  Consider this as almost a hotfix - test it in QA, and if it works :shipit:.

I'll write tests for it, then refactor it early next week and have it ready for the next release.