### PR TITLE
Stop Table Overflow on User Settings.

### DIFF
--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -413,6 +413,12 @@ a {
     max-height: 140px;
     overflow-y: hidden;
 }
+
+.table-hover{
+    word-break: break-all;
+    word-break: break-word; /* Non standard for webkit*/
+}
+
 select {
     word-wrap: normal;
 }


### PR DESCRIPTION
<h1> Purpose </h1>
Stops project titles from overflowing tables on user settings page addons. Closes #3804.
<h1> Changes </h1>
Simple CSS.
<h1> Side Effects </h1>
None.