### PR TITLE
Issue #2675 [staging & production] Can't mass-update permissions on child nodes

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2525,6 +2525,31 @@ class TestProject(OsfTestCase):
             contrib.unclaimed_records.keys()
         )
 
+    def test_permission_update_on_readded_contributor(self):
+        # A user is added as a contributor
+        user1 = UserFactory()
+        user2 = UserFactory()
+        self.project.add_contributor(contributor=user2, auth=self.consolidate_auth)
+        self.project.save()
+        # The user is removed
+        self.project.remove_contributor(
+            auth=self.consolidate_auth,
+            contributor=user2
+        )
+
+        self.project.reload()
+
+        self.project.add_contributors(
+            [
+                {'user': user1, 'permissions': ['read', 'write', 'admin'], 'visible': True},
+                {'user': user2, 'permissions': ['read', 'write', 'admin'], 'visible': False}
+            ],
+            auth=self.consolidate_auth
+        )
+        self.project.save()
+
+        assert(self.project.has_permission(user2, 'admin'))
+
 
 class TestTemplateNode(OsfTestCase):
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2536,12 +2536,6 @@ class TestProject(OsfTestCase):
         self.project.add_contributor(user, permissions=['read'])
         self.child_node.add_contributor(user, permissions=['read'])
 
-        # The user is removed
-        self.project.remove_contributor(
-            auth=self.consolidate_auth,
-            contributor=user
-        )
-
         # user is readded with permission admin
         self.child_node.add_contributor(user, permissions=['read','write','admin'])
         self.project.save()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2525,30 +2525,28 @@ class TestProject(OsfTestCase):
             contrib.unclaimed_records.keys()
         )
 
-    def test_permission_update_on_readded_contributor(self):
-        # A user is added as a contributor
-        user1 = UserFactory()
-        user2 = UserFactory()
-        self.project.add_contributor(contributor=user2, auth=self.consolidate_auth)
-        self.project.save()
+    def test_permission_override_on_readded_contributor(self):
+
+        # A child node created
+        self.child_node = NodeFactory(parent=self.project, creator=self.consolidate_auth)
+
+        # A user is added as with read permission
+        user = UserFactory()
+
+        self.project.add_contributor(user, permissions=['read'])
+        self.child_node.add_contributor(user, permissions=['read'])
+
         # The user is removed
         self.project.remove_contributor(
             auth=self.consolidate_auth,
-            contributor=user2
+            contributor=user
         )
 
-        self.project.reload()
-
-        self.project.add_contributors(
-            [
-                {'user': user1, 'permissions': ['read', 'write', 'admin'], 'visible': True},
-                {'user': user2, 'permissions': ['read', 'write', 'admin'], 'visible': False}
-            ],
-            auth=self.consolidate_auth
-        )
+        # user is readded with permission admin
+        self.child_node.add_contributor(user, permissions=['read','write','admin'])
         self.project.save()
 
-        assert(self.project.has_permission(user2, 'admin'))
+        assert(self.child_node.has_permission(user, 'admin'))
 
 
 class TestTemplateNode(OsfTestCase):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2532,13 +2532,11 @@ class TestProject(OsfTestCase):
 
         # A user is added as with read permission
         user = UserFactory()
-
-        self.project.add_contributor(user, permissions=['read'])
         self.child_node.add_contributor(user, permissions=['read'])
 
         # user is readded with permission admin
         self.child_node.add_contributor(user, permissions=['read','write','admin'])
-        self.project.save()
+        self.child_node.save()
 
         assert(self.child_node.has_permission(user, 'admin'))
 

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2241,7 +2241,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
             return True
 
         #Permissions must be overridden if changed when contributor is added to parent he/she is already on a child of.
-        elif contrib_to_add in self.contributors and contrib_to_add.get_permissions() != []:
+        elif contrib_to_add in self.contributors and self.get_permissions(contrib_to_add) != []:
             self.set_permissions(contrib_to_add, permissions)
             return True
         else:

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2241,7 +2241,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
             return True
 
         #Permissions must be overridden if changed when contributor is added to parent he/she is already on a child of.
-        elif contrib_to_add in self.contributors and self.get_permissions(contrib_to_add) != []:
+        elif contrib_to_add in self.contributors and permissions is not None:
             self.set_permissions(contrib_to_add, permissions)
             return True
         else:

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2242,7 +2242,9 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
 
         #Permissions must be overridden if changed when contributor is added to parent he/she is already on a child of.
         elif contrib_to_add in self.contributors and permissions is not None:
-            self.set_permissions(contrib_to_add, permissions, True)
+            self.set_permissions(contrib_to_add, permissions)
+            if save:
+                self.save()
             return True
         else:
             return False

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2239,6 +2239,11 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
 
             contributor_added.send(self, contributor=contributor, auth=auth)
             return True
+
+        #Permissions must be overridden if changed when contributor is added to parent he/she is already on a child of.
+        elif contrib_to_add in self.contributors and contrib_to_add.get_permissions() != []:
+            self.set_permissions(contrib_to_add, permissions)
+            return True
         else:
             return False
 

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2242,7 +2242,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
 
         #Permissions must be overridden if changed when contributor is added to parent he/she is already on a child of.
         elif contrib_to_add in self.contributors and permissions is not None:
-            self.set_permissions(contrib_to_add, permissions)
+            self.set_permissions(contrib_to_add, permissions, True)
             return True
         else:
             return False

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2245,7 +2245,8 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
             self.set_permissions(contrib_to_add, permissions)
             if save:
                 self.save()
-            return True
+
+            return False
         else:
             return False
 


### PR DESCRIPTION
# Purpose
This allows admins to mass update permissions on child nodes for contributors they've readded to the parent node of.

Closes issue https://github.com/CenterForOpenScience/osf.io/issues/2675

# Changes
Now when someone is added to a node they're already on there permission updates.

# Side Effects
None that I know of.