### PR TITLE
[feature] Use tb version with fix for shift-selecting files

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "raw-loader": "^0.5.1",
     "share": "0.7.27",
     "style-loader": "^0.8.3",
-    "treebeard": "git://github.com/caneruguz/treebeard.git#e3191c19053a1effb9176c70d3f1e3b7d127083f",
+    "treebeard": "git://github.com/caneruguz/treebeard.git#b6661a9bf14bb972be7b8eb55357c9784ded2af6",
     "typeahead.js": "^0.10.5",
     "url-loader": "^0.5.5",
     "webpack": "^1.7.2",


### PR DESCRIPTION
Purpose
-----------
Fixes #2843

Users could only shift + select a range of files that were visible in the grid (they could not select a file and then scroll to another file out of the view to highlight all of the files in between). 

Changes
------------
Use latest treebeard commit with the fix for shift + selecting files outside of the current view. 
