### PR TITLE
[Feature Fix] Fix GitHub UI Bugs

### DIFF
--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -454,3 +454,8 @@ button.close {
     word-break: break-all;
     word-break: break-word; /* Non standard for webkit*/
 }
+
+/* growlBox style */
+.alert.growl-animated {
+    padding-right: 35px; /* work as alert-dismissable in bootstrap */
+}

--- a/website/templates/emails/archive_copy_error_user.html.mako
+++ b/website/templates/emails/archive_copy_error_user.html.mako
@@ -3,7 +3,7 @@
 <%def name="content()">
 <tr>
   <td style="border-collapse: collapse;">
-  <h3 class="text-center" style="padding: 0;margin: 30px 0 0 0;border: none;list-style: none;font-weight: 300;text-align: center;">Issue registering ${src.title}</h3> 
+  <h3 class="text-center" style="padding: 0;margin: 30px 0 0 0;border: none;list-style: none;font-weight: 300;text-align: center;">Issue registering <a href="${src.url}">${src.title}</a></h3>
   </td>
 </tr>
 <tr>

--- a/website/templates/emails/archive_size_exceeded_user.html.mako
+++ b/website/templates/emails/archive_size_exceeded_user.html.mako
@@ -3,7 +3,7 @@
 <%def name="content()">
 <tr>
   <td style="border-collapse: collapse;">
-  <h3 class="text-center" style="padding: 0;margin: 30px 0 0 0;border: none;list-style: none;font-weight: 300;text-align: center;">Issue registering ${src.title}</h3> 
+  <h3 class="text-center" style="padding: 0;margin: 30px 0 0 0;border: none;list-style: none;font-weight: 300;text-align: center;">Issue registering <a href="${src.url}">${src.title}</a></h3>
   </td>
 </tr>
 <tr>

--- a/website/templates/emails/archive_success.html.mako
+++ b/website/templates/emails/archive_success.html.mako
@@ -3,7 +3,7 @@
 <%def name="content()">
 <tr>
   <td style="border-collapse: collapse;">
-    <h3 class="text-center" style="padding: 0;margin: 30px 0 0 0;border: none;list-style: none;font-weight: 300;text-align: center;">Registration of <b>${src.title}</b> finished</h3>
+    <h3 class="text-center" style="padding: 0;margin: 30px 0 0 0;border: none;list-style: none;font-weight: 300;text-align: center;">Registration of <b><a href="${src.url}">${src.title}</a></b> finished</h3>
   </td>
 </tr>
 <tr>

--- a/website/templates/emails/archive_uncaught_error_user.html.mako
+++ b/website/templates/emails/archive_uncaught_error_user.html.mako
@@ -3,7 +3,7 @@
 <%def name="content()">
 <tr>
   <td style="border-collapse: collapse;">
-  <h3 class="text-center" style="padding: 0;margin: 30px 0 0 0;border: none;list-style: none;font-weight: 300;text-align: center;">Issue registering ${src.title}</h3> 
+  <h3 class="text-center" style="padding: 0;margin: 30px 0 0 0;border: none;list-style: none;font-weight: 300;text-align: center;">Issue registering <a href="${src.url}"> ${src.title}</a></h3>
   </td>
 </tr>
 <tr>

--- a/website/templates/public/pages/getting_started.mako
+++ b/website/templates/public/pages/getting_started.mako
@@ -10,7 +10,7 @@
 
     <div href="#start">
         <div class="col-sm-4 col-md-3 affix-parent scrollspy">
-            <div data-spy="affix" data-offset-top="0" class="osf-affix gs-sidebar hidden-print hidden-xs panel panel-default" role="complementary">
+            <div data-spy="affix" data-offset-top="0" data-offset-bottom="250"  class="osf-affix gs-sidebar hidden-print hidden-xs panel panel-default" role="complementary">
                 <ul class="nav nav-stacked nav-pills gs-sidenav" style="min-width: 205px">
 
                     <li>


### PR DESCRIPTION
### Purpose
Fix Github Bugs:

1. Fix navigation overlap with Footer on Getting Started Page
https://github.com/CenterForOpenScience/osf.io/issues/3481
2. Include link to project in issue registering project email
https://github.com/CenterForOpenScience/osf.io/issues/3589
3. Check growl boxes and alerts across site for overlapping text
https://github.com/CenterForOpenScience/osf.io/issues/3700

### Changes
1. Add bottom offset for affax in navigation
2. Add a tag for project name on mail heading
3. Since growlbox doesn't support `.alert-dismissable`, manually add padding to box

### Side Effects
For adding project link in email, I can't test them locally.  
