### PR TITLE
[Feature Fix] Fixed search nodes not updating

### DIFF
--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -966,6 +966,7 @@ class User(GuidStoredObject, AddonModelMixin):
         from website import search
         try:
             search.search.update_user(self)
+            self.update_search_nodes()
         except search.exceptions.SearchUnavailableError as e:
             logger.exception(e)
             log_exception()


### PR DESCRIPTION
Purpose
-----------
Closes #2565.  Previously, the users information would not update in elastic search when they changed it.  This PR addresses and fixes this issue.

Changes
------------
All relevant code was already created, but the "update_search" method in framework/auth/core.py was missing a method call.  Adding this line fixed the issue.

Side effects
---------------
Currently this is being called every time a user changes any information on their profile.  Since not all changes will show up in elastic search (i.e. if they change their employment), this may have some performance issues.  This could be later addressed by making it asynchronous or making the method call only if the user changed information that would show up in elastic search.