### PR TITLE
[Feature Fix] Fix selection in project organizer blinks when the number of row is larger than 50

### DIFF
--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -254,11 +254,14 @@ function _poResolveRows(item) {
     }
     if(this.isMultiselected(item.id)){
         item.css = 'fangorn-selected';
+    } else {
+        item.css = '';
     }
+
     if (draggable) {
         css = 'po-draggable';
     }
-    item.css = '';
+
     default_columns = [{
         data : 'name',  // Data field name
         folderIcons : true,


### PR DESCRIPTION
### Purpose
When Treebear need to update the content in scroll bar. The selected item would flash. In this PR, I found the reason is that the selected item with class `fangorn-selected` was cleared  even though it doesn't need. Although `fangorn-selected` would be added again for selected item, it creates a time slot without `fangorn-selected`. Therefore, it leads to the blink in appearance.

Resolved #3365
And also during debugging process, another bug was found. When searching, it will add unnecessary margin space.

### Changes
Clear `item.css` only when item is not selected.

### Side Effects
None.