### PR TITLE
[Feature Fix] Decode the title in template dropdown menu

### DIFF
--- a/website/static/js/projectCreator.js
+++ b/website/static/js/projectCreator.js
@@ -69,7 +69,7 @@ function ProjectCreatorViewModel(params) {
     self.serialize = function() {
         var category = self.category();
         return {
-            title: $osf.htmlDecode(self.title()),
+            title: self.title(),
             category: category,
             description: self.description(),
             template: $('#createNodeTemplates').val()
@@ -164,7 +164,7 @@ function ProjectCreatorViewModel(params) {
         return ko.utils.arrayMap(nodes, function(node) {
             return {
                 'id': node.id,
-                'text': node.title
+                'text': $osf.htmlDecode(node.title)
             };
         });
     };

--- a/website/static/js/projectCreator.js
+++ b/website/static/js/projectCreator.js
@@ -69,7 +69,7 @@ function ProjectCreatorViewModel(params) {
     self.serialize = function() {
         var category = self.category();
         return {
-            title: self.title(),
+            title: $osf.htmlDecode(self.title()),
             category: category,
             description: self.description(),
             template: $('#createNodeTemplates').val()


### PR DESCRIPTION
### Purpose 
Solve the Bug found during the testing for pull request  #2969. It is to render the special characters correctly in template dropdown menu

### Change
Apply the decode method to the title before it display. Similar as #2969. 

* Before the change:
![screen shot 2015-06-09 at 2 47 55 pm](https://cloud.githubusercontent.com/assets/5420789/8067091/75990da8-0eb9-11e5-86f8-2e9db5ec0044.png)

* After the change:
![screen shot 2015-06-09 at 3 08 44 pm](https://cloud.githubusercontent.com/assets/5420789/8067121/a76c6442-0eb9-11e5-8ae0-2109af205de5.png)




### Side effect
None