### PR TITLE
Stop 'No Logs' Message From Flashing

### DIFF
--- a/website/static/js/logFeed.js
+++ b/website/static/js/logFeed.js
@@ -154,7 +154,7 @@ var LogsViewModel = oop.extend(Paginator, {
             self.addNewPaginators();
 
             //stops 'no logs' message from flashing
-            if(self.logs().length == 0){
+            if(self.logs().length === 0){
                 self.noLogs(true);
             } else {
                 self.noLogs(false);

--- a/website/static/js/logFeed.js
+++ b/website/static/js/logFeed.js
@@ -115,6 +115,7 @@ var LogsViewModel = oop.extend(Paginator, {
         self.logs = ko.observableArray(logs);
         self.url = url;
         self.anonymousUserName = '<em>A user</em>';
+        self.noLogs = ko.observable(false);
 
         self.tzname = ko.pureComputed(function() {
             var logs = self.logs();
@@ -151,6 +152,14 @@ var LogsViewModel = oop.extend(Paginator, {
             self.currentPage(response.page);
             self.numberOfPages(response.pages);
             self.addNewPaginators();
+
+            //stops 'no logs' message from flashing
+            if(self.logs().length == 0){
+                self.noLogs(true);
+            } else {
+                self.noLogs(false);
+            }
+
         }).fail(
             $osf.handleJSONError
         ).fail(function() {

--- a/website/templates/log_list.mako
+++ b/website/templates/log_list.mako
@@ -33,7 +33,7 @@
 	                	<p class="m-t-sm text-center"> Loading logs...  </p>
 	                </div>
                 </span>
-                <p data-bind="if: !logs().length && !loading()" class="help-block">
+                <p data-bind="if: noLogs" class="help-block">
                     No logs to show. Click the watch icon (<i class="fa fa-eye"></i>) icon on a
                     project's page to get activity updates here.
                 </p>


### PR DESCRIPTION
<h1> Purpose </h1>
Stop the brief flash of the 'No Logs' message in the project activity logs when loading logs. Closes #3641  
<h1> Changes </h1>
The check for no logs message was initially ```if: !logs().length && !loading()```, but because there is always a fraction of time between when the ajax call retrieves the data and when it's pushed into self.logs, there's always a short moment of time after loading when self.logs().length == 0 making this check always true. 

So you need a separate observable just to see if there are no logs.

<h1> Side Effect </h1>
None that I know of.