### PR TITLE
[feature fix] Ensure public projects create private pending embargoes

### DIFF
--- a/tests/test_registration_embargoes.py
+++ b/tests/test_registration_embargoes.py
@@ -101,6 +101,17 @@ class RegistrationEmbargoModelsTestCase(OsfTestCase):
         self.registration.save()
         assert_true(self.registration.pending_embargo)
 
+    def test_embargo_public_project_makes_private_pending_embargo(self):
+        self.registration.is_public = True
+        assert_true(self.registration.is_public)
+        self.registration.embargo_registration(
+            self.user,
+            datetime.datetime.utcnow() + datetime.timedelta(days=10)
+        )
+        self.registration.save()
+        assert_true(self.registration.pending_embargo)
+        assert_false(self.registration.is_public)
+
     def test_embargo_non_registration_raises_NodeStateError(self):
         self.registration.is_registration = False
         self.registration.save()

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2403,7 +2403,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
         self.save()
         return contributor
 
-    def set_privacy(self, permissions, auth=None):
+    def set_privacy(self, permissions, auth=None, logging=True):
         """Set the permissions for this node.
 
         :param permissions: A string, either 'public' or 'private'
@@ -2436,16 +2436,17 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
             if message:
                 status.push_status_message(message)
 
-        action = NodeLog.MADE_PUBLIC if permissions == 'public' else NodeLog.MADE_PRIVATE
-        self.add_log(
-            action=action,
-            params={
-                'project': self.parent_id,
-                'node': self._primary_key,
-            },
-            auth=auth,
-            save=False,
-        )
+        if logging:
+            action = NodeLog.MADE_PUBLIC if permissions == 'public' else NodeLog.MADE_PRIVATE
+            self.add_log(
+                action=action,
+                params={
+                    'project': self.parent_id,
+                    'node': self._primary_key,
+                },
+                auth=auth,
+                save=False,
+            )
         self.save()
         return True
 

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2423,7 +2423,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
                 self.embargo.save()
             self.is_public = True
         elif permissions == 'private' and self.is_public:
-            if self.is_registration:
+            if self.is_registration and not self.pending_embargo:
                 raise NodeStateError("Public registrations must be retracted, not made private.")
             else:
                 self.is_public = False
@@ -2749,6 +2749,8 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
         )
         # Embargo record needs to be saved to ensure the forward reference Node->Embargo
         self.embargo = embargo
+        if self.is_public:
+            self.set_privacy('private', Auth(user))
 
 
 @Node.subscribe('before_save')

--- a/website/project/views/register.py
+++ b/website/project/views/register.py
@@ -441,9 +441,9 @@ def node_register_template_page_post(auth, node, **kwargs):
         except ValidationValueError as err:
             raise HTTPError(http.BAD_REQUEST, data=dict(message_long=err.message))
     else:
-        register.set_privacy('public', auth)
+        register.set_privacy('public', auth, logging=False)
         for node in register.get_descendants_recursive():
-            node.set_privacy('public', auth)
+            node.set_privacy('public', auth, logging=False)
 
     return {
         'status': 'initiated',


### PR DESCRIPTION
## Purpose
Ensure that all pending embargoes are private rather than inherit privacy settings from the registrations parent project

## Changes
An embargo or its descendants may have addons with set_privacy callbacks that can't be ignored. As a result, a logging parameter to `Node#set_privacy` , defaulting to `True`, but can be disabled for edge cases such as this.

Closes-issue: https://trello.com/c/2lLlJ76j/62-pending-embargoes-inherit-privacy-from-project-when-they-should-default-to-being-private