### PR TITLE
[feature fix] Fix broken syntax checker in "invoke test_all"

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -383,9 +383,12 @@ def test_addons():
 
 
 @task
-def test(all=False):
+def test(all=False, syntax=False):
     """Alias of `invoke test_osf`.
     """
+    if syntax:
+        flake()
+
     if all:
         test_all()
     else:
@@ -393,8 +396,8 @@ def test(all=False):
 
 
 @task
-def test_all(flake=False):
-    if flake:
+def test_all(syntax=False):
+    if syntax:
         flake()
     test_osf()
     test_addons()


### PR DESCRIPTION
## Purpose
The syntax checker in `tasks.py` was not running currently, because the boolean flag (`flake`) overwrote the function name (`flake`) in the function scope.

With this change, it is now possible to run syntax checks in both `inv test --syntax` and `inv test --all`. This should make it easier to catch errors that would otherwise only be noticed in Travis CI failures.

## Summary of changes
The `flake` flag is renamed to `syntax` for clarity. It can now be used without having to run all unit tests.