### PR TITLE
[Hotfix] Dataverse logs

### DIFF
--- a/website/addons/dataverse/model.py
+++ b/website/addons/dataverse/model.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from time import sleep
 import requests
-import urlparse
 import httplib as http
 
 import pymongo
@@ -193,14 +192,7 @@ class AddonDataverseNodeSettings(StorageAddonBase, AddonOAuthNodeSettingsBase):
         }
 
     def create_waterbutler_log(self, auth, action, metadata):
-        path = metadata['path']
-        if 'name' in metadata:
-            name = metadata['name']
-        else:
-            query_string = urlparse.urlparse(metadata['full_path']).query
-            name = urlparse.parse_qs(query_string).get('name')
-
-        url = self.owner.web_url_for('addon_view_or_download_file', path=path, provider='dataverse')
+        url = self.owner.web_url_for('addon_view_or_download_file', path=metadata['path'], provider='dataverse')
         self.owner.add_log(
             'dataverse_{0}'.format(action),
             auth=auth,
@@ -208,7 +200,7 @@ class AddonDataverseNodeSettings(StorageAddonBase, AddonOAuthNodeSettingsBase):
                 'project': self.owner.parent_id,
                 'node': self.owner._id,
                 'dataset': self.dataset,
-                'filename': name,
+                'filename': metadata['name'],
                 'urls': {
                     'view': url,
                     'download': url + '?action=download'


### PR DESCRIPTION
Update dateverse to accept the new callback format
  Dataverse would send "full_path" for a round trip to give users a
  readable file name. Waterbutler now handles send back file names now.