### PR TITLE
[hotfix] Prevent editing of previous file versions

### DIFF
--- a/website/static/js/filepage/revisions.js
+++ b/website/static/js/filepage/revisions.js
@@ -28,6 +28,7 @@ var FileRevisionsTable = {
         self.file = file;
         self.canEdit = canEdit;
         self.enableEditing = enableEditing;
+        self.baseUrl = (window.location.href).split('?')[0];
 
         model.hasDate = self.file.provider !== 'dataverse';
 
@@ -102,7 +103,7 @@ var FileRevisionsTable = {
             return m('tr' + (isSelected ? '.active' : ''), [
                 m('td',  isSelected ?
                   revision.displayVersion :
-                  m('a', {href: revision.osfViewUrl}, revision.displayVersion)
+                  m('a', {href: parseInt(revision.displayVersion) === model.revisions.length ? self.baseUrl : revision.osfViewUrl}, revision.displayVersion)
                 ),
                 model.hasDate ? m('td', revision.displayDate) : false,
                 model.hasUser ?


### PR DESCRIPTION
Purpose
------------
Fixes #3011 

If a user navigated to the current file version from the versions table and then made some edits to create a new version, the user was not taken to the new version. As a result, the user could create new versions by editing this now out-dated file version. 

Changes
------------
Remove url params for current file version. 
