### PR TITLE
[feature fix] Update pending embargo label

### DIFF
--- a/website/templates/project/project_header.mako
+++ b/website/templates/project/project_header.mako
@@ -105,7 +105,7 @@
         % endif
 
         % if  node['pending_embargo']:
-            <div class="alert alert-info">This ${node['node_type']} is currently pending entering into an embargoed state.</div>
+            <div class="alert alert-info">This ${node['node_type']} is currently pending registration, awaiting approval from project administrators. This registration will be final and enter the embargo period when all project administrators approve the registration or 48 hours pass, whichever comes first. The embargo will keep the registration private until the embargo period ends.</div>
         % endif
 
         % if  node['embargo_end_date']:


### PR DESCRIPTION
## Purpose:
Make the pending embargo warning label more informative.

## Notes:
Closes-issue: https://trello.com/c/UvdsHEh0/58-pending-embargo-label-next-to-embargoed-registration-and-registration-is-publicly-viewable