### PR TITLE
[Feature Fix]Add Link clipping over modal when Project name too long

### DIFF
--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -313,6 +313,7 @@ a.btn-success.disabled {
 
 #addPointer td {
     vertical-align: middle;
+    word-break: break-all;
 }
 
 li.pointer {

--- a/website/templates/project/modal_add_pointer.mako
+++ b/website/templates/project/modal_add_pointer.mako
@@ -31,20 +31,22 @@
                             <a data-bind="click:addAll">Add all</a>
                         </div>
                         <div class="error" data-bind="text:errorMsg"></div>
-                        <table class="table table-striped">
-                            <tbody data-bind="foreach:{data:results, afterRender:addTips}">
-                                <tr data-bind="if:!($root.selected($data))">
-                                    <td>
-                                        <a
-                                                class="btn btn-default contrib-button"
-                                                data-bind="click:$root.add, tooltip: {title: 'Add link'}"
-                                            >+</a>
-                                    </td>
-                                    <td data-bind="text:title" class="overflow"></td>
-                                    <td data-bind="text:$root.authorText($data)"></td>
-                                </tr>
-                            </tbody>
-                        </table>
+                        <div class="table-responsive">
+                            <table class="table table-striped">
+                                <tbody data-bind="foreach:{data:results, afterRender:addTips}">
+                                    <tr data-bind="if:!($root.selected($data))">
+                                        <td>
+                                            <a
+                                                    class="btn btn-default contrib-button"
+                                                    data-bind="click:$root.add, tooltip: {title: 'Add link'}"
+                                                >+</a>
+                                        </td>
+                                        <td data-bind="text:title" class="overflow"></td>
+                                        <td data-bind="text:$root.authorText($data)"></td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
                         <div class='help-block'>
                             <div data-bind='if: foundResults'>
                                 <ul class="pagination pagination-sm" data-bind="foreach: paginators">
@@ -59,20 +61,22 @@
                             <span class="modal-subheader">Adding</span>
                             <a data-bind="click:removeAll">Remove all</a>
                         </div>
-                        <table class="table table-striped">
-                            <tbody data-bind="foreach:{data:selection, afterRender:addTips}">
-                                <tr>
-                                    <td>
-                                        <a
-                                                class="btn btn-default contrib-button"
-                                                data-bind="click:$root.remove, tooltip: {title: 'Remove link'}"
-                                            >-</a>
-                                    </td>
-                                    <td data-bind="text:title" class="overflow"></td>
-                                    <td data-bind="text:$root.authorText($data)"></td>
-                                </tr>
-                            </tbody>
-                        </table>
+                        <div class="table-responsive">
+                            <table class="table table-striped">
+                                <tbody data-bind="foreach:{data:selection, afterRender:addTips}">
+                                    <tr>
+                                        <td>
+                                            <a
+                                                    class="btn btn-default contrib-button"
+                                                    data-bind="click:$root.remove, tooltip: {title: 'Remove link'}"
+                                                >-</a>
+                                        </td>
+                                        <td data-bind="text:title" class="overflow"></td>
+                                        <td data-bind="text:$root.authorText($data)"></td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
                     </div>
 
                 </div>

--- a/website/templates/project/modal_add_pointer.mako
+++ b/website/templates/project/modal_add_pointer.mako
@@ -31,22 +31,20 @@
                             <a data-bind="click:addAll">Add all</a>
                         </div>
                         <div class="error" data-bind="text:errorMsg"></div>
-                        <div class="table-responsive">
-                            <table class="table table-striped">
-                                <tbody data-bind="foreach:{data:results, afterRender:addTips}">
-                                    <tr data-bind="if:!($root.selected($data))">
-                                        <td>
-                                            <a
-                                                    class="btn btn-default contrib-button"
-                                                    data-bind="click:$root.add, tooltip: {title: 'Add link'}"
-                                                >+</a>
-                                        </td>
-                                        <td data-bind="text:title" class="overflow"></td>
-                                        <td data-bind="text:$root.authorText($data)"></td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
+                        <table class="table table-striped">
+                            <tbody data-bind="foreach:{data:results, afterRender:addTips}">
+                                <tr data-bind="if:!($root.selected($data))">
+                                    <td>
+                                        <a
+                                                class="btn btn-default contrib-button"
+                                                data-bind="click:$root.add, tooltip: {title: 'Add link'}"
+                                            >+</a>
+                                    </td>
+                                    <td data-bind="text:title" class="overflow"></td>
+                                    <td data-bind="text:$root.authorText($data)"></td>
+                                </tr>
+                            </tbody>
+                        </table>
                         <div class='help-block'>
                             <div data-bind='if: foundResults'>
                                 <ul class="pagination pagination-sm" data-bind="foreach: paginators">
@@ -61,22 +59,20 @@
                             <span class="modal-subheader">Adding</span>
                             <a data-bind="click:removeAll">Remove all</a>
                         </div>
-                        <div class="table-responsive">
-                            <table class="table table-striped">
-                                <tbody data-bind="foreach:{data:selection, afterRender:addTips}">
-                                    <tr>
-                                        <td>
-                                            <a
-                                                    class="btn btn-default contrib-button"
-                                                    data-bind="click:$root.remove, tooltip: {title: 'Remove link'}"
-                                                >-</a>
-                                        </td>
-                                        <td data-bind="text:title" class="overflow"></td>
-                                        <td data-bind="text:$root.authorText($data)"></td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
+                        <table class="table table-striped">
+                            <tbody data-bind="foreach:{data:selection, afterRender:addTips}">
+                                <tr>
+                                    <td>
+                                        <a
+                                                class="btn btn-default contrib-button"
+                                                data-bind="click:$root.remove, tooltip: {title: 'Remove link'}"
+                                            >-</a>
+                                    </td>
+                                    <td data-bind="text:title" class="overflow"></td>
+                                    <td data-bind="text:$root.authorText($data)"></td>
+                                </tr>
+                            </tbody>
+                        </table>
                     </div>
 
                 </div>


### PR DESCRIPTION
# Purpose
Closes #2778. Originally, if a project name was very long, the row that contained the name in the Added section would overflow and leave the modal. 

# Changes
This change adds proper word breaking so that the rows always stay within their boundaries.

# Side Effects
All words will be broken at arbitrary points, including author names. May need discussion about redesign of modal to accommodate readability.
