### PR TITLE
[Fix] [Read] Prevent selection on link Project Organize click

### DIFF
--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -104,11 +104,14 @@ projectOrganizer.myProjects = new Bloodhound({
  */
 function _poTitleColumn(item) {
     var tb = this;
+    var preventSelect = function(e){
+        e.stopImmediatePropagation();
+    };
     var css = item.data.isSmartFolder ? 'project-smart-folder smart-folder' : '';
     if(item.data.archiving) {
         return  m('span', {'class': 'registration-archiving'}, item.data.name + ' [Archiving]');
     } else if(item.data.urls.fetch){
-        return m('a.fg-file-links', { 'class' : css, href : item.data.urls.fetch}, item.data.name);
+        return m('a.fg-file-links', { 'class' : css, href : item.data.urls.fetch, onclick : preventSelect}, item.data.name);
     } else {
         return  m('span', { 'class' : css}, item.data.name);
     }


### PR DESCRIPTION
## Purpose 
As reported in error #3781 when the user clicked cmd + link on Project organize the event bubbles up to select the row which has side effects triggering multiselect and showing a red flash background. 

## Changes
Added function to prevent bubbling when Project Organizer links are clicked

## Side Effects
None