### PR TITLE
[Fix] [Treebeard] Smooth scrolling in TB

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "raw-loader": "^0.5.1",
     "share": "~0.7.3",
     "style-loader": "^0.8.3",
-    "treebeard": "git://github.com/caneruguz/treebeard.git#ab9a52aa151060a61b14325fb24bc5002e21084f",
+    "treebeard": "git://github.com/caneruguz/treebeard.git#fdeb82d4937c4ecd72b85e10c361fadd33079713",
     "typeahead.js": "^0.10.5",
     "url-loader": "^0.5.5",
     "webpack": "^1.7.2",

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1691,8 +1691,7 @@ tbOptions = {
         var item = tb.find(row.id);
         _fangornMultiselect.call(tb,null,item);
     },
-    hScroll : 400,
-    naturalScrollLimit : 1000
+    hScroll : 400
 };
 
 /**


### PR DESCRIPTION
## Purpose
After the failure of the high number natural scroll it seemed worthwhile to try to fix actual virtual scrolling. It turns out this is related to wrong assignment of top margin in Treebeard. This PR updates OSF to use the latest TB commit and use it's default natural scroll limit number which is 50.

https://github.com/caneruguz/treebeard/commit/fdeb82d4937c4ecd72b85e10c361fadd33079713

## Changes
Package.json version for TB is changed
NaturalScrollLimit option is removed from fangorn.

## Side effects
None. 

@sloria