### PR TITLE
[feature fix]Feature/allow special characters in contributor search

### DIFF
--- a/tests/test_elastic.py
+++ b/tests/test_elastic.py
@@ -438,6 +438,40 @@ class TestAddContributor(SearchTestCase):
         assert_equal(len(contribs['users']), 0)
 
 
+    def test_search_fullname_special_character(self):
+        """Verify that searching for a fullname with a special character yields
+        exactly one result.
+        
+        """
+        contribs = search.search_contributor(self.name3)
+        assert_equal(len(contribs['users']), 1)
+
+        contribs = search.search_contributor(self.name4)
+        assert_equal(len(contribs['users']), 0)
+
+    def test_search_firstname_special_charcter(self):
+        """Verify that searching for a first name with a special character yields
+        exactly one result.
+        
+        """
+        contribs = search.search_contributor(self.name3.split(' ')[0])
+        assert_equal(len(contribs['users']), 1)
+        
+        contribs = search.search_contributor(self.name4.split(' ')[0])
+        assert_equal(len(contribs['users']), 0)
+
+    def test_search_partial_special_character(self):
+        """Verify that searching for a partial name with a special character yields
+        exctly one result.
+        
+        """
+        contribs = search.search_contributor(self.name3.split(' ')[0][:-1])
+        assert_equal(len(contribs['users']), 1)
+                    
+        contribs = search.search_contributor(self.name4.split(' ')[0][:-1])
+        assert_equal(len(contribs['users']), 0)
+
+
 class TestSearchExceptions(OsfTestCase):
     """
     Verify that the correct exception is thrown when the connection is lost

--- a/tests/test_elastic.py
+++ b/tests/test_elastic.py
@@ -387,7 +387,10 @@ class TestAddContributor(SearchTestCase):
         super(TestAddContributor, self).setUp()
         self.name1 = 'Roger1 Taylor1'
         self.name2 = 'John2 Deacon2'
+        self.name3 = u'j\xc3\xb3ebert3 Smith3'
+        self.name4 = u'B\xc3\xb3bbert4 Jones4'
         self.user = UserFactory(fullname=self.name1)
+        self.user3 = UserFactory(fullname=self.name3)
 
     def test_unreg_users_dont_show_in_search(self):
         unreg = UnregUserFactory()

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -358,7 +358,11 @@ def search_contributor(query, page=0, size=10, exclude=[], current_user=None):
 
     normalized_items=  []
     for item in items:
-        normalized_item = unicodedata.normalize('NFKD', six.u(item)).encode('ascii', 'ignore')
+        try:
+            normalized_item = six.u(item)
+        except TypeError:
+            normalized_item = item
+        normalized_item = unicodedata.normalize('NFKD', normalized_item).encode('ascii', 'ignore')
         normalized_items.append(normalized_item)
     items = normalized_items
     

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -355,6 +355,13 @@ def search_contributor(query, page=0, size=10, exclude=[], current_user=None):
     """
     start = (page * size)
     items = re.split(r'[\s-]+', query)
+
+    normalized_items=  []
+    for item in items:
+        normalized_item = unicodedata.normalize('NFKD', six.u(item)).encode('ascii', 'ignore')
+        normalized_items.append(normalized_item)
+    items = normalized_items
+    
     query = ''
 
     query = "  AND ".join('{}*~'.format(re.escape(item)) for item in items) + \

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -356,7 +356,7 @@ def search_contributor(query, page=0, size=10, exclude=[], current_user=None):
     start = (page * size)
     items = re.split(r'[\s-]+', query)
 
-    normalized_items=  []
+    normalized_items = []
     for item in items:
         try:
             normalized_item = six.u(item)
@@ -365,7 +365,7 @@ def search_contributor(query, page=0, size=10, exclude=[], current_user=None):
         normalized_item = unicodedata.normalize('NFKD', normalized_item).encode('ascii', 'ignore')
         normalized_items.append(normalized_item)
     items = normalized_items
-    
+
     query = ''
 
     query = "  AND ".join('{}*~'.format(re.escape(item)) for item in items) + \


### PR DESCRIPTION
## Purpose
Currently, when adding a contributor to a project, searching for a name with special characters such as accents yields no results, and logs an error in the console. This PR resolves this issue causing searches to return the relevant users.

## Changes
Given a query with special characters, normalizes each word in that query converting all characters to ascii prior to passing the query to elasticsearch.

Closes Issue https://github.com/CenterForOpenScience/osf.io/issues/2460(https://github.com/CenterForOpenScience/osf.io/issues/2460)