### PR TITLE
[Feature Fix] [Staging] Fix Wiki icons aren't shown 

### DIFF
--- a/website/static/css/pages/wiki-page.css
+++ b/website/static/css/pages/wiki-page.css
@@ -281,7 +281,7 @@
 }
 
 .wmd-button > span {
-    background-image: url(../../../addons/wiki/static/pagedown-ace/wmd-buttons.png);
+    background-image: url(../../../static/public/vendor/pagedown/wmd-buttons.png);
     background-repeat: no-repeat;
     background-position: 0px 0px;
     width: 20px;


### PR DESCRIPTION
### Purpose
This PR fixes wiki editor icons missing bug. In production, we process this img tag with webpack and create  data URI for img tag ([more info](https://css-tricks.com/data-uris/)). However, after I moved css code out of js file and load them statically, it will not be processed by webpack anymore. So data uri will not be created. In addition, the original image url is not  public. Then it can't be shown correctly.

The current solution is to use the public  image resource url which already exists. Another possible solution is to require the css code in js file. However, it will slow the page loading speed. So choose to apply the first solution. 

Resolved [Trello Bug](https://trello.com/c/SgmXjoyO/196-wiki-page-edit-tool-buttons-have-become-invisible)
### Changes
Before Change:
![a](https://cloud.githubusercontent.com/assets/5420789/8598831/096362da-262b-11e5-88c8-40a7b8be60ca.png)

After Change:
![aa](https://cloud.githubusercontent.com/assets/5420789/8598832/0becbdbc-262b-11e5-8add-a0566a5509cd.png)

