### PR TITLE
Fixed error with tags not working with symbols and apostrophes

### DIFF
--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -25,6 +25,7 @@ class TestSanitize(unittest.TestCase):
     def test_clean_tag(self):
         assert_equal(
             sanitize.clean_tag('\'\'\'\'\'"""""""<script></script>'),
+            '&#39;&#39;&#39;&#39;&#39;'
             '&quot;&quot;&quot;&quot;&quot;&quot;&quot;'
                 '&lt;script&gt;&lt;/script&gt;',
         )

--- a/website/project/views/tag.py
+++ b/website/project/views/tag.py
@@ -2,6 +2,7 @@ import httplib as http
 
 from modularodm.exceptions import ValidationError
 
+from flask import request
 from framework.auth.decorators import collect_auth
 from website.util.sanitize import clean_tag
 from website.project.model import Tag
@@ -33,8 +34,9 @@ def project_tag(tag, auth, **kwargs):
 @must_have_permission('write')
 @must_not_be_registration
 def project_addtag(auth, node, **kwargs):
+    data = request.get_json()
+    tag = clean_tag(data["tag"])
 
-    tag = clean_tag(kwargs['tag'])
     if tag:
         try:
             node.add_tag(tag=tag, auth=auth)
@@ -47,8 +49,8 @@ def project_addtag(auth, node, **kwargs):
 @must_have_permission('write')
 @must_not_be_registration
 def project_removetag(auth, node, **kwargs):
-
-    tag = clean_tag(kwargs['tag'])
+    data = request.get_json()
+    tag = clean_tag(data["tag"])
 
     if tag:
         node.remove_tag(tag=tag, auth=auth)

--- a/website/routes.py
+++ b/website/routes.py
@@ -1130,12 +1130,12 @@ def make_url_map(app):
 
         # Tags
         Rule([
-            '/project/<pid>/addtag/<tag>/',
-            '/project/<pid>/node/<nid>/addtag/<tag>/',
+            '/project/<pid>/addtag/',
+            '/project/<pid>/node/<nid>/addtag/',
         ], 'post', project_views.tag.project_addtag, json_renderer),
         Rule([
-            '/project/<pid>/removetag/<tag>/',
-            '/project/<pid>/node/<nid>/removetag/<tag>/',
+            '/project/<pid>/removetag/',
+            '/project/<pid>/node/<nid>/removetag/',
         ], 'post', project_views.tag.project_removetag, json_renderer),
 
         # Add / remove contributors

--- a/website/static/js/pages/project-dashboard-page.js
+++ b/website/static/js/pages/project-dashboard-page.js
@@ -120,7 +120,7 @@ $(document).ready(function () {
                 url: url,
                 contentType: 'application/json',
                 datatype: "json",
-                data: JSON.stringify(tagData)
+                data: tagData
             });
             request.fail(function(xhr, textStatus, error) {
                 Raven.captureMessage('Failed to add tag', {

--- a/website/static/js/pages/project-dashboard-page.js
+++ b/website/static/js/pages/project-dashboard-page.js
@@ -113,11 +113,14 @@ $(document).ready(function () {
         interactive: window.contextVars.currentUser.canEdit,
         maxChars: 128,
         onAddTag: function(tag){
-            var url = window.contextVars.node.urls.api + 'addtag/' + tag + '/';
+            var url = window.contextVars.node.urls.api + 'addtag/';
+            var tagData = {"tag": tag};
             var request = $.ajax({
-                url: url,
                 type: 'POST',
-                contentType: 'application/json'
+                url: url,
+                contentType: 'application/json',
+                datatype: "json",
+                data: JSON.stringify(tagData)
             });
             request.fail(function(xhr, textStatus, error) {
                 Raven.captureMessage('Failed to add tag', {
@@ -126,11 +129,14 @@ $(document).ready(function () {
             });
         },
         onRemoveTag: function(tag){
-            var url = window.contextVars.node.urls.api + 'removetag/' + tag + '/';
+            var url = window.contextVars.node.urls.api + 'removetag/';
+            var tagData = {"tag": tag};
             var request = $.ajax({
                 url: url,
                 type: 'POST',
-                contentType: 'application/json'
+                contentType: 'application/json',
+                datatype: "json",
+                data: JSON.stringify(tagData)
             });
             request.fail(function(xhr, textStatus, error) {
                 Raven.captureMessage('Failed to remove tag', {

--- a/website/util/sanitize.py
+++ b/website/util/sanitize.py
@@ -22,7 +22,7 @@ def clean_tag(data):
     :rtype: str
     """
     #TODO: make this a method of Tag?
-    return escape_html(data).replace('"', '&quot;').replace("'", '')
+    return escape_html(data).replace('"', '&quot;').replace("'", '&#39;')
 
 
 def escape_html(data):


### PR DESCRIPTION
## Purpose
Allow for "?"," ' " and other symbols / special characters in project tags.
Closes issue https://github.com/CenterForOpenScience/osf.io/issues/2696

## Changes
Changed post request from storing tag in url to creating separate json formatted data value.

## Side Effects
Allows for any symbol I've tested.  I also checked to make sure javscript was escaped.  Since the symbols are unlimited, it might make potential for spam or other unwanted tagging conventions.  I would be interested in taking input on this issue.