### PR TITLE
Feature/large file uploads

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,7 +1,6 @@
 {
     "indent": 4,
     "boss": true,
-    "curly": true,
     "eqeqeq": true,
     "eqnull": true,
     "expr": true,

--- a/website/addons/box/__init__.py
+++ b/website/addons/box/__init__.py
@@ -43,7 +43,7 @@ INCLUDE_CSS = {
 HAS_HGRID_FILES = True
 GET_HGRID_DATA = utils.box_addon_folder
 
-# MAX_FILE_SIZE = 5  # MB
+MAX_FILE_SIZE = 250  # MB
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 NODE_SETTINGS_TEMPLATE = None  # use default node settings template

--- a/website/addons/dropbox/__init__.py
+++ b/website/addons/dropbox/__init__.py
@@ -38,7 +38,7 @@ INCLUDE_CSS = {
 HAS_HGRID_FILES = True
 GET_HGRID_DATA = views.hgrid.dropbox_addon_folder
 
-# MAX_FILE_SIZE = 5  # MB
+MAX_FILE_SIZE = 150  # MB
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 NODE_SETTINGS_TEMPLATE = None  # use default node settings template

--- a/website/addons/figshare/__init__.py
+++ b/website/addons/figshare/__init__.py
@@ -31,6 +31,8 @@ INCLUDE_CSS = {}
 HAS_HGRID_FILES = True
 GET_HGRID_DATA = views.hgrid.figshare_hgrid_data
 
+MAX_FILE_SIZE = 50
+
 HERE = os.path.dirname(os.path.abspath(__file__))
 NODE_SETTINGS_TEMPLATE = None  # use default nodes settings templates
 USER_SETTINGS_TEMPLATE = os.path.join(HERE, 'templates', 'figshare_user_settings.mako')

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -136,7 +136,6 @@ function cancelUploads (row) {
 var uploadRowTemplate = function(item){
     var tb = this;
     var padding;
-    var progress = item.data.uploadState() === 'pending' ? 0 : Math.floor(item.data.progress);
     if (tb.filterOn) {
         padding = 20;
     } else {
@@ -152,12 +151,12 @@ var uploadRowTemplate = function(item){
             ]),
             m('.col-xs-3',
                 m('.progress', [
-                    m('.progress-bar.progress-bar-info.progress-bar-striped', {
+                    m('.progress-bar.progress-bar-info.progress-bar-striped.active', {
                         role : 'progressbar',
-                        'aria-valuenow' : progress,
+                        'aria-valuenow' : item.data.progress,
                         'aria-valuemin' : '0',
                         'aria-valuemax': '100',
-                        'style':'width: ' + progress + '%' }, m('span.sr-only', progress + '% Complete'))
+                        'style':'width: ' + item.data.progress + '%' }, m('span.sr-only', item.data.progress + '% Complete'))
                 ])
             ),
             m('.col-xs-2', [
@@ -566,23 +565,15 @@ function _fangornMouseOverRow(item, event) {
  */
 function _fangornUploadProgress(treebeard, file, progress) {
     var parent = file.treebeardParent;
-
-    var item,
-        child,
-        templateWithCancel,
-        templateWithoutCancel;
+    progress = Math.ceil(progress);
     for(var i = 0; i < parent.children.length; i++) {
-        child = parent.children[i];
-        if(!child.data.tmpID){
-            continue;
+        if (parent.children[i].data.tmpID !== file.tmpID) continue;
+        if (parent.children[i].data.progress !== progress) {
+            parent.children[i].data.progress = progress;
+            m.redraw();
         }
-        if(child.data.tmpID === file.tmpID) {
-            item = child;
-            item.data.progress = progress;
-            item.data.uploadState('uploading');
-        }
+        return;
     }
-    m.redraw();
 }
 
 /**
@@ -620,6 +611,17 @@ function _fangornAddedFile(treebeard, file) {
     if (!_fangornCanDrop(treebeard, item)) {
         return;
     }
+
+    if (item.data.provider === 'github') {
+        this.githubFileCache = this.githubFileCache || [];
+        var files = this.getActiveFiles().filter(function(f) {return f.isGithub;});
+        if (files.length > 0) {
+            this.githubFileCache.push(file);
+            this.files.splice(this.files.indexOf(files), 1);
+        }
+        file.isGithub = true;
+    }
+
     var configOption = resolveconfigOption.call(treebeard, item, 'uploadAdd', [file, item]);
 
     var tmpID = tempCounter++;
@@ -638,7 +640,8 @@ function _fangornAddedFile(treebeard, file) {
             edit: false
         },
         tmpID: tmpID,
-        uploadState : m.prop('pending')
+        progress: 0,
+        uploadState : m.prop('uploading'),
     };
     var newitem = treebeard.createItem(blankItem, item.id);
     return configOption || null;
@@ -694,6 +697,12 @@ function _fangornComplete(treebeard, file) {
     var item = file.treebeardParent;
     resolveconfigOption.call(treebeard, item, 'onUploadComplete', [item]);
     orderFolder.call(treebeard, item);
+
+    if (file.isGithub) {
+        if (this.githubFileCache.length > 0) {
+            this.processFile(this.githubFileCache.pop());
+        }
+    }
 }
 
 /**
@@ -762,10 +771,10 @@ function _fangornDropzoneError(treebeard, file, message, xhr) {
     var msgText;
     if (file.isDirectory) {
         msgText = 'Cannot upload directories, applications, or packages.';
-    } else if (xhr.status === 507) {
+    } else if (xhr && xhr.status === 507) {
         msgText = 'Cannot upload file due to insufficient storage.';
     } else {
-        msgText = DEFAULT_ERROR_MESSAGE;
+        msgText = message || DEFAULT_ERROR_MESSAGE;
     }
     var parent = file.treebeardParent || treebeardParent.dropzoneItemCache; // jshint ignore:line
     // Parent may be undefined, e.g. in Chrome, where file is an entry object
@@ -1974,7 +1983,8 @@ function _resizeHeight () {
     var topBuffer = tbody.offset().top + 50;
     var availableSpace = windowHeight - topBuffer;
     if(availableSpace > 0) {
-        tbody.height(availableSpace);
+        // Set a minimum height
+        tbody.height(availableSpace < 300 ? 300 : availableSpace);
     }
 }
 
@@ -2090,13 +2100,15 @@ tbOptions = {
     onmouseoverrow : _fangornMouseOverRow,
     sortDepth : 2,
     dropzone : {                                           // All dropzone options.
+        maxFilesize: 10000000,
         url: function(files) {return files[0].url;},
         clickable : '#treeGrid',
         addRemoveLinks: false,
         previewTemplate: '<div></div>',
-        parallelUploads: 1,
+        parallelUploads: 10,
         acceptDirectories: false,
-        fallback: function(){}
+        createImageThumbnails: false,
+        fallback: function(){},
     },
     resolveIcon : _fangornResolveIcon,
     resolveToggle : _fangornResolveToggle,

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -614,9 +614,9 @@ function _fangornAddedFile(treebeard, file) {
         return;
     }
 
-    if (SYNC_UPLOAD_ADDONS.indexof(item.data.provider) !== -1) {
+    if (SYNC_UPLOAD_ADDONS.indexOf(item.data.provider) !== -1) {
         this.syncFileCache = this.syncFileCache || {};
-        this.syncFileCache[item.data.provider] = this.syncFileCache[item.data.provider] || {};
+        this.syncFileCache[item.data.provider] = this.syncFileCache[item.data.provider] || [];
 
         var files = this.getActiveFiles().filter(function(f) {return f.isSync;});
         if (files.length > 0) {
@@ -2109,7 +2109,7 @@ tbOptions = {
         clickable : '#treeGrid',
         addRemoveLinks: false,
         previewTemplate: '<div></div>',
-        parallelUploads: 10,
+        parallelUploads: 5,
         acceptDirectories: false,
         createImageThumbnails: false,
         fallback: function(){},

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -43,6 +43,8 @@ var STATE_MAP = {
     }
 };
 
+var SYNC_UPLOAD_ADDONS = ['github', 'dataverse'];
+
 
 var OPERATIONS = {
     RENAME: {
@@ -612,14 +614,16 @@ function _fangornAddedFile(treebeard, file) {
         return;
     }
 
-    if (item.data.provider === 'github') {
-        this.githubFileCache = this.githubFileCache || [];
-        var files = this.getActiveFiles().filter(function(f) {return f.isGithub;});
+    if (SYNC_UPLOAD_ADDONS.indexof(item.data.provider) !== -1) {
+        this.syncFileCache = this.syncFileCache || {};
+        this.syncFileCache[item.data.provider] = this.syncFileCache[item.data.provider] || {};
+
+        var files = this.getActiveFiles().filter(function(f) {return f.isSync;});
         if (files.length > 0) {
-            this.githubFileCache.push(file);
+            this.syncFileCache[item.data.provider].push(file);
             this.files.splice(this.files.indexOf(files), 1);
         }
-        file.isGithub = true;
+        file.isSync = true;
     }
 
     var configOption = resolveconfigOption.call(treebeard, item, 'uploadAdd', [file, item]);
@@ -698,9 +702,9 @@ function _fangornComplete(treebeard, file) {
     resolveconfigOption.call(treebeard, item, 'onUploadComplete', [item]);
     orderFolder.call(treebeard, item);
 
-    if (file.isGithub) {
-        if (this.githubFileCache.length > 0) {
-            this.processFile(this.githubFileCache.pop());
+    if (file.isSync) {
+        if (this.syncFileCache[item.data.provider].length > 0) {
+            this.processFile(this.syncFileCache[item.data.provider].pop());
         }
     }
 }


### PR DESCRIPTION
  * No longer redraw upon every chunk sent, saves a crap load of CPU
  * No longer attempt to generate thumbnails for all file uploads
  * Enable parallel uploads for everything but Github
  * Make the upload progress animated
  * Handle rejected upload requests
  * Bump dropzones max file size, fangorn will handle that

Closes #3325