### PR TITLE
Fix status messages in index.mako

### DIFF
--- a/website/templates/index.mako
+++ b/website/templates/index.mako
@@ -6,14 +6,19 @@
     <div class="watermarked">
             % if status:
                 <div id="alert-container">
-                % for message, css_class, dismissible in status:
+                % for message, css_class, dismissible, trust in status:
                       <div class='alert alert-block alert-${css_class} fade in alert-front text-center'>
                         % if dismissible:
                         <button type="button" class="close" data-dismiss="alert" aria-label="Close">
                           <span aria-hidden="true">&times;</span>
                         </button>
                         % endif
-                        <p>${message}</p>
+
+                        % if trust:
+                          <p>${message | n}</p>
+                        % else:
+                          <p>${message}</p>
+                        % endif
                       </div>
                 % endfor
                 </div>


### PR DESCRIPTION
## Purpose
Viewing the /goodbye page generates a 500 internal server error on staging. (h/t @sloria). Fix that.

## Summary of changes
Applies changes previously made in base.mako/alert.mako to the almost identical overriding block in index.mako. This reflects new field of the `Status` namedtuple introduced in #2917.

Audited other OSF pages; did not see this block, or the `status` object in general, being overriden/used in other mako templates.
