### PR TITLE
[Feature Fix] Profile settings reorder fix

### DIFF
--- a/website/static/vendor/knockout-sortable/knockout-sortable.js
+++ b/website/static/vendor/knockout-sortable/knockout-sortable.js
@@ -351,7 +351,8 @@
         },
         connectClass: ko.bindingHandlers.sortable.connectClass,
         options: {
-            helper: "clone"
+            helper: "clone",
+            tolerance: "pointer"
         }
     };
 

--- a/website/templates/include/profile/jobs.mako
+++ b/website/templates/include/profile/jobs.mako
@@ -8,7 +8,8 @@
                     data: contents,
                     options: {
                         handle: '.sort-handle',
-                        containment: '#containDrag'
+                        containment: '#containDrag',
+                        tolerance: 'pointer'
                     }
                 }">
 

--- a/website/templates/include/profile/schools.mako
+++ b/website/templates/include/profile/schools.mako
@@ -8,7 +8,8 @@
                     data: contents,
                     options: {
                         handle: '.sort-handle',
-                        containment: '#containDrag'
+                        containment: '#containDrag',
+                        tolerance: 'pointer'
                     }
                 }">
 


### PR DESCRIPTION
# Purpose

This resolves issue #1506 . The last and first position reordering for the employment and education tag in Profile Information was non-functional.

# Changes

The the default setting for tolerance of a sortable instance is intersect (elements must overlap more than 50%). That amount of overlap was not possible for the first and last items of the list. Set tolerance to pointer so that the overlap of elements is determined by where the mouse is located on the screen.
Reference: [jQuery UI API] (http://api.jqueryui.com/sortable/#option-tolerance)

# Side effects

The entries are reordered based off of any overlap of the pointer and another entry.