### PR TITLE
[Fixes] Fangorn sorting fixes with move and rename

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "raw-loader": "^0.5.1",
     "share": "~0.7.3",
     "style-loader": "^0.8.3",
-    "treebeard": "git://github.com/caneruguz/treebeard.git#9a4261028f2d8acdc9625412d1df41ea060ab9e3",
+    "treebeard": "git://github.com/caneruguz/treebeard.git#e3191c19053a1effb9176c70d3f1e3b7d127083f",
     "typeahead.js": "^0.10.5",
     "url-loader": "^0.5.5",
     "webpack": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "raw-loader": "^0.5.1",
     "share": "~0.7.3",
     "style-loader": "^0.8.3",
-    "treebeard": "git://github.com/caneruguz/treebeard.git#fdeb82d4937c4ecd72b85e10c361fadd33079713",
+    "treebeard": "git://github.com/caneruguz/treebeard.git#9a4261028f2d8acdc9625412d1df41ea060ab9e3",
     "typeahead.js": "^0.10.5",
     "url-loader": "^0.5.5",
     "webpack": "^1.7.2",

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1007,7 +1007,7 @@ function _fangornOrderFolder(tree) {
     // Checking if this column does in fact have sorting
     if (this.isSorted[0]) {
         var sortDirection = this.isSorted[0].desc ? 'desc' : 'asc';
-        tree.sortChildren(this, sortDirection, 'text', 0);
+        tree.sortChildren(this, sortDirection, 'text', 0, 1);
         this.redraw();
     }
 }

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -353,11 +353,11 @@ function doItemOp(operation, to, from, rename, conflict) {
         from.move(to.id);
     }
 
-    tb.redraw();
-
     if (to.data.provider === from.provider) {
         tb.pendingFileOps.push(from.id);
     }
+    _fangornOrderFolder.call(tb, from.parent());
+
 
     $.ajax({
         type: 'POST',
@@ -450,7 +450,7 @@ function doItemOp(operation, to, from, rename, conflict) {
             }
         });
 
-        tb.redraw();
+        _fangornOrderFolder.call(tb, from.parent());
     });
 }
 

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -413,8 +413,8 @@ function doItemOp(operation, to, from, rename, conflict) {
             from.open = true;
             from.load = true;
         }
-
-        tb.redraw();
+        _fangornOrderFolder.call(tb, from.parent());
+        // no need to redraw because fangornOrderFolder does it
     }).fail(function(xhr, textStatus) {
         if (to.data.provider === from.provider) {
             tb.pendingFileOps.pop();


### PR DESCRIPTION
## Purpose
Fangorn file sorting alphabetically was broken because of a change to TB and moving, renaming was causing irregular behavior. This PR fixes the sorting of files and makes it more consistent across different user behaviors. 

## Changes
- Fixed the fangornorderFolder function and placed it in appropriate locations in the doItem function
- Fixed pertinent treebeard issues (for instance sort state was resetting at every redraw). Check the treebeard commits for details. 

## Side effects
Sorting is generally harmless and should not cause any other issues but this addition needs testing. 