### PR TITLE
[feature fix] Pointer created by Swagger docs belongs to wrong node

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -133,7 +133,7 @@ class NodeSerializer(JSONAPISerializer):
 class NodePointersSerializer(JSONAPISerializer):
 
     id = ser.CharField(read_only=True, source='_id')
-    node_id = ser.CharField(source='node._id', help_text='The ID of the node that this pointer points to')
+    target_node_id = ser.CharField(source='node._id', help_text='The ID of the node that this pointer points to')
     title = ser.CharField(read_only=True, source='node.title', help_text='The title of the node that this pointer '
                                                                          'points to')
 

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -1333,3 +1333,21 @@ class TestDeleteNodePointer(ApiTestCase):
     def test_deletes_private_node_pointer_logged_in_non_contributor(self):
         res = self.app.delete(self.private_url, auth=self.basic_auth_two, expect_errors=True)
         assert_equal(res.status_code, 403)
+
+    def test_return_deleted_public_node_pointer(self):
+        res = self.app.delete(self.public_url, auth=self.basic_auth)
+        self.public_project.reload() # Update the model to reflect changes made by post request
+        assert_equal(res.status_code, 204)
+
+        #check that deleted pointer can not be returned
+        res = self.app.get(self.public_url, auth=self.basic_auth, expect_errors=True)
+        assert_equal(res.status_code, 404)
+
+    def test_return_deleted_private_node_pointer(self):
+        res = self.app.delete(self.private_url, auth=self.basic_auth)
+        self.project.reload()  # Update the model to reflect changes made by post request
+        assert_equal(res.status_code, 204)
+
+        #check that deleted pointer can not be returned
+        res = self.app.get(self.private_url, auth=self.basic_auth, expect_errors=True)
+        assert_equal(res.status_code, 404)

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -982,14 +982,14 @@ class TestNodePointersList(ApiTestCase):
         res_json = res.json['data']
         assert_equal(len(res_json), 1)
         assert_equal(res.status_code, 200)
-        assert_in(res_json[0]['node_id'], self.public_pointer_project._id)
+        assert_in(res_json[0]['target_node_id'], self.public_pointer_project._id)
 
     def test_return_public_node_pointers_logged_in(self):
         res = self.app.get(self.public_url, auth=self.basic_auth_two)
         res_json = res.json['data']
         assert_equal(len(res_json), 1)
         assert_equal(res.status_code, 200)
-        assert_in(res_json[0]['node_id'], self.public_pointer_project._id)
+        assert_in(res_json[0]['target_node_id'], self.public_pointer_project._id)
 
     def test_return_private_node_pointers_logged_out(self):
         res = self.app.get(self.private_url, expect_errors=True)
@@ -1003,7 +1003,7 @@ class TestNodePointersList(ApiTestCase):
         res_json = res.json['data']
         assert_equal(res.status_code, 200)
         assert_equal(len(res_json), 1)
-        assert_in(res_json[0]['node_id'], self.pointer_project._id)
+        assert_in(res_json[0]['target_node_id'], self.pointer_project._id)
 
     def test_return_private_node_pointers_logged_in_non_contributor(self):
         res = self.app.get(self.private_url, auth=self.basic_auth_two, expect_errors=True)
@@ -1020,15 +1020,15 @@ class TestCreateNodePointer(ApiTestCase):
         self.project = ProjectFactory(is_public=False, creator=self.user)
         self.pointer_project = ProjectFactory(is_public=False, creator=self.user)
         self.private_url = '/{}nodes/{}/pointers/'.format(API_BASE, self.project._id)
-        self.private_payload = {'node_id': self.pointer_project._id}
+        self.private_payload = {'target_node_id': self.pointer_project._id}
 
         self.public_project = ProjectFactory(is_public=True, creator=self.user)
         self.public_pointer_project = ProjectFactory(is_public=True, creator=self.user)
         self.public_url = '/{}nodes/{}/pointers/'.format(API_BASE, self.public_project._id)
-        self.public_payload = {'node_id': self.public_pointer_project._id}
+        self.public_payload = {'target_node_id': self.public_pointer_project._id}
         self.fake_url = '/{}nodes/{}/pointers/'.format(API_BASE, 'fdxlq')
-        self.fake_payload = {'node_id': 'fdxlq'}
-        self.point_to_itself_payload = {'node_id': self.public_project._id}
+        self.fake_payload = {'target_node_id': 'fdxlq'}
+        self.point_to_itself_payload = {'target_node_id': self.public_project._id}
 
         self.user_two = UserFactory.build()
         self.user_two.set_password('password')
@@ -1037,7 +1037,7 @@ class TestCreateNodePointer(ApiTestCase):
 
         self.user_two_project = ProjectFactory(is_public=True, creator=self.user_two)
         self.user_two_url = '/{}nodes/{}/pointers/'.format(API_BASE, self.user_two_project._id)
-        self.user_two_payload = {'node_id': self.user_two_project._id}
+        self.user_two_payload = {'target_node_id': self.user_two_project._id}
 
     def test_creates_public_node_pointer_logged_out(self):
         res = self.app.post(self.public_url, self.public_payload, expect_errors=True)
@@ -1052,7 +1052,7 @@ class TestCreateNodePointer(ApiTestCase):
 
         res = self.app.post(self.public_url, self.public_payload, auth=self.basic_auth)
         assert_equal(res.status_code, 201)
-        assert_equal(res.json['data']['node_id'], self.public_pointer_project._id)
+        assert_equal(res.json['data']['target_node_id'], self.public_pointer_project._id)
 
     def test_creates_private_node_pointer_logged_out(self):
         res = self.app.post(self.private_url, self.private_payload, expect_errors=True)
@@ -1064,7 +1064,7 @@ class TestCreateNodePointer(ApiTestCase):
     def test_creates_private_node_pointer_logged_in_contributor(self):
         res = self.app.post(self.private_url, self.private_payload, auth=self.basic_auth)
         assert_equal(res.status_code, 201)
-        assert_equal(res.json['data']['node_id'], self.pointer_project._id)
+        assert_equal(res.json['data']['target_node_id'], self.pointer_project._id)
 
     def test_creates_private_node_pointer_logged_in_non_contributor(self):
         res = self.app.post(self.private_url, self.private_payload, auth=self.basic_auth_two, expect_errors=True)
@@ -1077,7 +1077,7 @@ class TestCreateNodePointer(ApiTestCase):
     def test_create_node_pointer_contributing_node_to_non_contributing_node(self):
         res = self.app.post(self.private_url, self.user_two_payload, auth=self.basic_auth)
         assert_equal(res.status_code, 201)
-        assert_equal(res.json['data']['node_id'], self.user_two_project._id)
+        assert_equal(res.json['data']['target_node_id'], self.user_two_project._id)
 
     def test_create_pointer_non_contributing_node_to_fake_node(self):
         res = self.app.post(self.private_url, self.fake_payload, auth=self.basic_auth_two, expect_errors=True)
@@ -1100,12 +1100,12 @@ class TestCreateNodePointer(ApiTestCase):
 
         res = self.app.post(self.public_url, self.point_to_itself_payload, auth=self.basic_auth)
         assert_equal(res.status_code, 201)
-        assert_equal(res.json['data']['node_id'], self.public_project._id)
+        assert_equal(res.json['data']['target_node_id'], self.public_project._id)
 
     def test_create_node_pointer_already_connected(self):
         res = self.app.post(self.public_url, self.public_payload, auth=self.basic_auth)
         assert_equal(res.status_code, 201)
-        assert_equal(res.json['data']['node_id'], self.public_pointer_project._id)
+        assert_equal(res.json['data']['target_node_id'], self.public_pointer_project._id)
 
         res = self.app.post(self.public_url, self.public_payload, auth=self.basic_auth, expect_errors=True)
         assert_equal(res.status_code, 400)
@@ -1226,7 +1226,7 @@ class TestNodePointerDetail(ApiTestCase):
         self.private_project = ProjectFactory(creator=self.user, is_public=False)
         self.pointer_project = ProjectFactory(creator=self.user, is_public=False)
         self.pointer = self.private_project.add_pointer(self.pointer_project, auth=Auth(self.user), save=True)
-        self.private_url = '/{}nodes/{}/pointers/{}'.format(API_BASE, self.private_project._id, self.pointer._id)
+        self.private_url = '/{}nodes/{}/pointers/{}/'.format(API_BASE, self.private_project._id, self.pointer._id)
 
         self.user_two = UserFactory.build()
         self.user_two.set_password('password')
@@ -1238,19 +1238,19 @@ class TestNodePointerDetail(ApiTestCase):
         self.public_pointer = self.public_project.add_pointer(self.public_pointer_project,
                                                               auth=Auth(self.user),
                                                               save=True)
-        self.public_url = '/{}nodes/{}/pointers/{}'.format(API_BASE, self.public_project._id, self.public_pointer._id)
+        self.public_url = '/{}nodes/{}/pointers/{}/'.format(API_BASE, self.public_project._id, self.public_pointer._id)
 
     def test_returns_public_node_pointer_detail_logged_out(self):
         res = self.app.get(self.public_url)
         assert_equal(res.status_code, 200)
         res_json = res.json['data']
-        assert_equal(res_json['node_id'], self.public_pointer_project._id)
+        assert_equal(res_json['target_node_id'], self.public_pointer_project._id)
 
     def test_returns_public_node_pointer_detail_logged_in(self):
         res = self.app.get(self.public_url, auth=self.basic_auth)
         res_json = res.json['data']
         assert_equal(res.status_code, 200)
-        assert_equal(res_json['node_id'], self.public_pointer_project._id)
+        assert_equal(res_json['target_node_id'], self.public_pointer_project._id)
 
     def test_returns_private_node_pointer_detail_logged_out(self):
         res = self.app.get(self.private_url, expect_errors=True)
@@ -1263,7 +1263,7 @@ class TestNodePointerDetail(ApiTestCase):
         res = self.app.get(self.private_url, auth=self.basic_auth)
         res_json = res.json['data']
         assert_equal(res.status_code, 200)
-        assert_equal(res_json['node_id'], self.pointer_project._id)
+        assert_equal(res_json['target_node_id'], self.pointer_project._id)
 
     def returns_private_node_pointer_detail_logged_in_non_contributor(self):
         res = self.app.get(self.private_url, auth=self.basic_auth_two, expect_errors=True)


### PR DESCRIPTION
# Purpose: 
- https://github.com/CenterForOpenScience/osf.io/issues/3536 Fixes Swagger Doc issue that would create a pointer to itself. 

# Changes: 
- Changed variable name in nodes/serializers.py from 'node_id' to 'target_node_id'. 
- Changed variable names in unit tests
- Added unit tests that attempt to return deleted pointers

# Side Effects:
None. 

# Notes: 
Closes issue:
https://github.com/CenterForOpenScience/osf.io/issues/3536