### PR TITLE
Feature/api node parent

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -114,7 +114,10 @@ class Link(object):
         kwarg_values = {key: _get_attr_from_tpl(attr_tpl, obj) for key, attr_tpl in self.kwargs.items()}
         arg_values = [_get_attr_from_tpl(attr_tpl, obj) for attr_tpl in self.args]
         query_kwarg_values = {key: _get_attr_from_tpl(attr_tpl, obj) for key, attr_tpl in self.query_kwargs.items()}
-
+        # Presumably, if you have are expecting a value but the value is empty, then the link is invalid.
+        for item in kwarg_values:
+            if kwarg_values[item] is None:
+                return None
         return absolute_reverse(
             self.endpoint,
             args=arg_values,

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -45,6 +45,9 @@ class NodeSerializer(JSONAPISerializer):
         'files': {
             'related': Link('nodes:node-files', kwargs={'node_id': '<pk>'})
         },
+        'parent': {
+            'self': Link('nodes:node-detail', kwargs={'node_id': '<parent_id>'})
+        }
     })
     properties = ser.SerializerMethodField(help_text='A dictionary of read-only booleans: registration, collection,'
                                                      'and dashboard. Collections are special nodes used by the Project '

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 import mock
+import urlparse
 from nose.tools import *  # flake8: noqa
 
 from website.models import Node
 from framework.auth.core import Auth
 from website.util.sanitize import strip_html
 from api.base.settings.defaults import API_BASE
+from website.settings import API_DOMAIN
 
 from tests.base import ApiTestCase, fake
 from tests.factories import (
@@ -436,6 +438,17 @@ class TestNodeDetail(ApiTestCase):
         res = self.app.get(self.private_url, auth=self.basic_auth_two, expect_errors=True)
         assert_equal(res.status_code, 403)
 
+    def test_top_level_project_has_no_parent(self):
+        res = self.app.get(self.public_url)
+        assert_equal(res.status_code, 200)
+        assert_equal(res.json['data']['links']['parent']['self'], None)
+
+    def test_child_project_has_parent(self):
+        public_component = NodeFactory(parent=self.public_project, creator=self.user, is_public=True)
+        public_component_url = '/{}nodes/{}/'.format(API_BASE, public_component._id)
+        res = self.app.get(public_component_url)
+        assert_equal(res.status_code, 200)
+        assert_equal(res.json['data']['links']['parent']['self'], urlparse.urljoin(API_DOMAIN, self.public_url))
 
 class TestNodeUpdate(ApiTestCase):
 


### PR DESCRIPTION
Purpose
-----------
Give Nodes the ability to link to the parent node, and to also show whether they are the top level node or not by returning `None`/`null` in the parent link field if they are the top level item.

Changes
------------
Added a parent link field and associated tests. Modified the resolve_url method in the Link class to recognize when a parameter is being passed in but is None that the link is not going to be valid.

Original JSON:
```json
"links": {
            "files": {
                "related": "http://localhost:8000/v2/nodes/2q3uv/files/"
            },
            "contributors": {
                "count": 6,
                "related": "http://localhost:8000/v2/nodes/2q3uv/contributors/"
            },
            "pointers": {
                "count": 4,
                "related": "http://localhost:8000/v2/nodes/2q3uv/pointers/"
            },
            "registrations": {
                "count": 1,
                "related": "http://localhost:8000/v2/nodes/2q3uv/registrations/"
            },
            "self": "http://localhost:8000/v2/nodes/2q3uv/",
            "html": "http://localhost:5000/2q3uv/",
            "children": {
                "count": 1,
                "related": "http://localhost:8000/v2/nodes/2q3uv/children/"
            }
        },
```

New JSON for top-level node:
```json
"links": {
            "files": {
                "related": "http://localhost:8000/v2/nodes/2q3uv/files/"
            },
            "parent": {
                "self": null
            },
            "contributors": {
                "count": 6,
                "related": "http://localhost:8000/v2/nodes/2q3uv/contributors/"
            },
            "pointers": {
                "count": 4,
                "related": "http://localhost:8000/v2/nodes/2q3uv/pointers/"
            },
            "registrations": {
                "count": 1,
                "related": "http://localhost:8000/v2/nodes/2q3uv/registrations/"
            },
            "self": "http://localhost:8000/v2/nodes/2q3uv/",
            "html": "http://localhost:5000/2q3uv/",
            "children": {
                "count": 1,
                "related": "http://localhost:8000/v2/nodes/2q3uv/children/"
            }
        },
```

New JSON for child node:
```json
 "links": {
                "files": {
                    "related": "http://localhost:8000/v2/nodes/7fhja/files/"
                },
                "parent": {
                    "self": "http://localhost:8000/v2/nodes/2q3uv/"
                },
                "contributors": {
                    "count": 1,
                    "related": "http://localhost:8000/v2/nodes/7fhja/contributors/"
                },
                "pointers": {
                    "count": 0,
                    "related": "http://localhost:8000/v2/nodes/7fhja/pointers/"
                },
                "registrations": {
                    "count": 0,
                    "related": "http://localhost:8000/v2/nodes/7fhja/registrations/"
                },
                "self": "http://localhost:8000/v2/nodes/7fhja/",
                "html": "http://localhost:5000/7fhja/",
                "children": {
                    "count": 0,
                    "related": "http://localhost:8000/v2/nodes/7fhja/children/"
                }
            },
```
Side effects
----------------
If anything was relying on being able to pass a None for some reason to a link field, it's not going to work any more. I don't know of anything like that, and the tests all pass. I'm pretty sure it would not be expected to work.

Note: @himanshuo needs this for the OSF Offline functionality, so please fast-track. @lyndsysimon @sloria 