### PR TITLE
Break emails in confirmation settings box

### DIFF
--- a/website/static/css/pages/project-page.css
+++ b/website/static/css/pages/project-page.css
@@ -112,3 +112,7 @@
 #addPointer td {
     vertical-align: middle;
 }
+
+.affix-bottom {
+    position: relative;
+}

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -402,7 +402,7 @@ select {
 }
 
 tr a {
-    word-break: break-all;
+    word-break: break-word;
 }
 
 .btn-link.project-toggle {

--- a/website/templates/profile/account.mako
+++ b/website/templates/profile/account.mako
@@ -49,7 +49,7 @@
                             </thead>
                             <tbody data-bind="foreach: profile().alternateEmails()">
                                 <tr>
-                                    <td style="width:100%">{{ $data.address }}</td>
+                                    <td style="word-break: break-all;">{{ $data.address }}</td>
                                     <td><a data-bind="click: $parent.makeEmailPrimary">make&nbsp;primary</a></td>
                                     <td><a data-bind="click: $parent.removeEmail"><i class="fa fa-times text-danger"></i></a></td>
                                 </tr>
@@ -65,7 +65,7 @@
                             <tbody>
                                 <!-- ko foreach: profile().unconfirmedEmails() -->
                                 <tr>
-                                    <td style="width:100%">{{ $data.address }}</td>
+                                    <td style="word-break: break-all;">{{ $data.address }}</td>
                                     <td><a data-bind="click: $parent.resendConfirmation">resend&nbsp;confirmation</a></td>
                                     <td><a data-bind="click: $parent.removeEmail"><i class="fa fa-times text-danger"></i></a></td>
                                 </tr>

--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -22,7 +22,7 @@
 
         % if 'write' in user['permissions']:
 
-            <div class="panel panel-default" data-spy="affix" data-offset-top="60" ><!-- Begin sidebar -->
+            <div class="panel panel-default" data-spy="affix" data-offset-top="60" data-offset-bottom="263"><!-- Begin sidebar -->
                 <ul class="nav nav-stacked nav-pills">
 
                     % if not node['is_registration']:
@@ -333,6 +333,14 @@
 % for name, capabilities in addon_capabilities.iteritems():
     <script id="capabilities-${name}" type="text/html">${capabilities}</script>
 % endfor
+
+
+<%def name="stylesheets()">
+    ${parent.stylesheets()}
+
+    <link rel="stylesheet" href="/static/css/pages/project-page.css">
+</%def>
+
 
 <%def name="javascript_bottom()">
     <% import json %>


### PR DESCRIPTION
## Purpose
Fixes these Trello issues
- https://trello.com/c/1AppLiKD
- issue with breaking user names: https://trello.com/c/70apE9EO
- affix navbar in project settings: https://trello.com/c/cysFBshY

## Changes
Remove the 100% style and add word-break rule to the td. 
Add project css to project settings with new affix-bottom rule