### PR TITLE
[Feature Fix]  [Firefox] Fix the incorrect time shown on file version table 

### DIFF
--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -401,6 +401,11 @@ var LOCAL_DATEFORMAT = 'YYYY-MM-DD hh:mm A';
 var UTC_DATEFORMAT = 'YYYY-MM-DD HH:mm UTC';
 var FormattableDate = function(date) {
     if (typeof date === 'string') {
+        // If Firefox, add 'Z' to the date string (Z is timezone for UTC)
+        if(navigator.userAgent.toLowerCase().indexOf('firefox') > -1)
+        {
+           date = date + "Z";
+        }
         // The date as a Date object
         this.date = new Date(date);
     } else {


### PR DESCRIPTION
## Purpose
This PR is to solve the issue that on firefox it shows the wrong file modified date. 

Resolved #2972 

## Change
Different from all the other browsers, Firefox assumes  the input(`DateString`) of  `new Date(DateString)` is the date based on local time zone while all the other browsers treat the input based on UTC time zone. In our case, the input date string is UTC time-zone. Therefore, we need manually add offset  when displaying on firefox, by adding ''Z' at the end of date string. The letter Z ("Zulu") indicates  Coordinated Universal Time (see UTC±00:00).

So in summary, the PR code is to add 'Z' at the end of date time string. The action is only limited to Firefox. Since it changes the osfHelper.js, the solution will apply all the hidden date-shown problems on Firefox.

Reference material --[Stackoverflow Question](http://stackoverflow.com/questions/15109894/new-date-works-differently-in-chrome-and-firefox)

## Side effect
None.