### PR TITLE
[feature] Enable sentry logging for APIv2

### DIFF
--- a/api/base/middleware.py
+++ b/api/base/middleware.py
@@ -1,5 +1,6 @@
-from framework.transactions import commands, messages, utils
 from pymongo.errors import OperationFailure
+from raven.contrib.django.raven_compat.models import sentry_exception_handler
+from framework.transactions import commands, messages, utils
 
 # TODO: Verify that a transaction is being created for every
 # individual request.
@@ -19,6 +20,7 @@ class TokuTransactionsMiddleware(object):
         """If an exception occurs, rollback the current transaction
         if it exists.
         """
+        sentry_exception_handler(request=request)
         try:
             commands.rollback()
         except OperationFailure as err:

--- a/api/base/middleware.py
+++ b/api/base/middleware.py
@@ -1,5 +1,6 @@
 from pymongo.errors import OperationFailure
 from raven.contrib.django.raven_compat.models import sentry_exception_handler
+
 from framework.transactions import commands, messages, utils
 
 # TODO: Verify that a transaction is being created for every

--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -42,7 +42,13 @@ INSTALLED_APPS = (
     # 3rd party
     'rest_framework',
     'rest_framework_swagger',
+    'raven.contrib.django.raven_compat',
 )
+
+# TODO: Are there more granular ways to configure reporting specifically related to the API?
+RAVEN_CONFIG = {
+    'dsn': osf_settings.SENTRY_DSN
+}
 
 REST_FRAMEWORK = {
     'PAGE_SIZE': 10,


### PR DESCRIPTION
Refs #3163 

## Purpose
Allow Sentry to track errors that happen in the Django app used by APIv2.

## Summary of changes
Adds raven middleware to Django. Raven is already listed as a requirement for flask, so no new user installation is needed.

Applies a fix to ensure that Sentry catches problems when used with other error handling middleware, as [suggested](http://raven.readthedocs.org/en/latest/integrations/django.html#error-handling-middleware) by the Sentry docs.

## Blockers
Not sure how to test this locally, since I don't have the SENTRY_DSN keys needed to send actual data to the server.

Feedback on more granular reporting options would also be welcome. It would be nice if we could filter API/django errors out from the OSF/flask errors in a clear way. @brianjgeiger ?