### PR TITLE
[Feature Fix] Reset values of external link add-on to default when deleted.

### DIFF
--- a/website/addons/forward/model.py
+++ b/website/addons/forward/model.py
@@ -27,6 +27,15 @@ class ForwardNodeSettings(AddonNodeSettingsBase):
     def link_text(self):
         return self.label if self.label else self.url
 
+    def on_delete(self):
+        self.reset()
+
+    def reset(self):
+        self.url = None
+        self.label = None
+        self.redirect_bool = True
+        self.redirect_secs = 15
+
 
 @ForwardNodeSettings.subscribe('before_save')
 def validate_circular_reference(schema, instance):


### PR DESCRIPTION
# Purpose
Currently when the External Link add-on is disabled then re-enabled the url present before disabling the add-on is still present after the add-on re-enabled.

This PR causes the values in the external link after re-enabling are the defaults.

This closes issue https://github.com/CenterForOpenScience/osf.io/issues/3496.

# Changes
Upon disabling the external link add-on it's url, label, redirect_bool, and redirect_secs are set to their default values.