### PR TITLE
add a button to redirect user to sharing page

### DIFF
--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -1508,6 +1508,11 @@ tbody.file-version{
     width: 400px;
 }
 
+.dotted-underline{
+    color: #000;
+    border-bottom: 1px dotted;
+    text-decoration: none;
+}
 /* Contributors list */
 
 #contributors {

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -91,7 +91,7 @@
         <div id="contributors" class="row" style="line-height:25px">
             <div class="col-sm-12">
                 % if user['is_contributor']:
-                    <a href="${node['url']}contributors/">Contributors</a>:
+                    <a class="dotted-underline" href="${node['url']}contributors/">Contributors</a>:
                 % else:
                     Contributors:
                 % endif

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -90,7 +90,12 @@
         </div>
         <div id="contributors" class="row" style="line-height:25px">
             <div class="col-sm-12">
-                Contributors:
+                % if user['is_contributor']:
+                    <a href="${node['url']}contributors/">Contributors</a>:
+                % else:
+                    Contributors:
+                % endif
+
                 % if node['anonymous'] and not node['is_public']:
                     <ol>Anonymous Contributors</ol>
                 % else:
@@ -102,11 +107,6 @@
                         }'></div>
 
                     </ol>
-                    % if 'admin' in user['permissions']:
-                        <a class="btn-mini btn-success btn-sm" href="${node['url']}contributors/">
-                            <i class="fa fa-external-link"></i> Manage
-                        </a>
-                    % endif
                 % endif
                 % if node['is_fork']:
                     <br />Forked from <a class="node-forked-from" href="/${node['forked_from_id']}/">${node['forked_from_display_absolute_url']}</a> on

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -100,7 +100,13 @@
                             "uri": "${node["api_url"]}get_contributors/",
                             "replace": true
                         }'></div>
+
                     </ol>
+                    % if 'admin' in user['permissions']:
+                        <a class="btn-mini btn-success btn-sm" href="${node['url']}contributors/">
+                            <i class="fa fa-external-link"></i> Manage
+                        </a>
+                    % endif
                 % endif
                 % if node['is_fork']:
                     <br />Forked from <a class="node-forked-from" href="/${node['forked_from_id']}/">${node['forked_from_display_absolute_url']}</a> on


### PR DESCRIPTION
<b>Purpose</b>
Add a button on project overview page to let user know where to go to manage contributor.


<b>Changes</b>
After change:
![screen shot 2015-06-02 at 3 32 01 pm](https://cloud.githubusercontent.com/assets/4974056/7945091/91f8553a-093c-11e5-841e-bbff36448146.png)
