### PR TITLE
Mention MFR on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ installed. Consult the Waterbutler
 [repository](https://github.com/CenterForOpenScience/waterbutler) and
 [documentation](https://waterbutler.readthedocs.org/en/latest/) for information on how to set up and run this service.
 
+#### Modular File Renderer
+
+The Modular File Renderer (MFR) is used to render uploaded files to HTML via an iFrame so that they can be viewed directly on the OSF. Files will not be rendered if the MFR is not running. Consult [repository] (https://github.com/CenterForOpenScience/modular-file-renderer) for information on how to install and run the MFR. 
+
 ## Installation
 
 These instructions assume a working knowledge of package managers and the command line.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ installed. Consult the Waterbutler
 
 #### Modular File Renderer
 
-The Modular File Renderer (MFR) is used to render uploaded files to HTML via an iFrame so that they can be viewed directly on the OSF. Files will not be rendered if the MFR is not running. Consult [repository] (https://github.com/CenterForOpenScience/modular-file-renderer) for information on how to install and run the MFR. 
+The Modular File Renderer (MFR) is used to render uploaded files to HTML via an iFrame so that they can be viewed directly on the OSF. Files will not be rendered if the MFR is not running. Consult the MFR [repository] (https://github.com/CenterForOpenScience/modular-file-renderer) for information on how to install and run the MFR.
 
 ## Installation
 


### PR DESCRIPTION
# Purpose 
#3680 README.md did not mention any information about the MFR.

# Changes
There is now a section in README.md that describes the purpose/function of the MFR and links it to the MFR repository for instructions on how to install and run it. 