### PR TITLE
[Feature Fix] Reset default buttons on bootbox modal

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -447,7 +447,7 @@ class TestProjectViews(OsfTestCase):
         assert_equal(len(res.json['others_count']), 1)
         assert_equal(res.json['contributors'][0]['separator'], ',')
         assert_equal(res.json['contributors'][1]['separator'], ',')
-        assert_equal(res.json['contributors'][2]['separator'], '&nbsp;&')
+        assert_equal(res.json['contributors'][2]['separator'], '&')
 
     def test_edit_node_title(self):
         url = "/api/v1/project/{0}/edit/".format(self.project._id)

--- a/website/addons/badges/templates/dashboard_assertions.mako
+++ b/website/addons/badges/templates/dashboard_assertions.mako
@@ -54,23 +54,31 @@ $script.ready('hgrid', function() {
 
         $('.revoke-badge').click(function() {
             var $self = $(this);
-            bootbox.confirm('Revoke this badge?', function(result) {
-                var bid = $self.attr('aid');
-                var url = $self.attr('url');
-                if(result && bid) {
-                    $.ajax({
-                        url: url + 'badges/revoke/',
-                        method: 'POST',
-                        dataType: 'json',
-                        contentType: 'application/json',
-                        data: JSON.stringify({reason: '', id: bid}),
-                        success: function(data) {
-                            location.reload();
-                        },
-                        error: function(xhr, status, error) {
-                            $.osf.growl('Could not revoke badge','');
-                        }
-                    });
+            bootbox.confirm({
+                message: 'Revoke this badge?',
+                callback: function(result) {
+                    var bid = $self.attr('aid');
+                    var url = $self.attr('url');
+                    if (result && bid) {
+                        $.ajax({
+                            url: url + 'badges/revoke/',
+                            method: 'POST',
+                            dataType: 'json',
+                            contentType: 'application/json',
+                            data: JSON.stringify({reason: '', id: bid}),
+                            success: function (data) {
+                                location.reload();
+                            },
+                            error: function (xhr, status, error) {
+                                $.osf.growl('Could not revoke badge', '');
+                            }
+                        });
+                    }
+                },
+                buttons:{
+                    confirm:{
+                        label:'Revoke'
+                    }
                 }
             });
         });

--- a/website/addons/box/static/boxNodeConfig.js
+++ b/website/addons/box/static/boxNodeConfig.js
@@ -221,6 +221,12 @@ var ViewModel = function(url, selector, folderPicker) {
                 if (confirmed) {
                     return sendDeauth();
                 }
+            },
+            buttons:{
+                confirm:{
+                    label:'Deauthorize',
+                    className:'btn-danger'
+                }
             }
         });
     };
@@ -254,6 +260,11 @@ var ViewModel = function(url, selector, folderPicker) {
                     return $osf.putJSON(self.urls().importAuth, {})
                         .done(onImportSuccess)
                         .fail(onImportError);
+                }
+            },
+            buttons:{
+                confirm:{
+                    label:'Import'
                 }
             }
         });

--- a/website/addons/box/static/boxUserConfig.js
+++ b/website/addons/box/static/boxUserConfig.js
@@ -101,6 +101,12 @@ function ViewModel(url) {
                 if (confirmed) {
                     sendDeauth();
                 }
+            },
+            buttons:{
+                confirm:{
+                    label:'Delete',
+                    className:'btn-danger'
+                }
             }
         });
     };

--- a/website/addons/dataverse/static/dataverseNodeConfig.js
+++ b/website/addons/dataverse/static/dataverseNodeConfig.js
@@ -483,6 +483,11 @@ ViewModel.prototype.importAuth = function() {
                         if (confirmed) {
                             self.connectExistingAccount.call(self, (self.accounts()[0].id));
                         }
+                    },
+                    buttons:{
+                        confirm:{
+                            label:'Import'
+                        }
                     }
                 });
             }
@@ -526,6 +531,12 @@ ViewModel.prototype.deauthorize = function() {
         callback: function(confirmed) {
             if (confirmed) {
                 self._deauthorizeConfirm();
+            }
+        },
+        buttons:{
+            confirm:{
+                label:'Deauthorize',
+                className:'btn-danger'
             }
         }
     });

--- a/website/addons/dataverse/static/dataverseUserConfig.js
+++ b/website/addons/dataverse/static/dataverseUserConfig.js
@@ -122,6 +122,12 @@ function ViewModel(url) {
                 if (confirm) {
                     self.disconnectAccount(account);
                 }
+            },
+            buttons:{
+                confirm:{
+                    label:'Delete',
+                    className:'btn-danger'
+                }
             }
         });
     };

--- a/website/addons/dropbox/static/dropboxUserConfig.js
+++ b/website/addons/dropbox/static/dropboxUserConfig.js
@@ -102,6 +102,12 @@ function ViewModel(url) {
                 if (confirmed) {
                     sendDeauth();
                 }
+            },
+            buttons:{
+                confirm:{
+                    label:'Delete',
+                    className:'btn-danger'
+                }
             }
         });
     };

--- a/website/addons/figshare/static/figshare-node-cfg.js
+++ b/website/addons/figshare/static/figshare-node-cfg.js
@@ -38,6 +38,12 @@ var $osf = require('osfHelpers');
                             }
                         });
                     }
+                },
+                buttons:{
+                    confirm:{
+                        label:'Remove',
+                        className:'btn-danger'
+                    }
                 }
             });
         });

--- a/website/addons/figshare/static/user-cfg.js
+++ b/website/addons/figshare/static/user-cfg.js
@@ -24,6 +24,12 @@ $(document).ready(function() {
                             }
                         });
                     }
+                },
+                buttons:{
+                    confirm:{
+                        label:'Delete',
+                        className:'btn-danger'
+                    }
                 }
             });
         });

--- a/website/addons/forward/templates/forward_node_settings.mako
+++ b/website/addons/forward/templates/forward_node_settings.mako
@@ -31,7 +31,7 @@
                 </div>
 
             <div class="form-group">
-                <label>Automatic Forward: <input type="radio" name="forward"  data-bind="checked: redirectBool, checkedValue: true"/> &nbsp;Yes &nbsp;&nbsp;</label>
+                <label>Automatic Forward:&nbsp;<input type="radio" name="forward"  data-bind="checked: redirectBool, checkedValue: true"/> &nbsp;Yes &nbsp;&nbsp;</label>
                 <label><input type="radio" name="forward"  data-bind="checked: redirectBool, checkedValue: false"/> &nbsp;No &nbsp;&nbsp; </label>
             </div>
 

--- a/website/addons/github/static/github-node-cfg.js
+++ b/website/addons/github/static/github-node-cfg.js
@@ -97,6 +97,12 @@ var GithubConfigHelper = (function() {
                         $osf.handleJSONError
                     );
                     }
+                },
+                buttons:{
+                    confirm:{
+                        label:'Deauthorize',
+                        className:'btn-danger'
+                    }
                 }
             });
         });

--- a/website/addons/github/static/user-cfg.js
+++ b/website/addons/github/static/user-cfg.js
@@ -25,6 +25,12 @@ $(document).ready(function() {
                         }
                     });
                 }
+            },
+            buttons:{
+                confirm:{
+                    label:'Remove',
+                    className:'btn-danger'
+                }
             }
         });
     });

--- a/website/addons/googledrive/static/googleDriveUserConfig.js
+++ b/website/addons/googledrive/static/googleDriveUserConfig.js
@@ -83,6 +83,12 @@ var ViewModel = function(url) {
                 if (confirmed) {
                     sendDeauth();
                 }
+            },
+            buttons:{
+                confirm:{
+                    label:'Delete',
+                    className:'btn-danger'
+                }
             }
         });
     };

--- a/website/addons/s3/static/s3NodeConfig.js
+++ b/website/addons/s3/static/s3NodeConfig.js
@@ -137,6 +137,11 @@ ViewModel.prototype.deauthorizeNode = function() {
             if (confirm) {
                 self._deauthorizeNodeConfirm();
             }
+        },
+        buttons:{
+            confirm:{
+                label:'Deauthorize'
+            }
         }
     });
 };
@@ -170,6 +175,11 @@ ViewModel.prototype.importAuth = function() {
         callback: function(confirmed) {
             if (confirmed) {
                 return self._importAuthConfirm();
+            }
+        },
+        buttons:{
+            confirm:{
+                label:'Import'
             }
         }
     });
@@ -233,6 +243,11 @@ ViewModel.prototype.createBucket = function(bucketName) {
                 if (result) {
                     self.openCreateBucket();
                 }
+            },
+            buttons:{
+                confirm:{
+                    label:'Try new one'
+                }
             }
         });
     });
@@ -253,6 +268,11 @@ ViewModel.prototype.openCreateBucket = function() {
                 callback: function(result) {
                     if (result) {
                         self.openCreateBucket();
+                    }
+                },
+                buttons:{
+                    confirm:{
+                        label:'Try new one'
                     }
                 }
             });

--- a/website/addons/s3/static/user-cfg.js
+++ b/website/addons/s3/static/user-cfg.js
@@ -15,6 +15,12 @@ $('#s3RemoveAccess').on('click', function() {
             if(result) {
                 deleteToken();
             }
+        },
+        buttons:{
+            confirm:{
+                label:'Remove',
+                className:'btn-danger'
+            }
         }
     });
 });

--- a/website/addons/twofactor/static/twoFactorUserConfig.js
+++ b/website/addons/twofactor/static/twoFactorUserConfig.js
@@ -135,6 +135,12 @@ ViewModel.prototype.disableTwofactor = function() {
             if (confirmed) {
                 self.disableTwofactorConfirm.call(self);
             }
+        },
+        buttons:{
+            confirm:{
+                label:'Disable',
+                className:'btn-danger'
+            }
         }
     });
 };
@@ -174,6 +180,11 @@ ViewModel.prototype.enableTwofactor = function() {
         callback: function(confirmed) {
             if (confirmed) {
                 self.enableTwofactorConfirm.call(self);
+            }
+        },
+        buttons:{
+            confirm:{
+                label:'Enable',
             }
         }
     });

--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -59,12 +59,12 @@ def get_node_contributors_abbrev(auth, node, **kwargs):
     for index, user in enumerate(users[:max_count]):
 
         if index == max_count - 1 and len(users) > max_count:
-            separator = '&nbsp;&'
+            separator = '&'
             others_count = str(n_contributors - 3)
         elif index == len(users) - 1:
             separator = ''
         elif index == len(users) - 2:
-            separator = '&nbsp&'
+            separator = '&'
         else:
             separator = ','
 

--- a/website/static/js/accountClaimer.js
+++ b/website/static/js/accountClaimer.js
@@ -52,6 +52,11 @@ function onClickIfLoggedIn() {
                         $osf.handleJSONError
                     );
                 }
+            },
+            buttons:{
+                confirm:{
+                    label:'Claim'
+                }
             }
         });
     }

--- a/website/static/js/accountSettings.js
+++ b/website/static/js/accountSettings.js
@@ -224,6 +224,11 @@ var UserProfileViewModel = oop.extend(ChangeMessageMixin, {
                             'success');
                     });
                 }
+            },
+            buttons:{
+                confirm:{
+                    label:'Resend'
+                }
             }
         });
     },
@@ -240,6 +245,12 @@ var UserProfileViewModel = oop.extend(ChangeMessageMixin, {
                         self.client.update(self.profile()).done(function () {
                             $osf.growl('Email Removed', '<em>' + email.address() + '<em>', 'success');
                         });
+                    }
+                },
+                buttons:{
+                    confirm:{
+                        label:'Remove',
+                        className:'btn-danger'
                     }
                 }
             });
@@ -298,6 +309,11 @@ var DeactivateAccountViewModel = oop.defclass({
                 if (confirmed) {
                     return self._requestDeactivation();
                 }
+            },
+            buttons:{
+                confirm:{
+                    label:'Request'
+                }
             }
         });
     }
@@ -338,6 +354,11 @@ var ExportAccountViewModel = oop.defclass({
             callback: function(confirmed) {
                 if (confirmed) {
                     return self._requestExport();
+                }
+            },
+            buttons:{
+                confirm:{
+                    label:'Request'
                 }
             }
         });

--- a/website/static/js/addonPermissions.js
+++ b/website/static/js/addonPermissions.js
@@ -43,6 +43,12 @@ var AddonPermissionsTable = {
                             }
                         });
                     }
+                },
+                buttons:{
+                    confirm:{
+                        label:'Remove',
+                        className:'btn-danger'
+                    }
                 }
             });
     });

--- a/website/static/js/addonSettings.js
+++ b/website/static/js/addonSettings.js
@@ -54,6 +54,12 @@ var ExternalAccount = oop.defclass({
                 if (confirm) {
                     self._deauthorizeNodeConfirm(node);
                 }
+            },
+            buttons:{
+                confirm:{
+                    label:'Remove',
+                    className:'btn-danger'
+                }
             }
         });
     }
@@ -92,6 +98,12 @@ var OAuthAddonSettingsViewModel = oop.defclass({
             callback: function(confirm) {
                 if (confirm) {
                     self.disconnectAccount(account);
+                }
+            },
+            buttons:{
+                confirm:{
+                    label:'Delete',
+                    className:'btn-danger'
                 }
             }
         });

--- a/website/static/js/citationsNodeConfig.js
+++ b/website/static/js/citationsNodeConfig.js
@@ -161,6 +161,11 @@ var CitationsFolderPickerViewModel = oop.extend(FolderPickerViewModel, {
                             if (confirmed) {
                                 self.connectExistingAccount.call(self, (self.accounts()[0].id));
                             }
+                        },
+                        buttons:{
+                            confirm:{
+                                label:'Import'
+                            }
                         }
                     });
                 }

--- a/website/static/js/contribManager.js
+++ b/website/static/js/contribManager.js
@@ -143,6 +143,12 @@ var ContributorModel = function(contributor, currentUserCanEdit, pageOwner, isRe
                                     $osf.handleJSONError
                                 );
                             }
+                        },
+                        buttons:{
+                            confirm:{
+                                label:'Delete',
+                                className:'btn-danger'
+                            }
                         }
                     });
                 }).fail(
@@ -372,6 +378,12 @@ var ContributorsViewModel = function(contributors, adminContributors, user, isRe
                         );
                         self.forceSubmit(false);
                     });
+                }
+            },
+            buttons:{
+                confirm:{
+                    label:'Save',
+                    className:'btn-success'
                 }
             }
         });

--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -54,6 +54,12 @@ var FileViewPage = {
                     }).fail(function() {
                         $osf.growl('Error', 'Could not delete file.');
                     });
+                },
+                buttons:{
+                    confirm:{
+                        label:'Delete',
+                        className:'btn-danger'
+                    }
                 }
             });
         });

--- a/website/static/js/folderPickerNodeConfig.js
+++ b/website/static/js/folderPickerNodeConfig.js
@@ -353,6 +353,11 @@ var FolderPickerViewModel = oop.defclass({
                     self._importAuthConfirm();
                     self.loadingImport(true);
                 }
+            },
+            buttons:{
+                confirm:{
+                    label:'Import'
+                }
             }
         });
     },
@@ -396,6 +401,12 @@ var FolderPickerViewModel = oop.defclass({
                 if (confirmed) {
                     self._deauthorizeConfirm();
                     self.loadingImport(false);
+                }
+            },
+            buttons:{
+                confirm:{
+                    label:'Disconnect',
+                    className:'btn-danger'
                 }
             }
         });

--- a/website/static/js/nodeControl.js
+++ b/website/static/js/nodeControl.js
@@ -316,6 +316,11 @@ var ProjectViewModel = function(data) {
                 if (confirmed) {
                     self.createIdentifiers();
                 }
+            },
+            buttons:{
+                confirm:{
+                    label:'Create'
+                }
             }
         });
     };

--- a/website/static/js/pages/profile-settings-addons-page.js
+++ b/website/static/js/pages/profile-settings-addons-page.js
@@ -21,14 +21,19 @@ $('.addon-select').on('change', function() {
         var name = $that.attr('name');
         var capabilities = $('#capabilities-' + name).html();
         if (capabilities) {
-            bootbox.confirm(
-                capabilities,
-                function(result) {
+            bootbox.confirm({
+                message: capabilities,
+                callback: function(result) {
                     if (!result) {
                         $that.attr('checked', false);
                     }
+                },
+                buttons:{
+                    confirm:{
+                        label:'Confirm'
+                    }
                 }
-            );
+        });
         }
     }
 });
@@ -83,6 +88,12 @@ $('#selectAddonsForm').on('submit', function() {
                     submit();
                 } else{
                     unchecked.each(function(i, el){ $(el).prop('checked', true); });
+                }
+            },
+            buttons:{
+                confirm:{
+                    label:'Remove',
+                    className:'btn-danger'
                 }
             }
         });

--- a/website/static/js/pages/profile-settings-addons-page.js
+++ b/website/static/js/pages/profile-settings-addons-page.js
@@ -57,7 +57,16 @@ $('#selectAddonsForm').on('submit', function() {
         });
         request.fail(function() {
             var msg = 'Sorry, we had trouble saving your settings. If this persists please contact <a href="mailto: support@osf.io">support@osf.io</a>';
-            bootbox.alert({title: 'Request failed', message: msg});
+            bootbox.alert({
+                title: 'Request failed',
+                message: msg,
+                buttons:{
+                    ok:{
+                        label:'Close',
+                        className:'btn-default'
+                    }
+                }
+            });
         });
     };
 

--- a/website/static/js/pages/project-settings-page.js
+++ b/website/static/js/pages/project-settings-page.js
@@ -75,7 +75,15 @@ $(document).ready(function() {
             $commentMsg.text('Successfully updated settings.');
             window.location.reload();
         }).fail(function() {
-            bootbox.alert('Could not set commenting configuration. Please try again.');
+            bootbox.alert({
+                message: 'Could not set commenting configuration. Please try again.',
+                buttons:{
+                    ok:{
+                        label:'Close',
+                        className:'btn-default'
+                    }
+                }
+            });
         });
 
         return false;

--- a/website/static/js/pages/project-settings-page.js
+++ b/website/static/js/pages/project-settings-page.js
@@ -141,14 +141,19 @@ $(document).ready(function() {
             var name = $that.attr('name');
             var capabilities = $('#capabilities-' + name).html();
             if (capabilities) {
-                bootbox.confirm(
-                    capabilities,
-                    function(result) {
+                bootbox.confirm({
+                    message: capabilities,
+                    callback: function(result) {
                         if (!result) {
                             $(that).attr('checked', false);
                         }
+                    },
+                    buttons:{
+                        confirm:{
+                            label:'Confirm'
+                        }
                     }
-                );
+               });
             }
         }
     });

--- a/website/static/js/pages/register_1-page.js
+++ b/website/static/js/pages/register_1-page.js
@@ -18,7 +18,13 @@ function registrationFailed() {
     $osf.unblock();
     bootbox.alert({
         title : 'Registration failed',
-        message : 'There was a problem completing your registration right now. Please try again later. If this should not have occurred and the issue persists, please report it to <a href=\"mailto:support@osf.io\">support@osf.io</a> '
+        message : 'There was a problem completing your registration right now. Please try again later. If this should not have occurred and the issue persists, please report it to <a href=\"mailto:support@osf.io\">support@osf.io</a> ',
+        buttons:{
+            ok:{
+                label:'Close',
+                className:'btn-default'
+            }
+        }
     } );
 }
 
@@ -112,22 +118,32 @@ $(document).ready(function() {
                                 if (result) {
                                     registerNode(data);
                                 }
-                            }
+                            },
+                            buttons:{
+                                confirm:{
+                                    label:'Register'
+                                }
+                           }
                         }
                     );
                 };
                 var preRegisterErrors = function(confirm, reject) {
-                    bootbox.confirm(
-                        $osf.joinPrompts(
-                            response.errors, 
+                    bootbox.confirm({
+                        message: ($osf.joinPrompts(
+                            response.errors,
                             'Before you continue...'
-                        ) + '<br /><hr /> ' + language.registerSkipAddons,
-                        function(result) {
-                            if(result) {
+                        ) + '<br /><hr /> ' + language.registerSkipAddons),
+                        callback: function (result) {
+                            if (result) {
                                 confirm();
                             }
+                        },
+                        buttons:{
+                            confirm:{
+                                label:'Continue'
+                            }
                         }
-                    );
+                    });
                 };
 
                 if (response.errors && response.errors.length) {

--- a/website/static/js/privateLinkTable.js
+++ b/website/static/js/privateLinkTable.js
@@ -147,6 +147,12 @@ function ViewModel(url, nodeIsPublic) {
                     $osf.growl('Error:','Failed to delete the private link.');
                 });
                 }
+            },
+            buttons:{
+                confirm:{
+                    label:'Remove',
+                    className:'btn-danger'
+                }
             }
         });
     };

--- a/website/static/js/profile.js
+++ b/website/static/js/profile.js
@@ -311,6 +311,12 @@ BaseViewModel.prototype.cancel = function(data, event) {
                         self.mode('view');
                     }
                 }
+            },
+            buttons:{
+                confirm:{
+                    label:'Discard',
+                    className:'btn-danger'
+                }
             }
         });
     } else {

--- a/website/static/js/project.js
+++ b/website/static/js/project.js
@@ -19,14 +19,19 @@ NodeActions.beforeForkNode = function(url, done) {
         url: url,
         contentType: 'application/json'
     }).done(function(response) {
-        bootbox.confirm(
-            $osf.joinPrompts(response.prompts, ('<h4>Are you sure you want to fork this project?</h4>')),
-            function(result) {
+        bootbox.confirm({
+            message: $osf.joinPrompts(response.prompts, ('<h4>Are you sure you want to fork this project?</h4>')),
+            callback: function (result) {
                 if (result) {
                     done && done();
                 }
+            },
+            buttons:{
+                confirm:{
+                    label:'fork'
+                }
             }
-        );
+        });
     }).fail(
         $osf.handleJSONError
     );
@@ -74,6 +79,11 @@ NodeActions.forkPointer = function(pointerId) {
                     $osf.growl('Error','Could not fork link.');
                 });
             }
+        },
+        buttons:{
+            confirm:{
+                label:'Fork'
+            }
         }
     });
 };
@@ -83,18 +93,23 @@ NodeActions.beforeTemplate = function(url, done) {
         url: url,
         contentType: 'application/json'
     }).success(function(response) {
-        bootbox.confirm(
-            $osf.joinPrompts(response.prompts,
+        bootbox.confirm({
+            message: $osf.joinPrompts(response.prompts,
                 ('<h4>Are you sure you want to create a new project using this project as a template?</h4>' +
                 '<p>Any add-ons configured for this project will not be authenticated in the new project.</p>')),
                 //('Are you sure you want to create a new project using this project as a template? ' +
                 //  'Any add-ons configured for this project will not be authenticated in the new project.')),
-            function (result) {
+            callback: function (result) {
                 if (result) {
                     done && done();
                 }
+            },
+            buttons:{
+                confirm:{
+                    label:'Create'
+                }
             }
-        );
+        });
     });
 };
 
@@ -264,6 +279,12 @@ $(document).ready(function() {
                     var pointerElm = $this.closest('.list-group-item');
                     NodeActions.removePointer(pointerId, pointerElm);
                 }
+            },
+            buttons:{
+                    confirm:{
+                        label:'Remove',
+                        className:'btn-danger'
+                    }
             }
         });
     });

--- a/website/static/js/registerNode.js
+++ b/website/static/js/registerNode.js
@@ -45,6 +45,11 @@ $(document).ready(function() {
                 if(confirmed) {
                     window.location.href = target;
                 }
+            },
+            buttons:{
+                confirm:{
+                    label:'Register'
+                }
             }
         });
     });

--- a/website/templates/project/addon/page.mako
+++ b/website/templates/project/addon/page.mako
@@ -47,7 +47,15 @@
     <script type="text/javascript">
         // Show capabilities modal on addon widget help
         $('.addon-capabilities').on('click', function() {
-            bootbox.alert($('#capabilities').html());
+            bootbox.alert({
+                message:$('#capabilities').html(),
+                buttons:{
+                    ok:{
+                        label:'Close',
+                        className:'btn-default'
+                    }
+                }
+            });
         });
     </script>
 

--- a/website/templates/project/contributors.mako
+++ b/website/templates/project/contributors.mako
@@ -128,7 +128,7 @@
                             </div>
 
                             <div class="btn-group">
-                                <button class="btn btn-default btn-sm m-r-xs copy-button"
+                                <button class="btn btn-primary btn-sm m-r-xs copy-button"
                                         data-bind="attr: {data-clipboard-text: linkUrl}" >
                                     Copy
                                 </button>


### PR DESCRIPTION
Resolved Trello Bugs:
1. https://trello.com/c/qMNdQm1g/29-view-only-links-copy-link-button-not-labeled-and-wrong-color-shape
2. https://trello.com/c/M6gDRXW0/30-ok-should-not-be-used-for-buttons
3. https://trello.com/c/QUx3q3Lk/18-delete-file-modal
4. https://trello.com/c/R7Wy5E9G/40-external-link-automatic-forward-options-yes-or-no-should-not-be-in-a-select-dropdown
5.https://trello.com/c/2QIU8n4V/65-public-activity-page-extra-space-between-contributor-and
Override Default button setting for bootbox.confirm and bootbox.alert 