### PR TITLE
[Hotfix] Fix unnecessary setting of showTotal with natural scrolling

### DIFF
--- a/website/static/js/fileViewTreebeard.js
+++ b/website/static/js/fileViewTreebeard.js
@@ -67,7 +67,9 @@ function FileViewTreebeard(data) {
         ontogglefolder : function (tree) {
             Fangorn.DefaultOptions.ontogglefolder.call(this, tree);
             var containerHeight = this.select('#tb-tbody').height();
-            this.options.showTotal = Math.floor(containerHeight / this.options.rowHeight) + 1;
+            if (!this.options.naturalScrollLimit){
+                this.options.showTotal = Math.floor(containerHeight / this.options.rowHeight) + 1;
+            }
             this.redraw();
         },
         lazyLoadOnLoad: function(tree, event) {


### PR DESCRIPTION
## Purpose
Fixes the regression bug reported in Trello: https://trello.com/c/sg9bu0Hx

## Changes
Surround old showTotal code with check to see if natural scroll limit is on so that showTotal doesn't get set if Treebeard is using natural scroll.

## Side effects
None. 