### PR TITLE
[Feature Fix] Fix component log shows "A user" while loading

### DIFF
--- a/website/static/js/logFeed.js
+++ b/website/static/js/logFeed.js
@@ -106,6 +106,7 @@ var LogsViewModel = oop.extend(Paginator, {
         self.loading = ko.observable(false);
         self.logs = ko.observableArray(logs);
         self.url = url;
+        self.anonymousUserName = '<em>A user</em>';
 
         self.tzname = ko.pureComputed(function() {
             var logs = self.logs();

--- a/website/static/js/pages/render-nodes.js
+++ b/website/static/js/pages/render-nodes.js
@@ -2,7 +2,6 @@
 
 var $osf = require('js/osfHelpers');
 var $ = require('jquery');
-var ko = require('knockout');
 
 // model for components, due to simplicity did not create a new file
 var ComponentControl = {

--- a/website/static/js/pages/render-nodes.js
+++ b/website/static/js/pages/render-nodes.js
@@ -5,7 +5,6 @@ var $ = require('jquery');
 
 // model for components, due to simplicity did not create a new file
 var ComponentControl = {
-     anonymousUserName:'<em>A User</em>'
 };
 
 // binds to component scope in render_nodes.mako

--- a/website/static/js/pages/render-nodes.js
+++ b/website/static/js/pages/render-nodes.js
@@ -6,7 +6,7 @@ var ko = require('knockout');
 
 // model for components, due to simplicity did not create a new file
 var ComponentControl = {
-     anonymousUserName:ko.observable('<em>A user</em>')
+     anonymousUserName:'<em>A User</em>'
 };
 
 // binds to component scope in render_nodes.mako

--- a/website/static/js/pages/render-nodes.js
+++ b/website/static/js/pages/render-nodes.js
@@ -2,9 +2,12 @@
 
 var $osf = require('js/osfHelpers');
 var $ = require('jquery');
+var ko = require('knockout');
 
 // model for components, due to simplicity did not create a new file
-var ComponentControl = {};
+var ComponentControl = {
+     anonymousUserName:ko.observable("<em>A user</em>")
+};
 
 // binds to component scope in render_nodes.mako
 $('.render-nodes-list').each(function() {

--- a/website/templates/util/render_node.mako
+++ b/website/templates/util/render_node.mako
@@ -78,7 +78,7 @@
                     <dt><span class="date log-date" data-bind="text: log.date.local, tooltip: {title: log.date.utc}"></span></dt>
                     <dd class="log-content">
                         <span data-bind="if:log.anonymous">
-                           <span data-bind="text: anonymousUserName"></span>
+                           <span data-bind="html: $parent.anonymousUserName"></span>
                         </span>
                         <span data-bind="ifnot:log.anonymous">
                             <a data-bind="text: log.userFullName || log.apiKey, attr: {href: log.userURL}"></a>

--- a/website/templates/util/render_node.mako
+++ b/website/templates/util/render_node.mako
@@ -78,7 +78,7 @@
                     <dt><span class="date log-date" data-bind="text: log.date.local, tooltip: {title: log.date.utc}"></span></dt>
                     <dd class="log-content">
                         <span data-bind="if:log.anonymous">
-                            <span data-bind="html: anonymousUserName"></span>
+                           <span data-bind="text: anonymousUserName"></span>
                         </span>
                         <span data-bind="ifnot:log.anonymous">
                             <a data-bind="text: log.userFullName || log.apiKey, attr: {href: log.userURL}"></a>

--- a/website/templates/util/render_node.mako
+++ b/website/templates/util/render_node.mako
@@ -78,7 +78,7 @@
                     <dt><span class="date log-date" data-bind="text: log.date.local, tooltip: {title: log.date.utc}"></span></dt>
                     <dd class="log-content">
                         <span data-bind="if:log.anonymous">
-                            <span><em>A user</em></span>
+                            <span data-bind="html: anonymousUserName"></span>
                         </span>
                         <span data-bind="ifnot:log.anonymous">
                             <a data-bind="text: log.userFullName || log.apiKey, attr: {href: log.userURL}"></a>


### PR DESCRIPTION
### Purpose
When user open the recent activity record of component on project dashboard, it will only show "A User" at the beginning.  The reason behind it is that when knockout is loading, it will show the html that is not rendered by knockout. 

Resolve -- #3216
### Changes
The way I solve it is to let the html that is not rendered by knockout display nothing. In another word, I use knockout HTML binding to show "A User".

1)Create knockout binder variable `anonymousUserName` and assigned with html `<em>A user</em>`
2) Apply the binder to the span.

### Side effect
When `render_node.mako` is used in other places, remember to set the knockout variable --`anonymousUserName`.