### PR TITLE
Apply regex fix for search params

### DIFF
--- a/website/static/js/search.js
+++ b/website/static/js/search.js
@@ -218,6 +218,11 @@ var ViewModel = function(params) {
 
     self.search = function(noPush, validate) {
 
+        // Check for NOTs and ANDs put spaces before the ones that don't have spaces
+        var query = self.query().replace(/\s?NOT tags:/g, ' NOT tags:');
+        query = query.replace(/\s?AND tags:/g, ' NOT tags:');
+        self.query(query);
+
         var jsonData = {'query': self.fullQuery(), 'from': self.currentIndex(), 'size': self.resultsPerPage()};
         var url = self.queryUrl + self.category().url();
 

--- a/website/static/js/search.js
+++ b/website/static/js/search.js
@@ -220,7 +220,7 @@ var ViewModel = function(params) {
 
         // Check for NOTs and ANDs put spaces before the ones that don't have spaces
         var query = self.query().replace(/\s?NOT tags:/g, ' NOT tags:');
-        query = query.replace(/\s?AND tags:/g, ' NOT tags:');
+        query = query.replace(/\s?AND tags:/g, ' AND tags:');
         self.query(query);
 
         var jsonData = {'query': self.fullQuery(), 'from': self.currentIndex(), 'size': self.resultsPerPage()};


### PR DESCRIPTION
Fix for #2481

Searches for and replaces ```/\s?NOT tags:/``` with correct one:
```/\sNOT tags:/```, also does this for AND. This should put the correct space between
previous symbols and the keywords NOT and AND.

If there is already a tag in a ```tags:("")``` structure that matches the tag clicked on, it shouldn't add it, but it will correct the spacing issue.

## Repercussions
It will put spaces in front of NOT tags: and AND tags:, I believe these are specific enough not to cause issues. That being said it would be possible to mess up the search parameters, but then a normal search without this fix would possibly fail too.