### PR TITLE
[hotfix] Update mailchimp subscriptions when primary username is changed

### DIFF
--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -223,6 +223,7 @@ class User(GuidStoredObject, AddonModelMixin):
     # The primary email address for the account.
     # This value is unique, but multiple "None" records exist for:
     #   * unregistered contributors where an email address was not provided.
+    # TODO: Update mailchimp subscription on username change in user.save()
     username = fields.StringField(required=False, unique=True, index=True)
 
     # Hashed. Use `User.set_password` and `User.check_password`
@@ -985,6 +986,7 @@ class User(GuidStoredObject, AddonModelMixin):
         }
 
     def save(self, *args, **kwargs):
+        # TODO: Update mailchimp subscription on username change
         # Avoid circular import
         from framework.analytics import tasks as piwik_tasks
         self.username = self.username.lower().strip() if self.username else None

--- a/website/mailchimp_utils.py
+++ b/website/mailchimp_utils.py
@@ -79,7 +79,7 @@ def unsubscribe_mailchimp(list_name, user_id, username=None):
     user = User.load(user_id)
     m = get_mailchimp_api()
     list_id = get_list_id_from_name(list_name=list_name)
-    m.lists.unsubscribe(id=list_id, email={'email': user.username if user else username})
+    m.lists.unsubscribe(id=list_id, email={'email': username or user.username})
 
     # Update mailing_list user field
     if user.mailing_lists is None:

--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -229,6 +229,7 @@ def update_user(auth):
     user.save()
 
     # Update subscribed mailing lists with new primary email
+    # TODO: move to user.save()
     for list_name, subscription in user.mailing_lists.iteritems():
         if subscription:
             mailchimp_utils.subscribe_mailchimp(list_name, user._id)

--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -205,6 +205,11 @@ def update_user(auth):
                             mails.PRIMARY_EMAIL_CHANGED,
                             user=user,
                             new_address=username)
+
+            # Remove old primary email from subscribed mailing lists
+            for list_name, subscription in user.mailing_lists.iteritems():
+                if subscription:
+                    mailchimp_utils.unsubscribe_mailchimp(list_name, user._id, username=user.username)
             user.username = username
 
     ###################
@@ -222,6 +227,11 @@ def update_user(auth):
             user.timezone = data['timezone']
 
     user.save()
+
+    # Update subscribed mailing lists with new primary email
+    for list_name, subscription in user.mailing_lists.iteritems():
+        if subscription:
+            mailchimp_utils.subscribe_mailchimp(list_name, user._id)
 
     return _profile_view(user)
 


### PR DESCRIPTION
Purpose
-----------
From @GaryKriebel in #3311: 
> If I add a 2nd email to my account, then make that 2nd email primary, will that action remove the first email from the mailchimp subscription and then subscribe the newly tabbed primary email address?

Changes
------------
When a user changes their primary email address, unsubscribe the old primary email from any mailchimp mailing lists subscriptions and subscribe the new primary email address. 