### PR TITLE
[WIP] Feature: streamline configuring add-ons for a node

### DIFF
--- a/website/addons/base/__init__.py
+++ b/website/addons/base/__init__.py
@@ -700,7 +700,6 @@ class AddonNodeSettingsBase(AddonSettingsBase):
                 'url': self.owner.url,
                 'is_registration': self.owner.is_registration,
             },
-            'node_settings_template': os.path.basename(self.config.node_settings_template),
         })
         return ret
 

--- a/website/addons/base/utils.py
+++ b/website/addons/base/utils.py
@@ -2,10 +2,12 @@ from os.path import basename
 
 from website import settings
 
-def serialize_addon_config(config, user):
+def serialize_addon_config(config, user, node=None):
     lookup = config.template_lookup
 
     user_addon = user.get_addon(config.short_name)
+    node_addon = node.get_addon(config.short_name) if node else None
+
     ret = {
         'addon_short_name': config.short_name,
         'addon_full_name': config.full_name,
@@ -14,9 +16,12 @@ def serialize_addon_config(config, user):
         'is_enabled': user_addon is not None,
         'addon_icon_url': config.icon_url,
     }
-    ret.update(user_addon.to_json(user) if user_addon else {})
+    if node_addon:
+        ret.update(node_addon.to_json(user) if user_addon else {})
+    else:
+        ret.update(user_addon.to_json(user) if user_addon else {})
     return ret
 
-def get_addons_by_config_type(config_type, user):
+def get_addons_by_config_type(config_type, user, node=None):
     addons = [addon for addon in settings.ADDONS_AVAILABLE if config_type in addon.configs]
-    return [serialize_addon_config(addon_config, user) for addon_config in sorted(addons, key=lambda cfg: cfg.full_name.lower())]
+    return [serialize_addon_config(addon_config, user, node) for addon_config in sorted(addons, key=lambda cfg: cfg.full_name.lower())]

--- a/website/addons/box/views/config.py
+++ b/website/addons/box/views/config.py
@@ -20,12 +20,15 @@ from website.addons.box.client import get_node_client
 from website.addons.box.client import get_client_from_user_settings
 
 
-@must_have_addon('box', 'node')
 @must_have_permission(permissions.WRITE)
-def box_config_get(node_addon, auth, **kwargs):
+def box_config_get(auth, node, **kwargs):
     """API that returns the serialized node settings."""
+    node_addon = node.get_addon('box', 'node')
+    if not node_addon:
+        node.add_addon('box', auth)
+        node.save()
     return {
-        'result': serialize_settings(node_addon, auth.user),
+        'result': serialize_settings(node.get_addon('box', 'node'), auth.user),
     }
 
 

--- a/website/addons/dataverse/templates/dataverse_node_settings.mako
+++ b/website/addons/dataverse/templates/dataverse_node_settings.mako
@@ -21,7 +21,7 @@
              <!-- Import Access Token Button -->
             <span data-bind="if: showImport">
                 <a data-bind="click: importAuth" href="#" class="text-primary pull-right addon-auth">
-                    Import Access Token
+                    Import Account From Profile
                 </a>
             </span>
 

--- a/website/addons/dataverse/templates/dataverse_node_settings.mako
+++ b/website/addons/dataverse/templates/dataverse_node_settings.mako
@@ -28,7 +28,7 @@
             <!-- Show Token Create Button -->
             <span data-bind="if: showTokenCreateButton">
                 <a href="#dataverseInputCredentials" data-toggle="modal" class="pull-right text-primary addon-auth">
-                    Connect an account
+                    Connect Account
                 </a>
             </span>
 

--- a/website/addons/dataverse/views/auth.py
+++ b/website/addons/dataverse/views/auth.py
@@ -20,10 +20,10 @@ def dataverse_add_user_auth(auth, node, **kwargs):
 
 
 @decorators.must_have_permission('write')
+@decorators.must_have_addon('dataverse', 'node')
 @decorators.must_not_be_registration
-def dataverse_remove_user_auth(auth, node, **kwargs):
+def dataverse_remove_user_auth(auth, node_addon, **kwargs):
     """Remove Dataverse authorization and settings from node"""
-    node_addon = node.get_addon('dataverse', 'node')
     provider = DataverseProvider()
     return provider.remove_user_auth(node_addon, auth.user)
 

--- a/website/addons/dataverse/views/auth.py
+++ b/website/addons/dataverse/views/auth.py
@@ -9,10 +9,10 @@ from website.util import api_url_for
 
 
 @decorators.must_have_permission('write')
-@decorators.must_have_addon('dataverse', 'node')
 @decorators.must_not_be_registration
-def dataverse_add_user_auth(auth, node_addon, **kwargs):
+def dataverse_add_user_auth(auth, node, **kwargs):
     """Allows for importing existing auth to AddonDataverseNodeSettings"""
+    node_addon = node.get_addon('dataverse', 'node')
 
     provider = DataverseProvider()
     external_account_id = request.get_json().get('external_account_id')
@@ -20,11 +20,10 @@ def dataverse_add_user_auth(auth, node_addon, **kwargs):
 
 
 @decorators.must_have_permission('write')
-@decorators.must_have_addon('dataverse', 'node')
 @decorators.must_not_be_registration
-def dataverse_remove_user_auth(auth, node_addon, **kwargs):
+def dataverse_remove_user_auth(auth, node, **kwargs):
     """Remove Dataverse authorization and settings from node"""
-
+    node_addon = node.get_addon('dataverse', 'node')
     provider = DataverseProvider()
     return provider.remove_user_auth(node_addon, auth.user)
 

--- a/website/addons/dataverse/views/config.py
+++ b/website/addons/dataverse/views/config.py
@@ -73,12 +73,14 @@ def dataverse_add_user_account(auth, **kwargs):
 
 @must_be_logged_in
 @decorators.must_be_valid_project
-def dataverse_get_config(auth, node, **kwargs):
+def dataverse_get_config(node, **kwargs):
     """API that returns the serialized node settings."""
+    auth = kwargs.get('auth')
+    node_addon = node.get_or_add_addon('dataverse', **kwargs)
 
     result = DataverseSerializer(
         user_settings=auth.user.get_addon('dataverse'),
-        node_settings=node.get_addon('dataverse', 'node'),
+        node_settings=node_addon
     ).serialized_node_settings
     return {'result': result}, http.OK
 

--- a/website/addons/dataverse/views/config.py
+++ b/website/addons/dataverse/views/config.py
@@ -76,11 +76,14 @@ def dataverse_add_user_account(auth, **kwargs):
 def dataverse_get_config(node, **kwargs):
     """API that returns the serialized node settings."""
     auth = kwargs.get('auth')
-    node_addon = node.get_or_add_addon('dataverse', **kwargs)
+    node_addon = node.get_addon('dataverse', 'node')
+    if not node_addon:
+        node.add_addon('dataverse', auth)
+        node.save()
 
     result = DataverseSerializer(
         user_settings=auth.user.get_addon('dataverse'),
-        node_settings=node_addon
+        node_settings=node.get_addon('dataverse', 'node')
     ).serialized_node_settings
     return {'result': result}, http.OK
 

--- a/website/addons/dataverse/views/config.py
+++ b/website/addons/dataverse/views/config.py
@@ -90,10 +90,10 @@ def dataverse_get_config(node, **kwargs):
 
 @decorators.must_have_permission('write')
 @decorators.must_have_addon('dataverse', 'user')
-def dataverse_get_datasets(auth, node, **kwargs):
+@decorators.must_have_addon('dataverse', 'node')
+def dataverse_get_datasets(node_addon, **kwargs):
     """Get list of datasets from provided Dataverse alias"""
     alias = request.json.get('alias')
-    node_addon = node.get_addon('dataverse', 'node')
 
     connection = client.connect_from_settings(node_addon)
     dataverse = client.get_dataverse(connection, alias)

--- a/website/addons/dataverse/views/config.py
+++ b/website/addons/dataverse/views/config.py
@@ -73,22 +73,22 @@ def dataverse_add_user_account(auth, **kwargs):
 
 @must_be_logged_in
 @decorators.must_be_valid_project
-@decorators.must_have_addon('dataverse', 'node')
-def dataverse_get_config(node_addon, auth, **kwargs):
+def dataverse_get_config(auth, node, **kwargs):
     """API that returns the serialized node settings."""
+
     result = DataverseSerializer(
         user_settings=auth.user.get_addon('dataverse'),
-        node_settings=node_addon,
+        node_settings=node.get_addon('dataverse', 'node'),
     ).serialized_node_settings
     return {'result': result}, http.OK
 
 
 @decorators.must_have_permission('write')
 @decorators.must_have_addon('dataverse', 'user')
-@decorators.must_have_addon('dataverse', 'node')
-def dataverse_get_datasets(node_addon, **kwargs):
+def dataverse_get_datasets(auth, node, **kwargs):
     """Get list of datasets from provided Dataverse alias"""
     alias = request.json.get('alias')
+    node_addon = node.get_addon('dataverse', 'node')
 
     connection = client.connect_from_settings(node_addon)
     dataverse = client.get_dataverse(connection, alias)
@@ -102,12 +102,15 @@ def dataverse_get_datasets(node_addon, **kwargs):
 
 @decorators.must_have_permission('write')
 @decorators.must_have_addon('dataverse', 'user')
-@decorators.must_have_addon('dataverse', 'node')
-def dataverse_set_config(node_addon, auth, **kwargs):
+def dataverse_set_config(auth, node, **kwargs):
     """Saves selected Dataverse and dataset to node settings"""
+    node_addon = node.get_addon('dataverse', 'node')
 
     user_settings = node_addon.user_settings
     user = auth.user
+
+    node.add_addon('datavserse', auth)
+    node.save()
 
     if user_settings and user_settings.owner != user:
         raise HTTPError(http.FORBIDDEN)

--- a/website/addons/dropbox/views/config.py
+++ b/website/addons/dropbox/views/config.py
@@ -25,8 +25,11 @@ from dropbox.rest import ErrorResponse
 def dropbox_config_get(node, **kwargs):
     """API that returns the serialized node settings."""
     auth = kwargs['auth']
-    node_addon = node.get_or_add_addon('dropbox', **kwargs)
-    return {'result': serialize_settings(node_addon, auth.user)}
+    node_addon = node.get_addon('dropbox', 'node')
+    if not node_addon:
+        node.add_addon('dropbox', auth)
+        node.save()
+    return {'result': serialize_settings(node.get_addon('dropbox', 'node'), auth.user)}
 
 
 def serialize_folder(metadata):

--- a/website/addons/dropbox/views/config.py
+++ b/website/addons/dropbox/views/config.py
@@ -22,9 +22,9 @@ from dropbox.rest import ErrorResponse
 
 @collect_auth
 @must_be_valid_project
-@must_have_addon('dropbox', 'node')
-def dropbox_config_get(node_addon, auth, **kwargs):
+def dropbox_config_get(auth, node, **kwargs):
     """API that returns the serialized node settings."""
+    node_addon = node.get_addon('dropbox', 'node')
     return {'result': serialize_settings(node_addon, auth.user)}
 
 
@@ -122,14 +122,19 @@ def serialize_settings(node_settings, current_user, client=None):
 @must_have_permission('write')
 @must_not_be_registration
 @must_have_addon('dropbox', 'user')
-@must_have_addon('dropbox', 'node')
 @must_be_addon_authorizer('dropbox')
-def dropbox_config_put(node_addon, user_addon, auth, **kwargs):
+def dropbox_config_put(auth, node, **kwargs):
     """View for changing a node's linked dropbox folder."""
     folder = request.json.get('selected')
     path = folder['path']
+
+    node_addon = node.get_addon('dropbox', 'node')
     node_addon.set_folder(path, auth=auth)
     node_addon.save()
+
+    node.add_addon('dropbox', auth)
+    node.save()
+
     return {
         'result': {
             'folder': {

--- a/website/addons/dropbox/views/config.py
+++ b/website/addons/dropbox/views/config.py
@@ -22,9 +22,10 @@ from dropbox.rest import ErrorResponse
 
 @collect_auth
 @must_be_valid_project
-def dropbox_config_get(auth, node, **kwargs):
+def dropbox_config_get(node, **kwargs):
     """API that returns the serialized node settings."""
-    node_addon = node.get_addon('dropbox', 'node')
+    auth = kwargs['auth']
+    node_addon = node.get_or_add_addon('dropbox', **kwargs)
     return {'result': serialize_settings(node_addon, auth.user)}
 
 

--- a/website/addons/figshare/views/config.py
+++ b/website/addons/figshare/views/config.py
@@ -21,11 +21,15 @@ from ..utils import options_to_hgrid
 ###### AJAX Config
 @must_be_logged_in
 @must_be_valid_project
-@must_have_addon('figshare', 'node')
-def figshare_config_get(node_addon, auth, **kwargs):
+def figshare_config_get(node, **kwargs):
     """API that returns the serialized node settings."""
+    auth = kwargs.get('auth')
+    node_addon = node.get_addon('figshare', 'node')
+    if not node_addon:
+        node.add_addon('figshare', auth)
+        node.save()
     return {
-        'result': serialize_settings(node_addon, auth.user),
+        'result': serialize_settings(node.get_addon('figshare', 'node'), auth.user),
     }
 
 

--- a/website/addons/forward/views/config.py
+++ b/website/addons/forward/views/config.py
@@ -18,8 +18,11 @@ from website.addons.forward.utils import serialize_settings
 
 @must_have_permission('write')
 @must_be_valid_project
-def forward_config_get(node, **kwargs):
-    node_addon = node.get_or_add_addon('forward', **kwargs)
+def forward_config_get(auth, node, **kwargs):
+    node_addon = node.get_addon('forward', 'node')
+    if not node_addon:
+        node.add_addon('forward', auth)
+        node.save()
     return serialize_settings(node.get_addon('forward', 'node'))
 
 

--- a/website/addons/forward/views/config.py
+++ b/website/addons/forward/views/config.py
@@ -16,10 +16,11 @@ from website.project.decorators import (
 from website.addons.forward.utils import serialize_settings
 
 
+@must_have_permission('write')
 @must_be_valid_project
-@must_have_addon('forward', 'node')
-def forward_config_get(node_addon, **kwargs):
-    return serialize_settings(node_addon)
+def forward_config_get(node, **kwargs):
+    node_addon = node.get_or_add_addon('forward', **kwargs)
+    return serialize_settings(node.get_addon('forward', 'node'))
 
 
 @must_have_permission('write')

--- a/website/addons/github/views/auth.py
+++ b/website/addons/github/views/auth.py
@@ -50,7 +50,8 @@ def github_oauth_start(auth, **kwargs):
     user_settings = user.get_addon('github')
 
     if node:
-        github_node = node.get_addon('github')
+        node.add_addon('github', auth)
+        github_node = node.get_addon('github', 'node')
         github_node.user_settings = user_settings
         github_node.save()
 

--- a/website/addons/googledrive/views/config.py
+++ b/website/addons/googledrive/views/config.py
@@ -17,12 +17,15 @@ from website.addons.googledrive.utils import serialize_settings
 
 
 @must_be_logged_in
-@must_have_addon('googledrive', 'node')
 @must_have_permission(permissions.WRITE)
-def googledrive_config_get(node_addon, auth, **kwargs):
+def googledrive_config_get(auth, node, **kwargs):
     """API that returns the serialized node settings."""
+    node_addon = node.get_addon('googledrive', 'node')
+    if not node_addon:
+        node.add_addon('googledrive', auth)
+        node.save()
     return {
-        'result': serialize_settings(node_addon, auth.user),
+        'result': serialize_settings(node.get_addon('googledrive', 'node'), auth.user),
     }
 
 

--- a/website/addons/mendeley/views.py
+++ b/website/addons/mendeley/views.py
@@ -25,15 +25,20 @@ def mendeley_get_user_accounts(auth):
 
 
 @must_have_permission('read')
-@must_have_addon('mendeley', 'node')
-def mendeley_get_config(auth, node_addon, **kwargs):
+def mendeley_get_config(node, **kwargs):
     """ Serialize node addon settings and relevant urls
     (see serialize_settings/serialize_urls)
     """
+    auth = kwargs.get('auth')
     provider = MendeleyCitationsProvider()
+    node_addon = node.get_addon('mendeley', 'node')
+    if not node_addon:
+        node.add_addon('mendeley', auth)
+        node.save()
+
     return {
         'result': provider.serializer(
-            node_addon,
+            node.get_addon('mendeley', 'node'),
             auth.user.get_addon('mendeley')
         ).serialized_node_settings
     }

--- a/website/addons/s3/templates/s3_node_settings.mako
+++ b/website/addons/s3/templates/s3_node_settings.mako
@@ -15,7 +15,7 @@
             </span>
             <span data-bind="if: showImport">
                 <a data-bind="click: importAuth" class="text-primary pull-right addon-auth">
-                  Import Access Token
+                  Import Account From Profile
                 </a>
             </span>
         </small>

--- a/website/addons/s3/views/config.py
+++ b/website/addons/s3/views/config.py
@@ -112,10 +112,15 @@ def s3_post_node_settings(node, auth, user_addon, node_addon, **kwargs):
 
 
 @must_be_logged_in
-@must_have_addon('s3', 'node')
 @must_have_permission('write')
 @must_not_be_registration
-def s3_get_node_settings(auth, node_addon, **kwargs):
+def s3_get_node_settings(node, **kwargs):
+    auth = kwargs.get('auth')
+    node_addon = node.get_addon('s3', 'node')
+    if not node_addon:
+        node.add_addon('s3', auth)
+        node.save()
+    node_addon = node.get_addon('s3', 'node')
     result = node_addon.to_json(auth.user)
     result['urls'] = utils.serialize_urls(node_addon, auth.user)
 

--- a/website/addons/zotero/views.py
+++ b/website/addons/zotero/views.py
@@ -22,7 +22,6 @@ def zotero_list_accounts_user(auth):
 
 
 @must_have_permission('write')
-# @must_have_addon('zotero', 'node')
 def zotero_get_config(node, **kwargs):
     """Serialize node addon settings and relevant urls
     (see serialize_settings/serialize_urls)

--- a/website/addons/zotero/views.py
+++ b/website/addons/zotero/views.py
@@ -22,16 +22,20 @@ def zotero_list_accounts_user(auth):
 
 
 @must_have_permission('write')
-@must_have_addon('zotero', 'node')
-def zotero_get_config(auth, node_addon, **kwargs):
+# @must_have_addon('zotero', 'node')
+def zotero_get_config(node, **kwargs):
     """Serialize node addon settings and relevant urls
     (see serialize_settings/serialize_urls)
     """
-
+    auth = kwargs.get('auth')
+    node_addon = node.get_addon('zotero', 'node')
+    if not node_addon:
+        node.add_addon('zotero', auth)
+        node.save()
     provider = ZoteroCitationsProvider()
     return {
         'result': provider.serializer(
-            node_settings=node_addon,
+            node_settings=node.get_addon('zotero', 'node'),
             user_settings=auth.user.get_addon('zotero'),
         ).serialized_node_settings
     }

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -276,7 +276,7 @@ def node_forks(auth, node, **kwargs):
 def node_setting(auth, node, **kwargs):
 
     ret = _view_project(node, auth, primary=True)
-    ret['addon_settings'] = addon_utils.get_addons_by_config_type('node', auth.user)
+    ret['addon_settings'] = addon_utils.get_addons_by_config_type('node', auth.user, node)
 
     accounts_addons = ([addon for addon in settings.ADDONS_AVAILABLE if 'node' in addon.owners
                         and addon.short_name not in settings.SYSTEM_ADDED_ADDONS['node']])

--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -172,7 +172,7 @@
                                     addons = [
                                         addon
                                         for addon in addons_available
-                                        if category in addon.categories
+                                        if category in addon.categories and category == 'documentation'
                                     ]
                                 %>
 
@@ -210,7 +210,6 @@
                     </div>
                 </div>
 
-                % if addon_enabled_settings:
                     <span id="configureAddonsAnchor" class="anchor"></span>
 
                     <div id="configureAddons" class="panel panel-default">
@@ -220,8 +219,8 @@
                         </div>
                         <div class="panel-body">
 
-                        % for node_settings_dict in addon_enabled_settings or []:
-                            ${render_node_settings(node_settings_dict)}
+                        % for addon in addon_settings or []:
+                            ${render_node_settings(addon)}
 
                                 % if not loop.last:
                                     <hr />
@@ -231,8 +230,6 @@
 
                         </div>
                     </div>
-
-                % endif
 
             % endif
 
@@ -324,7 +321,7 @@
 <%def name="render_node_settings(data)">
     <%
        template_name = data['node_settings_template']
-       tpl = data['template_lookup'].get_template(template_name).render(**data)
+       tpl = template_name.render(**data)
     %>
     ${tpl}
 </%def>


### PR DESCRIPTION
Purpose
------------
This PR allows users to configure an add-on on a project's settings page without having to check it off in the "Select Add-ons" list first. This is what "Configure Add-ons" will look like:

![screen shot 2015-07-13 at 5 16 02 pm](https://cloud.githubusercontent.com/assets/6414394/8675633/1eb9e5e6-2a13-11e5-9fba-59d4bfe04988.png)

![screen shot 2015-07-14 at 10 27 44 am](https://cloud.githubusercontent.com/assets/6414394/8675651/38166172-2a13-11e5-89c3-50a17ef86f65.png)



Side Effects/ Questions
--------------------------------
- It doesn't make sense to add the "Wiki" to "Configure Add-ons" but it looks strange on it's own in "Select Add-ons" so it should probably go somewhere else:
![screen shot 2015-07-14 at 10 26 58 am](https://cloud.githubusercontent.com/assets/6414394/8675624/0df17d64-2a13-11e5-95da-f0148876145f.png)
- What should happen to "OSF Storage" listed under "Select Add-ons"? 
- Previously, the terms modals were shown when the user checked off the add-on in "Select Add-ons", so that they would have to agree to the terms before they could configure it. Since that has been removed, the terms modals need to be shown somewhere else. Maybe when users click "Connect Account"? 