### PR TITLE
[Feature Fix] Replace right icon for view button on addon

### DIFF
--- a/website/addons/dataverse/static/dataverseFangornConfig.js
+++ b/website/addons/dataverse/static/dataverseFangornConfig.js
@@ -179,7 +179,7 @@ var _dataverseItemButtons = {
                         onclick: function(event) {
                             gotoFile(item);
                         },
-                        icon: 'fa fa-external-link',
+                        icon: 'fa fa-file-o',
                         className : 'text-info'
                     }, 'View'));
 

--- a/website/addons/figshare/static/figshareFangornConfig.js
+++ b/website/addons/figshare/static/figshareFangornConfig.js
@@ -54,7 +54,7 @@ var _figshareItemButtons = {
                     onclick: function(event) {
                         Fangorn.ButtonEvents._gotoFileEvent.call(tb, item);
                     },
-                    icon: 'fa fa-external-link',
+                    icon: 'fa fa-file-o',
                     className : 'text-info'
                 }, 'View'));
         }

--- a/website/addons/github/static/githubFangornConfig.js
+++ b/website/addons/github/static/githubFangornConfig.js
@@ -214,7 +214,7 @@ var _githubItemButtons = {
                         onclick: function(event) {
                             gotoFile.call(tb, item);
                         },
-                        icon: 'fa fa-external-link',
+                        icon: 'fa fa-file-o',
                         className : 'text-info'
                     }, 'View'));
 


### PR DESCRIPTION
### Purpose
The view icons of addon files are wrong. In this PR, it replaces them with the correct one.

Resolved [Trello Bug](https://trello.com/c/0U0gRPaL/140-files-widget-view-button-is-improperly-styled-for-figshare-and-github-add-ons)

