### PR TITLE
[feature fix] Unclaimed admin accounts should not get tokens

### DIFF
--- a/website/archiver/listeners.py
+++ b/website/archiver/listeners.py
@@ -52,11 +52,12 @@ def archive_callback(dst):
         archiver_utils.archive_success(dst, dst.registered_user)
         if dst.pending_embargo:
             for contributor in dst.contributors:
-                project_utils.send_embargo_email(
-                    dst.root,
-                    contributor,
-                    urls=root_job.meta['embargo_urls'].get(contributor._id),
-                )
+                if contributor.is_active:
+                    project_utils.send_embargo_email(
+                        dst.root,
+                        contributor,
+                        urls=root_job.meta['embargo_urls'].get(contributor._id),
+                    )
         else:
             archiver_utils.send_archiver_success_mail(dst.root)
     else:

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2634,7 +2634,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
             retraction.justification = justification
         retraction.state = Retraction.PENDING
 
-        admins = [contrib for contrib in self.contributors if self.has_permission(contrib, 'admin')]
+        admins = [contrib for contrib in self.contributors if self.has_permission(contrib, 'admin') and contrib.is_active]
 
         approval_state = {}
         # Create approve/disapprove tokens
@@ -2689,9 +2689,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
         # Convert Date to Datetime
         embargo.end_date = datetime.datetime.combine(end_date, datetime.datetime.min.time())
 
-        # Collect list of admins for registration
-        admins = [contrib for contrib in self.contributors if self.has_permission(contrib, 'admin')]
-
+        admins = [contrib for contrib in self.contributors if self.has_permission(contrib, 'admin') and contrib.is_active]
         approval_state = {}
         # Create approve/disapprove keys
         for admin in admins:


### PR DESCRIPTION
## Purpose:
Unclaimed accounts can be given admin rights to projects and registrations. As a result, they were also being assigned approval/disapproval tokens for retractions and embargoes.

## Changes:
Unclaimed accounts are now ignored and will neither be assigned approval/disapproval tokens nor sent emails.

## Side Effects:
N/A

## Notes:
Closes-issue: https://trello.com/c/sXQJW73i/68-unconfirmed-contributors-receive-emails