### PR TITLE
Fix Scroll Spy

### DIFF
--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -617,7 +617,7 @@ ko.bindingHandlers.listing = {
 
 /* Responsive Affix for side nav */
 var fixAffixWidth = function() {
-    $('.affix, .affix-top, .affix-bottom').each(function (){
+    $('.osf-affix').each(function (){
         var el = $(this);
         var colsize = el.parent('.affix-parent').width();
         el.outerWidth(colsize);


### PR DESCRIPTION
<h1> Purpose </h1>
Fix issue where the width of the scroll spy would contract if it was refreshed by applying a selected addon in the middle of the page. Close #3872.
<h1> Changes </h1>
Resize function now applies to parent '.osf-affix' instead of three children '.affix, .affix-top, affix-bottom'.
<h1> Side Effects </h1>
None that I know of.