### PR TITLE
[Hotfix] Moved nested files

### DIFF
--- a/scripts/osfstorage/correct_moved_node_settings.py
+++ b/scripts/osfstorage/correct_moved_node_settings.py
@@ -1,0 +1,41 @@
+import sys
+import logging
+
+from scripts import utils as script_utils
+from framework.transactions.context import TokuTransaction
+
+from website.app import init_app
+from website.addons.osfstorage import model
+
+logger = logging.getLogger(__name__)
+
+def do_migration():
+    for node_settings in model.OsfStorageNodeSettings.find():
+        for child in iter_children(node_settings.root_node):
+            if child.node_settings != node_settings:
+                logger.info('Update node_settings for {!r} in project {!r}'.format(child, node_settings.owner,))
+                child.node_settings = node_settings
+                child.save()
+
+
+def iter_children(file_node):
+    to_go = [file_node]
+    while to_go:
+        for child in to_go.pop(0).children:
+            if child.is_folder:
+                to_go.append(child)
+            yield child
+
+
+def main(dry=True):
+    init_app(set_backends=True, routes=False)  # Sets the storage backends on all models
+    with TokuTransaction():
+        do_migration()
+        if dry:
+            raise Exception('Abort Transaction - Dry Run')
+
+if __name__ == '__main__':
+    dry = 'dry' in sys.argv
+    if not dry:
+        script_utils.add_file_logger(logger, __file__)
+    main(dry=dry)

--- a/website/addons/osfstorage/model.py
+++ b/website/addons/osfstorage/model.py
@@ -351,11 +351,19 @@ class OsfStorageFileNode(StoredObject):
     def move_under(self, destination_parent, name=None):
         self.name = name or self.name
         self.parent = destination_parent
-        self.node_settings = destination_parent.node_settings
-
-        self.save()
+        self._update_node_settings(save=True)
+        # Trust _update_node_settings to save us
 
         return self
+
+    def _update_node_settings(self, recursive=True, save=True):
+        if self.parent is not None:
+            self.node_settings = self.parent.node_settings
+        if save:
+            self.save()
+        if recursive and self.is_folder:
+            for child in self.children:
+                child._update_node_settings(save=save)
 
     def __repr__(self):
         return '<{}(name={!r}, node_settings={!r})>'.format(

--- a/website/addons/osfstorage/tests/test_models.py
+++ b/website/addons/osfstorage/tests/test_models.py
@@ -14,11 +14,9 @@ import datetime
 
 from modularodm import exceptions as modm_errors
 
-from website.models import NodeLog
 
 from website.addons.osfstorage import utils
 from website.addons.osfstorage import model
-from website.addons.osfstorage import errors
 from website.addons.osfstorage import settings
 
 
@@ -237,6 +235,22 @@ class TestOsfstorageFileNode(StorageTestCase):
         assert_equal(copied.parent, copy_to)
         assert_equal(to_copy.parent, self.node_settings.root_node)
 
+    def test_move_nested(self):
+        new_project = ProjectFactory()
+        other_node_settings = new_project.get_addon('osfstorage')
+        move_to = other_node_settings.root_node.append_folder('Cloud')
+
+        to_move = self.node_settings.root_node.append_folder('Carp')
+        child = to_move.append_file('A dee um')
+
+        moved = to_move.move_under(move_to)
+        child.reload()
+
+        assert_equal(moved, to_move)
+        assert_equal(other_node_settings, to_move.node_settings)
+        assert_equal(other_node_settings, move_to.node_settings)
+        assert_equal(other_node_settings, child.node_settings)
+
     def test_copy_rename(self):
         to_copy = self.node_settings.root_node.append_file('Carp')
         copy_to = self.node_settings.root_node.append_folder('Cloud')
@@ -417,4 +431,3 @@ class TestOsfStorageFileVersion(OsfTestCase):
         version.reload()
         assert_in('archive', version.metadata)
         assert_equal(version.metadata['archive'], 'glacier')
-


### PR DESCRIPTION
Correctly set node_settings when moving nested OsfStorageFileNodes
  Upon moving a OsfStorageFileNode to another node the node being moved
  would have its node_settings field updated but would not recurse down
  to update its children.

  OsfStorageFileNode._update_node_settings addresses this issue.

  OsfStorageFileNode.move_under now calls _update_node_settings before
  returning

  The migration to fix this is located at
  scripts/osfstorage/correct_moved_node_settings.py