### PR TITLE
[api] Hide registration count and link in registration serializer

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -130,6 +130,31 @@ class NodeSerializer(JSONAPISerializer):
         return instance
 
 
+class NodeRegistrationSerializer(NodeSerializer):
+    # Removed registration link as it is not possible to register a registration
+    links = LinksField({
+        'html': 'get_absolute_url',
+        'children': {
+            'related': Link('nodes:node-children', kwargs={'node_id': '<pk>'}),
+            'count': 'get_node_count',
+        },
+        'contributors': {
+            'related': Link('nodes:node-contributors', kwargs={'node_id': '<pk>'}),
+            'count': 'get_contrib_count',
+        },
+        'pointers': {
+            'related': Link('nodes:node-pointers', kwargs={'node_id': '<pk>'}),
+            'count': 'get_pointers_count',
+        },
+        'files': {
+            'related': Link('nodes:node-files', kwargs={'node_id': '<pk>'})
+        },
+        'parent': {
+            'self': Link('nodes:node-detail', kwargs={'node_id': '<parent_id>'})
+        }
+    })
+
+
 class NodePointersSerializer(JSONAPISerializer):
 
     id = ser.CharField(read_only=True, source='_id')

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -9,7 +9,7 @@ from website.models import Node, Pointer
 from api.users.serializers import ContributorSerializer
 from api.base.filters import ODMFilterMixin, ListFilterMixin
 from api.base.utils import get_object_or_404, waterbutler_url_for
-from .serializers import NodeSerializer, NodePointersSerializer, NodeFilesSerializer
+from .serializers import NodeSerializer, NodeRegistrationSerializer, NodePointersSerializer, NodeFilesSerializer
 from .permissions import ContributorOrPublic, ReadOnlyIfRegistration, ContributorOrPublicForPointers
 
 
@@ -153,7 +153,7 @@ class NodeRegistrationsList(generics.ListAPIView, NodeMixin):
         drf_permissions.IsAuthenticatedOrReadOnly,
     )
 
-    serializer_class = NodeSerializer
+    serializer_class = NodeRegistrationSerializer
 
     # overrides ListAPIView
     def get_queryset(self):


### PR DESCRIPTION
Created new serializer for registrations extending node serializer but excluding registrations from the linksfield