### PR TITLE
Rework apiv2url to use uri.js

### DIFF
--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -29,20 +29,26 @@ var growl = function(title, message, type) {
 /**
  * Generate OSF absolute URLs, including prefix and arguments. Assumes access to mako globals for pieces of URL.
  * Can optionally pass in an object with params (name:value) to be appended to URL. Calling as:
- *   apiV2Url("users/4urxt/applications", {"a":1, "filter[fullname]":"lawrence"}, "https://staging2.osf.io/api/v2/")
+ *   apiV2Url("users/4urxt/applications",
+ *      {query:
+ *          {"a":1, "filter[fullname]": "lawrence"},
+ *       prefix: "https://staging2.osf.io/api/v2/"})
  * would yield the result:
  *  "https://staging2.osf.io/api/v2/users/4urxt/applications?a=1&filter%5Bfullname%5D=lawrence"
- * @param {String} pathString The string to be appended to the absolute base path, eg "users/4urxt"
- * @param {Object} paramsObject (optional) An object containing parameters to add to the URL. Otherwise pass 'undefined'.
- * @param {String} apiPrefix (optional) Manually specify the prefix used for API routes (useful for testing)
+ * @param {String} path The string to be appended to the absolute base path, eg "users/4urxt"
+ * @param {Object} options (optional)
  */
-var apiV2Url = function (pathString, paramsObject, apiPrefix){
-    apiPrefix = apiPrefix || window.contextVars.apiV2Prefix;
+var apiV2Url = function (path, options){
+    var defaults = {
+        prefix: window.contextVars.apiV2Prefix, // Manually specify the prefix for API routes (useful for testing)
+        query: {}  // Optional query parameters to be appended to URL
+    };
+    var opts = $.extend({}, defaults, options);
 
-    var apiUrl = URI(apiPrefix);
-    var pathSegments = URI(pathString).segment();
+    var apiUrl = URI(opts.prefix);
+    var pathSegments = URI(path).segment();
     pathSegments.forEach(function(el){apiUrl.segment(el)});  // Hack to prevent double slashes when joining base + path
-    apiUrl.query(paramsObject);
+    apiUrl.query(opts.query);
 
     return apiUrl.toString();
 };

--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -40,8 +40,11 @@ var growl = function(title, message, type) {
  * @param {Object} options (optional)
  */
 var apiV2Url = function (path, options){
+    var contextVars = window.contextVars || {};
+    var defaultPrefix = contextVars.apiV2Prefix || '';
+
     var defaults = {
-        prefix: window.contextVars.apiV2Prefix, // Manually specify the prefix for API routes (useful for testing)
+        prefix: defaultPrefix, // Manually specify the prefix for API routes (useful for testing)
         query: {}  // Optional query parameters to be appended to URL
     };
     var opts = $.extend({}, defaults, options);

--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -4,6 +4,7 @@ var $ = require('jquery');
 require('jquery-blockui');
 var Raven = require('raven-js');
 var moment = require('moment');
+var URI = require('URIjs');
 
 // TODO: For some reason, this require is necessary for custom ko validators to work
 // Why?!
@@ -37,18 +38,12 @@ var growl = function(title, message, type) {
 var apiV2Url = function (pathString, paramsObject, apiPrefix){
     apiPrefix = apiPrefix || window.contextVars.apiV2Prefix;
 
-    // Don't output double slashes when concatenating two strings with adjoining slashes
-    if (apiPrefix && pathString && apiPrefix.charAt(apiPrefix.length - 1) === "/" && pathString.charAt(0) === "/"){
-        pathString = pathString.substring(1); // Strip off the redundant leading slash
-    }
+    var apiUrl = URI(apiPrefix);
+    var pathSegments = URI(pathString).segment();
+    pathSegments.forEach(function(el){apiUrl.segment(el)});  // Hack to prevent double slashes when joining base + path
+    apiUrl.query(paramsObject);
 
-    var apiUrl = apiPrefix + pathString;
-    // Add parameters to URL (if any). Ensure encoding as necessary
-    if (paramsObject){
-        apiUrl += "?";
-        apiUrl += $.param(paramsObject);
-    }
-    return apiUrl;
+    return apiUrl.toString();
 };
 
 

--- a/website/static/js/tests/osfHelpers.test.js
+++ b/website/static/js/tests/osfHelpers.test.js
@@ -28,26 +28,29 @@ describe('osfHelpers', () => {
     describe('apiV2Url', () => {
         it('returns correctly formatted URLs for described inputs', () => {
             var fullUrl = $osf.apiV2Url('/nodes/abcd3/contributors/',
-                                         undefined,
-                                         'http://localhost:8000/v2/');
+                {prefix: 'http://localhost:8000/v2/'});
             assert.equal(fullUrl, "http://localhost:8000/v2/nodes/abcd3/contributors/");
 
             // No double slashes when apiPrefix and pathString have adjoining slashes
-            fullUrl = $osf.apiV2Url('nodes/abcd3/contributors/', undefined, 'http://localhost:8000/v2/');
+            fullUrl = $osf.apiV2Url('nodes/abcd3/contributors/',
+                {prefix: 'http://localhost:8000/v2/'});
             assert.equal(fullUrl, "http://localhost:8000/v2/nodes/abcd3/contributors/");
 
             // User is still responsible for the trailing slash. If they omit it, it doesn't appear at end of URL
-            fullUrl = $osf.apiV2Url('/nodes/abcd3/contributors', undefined, 'http://localhost:8000/v2/');
+            fullUrl = $osf.apiV2Url('/nodes/abcd3/contributors',
+                {prefix: 'http://localhost:8000/v2/'});
             assert.notEqual(fullUrl, "http://localhost:8000/v2/nodes/abcd3/contributors/");
 
             // Correctly handles- and encodes- URLs with parameters
             fullUrl = $osf.apiV2Url('/nodes/abcd3/contributors/',
-                                  {'filter[fullname]': 'bob', 'page_size':10},
-                                  'https://staging2.osf.io/api/v2/');
+                {query:
+                    {'filter[fullname]': 'bob', 'page_size':10},
+                prefix: 'https://staging2.osf.io/api/v2/'});
             assert.equal(fullUrl, "https://staging2.osf.io/api/v2/nodes/abcd3/contributors/?filter%5Bfullname%5D=bob&page_size=10");
 
             // Given a blank string, should return the base path (domain + port + prefix) with no extra cruft at end
-            fullUrl = $osf.apiV2Url('', undefined, 'http://localhost:8000/v2/');
+            fullUrl = $osf.apiV2Url('',
+                {prefix: 'http://localhost:8000/v2/'});
             assert.equal(fullUrl, "http://localhost:8000/v2/");
         });
     });


### PR DESCRIPTION
## Purpose
Per @sloria feedback in #3012, reworked JS `apiV2Url` helper function to use URI.js. This will encourage consistent URL construction across various OSF libraries.

Needed a small workaround to join paths with trailing + leading slashes (eg `http://osf.io/api/v2/` + `/users/4urxt`), as otherwise encountered double slashes in result. Open to feedback if there's a more elegant way.
