### PR TITLE
[WIP] Delete comma space

### DIFF
--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -997,7 +997,7 @@ class User(GuidStoredObject, AddonModelMixin):
             'user_profile_url': self.profile_url,
             'user_display_name': name_formatters[formatter](self),
             'user_is_claimed': self.is_claimed,
-            'separator':separator
+            'separator': separator
         }
 
     def save(self, *args, **kwargs):

--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -991,12 +991,13 @@ class User(GuidStoredObject, AddonModelMixin):
             if self._id in node.visible_contributor_ids
         )
 
-    def get_summary(self, formatter='long'):
+    def get_summary(self, separator='', formatter='long'):
         return {
             'user_fullname': self.fullname,
             'user_profile_url': self.profile_url,
             'user_display_name': name_formatters[formatter](self),
-            'user_is_claimed': self.is_claimed
+            'user_is_claimed': self.is_claimed,
+            'separator':separator
         }
 
     def save(self, *args, **kwargs):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -447,7 +447,7 @@ class TestProjectViews(OsfTestCase):
         assert_equal(len(res.json['others_count']), 1)
         assert_equal(res.json['contributors'][0]['separator'], ',')
         assert_equal(res.json['contributors'][1]['separator'], ',')
-        assert_equal(res.json['contributors'][2]['separator'], '&')
+        assert_equal(res.json['contributors'][2]['separator'], ' &amp;')
 
     def test_edit_node_title(self):
         url = "/api/v1/project/{0}/edit/".format(self.project._id)

--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -302,10 +302,10 @@ def edit_profile(**kwargs):
     return ret
 
 
-def get_profile_summary(user_id, formatter='long'):
+def get_profile_summary(user_id, separator='', formatter='long'):
 
     user = User.load(user_id)
-    return user.get_summary(formatter)
+    return user.get_summary(separator, formatter)
 
 
 @must_be_logged_in

--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -57,7 +57,6 @@ def get_node_contributors_abbrev(auth, node, **kwargs):
     others_count = ''
 
     for index, user in enumerate(users[:max_count]):
-
         if index == max_count - 1 and len(users) > max_count:
             separator = ' &amp;'
             others_count = str(n_contributors - 3)

--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -59,12 +59,12 @@ def get_node_contributors_abbrev(auth, node, **kwargs):
     for index, user in enumerate(users[:max_count]):
 
         if index == max_count - 1 and len(users) > max_count:
-            separator = '&'
+            separator = ' &amp;'
             others_count = str(n_contributors - 3)
         elif index == len(users) - 1:
             separator = ''
         elif index == len(users) - 2:
-            separator = '&'
+            separator = ' &amp;'
         else:
             separator = ','
 

--- a/website/templates/util/render_user.mako
+++ b/website/templates/util/render_user.mako
@@ -3,7 +3,7 @@
         rel="tooltip"
         href="${user_profile_url}"
         data-original-title="${user_fullname}"
-    >${user_display_name}</a>
+    >${user_display_name}</a><span>${separator}</span>
 % else:
-    <span class="overflow contributor-name">${user_display_name}</span>
+    <span class="overflow contributor-name">${user_display_name}</span><span>${separator}</span>
 % endif

--- a/website/templates/util/render_users_abbrev.mako
+++ b/website/templates/util/render_users_abbrev.mako
@@ -4,12 +4,12 @@
                 "tpl": "util/render_user.mako",
                 "uri": "/api/v1/profile/${contributor['user_id']}/summary/",
                 "view_kwargs": {
-                    "formatter": "surname"
+                    "formatter": "surname",
+                    "separator":"${contributor['separator']}"
                 },
                 "replace": true
         }'>
         </div>
-        <span>${contributor['separator']}</span>
     % endfor
     % if others_count:
         <a href="${node_url}">${others_count} more</a>


### PR DESCRIPTION
### Purpose
In name abbreviation of project, the comma has extra space before it. The reason is because we use two mako files to do this and it has new line between name span and comma span. So in html, it will treat this new line as space.  For this solution, I make the name span and comma span in the same mako file. Now there is nothing between them. It will not add unnecessary space before comma span.

Related Trello Bug Card -- https://trello.com/c/2QIU8n4V/65-public-activity-page-extra-space-between-contributor-and

Related Github issue -- #3669

Related Stackoverflow [Question](http://stackoverflow.com/questions/31522458/how-to-set-correct-comma-position-in-html/31522492#31522492) 
### Changes
In this solution, I added a new variable "separator" for get_summary and get_profile_summary method. It is used to transfer the separator between the name. 

Before Change:
![screenshot 2015-07-20 13 12 09](https://cloud.githubusercontent.com/assets/5420789/8787637/41a945ac-2f03-11e5-9c35-ff37d602f4c2.png)

After Change:
![screenshot 2015-07-20 13 12 41](https://cloud.githubusercontent.com/assets/5420789/8787785/03d6ab74-2f04-11e5-86ea-f1a480e20bb4.png)
### Others.
This solution is largely relied on the existing code. However, since these two mako files are only used here, it may be better way to combine them together. In that case, we don't need this PR.
