### PR TITLE
[hotfix] [SHARE]ish remove the bit of code responsible for appending Z to date/times when using Firefox

### DIFF
--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -476,10 +476,6 @@ var LOCAL_DATEFORMAT = 'YYYY-MM-DD hh:mm A';
 var UTC_DATEFORMAT = 'YYYY-MM-DD HH:mm UTC';
 var FormattableDate = function(date) {
     if (typeof date === 'string') {
-        // If Firefox, add 'Z' to the date string (Z is timezone for UTC)
-        if(navigator.userAgent.toLowerCase().indexOf('firefox') > -1 && date.slice(-1) !== 'Z') {
-           date = date + 'Z';
-        }
         // The date as a Date object
         this.date = new Date(date);
     } else {

--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -467,6 +467,14 @@ var applyBindings = function(viewModel, selector) {
 };
 
 
+var hasTimeComponent = function(dateString) {
+    return dateString.indexOf('T') !== -1;
+};
+
+var forceUTC = function(dateTimeString) {
+    return dateTimeString.slice(-1) === 'Z' ? dateTimeString : dateTimeString + 'Z';
+};
+
 /**
   * A date object with two formats: local time or UTC time.
   * @param {String} date The original date as a string. Should be an standard
@@ -475,15 +483,16 @@ var applyBindings = function(viewModel, selector) {
 var LOCAL_DATEFORMAT = 'YYYY-MM-DD hh:mm A';
 var UTC_DATEFORMAT = 'YYYY-MM-DD HH:mm UTC';
 var FormattableDate = function(date) {
+
     if (typeof date === 'string') {
-        // The date as a Date object
-        this.date = new Date(date);
+        this.date = new Date(hasTimeComponent(date) ? forceUTC(date) : date);
     } else {
         this.date = date;
     }
     this.local = moment(this.date).format(LOCAL_DATEFORMAT);
     this.utc = moment.utc(this.date).format(UTC_DATEFORMAT);
 };
+
 
 /**
  * Escapes html characters in a string.

--- a/website/static/js/tests/osfHelpers.test.js
+++ b/website/static/js/tests/osfHelpers.test.js
@@ -241,6 +241,37 @@ describe('osfHelpers', () => {
             var expectedUTC = moment.utc(date).format('YYYY-MM-DD HH:mm UTC');
             assert.equal(fd.utc, expectedUTC);
         });
+        it('should parse date and datetime strings', () => {
+            var year = 2014;
+            var month = 11;
+            var day = 15;
+            var hour = 10;
+            var minute = 33;
+            var second = 17;
+            var millisecond = 123;
+
+            var dateString = [year, month, day].join('-');
+            var dateTimeString = dateString + 'T' + [hour, minute, second].join(':') + '.' + millisecond.toString();
+
+            var parsedDate = new $osf.FormattableDate(dateString).date;
+            var parsedDateTime = new $osf.FormattableDate(dateTimeString).date;
+
+            assert.equal(parsedDate.getUTCFullYear(), year);
+            assert.equal(parsedDate.getUTCMonth(), month - 1); // Javascript months count from 0
+            assert.equal(parsedDate.getUTCDate(), day);
+            assert.equal(parsedDate.getUTCHours(), 0);
+            assert.equal(parsedDate.getUTCMinutes(), 0);
+            assert.equal(parsedDate.getUTCSeconds(), 0);
+            assert.equal(parsedDate.getUTCMinutes(), 0);
+
+            assert.equal(parsedDateTime.getUTCFullYear(), year);
+            assert.equal(parsedDateTime.getUTCMonth(), month - 1); // Javascript months count from 0
+            assert.equal(parsedDateTime.getUTCDate(), day);
+            assert.equal(parsedDateTime.getUTCHours(), hour);
+            assert.equal(parsedDateTime.getUTCMinutes(), minute);
+            assert.equal(parsedDateTime.getUTCSeconds(), second);
+            assert.equal(parsedDateTime.getUTCMilliseconds(), millisecond);
+        });
     });
 
     describe('confirmDangerousAction', () => {


### PR DESCRIPTION
Fixes #3172 #3176 

Purpose
-----------
Make it so that osfHelpers.FormattableDate can accept ISO 8601 formatted date strings, rather than just date-time strings, in Firefox

Changes
------------
No longer append "Z" to the date/time string in Firefox

Side-effects
----------------
I'm not sure why that "Z" is appended (locally on my firefox, the behavior is the same with or without the "Z"), but if there was a good reason for adding that then other places that display datetimes may be broken. Will try to find them.