### PR TITLE
[WIP] Collapse private components into one item, API-side

### DIFF
--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -2,6 +2,7 @@ import re
 import functools
 
 from modularodm import Q
+from utils import TRUTHY, FALSY
 from rest_framework.filters import OrderingFilter
 from rest_framework import serializers as ser
 
@@ -35,8 +36,6 @@ def intersect(x, y):
 class FilterMixin(object):
     """ View mixin with helper functions for filtering. """
 
-    TRUTHY = set(['true', 'True', 1, '1'])
-    FALSY = set(['false', 'False', 0, '0'])
     DEFAULT_OPERATOR = 'eq'
 
     def __init__(self, *args, **kwargs):
@@ -62,9 +61,9 @@ class FilterMixin(object):
         field_type = type(self.serializer_class._declared_fields[field])
         value = value.strip()
         if field_type == ser.BooleanField:
-            if value in self.TRUTHY:
+            if value in TRUTHY:
                 return True
-            elif value in self.FALSY:
+            elif value in FALSY:
                 return False
             # TODO Should we handle if the value is neither TRUTHY nor FALSY (first add test for how we'd expect it to
             # work, then ensure that it works that way).

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -122,6 +122,11 @@ class Link(object):
         arg_values = [_get_attr_from_tpl(attr_tpl, obj) for attr_tpl in self.args]
         query_kwarg_values = {key: _get_attr_from_tpl(attr_tpl, obj) for key, attr_tpl in self.query_kwargs.items()}
 
+        if isinstance(obj, dict):  # helps for creating fake components
+            if 'is_fake_component' in obj:
+                if obj['is_fake_component'] is True:
+                    return ''
+
         return absolute_reverse(
             self.endpoint,
             args=arg_values,

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -80,21 +80,28 @@ def _tpl(val):
 
 
 def _get_attr_from_tpl(attr_tpl, obj):
-    attr_name = _tpl(str(attr_tpl))
-    if attr_name:
-        attribute_value = getattr(obj, attr_name, ser.empty)
-        if attribute_value is not ser.empty:
-            return attribute_value
-        elif attr_name in obj:
-            return obj[attr_name]
+    if isinstance(obj, dict):  # helps for creating fake components
+        if 'is_fake_component' in obj:
+            if obj['is_fake_component'] is True:
+                return ''
+    try:
+        return obj.pk
+    except AttributeError:
+        attr_name = _tpl(str(attr_tpl))
+        if attr_name:
+            attribute_value = getattr(obj, attr_name, ser.empty)
+            if attribute_value is not ser.empty:
+                return attribute_value
+            elif attr_name in obj:
+                return obj[attr_name]
+            else:
+                raise AttributeError(
+                    '{attr_name!r} is not a valid '
+                    'attribute of {obj!r}'.format(
+                        attr_name=attr_name, obj=obj,  # Eric said this might be fixed in other PR's?
+                    ))
         else:
-            raise AttributeError(
-                '{attr_name!r} is not a valid '
-                'attribute of {obj!r}'.format(
-                    attr_name=attr_name, obj=obj,
-                ))
-    else:
-        return attr_tpl
+            return attr_tpl
 
 
 # TODO: Make this a Field that is usable on its own?

--- a/api/base/utils.py
+++ b/api/base/utils.py
@@ -15,13 +15,6 @@ from website import util as website_util  # noqa
 def absolute_reverse(view_name, query_kwargs=None, args=None, kwargs=None):
     """Like django's `reverse`, except returns an absolute URL. Also add query parameters."""
 
-    # helps for creating fake components
-    if kwargs is not None:
-        if 'node_id' in kwargs:
-            if kwargs['node_id'] == '':  # TODO This doesn't seem like a safe way to do this...(how to set
-                                         # TODO node_id in kwargs?, or how to pass 'is_fake_component' to kwargs?)
-                return ''
-
     relative_url = reverse(view_name, kwargs=kwargs)
 
     url = website_util.api_v2_url(relative_url, params=query_kwargs,

--- a/api/base/utils.py
+++ b/api/base/utils.py
@@ -14,6 +14,14 @@ from website import util as website_util  # noqa
 
 def absolute_reverse(view_name, query_kwargs=None, args=None, kwargs=None):
     """Like django's `reverse`, except returns an absolute URL. Also add query parameters."""
+
+    # helps for creating fake components
+    if kwargs is not None:
+        if 'node_id' in kwargs:
+            if kwargs['node_id'] == '':  # TODO This doesn't seem like a safe way to do this...(how to set
+                                         # TODO node_id in kwargs?, or how to pass 'is_fake_component' to kwargs?)
+                return ''
+
     relative_url = reverse(view_name, kwargs=kwargs)
 
     url = website_util.api_v2_url(relative_url, params=query_kwargs,

--- a/api/base/utils.py
+++ b/api/base/utils.py
@@ -11,6 +11,8 @@ from api.base import settings as api_settings
 from website import settings as website_settings
 from website import util as website_util  # noqa
 
+TRUTHY = set(['true', 'True', 1, '1'])
+FALSY = set(['false', 'False', 0, '0'])
 
 def absolute_reverse(view_name, query_kwargs=None, args=None, kwargs=None):
     """Like django's `reverse`, except returns an absolute URL. Also add query parameters."""

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -66,6 +66,10 @@ class NodeSerializer(JSONAPISerializer):
         type_ = 'nodes'
 
     def get_absolute_url(self, obj):
+        if isinstance(obj, dict):  # helps for creating fake components
+            if 'is_fake_component' in obj:
+                if obj['is_fake_component'] is True:
+                    return ''
         return obj.absolute_url
 
     # TODO: See if we can get the count filters into the filter rather than the serializer.
@@ -79,23 +83,48 @@ class NodeSerializer(JSONAPISerializer):
         return auth
 
     def get_node_count(self, obj):
+        if isinstance(obj, dict):  # helps for creating fake components
+            if 'is_fake_component' in obj:
+                if obj['is_fake_component'] is True:
+                    return 0
         auth = self.get_user_auth(self.context['request'])
         nodes = [node for node in obj.nodes if node.can_view(auth) and node.primary]
         return len(nodes)
 
     def get_contrib_count(self, obj):
+        if isinstance(obj, dict):  # helps for creating fake components
+            if 'is_fake_component' in obj:
+                if obj['is_fake_component'] is True:
+                    return 0
         return len(obj.contributors)
 
     def get_registration_count(self, obj):
+        if isinstance(obj, dict):  # helps for creating fake components
+            if 'is_fake_component' in obj:
+                if obj['is_fake_component'] is True:
+                    return 0
         auth = self.get_user_auth(self.context['request'])
         registrations = [node for node in obj.node__registrations if node.can_view(auth)]
         return len(registrations)
 
     def get_pointers_count(self, obj):
+        if isinstance(obj, dict):  # helps for creating fake components
+            if 'is_fake_component' in obj:
+                if obj['is_fake_component'] is True:
+                    return 0
         return len(obj.nodes_pointer)
 
     @staticmethod
     def get_properties(obj):
+        if isinstance(obj, dict):  # helps for creating fake components
+            if 'is_fake_component' in obj:
+                if obj['is_fake_component'] is True:
+                    fake_ret = {
+                        'registration': False,
+                        'collection': False,
+                        'dashboard': False,
+                    }
+                    return fake_ret
         ret = {
             'registration': obj.is_registration,
             'collection': obj.is_folder,
@@ -105,6 +134,10 @@ class NodeSerializer(JSONAPISerializer):
 
     @staticmethod
     def get_tags(obj):
+        if isinstance(obj, dict):  # helps for creating fake components
+            if 'is_fake_component' in obj:
+                if obj['is_fake_component'] is True:
+                    return ''  # TODO maybe do this as return [] ?
         ret = {
             'system': [tag._id for tag in obj.system_tags],
             'user': [tag._id for tag in obj.tags],

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -202,13 +202,13 @@ class NodeChildrenList(generics.ListAPIView, NodeMixin):
                 title_with_count = "{} Private Components".format(count_private_nodes)
             fake_component = {
                 'primary': True,
-                '_id': '',  # TODO should have id?
+                '_id': '',  # TODO should have id? - e.g. 'abcd3'
                 'category': '',
                 'node_type': 'component',
-                'url': '',  # '/search/?tags={12345}',  # TODO should have a url?
+                'url': '',  # TODO should have a url? - e.g. '/search/?tags={12345}','/search/?tags={12345}',
                 'title': title_with_count,
-                'path': '',  # '/-- private project --/',  # TODO should have path?
-                'api_url': '',  # '/api/v2/12345',  # TODO should have api_url?; API_PREFIX (real site)/API_BASE (tests)
+                'path': '',  # TODO should have path? - e.g. '/-- private project --/',
+                'api_url': '',  # TODO should have api_url? - e.g. '/api/v2/12345',
                 'is_public': True,
                 'is_registration': False,
                 'is_fake_component': True,

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -181,7 +181,40 @@ class NodeChildrenList(generics.ListAPIView, NodeMixin):
             auth = Auth(None)
         else:
             auth = Auth(user)
-        children = [node for node in nodes if node.can_view(auth) and node.primary]
+        children = []
+        count_private_nodes = 0
+        # Add visible nodes to children list; count number of private nodes.
+        for node in nodes:
+            if node.primary:
+                if node.can_view(auth):
+                    children.append(node)
+                else:  # not node.can_view(auth)
+                    count_private_nodes += 1
+
+        if count_private_nodes == 0:
+           return children
+        else:  # add a fake, visible component with the number of private nodes as its title
+            if count_private_nodes == 1:
+                title_with_count = "1 Private Component"
+            else:  # count_private_nodes > 1
+                title_with_count = "{} Private Components".format(count_private_nodes)
+            # fake_component = Node(title=title_with_count)  TODO delete this
+            # fake_component.add_permission(user, 'read', save=False)
+            fc = {
+                'primary': True,
+                '_id': '12345',
+                'category': '',
+                'node_type': 'component',
+                'url': '',  # /search/?tags={12345}',  # TODO should have a url?
+                'title': title_with_count,
+                'path': '/-- private project --/',
+                'api_url': '',  # '/api/v2/12345',  #or 'API_PREFIX' (for real site) or 'API_BASE' (for tests)
+                'is_public': True,
+                'is_registration': False,
+                'is_fake_component': True,
+            }
+            children.append(fc)
+
         return children
 
 

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -198,22 +198,20 @@ class NodeChildrenList(generics.ListAPIView, NodeMixin):
                 title_with_count = "1 Private Component"
             else:  # count_private_nodes > 1
                 title_with_count = "{} Private Components".format(count_private_nodes)
-            # fake_component = Node(title=title_with_count)  TODO delete this
-            # fake_component.add_permission(user, 'read', save=False)
-            fc = {
+            fake_component = {
                 'primary': True,
-                '_id': '12345',
+                '_id': '',  # TODO should have id?
                 'category': '',
                 'node_type': 'component',
                 'url': '',  # /search/?tags={12345}',  # TODO should have a url?
                 'title': title_with_count,
                 'path': '/-- private project --/',
-                'api_url': '',  # '/api/v2/12345',  #or 'API_PREFIX' (for real site) or 'API_BASE' (for tests)
+                'api_url': '',  # '/api/v2/12345',  # TODO should have api_url?; API_PREFIX (real site)/API_BASE (tests)
                 'is_public': True,
                 'is_registration': False,
                 'is_fake_component': True,
             }
-            children.append(fc)
+            children.append(fake_component)
 
         return children
 

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -899,8 +899,8 @@ class TestNodeChildrenList(ApiTestCase):
         res = self.app.get(self.public_project_url_with_true_private_param)
         assert_equal(len(res.json['data']), 1)  # 1 public component; no fake node should have been created
 
-        # TODO tests failed without 'Node.remove()' here, but once I added and then removed it they passed again...
-        # TODO Related to immediately above: Does this need a teardown function?
+        # TODO final test failed once without 'Node.remove()' here, but once I added and then removed 'Node.remove()'
+        # they passed again... Is something wrong outside of this class? Does this need a teardown function?
 
 class TestNodePointersList(ApiTestCase):
 


### PR DESCRIPTION
### Purpose

- Private components that are children of a project are listed in the file tree as separate items. When there is more than one, the list of private components grows. This can be distracting, and does not provide users with much information, considering how much space it can take up. This PR creates a single fake node with the title "```<number of private nodes>``` Private Components" that is returned when explicitly requested.
- Addresses #2951 

### Changes

- Private nodes are not returned in the "Node Children List" in the API -- instead, a single fake node is returned that gives the number of private nodes. However, the fake node is only given when explicitly requested. For example:
    - ```/v2/nodes/abcd3/children/``` (default URL without query parameters) will only return the non-private nodes.
![screen shot 2015-06-24 at 3 47 24 pm](https://cloud.githubusercontent.com/assets/10687411/8339901/e2509242-1a88-11e5-93e6-52f5115173cd.png)

    - ```/v2/nodes/abcd3/children/?include_private=False``` will only return the non-private nodes.
![screen shot 2015-06-24 at 3 47 13 pm](https://cloud.githubusercontent.com/assets/10687411/8339891/d29d1582-1a88-11e5-9867-2dbb7a201ff6.png)

    - ```/v2/nodes/abcd3/children/?include_private=True``` will return the non-private nodes, plus the fake node.
![screen shot 2015-06-24 at 3 46 55 pm](https://cloud.githubusercontent.com/assets/10687411/8339913/f033e9c2-1a88-11e5-879b-08fb3bded78d.png)