### PR TITLE
[Feature] No more dual OSF servers

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,4 +13,4 @@ if __name__ == '__main__':
     if port:
         port = int(port)
 
-    app.run(host=host, port=port, extra_files=[settings.ASSET_HASH_PATH])
+    app.run(host=host, port=port, extra_files=[settings.ASSET_HASH_PATH], threaded=settings.DEBUG_MODE)

--- a/tasks.py
+++ b/tasks.py
@@ -53,7 +53,7 @@ def server(host=None, port=5000, debug=True, live=False):
         server.watch(os.path.join(HERE, 'website', 'static', 'public'))
         server.serve(port=port)
     else:
-        app.run(host=host, port=port, debug=debug, extra_files=[settings.ASSET_HASH_PATH])
+        app.run(host=host, port=port, debug=debug, threaded=debug, extra_files=[settings.ASSET_HASH_PATH])
 
 
 @task

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1272,20 +1272,8 @@ class TestNode(OsfTestCase):
         )
 
     def test_web_url_for_absolute(self):
-        orig_offload_domain = settings.OFFLOAD_DOMAIN
-        settings.OFFLOAD_DOMAIN = 'http://localhost:5001/'
         result = self.parent.web_url_for('view_project', _absolute=True)
         assert_in(settings.DOMAIN, result)
-        assert_not_in(settings.OFFLOAD_DOMAIN, result)
-        settings.OFFLOAD_DOMAIN = orig_offload_domain
-
-    def test_web_url_for_absolute_offload(self):
-        orig_offload_domain = settings.OFFLOAD_DOMAIN
-        settings.OFFLOAD_DOMAIN = 'http://localhost:5001/'
-        result = self.parent.web_url_for('view_project', _absolute=True, _offload=True)
-        assert_in(settings.OFFLOAD_DOMAIN, result)
-        assert_not_in(settings.DOMAIN, result)
-        settings.OFFLOAD_DOMAIN = orig_offload_domain
 
     def test_category_display(self):
         node = NodeFactory(category='hypothesis')
@@ -1313,20 +1301,8 @@ class TestNode(OsfTestCase):
         )
 
     def test_api_url_for_absolute(self):
-        orig_offload_domain = settings.OFFLOAD_DOMAIN
-        settings.OFFLOAD_DOMAIN = 'http://localhost:5001/'
         result = self.parent.api_url_for('view_project', _absolute=True)
         assert_in(settings.DOMAIN, result)
-        assert_not_in(settings.OFFLOAD_DOMAIN, result)
-        settings.OFFLOAD_DOMAIN = orig_offload_domain
-
-    def test_api_url_for_absolute_offload(self):
-        orig_offload_domain = settings.OFFLOAD_DOMAIN
-        settings.OFFLOAD_DOMAIN = 'http://localhost:5001/'
-        result = self.parent.api_url_for('view_project', _absolute=True, _offload=True)
-        assert_in(settings.OFFLOAD_DOMAIN, result)
-        assert_not_in(settings.DOMAIN, result)
-        settings.OFFLOAD_DOMAIN = orig_offload_domain
 
     def test_node_factory(self):
         node = NodeFactory()

--- a/website/addons/osfstorage/model.py
+++ b/website/addons/osfstorage/model.py
@@ -80,7 +80,6 @@ class OsfStorageNodeSettings(AddonNodeSettingsBase):
             'baseUrl': self.owner.api_url_for(
                 'osfstorage_get_metadata',
                 _absolute=True,
-                _offload=True
             )
         })
 

--- a/website/app.py
+++ b/website/app.py
@@ -26,6 +26,7 @@ def build_js_config_files(settings):
     with open(os.path.join(settings.STATIC_FOLDER, 'built', 'nodeCategories.json'), 'wb') as fp:
         json.dump(Node.CATEGORY_MAP, fp)
 
+
 def init_addons(settings, routes=True):
     """Initialize each addon in settings.ADDONS_REQUESTED.
 
@@ -42,9 +43,6 @@ def init_addons(settings, routes=True):
             settings.ADDONS_AVAILABLE_DICT[addon.short_name] = addon
     settings.ADDON_CAPABILITIES = render_addon_capabilities(settings.ADDONS_AVAILABLE)
 
-def add_cors_headers(response):
-    response.headers['Access-Control-Allow-Origin'] = '*'
-    return response
 
 def attach_handlers(app, settings):
     """Add callback handlers to ``app`` in the correct order."""
@@ -61,11 +59,6 @@ def attach_handlers(app, settings):
     # framework.session's before_request handler must go after
     # prepare_private_key, else view-only links won't work
     add_handlers(app, {'before_request': framework.sessions.before_request})
-
-    # Needed to allow the offload server and main server to properly interact
-    # without cors issues. See @jmcarp, @chrisseto, or @icereval for more detail
-    if settings.DEBUG_MODE:
-        add_handlers(app, {'after_request': add_cors_headers})
 
     return app
 

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -1805,13 +1805,12 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
     def url(self):
         return '/{}/'.format(self._primary_key)
 
-    def web_url_for(self, view_name, _absolute=False, _offload=False, _guid=False, *args, **kwargs):
-        return web_url_for(view_name, pid=self._primary_key, _absolute=_absolute,
-                           _offload=_offload, _guid=_guid, *args, **kwargs)
+    def web_url_for(self, view_name, _absolute=False, _guid=False, *args, **kwargs):
+        return web_url_for(view_name, pid=self._primary_key, _absolute=_absolute, _guid=_guid, *args, **kwargs)
 
-    def api_url_for(self, view_name, _absolute=False, _offload=False, *args, **kwargs):
-        return api_url_for(view_name, pid=self._primary_key, _absolute=_absolute,
-                           _offload=_offload, *args, **kwargs)
+    def api_url_for(self, view_name, _absolute=False, *args, **kwargs):
+        return api_url_for(view_name, pid=self._primary_key, _absolute=_absolute, *args, **kwargs)
+
     @property
     def absolute_url(self):
         if not self.url:

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -43,7 +43,6 @@ BUILT_TEMPLATES = os.path.join(BASE_PATH, 'templates/_log_templates.mako')
 
 DOMAIN = 'http://localhost:5000/'
 API_DOMAIN = 'http://localhost:8000/'
-OFFLOAD_DOMAIN = 'http://localhost:5001/'
 GNUPG_HOME = os.path.join(BASE_PATH, 'gpg')
 GNUPG_BINARY = 'gpg'
 

--- a/website/util/__init__.py
+++ b/website/util/__init__.py
@@ -38,7 +38,7 @@ def _get_guid_url_for(url):
     guid_url = guid_url_profile_pattern.sub('', guid_url, count=1)
     return guid_url
 
-def api_url_for(view_name, _absolute=False, _offload=False, _xml=False, *args, **kwargs):
+def api_url_for(view_name, _absolute=False, _xml=False, *args, **kwargs):
     """Reverse URL lookup for API routes (that use the JSONRenderer or XMLRenderer).
     Takes the same arguments as Flask's url_for, with the addition of
     `_absolute`, which will make an absolute URL with the correct HTTP scheme
@@ -51,8 +51,7 @@ def api_url_for(view_name, _absolute=False, _offload=False, _xml=False, *args, *
     if _absolute:
         # We do NOT use the url_for's _external kwarg because app.config['SERVER_NAME'] alters
         # behavior in an unknown way (currently breaks tests). /sloria /jspies
-        domain = website_settings.OFFLOAD_DOMAIN if _offload else website_settings.DOMAIN
-        return urlparse.urljoin(domain, url)
+        return urlparse.urljoin(website_settings.DOMAIN, url)
     return url
 
 
@@ -82,7 +81,7 @@ def api_v2_url(path_str,
     return str(base_url)
 
 
-def web_url_for(view_name, _absolute=False, _offload=False, _guid=False, *args, **kwargs):
+def web_url_for(view_name, _absolute=False, _guid=False, *args, **kwargs):
     """Reverse URL lookup for web routes (those that use the OsfWebRenderer).
     Takes the same arguments as Flask's url_for, with the addition of
     `_absolute`, which will make an absolute URL with the correct HTTP scheme
@@ -95,8 +94,7 @@ def web_url_for(view_name, _absolute=False, _offload=False, _guid=False, *args, 
     if _absolute:
         # We do NOT use the url_for's _external kwarg because app.config['SERVER_NAME'] alters
         # behavior in an unknown way (currently breaks tests). /sloria /jspies
-        domain = website_settings.OFFLOAD_DOMAIN if _offload else website_settings.DOMAIN
-        return urlparse.urljoin(domain, url)
+        return urlparse.urljoin(website_settings.DOMAIN, url)
     return url
 
 


### PR DESCRIPTION
Run Flask in multithreaded mode when in debug mode to avoid having to run multiple osf servers for waterbutler