### PR TITLE
update box log template

### DIFF
--- a/website/addons/box/templates/log_templates.mako
+++ b/website/addons/box/templates/log_templates.mako
@@ -1,14 +1,14 @@
 <script type="text/html" id="box_file_added">
 added file
 <a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect">
-    {{ stripSlash(params.fullPath || params.path) }}</a> to
+    {{ stripSlash(params.path) }}</a> to
 Box in
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
 
 <script type="text/html" id="box_folder_created">
 created folder
-<span class="overflow log-folder">{{ stripSlash(params.fullPath || params.path) }}</span> in
+<span class="overflow log-folder">{{ stripSlash(params.path) }}</span> in
 Box in
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
@@ -16,7 +16,7 @@ Box in
 <script type="text/html" id="box_file_updated">
 updated file
 <a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect">
-    {{ stripSlash(params.fullPath || params.path) }}</a> to
+    {{ stripSlash(params.path) }}</a> to
 Box in
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
@@ -24,7 +24,7 @@ Box in
 
 <script type="text/html" id="box_file_removed">
 removed {{ pathType(params.path) }} <span class="overflow">
-    {{ stripSlash(params.fullPath || params.name) }}</span> from
+    {{ stripSlash(params.path) }}</span> from
 Box in
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>


### PR DESCRIPTION
<b>Purpose</b>
Fix the problem that box addon log are not displaying. Close https://github.com/CenterForOpenScience/osf.io/issues/3233.

<b>Changes</b>
Before: 
![image](https://cloud.githubusercontent.com/assets/4974056/8293350/d581688e-1902-11e5-8a4c-4b34018fbb53.png)
After:
![screen shot 2015-06-22 at 5 19 39 pm](https://cloud.githubusercontent.com/assets/4974056/8293365/e59b780e-1902-11e5-9b23-1a6c4ded9bcf.png)

