### PR TITLE
[Hot Fix] Add disabled class to disable pointer-event on page change button

### DIFF
--- a/website/static/css/pages/search-page.css
+++ b/website/static/css/pages/search-page.css
@@ -163,8 +163,6 @@ div.search-result  {
     overflow-x: hidden;
 }
 
-
-
 .search-results.search-result h5 small{
     color: white;
     font-size: 10pt;
@@ -176,10 +174,15 @@ div.search-result  {
 
 }
 /* Search Contributors */
-
 .search-contributor-result td {
     padding-right: 10px;
 }
 .search-contributor-links {
     padding-top: 10px;
+}
+
+/* Disable pointer events in page changing */
+.disabled {
+    cursor: default !important;
+    pointer-events: none;
 }


### PR DESCRIPTION
### Purpose
In staging, when clicking disabled page change button, it will still change the page.

Resolve the bug on  [trello](https://trello.com/c/iTYLyqOF/117-page-count-for-search-results-increase-decrease-beyond-the-total-results-available).
### Changes
Add the disabled class in deleted `site.css` to `search.css`.

### Side Effect
None. It is only applied to search page.