### PR TITLE
[WIP] Update node JSON responses to match JSONAPI 1.0 spec

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -1,6 +1,9 @@
 import collections
 import re
 
+from collections import OrderedDict
+from rest_framework import pagination
+
 from rest_framework import serializers as ser
 from website.util.sanitize import strip_html
 from api.base.utils import absolute_reverse, waterbutler_url_for
@@ -173,6 +176,10 @@ class JSONAPISerializer(ser.Serializer):
         """
         ret = {}
         meta = getattr(self, 'Meta', None)
+        meta = OrderedDict([
+                    ('total', self.page.paginator.count),
+                    ('per_page', self.page.paginator.per_page),
+                ])
         type_ = getattr(meta, 'type_', None)
         assert type_ is not None, 'Must define Meta.type_'
         data = super(JSONAPISerializer, self).to_representation(obj)
@@ -191,4 +198,3 @@ class JSONAPISerializer(ser.Serializer):
         if clean_html is True:
             self._validated_data = _rapply(self.validated_data, strip_html)
         return ret
-

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -68,6 +68,11 @@ class LinksField(ser.Field):
             ret['self'] = obj.get_absolute_url()
         return ret
 
+class LinksFieldNoSelfLink(LinksField):
+    def to_representation(self, obj):
+        ret = _rapply(self.links, _url_val, obj=obj, serializer=self.parent)
+        return ret
+
 _tpl_pattern = re.compile(r'\s*<\s*(\S*)\s*>\s*')
 
 

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -1,9 +1,6 @@
 import collections
 import re
 
-from collections import OrderedDict
-from rest_framework import pagination
-
 from rest_framework import serializers as ser
 from website.util.sanitize import strip_html
 from api.base.utils import absolute_reverse, waterbutler_url_for
@@ -176,10 +173,6 @@ class JSONAPISerializer(ser.Serializer):
         """
         ret = {}
         meta = getattr(self, 'Meta', None)
-        meta = OrderedDict([
-                    ('total', self.page.paginator.count),
-                    ('per_page', self.page.paginator.per_page),
-                ])
         type_ = getattr(meta, 'type_', None)
         assert type_ is not None, 'Must define Meta.type_'
         data = super(JSONAPISerializer, self).to_representation(obj)

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -68,6 +68,7 @@ class LinksField(ser.Field):
             ret['self'] = obj.get_absolute_url()
         return ret
 
+
 class LinksFieldNoSelfLink(LinksField):
     def to_representation(self, obj):
         ret = _rapply(self.links, _url_val, obj=obj, serializer=self.parent)
@@ -190,3 +191,4 @@ class JSONAPISerializer(ser.Serializer):
         if clean_html is True:
             self._validated_data = _rapply(self.validated_data, strip_html)
         return ret
+

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -23,7 +23,7 @@ class NodeSerializer(JSONAPISerializer):
     tags = ser.SerializerMethodField(help_text='A dictionary that contains two lists of tags: '
                                                'user and system. Any tag that a user will define in the UI will be '
                                                'a user tag')
-
+    attributes = ser.SerializerMethodField(help_text='A dictionary that contains properties')
     links = LinksField({
         'html': 'get_absolute_url',
         'children': {
@@ -93,6 +93,26 @@ class NodeSerializer(JSONAPISerializer):
 
     def get_pointers_count(self, obj):
         return len(obj.nodes_pointer)
+
+    @staticmethod
+    def get_attributes(obj):
+        ret = {
+            'title': obj.title,
+            'description': obj.description,
+            'category': obj.category,
+            'date_created': obj.date_created,
+            'date_modifed': obj.date_modified,
+            'public': obj.is_public,
+            'tags':  {
+                'system': [tag._id for tag in obj.system_tags],
+                'user': [tag._id for tag in obj.tags],
+            },
+            'dashboard': obj.is_dashboard,
+            'collection': obj.is_folder,
+            'registration': obj.is_registration
+
+        }
+        return ret
 
     @staticmethod
     def get_properties(obj):

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -1,6 +1,6 @@
+from collections import OrderedDict
 from rest_framework import serializers as ser
 
-from collections import OrderedDict
 from website.models import Node
 from framework.auth.core import Auth
 from rest_framework import exceptions

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -7,7 +7,6 @@ from rest_framework import exceptions
 from api.base.serializers import JSONAPISerializer, LinksField, Link, WaterbutlerLink, LinksFieldNoSelfLink
 
 
-
 class NodeSerializer(JSONAPISerializer):
     # TODO: If we have to redo this implementation in any of the other serializers, subclass ChoiceField and make it
     # handle blank choices properly. Currently DRF ChoiceFields ignore blank options, which is incorrect in this
@@ -113,7 +112,7 @@ class NodeSerializer(JSONAPISerializer):
             ('date_created', obj.date_created),
             ('date_modifed', obj.date_modified),
             ('public', obj.is_public),
-            ('tags',  {
+            ('tags', {
                 'system': [tag._id for tag in obj.system_tags],
                 'user': [tag._id for tag in obj.tags],
             }),

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -52,7 +52,7 @@ class NodeSerializer(JSONAPISerializer):
                 }
             },
         },
-        'pointers': {
+        'registrations': {
             'links': {
                 'related': {
                     'href': Link('nodes:node-registrations', kwargs={'node_id': '<pk>'}),

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -19,23 +19,48 @@ class NodeSerializer(JSONAPISerializer):
     description = ser.CharField(required=False, allow_blank=True, allow_null=True, write_only=True)
     category = ser.ChoiceField(choices=category_choices, help_text="Choices: " + category_choices_string, write_only=True)
     attributes = ser.SerializerMethodField(help_text='A dictionary containing node properties')
-    links = LinksField({
-        'html': 'get_absolute_url',
+    relationships = ser.SerializerMethodField(help_text='A dictionary containing relationships')
+    links = LinksField({'html': 'get_absolute_url'})
+    relationships = LinksField({
         'children': {
-            'related': Link('nodes:node-children', kwargs={'node_id': '<pk>'}),
-            'count': 'get_node_count',
+            'links': {
+                'related': {
+                    'href': Link('nodes:node-children', kwargs={'node_id': '<pk>'}),
+                    'meta': {
+                        'count': 'get_node_count'
+                    }
+                }
+            },
         },
         'contributors': {
-            'related': Link('nodes:node-contributors', kwargs={'node_id': '<pk>'}),
-            'count': 'get_contrib_count',
+            'links': {
+                'related': {
+                    'href': Link('nodes:node-contributors', kwargs={'node_id': '<pk>'}),
+                    'meta': {
+                        'count': 'get_contrib_count'
+                    }
+                }
+            },
         },
         'pointers': {
-            'related': Link('nodes:node-pointers', kwargs={'node_id': '<pk>'}),
-            'count': 'get_pointers_count',
+            'links': {
+                'related': {
+                    'href': Link('nodes:node-pointers', kwargs={'node_id': '<pk>'}),
+                    'meta': {
+                        'count': 'get_pointers_count'
+                    }
+                }
+            },
         },
-        'registrations': {
-            'related': Link('nodes:node-registrations', kwargs={'node_id': '<pk>'}),
-            'count': 'get_registration_count',
+        'pointers': {
+            'links': {
+                'related': {
+                    'href': Link('nodes:node-registrations', kwargs={'node_id': '<pk>'}),
+                    'meta': {
+                        'count': 'get_registration_count'
+                    }
+                }
+            },
         },
         'files': {
             'related': Link('nodes:node-files', kwargs={'node_id': '<pk>'})
@@ -75,6 +100,26 @@ class NodeSerializer(JSONAPISerializer):
 
     def get_pointers_count(self, obj):
         return len(obj.nodes_pointer)
+
+    @staticmethod
+    def get_attributes(obj):
+        ret = {
+            'title': obj.title,
+            'description': obj.description,
+            'category': obj.category,
+            'date_created': obj.date_created,
+            'date_modifed': obj.date_modified,
+            'public': obj.is_public,
+            'tags':  {
+                'system': [tag._id for tag in obj.system_tags],
+                'user': [tag._id for tag in obj.tags],
+            },
+            'dashboard': obj.is_dashboard,
+            'collection': obj.is_folder,
+            'registration': obj.is_registration
+
+        }
+        return ret
 
     @staticmethod
     def get_attributes(obj):

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -15,15 +15,10 @@ class NodeSerializer(JSONAPISerializer):
     filterable_fields = frozenset(['title', 'description', 'public'])
 
     id = ser.CharField(read_only=True, source='_id')
-    title = ser.CharField(required=True)
-    description = ser.CharField(required=False, allow_blank=True, allow_null=True)
-    category = ser.ChoiceField(choices=category_choices, help_text="Choices: " + category_choices_string)
-    date_created = ser.DateTimeField(read_only=True)
-    date_modified = ser.DateTimeField(read_only=True)
-    tags = ser.SerializerMethodField(help_text='A dictionary that contains two lists of tags: '
-                                               'user and system. Any tag that a user will define in the UI will be '
-                                               'a user tag')
-    attributes = ser.SerializerMethodField(help_text='A dictionary that contains properties')
+    title = ser.CharField(required=True, write_only=True)
+    description = ser.CharField(required=False, allow_blank=True, allow_null=True, write_only=True)
+    category = ser.ChoiceField(choices=category_choices, help_text="Choices: " + category_choices_string, write_only=True)
+    attributes = ser.SerializerMethodField(help_text='A dictionary containing node properties')
     links = LinksField({
         'html': 'get_absolute_url',
         'children': {
@@ -46,21 +41,8 @@ class NodeSerializer(JSONAPISerializer):
             'related': Link('nodes:node-files', kwargs={'node_id': '<pk>'})
         },
     })
-    properties = ser.SerializerMethodField(help_text='A dictionary of read-only booleans: registration, collection,'
-                                                     'and dashboard. Collections are special nodes used by the Project '
-                                                     'Organizer to, as you would imagine, organize projects. '
-                                                     'A dashboard is a collection node that serves as the root of '
-                                                     'Project Organizer collections. Every user will always have '
-                                                     'one Dashboard')
-    # TODO: When we have 'admin' permissions, make this writable for admins
-    public = ser.BooleanField(source='is_public', read_only=True,
-                              help_text='Nodes that are made public will give read-only access '
-                                                            'to everyone. Private nodes require explicit read '
-                                                            'permission. Write and admin access are the same for '
-                                                            'public and private nodes. Administrators on a parent '
-                                                            'node have implicit read permissions for all child nodes',
-                              )
-    # TODO: finish me
+
+    # TODO: When we have 'admin' permissions, make public writable for admins
 
     class Meta:
         type_ = 'nodes'
@@ -111,23 +93,6 @@ class NodeSerializer(JSONAPISerializer):
             'collection': obj.is_folder,
             'registration': obj.is_registration
 
-        }
-        return ret
-
-    @staticmethod
-    def get_properties(obj):
-        ret = {
-            'registration': obj.is_registration,
-            'collection': obj.is_folder,
-            'dashboard': obj.is_dashboard,
-        }
-        return ret
-
-    @staticmethod
-    def get_tags(obj):
-        ret = {
-            'system': [tag._id for tag in obj.system_tags],
-            'user': [tag._id for tag in obj.tags],
         }
         return ret
 

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers as ser
 
+from collections import OrderedDict
 from website.models import Node
 from framework.auth.core import Auth
 from rest_framework import exceptions
@@ -103,42 +104,20 @@ class NodeSerializer(JSONAPISerializer):
 
     @staticmethod
     def get_attributes(obj):
-        ret = {
-            'title': obj.title,
-            'description': obj.description,
-            'category': obj.category,
-            'date_created': obj.date_created,
-            'date_modifed': obj.date_modified,
-            'public': obj.is_public,
-            'tags':  {
+        ret = OrderedDict((
+            ('title', obj.title),
+            ('description', obj.description),
+            ('category', obj.category),
+            ('date_created', obj.date_created),
+            ('date_modifed', obj.date_modified),
+            ('public', obj.is_public),
+            ('tags',  {
                 'system': [tag._id for tag in obj.system_tags],
                 'user': [tag._id for tag in obj.tags],
-            },
-            'dashboard': obj.is_dashboard,
-            'collection': obj.is_folder,
-            'registration': obj.is_registration
-
-        }
-        return ret
-
-    @staticmethod
-    def get_attributes(obj):
-        ret = {
-            'title': obj.title,
-            'description': obj.description,
-            'category': obj.category,
-            'date_created': obj.date_created,
-            'date_modifed': obj.date_modified,
-            'public': obj.is_public,
-            'tags':  {
-                'system': [tag._id for tag in obj.system_tags],
-                'user': [tag._id for tag in obj.tags],
-            },
-            'dashboard': obj.is_dashboard,
-            'collection': obj.is_folder,
-            'registration': obj.is_registration
-
-        }
+            }),
+            ('dashboard', obj.is_dashboard),
+            ('collection', obj.is_folder),
+            ('registration', obj.is_registration)))
         return ret
 
     def create(self, validated_data):

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -7,6 +7,7 @@ from rest_framework import exceptions
 from api.base.serializers import JSONAPISerializer, LinksField, Link, WaterbutlerLink, LinksFieldNoSelfLink
 
 
+
 class NodeSerializer(JSONAPISerializer):
     # TODO: If we have to redo this implementation in any of the other serializers, subclass ChoiceField and make it
     # handle blank choices properly. Currently DRF ChoiceFields ignore blank options, which is incorrect in this
@@ -63,7 +64,9 @@ class NodeSerializer(JSONAPISerializer):
             },
         },
         'files': {
-            'related': Link('nodes:node-files', kwargs={'node_id': '<pk>'})
+            'links': {
+                'related': Link('nodes:node-files', kwargs={'node_id': '<pk>'})
+            }
         },
     })
 

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 from website.models import Node
 from framework.auth.core import Auth
 from rest_framework import exceptions
-from api.base.serializers import JSONAPISerializer, LinksField, Link, WaterbutlerLink
+from api.base.serializers import JSONAPISerializer, LinksField, Link, WaterbutlerLink, LinksFieldNoSelfLink
 
 
 class NodeSerializer(JSONAPISerializer):
@@ -20,9 +20,8 @@ class NodeSerializer(JSONAPISerializer):
     description = ser.CharField(required=False, allow_blank=True, allow_null=True, write_only=True)
     category = ser.ChoiceField(choices=category_choices, help_text="Choices: " + category_choices_string, write_only=True)
     attributes = ser.SerializerMethodField(help_text='A dictionary containing node properties')
-    relationships = ser.SerializerMethodField(help_text='A dictionary containing relationships')
     links = LinksField({'html': 'get_absolute_url'})
-    relationships = LinksField({
+    relationships = LinksFieldNoSelfLink({
         'children': {
             'links': {
                 'related': {

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -13,6 +13,7 @@ from .serializers import NodeSerializer, NodePointersSerializer, NodeFilesSerial
 from .permissions import ContributorOrPublic, ReadOnlyIfRegistration, ContributorOrPublicForPointers
 
 
+
 class NodeMixin(object):
     """Mixin with convenience methods for retrieving the current node based on the
     current URL. By default, fetches the current node based on the pk kwarg.

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -13,7 +13,6 @@ from .serializers import NodeSerializer, NodePointersSerializer, NodeFilesSerial
 from .permissions import ContributorOrPublic, ReadOnlyIfRegistration, ContributorOrPublicForPointers
 
 
-
 class NodeMixin(object):
     """Mixin with convenience methods for retrieving the current node based on the
     current URL. By default, fetches the current node based on the pk kwarg.

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -348,9 +348,9 @@ class TestNodeCreate(ApiTestCase):
     def test_creates_public_project_logged_in(self):
         res = self.app.post_json(self.url, self.public_project, auth=self.basic_auth)
         assert_equal(res.status_code, 201)
-        assert_equal(res.json['data']['title'], self.public_project['title'])
-        assert_equal(res.json['data']['description'], self.public_project['description'])
-        assert_equal(res.json['data']['category'], self.public_project['category'])
+        assert_equal(res.json['data']['attributes']['title'], self.public_project['title'])
+        assert_equal(res.json['data']['attributes']['description'], self.public_project['description'])
+        assert_equal(res.json['data']['attributes']['category'], self.public_project['category'])
 
     def test_creates_private_project_logged_out(self):
         res = self.app.post_json(self.url, self.private_project, expect_errors=True)
@@ -362,9 +362,9 @@ class TestNodeCreate(ApiTestCase):
     def test_creates_private_project_logged_in_contributor(self):
         res = self.app.post_json(self.url, self.private_project, auth=self.basic_auth)
         assert_equal(res.status_code, 201)
-        assert_equal(res.json['data']['title'], self.private_project['title'])
-        assert_equal(res.json['data']['description'], self.private_project['description'])
-        assert_equal(res.json['data']['category'], self.private_project['category'])
+        assert_equal(res.json['data']['attributes']['title'], self.private_project['title'])
+        assert_equal(res.json['data']['attributes']['description'], self.private_project['description'])
+        assert_equal(res.json['data']['attributes']['category'], self.private_project['category'])
 
     def test_creates_project_creates_project_and_sanitizes_html(self):
         title = '<em>Cool</em> <strong>Project</strong>'
@@ -381,9 +381,9 @@ class TestNodeCreate(ApiTestCase):
         url = '/{}nodes/{}/'.format(API_BASE, project_id)
 
         res = self.app.get(url, auth=self.basic_auth)
-        assert_equal(res.json['data']['title'], strip_html(title))
-        assert_equal(res.json['data']['description'], strip_html(description))
-        assert_equal(res.json['data']['category'], self.category)
+        assert_equal(res.json['data']['attributes']['title'], strip_html(title))
+        assert_equal(res.json['data']['attributes']['description'], strip_html(description))
+        assert_equal(res.json['data']['attributes']['category'], self.category)
 
 
 class TestNodeDetail(ApiTestCase):
@@ -407,16 +407,16 @@ class TestNodeDetail(ApiTestCase):
     def test_return_public_project_details_logged_out(self):
         res = self.app.get(self.public_url)
         assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['title'], self.public_project.title)
-        assert_equal(res.json['data']['description'], self.public_project.description)
-        assert_equal(res.json['data']['category'], self.public_project.category)
+        assert_equal(res.json['data']['attributes']['title'], self.public_project.title)
+        assert_equal(res.json['data']['attributes']['description'], self.public_project.description)
+        assert_equal(res.json['data']['attributes']['category'], self.public_project.category)
 
     def test_return_public_project_details_logged_in(self):
         res = self.app.get(self.public_url, auth=self.basic_auth)
         assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['title'], self.public_project.title)
-        assert_equal(res.json['data']['description'], self.public_project.description)
-        assert_equal(res.json['data']['category'], self.public_project.category)
+        assert_equal(res.json['data']['attributes']['title'], self.public_project.title)
+        assert_equal(res.json['data']['attributes']['description'], self.public_project.description)
+        assert_equal(res.json['data']['attributes']['category'], self.public_project.category)
 
     def test_return_private_project_details_logged_out(self):
         res = self.app.get(self.private_url, expect_errors=True)
@@ -428,9 +428,9 @@ class TestNodeDetail(ApiTestCase):
     def test_return_private_project_details_logged_in_contributor(self):
         res = self.app.get(self.private_url, auth=self.basic_auth)
         assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['title'], self.private_project.title)
-        assert_equal(res.json['data']['description'], self.private_project.description)
-        assert_equal(res.json['data']['category'], self.private_project.category)
+        assert_equal(res.json['data']['attributes']['title'], self.private_project.title)
+        assert_equal(res.json['data']['attributes']['description'], self.private_project.description)
+        assert_equal(res.json['data']['attributes']['category'], self.private_project.category)
 
     def test_return_private_project_details_logged_in_non_contributor(self):
         res = self.app.get(self.private_url, auth=self.basic_auth_two, expect_errors=True)
@@ -493,9 +493,9 @@ class TestNodeUpdate(ApiTestCase):
             'public': True,
         }, auth=self.basic_auth)
         assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['title'], self.new_title)
-        assert_equal(res.json['data']['description'], self.new_description)
-        assert_equal(res.json['data']['category'], self.new_category)
+        assert_equal(res.json['data']['attributes']['title'], self.new_title)
+        assert_equal(res.json['data']['attributes']['description'], self.new_description)
+        assert_equal(res.json['data']['attributes']['category'], self.new_category)
 
         # Public project, logged in, unauthorized
         res = self.app.put_json(self.public_url, {
@@ -526,9 +526,9 @@ class TestNodeUpdate(ApiTestCase):
             'public': False,
         }, auth=self.basic_auth)
         assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['title'], self.new_title)
-        assert_equal(res.json['data']['description'], self.new_description)
-        assert_equal(res.json['data']['category'], self.new_category)
+        assert_equal(res.json['data']['attributes']['title'], self.new_title)
+        assert_equal(res.json['data']['attributes']['description'], self.new_description)
+        assert_equal(res.json['data']['attributes']['category'], self.new_category)
 
     def test_update_private_project_logged_in_non_contributor(self):
         res = self.app.put_json(self.private_url, {
@@ -554,8 +554,8 @@ class TestNodeUpdate(ApiTestCase):
             'public': True,
         }, auth=self.basic_auth)
         assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['title'], strip_html(new_title))
-        assert_equal(res.json['data']['description'], strip_html(new_description))
+        assert_equal(res.json['data']['attributes']['title'], strip_html(new_title))
+        assert_equal(res.json['data']['attributes']['description'], strip_html(new_description))
 
     def test_partial_update_project_updates_project_correctly_and_sanitizes_html(self):
         new_title = 'An <script>alert("even cooler")</script> project'
@@ -570,9 +570,9 @@ class TestNodeUpdate(ApiTestCase):
 
         res = self.app.get(url)
         assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['title'], strip_html(new_title))
-        assert_equal(res.json['data']['description'], self.description)
-        assert_equal(res.json['data']['category'], self.category)
+        assert_equal(res.json['data']['attributes']['title'], strip_html(new_title))
+        assert_equal(res.json['data']['attributes']['description'], self.description)
+        assert_equal(res.json['data']['attributes']['category'], self.category)
 
     def test_writing_to_public_field(self):
         title = "Cool project"
@@ -590,7 +590,7 @@ class TestNodeUpdate(ApiTestCase):
         res = self.app.patch_json(url, {
             'is_public': False,
         }, auth=self.basic_auth, expect_errors=True)
-        assert_true(res.json['data']['public'])
+        assert_true(res.json['data']['attributes']['public'])
         # TODO: Figure out why the validator isn't raising when attempting to write to a read-only field
         # assert_equal(res.status_code, 403)
 
@@ -606,9 +606,9 @@ class TestNodeUpdate(ApiTestCase):
             'title': self.new_title,
         }, auth=self.basic_auth)
         assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['title'], self.new_title)
-        assert_equal(res.json['data']['description'], self.description)
-        assert_equal(res.json['data']['category'], self.category)
+        assert_equal(res.json['data']['attributes']['title'], self.new_title)
+        assert_equal(res.json['data']['attributes']['description'], self.description)
+        assert_equal(res.json['data']['attributes']['category'], self.category)
 
         # Public resource, logged in, unauthorized
         res = self.app.patch_json(self.public_url, {
@@ -626,9 +626,9 @@ class TestNodeUpdate(ApiTestCase):
     def test_partial_update_private_project_logged_in_contributor(self):
         res = self.app.patch_json(self.private_url, {'title': self.new_title}, auth=self.basic_auth)
         assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['title'], self.new_title)
-        assert_equal(res.json['data']['description'], self.description)
-        assert_equal(res.json['data']['category'], self.category)
+        assert_equal(res.json['data']['attributes']['title'], self.new_title)
+        assert_equal(res.json['data']['attributes']['description'], self.description)
+        assert_equal(res.json['data']['attributes']['category'], self.category)
 
     def test_partial_update_private_project_logged_in_non_contributor(self):
         res = self.app.patch_json(self.private_url,
@@ -849,12 +849,12 @@ class TestNodeRegistrationList(ApiTestCase):
     def test_return_public_registrations_logged_out(self):
         res = self.app.get(self.public_url)
         assert_equal(res.status_code, 200)
-        assert_equal(res.json['data'][0]['title'], self.public_project.title)
+        assert_equal(res.json['data'][0]['attributes']['title'], self.public_project.title)
 
     def test_return_public_registrations_logged_in(self):
         res = self.app.get(self.public_url, auth=self.basic_auth)
         assert_equal(res.status_code, 200)
-        assert_equal(res.json['data'][0]['category'], self.public_project.category)
+        assert_equal(res.json['data'][0]['attributes']['category'], self.public_project.category)
 
     def test_return_private_registrations_logged_out(self):
         res = self.app.get(self.private_url, expect_errors=True)
@@ -866,7 +866,7 @@ class TestNodeRegistrationList(ApiTestCase):
     def test_return_private_registrations_logged_in_contributor(self):
         res = self.app.get(self.private_url, auth=self.basic_auth)
         assert_equal(res.status_code, 200)
-        assert_equal(res.json['data'][0]['category'], self.project.category)
+        assert_equal(res.json['data'][0]['attributes']['category'], self.project.category)
 
     def test_return_private_registrations_logged_in_non_contributor(self):
         res = self.app.get(self.private_url, auth=self.basic_auth_two, expect_errors=True)


### PR DESCRIPTION
<h1> Purpose </h1>

References Issue #3074.   API v2 should be formatting JSON responses to adhere to the JSONAPI v1 specification http://jsonapi.org/.  The JSONAPI v1 spec was released 5-29-15.  This PR modifies the <b> node </b> response to match the new spec.  Other responses will be formatted in subsequent PR's.

<h1> Changes </h1>
Condenses many node properties into an attributes field and links into a relationships field. Modifies tests to handle new response formatting.

New formatting:
![screen shot 2015-07-17 at 9 18 13 am](https://cloud.githubusercontent.com/assets/9755598/8747891/d419a40a-2c64-11e5-87ae-6123b1989b49.png)

Old formatting: 
![screen shot 2015-07-17 at 9 18 44 am](https://cloud.githubusercontent.com/assets/9755598/8747883/cd1186a0-2c64-11e5-8f72-d0193e857d7e.png)



<h1> Side Effects </h1>
API is now returning node objects with different formatting.

<h1> TODO </h1>
- [ ] Make sure formatting is correct
- [x] What should pagination look like?  