### PR TITLE
[feature] Fix add-on order of appearance 

### DIFF
--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import logging
-import operator
 import httplib
 import httplib as http
 import os

--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -342,7 +342,7 @@ def user_addons(auth, **kwargs):
     ret = {}
 
     addons = [addon.config for addon in user.get_addons()]
-    addons.sort(key=operator.attrgetter("full_name"), reverse=False)
+    addons.sort(key=lambda addon: addon.full_name.lower(), reverse=False)
     addons_enabled = []
     addon_enabled_settings = []
     user_addons_enabled = {}
@@ -367,7 +367,7 @@ def user_addons(auth, **kwargs):
         for addon in sorted(settings.ADDONS_AVAILABLE)
         if 'user' in addon.owners and addon.short_name not in settings.SYSTEM_ADDED_ADDONS['user']
     ]
-    ret['addons_available'].sort(key=operator.attrgetter("full_name"), reverse=False)
+    ret['addons_available'].sort(key=lambda addon: addon.full_name.lower(), reverse=False)
     ret['addons_enabled'] = addons_enabled
     ret['addon_enabled_settings'] = addon_enabled_settings
     ret['user_addons_enabled'] = user_addons_enabled

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -281,7 +281,7 @@ def node_setting(auth, node, **kwargs):
             # TODO inject only short_name and render fully client side
             config['template_lookup'] = addon.config.template_lookup
             addon_enabled_settings.append(config)
-    addon_enabled_settings = sorted(addon_enabled_settings, key=lambda addon: addon['addon_full_name'])
+    addon_enabled_settings = sorted(addon_enabled_settings, key=lambda addon: addon['addon_full_name'].lower())
 
     ret['addon_categories'] = settings.ADDON_CATEGORIES
     ret['addons_available'] = sorted([
@@ -289,7 +289,7 @@ def node_setting(auth, node, **kwargs):
         for addon in settings.ADDONS_AVAILABLE
         if 'node' in addon.owners
         and addon.short_name not in settings.SYSTEM_ADDED_ADDONS['node']
-    ], key=lambda addon: addon.full_name)
+    ], key=lambda addon: addon.full_name.lower())
 
     ret['addons_enabled'] = addons_enabled
     ret['addon_enabled_settings'] = addon_enabled_settings


### PR DESCRIPTION
Purpose
-----------
Closes #896 

Figshare was listed last in the user and project settings page for configuring addons: 
![screen shot 2015-06-17 at 10 25 53 am](https://cloud.githubusercontent.com/assets/6414394/8209557/8b6fd9a4-14db-11e5-9d54-9cdb702b593f.png)


Changes
--------------
Sort lowercased addon names on user and project settings pages so that they show up in alphabetical order regardless of capitalization: 
![screen shot 2015-06-17 at 10 26 04 am](https://cloud.githubusercontent.com/assets/6414394/8209560/90ae4f0e-14db-11e5-83f1-a125cb8c2976.png)
