### PR TITLE
Removes Dataverse File View Tooltip that Prevented Right Click Functions.

### DIFF
--- a/website/addons/dataverse/static/dataverseFangornConfig.js
+++ b/website/addons/dataverse/static/dataverseFangornConfig.js
@@ -231,7 +231,6 @@ function _fangornDataverseTitle(item, col) {
                 onclick: function () {
                     gotoFile(item);
                 },
-                'data-placement': 'bottom'
             }, item.data.name
                 )
         ]);

--- a/website/addons/dataverse/static/dataverseFangornConfig.js
+++ b/website/addons/dataverse/static/dataverseFangornConfig.js
@@ -231,8 +231,6 @@ function _fangornDataverseTitle(item, col) {
                 onclick: function () {
                     gotoFile(item);
                 },
-                'data-toggle': 'tooltip',
-                title: 'View file',
                 'data-placement': 'bottom'
             }, item.data.name
                 )


### PR DESCRIPTION
<h1> Purpose </h1>
Removes unnecessary tooltip on dataverse file page. Closes #3858.
<h1> Changes </h1>
Removed tooltip tags.
<h1> Notes </h1>
Initially this was thought to effect the right click functionality, but it doesn't.