### PR TITLE
[Feature Fix] Update to view link icons

### DIFF
--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2640,7 +2640,7 @@ class PrivateLink(StoredObject):
             "key": self.key,
             "name": self.name,
             "creator": {'fullname': self.creator.fullname, 'url': self.creator.profile_url},
-            "nodes": [{'title': x.title, 'url': x.url, 'scale': str(self.node_scale(x)) + 'px', 'imgUrl': self.node_icon(x)}
+            "nodes": [{'title': x.title, 'url': x.url, 'scale': str(self.node_scale(x)) + 'px', 'imgUrl': self.node_icon(x), 'category': x.category}
                       for x in self.nodes if not x.is_deleted],
             "anonymous": self.anonymous
         }

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2626,13 +2626,6 @@ class PrivateLink(StoredObject):
             offset = 20 if node.parent_node is not None else 0
             return offset + self.node_scale(node.parent_node)
 
-    def node_icon(self, node):
-        if node.category == 'project':
-            node_type = "reg-project" if node.is_registration else "project"
-        else:
-            node_type = "reg-component" if node.is_registration else "component"
-        return "/static/img/hgrid/{0}.png".format(node_type)
-
     def to_json(self):
         return {
             "id": self._id,
@@ -2640,7 +2633,7 @@ class PrivateLink(StoredObject):
             "key": self.key,
             "name": self.name,
             "creator": {'fullname': self.creator.fullname, 'url': self.creator.profile_url},
-            "nodes": [{'title': x.title, 'url': x.url, 'scale': str(self.node_scale(x)) + 'px', 'imgUrl': self.node_icon(x), 'category': x.category}
+            "nodes": [{'title': x.title, 'url': x.url, 'scale': str(self.node_scale(x)) + 'px', 'category': x.category}
                       for x in self.nodes if not x.is_deleted],
             "anonymous": self.anonymous
         }

--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -4,6 +4,7 @@ var $ = require('jquery');
 require('jquery-blockui');
 var Raven = require('raven-js');
 var moment = require('moment');
+var iconmap = require('js/iconmap');
 
 // TODO: For some reason, this require is necessary for custom ko validators to work
 // Why?!
@@ -353,6 +354,26 @@ ko.bindingHandlers.anchorScroll = {
                 }
             }
         });
+    }
+};
+
+/**
+ * Adds class returned from iconmap to the element. The value accessor should be the 
+ * category of the node.
+ * Example:
+ * <span data-bind="getIcon: 'analysis'"></span>
+ */
+ko.bindingHandlers.getIcon = {
+    init: function(elem, valueAccessor) {
+        var icon;
+        var category = valueAccessor();
+        if (Object.keys(iconmap.componentIcons).indexOf(category) >=0 ){
+            icon = iconmap.componentIcons[category];
+        }
+        else {
+            icon = iconmap.projectIcons[category];
+        }
+        $(elem).addClass(icon);
     }
 };
 

--- a/website/templates/project/contributors.mako
+++ b/website/templates/project/contributors.mako
@@ -137,7 +137,8 @@
                         <td class="col-sm-4">
                            <ul class="narrow-list list-overflow" data-bind="foreach: nodesList">
                                <li data-bind="style:{marginLeft: $data.scale}">
-                                  <img data-bind="attr:{src: imgUrl}" /><a data-bind="text:$data.title, attr: {href: $data.url}"></a>
+                                  <span data-bind="getIcon: $data.category"></span>
+                                  <a data-bind="text:$data.title, attr: {href: $data.url}"></a>
                                </li>
                            </ul>
                            <button class="btn btn-default btn-mini more-link-node" data-bind="text:hasMoreText, visible: moreNode, click: displayAllNodes"></button>


### PR DESCRIPTION
# Purpose

This resolves issue #2971. The icons that are displayed on the sharing page under View-only Links are outdated.

# Changes

This requires the custom binding called `getIcon` defined in *osfHelpers.js* from PR #2953. The category of the node is added to what is returned by `to_json` in *model.py*. This is necessary so that the category can be given to `getIcon` in *contributors.mako*. The old image code has been taken out of *model.py*.

# Side effects

Under View-only Links on the project sharing page, the updated icon is displayed next to the title of the component. There is an added field to what is returned by `to_json`.

Fix:
![screen shot 2015-06-08 at 11 20 34 am](https://cloud.githubusercontent.com/assets/7131985/8038664/b2204c9c-0dd2-11e5-9e0f-17b665ee0231.png)
