### PR TITLE
improve remove email from account email alert

### DIFF
--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -714,11 +714,13 @@ class User(GuidStoredObject, AddonModelMixin):
         mails.send_mail(to_addr=self.username,
                         mail=mails.REMOVED_EMAIL,
                         user=self,
-                        removed_email=email)
+                        removed_email=email,
+                        security_addr='alternative email address (' + str(email) + ')')
         mails.send_mail(to_addr=email,
                         mail=mails.REMOVED_EMAIL,
                         user=self,
-                        removed_email=email)
+                        removed_email=email,
+                        security_addr='primary email address (' + str(self.username) + ')')
 
     def get_confirmation_token(self, email, force=False):
         """Return the confirmation token for a given email.

--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -715,12 +715,12 @@ class User(GuidStoredObject, AddonModelMixin):
                         mail=mails.REMOVED_EMAIL,
                         user=self,
                         removed_email=email,
-                        security_addr='alternative email address (' + str(email) + ')')
+                        security_addr='alternative email address ({})'.format(email))
         mails.send_mail(to_addr=email,
                         mail=mails.REMOVED_EMAIL,
                         user=self,
                         removed_email=email,
-                        security_addr='primary email address (' + str(self.username) + ')')
+                        security_addr='primary email address ({})'.format(self.username))
 
     def get_confirmation_token(self, email, force=False):
         """Return the confirmation token for a given email.

--- a/website/templates/emails/email_removed.txt.mako
+++ b/website/templates/emails/email_removed.txt.mako
@@ -1,6 +1,7 @@
 Hello ${user.fullname},
 
-I just wanted to let you know, the email address ${removed_email} has been removed from your account. For security purposes, a copy of this message has also been sent to you account's primary email address (${user.username}).
+I just wanted to let you know, the email address ${removed_email} has been removed from your account. For security purposes, a copy of this message has also been sent to your account's ${security_addr}.
+
 
 If you did not request this action, let us know at contact@cos.io.
 


### PR DESCRIPTION
<b>Purpose</b>
Fix the typo and improve the language part for remove email's email alert. Closes https://github.com/CenterForOpenScience/osf.io/issues/3857.

<b>Changes</b>
Originally, remove an email will send two of the same email to both the email got removed and the primary email.
After change:
<b>Email One: </b>
[website.mails]  DEBUG: Sending email...
[website.mails]  DEBUG: To: tianxia@test.com
From: openscienceframework-noreply@osf.io
Subject: Email address removed from your OSF account
Message: Hello tianxia,

I just wanted to let you know, the email address helloworld@test.com has been removed from your account. For security purposes, a copy of this message has also been sent to your account's alternative email address (helloworld@test.com).


If you did not request this action, let us know at contact@cos.io.

Sincerely yours,

The OSF Robot
<b>Email Two: </b>
[website.mails]  DEBUG: Sending email...
[website.mails]  DEBUG: To: helloworld@test.com
From: openscienceframework-noreply@osf.io
Subject: Email address removed from your OSF account
Message: Hello tianxia,

I just wanted to let you know, the email address helloworld@test.com has been removed from your account. For security purposes, a copy of this message has also been sent to your account's primary email address (tianxia@test.com).


If you did not request this action, let us know at contact@cos.io.

Sincerely yours,

The OSF Robot