### PR TITLE
[Feature Fix] Fix GitHub UI Bugs

### DIFF
--- a/website/addons/s3/views/config.py
+++ b/website/addons/s3/views/config.py
@@ -20,6 +20,11 @@ def s3_post_user_settings(auth, **kwargs):
     except KeyError:
         raise HTTPError(httplib.BAD_REQUEST)
 
+    if not (access_key and secret_key):
+        return {
+            'message': ('All the fields above are required.')
+        }, httplib.BAD_REQUEST
+
     if not utils.can_list(access_key, secret_key):
         return {
             'message': ('Unable to list buckets.\n'

--- a/website/static/js/nodeControl.js
+++ b/website/static/js/nodeControl.js
@@ -221,6 +221,7 @@ var ProjectViewModel = function(data) {
      * Add project to the Project Organizer.
      */
     self.addToDashboard = function() {
+        $('#addDashboardFolder').tooltip('hide');
         self.inDashboard(true);
         var jsonData = {
             'toNodeID': self.dashboard,
@@ -236,6 +237,7 @@ var ProjectViewModel = function(data) {
      * Remove project from the Project Organizer.
      */
     self.removeFromDashboard = function() {
+        $('#removeDashboardFolder').tooltip('hide');
         self.inDashboard(false);
         var deleteUrl = '/api/v1/folder/' + self.dashboard + '/pointer/' + self._id;
         $.ajax({url: deleteUrl, type: 'DELETE'})

--- a/website/templates/emails/archive_copy_error_user.html.mako
+++ b/website/templates/emails/archive_copy_error_user.html.mako
@@ -1,9 +1,11 @@
 <%inherit file="notify_base.mako" />
 
+
 <%def name="content()">
 <tr>
   <td style="border-collapse: collapse;">
-  <h3 class="text-center" style="padding: 0;margin: 30px 0 0 0;border: none;list-style: none;font-weight: 300;text-align: center;">Issue registering <a href="${src.url}">${src.title}</a></h3>
+  <% from website import settings %>
+  <h3 class="text-center" style="padding: 0;margin: 30px 0 0 0;border: none;list-style: none;font-weight: 300;text-align: center;">Issue registering <a href="${settings.DOMAIN.rstrip('/')+ src.url}">${src.title}</a></h3>
   </td>
 </tr>
 <tr>

--- a/website/templates/emails/archive_size_exceeded_user.html.mako
+++ b/website/templates/emails/archive_size_exceeded_user.html.mako
@@ -3,7 +3,8 @@
 <%def name="content()">
 <tr>
   <td style="border-collapse: collapse;">
-  <h3 class="text-center" style="padding: 0;margin: 30px 0 0 0;border: none;list-style: none;font-weight: 300;text-align: center;">Issue registering <a href="${src.url}">${src.title}</a></h3>
+  <% from website import settings %>    
+  <h3 class="text-center" style="padding: 0;margin: 30px 0 0 0;border: none;list-style: none;font-weight: 300;text-align: center;">Issue registering <a href="${settings.DOMAIN.rstrip('/') + src.url}">${src.title}</a></h3>
   </td>
 </tr>
 <tr>

--- a/website/templates/emails/archive_success.html.mako
+++ b/website/templates/emails/archive_success.html.mako
@@ -1,14 +1,16 @@
 <%inherit file="notify_base.mako" />
 
+
 <%def name="content()">
+<% from website import settings %>
 <tr>
   <td style="border-collapse: collapse;">
-    <h3 class="text-center" style="padding: 0;margin: 30px 0 0 0;border: none;list-style: none;font-weight: 300;text-align: center;">Registration of <b><a href="${src.url}">${src.title}</a></b> finished</h3>
+
+    <h3 class="text-center" style="padding: 0;margin: 30px 0 0 0;border: none;list-style: none;font-weight: 300;text-align: center;">Registration of <b><a href="${settings.DOMAIN.rstrip('/') + src.url}">${src.title}</a></b> finished</h3>
   </td>
 </tr>
 <tr>
   <td style="border-collapse: collapse;">
-    <% from website import settings %>
     You can view the registration <a href="${settings.DOMAIN.rstrip('/') + src.url}">here.</a>
   </td>
 </tr>

--- a/website/templates/emails/archive_uncaught_error_user.html.mako
+++ b/website/templates/emails/archive_uncaught_error_user.html.mako
@@ -1,9 +1,11 @@
 <%inherit file="notify_base.mako" />
 
+
 <%def name="content()">
 <tr>
   <td style="border-collapse: collapse;">
-  <h3 class="text-center" style="padding: 0;margin: 30px 0 0 0;border: none;list-style: none;font-weight: 300;text-align: center;">Issue registering <a href="${src.url}"> ${src.title}</a></h3>
+  <% from website import settings %>
+  <h3 class="text-center" style="padding: 0;margin: 30px 0 0 0;border: none;list-style: none;font-weight: 300;text-align: center;">Issue registering <a href="${settings.DOMAIN.rstrip('/') + src.url}"> ${src.title}</a></h3>
   </td>
 </tr>
 <tr>

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -45,14 +45,14 @@
                     <div class="btn-group" style="display: none;" data-bind="visible: true">
 
                         <!-- ko ifnot: inDashboard -->
-                           <a data-bind="click: addToDashboard, tooltip: {title: 'Add to Dashboard Folder',
+                           <a id="addDashboardFolder" data-bind="click: addToDashboard, tooltip: {title: 'Add to Dashboard Folder',
                             placement: 'bottom', container : 'body'}" class="btn btn-default">
                                <i class="fa fa-folder-open"></i>
                                <i class="fa fa-plus"></i>
                            </a>
                         <!-- /ko -->
                         <!-- ko if: inDashboard -->
-                           <a data-bind="click: removeFromDashboard, tooltip: {title: 'Remove from Dashboard Folder',
+                           <a id="removeDashboardFolder" data-bind="click: removeFromDashboard, tooltip: {title: 'Remove from Dashboard Folder',
                             placement: 'bottom', container : 'body'}" class="btn btn-default">
                                <i class="fa fa-folder-open"></i>
                                <i class="fa fa-minus"></i>


### PR DESCRIPTION
### Purpose

Resolve Github Issues:
1.  Incorrect error message when Amazon S3 credentials not entered
https://github.com/CenterForOpenScience/osf.io/issues/3810
2.  Project Organizer Folder Button Message Lag
https://github.com/CenterForOpenScience/osf.io/issues/3820

Trello Bug:
https://trello.com/c/P1sz0tUV/32-broken-link-to-project-in-issue-registering-email

### Change
1) Add logic that if one of access_key and secret_key is empty, show non-empty filed warning message.
2) Hide the tooltip when delete the DOM (by if binding)
3) Add correct URL for email template

### Side Effect
None.