### PR TITLE
[feature] Limit length of component titles

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,6 +8,8 @@ import pytz
 import datetime
 import urlparse
 import itsdangerous
+import random
+import string
 from dateutil import parser
 
 from modularodm import Q
@@ -1762,7 +1764,6 @@ class TestDashboard(OsfTestCase):
 class TestAddonCallbacks(OsfTestCase):
     """Verify that callback functions are called at the right times, with the
     right arguments.
-
     """
     callbacks = {
         'after_remove_contributor': None,
@@ -2126,11 +2127,24 @@ class TestProject(OsfTestCase):
             proj.set_title('', auth=self.consolidate_auth)
         #assert_equal(proj.title, 'That Was Then')
 
+    def test_set_title_fails_if_too_long(self):
+        proj = ProjectFactory(title='That Was Then', creator=self.user)
+        long_title = ''.join(random.choice(string.ascii_letters + string.digits)
+                             for _ in range(201))
+        with assert_raises(ValidationValueError):
+            proj.set_title(long_title, auth=self.consolidate_auth)
+
     def test_title_cant_be_empty(self):
         with assert_raises(ValidationValueError):
             proj = ProjectFactory(title='', creator=self.user)
         with assert_raises(ValidationValueError):
             proj = ProjectFactory(title=' ', creator=self.user)
+
+    def test_title_cant_be_too_long(self):
+        long_title = ''.join(random.choice(string.ascii_letters + string.digits)
+                             for _ in range(201))
+        with assert_raises(ValidationValueError):
+            proj = ProjectFactory(title=long_title, creator=self.user)
 
     def test_contributor_can_edit(self):
         contributor = UserFactory()

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -162,7 +162,6 @@ class Comment(GuidStoredObject):
 
     @classmethod
     def create(cls, auth, **kwargs):
-
         comment = cls(**kwargs)
         comment.save()
 
@@ -501,7 +500,7 @@ def get_pointer_parent(pointer):
     # of the pointed-at `Node`, not the parents of the `Pointer`; use the
     # back-reference syntax to find the parents of the `Pointer`.
     parent_refs = pointer.node__parent
-    assert len(parent_refs) == 1, 'Pointer must have exactly one parent'
+    assert len(parent_refs) == 1, 'Pointer must have exactly one parent.'
     return parent_refs[0]
 
 
@@ -515,12 +514,15 @@ def validate_category(value):
 
 
 def validate_title(value):
-    """Validator for Node#title. Makes sure that the value exists.
+    """Validator for Node#title. Makes sure that the value exists and is not
+    above 200 characters.
     """
     if value is None or not value.strip():
         raise ValidationValueError('Title cannot be blank.')
-    return True
 
+    if len(value) > 200:
+            raise ValidationValueError('Title cannot exceed 200 characters.')
+    return True
 
 def validate_user(value):
     if value != {}:
@@ -1065,10 +1067,10 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
 
     def save(self, *args, **kwargs):
         update_piwik = kwargs.pop('update_piwik', True)
-
         self.adjust_permissions()
 
         first_save = not self._is_loaded
+
         if first_save and self.is_dashboard:
             existing_dashboards = self.creator.node__contributed.find(
                 Q('is_dashboard', 'eq', True)
@@ -1499,8 +1501,9 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
         :param str title: The new title.
         :param auth: All the auth information including user, API key.
         """
-        if title is None or not title.strip():
-            raise ValidationValueError('Title cannot be blank.')
+        #Called so validation does not have to wait until save.
+        validate_title(title)
+
         original_title = self.title
         self.title = title
         self.add_log(

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -41,7 +41,6 @@ from website.util.sanitize import strip_html
 
 logger = logging.getLogger(__name__)
 
-
 @must_be_valid_project
 @must_have_permission(WRITE)
 @must_not_be_registration
@@ -52,10 +51,10 @@ def edit_node(auth, node, **kwargs):
     if edited_field == 'title':
         try:
             node.set_title(value, auth=auth)
-        except ValidationValueError:
+        except ValidationValueError as e:
             raise HTTPError(
                 http.BAD_REQUEST,
-                data=dict(message_long='Title cannot be blank.')
+                data=dict(message_long=e.message)
             )
     elif edited_field == 'description':
         node.set_description(value, auth=auth)
@@ -72,7 +71,6 @@ def edit_node(auth, node, **kwargs):
 def project_new(**kwargs):
     return {}
 
-
 @must_be_logged_in
 def project_new_post(auth, **kwargs):
     user = auth.user
@@ -83,9 +81,6 @@ def project_new_post(auth, **kwargs):
     category = data.get('category', 'project')
     template = data.get('template')
     description = strip_html(data.get('description'))
-
-    if not title or len(title) > 200:
-        raise HTTPError(http.BAD_REQUEST)
 
     if template:
         original_node = Node.load(template)
@@ -106,8 +101,13 @@ def project_new_post(auth, **kwargs):
         )
 
     else:
-        project = new_node(category, title, user, description)
-
+        try:
+            project = new_node(category, title, user, description)
+        except ValidationValueError as e:
+            raise HTTPError(
+                http.BAD_REQUEST,
+                data=dict(message_long=e.message)
+            )
     return {
         'projectUrl': project.url
     }, http.CREATED
@@ -131,9 +131,6 @@ def folder_new_post(auth, node, **kwargs):
     user = auth.user
 
     title = request.json.get('title')
-
-    if not title or len(title) > 200:
-        raise HTTPError(http.BAD_REQUEST)
 
     if not node.is_folder:
         raise HTTPError(http.BAD_REQUEST)
@@ -174,7 +171,6 @@ def add_folder(auth, **kwargs):
 # New Node
 ##############################################################################
 
-
 @must_be_valid_project
 @must_have_permission(WRITE)
 @must_not_be_registration
@@ -182,12 +178,19 @@ def project_new_node(auth, node, **kwargs):
     form = NewNodeForm(request.form)
     user = auth.user
     if form.validate():
-        node = new_node(
-            title=strip_html(form.title.data),
-            user=user,
-            category=form.category.data,
-            parent=node,
-        )
+        try:
+            node = new_node(
+                title=strip_html(form.title.data),
+                user=user,
+                category=form.category.data,
+                parent=node,
+            )
+        except ValidationValueError as e:
+            raise HTTPError(
+                http.BAD_REQUEST,
+                data=dict(message_long=e.message)
+            )
+
         message = (
             'Your component was created successfully. You can keep working on the component page below, '
             'or return to the <u><a href="{url}">Project Page</a></u>.'

--- a/website/static/js/nodeControl.js
+++ b/website/static/js/nodeControl.js
@@ -188,9 +188,13 @@ var ProjectViewModel = function(data) {
         $('#nodeTitleEditable').editable($.extend({}, editableOptions, {
             name: 'title',
             title: 'Edit Title',
+            tpl: '<input type="text" maxlength="200">',
             validate: function (value) {
                 if ($.trim(value) === '') {
                     return 'Title cannot be blank.';
+                }
+                else if(value.length > 200){
+                    return 'Title cannot exceed 200 characters.';
                 }
             }
         }));

--- a/website/static/js/project.js
+++ b/website/static/js/project.js
@@ -128,7 +128,7 @@ $(function() {
 
         if ($.trim($('#title').val()) === '') {
 
-            $('#alert').text('The new component title cannot be empty');
+            $('#newComponent .modal-alert').text('The new component title cannot be empty.');
 
             $('#add-component-submit')
                 .removeAttr('disabled', 'disabled')
@@ -136,7 +136,7 @@ $(function() {
 
             e.preventDefault();
         } else if ($(e.target).find('#title').val().length > 200) {
-            $('#alert').text('The new component title cannot be more than 200 characters.');
+            $('#newComponent .modal-alert').text('The new component title cannot be more than 200 characters.'); //This alert never appears...
 
             $('#add-component-submit')
                 .removeAttr('disabled', 'disabled')

--- a/website/templates/project/modal_add_component.mako
+++ b/website/templates/project/modal_add_component.mako
@@ -9,7 +9,8 @@
                 </div><!-- end modal-header -->
                 <div class="modal-body">
                     <div class="form-group">
-                        <input id="title" placeholder="Component Title" name="title" type="text" class='form-control'>
+                        <input id="title" maxlength="200" placeholder="Component Title" name="title"  type="text" class='form-control'>
+                        <div class="modal-alert"></div>
                     </div>
                     <div class="form-group">
                         <select id="category" name="category" class="form-control">


### PR DESCRIPTION
Purpose
-------------------------
Currently when making a new component on the osf a modal will pop up and allow you to enter a title as long as you wish, but if your title is longer than 200 characters, the component will not be created.

Closes Issue https://github.com/CenterForOpenScience/openscienceframework.org/issues/2993

Changes
------------------
I simply added a maxlength="200" into the field for component titles. Stopping users form being able to enter a title longer than 200 characters.

Edit: Because we want there to be consistency in title length, there were many changes in order to secure that title length remains around 200 throughout the system. Both front end and back end validations were added in order to enforce the 200 character limit on titles. You can no longer edit a title to be as long as you desire as shown in https://github.com/CenterForOpenScience/osf.io/issues/2993#issuecomment-110046427.

Projects will now not be able to be created if a user attempts to make a title past 200 characters. They will also not be able to enter titles past 200 characters in the fields that edit said titles, so project creation should not fail for this reason.
