### PR TITLE
[hotfix] Unsubscribe merged-in user from mailchimp mailing lists

### DIFF
--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -1142,9 +1142,11 @@ class User(GuidStoredObject, AddonModelMixin):
 
         for key, value in user.mailing_lists.iteritems():
             # subscribe to each list if either user was subscribed
-            self.mailing_lists[key] = value or self.mailing_lists.get(key)
-        # - clear subscriptions for merged user
-        user.mailing_lists = {}
+            subscription = value or self.mailing_lists.get(key)
+            signals.user_merged.send(self, list_name=key, subscription=subscription)
+
+            # clear subscriptions for merged user
+            signals.user_merged.send(user, list_name=key, subscription=False)
 
         for node_id, timestamp in user.comments_viewed_timestamp.iteritems():
             if not self.comments_viewed_timestamp.get(node_id):

--- a/framework/auth/signals.py
+++ b/framework/auth/signals.py
@@ -6,6 +6,7 @@ signals = blinker.Namespace()
 user_registered = signals.signal('user-registered')
 user_confirmed = signals.signal('user-confirmed')
 user_email_removed = signals.signal('user-email-removed')
+user_merged = signals.signal('user-merged')
 
 contributor_removed = signals.signal('contributor-removed')
 node_deleted = signals.signal('node-deleted')

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -1,3 +1,4 @@
+import mock
 import datetime
 
 from modularodm import Q
@@ -10,6 +11,7 @@ from website import models
 from tests import base
 from tests.base import fake
 from tests import factories
+from framework.tasks import handlers
 
 
 class TestUser(base.OsfTestCase):
@@ -134,6 +136,8 @@ class TestUserMerging(base.OsfTestCase):
     def setUp(self):
         super(TestUserMerging, self).setUp()
         self.user = factories.UserFactory()
+        with self.context:
+            handlers.celery_before_request()
 
     def _add_unconfirmed_user(self):
 
@@ -221,7 +225,8 @@ class TestUserMerging(base.OsfTestCase):
         with assert_raises(exceptions.MergeConflictError):
             self.user.merge_user(unregistered)
 
-    def test_merge(self):
+    @mock.patch('website.mailchimp_utils.get_mailchimp_api')
+    def test_merge(self, mock_get_mailchimp_api):
         other_user = factories.UserFactory()
         other_user.save()
 
@@ -363,9 +368,15 @@ class TestUserMerging(base.OsfTestCase):
             set(self.user._fields),
         )
 
+        # mock mailchimp
+        mock_client = mock.MagicMock()
+        mock_get_mailchimp_api.return_value = mock_client
+        mock_client.lists.list.return_value = {'data': [{'id': x, 'list_name': list_name} for x, list_name in enumerate(self.user.mailing_lists)]}
+
         # perform the merge
         self.user.merge_user(other_user)
         self.user.save()
+        handlers.celery_teardown_request()
 
         # check each field/value pair
         for k, v in expected.iteritems():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -21,8 +21,10 @@ from framework.sessions.model import Session
 from framework.auth import exceptions as auth_exc
 from framework.auth.exceptions import ChangePasswordError, ExpiredTokenError
 from framework.auth.utils import impute_names_model
+from framework.auth.signals import user_merged
+from framework.tasks import handlers
 from framework.bcrypt import check_password_hash
-from website import filters, language, settings
+from website import filters, language, settings, mailchimp_utils
 from website.exceptions import NodeStateError
 from website.profile.utils import serialize_user
 from website.project.model import (
@@ -40,7 +42,7 @@ from website.addons.wiki.exceptions import (
     PageNotFoundError,
 )
 
-from tests.base import OsfTestCase, Guid, fake
+from tests.base import OsfTestCase, Guid, fake, capture_signals
 from tests.factories import (
     UserFactory, ApiKeyFactory, NodeFactory, PointerFactory,
     ProjectFactory, NodeLogFactory, WatchConfigFactory,
@@ -846,6 +848,9 @@ class TestMergingUsers(OsfTestCase):
 
     def setUp(self):
         super(TestMergingUsers, self).setUp()
+        with self.context:
+            handlers.celery_before_request()
+
         self.master = UserFactory(
             fullname='Joe Shmo',
             is_registered=True,
@@ -876,6 +881,29 @@ class TestMergingUsers(OsfTestCase):
     def test_dupe_email_is_appended(self):
         self._merge_dupe()
         assert_in('joseph123@hotmail.com', self.master.emails)
+
+    def test_send_user_merged_signal(self):
+        self.dupe.mailing_lists['foo'] = True
+        self.dupe.save()
+
+        with capture_signals() as mock_signals:
+            self._merge_dupe()
+            assert_equal(mock_signals.signals_sent(), set([user_merged]))
+
+    @mock.patch('website.mailchimp_utils.get_mailchimp_api')
+    def test_merged_user_unsubscribed_from_mailing_lists(self, mock_get_mailchimp_api):
+        list_name = 'foo'
+        username = self.dupe.username
+        self.dupe.mailing_lists[list_name] = True
+        self.dupe.save()
+        mock_client = mock.MagicMock()
+        mock_get_mailchimp_api.return_value = mock_client
+        mock_client.lists.list.return_value = {'data': [{'id': 2, 'list_name': list_name}]}
+        list_id = mailchimp_utils.get_list_id_from_name(list_name)
+        mailchimp_utils.unsubscribe_mailchimp(list_name, self.dupe._id, username=username)
+        handlers.celery_teardown_request()
+        mock_client.lists.unsubscribe.assert_called_with(id=list_id, email={'email': username})
+        assert_false(self.dupe.mailing_lists[list_name])
 
     def test_inherits_projects_contributed_by_dupe(self):
         project = ProjectFactory()

--- a/website/mailchimp_utils.py
+++ b/website/mailchimp_utils.py
@@ -67,18 +67,20 @@ def subscribe_mailchimp(list_name, user_id):
 @queued_task
 @app.task
 @transaction()
-def unsubscribe_mailchimp(list_name, user_id):
+def unsubscribe_mailchimp(list_name, user_id, username=None):
     """Unsubscribe a user from a mailchimp mailing list given its name.
 
     :param str list_name: mailchimp mailing list name
-    :param str username: current user's email
+    :param str user_id: current user's id
+    :param str username: current user's email (required for merged users)
 
     :raises: ListNotSubscribed if user not already subscribed
     """
     user = User.load(user_id)
+    username = user.username if user else username
     m = get_mailchimp_api()
     list_id = get_list_id_from_name(list_name=list_name)
-    m.lists.unsubscribe(id=list_id, email={'email': user.username})
+    m.lists.unsubscribe(id=list_id, email={'email': username})
 
     # Update mailing_list user field
     if user.mailing_lists is None:

--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -18,6 +18,7 @@ from framework.auth.decorators import collect_auth
 from framework.auth.decorators import must_be_logged_in
 from framework.auth.exceptions import ChangePasswordError
 from framework.auth.views import send_confirm_email
+from framework.auth.signals import user_merged
 from framework.exceptions import HTTPError, PermissionsError
 from framework.flask import redirect  # VOL-aware redirect
 from framework.status import push_status_message
@@ -427,6 +428,7 @@ def user_choose_mailing_lists(auth, **kwargs):
     return {'message': 'Successfully updated mailing lists', 'result': user.mailing_lists}, 200
 
 
+@user_merged.connect
 def update_subscription(user, list_name, subscription):
     """ Update mailing list subscription in mailchimp.
 
@@ -438,7 +440,7 @@ def update_subscription(user, list_name, subscription):
         mailchimp_utils.subscribe_mailchimp(list_name, user._id)
     else:
         try:
-            mailchimp_utils.unsubscribe_mailchimp(list_name, user._id)
+            mailchimp_utils.unsubscribe_mailchimp(list_name, user._id, username=user.username)
         except mailchimp_utils.mailchimp.ListNotSubscribedError:
             raise HTTPError(http.BAD_REQUEST,
                 data=dict(message_short="ListNotSubscribedError",

--- a/website/signals.py
+++ b/website/signals.py
@@ -11,4 +11,5 @@ ALL_SIGNALS = [
     auth.user_confirmed,
     auth.user_email_removed,
     auth.user_registered,
+    auth.user_merged
 ]


### PR DESCRIPTION
Purpose
-----------
Fixes #3289 

A user merged into another user account would get its `mailing_lists` field cleared on the OSF, but would not get unsubscribed on mailchimp.

Changes
------------
Send a `user_merged` signal from `user.merge_user` to `update_subscription`, which updates mailing list subscriptions on both the osf and mailchimp for a user.

Change `unsubscribe_mailchimp` to take a username as an optional parameter, so that the merged user (whose username gets deleted) can still get removed from the mailing list.