### PR TITLE
[Ready] [Fix] Use better list of files for canceling uploads

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -89,7 +89,8 @@ function findByTempID(parent, tmpID) {
 
 function cancelUploads (row) {
     var tb = this;
-    var filesArr = tb.dropzone.getUploadingFiles();
+    var uploading = tb.dropzone.getUploadingFiles();
+    var filesArr = uploading.concat(tb.dropzone.getQueuedFiles());
     for (var i = 0; i < filesArr.length; i++) {
         var j = filesArr[i];
         if(!row){

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -762,7 +762,9 @@ function _fangornDropzoneError(treebeard, file, message, xhr) {
             child.removeSelf();
         }
     }
-    $osf.growl('Error', msgText);
+    if (msgText !== 'Upload canceled.') {
+        $osf.growl('Error', msgText);
+    }
     treebeard.options.uploadInProgress = false;
 }
 

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -89,7 +89,7 @@ function findByTempID(parent, tmpID) {
 
 function cancelUploads (row) {
     var tb = this;
-    var filesArr = tb.dropzone.getQueuedFiles();
+    var filesArr = tb.dropzone.getUploadingFiles();
     for (var i = 0; i < filesArr.length; i++) {
         var j = filesArr[i];
         if(!row){


### PR DESCRIPTION
## Purpose
There has been some inconsistencies with upload canceling, for instance single file canceling has not always been successful. This PR makes improvements to make cancel upload more stable. 

## Changes
- the function called to get list of files being uploaded now includes both uploading and queued files
- the growl boxes are removed when the dropzone error is "Upload canceled." because a) this cancel is not an error, it's initiated by user, b) there was a single growl message for each file which was bad UI. 

## Side effects
The only side effect is the removal of upload canceled error message since this change does not take into account times when canceling uploading might be in fact an error but I can't think of any case where that scenario would happen. Open to input on that one. 