### PR TITLE
[feature fix] Project buttons disabled for non-users

### DIFF
--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -59,7 +59,11 @@
 
                     </div>
                     <!-- /ko -->
-                    <div class="btn-group">
+                    <div
+                        % if not user_name:
+                            data-bind="tooltip: {title: 'Only users can watch and duplicate projects', placement: 'bottom'}"
+                        % endif
+                            class="btn-group">
                         <a
                         % if user_name and (node['is_public'] or user['has_read_permissions']) and not node['is_registration']:
                             data-bind="click: toggleWatch, tooltip: {title: watchButtonAction, placement: 'bottom'}"

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -61,7 +61,7 @@
                     <!-- /ko -->
                     <div
                         % if not user_name:
-                            data-bind="tooltip: {title: 'Only users can watch and duplicate projects', placement: 'bottom'}"
+                            data-bind="tooltip: {title: 'Log-in or create an account to watch/duplicate this project', placement: 'bottom'}"
                         % endif
                             class="btn-group">
                         <a

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -71,11 +71,16 @@
                             <i class="fa fa-eye"></i>
                             <span data-bind="text: watchButtonDisplay" id="watchCount"></span>
                         </a>
-                        <a class="btn btn-default"
-                           data-bind="tooltip: {title: 'Duplicate', placement: 'bottom'}"
-                           data-target="#duplicateModal" data-toggle="modal"
-                           href="#">
-                          <span class="glyphicon glyphicon-share"></span>&nbsp; ${ node['templated_count'] + node['fork_count'] + node['points'] }
+                        <a
+                        % if user_name:
+                            class="btn btn-default"
+                            data-bind="tooltip: {title: 'Duplicate', placement: 'bottom'}"
+                            data-target="#duplicateModal" data-toggle="modal"
+                        % else:
+                            class="btn btn-default disabled"
+                        % endif
+                            href="#">
+                            <span class="glyphicon glyphicon-share"></span>&nbsp; ${ node['templated_count'] + node['fork_count'] + node['points'] }
                         </a>
                     </div>
                     % if 'badges' in addons_enabled and badges and badges['can_award']:


### PR DESCRIPTION
### Purpose
Fixes #3249
Replaces #3256

The duplicate button in the top-right corner of the project dashboard page appeared active to all visitors, even non users for whom it would not work.

### Changes
Made the duplicate button appear as disabled if the page is accessed by a non-user.

Added a tooltip to the watch/duplicate button group stating that only users can watch and duplicate; looks like this:

![screen shot 2015-06-24 at 2 11 51 pm](https://cloud.githubusercontent.com/assets/5955359/8337749/e87918aa-1a7a-11e5-884c-84282eb623f5.png)
