### PR TITLE
HTML decode entities in project titles

### DIFF
--- a/website/static/js/registrationRetraction.js
+++ b/website/static/js/registrationRetraction.js
@@ -24,9 +24,9 @@ var RegistrationRetractionViewModel = oop.extend(
             var self = this;
 
             self.submitUrl = submitUrl;
-            self.registrationTitle = registrationTitle;
+            self.registrationTitle = $osf.htmlDecode(registrationTitle);
             // Truncate title to around 50 chars
-            var parts = registrationTitle.slice(0, 50).split(' ');
+            var parts = self.registrationTitle.slice(0, 50).split(' ');
             if (parts.length > 1) {
                 self.truncatedTitle = parts.slice(0, -1).join(' ');
             }

--- a/website/static/js/tests/registrationRetraction.test.js
+++ b/website/static/js/tests/registrationRetraction.test.js
@@ -63,6 +63,11 @@ describe('registrationRetraction', () => {
                 assert.isTrue(vm.confirmationText.isValid());
             });
 
+            it('decodes html entities in project title', () => {
+                var test = new registrationRetraction.ViewModel(submitUrl, 'Carrot &gt;== Cake');
+                assert.equal(test.registrationTitle, 'Carrot >== Cake');
+            });
+
             describe('submit', () => {
                 var postSpy;
                 var changeMessageSpy;


### PR DESCRIPTION
Fixes https://trello.com/c/0TufdPXI/101-html-characters-in-title-are-escaped-in-retractions-confirmation-modal