### PR TITLE
Hotfix/User settings menu fix

### DIFF
--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -1760,6 +1760,9 @@ span.edit-profile-settings {
     bottom: 0;
     right: 0;
 }
+.profile-panel.affix{
+    top:50px;
+}
 
 div.profile-fullname{
     display: block;

--- a/website/static/js/pages/profile-settings-page.js
+++ b/website/static/js/pages/profile-settings-page.js
@@ -18,7 +18,6 @@ function fixAffixWidth() {
 
 
 $(document).ready(function() {
-
     $(window).resize(function (){ fixAffixWidth(); });
-    $('.profile-page .panel').on('affixed.bs.affix', function(){ fixAffixWidth(); });
+    $('.profile-page .panel').on('affixed.bs.affix', function(){ fixAffixWidth();});
 });

--- a/website/static/js/pages/profile-settings-page.js
+++ b/website/static/js/pages/profile-settings-page.js
@@ -6,3 +6,19 @@ new profile.Names('#names', ctx.nameUrls, ['edit']);
 new profile.Social('#social', ctx.socialUrls, ['edit']);
 new profile.Jobs('#jobs', ctx.jobsUrls, ['edit']);
 new profile.Schools('#schools', ctx.schoolsUrls, ['edit']);
+
+// Reusable function to fix affix widths to columns.
+function fixAffixWidth() {
+    $('.affix, .affix-top, .affix-bottom').each(function (){
+        var el = $(this);
+        var colsize = el.parent('.affix-parent').width();
+        el.outerWidth(colsize);
+    });
+}
+
+
+$(document).ready(function() {
+
+    $(window).resize(function (){ fixAffixWidth(); });
+    $('.profile-page .panel').on('affixed.bs.affix', function(){ fixAffixWidth(); });
+});

--- a/website/templates/profile/settings.mako
+++ b/website/templates/profile/settings.mako
@@ -2,7 +2,7 @@
 <%def name="title()">Settings</%def>
 <%def name="content()">
 <% from website import settings %>
-<h2 class="page-header">Profile Information</h2>
+<h2 class="page-header" data-spy="affix" data-offset-top="80" data-offset-bottom="268">Profile Information</h2>
 
 ## TODO: Review and un-comment
 ##<div class="row">
@@ -16,10 +16,10 @@
 ##    </div>
 ##</div>
 
-<div class="row">
+<div class="row profile-page">
 
-    <div class="col-sm-3">
-        <div class="panel panel-default">
+    <div class="col-sm-3 affix-parent">
+        <div class="panel panel-default" data-spy="affix" data-offset-top="80" data-offset-bottom="268">
             <ul class="nav nav-stacked nav-pills">
                 <li><a href="#">Profile Information</a></li>
                 <li><a href="${ web_url_for('user_account') }">Account Settings</a></li>

--- a/website/templates/profile/settings.mako
+++ b/website/templates/profile/settings.mako
@@ -2,7 +2,7 @@
 <%def name="title()">Settings</%def>
 <%def name="content()">
 <% from website import settings %>
-<h2 class="page-header" data-spy="affix" data-offset-top="80" data-offset-bottom="268">Profile Information</h2>
+<h2 class="page-header">Profile Information</h2>
 
 ## TODO: Review and un-comment
 ##<div class="row">
@@ -16,10 +16,11 @@
 ##    </div>
 ##</div>
 
+
 <div class="row profile-page">
 
     <div class="col-sm-3 affix-parent">
-        <div class="panel panel-default" data-spy="affix" data-offset-top="80" data-offset-bottom="268">
+        <div class="panel panel-default profile-panel" data-spy="affix" data-offset-top="100" data-offset-bottom="268">
             <ul class="nav nav-stacked nav-pills">
                 <li><a href="#">Profile Information</a></li>
                 <li><a href="${ web_url_for('user_account') }">Account Settings</a></li>


### PR DESCRIPTION
## Purpose
Allow for menu in profile settings to scroll in user settings page
Answers: https://github.com/CenterForOpenScience/osf.io/issues/2313

## Changes
Added affix properties to menu.  Used javascript function to maintain width.  Added CSS property to attach menu to top of page.

## Side Effects
Allows for menu to move with the page