### PR TITLE
[hotfix] claiming users

### DIFF
--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -262,6 +262,7 @@ class User(GuidStoredObject, AddonModelMixin):
     #       'referrer_id': <user ID of referrer>,
     #       'token': <token used for verification urls>,
     #       'email': <email the referrer provided or None>,
+    #       'claimer_email': <email the claimer entered or None>,
     #       'last_sent': <timestamp of last email sent to referrer or None>
     #   }
     #   ...

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1820,7 +1820,7 @@ class TestClaimViews(OsfTestCase):
         url = '/user/{uid}/{pid}/claim/?token=badtoken'.format(**locals())
         res = self.app.get(url, expect_errors=True).maybe_follow()
         assert_equal(res.status_code, 200)
-        assert_equal(res.request.path, '/account/')
+        assert_equal(res.request.path, web_url_for('auth_login'))
 
     def test_posting_to_claim_form_with_valid_data(self):
         url = self.user.get_claim_url(self.project._primary_key)

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2014,7 +2014,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
                     self.add_permission(new, permission)
                 self.permissions.pop(old._id)
                 if old._id in self.visible_contributor_ids:
-                    self.visible_contributor_ids.remove(old._id)
+                    self.visible_contributor_ids[self.visible_contributor_ids.index(old._id)] = new._id
                 return True
         return False
 

--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -623,7 +623,8 @@ def claim_user_form(auth, **kwargs):
     unclaimed_record = user.unclaimed_records[pid]
     user.fullname = unclaimed_record['name']
     user.update_guessed_names()
-    claimer_email = unclaimed_record['claimer_email']
+    # The email can be the original referrer email if no claimer email has been specified.
+    claimer_email = unclaimed_record.get('claimer_email') or unclaimed_record.get('email')
     form = SetEmailAndPasswordForm(request.form, token=token)
     if request.method == 'POST':
         if form.validate():

--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -240,7 +240,7 @@ def project_removecontributor(auth, node, **kwargs):
     if outcome:
         if auth.user == contributor:
             status.push_status_message('Removed self from project', 'info')
-            return {'redirectUrl': '/dashboard/'}
+            return {'redirectUrl': web_url_for('dashboard')}
         status.push_status_message('Contributor removed', 'info')
         return {}
 
@@ -411,7 +411,7 @@ def send_claim_registered_email(claimer, unreg_user, node, throttle=24 * 3600):
             message_long='User account can only be claimed with an existing user once every 24 hours'
         ))
     unclaimed_record['token'] = generate_confirm_token()
-    unclaimed_record['email'] = claimer.username
+    unclaimed_record['claimer_email'] = claimer.username
     unreg_user.save()
     referrer = User.load(unclaimed_record['referrer_id'])
     claim_url = web_url_for(
@@ -456,15 +456,17 @@ def send_claim_email(email, user, node, notify=True, throttle=24 * 3600):
         emailed during which the referrer will not be emailed again.
 
     """
-    invited_email = email.lower().strip()
+    claimer_email = email.lower().strip()
 
     unclaimed_record = user.get_unclaimed_record(node._primary_key)
     referrer = User.load(unclaimed_record['referrer_id'])
     claim_url = user.get_claim_url(node._primary_key, external=True)
     # If given email is the same provided by user, just send to that email
-    if unclaimed_record.get('email') == invited_email:
+    if unclaimed_record.get('email') == claimer_email:
         mail_tpl = mails.INVITE
-        to_addr = invited_email
+        to_addr = claimer_email
+        unclaimed_record['claimer_email'] = claimer_email
+        user.save()
     else:  # Otherwise have the referrer forward the email to the user
         # roll the valid token for each email, thus user cannot change email and approve a different email address
         timestamp = unclaimed_record.get('last_sent')
@@ -474,13 +476,13 @@ def send_claim_email(email, user, node, notify=True, throttle=24 * 3600):
             ))
         unclaimed_record['last_sent'] = get_timestamp()
         unclaimed_record['token'] = generate_confirm_token()
-        unclaimed_record['email'] = email
+        unclaimed_record['claimer_email'] = claimer_email
         user.save()
         claim_url = user.get_claim_url(node._primary_key, external=True)
         if notify:
             pending_mail = mails.PENDING_VERIFICATION
             mails.send_mail(
-                invited_email,
+                claimer_email,
                 pending_mail,
                 user=user,
                 referrer=referrer,
@@ -496,7 +498,7 @@ def send_claim_email(email, user, node, notify=True, throttle=24 * 3600):
         referrer=referrer,
         node=node,
         claim_url=claim_url,
-        email=invited_email,
+        email=claimer_email,
         fullname=unclaimed_record['name']
     )
     return to_addr
@@ -617,21 +619,21 @@ def claim_user_form(auth, **kwargs):
         raise HTTPError(http.BAD_REQUEST)
     # If claim token not valid, redirect to registration page
     if not verify_claim_token(user, token, pid):
-        return redirect('/account/')
+        return redirect(web_url_for('auth_login'))
     unclaimed_record = user.unclaimed_records[pid]
     user.fullname = unclaimed_record['name']
     user.update_guessed_names()
-    email = unclaimed_record['email']
+    claimer_email = unclaimed_record['claimer_email']
     form = SetEmailAndPasswordForm(request.form, token=token)
     if request.method == 'POST':
         if form.validate():
-            username, password = email, form.password.data
+            username, password = claimer_email, form.password.data
             user.register(username=username, password=password)
             # Clear unclaimed records
             user.unclaimed_records = {}
             user.save()
             # Authenticate user and redirect to project page
-            response = redirect('/settings/')
+            response = redirect(web_url_for('user_profile'))
             node = Node.load(pid)
             status.push_status_message(language.CLAIMED_CONTRIBUTOR.format(node=node),
                 'success')
@@ -640,7 +642,7 @@ def claim_user_form(auth, **kwargs):
             forms.push_errors_to_status(form.errors)
     return {
         'firstname': user.given_name,
-        'email': email if email else '',
+        'email': claimer_email if claimer_email else '',
         'fullname': user.fullname,
         'form': forms.utils.jsonify(form) if is_json_request() else form,
     }
@@ -691,7 +693,7 @@ def claim_user_post(node, **kwargs):
     if 'value' in reqdata:  # Submitted email address
         email = reqdata['value'].lower().strip()
         claimer = get_user(email=email)
-        if claimer:
+        if claimer and claimer.is_registered:
             send_claim_registered_email(claimer=claimer, unreg_user=user,
                 node=node)
         else:

--- a/website/static/js/accountClaimer.js
+++ b/website/static/js/accountClaimer.js
@@ -23,7 +23,8 @@ function AccountClaimer (selector) {
 function getClaimUrl() {
     var uid = $(this).data('pk');
     var pid = global.nodeId;
-    return '/api/v1/user/' + uid + '/' + pid +  '/claim/email/';
+    var viewOnlyToken = $osf.urlParams().view_only;
+    return '/api/v1/user/' + uid + '/' + pid +  '/claim/email/' + (viewOnlyToken ? '?view_only=' + viewOnlyToken : '');
 }
 
 function alertFinished(email) {
@@ -77,7 +78,7 @@ AccountClaimer.prototype = {
                 success: function(data) {
                     alertFinished(data.email);
                 },
-                error: $osf.handleEditableError,
+                error: $osf.handleJSONError,
                 display: function(value, sourceData){
                     if (sourceData && sourceData.fullname) {
                         $(this).text(sourceData.fullname);


### PR DESCRIPTION
* store `claimer_email` separate from `email` when claiming accounts, `email` being provided explicitly by the `referrer`
* allow user account claiming from `view_only` links
* properly email claimers w/ a direct invitation/sign up link when they enter the same `claimer_email` the `referrer` entered