### PR TITLE
Stops Flashing of Change/Cancel Buttons when Disabled.

### DIFF
--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -67,6 +67,7 @@
         % if 'write' in user['permissions']:  ## Begin Configure Project
 
             % if not node['is_registration']:
+
                 <div class="panel panel-default">
                     <span id="configureNodeAnchor" class="anchor"></span>
                     <div class="panel-heading clearfix">

--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -67,7 +67,6 @@
         % if 'write' in user['permissions']:  ## Begin Configure Project
 
             % if not node['is_registration']:
-
                 <div class="panel panel-default">
                     <span id="configureNodeAnchor" class="anchor"></span>
                     <div class="panel-heading clearfix">
@@ -81,19 +80,23 @@
                                                         optionsText: 'label',
                                                         value: selectedCategory"></select>
                         </h5>
-                        <p data-bind="if: !disabled">
-                            <button data-bind="css: {disabled: !dirty()},
-                                               click: updateCategory"
-                                    class="btn btn-primary">Change</button>
-                            <button data-bind="css: {disabled: !dirty()},
-                                               click: cancelUpdateCategory"
-                                    class="btn btn-default">Cancel</button>
-                        </p>
-                        <span data-bind="css: messageClass, html: message"></span>
-                        <span data-bind="if: disabled" class="help-block">
-                            A top-level project's category cannot be changed
-                        </span>
-                    </div>
+
+                    % if 'component' == node['node_type']:
+                            <p data-bind="if: !disabled">
+                                <button data-bind="css: {disabled: !dirty()},
+                                                   click: updateCategory"
+                                        class="btn btn-primary">Change</button>
+                                <button data-bind="css: {disabled: !dirty()},
+                                                   click: cancelUpdateCategory"
+                                        class="btn btn-default">Cancel</button>
+                            </p>
+                            <span data-bind="css: messageClass, html: message"></span>
+                    % else:
+                            <span data-bind="if: disabled" class="help-block">
+                                A top-level project's category cannot be changed
+                            </span>
+                        </div>
+                    % endif
 
                     % if 'admin' in user['permissions']:
                         <hr />


### PR DESCRIPTION
<h1> Purpose </h1>
Fix flash of Change/Cancel on "Project Settings Page". Close #3649.
<h1> Changes </h1>
simple change to .mako
<h1> Side Effects </h1>
None.