### PR TITLE
[Hotfix] Fix merge email being sent to the account sending the request

### DIFF
--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -221,7 +221,7 @@ def send_confirm_email(user, email):
         merge_target = None
 
     mails.send_mail(
-        email,
+        merge_target.username if merge_target else email,
         mails.CONFIRM_MERGE if merge_target else mails.CONFIRM_EMAIL,
         'plain',
         user=user,


### PR DESCRIPTION
## Purpose
To prevent the email confirming the merge being sent to the email requesting the merge, rather than the email that is to be merged. Fixes #3346

## Changes
Confirm email method now changes the to_addr based on whether there this is a merge request.

## Side Effects
I do not believe there is any.