### PR TITLE
Stops search from excluding results with same name as those on node 

### DIFF
--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -391,7 +391,9 @@ def search_contributor(query, page=0, size=10, exclude=[], current_user=None):
         normalized_items.append(normalized_item)
     items = normalized_items
 
-    query = ''
+    # Prevents exclusion of contributors with names that are similar to query
+    for item in items:
+        exclude = [contrib for contrib in exclude if item not in contrib.fullname]
 
     query = "  AND ".join('{}*~'.format(re.escape(item)) for item in items) + \
             "".join(' NOT "{}"'.format(excluded) for excluded in exclude)

--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -99,7 +99,7 @@ var AddContributorViewModel = oop.extend(Paginator, {
         });
     },
     alreadyAdded : function(contrib) {
-        if ($osf.mapByProperty(this.contributors(), 'id').indexOf(contrib.id) == -1) {
+        if ($osf.mapByProperty(this.contributors(), 'id').indexOf(contrib.id) === -1) {
             return false;
         } else {
             return true;
@@ -249,10 +249,10 @@ var AddContributorViewModel = oop.extend(Paginator, {
     addButtonTips: function(contrib) {
         if(this.alreadyAdded(contrib)){
             // This would be have tooltip, but KO can't make them for disabled inputs, so displays msg instead.
-            contrib.displayProjectsInCommon = "Already added to this component";
-            return "";
+            contrib.displayProjectsInCommon = 'Already added to this component';
+            return '';
         }else{
-            return "Add contributor";
+            return 'Add contributor';
         }
     },
     afterRender: function(elm, data) {
@@ -424,27 +424,6 @@ function ContribAdder(selector, nodeTitle, nodeId, parentTitle) {
         self.nodeId, self.parentTitle);
     self.init();
 }
-
-ko.bindingHandlers.tooltip = {
-    init: function(element, valueAccessor) {
-        var local = ko.utils.unwrapObservable(valueAccessor()),
-            options = {};
-
-        ko.utils.extend(options, ko.bindingHandlers.tooltip.options);
-        ko.utils.extend(options, local);
-
-        $(element).tooltip(options);
-
-        ko.utils.domNodeDisposal.addDisposeCallback(element, function() {
-            $(element).tooltip("destroy");
-        });
-    },
-    options: {
-        placement: "right",
-        trigger: "click"
-    }
-};
-
 
 ContribAdder.prototype.init = function() {
     var self = this;

--- a/website/templates/project/modal_add_contributor.mako
+++ b/website/templates/project/modal_add_contributor.mako
@@ -63,7 +63,7 @@
                                         <td style="padding-right: 10px;">
                                             <a
                                                     class="btn btn-default contrib-button btn-mini"
-                                                    data-bind="click:$root.add, tooltip: {title: 'Add contributor'}"
+                                                    data-bind="click:$root.add, tooltip: {title: $root.addButtonTips(contributor)}, css:{disabled:$root.alreadyAdded(contributor)}"
                                                 >+</a>
                                         </td>
                                         <td>


### PR DESCRIPTION
**Purpose**
Allows contributor search to find contributors with names similar to the names of contributors already on the node. Closes #3302.
**Changes**
Removes names of used in query from excluded list. Tweaks UI  to prevent the user from adding a the same contributor twice.
**Side Effects**
If a contributor is already on the node they now show in search results, but the cannot be added via modal.