### PR TITLE
[hold] [Feature] Fixed wording in one of the pre-registration questions

### DIFF
--- a/website/project/metadata/brandt-prereg-1.json
+++ b/website/project/metadata/brandt-prereg-1.json
@@ -42,7 +42,7 @@
                     {"type": "select",   "id": "item22", "label": "The similarities/difference in remuneration are", "options": ["Exact", "Close", "Different"], "caption": "Choose..."},
                     {"type": "select",   "id": "item23", "label": "The similarities/differences between participant populations are", "options": ["Exact", "Close", "Different"], "caption": "Choose..."},
                     {"type": "textarea", "id": "item24", "label": "What differences between the original study and your study might be expected to influence the size and/or direction of the effect?"},
-                    {"type": "textarea", "id": "item25", "label": "I have taken the following steps to test whether the differences listed in #22 will influence the outcome of my replication attempt"}
+                    {"type": "textarea", "id": "item25", "label": "I have taken the following steps to test whether the differences listed in the previous question will influence the outcome of my replication attempt"}
                 ]
             },
             {


### PR DESCRIPTION
Purpose
----------
Closes #2679.  The question was referencing another question by number but the questions were not numbered.

Changes
------------
Used http://www.sciencedirect.com/science/article/pii/S0022103113001819 as a reference to determine that, in addition to their being a number where there shouldn't be, it was referencing the wrong question.  This was remedied by changing the wording to say "the previous question" instead of using a number.

Side Effects
--------------
There should be no side effects from this since the only thing that changed was text.