### PR TITLE
[hotfix-fix] Fix unsubscribing merged-in user from mailchimp

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -900,7 +900,7 @@ class TestMergingUsers(OsfTestCase):
         mock_get_mailchimp_api.return_value = mock_client
         mock_client.lists.list.return_value = {'data': [{'id': 2, 'list_name': list_name}]}
         list_id = mailchimp_utils.get_list_id_from_name(list_name)
-        mailchimp_utils.unsubscribe_mailchimp(list_name, self.dupe._id, username=username)
+        self._merge_dupe()
         handlers.celery_teardown_request()
         mock_client.lists.unsubscribe.assert_called_with(id=list_id, email={'email': username})
         assert_false(self.dupe.mailing_lists[list_name])

--- a/website/mailchimp_utils.py
+++ b/website/mailchimp_utils.py
@@ -79,7 +79,7 @@ def unsubscribe_mailchimp(list_name, user_id, username=None):
     user = User.load(user_id)
     m = get_mailchimp_api()
     list_id = get_list_id_from_name(list_name=list_name)
-    m.lists.unsubscribe(id=list_id, email={'email': user.username if user else username})
+    m.lists.unsubscribe(id=list_id, email={'email': username or user.username})
 
     # Update mailing_list user field
     if user.mailing_lists is None:


### PR DESCRIPTION
Purpose
-----------
Fixes https://trello.com/c/zanyrsrX/11-merged-accounts-still-receive-emails-to-both-email-accounts

Changes
------------
Fix conditional for which username to use -- if a username is passed in to the function use that, otherwise use `user.username`. Also fix test to call `user.merge_user` instead of calling `unsubscribe_mailchimp` directly. 