### PR TITLE
[hotfix] Add validators for User.social

### DIFF
--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -22,7 +22,7 @@ from framework.sentry import log_exception
 from framework.addons import AddonModelMixin
 from framework.sessions.model import Session
 from framework.sessions.utils import remove_sessions_for_user
-from framework.exceptions import PermissionsError
+from framework.exceptions import PermissionsError, ProfileValidationError
 from framework.guid.model import GuidStoredObject
 from framework.bcrypt import generate_password_hash, check_password_hash
 from framework.auth.exceptions import ChangePasswordError, ExpiredTokenError
@@ -90,12 +90,87 @@ def validate_personal_site(value):
         try:
             validate_url(value)
         except ValidationError:
-            # Reraise with a better message
-            raise ValidationError('Invalid personal URL.')
+            raise ProfileValidationError(
+                'personal',
+                'Invalid personal URL.'
+            )
+
+
+def validate_twitter(value):
+    if value:
+        if not re.match(r'^\w+$', value):
+            raise ProfileValidationError(
+                'twitter',
+                'The twitter handle provided is not of valid form.')
+        else:
+            # TODO(hrybacki): confirm that this handle is not anywhere else in the DB
+            pass
+
+
+def validate_github(value):
+    if value:
+        if not re.match(r'^\w+$', value):
+            raise ProfileValidationError(
+                'github',
+                'The GitHub username provided is not of valid form.'
+            )
+
+
+def validate_orcid(value):
+    if value:
+        if not re.match(r'^[\d]{4}-[\d]{4}-[\d]{4}-[\d]{4}$', value):
+            raise ProfileValidationError(
+                'orcid',
+                'The orcid provided is not of valid form.'
+            )
+
+
+def validate_scholar(value):
+    if value:
+        if not re.match(r'^\w+$', value):
+            raise ProfileValidationError(
+                'scholar',
+                'The Google Scholar id provided is not of valid form.'
+            )
+
+
+def validate_linkedin(value):
+    if value:
+        # LinkedIn profiles can be in/<UserID>, profile/<ProfileID>, or pub/<some link>
+        if not re.match(r'^in\/\w+$|^profile\/\w+$|^pub\/.+$', value):
+            raise ProfileValidationError(
+                'linkedin',
+                'The LinkedIn ID provided is not of valid form.'
+            )
+
+
+def validate_impactstory(value):
+    if value:
+        if not re.match(r'^\w+$', value):
+            raise ProfileValidationError(
+                'impactStory',
+                'The Impact Story ID provided is not of valid form.'
+            )
+
+
+def validate_researcherid(value):
+    if value:
+        if not re.match(r'^[A-Za-z]-\d{4}-\d{4}$', value):
+            raise ProfileValidationError(
+                'researcherId',
+                'The Researcher ID provided is not of valid form.'
+            )
 
 
 def validate_social(value):
     validate_personal_site(value.get('personal'))
+    validate_twitter(value.get('twitter'))
+    validate_github(value.get('github'))
+    validate_orcid(value.get('orcid'))
+    validate_scholar(value.get('scholar'))
+    validate_linkedin(value.get('linkedin'))
+    validate_impactstory(value.get('impactStory'))
+    validate_researcherid(value.get('researcherId'))
 
 
 def validate_email(item):
@@ -349,6 +424,12 @@ class User(GuidStoredObject, AddonModelMixin):
     # Format: {
     #     'personal': <personal site>,
     #     'twitter': <twitter id>,
+    #     'orcid': <orc id>,
+    #     'github': <github id>,
+    #     'scholar': <scholar id>,
+    #     'linkedIn': <linkedIn id>,
+    #     'impactStory': <impact story id>,
+    #     'researcherId: <researcher id>
     # }
 
     # hashed password used to authenticate to Piwik

--- a/framework/exceptions/__init__.py
+++ b/framework/exceptions/__init__.py
@@ -4,6 +4,8 @@ import copy
 import httplib as http
 from flask import request
 
+from modularodm.exceptions import ValidationError
+
 class FrameworkError(Exception):
     """Base class from which framework-related errors inherit."""
     pass
@@ -91,3 +93,18 @@ class PermissionsError(FrameworkError):
     """Raised if an action cannot be performed due to insufficient permissions
     """
     pass
+
+
+class ProfileValidationError(ValidationError):
+    """Raised if a field in User.social does not pass validation."""
+    def __init__(self, field, message):
+        self.field = field
+        self.message = message
+
+    @property
+    def message_short(self):
+        return 'Failed to validate {}'.format(self.field)
+
+    @property
+    def message_long(self):
+        return self.message


### PR DESCRIPTION
## Purpose:
Add backend validators for `User.profile`.

## Changes:
- Added validator/tests for:
  1. Twitter
  2. GitHub
  3. orcid
  4. Google Scholar
  5. LinkedIn
  6. Impact Story
  7. ResearcherID

- Added ProfileValidationError which can hand short/long error
messages to error.mako for more informative user feedback

## Side Effects:
This will could cause a lot of errors to be thrown whenever `User.save()` is called. I haven't the slightest clue how dirty the `User.profile` fields are as we've never run validation on them. Migration @sloria ?

## Notes:
Closes-Issue: #3513