### PR TITLE
[hotfix] Initialize github repositories created through the OSF

### DIFF
--- a/website/addons/github/views/repos.py
+++ b/website/addons/github/views/repos.py
@@ -25,7 +25,7 @@ def github_create_repo(**kwargs):
     connection = GitHub.from_settings(user_settings)
 
     try:
-        repo = connection.create_repo(repo_name)
+        repo = connection.create_repo(repo_name, auto_init=True)
     except GitHubError:
         # TODO: Check status code
         raise HTTPError(http.BAD_REQUEST)


### PR DESCRIPTION
Purpose
-----------
Fixes #2976 

Now when a user creates a new github repository through the OSF, it's initialized with a master branch that contains a readme.md file. This way, a user can upload files directly to the new repository without having to commit to it first. 

Changes
------------
Set auto_init=True when creating a new github repo.