### PR TITLE
fix the create new component success alert redirect

### DIFF
--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -182,7 +182,7 @@ def project_new_node(auth, node, **kwargs):
     user = auth.user
     if form.validate():
         try:
-            node = new_node(
+            new_component = new_node(
                 title=strip_html(form.title.data),
                 user=user,
                 category=form.category.data,
@@ -202,7 +202,7 @@ def project_new_node(auth, node, **kwargs):
 
         return {
             'status': 'success',
-        }, 201, None, node.url
+        }, 201, None, new_component.url
     else:
         status.push_errors_to_status(form.errors)
     raise HTTPError(http.BAD_REQUEST, redirect_url=node.url)


### PR DESCRIPTION
<b>Purpose</b>
Fix the redirect link in the successful component creation alert. Closeshttps://github.com/CenterForOpenScience/osf.io/issues/3799