### PR TITLE
[hotfix] Include delete button in files tab toolbar for draft dataverse files 

### DIFF
--- a/website/addons/dataverse/static/dataverseFangornConfig.js
+++ b/website/addons/dataverse/static/dataverseFangornConfig.js
@@ -145,7 +145,7 @@ var _dataverseItemButtons = {
                     className: 'text-info'
                 }, 'Download')
             );
-            if (item.parent().data.state === 'draft' && item.data.permissions.edit) {
+            if (item.parent().data.version === 'latest' && item.data.permissions.edit) {
                 buttons.push(
                     m.component(Fangorn.Components.button, {
                         onclick: function (event) {


### PR DESCRIPTION
Purpose
-------------
Closes #3186 

The delete button for draft dataverse files was not showing in the files grid toolbar, even though it is possible to delete those files through the file detail page. 

Changes
------------
Replaced the outdated `item.data.state` with `item.data.version` so that the check for whether the file is in a draft dataverse is correct. 

The delete button now shows up in the files grid toolbar: 
![screen shot 2015-06-17 at 3 04 30 pm](https://cloud.githubusercontent.com/assets/6414394/8216128/8c517dce-1502-11e5-941e-83b281423158.png)

