### PR TITLE
[Feature] Set limit to max for citation_list requests

### DIFF
--- a/website/addons/mendeley/api.py
+++ b/website/addons/mendeley/api.py
@@ -4,5 +4,5 @@ from mendeley.session import MendeleySession
 class APISession(MendeleySession):
 
     def request(self, *args, **kwargs):
-        kwargs['params'] = {'view': 'all'}
+        kwargs['params'] = {'view': 'all', 'limit': '500'}
         return super(APISession, self).request(*args, **kwargs)

--- a/website/addons/mendeley/tests/test_api.py
+++ b/website/addons/mendeley/tests/test_api.py
@@ -35,4 +35,4 @@ class MendeleyApiTestCase(OsfTestCase):
         client = APISession(self.mock_partial, self.mock_credentials)
         client.request()
         args, kwargs = mock_request.call_args
-        assert_equal(kwargs['params'], {'view': 'all'})
+        assert_equal(kwargs['params'], {'view': 'all', 'limit': '500'})

--- a/website/addons/zotero/model.py
+++ b/website/addons/zotero/model.py
@@ -51,7 +51,10 @@ class Zotero(ExternalProvider):
         """List of CitationList objects, derived from Zotero collections"""
         client = self.client
 
-        collections = client.collections()
+        # Note: Pagination is the only way to ensure all of the collections
+        #       are retrieved. 100 is the limit per request. This applies
+        #       to Mendeley too, though that limit is 500.
+        collections = client.collections(limit=100)
 
         all_documents = serialize_folder(
             'All Documents',


### PR DESCRIPTION
Purpose
======
Closes https://github.com/CenterForOpenScience/osf.io/issues/3157

Changes
=======
* Add `limit: 500` argument to outgoing Mendeley requests
* Set `limit=100` to Zotero's `client.collections()` call in `citations_list`

Side Effects
=========
Also sets the max for Zotero, not just Mendeley.

Note
====
Pagination would be a more perfect solution, but this has been a user issue for a while.