### PR TITLE
Fix Growlbox Title Overlaping with 'x'

### DIFF
--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -24,7 +24,7 @@ var GrowlBox = require('js/growlBox');
  *
  */
 var growl = function(title, message, type) {
-    new GrowlBox(title + "&nbsp;&nbsp;&nbsp;&nbsp", message, type || 'danger');
+    new GrowlBox(title + '&nbsp;&nbsp;&nbsp;&nbsp', message, type || 'danger');
 };
 
 

--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -16,14 +16,15 @@ var GrowlBox = require('js/growlBox');
 
 /**
  * Convenience function to create a GrowlBox
- * Show a growl-style notification for messages. Defaults to an error type.
+ * Show a growl-style notification for messages. Defaults to an error type. Adds spaces to title to avoid overlapping
+ * upper right 'x' close button.
  * @param {String} title Shows in bold at the top of the box. Required or it looks foolish.
  * @param {String} message Shows a line below the title. This could be '' if there's nothing to say.
  * @param {String} type One of 'success', 'info', 'warning', or 'danger'. Defaults to danger.
  *
  */
 var growl = function(title, message, type) {
-    new GrowlBox(title, message, type || 'danger');
+    new GrowlBox(title + "&nbsp;&nbsp;&nbsp;&nbsp", message, type || 'danger');
 };
 
 

--- a/website/static/js/tests/osfHelpers.test.js
+++ b/website/static/js/tests/osfHelpers.test.js
@@ -21,7 +21,7 @@ describe('osfHelpers', () => {
 
             assert.calledWith(stub,
                 //adds non-breaking spaces to stop title overlapping upper right 'x' close button
-                {title: '<strong>The one &nbsp;&nbsp;&nbsp;&nbsp<strong><br />', message: 'the only'});
+                {title: '<strong>The one&nbsp;&nbsp;&nbsp;&nbsp<strong><br />', message: 'the only'});
             stub.restore();
         });
     });

--- a/website/static/js/tests/osfHelpers.test.js
+++ b/website/static/js/tests/osfHelpers.test.js
@@ -20,7 +20,8 @@ describe('osfHelpers', () => {
             assert.calledOnce(stub);
 
             assert.calledWith(stub,
-                {title: '<strong>The one<strong><br />', message: 'the only'});
+                //adds non-breaking spaces to stop title overlapping upper right 'x' close button
+                {title: '<strong>The one &nbsp;&nbsp;&nbsp;&nbsp<strong><br />', message: 'the only'});
             stub.restore();
         });
     });


### PR DESCRIPTION
<h1> Purpose </h1>
Stop growlbox titles from overlaping upper right 'x'. Close issue #3673.
<h1> Changes </h1>
Adds html spaces to title.
<h1> Side Effects </h1>
None that I know of.