### PR TITLE
Hotfix/transactional emails

### DIFF
--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -818,6 +818,54 @@ class TestSendEmails(OsfTestCase):
         )
         self.node_subscription.save()
 
+    def test_email_transactional_sent_without_errors(self):
+
+        users = [factories.UserFactory() for i in range(5)]
+        context = dict(
+            gravatar_url=self.user.gravatar_url,
+            content='',
+            target_user=None,
+            parent_comment='',
+            url=self.node.absolute_url
+        )
+        try:
+            emails.email_transactional(
+                [u._id for u in users],
+                self.node._id,
+                'comments',
+                self.user,
+                self.project,
+                datetime.datetime.utcnow(),
+                **context
+            )
+            assert(True)
+        except Exception:
+            assert(False)
+
+    def test_email_digest_sent_without_errors(self):
+
+        users = [factories.UserFactory() for i in range(5)]
+        context = dict(
+            gravatar_url=self.user.gravatar_url,
+            content='',
+            target_user=None,
+            parent_comment='',
+            url=self.node.absolute_url
+        )
+        try:
+            emails.email_digest(
+                [u._id for u in users],
+                self.node._id,
+                'comments',
+                self.user,
+                self.project,
+                datetime.datetime.utcnow(),
+                **context
+            )
+            assert(True)
+        except Exception:
+            assert(False)
+
     @mock.patch('website.notifications.emails.send')
     def test_notify_no_subscription(self, send):
         node = factories.NodeFactory()
@@ -1246,3 +1294,5 @@ class TestSendDigest(OsfTestCase):
         remove_sent_digest_notifications(digest_notification_ids=[digest_id])
         with assert_raises(NoResultsFound):
             NotificationDigest.find_one(Q('_id', 'eq', digest_id))
+
+            

--- a/website/templates/emails/digest.html.mako
+++ b/website/templates/emails/digest.html.mako
@@ -1,5 +1,3 @@
-<% from website.models import Node %>
-
 <%inherit file="notify_base.mako" />
 
 <% from website import util %>
@@ -10,6 +8,7 @@
             <thead class="block-head">
             <th colspan="2" style="padding: 0px 15px 0px 15px;">
                 <h3 style="padding: 0 15px 5px 15px; margin: 30px 0 0 0;border: none;list-style: none;font-weight: 300; border-bottom: 1px solid #eee; text-align: left;">
+                  <% from website.project.model import Node %>
                 ${Node.load(key).title}
                 %if parent :
                     <small style="font-size: 14px;color: #999;"> in ${Node.load(parent).title}</small>
@@ -34,7 +33,7 @@
 %endfor
 </%def>
 
-<%def name="conent()">
+<%def name="content()">
 <tr>
   <td style="border-collapse: collapse;">
     <h3 class="text-center" style="padding: 0;margin: 30px 0 0 0;border: none;list-style: none;font-weight: 300;text-align: center;">Recent Activity</h3>

--- a/website/templates/emails/transactional.html.mako
+++ b/website/templates/emails/transactional.html.mako
@@ -1,8 +1,6 @@
-<% from website.models import Node %>
+<%inherit file="notify_base.mako"/>
 
-<%inherit file="notify_base.html"/>
-
-<%def name="content">
+<%def name="content()">
     <table id="content" width="600" border="0" cellpadding="25" cellspacing="0" align="center" style="margin: 30px auto 0 auto;background: white;box-shadow: 0 0 2px #ccc;">
         <tbody>
             <tr>
@@ -14,6 +12,7 @@
                 <th colspan="2" style="padding: 0px 15px 0 15px">
                     <h3 style="padding: 0 15px 5px 15px; margin: 30px 0 0 0;border: none;list-style: none;font-weight: 300; border-bottom: 1px solid #eee; text-align: left;">
                                 ${node_title}
+                                <% from website.project.model import Node %>
                                 %if Node.load(node_id).parent_node:
                                     <small style="font-size: 14px;color: #999;"> in ${Node.load(node_id).parent_node.title} </small>
                                 %endif


### PR DESCRIPTION
closes https://github.com/CenterForOpenScience/osf.io/issues/3298

# Purpose

Sending transactional and digest emails for comments was failing.

# Changes

- Fix typos and broken imports in email templates
- Add regression tests

# Side Effects

None