### PR TITLE
[Feature Fix] Fix resolve icon view

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -197,7 +197,11 @@ function resolveIconView(item) {
     function returnView(type, category) {
         var iconType = projectIcons[type];
         if (type === 'component' || type === 'registeredComponent') {
-            iconType = componentIcons[category];
+            if (!item.data.permissions.view) {
+                return null;
+            } else {
+                iconType = componentIcons[category];
+            }
         } else if (type === 'project' || type === 'registeredProject') {
             iconType = projectIcons[category];
         }
@@ -211,9 +215,6 @@ function resolveIconView(item) {
     }
     if (item.data.nodeType === 'smartFolder') {
         return returnView('smartCollection');
-    }
-    if (item.data.nodeType === 'folder') {
-        return returnView('collection');
     }
     if (item.data.nodeType === 'pointer' && item.parent().data.nodeType !== 'folder') {
         return returnView('link');
@@ -246,7 +247,6 @@ function resolveIconView(item) {
  * @private
  */
 function _fangornResolveIcon(item) {
-    var projectIcons = iconmap.projectIcons;
     var privateFolder =  m('div.file-extension._folder_delete', ' '),
         pointerFolder = m('i.fa.fa-link', ' '),
         openFolder  = m('i.fa.fa-folder-open', ' '),
@@ -261,6 +261,7 @@ function _fangornResolveIcon(item) {
                 return m('span', {style: {width:'16px', height:'16px', background:'url(' + item.data.iconUrl+ ')', display:'block'}}, '');
             }
             if (!item.data.permissions.view) {
+                console.log("Private");
                 return privateFolder;
             }
             if (item.data.isPointer) {

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -216,20 +216,20 @@ function resolveIconView(item) {
     if (item.data.isDashboard) {
         return returnView('collection');
     }
-    if (item.data.nodeType === 'smartFolder' || item.data.isSmartFolder) {
+    if (item.data.isSmartFolder) {
         return returnView('smartCollection');
     }
     if ((item.data.nodeType === 'pointer' && item.parent().data.nodeType !== 'folder') || (item.data.isPointer && !item.parent().data.isFolder)) {
         return returnView('link');
     }
-    if (item.data.nodeType === 'project' || item.data.isProject) {
+    if (item.data.nodeType === 'project') {
         if (item.data.isRegistration) {
             return returnView('registeredProject', item.data.category);
         } else {
             return returnView('project', item.data.category);
         }
     }
-    if (item.data.nodeType === 'component' || item.data.isComponent) {
+    if (item.data.nodeType === 'component') {
         if (item.data.isRegistration) {
             return returnView('registeredComponent', item.data.category);
         }

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -213,27 +213,30 @@ function resolveIconView(item) {
         var template = m('span', { 'class' : iconType});
         return template;
     }
-    if (item.data.nodeType === 'smartFolder') {
+    if (item.data.isDashboard) {
+        return returnView('collection');
+    }
+    if (item.data.nodeType === 'smartFolder' || item.data.isSmartFolder) {
         return returnView('smartCollection');
     }
-    if (item.data.nodeType === 'pointer' && item.parent().data.nodeType !== 'folder') {
+    if ((item.data.nodeType === 'pointer' && item.parent().data.nodeType !== 'folder') || (item.data.isPointer && !item.parent().data.isFolder)) {
         return returnView('link');
     }
-    if (item.data.nodeType === 'project') {
+    if (item.data.nodeType === 'project' || item.data.isProject) {
         if (item.data.isRegistration) {
             return returnView('registeredProject', item.data.category);
         } else {
             return returnView('project', item.data.category);
         }
     }
-    if (item.data.nodeType === 'component') {
+    if (item.data.nodeType === 'component' || item.data.isComponent) {
         if (item.data.isRegistration) {
             return returnView('registeredComponent', item.data.category);
         }
         return returnView('component', item.data.category);
     }
 
-    if (item.data.nodeType === 'pointer') {
+    if (item.data.nodeType === 'pointer' || item.data.isPointer) {
         return returnView('link');
     }
     return null;
@@ -261,7 +264,6 @@ function _fangornResolveIcon(item) {
                 return m('span', {style: {width:'16px', height:'16px', background:'url(' + item.data.iconUrl+ ')', display:'block'}}, '');
             }
             if (!item.data.permissions.view) {
-                console.log("Private");
                 return privateFolder;
             }
             if (item.data.isPointer) {

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -267,7 +267,7 @@ function resolveconfigOption(item, option, args) {
  * @this Treebeard.controller
  */
 var inheritedFields = ['nodeId', 'nodeUrl', 'nodeApiUrl', 'permissions', 'provider', 'accept'];
-function inheritFromParent(item, parent, fields) {
+function inheritFromParent(item, parent, fields) {   
     inheritedFields.concat(fields || []).forEach(function(field) {
         item.data[field] = item.data[field] || parent.data[field];
     });
@@ -1073,7 +1073,7 @@ function _fangornTitleColumn(item, col) {
  * @returns {Array} An array of columns that get iterated through in Treebeard
  * @private
  */
-function _fangornResolveRows(item) {
+ function _fangornResolveRows(item) {
     var tb = this;
     var default_columns = [];
     var configOption;
@@ -1126,7 +1126,7 @@ function _fangornResolveRows(item) {
     }
     configOption = resolveconfigOption.call(this, item, 'resolveRows', [item]);
     return configOption || default_columns;
-}
+ }
 
 /**
  * Defines Column Titles separately since content and css may be different, allows more flexibility

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -330,7 +330,7 @@ function resolveconfigOption(item, option, args) {
  * @this Treebeard.controller
  */
 var inheritedFields = ['nodeId', 'nodeUrl', 'nodeApiUrl', 'permissions', 'provider', 'accept'];
-function inheritFromParent(item, parent, fields) {   
+function inheritFromParent(item, parent, fields) {
     inheritedFields.concat(fields || []).forEach(function(field) {
         item.data[field] = item.data[field] || parent.data[field];
     });
@@ -1136,7 +1136,7 @@ function _fangornTitleColumn(item, col) {
  * @returns {Array} An array of columns that get iterated through in Treebeard
  * @private
  */
- function _fangornResolveRows(item) {
+function _fangornResolveRows(item) {
     var tb = this;
     var default_columns = [];
     var configOption;
@@ -1189,7 +1189,7 @@ function _fangornTitleColumn(item, col) {
     }
     configOption = resolveconfigOption.call(this, item, 'resolveRows', [item]);
     return configOption || default_columns;
- }
+}
 
 /**
  * Defines Column Titles separately since content and css may be different, allows more flexibility

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -236,7 +236,7 @@ function resolveIconView(item) {
         return returnView('component', item.data.category);
     }
 
-    if (item.data.nodeType === 'pointer' || item.data.isPointer) {
+    if (item.data.nodeType === 'pointer') {
         return returnView('link');
     }
     return null;

--- a/website/static/js/pages/project-dashboard-page.js
+++ b/website/static/js/pages/project-dashboard-page.js
@@ -55,6 +55,22 @@ $(document).ready(function () {
     $.ajax({
         url:  nodeApiUrl + 'files/grid/'
     }).done(function (data) {
+        // console.log(data.data[0]);
+        // var children = data.data[0].children;
+        // var noPrivateData = [];
+        // var privateData = [];
+        // var x;
+        // for (x in data.data[0].children) {
+        //     if (children[x].name !== 'Private Component') {
+        //         noPrivateData.push(children[x]);
+        //     } else {
+        //         privateData.push(children[x]);
+        //     }
+        // }
+        // noPrivateData.push(privateData);
+        // data.data[0].children = noPrivateData;
+        // console.log(data.data);
+
         var fangornOpts = {
             divID: 'treeGrid',
             filesData: data.data,
@@ -75,32 +91,38 @@ $(document).ready(function () {
                 ];
             },
             resolveRows : function (item) {
-                var tb = this;
-                item.css = '';
-                if(tb.isMultiselected(item.id)){
-                    item.css = 'fangorn-selected';
-                }
-                var defaultColumns = [
-                        {
-                            data: 'name',
-                            folderIcons: true,
-                            filter: true,
-                            custom: Fangorn.DefaultColumns._fangornTitleColumn
-                        }];
-                if (item.parentID) {
-                    item.data.permissions = item.data.permissions || item.parent().data.permissions;
-                    if (item.data.kind === 'folder') {
-                        item.data.accept = item.data.accept || item.parent().data.accept;
-                    }
-                }
-                if(item.data.uploadState && (item.data.uploadState() === 'pending' || item.data.uploadState() === 'uploading')){
-                    return Fangorn.Utils.uploadRowTemplate.call(tb, item);
-                }
+                //if (item.data.name != 'Private Component') {
+                console.log(item.data.name);
 
-                var configOption = Fangorn.Utils.resolveconfigOption.call(this, item, 'resolveRows', [item]);
-                return configOption || defaultColumns;
-            }
+                    var tb = this;
+                    item.css = '';
+                    if(tb.isMultiselected(item.id)){
+                        item.css = 'fangorn-selected';
+                    }
+                    var defaultColumns = [
+                            {
+                                data: 'name',
+                                folderIcons: true,
+                                filter: true,
+                                custom: Fangorn.DefaultColumns._fangornTitleColumn
+                            }];
+                    if (item.parentID) {
+                        item.data.permissions = item.data.permissions || item.parent().data.permissions;
+                        if (item.data.kind === 'folder') {
+                            item.data.accept = item.data.accept || item.parent().data.accept;
+                        }
+                    }
+                    if(item.data.uploadState && (item.data.uploadState() === 'pending' || item.data.uploadState() === 'uploading')){
+                        return Fangorn.Utils.uploadRowTemplate.call(tb, item);
+                    }
+
+                    var configOption = Fangorn.Utils.resolveconfigOption.call(this, item, 'resolveRows', [item]);
+                    return configOption || defaultColumns;
+                }
+                //return defaultColumns;
+           // }
         };
+        
         var filebrowser = new Fangorn(fangornOpts);
     });
 

--- a/website/static/js/pages/project-dashboard-page.js
+++ b/website/static/js/pages/project-dashboard-page.js
@@ -100,9 +100,7 @@ $(document).ready(function () {
                     var configOption = Fangorn.Utils.resolveconfigOption.call(this, item, 'resolveRows', [item]);
                     return configOption || defaultColumns;
                 }
-                //return defaultColumns;
         };
-        
         var filebrowser = new Fangorn(fangornOpts);
     });
 

--- a/website/static/js/pages/project-dashboard-page.js
+++ b/website/static/js/pages/project-dashboard-page.js
@@ -92,7 +92,7 @@ $(document).ready(function () {
             },
             resolveRows : function (item) {
                 //if (item.data.name != 'Private Component') {
-                console.log(item.data.name);
+                //console.log(item.data.name);
 
                     var tb = this;
                     item.css = '';

--- a/website/static/js/pages/project-dashboard-page.js
+++ b/website/static/js/pages/project-dashboard-page.js
@@ -75,31 +75,31 @@ $(document).ready(function () {
                 ];
             },
             resolveRows : function (item) {
-                    var tb = this;
-                    item.css = '';
-                    if(tb.isMultiselected(item.id)){
-                        item.css = 'fangorn-selected';
-                    }
-                    var defaultColumns = [
-                            {
-                                data: 'name',
-                                folderIcons: true,
-                                filter: true,
-                                custom: Fangorn.DefaultColumns._fangornTitleColumn
-                            }];
-                    if (item.parentID) {
-                        item.data.permissions = item.data.permissions || item.parent().data.permissions;
-                        if (item.data.kind === 'folder') {
-                            item.data.accept = item.data.accept || item.parent().data.accept;
-                        }
-                    }
-                    if(item.data.uploadState && (item.data.uploadState() === 'pending' || item.data.uploadState() === 'uploading')){
-                        return Fangorn.Utils.uploadRowTemplate.call(tb, item);
-                    }
-
-                    var configOption = Fangorn.Utils.resolveconfigOption.call(this, item, 'resolveRows', [item]);
-                    return configOption || defaultColumns;
+                var tb = this;
+                item.css = '';
+                if(tb.isMultiselected(item.id)){
+                    item.css = 'fangorn-selected';
                 }
+                var defaultColumns = [
+                        {
+                            data: 'name',
+                            folderIcons: true,
+                            filter: true,
+                            custom: Fangorn.DefaultColumns._fangornTitleColumn
+                        }];
+                if (item.parentID) {
+                    item.data.permissions = item.data.permissions || item.parent().data.permissions;
+                    if (item.data.kind === 'folder') {
+                        item.data.accept = item.data.accept || item.parent().data.accept;
+                    }
+                }
+                if(item.data.uploadState && (item.data.uploadState() === 'pending' || item.data.uploadState() === 'uploading')){
+                    return Fangorn.Utils.uploadRowTemplate.call(tb, item);
+                }
+
+                var configOption = Fangorn.Utils.resolveconfigOption.call(this, item, 'resolveRows', [item]);
+                return configOption || defaultColumns;
+            }
         };
         var filebrowser = new Fangorn(fangornOpts);
     });

--- a/website/static/js/pages/project-dashboard-page.js
+++ b/website/static/js/pages/project-dashboard-page.js
@@ -55,22 +55,6 @@ $(document).ready(function () {
     $.ajax({
         url:  nodeApiUrl + 'files/grid/'
     }).done(function (data) {
-        // console.log(data.data[0]);
-        // var children = data.data[0].children;
-        // var noPrivateData = [];
-        // var privateData = [];
-        // var x;
-        // for (x in data.data[0].children) {
-        //     if (children[x].name !== 'Private Component') {
-        //         noPrivateData.push(children[x]);
-        //     } else {
-        //         privateData.push(children[x]);
-        //     }
-        // }
-        // noPrivateData.push(privateData);
-        // data.data[0].children = noPrivateData;
-        // console.log(data.data);
-
         var fangornOpts = {
             divID: 'treeGrid',
             filesData: data.data,
@@ -91,9 +75,6 @@ $(document).ready(function () {
                 ];
             },
             resolveRows : function (item) {
-                //if (item.data.name != 'Private Component') {
-                //console.log(item.data.name);
-
                     var tb = this;
                     item.css = '';
                     if(tb.isMultiselected(item.id)){
@@ -120,7 +101,6 @@ $(document).ready(function () {
                     return configOption || defaultColumns;
                 }
                 //return defaultColumns;
-           // }
         };
         
         var filebrowser = new Fangorn(fangornOpts);

--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -316,18 +316,6 @@ function _poToggleCheck(item) {
 }
 
 /**
- * Returns custom icons for OSF depending on the type of item
- * @param {Object} item A Treebeard _item object. Node information is inside item.data
- * @this Treebeard.controller
- * @returns {Object}  Returns a mithril template with the m() function.
- * @private
- */
-function _poResolveIcon(item) {
-    var newIcon = Fangorn.Utils.resolveIconView(item);
-    return newIcon;
-}
-
-/**
  * Returns custom folder toggle icons for OSF
  * @param {Object} item A Treebeard _item object. Node information is inside item.data
  * @this Treebeard.controller
@@ -1404,7 +1392,7 @@ var tbOptions = {
         _cleanupMithril();
     },
     onmultiselect : _poMultiselect,
-    resolveIcon : _poResolveIcon,
+    resolveIcon : Fangorn.Utils.resolveIconView,
     resolveToggle : _poResolveToggle,
     resolveLazyloadUrl : _poResolveLazyLoad,
     lazyLoadOnLoad : expandStateLoad,

--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -324,9 +324,6 @@ function _poToggleCheck(item) {
  */
 function _poResolveIcon(item) {
     var newIcon = Fangorn.Utils.resolveIconView(item);
-    if (newIcon === null) {
-        return m('span', { 'class' : 'collection'});
-    }
     return newIcon;
 }
 


### PR DESCRIPTION
# Purpose

This fixes issues created by PR #2871. The certificate and collection icons on the project organizer are incorrect. Private component icons appear on the file grid.

# Changes

`resolveIconView` in *fangorn.js* is revamped to handle requests from the project organizer and the file grid. The change in `resolveIconView` eradicates the need for `_poResolveIcon` in *projectorganizer.js*. The project organizer now calls `resolveIconView` directly.

# Side effects

In the file grid, the private component icon is used. In the project organizer, the dashboard icon, 'all my registrations' and 'all my project icons' display properly.

Fix:
![screen shot 2015-06-05 at 1 01 30 pm](https://cloud.githubusercontent.com/assets/7131985/8010994/0fce845a-0b83-11e5-9ceb-762158382f3f.png)

![screen shot 2015-06-05 at 1 01 06 pm](https://cloud.githubusercontent.com/assets/7131985/8011017/33e174ec-0b83-11e5-879d-4710bedf9d96.png)

Problem:
![screen shot 2015-06-05 at 9 58 30 am](https://cloud.githubusercontent.com/assets/7131985/8011021/378226d2-0b83-11e5-9448-e1817ae883f8.png)

![screen shot 2015-06-05 at 1 03 59 pm](https://cloud.githubusercontent.com/assets/7131985/8011049/6e873334-0b83-11e5-8744-2d05f4104942.png)