### PR TITLE
Fix count query checks for SHARE 

### DIFF
--- a/tests/test_share.py
+++ b/tests/test_share.py
@@ -98,6 +98,36 @@ class TestShareSearch(OsfTestCase):
         })
         assert_is(mock_count.called, True)
 
+    def test_share_count_cleans_query(self):
+        cleaned_query = share_search.clean_count_query({
+            'aggs': {
+                'sourceAgg': {
+                    'terms': {
+                        'field': '_type',
+                        'min_doc_count': 0,
+                        'size': 0
+                    }
+                }
+            },
+            'aggregations': {
+                'sourceAgg': {
+                    'terms': {
+                        'field': '_type',
+                        'min_doc_count': 0,
+                        'size': 0
+                    }
+                }
+            },
+            'from': 0,
+            'query':
+                {
+                    'match_all': {}
+                },
+            'size': 10
+        })
+        assert cleaned_query.keys() == ['query']
+
+
     @patch.object(share_search.share_es, 'search')
     def test_share_providers(self, mock_search):
         mock_search.return_value = {

--- a/website/search/share_search.py
+++ b/website/search/share_search.py
@@ -44,7 +44,7 @@ def remove_key(d, k):
 def count(query, index='share'):
     # Get rid of fields not allowed in count queries
     for field in ['from', 'size', 'aggs', 'aggregations']:
-        if query.get(field):
+        if query.get(field) is not None:
             del query[field]
 
     count = share_es.count(index=index, body=query)

--- a/website/search/share_search.py
+++ b/website/search/share_search.py
@@ -40,13 +40,18 @@ def remove_key(d, k):
     d.pop(k, None)
     return d
 
-@requires_search
-def count(query, index='share'):
+
+def clean_count_query(query):
     # Get rid of fields not allowed in count queries
     for field in ['from', 'size', 'aggs', 'aggregations']:
         if query.get(field) is not None:
             del query[field]
+    return query
 
+
+@requires_search
+def count(query, index='share'):
+    query = clean_count_query(query)
     count = share_es.count(index=index, body=query)
 
     return {


### PR DESCRIPTION
Purpose
----------
I made a mistake with python truthiness, keys that need to be deleted that have falsey values are skipped.

Changes
-----------
Explicitly check that the values are not None

Side-effects
----------------
None