### PR TITLE
[feature fix] JS Cleanup PR regression broke metadata viewmodel

### DIFF
--- a/website/static/js/metadata_1.js
+++ b/website/static/js/metadata_1.js
@@ -432,7 +432,7 @@ var MetaData = (function() {
             'item';
         var klass = contentDelegator[type];
         var args = Array.prototype.concat.apply([null], arguments);
-        return new Function.prototype.bind.apply(klass, args);
+        return new (Function.prototype.bind.apply(klass, args));
     }
 
     function Page(id, title, contents, $root) {


### PR DESCRIPTION
## Purpose:
Part of a [JS cleanup](https://github.com/CenterForOpenScience/osf.io/commit/d9f8353fa89fdaef636fddd3059e05463c7ba381) PR lead to regression bug preventing registration viewmodel from loading.

## Notes:
Closes-Issue: https://trello.com/c/cLeQHpN9/12-registrations-page-broken-page-not-being-populated-correctly.

It might be a good idea to have someone with a stronger JS background review other changes in that PR