### PR TITLE
[Feature Fix]  Delete Indication of Save for Editor

### DIFF
--- a/website/addons/wiki/templates/edit.mako
+++ b/website/addons/wiki/templates/edit.mako
@@ -59,7 +59,7 @@
                   <div class="osf-panel-header" data-bind="css : { 'bordered': $root.singleVis() === 'edit' }">
                     <div class="row">
                       <div class="col-md-6">
-                           <span class="wiki-panel-title" > <i class="fa fa-pencil-square-o"> </i>   Edit </span>
+                          <i class="fa fa-pencil-square-o"> </i> Edit
                       </div>
                         <div class="col-md-6">
                           <div class="pull-right">
@@ -131,7 +131,7 @@
                 <div class="osf-panel-header bordered" data-bind="css: { 'osf-panel-header-flex': $root.singleVis() !== 'view', 'bordered': $root.singleVis() === 'view' }">
                     <div class="row">
                         <div class="col-sm-6">
-                            <span class="wiki-panel-title" > <i class="fa fa-eye"> </i>  View</span>
+                             <i class="fa fa-eye"> </i>  View
                         </div>
                         <div class="col-sm-6">
 
@@ -174,7 +174,7 @@
               <div class="osf-panel-header osf-panel-header-flex" data-bind="css: {  'osf-panel-header-flex': $root.singleVis() !== 'compare', 'bordered': $root.singleVis() === 'compare'}">
                   <div class="row">
                       <div class="col-xs-12">
-                          <span class="wiki-panel-title"> <i class="fa fa-exchange"> </i>   Compare </span>                        
+                          <i class="fa fa-exchange"> </i> Compare
                           <div class="inline" data-bind="css: { 'pull-right' :  $root.singleVis() === 'compare' }">
                             <!-- Version Picker -->
                             <span class="compare-version-text"><i> <span data-bind="text: viewVersionDisplay"></span></i> to

--- a/website/static/js/filepage/editor.js
+++ b/website/static/js/filepage/editor.js
@@ -98,9 +98,7 @@ var FileEditor = {
                     });
                     m.redraw();
                 });
-            } else {
-                alert('There are no changes to save.');
-            }
+            } 
         }, 500);
 
         self.changed = function() {

--- a/website/static/js/filepage/editor.js
+++ b/website/static/js/filepage/editor.js
@@ -64,41 +64,39 @@ var FileEditor = {
         };
 
         self.saveFile = $osf.throttle(function() {
-            if(self.changed()) {
-                var oldstatus = self.observables.status();
-                model.editor.setReadOnly(true);
-                self.unthrottledStatus('saving');
+            var oldstatus = self.observables.status();
+            model.editor.setReadOnly(true);
+            self.unthrottledStatus('saving');
+            m.redraw();
+            var request = $.ajax({
+                type: 'PUT',
+                url: self.url,
+                data: model.editor.getValue(),
+                beforeSend: $osf.setXHRAuthorization
+            }).done(function () {
+                model.editor.setReadOnly(false);
+                self.unthrottledStatus(oldstatus);
+                $(document).trigger('fileviewpage:reload');
+                self.initialText = model.editor.getValue();
                 m.redraw();
-                var request = $.ajax({
-                    type: 'PUT',
-                    url: self.url,
-                    data: model.editor.getValue(),
-                    beforeSend: $osf.setXHRAuthorization
-                }).done(function () {
-                    model.editor.setReadOnly(false);
-                    self.unthrottledStatus(oldstatus);
-                    $(document).trigger('fileviewpage:reload');
-                    self.initialText = model.editor.getValue();
-                    m.redraw();
-                }).fail(function(xhr, textStatus, err) {
-                    var message;
-                    if (xhr.status === 507) {
-                        message = 'Could not update file. Insufficient storage space in your Dropbox.';
-                    } else {
-                        message = 'The file could not be updated.';
-                    }
-                    model.editor.setReadOnly(false);
-                    self.unthrottledStatus(oldstatus);
-                    $(document).trigger('fileviewpage:reload');
-                    model.editor.setValue(self.initialText);
-                    $osf.growl('Error', message);
-                    Raven.captureMessage('Could not PUT file content.', {
-                        textStatus: textStatus,
-                        url: self.url
-                    });
-                    m.redraw();
+            }).fail(function(xhr, textStatus, err) {
+                var message;
+                if (xhr.status === 507) {
+                    message = 'Could not update file. Insufficient storage space in your Dropbox.';
+                } else {
+                    message = 'The file could not be updated.';
+                }
+                model.editor.setReadOnly(false);
+                self.unthrottledStatus(oldstatus);
+                $(document).trigger('fileviewpage:reload');
+                model.editor.setValue(self.initialText);
+                $osf.growl('Error', message);
+                Raven.captureMessage('Could not PUT file content.', {
+                    textStatus: textStatus,
+                    url: self.url
                 });
-            } 
+                m.redraw();
+            });
         }, 500);
 
         self.changed = function() {


### PR DESCRIPTION
### Purpose
Disable the warning message --`There are no changes to save`
Resolved #3171

### Changes
1) Delete  class `wiki-panel-title` since it is never defined and used in any places.
2) Delete the checking for changes

### Side effects
When clicking unchanged file, it will still reload the file. This is just a temporary solution.  Big changes on wiki and editor in the future will apply a better way to reflect the status.