### PR TITLE
[WIP][hotfix] Ensure Archiver always uses an admin to register addons/components

### DIFF
--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -319,6 +319,31 @@ class TestCheckAuth(OsfTestCase):
             views.check_access(self.node, None, 'download')
         assert_equal(exc_info.exception.code, 401)
 
+    def test_has_permission_on_parent_node_copyto_pass_if_registration(self):
+        component_admin = AuthUserFactory()
+        component = ProjectFactory(creator=component_admin, parent=self.node)
+        component.is_registration = True
+
+        assert_false(component.has_permission(self.user, 'write'))
+        res = views.check_access(component, self.user, 'copyto')
+        assert_true(res)
+
+    def test_has_permission_on_parent_node_copyto_fail_if_not_registration(self):
+        component_admin = AuthUserFactory()
+        component = ProjectFactory(creator=component_admin, parent=self.node)
+
+        assert_false(component.has_permission(self.user, 'write'))
+        with assert_raises(HTTPError):
+            views.check_access(component, self.user, 'copyto')
+
+    def test_has_permission_on_parent_node_copyfrom(self):
+        component_admin = AuthUserFactory()
+        component = ProjectFactory(creator=component_admin, public=False, parent=self.node)
+
+        assert_false(component.has_permission(self.user, 'write'))
+        res = views.check_access(component, self.user, 'copyfrom')
+        assert_true(res)
+
 
 class OsfFileTestCase(OsfTestCase):
 

--- a/website/addons/base/views.py
+++ b/website/addons/base/views.py
@@ -99,6 +99,23 @@ def check_access(node, user, action, key=None):
     if permission == 'read':
         if node.is_public or key in node.private_link_keys_active:
             return True
+    # Users attempting to register projects with components might not have
+    # `write` permissions for all components. This will result in a 403 for
+    # all `copyto` actions as well as `copyfrom` actions if the component
+    # in question is not public. To get around this, we have to recursively
+    # check the node's parent node to determine if they have `write`
+    # permissions up the stack.
+    # TODO(hrybacki): is there a way to tell if this is for a registration?
+    # All nodes being registered that receive the `copyto` action will have
+    # `node.is_registration` == True. However, we have no way of telling if
+    # `copyfrom` actions are originating from a node being registered.
+    if action == 'copyfrom' or (action == 'copyto' and node.is_registration):
+        parent = node.parent_node
+        while parent:
+            if parent.has_permission(user, 'write'):
+                return True
+            parent = parent.parent_node
+
     code = httplib.FORBIDDEN if user else httplib.UNAUTHORIZED
     raise HTTPError(code)
 


### PR DESCRIPTION
## Purpose:
Current behavior always uses the user who initiated the registration to generate API tokens for Water Butler. As a result, if that admin was not an admin, or did not have write permissions, for the original addon/component, Water Butler would return a 403 after asking the OSF if the user has writes to `copyfrom` or `copyto` the component.
## Changes:
`addons.base.check_access` will now check for `write` permissions up the stack for all `copyto` and `copyfrom` requests.

## Notes:
Closes-issue: #3722