### PR TITLE
[Feature] Allow new forks to be created on the forks page of a project

### DIFF
--- a/website/templates/project/forks.mako
+++ b/website/templates/project/forks.mako
@@ -6,7 +6,7 @@
 </div>
 
 <div class="row">
-	<div class="col-md-8 col-md-offset-2">
+	<div class="col-sm-9">
 
     % if node['fork_count']:
         <div mod-meta='{
@@ -19,6 +19,16 @@
         <div>There have been no forks of this project.</div>
     % endif
 
+    </div>
+    <div class="col-sm-3">
+
+        <div>
+            % if user_name and (user['is_contributor'] or node['is_public']) and not disk_saving_mode:
+                <a class="btn btn-default" type="button" onclick="NodeActions.forkNode();">New Fork</a>
+            % endif
+        </div>
 
     </div>
+
+
 </div>

--- a/website/templates/project/forks.mako
+++ b/website/templates/project/forks.mako
@@ -24,7 +24,7 @@
 
         <div>
             % if user_name and (user['is_contributor'] or node['is_public']) and not disk_saving_mode:
-                <a class="btn btn-default" type="button" onclick="NodeActions.forkNode();">New Fork</a>
+                <a class="btn btn-success" type="button" onclick="NodeActions.forkNode();">New Fork</a>
             % endif
         </div>
 

--- a/website/templates/project/registrations.mako
+++ b/website/templates/project/registrations.mako
@@ -37,7 +37,7 @@
   <div class="col-sm-3">
     <div>
         % if 'admin' in user['permissions'] and not disk_saving_mode:
-          <a id="registerNode" href="${node['url']}register" class="btn btn-default" type="button">New Registration</a>
+          <a id="registerNode" href="${node['url']}register" class="btn btn-success" type="button">New Registration</a>
         % endif
     </div>
   </div>


### PR DESCRIPTION
### Purpose
fixes #3278

### Changes
I added a button to the forks page that allows new forks to be created easily with two clicks. In addition, I made the forks page as a whole look much more like the registrations page, as they both perform a similar function, just for different types of nodes.