### PR TITLE
Project Settings Page Rearrangement

### DIFF
--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -27,9 +27,7 @@
                     % if not node['is_registration']:
                         <li><a href="#configureNodeAnchor">Configure ${node['node_type'].capitalize()}</a></li>
 
-                        % if 'admin' in user['permissions']:
-                            <li><a href="#configureCommentingAnchor">Configure Commenting</a></li>
-                        % endif
+
 
                         % if 'write' in user['permissions']:
                             <li><a href="#selectAddonsAnchor">Select Add-ons</a></li>
@@ -39,7 +37,12 @@
                             % endif
 
                             <li><a href="#configureNotificationsAnchor">Configure Notifications</a></li>
-                        %endif
+                        % endif
+
+                        % if 'admin' in user['permissions']:
+                            <li><a href="#configureCommentingAnchor">Configure Commenting</a></li>
+                        % endif
+
 
                     % endif
 
@@ -109,50 +112,6 @@
             % endif
 
         % endif  ## End Configure Project
-
-        % if 'admin' in user['permissions']:  ## Begin Configure Commenting
-
-            % if not node['is_registration']:
-
-                <div class="panel panel-default">
-                    <span id="configureCommentingAnchor" class="anchor"></span>
-                    <div class="panel-heading clearfix">
-                        <h3 class="panel-title">Configure Commenting</h3>
-                    </div>
-
-                    <div class="panel-body">
-
-                        <form class="form" id="commentSettings">
-
-                            <div class="radio">
-                                <label>
-                                    <input type="radio" name="commentLevel" value="private" ${'checked' if comments['level'] == 'private' else ''}>
-                                    Only contributors can post comments
-                                </label>
-                            </div>
-                            <div class="radio">
-                                <label>
-                                    <input type="radio" name="commentLevel" value="public" ${'checked' if comments['level'] == 'public' else ''}>
-                                    When the ${node['node_type']} is public, any OSF user can post comments
-                                </label>
-                            </div>
-
-                            <button class="btn btn-success">Save</button>
-
-                            <!-- Flashed Messages -->
-                            <div class="help-block">
-                                <p id="configureCommentingMessage"></p>
-                            </div>
-                        </form>
-
-                    </div>
-
-                </div>
-
-            % endif
-
-        % endif  ## End Configure Commenting
-
 
         % if 'write' in user['permissions']:  ## Begin Select Addons
 
@@ -235,7 +194,6 @@
                 % endif
 
             % endif
-
         % endif  ## End Select Addons
 
         % if user['has_read_permissions']:  ## Begin Configure Notifications
@@ -265,7 +223,54 @@
 
             %endif
 
-        % endif  ## End Configure Addons
+        % endif End Configure Notifications
+
+
+
+        % if 'admin' in user['permissions']:  ## Begin Configure Commenting
+
+            % if not node['is_registration']:
+
+                <div class="panel panel-default">
+                    <span id="configureCommentingAnchor" class="anchor"></span>
+                    <div class="panel-heading clearfix">
+                        <h3 class="panel-title">Configure Commenting</h3>
+                    </div>
+
+                    <div class="panel-body">
+
+                        <form class="form" id="commentSettings">
+
+                            <div class="radio">
+                                <label>
+                                    <input type="radio" name="commentLevel" value="private" ${'checked' if comments['level'] == 'private' else ''}>
+                                    Only contributors can post comments
+                                </label>
+                            </div>
+                            <div class="radio">
+                                <label>
+                                    <input type="radio" name="commentLevel" value="public" ${'checked' if comments['level'] == 'public' else ''}>
+                                    When the ${node['node_type']} is public, any OSF user can post comments
+                                </label>
+                            </div>
+
+                            <button class="btn btn-success">Save</button>
+
+                            <!-- Flashed Messages -->
+                            <div class="help-block">
+                                <p id="configureCommentingMessage"></p>
+                            </div>
+                        </form>
+
+                    </div>
+
+                </div>
+
+            % endif
+
+        % endif  ## End Configure Commenting
+
+
 
         % if 'admin' in user['permissions']:  ## Begin Retract Registration
 


### PR DESCRIPTION
**Purpose**
Put "Configure Comments" and "Configure Notification" boxes together at bottom of page. Closes #3634.
**Changes**
Simple html changes
**Side Effects**
Having two small boxes at the bottom of the page can cause the nav sidebar highlighting to skip over second to last option, but otherwise works fine.