### PR TITLE
[feature] Add Twitter redirect endpoint

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1431,7 +1431,7 @@ class TestUserProfile(OsfTestCase):
             web_url_for('redirect_to_twitter', uid=non_existent_uid),
             expect_errors=True
         )
-        assert_equal(res.status_code, 400)
+        assert_equal(res.status_code, 404)
         assert_true(expected_error in res.body)
 
     def test_twitter_redirect_for_user_without_handle_returns_HTTPBad_request(self):

--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -798,8 +798,8 @@ def redirect_to_twitter(uid):
     if user:
         twitter_handle = user.social.get('twitter', None)
     else:
-        raise HTTPError(http.BAD_REQUEST, data={
-            'message_short': 'Invalid Request',
+        raise HTTPError(http.NOT_FOUND, data={
+            'message_short': 'User Not Found',
             'message_long': 'There is no active user associated with user id: {0}.'.format(uid)
         })
 


### PR DESCRIPTION
## Purpose:
Allow individuals to get automatically redirected to a user's Twitter account if one is associated with the respective user.

## Changes:
- Add a new endpoint `/@<uid>/` that will automatically redirect to the Twitter account associated with `uid` if the account **is active** and **has a Twitter handle** associated with it. 
- If either of these conditionals is not met, the user is prompted with a concise error message.
![screen shot 2015-07-01 at 2 01 46 pm](https://cloud.githubusercontent.com/assets/2614670/8461322/d0345c9e-1ff9-11e5-988b-e08be8a33e03.png)
![screen shot 2015-07-01 at 2 02 08 pm](https://cloud.githubusercontent.com/assets/2614670/8461323/d03b9f4a-1ff9-11e5-8827-a6c88ea04404.png)


## Side Effects:
A new route was added with a respective view.