### PR TITLE
[Feature Fix] Fix button rise on file widget

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1651,7 +1651,7 @@ var FGToolbar = {
             }, '')
         );
 
-        templates[toolbarModes.DEFAULT] =  m('.col-xs-12', m('.pull-right', [finalRowButtons, generalButtons]));
+        templates[toolbarModes.DEFAULT] =  m('.col-xs-12', m('.pull-right', [finalRowButtons,  m('span', generalButtons)]));
         return m('.row.tb-header-row', [
             m('#folderRow', { config : function () {
                 $('#folderRow input').focus();


### PR DESCRIPTION
### Purpose
Resolved [Trello bug](https://trello.com/c/tMwhsLdB/132-files-widget-search-and-information-buttons-are-raised-higher-than-others)

### Change
Add span tag to general buttons(search and information buttons)

### Side Effect
None. I tried to delete the span tag in finalRowButtons. But in `mithril`, nested component views must return either a virtual element or another component. So thinking in the opposite way, I added span tag to  the rise buttons.

And also this is not the perfect way to do it. It is still strange to me that why it increase 1 px in search button, comparing with production.