### PR TITLE
hotfix/update default elasticsearch index for share search

### DIFF
--- a/website/search/views.py
+++ b/website/search/views.py
@@ -205,7 +205,7 @@ def search_share():
     count = request.args.get('count') is not None
     raw = request.args.get('raw') is not None
     version = request.args.get('v')
-    index = 'share_v{}'.format(version) if version else 'share'
+    index = 'share_v{}'.format(version) if version else 'share_v2'
 
     if request.method == 'POST':
         query = request.get_json()


### PR DESCRIPTION
# changes
Right now, not adding a version query parameter defaults to an elasticsearch index that does not exist (share). This PR updates it to default to the index share_v2, which reflects the most recently updated schema.

# side effects
None anticipated