### PR TITLE
[hotfix] wiki menu error handling and pointers fix 

### DIFF
--- a/website/addons/wiki/templates/edit.mako
+++ b/website/addons/wiki/templates/edit.mako
@@ -48,6 +48,7 @@
                         <p class="m-t-sm fg-load-message"> Loading wiki pages...  </p>
                     </div>
                 </div>
+                <div class="hidden text-danger" id="wikiErrorMessage" style="padding: 15px"></div>
             </div>
 
             <!-- Menu with toggle collapsed -->

--- a/website/addons/wiki/tests/test_wiki.py
+++ b/website/addons/wiki/tests/test_wiki.py
@@ -148,36 +148,6 @@ class TestWikiViews(OsfTestCase):
         res = self.app.get(url)
         assert_equal(res.status_code, 200)
 
-    def test_serialize_wiki_toc(self):
-        project = ProjectFactory()
-        auth = Auth(project.creator)
-        NodeFactory(parent=project, creator=project.creator)
-        no_wiki = NodeFactory(parent=project, creator=project.creator)
-        project.save()
-
-        serialized = views._serialize_wiki_toc(project, auth=auth)
-        assert_equal(len(serialized), 2)
-        no_wiki.delete_addon('wiki', auth=auth)
-        serialized = views._serialize_wiki_toc(project, auth=auth)
-        assert_equal(len(serialized), 1)
-
-    def test_get_wiki_url_pointer_component(self):
-        """Regression test for issues
-        https://github.com/CenterForOpenScience/osf/issues/363 and
-        https://github.com/CenterForOpenScience/openscienceframework.org/issues/574
-
-        """
-        user = UserFactory()
-        pointed_node = NodeFactory(creator=user)
-        project = ProjectFactory(creator=user)
-        auth = Auth(user=user)
-        project.add_pointer(pointed_node, auth=auth, save=True)
-
-        serialized = views._serialize_wiki_toc(project, auth)
-        assert_equal(
-            serialized[0]['url'],
-            pointed_node.web_url_for('project_wiki_view', wname='home', _guid=True)
-        )
 
     def test_project_wiki_edit_post(self):
         self.project.update_node_wiki(
@@ -1202,7 +1172,7 @@ class TestWikiMenu(OsfTestCase):
 
     def test_format_component_wiki_pages_no_content_non_contributor(self):
         data = views.format_component_wiki_pages(node=self.project, auth=Auth(self.non_contributor))
-        expected = []
+        expected = [{}]
         assert_equal(data, expected)
 
     def test_project_wiki_grid_data(self):

--- a/website/static/js/pages/wiki-edit-page.js
+++ b/website/static/js/pages/wiki-edit-page.js
@@ -87,13 +87,23 @@ if (ctx.canEditPageName) {
 
 // Apply panels
 $(document).ready(function () {
-
+    var errorMsg = $('#wikiErrorMessage');
+    var grid = $('#grid');
     // Treebeard Wiki Menu
     $.ajax({
         url: ctx.urls.grid
     })
     .done(function (data) {
         new WikiMenu(data, ctx.wikiID, ctx.canEdit);
+    })
+    .fail(function(xhr, status, error) {
+        grid.addClass('hidden');
+        errorMsg.removeClass('hidden');
+        errorMsg.append('<p>Could not retrieve wiki pages. If this issue persists, ' +
+            'please report it to <a href="mailto:support@osf.io">support@osf.io</a>.</p>');
+        Raven.captureMessage('Could not GET wiki menu pages', {
+            url: ctx.urls.grid, status: status, error: error
+        });
     });
 
     var bodyElement = $('body');


### PR DESCRIPTION
Closes [#3764](https://github.com/CenterForOpenScience/osf.io/issues/3764)

- Adds error handling for the wiki menu, as shown below:
![screen shot 2015-07-23 at 11 12 28 am](https://cloud.githubusercontent.com/assets/7913604/8856814/241f681a-313b-11e5-91db-b7a911c30190.png)

- Removes ```_serialize_wiki_toc``` and moves relevant logic (including fix for pointers) to ```serialize_component_wiki```.