### PR TITLE
[Feature Fix] IE template dropdown not shown 

### DIFF
--- a/website/static/js/projectCreator.js
+++ b/website/static/js/projectCreator.js
@@ -170,6 +170,9 @@ function ProjectCreatorViewModel(params) {
     };
 
     self.templates = self.loadNodes(params.data);
+
+    // IE won't select template with id correctly. so we replace #createNodeTemplates with .createNodeTemplates
+    // More explanation -- https://github.com/CenterForOpenScience/osf.io/pull/2858
     $('.createNodeTemplates').select2({
         allowClear: true,
         placeholder: 'Select a project to use as a template',

--- a/website/static/js/projectCreator.js
+++ b/website/static/js/projectCreator.js
@@ -170,7 +170,7 @@ function ProjectCreatorViewModel(params) {
     };
 
     self.templates = self.loadNodes(params.data);
-    $('.select-template').select2({
+    $('.createNodeTemplates').select2({
         allowClear: true,
         placeholder: 'Select a project to use as a template',
         query: self.query

--- a/website/static/js/projectCreator.js
+++ b/website/static/js/projectCreator.js
@@ -170,7 +170,7 @@ function ProjectCreatorViewModel(params) {
     };
 
     self.templates = self.loadNodes(params.data);
-    $('#createNodeTemplates').select2({
+    $('.select-template').select2({
         allowClear: true,
         placeholder: 'Select a project to use as a template',
         query: self.query

--- a/website/templates/components/dashboard_templates.mako
+++ b/website/templates/components/dashboard_templates.mako
@@ -153,7 +153,7 @@
             <br />
             <label>Template (Optional)</label>
             <span class="help-block">Start typing to search. Selecting project as template will duplicate its structure in the new project without importing the content of that project.</span>
-            <input type="hidden" id="createNodeTemplates" class="select2-container" style="width: 100%">
+            <input type="hidden" id="createNode" class="select2-container select-template" style="width: 100%">
         </div>
     </div>
     <br />

--- a/website/templates/components/dashboard_templates.mako
+++ b/website/templates/components/dashboard_templates.mako
@@ -153,7 +153,7 @@
             <br />
             <label>Template (Optional)</label>
             <span class="help-block">Start typing to search. Selecting project as template will duplicate its structure in the new project without importing the content of that project.</span>
-            <input type="hidden" id="createNodeTemplates" class="select2-container select-template" style="width: 100%">
+            <input type="hidden" class="select2-container createNodeTemplates" style="width: 100%">
         </div>
     </div>
     <br />

--- a/website/templates/components/dashboard_templates.mako
+++ b/website/templates/components/dashboard_templates.mako
@@ -153,7 +153,7 @@
             <br />
             <label>Template (Optional)</label>
             <span class="help-block">Start typing to search. Selecting project as template will duplicate its structure in the new project without importing the content of that project.</span>
-            <input type="hidden" id="createNode" class="select2-container select-template" style="width: 100%">
+            <input type="hidden" id="createNodeTemplates" class="select2-container select-template" style="width: 100%">
         </div>
     </div>
     <br />


### PR DESCRIPTION
# Purpose
The change will make template selection shown on IE when creating project on dashboard.  Resolve #1504 .

# Changes
The change is quit simple. It only replace id selector -`#createNodeTemplates` with class selector-`.select-template`.

#### Before-Change:
![screen shot 2015-05-27 at 5 55 59 pm](https://cloud.githubusercontent.com/assets/5420789/7848433/bf27d686-0499-11e5-8fbe-916006fb3090.png)

#### After-Change:
![screen shot 2015-05-27 at 5 54 48 pm](https://cloud.githubusercontent.com/assets/5420789/7848436/c6d4b37c-0499-11e5-8f7b-950ce32298c2.png)

# Explanation
The change is very small, but the reason is very subtle. 

The selection bar is based on JQuery Library -[Select2](https://select2.github.io/). It needs to select input DOM and insert a new div DOM above that input DOM. In our case, input DOM is defined in mako template file with the ID -`#createNodeTemplates`. In IE, it will search unique ID starting from template. So it will insert the new DOM in template, which will not be shown. However, the other browsers will search unique ID from the shown HTML and consequently the inserted DOM will be shown. 

In order to getting ride of the side effect of using ID in template, the solution here is to replace a unique Id with a unique class. Therefore, it could be shown in all the browsers. 

# Side Effects
None. It only replaces the selector. And also the class name is new and unique, it will not influence others.
