### PR TITLE
Add Underline to Addon Message Links

### DIFF
--- a/website/addons/base/__init__.py
+++ b/website/addons/base/__init__.py
@@ -1026,7 +1026,7 @@ class AddonOAuthNodeSettingsBase(AddonNodeSettingsBase):
             if not auth or auth.user != removed:
                 url = node.web_url_for('node_setting')
                 message += (
-                    u' You can re-authenticate on the <a href="{url}">Settings</a> page.'
+                    u' You can re-authenticate on the <u><a href="{url}">Settings</a></u> page.'
                 ).format(url=url)
             #
             return message
@@ -1052,7 +1052,7 @@ class AddonOAuthNodeSettingsBase(AddonNodeSettingsBase):
         else:
             message = (
                 u'{addon} authorization not copied to forked {category}. You may '
-                u'authorize this fork on the <a href="{url}">Settings</a> '
+                u'authorize this fork on the <u><a href="{url}">Settings</a></u> '
                 u'page.'
             ).format(
                 addon=self.config.full_name,

--- a/website/addons/box/model.py
+++ b/website/addons/box/model.py
@@ -391,7 +391,7 @@ class BoxNodeSettings(StorageAddonBase, AddonNodeSettingsBase):
         else:
             message = (
                 u'Box authorization not copied to forked {cat}. You may '
-                'authorize this fork on the <a href="{url}">Settings</a> '
+                'authorize this fork on the <u><a href="{url}">Settings</a></u> '
                 'page.'
             ).format(
                 url=fork.web_url_for('node_setting'),
@@ -424,7 +424,7 @@ class BoxNodeSettings(StorageAddonBase, AddonNodeSettingsBase):
             if not auth or auth.user != removed:
                 url = node.web_url_for('node_setting')
                 message += (
-                    u' You can re-authenticate on the <a href="{url}">Settings</a> page.'
+                    u' You can re-authenticate on the <u><a href="{url}">Settings</a></u> page.'
                 ).format(url=url)
             #
             return message

--- a/website/addons/dataverse/model.py
+++ b/website/addons/dataverse/model.py
@@ -279,7 +279,7 @@ class AddonDataverseNodeSettings(StorageAddonBase, AddonOAuthNodeSettingsBase):
         else:
             message = (
                 'Dataverse authorization not copied to forked {cat}. You may '
-                'authorize this fork on the <a href="{url}">Settings</a> '
+                'authorize this fork on the <u><a href="{url}">Settings</a></u> '
                 'page.'
             ).format(
                 url=fork.web_url_for('node_setting'),
@@ -310,7 +310,7 @@ class AddonDataverseNodeSettings(StorageAddonBase, AddonOAuthNodeSettingsBase):
             if not auth or auth.user != removed:
                 url = node.web_url_for('node_setting')
                 message += (
-                    u' You can re-authenticate on the <a href="{url}">Settings</a> page.'
+                    u' You can re-authenticate on the <u><a href="{url}">Settings</a></u> page.'
                 ).format(url=url)
             #
             return message

--- a/website/addons/dropbox/model.py
+++ b/website/addons/dropbox/model.py
@@ -275,7 +275,7 @@ class DropboxNodeSettings(StorageAddonBase, AddonNodeSettingsBase):
         else:
             message = (
                 u'Dropbox authorization not copied to forked {cat}. You may '
-                'authorize this fork on the <a href="{url}">Settings</a> '
+                'authorize this fork on the <u><a href="{url}">Settings</a></u> '
                 'page.'
             ).format(
                 url=fork.web_url_for('node_setting'),
@@ -306,7 +306,7 @@ class DropboxNodeSettings(StorageAddonBase, AddonNodeSettingsBase):
             if not auth or auth.user != removed:
                 url = node.web_url_for('node_setting')
                 message += (
-                    u' You can re-authenticate on the <a href="{url}">Settings</a> page.'
+                    u' You can re-authenticate on the <u><a href="{url}">Settings</a></u> page.'
                 ).format(url=url)
             #
             return message

--- a/website/addons/figshare/messages.py
+++ b/website/addons/figshare/messages.py
@@ -15,15 +15,15 @@ BEFORE_FORK_NOT_OWNER = 'Because this figshare add-on has been authenticated by 
 
 AFTER_FORK_OWNER = 'figshare authorization copied to forked {category}. '
 
-AFTER_FORK_NOT_OWNER = 'figshare authorization not copied to forked {category}. You may authorize this fork on the <a href={url}>Settings</a> page. '
+AFTER_FORK_NOT_OWNER = 'figshare authorization not copied to forked {category}. You may authorize this fork on the <u><a href={url}>Settings</a></u> page. '
 
 BEFORE_REGISTER = 'The contents of figshare projects cannot be registered at this time. The figshare data associated with this {category} will not be included as part of this registration. '
 # END MODEL MESSAGES
 
 # MFR MESSAGES :views/crud.py
-FIGSHARE_VIEW_FILE_PRIVATE = 'Since this figshare file is unpublished we cannot render it. In order to access this content you will need to log into the <a href="{url}">figshare page</a> and view it there. '
+FIGSHARE_VIEW_FILE_PRIVATE = 'Since this figshare file is unpublished we cannot render it. In order to access this content you will need to log into the <u><a href="{url}">figshare page</a></u> and view it there. '
 
-FIGSHARE_VIEW_FILE_OVERSIZED = 'This figshare file is too large to render; <a href="{url}">download file</a> to view it. '
+FIGSHARE_VIEW_FILE_OVERSIZED = 'This figshare file is too large to render; <u><a href="{url}">download file</a></u> to view it. '
 
 '''
 Publishing this article is an irreversible operation. Once a figshare article is published it can never be deleted. Proceed with caution.

--- a/website/addons/github/model.py
+++ b/website/addons/github/model.py
@@ -448,7 +448,7 @@ class AddonGitHubNodeSettings(StorageAddonBase, AddonNodeSettingsBase):
                 'by {user}. Removing this user will also remove write access '
                 'to GitHub unless another contributor re-authenticates. You '
                 'can download the contents of this repository before removing '
-                'this contributor <a href="{url}">here</a>.'
+                'this contributor <u><a href="{url}">here</a></u>.'
             ).format(
                 category=node.project_or_component,
                 user=removed.fullname,
@@ -480,7 +480,7 @@ class AddonGitHubNodeSettings(StorageAddonBase, AddonNodeSettingsBase):
             if not auth or auth.user != removed:
                 url = node.web_url_for('node_setting')
                 message += (
-                    u' You can re-authenticate on the <a href="{url}">Settings</a> page.'
+                    u' You can re-authenticate on the <u><a href="{url}">Settings</a></u> page.'
                 ).format(url=url)
             #
             return message
@@ -549,7 +549,7 @@ class AddonGitHubNodeSettings(StorageAddonBase, AddonNodeSettingsBase):
         else:
             message = (
                 'GitHub authorization not copied to forked {cat}. You may '
-                'authorize this fork on the <a href={url}>Settings</a> '
+                'authorize this fork on the <u><a href={url}>Settings</a></u> '
                 'page.'
             ).format(
                 cat=fork.project_or_component,

--- a/website/addons/googledrive/model.py
+++ b/website/addons/googledrive/model.py
@@ -400,7 +400,7 @@ class GoogleDriveNodeSettings(StorageAddonBase, AddonNodeSettingsBase):
             message = 'Google Drive authorization copied to fork.'
         else:
             message = ('Google Drive authorization not copied to forked {cat}. You may '
-                       'authorize this fork on the <a href="{url}">Settings</a> '
+                       'authorize this fork on the <u><a href="{url}">Settings</a></u> '
                        'page.').format(
                 url=fork.web_url_for('node_setting'),
                 cat=fork.project_or_component
@@ -427,7 +427,7 @@ class GoogleDriveNodeSettings(StorageAddonBase, AddonNodeSettingsBase):
             if not auth or auth.user != removed:
                 url = node.web_url_for('node_setting')
                 message += (
-                    u' You can re-authenticate on the <a href="{url}">Settings</a> page.'
+                    u' You can re-authenticate on the <u><a href="{url}">Settings</a></u> page.'
                 ).format(url=url)
             #
             return message

--- a/website/addons/s3/model.py
+++ b/website/addons/s3/model.py
@@ -238,7 +238,7 @@ class AddonS3NodeSettings(StorageAddonBase, AddonNodeSettingsBase):
         else:
             message = (
                 'Amazon Simple Storage authorization not copied to forked {cat}. You may '
-                'authorize this fork on the <a href={url}>Settings</a> '
+                'authorize this fork on the <u><a href={url}>Settings</a></u> '
                 'page.'
             ).format(
                 cat=fork.project_or_component,
@@ -290,7 +290,7 @@ class AddonS3NodeSettings(StorageAddonBase, AddonNodeSettingsBase):
             if not auth or auth.user != removed:
                 url = node.web_url_for('node_setting')
                 message += (
-                    u' You can re-authenticate on the <a href="{url}">Settings</a> page.'
+                    u' You can re-authenticate on the <u><a href="{url}">Settings</a></u> page.'
                 ).format(url=url)
             #
             return message

--- a/website/addons/twofactor/models.py
+++ b/website/addons/twofactor/models.py
@@ -50,8 +50,8 @@ class TwoFactorUserSettings(AddonUserSettingsBase):
     #############
 
     def on_add(self):
-        push_status_message('Please <a href="#TfaVerify">activate your'
-                            ' device</a> before continuing.', 'info')
+        push_status_message('Please <u><a href="#TfaVerify">activate your'
+                            ' device</a></u> before continuing.', 'info')
         super(TwoFactorUserSettings, self).on_add()
         self.totp_secret = _generate_seed()
         self.totp_drift = 0


### PR DESCRIPTION
<h1> Purpose </h1>
Add underlines to addon error messages. Close #3887.
<h1> Changes </h1>
Adds ```<u>```tag to addon message links.
<h1> Side Effects </h1>
None that I know of.
