### PR TITLE
[feature fix] center icons on collapsed wiki menu

### DIFF
--- a/website/addons/wiki/templates/edit.mako
+++ b/website/addons/wiki/templates/edit.mako
@@ -56,7 +56,7 @@
                     <i class="fa fa-list"> </i>
                     <i class="fa fa-angle-right"> </i>
                 </div>
-                <div class="panel-body">
+                <div>
                     <%include file="wiki/templates/nav.mako"/>
                 </div>
             </div>


### PR DESCRIPTION
Fixes icons in collapsed menu being cut off on small screens, referenced in [#3685](https://github.com/CenterForOpenScience/osf.io/issues/3685#issuecomment-123445327). 

Trello card [here](https://trello.com/c/Cqsbok0V/157-collapsed-wiki-menu-s-icons-are-centered-in-small-windows).

[![Gyazo](http://i.gyazo.com/a36be62f9728ba1ae67d30f4cdf1fbe7.gif)](http://gyazo.com/a36be62f9728ba1ae67d30f4cdf1fbe7)