### PR TITLE
[feature] Remove unused User.aka field

### DIFF
--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -300,10 +300,6 @@ class User(GuidStoredObject, AddonModelMixin):
     #    ...
     # }
 
-    # nicknames, or other names by which this used is known
-    # TODO: remove - unused
-    aka = fields.StringField(list=True)
-
     # the date this user was registered
     # TODO: consider removal - this can be derived from date_registered
     date_registered = fields.DateTimeField(auto_now_add=dt.datetime.utcnow,
@@ -1143,8 +1139,6 @@ class User(GuidStoredObject, AddonModelMixin):
         for system_tag in user.system_tags:
             if system_tag not in self.system_tags:
                 self.system_tags.append(system_tag)
-
-        [self.aka.append(each) for each in user.aka if each not in self.aka]
 
         self.is_claimed = self.is_claimed or user.is_claimed
         self.is_invited = self.is_invited or user.is_invited

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -146,9 +146,6 @@ class TestUserMerging(base.OsfTestCase):
         self.user.system_tags = ['shared', 'user']
         self.unconfirmed.system_tags = ['shared', 'unconfirmed']
 
-        self.user.aka = ['shared', 'user']
-        self.unconfirmed.aka = ['shared', 'unconfirmed']
-
     def _add_unregistered_user(self):
         self.unregistered = factories.UnregUserFactory()
 
@@ -234,9 +231,6 @@ class TestUserMerging(base.OsfTestCase):
         today = datetime.datetime.now()
         yesterday = today - datetime.timedelta(days=1)
 
-        self.user.aka = ['foo']
-        other_user.aka = ['bar']
-
         self.user.api_keys = [factories.ApiKeyFactory()]
         other_user.api_keys = [factories.ApiKeyFactory()]
 
@@ -314,7 +308,6 @@ class TestUserMerging(base.OsfTestCase):
         ]
 
         calculated_fields = {
-            'aka': ['foo', 'bar'],
             'api_keys': [
                 self.user.api_keys[0]._id,
                 other_user.api_keys[0]._id,
@@ -412,7 +405,6 @@ class TestUserMerging(base.OsfTestCase):
         # TODO: test mailing_lists
 
         assert_equal(self.user.system_tags, ['shared', 'user', 'unconfirmed'])
-        assert_equal(self.user.aka, ['shared', 'user', 'unconfirmed'])
 
         # TODO: test emails
         # TODO: test watched


### PR DESCRIPTION
## Purpose:
Code clean up.

## Changes:
- Remove unused `User.aka` field.
- Update tests accordingly.

## Side Effects:
N/A