### PR TITLE
Ungroup Watch and Duplicate Buttons

### DIFF
--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -27,7 +27,11 @@
                 </h2>
             </div>
             <div class="col-sm-6 col-md-5">
-                <div class="btn-toolbar node-control pull-right">
+                <div class="btn-toolbar node-control pull-right"
+                    % if not user_name:
+                        data-bind="tooltip: {title: 'Log-in or create an account to watch/duplicate this project', placement: 'bottom'}"
+                    % endif
+                        >
                     <div class="btn-group">
                     % if not node["is_public"]:
                         <button class='btn btn-default disabled'>Private</button>
@@ -61,11 +65,7 @@
 
                     </div>
                     <!-- /ko -->
-                    <div
-                        % if not user_name:
-                            data-bind="tooltip: {title: 'Log-in or create an account to watch/duplicate this project', placement: 'bottom'}"
-                        % endif
-                            class="btn-group">
+                    <div class="btn-group">
                         <a
                         % if user_name and (node['is_public'] or user['has_read_permissions']) and not node['is_registration']:
                             data-bind="click: toggleWatch, tooltip: {title: watchButtonAction, placement: 'bottom', container : 'body'}"
@@ -77,6 +77,8 @@
                             <i class="fa fa-eye"></i>
                             <span data-bind="text: watchButtonDisplay" id="watchCount"></span>
                         </a>
+                    </div>
+                    <div class="btn-group">
                         <a
                         % if user_name:
                             class="btn btn-default"


### PR DESCRIPTION
<h1> Purpose </h1>
Make button grouping more consistent with the style guide. Close #3630.
<h1> Changes </h1>
Ungroups buttons and moves tooltip over both of them.
<h1> Side Effects </h1>
None that I know of
<h1> Old Look </h1>
![screen shot 2015-07-31 at 10 06 55 am](https://cloud.githubusercontent.com/assets/9688518/9008985/02e3423e-376c-11e5-9468-bd05a5d51f2e.png)
<h1> New  Look </h1>
![screen shot 2015-07-31 at 10 09 19 am](https://cloud.githubusercontent.com/assets/9688518/9009025/4a7e30c2-376c-11e5-96ae-6d5b5fff75db.png)


