### PR TITLE
[feature fix][WIP][#2537]Fix Google Drive's folder names in project setting…

### DIFF
--- a/website/static/js/folderPickerNodeConfig.js
+++ b/website/static/js/folderPickerNodeConfig.js
@@ -172,6 +172,17 @@ var FolderPickerViewModel = oop.defclass({
             return userIsOwner ? name : '';
         });
 
+        /**  Functions for Google Drive's linked and selected folders' URI decoded display text.*/
+        self.decodedFolderName = ko.pureComputed(function() {
+            var folder_name = self.folderName();
+            return decodeURIComponent(folder_name);
+        });
+
+        self.decodedSelectedFolderName = ko.pureComputed(function() {
+           var folder_name = self.selectedFolderName();
+            return decodeURIComponent(folder_name);
+        });
+
         self.treebeardOptions = {
             lazyLoadPreprocess: function(data) { 
                 return data;

--- a/website/static/js/folderpicker.js
+++ b/website/static/js/folderpicker.js
@@ -52,11 +52,18 @@ function treebeardTitleColumn(item, col) {
             tb.updateFolder(null, item);
         };
     }
-
-    return m('span', {
-        className: cls,
-        onclick: onclick
-    }, item.data.name);
+    if (item.data.addon == "googledrive"){
+        return m('span', {
+            className: cls,
+            onclick: onclick
+        }, decodeURIComponent(item.data.name));
+    }
+    else {
+        return m('span', {
+            className: cls,
+            onclick: onclick
+        }, item.data.name);
+    }
 }
 
 /**

--- a/website/templates/project/addon/node_settings_default.mako
+++ b/website/templates/project/addon/node_settings_default.mako
@@ -34,7 +34,11 @@
                 <p class="break-word">
                     <strong>Current Folder:</strong>
                     <a data-bind="ifnot: folderName() === '', attr.href: urls().files">
-                        {{folderName}}
+                        %if (addon_short_name == 'googledrive'):
+                            {{decodedFolderName}}
+                        %else:
+                            {{folderName}}
+                        %endif
                     </a>
                     <span data-bind="if: folderName() === ''" class="text-muted">
                         None
@@ -57,7 +61,11 @@
                         <form data-bind="submit: submitSettings">
                             <div class="break-word">
                                 <h4 data-bind="if: selected" class="${addon_short_name}-confirm-dlg">
-                                    Connect &ldquo;{{ selectedFolderName }}&rdquo;?
+                                     %if (addon_short_name == 'googledrive'):
+                                        Connect &ldquo;{{ decodedSelectedFolderName }}&rdquo;?
+                                    %else:
+                                        Connect &ldquo;{{ selectedFolderName }}&rdquo;?
+                                    %endif
                                 </h4>
                             </div>
                             <div class="pull-right">


### PR DESCRIPTION
…s tab not showing special characters. 
https://github.com/CenterForOpenScience/osf.io/issues/2537

## Purpose:

Google Drive's folders and files use URL encoding for their names. This can be properly displayed by using the standard method decodeURIComponent(), which has been previously used in the log history and file viewer code to regulate display of Google Drive parts. However, on the project setting page, where addon folders can be selected, all Google Drive names appear encoded (the functional side effect is that special characters are not shown properly, e.g space appears as %20). This fix creates exceptions on the folder picker for Google Drive folder so that decodeURIComponent() is called on their names before being displayed.

## Changes:
Google Drive's folder and file names now appear URL decoded universally in the OSF. Example:
![Google Drive's folder names](https://cloud.githubusercontent.com/assets/6268982/7837342/6578bdca-0454-11e5-8eb0-e56af240b49f.png)

## Side Effects:
Anything that uses folder picker.js to display folders should now show folder names correctly for Google Drive. There is a possibility this could be handled somewhere else, and that exceptions should not have been written on the main folder picker file for an addon. 
