### PR TITLE
[Feature Fix] Make default toggle: view [ON], revisions [OFF]

### DIFF
--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -135,7 +135,7 @@ var FileViewPage = {
         //Hack to polyfill the Panel interface
         //Ran into problems with mithrils caching messing up with multiple "Panels"
         self.revisions = m.component(FileRevisionsTable, self.file, self.node, self.enableEditing, self.canEdit);
-        self.revisions.selected = true;
+        self.revisions.selected = false;
         self.revisions.title = 'Revisions';
 
         // inform the mfr of a change in display size performed via javascript,


### PR DESCRIPTION
### Purpose
From the user perspective, usually the revision info is not primary interest. So it is more reasonable to hidden it at the default setting.

Resolve #3371 

### Change
Change the initial value of  `self.revisions.selected` from `true` to `false`

### Side Effect
None

