### PR TITLE
[Feature Fix] Add user warning if navigate away after adding files for upload

### DIFF
--- a/website/static/js/onboarder.js
+++ b/website/static/js/onboarder.js
@@ -422,7 +422,7 @@ function OBUploaderViewModel(params) {
     self.messageClass = ko.observable('text-info');
     // The target node to upload to to
     self.target = ko.observable(null);
-    //Boolean to track of if upload was successful
+    //Boolean to track if upload was successful
     self.success = false;
     /* Functions */
     self.toggle = function() {


### PR DESCRIPTION
Purpose
-----------

When a user is on the dashboard and they decide to upload a file, it is easy to believe just dragging the file has uploaded it. In reality, the user must select a project and hit upload. If a user has started this process and tries to navigate away from the dashboard before completing it, a popup had been added to warn them that their changes will not be saved and gives them an option to stay on the page and finish.

Closes Issue CenterForOpenScience/openscienceframework.org#1518
Changes
------------

Adds a popup if the user tries to navigate away from the dashboard with an unfinished upload.

Side Effects
----------------

None
