### PR TITLE
[feature] Bold project title in registration success email

### DIFF
--- a/website/templates/emails/archive_success.html.mako
+++ b/website/templates/emails/archive_success.html.mako
@@ -3,7 +3,7 @@
 <%def name="content()">
 <tr>
   <td style="border-collapse: collapse;">
-    <h3 class="text-center" style="padding: 0;margin: 30px 0 0 0;border: none;list-style: none;font-weight: 300;text-align: center;">Registration of ${src.title} finished</h3>
+    <h3 class="text-center" style="padding: 0;margin: 30px 0 0 0;border: none;list-style: none;font-weight: 300;text-align: center;">Registration of <b>${src.title}</b> finished</h3>
   </td>
 </tr>
 <tr>


### PR DESCRIPTION
# Purpose
Bold project titles in registration success email. close issue #3304.
# Changes
Puts `<b>` tag on project title.
# Side Effects
None.