### PR TITLE
[Hotfix] Update registration prompts

### DIFF
--- a/website/static/js/nodeControl.js
+++ b/website/static/js/nodeControl.js
@@ -36,14 +36,6 @@ var MESSAGES = {
     makeComponentPrivateWarning: 'Making a component private will prevent users from viewing it on this site, ' +
                         'but will have no impact on external sites, including Google\'s cache. ' +
                         'Would you like to continue?',
-    // TODO(hrybacki): Remove once Retraction/Embargoes goes is merged into production
-    makeRegistrationPublicWarning: '<b>Important Note:</b> As early as <u>June 8, 2015</u>, new registrations ' +
-                        'will be made public immediately or can be embargoed for up to four years. There ' +
-                        'will no longer be the option of creating a permanently private registration. This ' +
-                        'registration occurred before June 8, 2015, so you do retain the option of keeping it ' +
-                        'private. However, if you do choose to make the registration public now, then after ' +
-                        'June 8, 2015 you will not be able to return it to private. Are you sure that you would like ' +
-                        'to continue?',
 };
 
 // TODO(sloria): Fix this external dependency on nodeApiUrl
@@ -60,11 +52,8 @@ var COMPONENT = 'component';
 function setPermissions(permissions, nodeType) {
 
     var msgKey;
-    // TODO(hrybacki): Remove once Retraction/Embargoes goes is merged into production
-    var isRegistration = window.contextVars.node.isRegistration;
 
-    if (permissions === PUBLIC && isRegistration) { msgKey = 'makeRegistrationPublicWarning'; }
-    else if(permissions === PUBLIC && nodeType === PROJECT) { msgKey = 'makeProjectPublicWarning'; }
+    if(permissions === PUBLIC && nodeType === PROJECT) { msgKey = 'makeProjectPublicWarning'; }
     else if(permissions === PUBLIC && nodeType === COMPONENT) { msgKey = 'makeComponentPublicWarning'; }
     else if(permissions === PRIVATE && nodeType === PROJECT) { msgKey = 'makeProjectPrivateWarning'; }
     else { msgKey = 'makeComponentPrivateWarning'; }

--- a/website/static/js/nodeControl.js
+++ b/website/static/js/nodeControl.js
@@ -29,7 +29,7 @@ var MESSAGES = {
 
     makeComponentPublicWarning: 'Once a component is made public, there is no way to guarantee that ' +
                         'access to the data it contains can be completely prevented. Users ' +
-                        'should assume that one a component is made public, it will always ' +
+                        'should assume that once a component is made public, it will always ' +
                         'be public. The rest of the project, including other components, ' +
                         'will not be made public. <b>Review your component for sensitive or restricted information before making it public</b>. Are you absolutely sure you would like to continue?',
 

--- a/website/static/js/nodeControl.js
+++ b/website/static/js/nodeControl.js
@@ -36,6 +36,13 @@ var MESSAGES = {
     makeComponentPrivateWarning: 'Making a component private will prevent users from viewing it on this site, ' +
                         'but will have no impact on external sites, including Google\'s cache. ' +
                         'Would you like to continue?',
+    makeRegistrationPublicWarning: 'Once a registration is made public, there is no way to guarantee that ' +
+                        'access to the data it contains can be completely prevented. Users ' +
+                        'should assume that once a registration will be made public, it will always ' +
+                        'be public. <b>Once this action has been taken, you will not be able to make ' +
+                        'the registration private again.</b> Public registrations may be retracted leaving behind a ' +
+                        'record of its existance along with basic metadata related to the project, and its ' +
+                        'contributors.',
 };
 
 // TODO(sloria): Fix this external dependency on nodeApiUrl
@@ -52,8 +59,11 @@ var COMPONENT = 'component';
 function setPermissions(permissions, nodeType) {
 
     var msgKey;
+    // TODO(hrybacki): Remove once Retraction/Embargoes goes is merged into production
+    var isRegistration = window.contextVars.node.isRegistration;
 
-    if(permissions === PUBLIC && nodeType === PROJECT) { msgKey = 'makeProjectPublicWarning'; }
+    if (permissions === PUBLIC && isRegistration) { msgKey = 'makeRegistrationPublicWarning'; }
+    else if(permissions === PUBLIC && nodeType === PROJECT) { msgKey = 'makeProjectPublicWarning'; }
     else if(permissions === PUBLIC && nodeType === COMPONENT) { msgKey = 'makeComponentPublicWarning'; }
     else if(permissions === PRIVATE && nodeType === PROJECT) { msgKey = 'makeProjectPrivateWarning'; }
     else { msgKey = 'makeComponentPrivateWarning'; }

--- a/website/static/js/registerNode.js
+++ b/website/static/js/registerNode.js
@@ -13,27 +13,14 @@ var preRegisterMessage =  function(title, parentTitle, parentUrl, category) {
             '</b> including all components and data within it. This will <b>not</b> register' +
             ' its parent, <b>' + parentTitle + '</b>.' +
             ' If you want to register the parent, please go <a href="' +
-            parentUrl + '">here.</a>' +
-            // TODO(hrybacki): Remove once Retraction/Embargoes goes is merged into production
-            '<hr /><b>Important Note:</b> As early as <u>June 8, 2015</u>, registrations ' +
-            'will be made public immediately or can be embargoed for up to four years. ' +
-            'There will no longer be the option of creating a permanently private ' +
-            'registration. If you register before June 8, 2015 and leave your ' +
-            'registration private, then the registration can remain private. After June 8, 2015, ' +
-            'if you ever make it public, you will not be able to return it to private. ';
+            parentUrl + '">here.</a> After selecting OK, you will next select a registration form.';
     } else {
         return 'You are about to register <b>' + title + '</b> ' +
             'including all components and data within it. ' +
             'Registration creates a permanent, time-stamped, uneditable version ' +
             'of the project. If you would prefer to register only one particular ' +
-            'component, please navigate to that component and then initiate registration.' +
-            // TODO(hrybacki): Remove once Retraction/Embargoes goes is merged into production
-            '<hr /><b>Important Note:</b> As early as <u>June 8, 2015</u>, registrations ' +
-            'will be made public immediately or can be embargoed for up to four years. ' +
-            'There will no longer be the option of creating a permanently private ' +
-            'registration. If you register before June 8, 2015 and leave your ' +
-            'registration private, then the registration can remain private. After June 8, 2015, ' +
-            'if you ever make it public, you will not be able to return it to private.';
+            'component, please navigate to that component and then initiate registration. ' +
+            'After selecting OK, you will next select a registration form.';
     }
 };
 

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -29,7 +29,7 @@
                     <div class="btn-group">
                     % if not node["is_public"]:
                         <button class='btn btn-default disabled'>Private</button>
-                        % if 'admin' in user['permissions']:
+                        % if 'admin' in user['permissions'] and not node['pending_embargo']:
                             <a class="btn btn-default" data-bind="click: makePublic">Make Public</a>
                         % endif
                     % else:


### PR DESCRIPTION
## Purpose
Update registration prompts and behaviors to match introduction of retractions/embargoes into production.

## Changes
- Update the preregistration prompt.
- Update the post-registration `make public` prompt.
- Remove `make public` functionality for registrations *pending an embargo*

## Side Effects
N/A

## Notes:
Closes-issue: #3286 and #3287 