### PR TITLE
[hotfix] Fix regression preventing subfolder expansion in citationgrids.

### DIFF
--- a/website/static/js/citationGrid.js
+++ b/website/static/js/citationGrid.js
@@ -117,7 +117,7 @@ var makeButtons = function(item, col, buttons) {
                         class: button.css,
                         'data-toggle': 'tooltip',
                         'data-placement': 'bottom',
-                        'data-clipboard-target': item.data.csl.id,
+                        'data-clipboard-target': item.data.csl ? item.data.csl.id : button.clipboard,
                         config: mergeConfigs(button.config, tooltipConfig),
                         onclick: button.onclick ?
                             function(event) {


### PR DESCRIPTION
Regression was introduced in 7d8e492c4838daca0e15ef082678ea62c407607f.
The assumption was made that all items in the returned dataset would
have an item[data][csl] value - but folders do not. To resolve, I've
added a conditional that first checks for the existence of the key, and
falls back to the previous method of action.