### PR TITLE
[Feature Fix] Fix dashboard buttons fail to restore after canceling search

### DIFF
--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -1115,7 +1115,6 @@ var _dismissToolbar = function () {
     m.redraw();
 };
 
-
 var POToolbar = {
     controller: function (args) {
         var self = this;
@@ -1399,7 +1398,8 @@ var tbOptions = {
     resolveRefreshIcon : function () {
         return m('i.fa.fa-refresh.fa-spin');
     },
-    toolbarComponent : POToolbar
+    toolbarComponent : POToolbar,
+    naturalScrollLimit : 0
 };
 
 /**

--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -1189,8 +1189,7 @@ var POToolbar = {
                     id : 'renameInput',
                     helpTextId : 'renameHelpText',
                     placeholder : null,
-                    value : ctrl.tb.inputValue(),
-                    tooltip: 'Rename this item'
+                    value : ctrl.tb.inputValue()
                 }, ctrl.helpText())
                 ),
             m('.col-xs-3.tb-buttons-col',

--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -921,7 +921,7 @@ function applyTypeahead() {
                     $('#add-link-button').click(); //submits if the control is active
                 }
             } else {
-                $('#add-link-warning').text('');
+                $('#add-link-warning').removeClass('p-sm').text('');
                 $('#add-link-button').addClass('tb-disabled');
                 linkName = '';
                 linkID = '';
@@ -937,7 +937,7 @@ function applyTypeahead() {
                     linkName = datum.name;
                     linkID = datum.node_id;
                 } else {
-                    $('#add-link-warning').text('This project is already in the folder');
+                    $('#add-link-warning').addClass('p-sm').text('This project is already in the folder');
                 }
             }).fail($osf.handleJSONError);
         });
@@ -1221,7 +1221,7 @@ var POToolbar = {
                     type : 'text',
                     placeholder : 'Name of the project to find'
                 }),
-                m('#add-link-warning.text-warning.p-sm')
+                m('#add-link-warning.text-warning')
             ]
                 ),
             m('.col-xs-3.tb-buttons-col',

--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -1396,8 +1396,7 @@ var tbOptions = {
     resolveRefreshIcon : function () {
         return m('i.fa.fa-refresh.fa-spin');
     },
-    toolbarComponent : POToolbar,
-    naturalScrollLimit : 0
+    toolbarComponent : POToolbar
 };
 
 /**

--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -1243,7 +1243,6 @@ var POToolbar = {
             m.component(Fangorn.Components.button, {
                 onclick: function (event) {
                     ctrl.mode(Fangorn.Components.toolbarModes.SEARCH);
-                    ctrl.tb.clearMultiselect();
                 },
                 icon: 'fa fa-search',
                 className : 'text-primary'


### PR DESCRIPTION
### Purpose
This PR is mainly to solve #3341, which bring the original buttons back after canceling search. During the debugging, I also found and solved two other issues. 

1) As pointed in style guide, too short and obvious tooltip is unnecessary.

![screen shot 2015-06-26 at 11 14 56 am](https://cloud.githubusercontent.com/assets/5420789/8385761/af7f53a8-1c18-11e5-8900-f66693e8514c.png)

2) Unnecessary padding after clicking `Adding existing projects` button

![padding](https://cloud.githubusercontent.com/assets/5420789/8385814/05757e04-1c19-11e5-9368-d747e0a1a7cd.gif)

### Changes
1. Delete the code for clearing selection after opening the search
> ctrl.tb.clearMultiselect();

2. Add padding only when it gets warning messages
3. Delete the tooltips -- ` tooltip: 'Rename this item'`
 
### Side Effects
None.