### PR TITLE
[feature fix] API tests teardowns

### DIFF
--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -100,7 +100,6 @@ class TestNodeList(ApiTestCase):
         assert_in(self.public._id, ids)
         assert_not_in(self.private._id, ids)
 
-        Node.remove()
 
 
 class TestNodeFiltering(ApiTestCase):
@@ -950,8 +949,6 @@ class TestNodeChildrenList(ApiTestCase):
         private_component = NodeFactory(parent=self.project)
         res = self.app.get(self.private_project_url, auth=self.basic_auth)
         assert_equal(len(res.json['data']), 1)
-
-        Node.remove()
 
 
 class TestNodePointersList(ApiTestCase):

--- a/tests/api_tests/users/test_views.py
+++ b/tests/api_tests/users/test_views.py
@@ -18,7 +18,6 @@ class TestUsers(ApiTestCase):
 
     def tearDown(self):
         super(TestUsers, self).tearDown()
-        Node.remove()
 
     def test_returns_200(self):
         res = self.app.get('/{}users/'.format(API_BASE))
@@ -87,7 +86,6 @@ class TestUserDetail(ApiTestCase):
 
     def tearDown(self):
         super(TestUserDetail, self).tearDown()
-        Node.remove()
 
     def test_gets_200(self):
         url = "/{}users/{}/".format(API_BASE, self.user_one._id)
@@ -153,7 +151,6 @@ class TestUserNodes(ApiTestCase):
 
     def tearDown(self):
         super(TestUserNodes, self).tearDown()
-        Node.remove()
 
     def test_authorized_in_gets_200(self):
         url = "/{}users/{}/nodes/".format(API_BASE, self.user_one._id)


### PR DESCRIPTION
# Purpose: 
- https://github.com/CenterForOpenScience/osf.io/issues/3314

# Changes: 
- Removed unnecessary calls to Node.remove() in the test_views.py files and kept the ones that were necessary

# Side Effects:
None.

# Notes: 
Closes issue:
https://github.com/CenterForOpenScience/osf.io/issues/3314