### PR TITLE
[Feature] Add force_refresh argument to fetch_access_token for credential verification

### DIFF
--- a/website/addons/googledrive/model.py
+++ b/website/addons/googledrive/model.py
@@ -125,8 +125,8 @@ class GoogleDriveOAuthSettings(StoredObject):
     refresh_token = fields.StringField()
     expires_at = fields.DateTimeField()
 
-    def fetch_access_token(self):
-        self.refresh_access_token()
+    def fetch_access_token(self, force_refresh=None):
+        self.refresh_access_token(force=force_refresh)
         return self.access_token
 
     def refresh_access_token(self, force=False):
@@ -223,9 +223,9 @@ class GoogleDriveUserSettings(AddonUserSettingsBase):
             return self.oauth_settings.access_token is not None
         return False
 
-    def fetch_access_token(self):
+    def fetch_access_token(self, force_refresh=None):
         if self.oauth_settings:
-            return self.oauth_settings.fetch_access_token()
+            return self.oauth_settings.fetch_access_token(force_refresh)
         return None
 
     def clear(self):

--- a/website/addons/googledrive/model.py
+++ b/website/addons/googledrive/model.py
@@ -125,7 +125,7 @@ class GoogleDriveOAuthSettings(StoredObject):
     refresh_token = fields.StringField()
     expires_at = fields.DateTimeField()
 
-    def fetch_access_token(self, force_refresh=None):
+    def fetch_access_token(self, force_refresh=False):
         self.refresh_access_token(force=force_refresh)
         return self.access_token
 
@@ -223,7 +223,7 @@ class GoogleDriveUserSettings(AddonUserSettingsBase):
             return self.oauth_settings.access_token is not None
         return False
 
-    def fetch_access_token(self, force_refresh=None):
+    def fetch_access_token(self, force_refresh=False):
         if self.oauth_settings:
             return self.oauth_settings.fetch_access_token(force_refresh)
         return None

--- a/website/addons/googledrive/tests/test_views.py
+++ b/website/addons/googledrive/tests/test_views.py
@@ -267,6 +267,7 @@ class TestGoogleDriveUtils(OsfTestCase):
         self.patcher.start()
 
     def tearDown(self):
+        super(TestGoogleDriveUtils, self).tearDown()
         self.patcher.stop()
 
     def test_serialize_settings_helper_returns_correct_urls(self):

--- a/website/addons/googledrive/tests/test_views.py
+++ b/website/addons/googledrive/tests/test_views.py
@@ -262,6 +262,13 @@ class TestGoogleDriveUtils(OsfTestCase):
         # Log user in
         self.app.authenticate(*self.user.auth)
 
+        self.patcher = mock.patch('website.addons.googledrive.model.GoogleDriveUserSettings.fetch_access_token')
+        self.patcher.return_value = 'fakeaccesstoken'
+        self.patcher.start()
+
+    def tearDown(self):
+        self.patcher.stop()
+
     def test_serialize_settings_helper_returns_correct_urls(self):
         result = serialize_settings(self.node_settings, self.user)
         urls = result['urls']

--- a/website/addons/googledrive/utils.py
+++ b/website/addons/googledrive/utils.py
@@ -72,6 +72,7 @@ def serialize_urls(node_settings):
         'importAuth': node.api_url_for('googledrive_import_user_auth'),
         'folders': node.api_url_for('googledrive_folders'),
         'auth': node.api_url_for('googledrive_oauth_start'),
+        'settings': web_url_for('user_addons'),
     }
 
 
@@ -88,7 +89,7 @@ def serialize_settings(node_settings, current_user):
     valid_credentials = True
     if user_settings:
         try:
-            user_settings.fetch_access_token()
+            user_settings.fetch_access_token(force_refresh=True)
         except ExpiredAuthError:
             valid_credentials = False
     ret = {


### PR DESCRIPTION
Purpose
=======
Closes https://github.com/CenterForOpenScience/osf.io/issues/3748

Changes
=======
Added optional keyword argument to fetch_access_token() so that this addon will actually check if the credentials are valid when defining valid_credentials.

Side Effects
=========
Added 'settings' to urls for proper link to user addon settings (`/settings/addons/`), rather than `/settings/undefined`