### PR TITLE
[Feature Fix] IE search bar placeholder not visible 

### DIFF
--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -2130,6 +2130,16 @@ span#profileFullname{
 }
 
 /* Search bar */
+.search-label-placeholder {
+    position:absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    font-size: 20px;
+    color: #738EA2;
+    font-weight: 300;
+}
+
 .osf-search {
     padding: 10px 0;
     background: #B8ECC0;

--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -2138,6 +2138,7 @@ span#profileFullname{
     font-size: 20px;
     color: #738EA2;
     font-weight: 300;
+    visibility: hidden;
 }
 
 .osf-search {

--- a/website/static/js/navbarControl.js
+++ b/website/static/js/navbarControl.js
@@ -68,9 +68,38 @@ function NavbarControl (selector, data, options) {
     self.init();
 }
 
+/** Only for Search Bar Placeholder -- Allow IE and other browsers to work as the same */
+function placeholder(inputDom, inputLabel) {
+    inputDom.on('input', function () {
+        if (inputDom.val() === '') {
+            inputLabel.css( "visibility", "visible" );
+        } else {
+            inputLabel.css( "visibility", "hidden" );
+        }
+    });
+}
+
+function searchBarPlaceHolderInit() {
+    var inputDom =  $("#searchPageFullBar");
+    var inputLabel =  $('#searchBarLabel');
+    placeholder(inputDom, inputLabel);
+    inputDom.focus();
+
+    //Make sure IE cursor is located at the end of text
+    var $inputVal = inputDom.val();
+    inputDom.val('').val($inputVal);
+
+    //For search page with existing input, make sure placeholder is hidden.
+    if(inputDom.val() !== '' ){
+         inputLabel.css( "visibility", "hidden" );
+    }
+}
+
 NavbarControl.prototype.init = function() {
     var self = this;
     ko.applyBindings(self.viewModel, self.$element[0]);
+    searchBarPlaceHolderInit();
 };
+
 
 module.exports = NavbarControl;

--- a/website/static/js/navbarControl.js
+++ b/website/static/js/navbarControl.js
@@ -81,7 +81,9 @@ function placeholder(inputDom, inputLabel) {
 
 function searchBarPlaceHolderInit() {
     var inputDom =  $("#searchPageFullBar");
-    var inputLabel =  $('#searchBarLabel');
+    var inputLabel =  $("#searchBarLabel");
+    inputDom.attr("placeholder", ""); //Clear the original placeholder
+    inputLabel.css( "visibility", "visible" );
     placeholder(inputDom, inputLabel);
     inputDom.focus();
 
@@ -95,10 +97,19 @@ function searchBarPlaceHolderInit() {
     }
 }
 
+function isIE(userAgent) {
+  userAgent = userAgent || navigator.userAgent;
+  return userAgent.indexOf("MSIE ") > -1 || userAgent.indexOf("Trident/") > -1;
+}
+
+
 NavbarControl.prototype.init = function() {
     var self = this;
     ko.applyBindings(self.viewModel, self.$element[0]);
-    searchBarPlaceHolderInit();
+    if(isIE()){
+        searchBarPlaceHolderInit();
+    }
+    
 };
 
 

--- a/website/templates/search_bar.mako
+++ b/website/templates/search_bar.mako
@@ -3,7 +3,7 @@
         <div class="row">
             <div class="col-md-12">
                 <form class="input-group" data-bind="submit: submit">
-                    <input id="searchPageFullBar" name="search-placeholder" type="text" class="osf-search-input form-control" data-bind="value: query, hasFocus: true">
+                    <input id="searchPageFullBar" name="search-placeholder" type="text" class="osf-search-input form-control" placeholder="Search" data-bind="value: query, hasFocus: true">
                     <label id="searchBarLabel" class="search-label-placeholder" for="search-placeholder">Search</label>
                     <span class="input-group-btn">
                         <button type=button class="btn osf-search-btn" data-bind="click: submit"><i class="fa fa-circle-arrow-right fa-lg"></i></button>

--- a/website/templates/search_bar.mako
+++ b/website/templates/search_bar.mako
@@ -16,30 +16,3 @@
     </div>
 </div>
 
-<script>
-/** Only for Search Bar Placeholder -- Allow IE and other browsers to work as the same */
-function placeholder(inputDom, inputLabel) {
-    inputDom.on('input', function () {
-        if (inputDom.val() === '') {
-            inputLabel.css( "visibility", "visible" );
-        } else {
-            inputLabel.css( "visibility", "hidden" );
-        }
-    });
-}
-$(document).ready(function() {
-    var inputDom =  $("#searchPageFullBar");
-    var inputLabel =  $('#searchBarLabel');
-    placeholder(inputDom, inputLabel);
-    inputDom.focus();
-
-    //Make sure IE cursor is located at the end of text
-    var $inputVal = inputDom.val();
-    inputDom.val('').val($inputVal);
-
-    //For search page with existing input, make sure placeholder is hidden.
-    if(inputDom.val() !== '' ){
-         inputLabel.css( "visibility", "hidden" );
-    }
-});
-</script>

--- a/website/templates/search_bar.mako
+++ b/website/templates/search_bar.mako
@@ -3,7 +3,8 @@
         <div class="row">
             <div class="col-md-12">
                 <form class="input-group" data-bind="submit: submit">
-                    <input id="searchPageFullBar" type="text" class="osf-search-input form-control" placeholder="Search" data-bind="value: query, hasFocus: true">
+                    <input id="searchPageFullBar" name="search-placeholder" type="text" class="osf-search-input form-control" data-bind="value: query, hasFocus: true">
+                    <label id="searchBarLabel" class="search-label-placeholder" for="search-placeholder">Search</label>
                     <span class="input-group-btn">
                         <button type=button class="btn osf-search-btn" data-bind="click: submit"><i class="fa fa-circle-arrow-right fa-lg"></i></button>
                         <button type=button class="btn osf-search-btn" data-bind="click: help"><i class="fa fa-question fa-lg"></i></button>
@@ -14,3 +15,31 @@
         </div>
     </div>
 </div>
+
+<script>
+/** Only for Search Bar Placeholder -- Allow IE and other browsers to work as the same */
+function placeholder(inputDom, inputLabel) {
+    inputDom.on('input', function () {
+        if (inputDom.val() === '') {
+            inputLabel.css( "visibility", "visible" );
+        } else {
+            inputLabel.css( "visibility", "hidden" );
+        }
+    });
+}
+$(document).ready(function() {
+    var inputDom =  $("#searchPageFullBar");
+    var inputLabel =  $('#searchBarLabel');
+    placeholder(inputDom, inputLabel);
+    inputDom.focus();
+
+    //Make sure IE cursor is located at the end of text
+    var $inputVal = inputDom.val();
+    inputDom.val('').val($inputVal);
+
+    //For search page with existing input, make sure placeholder is hidden.
+    if(inputDom.val() !== '' ){
+         inputLabel.css( "visibility", "hidden" );
+    }
+});
+</script>


### PR DESCRIPTION
**Purpose**
Currently, the search bar place holder in IE can't not be shown. Because the default setting for IE is that when input is focused, then it will clear all the place holder. Resolves the #2248 .

**Changes**
I consulted other mainstream websites and found most of them had the same problem. But dropbox's sign-in page doesn't have this issue because it doesn't use placeholder from HTML5. Instead, it uses label tag to achieve the same goal.

So borrowing the same idea, I apply label tag and add the corresponding javascript and css code. 
1. Add search-label-placeholder class into site.css
2. Add label tag at the end of search input tag and assign unique ids to search input and label tags.
3. Add control javascript at the end of search_bar.mako

**Side Effects**
The same placeholder problem also happens in other pages. But since it is a javascript-based solution, Caner suggested me to only apply this solution to the search bar. 

Another question is that I put my javascript code in the mako file. Because it need to be applied every time search bar is loaded. But I am not sure weather this is the standardized  way to do it.

