### PR TITLE
[Hotfix] Github file view

### DIFF
--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -34,6 +34,11 @@ var FileViewPage = {
             content: waterbutler.buildDownloadUrl(self.file.path, self.file.provider, self.node.id, {accept_url: false, mode: 'render'})
         });
 
+        if ($osf.urlParams().branch) {
+            self.file.urls.revisions = waterbutler.buildRevisionsUrl(self.file.path, self.file.provider, self.node.id, {sha: $osf.urlParams().branch});
+            self.file.urls.content = waterbutler.buildDownloadUrl(self.file.path, self.file.provider, self.node.id, {accept_url: false, mode: 'render', branch: $osf.urlParams().branch});
+        }
+
         $(document).on('fileviewpage:delete', function() {
             bootbox.confirm({
                 title: 'Delete file?',


### PR DESCRIPTION
When branch is not passed to waterbutler and the viewed file does not exist on the default branch errors are raised and revisions is displayed incorrectly.

![screen shot 2015-07-27 at 15 34 20](https://cloud.githubusercontent.com/assets/5532905/8917863/ab56f97a-3482-11e5-8e82-b4b9f55386ed.png)

![screen shot 2015-07-27 at 17 08 48](https://cloud.githubusercontent.com/assets/5532905/8917862/ab565100-3482-11e5-94b3-e985c1bfb64f.png)