### PR TITLE
[Fix] projects list not appearing in create project onboarder template

### DIFF
--- a/website/static/js/onboarder.js
+++ b/website/static/js/onboarder.js
@@ -680,7 +680,7 @@ function ProjectCreateViewModel(response) {
         self.isOpen(!self.isOpen());
         self.focus(self.isOpen());
     };
-    self.nodes = response.nodes;
+    self.nodes = response.data;
 }
 
 ko.components.register('osf-ob-create', {


### PR DESCRIPTION
## Purpose

Fixes an issue caught before QA where the Create project box tempalte list does not populate the existing user nodes.
Bug: 
![screen shot 2015-07-02 at 2 54 56 pm](https://cloud.githubusercontent.com/assets/1314003/8485750/1fd49db6-20ce-11e5-988f-454274ca0ad9.png)

## Changes
The call to the existing nodes was not properly named after refactoring of this section 