### PR TITLE
[Feature Fix] Po collection icon fix

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -224,7 +224,7 @@ function resolveIconView(item) {
     }
     if (item.data.nodeType === 'project') {
         if (item.data.parentIsFolder && item.data.isFolder && item.data.isPointer) {
-            return returnView('collection', item.data.category);
+            return returnView('collection');
         }
         if (item.data.isRegistration) {
             return returnView('registeredProject', item.data.category);

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -223,7 +223,7 @@ function resolveIconView(item) {
         return returnView('link');
     }
     if (item.data.nodeType === 'project') {
-        if (item.data.parentIsFolder && item.data.isFolder && item.data.isPointer) {
+        if (item.data.parentIsFolder && item.data.isFolder) {
             return returnView('collection');
         }
         if (item.data.isRegistration) {

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -223,6 +223,9 @@ function resolveIconView(item) {
         return returnView('link');
     }
     if (item.data.nodeType === 'project') {
+        if (item.data.parentIsFolder && item.data.isFolder && item.data.isPointer) {
+            return returnView('collection', item.data.category);
+        }
         if (item.data.isRegistration) {
             return returnView('registeredProject', item.data.category);
         } else {


### PR DESCRIPTION
# Purpose

This fixes issues created by PR #2953 . The collection icons on the project organizer are incorrect -- they are displayed as project icons. 

# Changes

Some logic was added to `resolveIconView` in *fangorn.js* so that collection icons are displayed on the project organizer.

# Side effects

In the project organizer, the collection icons appear correctly.

# Screen shots
Fix:
![screen shot 2015-06-11 at 3 02 24 pm](https://cloud.githubusercontent.com/assets/7131985/8115960/0b67feea-104d-11e5-96a5-9bce7bca7d23.png)

Problem:
![screen shot 2015-06-11 at 3 10 25 pm](https://cloud.githubusercontent.com/assets/7131985/8115966/1b7e9320-104d-11e5-82a1-c555d20673af.png)
