### PR TITLE
[feature] external file view

### DIFF
--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -425,6 +425,7 @@ class TestAddonFileViews(OsfTestCase):
             'provider': '',
             'file_path': '',
             'sharejs_uuid': '',
+            'private': '',
             'urls': {
                 'files': '',
                 'render': '',

--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -431,6 +431,7 @@ class TestAddonFileViews(OsfTestCase):
                 'sharejs': '',
                 'mfr': '',
                 'gravatar': '',
+                'external': '',
             },
             'size': '',
             'extra': '',

--- a/website/addons/base/views.py
+++ b/website/addons/base/views.py
@@ -441,7 +441,7 @@ def addon_view_file(auth, node, node_addon, guid_file, extras):
         'provider': guid_file.provider,
         'file_path': guid_file.waterbutler_path,
         'panels_used': ['edit', 'view'],
-        'private': getattr(node_addon, 'is_private', None),
+        'private': getattr(node_addon, 'is_private', False),
         'sharejs_uuid': sharejs_uuid,
         'urls': {
             'files': node.web_url_for('collect_file_trees'),

--- a/website/addons/base/views.py
+++ b/website/addons/base/views.py
@@ -441,6 +441,7 @@ def addon_view_file(auth, node, node_addon, guid_file, extras):
         'provider': guid_file.provider,
         'file_path': guid_file.waterbutler_path,
         'panels_used': ['edit', 'view'],
+        'private': getattr(node_addon, 'is_private', None),
         'sharejs_uuid': sharejs_uuid,
         'urls': {
             'files': node.web_url_for('collect_file_trees'),
@@ -448,6 +449,7 @@ def addon_view_file(auth, node, node_addon, guid_file, extras):
             'sharejs': wiki_settings.SHAREJS_URL,
             'mfr': settings.MFR_SERVER_URL,
             'gravatar': get_gravatar(auth.user, 25),
+            'external': getattr(guid_file, 'external_url', None)
         },
         # Note: must be called after get_or_start_render. This is really only for github
         'size': size,

--- a/website/addons/figshare/model.py
+++ b/website/addons/figshare/model.py
@@ -46,7 +46,10 @@ class FigShareGuidFile(GuidFile):
 
     @property
     def external_url(self):
-        return self._metadata_cache['extra']['webView']
+        extra = self._metadata_cache['extra']
+        if extra['status'] == 'public':
+            return self._metadata_cache['extra']['webView']
+        return None
 
     def _exception_from_response(self, response):
         try:

--- a/website/addons/figshare/model.py
+++ b/website/addons/figshare/model.py
@@ -44,6 +44,10 @@ class FigShareGuidFile(GuidFile):
     def provider(self):
         return 'figshare'
 
+    @property
+    def external_url(self):
+        return self._metadata_cache['extra']['webView']
+
     def _exception_from_response(self, response):
         try:
             if response.json()['data']['extra']['status'] == 'drafts':

--- a/website/addons/figshare/static/figshareFangornConfig.js
+++ b/website/addons/figshare/static/figshareFangornConfig.js
@@ -58,7 +58,7 @@ var _figshareItemButtons = {
                 }, 'Delete')
             );
         }
-        if (item.kind === 'file' && item.data.permissions && item.data.permissions.view) {
+        if (item.kind === 'file' && item.data.permissions && item.data.permissions.view && item.data.extra.status === 'public') {
             buttons.push(
                 m('a.text-info.fangorn-toolbar-icon', {href: item.data.extra.webView}, [
                     m('i.fa.fa-external-link'),

--- a/website/addons/figshare/static/figshareFangornConfig.js
+++ b/website/addons/figshare/static/figshareFangornConfig.js
@@ -37,6 +37,16 @@ var _figshareItemButtons = {
         // Files can be deleted if private or if it is in a dataset that contains more than one file
         var privateOrSiblings = (item.data.extra && item.data.extra.status !== 'public') ||
             (!item.parent().data.isAddonRoot && item.parent().children.length > 1);
+        if (item.kind === 'file' && item.data.permissions && item.data.permissions.view) {
+            buttons.push(
+                m.component(Fangorn.Components.button, {
+                    onclick: function(event) {
+                        Fangorn.ButtonEvents._gotoFileEvent.call(tb, item);
+                    },
+                    icon: 'fa fa-file-o',
+                    className : 'text-info'
+                }, 'View'));
+        }
         if (item.kind === 'file' && privateOrSiblings && item.data.permissions && item.data.permissions.edit) {
             buttons.push(
                 m.component(Fangorn.Components.button, {
@@ -52,11 +62,12 @@ var _figshareItemButtons = {
             buttons.push(
                 m.component(Fangorn.Components.button, {
                     onclick: function(event) {
-                        Fangorn.ButtonEvents._gotoFileEvent.call(tb, item);
+                        window.open(item.data.extra.webView, '_self');
                     },
-                    icon: 'fa fa-file-o',
+                    icon: 'fa fa-external-link',
                     className : 'text-info'
-                }, 'View'));
+                }, 'View on figshare')
+            );
         }
         return m('span', buttons); // Tell fangorn this function is used.
     }

--- a/website/addons/figshare/static/figshareFangornConfig.js
+++ b/website/addons/figshare/static/figshareFangornConfig.js
@@ -60,13 +60,10 @@ var _figshareItemButtons = {
         }
         if (item.kind === 'file' && item.data.permissions && item.data.permissions.view) {
             buttons.push(
-                m.component(Fangorn.Components.button, {
-                    onclick: function(event) {
-                        window.open(item.data.extra.webView, '_self');
-                    },
-                    icon: 'fa fa-external-link',
-                    className : 'text-info'
-                }, 'View on figshare')
+                m('a.text-info.fangorn-toolbar-icon', {href: item.data.extra.webView}, [
+                    m('i.fa.fa-external-link'),
+                    m('span', 'View on figshare')
+                ])
             );
         }
         return m('span', buttons); // Tell fangorn this function is used.

--- a/website/addons/github/model.py
+++ b/website/addons/github/model.py
@@ -69,6 +69,10 @@ class GithubGuidFile(GuidFile):
         return os.path.split(self.path)[1]
 
     @property
+    def external_url(self):
+        return self._metadata_cache['extra']['webView']
+
+    @property
     def extra(self):
         if not self._metadata_cache:
             return {}

--- a/website/addons/github/static/githubFangornConfig.js
+++ b/website/addons/github/static/githubFangornConfig.js
@@ -220,13 +220,10 @@ var _githubItemButtons = {
             }
             if (item.data.permissions && item.data.permissions.view && !item.data.permissions.private) {
                 buttons.push(
-                    m.component(Fangorn.Components.button, {
-                        onclick: function(event) {
-                            window.open(item.data.extra.webView, '_self');
-                        },
-                        icon: 'fa fa-external-link',
-                        className : 'text-info'
-                    }, 'View on GitHub')
+                    m('a.text-info.fangorn-toolbar-icon', {href: item.data.extra.webView}, [
+                        m('i.fa.fa-external-link'),
+                        m('span', 'View on GitHub')
+                    ])
                 );
             }
         }

--- a/website/addons/github/static/githubFangornConfig.js
+++ b/website/addons/github/static/githubFangornConfig.js
@@ -197,6 +197,16 @@ var _githubItemButtons = {
                     className: 'text-primary'
                 }, 'Download')
             );
+            if (item.data.permissions && item.data.permissions.view) {
+                buttons.push(
+                    m.component(Fangorn.Components.button, {
+                        onclick: function(event) {
+                            gotoFile.call(tb, item);
+                        },
+                        icon: 'fa fa-file-o',
+                        className : 'text-info'
+                    }, 'View'));
+            }
             if (item.data.permissions && item.data.permissions.edit) {
                 buttons.push(
                     m.component(Fangorn.Components.button, {
@@ -208,16 +218,16 @@ var _githubItemButtons = {
                     }, 'Delete')
                 );
             }
-            if (item.data.permissions && item.data.permissions.view) {
+            if (item.data.permissions && item.data.permissions.view && !item.data.permissions.private) {
                 buttons.push(
                     m.component(Fangorn.Components.button, {
                         onclick: function(event) {
-                            gotoFile.call(tb, item);
+                            window.open(item.data.extra.webView, '_self');
                         },
-                        icon: 'fa fa-file-o',
+                        icon: 'fa fa-external-link',
                         className : 'text-info'
-                    }, 'View'));
-
+                    }, 'View on GitHub')
+                );
             }
         }
 

--- a/website/addons/github/views/hgrid.py
+++ b/website/addons/github/views/hgrid.py
@@ -76,7 +76,8 @@ def github_hgrid_data(node_settings, auth, **kwargs):
 
     permissions = {
         'edit': can_edit,
-        'view': True
+        'view': True,
+        'private': node_settings.is_private
     }
     urls = {
         'upload': node_settings.owner.api_url + 'github/file/' + (ref or ''),

--- a/website/addons/googledrive/model.py
+++ b/website/addons/googledrive/model.py
@@ -55,6 +55,10 @@ class GoogleDriveGuidFile(GuidFile):
         return '{0}_{1}_{2}.html'.format(self._id, self.unique_identifier, base64.b64encode(self.folder))
 
     @property
+    def external_url(self):
+        return self._metadata_cache['extra']['webView']
+
+    @property
     def mfr_temp_path(self):
         """Files names from Google Docs metadata doesn't necessarily correspond
         to download file names. Use the `downloadExt` field in the Docs metadata

--- a/website/static/css/fangorn.css
+++ b/website/static/css/fangorn.css
@@ -191,6 +191,9 @@
     border-radius: 2px;
     margin-top: 4px;
 }
+a.fangorn-toolbar-icon {
+    text-decoration: none;
+}
 .fangorn-toolbar-icon .fa {
     font-size: 15px;
 }

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -15,6 +15,7 @@ var $osf = require('js/osfHelpers');
 var waterbutler = require('js/waterbutler');
 
 var iconmap = require('js/iconmap');
+var storageAddons = require('json!storageAddons.json');
 
 // CSS
 require('css/fangorn.css');
@@ -1477,15 +1478,6 @@ var FGItemButtons = {
                     className : 'text-primary'
                 }, 'Download')
             );
-            if (item.data.permissions && item.data.permissions.edit) {
-                rowButtons.push(
-                    m.component(FGButton, {
-                        onclick: function(event) { _removeEvent.call(tb, event, [item]); },
-                        icon: 'fa fa-trash',
-                        className : 'text-danger'
-                    }, 'Delete'));
-
-            }
             if (item.data.permissions && item.data.permissions.view) {
                 rowButtons.push(
                     m.component(FGButton, {
@@ -1495,6 +1487,27 @@ var FGItemButtons = {
                         icon: 'fa fa-file-o',
                         className : 'text-info'
                     }, 'View'));
+            }
+            if (item.data.permissions && item.data.permissions.edit) {
+                rowButtons.push(
+                    m.component(FGButton, {
+                        onclick: function(event) { _removeEvent.call(tb, event, [item]); },
+                        icon: 'fa fa-trash',
+                        className : 'text-danger'
+                    }, 'Delete'));
+
+            }
+            if(storageAddons[item.data.provider].externalView) {
+                var providerFullName = storageAddons[item.data.provider].fullName;
+                rowButtons.push(
+                    m.component(FGButton, {
+                        onclick: function(event) {
+                            window.open(item.data.extra.webView, '_self');
+                        },
+                        icon: 'fa fa-external-link',
+                        className : 'text-info'
+                    }, 'View on ' + providerFullName)
+                );
             }
         } else if(item.data.provider && item.children.length !== 0) {
             rowButtons.push(

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1500,13 +1500,10 @@ var FGItemButtons = {
             if(storageAddons[item.data.provider].externalView) {
                 var providerFullName = storageAddons[item.data.provider].fullName;
                 rowButtons.push(
-                    m.component(FGButton, {
-                        onclick: function(event) {
-                            window.open(item.data.extra.webView, '_self');
-                        },
-                        icon: 'fa fa-external-link',
-                        className : 'text-info'
-                    }, 'View on ' + providerFullName)
+                    m('a.text-info.fangorn-toolbar-icon', {href: item.data.extra.webView}, [
+                        m('i.fa.fa-external-link'),
+                        m('span', 'View on ' + providerFullName)
+                    ])
                 );
             }
         } else if(item.data.provider && item.children.length !== 0) {

--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -9,6 +9,7 @@ var waterbutler = require('js/waterbutler');
 var utils = require('./util.js');
 var FileEditor = require('./editor.js');
 var FileRevisionsTable = require('./revisions.js');
+var storageAddons = require('json!storageAddons.json');
 
 // Sanity
 var Panel = utils.Panel;
@@ -203,6 +204,14 @@ var FileViewPage = {
         }
         $('#mfrIframeParent').removeClass().addClass(mfrIframeParentLayout);
         $('.file-view-panels').removeClass().addClass('file-view-panels').addClass(fileViewPanelsLayout);
+
+        if(ctrl.file.urls.external && !ctrl.file.privateRepo) {
+            m.render(document.getElementById('externalView'), [
+                m('p.text-muted', 'View this file on ', [
+                    m('a', {href:ctrl.file.urls.external}, storageAddons[ctrl.file.provider].fullName)
+                ], '.')
+            ]);
+        }
 
         m.render(document.getElementById('toggleBar'), m('.btn-toolbar.m-t-md', [
             ctrl.canEdit() ? m('.btn-group.m-l-xs.m-t-xs', [

--- a/website/static/storageAddons.json
+++ b/website/static/storageAddons.json
@@ -1,0 +1,34 @@
+{
+    "box": {
+        "fullName": "Box",
+        "externalView": false
+    },
+    "dataverse": {
+        "fullName": "Dataverse",
+        "externalView": false
+    },
+    "dropbox": {
+        "fullName": "Dropbox",
+        "externalView": false
+    },
+    "figshare": {
+        "fullName": "figshare",
+        "externalView": true
+    },
+    "github": {
+        "fullName": "GitHub",
+        "externalView": true
+    },
+    "googledrive": {
+        "fullName": "Google Drive",
+        "externalView": true
+    },
+    "osfstorage": {
+        "fullName": "OSF Storage",
+        "externalView": false
+    },
+    "s3": {
+        "fullName": "Amazon S3",
+        "externalView": false
+    }
+}

--- a/website/templates/project/view_file.mako
+++ b/website/templates/project/view_file.mako
@@ -137,6 +137,7 @@
 ## End Modals block
 
 <%def name="javascript_bottom()">
+    <% import json %>
     ${parent.javascript_bottom()}
     % for script in tree_js:
         <script type="text/javascript" src="${script | webpack_asset}"></script>
@@ -154,7 +155,7 @@
             size: ${size},
             extra: ${extra},
             error: '${error | js_str}',
-            privateRepo: '${private}',
+            privateRepo: ${private | sjson, n},
             name: '${file_name | js_str}',
             path: '${file_path | js_str}',
             provider: '${provider | js_str}',

--- a/website/templates/project/view_file.mako
+++ b/website/templates/project/view_file.mako
@@ -50,6 +50,7 @@
   <div id="fileViewPanelLeft" class="col-sm-9 panel-expand">
     <div class="row">
       <div id="mfrIframeParent" class="col-sm-9">
+        <div id="externalView"></div>
         <div id="mfrIframe" class="mfr mfr-file"></div>
       </div>
 
@@ -153,12 +154,14 @@
             size: ${size},
             extra: ${extra},
             error: '${error | js_str}',
+            privateRepo: '${private or '' | js_str}',
             name: '${file_name | js_str}',
             path: '${file_path | js_str}',
             provider: '${provider | js_str}',
             safeName: '${file_name | h,js_str}',
             materializedPath: '${materialized_path | js_str}',
           urls: {
+              external: '${(urls['external'] or '') | js_str}',
         %if error is None:
               render: '${urls['render']}',
         %endif

--- a/website/templates/project/view_file.mako
+++ b/website/templates/project/view_file.mako
@@ -154,7 +154,7 @@
             size: ${size},
             extra: ${extra},
             error: '${error | js_str}',
-            privateRepo: '${private or '' | js_str}',
+            privateRepo: '${private}',
             name: '${file_name | js_str}',
             path: '${file_path | js_str}',
             provider: '${provider | js_str}',


### PR DESCRIPTION
- Replaces [#3154](https://github.com/CenterForOpenScience/osf.io/pull/3154)

#### Purpose
- Adds a link to the file view page which links to the provider's external view of the file.
- Adds a "View on ..." button to the file tree which also links to the provider's external view. 
- Addresses [#2926](https://github.com/CenterForOpenScience/osf.io/issues/2926)
- Addons Supported:
 - [x] Google Drive
 - [x] GitHub (only public repos because GitHub sends you to an ugly 404 page if you try to view a file on a private repo that isn't yours)
 - [x] Figshare (only published files)

- Screenshot:
 - File detail page:
![screen shot 2015-07-21 at 10 22 08 am](https://cloud.githubusercontent.com/assets/7913604/8803001/714ec806-2f92-11e5-80d0-282d6ba3563c.png)


 - File tree:
![screen shot 2015-07-21 at 10 19 18 am](https://cloud.githubusercontent.com/assets/7913604/8802997/6f3b8cd4-2f92-11e5-8337-1dca5a31661d.png)


#### Notes
- Dependent on WaterButler PR [#65](https://github.com/CenterForOpenScience/waterbutler/pull/65)

