### PR TITLE
[Staging & Production] Add-on Configuring Confirmation confirm

### DIFF
--- a/website/static/js/pages/profile-settings-addons-page.js
+++ b/website/static/js/pages/profile-settings-addons-page.js
@@ -99,7 +99,7 @@ $(window).on('beforeunload',function() {
     var unchecked = checkedOnLoad.filter($('#selectAddonsForm input:not(:checked)'));
 
     if(unchecked.length > 0 || checked.length > 0) {
-        return 'The changes on addon setting are not submitted!'
+        return 'The changes on addon setting are not submitted!';
     }
 });
 

--- a/website/static/js/pages/profile-settings-addons-page.js
+++ b/website/static/js/pages/profile-settings-addons-page.js
@@ -46,11 +46,13 @@ $('#selectAddonsForm').on('submit', function() {
         formData[$elm.attr('name')] = $elm.is(':checked');
     });
 
-    var unchecked = checkedOnLoad.filter($('#selectAddonsForm input:not(:checked)'));
+    var unchecked = checkedOnLoad.filter('#selectAddonsForm input:not(:checked)');
 
     var submit = function() {
         var request = $osf.postJSON('/api/v1/settings/addons/', formData);
         request.done(function() {
+            checkedOnLoad = $('#selectAddonsForm input:checked');
+            uncheckedOnLoad = $('#selectAddonsForm input:not(:checked)');
             window.location.reload();
         });
         request.fail(function() {
@@ -94,9 +96,9 @@ for (var i=0; i < addonEnabledSettings.length; i++) {
 /* Before closing the page, Check whether the newly checked addon are updated or not */
 $(window).on('beforeunload',function() {
     //new checked items but not updated
-    var checked = uncheckedOnLoad.filter($('#selectAddonsForm input:checked'));
+    var checked = uncheckedOnLoad.filter('#selectAddonsForm input:checked');
     //new unchecked items but not updated
-    var unchecked = checkedOnLoad.filter($('#selectAddonsForm input:not(:checked)'));
+    var unchecked = checkedOnLoad.filter('#selectAddonsForm input:not(:checked)');
 
     if(unchecked.length > 0 || checked.length > 0) {
         return 'The changes on addon setting are not submitted!';

--- a/website/static/js/pages/profile-settings-addons-page.js
+++ b/website/static/js/pages/profile-settings-addons-page.js
@@ -33,7 +33,9 @@ $('.addon-select').on('change', function() {
     }
 });
 
+
 var checkedOnLoad = $('#selectAddonsForm input:checked');
+var uncheckedOnLoad = $('#selectAddonsForm input:not(:checked)');
 
 // TODO: Refactor into a View Model
 $('#selectAddonsForm').on('submit', function() {
@@ -88,6 +90,36 @@ for (var i=0; i < addonEnabledSettings.length; i++) {
                                       window.contextVars.addonsWithNodes[addonName].fullName);
    }
 }
+
+/* Before closing the page, Check whether the newly checked addon are updated or not */
+$(window).on('beforeunload',function() {
+    //new checked items but not updated
+    var checked = uncheckedOnLoad.filter($('#selectAddonsForm input:checked'));
+    //new unchecked items but not updated
+    var unchecked = checkedOnLoad.filter($('#selectAddonsForm input:not(:checked)'));
+    var checkedText = "";
+    var uncheckedText = "";
+
+    if(checked.length > 0) {
+        checkedText = $.map(checked, function (el) {
+            return [' [', $(el).closest('label').text().trim(), ']'].join('');
+        }).join('');
+        checkedText = [' -- ', checkedText, "."].join('');
+        checkedText = "Unsaved checked addons:" + checkedText + "\n";
+    }
+    if(unchecked.length > 0) {
+        uncheckedText = $.map(unchecked, function (el) {
+            return [' [', $(el).closest('label').text().trim(), ']'].join('');
+        }).join('');
+        uncheckedText = [' -- ', uncheckedText, '.'].join('');
+        uncheckedText = "Unsaved unchecked addons:" + uncheckedText;
+    }
+
+    if(unchecked.length > 0 || checked.length > 0) {
+        return "Are you sure you want to leave without submitting your add-ons setting? \n" + checkedText + uncheckedText;
+    }
+
+});
 
 /***************
 * OAuth addons *

--- a/website/static/js/pages/profile-settings-addons-page.js
+++ b/website/static/js/pages/profile-settings-addons-page.js
@@ -97,28 +97,10 @@ $(window).on('beforeunload',function() {
     var checked = uncheckedOnLoad.filter($('#selectAddonsForm input:checked'));
     //new unchecked items but not updated
     var unchecked = checkedOnLoad.filter($('#selectAddonsForm input:not(:checked)'));
-    var checkedText = "";
-    var uncheckedText = "";
-
-    if(checked.length > 0) {
-        checkedText = $.map(checked, function (el) {
-            return [' [', $(el).closest('label').text().trim(), ']'].join('');
-        }).join('');
-        checkedText = [' -- ', checkedText, "."].join('');
-        checkedText = "Unsaved checked addons:" + checkedText + "\n";
-    }
-    if(unchecked.length > 0) {
-        uncheckedText = $.map(unchecked, function (el) {
-            return [' [', $(el).closest('label').text().trim(), ']'].join('');
-        }).join('');
-        uncheckedText = [' -- ', uncheckedText, '.'].join('');
-        uncheckedText = "Unsaved unchecked addons:" + uncheckedText;
-    }
 
     if(unchecked.length > 0 || checked.length > 0) {
-        return "Are you sure you want to leave without submitting your add-ons setting? \n" + checkedText + uncheckedText;
+        return "The changes on addon setting are not submitted!"
     }
-
 });
 
 /***************

--- a/website/static/js/pages/profile-settings-addons-page.js
+++ b/website/static/js/pages/profile-settings-addons-page.js
@@ -99,7 +99,7 @@ $(window).on('beforeunload',function() {
     var unchecked = checkedOnLoad.filter($('#selectAddonsForm input:not(:checked)'));
 
     if(unchecked.length > 0 || checked.length > 0) {
-        return "The changes on addon setting are not submitted!"
+        return 'The changes on addon setting are not submitted!'
     }
 });
 

--- a/website/static/js/pages/project-settings-page.js
+++ b/website/static/js/pages/project-settings-page.js
@@ -145,7 +145,7 @@ $(document).ready(function() {
       var unchecked = checkedOnLoad.filter($('#selectAddonsForm input:not(:checked)'));
 
       if(unchecked.length > 0 || checked.length > 0) {
-        return 'The changes on addon setting are not submitted!'
+        return 'The changes on addon setting are not submitted!';
       }
     });
 

--- a/website/static/js/pages/project-settings-page.js
+++ b/website/static/js/pages/project-settings-page.js
@@ -135,4 +135,20 @@ $(document).ready(function() {
         }
     });
 
+    var checkedOnLoad = $('#selectAddonsForm input:checked');
+    var uncheckedOnLoad = $('#selectAddonsForm input:not(:checked)');
+    /* Before closing the page, Check whether the newly checked addon are updated or not */
+    $(window).on('beforeunload',function() {
+      //new checked items but not updated
+      var checked = uncheckedOnLoad.filter($('#selectAddonsForm input:checked'));
+      //new unchecked items but not updated
+      var unchecked = checkedOnLoad.filter($('#selectAddonsForm input:not(:checked)'));
+
+      if(unchecked.length > 0 || checked.length > 0) {
+        return "The changes on addon setting are not submitted!"
+      }
+    });
+
 });
+
+

--- a/website/static/js/pages/project-settings-page.js
+++ b/website/static/js/pages/project-settings-page.js
@@ -88,6 +88,8 @@ $(document).ready(function() {
 
     });
 
+    var checkedOnLoad = $('#selectAddonsForm input:checked');
+    var uncheckedOnLoad = $('#selectAddonsForm input:not(:checked)');
 
     // Set up submission for addon selection form
     $('#selectAddonsForm').on('submit', function() {
@@ -106,12 +108,26 @@ $(document).ready(function() {
             dataType: 'json',
             success: function() {
                 msgElm.text('Settings updated').fadeIn();
+                checkedOnLoad = $('#selectAddonsForm input:checked');
+                uncheckedOnLoad = $('#selectAddonsForm input:not(:checked)');
                 window.location.reload();
             }
         });
 
         return false;
 
+    });
+
+    /* Before closing the page, Check whether the newly checked addon are updated or not */
+    $(window).on('beforeunload',function() {
+      //new checked items but not updated
+      var checked = uncheckedOnLoad.filter('#selectAddonsForm input:checked');
+      //new unchecked items but not updated
+      var unchecked = checkedOnLoad.filter('#selectAddonsForm input:not(:checked)');
+
+      if(unchecked.length > 0 || checked.length > 0) {
+        return 'The changes on addon setting are not submitted!';
+      }
     });
 
     // Show capabilities modal on selecting an addon; unselect if user
@@ -133,20 +149,6 @@ $(document).ready(function() {
                 );
             }
         }
-    });
-
-    var checkedOnLoad = $('#selectAddonsForm input:checked');
-    var uncheckedOnLoad = $('#selectAddonsForm input:not(:checked)');
-    /* Before closing the page, Check whether the newly checked addon are updated or not */
-    $(window).on('beforeunload',function() {
-      //new checked items but not updated
-      var checked = uncheckedOnLoad.filter($('#selectAddonsForm input:checked'));
-      //new unchecked items but not updated
-      var unchecked = checkedOnLoad.filter($('#selectAddonsForm input:not(:checked)'));
-
-      if(unchecked.length > 0 || checked.length > 0) {
-        return 'The changes on addon setting are not submitted!';
-      }
     });
 
 });

--- a/website/static/js/pages/project-settings-page.js
+++ b/website/static/js/pages/project-settings-page.js
@@ -145,7 +145,7 @@ $(document).ready(function() {
       var unchecked = checkedOnLoad.filter($('#selectAddonsForm input:not(:checked)'));
 
       if(unchecked.length > 0 || checked.length > 0) {
-        return "The changes on addon setting are not submitted!"
+        return 'The changes on addon setting are not submitted!'
       }
     });
 


### PR DESCRIPTION
### Purpose
In our project and profile add-on setting pages, only when users click submit button, will the changes be saved. In case that users forget to submit, a confirmation page should be added when detecting there are unsubmitted add-on setting changes. 
Issues resolve -- #2155 

### Changes
The basic idea is to bind [beforeunload event](http://www.w3schools.com/jsref/event_onbeforeunload.asp). Before unloading, detect whether there are changed settings. If yes, return a static warning message.
![screen shot 2015-06-17 at 4 54 55 pm](https://cloud.githubusercontent.com/assets/5420789/8218564/aa0e30a0-1511-11e5-88d5-6d97f745c2af.png)

### Side effects
In our current style guide, it doesn't define the modal panel for confirmation.  So it doesn't follow the guideline for general modal panel.


