### PR TITLE
[ Feature Fix] Import token page jump

### DIFF
--- a/website/addons/github/static/github-node-cfg.js
+++ b/website/addons/github/static/github-node-cfg.js
@@ -53,6 +53,11 @@ var GithubConfigHelper = (function() {
     };
 
 
+    var isIE = function (userAgent) {
+        userAgent = userAgent || navigator.userAgent;
+        return userAgent.indexOf("MSIE ") > -1 || userAgent.indexOf("Trident/") > -1;
+    }
+
     $(document).ready(function() {
         $('#githubSelectRepo').on('change', function() {
             var value = $(this).val();
@@ -70,7 +75,9 @@ var GithubConfigHelper = (function() {
                 nodeApiUrl + 'github/user_auth/',
                 {}
             ).done(function() {
-                    window.location.hash = "#configureAddonsAnchor";
+                    if(isIE()){
+                        window.location.hash = "#configureAddonsAnchor";
+                    }
                     window.location.reload();
             }).fail(
                 $osf.handleJSONError

--- a/website/addons/github/static/github-node-cfg.js
+++ b/website/addons/github/static/github-node-cfg.js
@@ -59,7 +59,6 @@ var GithubConfigHelper = (function() {
             $.cookie("status", "disabled");
             alert("setScrollPostionBasedCookie");
         };
-
     }
 
     var updateScrollPostionAtCookie = function(){
@@ -70,8 +69,15 @@ var GithubConfigHelper = (function() {
         alert("updateScrollPostionAtCookie");
     }
 
+    var isIE = function (userAgent) {
+        userAgent = userAgent || navigator.userAgent;
+        return userAgent.indexOf("MSIE ") > -1 || userAgent.indexOf("Trident/") > -1;
+    }
+
     $(document).ready(function() {
-        setScrollPostionBasedCookie();
+        if(isIE()){
+            setScrollPostionBasedCookie();
+        };
         $('#githubSelectRepo').on('change', function() {
             var value = $(this).val();
             if (value) {
@@ -90,7 +96,9 @@ var GithubConfigHelper = (function() {
             ).done(function() {
                     //var currentScroll = $(window).scrollTop();
                     //alert(currentScroll);
-                    updateScrollPostionAtCookie();
+                    if(isIE()){
+                        updateScrollPostionAtCookie();
+                    };
                     window.location.reload();
             }).fail(
                 $osf.handleJSONError

--- a/website/addons/github/static/github-node-cfg.js
+++ b/website/addons/github/static/github-node-cfg.js
@@ -52,32 +52,8 @@ var GithubConfigHelper = (function() {
         });
     };
 
-    var setScrollPostionBasedCookie = function(){
-        if ($.cookie('status') !== null && $.cookie('status') === 'enabled' && $.cookie("location") !== null
-           && $.cookie("location") == $(location).attr('href')){
-            $(document).scrollTop( $.cookie("scroll") );
-            $.cookie("status", "disabled");
-            alert("setScrollPostionBasedCookie");
-        };
-    }
-
-    var updateScrollPostionAtCookie = function(){
-        // set a cookie that holds the current location.
-        $.cookie("location", $(location).attr('href'));
-        $.cookie("scroll", $(document).scrollTop() );
-        $.cookie("status", "enabled");
-        alert("updateScrollPostionAtCookie");
-    }
-
-    var isIE = function (userAgent) {
-        userAgent = userAgent || navigator.userAgent;
-        return userAgent.indexOf("MSIE ") > -1 || userAgent.indexOf("Trident/") > -1;
-    }
 
     $(document).ready(function() {
-        if(isIE()){
-            setScrollPostionBasedCookie();
-        };
         $('#githubSelectRepo').on('change', function() {
             var value = $(this).val();
             if (value) {
@@ -94,11 +70,7 @@ var GithubConfigHelper = (function() {
                 nodeApiUrl + 'github/user_auth/',
                 {}
             ).done(function() {
-                    //var currentScroll = $(window).scrollTop();
-                    //alert(currentScroll);
-                    if(isIE()){
-                        updateScrollPostionAtCookie();
-                    };
+                    window.location.hash = "#configureAddonsAnchor";
                     window.location.reload();
             }).fail(
                 $osf.handleJSONError

--- a/website/addons/github/static/github-node-cfg.js
+++ b/website/addons/github/static/github-node-cfg.js
@@ -52,8 +52,26 @@ var GithubConfigHelper = (function() {
         });
     };
 
-    $(document).ready(function() {
+    var setScrollPostionBasedCookie = function(){
+        if ($.cookie('status') !== null && $.cookie('status') === 'enabled' && $.cookie("location") !== null
+           && $.cookie("location") == $(location).attr('href')){
+            $(document).scrollTop( $.cookie("scroll") );
+            $.cookie("status", "disabled");
+            alert("setScrollPostionBasedCookie");
+        };
 
+    }
+
+    var updateScrollPostionAtCookie = function(){
+        // set a cookie that holds the current location.
+        $.cookie("location", $(location).attr('href'));
+        $.cookie("scroll", $(document).scrollTop() );
+        $.cookie("status", "enabled");
+        alert("updateScrollPostionAtCookie");
+    }
+
+    $(document).ready(function() {
+        setScrollPostionBasedCookie();
         $('#githubSelectRepo').on('change', function() {
             var value = $(this).val();
             if (value) {
@@ -70,7 +88,10 @@ var GithubConfigHelper = (function() {
                 nodeApiUrl + 'github/user_auth/',
                 {}
             ).done(function() {
-                window.location.reload();
+                    //var currentScroll = $(window).scrollTop();
+                    //alert(currentScroll);
+                    updateScrollPostionAtCookie();
+                    window.location.reload();
             }).fail(
                 $osf.handleJSONError
             );


### PR DESCRIPTION
## Purpose
In IE's default setting, `window.location.reload()` will load a new page and start at the top of the page. After users import token, they have to scroll down the page and then they could come back to the config setting part. In this fix, it will firstly set the scroll location with hash tag before reloading the page. 

Resolved #2690 
 
## Change
1) Set hash tag before reloading -- `window.location.hash = "#configureAddonsAnchor";`
2) Add IE browser recognition code. Only when user uses IE will hash tag be set.

## Side effects
None. Set hash and only limit to IE browser

## Others
Among those commits, I also tried to use cookie to record the scroll position before reloading. However, it is much more complicated and has potential security risk.  Hashtag is easier way and hopefully could be applied to solve the similar page jump issues in IE.