### PR TITLE
[Feature Fix]Improve relevance of search results

### DIFF
--- a/tests/test_elastic.py
+++ b/tests/test_elastic.py
@@ -462,7 +462,7 @@ class TestProjectSearchResults(SearchTestCase):
             is_public=True,
         )
 
-        self.project_possesive = ProjectFactory(
+        self.project_possessive = ProjectFactory(
             title=self.possessive,
             creator=self.user,
             is_public=True,
@@ -475,14 +475,26 @@ class TestProjectSearchResults(SearchTestCase):
         )
 
     def test_singular_query(self):
+        """Verify searching for singular term includes singular,
+        possessive and plural versions in results.
+
+        """
         results = query(self.singular)['results']
         assert_equal(len(results), 3)
 
     def test_plural_query(self):
+        """Verify searching for singular term includes singular,
+        possessive and plural versions in results.
+
+        """
         results = query(self.plural)['results']
         assert_equal(len(results), 3)
 
     def test_possessive_query(self):
+        """Verify searching for possessive term includes singular,
+        possessive and plural versions in results.
+
+        """
         results = query(self.possessive)['results']
         assert_equal(len(results), 3)
 

--- a/tests/test_elastic.py
+++ b/tests/test_elastic.py
@@ -439,6 +439,54 @@ class TestAddContributor(SearchTestCase):
         assert_equal(len(contribs['users']), 0)
 
 
+@requires_search
+class TestProjectSearchResults(SearchTestCase):
+    def setUp(self):
+        super(TestProjectSearchResults, self).setUp()
+        self.user = UserFactory(usename='Doug Bogie')
+        self.consolidate_auth = Auth(user=self.user)
+
+        self.title_singular = 'Spanish Inquisition'
+        self.title_plural = 'Spanish Inquisitions'
+        self.title_possesive = 'Spanish\'s Inquisition'
+
+        self.project_singular = ProjectFactory(
+            title=self.title_singular,
+            creator=self.user,
+            is_public=True,
+        )
+
+        self.project_plural = ProjectFactory(
+            title=self.title_plural,
+            creator=self.user,
+            is_public=True,
+        )
+
+        self.project_possesive = ProjectFactory(
+            title=self.title_possesive,
+            creator=self.user,
+            is_public=True,
+        )
+
+        self.project_unrelated = ProjectFactory(
+            title='Cardinal Richelieu',
+            creator=self.user,
+            is_public=True,
+        )
+
+    def test_singular_query(self):
+        results = query(self.title_singular)['results']
+        assert_equal(len(results), 3)
+
+    def test_plural_query(self):
+        results = query(self.title_plural)['results']
+        assert_equal(len(results), 3)
+
+    def test_possive_query(self):
+        results = query(self.title_possesive)['results']
+        assert_equal(len(results), 3)
+
+
 class TestSearchExceptions(OsfTestCase):
     """
     Verify that the correct exception is thrown when the connection is lost

--- a/tests/test_elastic.py
+++ b/tests/test_elastic.py
@@ -444,7 +444,6 @@ class TestProjectSearchResults(SearchTestCase):
     def setUp(self):
         super(TestProjectSearchResults, self).setUp()
         self.user = UserFactory(usename='Doug Bogie')
-        self.consolidate_auth = Auth(user=self.user)
 
         self.singular = 'Spanish Inquisition'
         self.plural = 'Spanish Inquisitions'

--- a/tests/test_elastic.py
+++ b/tests/test_elastic.py
@@ -446,24 +446,24 @@ class TestProjectSearchResults(SearchTestCase):
         self.user = UserFactory(usename='Doug Bogie')
         self.consolidate_auth = Auth(user=self.user)
 
-        self.title_singular = 'Spanish Inquisition'
-        self.title_plural = 'Spanish Inquisitions'
-        self.title_possesive = 'Spanish\'s Inquisition'
+        self.singular = 'Spanish Inquisition'
+        self.plural = 'Spanish Inquisitions'
+        self.possessive = 'Spanish\'s Inquisition'
 
         self.project_singular = ProjectFactory(
-            title=self.title_singular,
+            title=self.singular,
             creator=self.user,
             is_public=True,
         )
 
         self.project_plural = ProjectFactory(
-            title=self.title_plural,
+            title=self.plural,
             creator=self.user,
             is_public=True,
         )
 
         self.project_possesive = ProjectFactory(
-            title=self.title_possesive,
+            title=self.possessive,
             creator=self.user,
             is_public=True,
         )
@@ -475,15 +475,15 @@ class TestProjectSearchResults(SearchTestCase):
         )
 
     def test_singular_query(self):
-        results = query(self.title_singular)['results']
+        results = query(self.singular)['results']
         assert_equal(len(results), 3)
 
     def test_plural_query(self):
-        results = query(self.title_plural)['results']
+        results = query(self.plural)['results']
         assert_equal(len(results), 3)
 
-    def test_possive_query(self):
-        results = query(self.title_possesive)['results']
+    def test_possessive_query(self):
+        results = query(self.possessive)['results']
         assert_equal(len(results), 3)
 
 

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -320,22 +320,24 @@ def delete_index(index):
 def create_index(index=INDEX):
     '''Creates index with some specified mappings to begin with,
     all of which are applied to all projects, components, and registrations'''
+    english_analyzer = {
+        'type': 'string',
+        'analyzer': 'english'
+    }
     mapping = {
         'properties': {
             'tags': {
                 'type': 'string',
                 'index': 'not_analyzed',
             },
+        },
+        'project': {
+            'properties': {
+                'title': english_analyzer,
+                'description': english_analyzer,
+            }
         }
     }
-
-    require_english_analyzer = ['title', 'description']
-    for field in require_english_analyzer:
-        mapping['properties'][field] = {
-            'type': 'string',
-            'analyzer': 'english'
-        }
-
     es.indices.create(index, ignore=[400])
     for type_ in ['project', 'component', 'registration', 'user']:
         es.indices.put_mapping(index=index, doc_type=type_, body=mapping, ignore=[400, 404])

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -38,6 +38,12 @@ ALIASES = {
     'total': 'Total'
 }
 
+# Prevent tokenizing and stop word removal.
+NOT_ANALYZED_PROPERTY = {'type': 'string', 'index': 'not_analyzed'}
+
+# Perform stemming on the field it's applied to.
+ENGLISH_ANALYZER_PROPERTY = {'type': 'string', 'analyzer': 'english'}
+
 INDEX = settings.ELASTIC_INDEX
 
 try:
@@ -321,17 +327,16 @@ def create_index(index=INDEX):
     '''Creates index with some specified mappings to begin with,
     all of which are applied to all projects, components, and registrations.
     '''
-    english_analyzer = {'type': 'string', 'analyzer': 'english'}
-    not_analyzed_property = {'type': 'string', 'index': 'not_analyzed'}
-
+    document_types = ['project', 'component', 'registration', 'user']
     project_like_types = ['project', 'component', 'registration']
     analyzed_fields = ['title', 'description']
 
     es.indices.create(index, ignore=[400])
-    for type_ in ['project', 'component', 'registration', 'user']:
-        mapping = {'properties': {'tags': not_analyzed_property}}
+    for type_ in document_types:
+        mapping = {'properties': {'tags': NOT_ANALYZED_PROPERTY}}
         if type_ in project_like_types:
-            analyzers = {field: english_analyzer for field in analyzed_fields}
+            analyzers = {field: ENGLISH_ANALYZER_PROPERTY
+                         for field in analyzed_fields}
             mapping['properties'].update(analyzers)
 
         es.indices.put_mapping(index=index, doc_type=type_, body=mapping, ignore=[400, 404])

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -319,27 +319,21 @@ def delete_index(index):
 @requires_search
 def create_index(index=INDEX):
     '''Creates index with some specified mappings to begin with,
-    all of which are applied to all projects, components, and registrations'''
-    english_analyzer = {
-        'type': 'string',
-        'analyzer': 'english'
-    }
-    mapping = {
-        'properties': {
-            'tags': {
-                'type': 'string',
-                'index': 'not_analyzed',
-            },
-        },
-        'project': {
-            'properties': {
-                'title': english_analyzer,
-                'description': english_analyzer,
-            }
-        }
-    }
+    all of which are applied to all projects, components, and registrations.
+    '''
+    english_analyzer = {'type': 'string', 'analyzer': 'english'}
+    not_analyzed_property = {'type': 'string', 'index': 'not_analyzed'}
+
+    project_like_types = ['project', 'component', 'registration']
+    analyzed_fields = ['title', 'description']
+
     es.indices.create(index, ignore=[400])
     for type_ in ['project', 'component', 'registration', 'user']:
+        mapping = {'properties': {'tags': not_analyzed_property}}
+        if type_ in project_like_types:
+            analyzers = {field: english_analyzer for field in analyzed_fields}
+            mapping['properties'].update(analyzers)
+
         es.indices.put_mapping(index=index, doc_type=type_, body=mapping, ignore=[400, 404])
 
 

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -328,6 +328,14 @@ def create_index(index=INDEX):
             },
         }
     }
+
+    require_english_analyzer = ['title', 'description']
+    for field in require_english_analyzer:
+        mapping['properties'][field] = {
+            'type': 'string',
+            'analyzer': 'english'
+        }
+
     es.indices.create(index, ignore=[400])
     for type_ in ['project', 'component', 'registration', 'user']:
         es.indices.put_mapping(index=index, doc_type=type_, body=mapping, ignore=[400, 404])

--- a/website/search/util.py
+++ b/website/search/util.py
@@ -22,6 +22,10 @@ RE_XML_ILLEGAL = u'([\u0000-\u0008\u000b-\u000c\u000e-\u001f\ufffe-\uffff])' + \
 RE_XML_ILLEGAL_COMPILED = re.compile(RE_XML_ILLEGAL)
 
 
+TITLE_WEIGHT = 2
+DESCRIPTION_WEIGHT = 1.2
+
+
 def build_query(qs='*', start=0, size=10, sort=None):
     query = {
         'query': build_query_string(qs),
@@ -40,10 +44,17 @@ def build_query(qs='*', start=0, size=10, sort=None):
 
 # Match queryObject in search.js
 def build_query_string(qs):
+    field_boosts = {
+        'title': TITLE_WEIGHT,
+        'description': DESCRIPTION_WEIGHT,
+        '_all': 1,
+    }
+
+    fields = ['{}^{}'.format(k, v) for k,v in field_boosts.iteritems()]
     return {
         'query_string': {
             'default_field': '_all',
-            'fields': ['title^2', '_all', 'description^1.2'],
+            'fields': fields,
             'query': qs,
             'analyze_wildcard': True,
             'auto_generate_phrase_queries': True,

--- a/website/search/util.py
+++ b/website/search/util.py
@@ -43,7 +43,7 @@ def build_query_string(qs):
     return {
         'query_string': {
             'default_field': '_all',
-            'fields': ['_all', 'title^2'],
+            'fields': ['_all', 'title^2', 'description^1.2'],
             'query': qs,
             'analyze_wildcard': True,
             'lenient': True  # TODO, may not want to do this

--- a/website/search/util.py
+++ b/website/search/util.py
@@ -57,7 +57,6 @@ def build_query_string(qs):
             'fields': fields,
             'query': qs,
             'analyze_wildcard': True,
-            'auto_generate_phrase_queries': True,
             'lenient': True  # TODO, may not want to do this
         }
     }

--- a/website/search/util.py
+++ b/website/search/util.py
@@ -35,7 +35,6 @@ def build_query(qs='*', start=0, size=10, sort=None):
                 sort: 'desc'
             }
         ]
-
     return query
 
 
@@ -43,7 +42,6 @@ def build_query_string(qs):
     return {
         'query_string': {
             'default_field': '_all',
-            'fields': ['_all', 'title^2', 'description^1.2'],
             'query': qs,
             'analyze_wildcard': True,
             'lenient': True  # TODO, may not want to do this

--- a/website/search/util.py
+++ b/website/search/util.py
@@ -38,12 +38,15 @@ def build_query(qs='*', start=0, size=10, sort=None):
     return query
 
 
+# Match queryObject in search.js
 def build_query_string(qs):
     return {
         'query_string': {
             'default_field': '_all',
+            'fields': ['title^2', '_all', 'description^1.2'],
             'query': qs,
             'analyze_wildcard': True,
+            'auto_generate_phrase_queries': True,
             'lenient': True  # TODO, may not want to do this
         }
     }

--- a/website/search/util.py
+++ b/website/search/util.py
@@ -40,19 +40,10 @@ def build_query(qs='*', start=0, size=10, sort=None):
 
 
 def build_query_string(qs):
-    field_boosts = {
-        'title': 2,
-    }
-
-    fields = ['_all']
-    for field, boost in field_boosts.iteritems():
-        field = '{}^{}'.format(field, boost) if boost != 1 else field
-        fields.append(field)
-
     return {
         'query_string': {
             'default_field': '_all',
-            'fields': fields,
+            'fields': ['_all', 'title^2'],
             'query': qs,
             'analyze_wildcard': True,
             'lenient': True  # TODO, may not want to do this

--- a/website/search/util.py
+++ b/website/search/util.py
@@ -40,9 +40,19 @@ def build_query(qs='*', start=0, size=10, sort=None):
 
 
 def build_query_string(qs):
+    field_boosts = {
+        'title': 2,
+    }
+
+    fields = ['_all']
+    for field, boost in field_boosts.iteritems():
+        field = '{}^{}'.format(field, boost) if boost != 1 else field
+        fields.append(field)
+
     return {
         'query_string': {
             'default_field': '_all',
+            'fields': fields,
             'query': qs,
             'analyze_wildcard': True,
             'lenient': True  # TODO, may not want to do this

--- a/website/search/util.py
+++ b/website/search/util.py
@@ -50,7 +50,7 @@ def build_query_string(qs):
         '_all': 1,
     }
 
-    fields = ['{}^{}'.format(k, v) for k,v in field_boosts.iteritems()]
+    fields = ['{}^{}'.format(k, v) for k, v in field_boosts.iteritems()]
     return {
         'query_string': {
             'default_field': '_all',

--- a/website/static/js/search.js
+++ b/website/static/js/search.js
@@ -122,8 +122,8 @@ var ViewModel = function(params) {
                 'fields': ['title^2', '_all', 'description^1.2'],
                 'query': self.query(),
                 'analyze_wildcard': true,
-                'lenient': true,
                 'auto_generate_phrase_queries': true,
+                'lenient': true,
             }
         };
     });

--- a/website/static/js/search.js
+++ b/website/static/js/search.js
@@ -116,10 +116,18 @@ var ViewModel = function(params) {
     });
 
     self.queryObject = ko.pureComputed(function(){
+        var TITLE_BOOST = '2';
+        var DESCRIPTION_BOOST = '1.2';
+
+        var fields = [
+            '_all',
+            'title^' + TITLE_BOOST,
+            'description^' + DESCRIPTION_BOOST,
+        ];
         return {
             'query_string': {
                 'default_field': '_all',
-                'fields': ['title^2', '_all', 'description^1.2'],
+                'fields': fields,
                 'query': self.query(),
                 'analyze_wildcard': true,
                 'auto_generate_phrase_queries': true,

--- a/website/static/js/search.js
+++ b/website/static/js/search.js
@@ -119,6 +119,7 @@ var ViewModel = function(params) {
         return {
             'query_string': {
                 'default_field': '_all',
+                'fields': ['title^2', '_all'],
                 'query': self.query(),
                 'analyze_wildcard': true,
                 'lenient': true

--- a/website/static/js/search.js
+++ b/website/static/js/search.js
@@ -130,7 +130,6 @@ var ViewModel = function(params) {
                 'fields': fields,
                 'query': self.query(),
                 'analyze_wildcard': true,
-                'auto_generate_phrase_queries': true,
                 'lenient': true,
             }
         };

--- a/website/static/js/search.js
+++ b/website/static/js/search.js
@@ -123,8 +123,8 @@ var ViewModel = function(params) {
                 'query': self.query(),
                 'analyze_wildcard': true,
                 'lenient': true,
-                'auto_generate_phrase_queries':true,
-            }+
+                'auto_generate_phrase_queries': true,
+            }
         };
     });
 

--- a/website/static/js/search.js
+++ b/website/static/js/search.js
@@ -119,7 +119,7 @@ var ViewModel = function(params) {
         return {
             'query_string': {
                 'default_field': '_all',
-                'fields': ['title^2', '_all'],
+                'fields': ['title^2', '_all', 'description^1.2'],
                 'query': self.query(),
                 'analyze_wildcard': true,
                 'lenient': true

--- a/website/static/js/search.js
+++ b/website/static/js/search.js
@@ -122,8 +122,9 @@ var ViewModel = function(params) {
                 'fields': ['title^2', '_all', 'description^1.2'],
                 'query': self.query(),
                 'analyze_wildcard': true,
-                'lenient': true
-            }
+                'lenient': true,
+                'auto_generate_phrase_queries':true,
+            }+
         };
     });
 


### PR DESCRIPTION
## Purpose
Currently searches do not place relevant projects at the top of the results. Projects with titles similar to a given query are not at the top of the results page. Also, search results for a query with a singular word are different if the query has a query with a plural word (ex 'Horse' has different results than 'Horses'). This PR improves the apparent relevance of search results, and fixes plural and singular words yielding different results. 

resolves https://github.com/CenterForOpenScience/osf.io/issues/2552

## Changes
* Titles weight in relevance scoring increased to 2
* Descriptions weight in relevance scoring increased to 1.2
* Use phrase searching by default
* The 'english analyzer' is used for titles and descriptions which fixes the plural/singular issue

## Side Effects
Use of english analyzer may affect searches for projects with non-english titles or descriptions.