### PR TITLE
[hold] Restore v2/ to API URLs when appropriate

### DIFF
--- a/api/base/utils.py
+++ b/api/base/utils.py
@@ -15,7 +15,7 @@ def absolute_reverse(view_name, query_kwargs=None, args=None, kwargs=None):
     """Like django's `reverse`, except returns an absolute URL. Also add query parameters."""
     relative_url = reverse(view_name, kwargs=kwargs)
 
-    url = website_util.api_v2_url(relative_url, params=query_kwargs)
+    url = website_util.api_v2_url(relative_url, params=query_kwargs, base_prefix='')
     return url
 
 

--- a/website/util/__init__.py
+++ b/website/util/__init__.py
@@ -9,6 +9,7 @@ import furl
 from flask import request, url_for
 
 from website import settings as website_settings
+from api.base import settings as api_settings
 
 # Keep me: Makes rubeus importable from website.util
 from . import rubeus  # noqa
@@ -69,7 +70,7 @@ def api_url_for(view_name, _absolute=False, _xml=False, *args, **kwargs):
 def api_v2_url(path_str,
                params=None,
                base_route=website_settings.API_DOMAIN,
-               base_prefix='',
+               base_prefix=api_settings.API_BASE,
                **kwargs):
     """
     Convenience function for APIv2 usage: Concatenates parts of the absolute API url based on arguments provided

--- a/website/util/__init__.py
+++ b/website/util/__init__.py
@@ -80,6 +80,13 @@ def api_v2_url(path_str,
         'http://localhost:8000/nodes/abcd3/contributors/?filter%5Bfullname%5D=bob'
 
     This is NOT a full lookup function. It does not verify that a route actually exists to match the path_str given.
+
+    :param str path_str: The part of the API route that may vary, eg `users/`
+    :param dict params: Each key:value pair is appended as a URL parameter, ?key=value&key2=value2.
+    :param str base_route: The protocol, domain, and port of the url, eg http://localhost:8080
+    :param str base_prefix: The Django route prefix that is the same for all API calls, eg v2/
+    :param kwargs: Each additional kwarg entry will be appended as a URL parameter.
+    :return str: The concatenated URL
     """
     params = params or {}  # Optional params dict for special-character param names, eg filter[fullname]
 


### PR DESCRIPTION
## Purpose

Addresses regression in #3251 , plus my own past mistakes.

The api_v2_url function is intended to add configuration-dependent parts onto a URL fragment, eg to turn `/nodes/<pid>` into `http://api.osf.io/v2/nodes/<pid>`

In the process of removing the API_PREFIX variable, route stopped appending API_BASE as well.

Separately, the `absolute_reverse` function was appending `v2` twice (once by Django and once with a helper function), so some routes (eg Link fields) showed `v2/v2` erroneously.

## Summary of changes
Stop appending `v2/` when it is redundant, and resume appending it when it's needed.

TODO:
- [x] QA it by examining links fields and other API output.
