### PR TITLE
[Feature Fix] Put correct private component name in file tree

### DIFF
--- a/tests/test_rubeus.py
+++ b/tests/test_rubeus.py
@@ -19,6 +19,7 @@ from website.util.rubeus import sort_by_name
 from website.settings import ALL_MY_REGISTRATIONS_ID, ALL_MY_PROJECTS_ID, \
     ALL_MY_PROJECTS_NAME, ALL_MY_REGISTRATIONS_NAME, DISK_SAVING_MODE
 
+from website.util import sanitize
 
 class TestRubeus(OsfTestCase):
 
@@ -215,6 +216,49 @@ class TestRubeus(OsfTestCase):
         assert_false(private_dummy['permissions']['view'])
         assert_equal(private_dummy['name'], 'Private Component')
         assert_equal(len(private_dummy['children']), 0)
+
+    def test_get_node_name(self):
+        user = UserFactory()
+        auth = Auth(user=user)
+        another_user = UserFactory(username='bono@u2.com', fullname='Bono')
+        another_auth = Auth(user=another_user)
+
+        # Public (Can View)
+        public_project = ProjectFactory(is_public=True)
+        collector = rubeus.NodeFileCollector(node=public_project, auth=another_auth)
+        node_name = u'{0}: {1}'.format(public_project.project_or_component.capitalize(), sanitize.safe_unescape_html(public_project.title))
+        assert_equal(collector._get_node_name(public_project), node_name)
+
+        # Private  (Can't View)
+        project = ProjectFactory(creator=user, is_public=True)
+        registration_private = project.register_node(None, auth, '', None)
+        registration_private.is_public = False
+        registration_private.save()
+        collector = rubeus.NodeFileCollector(node=registration_private, auth=another_auth)
+        assert_equal(collector._get_node_name(registration_private), u'Private Registration')
+
+        content = ProjectFactory(creator=user)
+        node = ProjectFactory(creator=user)
+
+        forked_private = node.fork_node(auth=auth)
+        forked_private.is_public = False
+        forked_private.save()
+        collector = rubeus.NodeFileCollector(node=forked_private, auth=another_auth)
+        assert_equal(collector._get_node_name(forked_private), u'Private Fork')
+
+        pointer_private = node.add_pointer(content, auth=auth)
+        pointer_private.is_public = False
+        pointer_private.save()
+        collector = rubeus.NodeFileCollector(node=pointer_private, auth=another_auth)
+        assert_equal(collector._get_node_name(pointer_private), u'Private Link')
+
+        private_project = ProjectFactory(is_public=False)
+        collector = rubeus.NodeFileCollector(node=private_project, auth=another_auth)
+        assert_equal(collector._get_node_name(private_project), u'Private Component')
+
+        private_node = NodeFactory(is_public=False)
+        collector = rubeus.NodeFileCollector(node=private_node, auth=another_auth)
+        assert_equal(collector._get_node_name(private_node), u'Private Component')
 
     def test_collect_components_deleted(self):
         node = NodeFactory(creator=self.project.creator, parent=self.project)

--- a/tests/test_rubeus.py
+++ b/tests/test_rubeus.py
@@ -220,7 +220,7 @@ class TestRubeus(OsfTestCase):
     def test_get_node_name(self):
         user = UserFactory()
         auth = Auth(user=user)
-        another_user = UserFactory(username='bono@u2.com', fullname='Bono')
+        another_user = UserFactory()
         another_auth = Auth(user=another_user)
 
         # Public (Can View)
@@ -230,9 +230,8 @@ class TestRubeus(OsfTestCase):
         assert_equal(collector._get_node_name(public_project), node_name)
 
         # Private  (Can't View)
-        project = ProjectFactory(creator=user, is_public=True)
-        registration_private = project.register_node(None, auth, '', None)
-        registration_private.is_public = False
+        registration_private = RegistrationFactory(creator=user)
+        registration_private.is_publick = False
         registration_private.save()
         collector = rubeus.NodeFileCollector(node=registration_private, auth=another_auth)
         assert_equal(collector._get_node_name(registration_private), u'Private Registration')

--- a/website/util/rubeus.py
+++ b/website/util/rubeus.py
@@ -433,6 +433,24 @@ class NodeFileCollector(object):
                 rv.append(self._serialize_node(child, visited=visited))
         return rv
 
+    def _get_node_name(self, node):
+        """Input node object, return the project name to be display.
+        """
+        can_view = node.can_view(auth=self.auth)
+
+        if can_view:
+            node_name = u'{0}: {1}'.format(node.project_or_component.capitalize(), sanitize.safe_unescape_html(node.title))
+        elif node.is_registration:
+            node_name = u'Private Registration'
+        elif node.is_fork:
+            node_name = u'Private Fork'
+        elif not node.primary:
+            node_name = u'Private Link'
+        else:
+            node_name = u'Private Component'
+
+        return node_name
+
     def _serialize_node(self, node, visited=None):
         """Returns the rubeus representation of a node folder.
         """
@@ -443,11 +461,10 @@ class NodeFileCollector(object):
             children = self._collect_addons(node) + self._collect_components(node, visited)
         else:
             children = []
+
         return {
             # TODO: Remove safe_unescape_html when mako html safe comes in
-            'name': u'{0}: {1}'.format(node.project_or_component.capitalize(), sanitize.safe_unescape_html(node.title))
-            if can_view
-            else (u'Private Component' if node.primary else u'Private Link'),
+            'name': self._get_node_name(node),
             'category': node.category,
             'kind': FOLDER,
             'permissions': {


### PR DESCRIPTION
### Purpose
Display correct name for private project 
Resolved Issue https://github.com/CenterForOpenScience/osf.io/issues/3621

### Change
Delete the old code which only do simple if-statement judgement and replace it with a function to get the display name of project. 

### Side Effect
It is not a general solution and only apply in rubeus.py. Currently, the similar code that deal with the same issue is used in render_node.mako.  It may be better to put into node.py. Because it will be very likely to be used in many other places in future.

Code in render_node.mako
 
        %if summary['is_registration']:
            Private Registration
        %elif summary['is_fork']:
            Private Fork
        %elif not summary['primary']:
            Private Link
        %else:
            Private Component
        %endif