### PR TITLE
[hotfix] Vertically center all file tree logos #2

### DIFF
--- a/website/static/css/fangorn.css
+++ b/website/static/css/fangorn.css
@@ -19,6 +19,17 @@ text-align: center;
 	margin-right: 5px;
 }
 
+#treeGrid span {
+    vertical-align: middle;
+}
+#treeGrid .tb-td {
+    padding-top: 2px;
+    padding-bottom: 4px;
+}
+#treeGrid .tb-expand-icon-holder div {
+    vertical-align: middle;
+}
+
 .fangorn-hover {
     background: #E0EBF3;
 }

--- a/website/static/css/pages/file-view-page.css
+++ b/website/static/css/pages/file-view-page.css
@@ -78,3 +78,13 @@
     max-height: 500px;
     height: inherit;
 }
+#file-navigation span {
+    vertical-align: middle;
+}
+#file-navigation .tb-expand-icon-holder div {
+    vertical-align: middle;
+}
+#file-navigation .tb-td {
+    padding-top: 2px;
+    padding-bottom: 4px;
+}


### PR DESCRIPTION
### Purpose
fixes #3155
replaces (?) #3280

Though my previous PR was merged, it appears that the style-guide changes have removed all of that code, so I rewrote it in the now-correct locations.

### Changes
I added some CSS that specifically affects anything within areas specified by the "treeGrid" id. This fixes the problem where it exists and makes the project dashboard and files pages look a bit better without affecting, for example, the user dashboard.

### Side Effects
These CSS changes will affect any area specified by the "treeGrid" id, and will not always make it look better. I have checked, and I don't think that there are any of these ids that I do not know about, but it is entirely possible that I missed something.