### PR TITLE
Updating permissions text for Dataverse.

### DIFF
--- a/framework/addons/data/addons.json
+++ b/framework/addons/data/addons.json
@@ -123,7 +123,7 @@
         "Dataverse": {
             "Permissions": {
                 "status": "partial",
-                "text": "Making an OSF project public or private is independent of making a Dataverse study public or private, although the OSF can only access public studies on released Dataverses. The OSF allows you to release the latest draft version of a Dataverse study."
+                "text": "Making an OSF project public or private is independent of making a Dataverse study public or private. The OSF allows you to release the latest draft version of a Dataverse dataset."
             },
             "View / download file versions": {
                 "status": "partial",


### PR DESCRIPTION
Fixes https://github.com/CenterForOpenScience/osf.io/issues/2960
by replacing the permissions line in the modal:
![12629e6e-0aa6-11e5-9eb8-945d020ce6a5](https://cloud.githubusercontent.com/assets/9437946/7987694/0903f29e-0aad-11e5-8e3f-d9aef8063008.png)
with

Making an OSF project public or private is independent of making a Dataverse study public or private. The OSF allows you to release the latest draft version of a Dataverse dataset. 