### PR TITLE
[Feature Fix] Fix multiple clicks on create project button creates many of same project

### DIFF
--- a/website/static/js/projectCreator.js
+++ b/website/static/js/projectCreator.js
@@ -37,12 +37,13 @@ function ProjectCreatorViewModel(params) {
     self.hasFocus = params.hasFocus;
 
     self.usingTemplate = ko.observable(false);
+    self.enableCreateBtn =  ko.observable(true);
 
     self.disableSubmitBtn = function (){
-        $('#createProjectSubmitBtn').prop('disabled', true);
+        self.enableCreateBtn(false);
     };
     self.enableSubmitBtn = function (){
-        $('#createProjectSubmitBtn').prop('disabled', false);
+        self.enableCreateBtn(true);
     };
 
     self.submitForm = function () {

--- a/website/static/js/projectCreator.js
+++ b/website/static/js/projectCreator.js
@@ -40,11 +40,9 @@ function ProjectCreatorViewModel(params) {
 
     self.disableSubmitBtn = function (){
         $('#createProjectSubmitBtn').prop('disabled', true);
-        console.log("disable btn");
     };
     self.enableSubmitBtn = function (){
         $('#createProjectSubmitBtn').prop('disabled', false);
-         console.log("enable btn");
     };
 
     self.submitForm = function () {

--- a/website/static/js/projectCreator.js
+++ b/website/static/js/projectCreator.js
@@ -38,10 +38,20 @@ function ProjectCreatorViewModel(params) {
 
     self.usingTemplate = ko.observable(false);
 
+    self.disableSubmitBtn = function (){
+        $('#createProjectSubmitBtn').prop('disabled', true);
+        console.log("disable btn");
+    };
+    self.enableSubmitBtn = function (){
+        $('#createProjectSubmitBtn').prop('disabled', false);
+         console.log("enable btn");
+    };
+
     self.submitForm = function () {
         if (self.title().trim() === '') {
             self.errorMessage('This field is required.');
         } else {
+            self.disableSubmitBtn();
             self.createProject();
         }
     };
@@ -62,6 +72,7 @@ function ProjectCreatorViewModel(params) {
     };
 
     self.createFailure = function() {
+        self.enableSubmitBtn();
         $osf.growl('Could not create a new project.', 'Please try again. If the problem persists, email <a href="mailto:support@osf.io.">support@osf.io</a>');
 
     };

--- a/website/templates/components/dashboard_templates.mako
+++ b/website/templates/components/dashboard_templates.mako
@@ -159,7 +159,7 @@
     <br />
     <div class="row">
         <div class="col-md-12">
-            <button class="btn btn-primary pull-right" type="submit">Create</button>
+            <button id="createProjectSubmitBtn" class="btn btn-primary pull-right" type="submit">Create</button>
         </div>
     </div>
 </form>

--- a/website/templates/components/dashboard_templates.mako
+++ b/website/templates/components/dashboard_templates.mako
@@ -159,7 +159,7 @@
     <br />
     <div class="row">
         <div class="col-md-12">
-            <button id="createProjectSubmitBtn" class="btn btn-primary pull-right" type="submit">Create</button>
+            <button data-bind="enable: enableCreateBtn" class="btn btn-primary pull-right" type="submit">Create</button>
         </div>
     </div>
 </form>


### PR DESCRIPTION
### Purpose
The create project button could be clicked multiple times which result in creating duplicated projects. In this PR, it will disable the button once getting an effective clicking. 

Resolve #3187

### Changes
1) Add id for project create button
2) Disable the button when getting an effective submit
3) Enable the button when submit is failure.

### Side Effect
None.
