### PR TITLE
[Feature FIx] Fix comment panel style

### DIFF
--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -279,3 +279,54 @@ a {
 .popover h3 {
     font-weight: 500;
 }
+
+
+/* Comments Panel */
+.comment-actions i {
+    cursor: pointer;
+}
+
+.comment-container {
+    margin-top: 10px;
+    margin-bottom: 10px;
+}
+
+.comment-body {
+    padding: 5px;
+    background-color: white;
+}
+
+.comment-author {
+    color: #999999;
+}
+
+.comment-date {
+    color: #999999;
+}
+.edit-comment {
+    background-color: #F3F3F3;
+}
+
+.comment-body i {
+    padding-right: 5px;
+}
+
+.comment-handle-icon {
+    color: white;
+    vertical-align: middle;
+    line-height: 50px;
+    cursor: pointer;
+    position: relative;
+}
+
+.unread-comments-count {
+    font-size: medium;
+    color: white;
+    position: absolute;
+    margin-left: 40px;
+}
+
+/*  Add-on styles */
+.addon-auth {
+    margin-top: 4.8px;
+}

--- a/website/static/js/comment.js
+++ b/website/static/js/comment.js
@@ -100,8 +100,8 @@ var BaseComment = function() {
     self.replyNotEmpty = ko.computed(function() {
         return notEmpty(self.replyContent());
     });
-    self.saveButtonText = ko.computed(function() {
-        return self.submittingReply() ? 'Saving' : 'Save';
+    self.commentButtonText = ko.computed(function() {
+        return self.submittingReply() ? 'Commenting' : 'Comment';
     });
 
 };

--- a/website/templates/include/comment_template.mako
+++ b/website/templates/include/comment_template.mako
@@ -22,8 +22,8 @@
                     <textarea class="form-control" placeholder="Add a comment" data-bind="value: replyContent, valueUpdate: 'input', attr: {maxlength: $root.MAXLENGTH}"></textarea>
                 </div>
                 <div data-bind="if: replyNotEmpty" class="form-inline">
-                    <a class="btn btn-default btn-default" data-bind="click: submitReply, css: {disabled: submittingReply}"><i class="fa fa-check-square-o"></i> {{saveButtonText}}</a>
-                    <a class="btn btn-default btn-default" data-bind="click: cancelReply, css: {disabled: submittingReply}"><i class="fa fa-undo"></i> Cancel</a>
+                    <a class="btn btn-success" data-bind="click: submitReply, css: {disabled: submittingReply}"><i class="fa fa-check-square-o"></i> {{saveButtonText}}</a>
+                    <a class="btn btn-default" data-bind="click: cancelReply, css: {disabled: submittingReply}"><i class="fa fa-undo"></i> Cancel</a>
                     <span data-bind="text: replyErrorMessage" class="comment-error"></span>
                 </div>
                 <div class="comment-error">{{errorMessage}}</div>

--- a/website/templates/include/comment_template.mako
+++ b/website/templates/include/comment_template.mako
@@ -22,7 +22,7 @@
                     <textarea class="form-control" placeholder="Add a comment" data-bind="value: replyContent, valueUpdate: 'input', attr: {maxlength: $root.MAXLENGTH}"></textarea>
                 </div>
                 <div data-bind="if: replyNotEmpty" class="form-inline">
-                    <a class="btn btn-success" data-bind="click: submitReply, css: {disabled: submittingReply}"><i class="fa fa-check-square-o"></i> {{saveButtonText}}</a>
+                    <a class="btn btn-primary" data-bind="click: submitReply, css: {disabled: submittingReply}"><i class="fa fa-check-square-o"></i> {{commentButtonText}}</a>
                     <a class="btn btn-default" data-bind="click: cancelReply, css: {disabled: submittingReply}"><i class="fa fa-undo"></i> Cancel</a>
                     <span data-bind="text: replyErrorMessage" class="comment-error"></span>
                 </div>


### PR DESCRIPTION
### Purpose
Resolved [Trello bug](https://trello.com/c/DEgVxq18/134-comments-widget-buttons-need-to-be-overhauled)

### Change
1) After finding the missing css for comment panel in old `site.css`, add that part of code to `style.css`
2) Change save button color from grey to blue
3) Change button text from save to comment

### Side Effect
None
