### PR TITLE
[feature-fix] Circular import in api utils

### DIFF
--- a/api/base/utils.py
+++ b/api/base/utils.py
@@ -6,7 +6,9 @@ from rest_framework.exceptions import NotFound
 from rest_framework.reverse import reverse
 from django.utils.http import urlencode
 
-from website import settings
+from website import settings as website_settings
+from website import util as website_util # noqa
+
 
 def absolute_reverse(view_name, query_kwargs=None, args=None, kwargs=None):
     """Like django's `reverse`, except returns an absolute URL. Also add query parameters."""
@@ -15,7 +17,7 @@ def absolute_reverse(view_name, query_kwargs=None, args=None, kwargs=None):
     if query_kwargs:
         relative_url = '{}?{}'.format(relative_url, urlencode(query_kwargs))
 
-    domain = settings.API_DOMAIN
+    domain = website_settings.API_DOMAIN
     return urlparse.urljoin(domain, relative_url)
 
 
@@ -39,7 +41,7 @@ def waterbutler_url_for(request_type, provider, path, node_id, token, obj_args=N
     :param str token: The cookie to be used or None
     :param dict **query: Addition query parameters to be appended
     """
-    url = furl.furl(settings.WATERBUTLER_URL)
+    url = furl.furl(website_settings.WATERBUTLER_URL)
     url.path.segments.append(request_type)
 
     url.args.update({

--- a/api/base/utils.py
+++ b/api/base/utils.py
@@ -1,24 +1,24 @@
-import urlparse
+# -*- coding: utf-8 -*-
+
 import furl
-from modularodm.exceptions import NoResultsFound
-from modularodm import Q
+
 from rest_framework.exceptions import NotFound
 from rest_framework.reverse import reverse
-from django.utils.http import urlencode
+from modularodm.exceptions import NoResultsFound
+from modularodm import Q
 
+from api.base import settings as api_settings
 from website import settings as website_settings
-from website import util as website_util # noqa
+from website import util as website_util  # noqa
 
 
 def absolute_reverse(view_name, query_kwargs=None, args=None, kwargs=None):
     """Like django's `reverse`, except returns an absolute URL. Also add query parameters."""
     relative_url = reverse(view_name, kwargs=kwargs)
 
-    if query_kwargs:
-        relative_url = '{}?{}'.format(relative_url, urlencode(query_kwargs))
-
-    domain = website_settings.API_DOMAIN
-    return urlparse.urljoin(domain, relative_url)
+    url = website_util.api_v2_url(relative_url, params=query_kwargs,
+                                  base_prefix=api_settings.API_PATH)
+    return url
 
 
 def get_object_or_404(model_cls, query_or_pk):

--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -14,7 +14,6 @@ from modularodm.validators import URLValidator
 from modularodm.exceptions import NoResultsFound
 from modularodm.exceptions import ValidationError, ValidationValueError
 
-from api.base.utils import absolute_reverse
 import framework
 from framework import analytics
 from framework.sessions import session
@@ -414,6 +413,7 @@ class User(GuidStoredObject, AddonModelMixin):
 
     @property
     def absolute_api_v2_url(self):
+        from api.base.utils import absolute_reverse  # Avoid circular dependency
         return absolute_reverse('users:user-detail', kwargs={'pk': self.pk})
 
     # used by django and DRF


### PR DESCRIPTION
Addresses the first part of #3049.

## Purpose
Due to a circular import, some code in the `api.base.utils` and `website.util` modules had to be repeated.

This PR will:
1. Remove the circular dependency by moving one import
2. Bring helper functions up to spec with new helpers such as `api_v2_url`.

## Summary of changes
Close a circular import issue, enabling future use of website utils in api.

Modify the absolute_reverse function (used for API links) to apply the correct prefix in production.

This might bear some investigating in production- as discussed with @brianjgeiger , I'm a bit surprised that URLs look ok in production, even though this fix *should* offer improvements.