### PR TITLE
Fix file uploading issues

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -115,7 +115,7 @@ function findByTempID(parent, tmpID) {
 
 function cancelUploads (row) {
     var tb = this;
-    var filesArr = tb.dropzone.getActiveFiles();
+    var filesArr = tb.dropzone.getActiveFiles() + tb.dropzone.getRejectedFiles();
     for (var i = 0; i < filesArr.length; i++) {
         var j = filesArr[i];
         if(!row){
@@ -173,7 +173,6 @@ var uploadRowTemplate = function(item){
                         },
                         'onclick' : function (e) {
                             e.stopImmediatePropagation();
-                            $(this).closest('.tb-row').remove(); //TODO: refactor this bit of logic
                             cancelUploads.call(tb, item);
                         }},
                      m('span.text-muted','×')

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -115,11 +115,12 @@ function findByTempID(parent, tmpID) {
 
 function cancelUploads (row) {
     var tb = this;
-    var filesArr = tb.dropzone.getActiveFiles() + tb.dropzone.getRejectedFiles();
+    var filesArr = tb.dropzone.getActiveFiles();
+    var rejectedFilesArr = tb.dropzone.getRejectedFiles();
     for (var i = 0; i < filesArr.length; i++) {
         var j = filesArr[i];
         if(!row){
-            if (j.status !== 'queued') {
+            if (j.status == 'uploading') {
                 j.status = 'queued';
             }
             var parent = j.treebeardParent || tb.dropzoneItemCache;
@@ -134,6 +135,14 @@ function cancelUploads (row) {
                 tb.dropzone.processQueue();
             }
         }
+    }
+    // Note: removes all rejected files, not just the row the user clicks
+    for (var i = 0; i < rejectedFilesArr.length; i++) {
+        var rejectFile = rejectedFilesArr[i];
+        var parent = rejectFile.treebeardParent || tb.dropzoneItemCache;
+        var item = findByTempID(parent, rejectFile.tmpID);
+        tb.dropzone.removeFile(rejectFile);
+        tb.deleteNode(parent.id,item.id);
     }
     tb.isUploading(false);
 }
@@ -751,8 +760,8 @@ function _fangornDropzoneSuccess(treebeard, file, response) {
                 }
             });
         }
-        treebeard.redraw();
     }
+    treebeard.redraw();
 }
 
 /**

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -139,8 +139,6 @@ function cancelUploads (row) {
     for (var m = 0; m < rejectedFilesArr.length; m++) {
         if(row) {
             tb.deleteNode(row.parentID, row.id);
-            var rejectedFile = rejectedFilesArr[i];
-            tb.dropzone.removeFile(rejectedFile);
         }
     }
     tb.isUploading(false);

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -120,7 +120,7 @@ function cancelUploads (row) {
     for (var i = 0; i < filesArr.length; i++) {
         var j = filesArr[i];
         if(!row){
-            if (j.status == 'uploading') {
+            if (j.status === 'uploading') {
                 j.status = 'queued';
             }
             var parent = j.treebeardParent || tb.dropzoneItemCache;
@@ -136,13 +136,12 @@ function cancelUploads (row) {
             }
         }
     }
-    // Note: removes all rejected files, not just the row the user clicks
-    for (var i = 0; i < rejectedFilesArr.length; i++) {
-        var rejectFile = rejectedFilesArr[i];
-        var parent = rejectFile.treebeardParent || tb.dropzoneItemCache;
-        var item = findByTempID(parent, rejectFile.tmpID);
-        tb.dropzone.removeFile(rejectFile);
-        tb.deleteNode(parent.id,item.id);
+    for (var m = 0; m < rejectedFilesArr.length; m++) {
+        if(row) {
+            tb.deleteNode(row.parentID, row.id);
+            var rejectedFile = rejectedFilesArr[i];
+            tb.dropzone.removeFile(rejectedFile);
+        }
     }
     tb.isUploading(false);
 }

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -119,8 +119,8 @@ function cancelUploads (row) {
     for (var i = 0; i < filesArr.length; i++) {
         var j = filesArr[i];
         if(!row){
-            if (j.status !== "queued") {
-                j.status = "queued";
+            if (j.status !== 'queued') {
+                j.status = 'queued';
             }
             var parent = j.treebeardParent || tb.dropzoneItemCache;
             var item = findByTempID(parent, j.tmpID);
@@ -129,7 +129,7 @@ function cancelUploads (row) {
         } else {
             tb.deleteNode(row.parentID,row.id);
             if(row.data.tmpID === j.tmpID){
-                j.status = "queued";
+                j.status = 'queued';
                 tb.dropzone.removeFile(j);
                 tb.dropzone.processQueue();
             }


### PR DESCRIPTION
<h2>Purpose</h2>
To fix issue #2822 and another issue I discovered which is that the user is unable to cancel in-progress uploads. 
<h2>Changes</h2>
The user can now 'x' out queued and in-progress uploads. 
<h2>To Do</h2>
Clicking 'x' on a file that exceeds 128mb removes the row. 
However, when the warning message disappears, the row reappears (it can be 'x'ed again). 
More perplexingly, trying to upload another file exceeding 128mb causes the previous row to reappear: 

![screen shot 2015-07-06 at 3 56 27 pm](https://cloud.githubusercontent.com/assets/11323460/8531762/9e19d426-23f7-11e5-963f-5db5b672682d.png)

So, that has to be fixed. 
[edit] Should be fixed now

<h2>Notes</h2>

I noticed that in the cancelUploads function, getQueuedFiles excludes the in-progress upload and therefore returns 1 less than it should (or 0 if only one file is being uploaded - and so the for loop doesn’t iterate, resulting in the button’s apparent lack of response when clicked)

So, I used getActiveFiles instead since it includes files with states ‘queued’ OR ‘uploading’ (the files can have one state at a time it seems) 

This seems to fix the issue, except that when the user clicks ‘x’ on the ‘uploading’ file, it results in a TypeError because _fangornDropzoneError tries to access xhr.status when xhr is undefined. 
Then I wondered, why is the drop zone error hook being run? 

Looked into it, realized it happens in the first conditional of Dropzone’s removeFile which is called in fangorn.js cancelUploads function. 
![screen shot 2015-07-06 at 4 10 46 pm](https://cloud.githubusercontent.com/assets/11323460/8532051/979fa7e0-23f9-11e5-9ca7-d2e8680be778.png)
Because the in-progress upload has status 'uploading', it calls dropzone's cancelUpload which eventually triggers drozone's error hook. 

So, I figured an easy fix would be to change the status of that file to 'queued' before calling removeFile on it. 




