### PR TITLE
[hold] [Style] Fix mfr block into panel in file view page

### DIFF
--- a/website/static/css/pages/file-view-page.css
+++ b/website/static/css/pages/file-view-page.css
@@ -78,3 +78,8 @@
     max-height: 500px;
     height: inherit;
 }
+
+.mfr-logo-spin {
+    z-index: 1 !important;
+    top: 60px !important;
+}

--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -78,7 +78,7 @@ var FileViewPage = {
         self.editHeader = function() {
             return m('.row', [
                 m('.col-sm-12', m('span[style=display:block;]', [
-                    m('h3.panel-title',[m('i.fa.fa-pencil-square-o'), '   Edit ']),
+                    m('h3.panel-title','Edit'),
                     m('.pull-right', [
                         m('.progress.no-margin.pointer', {
                             'data-toggle': 'modal',

--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -78,7 +78,7 @@ var FileViewPage = {
         self.editHeader = function() {
             return m('.row', [
                 m('.col-sm-12', m('span[style=display:block;]', [
-                    m('h3.panel-title','Edit'),
+                    m('h3.panel-title',[m('i.fa.fa-pencil-square-o'), ' Edit ']),
                     m('.pull-right', [
                         m('.progress.no-margin.pointer', {
                             'data-toggle': 'modal',

--- a/website/static/js/filepage/revisions.js
+++ b/website/static/js/filepage/revisions.js
@@ -131,7 +131,7 @@ var FileRevisionsTable = {
     },
     view: function(ctrl) {
         return m('#revisionsPanel.panel.panel-default', [
-                m('.panel-heading.clearfix', m('h3.panel-title', 'Revisions')),
+                m('.panel-heading.clearfix', m('h3.panel-title', [m('i.fa.fa-history'),' Revisions'])),
                 m('.panel-body', {style:{'padding-right': '0','padding-left':'0', 'padding-bottom' : '0'}}, (function() {
                     if (!model.loaded()) {
                         return util.Spinner;

--- a/website/templates/project/view_file.mako
+++ b/website/templates/project/view_file.mako
@@ -52,7 +52,7 @@
       <div id="mfrIframeParent" class="col-sm-9">
         <div class="panel panel-default">
           <div class="panel-heading clearfix">
-            <h4 class="panel-title">View</h4>
+            <h4 class="panel-title"><i class="fa fa-eye"></i> View</h4>
           </div>
           <div class="panel-body">
             <div id="mfrIframe" class="mfr mfr-file"></div>

--- a/website/templates/project/view_file.mako
+++ b/website/templates/project/view_file.mako
@@ -50,7 +50,15 @@
   <div id="fileViewPanelLeft" class="col-sm-9 panel-expand">
     <div class="row">
       <div id="mfrIframeParent" class="col-sm-9">
-        <div id="mfrIframe" class="mfr mfr-file"></div>
+        <div class="panel panel-default">
+          <div class="panel-heading clearfix">
+            <h4 class="panel-title">View</h4>
+          </div>
+          <div class="panel-body">
+            <div id="mfrIframe" class="mfr mfr-file"></div>
+          </div>
+        </div>
+
       </div>
 
     <!-- This section is built by mithril in revisions.js -->


### PR DESCRIPTION
## Purpose
Fix this trello card: https://trello.com/c/kh9ClUOc
Also provide icon unity : https://trello.com/c/Z3pMRV5y 
but in this case unity was done by adding icons so that in this step at least we have same functionality as Wiki. we can remove all if that's the desired look. 

## Changes
- Wrap the mfr with panel classes
- Override mfr-logo-spin to make it fit within the space of the panel
- add icons to headers in file view page

## Side Effects
Mfr iframe seems to load normally and the toggle for widths are working. 