### PR TITLE
[hotfix] Ensure only users with read permissions see project settings tab

### DIFF
--- a/website/templates/project/project_header.mako
+++ b/website/templates/project/project_header.mako
@@ -63,7 +63,7 @@
                             <li><a href="${node['url']}contributors/">Sharing</a></li>
                         % endif
 
-                        % if not node['is_registration'] or (node['is_registration'] and 'admin' in user['permissions']):
+                        % if user['has_read_permissions'] and not node['is_registration'] or (node['is_registration'] and 'admin' in user['permissions']):
                             <li><a href="${node['url']}settings/">Settings</a></li>
                         % endif
 


### PR DESCRIPTION
Purpose
----------
Fix #3380 --  the settings tab of a project  was viewable to anyone, regardless of permissions. 

Changes
------------
Ensure only users with at least read permissions (contributors and read-only admins) can
see the project settings tab.