### PR TITLE
[Ready] Fix components widget not being sortable

### DIFF
--- a/website/templates/util/render_nodes.mako
+++ b/website/templates/util/render_nodes.mako
@@ -25,7 +25,7 @@
               $('.sortable').sortable({
                   containment: '#containment',
                   tolerance: 'pointer',
-                  items: '> li',
+                  items: '#components > li',
                   stop: function(event, ui){
                       var sortListElm = this;
                       var idList = $(sortListElm).sortable(


### PR DESCRIPTION
## Purpose
Fixes issue #3892 "re-enable reordering of components".

## Changes 
For some reason not clear to me the items that need to be sortable were given a selector that no longer showed the correct component rows that needed to be sorted. It was ```> li``` and it needed to be ```#components > li```. 

## Side Effects
This script is localized to this file only so there shouldn't be side effects. 