### PR TITLE
[hold] UnicodeEncodeError error in twitter disambiguation page

### DIFF
--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -731,16 +731,16 @@ def redirect_to_twitter(twitter_handle):
         user = User.find_one(Q('social.twitter', 'iexact', twitter_handle))
     except NoResultsFound:
         raise HTTPError(http.NOT_FOUND, data={
-            'message_short': 'User Not Found',
-            'message_long': 'There is no active user associated with the Twitter handle: {0}.'.format(twitter_handle)
+            u'message_short': 'User Not Found',
+            u'message_long': u'There is no active user associated with the Twitter handle: {0}.'.format(twitter_handle)
         })
     except MultipleResultsFound:
         users = User.find(Q('social.twitter', 'iexact', twitter_handle))
-        message_long = 'There are multiple OSF accounts associated with the ' \
-                       'Twitter handle: <strong>{0}</strong>. <br /> Please ' \
-                       'select from the accounts below. <br /><ul>'.format(twitter_handle)
+        message_long = u'There are multiple OSF accounts associated with the ' \
+                       u'Twitter handle: <strong>{0}</strong>. <br /> Please ' \
+                       u'select from the accounts below. <br /><ul>'.format(twitter_handle)
         for user in users:
-            message_long += '<li><a href="{0}">{1}</a></li>'.format(user.url, user.fullname)
+            message_long += u'<li><a href="{0}">{1}</a></li>'.format(user.url, user.fullname)
         message_long += '</ul>'
         raise HTTPError(http.MULTIPLE_CHOICES, data={
             'message_short': 'Multiple Users Found',


### PR DESCRIPTION
Possibly on hold pending #3576.

## Purpose
The new `redirect_to_twitter` disambiguation page (#3408 / #3453) fails when one of the usernames contains unicode. 

Example: I have registered two users on staging with the same twitter handle:
https://staging.osf.io/@occsci/

One of those users is named `Sam Pull string_with_unicode_(͡° ͜ʖ ͡°)`

The page returns "Unable to resolve" instead of a disambiguation page, and Sentry lists the following error:
`UnicodeEncodeError: 'ascii' codec can't encode characters in position 30-31: ordinal not in range(128)`

## Summary of changes
This includes one proposed fix- simply marking the strings as unicode so that `string.format` inserts unicode data correctly. This works on my local machine.

I have minimal handson experience with unicode issues, so there may well be a more robust way. Feedback welcome. @HarryRybacki ?


## Side notes
The page returns "Unable to resolve" because the exception raised is not an http error message- it's an expected error message not handled by the normal error renderer. (This one? https://github.com/CenterForOpenScience/osf.io/blob/develop/framework/exceptions/__init__.py#L70 )

The error message could do more to make clear that a server error occurred. But that would be a separate issue.