### PR TITLE
[feature/fix] Save session when generating an OAuth connection URL

### DIFF
--- a/framework/sessions/__init__.py
+++ b/framework/sessions/__init__.py
@@ -189,3 +189,10 @@ def before_request():
             return
         except:
             pass
+
+
+def after_request(response):
+    if session.data.get('auth_user_id'):
+        session.save()
+
+    return response

--- a/website/app.py
+++ b/website/app.py
@@ -58,7 +58,8 @@ def attach_handlers(app, settings):
     add_handlers(app, {'before_request': framework.sessions.prepare_private_key})
     # framework.session's before_request handler must go after
     # prepare_private_key, else view-only links won't work
-    add_handlers(app, {'before_request': framework.sessions.before_request})
+    add_handlers(app, {'before_request': framework.sessions.before_request,
+                       'after_request': framework.sessions.after_request})
 
     return app
 

--- a/website/oauth/models/__init__.py
+++ b/website/oauth/models/__init__.py
@@ -170,8 +170,6 @@ class ExternalProvider(object):
 
             url = oauth.authorization_url(self.auth_url_base)
 
-        session.save()
-
         return url
 
     @abc.abstractproperty

--- a/website/oauth/models/__init__.py
+++ b/website/oauth/models/__init__.py
@@ -170,6 +170,8 @@ class ExternalProvider(object):
 
             url = oauth.authorization_url(self.auth_url_base)
 
+        session.save()
+
         return url
 
     @abc.abstractproperty


### PR DESCRIPTION
This should resolve an issue where OAuth flows would not complete successfully, due to the state token not persisting across requests.

ref: https://trello.com/c/5zWI9LC3/12-unable-to-configure-google-drive-and-drop-box-with-new-access-tokens