### PR TITLE
[feature fix] wiki menu on xs screens

### DIFF
--- a/website/addons/wiki/templates/edit.mako
+++ b/website/addons/wiki/templates/edit.mako
@@ -24,7 +24,7 @@
         <div class="panel-toggle col-sm-${'3' if 'menu' in panels_used else '1' | n}">
 
             <!-- Menu with toggle normal -->
-            <div class="osf-panel panel panel-default reset-height ${'' if 'menu' in panels_used else 'hidden' | n}" data-bind="css: {  'osf-panel-flex': !$root.singleVis() }">
+            <div class="osf-panel panel panel-default reset-height ${'' if 'menu' in panels_used else 'hidden visible-xs' | n}" data-bind="css: {  'osf-panel-flex': !$root.singleVis() }">
                 <div class="panel-heading clearfix" data-bind="css: {  'osf-panel-heading-flex': !$root.singleVis()}">
                     % if user['can_edit']:
                         <div class="wiki-toolbar-icon text-success" data-toggle="modal" data-target="#newWiki">
@@ -51,7 +51,7 @@
             </div>
 
             <!-- Menu with toggle collapsed -->
-            <div class="osf-panel panel panel-default panel-collapsed text-center ${'hidden' if 'menu' in panels_used else '' | n}" >
+            <div class="osf-panel panel panel-default panel-collapsed hidden-xs text-center ${'hidden' if 'menu' in panels_used else '' | n}" >
                 <div class="panel-heading pointer">
                     <i class="fa fa-list"> </i>
                     <i class="fa fa-angle-right"> </i>

--- a/website/static/js/pages/wiki-edit-page.js
+++ b/website/static/js/pages/wiki-edit-page.js
@@ -131,9 +131,11 @@ $(document).ready(function () {
     $('.panel-collapse').on('click', function () {
         var el = $(this).closest('.panel-toggle');
         el.children('.osf-panel').addClass('hidden');
+        el.children('.osf-panel').addClass('visible-xs');
         panelToggle.removeClass('col-sm-3').addClass('col-sm-1');
         panelExpand.removeClass('col-sm-9').addClass('col-sm-11');
         el.children('.panel-collapsed').removeClass('hidden');
+        el.children('.panel-collapsed').removeClass('visible-xs');
         $('.wiki-nav').removeClass('hidden');
 
         bodyElement.trigger('toggleMenu', [false]);
@@ -142,6 +144,7 @@ $(document).ready(function () {
         var el = $(this).parent();
         var toggle = el.closest('.panel-toggle');
         toggle.children('.osf-panel').removeClass('hidden');
+        toggle.children('.osf-panel').removeClass('visible-xs');
         el.addClass('hidden');
         panelToggle.removeClass('col-sm-1').addClass('col-sm-3');
         panelExpand.removeClass('col-sm-11').addClass('col-sm-9');


### PR DESCRIPTION
[Trello](https://trello.com/c/eJNsz1fG/137-issues-when-collapsing-wiki-menu-and-then-making-window-smaller) fix.

Screenshot of wiki menu on small screen:

![screen shot 2015-07-20 at 1 10 41 pm](https://cloud.githubusercontent.com/assets/7913604/8782033/c601b226-2ee0-11e5-9937-4e8f8a9e8d9f.png)
