### PR TITLE
Update language used for adding contributors.

### DIFF
--- a/website/templates/project/modal_add_contributor.mako
+++ b/website/templates/project/modal_add_contributor.mako
@@ -193,8 +193,7 @@
                     <hr />
 
                     <div style="margin-bottom:10px;">
-                        Would you like to add these contributor(s) to any children of
-                        the current component?
+                        Select any other components that you would like to apply these settings to.
                     </div>
 
                     <div class="row">

--- a/website/templates/project/modal_add_contributor.mako
+++ b/website/templates/project/modal_add_contributor.mako
@@ -193,7 +193,7 @@
                     <hr />
 
                     <div style="margin-bottom:10px;">
-                        Select any other components that you would like to apply these settings to.
+                        Select any other components to which you would like to apply these settings.
                     </div>
 
                     <div class="row">


### PR DESCRIPTION
## Purpose
When adding a contributor to a project, the language prompting the user to choose components that should also be affected was misleading. 
This closes https://github.com/CenterForOpenScience/osf.io/issues/3166

## Changes
Changed text of prompt to *"Select any other components that you would like to apply these settings to."* from *"Would you like to add these contributor(s) to any children of the current component?"*.