### PR TITLE
Feature/disable blank submit

### DIFF
--- a/website/static/js/accountSettings.js
+++ b/website/static/js/accountSettings.js
@@ -169,7 +169,7 @@ var UserProfileViewModel = oop.extend(ChangeMessageMixin, {
 
         this.enableSubmit = ko.pureComputed(function ()
         {
-            return this.emailInput() !== '';
+            return this.emailInput().trim() !== '';
         }, this);
 
     },

--- a/website/static/js/accountSettings.js
+++ b/website/static/js/accountSettings.js
@@ -165,13 +165,19 @@ var UserProfileViewModel = oop.extend(ChangeMessageMixin, {
         this.super.constructor.call(this);
         this.client = new UserProfileClient();
         this.profile = ko.observable(new UserProfile());
-        this.emailInput = ko.observable();
+        this.emailInput = ko.observable('');
+
+        this.enableSubmit = ko.pureComputed(function ()
+        {
+            return this.emailInput() !== '';
+        }, this);
 
     },
     init: function () {
         this.client.fetch().done(
             function(profile) { this.profile(profile); }.bind(this)
         );
+        console.log(this.enableSubmit());
     },
     addEmail: function () {
         this.changeMessage('', 'text-info');

--- a/website/templates/profile/account.mako
+++ b/website/templates/profile/account.mako
@@ -69,9 +69,9 @@
                                     <td colspan="2">
                                         <form data-bind="submit: addEmail">
                                             <div class="form-group">
-                                              <input placeholder="Email address" data-bind="value: emailInput" class="form-control">
+                                              <input placeholder="Email address" data-bind="value: emailInput, valueUpdate: 'input'" class="form-control">
                                             </div>
-                                            <input type="submit" value="Add Email" class="btn btn-default">
+                                            <input type="submit" value="Add Email" class="btn btn-default" data-bind="enable: enableSubmit">
                                         </form>
                                         <div class="help-block">
                                             <p data-bind="html: message, attr: {class: messageClass}"></p>


### PR DESCRIPTION
<b>Purpose</b>
Fix the problem that add unconfirmation email submit button is always enable even if there is no input. Closes https://github.com/CenterForOpenScience/osf.io/issues/3413.

<b>Change</b>
Before:
![image](https://cloud.githubusercontent.com/assets/4974056/8464100/bf352946-200d-11e5-91ee-fe1d2ea0d14a.png)
After:
![screen shot 2015-07-01 at 4 25 19 pm](https://cloud.githubusercontent.com/assets/4974056/8464111/cfe4d1e2-200d-11e5-9ab9-642df46d4805.png)
