### PR TITLE
Remove data-offset-bottom for navigation in project settings

### DIFF
--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -22,7 +22,7 @@
 
         % if 'write' in user['permissions']:
 
-            <div class="panel panel-default" data-spy="affix" data-offset-top="60" data-offset-bottom="268"><!-- Begin sidebar -->
+            <div class="panel panel-default" data-spy="affix" data-offset-top="60" ><!-- Begin sidebar -->
                 <ul class="nav nav-stacked nav-pills">
 
                     % if not node['is_registration']:


### PR DESCRIPTION
## Purpose
Fixes the trello issue regarding breaking navbar in project settings: https://trello.com/c/cysFBshY

## Changes
Removed the bottom offset to make the navbar not stick to bottom.