### PR TITLE
Fix fangorn.js indexOf typo

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1853,7 +1853,7 @@ function _dropLogic(event, items, folder) {
     var tb = this;
 
     if (items.length < 1 ||
-        items.indoexOf(folder) > -1 ||
+        items.indexOf(folder) > -1 ||
         copyMode === 'forbidden'
     ) {
         return;


### PR DESCRIPTION
<b>Purpose</b>
To fix a typo in fangorn.js that was causing various problems, notably erring when trying to drag-move files from folder to folder. 
<b>Side Effects:</b>
None 

Before: 
![filemoveerror](https://cloud.githubusercontent.com/assets/11323460/8240505/062f52f0-15d1-11e5-8240-ca1ce219b88e.png)
After: 
![screen shot 2015-06-18 at 3 46 52 pm](https://cloud.githubusercontent.com/assets/11323460/8240542/4d2016b8-15d1-11e5-9207-df939c4c6fad.png)

