### PR TITLE
Better "Add Contributors" Pagination

### DIFF
--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -73,7 +73,7 @@ var AddContributorViewModel = oop.extend(Paginator, {
             }
         );
         self.foundResults = ko.pureComputed(function() {
-            return self.query() && self.results().length;
+            return self.results().length;
         });
 
         self.noResults = ko.pureComputed(function() {

--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -106,7 +106,18 @@ var AddContributorViewModel = oop.extend(Paginator, {
     goToPage: function(page) {
         this.page(page);
     },
-    /**
+
+    pageCollator: function(result) {
+        var self = this;
+        self.currentPage(self.pageToGet());
+        var start = self.currentPage()*RESULTS_PER_PAGE;
+        var end = start+RESULTS_PER_PAGE > result.length ?
+            result.length : start+RESULTS_PER_PAGE;
+        self.results(result.slice(start, end));
+        self.numberOfPages(Math.ceil(result.length/RESULTS_PER_PAGE));
+
+    },
+     /**
      * A simple Contributor model that receives data from the
      * contributor search endpoint. Adds an addiitonal displayProjectsinCommon
      * attribute which is the human-readable display of the number of projects the

--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -14,7 +14,7 @@ var Paginator = require('./paginator');
 
 var NODE_OFFSET = 25;
 // Max number of recent/common contributors to show
-var MAX_RECENT = 5;
+var RESULTS_PER_PAGE = 5;
 
 // TODO: Remove dependency on contextVars
 var nodeApiUrl = window.contextVars.node.urls.api;

--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -109,7 +109,7 @@ var AddContributorViewModel = oop.extend(Paginator, {
 
     pageCollator: function(result) {
         var self = this;
-        self.currentPage(self.pageToGet())
+        self.currentPage(self.pageToGet());
         var start = self.currentPage()*RESULTS_PER_PAGE;
         var end = start+RESULTS_PER_PAGE > result.length ?
             result.length : start+RESULTS_PER_PAGE;

--- a/website/templates/project/modal_add_contributor.mako
+++ b/website/templates/project/modal_add_contributor.mako
@@ -30,7 +30,7 @@
                             <div class="col-md-12">
                                 <div>
                                     <!-- ko if:parentId -->
-                                        <a data-bind="click:importFromParent, html:'Import contributors from <i>' + parentTitle + '</i>'"></a>
+                                        <a data-bind="click:startImport, html:'Import contributors from <i>' + parentTitle + '</i>'"></a>
                                     <!-- /ko -->
                                 </div>
                                 <div>


### PR DESCRIPTION
<h2>Purpose</h2>
Add pagination to to "Add Contributor" modal when contributors are imported from the parent (closes #3556) and fixes bug with persisting paginatior buttons when user selects "Most Common Projects" or "Most Recent Collaborators" as contributor searches.
<h2>Changes</h2>
Modifies the import function and adds function that collates results for paginator.
<h2>Side Effects</h2>
None that I know of.