### PR TITLE
[feature-fix] Alternative solution to database caching issues in DRF

### DIFF
--- a/api/base/api_globals.py
+++ b/api/base/api_globals.py
@@ -5,3 +5,6 @@ Made available in a separate file so as to be importable by Flask code, before (
 import threading
 
 api_globals = threading.local()
+
+# Store a reference to the current Django request. Threads may be reused; empty after request.
+api_globals.request = None

--- a/api/base/api_globals.py
+++ b/api/base/api_globals.py
@@ -1,0 +1,7 @@
+"""Global variables related to Django requests
+
+Made available in a separate file so as to be importable by Flask code, before (or in the absence of) Django
+"""
+import threading
+
+api_globals = threading.local()

--- a/api/base/middleware.py
+++ b/api/base/middleware.py
@@ -58,8 +58,15 @@ class TokuTransactionsMiddleware(object):
 class DjangoGlobalMiddleware(object):
     """
     Store request object on a thread-local variable for use in database caching mechanism.
-
-    Thread-locals should be auto-cleared when request is done (?), in which case no need to clean up separately.
     """
     def process_request(self, request):
         api_globals.request = request
+
+    def process_exception(self, request, exception):
+        sentry_exception_handler(request=request)
+        api_globals.request = None
+        return None
+
+    def process_response(self, request, response):
+        api_globals.request = None
+        return response

--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -150,7 +150,7 @@ SWAGGER_SETTINGS = {
         <h3>Filtering</h3>
         <p>Collections can be filtered by adding a query parameter in the form:</p>
         <pre>filter[&lt;fieldname&gt;]=&lt;matching information&gt;</pre>
-        <p>For example, if you were trying to find <a href="http://en.wikipedia.org/wiki/Lise_Meitner">Lise Metiner</a>:</p>
+        <p>For example, if you were trying to find <a href="http://en.wikipedia.org/wiki/Lise_Meitner">Lise Meitner</a>:</p>
         <pre>/users?filter[fullname]=meitn</pre>
         <p>You can filter on multiple fields, or the same field in different ways, by &-ing the query parameters together.</p>
         <pre>/users?filter[fullname]=lise&filter[family_name]=mei</pre>

--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -79,7 +79,7 @@ MIDDLEWARE_CLASSES = (
     # Needs to go before CommonMiddleware, so that transactions are always started,
     # even in the event of a redirect. CommonMiddleware may cause other middlewares'
     # process_request to be skipped, e.g. when a trailing slash is omitted
-    'api.base.middleware.FlaskRequestMiddleware',
+    'api.base.middleware.DjangoGlobalMiddleware',
     'api.base.middleware.TokuTransactionsMiddleware',
 
     # 'django.contrib.sessions.middleware.SessionMiddleware',

--- a/framework/mongo/__init__.py
+++ b/framework/mongo/__init__.py
@@ -1,9 +1,40 @@
 # -*- coding: utf-8 -*-
 
-from modularodm import FlaskStoredObject as StoredObject
+from flask import request
+from modularodm.storedobject import StoredObject as GenericStoredObject
+from modularodm.ext.concurrency import with_proxies, proxied_members
 
 from bson import ObjectId
 from .handlers import client, database, set_up_storage
+
+
+from api.base.api_globals import api_globals
+
+
+class DummyRequest(object):
+    pass
+dummy_request = DummyRequest()
+
+
+def get_cache_key():
+    """
+    Fetch a request key from either a Django or Flask request. Fall back on a process-global dummy object
+    if we are not in either type of request
+    """
+    # TODO: This is ugly use of exceptions; is there a better way to track whether in a given type of request?
+    try:
+        return request._get_current_object()
+    except RuntimeError:  # Not in a flask request context
+        try:
+            return api_globals.request
+        except AttributeError:  # Not in a Django request # TODO: Edge case- are threads re-used across requests?
+            return dummy_request
+
+
+@with_proxies(proxied_members, get_cache_key)
+class StoredObject(GenericStoredObject):
+    pass
+
 
 __all__ = [
     'StoredObject',

--- a/framework/mongo/__init__.py
+++ b/framework/mongo/__init__.py
@@ -25,9 +25,9 @@ def get_cache_key():
     try:
         return request._get_current_object()
     except RuntimeError:  # Not in a flask request context
-        try:
+        if hasattr(api_globals, 'request') and api_globals.request is not None:
             return api_globals.request
-        except AttributeError:  # Not in a Django request # TODO: Edge case- are threads re-used across requests?
+        else:  # Not in a Django request
             return dummy_request
 
 

--- a/framework/mongo/__init__.py
+++ b/framework/mongo/__init__.py
@@ -25,7 +25,7 @@ def get_cache_key():
     try:
         return request._get_current_object()
     except RuntimeError:  # Not in a flask request context
-        if hasattr(api_globals, 'request') and api_globals.request is not None:
+        if getattr(api_globals, 'request', None) is not None:
             return api_globals.request
         else:  # Not in a Django request
             return dummy_request

--- a/website/addons/box/model.py
+++ b/website/addons/box/model.py
@@ -6,7 +6,8 @@ from datetime import datetime
 import furl
 import pymongo
 import requests
-from modularodm import fields, StoredObject
+from modularodm import fields
+from framework.mongo import StoredObject
 from box import CredentialsV2, refresh_v2_token, BoxClientException
 
 from framework.auth import Auth


### PR DESCRIPTION
## Purpose
Our original attempt to address caching issues created several unintended side effects (see #3376). This is because simply pushing a flask request context is a very leaky abstraction.

This is an alternate attempt to resolve #3058 / #3303 in a way that does not involve Flask. It is a proposal, and may or may not be merged. The code is a bit messy and could stand to be refined, but it does pass the test case defined in #3058 without creating as many of the side effects seen in #3376.

## Summary of changes
- Replace the definition of `framework.mongo.StoredObject` (née `FlaskStoredObject`) with a new model whose key function is more framework-agnostic. Involves duplicating code from `modularodm.ext.odmflask` with minor modifications

- Removes FlaskRequestMiddleware

- Adds `DjangoGlobalMiddleware` and a new module, `api.base.api_globals` that exposes the current request using thread-local variables.

- Changes the Box addon to import the correct StoredObject definition, consistent with other OSF modules. Otherwise it may exhibit different caching behavior.

## TODO
- [x] QA on @pattisdr views that broke using the old middleware
- [x] Discussion with @lyndsysimon on best alternative course going forward
- [x] Fix failing test (`api_tests.nodes.test_views.py:test_returns_addon_folders`). It's not very clear why that test is failing. If a thread is reused across requests, then `api_globals.request` could start keying the wrong item in cache... needs review. Only breaks on this branch; FlaskRequestMiddleware or bare develop had no problems. (Solution: Django was indeed reusing threads across requests. The current version will work so long as requests are sequential, but not interwoven, within the same thread)
- [x] Discuss candidate fix with @sloria 