### PR TITLE
[Fix] [Ready] Improve feedback when add ons are not loaded due to connectivity 

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "raw-loader": "^0.5.1",
     "share": "0.7.27",
     "style-loader": "^0.8.3",
-    "treebeard": "git://github.com/caneruguz/treebeard.git#7042be173a813bd7072e8345f96e7dbbb7fac551",
+    "treebeard": "git://github.com/caneruguz/treebeard.git#8f984ef1de7d148c42d61f1156a5e076455aedfb",
     "typeahead.js": "^0.10.5",
     "url-loader": "^0.5.5",
     "webpack": "^1.7.2",

--- a/website/addons/box/static/boxFangornConfig.js
+++ b/website/addons/box/static/boxFangornConfig.js
@@ -1,6 +1,0 @@
-'use strict';
-
-var m = require('mithril');
-var Fangorn = require('js/fangorn');
-
-Fangorn.config.box = {};

--- a/website/addons/box/static/boxFangornConfig.js
+++ b/website/addons/box/static/boxFangornConfig.js
@@ -3,11 +3,4 @@
 var m = require('mithril');
 var Fangorn = require('js/fangorn');
 
-function _fangornLazyLoadError (item) {
-    item.notify.update('Box couldn\'t load, please try again later.', 'deleting', undefined, 3000);
-    return true;
-}
-
-Fangorn.config.box = {
-    lazyLoadError : _fangornLazyLoadError
-};
+Fangorn.config.box = {};

--- a/website/addons/dataverse/static/dataverseFangornConfig.js
+++ b/website/addons/dataverse/static/dataverseFangornConfig.js
@@ -201,6 +201,9 @@ function gotoFile (item) {
 
 function _fangornDataverseTitle(item, col) {
     var tb = this;
+    if (item.data.isAddonRoot && item.connected === false) { // as opposed to undefined, avoids unnecessary setting of this value
+        return Fangorn.Utils.connectCheckTemplate.call(this, item);
+    }
     var version = item.data.version === 'latest-published' ? 'Published' : 'Draft';
     if (item.data.addonFullname) {
         var contents = [m('dataverse-name', item.data.name + ' (' + version + ')')];

--- a/website/addons/dropbox/static/dropboxFangornConfig.js
+++ b/website/addons/dropbox/static/dropboxFangornConfig.js
@@ -1,6 +1,0 @@
-'use strict';
-
-var m = require('mithril');
-var Fangorn = require('js/fangorn');
-
-Fangorn.config.dropbox = {};

--- a/website/addons/dropbox/static/dropboxFangornConfig.js
+++ b/website/addons/dropbox/static/dropboxFangornConfig.js
@@ -3,11 +3,4 @@
 var m = require('mithril');
 var Fangorn = require('js/fangorn');
 
-function _fangornLazyLoadError (item) {
-    item.notify.update('Dropbox couldn\'t load, please try again later.', 'deleting', undefined, 3000);
-    return true;
-}
-
-Fangorn.config.dropbox = {
-    lazyLoadError : _fangornLazyLoadError
-};
+Fangorn.config.dropbox = {};

--- a/website/addons/github/static/githubFangornConfig.js
+++ b/website/addons/github/static/githubFangornConfig.js
@@ -274,6 +274,9 @@ function gotoFile (item) {
 }
 function _fangornGithubTitle(item, col)  {
     var tb = this;
+    if (item.data.isAddonRoot && item.connected === false) { // as opposed to undefined, avoids unnecessary setting of this value
+        return Fangorn.Utils.connectCheckTemplate.call(this, item);
+    }
     if (item.data.addonFullname) {
         var branch = item.data.branch || item.data.defaultBranch;
         return m('span',[

--- a/website/addons/googledrive/static/googleDriveFangornConfig.js
+++ b/website/addons/googledrive/static/googleDriveFangornConfig.js
@@ -1,6 +1,0 @@
-'use strict';
-
-var m = require('mithril');
-var Fangorn = require('js/fangorn');
-
-Fangorn.config.googledrive = {};

--- a/website/addons/googledrive/static/googleDriveFangornConfig.js
+++ b/website/addons/googledrive/static/googleDriveFangornConfig.js
@@ -3,11 +3,4 @@
 var m = require('mithril');
 var Fangorn = require('js/fangorn');
 
-function _fangornLazyLoadError(item) {
-    item.notify.update('Google Drive couldn\'t load, please try again later.', 'deleting', undefined, 3000);
-    return true;
-}
-
-Fangorn.config.googledrive = {
-    lazyLoadError : _fangornLazyLoadError
-};
+Fangorn.config.googledrive = {};

--- a/website/static/css/fangorn.css
+++ b/website/static/css/fangorn.css
@@ -30,7 +30,7 @@
     color: #eeeeee;
 }
 .fangorn-selected .text-danger {
-    color: #FFC6C5;
+    color: #FFFFFF;
 }
 .fangorn-selected a {
 	color : white;

--- a/website/static/css/fangorn.css
+++ b/website/static/css/fangorn.css
@@ -29,6 +29,9 @@
 .fangorn-selected .text-muted {
     color: #eeeeee;
 }
+.fangorn-selected .text-danger {
+    color: #FFC6C5;
+}
 .fangorn-selected a {
 	color : white;
 }

--- a/website/static/css/fangorn.css
+++ b/website/static/css/fangorn.css
@@ -5,9 +5,9 @@
 }
 
 .alert-deleting {
-	background: #F5F5F5;
-color: #F00;
-text-align: center;
+  background: #F5F5F5;
+  color: #A94442;
+  text-align: center;
 }
 
 .tb-head {
@@ -97,8 +97,8 @@ text-align: center;
 }
 .tb-notify {
 	white-space: nowrap;
-    height: 30px;
-    padding-top: 4px;
+  height: 34px;
+  padding-top: 4px;
 }
 
 .tb-row .progress {

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1682,7 +1682,11 @@ var FGToolbar = {
             }, '')
         );
 
-        templates[toolbarModes.DEFAULT] =  m('.col-xs-12', m('.pull-right', [finalRowButtons,  m('span', generalButtons)]));
+        if (item && item.connected !== false){
+            templates[toolbarModes.DEFAULT] =  m('.col-xs-12', m('.pull-right', [finalRowButtons,  m('span', generalButtons)]));
+        } else {
+            templates[toolbarModes.DEFAULT] =  m('.col-xs-12', m('.pull-right', m('span', generalButtons)));
+        }
         return m('.row.tb-header-row', [
             m('#folderRow', { config : function () {
                 $('#folderRow input').focus();

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1027,9 +1027,6 @@ function _fangornResolveLazyLoad(item) {
 function _fangornLazyLoadError (item) {
     item.connected = false;
     var configOption = resolveconfigOption.call(this, item, 'lazyLoadError', [item]);
-    if (!configOption) {
-        item.notify.update('OSF Storage files couldn\'t load. Please try again later.', 'deleting', undefined, 3000);
-    }
 }
 
 /**
@@ -1121,12 +1118,20 @@ function _fangornTitleColumn(item, col) {
         return m('a.fg-file-links',{ href: '/' + item.data.nodeID.toString() + '/'},
                 item.data.name);
     }
-    if (item.data.isAddonRoot && !item.connected) {
+    if (item.data.isAddonRoot && item.connected === false) { // as opposed to undefined.
         return m('span.text-danger', [
             m('span', item.data.name),
-            m('span.m-l-xs', ' files can\'t be loaded at this time.' ),
-            m('button.btn.btn-xs.btn-primary.m-l-xs', 'Try Again')
-            ]);
+            m('span.m-l-xs', ' can\'t be loaded at this time.' ),
+            m('button.btn.btn-xs.btn-default.m-l-xs', {
+                onclick : function(e){
+                    e.stopImmediatePropagation();
+                    if (tb.options.togglecheck.call(tb, item)) {
+                        var index = tb.returnIndex(item.id);
+                        tb.toggleFolder(index, e);
+                    }
+                }
+            },'Try Again')
+        ]);
     }
     return m('span', item.data.name);
 }

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1118,10 +1118,10 @@ function _fangornTitleColumn(item, col) {
         return m('a.fg-file-links',{ href: '/' + item.data.nodeID.toString() + '/'},
                 item.data.name);
     }
-    if (item.data.isAddonRoot && item.connected === false) { // as opposed to undefined.
+    if (item.data.isAddonRoot && item.connected === false) { // as opposed to undefined, avoids unnecessary setting of this value
         return m('span.text-danger', [
             m('span', item.data.name),
-            m('span.m-l-xs', ' can\'t be loaded at this time.' ),
+            m('em', ' can\'t be loaded at this time.' ),
             m('button.btn.btn-xs.btn-default.m-l-xs', {
                 onclick : function(e){
                     e.stopImmediatePropagation();
@@ -1130,7 +1130,7 @@ function _fangornTitleColumn(item, col) {
                         tb.toggleFolder(index, e);
                     }
                 }
-            },'Try Again')
+            }, [m('i.fa.fa-refresh'), ' Retry'])
         ]);
     }
     return m('span', item.data.name);

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1006,6 +1006,7 @@ function _removeEvent (event, items, col) {
  * @private
  */
 function _fangornResolveLazyLoad(item) {
+    item.connected = true;
     var configOption = resolveconfigOption.call(this, item, 'lazyload', [item]);
     if (configOption) {
         return configOption;
@@ -1024,9 +1025,10 @@ function _fangornResolveLazyLoad(item) {
  * @private
  */
 function _fangornLazyLoadError (item) {
+    item.connected = false;
     var configOption = resolveconfigOption.call(this, item, 'lazyLoadError', [item]);
     if (!configOption) {
-        item.notify.update('Files couldn\'t load. Please try again later.', 'deleting', undefined, 3000);
+        item.notify.update('OSF Storage files couldn\'t load. Please try again later.', 'deleting', undefined, 3000);
     }
 }
 
@@ -1115,9 +1117,16 @@ function _fangornTitleColumn(item, col) {
             }
         }, item.data.name);
     }
-    else if ((item.data.nodeType === 'project') || (item.data.nodeType ==='component')) {
+    if ((item.data.nodeType === 'project') || (item.data.nodeType ==='component')) {
         return m('a.fg-file-links',{ href: '/' + item.data.nodeID.toString() + '/'},
                 item.data.name);
+    }
+    if (item.data.isAddonRoot && !item.connected) {
+        return m('span.text-danger', [
+            m('span', item.data.name),
+            m('span.m-l-xs', ' files can\'t be loaded at this time.' ),
+            m('button.btn.btn-xs.btn-primary.m-l-xs', 'Try Again')
+            ]);
     }
     return m('span', item.data.name);
 }

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1106,6 +1106,9 @@ function gotoFileEvent (item) {
  */
 function _fangornTitleColumn(item, col) {
     var tb = this;
+    if (item.data.isAddonRoot && item.connected === false) { // as opposed to undefined, avoids unnecessary setting of this value
+        return _connectCheckTemplate.call(this, item);
+    }
     if (item.kind === 'file' && item.data.permissions.view) {
         return m('span.fg-file-links',{
             onclick: function(event) {
@@ -1118,22 +1121,30 @@ function _fangornTitleColumn(item, col) {
         return m('a.fg-file-links',{ href: '/' + item.data.nodeID.toString() + '/'},
                 item.data.name);
     }
-    if (item.data.isAddonRoot && item.connected === false) { // as opposed to undefined, avoids unnecessary setting of this value
-        return m('span.text-danger', [
-            m('span', item.data.name),
-            m('em', ' can\'t be loaded at this time.' ),
-            m('button.btn.btn-xs.btn-default.m-l-xs', {
-                onclick : function(e){
-                    e.stopImmediatePropagation();
-                    if (tb.options.togglecheck.call(tb, item)) {
-                        var index = tb.returnIndex(item.id);
-                        tb.toggleFolder(index, e);
-                    }
-                }
-            }, [m('i.fa.fa-refresh'), ' Retry'])
-        ]);
-    }
     return m('span', item.data.name);
+}
+
+/**
+ * Returns a reusable template for column titles when there is no connection
+ * @param {Object} item A Treebeard _item object for the row involved. Node information is inside item.data
+ * @this Treebeard.controller
+ * @private
+ */
+function _connectCheckTemplate(item){
+    var tb = this;
+    return m('span.text-danger', [
+        m('span', item.data.name),
+        m('em', ' can\'t be loaded at this time.' ),
+        m('button.btn.btn-xs.btn-default.m-l-xs', {
+            onclick : function(e){
+                e.stopImmediatePropagation();
+                if (tb.options.togglecheck.call(tb, item)) {
+                    var index = tb.returnIndex(item.id);
+                    tb.toggleFolder(index, e);
+                }
+            }
+        }, [m('i.fa.fa-refresh'), ' Retry'])
+    ]);
 }
 
 /**
@@ -2214,7 +2225,8 @@ Fangorn.Utils = {
     dismissToolbar : dismissToolbar,
     uploadRowTemplate : uploadRowTemplate,
     resolveIconView: resolveIconView,
-    orderFolder: orderFolder
+    orderFolder: orderFolder,
+    connectCheckTemplate : _connectCheckTemplate
 };
 
 Fangorn.DefaultOptions = tbOptions;

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1134,7 +1134,7 @@ function _connectCheckTemplate(item){
     var tb = this;
     return m('span.text-danger', [
         m('span', item.data.name),
-        m('em', ' can\'t be loaded at this time.' ),
+        m('em', ' could\'t load.' ),
         m('button.btn.btn-xs.btn-default.m-l-xs', {
             onclick : function(e){
                 e.stopImmediatePropagation();

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1693,7 +1693,7 @@ var FGToolbar = {
             }, '')
         );
 
-        if (item && item.connected !== false){
+        if (item && item.connected !== false){ // as opposed to undefined, avoids unnecessary setting of this value
             templates[toolbarModes.DEFAULT] =  m('.col-xs-12', m('.pull-right', [finalRowButtons,  m('span', generalButtons)]));
         } else {
             templates[toolbarModes.DEFAULT] =  m('.col-xs-12', m('.pull-right', m('span', generalButtons)));

--- a/website/static/js/pages/project-dashboard-page.js
+++ b/website/static/js/pages/project-dashboard-page.js
@@ -70,7 +70,7 @@ $(document).ready(function () {
                     return [
                         {
                             title: 'Name',
-                            width : '90%',
+                            width : '100%',
                             sort : true,
                             sortType : 'text'
                         }


### PR DESCRIPTION
## Purpose 
Fixes this github issue with connection error message: https://github.com/CenterForOpenScience/osf.io/issues/3205

This PR attempts to do a comprehensive fix that changes the way the title column is shown and adds a refresh button. 

## Changes
- Update of treebeard commit number (this change allows for refresh icon to switch back to plus icon) 
- remove notify from all addons
- Add a util function that gives a template for not connected
- Adjust addons so that the exact same format appears in all

## Side Effects
Potentially significant, although nothing came up in my testing. Still needs QA
For each add on:
- Check loads properly when connected
- Check loads properly with error message when not connected
- Check that toolbar appears with normal load
- Check that toolbar does not appear with not connected load
- Check retry button works. 