### PR TITLE
[hotfix] Fix figshare deleting public files

### DIFF
--- a/website/addons/figshare/static/figshareFangornConfig.js
+++ b/website/addons/figshare/static/figshareFangornConfig.js
@@ -34,9 +34,9 @@ var _figshareItemButtons = {
                 }, 'Download')
             );
         }
-        // Files can be deleted if private or if parent contains more than one child
+        // Files can be deleted if private or if it is in a dataset that contains more than one file
         var privateOrSiblings = (item.data.extra && item.data.extra.status !== 'public') ||
-            item.parent().children.length > 1;
+            (item.parent().data.isAddonRoot !== true && item.parent().children.length > 1);
         if (item.kind === 'file' && privateOrSiblings && item.data.permissions && item.data.permissions.edit) {
             buttons.push(
                 m.component(Fangorn.Components.button, {

--- a/website/addons/figshare/static/figshareFangornConfig.js
+++ b/website/addons/figshare/static/figshareFangornConfig.js
@@ -36,7 +36,7 @@ var _figshareItemButtons = {
         }
         // Files can be deleted if private or if it is in a dataset that contains more than one file
         var privateOrSiblings = (item.data.extra && item.data.extra.status !== 'public') ||
-            (item.parent().data.isAddonRoot !== true && item.parent().children.length > 1);
+            (!item.parent().data.isAddonRoot && item.parent().children.length > 1);
         if (item.kind === 'file' && privateOrSiblings && item.data.permissions && item.data.permissions.edit) {
             buttons.push(
                 m.component(Fangorn.Components.button, {


### PR DESCRIPTION
Purpose
-----------
Fixes #2183 

The delete button was showing up in the files grid toolbar for public figshare files that cannot be deleted. 

Changes
------------
Ensure public figshare files in a project do not have the delete button in the files toolbar unless they are part of a dataset that has multiple files.