### PR TITLE
Move Retraction/Embargo logs to parent project

### DIFF
--- a/scripts/embargo_registrations.py
+++ b/scripts/embargo_registrations.py
@@ -35,14 +35,13 @@ def main(dry_run=True):
             if not dry_run:
                 with TokuTransaction():
                     embargo.state = models.Embargo.ACTIVE
-                    parent_registration.add_log(
+                    parent_registration.registered_from.add_log(
                         action=NodeLog.EMBARGO_APPROVED,
                         params={
                             'node': parent_registration._id,
                             'embargo_id': embargo._id,
                         },
                         auth=Auth(parent_registration.embargo.initiated_by),
-                        save=False,
                     )
                     embargo.save()
 
@@ -60,14 +59,13 @@ def main(dry_run=True):
                 with TokuTransaction():
                     parent_registration.set_privacy('public')
                     embargo.state = models.Embargo.COMPLETED
-                    parent_registration.add_log(
+                    parent_registration.registered_from.add_log(
                         action=NodeLog.EMBARGO_COMPLETED,
                         params={
                             'node': parent_registration._id,
                             'embargo_id': embargo._id,
                         },
                         auth=Auth(parent_registration.embargo.initiated_by),
-                        save=False,
                     )
                     embargo.save()
 

--- a/scripts/retract_registrations.py
+++ b/scripts/retract_registrations.py
@@ -32,14 +32,13 @@ def main(dry_run=True):
             if not dry_run:
                 with TokuTransaction():
                     retraction.state = models.Retraction.RETRACTED
-                    parent_registration.add_log(
+                    parent_registration.registered_from.add_log(
                         action=NodeLog.RETRACTION_APPROVED,
                         params={
                             'node': parent_registration._id,
                             'retraction_id': parent_registration.retraction._id,
                         },
                         auth=Auth(parent_registration.retraction.initiated_by),
-                        save=False,
                     )
                     retraction.save()
 

--- a/scripts/tests/test_embargo_registrations.py
+++ b/scripts/tests/test_embargo_registrations.py
@@ -116,8 +116,8 @@ class TestRetractRegistrations(OsfTestCase):
         assert_true(self.registration.embargo_end_date)
         assert_false(self.registration.pending_embargo)
 
-    def test_embargo_approval_adds_to_parent_registrations_log(self):
-        initial_num_logs = len(self.registration.logs)
+    def test_embargo_approval_adds_to_parent_projects_log(self):
+        initial_project_logs = len(self.registration.registered_from.logs)
         # Embargo#iniation_date is read only
         self.registration.embargo._fields['initiation_date'].__set__(
             self.registration.embargo,
@@ -127,10 +127,11 @@ class TestRetractRegistrations(OsfTestCase):
         self.registration.embargo.save()
 
         main(dry_run=False)
-        assert_equal(len(self.registration.logs), initial_num_logs + 1)
+        # Logs: Created, made public, registered, embargo initiated, embargo approved
+        assert_equal(len(self.registration.registered_from.logs), initial_project_logs + 1)
 
-    def test_embargo_completion_adds_to_parent_registrations_log(self):
-        initial_num_logs = len(self.registration.logs)
+    def test_embargo_completion_adds_to_parent_projects_log(self):
+        initial_project_logs = len(self.registration.registered_from.logs)
         approval_token = self.registration.embargo.approval_state[self.user._id]['approval_token']
         self.registration.embargo.approve_embargo(self.user, approval_token)
         self.registration.save()
@@ -144,5 +145,5 @@ class TestRetractRegistrations(OsfTestCase):
         self.registration.embargo.save()
 
         main(dry_run=False)
-        # Approved embargo, made registration public, and completed embargo
-        assert_equal(len(self.registration.logs), initial_num_logs + 3)
+        # Logs: Created, made public, registered, embargo initiated, embargo approved, embargo completed
+        assert_equal(len(self.registration.registered_from.logs), initial_project_logs + 2)

--- a/scripts/tests/test_retract_registrations.py
+++ b/scripts/tests/test_retract_registrations.py
@@ -66,8 +66,8 @@ class TestRetractRegistrations(OsfTestCase):
         main(dry_run=False)
         assert_true(self.registration.retraction.is_retracted)
 
-    def test_retraction_adds_to_parent_registrations_log(self):
-        initial_num_logs = len(self.registration.logs)
+    def test_retraction_adds_to_parent_projects_log(self):
+        initial_project_logs = len(self.registration.registered_from.logs)
         # Retraction#iniation_date is read only
         self.registration.retraction._fields['initiation_date'].__set__(
             self.registration.retraction,
@@ -79,4 +79,5 @@ class TestRetractRegistrations(OsfTestCase):
 
         main(dry_run=False)
         assert_true(self.registration.retraction.is_retracted)
-        assert_equal(len(self.registration.logs), initial_num_logs + 1)
+        # Logs: Created, made public, retraction initiated, retracted approved
+        assert_equal(len(self.registration.registered_from.logs), initial_project_logs + 1)

--- a/tests/test_registration_retractions.py
+++ b/tests/test_registration_retractions.py
@@ -179,14 +179,15 @@ class RegistrationRetractionModelsTestCase(OsfTestCase):
         num_of_approvals = sum([val['has_approved'] for val in self.registration.retraction.approval_state.values()])
         assert_equal(num_of_approvals, 1)
 
-    def test_approval_adds_to_parent_registrations_log(self):
-        initial_num_logs = len(self.registration.logs)
+    def test_approval_adds_to_parent_projects_log(self):
+        initial_project_logs = len(self.registration.registered_from.logs)
         self.registration.retract_registration(self.user)
         self.registration.save()
 
         approval_token = self.registration.retraction.approval_state[self.user._id]['approval_token']
         self.registration.retraction.approve_retraction(self.user, approval_token)
-        assert_equal(len(self.registration.logs), initial_num_logs + 2)
+        # Logs: Created, registered, retraction initiated, retraction approved
+        assert_equal(len(self.registration.registered_from.logs), initial_project_logs + 2)
 
     def test_retraction_of_registration_pending_embargo_cancels_embargo(self):
         self.registration.is_public = True
@@ -210,8 +211,8 @@ class RegistrationRetractionModelsTestCase(OsfTestCase):
         assert_false(self.registration.embargo_end_date)
         assert_equal(self.registration.embargo.state, Retraction.CANCELLED)
 
-    def test_approval_of_registration_with_embargo_adds_to_parent_registrations_log(self):
-        initial_num_logs = len(self.registration.logs)
+    def test_approval_of_registration_with_embargo_adds_to_parent_projects_log(self):
+        initial_project_logs = len(self.registration.registered_from.logs)
         self.registration.is_public = True
         self.registration.embargo_registration(
             self.user,
@@ -225,8 +226,8 @@ class RegistrationRetractionModelsTestCase(OsfTestCase):
 
         approval_token = self.registration.retraction.approval_state[self.user._id]['approval_token']
         self.registration.retraction.approve_retraction(self.user, approval_token)
-        # Initiate Embargo, initiate of Retraction, approve of Retraction, and cancel of Embargo
-        assert_equal(len(self.registration.logs), initial_num_logs + 4)
+        # Logs: Created, registered, embargo initiated, retraction initiated, retraction approved, embargo cancelled
+        assert_equal(len(self.registration.registered_from.logs), initial_project_logs + 4)
 
     def test_retraction_of_registration_in_active_embargo_cancels_embargo(self):
         self.registration.is_public = True
@@ -326,15 +327,16 @@ class RegistrationRetractionModelsTestCase(OsfTestCase):
         self.registration.retraction.disapprove_retraction(self.user, disapproval_token)
         assert_equal(self.registration.retraction.state, Retraction.CANCELLED)
 
-    def test_disapproval_adds_to_parent_registrations_log(self):
-        initial_num_logs = len(self.registration.logs)
+    def test_disapproval_adds_to_parent_projects_log(self):
+        initial_project_logs = len(self.registration.registered_from.logs)
         self.registration.retract_registration(self.user)
         self.registration.save()
         self.registration.reload()
 
         disapproval_token = self.registration.retraction.approval_state[self.user._id]['disapproval_token']
         self.registration.retraction.disapprove_retraction(self.user, disapproval_token)
-        assert_equal(len(self.registration.logs), initial_num_logs + 2)
+        # Logs: Created, registered, retraction initiated, retraction cancelled
+        assert_equal(len(self.registration.registered_from.logs), initial_project_logs + 2)
 
     # Retraction property tests
     def test_new_retraction_is_pending_retraction(self):
@@ -700,12 +702,13 @@ class RegistrationRetractionViewsTestCase(OsfTestCase):
         assert_equal(self.registration.retraction.state, Retraction.PENDING)
         assert_is_none(self.registration.retraction.justification)
 
-    def test_valid_POST_retraction_adds_to_parent_node_log(self):
-        initial_num_logs = len(self.registration.logs)
-        res = self.app.post_json(
+    def test_valid_POST_retraction_adds_to_parent_projects_log(self):
+        initial_project_logs = len(self.registration.registered_from.logs)
+        self.app.post_json(
             self.retraction_post_url,
             {'justification': ''},
             auth=self.auth,
         )
-        self.registration.reload()
-        assert_equal(len(self.registration.logs), initial_num_logs + 1)
+        self.registration.registered_from.reload()
+        # Logs: Created, registered, retraction initiated
+        assert_equal(len(self.registration.registered_from.logs), initial_project_logs + 1)


### PR DESCRIPTION
## Purpose:
Previously, logs were added to a retraction or embargoes respective registration. A behavior change was requested to move the log up to the project the registration was created from. 

## Changes:
Logging was moved to the project level and updated tests accordingly.

`Node#set_privacy` was not logging actions, updated it and tests accordingly.

## Side Effects:
N/A

## Notes:
Currently, tests will fail due to a known caching error within Modular ODM. Michael and Lyndsy are aware.