### PR TITLE
[Ready] [Style] wiki dialog style update

### DIFF
--- a/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
+++ b/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
@@ -30,7 +30,7 @@
         
         link: "Hyperlink <a>",
         linkdescription: "enter link description here",
-        linkdialog: "<h4 class='modal-title'>Insert Hyperlink</h3><p>http://example.com/ \"optional title\"</p>",
+        linkdialog: "<div class='modal-header'> <h4 class='modal-title f-w-lg'>Insert Hyperlink</h4></div><div class='modal-body'> <p>http://example.com/ \"optional title\"</p></div>",
         
         quote: "Blockquote <blockquote>",
         quoteexample: "Blockquote",
@@ -40,7 +40,7 @@
         
         image: "Image <img>",
         imagedescription: "enter image description here",
-        imagedialog: "<h4 class='modal-title'>Insert Image</h3><p>http://example.com/images/diagram.jpg \"optional title\"<br><br>Need <a href='http://www.google.com/search?q=free+image+hosting' target='_blank'>free image hosting?</a></p>",
+        imagedialog: "<h4 class='modal-title f-w-lg'>Insert Image</h4><hr><p>http://example.com/images/diagram.jpg \"optional title\"<br><br>Need <a href='http://www.google.com/search?q=free+image+hosting' target='_blank'>free image hosting?</a></p>",
         
         olist: "Numbered List <ol>",
         ulist: "Bulleted List <ul>",
@@ -1257,7 +1257,7 @@
 
             // The main dialog box.
             dialog = doc.createElement("div");
-            dialog.className = "modal-content p-md";
+            dialog.className = "modal-content ";
             dialog.style.padding = "10px;";
             dialog.style.position = "fixed";
             dialog.style.width = "400px";
@@ -1266,9 +1266,8 @@
             // The dialog text.
             var question = doc.createElement("div");
             question.innerHTML = text;
-            question.style.padding = "5px";
             dialog.appendChild(question);
-            question.className = "modal-body";
+            question.className = "";
 
 
             // The web form container for the text box and buttons.
@@ -1297,28 +1296,30 @@
             // The ok button
             var okButton = doc.createElement("input");
             okButton.type = "button";
-            okButton.className = "btn btn-success pull-right";
+            okButton.className = "btn btn-success ";
             okButton.onclick = function () { return close(false); };
             okButton.value = "Apply";
             style = okButton.style;
-            style.margin = "20px 3px";
             style.display = "inline";
-            style.width = "7em";
 
 
             // The cancel button
             var cancelButton = doc.createElement("input");
             cancelButton.type = "button";
-            cancelButton.className = "btn btn-default pull-right";
+            cancelButton.className = "btn btn-default ";
             cancelButton.onclick = function () { return close(true); };
             cancelButton.value = "Cancel";
             style = cancelButton.style;
-            style.margin = "20px 3px";
             style.display = "inline";
-            style.width = "7em";
 
-            form.appendChild(cancelButton);
-            form.appendChild(okButton);
+            // Modal footer
+            var modalFooter = doc.createElement("div");
+            modalFooter.className = 'modal-footer';
+
+            modalFooter.appendChild(cancelButton);
+            modalFooter.appendChild(okButton);
+
+            form.appendChild(modalFooter);
 
             util.addEvent(doc.body, "keydown", checkEscape);
             dialog.style.top = "50%";

--- a/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
+++ b/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
@@ -30,7 +30,7 @@
         
         link: "Hyperlink <a>",
         linkdescription: "enter link description here",
-        linkdialog: "<p><b>Insert Hyperlink</b></p><p>http://example.com/ \"optional title\"</p>",
+        linkdialog: "<h4 class='modal-title'>Insert Hyperlink</h3><p>http://example.com/ \"optional title\"</p>",
         
         quote: "Blockquote <blockquote>",
         quoteexample: "Blockquote",
@@ -40,7 +40,7 @@
         
         image: "Image <img>",
         imagedescription: "enter image description here",
-        imagedialog: "<p><b>Insert Image</b></p><p>http://example.com/images/diagram.jpg \"optional title\"<br><br>Need <a href='http://www.google.com/search?q=free+image+hosting' target='_blank'>free image hosting?</a></p>",
+        imagedialog: "<h4 class='modal-title'>Insert Image</h3><p>http://example.com/images/diagram.jpg \"optional title\"<br><br>Need <a href='http://www.google.com/search?q=free+image+hosting' target='_blank'>free image hosting?</a></p>",
         
         olist: "Numbered List <ol>",
         ulist: "Bulleted List <ul>",
@@ -1285,22 +1285,23 @@
 
             // The input text box
             input = doc.createElement("input");
+            input.className = "form-control";
             input.type = "text";
             input.value = defaultInputText;
             style = input.style;
             style.display = "block";
-            style.width = "80%";
+            style.width = "90%";
             style.marginLeft = style.marginRight = "auto";
             form.appendChild(input);
 
             // The ok button
             var okButton = doc.createElement("input");
             okButton.type = "button";
-            okButton.className = "btn btn-success";
+            okButton.className = "btn btn-success pull-right";
             okButton.onclick = function () { return close(false); };
             okButton.value = "Apply";
             style = okButton.style;
-            style.margin = "10px";
+            style.margin = "20px 3px";
             style.display = "inline";
             style.width = "7em";
 
@@ -1308,11 +1309,11 @@
             // The cancel button
             var cancelButton = doc.createElement("input");
             cancelButton.type = "button";
-            cancelButton.className = "btn btn-default";
+            cancelButton.className = "btn btn-default pull-right";
             cancelButton.onclick = function () { return close(true); };
             cancelButton.value = "Cancel";
             style = cancelButton.style;
-            style.margin = "10px";
+            style.margin = "20px 3px";
             style.display = "inline";
             style.width = "7em";
 

--- a/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
+++ b/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
@@ -1257,7 +1257,7 @@
 
             // The main dialog box.
             dialog = doc.createElement("div");
-            dialog.className = "wmd-prompt-dialog";
+            dialog.className = "modal-content p-md";
             dialog.style.padding = "10px;";
             dialog.style.position = "fixed";
             dialog.style.width = "400px";
@@ -1268,6 +1268,8 @@
             question.innerHTML = text;
             question.style.padding = "5px";
             dialog.appendChild(question);
+            question.className = "modal-body";
+
 
             // The web form container for the text box and buttons.
             var form = doc.createElement("form"),
@@ -1294,8 +1296,9 @@
             // The ok button
             var okButton = doc.createElement("input");
             okButton.type = "button";
+            okButton.className = "btn btn-success";
             okButton.onclick = function () { return close(false); };
-            okButton.value = "OK";
+            okButton.value = "Apply";
             style = okButton.style;
             style.margin = "10px";
             style.display = "inline";
@@ -1305,6 +1308,7 @@
             // The cancel button
             var cancelButton = doc.createElement("input");
             cancelButton.type = "button";
+            cancelButton.className = "btn btn-default";
             cancelButton.onclick = function () { return close(true); };
             cancelButton.value = "Cancel";
             style = cancelButton.style;
@@ -1312,8 +1316,8 @@
             style.display = "inline";
             style.width = "7em";
 
-            form.appendChild(okButton);
             form.appendChild(cancelButton);
+            form.appendChild(okButton);
 
             util.addEvent(doc.body, "keydown", checkEscape);
             dialog.style.top = "50%";

--- a/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
+++ b/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
@@ -40,7 +40,7 @@
         
         image: "Image <img>",
         imagedescription: "enter image description here",
-        imagedialog: "<h4 class='modal-title f-w-lg'>Insert Image</h4><hr><p>http://example.com/images/diagram.jpg \"optional title\"<br><br>Need <a href='http://www.google.com/search?q=free+image+hosting' target='_blank'>free image hosting?</a></p>",
+        imagedialog: "<div class='modal-header'> <h4 class='modal-title f-w-lg'>Insert Image</h4></div><div class='modal-body'><p>http://example.com/images/diagram.jpg \"optional title\"<br><br>Need <a href='http://www.google.com/search?q=free+image+hosting' target='_blank'>free image hosting?</a></p></div>",
         
         olist: "Numbered List <ol>",
         ulist: "Bulleted List <ul>",

--- a/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
+++ b/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
@@ -30,7 +30,7 @@
         
         link: "Hyperlink <a>",
         linkdescription: "enter link description here",
-        linkdialog: "<div class='modal-header'> <h4 class='modal-title f-w-lg'>Add Hyperlink</h4></div><div class='modal-body'> <p>http://example.com/ \"optional title\"</p></div>",
+        linkdialog: "<div class='modal-header'> <h4 class='modal-title f-w-lg'>Add Hyperlink</h4></div><div class='modal-body'> <p><b>Example:</b><br>http://example.com/ \"optional title\"</p></div>",
         
         quote: "Blockquote <blockquote>",
         quoteexample: "Blockquote",
@@ -40,8 +40,8 @@
         
         image: "Image <img>",
         imagedescription: "enter image description here",
-        imagedialog: "<div class='modal-header'> <h4 class='modal-title f-w-lg'>Add Image</h4></div><div class='modal-body'><p>http://example.com/images/diagram.jpg \"optional title\"<br><br>Need <a href='http://www.google.com/search?q=free+image+hosting' target='_blank'>free image hosting?</a></p></div>",
-        
+        imagedialog: "<div class='modal-header'> <h4 class='modal-title f-w-lg'>Add Image</h4></div><div class='modal-body'><p><b>Example:</b><br>http://example.com/images/diagram.jpg \"optional title\"</p></div>",
+
         olist: "Numbered List <ol>",
         ulist: "Bulleted List <ul>",
         litem: "List item",

--- a/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
+++ b/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
@@ -30,7 +30,7 @@
         
         link: "Hyperlink <a>",
         linkdescription: "enter link description here",
-        linkdialog: "<div class='modal-header'> <h4 class='modal-title f-w-lg'>Insert Hyperlink</h4></div><div class='modal-body'> <p>http://example.com/ \"optional title\"</p></div>",
+        linkdialog: "<div class='modal-header'> <h4 class='modal-title f-w-lg'>Add Hyperlink</h4></div><div class='modal-body'> <p>http://example.com/ \"optional title\"</p></div>",
         
         quote: "Blockquote <blockquote>",
         quoteexample: "Blockquote",
@@ -40,7 +40,7 @@
         
         image: "Image <img>",
         imagedescription: "enter image description here",
-        imagedialog: "<div class='modal-header'> <h4 class='modal-title f-w-lg'>Insert Image</h4></div><div class='modal-body'><p>http://example.com/images/diagram.jpg \"optional title\"<br><br>Need <a href='http://www.google.com/search?q=free+image+hosting' target='_blank'>free image hosting?</a></p></div>",
+        imagedialog: "<div class='modal-header'> <h4 class='modal-title f-w-lg'>Add Image</h4></div><div class='modal-body'><p>http://example.com/images/diagram.jpg \"optional title\"<br><br>Need <a href='http://www.google.com/search?q=free+image+hosting' target='_blank'>free image hosting?</a></p></div>",
         
         olist: "Numbered List <ol>",
         ulist: "Bulleted List <ul>",
@@ -1298,7 +1298,7 @@
             okButton.type = "button";
             okButton.className = "btn btn-success ";
             okButton.onclick = function () { return close(false); };
-            okButton.value = "Apply";
+            okButton.value = "Add";
             style = okButton.style;
             style.display = "inline";
 

--- a/website/static/css/pages/wiki-page.css
+++ b/website/static/css/pages/wiki-page.css
@@ -309,24 +309,6 @@
     background-color: #F5F5F5;
 }
 
-/*.wmd-prompt-dialog > div {*/
-    /*font-size: 0.8em;*/
-    /*font-family: arial, helvetica, sans-serif;*/
-/*}*/
-
-
-/*.wmd-prompt-dialog > form > input[type="text"] {*/
-    /*border: 1px solid #999999;*/
-    /*color: black;*/
-/*}*/
-
-/*.wmd-prompt-dialog > form > input[type="button"]{*/
-    /*border: 1px solid #888888;*/
-    /*font-family: trebuchet MS, helvetica, sans-serif;*/
-    /*font-size: 0.8em;*/
-    /*font-weight: bold;*/
-/*}*/
-
 .wiki-single-heading {
     border: 1px solid #ddd;
 }

--- a/website/static/css/pages/wiki-page.css
+++ b/website/static/css/pages/wiki-page.css
@@ -309,23 +309,23 @@
     background-color: #F5F5F5;
 }
 
-.wmd-prompt-dialog > div {
-    font-size: 0.8em;
-    font-family: arial, helvetica, sans-serif;
-}
+/*.wmd-prompt-dialog > div {*/
+    /*font-size: 0.8em;*/
+    /*font-family: arial, helvetica, sans-serif;*/
+/*}*/
 
 
-.wmd-prompt-dialog > form > input[type="text"] {
-    border: 1px solid #999999;
-    color: black;
-}
+/*.wmd-prompt-dialog > form > input[type="text"] {*/
+    /*border: 1px solid #999999;*/
+    /*color: black;*/
+/*}*/
 
-.wmd-prompt-dialog > form > input[type="button"]{
-    border: 1px solid #888888;
-    font-family: trebuchet MS, helvetica, sans-serif;
-    font-size: 0.8em;
-    font-weight: bold;
-}
+/*.wmd-prompt-dialog > form > input[type="button"]{*/
+    /*border: 1px solid #888888;*/
+    /*font-family: trebuchet MS, helvetica, sans-serif;*/
+    /*font-size: 0.8em;*/
+    /*font-weight: bold;*/
+/*}*/
 
 .wiki-single-heading {
     border: 1px solid #ddd;


### PR DESCRIPTION
## Purpose
The wiki uses dialogs for adding link and adding image. This change brings the style of these dialog boxes to look like modals without using modal syntax but using the modal classes

Addresses issue: https://trello.com/c/YPSBca7A

## Changes 
The static vendor file in wiki/static/pagedown-ace/ was changed to use modal classes

## Side effects
This is a change in vendor library but it's not installed with package manager and I think it's stable enough but we need to keep an eye on this in case the markdown file is replaced. 

#### BEFORE:
![screen_shot_2015-07-09_at_2 20 27_pm](https://cloud.githubusercontent.com/assets/1314003/8674550/a4ff4d3c-2a0c-11e5-86e3-b017f13a2eb0.png)

#### AFTER: 
![screen shot 2015-07-14 at 9 44 25 am](https://cloud.githubusercontent.com/assets/1314003/8674600/f4523a70-2a0c-11e5-8c3f-0b3bf3eb284f.png)
