### PR TITLE
[feature fix] Registration supplement should not be link

### DIFF
--- a/website/templates/project/retracted_registration.mako
+++ b/website/templates/project/retracted_registration.mako
@@ -28,7 +28,7 @@
                 % if node['is_registration'] and node['registered_meta']:
                     <br />Registration Supplement:
                     % for meta in node['registered_meta']:
-                        <a href="${node['url']}register/${meta['name_no_ext']}">${meta['name_clean']}</a>
+                        ${meta['name_clean']}
                     % endfor
                 % endif
                 <br />


### PR DESCRIPTION
## Purpose:
Registration supplement data should not be accessible for retracted registrations.

## Changes:
Convert portion of template related to registration supplement from link to text.

## Side Effects:
None.

## Notes:
Closes-issue: https://trello.com/c/JKXdsj8G/50-retracted-registration-link-to-registration-supplement-information-gives-bad-request