### PR TITLE
Fix profile page initials error for strange names

### DIFF
--- a/website/static/js/profile.js
+++ b/website/static/js/profile.js
@@ -395,14 +395,11 @@ var NameViewModel = function(urls, modes, preventUnsaved, fetchCallback) {
     };
 
     self.initials = function(names) {
+        names = $.trim(names);
         return names
-            .split(' ')
+            .split(/\s+/)
             .map(function(name) {
-                if (name){
-                    return name[0].toUpperCase() + '.';
-                } else {
-                    return '';
-                }
+                return name[0].toUpperCase() + '.';
             })
             .filter(function(initial) {
                 return initial.match(/^[a-z]/i);

--- a/website/static/js/profile.js
+++ b/website/static/js/profile.js
@@ -394,11 +394,15 @@ var NameViewModel = function(urls, modes, preventUnsaved, fetchCallback) {
         });
     };
 
-    var initials = function(names) {
+    self.initials = function(names) {
         return names
             .split(' ')
             .map(function(name) {
-                return name[0].toUpperCase() + '.';
+                if (name){
+                    return name[0].toUpperCase() + '.';
+                } else {
+                    return '';
+                }
             })
             .filter(function(initial) {
                 return initial.match(/^[a-z]/i);
@@ -421,7 +425,7 @@ var NameViewModel = function(urls, modes, preventUnsaved, fetchCallback) {
         var given = $.trim(self.given() + ' ' + self.middle());
 
         if (given) {
-            cite = cite + ', ' + initials(given);
+            cite = cite + ', ' + self.initials(given);
         }
         if (self.suffix()) {
             cite = cite + ', ' + suffix(self.suffix());
@@ -434,7 +438,7 @@ var NameViewModel = function(urls, modes, preventUnsaved, fetchCallback) {
         if (self.given()) {
             cite = cite + ', ' + self.given();
             if (self.middle()) {
-                cite = cite + ' ' + initials(self.middle());
+                cite = cite + ' ' + self.initials(self.middle());
             }
         }
         if (self.suffix()) {

--- a/website/static/js/tests/profile.test.js
+++ b/website/static/js/tests/profile.test.js
@@ -68,6 +68,11 @@ describe('profile', () => {
                 });
             });
 
+            it('should not crash initials function when name contains two spaces', () => {
+                var initials = vm.initials('John  Quincy');
+                assert.equal(initials, 'J. Q.');
+            });
+
             describe('impute', () => {
                 it('should send request and update imputed names', (done) => {
                     vm.impute().done(() => {


### PR DESCRIPTION
Tied to #2933 / #3635 .

## Purpose
Fix a front-end error that occurs when entering a middle name with two consecutive spaces. (edge case, but was hindering some other QA work on that page)

## Summary of changes
- Only calculate initials from non-empty parts of a tokenized string.
- Add regression test to ensure function works as intended.

## Side effects
- Exposes the `initials` function in NameViewModel to allow for unit testing. Updates calls to this function to avoid breaking existing functionality.