### PR TITLE
[WIP] Feature/api Query parameter include requests

### DIFF
--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -79,7 +79,7 @@ MIDDLEWARE_CLASSES = (
     # Needs to go before CommonMiddleware, so that transactions are always started,
     # even in the event of a redirect. CommonMiddleware may cause other middlewares'
     # process_request to be skipped, e.g. when a trailing slash is omitted
-    'api.base.middleware.FlaskRequestMiddleware',
+    #'api.base.middleware.FlaskRequestMiddleware',
     'api.base.middleware.TokuTransactionsMiddleware',
 
     # 'django.contrib.sessions.middleware.SessionMiddleware',

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -23,6 +23,7 @@ class NodeSerializer(JSONAPISerializer):
     tags = ser.SerializerMethodField(help_text='A dictionary that contains two lists of tags: '
                                                'user and system. Any tag that a user will define in the UI will be '
                                                'a user tag')
+    include = ser.CharField(required=False)
 
     links = LinksField({
         'html': 'get_absolute_url',

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -25,6 +25,7 @@ class NodeMixin(object):
         obj = get_object_or_404(Node, self.kwargs[self.node_lookup_url_kwarg])
         # May raise a permission denied
         self.check_object_permissions(self.request, obj)
+        obj.include = self.request.query_params['include']
         return obj
 
 


### PR DESCRIPTION
## Purpose
Allow for inclusion of additional query parameters in API requests.  (http://jsonapi.org/format/#fetching-includes)

https://github.com/CenterForOpenScience/osf.io/issues/3072

## Changes
Added a temporary way to display the query parameter on the node serializer for testing purposes.

## Todo
- [ ] Process information
 - [ ] Create way to process query parameters in requests
 - [ ] Create way to connect parameters to database
 - [ ] Edit serializers to display information
 - [ ] Make way to allow for multiple query parameters
 - [ ] Make way to allow for processing query relationships
- [ ] Restrict requests
 - [ ] Restrict types of query parameters
 - [ ] Add authentication requirements
 - [ ] Add security protections
- [ ] Testing
 - [ ] Test proper and false requests
 - [ ] Security and authentication testing