### PR TITLE
[feature] JSONAPI Error formatting

### DIFF
--- a/api/base/exceptions.py
+++ b/api/base/exceptions.py
@@ -1,5 +1,5 @@
 
-def custom_exception_handler(exc, context):
+def jsonapi_exception_handler(exc, context):
     """
     Custom exception handler that nests detail inside errors.
     """

--- a/api/base/exceptions.py
+++ b/api/base/exceptions.py
@@ -1,7 +1,7 @@
 
 def jsonapi_exception_handler(exc, context):
     """
-    Custom exception handler that nests detail inside errors.
+    Custom exception handler that returns errors object as an array with a 'detail' member
     """
     from rest_framework.views import exception_handler
     response = exception_handler(exc, context)

--- a/api/base/exceptions.py
+++ b/api/base/exceptions.py
@@ -1,0 +1,14 @@
+
+def custom_exception_handler(exc, context):
+    """
+    Custom exception handler that nests detail inside errors.
+    """
+    from rest_framework.views import exception_handler
+    response = exception_handler(exc, context)
+
+    if response is not None:
+        if 'detail' in response.data:
+            response.data = {'errors': [response.data]}
+        else:
+            response.data = {'errors': [{'detail': response.data}]}
+    return response

--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -61,6 +61,7 @@ REST_FRAMEWORK = {
         'api.base.renderers.JSONAPIRenderer',
         'rest_framework.renderers.BrowsableAPIRenderer',
     ),
+    'EXCEPTION_HANDLER': 'api.base.utils.custom_exception_handler',
     'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.AcceptHeaderVersioning',
     'DEFAULT_VERSION': '2.0',
     'DEFAULT_FILTER_BACKENDS': ('api.base.filters.ODMOrderingFilter',),
@@ -72,7 +73,6 @@ REST_FRAMEWORK = {
         'api.base.authentication.drf.OSFSessionAuthentication',
         'api.base.authentication.drf.OSFCASAuthentication'
     ),
-    'EXCEPTION_HANDLER': 'api.base.utils.custom_exception_handler'
 }
 
 MIDDLEWARE_CLASSES = (

--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -61,7 +61,7 @@ REST_FRAMEWORK = {
         'api.base.renderers.JSONAPIRenderer',
         'rest_framework.renderers.BrowsableAPIRenderer',
     ),
-    'EXCEPTION_HANDLER': 'api.base.utils.custom_exception_handler',
+    'EXCEPTION_HANDLER': 'api.base.exceptions.jsonapi_exception_handler',
     'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.AcceptHeaderVersioning',
     'DEFAULT_VERSION': '2.0',
     'DEFAULT_FILTER_BACKENDS': ('api.base.filters.ODMOrderingFilter',),

--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -72,6 +72,7 @@ REST_FRAMEWORK = {
         'api.base.authentication.drf.OSFSessionAuthentication',
         'api.base.authentication.drf.OSFCASAuthentication'
     ),
+    'EXCEPTION_HANDLER': 'api.base.utils.custom_exception_handler'
 }
 
 MIDDLEWARE_CLASSES = (

--- a/api/base/utils.py
+++ b/api/base/utils.py
@@ -73,9 +73,8 @@ def custom_exception_handler(exc, context):
     response = exception_handler(exc, context)
 
     if response is not None:
-        if isinstance(response.data, (list)):
-            data = response.data
-            response = {}
-            response['data'] = {'errors': {'detail': data}}
-            return response
-        response.data['errors'] = [{'detail': response.data['detail']}]
+        if 'detail' in response.data:
+            response.data = {'errors': [response.data]}
+        else:
+            response.data = {'errors': [{'detail': response.data}]}
+    return response

--- a/api/base/utils.py
+++ b/api/base/utils.py
@@ -10,15 +10,6 @@ from modularodm.exceptions import NoResultsFound
 from website import util as website_util  # noqa
 from website import settings as website_settings
 
-from django.core.exceptions import PermissionDenied
-from django.http import Http404
-from django.utils import six
-from django.utils.translation import ugettext_lazy as _
-from rest_framework import status, exceptions
-from rest_framework.response import Response
-
-
-
 def absolute_reverse(view_name, query_kwargs=None, args=None, kwargs=None):
     """Like django's `reverse`, except returns an absolute URL. Also add query parameters."""
     relative_url = reverse(view_name, kwargs=kwargs)
@@ -64,6 +55,7 @@ def waterbutler_url_for(request_type, provider, path, node_id, token, obj_args=N
 
     url.args.update(query)
     return url.url
+
 
 def custom_exception_handler(exc, context):
     """

--- a/api/base/utils.py
+++ b/api/base/utils.py
@@ -55,18 +55,3 @@ def waterbutler_url_for(request_type, provider, path, node_id, token, obj_args=N
 
     url.args.update(query)
     return url.url
-
-
-def custom_exception_handler(exc, context):
-    """
-    Custom exception handler that nests detail inside errors.
-    """
-    from rest_framework.views import exception_handler
-    response = exception_handler(exc, context)
-
-    if response is not None:
-        if 'detail' in response.data:
-            response.data = {'errors': [response.data]}
-        else:
-            response.data = {'errors': [{'detail': response.data}]}
-    return response

--- a/manage.py
+++ b/manage.py
@@ -9,7 +9,6 @@ if __name__ == "__main__":
     from django.core.management import execute_from_command_line
     from website.app import init_app
 
-
     init_app(set_backends=True, routes=False, attach_request_handlers=False)
 
     if 'livereload' in sys.argv:

--- a/manage.py
+++ b/manage.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python
 import os
 import sys
-from website.app import init_app
 
 
 if __name__ == "__main__":
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'api.base.settings')
 
     from django.core.management import execute_from_command_line
+    from website.app import init_app
+
 
     init_app(set_backends=True, routes=False, attach_request_handlers=False)
 

--- a/tests/api_tests/base/test_auth.py
+++ b/tests/api_tests/base/test_auth.py
@@ -30,7 +30,7 @@ class TestOAuthValidation(ApiTestCase):
     def test_missing_token_fails(self):
         res = self.app.get(self.reachable_url, auth=None, auth_type='jwt', expect_errors=True)
         assert_equal(res.status_code, 403)
-        assert_equal(res.json.get("detail"),
+        assert_equal(res.json.get("errors")[0]['detail'],
                      'Authentication credentials were not provided.')
 
     @mock.patch('framework.auth.cas.CasClient.profile')

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -346,6 +346,7 @@ class TestNodeCreate(ApiTestCase):
         # presenting a basic authentication dialog box in the front end. We may change this as we understand CAS
         # a little better
         assert_equal(res.status_code, 403)
+        assert 'detail' in res.json['errors'][0].keys()
 
     def test_creates_public_project_logged_in(self):
         res = self.app.post_json(self.url, self.public_project, auth=self.basic_auth)
@@ -360,6 +361,7 @@ class TestNodeCreate(ApiTestCase):
         # presenting a basic authentication dialog box in the front end. We may change this as we understand CAS
         # a little better
         assert_equal(res.status_code, 403)
+        assert 'detail' in res.json['errors'][0].keys()
 
     def test_creates_private_project_logged_in_contributor(self):
         res = self.app.post_json(self.url, self.private_project, auth=self.basic_auth)
@@ -426,6 +428,8 @@ class TestNodeDetail(ApiTestCase):
         # presenting a basic authentication dialog box in the front end. We may change this as we understand CAS
         # a little better
         assert_equal(res.status_code, 403)
+        assert 'detail' in res.json['errors'][0].keys()
+
 
     def test_return_private_project_details_logged_in_contributor(self):
         res = self.app.get(self.private_url, auth=self.basic_auth)
@@ -437,6 +441,7 @@ class TestNodeDetail(ApiTestCase):
     def test_return_private_project_details_logged_in_non_contributor(self):
         res = self.app.get(self.private_url, auth=self.basic_auth_two, expect_errors=True)
         assert_equal(res.status_code, 403)
+        assert 'detail' in res.json['errors'][0].keys()
 
     def test_top_level_project_has_no_parent(self):
         res = self.app.get(self.public_url)
@@ -496,6 +501,8 @@ class TestNodeUpdate(ApiTestCase):
         # presenting a basic authentication dialog box in the front end. We may change this as we understand CAS
         # a little better
         assert_equal(res.status_code, 403)
+        assert 'detail' in res.json['errors'][0].keys()
+
 
     def test_update_public_project_logged_in(self):
         # Public project, logged in, contrib
@@ -518,6 +525,7 @@ class TestNodeUpdate(ApiTestCase):
             'public': True,
         }, auth=self.basic_auth_two, expect_errors=True)
         assert_equal(res.status_code, 403)
+        assert 'detail' in res.json['errors'][0].keys()
 
     def test_update_private_project_logged_out(self):
         res = self.app.put_json(self.private_url, {
@@ -530,6 +538,7 @@ class TestNodeUpdate(ApiTestCase):
         # presenting a basic authentication dialog box in the front end. We may change this as we understand CAS
         # a little better
         assert_equal(res.status_code, 403)
+        assert 'detail' in res.json['errors'][0].keys()
 
     def test_update_private_project_logged_in_contributor(self):
         res = self.app.put_json(self.private_url, {
@@ -551,6 +560,7 @@ class TestNodeUpdate(ApiTestCase):
             'public': False,
         }, auth=self.basic_auth_two, expect_errors=True)
         assert_equal(res.status_code, 403)
+        assert 'detail' in res.json['errors'][0].keys()
 
     def test_update_project_sanitizes_html_properly(self):
         """Post request should update resource, and any HTML in fields should be stripped"""
@@ -599,6 +609,8 @@ class TestNodeUpdate(ApiTestCase):
             'is_public': False,
         }, auth=self.basic_auth_two, expect_errors=True)
         assert_equal(res.status_code, 403)
+        assert 'detail' in res.json['errors'][0].keys()
+
         # Test creator writing to public field (supposed to be read-only)
         res = self.app.patch_json(url, {
             'is_public': False,
@@ -613,6 +625,8 @@ class TestNodeUpdate(ApiTestCase):
         # presenting a basic authentication dialog box in the front end. We may change this as we understand CAS
         # a little better
         assert_equal(res.status_code, 403)
+        assert 'detail' in res.json['errors'][0].keys()
+
 
     def test_partial_update_public_project_logged_in(self):
         res = self.app.patch_json(self.public_url, {
@@ -628,6 +642,8 @@ class TestNodeUpdate(ApiTestCase):
             'title': self.new_title,
         }, auth=self.basic_auth_two, expect_errors=True)
         assert_equal(res.status_code, 403)
+        assert 'detail' in res.json['errors'][0].keys()
+
 
     def test_partial_update_private_project_logged_out(self):
         res = self.app.patch_json(self.private_url, {'title': self.new_title}, expect_errors=True)
@@ -635,6 +651,8 @@ class TestNodeUpdate(ApiTestCase):
         # presenting a basic authentication dialog box in the front end. We may change this as we understand CAS
         # a little better
         assert_equal(res.status_code, 403)
+        assert 'detail' in res.json['errors'][0].keys()
+
 
     def test_partial_update_private_project_logged_in_contributor(self):
         res = self.app.patch_json(self.private_url, {'title': self.new_title}, auth=self.basic_auth)
@@ -649,6 +667,8 @@ class TestNodeUpdate(ApiTestCase):
                                   auth=self.basic_auth_two,
                                   expect_errors=True)
         assert_equal(res.status_code, 403)
+        assert 'detail' in res.json['errors'][0].keys()
+
 
 
 class TestNodeDelete(ApiTestCase):
@@ -679,12 +699,16 @@ class TestNodeDelete(ApiTestCase):
         # presenting a basic authentication dialog box in the front end. We may change this as we understand CAS
         # a little better
         assert_equal(res.status_code, 403)
+        assert 'detail' in res.json['errors'][0].keys()
+
 
     def test_deletes_public_node_fails_if_bad_auth(self):
         res = self.app.delete_json(self.public_url, auth=self.basic_auth_two, expect_errors=True)
         self.public_project.reload()
         assert_equal(res.status_code, 403)
         assert_equal(self.public_project.is_deleted, False)
+        assert 'detail' in res.json['errors'][0].keys()
+
 
     def test_deletes_public_node_succeeds_as_owner(self):
         res = self.app.delete_json(self.public_url, auth=self.basic_auth, expect_errors=True)
@@ -698,6 +722,8 @@ class TestNodeDelete(ApiTestCase):
         # presenting a basic authentication dialog box in the front end. We may change this as we understand CAS
         # a little better
         assert_equal(res.status_code, 403)
+        assert 'detail' in res.json['errors'][0].keys()
+
 
     def test_deletes_private_node_logged_in_contributor(self):
         res = self.app.delete(self.private_url, auth=self.basic_auth, expect_errors=True)
@@ -710,6 +736,8 @@ class TestNodeDelete(ApiTestCase):
         self.project.reload()
         assert_equal(res.status_code, 403)
         assert_equal(self.project.is_deleted, False)
+        assert 'detail' in res.json['errors'][0].keys()
+
 
     def test_deletes_private_node_logged_in_read_only_contributor(self):
         self.project.add_contributor(self.user_two, permissions=['read'])
@@ -718,10 +746,13 @@ class TestNodeDelete(ApiTestCase):
         self.project.reload()
         assert_equal(res.status_code, 403)
         assert_equal(self.project.is_deleted, False)
+        assert 'detail' in res.json['errors'][0].keys()
+
 
     def test_deletes_invalid_node(self):
         res = self.app.delete(self.fake_url, auth=self.basic_auth, expect_errors=True)
         assert_equal(res.status_code, 404)
+        assert 'detail' in res.json['errors'][0].keys()
 
 
 class TestNodeContributorList(ApiTestCase):
@@ -767,6 +798,8 @@ class TestNodeContributorList(ApiTestCase):
         # presenting a basic authentication dialog box in the front end. We may change this as we understand CAS
         # a little better
         assert_equal(res.status_code, 403)
+        assert 'detail' in res.json['errors'][0].keys()
+
 
     def test_return_private_contributor_list_logged_in_contributor(self):
         self.private_project.add_contributor(self.user_two)
@@ -781,6 +814,8 @@ class TestNodeContributorList(ApiTestCase):
     def test_return_private_contributor_list_logged_in_non_contributor(self):
         res = self.app.get(self.private_url, auth=self.basic_auth_two, expect_errors=True)
         assert_equal(res.status_code, 403)
+        assert 'detail' in res.json['errors'][0].keys()
+
 
 
 class TestNodeContributorFiltering(ApiTestCase):
@@ -875,6 +910,8 @@ class TestNodeRegistrationList(ApiTestCase):
         # presenting a basic authentication dialog box in the front end. We may change this as we understand CAS
         # a little better
         assert_equal(res.status_code, 403)
+        assert 'detail' in res.json['errors'][0].keys()
+
 
     def test_return_private_registrations_logged_in_contributor(self):
         res = self.app.get(self.private_url, auth=self.basic_auth)
@@ -884,6 +921,8 @@ class TestNodeRegistrationList(ApiTestCase):
     def test_return_private_registrations_logged_in_non_contributor(self):
         res = self.app.get(self.private_url, auth=self.basic_auth_two, expect_errors=True)
         assert_equal(res.status_code, 403)
+        assert 'detail' in res.json['errors'][0].keys()
+
 
 
 class TestNodeChildrenList(ApiTestCase):
@@ -935,6 +974,8 @@ class TestNodeChildrenList(ApiTestCase):
         # presenting a basic authentication dialog box in the front end. We may change this as we understand CAS
         # a little better
         assert_equal(res.status_code, 403)
+        assert 'detail' in res.json['errors'][0].keys()
+
 
     def test_return_private_node_children_list_logged_in_contributor(self):
         res = self.app.get(self.private_project_url, auth=self.basic_auth)
@@ -945,6 +986,8 @@ class TestNodeChildrenList(ApiTestCase):
     def test_return_private_node_children_list_logged_in_non_contributor(self):
         res = self.app.get(self.private_project_url, auth=self.basic_auth_two, expect_errors=True)
         assert_equal(res.status_code, 403)
+        assert 'detail' in res.json['errors'][0].keys()
+
 
     def test_node_children_list_does_not_include_unauthorized_projects(self):
         private_component = NodeFactory(parent=self.project)
@@ -997,6 +1040,8 @@ class TestNodePointersList(ApiTestCase):
         # presenting a basic authentication dialog box in the front end. We may change this as we understand CAS
         # a little better
         assert_equal(res.status_code, 403)
+        assert 'detail' in res.json['errors'][0].keys()
+
 
     def test_return_private_node_pointers_logged_in_contributor(self):
         res = self.app.get(self.private_url, auth=self.basic_auth)
@@ -1008,6 +1053,8 @@ class TestNodePointersList(ApiTestCase):
     def test_return_private_node_pointers_logged_in_non_contributor(self):
         res = self.app.get(self.private_url, auth=self.basic_auth_two, expect_errors=True)
         assert_equal(res.status_code, 403)
+        assert 'detail' in res.json['errors'][0].keys()
+
 
 
 class TestCreateNodePointer(ApiTestCase):
@@ -1045,10 +1092,14 @@ class TestCreateNodePointer(ApiTestCase):
         # presenting a basic authentication dialog box in the front end. We may change this as we understand CAS
         # a little better
         assert_equal(res.status_code, 403)
+        assert 'detail' in res.json['errors'][0].keys()
+
 
     def test_creates_public_node_pointer_logged_in(self):
         res = self.app.post(self.public_url, self.public_payload, auth=self.basic_auth_two, expect_errors=True)
         assert_equal(res.status_code, 403)
+        assert 'detail' in res.json['errors'][0].keys()
+
 
         res = self.app.post(self.public_url, self.public_payload, auth=self.basic_auth)
         assert_equal(res.status_code, 201)
@@ -1060,6 +1111,8 @@ class TestCreateNodePointer(ApiTestCase):
         # presenting a basic authentication dialog box in the front end. We may change this as we understand CAS
         # a little better
         assert_equal(res.status_code, 403)
+        assert 'detail' in res.json['errors'][0].keys()
+
 
     def test_creates_private_node_pointer_logged_in_contributor(self):
         res = self.app.post(self.private_url, self.private_payload, auth=self.basic_auth)
@@ -1069,10 +1122,14 @@ class TestCreateNodePointer(ApiTestCase):
     def test_creates_private_node_pointer_logged_in_non_contributor(self):
         res = self.app.post(self.private_url, self.private_payload, auth=self.basic_auth_two, expect_errors=True)
         assert_equal(res.status_code, 403)
+        assert 'detail' in res.json['errors'][0].keys()
+
 
     def test_create_node_pointer_non_contributing_node_to_contributing_node(self):
         res = self.app.post(self.private_url, self.user_two_payload, auth=self.basic_auth_two, expect_errors=True)
         assert_equal(res.status_code, 403)
+        assert 'detail' in res.json['errors'][0].keys()
+
 
     def test_create_node_pointer_contributing_node_to_non_contributing_node(self):
         res = self.app.post(self.private_url, self.user_two_payload, auth=self.basic_auth)
@@ -1082,21 +1139,31 @@ class TestCreateNodePointer(ApiTestCase):
     def test_create_pointer_non_contributing_node_to_fake_node(self):
         res = self.app.post(self.private_url, self.fake_payload, auth=self.basic_auth_two, expect_errors=True)
         assert_equal(res.status_code, 403)
+        assert 'detail' in res.json['errors'][0].keys()
+
 
     def test_create_pointer_contributing_node_to_fake_node(self):
         res = self.app.post(self.private_url, self.fake_payload, auth=self.basic_auth, expect_errors=True)
         assert_equal(res.status_code, 404)
+        assert 'detail' in res.json['errors'][0].keys()
+
 
     def test_create_fake_node_pointing_to_contributing_node(self):
         res = self.app.post(self.fake_url, self.private_payload, auth=self.basic_auth, expect_errors=True)
         assert_equal(res.status_code, 404)
+        assert 'detail' in res.json['errors'][0].keys()
+
 
         res = self.app.post(self.fake_url, self.private_payload, auth=self.basic_auth_two, expect_errors=True)
         assert_equal(res.status_code, 404)
+        assert 'detail' in res.json['errors'][0].keys()
+
 
     def test_create_node_pointer_to_itself(self):
         res = self.app.post(self.public_url, self.point_to_itself_payload, auth=self.basic_auth_two, expect_errors=True)
         assert_equal(res.status_code, 403)
+        assert 'detail' in res.json['errors'][0].keys()
+
 
         res = self.app.post(self.public_url, self.point_to_itself_payload, auth=self.basic_auth)
         assert_equal(res.status_code, 201)
@@ -1109,6 +1176,8 @@ class TestCreateNodePointer(ApiTestCase):
 
         res = self.app.post(self.public_url, self.public_payload, auth=self.basic_auth, expect_errors=True)
         assert_equal(res.status_code, 400)
+        assert 'detail' in res.json['errors'][0].keys()
+
 
 
 class TestNodeFilesList(ApiTestCase):
@@ -1146,6 +1215,8 @@ class TestNodeFilesList(ApiTestCase):
         # presenting a basic authentication dialog box in the front end. We may change this as we understand CAS
         # a little better
         assert_equal(res.status_code, 403)
+        assert 'detail' in res.json['errors'][0].keys()
+
 
     def test_returns_private_files_logged_in_contributor(self):
         res = self.app.get(self.private_url, auth=self.basic_auth)
@@ -1156,6 +1227,8 @@ class TestNodeFilesList(ApiTestCase):
     def test_returns_private_files_logged_in_non_contributor(self):
         res = self.app.get(self.private_url, auth=self.basic_auth_two, expect_errors=True)
         assert_equal(res.status_code, 403)
+        assert 'detail' in res.json['errors'][0].keys()
+
 
     def test_returns_addon_folders(self):
         user_auth = Auth(self.user)
@@ -1203,6 +1276,8 @@ class TestNodeFilesList(ApiTestCase):
         mock_waterbutler_request.return_value = mock_res
         res = self.app.get(url, auth=self.basic_auth, expect_errors=True)
         assert_equal(res.status_code, 403)
+        assert 'detail' in res.json['errors'][0].keys()
+
 
     @mock.patch('api.nodes.views.requests.get')
     def test_handles_bad_waterbutler_request(self, mock_waterbutler_request):
@@ -1213,6 +1288,8 @@ class TestNodeFilesList(ApiTestCase):
         mock_waterbutler_request.return_value = mock_res
         res = self.app.get(url, auth=self.basic_auth, expect_errors=True)
         assert_equal(res.status_code, 400)
+        assert 'detail' in res.json['errors'][0].keys()
+
 
 
 class TestNodePointerDetail(ApiTestCase):
@@ -1258,6 +1335,8 @@ class TestNodePointerDetail(ApiTestCase):
         # presenting a basic authentication dialog box in the front end. We may change this as we understand CAS
         # a little better
         assert_equal(res.status_code, 403)
+        assert 'detail' in res.json['errors'][0].keys()
+
 
     def test_returns_private_node_pointer_detail_logged_in_contributor(self):
         res = self.app.get(self.private_url, auth=self.basic_auth)
@@ -1268,6 +1347,8 @@ class TestNodePointerDetail(ApiTestCase):
     def returns_private_node_pointer_detail_logged_in_non_contributor(self):
         res = self.app.get(self.private_url, auth=self.basic_auth_two, expect_errors=True)
         assert_equal(res.status_code, 403)
+        assert 'detail' in res.json['errors'][0].keys()
+
 
 
 class TestDeleteNodePointer(ApiTestCase):
@@ -1301,6 +1382,8 @@ class TestDeleteNodePointer(ApiTestCase):
         # presenting a basic authentication dialog box in the front end. We may change this as we understand CAS
         # a little better
         assert_equal(res.status_code, 403)
+        assert 'detail' in res.json['errors'][0].keys()
+
 
     def test_deletes_public_node_pointer_fails_if_bad_auth(self):
         node_count_before = len(self.public_project.nodes_pointer)
@@ -1308,6 +1391,8 @@ class TestDeleteNodePointer(ApiTestCase):
         self.public_project.reload()
         # This is could arguably be a 405, but we don't need to go crazy with status codes
         assert_equal(res.status_code, 403)
+        assert 'detail' in res.json['errors'][0].keys()
+
         assert_equal(node_count_before, len(self.public_project.nodes_pointer))
 
     def test_deletes_public_node_pointer_succeeds_as_owner(self):
@@ -1323,6 +1408,8 @@ class TestDeleteNodePointer(ApiTestCase):
         # presenting a basic authentication dialog box in the front end. We may change this as we understand CAS
         # a little better
         assert_equal(res.status_code, 403)
+        assert 'detail' in res.json['errors'][0].keys()
+
 
     def test_deletes_private_node_pointer_logged_in_contributor(self):
         res = self.app.delete(self.private_url, auth=self.basic_auth)
@@ -1333,3 +1420,5 @@ class TestDeleteNodePointer(ApiTestCase):
     def test_deletes_private_node_pointer_logged_in_non_contributor(self):
         res = self.app.delete(self.private_url, auth=self.basic_auth_two, expect_errors=True)
         assert_equal(res.status_code, 403)
+        assert 'detail' in res.json['errors'][0].keys()
+


### PR DESCRIPTION
<h1> Purpose </h1>

Regarding issue #3074.  The API v2 should adhere to the JSONAPI v1 spec jhttp://jsonapi.org/format/  for formatting of JSON responses.

 This PR formats the errors, per http://jsonapi.org/format/#error-objects

<h1>Changes </h1>

Creates a custom exception handler to return an `error` object as an array with a `detail` member.
<b> New exception </b>
![screen shot 2015-07-22 at 9 47 37 am](https://cloud.githubusercontent.com/assets/9755598/8826763/c5a7c672-3056-11e5-94db-3497ae181788.png)

<b> Old exception </b>
![screen shot 2015-07-22 at 9 47 16 am](https://cloud.githubusercontent.com/assets/9755598/8826761/c2b3c18c-3056-11e5-8da6-c8b35bf168c5.png)