### PR TITLE
[feature-fix] fix user settings css

### DIFF
--- a/website/addons/dataverse/templates/dataverse_user_settings.mako
+++ b/website/addons/dataverse/templates/dataverse_user_settings.mako
@@ -18,7 +18,7 @@
         <thead>
             <tr class="user-settings-addon-auth">
                 <th class="text-muted default-authorized-by">Authorized on <a data-bind="attr.href: dataverseUrl"><em>{{ dataverseHost }}</em></a></th>
-                <th><a data-bind="click: $root.askDisconnect" class="text-danger">Disconnect Account</a></th>
+                <th><a data-bind="click: $root.askDisconnect" class="text-danger pull-right default-authorized-by">Disconnect Account</a></th>
             </tr>
         </thead>
         <!-- ko if: connectedNodes().length > 0 -->
@@ -30,7 +30,7 @@
                 </td>
                 <td>
                     <a data-bind="click: $parent.deauthorizeNode">
-                        <i class="fa fa-times text-danger" title="Deauthorize Project"></i>
+                        <i class="fa fa-times text-danger pull-right" title="Deauthorize Project"></i>
                     </a>
                 </td>
             </tr>

--- a/website/templates/profile/account.mako
+++ b/website/templates/profile/account.mako
@@ -102,7 +102,7 @@
                     </div>
                 </div>
 				<div class="panel panel-default">
-                  <div class="panel-heading"><h3 class="panel-title">Security Settings</h3></div>
+                  <div class="panel-heading clearfix"><h3 class="panel-title">Security Settings</h3></div>
                   <div class="panel-body">
                     % for addon in addons:
                     ${render_user_settings(addon) }

--- a/website/templates/profile/user_settings_default.mako
+++ b/website/templates/profile/user_settings_default.mako
@@ -14,7 +14,7 @@
         <thead>
             <tr class="user-settings-addon-auth">
                 <th class="text-muted default-authorized-by">Authorized by <em><a data-bind="attr.href: profileUrl, text: name"></a></em></th>
-                <th><a data-bind="click: $root.askDisconnect" class="text-danger">Disconnect Account</a></th>
+                <th><a data-bind="click: $root.askDisconnect" class="text-danger pull-right default-authorized-by">Disconnect Account</a></th>
             </tr>
         </thead>
         <!-- ko if: connectedNodes().length > 0 -->
@@ -26,7 +26,7 @@
                 </td>
                 <td>
                     <a data-bind="click: $parent.deauthorizeNode">
-                        <i class="fa fa-times text-danger" title="disconnect Project"></i>
+                        <i class="fa fa-times text-danger pull-right" title="disconnect Project"></i>
                     </a>
                 </td>
             </tr>


### PR DESCRIPTION
- Fix "Security Settings" heading on user account settings
- In the linked accounts table for Dataverse, Mendeley and Zotero make "Delete Account" right-aligned and not bolded