### PR TITLE
[Feature-fix] [3324] Fix sort on file-view tree

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -433,7 +433,7 @@ function doItemOp(operation, to, from, rename, conflict) {
     if (to.data.provider === from.provider) {
         tb.pendingFileOps.push(from.id);
     }
-    _fangornOrderFolder.call(tb, from.parent());
+    orderFolder.call(tb, from.parent());
 
 
     $.ajax({
@@ -491,7 +491,7 @@ function doItemOp(operation, to, from, rename, conflict) {
             from.load = true;
         }
         // no need to redraw because fangornOrderFolder does it
-        _fangornOrderFolder.call(tb, from.parent());
+        orderFolder.call(tb, from.parent());
     }).fail(function(xhr, textStatus) {
         if (to.data.provider === from.provider) {
             tb.pendingFileOps.pop();
@@ -527,7 +527,7 @@ function doItemOp(operation, to, from, rename, conflict) {
             }
         });
 
-        _fangornOrderFolder.call(tb, from.parent());
+        orderFolder.call(tb, from.parent());
     });
 }
 
@@ -693,7 +693,7 @@ function _fangornDropzoneDrop(treebeard, event) {
 function _fangornComplete(treebeard, file) {
     var item = file.treebeardParent;
     resolveconfigOption.call(treebeard, item, 'onUploadComplete', [item]);
-    _fangornOrderFolder.call(treebeard, item);
+    orderFolder.call(treebeard, item);
 }
 
 /**
@@ -862,7 +862,7 @@ function _createFolder(event, dismissCallback, helpText) {
     }).then(function(item) {
         inheritFromParent({data: item}, parent, ['branch']);
         item = tb.createItem(item, parent.id);
-        _fangornOrderFolder.call(tb, parent);
+        orderFolder.call(tb, parent);
         item.notify.update('New folder created!', 'success', undefined, 1000);
         if(dismissCallback) {
             dismissCallback();
@@ -1072,7 +1072,7 @@ function _fangornLazyLoadOnLoad (tree, event) {
     reapplyTooltips();
 
     if (tree.depth > 1) {
-        _fangornOrderFolder.call(this, tree);
+        orderFolder.call(this, tree);
     }
 }
 
@@ -1082,7 +1082,7 @@ function _fangornLazyLoadOnLoad (tree, event) {
  * @this Treebeard.controller
  * @private
  */
-function _fangornOrderFolder(tree) {
+function orderFolder(tree) {
     // Checking if this column does in fact have sorting
     var sortDirection = '';
     if (this.isSorted[0]) {
@@ -1512,7 +1512,7 @@ var FGItemButtons = {
     }
 };
 
-var _dismissToolbar = function(){
+var dismissToolbar = function(){
     var tb = this;
     if (tb.toolbarMode() === toolbarModes.SEARCH){
         tb.resetFilter();
@@ -1532,7 +1532,7 @@ var FGToolbar = {
         self.mode = self.tb.toolbarMode;
         self.isUploading = args.treebeard.isUploading;
         self.helpText = m.prop('');
-        self.dismissToolbar = _dismissToolbar.bind(self.tb);
+        self.dismissToolbar = dismissToolbar.bind(self.tb);
         self.createFolder = function(event){
             _createFolder.call(self.tb, event, self.dismissToolbar, self.helpText );
         };
@@ -1733,7 +1733,7 @@ function filterRowsNotInParent(rows) {
  * @param {Object} item A Treebeard _item object.
  * @private
  */
-function _openParentFolders (item) {
+function openParentFolders (item) {
     var tb = this;
     // does it have a parent? If so change open
     var parent = item.parent();
@@ -1743,7 +1743,7 @@ function _openParentFolders (item) {
             parent.load = true;
             tb.toggleFolder(index);
         }
-        _openParentFolders.call(tb, parent);
+        openParentFolders.call(tb, parent);
     }
     return;
 }
@@ -1760,10 +1760,10 @@ function _openParentFolders (item) {
     var scrollToItem = false;
     filterRowsNotInParent.call(tb, tb.multiselected());
     if (tb.toolbarMode() === 'search') {
-        _dismissToolbar.call(tb);
+        dismissToolbar.call(tb);
         scrollToItem = true;
         // recursively open parents of the selected item but do not lazyload;
-        _openParentFolders.call(tb, row);
+        openParentFolders.call(tb, row);
     }
 
     if (tb.multiselected().length === 1){
@@ -2033,7 +2033,7 @@ tbOptions = {
                 return;
             }
             tb.clearMultiselect();
-            _dismissToolbar.call(tb);
+            dismissToolbar.call(tb);
         });
 
         $(window).on('beforeunload', function() {
@@ -2052,7 +2052,7 @@ tbOptions = {
         }
         $(window).on('keydown', function(event){
             if (event.keyCode === ESCAPE_KEY) {
-                _dismissToolbar.call(tb);
+                dismissToolbar.call(tb);
             }
         });
     },
@@ -2197,11 +2197,11 @@ Fangorn.Utils = {
     reapplyTooltips : reapplyTooltips,
     setCurrentFileID: setCurrentFileID,
     scrollToFile: scrollToFile,
-    openParentFolders : _openParentFolders,
-    dismissToolbar : _dismissToolbar,
+    openParentFolders : openParentFolders,
+    dismissToolbar : dismissToolbar,
     uploadRowTemplate : uploadRowTemplate,
     resolveIconView: resolveIconView,
-    orderFolder: _fangornOrderFolder
+    orderFolder: orderFolder
 };
 
 Fangorn.DefaultOptions = tbOptions;

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1086,9 +1086,11 @@ function _fangornOrderFolder(tree) {
     // Checking if this column does in fact have sorting
     if (this.isSorted[0]) {
         var sortDirection = this.isSorted[0].desc ? 'desc' : 'asc';
-        tree.sortChildren(this, sortDirection, 'text', 0, 1);
-        this.redraw();
+    } else {
+        var sortDirection = 'asc';
     }
+    tree.sortChildren(this, sortDirection, 'text', 0, 1);
+    this.redraw();
 }
 
 /**
@@ -2197,7 +2199,8 @@ Fangorn.Utils = {
     openParentFolders : _openParentFolders,
     dismissToolbar : _dismissToolbar,
     uploadRowTemplate : uploadRowTemplate,
-    resolveIconView: resolveIconView
+    resolveIconView: resolveIconView,
+    orderFolder: _fangornOrderFolder
 };
 
 Fangorn.DefaultOptions = tbOptions;

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1084,10 +1084,11 @@ function _fangornLazyLoadOnLoad (tree, event) {
  */
 function _fangornOrderFolder(tree) {
     // Checking if this column does in fact have sorting
+    var sortDirection = '';
     if (this.isSorted[0]) {
-        var sortDirection = this.isSorted[0].desc ? 'desc' : 'asc';
+        sortDirection = this.isSorted[0].desc ? 'desc' : 'asc';
     } else {
-        var sortDirection = 'asc';
+        sortDirection = 'asc';
     }
     tree.sortChildren(this, sortDirection, 'text', 0, 1);
     this.redraw();

--- a/website/static/js/fileViewTreebeard.js
+++ b/website/static/js/fileViewTreebeard.js
@@ -77,6 +77,9 @@ function FileViewTreebeard(data) {
             if(!event) {
                 Fangorn.Utils.scrollToFile.call(tb, tb.currentFileID);
             }
+            if (tree.depth > 1) {
+                Fangorn.Utils.orderFolder.call(this, tree);
+            }
         },
         resolveRows: function (item) {
             var tb = this;


### PR DESCRIPTION
## Purpose
Fixes #3324, which was the problem that in file-view, the file tree was not sorted. As suggested by @lyndsysimon, this now also renames the methods being exported by Utils, removing underscores to maintain consistency in naming conventions.

## Changes
This makes it so that if there are no Column titles, the file tree is sorted in 'asc' mode. 
![screen shot 2015-06-25 at 3 59 35 pm](https://cloud.githubusercontent.com/assets/6268982/8364300/4bf2a1c0-1b53-11e5-85df-4a6a72697219.png)

## Side Effects
Files will always be sorted in ascending fashion if there is no column titles for all fangorn derived file trees (if and only if the method Fangorn.Utils.orderFiles is called when there are no titles). 
