### PR TITLE
[feature-fix] Add link to public figshare folders on warning messages

### DIFF
--- a/website/addons/figshare/messages.py
+++ b/website/addons/figshare/messages.py
@@ -1,11 +1,13 @@
 FIGSHARE = 'figshare'
 
 # MODEL MESSAGES :model.py
-BEFORE_PAGE_LOAD_PRIVATE_NODE_MIXED_FS = 'Warnings: This OSF {category} is private but ' + FIGSHARE + ' project {project_id} may contain some public files or filesets. '
+BEFORE_PAGE_LOAD_PRIVATE_NODE_MIXED_FS = 'Warnings: This OSF {category} is private but ' + FIGSHARE + ' project {project_id} may contain some public files or filesets. The files in this ' + FIGSHARE + ' project can be viewed on figshare ' + \
+                                         '<a href="https://figshare.com/articles/{encoded_folder_name}/{project_id}">here</a>. '
 
 BEFORE_PAGE_LOAD_PUBLIC_NODE_MIXED_FS = 'Warnings: This OSF {category} is public but ' + FIGSHARE + ' project {project_id} may contain some private files or filesets. '
 
-BEFORE_PAGE_LOAD_PERM_MISMATCH = 'Warnings: This OSF {category} is {node_perm}, but the ' + FIGSHARE + ' article {figshare_id} is {figshare_perm}. '
+BEFORE_PAGE_LOAD_PERM_MISMATCH = 'Warnings: This OSF {category} is {node_perm}, but the ' + FIGSHARE + ' article {figshare_id} is {figshare_perm}. The files in this ' + FIGSHARE + ' project can be viewed on figshare ' + \
+                                 '<a href="https://figshare.com/articles/{encoded_folder_name}/{figshare_id}">here</a>. '
 
 BEFORE_PAGE_LOAD_PUBLIC_NODE_PRIVATE_FS = 'Users can view the contents of this private ' + FIGSHARE + ' article. '
 

--- a/website/addons/figshare/model.py
+++ b/website/addons/figshare/model.py
@@ -313,12 +313,12 @@ class AddonFigShareNodeSettings(StorageAddonBase, AddonNodeSettingsBase):
             return []
         figshare = node.get_addon('figshare')
         # Quit if no user authorization
-
+        encoded_folder_name = figshare.folder_name.replace(' ', '_')
         node_permissions = 'public' if node.is_public else 'private'
 
         if figshare.figshare_type == 'project':
             if node_permissions == 'private':
-                message = messages.BEFORE_PAGE_LOAD_PRIVATE_NODE_MIXED_FS.format(category=node.project_or_component, project_id=figshare.figshare_id)
+                message = messages.BEFORE_PAGE_LOAD_PRIVATE_NODE_MIXED_FS.format(category=node.project_or_component, project_id=figshare.figshare_id, encoded_folder_name=encoded_folder_name)
                 return [message]
             else:
                 message = messages.BEFORE_PAGE_LOAD_PUBLIC_NODE_MIXED_FS.format(category=node.project_or_component, project_id=figshare.figshare_id)
@@ -334,6 +334,7 @@ class AddonFigShareNodeSettings(StorageAddonBase, AddonNodeSettingsBase):
                 node_perm=node_permissions,
                 figshare_perm=article_permissions,
                 figshare_id=self.figshare_id,
+                encoded_folder_name=encoded_folder_name,
             )
             if article_permissions == 'private' and node_permissions == 'public':
                 message += messages.BEFORE_PAGE_LOAD_PUBLIC_NODE_PRIVATE_FS


### PR DESCRIPTION
@sloria Fixes the problems with the figshare messages, and have it so it doesn't link to private folders (for now, those won't have a link)