### PR TITLE
[Feature FIx] [Style guideline] Change button position and color for link redirect

### DIFF
--- a/website/addons/forward/templates/forward_widget.mako
+++ b/website/addons/forward/templates/forward_widget.mako
@@ -12,8 +12,8 @@
         <p>You will be automatically forwarded in {{ timeLeft }} seconds.</p>
 
         <div class="spaced-buttons" data-bind="visible: redirecting">
-            <a class="btn btn-success" data-bind="click: doRedirect">Redirect</a>
-            <a class="btn btn-warning" data-bind="click: cancelRedirect">Cancel</a>
+            <a class="btn btn-default" data-bind="click: cancelRedirect">Cancel</a>
+            <a class="btn btn-primary" data-bind="click: doRedirect">Redirect</a>
         </div>
 
     </div>
@@ -26,7 +26,7 @@
         </div>
 
         <div class="spaced-buttons">
-            <a class="btn btn-success" data-bind="click: doRedirect">Redirect</a>
+            <a class="btn btn-primary" data-bind="click: doRedirect">Redirect</a>
         </div>
 
     </div>


### PR DESCRIPTION
### Purpose
Resolved [Trello bug](https://trello.com/c/iGzDgfAP/158-external-link-buttons-out-of-order)

### Change
Before Change:
![screenshot 2015-07-08 09 26 22](https://cloud.githubusercontent.com/assets/5420789/8571249/960cfe36-2553-11e5-8255-95f48dac7ad0.png)

After Change:
![screenshot 2015-07-08 09 24 38](https://cloud.githubusercontent.com/assets/5420789/8571256/9c4bea6e-2553-11e5-9ffa-951115c8ad50.png)

### Side Effect
The original color for cancel button is warning. Should we retain this, or just change to grey in order to follow the style guide? I suggest to follow the style guide.
