### PR TITLE
[Feature] Fix unnecessary space before comma

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -447,7 +447,7 @@ class TestProjectViews(OsfTestCase):
         assert_equal(len(res.json['others_count']), 1)
         assert_equal(res.json['contributors'][0]['separator'], ',')
         assert_equal(res.json['contributors'][1]['separator'], ',')
-        assert_equal(res.json['contributors'][2]['separator'], '&')
+        assert_equal(res.json['contributors'][2]['separator'], ' &')
 
     def test_edit_node_title(self):
         url = "/api/v1/project/{0}/edit/".format(self.project._id)

--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -38,7 +38,7 @@ from website.project.decorators import (must_have_permission, must_be_valid_proj
 @must_be_valid_project(retractions_valid=True)
 def get_node_contributors_abbrev(auth, node, **kwargs):
     anonymous = has_anonymous_link(node, auth)
-
+    formatter = 'surname'
     max_count = kwargs.get('max_count', 3)
     if 'user_ids' in kwargs:
         users = [
@@ -56,22 +56,23 @@ def get_node_contributors_abbrev(auth, node, **kwargs):
     n_contributors = len(users)
     others_count = ''
 
+
     for index, user in enumerate(users[:max_count]):
 
         if index == max_count - 1 and len(users) > max_count:
-            separator = '&'
+            separator = ' &'
             others_count = str(n_contributors - 3)
         elif index == len(users) - 1:
             separator = ''
         elif index == len(users) - 2:
-            separator = '&'
+            separator = ' &'
         else:
             separator = ','
+        contributor = user.get_summary(formatter)
+        contributor['user_id'] = user._primary_key
+        contributor['separator'] = separator
 
-        contributors.append({
-            'user_id': user._primary_key,
-            'separator': separator,
-        })
+        contributors.append(contributor)
 
     return {
         'contributors': contributors,

--- a/website/static/css/pages/project-page.css
+++ b/website/static/css/pages/project-page.css
@@ -27,10 +27,6 @@
     content: "";
 }
 
-.contributor-name {
-    margin-right: -4px;
-}
-
 /* Project Navigation */
 #projectSubnav .navbar-collapse {
     padding-left: 0;

--- a/website/templates/util/render_user.mako
+++ b/website/templates/util/render_user.mako
@@ -1,9 +1,9 @@
 % if user_is_claimed:
-<a class="overflow contributor-name"
+<a class="overflow"
         rel="tooltip"
         href="${user_profile_url}"
         data-original-title="${user_fullname}"
     >${user_display_name}</a>
 % else:
-    <span class="overflow contributor-name">${user_display_name}</span>
+    <span class="overflow">${user_display_name}</span>
 % endif

--- a/website/templates/util/render_user.mako
+++ b/website/templates/util/render_user.mako
@@ -1,9 +1,0 @@
-% if user_is_claimed:
-<a class="overflow"
-        rel="tooltip"
-        href="${user_profile_url}"
-        data-original-title="${user_fullname}"
-    >${user_display_name}</a>
-% else:
-    <span class="overflow">${user_display_name}</span>
-% endif

--- a/website/templates/util/render_users_abbrev.mako
+++ b/website/templates/util/render_users_abbrev.mako
@@ -1,18 +1,25 @@
 <div class="project-authors">
-    % for contributor in contributors:
-        <div mod-meta='{
-                "tpl": "util/render_user.mako",
-                "uri": "/api/v1/profile/${contributor['user_id']}/summary/",
-                "view_kwargs": {
-                    "formatter": "surname"
-                },
-                "replace": true
-        }'>
-        </div>
-        <span>${contributor['separator']}</span>
-    % endfor
-    % if others_count:
-        <a href="${node_url}">${others_count} more</a>
-    % endif
+  ${render_contributors(contributors, others_count)}
 </div>
+
+<%def name="render_user(contributor)">
+  % if contributor['user_is_claimed']:
+      <a class="overflow"
+              rel="tooltip"
+              href="${contributor['user_profile_url']}"
+              data-original-title="${contributor['user_fullname']}"
+              >${contributor['user_display_name']}</a><span>${contributor['separator']}</span>
+  % else:
+      <span class="overflow">${contributor['user_display_name']}</span><span>${contributor['separator']}</span>
+  % endif
+</%def>
+
+<%def name="render_contributors(contributors, others_count)">
+  % for i, contributor in enumerate(contributors):
+      ${render_user(contributor)}
+  % endfor
+  % if others_count:
+      <a href="${node_url}">${others_count} more</a>
+  % endif
+</%def>
 


### PR DESCRIPTION
### Purpose
In this PR, it is to delete the unnecessary space before comma. And also it found and deleted the non-standardized code for displaying comma in abbreviation of contributor names. 

Although there is [previous PR](https://github.com/CenterForOpenScience/osf.io/pull/3713) to solve it,  it is not modular and complete method.

Related Trello Bug Card -- https://trello.com/c/2QIU8n4V/65-public-activity-page-extra-space-between-contributor-and

Related Github issue -- #3669

Related Stackoverflow [Question](http://stackoverflow.com/questions/31522458/how-to-set-correct-comma-position-in-html/31522492#31522492) 

### Change
 The biggest change in this PR is to delete `render_user.mako` and puts its refactored code into `render_users_abbrev.mako`.   Other small changes are listed below.

1) Delete `.contributor-name` class. It is a smart way to delete the space before comma.  However, it is hard to be maintained.
2) Edit new testing for `get_node_contributors_abbrev ` in `contributor.py`

### Side Effect
Since I change some python code,  there are some testing code for specific functions. I am not sure whether it would be unconsistente with some testing results.