### PR TITLE
fix add link modal search

### DIFF
--- a/website/static/js/pointers.js
+++ b/website/static/js/pointers.js
@@ -40,10 +40,12 @@ var AddPointerViewModel = oop.extend(Paginator, {
     },
     searchAllProjects: function() {
         this.includePublic(true);
+        this.pageToGet(0);
         this.fetchResults();
     },
     searchMyProjects: function() {
         this.includePublic(false);
+        this.pageToGet(0);
         this.fetchResults();
     },
     fetchResults: function() {


### PR DESCRIPTION
<b>Purpose</b>
Fix the problem that when search from different option the page num doesn't reset. Closes https://trello.com/c/jN6sHnR1/204-add-links-modal-clicking-past-last-page-and-through-internal-pages-of-search-results-sometimes-yields-invalid-value-for-page-mes and Closes https://github.com/CenterForOpenScience/osf.io/issues/3497