### PR TITLE
[hotfix] Remove broken action icons from link boxes in registrations

### DIFF
--- a/website/templates/util/render_node.mako
+++ b/website/templates/util/render_node.mako
@@ -48,7 +48,7 @@
             <!-- Show/Hide recent activity log -->
             % if not summary['archiving']:
             <div class="pull-right">
-                % if not summary['primary'] and 'admin' in user['permissions']:
+                % if not summary['primary'] and 'admin' in user['permissions'] and not node['is_registration']:
                     <i class="fa fa-times remove-pointer" data-id="${summary['id']}" data-toggle="tooltip" title="Remove link"></i>
                     <i class="fa fa-code-fork" onclick="NodeActions.forkPointer('${summary['id']}', '${summary['primary_id']}');" data-toggle="tooltip" title="Fork this ${summary['node_type']} into ${node['node_type']} ${node['title']}"></i>
                 % endif


### PR DESCRIPTION
### Purpose
Fixes #3646

### Changes
Added parameter that the node must not be a registration in order to show the icons that were not working.