### PR TITLE
[Feature-fix] Merge email displays mergee name #3346

### DIFF
--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -221,7 +221,7 @@ def send_confirm_email(user, email):
         merge_target = None
 
     mails.send_mail(
-        merge_target.username if merge_target else email,
+        email,
         mails.CONFIRM_MERGE if merge_target else mails.CONFIRM_EMAIL,
         'plain',
         user=user,

--- a/website/templates/emails/confirm_merge.txt.mako
+++ b/website/templates/emails/confirm_merge.txt.mako
@@ -1,4 +1,4 @@
-Hello ${user.fullname},
+Hello ${merge_target.fullname},
 
 This email is to notify you that ${user.username} has an initiated an account merge with your account on the Open Science Framework (OSF). This merge will move all of the projects and components associated with ${email} and with ${user.username} into one account. All projects and components will be displayed under ${user.username}.
 


### PR DESCRIPTION
## Purpose
Merge email now displays correct name, fixing #3346. Also supersedes #3348, where I screwed up.

## Changes
Template now pulls from merge_account for name rather than user.

## Side Effects
Should be none