### PR TITLE
[feature fix] Reverse direction of Twitter redirect

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1417,11 +1417,10 @@ class TestUserProfile(OsfTestCase):
     def test_twitter_redirect_success(self):
         self.user.social['twitter'] = fake.last_name()
         self.user.save()
-        expected_redirect = web_url_for('profile_view_id', uid=self.user._id)
 
         res = self.app.get(web_url_for('redirect_to_twitter', twitter_handle=self.user.social['twitter']))
         assert_equals(res.status_code, http.FOUND)
-        assert_in(expected_redirect, res.location)
+        assert_in(self.user.url, res.location)
 
     def test_twitter_redirect_is_case_insensitive(self):
         self.user.social['twitter'] = fake.last_name()
@@ -1459,8 +1458,8 @@ class TestUserProfile(OsfTestCase):
         )
         assert_equal(res.status_code, http.MULTIPLE_CHOICES)
         assert_true(expected_error in res.body)
-        assert_true(web_url_for('profile_view_id', uid=self.user._id) in res.body)
-        assert_true(web_url_for('profile_view_id', uid=user2._id) in res.body)
+        assert_true(self.user.url in res.body)
+        assert_true(user2.url in res.body)
 
 
 class TestUserAccount(OsfTestCase):

--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -806,16 +806,11 @@ def redirect_to_twitter(twitter_handle):
                        'Twitter handle: <strong>{0}</strong>. <br /> Please ' \
                        'select from the accounts below. <br /><ul>'.format(twitter_handle)
         for user in users:
-            message_long += '<li><a href="{0}">{1}</a></li>'.format(web_url_for(
-                'profile_view_id',
-                uid=user._id),
-                user.fullname
-            )
+            message_long += '<li><a href="{0}">{1}</a></li>'.format(user.url, user.fullname)
         message_long += '</ul>'
         raise HTTPError(http.MULTIPLE_CHOICES, data={
             'message_short': 'Multiple Users Found',
             'message_long': message_long
         })
 
-    redirect_url = web_url_for('profile_view_id', uid=user._id)
-    return redirect(redirect_url)
+    return redirect(user.url)

--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -8,7 +8,7 @@ import os
 from dateutil.parser import parse as parse_date
 
 from flask import request
-from modularodm.exceptions import ValidationError, NoResultsFound
+from modularodm.exceptions import ValidationError, NoResultsFound, MultipleResultsFound
 from modularodm import Q
 
 from framework import sentry
@@ -786,31 +786,36 @@ def request_deactivation(auth):
     return {'message': 'Sent account deactivation request'}
 
 
-def redirect_to_twitter(uid):
-    """Redirect GET requests for /@uid/ to respective the Twitter account if a User
-    exists and has a Twitter handle associated with the account.
+def redirect_to_twitter(twitter_handle):
+    """Redirect GET requests for /@TwitterHandle/ to respective the OSF user
+    account if it associated with an active account
 
     :param uid: uid for requested User
     :return: Redirect to User's Twitter account page
     """
-    user = User.load(uid)
-
-    if user:
-        twitter_handle = user.social.get('twitter', None)
-    else:
+    try:
+        user = User.find_one(Q('social.twitter', 'iexact', twitter_handle))
+    except NoResultsFound:
         raise HTTPError(http.NOT_FOUND, data={
             'message_short': 'User Not Found',
-            'message_long': 'There is no active user associated with user id: {0}.'.format(uid)
+            'message_long': 'There is no active user associated with the Twitter handle: {0}.'.format(twitter_handle)
+        })
+    except MultipleResultsFound:
+        users = User.find(Q('social.twitter', 'iexact', twitter_handle))
+        message_long = 'There are multiple OSF accounts associated with the ' \
+                       'Twitter handle: <strong>{0}</strong>. <br /> Please ' \
+                       'select from the accounts below. <br /><ul>'.format(twitter_handle)
+        for user in users:
+            message_long += '<li><a href="{0}">{1}</a></li>'.format(web_url_for(
+                'profile_view_id',
+                uid=user._id),
+                user.fullname
+            )
+        message_long += '</ul>'
+        raise HTTPError(http.MULTIPLE_CHOICES, data={
+            'message_short': 'Multiple Users Found',
+            'message_long': message_long
         })
 
-    if twitter_handle:
-        # TODO(hrybacki): Verify Twitter handle is for a real account.
-        # Requires authenticated access to Twitter API
-        redirect_url = "https://twitter.com/{0}".format(twitter_handle)
-    else:
-        raise HTTPError(http.BAD_REQUEST, data={
-            'message_short': 'Invalid Request',
-            'message_long': '{0} does not have a Twitter handle associated with their account.'.format(user.fullname)
-        })
-
+    redirect_url = web_url_for('profile_view_id', uid=user._id)
     return redirect(redirect_url)

--- a/website/routes.py
+++ b/website/routes.py
@@ -531,7 +531,7 @@ def make_url_map(app):
         ),
 
         Rule(
-            '/@<uid>/',
+            '/@<twitter_handle>/',
             'get',
             profile_views.redirect_to_twitter,
             OsfWebRenderer('error.mako', render_mako_string)


### PR DESCRIPTION
## Purpose:
Reverse the direction of the Twitter redirect end point.

## Changes:
Instead of resolving a Twitter handle from a User's uid, we now resolve a User's uid, and respective profile url, from a Twitter handle.

## Side Effects:
None.

## Notes:
- If multiple OSF user accounts are associated with a Twitter handle, the user is redirected to a page where they can select the account whose profile they wish to view.