### PR TITLE
[Feature] Glacier Deduping

### DIFF
--- a/website/addons/osfstorage/model.py
+++ b/website/addons/osfstorage/model.py
@@ -298,6 +298,8 @@ class OsfStorageFileNode(StoredObject):
         if metadata:
             version.update_metadata(metadata)
 
+        version._find_matching_archive(save=False)
+
         version.save()
         self.versions.append(version)
         self.save()
@@ -414,6 +416,10 @@ class OsfStorageFileVersion(StoredObject):
     def location_hash(self):
         return self.location['object']
 
+    @property
+    def archive(self):
+        return self.metadata.get('archive')
+
     def is_duplicate(self, other):
         return self.location_hash == other.location_hash
 
@@ -428,6 +434,36 @@ class OsfStorageFileVersion(StoredObject):
             # Incorrect version
             self.date_modified = parse_date(self.metadata['modified'], ignoretz=True)
         self.save()
+
+    def _find_matching_archive(self, save=True):
+        """Find another version with the same sha256 as this file.
+        If found copy its vault name and glacier id, no need to create additional backups.
+        returns True if found otherwise false
+        """
+        if 'sha256' not in self.metadata:
+            return False  # Dont bother searching for nothing
+
+        if 'vault' in self.metadata and 'archive' in self.metadata:
+            # Shouldn't ever happen, but we already have an archive
+            return True  # We've found ourself
+
+        qs = self.__class__.find(
+            Q('_id', 'ne', self._id) &
+            Q('metadata.vault', 'ne', None) &
+            Q('metadata.archive', 'ne', None) &
+            Q('metadata.sha256', 'eq', self.metadata['sha256'])
+        ).limit(1)
+        if qs.count() < 1:
+            return False
+        other = qs[0]
+        try:
+            self.metadata['vault'] = other.metadata['vault']
+            self.metadata['archive'] = other.metadata['archive']
+        except KeyError:
+            return False
+        if save:
+            self.save()
+        return True
 
 
 @unique_on(['node', 'path'])

--- a/website/addons/osfstorage/tests/test_views.py
+++ b/website/addons/osfstorage/tests/test_views.py
@@ -297,6 +297,37 @@ class TestUploadFileHook(HookTestCase):
 
         assert_equal(res.status_code, 400)
 
+    def test_archive(self):
+        name = 'ლ(ಠ益ಠლ).unicode'
+        parent = self.node_settings.root_node.append_folder('cheesey')
+        res = self.send_upload_hook(parent, self.make_payload(name=name, hashes={'sha256': 'foo'}))
+
+        assert_equal(res.status_code, 201)
+        assert_equal(res.json['status'], 'success')
+        assert_is(res.json['archive'], True)
+
+        self.send_hook(
+            'osfstorage_update_metadata',
+            {},
+            payload={'metadata': {
+                'vault': 'Vault 101',
+                'archive': '101 tluaV',
+            }, 'version': res.json['version']},
+            method='put_json',
+        )
+
+        res = self.send_upload_hook(parent, self.make_payload(
+            name=name,
+            hashes={'sha256': 'foo'},
+            metadata={
+                'name': 'lakdjf',
+                'provider': 'testing',
+            }))
+
+        assert_equal(res.status_code, 200)
+        assert_equal(res.json['status'], 'success')
+        assert_is(res.json['archive'], False)
+
     # def test_upload_update_deleted(self):
     #     pass
 

--- a/website/addons/osfstorage/views.py
+++ b/website/addons/osfstorage/views.py
@@ -155,7 +155,7 @@ def osfstorage_create_child(file_node, payload, node_addon, **kwargs):
 
     if not is_folder:
         try:
-            file_node.create_version(
+            version = file_node.create_version(
                 user,
                 dict(payload['settings'], **dict(
                     payload['worker'], **{
@@ -165,13 +165,19 @@ def osfstorage_create_child(file_node, payload, node_addon, **kwargs):
                 ),
                 dict(payload['metadata'], **payload['hashes'])
             )
+            version_id = version._id
+            archive_exists = version.archive is not None
         except KeyError:
             raise HTTPError(httplib.BAD_REQUEST)
+    else:
+        version_id = None
+        archive_exists = False
 
     return {
         'status': 'success',
+        'archive': not archive_exists,  # Should waterbutler also archive this file
         'data': file_node.serialized(),
-        'version': None if is_folder else file_node.versions[-1]._id
+        'version': version_id,
     }, httplib.CREATED if created else httplib.OK
 
 


### PR DESCRIPTION
Detect existing glacier archives upon upload to avoid make dups

  When the upload callback is hit a query is done look for any versions
  with a matching sha256 and a vault and archive field. If found that
  version's vault and archive will be copied to the new version.

  An "archive" key is now included in the response indicating whether
  or not the new version should be sent to glacier.

This is the sister PR of https://github.com/CenterForOpenScience/waterbutler/pull/62. Both are not breaking changes meaning they do not have to be merged at the same time but both must be merged to work.