### PR TITLE
[hold][Feature Fix] Fix escaped html appearing in user job and school information.

### DIFF
--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -30,6 +30,7 @@ from website.profile import utils as profile_utils
 from website.util import web_url_for, paths
 from website.util.sanitize import escape_html
 from website.util.sanitize import strip_html
+from website.util.sanitize import safe_unescape_html_in_results
 from website.views import _render_nodes
 
 
@@ -556,6 +557,7 @@ def serialize_social(auth, uid=None, **kwargs):
     return ret
 
 
+@safe_unescape_html_in_results
 def serialize_job(job):
     return {
         'institution': job.get('institution'),
@@ -569,6 +571,7 @@ def serialize_job(job):
     }
 
 
+@safe_unescape_html_in_results
 def serialize_school(school):
     return {
         'institution': school.get('institution'),

--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -30,7 +30,7 @@ from website.profile import utils as profile_utils
 from website.util import web_url_for, paths
 from website.util.sanitize import escape_html
 from website.util.sanitize import strip_html
-from website.util.sanitize import safe_unescape_html_in_results
+from website.util.sanitize import safe_unescape_html
 from website.views import _render_nodes
 
 
@@ -557,9 +557,8 @@ def serialize_social(auth, uid=None, **kwargs):
     return ret
 
 
-@safe_unescape_html_in_results
 def serialize_job(job):
-    return {
+    job_serialized = {
         'institution': job.get('institution'),
         'department': job.get('department'),
         'title': job.get('title'),
@@ -569,11 +568,11 @@ def serialize_job(job):
         'endYear': job.get('endYear'),
         'ongoing': job.get('ongoing', False),
     }
+    return safe_unescape_html(job_serialized)
 
 
-@safe_unescape_html_in_results
 def serialize_school(school):
-    return {
+    school_serialized = {
         'institution': school.get('institution'),
         'department': school.get('department'),
         'degree': school.get('degree'),
@@ -583,6 +582,7 @@ def serialize_school(school):
         'endYear': school.get('endYear'),
         'ongoing': school.get('ongoing', False),
     }
+    return safe_unescape_html(school_serialized)
 
 
 def serialize_contents(field, func, auth, uid=None):

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -362,6 +362,7 @@ def update_user(user, index=None):
         'social': user.social_links,
         'boost': 2,  # TODO(fabianvf): Probably should make this a constant or something
     }
+    user_doc = sanitize.safe_unescape_html(user_doc)
 
     es.index(index=index, doc_type='user', body=user_doc, id=user._id, refresh=True)
 

--- a/website/util/sanitize.py
+++ b/website/util/sanitize.py
@@ -99,19 +99,6 @@ def safe_unescape_html(value):
     return value
 
 
-# TODO: Remove safe_unescape_html when mako html safe comes in
-def safe_unescape_html_in_results(func):
-    """ Return the functions results without escaped html
-
-    :param func: Function returning a dict, iterable, or string
-    :return: function
-    """
-    def wrapper(*args, **kwargs):
-        result = func(*args, **kwargs)
-        return safe_unescape_html(result)
-    return wrapper
-
-
 def safe_json(value):
     """
     Dump a string to JSON in a manner that can be used for JS strings in mako templates.

--- a/website/util/sanitize.py
+++ b/website/util/sanitize.py
@@ -99,6 +99,19 @@ def safe_unescape_html(value):
     return value
 
 
+# TODO: Remove safe_unescape_html when mako html safe comes in
+def safe_unescape_html_in_results(func):
+    """ Return the functions results without escaped html
+
+    :param func: Function returning a dict, iterable, or string
+    :return: function
+    """
+    def wrapper(*args, **kwargs):
+        result = func(*args, **kwargs)
+        return safe_unescape_html(result)
+    return wrapper
+
+
 def safe_json(value):
     """
     Dump a string to JSON in a manner that can be used for JS strings in mako templates.


### PR DESCRIPTION
# Purpose
Escaped html characters appears in a users job and school information both in search results and on the profile page.

![screen shot 2015-07-09 at 11 00 16 am](https://cloud.githubusercontent.com/assets/6082535/8598736/6a700f2a-262a-11e5-9a67-c4e5b5a3de53.png)

![screen shot 2015-07-09 at 11 06 15 am](https://cloud.githubusercontent.com/assets/6082535/8598770/a0afcc56-262a-11e5-89cd-82b21c5c0292.png)

# Changes
* Unescape html in user document before storing in elastic search.
* Unescape html in the results of serialize_job and serialize_school.