### PR TITLE
[Staging] [Feature Fix] Fix the box background style missing in front page

### DIFF
--- a/website/templates/index.mako
+++ b/website/templates/index.mako
@@ -50,26 +50,26 @@
                         <div class="form-group" data-bind="css: {'has-error': fullName() && !fullName.isValid(), 'has-success': fullName() && fullName.isValid()}">
                               <label class="placeholder-replace" style="display:none">Full Name</label>
                               <input class="form-control" placeholder="Full Name" data-bind=" value: fullName, disable: submitted(), event: { blur: trim.bind($data, fullName)}">
-                              <p class="help-block signup-help" data-bind="validationMessage: fullName" style="display: none;"></p>
+                              <p class="help-block osf-box-lt" data-bind="validationMessage: fullName" style="display: none;"></p>
                           </div>
                           <div class="form-group" data-bind="css: {'has-error': email1() && !email1.isValid(), 'has-success': email1() && email1.isValid()}">
                               <label class="placeholder-replace" style="display:none">Contact Email</label>
                               <input class="form-control" placeholder="Contact Email" data-bind=" value: email1, disable: submitted(), event: { blur: trim.bind($data, email1)}">
-                              <p class="help-block signup-help" data-bind="validationMessage: email1" style="display: none;"></p>
+                              <p class="help-block osf-box-lt" data-bind="validationMessage: email1" style="display: none;"></p>
                           </div>
                           <div class="form-group" data-bind="css: {'has-error': email2() && !email2.isValid(),'has-success': email2() && email2.isValid()}">
                               <label class="placeholder-replace" style="display:none">Confirm Email</label>
                               <input class="form-control" placeholder="Confirm Email" data-bind="value: email2, disable: submitted(), event: { blur: trim.bind($data, email2)}">
-                              <p class="help-block signup-help" data-bind="validationMessage: email2" style="display: none;"></p>
+                              <p class="help-block osf-box-lt" data-bind="validationMessage: email2" style="display: none;"></p>
                           </div>
                           <div class="form-group" data-bind="css: {'has-error': password() && !password.isValid(), 'has-success': password() && password.isValid()}">
                               <label class="placeholder-replace" style="display:none">Password</label>
                               <input type="password" class="form-control" placeholder="Password (Must be 6 to 256 characters)" data-bind=" value: password, disable: submitted(), event: {blur: trim.bind($data, password)}">
-                                <p class="help-block signup-help" data-bind="validationMessage: password" style="display: none;"></p>
+                                <p class="help-block osf-box-lt" data-bind="validationMessage: password" style="display: none;"></p>
                           </div>
 
                           <!-- Flashed Messages -->
-                          <div class="help-block signup-help" >
+                          <div class="help-block osf-box-lt" >
                               <p data-bind="html: flashMessage, attr.class: flashMessageClass" class=""></p>
                           </div>
                           <div>


### PR DESCRIPTION
### Purpose
The box background style on front page is missing on staging.  The cause is because `signup-help` was deleted in previous PR https://github.com/CenterForOpenScience/osf.io/pull/3890. 

Reported by @alexschiller  Good catch!

### Change
There are five usages case for `signup-help` See one example below.
Before Change:
![screenshot 2015-07-31 16 40 05](https://cloud.githubusercontent.com/assets/5420789/9016994/246102de-37a3-11e5-8e4d-bb5512da8e13.png)

After Change:
![screenshot 2015-07-31 16 41 46](https://cloud.githubusercontent.com/assets/5420789/9016992/1ee9ed20-37a3-11e5-8148-adbf79556263.png)

### Side Effect
In production, it has radius (rounded boarder). However, our style guideline only offers non-radius box. This PR follow the guideline, but it will be inconsistent with other input fields on front page.
![screenshot 2015-07-31 16 40 51](https://cloud.githubusercontent.com/assets/5420789/9017087/7904e60c-37a3-11e5-8d94-d86bc057e3e6.png)
