### PR TITLE
Feature/issue2163

### DIFF
--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -34,3 +34,9 @@ class TestSanitize(unittest.TestCase):
             sanitize.strip_html('<foo>bar</foo>'),
             'bar'
         )
+
+    def test_unescape_html(self):
+        assert_equal(
+            sanitize.unescape_html('&lt;&gt; diamonds &amp; diamonds &lt;&gt;'),
+            '<> diamonds & diamonds <>'
+        )

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -37,6 +37,6 @@ class TestSanitize(unittest.TestCase):
 
     def test_unescape_html(self):
         assert_equal(
-            sanitize.unescape_html('&lt;&gt; diamonds &amp; diamonds &lt;&gt;'),
+            sanitize.safe_unescape_html('&lt;&gt; diamonds &amp; diamonds &lt;&gt;'),
             '<> diamonds & diamonds <>'
         )

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -165,7 +165,7 @@ def format_result(result, parent_id=None):
     formatted_result = {
         'contributors': result['contributors'],
         'wiki_link': result['url'] + 'wiki/',
-        # TODO: Remove when html safe comes in
+        # TODO: Remove safe_unescape_html when mako html safe comes in
         'title': sanitize.safe_unescape_html(result['title']),
         'url': result['url'],
         'is_component': False if parent_info is None else True,

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -24,6 +24,7 @@ from website.filters import gravatar
 from website.models import User, Node
 from website.search import exceptions
 from website.search.util import build_query
+from website.util import sanitize
 
 logger = logging.getLogger(__name__)
 
@@ -165,10 +166,10 @@ def format_result(result, parent_id=None):
         'contributors': result['contributors'],
         'wiki_link': result['url'] + 'wiki/',
         # TODO: Remove when html safe comes in
-        'title': result['title'].replace('&amp;', '&'),
+        'title': sanitize.unescape(result['title']),
         'url': result['url'],
         'is_component': False if parent_info is None else True,
-        'parent_title': parent_info.get('title').replace('&amp;', '&') if parent_info else None,
+        'parent_title': sanitize.unescape(parent_info.get('title')) if parent_info else None,
         'parent_url': parent_info.get('url') if parent_info is not None else None,
         'tags': result['tags'],
         'is_registration': (result['is_registration'] if parent_info is None

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -166,10 +166,10 @@ def format_result(result, parent_id=None):
         'contributors': result['contributors'],
         'wiki_link': result['url'] + 'wiki/',
         # TODO: Remove when html safe comes in
-        'title': sanitize.unescape_html(result['title']),
+        'title': sanitize.safe_unescape_html(result['title']),
         'url': result['url'],
         'is_component': False if parent_info is None else True,
-        'parent_title': sanitize.unescape_html(parent_info.get('title')) if parent_info else None,
+        'parent_title': sanitize.safe_unescape_html(parent_info.get('title')) if parent_info else None,
         'parent_url': parent_info.get('url') if parent_info is not None else None,
         'tags': result['tags'],
         'is_registration': (result['is_registration'] if parent_info is None

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -166,10 +166,10 @@ def format_result(result, parent_id=None):
         'contributors': result['contributors'],
         'wiki_link': result['url'] + 'wiki/',
         # TODO: Remove when html safe comes in
-        'title': sanitize.unescape(result['title']),
+        'title': sanitize.unescape_html(result['title']),
         'url': result['url'],
         'is_component': False if parent_info is None else True,
-        'parent_title': sanitize.unescape(parent_info.get('title')) if parent_info else None,
+        'parent_title': sanitize.unescape_html(parent_info.get('title')) if parent_info else None,
         'parent_url': parent_info.get('url') if parent_info is not None else None,
         'tags': result['tags'],
         'is_registration': (result['is_registration'] if parent_info is None

--- a/website/util/rubeus.py
+++ b/website/util/rubeus.py
@@ -10,6 +10,7 @@ from modularodm import Q
 from framework.auth.decorators import Auth
 
 from website.util import paths
+from website.util import sanitize
 from website.settings import (
     ALL_MY_PROJECTS_ID, ALL_MY_REGISTRATIONS_ID, ALL_MY_PROJECTS_NAME,
     ALL_MY_REGISTRATIONS_NAME, DISK_SAVING_MODE
@@ -26,20 +27,6 @@ DEFAULT_PERMISSIONS = {
     'view': True,
     'edit': False,
 }
-
-
-def unescape(s):
-    """
-    Return a string without html escape characters.
-
-    :param s: A string
-    :return: A string without html escape characters
-
-    """
-    s = s.replace('&amp;', '&')
-    s = s.replace('&lt;', '<')
-    s = s.replace('&gt;', '>')
-    return s
 
 def format_filesize(size):
     return hurry.filesize.size(size, system=hurry.filesize.alternative)
@@ -338,7 +325,7 @@ class NodeProjectCollector(object):
 
         return {
             #TODO Remove the replace when mako html safe comes around
-            'name': unescape(node.title) if can_view else u'Private Component',
+            'name': sanitize.unescape(node.title) if can_view else u'Private Component',
             'kind': FOLDER,
             'category': node.category,
             # Once we get files into the project organizer, files would be kind of FILE
@@ -456,7 +443,7 @@ class NodeFileCollector(object):
             children = []
         return {
             # #TODO Remove the replace when mako html safe comes around
-            'name': u'{0}: {1}'.format(node.project_or_component.capitalize(), unescape(node.title))
+            'name': u'{0}: {1}'.format(node.project_or_component.capitalize(), sanitize.unescape(node.title))
             if can_view
             else u'Private Component',
             'kind': FOLDER,

--- a/website/util/rubeus.py
+++ b/website/util/rubeus.py
@@ -28,6 +28,19 @@ DEFAULT_PERMISSIONS = {
 }
 
 
+def unescape(s):
+    """
+    Return a string without html escape characters.
+
+    :param s: A string
+    :return: A string without html escape characters
+
+    """
+    s = s.replace('&amp;', '&')
+    s = s.replace('&lt;', '<')
+    s = s.replace('&gt;', '>')
+    return s
+
 def format_filesize(size):
     return hurry.filesize.size(size, system=hurry.filesize.alternative)
 
@@ -325,7 +338,7 @@ class NodeProjectCollector(object):
 
         return {
             #TODO Remove the replace when mako html safe comes around
-            'name': node.title.replace('&amp;', '&') if can_view else u'Private Component',
+            'name': unescape(node.title) if can_view else u'Private Component',
             'kind': FOLDER,
             'category': node.category,
             # Once we get files into the project organizer, files would be kind of FILE
@@ -443,7 +456,7 @@ class NodeFileCollector(object):
             children = []
         return {
             # #TODO Remove the replace when mako html safe comes around
-            'name': u'{0}: {1}'.format(node.project_or_component.capitalize(), node.title.replace('&amp;', '&'))
+            'name': u'{0}: {1}'.format(node.project_or_component.capitalize(), unescape(node.title))
             if can_view
             else u'Private Component',
             'kind': FOLDER,

--- a/website/util/rubeus.py
+++ b/website/util/rubeus.py
@@ -324,7 +324,7 @@ class NodeProjectCollector(object):
             to_expand = False
 
         return {
-            #TODO Remove the replace when mako html safe comes around
+            # TODO: Remove safe_unescape_html when mako html safe comes in
             'name': sanitize.safe_unescape_html(node.title) if can_view else u'Private Component',
             'kind': FOLDER,
             'category': node.category,
@@ -442,7 +442,7 @@ class NodeFileCollector(object):
         else:
             children = []
         return {
-            # #TODO Remove the replace when mako html safe comes around
+            # TODO: Remove safe_unescape_html when mako html safe comes in
             'name': u'{0}: {1}'.format(node.project_or_component.capitalize(), sanitize.safe_unescape_html(node.title))
             if can_view
             else u'Private Component',

--- a/website/util/rubeus.py
+++ b/website/util/rubeus.py
@@ -325,7 +325,7 @@ class NodeProjectCollector(object):
 
         return {
             #TODO Remove the replace when mako html safe comes around
-            'name': sanitize.unescape(node.title) if can_view else u'Private Component',
+            'name': sanitize.unescape_html(node.title) if can_view else u'Private Component',
             'kind': FOLDER,
             'category': node.category,
             # Once we get files into the project organizer, files would be kind of FILE
@@ -443,7 +443,7 @@ class NodeFileCollector(object):
             children = []
         return {
             # #TODO Remove the replace when mako html safe comes around
-            'name': u'{0}: {1}'.format(node.project_or_component.capitalize(), sanitize.unescape(node.title))
+            'name': u'{0}: {1}'.format(node.project_or_component.capitalize(), sanitize.unescape_html(node.title))
             if can_view
             else u'Private Component',
             'kind': FOLDER,

--- a/website/util/rubeus.py
+++ b/website/util/rubeus.py
@@ -325,7 +325,7 @@ class NodeProjectCollector(object):
 
         return {
             #TODO Remove the replace when mako html safe comes around
-            'name': sanitize.unescape_html(node.title) if can_view else u'Private Component',
+            'name': sanitize.safe_unescape_html(node.title) if can_view else u'Private Component',
             'kind': FOLDER,
             'category': node.category,
             # Once we get files into the project organizer, files would be kind of FILE
@@ -443,7 +443,7 @@ class NodeFileCollector(object):
             children = []
         return {
             # #TODO Remove the replace when mako html safe comes around
-            'name': u'{0}: {1}'.format(node.project_or_component.capitalize(), sanitize.unescape_html(node.title))
+            'name': u'{0}: {1}'.format(node.project_or_component.capitalize(), sanitize.safe_unescape_html(node.title))
             if can_view
             else u'Private Component',
             'kind': FOLDER,

--- a/website/util/sanitize.py
+++ b/website/util/sanitize.py
@@ -69,7 +69,11 @@ def safe_unescape_html(s):
     :return: A string without html escape characters
 
     """
-    s = s.replace('&amp;', '&')
-    s = s.replace('&lt;', '<')
-    s = s.replace('&gt;', '>')
+    safe_characters = {
+        '&amp;': '&',
+        '&lt;': '<',
+        '&gt;': '>',
+    }
+    for escape_sequence, character in safe_characters.items():
+        s = s.replace(escape_sequence, character)
     return s

--- a/website/util/sanitize.py
+++ b/website/util/sanitize.py
@@ -60,7 +60,7 @@ def assert_clean(data):
     return escape_html(data)
 
 
-def unescape_html(s):
+def safe_unescape_html(s):
     """
     Return a string without html escape characters.
 

--- a/website/util/sanitize.py
+++ b/website/util/sanitize.py
@@ -58,3 +58,17 @@ def assert_clean(data):
             raise ValueError
 
     return escape_html(data)
+
+
+def unescape(s):
+    """
+    Return a string without html escape characters.
+
+    :param s: A string
+    :return: A string without html escape characters
+
+    """
+    s = s.replace('&amp;', '&')
+    s = s.replace('&lt;', '<')
+    s = s.replace('&gt;', '>')
+    return s

--- a/website/util/sanitize.py
+++ b/website/util/sanitize.py
@@ -60,7 +60,7 @@ def assert_clean(data):
     return escape_html(data)
 
 
-def unescape(s):
+def unescape_html(s):
     """
     Return a string without html escape characters.
 

--- a/website/util/sanitize.py
+++ b/website/util/sanitize.py
@@ -60,6 +60,7 @@ def assert_clean(data):
     return escape_html(data)
 
 
+# TODO: Remove safe_unescape_html when mako html safe comes in
 def safe_unescape_html(s):
     """
     Return a string without html escape characters.


### PR DESCRIPTION
## Purpose
Escaped html characters, `&lt;` and `&gt;` would appear in a project's title in the path on the file page, the project organizer, and in search results, when the '<' and '>' characters should have been displayed. This PR fixes this issue replacing  `&lt;` and `&gt;` with '<' and '>' respectively.

Closes Issue: https://github.com/CenterForOpenScience/osf.io/issues/2163

## Changes
* Created a function, unescape_html, in sanitize.py that replaces escaped ampersands, less thans, and greater thans, with their unescaped characters.
* call unesacpe_html on a node's title when serializing nodes in rubeus.py, and when formatting elasticsearch results.