### PR TITLE
[feature] Increase Embargo max date to four years

### DIFF
--- a/website/language.py
+++ b/website/language.py
@@ -120,7 +120,7 @@ time stamps will always be linked to the original.</p>
 '''
 REGISTRATION_EMBARGO_INFO = '''
 <p>You can choose whether to make your registration public immediately or
-embargo it for up to 1 year. At the end of the embargo period the registration
+embargo it for up to four years. At the end of the embargo period the registration
 is automatically made public. After becoming public, the only way to remove a
 registration is to retract it. Retractions show only the registration title,
 contributors, and description to indicate that a registration was made and

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -34,7 +34,7 @@ RETRACTION_PENDING_TIME = datetime.timedelta(days=2)
 EMBARGO_PENDING_TIME = datetime.timedelta(days=2)
 # Date range for embargo periods
 EMBARGO_END_DATE_MIN = datetime.timedelta(days=2)
-EMBARGO_END_DATE_MAX = datetime.timedelta(days=365)
+EMBARGO_END_DATE_MAX = datetime.timedelta(days=1460)  # Four years
 
 LOAD_BALANCER = False
 PROXY_ADDRS = []

--- a/website/static/js/pages/register_1-page.js
+++ b/website/static/js/pages/register_1-page.js
@@ -80,7 +80,7 @@ $(document).ready(function() {
                 registrationViewModel.continueText('');
                 $osf.growl(
                     'Invalid embargo end date',
-                    'Please choose a date more than two days, but less than one year, from today.',
+                    'Please choose a date more than two days, but less than four years, from today.',
                     'warning'
                 );
                 $('#endDatePicker').focus();

--- a/website/static/js/registerNode.js
+++ b/website/static/js/registerNode.js
@@ -15,7 +15,7 @@ var preRegisterMessage =  function(title, parentTitle, parentUrl, category) {
             ' If you want to register the parent, please go <a href="' +
             parentUrl + '">here.</a>' +
             '<hr /><b>Important Note:</b> As early as <u>June 8, 2015</u>, registrations ' +
-            'will be made public immediately or can be embargoed for up to one year. ' +
+            'will be made public immediately or can be embargoed for up to four years. ' +
             'There will no longer be the option of creating a permanently private ' +
             'registration. If you register before June 8, 2015 and leave your ' +
             'registration private, then the registration can remain private. After June 8, 2015, ' +
@@ -28,7 +28,7 @@ var preRegisterMessage =  function(title, parentTitle, parentUrl, category) {
             'initiate registration. '+
             // TODO(hrybacki): Remove once Retraction/Embargoes goes is merged into production
             '<hr /><b>Important Note:</b> As early as <u>June 8, 2015</u>, registrations ' +
-            'will be made public immediately or can be embargoed for up to one year. ' +
+            'will be made public immediately or can be embargoed for up to four years. ' +
             'There will no longer be the option of creating a permanently private ' +
             'registration. If you register before June 8, 2015 and leave your ' +
             'registration private, then the registration can remain private. After June 8, 2015, ' +

--- a/website/static/js/registrationEmbargo.js
+++ b/website/static/js/registrationEmbargo.js
@@ -13,8 +13,9 @@ var RegistrationEmbargoViewModel = function() {
         message: 'Enter registration into embargo'
     };
     var today = new Date();
+    // TODO(hrybacki): Import min/max dates from website.settings
     var TWO_DAYS_FROM_TODAY_TIMESTAMP = new Date().getTime() + (2 * 24 * 60 * 60 * 1000);
-    var ONE_YEAR_FROM_TODAY_TIMESTAMP = new Date().getTime() + (365 * 24 * 60 * 60 * 1000);
+    var FOUR_YEARS_FROM_TODAY_TIMESTAMP = new Date().getTime() + (1460 * 24 * 60 * 60 * 1000);
 
     self.registrationOptions = [
         MAKE_PUBLIC,
@@ -41,7 +42,7 @@ var RegistrationEmbargoViewModel = function() {
     });
     self.isEmbargoEndDateValid = ko.computed(function() {
         var endEmbargoDateTimestamp = self.embargoEndDate().getTime();
-        return (endEmbargoDateTimestamp < ONE_YEAR_FROM_TODAY_TIMESTAMP && endEmbargoDateTimestamp > TWO_DAYS_FROM_TODAY_TIMESTAMP);
+        return (endEmbargoDateTimestamp < FOUR_YEARS_FROM_TODAY_TIMESTAMP && endEmbargoDateTimestamp > TWO_DAYS_FROM_TODAY_TIMESTAMP);
     });
     self.requestingEmbargo = ko.pureComputed(function() {
         var choice = self.registrationChoice();

--- a/website/static/js/tests/registrationEmbargo.test.js
+++ b/website/static/js/tests/registrationEmbargo.test.js
@@ -50,9 +50,9 @@ describe('registrationEmbargo', () => {
                 vm.pikaday(invalidPastDate);
                 assert.isFalse(vm.isEmbargoEndDateValid());
             });
-            it('returns false for date more than 365 days in the future', () => {
+            it('returns false for date more than 4 years in the future', () => {
                 var invalidFutureDate = new Date();
-                invalidFutureDate.setDate(invalidFutureDate.getDate() + 366);
+                invalidFutureDate.setDate(invalidFutureDate.getDate() + 1460);
                 vm.pikaday(invalidFutureDate);
                 assert.isFalse(vm.isEmbargoEndDateValid());
             });


### PR DESCRIPTION
## Purpose:
The community has requested that we increase the maximum date for an Embargo from one year to four years.

## Changes:
Change the default setting from one to four years, adjust tests, and update website language accordingly.

## Side Effects:
None.

## Notes:
Closes-issue: #3094