### PR TITLE
Fixed side menu bar in user profile settings

### DIFF
--- a/website/static/js/pages/profile-settings-page.js
+++ b/website/static/js/pages/profile-settings-page.js
@@ -6,3 +6,22 @@ new profile.Names('#names', ctx.nameUrls, ['edit']);
 new profile.Social('#social', ctx.socialUrls, ['edit']);
 new profile.Jobs('#jobs', ctx.jobsUrls, ['edit']);
 new profile.Schools('#schools', ctx.schoolsUrls, ['edit']);
+
+// Reusable function to fix affix widths to columns.
+function fixAffixWidth() {
+    $('.affix, .affix-top, .affix-bottom').each(function (){
+        var el = $(this);
+        var colsize = el.parent('.affix-parent').width();
+        el.outerWidth(colsize);
+    });
+}
+
+$(document).ready(function() {
+
+    $(window).resize(function () {
+        fixAffixWidth();
+    });
+    $('.profile-page .panel').on('affixed.bs.affix', function () {
+        fixAffixWidth();
+    });
+});

--- a/website/templates/profile/settings.mako
+++ b/website/templates/profile/settings.mako
@@ -2,7 +2,6 @@
 <%def name="title()">Settings</%def>
 <%def name="content()">
 <% from website import settings %>
-<h2 class="page-header">Profile Information</h2>
 
 ## TODO: Review and un-comment
 ##<div class="row">
@@ -16,11 +15,13 @@
 ##    </div>
 ##</div>
 
-<div class="row">
+        <div class="row"  href="#start">
 
-    <div class="col-sm-3">
-        <div class="panel panel-default">
-            <ul class="nav nav-stacked nav-pills">
+    <div class="profile-page">
+
+    <div class="col-sm-3 nav-list-spy">
+        <div class="gs-sidebar hidden-print hidden-xs panel panel-default" data-spy="affix" data-offset-top="60" data-offset-bottom="268" data-target-top="page-header">
+            <ul class="nav nav-stacked nav-pills gs-sidenav" style="min-width: 210px">
                 <li><a href="#">Profile Information</a></li>
                 <li><a href="${ web_url_for('user_account') }">Account Settings</a></li>
                 <li><a href="${ web_url_for('user_addons') }">Configure Add-ons</a></li>
@@ -28,8 +29,10 @@
             </ul>
         </div><!-- end sidebar -->
     </div>
-
     <div class="col-sm-9 col-md-7">
+    <h2>Profile Information</h2>
+
+
 
         <div id="userProfile">
 
@@ -65,7 +68,6 @@
     </div>
 
 </div>
-
 ## TODO: Review and un-comment
 ##<div mod-meta='{
 ##        "tpl": "util/render_keys.mako",
@@ -102,3 +104,4 @@
 </script>
 <script src=${"/static/public/js/profile-settings-page.js" | webpack_asset}></script>
 </%def>
+</div>


### PR DESCRIPTION
Purpose
Currently, the side menu bar in the user profile settings page does not scroll with the rest of the page:
https://github.com/CenterForOpenScience/osf.io/issues/2313
Additionally, I notice that the formatting of the page is different from most as the title is above the menu heading rather than to the left of it.  Here are some examples of the normal format:
https://osf.io/explore/activity/
https://osf.io/getting-started/
https://osf.io/hnim5/settings/

Changes:
Made menu scroll up and down with page and rearranged title.

Side Effects
Fixes scrolling problem and makes page more consistent with website.  However, this might be too dramatic of a change for what you're looking for.  As just a humble intern, I understand that this might be a bit too dramatic for my skill set.  I just want for this format to be considered.  I started this as a hotfix but it may be more of feature suggestion/ discussion item.  If this seems interesting to anybody, I can continue work or pass it off to somebody more knowledgable.