### PR TITLE
Increase z-index for slide in panel

### DIFF
--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -38,7 +38,7 @@ a {
     width:100%;
     padding-top:20px;
     padding-bottom:20px;
-    z-index:1;
+    z-index:9;
     background-color:white;
     border-top:2px solid black;
     display:none;


### PR DESCRIPTION
## Purpose
Fixes this issue: https://github.com/CenterForOpenScience/osf.io/issues/3696

## Changes
Increase z-index to 9 so that it covers most things on the page but not the top fixed bars. 

## Side Effects
Not sure, as with z-indexes other values might have different. Tested against navigation bars and modals. 