### PR TITLE
[hotfix] Fix grammar in links description

### DIFF
--- a/website/templates/public/pages/help/links.mako
+++ b/website/templates/public/pages/help/links.mako
@@ -4,9 +4,9 @@
     instead of making a new component or project inside the project, the component already exists separately and
     is only being pointed to from the present project.</p>
 <p>Any existing public project can be a link, be it your own project or someone else's. Linking is useful if
-    you want to reference another persons's work or indicate that something is part of a larger
+    you want to reference another person's work or indicate that something is part of a larger
     project.</p>
-<p>A link can created be by visiting the project you want to add the link to. Click "Add Links" in the components
+<p>A link can be created by visiting the project you want to add the link to. Click "Add Links" in the components
     section of your project dashboard and search for the project you wish to link to.</p>
 
 <div class="row">


### PR DESCRIPTION
### Purpose
Fixes #3315

### Changes
Changes two strings:
1: "persons's" to "person's"
2: "created be" to "be created"