### PR TITLE
[hotfix] Allow LinkedIn pub/ profile links

### DIFF
--- a/website/static/js/profile.js
+++ b/website/static/js/profile.js
@@ -17,7 +17,7 @@ var socialRules = {
     researcherId: /researcherid\.com\/rid\/([-\w]+)/i,
     scholar: /scholar\.google\.com\/citations\?user=(\w+)/i,
     twitter: /twitter\.com\/(\w+)/i,
-    linkedIn: /.*\/?(in\/.*|profile\/.*)/i,
+    linkedIn: /.*\/?(in\/.*|profile\/.*|pub\/.*)/i,
     impactStory: /impactstory\.org\/([\w\.-]+)/i,
     github: /github\.com\/(\w+)/i
 };

--- a/website/templates/include/profile/social.mako
+++ b/website/templates/include/profile/social.mako
@@ -59,7 +59,7 @@
                 <label>LinkedIn</label>
                 <div class="input-group">
                 <span class="input-group-addon">https://www.linkedin.com/</span>
-                <input class="form-control" data-bind="value: linkedIn" placeholder="in/userID or profile/view?id=profileID"/>
+                <input class="form-control" data-bind="value: linkedIn" placeholder="in/userID, profile/view?id=profileID, or pub/pubID"/>
                 </div>
             </div>
 


### PR DESCRIPTION
## Purpose:
Allow users to use their LinkedIn pub/ endpoints

## Changes:
- Update JS regex to handle full URLs
- Update placeholder

## Side Effects:
None.

## Notes:
Closes-issue: https://trello.com/c/Fwfsu1EA/188-can-input-either-linkedin-profile-id-or-user-id