### PR TITLE
[feature fix] Fix typo in registration warning modal

### DIFF
--- a/website/static/js/nodeControl.js
+++ b/website/static/js/nodeControl.js
@@ -38,7 +38,7 @@ var MESSAGES = {
                         'Would you like to continue?',
     // TODO(hrybacki): Remove once Retraction/Embargoes goes is merged into production
     makeRegistrationPublicWarning: '<b>Important Note:</b> As early as <u>June 8, 2015</u>, new registrations ' +
-                        'will be made public immediately or can be embargoed for up to one year. There ' +
+                        'will be made public immediately or can be embargoed for up to four years. There ' +
                         'will no longer be the option of creating a permanently private registration. This ' +
                         'registration occurred before June 8, 2015, so you do retain the option of keeping it ' +
                         'private. However, if you do choose to make the registration public now, then after ' +


### PR DESCRIPTION
## Purpose:
Update language to match new four year max embargo period.

## Notes: 
Closes-issue: https://trello.com/c/dyXQKA8m/72-warning-modal-language-needs-to-change