### PR TITLE
Revert third party file to original (knockout-sortable.js)

### DIFF
--- a/website/static/vendor/knockout-sortable/knockout-sortable.js
+++ b/website/static/vendor/knockout-sortable/knockout-sortable.js
@@ -351,8 +351,7 @@
         },
         connectClass: ko.bindingHandlers.sortable.connectClass,
         options: {
-            helper: "clone",
-            tolerance: "pointer"
+            helper: "clone"
         }
     };
 


### PR DESCRIPTION
# Purpose

This is related to PR #2811. The merge included a change to a third party file (knockout-sortable.js).

# Changes

The addition to the third party file was removed.

# Side effects

There should be no side effects.