### PR TITLE
[feature_fix] #2516 Create loading text for in-between clicking 'Import access token' and…

### DIFF
--- a/website/static/js/folderPickerNodeConfig.js
+++ b/website/static/js/folderPickerNodeConfig.js
@@ -52,6 +52,8 @@ var FolderPickerViewModel = oop.defclass({
         self.ownerName = ko.observable('');
         // whether the auth token is valid
         self.validCredentials = ko.observable(true);
+        // whether import token has been clicked
+        self.loadingImport = ko.observable(false);
         // current folder
         self.folder = ko.observable({
             name: null,
@@ -141,7 +143,17 @@ var FolderPickerViewModel = oop.defclass({
             var userHasAuth = self.userHasAuth();
             var nodeHasAuth = self.nodeHasAuth();
             var loaded = self.loadedSettings();
-            return userHasAuth && !nodeHasAuth && loaded;
+            var onclick = self.loadingImport();
+            return userHasAuth && !nodeHasAuth && loaded && !onclick;
+        });
+
+        /** Whether or not show loading icon after import button */
+        self.showLoading = ko.pureComputed(function() {
+            var userHasAuth = self.userHasAuth();
+            var nodeHasAuth = self.nodeHasAuth();
+            var loaded = self.loadedSettings();
+            var onclick = self.loadingImport();
+            return userHasAuth && !nodeHasAuth && loaded && onclick;
         });
 
         /** Whether or not to show the full settings pane. */
@@ -339,6 +351,7 @@ var FolderPickerViewModel = oop.defclass({
             callback: function(confirmed) {
                 if (confirmed) {
                     self._importAuthConfirm();
+                    self.loadingImport(true);
                 }
             }
         });
@@ -382,6 +395,7 @@ var FolderPickerViewModel = oop.defclass({
             callback: function(confirmed) {
                 if (confirmed) {
                     self._deauthorizeConfirm();
+                    self.loadingImport(false);
                 }
             }
         });

--- a/website/templates/project/addon/node_settings_default.mako
+++ b/website/templates/project/addon/node_settings_default.mako
@@ -19,6 +19,13 @@
                 </a>
             </span>
 
+            <!-- Loading Import Text -->
+            <span data-bind="if: showLoading">
+                <p class="text-muted pull-right addon-auth">
+                    Loading ...
+                </p>
+            </span>
+
             <!-- Oauth Start Button -->
             <span data-bind="if: showTokenCreateButton">
                 <a data-bind="click: connectAccount" class="text-primary pull-right addon-auth">


### PR DESCRIPTION
… the addon folder loading in projects' settings.
#2516 

## Purpose
When clicking on an 'Import Access Token' button, the figshare addon folders delays upon loading. While it is loading, the 'Import Access Token' continues being shown. This fix removes that button upon accepting import and replaces it with a 'Loading ...' text until it actually loads, when it its replaced by the 'Deauthorize' button.

## Changes
Now, for every addon, clicking on import button leads to loading text to appear. This is mostly noticeable for figshare since it loads very slowly. This is done by adding a new observable (whether or not import has been clicked) and a new computed function (if it's loading or not).

![screen shot 2015-05-28 at 4 12 06 pm](https://cloud.githubusercontent.com/assets/6268982/7870007/5a37ddb4-0554-11e5-85fc-e6c667741092.png)

## Side Effects
Issue #2516 points to the problem for figshare, but that is true for all addons using a 'Import Access Token' button, except most addon folders load quickly enough for it to be noticeable. This fix adds the loading text to all of those addons, regardless of loading speed.