### PR TITLE
[feature fix] component link icons in wiki menu

### DIFF
--- a/website/addons/wiki/tests/test_wiki.py
+++ b/website/addons/wiki/tests/test_wiki.py
@@ -1194,6 +1194,7 @@ class TestWikiMenu(OsfTestCase):
                 ],
                 'kind': 'component',
                 'category': self.component.category,
+                'pointer': False,
             }
         ]
         data = views.format_component_wiki_pages(node=self.project, auth=self.consolidate_auth)

--- a/website/addons/wiki/views.py
+++ b/website/addons/wiki/views.py
@@ -546,6 +546,7 @@ def format_component_wiki_pages(node, auth):
             },
             'kind': 'component',
             'category': wiki_page['category'],
+            'pointer': wiki_page['is_pointer'],
             'children': children,
         }
         if len(component_page['children']) > 0:

--- a/website/static/js/wikiMenu.js
+++ b/website/static/js/wikiMenu.js
@@ -26,6 +26,9 @@ function resolveIcon(item) {
         return m('span', { 'class' : icons[category]});
     }
     if (item.data.kind === 'component' && item.parent().data.title === 'Component Wiki Pages') {
+        if(item.data.pointer) {
+            return m('i.fa.fa-link', '');
+        }
         return returnView(item.data.category);
     }
     if (item.data.type === 'heading') {


### PR DESCRIPTION
[Trello](https://trello.com/c/36HLF5nG/154-links-on-projects-do-not-have-link-icons-in-wiki-menu) bug fix.