### PR TITLE
Hotfix/mobileFixes

### DIFF
--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -2072,6 +2072,15 @@ span#profileFullname{
         text-decoration: none !important;
         padding: 14px;
     }
+     .navbar-brand {
+        margin-left: 0 !important;
+        height: 48px !important;
+        line-height: 27px !important;
+        padding: 11px 15px 10px 15px !important;
+    }
+    .osf-navbar-logo {
+        margin-top: 0px !important;
+    }
 }
 
 @media (min-width: 768px) {

--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -1770,6 +1770,7 @@ div.profile-fullname{
 span#profileFullname{
     position: absolute;
     bottom: 0;
+    margin-bottom: 20px;
 }
 
 .scripted {display: none;}
@@ -1858,15 +1859,22 @@ span#profileFullname{
     background: rgba(187, 187, 187, 0.2);
 }
 .osf-navbar .navbar-nav>li>a {
-    padding-top: 9px;
-    padding-bottom: 6px;
-    line-height: 24px;
+    padding-top: 8px;
+    padding-bottom: 7px;
+    line-height: 27px;
 }
 
+/*.navbar-brand {*/
+    /*height: 42px;*/
+    /*line-height: 14px;*/
+    /*padding:13px 15px;*/
+/*}*/
+
 .navbar-brand {
-    height: 42px;
-    line-height: 14px;
-    padding:13px 15px;
+    margin-left: 0 !important;
+    height: 42px !important;
+    line-height: 27px !important;
+    padding: 8px 15px 7px 15px !important;
 }
 
 .osf-navbar .navbar-form {
@@ -1885,9 +1893,10 @@ span#profileFullname{
     background-color: white;
 }
 
-.navbar-mid>li>a{
-    padding-bottom: 8px !important;
-}
+/*.navbar-mid>li>a{*/
+    /*padding-top: 8px !important;*/
+    /*padding-bottom: 7px !important;*/
+/*}*/
 
 .icon-lg {
     font-size: 20px;
@@ -1897,7 +1906,7 @@ span#profileFullname{
 .osf-navbar-logo {
     float: left;
     margin-right: 8px;
-    margin-top: -7px;
+    /*margin-top: -7px;*/
 }
 
 .osf-navbar .navbar-nav>li>a.btn {
@@ -1911,6 +1920,7 @@ span#profileFullname{
     border: 1px solid #CDCDCD;
     border-radius: 13px;
     margin-right: 5px;
+    margin-top: -2px;
 }
 
 
@@ -2073,13 +2083,14 @@ span#profileFullname{
         padding: 14px;
     }
      .navbar-brand {
-        margin-left: 0 !important;
-        height: 48px !important;
-        line-height: 27px !important;
         padding: 11px 15px 10px 15px !important;
     }
     .osf-navbar-logo {
         margin-top: 0px !important;
+    }
+    span#profileFullname{
+        font-size: 20px;
+        margin-bottom: 30px;
     }
 }
 

--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -737,10 +737,6 @@ table.table.table-plain th, table.table.table-plain td {
   border-top: 0px solid #ddd;
 }
 
-.table-row {
-    margin-top: 10px;
-}
-
 ul#projects-list{
     list-style-image:url('/static/img/folder.gif');
     width:210px;

--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -737,6 +737,10 @@ table.table.table-plain th, table.table.table-plain td {
   border-top: 0px solid #ddd;
 }
 
+.table-row {
+    margin-top: 10px;
+}
+
 ul#projects-list{
     list-style-image:url('/static/img/folder.gif');
     width:210px;

--- a/website/templates/profile.mako
+++ b/website/templates/profile.mako
@@ -38,43 +38,30 @@
 <div class="row">
 
     <div class="col-sm-6">
-        <div class="row">
-            <div class="col-xs-4">
-                <span>Name</span>
-            </div>
-            <div class="col-xs-8">
-                <span>${profile["fullname"]}</span>
-            </div>
-        </div>
-        % if profile.get('date_registered'):
-            <div class="row table-row">
-                <div class="col-xs-4">
-                    <span>Member&nbsp;Since</span>
-                </div>
-                <div class="col-xs-8">
-                    <span>${profile['date_registered']}</span>
-                </div>
-            </div>
-        % endif
-        % if profile.get('url') and profile.get('display_absolute_url'):
-            <div class="row table-row">
-                <div class="col-xs-4">
-                    <span>Public&nbsp;Profile</span>
-                </div>
-                <div class="col-xs-8">
-                    <span><a href="${profile['url']}">${profile['display_absolute_url']}</a></span>
-                </div>
-            </div>
-        % endif
-
-        <div>
-            <h2>
-               ${profile['activity_points'] or "No"} activity point${'s' if profile['activity_points'] != 1 else ''}<br />
-               ${profile["number_projects"]} project${'s' if profile["number_projects"] != 1  else ''}, ${profile["number_public_projects"]} public
-            </h2>
-        </div>
-
+        <table class="table table-plain">
+            <tr>
+              <td>Name</td>
+              <td class="fullname" width="300px">${profile["fullname"]}</td>
+            </tr>
+            % if profile.get('date_registered'):
+                <tr>
+                    <td>Member&nbsp;Since</td>
+                    <td>${profile['date_registered']}</td>
+                </tr>
+            % endif
+            % if profile.get('url') and profile.get('display_absolute_url'):
+                <tr>
+                    <td>Public&nbsp;Profile</td>
+                    <td><a href="${profile['url']}">${profile['display_absolute_url']}</a></td>
+                </tr>
+            % endif
+        </table>
+        <h2>
+           ${profile['activity_points'] or "No"} activity point${'s' if profile['activity_points'] != 1 else ''}<br />
+           ${profile["number_projects"]} project${'s' if profile["number_projects"] != 1  else ''}, ${profile["number_public_projects"]} public
+        </h2>
     </div>
+</div>
 
     <div class="col-sm-6">
 

--- a/website/templates/profile.mako
+++ b/website/templates/profile.mako
@@ -47,7 +47,7 @@
             </div>
         </div>
         % if profile.get('date_registered'):
-            <div class="row">
+            <div class="row table-row">
                 <div class="col-xs-4">
                     <span>Member&nbsp;Since</span>
                 </div>
@@ -57,7 +57,7 @@
             </div>
         % endif
         % if profile.get('url') and profile.get('display_absolute_url'):
-            <div class="row">
+            <div class="row table-row">
                 <div class="col-xs-4">
                     <span>Public&nbsp;Profile</span>
                 </div>

--- a/website/templates/profile.mako
+++ b/website/templates/profile.mako
@@ -38,35 +38,41 @@
 <div class="row">
 
     <div class="col-sm-6">
-
-
-        <div>
-            <table class="table table-plain">
-                <tr>
-                  <td>Name</td>
-                  <td class="fullname overflow-block" width="300px">${profile["fullname"]}</td>
-                </tr>
-                % if profile.get('date_registered'):
-                    <tr>
-                        <td>Member&nbsp;Since</td>
-                        <td>${profile['date_registered']}</td>
-                    </tr>
-                % endif
-                % if profile.get('url') and profile.get('display_absolute_url'):
-                    <tr>
-                        <td>Public&nbsp;Profile</td>
-                        <td><a href="${profile['url']}">${profile['display_absolute_url']}</a></td>
-                    </tr>
-                % endif
-            </table>
+        <div class="row">
+            <div class="col-xs-4">
+                <span>Name</span>
+            </div>
+            <div class="col-xs-8">
+                <span>${profile["fullname"]}</span>
+            </div>
         </div>
+        % if profile.get('date_registered'):
+            <div class="row">
+                <div class="col-xs-4">
+                    <span>Member&nbsp;Since</span>
+                </div>
+                <div class="col-xs-8">
+                    <span>${profile['date_registered']}</span>
+                </div>
+            </div>
+        % endif
+        % if profile.get('url') and profile.get('display_absolute_url'):
+            <div class="row">
+                <div class="col-xs-4">
+                    <span>Public&nbsp;Profile</span>
+                </div>
+                <div class="col-xs-8">
+                    <span><a href="${profile['url']}">${profile['display_absolute_url']}</a></span>
+                </div>
+            </div>
+        % endif
+
         <div>
             <h2>
                ${profile['activity_points'] or "No"} activity point${'s' if profile['activity_points'] != 1 else ''}<br />
                ${profile["number_projects"]} project${'s' if profile["number_projects"] != 1  else ''}, ${profile["number_public_projects"]} public
             </h2>
         </div>
-
 
     </div>
 

--- a/website/templates/profile.mako
+++ b/website/templates/profile.mako
@@ -61,8 +61,6 @@
            ${profile["number_projects"]} project${'s' if profile["number_projects"] != 1  else ''}, ${profile["number_public_projects"]} public
         </h2>
     </div>
-</div>
-
     <div class="col-sm-6">
 
 


### PR DESCRIPTION
Purpose
-----------
These fixes close #2781, #2773, and #2260.  Prior to these fixes, certain elements were not centered in the navbar and the navbar was also wider than it should be on the "Profile" page when on mobile.  Also, the name header on the "Profile page" for mobile was getting obscured/overlapping links previously and this addresses that.  This PR cleans up these misaligned UI elements to create a smoother user experience.

Changes
-----------
* Adjusted line height of the text next to the logo/gravatar to make sure that it was centered with the image
* Adjusted the padding/margins on the images so that they vertically center
* Changed the size of the font and the margins of the name header on the "Profile" page so that the name fits better.
* Removed a class from the table on the "Profile" page that does not seem to do anything other than make the table too wide

Side Effects
----------------
Many of the changes could be made without any performance issues between the full site and the mobile site.   Anything that needed to be different on the two was done using @media tags in the CSS so it would not have any side effects on the other.  Tested on Chrome, Firefox, and Safari.