### PR TITLE
[Feature fix] Mendeley properly displays/copies italics

### DIFF
--- a/website/static/css/site.css
+++ b/website/static/css/site.css
@@ -1988,6 +1988,10 @@ div.profile-fullname{
 /* Project Dashboard */
 
 
+.csl-entry {
+    display: inline;
+}
+
 .addon-widget-container {
     border:1px solid #ddd;
     margin-bottom: 20px;

--- a/website/static/js/citationGrid.js
+++ b/website/static/js/citationGrid.js
@@ -117,7 +117,7 @@ var makeButtons = function(item, col, buttons) {
                         class: button.css,
                         'data-toggle': 'tooltip',
                         'data-placement': 'bottom',
-                        'data-clipboard-text': button.clipboard,
+                        'data-clipboard-target': item.data.csl.id,
                         config: mergeConfigs(button.config, tooltipConfig),
                         onclick: button.onclick ?
                             function(event) {
@@ -355,7 +355,7 @@ CitationGrid.prototype.makeBibliography = function(folder) {
             return child.data.csl;
         })
     );
-    var citeproc = citations.makeCiteproc(this.styleXml, data, 'text');
+    var citeproc = citations.makeCiteproc(this.styleXml, data, 'html');
     var bibliography = citeproc.makeBibliography();
     if (bibliography[0].entry_ids) {
         return utils.reduce(
@@ -400,7 +400,9 @@ CitationGrid.prototype.resolveRowAux = function(item) {
                 return item.data.name;
             }
             else {
-                return self.getCitation(item);
+                return m("span", {id: item.data.csl.id}, [
+                    m.trust(self.getCitation(item))
+                        ]);
             }
         }
     }, {


### PR DESCRIPTION
Purpose
-
After PR https://github.com/CenterForOpenScience/osf.io/pull/2950, QA noted that citations were not working with italics.  I also noted that they were not displaying this way in the widget.  This PR seeks to address both of these issues.

Changes
-
Previously, we were requesting the citations from citeproc.js in 'text' format, hence them displaying with no styling.  Now we request in 'html' format to preserve styling.  This meant also updating the mithril call that renders the rows in order to print it as html as opposed to printing the html as text.  Lastly (for this part), CSS styling had to be added so that the returned div would have 'display: inline' or else it would not show up.

For the copying aspect, we were previously passing the third party system plain text to copy, hence the lack of formatting.  Now that there was HTML there, I discovered that we could copy this by passing the copier a "target" (by using the parent's id) and it would be able to copy it as stylized text.

Side Effects
- 
Many of these changes occurred in citationGrid.js, which is used for Zotero and Mendeley.  I have tested it on both and it appears to be working on both.