### PR TITLE
Create Fork Modal Message Incorrect

### DIFF
--- a/website/addons/base/__init__.py
+++ b/website/addons/base/__init__.py
@@ -779,11 +779,9 @@ class AddonNodeSettingsBase(AddonSettingsBase):
         :returns Alert message
         """
 
-        category = node.project_or_component
-
         if hasattr(self, "user_settings"):
             if self.user_settings is None:
-                  return (
+                return (
                     u'Because you have not configured the authorization for this {addon} add-on this '
                     u'{category} will not transfer your authentication token to '
                     u'the new forked {category}.'

--- a/website/addons/base/__init__.py
+++ b/website/addons/base/__init__.py
@@ -772,14 +772,44 @@ class AddonNodeSettingsBase(AddonSettingsBase):
         pass
 
     def before_fork(self, node, user):
-        """
-
+        """Return warning text to display if user auth will be copied to a
+        fork.
         :param Node node:
-        :param User user:
-        :returns: Alert message
-
+        :param Uder user
+        :returns Alert message
         """
-        pass
+
+        category = node.project_or_component
+
+        if hasattr(self, "user_settings"):
+            if self.user_settings is None:
+                  return (
+                    u'Because you have not configured the authorization for this {addon} add-on this '
+                    u'{category} will not transfer your authentication token to '
+                    u'the new forked {category}.'
+                ).format(
+                    addon=self.config.full_name,
+                    category=node.project_or_component,
+                )
+
+            elif self.user_settings and self.user_settings.owner == user:
+                return (
+                    u'Because you have authorized the {addon} add-on for this '
+                    u'{category}, forking it will also transfer your authentication token to '
+                    u'the forked {category}.'
+                ).format(
+                    addon=self.config.full_name,
+                    category=node.project_or_component,
+                )
+            else:
+                return (
+                    u'Because the {addon} add-on has been authorized by a different '
+                    u'user, forking it will not transfer authentication token to the forked '
+                    u'{category}.'
+                ).format(
+                    addon=self.config.full_name,
+                    category=node.project_or_component,
+                )
 
     def after_fork(self, node, fork, user, save=True):
         """
@@ -1004,31 +1034,6 @@ class AddonOAuthNodeSettingsBase(AddonNodeSettingsBase):
                 ).format(url=url)
             #
             return message
-
-    def before_fork_message(self, node, user):
-        """Return warning text to display if user auth will be copied to a
-        fork.
-        """
-        if self.user_settings and self.user_settings.owner == user:
-            return (
-                u'Because you have authorized the {addon} add-on for this '
-                u'{category}, forking it will also transfer your authentication token to '
-                u'the forked {category}.'
-            ).format(
-                addon=self.config.full_name,
-                category=node.project_or_component,
-            )
-        return (
-            u'Because the {addon} add-on has been authorized by a different '
-            u'user, forking it will not transfer authentication token to the forked '
-            u'{category}.'
-        ).format(
-            addon=self.config.full_name,
-            category=node.project_or_component,
-        )
-
-    # backwards compatibility
-    before_fork = before_fork_message
 
     def after_fork(self, node, fork, user, save=True):
         """After forking, copy user settings if the user is the one who authorized

--- a/website/addons/base/__init__.py
+++ b/website/addons/base/__init__.py
@@ -782,9 +782,9 @@ class AddonNodeSettingsBase(AddonSettingsBase):
         if hasattr(self, "user_settings"):
             if self.user_settings is None:
                 return (
-                    u'Because you have not configured the authorization for this {addon} add-on this '
-                    u'{category} will not transfer your authentication token to '
-                    u'the new forked {category}.'
+                    u'Because you have not configured the authorization for this {addon} add-on, this '
+                    u'{category} will not transfer your authentication to '
+                    u'the forked {category}.'
                 ).format(
                     addon=self.config.full_name,
                     category=node.project_or_component,
@@ -793,7 +793,7 @@ class AddonNodeSettingsBase(AddonSettingsBase):
             elif self.user_settings and self.user_settings.owner == user:
                 return (
                     u'Because you have authorized the {addon} add-on for this '
-                    u'{category}, forking it will also transfer your authentication token to '
+                    u'{category}, forking it will also transfer your authentication to '
                     u'the forked {category}.'
                 ).format(
                     addon=self.config.full_name,
@@ -802,7 +802,7 @@ class AddonNodeSettingsBase(AddonSettingsBase):
             else:
                 return (
                     u'Because the {addon} add-on has been authorized by a different '
-                    u'user, forking it will not transfer authentication token to the forked '
+                    u'user, forking it will not transfer authentication to the forked '
                     u'{category}.'
                 ).format(
                     addon=self.config.full_name,

--- a/website/addons/box/model.py
+++ b/website/addons/box/model.py
@@ -357,8 +357,6 @@ class BoxNodeSettings(StorageAddonBase, AddonNodeSettingsBase):
     # backwards compatibility
     before_register = before_register_message
 
-
-
     def before_remove_contributor_message(self, node, removed):
         """Return warning text to display if removed contributor is the user
         who authorized the Box addon

--- a/website/addons/box/model.py
+++ b/website/addons/box/model.py
@@ -357,26 +357,7 @@ class BoxNodeSettings(StorageAddonBase, AddonNodeSettingsBase):
     # backwards compatibility
     before_register = before_register_message
 
-    def before_fork_message(self, node, user):
-        """Return warning text to display if user auth will be copied to a
-        fork.
-        """
-        category = node.project_or_component
-        if self.user_settings and self.user_settings.owner == user:
-            return (
-                u'Because you have authorized the Box add-on for this '
-                '{category}, forking it will also transfer your authentication token to '
-                'the forked {category}.'
-            ).format(category=category)
-        else:
-            return (
-                u'Because the Box add-on has been authorized by a different '
-                'user, forking it will not transfer authentication token to the forked '
-                '{category}.'
-            ).format(category=category)
 
-    # backwards compatibility
-    before_fork = before_fork_message
 
     def before_remove_contributor_message(self, node, removed):
         """Return warning text to display if removed contributor is the user

--- a/website/addons/dataverse/model.py
+++ b/website/addons/dataverse/model.py
@@ -239,24 +239,6 @@ class AddonDataverseNodeSettings(StorageAddonBase, AddonOAuthNodeSettingsBase):
     # backwards compatibility
     before_register = before_register_message
 
-    def before_fork_message(self, node, user):
-        """Return warning text to display if user auth will be copied to a
-        fork.
-        """
-        category = node.project_or_component
-        if self.user_settings and self.user_settings.owner == user:
-            return ('Because you have authorized the Dataverse add-on for this '
-                '{category}, forking it will also transfer your authentication '
-                'to the forked {category}.').format(category=category)
-
-        else:
-            return ('Because the Dataverse add-on has been authorized by a different '
-                    'user, forking it will not transfer authentication to the forked '
-                    '{category}.').format(category=category)
-
-    # backwards compatibility
-    before_fork = before_fork_message
-
     def before_remove_contributor_message(self, node, removed):
         """Return warning text to display if removed contributor is the user
         who authorized the Dataverse addon

--- a/website/addons/dropbox/model.py
+++ b/website/addons/dropbox/model.py
@@ -220,24 +220,6 @@ class DropboxNodeSettings(StorageAddonBase, AddonNodeSettingsBase):
     # backwards compatibility
     before_register = before_register_message
 
-    def before_fork_message(self, node, user):
-        """Return warning text to display if user auth will be copied to a
-        fork.
-        """
-        category = node.project_or_component
-        if self.user_settings and self.user_settings.owner == user:
-            return (u'Because you have authorized the Dropbox add-on for this '
-                '{category}, forking it will also transfer your authentication token to '
-                'the forked {category}.').format(category=category)
-
-        else:
-            return (u'Because the Dropbox add-on has been authorized by a different '
-                    'user, forking it will not transfer authentication token to the forked '
-                    '{category}.').format(category=category)
-
-    # backwards compatibility
-    before_fork = before_fork_message
-
     def before_remove_contributor_message(self, node, removed):
         """Return warning text to display if removed contributor is the user
         who authorized the Dropbox addon

--- a/website/addons/figshare/model.py
+++ b/website/addons/figshare/model.py
@@ -384,22 +384,6 @@ class AddonFigShareNodeSettings(StorageAddonBase, AddonNodeSettingsBase):
             #
             return message
 
-    def before_fork(self, node, user):
-        """
-
-        :param Node node:
-        :param User user:
-        :return str: Alert message
-
-        """
-        if self.user_settings and self.user_settings.owner == user:
-            return messages.BEFORE_FORK_OWNER.format(
-                category=node.project_or_component,
-            )
-        return messages.BEFORE_FORK_NOT_OWNER.format(
-            category=node.project_or_component,
-        )
-
     def after_fork(self, node, fork, user, save=True):
         """
 

--- a/website/addons/github/model.py
+++ b/website/addons/github/model.py
@@ -520,30 +520,6 @@ class AddonGitHubNodeSettings(StorageAddonBase, AddonNodeSettingsBase):
             )
         )
 
-    def before_fork(self, node, user):
-        """
-
-        :param Node node:
-        :param User user:
-        :return str: Alert message
-
-        """
-        if self.user_settings and self.user_settings.owner == user:
-            return (
-                'Because you have authenticated the GitHub add-on for this '
-                '{cat}, forking it will also transfer your authorization to '
-                'the forked {cat}.'
-            ).format(
-                cat=node.project_or_component,
-            )
-        return (
-            'Because this GitHub add-on has been authenticated by a different '
-            'user, forking it will not transfer authentication to the forked '
-            '{cat}.'
-        ).format(
-            cat=node.project_or_component,
-        )
-
     def after_fork(self, node, fork, user, save=True):
         """
 

--- a/website/addons/googledrive/model.py
+++ b/website/addons/googledrive/model.py
@@ -366,24 +366,6 @@ class GoogleDriveNodeSettings(StorageAddonBase, AddonNodeSettingsBase):
     # backwards compatibility
     before_register = before_register_message
 
-    def before_fork_message(self, node, user):
-        """Return warning text to display if user auth will be copied to a
-        fork.
-        """
-        category = node.project_or_component
-        if self.user_settings and self.user_settings.owner == user:
-            return (u'Because you have authorized the Google Drive add-on for this '
-                    '{category}, forking it will also transfer your authentication token to '
-                    'the forked {category}.').format(category=category)
-
-        else:
-            return (u'Because the Google Drive add-on has been authorized by a different '
-                    'user, forking it will not transfer authentication token to the forked '
-                    '{category}.').format(category=category)
-
-    # backwards compatibility
-    before_fork = before_fork_message
-
     def before_remove_contributor_message(self, node, removed):
         """Return warning text to display if removed contributor is the user
         who authorized the GoogleDrive addon

--- a/website/addons/s3/model.py
+++ b/website/addons/s3/model.py
@@ -240,31 +240,6 @@ class AddonS3NodeSettings(StorageAddonBase, AddonNodeSettingsBase):
 
         return clone, message
 
-    def before_fork(self, node, user):
-        """
-
-        :param Node node:
-        :param User user:
-        :return str: Alert message
-
-        """
-
-        if self.user_settings and self.user_settings.owner == user:
-            return (
-                'Because you have authenticated the S3 add-on for this '
-                '{cat}, forking it will also transfer your authorization to '
-                'the forked {cat}.'
-            ).format(
-                cat=node.project_or_component,
-            )
-        return (
-            'Because this S3 add-on has been authenticated by a different '
-            'user, forking it will not transfer authentication to the forked '
-            '{cat}.'
-        ).format(
-            cat=node.project_or_component,
-        )
-
     def before_remove_contributor(self, node, removed):
         """
 


### PR DESCRIPTION
<h2>Purpose </h2>
Fix representative error message caused by forking unconfigured addons. Closes #3521.
<h2>Changes </h2>
Now all addons use same error reporting function which properly accounts for unconfigured addons.
<h2> Side Effects </h2>
Now all relavant addons use the same function before_fork from the superclass AddonNodeSettingsBase instead having separately defined, but functionally incidental functions.
