### PR TITLE
[Feature] Use test index when testing search.

### DIFF
--- a/tests/test_elastic.py
+++ b/tests/test_elastic.py
@@ -18,6 +18,11 @@ from tests.factories import (
     UnregUserFactory, UnconfirmedUserFactory
 )
 
+TEST_INDEX = 'test'
+elastic_search.INDEX = TEST_INDEX
+settings.ELASTIC_INDEX = TEST_INDEX
+
+
 @requires_search
 class SearchTestCase(OsfTestCase):
 

--- a/tests/test_elastic.py
+++ b/tests/test_elastic.py
@@ -19,8 +19,6 @@ from tests.factories import (
 )
 
 TEST_INDEX = 'test'
-elastic_search.INDEX = TEST_INDEX
-settings.ELASTIC_INDEX = TEST_INDEX
 
 
 @requires_search
@@ -32,6 +30,8 @@ class SearchTestCase(OsfTestCase):
         search.create_index(elastic_search.INDEX)
     def setUp(self):
         super(SearchTestCase, self).setUp()
+        elastic_search.INDEX = TEST_INDEX
+        settings.ELASTIC_INDEX = TEST_INDEX
         search.delete_index(elastic_search.INDEX)
         search.create_index(elastic_search.INDEX)
 

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -116,7 +116,7 @@ def get_tags(query, index):
 
 
 @requires_search
-def search(query, index=INDEX, doc_type='_all'):
+def search(query, index=None, doc_type='_all'):
     """Search for a query
 
     :param query: The substring of the username/project name/tag to search for
@@ -129,6 +129,7 @@ def search(query, index=INDEX, doc_type='_all'):
         tags: A list of tags that are returned by the search query
         typeAliases: the doc_types that exist in the search database
     """
+    index = index or INDEX
     tag_query = copy.deepcopy(query)
     count_query = copy.deepcopy(query)
 
@@ -208,7 +209,8 @@ def load_parent(parent_id):
 
 
 @requires_search
-def update_node(node, index=INDEX):
+def update_node(node, index=None):
+    index = index or INDEX
     from website.addons.wiki.model import NodeWikiPage
 
     component_categories = [k for k in Node.CATEGORY_MAP.keys() if not k == 'project']
@@ -269,7 +271,8 @@ def update_node(node, index=INDEX):
 
 
 @requires_search
-def update_user(user, index=INDEX):
+def update_user(user, index=None):
+    index = index or INDEX
     if not user.is_active:
         try:
             es.delete(index=index, doc_type='user', id=user._id, refresh=True, ignore=[404])
@@ -323,10 +326,11 @@ def delete_index(index):
 
 
 @requires_search
-def create_index(index=INDEX):
+def create_index(index=None):
     '''Creates index with some specified mappings to begin with,
     all of which are applied to all projects, components, and registrations.
     '''
+    index = index or INDEX
     document_types = ['project', 'component', 'registration', 'user']
     project_like_types = ['project', 'component', 'registration']
     analyzed_fields = ['title', 'description']
@@ -343,7 +347,8 @@ def create_index(index=INDEX):
 
 
 @requires_search
-def delete_doc(elastic_document_id, node, index=INDEX, category=None):
+def delete_doc(elastic_document_id, node, index=None, category=None):
+    index = index or INDEX
     category = category or 'registration' if node.is_registration else node.project_or_component
     es.delete(index=index, doc_type=category, id=elastic_document_id, refresh=True, ignore=[404])
 

--- a/website/search/search.py
+++ b/website/search/search.py
@@ -20,15 +20,18 @@ def requires_search(func):
 
 
 @requires_search
-def search(query, index=settings.ELASTIC_INDEX, doc_type=None):
+def search(query, index=None, doc_type=None):
+    index = index or settings.ELASTIC_INDEX
     return search_engine.search(query, index=index, doc_type=doc_type)
 
 @requires_search
-def update_node(node, index=settings.ELASTIC_INDEX):
+def update_node(node, index=None):
+    index = index or settings.ELASTIC_INDEX
     search_engine.update_node(node, index=index)
 
 @requires_search
-def delete_node(node, index=settings.ELASTIC_INDEX):
+def delete_node(node, index=None):
+    index = index or settings.ELASTIC_INDEX
     doc_type = node.project_or_component
     if node.is_registration:
         doc_type = 'registration'
@@ -36,7 +39,8 @@ def delete_node(node, index=settings.ELASTIC_INDEX):
 
 
 @requires_search
-def update_user(user, index=settings.ELASTIC_INDEX):
+def update_user(user, index=None):
+    index = index or settings.ELASTIC_INDEX
     search_engine.update_user(user, index=index)
 
 
@@ -49,7 +53,8 @@ def delete_index(index):
     search_engine.delete_index(index)
 
 @requires_search
-def create_index(index=settings.ELASTIC_INDEX):
+def create_index(index=None):
+    index = index or settings.ELASTIC_INDEX
     search_engine.create_index(index=index)
 
 

--- a/website/search_migration/migrate.py
+++ b/website/search_migration/migrate.py
@@ -43,7 +43,8 @@ def migrate_users(index):
     logger.info('Users iterated: {0}\nUsers migrated: {1}'.format(n_iter, n_migr))
 
 
-def migrate(delete, index=settings.ELASTIC_INDEX, app=None):
+def migrate(delete, index=None, app=None):
+    index = index or settings.ELASTIC_INDEX
     app = app or init_app("website.settings", set_backends=True, routes=True)
 
     script_utils.add_file_logger(logger, __file__)


### PR DESCRIPTION
## Purpose
Currently tests involving search hit the 'website' index. This PR has the elastic search tests hit a test index. 
This closes issue  https://github.com/CenterForOpenScience/osf.io/issues/1228.

## Changes
* test_elastic.py sets the default index to a test index.
* In functions where 'index' is an argument, moved assigning of default index from the function header to the function body.