### PR TITLE
[feature] Update alert href classes to use current style guide

### DIFF
--- a/website/templates/project/project_header.mako
+++ b/website/templates/project/project_header.mako
@@ -86,7 +86,7 @@
     % if node['is_registration']:  ## Begin registration undismissable labels
 
         % if not node['is_retracted']:
-            <div class="alert alert-info">This ${node['node_type']} is a registration of <a class="alert-link" href="${node['registered_from_url']}">this ${node['node_type']}</a>; the content of the ${node['node_type']} has been frozen and cannot be edited.
+            <div class="alert alert-info">This ${node['node_type']} is a registration of <a class="link-solidk" href="${node['registered_from_url']}">this ${node['node_type']}</a>; the content of the ${node['node_type']} has been frozen and cannot be edited.
             </div>
             <style type="text/css">
             .watermarked {
@@ -101,7 +101,7 @@
         % endif
 
         % if  node['is_retracted']:
-            <div class="alert alert-danger">This ${node['node_type']} is a retracted registration of <a class="alert-link" href="${node['registered_from_url']}">this ${node['node_type']}</a>; the content of the ${node['node_type']} has been taken down for the reason(s) stated below.</div>
+            <div class="alert alert-danger">This ${node['node_type']} is a retracted registration of <a class="link-solid" href="${node['registered_from_url']}">this ${node['node_type']}</a>; the content of the ${node['node_type']} has been taken down for the reason(s) stated below.</div>
         % endif
 
         % if  node['pending_embargo']:
@@ -115,7 +115,7 @@
     % endif  ## End registration undismissable labels
 
     % if node['anonymous'] and user['is_contributor']:
-        <div class="alert alert-info">This ${node['node_type']} is being viewed through an anonymized, view-only link. If you want to view it as a contributor, click <a class="alert-link" href="${node['redirect_url']}">here</a>.</div>
+        <div class="alert alert-info">This ${node['node_type']} is being viewed through an anonymized, view-only link. If you want to view it as a contributor, click <a class="link-solid" href="${node['redirect_url']}">here</a>.</div>
     % endif
 
     % if node['link'] and not node['is_public'] and not user['is_contributor']:


### PR DESCRIPTION
## Purpose:
Update project header alert links to follow [the style guide](https://centerforopenscience.github.io/osf-style/style.html#links).

## Changes:
Change link classes.

## Side Effects:
None.

## Notes:
Closes-bug: https://trello.com/c/O4XYyrJQ/170-registration-overview-this-project-link-should-be-underlined