### PR TITLE
Feature fix/modal titles

### DIFF
--- a/website/addons/badges/templates/badges_user_settings.mako
+++ b/website/addons/badges/templates/badges_user_settings.mako
@@ -38,7 +38,7 @@ You have not created any Badges.
               '<input type="url" class="form-control" name="imageurl" placeholder="Image URL"><br />' +
               '<textarea class="form-control" name="criteria" placeholder="Criteria" />' +
               '</form>',
-              title: 'Create a New Badge',
+              title: 'Create a new badge',
               buttons: {
                 submit: {
                   label: "Submit",

--- a/website/addons/badges/templates/dashboard_badges.mako
+++ b/website/addons/badges/templates/dashboard_badges.mako
@@ -29,7 +29,7 @@ You have not created any Badges.
               '<input type="url" class="form-control" name="imageurl" placeholder="Image URL"><br />' +
               '<textarea class="form-control" name="criteria" placeholder="Criteria" />' +
               '</form>',
-              title: 'Create a New Badge',
+              title: 'Create a new badge',
               buttons: {
                 submit: {
                   label: "Save",

--- a/website/addons/box/static/boxNodeConfig.js
+++ b/website/addons/box/static/boxNodeConfig.js
@@ -253,7 +253,7 @@ var ViewModel = function(url, selector, folderPicker) {
         */
     self.importAuth = function() {
         bootbox.confirm({
-            title: 'Import Box Access Token?',
+            title: 'Import Box access token?',
             message: 'Are you sure you want to authorize this project with your Box access token?',
             callback: function(confirmed) {
                 if (confirmed) {

--- a/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
+++ b/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
@@ -30,7 +30,7 @@
         
         link: "Hyperlink <a>",
         linkdescription: "enter link description here",
-        linkdialog: "<div class='modal-header'> <h4 class='modal-title f-w-lg'>Add Hyperlink</h4></div><div class='modal-body'> <p><b>Example:</b><br>http://example.com/ \"optional title\"</p></div>",
+        linkdialog: "<div class='modal-header'> <h4 class='modal-title f-w-lg'>Add hyperlink</h4></div><div class='modal-body'> <p><b>Example:</b><br>http://example.com/ \"optional title\"</p></div>",
         
         quote: "Blockquote <blockquote>",
         quoteexample: "Blockquote",
@@ -40,7 +40,7 @@
         
         image: "Image <img>",
         imagedescription: "enter image description here",
-        imagedialog: "<div class='modal-header'> <h4 class='modal-title f-w-lg'>Add Image</h4></div><div class='modal-body'><p><b>Example:</b><br>http://example.com/images/diagram.jpg \"optional title\"</p></div>",
+        imagedialog: "<div class='modal-header'> <h4 class='modal-title f-w-lg'>Add image</h4></div><div class='modal-body'><p><b>Example:</b><br>http://example.com/images/diagram.jpg \"optional title\"</p></div>",
 
         olist: "Numbered List <ol>",
         ulist: "Bulleted List <ul>",

--- a/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
+++ b/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
@@ -30,7 +30,7 @@
         
         link: "Hyperlink <a>",
         linkdescription: "enter link description here",
-        linkdialog: "<div class='modal-header'> <h4 class='modal-title f-w-lg'>Add hyperlink</h4></div><div class='modal-body'> <p><b>Example:</b><br>http://example.com/ \"optional title\"</p></div>",
+        linkdialog: "<div class='modal-header'> <h4 class='modal-title f-w-lg'>Add hyperlink?</h4></div><div class='modal-body'> <p><b>Example:</b><br>http://example.com/ \"optional title\"</p></div>",
         
         quote: "Blockquote <blockquote>",
         quoteexample: "Blockquote",

--- a/website/addons/wiki/templates/add_wiki_page.mako
+++ b/website/addons/wiki/templates/add_wiki_page.mako
@@ -7,7 +7,7 @@
             <form class="form">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                    <h3 class="modal-title">Add new wiki page</h3>
+                    <h3 class="modal-title">Add new wiki page?</h3>
                 </div><!-- end modal-header -->
                 <div class="modal-body">
                     <div class='form-group'>

--- a/website/addons/wiki/templates/add_wiki_page.mako
+++ b/website/addons/wiki/templates/add_wiki_page.mako
@@ -7,7 +7,7 @@
             <form class="form">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                    <h3 class="modal-title">Add New Wiki Page</h3>
+                    <h3 class="modal-title">Add new wiki page</h3>
                 </div><!-- end modal-header -->
                 <div class="modal-body">
                     <div class='form-group'>

--- a/website/addons/wiki/templates/delete_wiki_page.mako
+++ b/website/addons/wiki/templates/delete_wiki_page.mako
@@ -6,7 +6,7 @@
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                <h3 class="modal-title">Delete Wiki Page</h3>
+                <h3 class="modal-title">Delete wiki page</h3>
             </div><!-- end modal-header -->
             <div class="modal-body">
                 <div id="alert" style="padding-bottom:10px">Are you sure you want to delete this wiki page?</div>

--- a/website/addons/wiki/templates/delete_wiki_page.mako
+++ b/website/addons/wiki/templates/delete_wiki_page.mako
@@ -6,7 +6,7 @@
         <div class="modal-content">
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                <h3 class="modal-title">Delete wiki page</h3>
+                <h3 class="modal-title">Delete wiki page?</h3>
             </div><!-- end modal-header -->
             <div class="modal-body">
                 <div id="alert" style="padding-bottom:10px">Are you sure you want to delete this wiki page?</div>

--- a/website/addons/wiki/templates/edit.mako
+++ b/website/addons/wiki/templates/edit.mako
@@ -229,7 +229,7 @@
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <h3 class="modal-title">The permissions for this page have changed</h3>
+        <h3 class="modal-title">Page permissions have changed</h3>
       </div>
       <div class="modal-body">
         <p>Your browser should refresh shortly&hellip;</p>
@@ -242,7 +242,7 @@
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <h3 class="modal-title">The content of this wiki has been moved to a different page</h3>
+        <h3 class="modal-title">Wiki content has moved</h3>
       </div>
       <div class="modal-body">
         <p>Your browser should refresh shortly&hellip;</p>
@@ -255,7 +255,7 @@
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
-        <h3 class="modal-title">This wiki page has been deleted</h3>
+        <h3 class="modal-title">Wiki page deleted</h3>
       </div>
       <div class="modal-body">
         <p>Press Confirm to return to the project wiki home page.</p>

--- a/website/static/js/citationsNodeConfig.js
+++ b/website/static/js/citationsNodeConfig.js
@@ -160,7 +160,7 @@ var CitationsFolderPickerViewModel = oop.extend(FolderPickerViewModel, {
                     });
                 } else {
                     bootbox.confirm({
-                        title: 'Import ' + self.addonName + ' Access Token?',
+                        title: 'Import ' + self.addonName + ' access token?',
                         message: self.messages.confirmAuth(),
                         callback: function(confirmed) {
                             if (confirmed) {

--- a/website/templates/project/modal_add_component.mako
+++ b/website/templates/project/modal_add_component.mako
@@ -5,7 +5,7 @@
             <form class="form" role="form" action="${node['url']}newnode/" method="post" id="componentForm">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                    <h3 class="modal-title">Add Component</h3>
+                    <h3 class="modal-title">Add component</h3>
                 </div><!-- end modal-header -->
                 <div class="modal-body">
                     <div class="form-group">

--- a/website/templates/project/modal_add_component.mako
+++ b/website/templates/project/modal_add_component.mako
@@ -5,7 +5,7 @@
             <form class="form" role="form" action="${node['url']}newnode/" method="post" id="componentForm">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                    <h3 class="modal-title">Add component</h3>
+                    <h3 class="modal-title">Add component?</h3>
                 </div><!-- end modal-header -->
                 <div class="modal-body">
                     <div class="form-group">


### PR DESCRIPTION
Fix modal titles to be in accordance with new guidelines added in https://github.com/CenterForOpenScience/osf-style/pull/66.

These guidelines were chosen due to this discussion: https://github.com/CenterForOpenScience/osf-style/issues/61. If accepted, this will close the issue.

These changes only correct the modal titles that were easy to find. Others may not be in accordance with the new styling.