### PR TITLE
 Fix language of "Resend Email Confirmation" Modal 

### DIFF
--- a/website/static/js/accountSettings.js
+++ b/website/static/js/accountSettings.js
@@ -214,7 +214,7 @@ var UserProfileViewModel = oop.extend(ChangeMessageMixin, {
         self.changeMessage('', 'text-info');
         bootbox.confirm({
             title: 'Resend Email Confirmation?',
-            message: 'Are you sure that you want to resend email confirmation at ' + '<em><b>' + email.address() + '</b></em>',
+            message: 'Are you sure that you want to resend email confirmation to ' + '<em><b>' + email.address() + '</b></em>',
             callback: function (confirmed) {
                 if (confirmed) {
                     self.client.update(self.profile(), email).done(function () {


### PR DESCRIPTION
<h1>Purpose</h1>
Fix language in "Resend Email Confirmation" modal. Close #3650 .
<h1> Changes </h1>
simple html change
<h1> Side Effects </h1>
None