### PR TITLE
[hotfix] Allow full path for LinkedIn profile 

### DIFF
--- a/website/static/js/filepage/revisions.js
+++ b/website/static/js/filepage/revisions.js
@@ -28,6 +28,7 @@ var FileRevisionsTable = {
         self.file = file;
         self.canEdit = canEdit;
         self.enableEditing = enableEditing;
+        self.baseUrl = (window.location.href).split('?')[0];
 
         model.hasDate = self.file.provider !== 'dataverse';
 
@@ -102,7 +103,7 @@ var FileRevisionsTable = {
             return m('tr' + (isSelected ? '.active' : ''), [
                 m('td',  isSelected ?
                   revision.displayVersion :
-                  m('a', {href: revision.osfViewUrl}, revision.displayVersion)
+                  m('a', {href: parseInt(revision.displayVersion) === model.revisions.length ? self.baseUrl : revision.osfViewUrl}, revision.displayVersion)
                 ),
                 model.hasDate ? m('td', revision.displayDate) : false,
                 model.hasUser ?

--- a/website/static/js/profile.js
+++ b/website/static/js/profile.js
@@ -446,7 +446,6 @@ var extendLink = function(obs, $parent, label, baseUrl) {
         // Prevent click from submitting form
         event && event.preventDefault();
         if (obs()) {
-            console.log(baseUrl + ' ' + obs());
             return baseUrl ? baseUrl + obs() : obs();
         }
         return '';

--- a/website/static/js/profile.js
+++ b/website/static/js/profile.js
@@ -17,7 +17,7 @@ var socialRules = {
     researcherId: /researcherid\.com\/rid\/([-\w]+)/i,
     scholar: /scholar\.google\.com\/citations\?user=(\w+)/i,
     twitter: /twitter\.com\/(\w+)/i,
-    linkedIn: /linkedin\.com\/profile\/view\?id=(\d+)/i,
+    linkedIn: /linkedin\.com\/(\d+)/i,
     impactStory: /impactstory\.org\/([\w\.-]+)/i,
     github: /github\.com\/(\w+)/i
 };
@@ -499,7 +499,7 @@ var SocialViewModel = function(urls, modes) {
     );
     self.linkedIn = extendLink(
         ko.observable().extend({trimmed: true, cleanup: cleanByRule(socialRules.linkedIn)}),
-        self, 'linkedIn', 'https://www.linkedin.com/profile/view?id='
+        self, 'linkedIn', 'https://www.linkedin.com/'
     );
     self.impactStory = extendLink(
         ko.observable().extend({trimmed: true, cleanup: cleanByRule(socialRules.impactStory)}),

--- a/website/static/js/profile.js
+++ b/website/static/js/profile.js
@@ -17,7 +17,7 @@ var socialRules = {
     researcherId: /researcherid\.com\/rid\/([-\w]+)/i,
     scholar: /scholar\.google\.com\/citations\?user=(\w+)/i,
     twitter: /twitter\.com\/(\w+)/i,
-    linkedIn: /linkedin\.com\/(\d+)/i,
+    linkedIn: /.*\/?(in\/.*|profile\/.*)/i,
     impactStory: /impactstory\.org\/([\w\.-]+)/i,
     github: /github\.com\/(\w+)/i
 };
@@ -446,6 +446,7 @@ var extendLink = function(obs, $parent, label, baseUrl) {
         // Prevent click from submitting form
         event && event.preventDefault();
         if (obs()) {
+            console.log(baseUrl + ' ' + obs());
             return baseUrl ? baseUrl + obs() : obs();
         }
         return '';

--- a/website/templates/include/profile/social.mako
+++ b/website/templates/include/profile/social.mako
@@ -58,8 +58,8 @@
             <div class="form-group">
                 <label>LinkedIn</label>
                 <div class="input-group">
-                <span class="input-group-addon">https://www.linkedin.com/profile/view?id=</span>
-                <input class="form-control" data-bind="value: linkedIn" placeholder="profileID"/>
+                <span class="input-group-addon">https://www.linkedin.com/</span>
+                <input class="form-control" data-bind="value: linkedIn" placeholder="path to UserID or profileID"/>
                 </div>
             </div>
 

--- a/website/templates/include/profile/social.mako
+++ b/website/templates/include/profile/social.mako
@@ -59,7 +59,7 @@
                 <label>LinkedIn</label>
                 <div class="input-group">
                 <span class="input-group-addon">https://www.linkedin.com/</span>
-                <input class="form-control" data-bind="value: linkedIn" placeholder="path to UserID or profileID"/>
+                <input class="form-control" data-bind="value: linkedIn" placeholder="in/userID or profile/view?id=profileID"/>
                 </div>
             </div>
 


### PR DESCRIPTION
## Purpose:
Allow users to link their LinkedIn profile by either their LinkedIn UserID or ProfileID.

## Changes:
- Template and JS no longer assume the use of LinkedIn ProfileID.
- Allow user to add path to either UserID or ProfileID

## Side Effects:
None.

Closes-issue: #3401