### PR TITLE
Add regression test for s3 config

### DIFF
--- a/website/addons/s3/tests/test_view.py
+++ b/website/addons/s3/tests/test_view.py
@@ -140,6 +140,23 @@ class TestS3ViewsConfig(OsfTestCase):
         assert_equals(self.user_settings.access_key, 'Steven Hawking')
         assert_equals(self.user_settings.secret_key, 'Atticus Fitch killing mocking')
 
+    @mock.patch('website.addons.s3.views.config.utils.can_list', return_value=True)
+    def test_user_settings_when_user_does_not_have_addon(self, _):
+        user = AuthUserFactory()
+        url = self.project.api_url_for('s3_post_user_settings')
+        self.app.post_json(
+            url,
+            {
+                'access_key': 'ABCDEFG',
+                'secret_key': 'We are the champions'
+            },
+            auth=user.auth
+        )
+        user.reload()
+        user_settings = user.get_addon('s3')
+        assert_equals(user_settings.access_key, 'ABCDEFG')
+        assert_equals(user_settings.secret_key, 'We are the champions')
+
     def test_s3_remove_user_settings(self):
         self.user_settings.access_key = 'to-kill-a-mocking-bucket'
         self.user_settings.secret_key = 'itsasecret'


### PR DESCRIPTION
Regression test for issue fixed by #3606, where Amazon S3 could not be configured the first time a user tries to connect an account.