### PR TITLE
Stop Displaying Retracted Registrations in Public Activity.

### DIFF
--- a/website/discovery/views.py
+++ b/website/discovery/views.py
@@ -37,7 +37,7 @@ def activity():
             if node.is_public and not node.is_registration and not node.is_deleted:
                 if len(popular_public_projects) < 10:
                     popular_public_projects.append(node)
-            elif node.is_public and node.is_registration and not node.is_deleted:
+            elif node.is_public and node.is_registration and not node.is_deleted and not node.is_retracted:
                 if len(popular_public_registrations) < 10:
                     popular_public_registrations.append(node)
             if len(popular_public_projects) >= 10 and len(popular_public_registrations) >= 10:


### PR DESCRIPTION
<h1> Purpose </h1>
Stop displaying retracted registrations on the Public Activity page. Close #3671.
<h1> Changes </h1>
simple change to /discovery/views.py
<h1> Side Effects </h1> 
None that I know of.