### PR TITLE
Issue #2675 [staging & production] Can't mass-update permissions on child nodes

### DIFF
--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2239,6 +2239,11 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
 
             contributor_added.send(self, contributor=contributor, auth=auth)
             return True
+
+        #Permissions must be overridden if changed when contributor is added to parent he/she is already on a child of.
+        elif contrib_to_add in self.contributors and contrib_to_add.get_permissions() != []:
+            self.set_permissions(contrib_to_add, permissions)
+            return True
         else:
             return False
 


### PR DESCRIPTION
**Purpose** 
This allows admins to mass update permissions on child nodes for contributors they've readded to the parent node of.
**Changes**
Now when someone is added to a node they're already on there permission updates.
**Side Effects**
None that I know of.