### PR TITLE
[feature][cleanup] DRY settings navpanel links

### DIFF
--- a/website/templates/include/profile/settings_navpanel.mako
+++ b/website/templates/include/profile/settings_navpanel.mako
@@ -1,0 +1,10 @@
+<%page args="current_page=''" />
+
+<div class="panel panel-default">
+    <ul class="nav nav-stacked nav-pills">
+        <li><a href="${ '#' if current_page == 'profile' else web_url_for('user_profile') }">Profile Information</a></li>
+        <li><a href="${ '#' if current_page == 'account' else web_url_for('user_account') }">Account Settings</a></li>
+        <li><a href="${ '#' if current_page == 'addons' else  web_url_for('user_addons') }">Configure Add-ons</a></li>
+        <li><a href="${ '#' if current_page == 'notifications' else web_url_for('user_notifications') }">Notifications</a></li>
+    </ul>
+</div><!-- end sidebar -->

--- a/website/templates/profile/account.mako
+++ b/website/templates/profile/account.mako
@@ -14,14 +14,7 @@
         <h2 class="page-header">Account Settings</h2>
         <div class="row">
             <div class="col-md-3">
-                <div class="panel panel-default">
-                    <ul class="nav nav-stacked nav-pills">
-                        <li><a href="${ web_url_for('user_profile') }">Profile Information</a></li>
-                        <li><a href="#">Account Settings</a></li>
-                        <li><a href="${ web_url_for('user_addons') }">Configure Add-ons</a></li>
-                        <li><a href="${ web_url_for('user_notifications') }">Notifications</a></li>
-                    </ul>
-                </div>
+              <%include file="include/profile/settings_navpanel.mako" args="current_page='account'"/>
             </div>
             <div class="col-md-6">
                 <div id="connectedEmails" class="panel panel-default scripted">

--- a/website/templates/profile/addons.mako
+++ b/website/templates/profile/addons.mako
@@ -14,16 +14,7 @@
 <div class="row">
 
     <div class="col-sm-3">
-
-        <div class="panel panel-default">
-            <ul class="nav nav-stacked nav-pills">
-                <li><a href="${ web_url_for('user_profile') }">Profile Information</a></li>
-                <li><a href="${ web_url_for('user_account') }">Account Settings</a></li>
-                <li><a href="#">Configure Add-ons</a></li>
-                <li><a href="${ web_url_for('user_notifications') }">Notifications</a></li>
-            </ul>
-        </div><!-- end sidebar -->
-
+      <%include file="include/profile/settings_navpanel.mako" args="current_page='addons'"/>
     </div>
 
     <div class="col-sm-9 col-md-7">

--- a/website/templates/profile/notifications.mako
+++ b/website/templates/profile/notifications.mako
@@ -14,14 +14,7 @@
 <div class="row">
 
     <div class="col-md-3">
-        <div class="panel panel-default">
-            <ul class="nav nav-stacked nav-pills">
-                <li><a href="${ web_url_for('user_profile') }">Profile Information</a></li>
-                <li><a href="${ web_url_for('user_account') }">Account Settings</a></li>
-                <li><a href="${ web_url_for('user_addons') }">Configure Add-ons</a></li>
-                <li><a href="#">Notifications</a></li>
-            </ul>
-        </div><!-- end sidebar -->
+      <%include file="include/profile/settings_navpanel.mako" args="current_page='notifications'"/>
     </div>
 
     <div class="col-md-6">

--- a/website/templates/profile/settings.mako
+++ b/website/templates/profile/settings.mako
@@ -19,14 +19,7 @@
 <div class="row">
 
     <div class="col-sm-3">
-        <div class="panel panel-default">
-            <ul class="nav nav-stacked nav-pills">
-                <li><a href="#">Profile Information</a></li>
-                <li><a href="${ web_url_for('user_account') }">Account Settings</a></li>
-                <li><a href="${ web_url_for('user_addons') }">Configure Add-ons</a></li>
-                <li><a href="${ web_url_for('user_notifications') }">Notifications</a></li>
-            </ul>
-        </div><!-- end sidebar -->
+      <%include file="include/profile/settings_navpanel.mako" args="current_page='profile'"/>
     </div>
 
     <div class="col-sm-9 col-md-7">


### PR DESCRIPTION
Per @sloria discussion.

## Purpose
The various settings pages have a lot of redundant code that needs to be maintained. This moves the sidebar navpanel to a single include, and controls which link is inactive via the `current_page` argument.

## Side effects
Should be none. But further DRY cleanup might be merited in the future.