### PR TITLE
[Feature Fix] Include how to copy file in file organizer information

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1668,8 +1668,8 @@ var FGToolbar = {
                         m('p', [ m('b', 'Select rows:'), m('span', ' Click on a row (outside the name) to show further actions in the toolbar.')]),
                         m('p', [ m('b', 'Select Multiple Files:'), m('span', ' Use command or shift keys to select multiple files.')]),
                         m('p', [ m('b', 'Open Files:'), m('span', ' Click a file name to go to the file.')]),
-                        m('p', [ m('b', 'Open Files in New Tab:'), m('span',  ' Press Command (or Ctrl in Windows) and  click a file name to open it in a new tab.')]),
-                        m('p', [ m('b', 'Copy Files:'), m('span', ' Press Option (or Alt in Windows) while dragging a file to a new folder or component.')])
+                        m('p', [ m('b', 'Open Files in New Tab:'), m('span',  ' Press command (or ctrl in Windows) and  click a file name to open it in a new tab.')]),
+                        m('p', [ m('b', 'Copy Files:'), m('span', ' Press option (or alt in Windows) while dragging a file to a new folder or component.')])
                     ]);
                     var mithrilButtons = m('div', [
                         m('span.tb-modal-btn', { 'class' : 'text-primary', onclick : function(event) { ctrl.tb.modal.dismiss(); } }, 'Close'),

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1669,7 +1669,7 @@ var FGToolbar = {
                         m('p', [ m('b', 'Select Multiple Files:'), m('span', ' Use command or shift keys to select multiple files.')]),
                         m('p', [ m('b', 'Open Files:'), m('span', ' Click a file name to go to the file.')]),
                         m('p', [ m('b', 'Open Files in New Tab:'), m('span',  ' Press Command (or Ctrl in Windows) and  click a file name to open it in a new tab.')]),
-                        m('p', [ m('b', 'Copy Files'), m('span', ' Press Option (or Alt in Windows) while dragging a file to a new folder or component.')])
+                        m('p', [ m('b', 'Copy Files:'), m('span', ' Press Option (or Alt in Windows) while dragging a file to a new folder or component.')])
                     ]);
                     var mithrilButtons = m('div', [
                         m('span.tb-modal-btn', { 'class' : 'text-primary', onclick : function(event) { ctrl.tb.modal.dismiss(); } }, 'Close'),

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1665,7 +1665,7 @@ var FGToolbar = {
                 onclick: function(event){
                     var mithrilContent = m('div', [
                         m('h3.break-word.m-b-lg', 'How to Use the File Browser'),
-                        m('p', [ m('b', 'Select rows:'), m('span', ' Click on a row (outside the name) to show further actions in the toolbar.')]),
+                        m('p', [ m('b', 'Select Rows:'), m('span', ' Click on a row (outside the name) to show further actions in the toolbar.')]),
                         m('p', [ m('b', 'Select Multiple Files:'), m('span', ' Use command or shift keys to select multiple files.')]),
                         m('p', [ m('b', 'Open Files:'), m('span', ' Click a file name to go to the file.')]),
                         m('p', [ m('b', 'Open Files in New Tab:'), m('span',  ' Press command (or ctrl in Windows) and  click a file name to open it in a new tab.')]),

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1669,6 +1669,7 @@ var FGToolbar = {
                         m('p', [ m('b', 'Select Multiple Files:'), m('span', ' Use command or shift keys to select multiple files.')]),
                         m('p', [ m('b', 'Open Files:'), m('span', ' Click a file name to go to the file.')]),
                         m('p', [ m('b', 'Open Files in New Tab:'), m('span',  ' Press Command (or Ctrl in Windows) and  click a file name to open it in a new tab.')]),
+                        m('p', [ m('b', 'Copy Files'), m('span', ' Press Option (or Alt in Windows) while dragging a file to a new folder or component.')])
                     ]);
                     var mithrilButtons = m('div', [
                         m('span.tb-modal-btn', { 'class' : 'text-primary', onclick : function(event) { ctrl.tb.modal.dismiss(); } }, 'Close'),


### PR DESCRIPTION
## Purpose
The file tree's information panel did not include how to copy files. This PR adds instructions for copying files to this information.
This closes https://github.com/CenterForOpenScience/osf.io/issues/3182.


## Changes
Added instructions for coping files to the file tree's information panel.