### PR TITLE
[Hotfix] Dataverse logs

### DIFF
--- a/website/addons/dataverse/model.py
+++ b/website/addons/dataverse/model.py
@@ -200,7 +200,7 @@ class AddonDataverseNodeSettings(StorageAddonBase, AddonOAuthNodeSettingsBase):
                 'project': self.owner.parent_id,
                 'node': self.owner._id,
                 'dataset': self.dataset,
-                'filename': metadata['name'],
+                'filename': metadata['materialized'].strip('/'),
                 'urls': {
                     'view': url,
                     'download': url + '?action=download'


### PR DESCRIPTION
metadata does not include a name field
![screen shot 2015-07-21 at 09 50 18](https://cloud.githubusercontent.com/assets/5532905/8802226/11a01436-2f8e-11e5-9b7c-d7bc007cc449.png)
