### PR TITLE
[feature-fix] Fix user settings s3 config

### DIFF
--- a/website/addons/s3/views/config.py
+++ b/website/addons/s3/views/config.py
@@ -12,8 +12,8 @@ from website.project.decorators import must_not_be_registration
 
 
 @must_be_logged_in
-@must_have_addon('s3', 'user')
-def s3_post_user_settings(user_addon, **kwargs):
+def s3_post_user_settings(auth, **kwargs):
+    user_addon = auth.user.get_or_add_addon('s3')
     try:
         access_key = request.json['access_key']
         secret_key = request.json['secret_key']


### PR DESCRIPTION
Remove the decorator that requires the user to have the s3 addon enabled in order to connect an account because it may not exist at that point. 