### PR TITLE
[hotfix] fix the view_only_link_tiime

### DIFF
--- a/website/project/model.py
+++ b/website/project/model.py
@@ -38,6 +38,7 @@ from framework.analytics import (
 )
 from framework.sentry import log_exception
 from framework.transactions.context import TokuTransaction
+from framework.utils import iso8601format
 
 from website import language
 from website import settings
@@ -2644,7 +2645,7 @@ class PrivateLink(StoredObject):
     def to_json(self):
         return {
             "id": self._id,
-            "date_created": self.date_created.strftime('%m/%d/%Y %I:%M %p UTC'),
+            "date_created": iso8601format(self.date_created),
             "key": self.key,
             "name": self.name,
             "creator": {'fullname': self.creator.fullname, 'url': self.creator.profile_url},


### PR DESCRIPTION
<b>Purpose</b>
Fix the datetime display on view-only link table. Close https://github.com/CenterForOpenScience/osf.io/issues/3232.

<b>Changes</b>
Currently:
![image](https://cloud.githubusercontent.com/assets/4974056/8292514/195ae580-18fe-11e5-933f-4e347d4059f1.png)
after fix:
![screen shot 2015-06-22 at 4 45 43 pm](https://cloud.githubusercontent.com/assets/4974056/8292526/2e08413a-18fe-11e5-83ae-556cb06cdd7b.png)
