### PR TITLE
[feature] Add jshint as dependency and invoke task.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "html-loader": "^0.2.3",
     "imports-loader": "^0.6.3",
     "jquery.cookie": "^1.4.1",
-    "jshint": "^2.8.0",
     "json-loader": "^0.5.1",
     "jstimezonedetect": "^1.0.5",
     "knockout": "~3.2.0",
@@ -57,6 +56,7 @@
   "devDependencies": {
     "chai": "^2.1.1",
     "faker": "^2.1.2",
+    "jshint": "^2.8.0",
     "karma": "^0.12.31",
     "karma-chrome-launcher": "^0.1.7",
     "karma-firefox-launcher": "^0.1.4",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "html-loader": "^0.2.3",
     "imports-loader": "^0.6.3",
     "jquery.cookie": "^1.4.1",
+    "jshint": "^2.8.0",
     "json-loader": "^0.5.1",
     "jstimezonedetect": "^1.0.5",
     "knockout": "~3.2.0",
@@ -37,6 +38,7 @@
     "markdown-it-sanitizer": "~0.3.0",
     "markdown-it-toc": "~1.1.0",
     "markdown-it-video": "~0.2.1",
+    "mime-types": "~2.0.12",
     "mithril": "^0.2",
     "moment": "^2.9.0",
     "morgan": "^1.5.1",
@@ -50,8 +52,7 @@
     "typeahead.js": "^0.10.5",
     "url-loader": "^0.5.5",
     "webpack": "^1.7.2",
-    "ws": "~0.4.32",
-    "mime-types": "~2.0.12"
+    "ws": "~0.4.32"
   },
   "devDependencies": {
     "chai": "^2.1.1",

--- a/tasks.py
+++ b/tasks.py
@@ -174,6 +174,7 @@ def shell():
     code.interact(banner, local=context)
     return
 
+
 @task(aliases=['mongo'])
 def mongoserver(daemon=False, config=None):
     """Run the mongod process.
@@ -315,7 +316,7 @@ def elasticsearch():
 
 @task
 def migrate_search(delete=False, index=settings.ELASTIC_INDEX):
-    '''Migrate the search-enabled models.'''
+    """Migrate the search-enabled models."""
     from website.search_migration.migrate import migrate
     migrate(delete, index=index)
 
@@ -325,6 +326,14 @@ def mailserver(port=1025):
     """Run a SMTP test server."""
     cmd = 'python -m smtpd -n -c DebuggingServer localhost:{port}'.format(port=port)
     run(bin_prefix(cmd), pty=True)
+
+
+@task
+def jshint():
+    """Run JSHint syntax check"""
+    js_folder = os.path.join(HERE, 'website', 'static', 'js')
+    cmd = 'jshint {}'.format(js_folder)
+    run(cmd, echo=True)
 
 
 @task(aliases=['flake8'])
@@ -340,6 +349,7 @@ def pip_install(req_file):
     if WHEELHOUSE_PATH:
         cmd += ' --no-index --find-links={}'.format(WHEELHOUSE_PATH)
     return cmd
+
 
 @task(aliases=['req'])
 def requirements(addons=False, release=False, dev=False):
@@ -373,6 +383,7 @@ def test_module(module=None, verbosity=2):
     # Use pty so the process buffers "correctly"
     run(bin_prefix(TEST_CMD) + args, pty=True)
 
+
 @task
 def test_osf():
     """Run the OSF test suite."""
@@ -392,24 +403,19 @@ def test_addons():
 
 @task
 def test(all=False, syntax=False):
-    """Alias of `invoke test_osf`.
+    """
+    Run unit tests: OSF (always), plus addons and syntax checks (optional)
     """
     if syntax:
         flake()
+        jshint()
+
+    test_osf()
 
     if all:
-        test_all()
-    else:
-        test_osf()
+        test_addons()
+        karma(single=True, browsers='PhantomJS')
 
-
-@task
-def test_all(syntax=False):
-    if syntax:
-        flake()
-    test_osf()
-    test_addons()
-    karma(single=True, browsers='PhantomJS')
 
 @task
 def karma(single=False, sauce=False, browsers=None):
@@ -468,6 +474,7 @@ def addon_requirements():
             except IOError:
                 pass
     print('Finished')
+
 
 @task
 def encryption(owner=None):
@@ -745,6 +752,7 @@ def bundle_certs(domain, cert_path):
     )
     run(cmd)
 
+
 @task
 def clean_assets():
     """Remove built JS files."""
@@ -771,6 +779,7 @@ def webpack(clean=False, watch=False, dev=False):
     command = ' '.join(args)
     run(command, echo=True)
 
+
 @task()
 def assets(dev=False, watch=False):
     """Install and build static assets."""
@@ -783,6 +792,7 @@ def assets(dev=False, watch=False):
     # on prod
     webpack(clean=False, watch=watch, dev=dev)
 
+
 @task
 def generate_self_signed(domain):
     """Generate self-signed SSL key and certificate.
@@ -792,6 +802,7 @@ def generate_self_signed(domain):
         ' -keyout {0}.key -out {0}.crt'
     ).format(domain)
     run(cmd)
+
 
 @task
 def update_citation_styles():


### PR DESCRIPTION
## Purpose
Encourages local testers to run jshint per new Travis requirements in #3107, before pushing to github.

## Summary of changes
- Add jshint to the list of packages that node installs automatically.
- Add a call to jshint (as specified by `.travis.yml`) to the syntax checks called by `inv test --syntax`.
- Consolidated two highly redundant commands (`inv test` and `inv test_all`) into one command with a flag. This will probably inconvenience *someone*...
- Very trivial adjustments for PEP8.