### PR TITLE
[Feature Fix] Fix revision table gets cutoff when resizing

### DIFF
--- a/website/static/js/filepage/revisions.js
+++ b/website/static/js/filepage/revisions.js
@@ -140,7 +140,7 @@ var FileRevisionsTable = {
                     return m('.alert.alert-warning', {style:{margin: '10px'}}, model.errorMessage);
                 }
 
-                return m('table.table', [
+                return m('table.table', {style: {'table-layout': 'fixed'}}, [
                     ctrl.getTableHead(),
                     m('tbody', model.revisions.map(ctrl.makeTableRow))
                 ]);

--- a/website/static/js/filepage/revisions.js
+++ b/website/static/js/filepage/revisions.js
@@ -140,7 +140,7 @@ var FileRevisionsTable = {
                     return m('.alert.alert-warning', {style:{margin: '10px'}}, model.errorMessage);
                 }
 
-                return m('table.table', {style: {'table-layout': 'fixed'}}, [
+                return m('table.table', {style: {tableLayout: 'fixed'}}, [
                     ctrl.getTableHead(),
                     m('tbody', model.revisions.map(ctrl.makeTableRow))
                 ]);


### PR DESCRIPTION
## Purpose
Make sure the size of revision table remain in div.

Resolved  #3152
## Change
Set css attribute `table-layout` as `fixed` . Therefore, follow the rules described in w3school:
> The horizontal layout only depends on the table's width and the width of the columns, not the 
> contents of the cells

Because the content of data items shown in this table are usually with the similar width. So it is OK to set all the items as the same width in the table.

**After the change:**
![screen shot 2015-06-25 at 12 21 37 pm](https://cloud.githubusercontent.com/assets/5420789/8361422/2165d1d2-1b41-11e5-9e0a-33a6e2f324e5.png)

Note: Related [Stackoverflow Question](http://stackoverflow.com/questions/17969877/force-html-tables-to-not-exceed-their-containers-size)

And also just to clarify, based on [Mithril's docs](https://lhorie.github.io/mithril/mithril.html): 
> Mithril also does not auto-camel-case CSS properties on inline style attributes, so you should use the > Javascript syntax when setting them via Javascript objects:
    
    `m("table", {style: {tableLayout: "fixed"}}); //yields <table style="table-layout: fixed;"></table>`

## Side Effect
None.

## Others
Similar cutoff also happens in user profile page, but the widths of data items there vary a lot. So it is better to remain the same and don't set `table-layout` as `fixed`.

