### PR TITLE
Feature/paginator fix

### DIFF
--- a/website/static/css/pages/search-page.css
+++ b/website/static/css/pages/search-page.css
@@ -180,9 +180,3 @@ div.search-result  {
 .search-contributor-links {
     padding-top: 10px;
 }
-
-/* Disable pointer events in page changing */
-.disabled {
-    cursor: default !important;
-    pointer-events: none;
-}

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -336,3 +336,9 @@ a {
 .addon-auth {
     margin-top: 4.8px;
 }
+
+/* Disable pointer events in page changing */
+.disabled {
+    cursor: default !important;
+    pointer-events: none;
+}

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -337,7 +337,7 @@ a {
     margin-top: 4.8px;
 }
 
-/* Disable pointer events in page changing */
+/* bootstrap disable doesn't disable pointer event. This disable class adds pointer event disable. */
 .disabled {
     cursor: default !important;
     pointer-events: none;

--- a/website/static/js/paginator.js
+++ b/website/static/js/paginator.js
@@ -34,7 +34,9 @@ var Paginator = oop.defclass({
                 text: '1',
                 handler: function() {
                     self.pageToGet(0);
-                    self.fetchResults();
+                    if (self.pageToGet() !== self.currentPage()) {
+                        self.fetchResults();
+                    }
                 }
             });
             if (self.numberOfPages() <= MAX_PAGES_ON_PAGINATOR) {
@@ -44,7 +46,9 @@ var Paginator = oop.defclass({
                         text: i + 1,
                         handler: function() {
                             self.pageToGet(parseInt(this.text) - 1);
-                            self.fetchResults();
+                            if (self.pageToGet() !== self.currentPage()) {
+                                self.fetchResults();
+                            }
                         }
                     });/* jshint ignore:line */
                     // function defined inside loop
@@ -56,7 +60,9 @@ var Paginator = oop.defclass({
                         text: i + 1,
                         handler: function() {
                             self.pageToGet(parseInt(this.text) - 1);
-                            self.fetchResults();
+                            if (self.pageToGet() !== self.currentPage()) {
+                                self.fetchResults();
+                            }
                         }
                     });/* jshint ignore:line */
                     // functions defined inside loop
@@ -79,7 +85,9 @@ var Paginator = oop.defclass({
                         text: i + 1,
                         handler: function() {
                             self.pageToGet(parseInt(this.text) - 1);
-                            self.fetchResults();
+                            if (self.pageToGet() !== self.currentPage()) {
+                                self.fetchResults();
+                            }
                         }
                     });/* jshint ignore:line */
                     // function defined inside loop
@@ -97,7 +105,9 @@ var Paginator = oop.defclass({
                         text: i + 1,
                         handler: function() {
                             self.pageToGet(parseInt(this.text) - 1);
-                            self.fetchResults();
+                            if (self.pageToGet() !== self.currentPage()) {
+                                self.fetchResults();
+                            }
                         }
                     });/* jshint ignore:line */
                     // functions defined inside loop
@@ -114,7 +124,9 @@ var Paginator = oop.defclass({
                 text: self.numberOfPages(),
                 handler: function() {
                     self.pageToGet(self.numberOfPages() - 1);
-                    self.fetchResults();
+                    if (self.pageToGet() !== self.currentPage()) {
+                        self.fetchResults();
+                    }
                 }
             });
             self.paginators.push({
@@ -124,13 +136,17 @@ var Paginator = oop.defclass({
             });
         }
     },
-    nextPage: function(){
+    nextPage: function() {
         this.pageToGet(this.currentPage() + 1);
-        this.fetchResults();
+        if (this.pageToGet() < this.numberOfPages()){
+            this.fetchResults();
+        }
     },
     previousPage: function(){
         this.pageToGet(this.currentPage() - 1);
-        this.fetchResults();
+        if (this.pageToGet() >=0) {
+            this.fetchResults();
+        }
     },
     fetchResults: function() {
         throw new Error('Paginator subclass must define a "fetchResults" method.');

--- a/website/static/js/paginator.js
+++ b/website/static/js/paginator.js
@@ -142,9 +142,9 @@ var Paginator = oop.defclass({
             this.fetchResults();
         }
     },
-    previousPage: function(){
+    previousPage: function() {
         this.pageToGet(this.currentPage() - 1);
-        if (this.pageToGet() >=0) {
+        if (this.pageToGet() >= 0) {
             this.fetchResults();
         }
     },

--- a/website/static/js/tests/paginator.test.js
+++ b/website/static/js/tests/paginator.test.js
@@ -48,6 +48,18 @@ describe('Paginator', () => {
         assert.equal(paginator.pageToGet() + 1, currentPage);
     });
 
+    it('previousPage doesnot fetchResult when pageNum is 0', () => {
+        numberOfPages = 5;
+        currentPage = 0;
+        paginator.configure(function(p){
+            p.numberOfPages(numberOfPages);
+            p.currentPage(currentPage);
+        });
+        paginator.previousPage();
+        assert.isFalse(paginator.fetchResults.called);
+        assert.equal(paginator.pageToGet() + 1, currentPage);
+    });
+
     it('nextPage', () => {
         numberOfPages = 5;
         paginator.configure(function(p){
@@ -55,6 +67,18 @@ describe('Paginator', () => {
         });
         paginator.nextPage();
         assert.calledOnce(paginator.fetchResults);
+        assert.equal(paginator.pageToGet() - 1, currentPage);
+    });
+
+    it('nextPage doesnot fetchResult when pageNum is at the end', () => {
+        numberOfPages = 5;
+        currentPage = 4;
+        paginator.configure(function(p){
+            p.numberOfPages(numberOfPages);
+            p.currentPage(currentPage);
+        });
+        paginator.nextPage();
+        assert.isFalse(paginator.fetchResults.called);
         assert.equal(paginator.pageToGet() - 1, currentPage);
     });
 


### PR DESCRIPTION
<b>Purpose</b>
Fix the problem that altho the button is disabled but the handler is still triggered. Also add the front end check to reduce the number of unnecessary request. Closes https://trello.com/c/TNgl1ahR/182-clicking-past-last-page-of-log-brings-up-bad-request-growl-box