### PR TITLE
[Feature FIx] Add missing style for wiki

### DIFF
--- a/website/static/css/pages/wiki-page.css
+++ b/website/static/css/pages/wiki-page.css
@@ -11,6 +11,15 @@
     padding: 10px;
 }
 
+.osf-panel {
+    border: 1px solid #ddd;
+    height: 750px;
+    overflow: auto;
+    display: block;
+    position: relative;
+    overflow-x: hidden;
+}
+
 @media (max-width: 991px) {
     .osf-panel {
         margin-bottom: 20px;
@@ -64,6 +73,7 @@
     text-decoration: none !important;
 }
 
+/*Special for wiki panel */
 .osf-panel-flex {
     width: 100%;
     display: -webkit-box;
@@ -108,6 +118,39 @@
 .reset-height {
     height: auto;
 }
+
+
+.osf-panel  .fa-angle-right, .osf-panel .fa-angle-left {
+    cursor: pointer;
+}
+.osf-panel .fa-list {
+    color: #808080;
+}
+
+.osf-panel .superlist li {
+    display: block;
+    font-size: 20px;
+}
+
+.osf-panel .navbar-collapse {
+    background: #F5F5F5;
+    padding: 0px;
+}
+
+.superlist li {
+    display: inline-block;
+    float: none;
+}
+.superlist li a {
+    padding: 15px 10px;
+}
+
+@media (max-width: 768px) {
+ .superlist.navbar-nav {
+    margin: 0;
+ }
+}
+
 
 /* Style for Ace wiki editor */
 .wiki-editor {

--- a/website/static/css/pages/wiki-page.css
+++ b/website/static/css/pages/wiki-page.css
@@ -11,20 +11,6 @@
     padding: 10px;
 }
 
-.osf-panel {
-    border: 1px solid #ddd;
-    height: 750px;
-    overflow: auto;
-    display: block;
-    position: relative;
-    overflow-x: hidden;
-}
-
-@media (max-width: 991px) {
-    .osf-panel {
-        margin-bottom: 20px;
-    }
-}
 .panel-collapsed {
     background: #F5F5F5;
 }
@@ -119,22 +105,9 @@
     height: auto;
 }
 
-
-.osf-panel  .fa-angle-right, .osf-panel .fa-angle-left {
-    cursor: pointer;
-}
-.osf-panel .fa-list {
-    color: #808080;
-}
-
 .osf-panel .superlist li {
     display: block;
     font-size: 20px;
-}
-
-.osf-panel .navbar-collapse {
-    background: #F5F5F5;
-    padding: 0px;
 }
 
 .superlist li {
@@ -150,7 +123,6 @@
     margin: 0;
  }
 }
-
 
 /* Style for Ace wiki editor */
 .wiki-editor {

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -336,3 +336,32 @@ a {
 .addon-auth {
     margin-top: 4.8px;
 }
+
+/* OSF-panel */
+.osf-panel {
+    border: 1px solid #ddd;
+    height: 750px;
+    overflow: auto;
+    display: block;
+    position: relative;
+    overflow-x: hidden;
+}
+
+@media (max-width: 991px) {
+    .osf-panel {
+        margin-bottom: 20px;
+    }
+}
+
+.osf-panel  .fa-angle-right, .osf-panel .fa-angle-left {
+    cursor: pointer;
+}
+.osf-panel .fa-list {
+    color: #808080;
+}
+
+.osf-panel .navbar-collapse {
+    background: #F5F5F5;
+    padding: 0px;
+}
+

--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -277,7 +277,7 @@
                     <div class="panel panel-default">
                         <span id="retractRegistrationAnchor" class="anchor"></span>
 
-                        <div class="panel-heading">
+                        <div class="panel-heading clearfix">
                             <h3 class="panel-title">Retract Registration</h3>
                         </div>
 


### PR DESCRIPTION
### Purpose
Wiki has a style missing and panel misses clearfix class.

And also resolved [trello bug](https://trello.com/c/SQlHYxDs/161-text-misaligned-on-settings-page-of-registration-for-retraction)

### Changes
Before Change:
![screenshot 2015-07-08 14 50 53](https://cloud.githubusercontent.com/assets/5420789/8579528/209d6cb4-2583-11e5-8cc5-9ce42266220b.png)
![screenshot 2015-07-08 15 09 13](https://cloud.githubusercontent.com/assets/5420789/8579572/60261642-2583-11e5-9419-201b6212cbb1.png)

After Change:
![screenshot 2015-07-08 15 04 49](https://cloud.githubusercontent.com/assets/5420789/8579538/32ef6e58-2583-11e5-8820-3cdc79c5fde5.png)
![screenshot 2015-07-08 15 09 27](https://cloud.githubusercontent.com/assets/5420789/8579579/65a77980-2583-11e5-9adf-250bd1e1edca.png)