### PR TITLE
Remove aggregations from count query before executing it

### DIFF
--- a/website/search/share_search.py
+++ b/website/search/share_search.py
@@ -42,10 +42,10 @@ def remove_key(d, k):
 
 @requires_search
 def count(query, index='share'):
-    if query.get('from') is not None:
-        del query['from']
-    if query.get('size') is not None:
-        del query['size']
+    # Get rid of fields not allowed in count queries
+    for field in ['from', 'size', 'aggs', 'aggregations']:
+        if query.get(field):
+            del query[field]
 
     count = share_es.count(index=index, body=query)
 


### PR DESCRIPTION
Purpose
-----------
When a query is posted at the SHARE API that contains an aggregation and the url parameter ```count``` is set to True, we throw a 500 because aggregations aren't allowed in count queries.

Changes
------------
If a count query is being made, I remove aggregations from it so that the document count for that query can still be correctly returned.

Side-effects
---------------
I don't think any side-effects are really possible from this PR.