### PR TITLE
[feature-fix] Make all add-on profile authorizer names grey

### DIFF
--- a/website/addons/figshare/templates/figshare_user_settings.mako
+++ b/website/addons/figshare/templates/figshare_user_settings.mako
@@ -5,7 +5,7 @@
         figshare
         <small class="authorized-by">
             % if authorized:
-                    authorized by <a href=${profile_url}><em> ${name} </em></a>
+                    authorized by <em> ${name} </em>
                 <a id="figshareDelKey" class="text-danger pull-right addon-auth">Disconnect Account</a>
             % else:
                 <a id="figshareAddKey" class="text-primary pull-right addon-auth">

--- a/website/addons/github/templates/github_user_settings.mako
+++ b/website/addons/github/templates/github_user_settings.mako
@@ -6,9 +6,7 @@
         <small class="authorized-by">
             % if authorized:
                     authorized by
-                    <a href="https://github.com/${authorized_github_user}" target="_blank">
                         <em>${authorized_github_user}</em>
-                    </a>
                 <a id="githubDelKey" class="text-danger pull-right addon-auth">Disconnect Account</a>
             % else:
                 <a id="githubAddKey" class="text-primary pull-right addon-auth">

--- a/website/addons/s3/templates/s3_user_settings.mako
+++ b/website/addons/s3/templates/s3_user_settings.mako
@@ -7,7 +7,7 @@
 
             <small class="authorized-by">
                 % if has_auth:
-                    authorized by <a href=${profile_url}><em>${name}</em></a></th>
+                    authorized by <em>${name}</em>
                     <a id="s3RemoveAccess" class="text-danger pull-right addon-auth">Disconnect Account</a>
                 % endif
             </small>

--- a/website/templates/profile/user_settings_default.mako
+++ b/website/templates/profile/user_settings_default.mako
@@ -14,7 +14,7 @@
         <table class="table table-hover">
             <thead>
                 <tr class="user-settings-addon-auth">
-                    <th class="text-muted default-authorized-by">Authorized by <em><a data-bind="attr.href: profileUrl, text: name"></a></em></th>
+                    <th class="text-muted default-authorized-by">Authorized by <em><span data-bind="text: name"></span></em></th>
                     <th><a data-bind="click: $root.askDisconnect" class="text-danger pull-right default-authorized-by">Disconnect Account</a></th>
                 </tr>
             </thead>


### PR DESCRIPTION
Purpose
-----------
Some of the add-on authorizer names on the user settings page link to their profile on the add-on, while others link to the user's OSF profile and some are greyed out: 
![screen shot 2015-07-21 at 1 26 15 pm](https://cloud.githubusercontent.com/assets/6414394/8807675/21f97462-2fac-11e5-8909-80f3d8f9b7a0.png)


Changes
------------
Make all of the add-on authorizer names grey for consistency:
![screen shot 2015-07-21 at 1 24 47 pm](https://cloud.githubusercontent.com/assets/6414394/8807652/f2c85f8c-2fab-11e5-879b-f2eda7009042.png)
