### PR TITLE
[feature fix] Fix typos in embargo/retraction emails

### DIFF
--- a/website/templates/emails/pending_embargo_admin.txt.mako
+++ b/website/templates/emails/pending_embargo_admin.txt.mako
@@ -1,6 +1,6 @@
 Hello ${user.fullname},
 
-I just wanted to let you know, ${initiated_by} has requested an embargoed registration for a project you adminstor.
+We just wanted to let you know that ${initiated_by} has requested an embargoed registration for a project you adminstor.
 
 The proposed registration can be reviewed here: ${registration_link}.
 

--- a/website/templates/emails/pending_embargo_non_admin.txt.mako
+++ b/website/templates/emails/pending_embargo_non_admin.txt.mako
@@ -1,6 +1,6 @@
 Hello ${user.fullname},
 
-I just wanted to let you know, ${initiated_by} has requested an embargoed registration for a project you contribute to.
+We just wanted to let you know that ${initiated_by} has requested an embargoed registration for a project you contribute to.
 
 If approved, a registration will be created for the project, viewable here: ${registration_link}, and it will remain
 private until it is retracted, manually made public, or the embargo end date has passed on ${embargo_end_date.date()}.

--- a/website/templates/emails/pending_retraction_admin.txt.mako
+++ b/website/templates/emails/pending_retraction_admin.txt.mako
@@ -1,7 +1,7 @@
 Hello ${user.fullname},
 
 
-I just wanted to let you know, ${initiated_by} has initiated a retraction for the following registration: ${registration_link}
+We just wanted to let you know that ${initiated_by} has initiated a retraction for the following registration: ${registration_link}
 
 To approve this action click the following link: ${approval_link}
 
@@ -12,4 +12,4 @@ the retraction within ${approval_time_span} hours of midnight tonight (EDT) the 
 
 Sincerely yours,
 
-The OSF Robot
+The OSF Robots

--- a/website/templates/emails/pending_retraction_non_admin.txt.mako
+++ b/website/templates/emails/pending_retraction_non_admin.txt.mako
@@ -1,6 +1,6 @@
 Hello ${user.fullname},
 
-I just wanted to let you know, ${initiated_by} has requested a retraction for the following registration: ${registration_link}.
+We just wanted to let you know that ${initiated_by} has requested a retraction for the following registration: ${registration_link}.
 
 Sincerely yours,
 


### PR DESCRIPTION
## Purpose:
Fix typos in retraction and embargo emails.

## Notes:
Closes-issue: https://trello.com/c/FTISFUZZ/71-spelling-error-in-registration-pending-email-for-embargo