### PR TITLE
[Feature Fix] Fix the btn-group usage for import github

### DIFF
--- a/website/templates/include/profile/social.mako
+++ b/website/templates/include/profile/social.mako
@@ -39,19 +39,14 @@
             <div class="form-group">
                 <label>GitHub</label>
                 <div class="input-group">
-                <span class="input-group-addon">https://github.com/</span>
-                <div data-bind="css: {'input-group': github.hasAddon()}">
+                    <span class="input-group-addon">https://github.com/</span>
                     <input class="form-control" data-bind="value: github" placeholder="username"/>
-                    <span
-                            class="input-group-btn"
-                            data-bind="if: github.hasAddon()"
-                        >
+                    <span class="input-group-btn" data-bind="if: github.hasAddon()">
                         <button
                                 class="btn btn-primary"
                                 data-bind="click: github.importAddon"
-                            >Import</button>
-                    </span>
-                    </div>
+                                >Import</button>
+                     </span>
                 </div>
             </div>
 


### PR DESCRIPTION
### Purpose
This PR is to fix the issue that gitHub input form have rounded corners. The reason behind it is because we use a btn-group inside a btn-group, which results in the border issues. I change it into use one btn-group.

Resolved https://github.com/CenterForOpenScience/osf.io/issues/3808

### Change
Before Change:
![Before Change]
(https://cloud.githubusercontent.com/assets/8591162/8881207/195e6a58-320c-11e5-8c21-c8d83d0afde4.png)
After Change:
![screenshot 2015-07-24 17 08 37](https://cloud.githubusercontent.com/assets/5420789/8884937/013b3060-3229-11e5-9c34-8eef9c8851a7.png)


### Side Effect
None