### PR TITLE
[Feature Fix] Fix three styleguide bugs on trello

### DIFF
--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -72,8 +72,7 @@ var FileViewPage = {
         self.editHeader = function() {
             return m('.row', [
                 m('.col-sm-12', m('span[style=display:block;]', [
-                    m('i.fa.fa-pencil-square-o'),
-                    ' Edit',
+                    m('h3.panel-title',[m('i.fa.fa-pencil-square-o'), '   Edit ']),
                     m('.pull-right', [
                         m('.progress.no-margin.pointer', {
                             'data-toggle': 'modal',

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -234,7 +234,7 @@
 
          <div class="citations panel panel-default">
             <div class="panel-heading clearfix">
-                <h3 class="panel-title">Citation</h3>
+                <h3 class="panel-title"  style="padding-top: 3px">Citation</h3>
                 <div class="pull-right">
                     <span class="permalink">${node['display_absolute_url']}</span><a href="#" class="m-sm project-toggle"><i class="fa fa-angle-down"></i></a>
                 </div>
@@ -288,7 +288,7 @@
 % if ('write' in user['permissions'] and not node['is_registration']) or node['children']:
     <div class="components panel panel-default">
         <div class="panel-heading clearfix">
-            <h3 class="panel-title">Components </h3>
+            <h3 class="panel-title" style="padding-bottom: 5px; padding-top: 5px;">Components </h3>
             <div class="pull-right">
                 % if 'write' in user['permissions'] and not node['is_registration']:
                     <a class="btn btn-sm btn-default" data-toggle="modal" data-target="#newComponent">Add Component</a>

--- a/website/templates/util/render_node.mako
+++ b/website/templates/util/render_node.mako
@@ -9,7 +9,7 @@
         ">
 
         <h4 class="list-group-item-heading">
-            <span class="component-overflow" style="line-height: 1.5;">
+            <span class="component-overflow f-w-lg" style="line-height: 1.5;">
             % if not summary['primary']:
               <i class="fa fa-link" data-toggle="tooltip" title="Linked ${summary['node_type']}"></i>
             % endif


### PR DESCRIPTION
Resolve:
1.  Center the panel title
https://trello.com/c/q4GC7v9Y/211-project-overview-container-titles-not-centered
2. Add proper font to edit
https://trello.com/c/OQhuTDYQ/201-file-details-page-font-size-difference-between-edit-and-revisions-pane-headers
3. Bold component and project tile
https://trello.com/c/ZiLuaNbu/236-project-and-component-titles-are-not-bolded