### PR TITLE
fix the osf side for anony osf file version

### DIFF
--- a/website/addons/osfstorage/views.py
+++ b/website/addons/osfstorage/views.py
@@ -74,7 +74,7 @@ def osfstorage_update_metadata(node_addon, payload, **kwargs):
 @must_be_signed
 @decorators.autoload_filenode(must_be='file')
 def osfstorage_get_revisions(file_node, node_addon, payload, **kwargs):
-    is_anon = has_anonymous_link(node_addon.owner, Auth(private_key=payload.get('view_only')))
+    is_anon = has_anonymous_link(node_addon.owner, Auth(private_key=request.args.get('view_only')))
 
     # Return revisions in descending order
     return {


### PR DESCRIPTION
<b>Purpose</b>
Fix the problem that user name is showing up in file version table of OSF storage files under anonymous link . Combine with @chrisseto 's fix in waterbulter https://github.com/CenterForOpenScience/waterbutler/commit/5ee3305cf608e02001c5db2c032240ce9df021d6. Close https://github.com/CenterForOpenScience/osf.io/issues/3253.