### PR TITLE
[Hotfix] Dragging a file or folder onto a file now uploads to its parent.

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1859,6 +1859,10 @@ function _dropLogic(event, items, folder) {
         return;
     }
 
+    if (folder.data.kind === 'file') {
+        folder = folder.parent();
+    }
+
     // if (items[0].data.kind === 'folder' && ['github', 'figshare', 'dataverse'].indexOf(folder.data.provider) !== -1) { return; }
 
     if (!folder.open) {
@@ -1907,6 +1911,10 @@ function getCopyMode(folder, items) {
     var canMove = true;
     var mustBeIntra = (folder.data.provider === 'github');
     var cannotBeFolder = (folder.data.provider === 'figshare' || folder.data.provider === 'dataverse');
+
+    if (folder.data.kind === 'file') {
+        folder = folder.parent();
+    }
 
     if (folder.parentId === 0 ||
         folder.data.kind !== 'folder' ||


### PR DESCRIPTION
# Purpose
Fixes #3509 

If drop target is a file change the target to its parent.
![untitled](https://cloud.githubusercontent.com/assets/5532905/8606745/e3b786d4-265b-11e5-85eb-43c606c48f91.gif)
