### PR TITLE
Fix twofactor warning message

### DIFF
--- a/website/addons/twofactor/models.py
+++ b/website/addons/twofactor/models.py
@@ -52,8 +52,8 @@ class TwoFactorUserSettings(AddonUserSettingsBase):
 
     def on_add(self):
         # TODO(hrybacki, sloria): push status message shouldn't need a session
-        push_status_message('Please <a href="#TfaVerify">activate your'
-                            ' device</a> before continuing.')
+        push_status_message('<span id="tfa-activation-warning">Please <a href="#TfaVerify">activate your'
+                            ' device</a> before continuing.</span>')
         super(TwoFactorUserSettings, self).on_add()
         self.totp_secret = _generate_seed()
         self.totp_drift = 0

--- a/website/addons/twofactor/models.py
+++ b/website/addons/twofactor/models.py
@@ -52,7 +52,7 @@ class TwoFactorUserSettings(AddonUserSettingsBase):
 
     def on_add(self):
         # TODO(hrybacki, sloria): push status message shouldn't need a session
-        push_status_message('<span id="tfa-activation-warning">Please <a href="#TfaVerify">activate your'
+        push_status_message('<span id="TfaActivationWarning">Please <a href="#TfaVerify">activate your'
                             ' device</a> before continuing.</span>')
         super(TwoFactorUserSettings, self).on_add()
         self.totp_secret = _generate_seed()

--- a/website/addons/twofactor/static/twoFactorUserConfig.js
+++ b/website/addons/twofactor/static/twoFactorUserConfig.js
@@ -36,7 +36,9 @@ function ViewModel(qrCodeSelector, otpURL) {
         osfHelpers.postJSON(
             SETTINGS_URL,
             {code: self.tfaCode()}
-        ).done(function() {
+        ).done(function(response) {
+            $('#Tfa-success-message').html(response['message']);
+            $('.close').click();
             $('#TfaVerify').slideUp(function() {
                 $('#TfaDeactivate').slideDown();
             });

--- a/website/addons/twofactor/static/twoFactorUserConfig.js
+++ b/website/addons/twofactor/static/twoFactorUserConfig.js
@@ -38,7 +38,7 @@ function ViewModel(qrCodeSelector, otpURL) {
             {code: self.tfaCode()}
         ).done(function(response) {
             $('#Tfa-success-message').html(response['message']);
-            $('.close').click();
+            $('#tfa-activation-warning').closest('#alert-container').hide();
             $('#TfaVerify').slideUp(function() {
                 $('#TfaDeactivate').slideDown();
             });

--- a/website/addons/twofactor/static/twoFactorUserConfig.js
+++ b/website/addons/twofactor/static/twoFactorUserConfig.js
@@ -37,8 +37,8 @@ function ViewModel(qrCodeSelector, otpURL) {
             SETTINGS_URL,
             {code: self.tfaCode()}
         ).done(function(response) {
-            $('#Tfa-success-message').html(response['message']);
-            $('#tfa-activation-warning').closest('#alert-container').hide();
+            $('#TfaSuccessMessage').html(response['message']);
+            $('#TfaActivationWarning').closest('#alert-container').hide();
             $('#TfaVerify').slideUp(function() {
                 $('#TfaDeactivate').slideDown();
             });

--- a/website/addons/twofactor/templates/twofactor_user_settings.mako
+++ b/website/addons/twofactor/templates/twofactor_user_settings.mako
@@ -45,7 +45,7 @@
     </div>
 % endif
 <div id="TfaDeactivate" ${ 'style="display:none"' if not is_confirmed else ''}>
-    <p class="text-success">Enabled</p>
+    <p class="text-success" id="Tfa-success-message"></p>
 </div>
 </div>
 

--- a/website/addons/twofactor/templates/twofactor_user_settings.mako
+++ b/website/addons/twofactor/templates/twofactor_user_settings.mako
@@ -46,6 +46,7 @@
 % endif
 <div id="TfaDeactivate" ${ 'style="display:none"' if not is_confirmed else ''}>
     <p class="text-success" id="Tfa-success-message"></p>
+    <p class="text-success">Two-factor Authentication is enabled</p>
 </div>
 </div>
 

--- a/website/addons/twofactor/templates/twofactor_user_settings.mako
+++ b/website/addons/twofactor/templates/twofactor_user_settings.mako
@@ -45,7 +45,7 @@
     </div>
 % endif
 <div id="TfaDeactivate" ${ 'style="display:none"' if not is_confirmed else ''}>
-    <p class="text-success" id="Tfa-success-message"></p>
+    <p class="text-success" id="TfaSuccessMessage"></p>
     <p class="text-success">Two-factor Authentication is enabled</p>
 </div>
 </div>


### PR DESCRIPTION
<h2>Purpose:</h2> 
<p>Issue #2385: To remove the persisting warning message after authenticating the two-factor addon so that it doesn't continue to say "Please activate your device before continuing" at the top of the page</p>

<h2>Changes:</h2>
<p>If entered the correct verification code, hitting submit enables the twofactor addon (assuming correct verification code), displays the returned JSON message, and closes the warning message at the top</p>

Before verification:
![screen shot 2015-06-18 at 10 36 19 am](https://cloud.githubusercontent.com/assets/11323460/8233794/25c23310-15a6-11e5-97bc-62812527bb67.png)

After:
![screen shot 2015-06-18 at 10 36 41 am](https://cloud.githubusercontent.com/assets/11323460/8233801/30acac7e-15a6-11e5-92be-ce163cd39df0.png)



<h2>Side effects:</h2>
<p>This might not be the ideal solution</p>