### PR TITLE
[Fix] [Ready] Fix broken TOC anchor links in Wiki 

### DIFF
--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -381,7 +381,7 @@ ko.bindingHandlers.anchorScroll = {
                 // get location of the target
                 var target = $item.attr('href');
                 // if target has a scrollbar scroll it, otherwise scroll the page
-                if ( $element.get(0).scrollHeight > $element.height() ) {
+                if ( $element.get(0).scrollHeight > $element.innerHeight() ) {
                     offset = $(target).position();
                     $element.scrollTop(offset.top - buffer);
                 } else {


### PR DESCRIPTION
## Purpose
With the recent change to wiki to allow full page containers the anchor scroll function was broken. This PR fixes that to restore full page anchor links.

## Changes
Update the value that the height is using to make sure proper logic is run.

## Side Effects
None. 