### PR TITLE
[Hotfix] Figshare can view folders

### DIFF
--- a/website/addons/figshare/static/figshareFangornConfig.js
+++ b/website/addons/figshare/static/figshareFangornConfig.js
@@ -48,7 +48,7 @@ var _figshareItemButtons = {
                 }, 'Delete')
             );
         }
-        if (item.data.permissions && item.data.permissions.view) {
+        if (item.kind === 'file' && item.data.permissions && item.data.permissions.view) {
             buttons.push(
                 m.component(Fangorn.Components.button, {
                     onclick: function(event) {


### PR DESCRIPTION
# Purpose
Fixes #3407

# Issue
Figshare overrides the toolbar generation function and did not check that kind is a file.

# Side Effects
None