### PR TITLE
[Style Guide] Detele unconsistent focus border and use bootstrap default style

### DIFF
--- a/website/static/css/projectorganizer.css
+++ b/website/static/css/projectorganizer.css
@@ -294,12 +294,6 @@ height: 32px ;
     background-color: #fff;
 }
 
-.typeahead:focus {
-    -webkit-box-shadow: rgba(102, 175, 232, 0.576471) 0px 0px 7.668470859527588px 0px;
-    -moz-box-shadow: rgba(102, 175, 232, 0.576471) 0px 0px 7.668470859527588px 0px;
-    box-shadow: rgba(102, 175, 232, 0.576471) 0px 0px 7.668470859527588px 0px;
-}
-
 .tt-query {
     -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
     -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);

--- a/website/static/css/typeahead.css
+++ b/website/static/css/typeahead.css
@@ -39,10 +39,6 @@ input.typeahead.tt-input {
     background-color: #fff;
 }
 
-.typeahead:focus {
-    border: 2px solid #0097cf;
-}
-
 .tt-query {
     -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
     -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);


### PR DESCRIPTION
### Purpose
Unify the focus border on dashboard.

Resolved [bug](https://trello.com/c/kBV30AgO/82-dashboard-go-to-my-project-and-select-a-project-search-boxes-do-not-match-osf-style) found in trello
### Change
Delete css for creating focus border on typehead. Instead, Bootstrap focus border will be applied.

Note: Find some duplicated css code and need to be cleaned up (`projectorganizer.css` and `typeahead.css`)

#### Before change:
![inputboxhighligh](https://cloud.githubusercontent.com/assets/5420789/8524168/99fbd892-23c7-11e5-91be-a1e9cbaf87d4.gif)

#### After change:
![afterchange](https://cloud.githubusercontent.com/assets/5420789/8524190/ad9e92cc-23c7-11e5-82a7-92002bca7015.gif)

### Side Effect
None.