### PR TITLE
hotfix: update dataverse to reflect changes in 4.0

### DIFF
--- a/website/templates/public/pages/help/addons/dataverse.mako
+++ b/website/templates/public/pages/help/addons/dataverse.mako
@@ -2,14 +2,14 @@
     <span id="dataverse" class="anchor"></span>
     <h4>Dataverse</h4>
     <p><a href="https://osf.io/w75g2/">Dataverse</a> is a an open source web application to share, preserve, cite, explore,
-        and analyze research data. Enabling Dataverse for your project will allow contibutores to view, download,
-        and upload files to and from a Dataverse study/dataset. All from your project's "Files" page.</p>
-    <p>Currently, the OSF only supports linking Dataverses that you have already released on the
+        and analyze research data. Enabling Dataverse for your project will allow contibutors to view, download,
+        and upload files to and from a Dataverse dataset. All from your project's "Files" page.</p>
+    <p>Currently, the OSF only supports linking Dataverse datasets that are a part of the 
         <a href="http://thedata.harvard.edu/dvn/">Harvard Dataverse Network</a>.</p>
-    <p>To link a Dataverse study to a project/component, visit the project you want to add a Dataverse study to. Then go to
+    <p>To link a Dataverse dataset to a project/component, visit the project you want to add a Dataverse to. Then go to
         "Settings" in the grey navigation bar. Check "Dataverse" under "Select Add-ons" to enable the add-on. Read, then
         click "OK" on the pop-up, then submit. Next, authenticate with Dataverse by entering your Dataverse username and
-        password and clicking "Submit". You can then choose the Dataverse study you would like to add to your OSF project.
+        password and clicking "Submit". You can then choose the Dataverse dataset you would like to add to your OSF project.
         Click "Submit" to save your settings.</p>
     <p>Contributors to your project will have access to both released and draft versions of your study, but only the most
         recent release will be made public alongside your OSF project.</p>

--- a/website/templates/public/pages/help/addons/dataverse.mako
+++ b/website/templates/public/pages/help/addons/dataverse.mako
@@ -2,7 +2,7 @@
     <span id="dataverse" class="anchor"></span>
     <h4>Dataverse</h4>
     <p><a href="https://osf.io/w75g2/">Dataverse</a> is a an open source web application to share, preserve, cite, explore,
-        and analyze research data. Enabling Dataverse for your project will allow contibutors to view, download,
+        and analyze research data. Enabling Dataverse for your project will allow contributors to view, download,
         and upload files to and from a Dataverse dataset. All from your project's "Files" page.</p>
     <p>Currently, the OSF only supports linking Dataverse datasets that are a part of the 
         <a href="http://thedata.harvard.edu/dvn/">Harvard Dataverse Network</a>.</p>


### PR DESCRIPTION
Studies are now called datasets
Remove reference to only public datasets as now drafts can be linked