### PR TITLE
[Feature-Fix] Fix restoring comments

### DIFF
--- a/website/project/views/comment.py
+++ b/website/project/views/comment.py
@@ -252,7 +252,7 @@ def delete_comment(auth, **kwargs):
 @must_be_contributor_or_public
 def undelete_comment(auth, **kwargs):
 
-    cid = kwargs.get('comment')
+    cid = kwargs.get('cid')
     comment = get_comment(cid, auth, owner=True)
     comment.undelete(auth=auth, save=True)
 


### PR DESCRIPTION
# Purpose
Currently when you attempt to restore a comment, there is no effect. This PR causes comments to properly be restored.

This closes https://github.com/CenterForOpenScience/osf.io/issues/3638

# Changes
In the undelete_comment function use 'cid' keyword to get the comment id.
