### PR TITLE
[WIP] Send newly added contributors confirmation email

### DIFF
--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -50,6 +50,10 @@ def generate_claim_token():
     return security.random_string(30)
 
 
+def generate_contributor_add_token():
+    return security.random_string(30)
+
+
 def string_required(value):
     if value is None or value == '':
         raise ValidationValueError('Value must not be empty.')

--- a/tasks.py
+++ b/tasks.py
@@ -191,7 +191,7 @@ def mongoserver(daemon=False, config=None):
     if config:
         cmd += ' --config {0}'.format(config)
     if daemon:
-        cmd += " --fork"
+        cmd += " --fork --syslog"
     run(cmd, echo=True)
 
 
@@ -309,6 +309,8 @@ def elasticsearch():
     import platform
     if platform.linux_distribution()[0] == 'Ubuntu':
         run("sudo service elasticsearch start")
+    elif platform.linux_distribution()[0] == 'Arch':
+        run("sudo systemctl start elasticsearch")
     elif platform.system() == 'Darwin':  # Mac OSX
         run('elasticsearch')
     else:

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -375,6 +375,33 @@ class TestProjectViews(OsfTestCase):
             [project.creator, unregistered_user, reg_user1]
         )
 
+    def test_project_confirm_contributor_valid_link_from_email(self):
+        url = "/project/{pid}/contributor/{uid}/token/{token}/".format(
+            pid=self.project._id, uid=self.user2._id,
+            token=self.project.get_or_create_contributor_added_token(self.user2._id)
+        )
+        self.app.get(url)
+
+    def test_project_confirm_contributor_participation(self):
+        url = "/project/{pid}/contributor/{uid}/token/{token}/ok/".format(
+            pid=self.project._id, uid=self.user2._id,
+            token=self.project.get_or_create_contributor_added_token(self.user2._id)
+        )
+        self.app.get(url).follow()
+        self.project.reload()
+        assert_in(self.user2._id, self.project.contributors)
+        assert_not_in(self.user2._id, self.project.pending_contributors)
+
+    def test_project_deny_contributor_participation(self):
+        url = "/project/{pid}/contributor/{uid}/token/{token}/nope/".format(
+            pid=self.project._id, uid=self.user2._id,
+            token=self.project.get_or_create_contributor_added_token(self.user2._id)
+        )
+        self.app.get(url).follow()
+        self.project.reload()
+        assert_not_in(self.user2._id, self.project.contributors)
+        assert_in(self.user2._id, self.project.pending_contributors)
+
     def test_project_remove_contributor(self):
         url = "/api/v1/project/{0}/removecontributors/".format(self.project._id)
         # User 1 removes user2

--- a/website/mails.py
+++ b/website/mails.py
@@ -131,6 +131,8 @@ INVITE = Mail('invite', subject='You have been added as a contributor to an OSF 
 FORWARD_INVITE = Mail('forward_invite', subject='Please forward to ${fullname}')
 FORWARD_INVITE_REGiSTERED = Mail('forward_invite_registered', subject='Please forward to ${fullname}')
 
+CONTRIBUTOR_ADD_INVITE = Mail('contributor_invite', subject="[via OSF] You've been added as a project contributor")
+
 FORGOT_PASSWORD = Mail('forgot_password', subject='Reset Password')
 PENDING_VERIFICATION = Mail('pending_invite', subject="Your account is almost ready!")
 PENDING_VERIFICATION_REGISTERED = Mail('pending_registered', subject='Received request to be a contributor')

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -332,6 +332,9 @@ def node_choose_addons(auth, node, **kwargs):
 def node_contributors(auth, node, **kwargs):
     ret = _view_project(node, auth, primary=True)
     ret['contributors'] = utils.serialize_contributors(node.contributors, node)
+    # tack on pending data from this node for each user
+    for contributor in ret['contributors']:
+        contributor['pending'] = contributor["id"] in node.pending_contributors
     ret['adminContributors'] = utils.serialize_contributors(node.admin_contributors, node, admin=True)
     return ret
 

--- a/website/routes.py
+++ b/website/routes.py
@@ -1159,6 +1159,17 @@ def make_url_map(app):
             '/project/<pid>/node/<nid>/removecontributors/',
         ], 'post', project_views.contributor.project_removecontributor, json_renderer),
 
+        # confirm / deny participation in a project
+        Rule(['/project/<string:pid>/contributor/<string:uid>/confirm/<string:token>/'], 'get',
+             project_views.contributor.confirm_participation,
+             OsfWebRenderer('confirm_node_add.mako')),
+        Rule(['/project/<string:pid>/contributor/<string:uid>/confirm/<string:token>/ok/'], 'get',
+             project_views.contributor.verify_added_token,
+             json_renderer),
+        Rule(['/project/<string:pid>/contributor/<string:uid>/confirm/<string:token>/nope/'], 'get',
+             project_views.contributor.deny_added_token,
+             json_renderer),
+        
         # Forks
         Rule(
             [

--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -342,10 +342,11 @@ var AddContributorViewModel = oop.extend(Paginator, {
             }
         ).done(function() {
             window.location.reload();
-        }).fail(function() {
+        }).fail(function(xhr) {
+            var response = xhr.responseJSON;
             $('.modal').modal('hide');
             $osf.unblock();
-            $osf.growl('Error', 'Add contributor failed.');
+            $osf.growl('Error', 'Add contributor failed (' + response.message_long + ")" );
         });
     },
     clear: function() {

--- a/website/templates/emails/contributor_invite.txt.mako
+++ b/website/templates/emails/contributor_invite.txt.mako
@@ -1,0 +1,10 @@
+Hello ${user.fullname},
+
+You've been added as a contributor to the ${node.title} (${node.absolute_url}) project.
+
+Please confirm your participation by visiting this link:
+
+${project_url}
+
+From the Open Science Framework Robot
+

--- a/website/templates/project/confirm_contributor_participation.mako
+++ b/website/templates/project/confirm_contributor_participation.mako
@@ -1,0 +1,12 @@
+<%inherit file="project/project_base.mako"/>
+<%def name="title()">Confirm project contributorship</%def>
+
+<legend class="text-center">Confirm project contributorship</legend>
+
+## <button class="btn btn-primary addon-settings-submit pull-right">Confirm</button>
+## <button class="btn btn-primary addon-settings-submit pull-right">Deny</button>
+
+<a href=confirmUrl>Confirm</a>
+
+<a href=denyUrl>Deny</a>
+

--- a/website/templates/project/contributors.mako
+++ b/website/templates/project/contributors.mako
@@ -184,6 +184,9 @@
             <span data-bind="if: profileUrl">
                 <a class="no-sort" data-bind="text: contributor.shortname, attr:{href: profileUrl}"></a>
             </span>
+            <!-- ko if: contributor.pending -->
+                <span>(unconfirmed)</span>
+            <!-- /ko -->
         </td>
         <td class="permissions">
             <!-- ko if: contributor.canEdit() -->

--- a/website/templates/util/render_contributors.mako
+++ b/website/templates/util/render_contributors.mako
@@ -11,10 +11,12 @@
                 is_condensed = True
         %>
         % if contributor['registered']:
-            <a class='user-profile' rel="${'tooltip' if is_condensed else ''}" title="${contributor['fullname']}" href="/${contributor['id']}/">${condensed}</a></li>
+            <a class='user-profile' rel="${'tooltip' if is_condensed else ''}" title="${contributor['fullname']}" href="/${contributor['id']}/">${condensed}</a>
         % else:
-            <span rel="${'tooltip' if is_condensed else ''}" title="${contributor['fullname']}">${condensed}</span></li>
+            <span rel="${'tooltip' if is_condensed else ''}" title="${contributor['fullname']}">${condensed}</span>
 
         %endif
+        <span>${"(unconfirmed)" if contributor['pending'] else ""}</span>
+        </li>
 % endfor
 


### PR DESCRIPTION
@JeffSpies @sloria @samanehsan  - thank you all for your time on Friday.  Here is the work I accomplished, plus a little more that I did on the way back.

The goal:
=======

Send emails to newly added contributors when they are added.  Show newly added contributors as unconfirmed until they have confirmed via email.  People can deny participation, in which case they can't be re-added to the project (to prevent spam and unwelcome inclusion.)

Work to do before merging this PR:
==========================

1. consider giving contributors who deny involvement a way to re-activate themselves if they want.  The whole point of deactivating them is to prevent spam.  However, this should not prevent people completely, with no recourse, from ever joining a project.  Add a link/button to project page for people who have denied participation in the past, to later click a button to add themselves, if they do indeed want to be a listed contributor.
2. Routes are broken for the confirmation process.  I really tried to figure this out, but I would appreciate some guidance in debugging this.  I only get 404 errors, and do not know how to debug further.
3. Clean up a UserWarning that I think I have introduced by adding "pending" data to User objects, for sake of showing "(unconfirmed)" status on name display.  There's probably a better way to do things.
4. Make confirmation/denial links into pretty Bootstrap buttons.

I'm happy to do this work, but I will need a little bit of guidance, particularly for 2.