### PR TITLE
[Feature Fix] Fix search result has unnecessary margin 

### DIFF
--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -1399,7 +1399,8 @@ var tbOptions = {
     resolveRefreshIcon : function () {
         return m('i.fa.fa-refresh.fa-spin');
     },
-    toolbarComponent : POToolbar
+    toolbarComponent : POToolbar,
+    naturalScrollLimit : 0
 };
 
 /**


### PR DESCRIPTION
### Purpose
Set the naturalScrollLimit as 0 and then no margin will be added
Resolved #3393 

### Change
As Caner introduced, in `fangorn.js`, it also sets `naturalScrollLimit` to 0 with the same purpose. The reason behind it is that in Treebear, the default value of  `naturalScrollLimit` is 50. It means if items to show is below this number (50), `onscroll` in Treebear should not be run.

Before searching, the number of items is larger than 50. But after searching, the number of rows decrease and mostly will be less than 50. In that case, it will not run `onscroll`  in Treebear. That's the reason why it leaves blank space behind. 

### Side Effect
None.