### PR TITLE
[Feature Fix]Add link modal clipping names

### DIFF
--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -313,7 +313,6 @@ a.btn-success.disabled {
 
 #addPointer td {
     vertical-align: middle;
-    word-break: break-all;
 }
 
 li.pointer {

--- a/website/templates/project/modal_add_pointer.mako
+++ b/website/templates/project/modal_add_pointer.mako
@@ -1,6 +1,6 @@
 <div class="modal fade" id="addPointer">
 
-    <div class="modal-dialog">
+    <div class="modal-dialog modal-lg">
 
         <div class="modal-content">
 


### PR DESCRIPTION
# Purpose
QA brought up Add Link's modal is breaking last names into single character lines if Project name is too long. This PR fixes this problem.

# Changes
Took out break-word: break-all css in site.css. Added modal-lg to class to allow for more space in general.

# Side Effects
There should be no side effects as this is a simple bug fix.