### PR TITLE
Stop Project Titles from Overlapping on Add Links Page

### DIFF
--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -417,7 +417,7 @@ select {
     word-wrap: normal;
 }
 
-tr a, b, em {
+tr a, b, em, td {
     word-break: break-word;
 }
 


### PR DESCRIPTION
<h1> Purpose </h1>
Stop project titles from over lapping. Close issue #3625. This was not fixed by #3697 
<h1> Changes </h1>
Simple css.