### PR TITLE
[feature][markupsafe][review]Escape user-entered text inserted in growl and bootboxes

### DIFF
--- a/website/static/js/accountSettings.js
+++ b/website/static/js/accountSettings.js
@@ -200,7 +200,8 @@ var UserProfileViewModel = oop.extend(ChangeMessageMixin, {
                 for (var i=0; i<emails.length; i++) {
                     if (emails[i].address() === email.address()) {
                         this.emailInput('');
-                        $osf.growl('<em>' + email.address()  + '</em> added to your account.','You will receive a confirmation email at <em>' + email.address()  + '</em>. Please check your email and confirm.', 'success');
+                        var addrText = $osf.htmlEscape(email.address());
+                        $osf.growl('<em>' + addrText  + '</em> added to your account.','You will receive a confirmation email at <em>' + addrText  + '</em>. Please check your email and confirm.', 'success');
                         return;
                     }
                 }
@@ -213,15 +214,16 @@ var UserProfileViewModel = oop.extend(ChangeMessageMixin, {
     resendConfirmation: function(email){
         var self = this;
         self.changeMessage('', 'text-info');
+        var addrText = $osf.htmlEscape(email.address());
         bootbox.confirm({
             title: 'Resend Email Confirmation?',
-            message: 'Are you sure that you want to resend email confirmation to ' + '<em><b>' + email.address() + '</b></em>',
+            message: 'Are you sure that you want to resend email confirmation to ' + '<em>' + addrText + '</em>',
             callback: function (confirmed) {
                 if (confirmed) {
                     self.client.update(self.profile(), email).done(function () {
                         $osf.growl(
-                            'Email confirmation resent to <em>' + email.address() + '</em>',
-                            'You will receive a new confirmation email at <em>' + email.address()  + '</em>. Please check your email and confirm.',
+                            'Email confirmation resent to <em>' + addrText + '</em>',
+                            'You will receive a new confirmation email at <em>' + addrText  + '</em>. Please check your email and confirm.',
                             'success');
                     });
                 }
@@ -237,14 +239,15 @@ var UserProfileViewModel = oop.extend(ChangeMessageMixin, {
         var self = this;
         self.changeMessage('', 'text-info');
         if (self.profile().emails().indexOf(email) !== -1) {
+            var addrText = $osf.htmlEscape(email.address());
             bootbox.confirm({
                 title: 'Remove Email?',
-                message: 'Are you sure that you want to remove ' + '<em><b>' + email.address() + '</b></em>' + ' from your email list?',
+                message: 'Are you sure that you want to remove ' + '<em>' + addrText + '</em>' + ' from your email list?',
                 callback: function (confirmed) {
                     if (confirmed) {
                         self.profile().emails.remove(email);
                         self.client.update(self.profile()).done(function () {
-                            $osf.growl('Email Removed', '<em>' + email.address() + '</em>', 'success');
+                            $osf.growl('Email Removed', '<em>' + addrText + '</em>', 'success');
                         });
                     }
                 },
@@ -265,7 +268,8 @@ var UserProfileViewModel = oop.extend(ChangeMessageMixin, {
             this.profile().primaryEmail().isPrimary(false);
             email.isPrimary(true);
             this.client.update(this.profile()).done(function () {
-                $osf.growl('Made Primary', '<em>' + email.address() + '<em>', 'success');
+                var addrText = $osf.htmlEscape(email.address());
+                $osf.growl('Made Primary', '<em>' + addrText + '<em>', 'success');
             });
         } else {
             $osf.growl('Error', 'Please refresh the page and try again.', 'danger');


### PR DESCRIPTION
## Purpose

For cosmetic reasons, user-entered text should be correctly HTML-escaped in growl and bootbox messages.
Reported on Trello board.

## Summary of changes

Applies `$osf.htmlEscape` to email addresses used in growl and bootbox on the account settings page. (for email address registration)

Affects functionality on  `/settings/accounts`:
1. Initial registration of new email addresses (green message in corner)
2. Resend confirmation link (confirmation box + green message in corner)
3. Remove email address button (confirmation box + green message in corner)
4. Make primary  (green message in corner)

## Test case
Sign up with an email address that contains certain [old-school](http://stackoverflow.com/a/15532395/1422268) escape sequences, eg `&amp_text@cos.io`. The address should display correctly.

## Related
#2933 
#3635 (addendum)