### PR TITLE
Feature/meeting downloads

### DIFF
--- a/website/conferences/views.py
+++ b/website/conferences/views.py
@@ -160,7 +160,6 @@ def _render_conference_node(node, idx):
     }
 
 
-
 def conference_data(meeting):
     try:
         Conference.find_one(Q('endpoint', 'iexact', meeting))

--- a/website/conferences/views.py
+++ b/website/conferences/views.py
@@ -125,7 +125,7 @@ def add_poster_by_email(conference, message):
     )
 
 
-def _render_conference_node(node, idx, downloads=False):
+def _render_conference_node(node, idx):
     storage_settings = node.get_addon('osfstorage')
     records = storage_settings.root_node.children
     try:
@@ -146,21 +146,19 @@ def _render_conference_node(node, idx, downloads=False):
         download_url = ''
         download_count = 0
 
-    if not downloads:
-        author = node.visible_contributors[0]
+    author = node.visible_contributors[0]
 
-        return {
-            'id': idx,
-            'title': node.title,
-            'nodeUrl': node.url,
-            'author': author.family_name,
-            'authorUrl': node.creator.url,
-            'category': 'talk' if 'talk' in node.system_tags else 'poster',
-            'download': download_count,
-            'downloadUrl': download_url,
-        }
-    else:
-        return download_count
+    return {
+        'id': idx,
+        'title': node.title,
+        'nodeUrl': node.url,
+        'author': author.family_name,
+        'authorUrl': node.creator.url,
+        'category': 'talk' if 'talk' in node.system_tags else 'poster',
+        'download': download_count,
+        'downloadUrl': download_url,
+    }
+
 
 
 def conference_data(meeting):
@@ -219,12 +217,12 @@ def conference_view(**kwargs):
         projects = Node.find(query)
         submissions = projects.count()
         downloads_list = [
-            _render_conference_node(each, idx, downloads=True)
+            _render_conference_node(each, idx)
             for idx, each in enumerate(projects)
         ]
         total = 0
         for count in downloads_list:
-            total += count
+            total += count['download']
 
         if submissions < settings.CONFERNCE_MIN_COUNT:
             continue

--- a/website/conferences/views.py
+++ b/website/conferences/views.py
@@ -125,7 +125,7 @@ def add_poster_by_email(conference, message):
     )
 
 
-def _render_conference_node(node, idx):
+def _render_conference_node(node, idx, downloads=False):
     storage_settings = node.get_addon('osfstorage')
     records = storage_settings.root_node.children
     try:
@@ -146,18 +146,21 @@ def _render_conference_node(node, idx):
         download_url = ''
         download_count = 0
 
-    author = node.visible_contributors[0]
+    if not downloads:
+        author = node.visible_contributors[0]
 
-    return {
-        'id': idx,
-        'title': node.title,
-        'nodeUrl': node.url,
-        'author': author.family_name,
-        'authorUrl': node.creator.url,
-        'category': 'talk' if 'talk' in node.system_tags else 'poster',
-        'download': download_count,
-        'downloadUrl': download_url,
-    }
+        return {
+            'id': idx,
+            'title': node.title,
+            'nodeUrl': node.url,
+            'author': author.family_name,
+            'authorUrl': node.creator.url,
+            'category': 'talk' if 'talk' in node.system_tags else 'poster',
+            'download': download_count,
+            'downloadUrl': download_url,
+        }
+    else:
+        return download_count
 
 
 def conference_data(meeting):
@@ -215,6 +218,14 @@ def conference_view(**kwargs):
         )
         projects = Node.find(query)
         submissions = projects.count()
+        downloads_list = [
+            _render_conference_node(each, idx, downloads=True)
+            for idx, each in enumerate(projects)
+        ]
+        total = 0
+        for count in downloads_list:
+            total += count
+
         if submissions < settings.CONFERNCE_MIN_COUNT:
             continue
         meetings.append({
@@ -222,6 +233,7 @@ def conference_view(**kwargs):
             'active': conf.active,
             'url': web_url_for('conference_results', meeting=conf.endpoint),
             'submissions': submissions,
+            'downloads': total,
         })
     meetings.sort(key=lambda meeting: meeting['submissions'], reverse=True)
 

--- a/website/static/js/conference.js
+++ b/website/static/js/conference.js
@@ -1,4 +1,4 @@
-var $ = require('jquery');
+    var $ = require('jquery');
 var m = require('mithril');
 var Treebeard = require('treebeard');
 

--- a/website/static/js/conference.js
+++ b/website/static/js/conference.js
@@ -1,4 +1,4 @@
-    var $ = require('jquery');
+var $ = require('jquery');
 var m = require('mithril');
 var Treebeard = require('treebeard');
 

--- a/website/templates/public/pages/meeting_landing.mako
+++ b/website/templates/public/pages/meeting_landing.mako
@@ -49,6 +49,7 @@
                             </span>
                         </td>
                         <td>${meeting['submissions']} submission(s)</td>
+                        <td>${meeting['downloads']} download(s)</td>
                     </tr>
                 % endfor
                 </tbody>


### PR DESCRIPTION
<b>Purpose</b>
Provide downloads count for each meeting on meetings page. Solves https://github.com/CenterForOpenScience/osf.io/issues/2720.

<b>Changes</b>
Now in meetings page there will be numbers beside submissions indicating the downloads total for each meeting.

<b>Side Effect</b>
Now the meeting page will need to render all the nodes inside each meeting and calculate their downloads. That can slow the page rendering time by a lot.