### PR TITLE
modify the querry to return the right number of user

### DIFF
--- a/scripts/analytics/benchmarks.py
+++ b/scripts/analytics/benchmarks.py
@@ -24,8 +24,9 @@ def get_active_users(extra=None):
     query = (
         Q('is_registered', 'eq', True) &
         Q('password', 'ne', None) &
-        Q('is_merged', 'ne', True) &
-        Q('date_confirmed', 'ne', None)
+        Q('merged_by', 'eq', None) &
+        Q('date_confirmed', 'ne', None) &
+        Q('date_disabled', ' eq', None)
     )
     query = query & extra if extra else query
     return User.find(query)


### PR DESCRIPTION
<b>Purpose</b>
Update the daily user count script. Related to https://github.com/CenterForOpenScience/osf.io/issues/2853


<b>Change</b>
Add query to exclude disabled user and correct the query for merged user.


<b>Side Effect</b>
There are no side effect of this pr but it does not fix the main problem of https://github.com/CenterForOpenScience/osf.io/issues/2853. That need a elastic search index reset on production and might need to run migrate user on production as well.