### PR TITLE
[Feature Fix] Fix test_elastic error

### DIFF
--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -393,7 +393,7 @@ class User(GuidStoredObject, AddonModelMixin):
         return '<User({0!r}) with id {1!r}>'.format(self.username, self._id)
 
     def __str__(self):
-        return self.fullname
+        return self.fullname.encode('ascii', 'replace')
 
     __unicode__ = __str__
 


### PR DESCRIPTION
# Purpose
Using UserFactory to create a user with a name containing non-ascii characters would throw a UnicodeEncodeError.

# Changes
User \__str\__ returns the user's name encoded as ascii with non-ascii characters replaced with '?'.