### PR TITLE
[feature] Move Dataverse version select dropdown into action toolbar

### DIFF
--- a/website/addons/dataverse/static/dataverseFangornConfig.js
+++ b/website/addons/dataverse/static/dataverseFangornConfig.js
@@ -108,6 +108,22 @@ var _dataverseItemButtons = {
                 });
             }
         }
+        if (item.data.addonFullname) {
+            var options = [
+                m('option', {selected: item.data.version === 'latest-published', value: 'latest-published'}, 'Published'),
+                m('option', {selected: item.data.version === 'latest', value: 'latest'}, 'Draft')
+            ];
+            buttons.push(
+                m.component(Fangorn.Components.dropdown, {
+                    'label': 'Version: ',
+                    onchange: function (e) {
+                        changeState(tb, item, e.target.value);
+                    },
+                    icon: 'fa fa-external-link',
+                    className: 'text-info'
+                }, options)
+            );
+        }
         if (item.kind === 'folder' && item.data.addonFullname && item.data.version === 'latest' && item.data.permissions.edit) {
             buttons.push(
                 m.component(Fangorn.Components.button, {
@@ -184,8 +200,9 @@ function gotoFile (item) {
 
 function _fangornDataverseTitle(item, col) {
     var tb = this;
+    var version = item.data.version === 'latest-published' ? 'Published' : 'Draft';
     if (item.data.addonFullname) {
-        var contents = [m('dataverse-name', item.data.name + ' ')];
+        var contents = [m('dataverse-name', item.data.name + ' (' + version + ')')];
         if (item.data.hasPublishedFiles) {
             if (item.data.permissions.edit) {
                 // Default to version in url parameters for file view page
@@ -193,21 +210,6 @@ function _fangornDataverseTitle(item, col) {
                 if (urlParams.version && urlParams.version !== item.data.version) {
                     item.data.version = urlParams.version;
                 }
-                var options = [
-                    m('option', {selected: item.data.version === 'latest-published', value: 'latest-published'}, 'Published'),
-                    m('option', {selected: item.data.version === 'latest', value: 'latest'}, 'Draft')
-                ];
-                contents.push(
-                    m('span', [
-                        m('select', {
-                            class: 'dataverse-state-select',
-                            style: { color : '#000000'},
-                            onchange: function (e) {
-                                changeState(tb, item, e.target.value);
-                            }
-                        }, options)
-                    ])
-                );
             } else {
                 contents.push(
                     m('span.text-muted', '[Published]')


### PR DESCRIPTION
Purpose: 
------------
Partially addresses #2369. The dataverse drop-down for selecting the study version is cut-off with long study names (or if the grid is narrow) because it is still in-line: 
![screen shot 2015-06-15 at 11 25 10 am](https://cloud.githubusercontent.com/assets/6414394/8163483/4266ebfc-1351-11e5-9eaa-280a06e5255b.png)




Changes: 
------------
Move the dataverse version select box to the treebeard toolbar along with other action buttons. Also include the current version after the study title to remain consistent with github: 
![screen shot 2015-06-15 at 11 19 04 am](https://cloud.githubusercontent.com/assets/6414394/8163374/a53054cc-1350-11e5-8c17-448a1003311b.png)
