### PR TITLE
[hotfix] unregistered emails

### DIFF
--- a/website/templates/emails/forward_invite.txt.mako
+++ b/website/templates/emails/forward_invite.txt.mako
@@ -10,7 +10,7 @@ After ${fullname} confirms their account, they will be able to contribute to the
 
 Hello ${fullname},
 
-You have been added by ${referrer.fullname} as a contributor to the project "${node.title}" on the <a href="http://osf.io/">Open Science Framework</a>. To set a password for your account, visit:
+You have been added by ${referrer.fullname} as a contributor to the project "${node.title}" on the Open Science Framework. To set a password for your account, visit:
 
 ${claim_url}
 
@@ -21,4 +21,4 @@ Sincerely,
 The OSF Team
 
 
-Want more information? Visit http://osf.io/ or http://cos.io/ for information about the Open Science Framework and its supporting organization, the Center for Open Science. Questions? Email contact@osf.io
+Want more information? Visit http://osf.io/ or http://cos.io/ for information about the Open Science Framework and its supporting organization, the Center for Open Science. Questions? Email contact@osf.io.

--- a/website/templates/emails/forward_invite_registered.txt.mako
+++ b/website/templates/emails/forward_invite_registered.txt.mako
@@ -10,7 +10,7 @@ After ${fullname} confirms their account, they will be able to contribute to the
 
 Hello ${fullname},
 
-You have been added by ${referrer.fullname} as a contributor to the project "${node.title}" on the <a href="http://osf.io">Open Science Framework</a>. To claim yourself as a contributor to the project, visit this url:
+You have been added by ${referrer.fullname} as a contributor to the project "${node.title}" on the Open Science Framework. To claim yourself as a contributor to the project, visit this url:
 
 ${claim_url}
 

--- a/website/templates/emails/invite.txt.mako
+++ b/website/templates/emails/invite.txt.mako
@@ -1,6 +1,6 @@
 Hello ${fullname},
 
-You have been added by ${referrer.fullname} as a contributor to the project "${node.title}" on the <a href="http://osf.io/">Open Science Framework</a>. To set a password for your account, visit:
+You have been added by ${referrer.fullname} as a contributor to the project "${node.title}" on the Open Science Framework. To set a password for your account, visit:
 
 ${claim_url}
 


### PR DESCRIPTION
Fixed a typo (link should have been line) and removed line breaks that were causing weird formatting in the emails. Also changed some capitalization errors and embedded the OSF link instead of typing it out.