### PR TITLE
[Feature] Prevent unintended wiki page-refresh

### DIFF
--- a/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
+++ b/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
@@ -1536,7 +1536,7 @@
                     }
 
                     state.restore();
-                    previewManager.refresh();
+                    //previewManager.refresh(); //OSF Note: removed for issue 3518
                 };
 
                 var noCleanup = button.textOp(chunks, fixupInputArea);


### PR DESCRIPTION
Purpose
======
Closes https://github.com/CenterForOpenScience/osf.io/issues/3518

Changes
=======
Line causing bug (from library ```pagedown-ace```) commented out. See [line 1527-1529](https://github.com/mfraezz/osf.io/blob/19d8a5cbf112a565055cc8b02706e71c26529b05/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js#L1527-1529) for details from original author. 

Side Effects
=========
None locally observable. This line never worked in FF locally / on staging and production (generated ```TypeError: not a function```) without causing any actual problems, and without exhibiting the closed issue.