### PR TITLE
[Feature Fix] Refine Class name and put it to the right place

### DIFF
--- a/website/static/css/pages/project-page.css
+++ b/website/static/css/pages/project-page.css
@@ -118,8 +118,3 @@
     word-break: break-all;
     word-break: break-word; /* Non standard for webkit*/
 }
-
-/* modal for add link and contributor */
-.icon-width-td {
-    width: 50px;
-}

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -438,3 +438,8 @@ tr a {
 button.close {
     line-height: 0.9;
 }
+
+/* table for add link and contributor */
+.osf-icon-td {
+    width: 50px;
+}

--- a/website/templates/project/modal_add_contributor.mako
+++ b/website/templates/project/modal_add_contributor.mako
@@ -61,7 +61,7 @@
                                 </thead>
                                 <tbody data-bind="foreach:{data:results, as: 'contributor', afterRender:addTips}">
                                     <tr data-bind="if:!($root.selected($data))">
-                                        <td class="p-r-sm icon-width-td" >
+                                        <td class="p-r-sm osf-icon-td" >
                                             <a
                                                     class="btn btn-success contrib-button btn-mini"
                                                     data-bind="click:$root.add, tooltip: {title: 'Add contributor'}"
@@ -148,7 +148,7 @@
                                 </thead>
                                 <tbody data-bind="sortable: {data: selection, as: 'contributor', afterRender: makeAfterRender(), options: {containment: 'parent'}}">
                                     <tr>
-                                        <td class="p-r-sm" class="icon-width-td">
+                                        <td class="p-r-sm" class="osf-icon-td">
                                             <a
                                                     class="btn btn-default contrib-button btn-mini"
                                                     data-bind="click:$root.remove, tooltip: {title: 'Remove contributor'}"

--- a/website/templates/project/modal_add_pointer.mako
+++ b/website/templates/project/modal_add_pointer.mako
@@ -37,7 +37,7 @@
                         <table class="table table-striped">
                             <tbody data-bind="foreach:{data:results, afterRender:addTips}">
                                 <tr data-bind="if:!($root.selected($data))">
-                                    <td class="icon-width-td">
+                                    <td class="osf-icon-td">
                                         <a
                                                 class="btn btn-success contrib-button"
                                                 data-bind="click:$root.add, tooltip: {title: 'Add link'}"
@@ -65,7 +65,7 @@
                         <table class="table table-striped">
                             <tbody data-bind="foreach:{data:selection, afterRender:addTips}">
                                 <tr>
-                                    <td class="icon-width-td">
+                                    <td class="osf-icon-td">
                                         <a
                                                 class="btn btn-default contrib-button"
                                                 data-bind="click:$root.remove, tooltip: {title: 'Remove link'}"


### PR DESCRIPTION
Make-up PR  for PR https://github.com/CenterForOpenScience/osf.io/pull/3609

1. The class is applied in multiple pages and it has to be in style.css
2. Change the class name from `icon-width-td` to `osf-icon-td`