### PR TITLE
Makes sure 'download as zip' doesn't button appear when there are no files.

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1478,7 +1478,7 @@ var FGItemButtons = {
                     }, 'Delete'));
 
             }
-        } else if(item.data.provider) {
+        } else if(item.data.provider && item.children.length != 0) {
             rowButtons.push(
                 m.component(FGButton, {
                     onclick: function(event) { _downloadZipEvent.call(tb, event, item); },


### PR DESCRIPTION
<h1> Purpose </h1>
Makes sure 'download as zip' doesn't button appear when there are no files. Closes #3018.
<h1> Changes </h1>
Just adds condition to make sure OSF storage isn't empty.
<h1> Side effects </h1>
None that I know of.
