### PR TITLE
[Hotfix] [High Priority]  Reduce natural scroll to 0 to avoid side effects in fangorn

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -2014,7 +2014,8 @@ tbOptions = {
         var item = tb.find(row.id);
         _fangornMultiselect.call(tb,null,item);
     },
-    hScroll : 400
+    hScroll : 400,
+    naturalScrollLimit : 0
 };
 
 /**


### PR DESCRIPTION
## Purpose
Fixes this bug on production: https://github.com/CenterForOpenScience/osf.io/issues/2845

## Changes
The Treebeard default value of natural scroll is at 50 items. Fangorn did not override this. However if at some point the row count went below 50 (i.e. because folders were closed) the required scroll refresh was not taking place because the visible items were now below 50. 
Changed the natural scroll setting to 0 to make sure that scroll drawing will always occur. 

## Side effects
Should not be any. Now it relies completely on the virtual scrolling and it seems to be working well. 

@sloria @lbanner 