### PR TITLE
[Enhancement] Allow conference search to use tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "raw-loader": "^0.5.1",
     "share": "~0.7.3",
     "style-loader": "^0.8.3",
-    "treebeard": "git://github.com/caneruguz/treebeard.git#fdeb82d4937c4ecd72b85e10c361fadd33079713",
+    "treebeard": "git://github.com/caneruguz/treebeard.git#bf6a1f400bcf4cb1894adc4ad3e2adde0e81981a",
     "typeahead.js": "^0.10.5",
     "url-loader": "^0.5.5",
     "webpack": "^1.7.2",

--- a/website/conferences/views.py
+++ b/website/conferences/views.py
@@ -157,7 +157,7 @@ def _render_conference_node(node, idx):
         'category': 'talk' if 'talk' in node.system_tags else 'poster',
         'download': download_count,
         'downloadUrl': download_url,
-        'tags' :' '.join(tags)
+        'tags': ' '.join(tags)
     }
 
 

--- a/website/conferences/views.py
+++ b/website/conferences/views.py
@@ -146,6 +146,7 @@ def _render_conference_node(node, idx):
         download_count = 0
 
     author = node.visible_contributors[0]
+    tags = [tag._id for tag in node.tags]
 
     return {
         'id': idx,
@@ -156,6 +157,7 @@ def _render_conference_node(node, idx):
         'category': 'talk' if 'talk' in node.system_tags else 'poster',
         'download': download_count,
         'downloadUrl': download_url,
+        'tags' :' '.join(tags)
     }
 
 

--- a/website/static/js/conference.js
+++ b/website/static/js/conference.js
@@ -88,7 +88,8 @@ function Meeting(data) {
         showFilter : true,     // Gives the option to filter by showing the filter box.
         filterStyle : { 'float' : 'right', 'width' : '50%'},
         allowMove : false,       // Turn moving on or off.
-        hoverClass : 'fangorn-hover'
+        hoverClass : 'fangorn-hover',
+        hiddenFilterRows : ['tags']
     };
     var grid = new Treebeard(tbOptions);
 }


### PR DESCRIPTION
## Purpose
This PR resolves this issue: #2831 

## Changes
- Treebeard has been updated to allow for including filtering on columsn that are not visible
- Tags are provided as a data point in the back end
- hiddenFilterRows option is added to conference

## Side Effects
Because of the commit order issue with Treebeard to make sure this works it needs to go in AFTER this PR is merged: https://github.com/CenterForOpenScience/osf.io/pull/2852
Although this is not absolutely necessry (the changes in treebeard are not breaking changes) it's best to be safe with production code and not need to test things again. I will be more careful about order of commits for future fixes. 