### PR TITLE
[feature fix] Update `Regstrations` section of Getting Started page

### DIFF
--- a/website/templates/public/pages/help/registrations.mako
+++ b/website/templates/public/pages/help/registrations.mako
@@ -1,15 +1,17 @@
 <div class="col-md-12 col-sm-12">
     <span id="registrations" class="anchor"></span>
     <h4>Registrations</h4>
-    <p>Registrations are permanent, read only copies of a project. Registration saves the state of
-        a project at a particular point in time&mdash;such as right before data collection, or right when a manuscript
-        is submitted.</p>
-    <p>To register a project, click on the button in the grey navigation bar. Click on "New Registration", select a
-        meta-data template, fill it out, and then confirm the registration. The registration will at a separate,
+    <p>Registration creates a frozen version of the project that can never be edited or deleted but can be
+      retracted. You can register your project by selecting a registration form, entering information about
+      your project, and then confirming. You will be able to continue editing the original project, however,
+      and the frozen version with timestamps will always be linked to the original. Retracting a registration
+      will leave behind metadata about when the registration was created and retracted but removes the contents
+      of the registration.</p>
+
+    <p>A registration can be made public immediately or entered into an embargo period of up to 4 years. At the
+      end of the embargo period, the registration will automatically become public.</p>
+
+    <p>To register a project, click on the <em>Registrations</em> button in the grey navigation bar. Click on "New Registration", select a
+        meta-data template, fill it out, and then confirm the registration. The registration will be at a separate,
         permanent URL that is linked to the project. Then, you can continue editing and revising the project itself.</p>
-    <div class="col-md-8 col-md-offset-2 col-sm-12">
-        <div class="gs-video embed-responsive embed-responsive-16by9">
-            <div class="embed-responsive-item youtube-loader" id="rj89AgTdIvA"></div>
-        </div>
-    </div>
 </div>


### PR DESCRIPTION
## Purpose:
Update `Registrations` section of the Getting Started page

## Changes
1. Remove the outdated video.
2. Update language.

## Side Effects:
None.

## Notes:
Closes-issue: https://trello.com/c/hCSeRcgL/64-registrations-video-should-be-removed-from-getting-started-page