### PR TITLE
[Feature Fix] Add component-overflow class to whole site(style.css)

### DIFF
--- a/website/static/css/pages/profile-page.css
+++ b/website/static/css/pages/profile-page.css
@@ -35,12 +35,7 @@ table.table.table-plain th, table.table.table-plain td {
 
 /* Profile gravatar
 -------------------------------------------------- */
-.profile-gravatar{
+.profile-gravatar {
     width:70px;
     height:70px;
-}
-.component-overflow {
-    word-wrap: break-word;
-    max-width: 90%;
-    display: inline-block;
 }

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -279,3 +279,10 @@ a {
 .popover h3 {
     font-weight: 500;
 }
+
+/* In list group, not allow icon to be pushed down */
+.component-overflow {
+    word-wrap: break-word;
+    max-width: 90%;
+    display: inline-block;
+}


### PR DESCRIPTION
### Purpose
In order to not allow the icons to be pushed down in list group, apply component-overflow to the whole site (Add the class to `style.css`)

Related to another [PR](https://github.com/CenterForOpenScience/osf.io/pull/3439)
Resolve [Trello bug](https://trello.com/c/ssIWdear/122-icon-in-registrations-is-pushed-down)

### Changes
Apply component-overflow to the whole site (Add the class to `style.css`)

### Side Effect
None 

