### PR TITLE
[feature] Add validators for User.social

### DIFF
--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -22,7 +22,7 @@ from framework.sentry import log_exception
 from framework.addons import AddonModelMixin
 from framework.sessions.model import Session
 from framework.sessions.utils import remove_sessions_for_user
-from framework.exceptions import PermissionsError
+from framework.exceptions import PermissionsError, ProfileValidationError
 from framework.guid.model import GuidStoredObject
 from framework.bcrypt import generate_password_hash, check_password_hash
 from framework.auth.exceptions import ChangePasswordError, ExpiredTokenError
@@ -90,12 +90,92 @@ def validate_personal_site(value):
         try:
             validate_url(value)
         except ValidationError:
-            # Reraise with a better message
-            raise ValidationError('Invalid personal URL.')
+            raise ProfileValidationError(
+                'personal',
+                'Invalid personal URL.'
+            )
+
+
+def validate_twitter(value):
+    if value:
+        if not re.match(r'^\w+$', value):
+            raise ProfileValidationError(
+                'twitter',
+                'The twitter handle provided is not of valid form.')
+        else:
+            if User.find(Q('social.twitter', 'eq', value)).count():
+                raise ProfileValidationError(
+                    'Invalid Request',
+                    'The twitter handle provided is already associated with '
+                    'another OSF account. If you believe this is wrong, '
+                    'contact suppoert@osf.io for further direction.'
+                )
+
+
+def validate_github(value):
+    if value:
+        if not re.match(r'^\w+$', value):
+            raise ProfileValidationError(
+                'github',
+                'The GitHub username provided is not of valid form.'
+            )
+
+
+def validate_orcid(value):
+    if value:
+        if not re.match(r'^[\d]{4}-[\d]{4}-[\d]{4}-[\d]{4}$', value):
+            raise ProfileValidationError(
+                'orcid',
+                'The orcid provided is not of valid form.'
+            )
+
+
+def validate_scholar(value):
+    if value:
+        if not re.match(r'^\w+$', value):
+            raise ProfileValidationError(
+                'scholar',
+                'The Google Scholar id provided is not of valid form.'
+            )
+
+
+def validate_linkedin(value):
+    if value:
+        # LinkedIn profiles can be in/<UserID>, profile/<ProfileID>, or pub/<some link>
+        if not re.match(r'^in\/\w+$|^profile\/\w+$|^pub\/.+$', value):
+            raise ProfileValidationError(
+                'linkedin',
+                'The LinkedIn ID provided is not of valid form.'
+            )
+
+
+def validate_impactstory(value):
+    if value:
+        if not re.match(r'^\w+$', value):
+            raise ProfileValidationError(
+                'impactStory',
+                'The Impact Story ID provided is not of valid form.'
+            )
+
+
+def validate_researcherid(value):
+    if value:
+        if not re.match(r'^[A-Za-z]-\d{4}-\d{4}$', value):
+            raise ProfileValidationError(
+                'researcherId',
+                'The Researcher ID provided is not of valid form.'
+            )
 
 
 def validate_social(value):
     validate_personal_site(value.get('personal'))
+    validate_twitter(value.get('twitter'))
+    validate_github(value.get('github'))
+    validate_orcid(value.get('orcid'))
+    validate_scholar(value.get('scholar'))
+    validate_linkedin(value.get('linkedin'))
+    validate_impactstory(value.get('impactStory'))
+    validate_researcherid(value.get('researcherId'))
 
 
 def validate_email(item):
@@ -349,6 +429,12 @@ class User(GuidStoredObject, AddonModelMixin):
     # Format: {
     #     'personal': <personal site>,
     #     'twitter': <twitter id>,
+    #     'orcid': <orc id>,
+    #     'github': <github id>,
+    #     'scholar': <scholar id>,
+    #     'linkedIn': <linkedIn id>,
+    #     'impactStory': <impact story id>,
+    #     'researcherId: <researcher id>
     # }
 
     # hashed password used to authenticate to Piwik

--- a/framework/exceptions/__init__.py
+++ b/framework/exceptions/__init__.py
@@ -4,9 +4,12 @@ import copy
 import httplib as http
 from flask import request
 
+from modularodm.exceptions import ValidationError
+
 class FrameworkError(Exception):
     """Base class from which framework-related errors inherit."""
     pass
+
 
 class HTTPError(FrameworkError):
 
@@ -91,3 +94,18 @@ class PermissionsError(FrameworkError):
     """Raised if an action cannot be performed due to insufficient permissions
     """
     pass
+
+
+class ProfileValidationError(ValidationError):
+    """Raised if a field in User.social does not pass validation."""
+    def __init__(self, field, message):
+        self.field = field
+        self.message = message
+
+    @property
+    def message_short(self):
+        return 'Failed to validate {}'.format(self.field)
+
+    @property
+    def message_long(self):
+        return self.message

--- a/tests/api_tests/users/test_views.py
+++ b/tests/api_tests/users/test_views.py
@@ -2,7 +2,7 @@
 from nose.tools import *  # flake8: noqa
 
 from website.models import Node
-from tests.base import ApiTestCase
+from tests.base import ApiTestCase, fake
 from api.base.settings.defaults import API_BASE
 from tests.factories import UserFactory, ProjectFactory, FolderFactory, DashboardFactory
 
@@ -77,7 +77,7 @@ class TestUserDetail(ApiTestCase):
         super(TestUserDetail, self).setUp()
         self.user_one = UserFactory.build()
         self.user_one.set_password('justapoorboy')
-        self.user_one.social['twitter'] = 'howtopizza'
+        self.user_one.social['twitter'] = fake.first_name()
         self.user_one.save()
         self.auth_one = (self.user_one.username, 'justapoorboy')
         self.user_two = UserFactory.build()
@@ -99,7 +99,10 @@ class TestUserDetail(ApiTestCase):
         res = self.app.get(url)
         user_json = res.json['data']
         assert_equal(user_json['fullname'], self.user_one.fullname)
-        assert_equal(user_json['social_accounts']['twitter'], 'howtopizza')
+        assert_equal(
+            user_json['social_accounts']['twitter'],
+            self.user_one.social['twitter']
+        )
 
     def test_get_incorrect_pk_user_logged_in(self):
         url = "/{}users/{}/".format(API_BASE, self.user_two._id)
@@ -121,7 +124,7 @@ class TestUserNodes(ApiTestCase):
         super(TestUserNodes, self).setUp()
         self.user_one = UserFactory.build()
         self.user_one.set_password('justapoorboy')
-        self.user_one.social['twitter'] = 'howtopizza'
+        self.user_one.social['twitter'] = fake.first_name()
         self.user_one.save()
         self.auth_one = (self.user_one.username, 'justapoorboy')
         self.user_two = UserFactory.build()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -17,7 +17,7 @@ from modularodm.exceptions import ValidationError, ValidationValueError, Validat
 
 
 from framework.analytics import get_total_activity_count
-from framework.exceptions import PermissionsError
+from framework.exceptions import PermissionsError, ProfileValidationError
 from framework.auth import User, Auth
 from framework.sessions.model import Session
 from framework.auth import exceptions as auth_exc
@@ -97,18 +97,139 @@ class TestUserValidation(OsfTestCase):
         assert_equal(self.user.social_links['personal'], 'http://cos.io/')
         assert_equal(len(self.user.social_links), 1)
 
-    def test_various_social_handles(self):
-        self.user.social = {
-            'personal': 'http://cos.io/',
-            'twitter': 'OSFramework',
-            'github': 'CenterForOpenScience'
-        }
+    def test_invalid_personal_site(self):
+        self.user.social = {'personal': 'not a real url'}
+        with assert_raises(ProfileValidationError):
+            self.user.save()
+
+    def test_valid_personal_site(self):
+        self.user.social = {'personal': 'http://cos.io/'}
         self.user.save()
-        assert_equal(self.user.social_links, {
-            'personal': 'http://cos.io/',
-            'twitter': 'http://twitter.com/OSFramework',
-            'github': 'http://github.com/CenterForOpenScience'
-        })
+        assert_equal(
+            self.user.social_links,
+            {'personal': 'http://cos.io/'}
+        )
+
+    def test_invalid_twitter_handle(self):
+        self.user.social = {'twitter': '1234 not valid @ twitter handle'}
+        with assert_raises(ProfileValidationError):
+            self.user.save()
+
+    def test_duplicate_twitter_handle(self):
+        user2 = AuthUserFactory()
+        user2.social = {'twitter': 'SomeRandomPerson'}
+        user2.save()
+
+        self.user.social = {'twitter': 'SomeRandomPerson'}
+        with assert_raises(ProfileValidationError):
+            self.user.save()
+
+        user2.social = {}
+        user2.save()
+
+    def test_valid_twitter_handle(self):
+        self.user.social = {'twitter': 'SomeRandomPerson'}
+        self.user.save()
+        assert_equal(
+            self.user.social_links,
+            {'twitter': 'http://twitter.com/SomeRandomPerson'}
+        )
+
+    def test_invalid_github_username(self):
+        self.user.social = {'github': '1234 not a valid GH handle!!#@'}
+        with assert_raises(ProfileValidationError):
+            self.user.save()
+
+    def test_valid_github_username(self):
+        self.user.social = {'github': 'SomeRandomPerson'}
+        self.user.save()
+        assert_equal(
+            self.user.social_links,
+            {'github': 'http://github.com/SomeRandomPerson'}
+        )
+
+    def test_invalid_orcid(self):
+        invalid_values = [
+            '1234-5678-9012-3456-7890',
+            '1234-5678-9012',
+            '1234567890123456',
+            '1234-5678-9012-345a'
+        ]
+        for value in invalid_values:
+            self.user.social = {'orcid': value}
+            with assert_raises(ProfileValidationError):
+                self.user.save()
+
+    def test_valid_orcid(self):
+        self.user.social = {'orcid': '1234-5678-9012-3456'}
+        self.user.save()
+        assert_equal(
+            self.user.social_links,
+            {'orcid': 'http://orcid.com/1234-5678-9012-3456'}
+        )
+
+    def test_invalid_scholar(self):
+        self.user.social = {'scholar': 'not a valid scholar id ##@'}
+        with assert_raises(ProfileValidationError):
+            self.user.save()
+
+    def test_valid_scholar(self):
+        self.user.social = {'scholar': 'SomeRandomPerson'}
+        self.user.save()
+        assert_equal(
+            self.user.social_links,
+            {'scholar': 'http://scholar.google.com/citation?user=SomeRandomPerson'}
+        )
+
+    def test_invalid_linkedin(self):
+        invalid_values = [
+            'not a correct endpoint',
+            'wrong/pew2',
+            'in/what about spaces?',
+            'profile/not$a!!%valid$%url !'
+            'pub/pew/pew.pew/!? wrong'
+        ]
+        for value in invalid_values:
+            self.user.social = {'linkedin': value}
+            with assert_raises(ProfileValidationError):
+                self.user.save()
+
+    def test_valid_linkedin(self):
+        valid_values = [
+            'in/SomeRandomPerson',
+            'profile/12341234abcv',
+            'pub/some-person/123abc'
+        ]
+        for value in valid_values:
+            self.user.social = {'linkedIn': value}
+            self.user.save()
+            # TODO(hrybacki): test `User.social_links` after  issue #3401 is resolved
+
+    def test_invalid_impactstory(self):
+         self.user.social = {'impactStory': 'not a valid@ impactStory ID'}
+         with assert_raises(ProfileValidationError):
+             self.user.save()
+
+    def test_valid_impactstory(self):
+        self.user.social = {'impactStory': 'SomeRandomResearcher'}
+        self.user.save()
+        assert_equal(
+            self.user.social_links,
+            {'impactStory': 'https://impactstory.org/SomeRandomResearcher'}
+        )
+
+    def test_invalid_researcherid(self):
+        self.user.social = {'researcherId': 'not a researcher id'}
+        with assert_raises(ProfileValidationError):
+            self.user.save()
+
+    def test_valid_researcherid(self):
+        self.user.social = {'researcherId': 'A-2345-6789'}
+        self.user.save()
+        assert_equal(
+            self.user.social_links,
+            {'researcherId': 'http://researcherid.com/rid/A-2345-6789'}
+        )
 
     def test_nonsocial_ignored(self):
         self.user.social = {

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1093,27 +1093,27 @@ class TestUserProfile(OsfTestCase):
         assert_equal(res.json['message_long'], 'Invalid personal URL.')
 
     def test_serialize_social_editable(self):
-        self.user.social['twitter'] = 'howtopizza'
+        self.user.social['twitter'] = 'howtopizza1'
         self.user.save()
         url = api_url_for('serialize_social')
         res = self.app.get(
             url,
             auth=self.user.auth,
         )
-        assert_equal(res.json.get('twitter'), 'howtopizza')
+        assert_equal(res.json.get('twitter'), 'howtopizza1')
         assert_true(res.json.get('github') is None)
         assert_true(res.json['editable'])
 
     def test_serialize_social_not_editable(self):
         user2 = AuthUserFactory()
-        self.user.social['twitter'] = 'howtopizza'
+        self.user.social['twitter'] = 'howtopizza2'
         self.user.save()
         url = api_url_for('serialize_social', uid=self.user._id)
         res = self.app.get(
             url,
             auth=user2.auth,
         )
-        assert_equal(res.json.get('twitter'), 'howtopizza')
+        assert_equal(res.json.get('twitter'), 'howtopizza2')
         assert_true(res.json.get('github') is None)
         assert_false(res.json['editable'])
 

--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -17,7 +17,7 @@ from framework.auth.decorators import must_be_logged_in
 from framework.auth.exceptions import ChangePasswordError
 from framework.auth.views import send_confirm_email
 from framework.auth.signals import user_merged
-from framework.exceptions import HTTPError, PermissionsError
+from framework.exceptions import HTTPError, PermissionsError, ProfileValidationError
 from framework.flask import redirect  # VOL-aware redirect
 from framework.status import push_status_message
 
@@ -621,9 +621,9 @@ def unserialize_social(auth, **kwargs):
 
     try:
         user.save()
-    except ValidationError as exc:
+    except ProfileValidationError as exc:
         raise HTTPError(http.BAD_REQUEST, data=dict(
-            message_long=exc.args[0]
+            message_long=exc.message_long
         ))
 
 


### PR DESCRIPTION
## Purpose:
Add backend validators for `User.profile`.

## Changes:
- Added validator/tests for:
  1. Twitter
  2. GitHub
  3. orcid
  4. Google Scholar
  5. LinkedIn
  6. Impact Story
  7. ResearcherID

- Added ProfileValidationError which can hand short/long error
messages to error.mako for more informative user feedback

## Side Effects:
This will could cause a lot of errors to be thrown whenever `User.save()` is called. I haven't the slightest clue how dirty the `User.profile` fields are as we've never run validation on them. Migration @sloria ?

## Notes:
Closes-Issue: #3513