### PR TITLE
[Feature Fix] Fix comment panel bug related to style guideline problem

### DIFF
--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -285,6 +285,7 @@ a {
     word-wrap: break-word;
     max-width: 90%;
     display: inline-block;
+}
 
 /* Comments Panel */
 .comment-actions i {

--- a/website/static/js/comment.js
+++ b/website/static/js/comment.js
@@ -248,7 +248,7 @@ var CommentModel = function(data, $parent, $root) {
     });
 
     self.toggleIcon = ko.computed(function() {
-            return self.showChildren() ? 'fa fa-minus-square-o' : 'fa fa-plus-square-o';
+            return self.showChildren() ? 'fa fa-minus' : 'fa fa-plus';
     });
     self.editHighlight = ko.computed(function() {
         return self.canEdit() && self.hoverContent();

--- a/website/templates/include/comment_template.mako
+++ b/website/templates/include/comment_template.mako
@@ -95,11 +95,11 @@
                     <div class="comment-content">
 
                         <div data-bind="ifnot: editing">
-                            <span data-bind="if: hasChildren">
+                            <span class="component-overflow"
+                              data-bind="html: contentDisplay, css: {'edit-comment': editHighlight}, event: {mouseenter: startHoverContent, mouseleave: stopHoverContent}"></span>
+                            <span class="pull-right" data-bind="if: hasChildren">
                                 <i data-bind="css: toggleIcon, click: toggle"></i>
                             </span>
-                            <span class="overflow"
-                              data-bind="html: contentDisplay, css: {'edit-comment': editHighlight}, event: {mouseenter: startHoverContent, mouseleave: stopHoverContent}"></span>
                         </div>
 
                         <!--
@@ -111,8 +111,8 @@
                                 <textarea class="form-control" data-bind="value: content, valueUpdate: 'input', attr: {maxlength: $root.MAXLENGTH}"></textarea>
                             </div>
                             <div class="form-inline">
-                                <a class="btn btn-default btn-default" data-bind="click: submitEdit, visible: editNotEmpty"><i class="fa fa-check-square-o"></i> Save</a>
-                                <a class="btn btn-default btn-default" data-bind="click: cancelEdit"><i class="fa fa-undo"></i> Cancel</a>
+                                <a class="btn btn-success" data-bind="click: submitEdit, visible: editNotEmpty"><i class="fa fa-check-square-o"></i> Save</a>
+                                <a class="btn btn-default" data-bind="click: cancelEdit"><i class="fa fa-undo"></i> Cancel</a>
                                 <span data-bind="text: editErrorMessage" class="comment-error"></span>
                             </div>
                         </div>

--- a/website/templates/include/comment_template.mako
+++ b/website/templates/include/comment_template.mako
@@ -23,8 +23,8 @@
                 </div>
                 <div class="clearfix">
                     <div data-bind="if: replyNotEmpty" class="form-inline pull-right">
-                        <a class="btn btn-default" data-bind="click: cancelReply, css: {disabled: submittingReply}"> Cancel</a>
-                        <a class="btn btn-success" data-bind="click: submitReply, css: {disabled: submittingReply}"> {{commentButtonText}}</a>
+                        <a class="btn btn-default btn-sm" data-bind="click: cancelReply, css: {disabled: submittingReply}"> Cancel</a>
+                        <a class="btn btn-success btn-sm" data-bind="click: submitReply, css: {disabled: submittingReply}"> {{commentButtonText}}</a>
                         <span data-bind="text: replyErrorMessage" class="comment-error"></span>
                     </div>
                 </div>
@@ -52,8 +52,8 @@
                 <div data-bind="if: canEdit">
                     <a data-bind="click: startUndelete">Restore</a>
                     <div data-bind="if: undeleting">
-                        <a class="btn btn-default btn-sm" data-bind="click: submitUndelete">Submit</a>
                         <a class="btn btn-default btn-sm" data-bind="click: cancelUndelete">Cancel</a>
+                        <a class="btn btn-success btn-sm" data-bind="click: submitUndelete">Save</a>
                     </div>
                 </div>
             </div>
@@ -67,8 +67,8 @@
                 </div>
                 <a data-bind="click: startUnreportAbuse">Not abuse</a>
                 <div data-bind="if: unreporting">
-                    <a class="btn btn-primary btn-sm" data-bind="click: submitUnreportAbuse">Submit</a>
                     <a class="btn btn-default btn-sm" data-bind="click: cancelUnreportAbuse">Cancel</a>
+                    <a class="btn btn-primary btn-sm" data-bind="click: submitUnreportAbuse">Save</a>
                 </div>
             </div>
 
@@ -114,8 +114,8 @@
                             </div>
                             <div class="clearfix">
                                 <div class="form-inline pull-right">
-                                    <a class="btn btn-default" data-bind="click: cancelEdit"> Cancel</a>
-                                    <a class="btn btn-success" data-bind="click: submitEdit, visible: editNotEmpty"> Save</a>
+                                    <a class="btn btn-default btn-sm" data-bind="click: cancelEdit">Cancel</a>
+                                    <a class="btn btn-success btn-sm" data-bind="click: submitEdit, visible: editNotEmpty">Save</a>
                                     <span data-bind="text: editErrorMessage" class="comment-error"></span>
                                 </div>
                             </div>
@@ -153,13 +153,13 @@
                             <select class="form-control" data-bind="options: abuseOptions, optionsText: abuseLabel, value: abuseCategory"></select>
                             <input class="form-control" data-bind="value: abuseText" placeholder="Describe abuse" />
                         </form>
-                        <a class="btn btn-danger btn-sm" data-bind="click: submitAbuse"> Report</a>
                         <a class="btn btn-default btn-sm" data-bind="click: cancelAbuse"> Cancel</a>
+                        <a class="btn btn-danger btn-sm" data-bind="click: submitAbuse"> Report</a>
                     </div>
 
                     <div class="comment-delete" data-bind="if: deleting">
-                        <a class="btn btn-danger btn-sm" data-bind="click: submitDelete">Delete</a>
                         <a class="btn btn-default btn-sm" data-bind="click: cancelDelete">Cancel</a>
+                        <a class="btn btn-danger btn-sm" data-bind="click: submitDelete">Delete</a>
                     </div>
 
                 </div>
@@ -179,8 +179,8 @@
                     </div>
                     <div class="clearfix">
                         <div class="pull-right">
-                            <a class="btn btn-default" data-bind="click: cancelReply, css: {disabled: submittingReply}"> Cancel</a>
-                            <a class="btn btn-success" data-bind="click: submitReply, visible: replyNotEmpty, css: {disabled: submittingReply}"> {{commentButtonText}}</a>
+                            <a class="btn btn-default btn-sm" data-bind="click: cancelReply, css: {disabled: submittingReply}"> Cancel</a>
+                            <a class="btn btn-success btn-sm" data-bind="click: submitReply, visible: replyNotEmpty, css: {disabled: submittingReply}"> {{commentButtonText}}</a>
                             <span data-bind="text: replyErrorMessage" class="comment-error"></span>
                         </div>
                     </div>

--- a/website/templates/include/comment_template.mako
+++ b/website/templates/include/comment_template.mako
@@ -21,10 +21,12 @@
                 <div class="form-group">
                     <textarea class="form-control" placeholder="Add a comment" data-bind="value: replyContent, valueUpdate: 'input', attr: {maxlength: $root.MAXLENGTH}"></textarea>
                 </div>
-                <div data-bind="if: replyNotEmpty" class="form-inline">
-                    <a class="btn btn-success" data-bind="click: submitReply, css: {disabled: submittingReply}"><i class="fa fa-check-square-o"></i> {{commentButtonText}}</a>
-                    <a class="btn btn-default" data-bind="click: cancelReply, css: {disabled: submittingReply}"><i class="fa fa-undo"></i> Cancel</a>
-                    <span data-bind="text: replyErrorMessage" class="comment-error"></span>
+                <div class="clearfix">
+                    <div data-bind="if: replyNotEmpty" class="form-inline pull-right">
+                        <a class="btn btn-default" data-bind="click: cancelReply, css: {disabled: submittingReply}"> Cancel</a>
+                        <a class="btn btn-success" data-bind="click: submitReply, css: {disabled: submittingReply}"> {{commentButtonText}}</a>
+                        <span data-bind="text: replyErrorMessage" class="comment-error"></span>
+                    </div>
                 </div>
                 <div class="comment-error">{{errorMessage}}</div>
             </form>
@@ -110,10 +112,12 @@
                             <div class="form-group" style="padding-top: 10px">
                                 <textarea class="form-control" data-bind="value: content, valueUpdate: 'input', attr: {maxlength: $root.MAXLENGTH}"></textarea>
                             </div>
-                            <div class="form-inline">
-                                <a class="btn btn-success" data-bind="click: submitEdit, visible: editNotEmpty"><i class="fa fa-check-square-o"></i> Save</a>
-                                <a class="btn btn-default" data-bind="click: cancelEdit"><i class="fa fa-undo"></i> Cancel</a>
-                                <span data-bind="text: editErrorMessage" class="comment-error"></span>
+                            <div class="clearfix">
+                                <div class="form-inline pull-right">
+                                    <a class="btn btn-default" data-bind="click: cancelEdit"> Cancel</a>
+                                    <a class="btn btn-success" data-bind="click: submitEdit, visible: editNotEmpty"> Save</a>
+                                    <span data-bind="text: editErrorMessage" class="comment-error"></span>
+                                </div>
                             </div>
                         </div>
 
@@ -149,13 +153,13 @@
                             <select class="form-control" data-bind="options: abuseOptions, optionsText: abuseLabel, value: abuseCategory"></select>
                             <input class="form-control" data-bind="value: abuseText" placeholder="Describe abuse" />
                         </form>
-                        <a class="btn btn-danger btn-sm" data-bind="click: submitAbuse"><i class="fa fa-check-square-o"></i> Report</a>
-                        <a class="btn btn-default btn-sm" data-bind="click: cancelAbuse"><i class="fa fa-undo"></i> Cancel</a>
+                        <a class="btn btn-danger btn-sm" data-bind="click: submitAbuse"> Report</a>
+                        <a class="btn btn-default btn-sm" data-bind="click: cancelAbuse"> Cancel</a>
                     </div>
 
                     <div class="comment-delete" data-bind="if: deleting">
-                        <a class="btn btn-danger btn-sm" data-bind="click: submitDelete"><i class="fa fa-check-square-o"></i> Delete</a>
-                        <a class="btn btn-default btn-sm" data-bind="click: cancelDelete"><i class="fa fa-undo"></i> Cancel</a>
+                        <a class="btn btn-danger btn-sm" data-bind="click: submitDelete">Delete</a>
+                        <a class="btn btn-default btn-sm" data-bind="click: cancelDelete">Cancel</a>
                     </div>
 
                 </div>
@@ -173,10 +177,12 @@
                     <div class="form-group" style="padding-top: 10px">
                         <textarea class="form-control" placeholder="Add a comment" data-bind="value: replyContent, valueUpdate: 'input', attr: {maxlength: $root.MAXLENGTH}"></textarea>
                     </div>
-                    <div>
-                        <a class="btn btn-success" data-bind="click: submitReply, visible: replyNotEmpty, css: {disabled: submittingReply}"><i class="fa fa-check-square-o"></i> {{commentButtonText}}</a>
-                        <a class="btn btn-default" data-bind="click: cancelReply, css: {disabled: submittingReply}"><i class="fa fa-undo"></i> Cancel</a>
-                        <span data-bind="text: replyErrorMessage" class="comment-error"></span>
+                    <div class="clearfix">
+                        <div class="pull-right">
+                            <a class="btn btn-default" data-bind="click: cancelReply, css: {disabled: submittingReply}"> Cancel</a>
+                            <a class="btn btn-success" data-bind="click: submitReply, visible: replyNotEmpty, css: {disabled: submittingReply}"> {{commentButtonText}}</a>
+                            <span data-bind="text: replyErrorMessage" class="comment-error"></span>
+                        </div>
                     </div>
                 </div>
 


### PR DESCRIPTION
Resolve Trello Bugs about comment panel:
1. [Button size](https://trello.com/c/td4qBlTm/138-comments-widget-for-making-a-new-comment-or-replying-buttons-are-too-big)
2. [Button position](https://trello.com/c/E0TinF4t/146-comments-widget-buttons-out-of-order)
3. [Button color](https://trello.com/c/AMBfenGU/139-comments-widget-edit-comment-should-have-a-green-save-button-not-a-gray-button)
4. [Unnecessary Icons](https://trello.com/c/mkZcgQAh/136-comments-widget-buttons-should-not-have-icons)
5. Wrong icons

Changes:
Before Changes:
![screenshot 2015-07-08 11 12 39](https://cloud.githubusercontent.com/assets/5420789/8574481/dddc4b20-2564-11e5-899f-fc8deb6bf632.png)
![screenshot 2015-07-08 11 12 25](https://cloud.githubusercontent.com/assets/5420789/8574484/e01e1760-2564-11e5-860f-61669af35b9c.png)

After Changes:
![screenshot 2015-07-08 10 05 44](https://cloud.githubusercontent.com/assets/5420789/8574490/e6c7914a-2564-11e5-9ce1-4a4612c6823b.png)
![screenshot 2015-07-08 11 11 34](https://cloud.githubusercontent.com/assets/5420789/8574503/f3dd1f8a-2564-11e5-9e31-4904a50e8c80.png)



