### PR TITLE
Filter Typeahead Results for Registration Onboarder.

### DIFF
--- a/website/static/js/onboarder.js
+++ b/website/static/js/onboarder.js
@@ -139,7 +139,7 @@ ko.bindingHandlers.projectSearch = {
             var nodes = params.data;
             // Compute relevant URLs for each search result, filters results that would result in a 'forbidden' error.
             nodes = nodes.filter(function(node) {
-               return viewModel.permissionsAllowed.indexOf(node['permissions']) > -1;
+               return viewModel.permissionsAllowed.indexOf(node.permissions) > -1;
             });
 
             initTypeahead(element, nodes, viewModel, params);

--- a/website/static/js/onboarder.js
+++ b/website/static/js/onboarder.js
@@ -137,11 +137,7 @@ ko.bindingHandlers.projectSearch = {
         }
         if (Array.isArray(nodesOrURL)) {
             var nodes = params.data;
-            // Compute relevant URLs for each search result, filters results that would result in a 'forbidden' error.
-            nodes = nodes.filter(function(node) {
-               return viewModel.permissionsAllowed.indexOf(node.permissions) > -1;
-            });
-
+            // Compute relevant URLs for each search result.
             initTypeahead(element, nodes, viewModel, params);
         } else if (typeof nodesOrURL === 'string') { // params.data is a URL
             var url = nodesOrURL;
@@ -179,9 +175,6 @@ function ProjectSearchViewModel(params) {
     self.submitText = params.submitText || 'Submit';
     self.projectPlaceholder = params.projectPlaceholder || 'Type to search for a project';
     self.componentPlaceholder = params.componentPlaceholder || 'Optional: Type to search for a component';
-    // node must have one of these permission for typeahead results, stops users for getting 'forbidden' error from
-    // typeahead results.
-    self.permissionsAllowed = params.permissionsAllowed || ['read','write','admin'];
 
     /* Observables */
     // If params.enableComponents is passed in, use that value, otherwise default to true

--- a/website/static/js/onboarder.js
+++ b/website/static/js/onboarder.js
@@ -137,7 +137,11 @@ ko.bindingHandlers.projectSearch = {
         }
         if (Array.isArray(nodesOrURL)) {
             var nodes = params.data;
-            // Compute relevant URLs for each search result
+            // Compute relevant URLs for each search result, filters results that would result in a 'forbidden' error.
+            nodes = nodes.filter(function(node) {
+               return viewModel.permissionsAllowed.indexOf(node['permissions']) > -1;
+            });
+
             initTypeahead(element, nodes, viewModel, params);
         } else if (typeof nodesOrURL === 'string') { // params.data is a URL
             var url = nodesOrURL;
@@ -175,6 +179,9 @@ function ProjectSearchViewModel(params) {
     self.submitText = params.submitText || 'Submit';
     self.projectPlaceholder = params.projectPlaceholder || 'Type to search for a project';
     self.componentPlaceholder = params.componentPlaceholder || 'Optional: Type to search for a component';
+    // node must have one of these permission for typeahead results, stops users for getting 'forbidden' error from
+    // typeahead results.
+    self.permissionsAllowed = params.permissionsAllowed || ['read','write','admin'];
 
     /* Observables */
     // If params.enableComponents is passed in, use that value, otherwise default to true

--- a/website/static/js/pages/dashboard-page.js
+++ b/website/static/js/pages/dashboard-page.js
@@ -25,7 +25,9 @@ var request = $.getJSON(url, function(response) {
     });
 
     // If we need to change what nodes can be registered, filter here
-    var registrationSelection = uploadSelection;
+    var registrationSelection = ko.utils.arrayFilter(allNodes, function(node) {
+        return $.inArray(node.permissions, ['admin']) !== -1;
+    });
 
     $osf.applyBindings({nodes: allNodes}, '#obGoToProject');
     $osf.applyBindings({nodes: registrationSelection, enableComponents: true}, '#obRegisterProject');

--- a/website/templates/components/dashboard_templates.mako
+++ b/website/templates/components/dashboard_templates.mako
@@ -65,6 +65,7 @@
                 params="data: data,
                         onSubmit: onRegisterSubmit,
                         enableComponents: false,
+                        permissionsAllowed: ['admin'],
                         submitText: 'Continue registration'">
                 </osf-project-search>
             </div><!-- end col-md -->

--- a/website/templates/components/dashboard_templates.mako
+++ b/website/templates/components/dashboard_templates.mako
@@ -65,7 +65,6 @@
                 params="data: data,
                         onSubmit: onRegisterSubmit,
                         enableComponents: false,
-                        permissionsAllowed: ['admin'],
                         submitText: 'Continue registration'">
                 </osf-project-search>
             </div><!-- end col-md -->


### PR DESCRIPTION
<h1> Purpose </h1>
Filter typeahead results for registration project search, so that those without admin privileges won't get a 'forbidden' error. Close #3738.
<h1> Changes </h1>
Added permissionsAllowed as a parameter to the ProjectSearchViewModel, used it to filter results and set to admin for registration search.
<h1> Side Effects </h1>
None that I know of.