### PR TITLE
[Hot fix] Clear hover light effect on comment panel

### DIFF
--- a/website/static/js/comment.js
+++ b/website/static/js/comment.js
@@ -222,8 +222,6 @@ var CommentModel = function(data, $parent, $root) {
 
     self.showChildren = ko.observable(false);
 
-    self.hoverContent = ko.observable(false);
-
     self.reporting = ko.observable(false);
     self.deleting = ko.observable(false);
     self.unreporting = ko.observable(false);
@@ -250,9 +248,7 @@ var CommentModel = function(data, $parent, $root) {
     self.toggleIcon = ko.computed(function() {
             return self.showChildren() ? 'fa fa-minus' : 'fa fa-plus';
     });
-    self.editHighlight = ko.computed(function() {
-        return self.canEdit() && self.hoverContent();
-    });
+
     self.canReport = ko.computed(function() {
         return self.$root.canComment() && !self.canEdit();
     });
@@ -281,7 +277,6 @@ CommentModel.prototype.cancelEdit = function() {
     this.editing(false);
     this.$root.editors -= 1;
     this.editErrorMessage('');
-    this.hoverContent(false);
     this.content(this._content);
 };
 
@@ -398,13 +393,6 @@ CommentModel.prototype.cancelUnreportAbuse = function() {
     this.unreporting(false);
 };
 
-CommentModel.prototype.startHoverContent = function() {
-    this.hoverContent(true);
-};
-
-CommentModel.prototype.stopHoverContent = function() {
-    this.hoverContent(false);
-};
 
 CommentModel.prototype.toggle = function () {
     this.fetch();

--- a/website/templates/include/comment_template.mako
+++ b/website/templates/include/comment_template.mako
@@ -101,8 +101,7 @@
                     <div class="comment-content">
 
                         <div data-bind="ifnot: editing">
-                            <span class="component-overflow"
-                              data-bind="html: contentDisplay, css: {'edit-comment': editHighlight}, event: {mouseenter: startHoverContent, mouseleave: stopHoverContent}"></span>
+                            <span class="component-overflow" data-bind="html: contentDisplay"></span>
                             <span class="pull-right" data-bind="if: hasChildren">
                                 <i data-bind="css: toggleIcon, click: toggle"></i>
                             </span>


### PR DESCRIPTION
### Purpose
The hover-edit function has been disabled, but the hover effect is still shown. In this PR, it will clear the hover highlight code for comment.

Resolve issue: https://github.com/CenterForOpenScience/osf.io/issues/3780

### Changes
Delete the hover light code in comment.js and comment_template.mako

### Side Effect 
None.