### PR TITLE
Hide empty component box when user doesn't have write permissions

### DIFF
--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -268,35 +268,36 @@
 </div>
 
 <%def name="children()">
-<div class="components addon-widget-container">
-    <div class="addon-widget-header clearfix">
-        <h4>Components </h4>
-        <div class="pull-right">
-            % if 'write' in user['permissions'] and not node['is_registration']:
-                <a class="btn btn-sm btn-default" data-toggle="modal" data-target="#newComponent">Add Component</a>
-                <a class="btn btn-sm btn-default" data-toggle="modal" data-target="#addPointer">Add Links</a>
+% if 'write' in user['permissions'] or node['children']:
+    <div class="components addon-widget-container">
+        <div class="addon-widget-header clearfix">
+            <h4>Components </h4>
+            <div class="pull-right">
+                % if 'write' in user['permissions'] and not node['is_registration']:
+                    <a class="btn btn-sm btn-default" data-toggle="modal" data-target="#newComponent">Add Component</a>
+                    <a class="btn btn-sm btn-default" data-toggle="modal" data-target="#addPointer">Add Links</a>
+                % endif
+            </div>
+        </div><!-- end addon-widget-header -->
+        <div class="addon-widget-body">
+            % if node['children']:
+                <div id="containment">
+                    <div mod-meta='{
+                        "tpl": "util/render_nodes.mako",
+                        "uri": "${node["api_url"]}get_children/",
+                        "replace": true,
+                        "kwargs": {
+                          "sortable" : ${'true' if not node['is_registration'] else 'false'},
+                          "pluralized_node_type": "components"
+                        }
+                      }'></div>
+                </div><!-- end containment -->
+            % else:
+              <p>No components have been added to this ${node['node_type']}.</p>
             % endif
-        </div>
-    </div><!-- end addon-widget-header -->
-    <div class="addon-widget-body">
-        % if node['children']:
-            <div id="containment">
-                <div mod-meta='{
-                    "tpl": "util/render_nodes.mako",
-                    "uri": "${node["api_url"]}get_children/",
-                    "replace": true,
-                    "kwargs": {
-                      "sortable" : ${'true' if not node['is_registration'] else 'false'},
-                      "pluralized_node_type": "components"
-                    }
-                  }'></div>
-            </div><!-- end containment -->
-        % else:
-          <p>No components have been added to this ${node['node_type']}.</p>
-        % endif
-    </div><!-- end addon-widget-body -->
-</div><!-- end components -->
-
+        </div><!-- end addon-widget-body -->
+    </div><!-- end components -->
+%endif
 % for name, capabilities in addon_capabilities.iteritems():
     <script id="capabilities-${name}" type="text/html">${capabilities}</script>
 % endfor

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -274,7 +274,7 @@
 </div>
 
 <%def name="children()">
-% if 'write' in user['permissions'] or node['children']:
+% if ('write' in user['permissions'] and not node['is_registration']) or node['children']:
     <div class="components addon-widget-container">
         <div class="addon-widget-header clearfix">
             <h4>Components </h4>


### PR DESCRIPTION
## Purpose

Very simple fix to hide empty component box when user does not have write permissions.

https://github.com/CenterForOpenScience/osf.io/issues/2892

## Side Effects

Is this feature desired?