### PR TITLE
[Ready] Make Files nav item selected in file detail page

### DIFF
--- a/website/static/js/pages/view-file-tree-page.js
+++ b/website/static/js/pages/view-file-tree-page.js
@@ -32,6 +32,6 @@ $(document).ready(function() {
         panelVisible.show();
         panelHidden.hide();
     });
-    $('.osf-project-navbar li:contains("Files")').addClass('active');
+    $('.osf-project-navbar li#project-nav-files').addClass('active');
 
 });

--- a/website/static/js/pages/view-file-tree-page.js
+++ b/website/static/js/pages/view-file-tree-page.js
@@ -32,5 +32,6 @@ $(document).ready(function() {
         panelVisible.show();
         panelHidden.hide();
     });
+    $('.osf-project-navbar li:contains("Files")').addClass('active');
 
 });

--- a/website/templates/project/project_header.mako
+++ b/website/templates/project/project_header.mako
@@ -33,7 +33,7 @@
                         <li><a href="${node['url']}"  class="project-title"> ${node['title'] | n}  </a></li>
 
                     % if not node['is_retracted']:
-                        <li><a href="${node['url']}files/">Files</a></li>
+                        <li id="project-nav-files"><a href="${node['url']}files/">Files</a></li>
                         <!-- Add-on tabs -->
                         % for addon in addons_enabled:
 


### PR DESCRIPTION
## Purpose
Fixes #645 "when viewing a file, "files" should be active"

## Changes
After loading file details page jQuery finds and adds "active" class to Files menu item. 

## Side Effects
None