### PR TITLE
allow admin on parent project to watch the private component

### DIFF
--- a/website/static/js/nodeControl.js
+++ b/website/static/js/nodeControl.js
@@ -137,7 +137,7 @@ var ProjectViewModel = function(data) {
     });
 
     self.canBeOrganized = ko.pureComputed(function() {
-        return !!(self.user.username && (self.nodeIsPublic || self.user.is_contributor));
+        return !!(self.user.username && (self.nodeIsPublic || self.user.has_read_permissions));
     });
 
     // Add icon to title

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -61,7 +61,7 @@
                     <!-- /ko -->
                     <div class="btn-group">
                         <a
-                        % if user_name and (node['is_public'] or user['is_contributor']) and not node['is_registration']:
+                        % if user_name and (node['is_public'] or user['has_read_permissions']) and not node['is_registration']:
                             data-bind="click: toggleWatch, tooltip: {title: watchButtonAction, placement: 'bottom'}"
                             class="btn btn-default"
                         % else:


### PR DESCRIPTION
<b>Purpose</b>
Fix the problem that admin contributor on parent project can't watch the private component or add the private component to their project organizor. Solves https://github.com/CenterForOpenScience/osf.io/issues/2715.


<b>Changes</b>
After change:
![screen shot 2015-05-18 at 3 22 08 pm](https://cloud.githubusercontent.com/assets/4974056/7688337/b1d5a01e-fd71-11e4-9e7d-9768ebab458c.png)
