### PR TITLE
[Fix] [Ready] Close missing bracket in style.css

### DIFF
--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -361,7 +361,7 @@ a {
 
 .default-authorized-by {
     font-weight: normal !important;
-
+}
 /* bootstrap disable doesn't disable pointer event. This disable class adds pointer event disable. */
 .disabled {
     cursor: default !important;


### PR DESCRIPTION
## Purpose
There was a curious error where a class in style.css for panel heading was not applying. Turns out a style did not have closing bracket. 

## Change
Added the missing closing bracket

## Side effects
None