### PR TITLE
[feature fix] Disallow individual retraction of nested registration nodes

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1274,6 +1274,11 @@ class TestNode(OsfTestCase):
         result = self.parent.web_url_for('view_project', _absolute=True)
         assert_in(settings.DOMAIN, result)
 
+    def test_root_id(self):
+        registration = RegistrationFactory(project=self.parent)
+        root_id = registration.root_id
+        assert_equal(root_id, registration.nodes[0].root_id)
+
     def test_category_display(self):
         node = NodeFactory(category='hypothesis')
         assert_equal(node.category_display, 'Hypothesis')

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -1989,12 +1989,6 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
     def project_or_component(self):
         return 'project' if self.category == 'project' else 'component'
 
-    @property
-    def root_id(self):
-        if self.root:
-            return self.root._primary_key
-        return None
-
     def is_contributor(self, user):
         return (
             user is not None

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -1989,6 +1989,12 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
     def project_or_component(self):
         return 'project' if self.category == 'project' else 'component'
 
+    @property
+    def root_id(self):
+        if self.root:
+            return self.root._primary_key
+        return None
+
     def is_contributor(self, user):
         return (
             user is not None

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2669,6 +2669,9 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
         if not self.is_registration or (not self.is_public and not (self.embargo_end_date or self.pending_embargo)):
             raise NodeStateError('Only public registrations or active embargoes may be retracted.')
 
+        if self.root is not self:
+            raise NodeStateError('Retraction of non-parent registrations is not permitted.')
+
         retraction = self._initiate_retraction(user, justification, save=True)
         self.registered_from.add_log(
             action=NodeLog.RETRACTION_INITIATED,

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -733,6 +733,7 @@ def _view_project(node, auth, primary=False):
             'pending_embargo': node.pending_embargo,
             'registered_from_url': node.registered_from.url if node.is_registration else '',
             'registered_date': iso8601format(node.registered_date) if node.is_registration else '',
+            'root_id': node.root_id,
             'registered_meta': [
                 {
                     'name_no_ext': from_mongo(meta),

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -733,7 +733,7 @@ def _view_project(node, auth, primary=False):
             'pending_embargo': node.pending_embargo,
             'registered_from_url': node.registered_from.url if node.is_registration else '',
             'registered_date': iso8601format(node.registered_date) if node.is_registration else '',
-            'root_id': node.root_id,
+            'root_id': node.root._id,
             'registered_meta': [
                 {
                     'name_no_ext': from_mongo(meta),

--- a/website/project/views/register.py
+++ b/website/project/views/register.py
@@ -104,6 +104,12 @@ def node_registration_retraction_post(auth, node, **kwargs):
             'message_long': 'Retractions of non-registrations is not permitted.'
         })
 
+    if node.root is not node:
+        raise HTTPError(http.BAD_REQUEST, data={
+            'message_short': 'Invalid Request',
+            'message_long': 'Retraction of non-parent registrations is not permitted.'
+        })
+
     data = request.get_json()
     try:
         node.retract_registration(auth.user, data.get('justification', None))

--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -283,18 +283,31 @@
                         </div>
 
                         <div class="panel-body">
-                            <div class="help-block">
-                                Retracting a registration will remove its content from the OSF, but leave basic metadata
-                                behind. The title of a retracted registration and its contributor list will remain, as will
-                                justification or explanation of the retraction, should you wish to provide it. Retracted
-                                registrations will be marked with a <strong>retracted</strong> tag.
-                            </div>
 
-                            %if not node['pending_retraction']:
-                                <a class="btn btn-danger" href="${web_url_for('node_registration_retraction_get', pid=node['id'])}">Retract Registration</a>
+                            % if parent_node['exists']:
+
+                                <div class="help-block">
+                                  Retracting children components of a registration is not allowed. Should you wish to
+                                  retract this component, please retract its parent registration.
+                                </div>
+
                             % else:
-                                <p><strong>This registration is already pending a retraction.</strong></p>
-                            %endif
+
+                                <div class="help-block">
+                                    Retracting a registration will remove its content from the OSF, but leave basic metadata
+                                    behind. The title of a retracted registration and its contributor list will remain, as will
+                                    justification or explanation of the retraction, should you wish to provide it. Retracted
+                                    registrations will be marked with a <strong>retracted</strong> tag.
+                                </div>
+
+                                %if not node['pending_retraction']:
+                                    <a class="btn btn-danger" href="${web_url_for('node_registration_retraction_get', pid=node['id'])}">Retract Registration</a>
+                                % else:
+                                    <p><strong>This registration is already pending a retraction.</strong></p>
+                                %endif
+
+                            % endif
+
 
                         </div>
                     </div>

--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -288,7 +288,7 @@
 
                                 <div class="help-block">
                                   Retracting children components of a registration is not allowed. Should you wish to
-                                  retract this component, please retract its parent registration.
+                                  retract this component, please retract its parent registration <a href="${web_url_for('node_setting', pid=node['root_id'])}">here</a>.
                                 </div>
 
                             % else:


### PR DESCRIPTION
## Purpose:
Desired behavior allows for children components or subprojects to be retracted **only ** when the parent registration is retracted.

## Changes:
Checks in place at the model and view level to ensure children cannot be retracted. Updated settings page to inform user and provide link to root registration's settings page.

## Side Effects:
None.

## Notes:
Closes-issue: https://trello.com/c/FGxAqxPi/112-retracted-components-of-registrations-that-have-not-been-retracted-show-up-in-project-organizer