### PR TITLE
[hotfix] [SHARE] Prevents the footer from popping back up again as the query changes

### DIFF
--- a/website/static/js/share/footer.js
+++ b/website/static/js/share/footer.js
@@ -6,14 +6,15 @@ var Footer = {};
 
 Footer.view = function(ctrl) {
     return m('', [
-        m(
-            'ul.provider-footer.col-xs-12.col-lg-10.col-lg-offset-1',
-            {
-                style: {
-                    'list-style-type': 'none'
-                }
-            },
-            ctrl.renderProviders()
+        m('.col-xs-12.col-lg-10.col-lg-offset-1',
+            m('ul.provider-footer',
+                {
+                    style: {
+                        'list-style-type': 'none'
+                    }
+                },
+                ctrl.renderProviders()
+            )
         ),
         m('.row', m('.col-md-12', {style: 'padding-top: 30px;'}, m('span', m.trust(MESSAGES.ABOUTSHARE))))
     ]);

--- a/website/static/js/share/utils.js
+++ b/website/static/js/share/utils.js
@@ -88,6 +88,7 @@ utils.loadMore = function(vm) {
 };
 
 utils.search = function(vm) {
+    vm.showFooter = false;
     var ret = m.deferred();
     if (!vm.query() || vm.query().length === 0){
         vm.query = m.prop('');


### PR DESCRIPTION
Purpose
-----------
When using SHARE, if you hide the footer by clicking it or performing a query, and then search with an empty bar, and then search with a real query again, the footer will be visible at the same time as the search bar. This looks really weird. Also, the webkit columns don't display properly on chrome and safari.

Changes
-------------
Hide the footer on query, and make the columns behave as they should.