### PR TITLE
[Feature Fix] 1Password autofill fix

### DIFF
--- a/website/templates/nav.mako
+++ b/website/templates/nav.mako
@@ -81,10 +81,10 @@
                             method="POST"
                         >
                         <div class="form-group">
-                            <input type="email" class="input-sm form-control" data-bind="value: username" name="username" placeholder="Email">
+                            <input type="email" class="input-sm form-control" data-bind="value: username" name="username" placeholder="Email" aria-label="Username">
                         </div>
                         <div class="form-group">
-                            <input type="password" class="input input-sm form-control" data-bind="value: password" name="password" placeholder="Password">
+                            <input type="password" class="input input-sm form-control" data-bind="value: password" name="password" placeholder="Password" aria-label="Password">
                         </div>
                         <button type="submit" class="btn btn-sm btn-success">Sign In</button>
                     </form>


### PR DESCRIPTION
# Purpose

This resolves issue #2517. 1Password was auto-filling the username and password into the wrong fields.

# Changes

Added aria-label to the login username and login password field. 1Password uses labels to determine which fields to fill.

# Side effects

There are no anticipated side-effects.