### PR TITLE
Fix Flashing Change Cancel Buttons

### DIFF
--- a/website/static/js/pages/project-settings-page.js
+++ b/website/static/js/pages/project-settings-page.js
@@ -53,7 +53,7 @@ $(document).ready(function() {
             window.contextVars.node.urls.update,
             disableCategory
         );
-        ko.applyBindings(categorySettingsVM, $('#nodeCategorySettings')[0]);
+        $osf.applyBindings(categorySettingsVM, $('#nodeCategorySettings')[0]);
     }
 
     $('#deleteNode').on('click', function() {

--- a/website/static/js/projectSettings.js
+++ b/website/static/js/projectSettings.js
@@ -17,7 +17,7 @@ var NodeCategorySettings = oop.extend(
             var self = this;
 
             self.disabled = disabled || false;
-
+            self.disableButtons = ko.observable(disabled || false);
             self.UPDATE_SUCCESS_MESSAGE = 'Category updated successfully';
             self.UPDATE_ERROR_MESSAGE = 'Error updating category, please try again. If the problem persists, email ' +
                 '<a href="mailto:support@osf.io">support@osf.io</a>.';

--- a/website/static/js/projectSettings.js
+++ b/website/static/js/projectSettings.js
@@ -17,7 +17,6 @@ var NodeCategorySettings = oop.extend(
             var self = this;
 
             self.disabled = disabled || false;
-            self.disableButtons = ko.observable(disabled || false);
             self.UPDATE_SUCCESS_MESSAGE = 'Category updated successfully';
             self.UPDATE_ERROR_MESSAGE = 'Error updating category, please try again. If the problem persists, email ' +
                 '<a href="mailto:support@osf.io">support@osf.io</a>.';

--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -80,19 +80,27 @@
                                                         optionsText: 'label',
                                                         value: selectedCategory"></select>
                         </h5>
-                        <p data-bind="if: !disabled">
-                            <button data-bind="css: {disabled: !dirty()},
-                                               click: cancelUpdateCategory"
-                                    class="btn btn-default">Cancel</button>
-                            <button data-bind="css: {disabled: !dirty()},
-                                               click: updateCategory"
-                                    class="btn btn-primary">Change</button>
-                        </p>
-                        <span data-bind="css: messageClass, html: message"></span>
+                        <div style="display: none" data-bind="visible: disableButtons()">
 
-                        <span data-bind="if: disabled" class="help-block">
-                            A top-level project's category cannot be changed
-                        </span>
+                             <span class="help-block">
+                                A top-level project's category cannot be changed
+                            </span>
+                        </div>
+
+                        <div style="display: none" data-bind="visible: !disableButtons()">
+                            <button data-bind="visible : disable() css: {disabled: !dirty()},
+                                click: cancelUpdateCategory"
+                                class="btn btn-default">
+                                Cancel</button>
+
+                            <button data-bind="css: {disabled: !dirty()},
+                                click: updateCategory"
+                                class="btn btn-primary">
+                                Change</button>
+
+                            <span data-bind="css: messageClass, html: message"></span>
+                        </div>
+
                     </div>
 
                     % if 'admin' in user['permissions']:

--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -72,7 +72,7 @@
                     <div class="panel-heading clearfix">
                         <h3 id="configureNode" class="panel-title">Configure ${node['node_type'].capitalize()}</h3>
                     </div>
-                    <div id="nodeCategorySettings" class="panel-body">
+                    <div id="nodeCategorySettings" class="panel-body scripted">
                         <h5>
                             Category: <select data-bind="attr.disabled: disabled,
                                                         options: categories,
@@ -80,27 +80,19 @@
                                                         optionsText: 'label',
                                                         value: selectedCategory"></select>
                         </h5>
-                        <div style="display: none" data-bind="visible: disableButtons()">
-
-                             <span class="help-block">
-                                A top-level project's category cannot be changed
-                            </span>
-                        </div>
-
-                        <div style="display: none" data-bind="visible: !disableButtons()">
-                            <button data-bind="visible : disable() css: {disabled: !dirty()},
-                                click: cancelUpdateCategory"
-                                class="btn btn-default">
-                                Cancel</button>
-
+                        <p data-bind="if: !disabled">
                             <button data-bind="css: {disabled: !dirty()},
-                                click: updateCategory"
-                                class="btn btn-primary">
-                                Change</button>
+                                               click: cancelUpdateCategory"
+                                    class="btn btn-default">Cancel</button>
+                            <button data-bind="css: {disabled: !dirty()},
+                                               click: updateCategory"
+                                    class="btn btn-primary">Change</button>
+                        </p>
+                        <span data-bind="css: messageClass, html: message"></span>
 
-                            <span data-bind="css: messageClass, html: message"></span>
-                        </div>
-
+                        <span data-bind="if: disabled" class="help-block">
+                            A top-level project's category cannot be changed
+                        </span>
                     </div>
 
                     % if 'admin' in user['permissions']:


### PR DESCRIPTION
<h1> Purpose </h1>
Stop the change/cancel buttons on the project setting from briefly flashing during loading. Close #3649...Again.
<h1> Changes </h1>
This issue was a lot more problematic then expected, for some reason simply putting a ko containerless conditional statement around the buttons doesn't cut it, so this was the best I could come up with.
<h1> Side Effects </h1>
None that I know of.