### PR TITLE
[Feature Fix] Fix Dragging project or component in Dashboard to ineligible row causes highlight to persist

### DIFF
--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -1369,7 +1369,7 @@ var tbOptions = {
         rowDiv.first().trigger('click');
 
         $('.gridWrapper').on('mouseout', function () {
-            rowDiv.removeClass('po-hover');
+            tb.select('.tb-row').removeClass('po-hover');
         });
     },
     createcheck : function (item, parent) {


### PR DESCRIPTION
### Purpose
The highlight created by dragging will be removed. 

Resolve #3191 

### Changes
In old code, it stores the result of `tb.select('.tb-row')`. However, at the beginning, it only has one row. What we need in mouseout event is to deal with all the rows after loading completely. So I replace the variable `rowDiv` with the selector. Therefore it will select all the rows again after they load completely.

### Side effects
None.

