### PR TITLE
[feature fix] Fix draggable addon icons 

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -150,7 +150,7 @@ function _fangornResolveIcon(item) {
 
     if (item.kind === 'folder') {
         if (item.data.iconUrl) {
-            return m('img', {src: item.data.iconUrl, style: {width: '16px', height: 'auto'}});
+            return m('span', {style: {width:'16px', height:'16px', background:'url(' + item.data.iconUrl+ ')', display:'block'}}, '');
         }
         if (!item.data.permissions.view) {
             return privateFolder;
@@ -169,6 +169,7 @@ function _fangornResolveIcon(item) {
 
     icon = getExtensionIconClass(item.data.name);
     if (icon) {
+        alert("Problem");
         return m('div.file-extension', { 'class': icon });
     }
     return m('i.fa.fa-file-text-o');

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -169,7 +169,6 @@ function _fangornResolveIcon(item) {
 
     icon = getExtensionIconClass(item.data.name);
     if (icon) {
-        alert("Problem");
         return m('div.file-extension', { 'class': icon });
     }
     return m('i.fa.fa-file-text-o');


### PR DESCRIPTION
# Purpose

This resolves issue #2263 and issue #2761. The addon icons (i.e. dropbox logo) were able to be clicked on and dragged.

# Changes

The fangorn.js returns a span instead of an img

# Side effects

The icons do not act like pictures.