### PR TITLE
[Feature] Improve upload row feedback

### DIFF
--- a/website/static/css/fangorn.css
+++ b/website/static/css/fangorn.css
@@ -53,6 +53,9 @@ text-align: center;
 	background: #337AB7;
 	color: #FFF;
 }
+.fangorn-selected .text-muted {
+    color: #eeeeee;
+}
 .fangorn-selected a {
 	color : white;
 }
@@ -118,6 +121,10 @@ text-align: center;
     padding-top: 4px;
 }
 
+.tb-row .progress {
+    height: 12px;
+    margin-top: 5px;
+}
 .tb-expand-icon-holder {
 	cursor: default;
 }

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -283,20 +283,22 @@ function _fangornUploadProgress(treebeard, file, progress) {
         }
         if(child.data.tmpID === file.tmpID) {
             item = child;
+            item.uploadState = 'uploading';
+            item.progress = progress;
         }
     }
-    templateWithCancel = m('span', [
-        cancelUploadTemplate.call(treebeard, item),
-        m('span', file.name.slice(0,25) + '... : ' + 'Uploaded ' + Math.floor(progress) + '%'),
-    ]);
-    templateWithoutCancel = m('span', [
-        m('span', file.name.slice(0,25) + '... : ' + 'Upload Successful'),
-    ]);
-    if (progress < 100) {
-        item.notify.update(templateWithCancel, 'success', null, 0);
-    } else {
-        item.notify.update(templateWithoutCancel, 'success', null, 2000);
-    }
+    //templateWithCancel = m('span', [
+    //    cancelUploadTemplate.call(treebeard, item),
+    //    m('span', file.name.slice(0,25) + '... : ' + 'Uploaded ' + Math.floor(progress) + '%'),
+    //]);
+    //templateWithoutCancel = m('span', [
+    //    m('span', file.name.slice(0,25) + '... : ' + 'Upload Successful'),
+    //]);
+    //if (progress < 100) {
+    //    item.notify.update(templateWithCancel, 'success', null, 0);
+    //} else {
+    //    item.notify.update(templateWithoutCancel, 'success', null, 2000);
+    //}
 }
 
 /**
@@ -350,7 +352,8 @@ function _fangornAddedFile(treebeard, file) {
             view: false,
             edit: false
         },
-        tmpID: tmpID
+        tmpID: tmpID,
+        uploadState : 'pending'
     };
     var newitem = treebeard.createItem(blankItem, item.id);
     return configOption || null;

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -314,18 +314,7 @@ function _fangornUploadProgress(treebeard, file, progress) {
             item.data.uploadState('uploading');
         }
     }
-    //templateWithCancel = m('span', [
-    //    cancelUploadTemplate.call(treebeard, item),
-    //    m('span', file.name.slice(0,25) + '... : ' + 'Uploaded ' + Math.floor(progress) + '%'),
-    //]);
-    //templateWithoutCancel = m('span', [
-    //    m('span', file.name.slice(0,25) + '... : ' + 'Upload Successful'),
-    //]);
-    //if (progress < 100) {
-    //    item.notify.update(templateWithCancel, 'success', null, 0);
-    //} else {
-    //    item.notify.update(templateWithoutCancel, 'success', null, 2000);
-    //}
+    m.redraw();
 }
 
 /**

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1762,7 +1762,8 @@ Fangorn.Utils = {
     setCurrentFileID: setCurrentFileID,
     scrollToFile: scrollToFile,
     openParentFolders : _openParentFolders,
-    dismissToolbar : _dismissToolbar
+    dismissToolbar : _dismissToolbar,
+    uploadRowTemplate : uploadRowTemplate
 };
 
 Fangorn.DefaultOptions = tbOptions;

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -118,7 +118,7 @@ var uploadRowTemplate = function(item){
                             e.stopImmediatePropagation();
                             cancelUploads.call(tb, item);
                         }},
-                     m('span.text-danger','×')
+                     m('span.text-muted','×')
                 )),
             ]),
 

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -858,6 +858,7 @@ function _fangornTitleColumn(item, col) {
  * @private
  */
 function _fangornResolveRows(item) {
+    var tb = this;
     var default_columns = [];
     var configOption;
     item.css = '';
@@ -865,19 +866,10 @@ function _fangornResolveRows(item) {
         item.css = 'fangorn-selected';
     }
 
-    if(item.data.tmpID){
-        return [
-        {
-            data : '',  // Data field name
-            css : 't-a-c',
-            custom : function(){ return m('span.text-muted', [m('span', cancelUploadTemplate.call(this, item)), m('span', item.data.name.slice(0,25) + '... : ' + 'Upload pending.')]); }
-        },
-        {
-            data : '',  // Data field name
-            custom : function(){ return '';}
-        }
-        ];
+    if(item.data.uploadState && (item.data.uploadState() === 'pending' || item.data.uploadState() === 'uploading')){
+        return uploadRowTemplate.call(tb, item);
     }
+
     if (item.parentID) {
         item.data.permissions = item.data.permissions || item.parent().data.permissions;
         if (item.data.kind === 'folder') {

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -283,8 +283,8 @@ function _fangornUploadProgress(treebeard, file, progress) {
         }
         if(child.data.tmpID === file.tmpID) {
             item = child;
-            item.uploadState = 'uploading';
-            item.progress = progress;
+            item.data.progress = progress;
+            item.data.uploadState('uploading');
         }
     }
     //templateWithCancel = m('span', [
@@ -353,7 +353,7 @@ function _fangornAddedFile(treebeard, file) {
             edit: false
         },
         tmpID: tmpID,
-        uploadState : 'pending'
+        uploadState : m.prop('pending')
     };
     var newitem = treebeard.createItem(blankItem, item.id);
     return configOption || null;
@@ -447,6 +447,7 @@ function _fangornDropzoneSuccess(treebeard, file, response) {
     }
     if (item.data.tmpID) {
         item.data.tmpID = null;
+        item.data.uploadState('completed');
     }
     // Remove duplicates if file was updated
     var status = file.xhr.status;

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -90,20 +90,47 @@ function cancelUploads (row) {
     tb.isUploading(false);
 }
 
-var cancelUploadTemplate = function(row){
-    var treebeard = this;
-    return m('.btn.m-l-sm.text-muted', {
-            config : function() {
-                reapplyTooltips();
-            },
-            'onclick' : function (e) {
-                e.stopImmediatePropagation();
-                cancelUploads.call(treebeard, row);
-            }},
-        m('.fa.fa-times-circle.text-danger', {
-            style : 'display:block;font-size:18px; margin-top: -4px;',
-        }, '')
-    );
+var uploadRowTemplate = function(item){
+    var tb = this;
+    var progress = item.data.uploadState() === 'pending' ? 0 : Math.floor(item.data.progress);
+    var columns = [{
+        data : '',  // Data field name
+        css : '',
+        custom : function(){ return m('row.text-muted', [
+            m('.col-xs-7', {style: 'padding-left:40px;overflow: hidden;text-overflow: ellipsis;'}, item.data.name),
+            m('.col-xs-3',
+                m('.progress', [
+                    m('.progress-bar.progress-bar-info.progress-bar-striped', {
+                        role : 'progressbar',
+                        'aria-valuenow' : progress,
+                        'aria-valuemin' : '0',
+                        'aria-valuemax': '100',
+                        'style':'width: ' + progress + '%' }, m('span.sr-only', progress + '% Complete'))
+                ])
+            ),
+            m('.col-xs-2', [
+                m('span', m('.fangorn-toolbar-icon.m-l-sm', {
+                        style : 'padding: 0px 6px 2px 2px;font-size: 16px;display: inline;',
+                        config : function() {
+                            reapplyTooltips();
+                        },
+                        'onclick' : function (e) {
+                            e.stopImmediatePropagation();
+                            cancelUploads.call(tb, item);
+                        }},
+                     m('span.text-danger','×')
+                )),
+            ]),
+
+        ]); }
+    }];
+    if(tb.options.placement === 'files'){
+        columns.push({
+            data : '',  // Data field name
+            custom : function(){ return '';}
+        });
+    }
+    return columns;
 };
 
 /**

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1552,6 +1552,7 @@ tbOptions = {
     resolveRows : _fangornResolveRows,
     hoverClassMultiselect : 'fangorn-selected',
     multiselect : true,
+    placement : 'files',
     title : function() {
         //TODO Add disk saving mode message
         // if(window.contextVars.diskSavingMode) {

--- a/website/static/js/pages/project-dashboard-page.js
+++ b/website/static/js/pages/project-dashboard-page.js
@@ -73,6 +73,7 @@ $(document).ready(function () {
                 ];
             },
             resolveRows : function (item) {
+                var tb = this;
                 if(this.isMultiselected(item.id)){
                     item.css = 'fangorn-selected';
                 }
@@ -89,15 +90,8 @@ $(document).ready(function () {
                         item.data.accept = item.data.accept || item.parent().data.accept;
                     }
                 }
-                if (item.data.tmpID) {
-                    defaultColumns = [
-                        {
-                            data : 'name',  // Data field name
-                            folderIcons : true,
-                            filter : true,
-                            custom : function () { return m('span.text-muted', 'Uploading ' + item.data.name + '...'); }
-                        }
-                    ];
+                if(item.data.uploadState && (item.data.uploadState() === 'pending' || item.data.uploadState() === 'uploading')){
+                    return Fangorn.Utils.uploadRowTemplate.call(tb, item);
                 }
 
                 var configOption = Fangorn.Utils.resolveconfigOption.call(this, item, 'resolveRows', [item]);


### PR DESCRIPTION
## Purpose
As files are uploaded to OSF the existing feedback system had a few problems
- It's application state for uploads was not reliable (it was switching back to pending after success)
- The alignment was off between notification and native row drawing
- Placement of cancel buttons for upload was not on the right. 

This PR aims to bring a better UI to the upload experience by setting proper states, showing a progress bar and improving the cancel upload button while maintaining responsive design.

## Changes
- Upload html is now native to the resolverow function, i.e. not using notification for upload. 
- Template for upload rows is separated to be reused so the code is not repeated
- upload state is set where it should be
- Progress bar is added

## Side effects
Project Dashboard is properly taken care of and upload is not possible in other Treebeard instances so there shouldn't be any side effect. Tested in Chrome, Firefox, Safari.   

![screen shot 2015-05-18 at 4 40 11 pm](https://cloud.githubusercontent.com/assets/1314003/7689870/855e5092-fd7d-11e4-9199-881923e9fb2a.png)
