### PR TITLE
fix the import dataverse token doesn't enable addon_user_settings

### DIFF
--- a/website/addons/dataverse/views/config.py
+++ b/website/addons/dataverse/views/config.py
@@ -60,10 +60,11 @@ def dataverse_add_user_account(auth, **kwargs):
         user.external_accounts.append(provider.account)
         user.save()
 
-    user_settings = auth.user.get_addon('dataverse')
+    user_settings = user.get_addon('dataverse')
     if not user_settings:
-        auth.user.add_addon(addon_name='dataverse', auth=auth)
-        auth.user.save()
+        user.add_addon(addon_name='dataverse', auth=auth)
+        user.save()
+
     return {}
 
 

--- a/website/addons/dataverse/views/config.py
+++ b/website/addons/dataverse/views/config.py
@@ -63,6 +63,7 @@ def dataverse_add_user_account(auth, **kwargs):
     user_settings = auth.user.get_addon('dataverse')
     if not user_settings:
         auth.user.add_addon(addon_name='dataverse', auth=auth)
+        auth.user.save()
     return {}
 
 

--- a/website/addons/dataverse/views/config.py
+++ b/website/addons/dataverse/views/config.py
@@ -60,6 +60,9 @@ def dataverse_add_user_account(auth, **kwargs):
         user.external_accounts.append(provider.account)
         user.save()
 
+    user_settings = auth.user.get_addon('dataverse')
+    if not user_settings:
+        auth.user.add_addon(addon_name='dataverse', auth=auth)
     return {}
 
 


### PR DESCRIPTION
<b>Purpose</b>
Fix dataverse import token error. Closes https://trello.com/c/x1nwc3bi/32-dataverse-confirmation-modal-ok-does-no-action. Replace https://github.com/CenterForOpenScience/osf.io/pull/3448.