### PR TITLE
[Feature] Add links to the components and projects on file trees

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1073,6 +1073,13 @@ function _fangornUploadMethod(item) {
     return configOption || 'PUT';
 }
 
+function gotoNode(item) {
+    var tb = this;
+    var redir = item.data.nodeID;
+    var loc = window.location.origin;
+    var fileurl = loc + '/' + redir.toString() + '/';
+    window.open(fileurl, '_self');
+}
 
 function gotoFileEvent (item) {
     var tb = this;
@@ -1100,6 +1107,14 @@ function _fangornTitleColumn(item, col) {
             onclick: function(event) {
                 event.stopImmediatePropagation();
                 gotoFileEvent.call(tb, item);
+            }
+        }, item.data.name);
+    }
+    else if ((item.data.nodeType === 'project') || (item.data.nodeType ==='component')) {
+        return m('span.fg-file-links',{
+            onclick: function(event) {
+                event.stopImmediatePropagation();
+                gotoNode.call(tb, item);
             }
         }, item.data.name);
     }

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1073,14 +1073,6 @@ function _fangornUploadMethod(item) {
     return configOption || 'PUT';
 }
 
-function gotoNode(item) {
-    var tb = this;
-    var redir = item.data.nodeID;
-    var baseurl = window.location.origin;
-    var nodeurl = baseurl + '/' + redir.toString() + '/';
-    window.open(nodeurl, '_self');
-}
-
 function gotoFileEvent (item) {
     var tb = this;
     var redir = new URI(item.data.nodeUrl);
@@ -1111,12 +1103,8 @@ function _fangornTitleColumn(item, col) {
         }, item.data.name);
     }
     else if ((item.data.nodeType === 'project') || (item.data.nodeType ==='component')) {
-        return m('span.fg-file-links',{
-            onclick: function(event) {
-                event.stopImmediatePropagation();
-                gotoNode.call(tb, item);
-            }
-        }, item.data.name);
+        return m('a.fg-file-links',{ href: '/' + item.data.nodeID.toString() + '/'},
+                item.data.name);
     }
     return m('span', item.data.name);
 }

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1076,9 +1076,9 @@ function _fangornUploadMethod(item) {
 function gotoNode(item) {
     var tb = this;
     var redir = item.data.nodeID;
-    var loc = window.location.origin;
-    var fileurl = loc + '/' + redir.toString() + '/';
-    window.open(fileurl, '_self');
+    var baseurl = window.location.origin;
+    var nodeurl = baseurl + '/' + redir.toString() + '/';
+    window.open(nodeurl, '_self');
 }
 
 function gotoFileEvent (item) {


### PR DESCRIPTION
## Purpose 
Components and projects should have links to their base page just like files have links for file pages, as per #3593.

## Changes
Added function gotonode that opens the window with the node clicked, be it project or component. Also, made the row clickable like files.

## Side-Effects
All trees created with fangorn that use the method _fangornMakeRow to create its rows will have links for its projects and components.
