### PR TITLE
[HOLD] Change swagger docs from active to read-only

### DIFF
--- a/api/static/css/osf_screen.css
+++ b/api/static/css/osf_screen.css
@@ -755,7 +755,7 @@
   float: right;
 }
 .swagger-ui-wrap ul#resources li.resource ul.endpoints li.endpoint ul.operations li.operation div.content div.sandbox_header input.submit {
-  display: block;
+  display: none;
   clear: none;
   float: left;
   padding: 6px 8px;


### PR DESCRIPTION
# Purpose: 
- https://github.com/CenterForOpenScience/osf.io/issues/3552 To disable having active swagger docs pages and just have them display the docs. 

# Changes: 
- Changed 'display' value in osf_screen.css file that corresponds to the "try it out!" buttons

# Side Effects:
None.

# Notes: 
Closes issue:
https://github.com/CenterForOpenScience/osf.io/issues/3552