### PR TITLE
[RFR] Archiver fixes

### DIFF
--- a/tests/test_archiver.py
+++ b/tests/test_archiver.py
@@ -5,6 +5,7 @@ import datetime
 from modularodm import Q
 import functools
 
+from contextlib import nested
 import mock  # noqa
 from mock import call
 from nose.tools import *  # noqa PEP8 asserts
@@ -676,10 +677,36 @@ class TestArchiverDecorators(ArchiverTestCase):
             [e.message]
         )
 
-class TestArchiverBehavior(self):
+class TestArchiverBehavior(OsfTestCase):
 
-    def test_archiving_registrations_not_added_to_search(self):
-        assert(false)
+    @mock.patch('website.project.model.Node.update_search')
+    def test_archiving_registrations_not_added_to_search(self, mock_update_search):
+        proj = factories.ProjectFactory()
+        reg = factories.RegistrationFactory(project=proj)
+        ArchiveJob(
+            src_node=proj,
+            dst_node=reg,
+            initiator=proj.creator
+        )
+        reg.save()
+        mock_update_search.assert_not_called()
 
-    def test_archiving_nodes_added_to_search_on_success_if_public(self):
-        assert(false)
+
+    @mock.patch('website.project.model.Node.update_search')
+    @mock.patch('website.archiver.utils.send_archiver_success_mail')
+    def test_archiving_nodes_added_to_search_on_success_if_public(self, mock_send, mock_update_search):
+        proj = factories.ProjectFactory()
+        reg = factories.RegistrationFactory(project=proj)
+        job = ArchiveJob(
+            src_node=proj,
+            dst_node=reg,
+            initiator=proj.creator
+        )
+        reg.save()
+        with nested(
+                mock.patch('website.archiver.model.ArchiveJob.archive_tree_finished', mock.Mock(return_value=True)),
+                mock.patch('website.archiver.model.ArchiveJob.sent', mock.PropertyMock(return_value=False)),
+                mock.patch('website.archiver.model.ArchiveJob.success', mock.PropertyMock(return_value=True))
+        ) as (mock_finished, mock_sent, mock_success):
+            listeners.archive_callback(reg)
+        mock_update_search.assert_called_once_with()

--- a/tests/test_archiver.py
+++ b/tests/test_archiver.py
@@ -675,3 +675,11 @@ class TestArchiverDecorators(ArchiverTestCase):
             self.user,
             [e.message]
         )
+
+class TestArchiverBehavior(self):
+
+    def test_archiving_registrations_not_added_to_search(self):
+        assert(false)
+
+    def test_archiving_nodes_added_to_search_on_success_if_public(self):
+        assert(false)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3178,7 +3178,6 @@ class TestRegisterNode(OsfTestCase):
     def test_registration_list(self):
         assert_in(self.registration._id, self.project.node__registrations)
 
-
 class TestNodeLog(OsfTestCase):
 
     def setUp(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2508,23 +2508,6 @@ class TestProject(OsfTestCase):
         assert_true(registration.is_public)
         assert_equal(self.project.logs[-1].action, NodeLog.EMBARGO_CANCELLED)
 
-    def test_set_privacy_makes_child_registrations_public(self):
-        proj = ProjectFactory()
-        c1 = ProjectFactory(parent=proj)
-        c2a = ProjectFactory(parent=c1)
-        c2b = ProjectFactory(parent=c1)
-        reg = RegistrationFactory(project=proj)
-        r1 = reg.nodes[0]
-        r2a = r1.nodes[0]
-        r2b = r1.nodes[1]
-        for node in [reg, r1, r2a, r2b]:
-            node.is_public = False
-            node.save()
-            assert_false(node.is_public)
-        reg.set_privacy('public')
-        for node in [reg, r1, r2a, r2b]:
-            assert_true(node.is_public)
-        
     def test_set_description(self):
         old_desc = self.project.description
         self.project.set_description(

--- a/website/archiver/listeners.py
+++ b/website/archiver/listeners.py
@@ -14,10 +14,17 @@ from website.archiver import signals as archiver_signals
 from website.project import signals as project_signals
 from website.project import utils as project_utils
 
+def node_and_visible_descendants(node):
+    """Gets an iterator for a node and all of its visible descendants
+
+    :param node Node: target Node
+    """
+    return itertools.chain([node], node.get_descendants_recursive(lambda n: n.primary))
 
 @project_signals.after_create_registration.connect
 def after_register(src, dst, user):
-    """Blinker listener for registration initiations. Enqueqes an archive task
+    """Blinker listener for registration initiations. Enqueqes a chain
+    of archive tasks for the current node and its descendants
 
     :param src: Node being registered
     :param dst: registration Node
@@ -26,8 +33,7 @@ def after_register(src, dst, user):
     archiver_utils.before_archive(dst, user)
     if dst.root != dst:  # if not top-level registration
         return
-    targets = itertools.chain([dst], dst.get_descendants_recursive(lambda n: n.primary))
-    archive_tasks = [archive.si(job_pk=t.archive_job._id) for t in targets]
+    archive_tasks = [archive.si(job_pk=t.archive_job._id) for t in node_and_visible_descendants(dst)]
     handlers.enqueue_task(
         celery.chain(*archive_tasks)
     )
@@ -35,8 +41,8 @@ def after_register(src, dst, user):
 @project_signals.archive_callback.connect
 @fail_archive_on_error
 def archive_callback(dst):
-    """Blinker listener for updates to the archive task. When no tasks are
-    pending, either fail the registration or send a success email
+    """Blinker listener for updates to the archive task. When the tree of ArchiveJob
+    instances is complete, proceed to send success or failure mails
 
     :param dst: registration Node
     """
@@ -60,7 +66,7 @@ def archive_callback(dst):
                     )
         else:
             archiver_utils.send_archiver_success_mail(root)
-        for node in itertools.chain([root], root.get_descendants_recursive(lambda n: n.primary)):
+        for node in node_and_visible_descendants(root):
             node.save()  # update search if public
     else:
         archiver_utils.handle_archive_fail(

--- a/website/archiver/listeners.py
+++ b/website/archiver/listeners.py
@@ -57,13 +57,12 @@ def archive_callback(dst):
     if root_job.success:
         archiver_utils.archive_success(root, root.registered_user)
         if dst.pending_embargo:
-            for contributor in root.contributors:
-                if contributor.is_active:
-                    project_utils.send_embargo_email(
-                        root,
-                        contributor,
-                        urls=root_job.meta['embargo_urls'].get(contributor._id),
-                    )
+            for contributor in root.active_contributors():
+                project_utils.send_embargo_email(
+                    root,
+                    contributor,
+                    urls=root_job.meta['embargo_urls'].get(contributor._id),
+                )
         else:
             archiver_utils.send_archiver_success_mail(root)
         for node in node_and_visible_descendants(root):

--- a/website/archiver/listeners.py
+++ b/website/archiver/listeners.py
@@ -67,7 +67,7 @@ def archive_callback(dst):
         else:
             archiver_utils.send_archiver_success_mail(root)
         for node in node_and_visible_descendants(root):
-            node.save()  # update search if public
+            node.update_search()  # update search if public
     else:
         archiver_utils.handle_archive_fail(
             ARCHIVER_UNCAUGHT_ERROR,

--- a/website/archiver/model.py
+++ b/website/archiver/model.py
@@ -24,6 +24,7 @@ class ArchiveTarget(StoredObject):
         default=lambda: str(ObjectId())
     )
 
+    # addon_short_name of target addon
     name = fields.StringField()
 
     status = fields.StringField(default=ARCHIVER_INITIATED)
@@ -48,7 +49,9 @@ class ArchiveJob(StoredObject):
         default=lambda: str(ObjectId())
     )
 
+    # whether or not the ArchiveJob is complete (success or fail)
     done = fields.BooleanField(default=False)
+    # whether or not emails have been sent for this ArchiveJob
     sent = fields.BooleanField(default=False)
     status = fields.StringField(default=ARCHIVER_INITIATED)
     datetime_initiated = fields.DateTimeField(default=datetime.datetime.utcnow)
@@ -60,6 +63,11 @@ class ArchiveJob(StoredObject):
     target_addons = fields.ForeignField('archivetarget', list=True)
 
     # This field is used for stashing embargo URLs while still in the app context
+    # Format: {
+    #     'view': <str> url,
+    #     'approve': <str> url,
+    #     'disapprove': <str> url,
+    # }
     meta = fields.DictionaryField()
 
     @property

--- a/website/archiver/model.py
+++ b/website/archiver/model.py
@@ -27,6 +27,14 @@ class ArchiveTarget(StoredObject):
     name = fields.StringField()
 
     status = fields.StringField(default=ARCHIVER_INITIATED)
+    # <dict> representation of a website.archiver.AggregateStatResult
+    # Format: {
+    #     'target_id': <str>,
+    #     'target_name': <str>,
+    #     'targets': <list>(StatResult | AggregateStatResult),
+    #     'num_files': <int>,
+    #     'disk_usage': <float>,
+    # }
     stat_result = fields.DictionaryField()
     errors = fields.StringField(list=True)
 

--- a/website/archiver/model.py
+++ b/website/archiver/model.py
@@ -16,6 +16,8 @@ from website.addons.base import StorageAddonBase
 from website import settings
 
 class ArchiveTarget(StoredObject):
+    """Stores the results of archiving a single addon
+    """
 
     _id = fields.StringField(
         primary=True,
@@ -97,12 +99,17 @@ class ArchiveJob(StoredObject):
         return False
 
     def _fail_above(self):
+        """Marks all ArchiveJob instances attached to Nodes above this as failed
+        """
         parent = self.parent
         if parent:
             parent.status = ARCHIVER_FAILURE
             parent.save()
 
     def _post_update_target(self):
+        """Checks for success or failure if the ArchiveJob on self.dst_node
+        is finished
+        """
         if self.status == ARCHIVER_FAILURE:
             return
         if self._archive_node_finished():

--- a/website/archiver/tasks.py
+++ b/website/archiver/tasks.py
@@ -88,9 +88,7 @@ def stat_addon(addon_short_name, job_pk):
     """Collect metadata about the file tree of a given addon
 
     :param addon_short_name: AddonConfig.short_name of the addon to be examined
-    :param src_pk: primary key of node being registered
-    :param dst_pk: primary key of registration node
-    :param user_pk: primary key of registration initatior
+    :param job_pk: primary key of archive_job
     :return: AggregateStatResult containing file tree metadata
     """
     create_app_context()
@@ -151,9 +149,7 @@ def archive_addon(addon_short_name, job_pk, stat_result):
     WaterBulter API
 
     :param addon_short_name: AddonConfig.short_name of the addon to be archived
-    :param src_pk: primary key of node being registered
-    :param dst_pk: primary key of registration node
-    :param user_pk: primary key of registration initatior
+    :param job_pk: primary key of ArchiveJob
     :return: None
     """
     create_app_context()
@@ -196,9 +192,7 @@ def archive_node(results, job_pk):
     create a celery.group group of subtasks to archive addons
 
     :param results: results from the #stat_addon subtasks spawned in #stat_node
-    :param src_pk: primary key of node being registered
-    :param dst_pk: primary key of registration node
-    :param user_pk: primary key of registration initatior
+    :param job_pk: primary key of ArchiveJob
     :return: None
     """
     create_app_context()
@@ -231,13 +225,11 @@ def archive_node(results, job_pk):
 @celery_app.task(bind=True, base=ArchiverTask, name='archiver.archive')
 @logged('archive')
 def archive(self, job_pk):
-    """Saves the celery task id, and start a celery.chord
-    that runs stat_addon for each addon attached to the Node,
-    then runs archive node with the result
+    """Starts a celery.chord that runs stat_addon for each
+    complete addon attached to the Node, then runs
+    #archive_node with the result
 
-    :param src_pk: primary key of node being registered
-    :param dst_pk: primary key of registration node
-    :param user_pk: primary key of registration initatior
+    :param job_pk: primary key of ArchiveJob
     :return: None
     """
     create_app_context()

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -764,6 +764,11 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
             or is_api_node
         )
 
+    def active_contributors(self, include=lambda n: True):
+        for contrib in self.contributors:
+            if contrib.is_active and include(contrib):
+                yield contrib
+
     def is_admin_parent(self, user):
         if self.has_permission(user, 'admin', check_parent=False):
             return True

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -554,6 +554,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
         'is_public',
         'is_deleted',
         'wiki_pages_current',
+        'is_retracted',
     }
 
     # Maps category identifier => Human-readable representation for use in
@@ -2659,7 +2660,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
             retraction.save()
         return retraction
 
-    def retract_registration(self, user, justification=None):
+    def retract_registration(self, user, justification=None, save=True):
         """Retract public registration. Instantiate new Retraction object
         and associate it with the respective registration.
         """
@@ -2677,6 +2678,9 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
             auth=Auth(user),
         )
         self.retraction = retraction
+        if save:
+            self.save()
+        self.update_search()
 
     def _is_embargo_date_valid(self, end_date):
         today = datetime.datetime.utcnow()

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2413,8 +2413,6 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
                         auth=auth,
                     )
                     self.embargo.save()
-                for child in self.nodes_primary:
-                    child.set_privacy(permissions, auth, log, save)
             self.is_public = True
         elif permissions == 'private' and self.is_public:
             if self.is_registration and not self.pending_embargo:
@@ -2680,7 +2678,6 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
         self.retraction = retraction
         if save:
             self.save()
-        self.update_search()
 
     def _is_embargo_date_valid(self, end_date):
         today = datetime.datetime.utcnow()

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -1112,7 +1112,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
         if not self.is_public:
             if first_save or 'is_public' not in saved_fields:
                 need_update = False
-        if self.is_folder:
+        if self.is_folder or self.archiving:
             need_update = False
         if need_update:
             self.update_search()

--- a/website/project/views/register.py
+++ b/website/project/views/register.py
@@ -176,6 +176,8 @@ def node_registration_retraction_approve(auth, node, token, **kwargs):
     try:
         node.retraction.approve_retraction(auth.user, token)
         node.retraction.save()
+        if node.is_retracted:
+            node.update_search()
     except InvalidRetractionApprovalToken as e:
         raise HTTPError(http.BAD_REQUEST, data={
             'message_short': e.message_short,

--- a/website/project/views/register.py
+++ b/website/project/views/register.py
@@ -443,7 +443,7 @@ def node_register_template_page_post(auth, node, **kwargs):
         register.archive_job.meta = {
             'embargo_urls': {
                 contrib._id: project_utils.get_embargo_urls(register, contrib)
-                for contrib in node.contributors
+                for contrib in node.active_contributors()
             }
         }
         register.archive_job.save()


### PR DESCRIPTION
- only add registrations to search after archive success
- update ES when retracting registrations

resolves:
- https://trello.com/c/3F9kmNmk/85-no-distinction-of-retracted-registrations-in-search-results
- https://trello.com/c/2pc5ZT9S/91-registration-stuck-on-archiving-can-be-seen-via-the-search-bar
- https://trello.com/c/T4SORuwV/78-making-existing-private-registration-public-does-not-make-all-components-in-that-registration-public