### PR TITLE
[feature fix] Empty Component Wiki Pages

### DIFF
--- a/website/addons/wiki/views.py
+++ b/website/addons/wiki/views.py
@@ -456,13 +456,13 @@ def project_wiki_grid_data(auth, node, **kwargs):
     }
     pages.append(project_wiki_pages)
 
-    if len(node.nodes) > 0:
-        component_wiki_pages = {
-            'title': 'Component Wiki Pages',
-            'kind': 'folder',
-            'type': 'heading',
-            'children': format_component_wiki_pages(node, auth)
-        }
+    component_wiki_pages = {
+        'title': 'Component Wiki Pages',
+        'kind': 'folder',
+        'type': 'heading',
+        'children': format_component_wiki_pages(node, auth)
+    }
+    if len(component_wiki_pages['children']) > 0:
         pages.append(component_wiki_pages)
 
     return pages


### PR DESCRIPTION
Fix for [this](https://trello.com/c/KRzmK3bk/136-empty-wiki-components-folder-if-pages-have-no-content) Trello bug.