### PR TITLE
Patch archive_errors during testing to prevent API calls

### DIFF
--- a/website/addons/figshare/tests/test_models.py
+++ b/website/addons/figshare/tests/test_models.py
@@ -359,7 +359,8 @@ class TestCallbacks(OsfTestCase):
         assert_true(self.node_settings.figshare_title is None)
 
     @mock.patch('website.archiver.tasks.archive.si')
-    def test_does_not_get_copied_to_registrations(self, mock_archive):
+    @mock.patch('website.addons.figshare.model.AddonFigShareNodeSettings.archive_errors')
+    def test_does_not_get_copied_to_registrations(self, mock_errors, mock_archive):
         registration = self.project.register_node(
             schema=None,
             auth=Auth(user=self.project.creator),


### PR DESCRIPTION
# Purpose 
One failing test was merged in with 0.40.0

# Changes

Patch the figshare node settings model's archive_errors method, which makes API calls during Node#register_node. 

# Side Effects

None