### PR TITLE
fix the typo problem when file can't load

### DIFF
--- a/website/static/js/accountSettings.js
+++ b/website/static/js/accountSettings.js
@@ -217,7 +217,7 @@ var UserProfileViewModel = oop.extend(ChangeMessageMixin, {
         var addrText = $osf.htmlEscape(email.address());
         bootbox.confirm({
             title: 'Resend Email Confirmation?',
-            message: 'Are you sure that you want to resend email confirmation to ' + '<em>' + addrText + '</em>',
+            message: 'Are you sure that you want to resend email confirmation to ' + '<em>' + addrText + '</em>?',
             callback: function (confirmed) {
                 if (confirmed) {
                     self.client.update(self.profile(), email).done(function () {

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1135,7 +1135,7 @@ function _connectCheckTemplate(item){
     var tb = this;
     return m('span.text-danger', [
         m('span', item.data.name),
-        m('em', ' could\'t load.' ),
+        m('em', ' couldn\'t load.' ),
         m('button.btn.btn-xs.btn-default.m-l-xs', {
             onclick : function(e){
                 e.stopImmediatePropagation();


### PR DESCRIPTION
<b>Purpose</b>
Fix the language type of file can't load and add question mark for resend email modal. Closes https://github.com/CenterForOpenScience/osf.io/issues/3884 and https://github.com/CenterForOpenScience/osf.io/issues/3889