### PR TITLE
improve the error message on add unconfirmed invalid email

### DIFF
--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -107,12 +107,7 @@ def resend_confirmation(auth):
     if primary or confirmed:
         raise HTTPError(httplib.BAD_REQUEST, data={'message_long': 'Cannnot resend confirmation for confirmed emails'})
 
-    try:
-        user.add_unconfirmed_email(address)
-    except (ValidationError, ValueError):
-        raise HTTPError(http.BAD_REQUEST, data=dict(
-            message_long="Invalid Email")
-        )
+    user.add_unconfirmed_email(address)
 
     # TODO: This setting is now named incorrectly.
     if settings.CONFIRM_REGISTRATIONS_BY_EMAIL:

--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -107,7 +107,12 @@ def resend_confirmation(auth):
     if primary or confirmed:
         raise HTTPError(httplib.BAD_REQUEST, data={'message_long': 'Cannnot resend confirmation for confirmed emails'})
 
-    user.add_unconfirmed_email(address)
+    try:
+        user.add_unconfirmed_email(address)
+    except (ValidationError, ValueError):
+        raise HTTPError(http.BAD_REQUEST, data=dict(
+            message_long="Invalid Email")
+        )
 
     # TODO: This setting is now named incorrectly.
     if settings.CONFIRM_REGISTRATIONS_BY_EMAIL:
@@ -167,7 +172,12 @@ def update_user(auth):
         ]
 
         for address in added_emails:
-            user.add_unconfirmed_email(address)
+            try:
+                user.add_unconfirmed_email(address)
+            except (ValidationError, ValueError):
+                raise HTTPError(http.BAD_REQUEST, data=dict(
+                    message_long="Invalid Email")
+                )
 
             # TODO: This setting is now named incorrectly.
             if settings.CONFIRM_REGISTRATIONS_BY_EMAIL:

--- a/website/static/js/accountSettings.js
+++ b/website/static/js/accountSettings.js
@@ -211,6 +211,8 @@ var UserProfileViewModel = oop.extend(ChangeMessageMixin, {
                         return;
                     }
                 }
+            }.bind(this)).fail(function(){
+                this.profile().emails.remove(email);
             }.bind(this));
         } else {
             this.changeMessage('Email cannot be empty.', 'text-danger');

--- a/website/static/js/accountSettings.js
+++ b/website/static/js/accountSettings.js
@@ -102,12 +102,14 @@ var UserProfileClient = oop.defclass({
         ).done(function (data) {
             ret.resolve(this.unserialize(data, profile));
         }.bind(this)).fail(function(xhr, status, error) {
-            if (error.toLowerCase() !== 'bad request') {
+                console.log(xhr);
+            if (xhr.status === 400) {
+                $osf.growl('Error', xhr.responseJSON.message_long);
+
+            } else {
                 $osf.growl('Error', 'User profile not updated. Please refresh the page and try ' +
                 'again or contact <a href="mailto: support@cos.io">support@cos.io</a> ' +
                 'if the problem persists.', 'danger');
-            } else {
-                $osf.growl('Error', 'Invalid Email');
             }
 
             Raven.captureMessage('Error fetching user profile', {

--- a/website/static/js/accountSettings.js
+++ b/website/static/js/accountSettings.js
@@ -102,7 +102,6 @@ var UserProfileClient = oop.defclass({
         ).done(function (data) {
             ret.resolve(this.unserialize(data, profile));
         }.bind(this)).fail(function(xhr, status, error) {
-                console.log(xhr);
             if (xhr.status === 400) {
                 $osf.growl('Error', xhr.responseJSON.message_long);
 

--- a/website/static/js/accountSettings.js
+++ b/website/static/js/accountSettings.js
@@ -102,15 +102,20 @@ var UserProfileClient = oop.defclass({
         ).done(function (data) {
             ret.resolve(this.unserialize(data, profile));
         }.bind(this)).fail(function(xhr, status, error) {
-            $osf.growl('Error', 'User profile not updated. Please refresh the page and try ' +
+            if (error.toLowerCase() !== 'bad request') {
+                $osf.growl('Error', 'User profile not updated. Please refresh the page and try ' +
                 'again or contact <a href="mailto: support@cos.io">support@cos.io</a> ' +
                 'if the problem persists.', 'danger');
+            } else {
+                $osf.growl('Error', 'Invalid Email');
+            }
+
             Raven.captureMessage('Error fetching user profile', {
                 url: this.urls.update,
                 status: status,
                 error: error
             });
-                ret.reject(xhr, status, error);
+            ret.reject(xhr, status, error);
         }.bind(this));
 
         return ret;
@@ -205,7 +210,6 @@ var UserProfileViewModel = oop.extend(ChangeMessageMixin, {
                         return;
                     }
                 }
-                this.changeMessage('Invalid Email.', 'text-danger');
             }.bind(this));
         } else {
             this.changeMessage('Email cannot be empty.', 'text-danger');

--- a/website/templates/profile/account.mako
+++ b/website/templates/profile/account.mako
@@ -68,7 +68,7 @@
                                         <form data-bind="submit: addEmail">
                                             <div class="form-group">
                                                 ## email input verification is not supported on safari
-                                              <input placeholder="Email address" type="email" data-bind="value: emailInput" class="form-control" required maxlength="254">
+                                              <input placeholder="Email address" data-bind="value: emailInput" class="form-control" required maxlength="254">
                                             </div>
                                             <input type="submit" value="Add Email" class="btn btn-success">
                                         </form>

--- a/website/templates/profile/account.mako
+++ b/website/templates/profile/account.mako
@@ -68,7 +68,7 @@
                                         <form data-bind="submit: addEmail">
                                             <div class="form-group">
                                                 ## email input verification is not supported on safari
-                                              <input placeholder="Email address" data-bind="value: emailInput" class="form-control" required maxlength="254">
+                                              <input placeholder="Email address" type="email" data-bind="value: emailInput" class="form-control" required maxlength="254">
                                             </div>
                                             <input type="submit" value="Add Email" class="btn btn-success">
                                         </form>


### PR DESCRIPTION
<b>Purpose</b>
Change the error return from backend from 500 to 404 while adding an invalid unconfirmed email. Also improve the error message when the front end email validate is not supported(Safari). Closes https://github.com/CenterForOpenScience/osf.io/issues/3851.

<b>Changes</b>
In Safari, add an invalid unconfirmed email,
Used to be:
![image](https://cloud.githubusercontent.com/assets/4974056/8941699/1918c1ac-353f-11e5-93d6-e93b1152b99b.png)
After the change:
![screen shot 2015-07-28 at 3 41 43 pm](https://cloud.githubusercontent.com/assets/4974056/8941710/2c96aba4-353f-11e5-91c7-256284a3a88c.png)
