### PR TITLE
[Hotfix] large uploads

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,7 +1,6 @@
 {
     "indent": 4,
     "boss": true,
-    "curly": true,
     "eqeqeq": true,
     "eqnull": true,
     "expr": true,


### PR DESCRIPTION
  * No longer redraw upon every chunk sent, saves a crap load of CPU
  * No longer attempt to generate thumbnails for all file uploads
  * Enable parallel uploads for everything but Github
  * Make the upload progress animated
  * Handle rejected upload requests
  * Bump dropzones max file size, fangorn will handle that

Closes #3325