### PR TITLE
disable button jump when tooltip

### DIFF
--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -63,7 +63,7 @@
                         <a
                         % if user_name and (node['is_public'] or user['has_read_permissions']) and not node['is_registration']:
                             data-bind="click: toggleWatch, tooltip: {title: watchButtonAction, placement: 'bottom'}"
-                            class="btn btn-default"
+                            class="btn btn-default" data-container="body"
                         % else:
                             class="btn btn-default disabled"
                         % endif


### PR DESCRIPTION
### Purpose
Solve the button jump when using tooltip. See gif below:
![tooltipmove](https://cloud.githubusercontent.com/assets/5420789/8210539/7efd7096-14e0-11e5-9b90-c58a2a4371b3.gif)

### Change
Add the body as container, then it will not be influenced by other.
> #### [Popovers in button groups and input groups require special setting](http://getbootstrap.com/javascript/#popovers)
> When using popovers on elements within a `.btn-group` or an `.input-group`, you'll have to specify the option `container: 'body'` (documented below) to avoid unwanted side effects (such as the element growing wider and/or losing its rounded corners when the popover is triggered).

More details see a github discussion -- [link](https://github.com/twbs/bootstrap/pull/6378)

After adding `data-container="body"` to the button with tooltip, see the gif below:
![tooltipafter](https://cloud.githubusercontent.com/assets/5420789/8210567/aa580602-14e0-11e5-8bad-14bd8fe8cc74.gif)

### Side effects.
None. It only sets the container of the tooltip button. I already tested it in four major browsers. It works well.

### Lesson
When using bootstrap group button with tooltip, remember to add `data-container="body"`.