### PR TITLE
[3297][Feature] Fix embargo wording on logs

### DIFF
--- a/website/templates/log_templates.mako
+++ b/website/templates/log_templates.mako
@@ -30,7 +30,7 @@ Embargo for
 </script>
 
 <script type="text/html" id="embargo_initiated">
-initiated embargo of
+initiated an embargoed registration of
 <a class="log-node-title-link overflow" data-bind="text: nodeTitle, attr: {href: nodeUrl}"></a>
 </script>
 


### PR DESCRIPTION
## Purpose 
As per request of issue #3297, this changes the wording for embargo initiated triggered logs.

## Changes
The logs now say 'initiated an embargoed registration' instead of 'initiated embargo'

## Side Effects
Should be none.