### PR TITLE
[Hotfix] Fix hidden search bar in mobile 

### DIFF
--- a/website/static/css/search-bar.css
+++ b/website/static/css/search-bar.css
@@ -18,7 +18,7 @@
     box-shadow: 0 0 9px -2px #464545;
     left: 0;
     top: 50px;
-    z-index: 1028;
+    z-index: 1030; /* Should not less than 1030 */
 }
 
 .osf-search-input {

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -156,9 +156,6 @@ a {
         color: #FFF;
     }
 
-    .osf-search {
-        z-index: 1028;
-    }
     #searchControls > .osf-search {
         z-index: 99;
     }
@@ -194,9 +191,6 @@ a {
     .navbar-brand {
         margin-left: 0 !important;
         padding-left: 0;
-    }
-    .osf-search {
-        z-index: 1028; /* should be less than 1030 to not cover navbar */
     }
 }
 


### PR DESCRIPTION
### Purpose
In this PR, it is to fix the hidden of search bar when expanding the menu at the same time.
Resovled #3881 

### Change
1) Since the menu's z-index is 1030, so I change search-bar's z-index from 1028 to 1030. Therefore, it will not be covered. 
2) Delete unnecessary z-index code in style.css for navbar


After clicking menu icon -- before Change:
![screenshot 2015-08-02 16 04 44](https://cloud.githubusercontent.com/assets/5420789/9027769/4459df5a-3930-11e5-98a2-235f1b3ccab2.png)

After clicking menu icon -- After Change:
![screenshot 2015-08-02 16 05 01](https://cloud.githubusercontent.com/assets/5420789/9027771/4b4d8ac8-3930-11e5-859c-3a543c08f01a.png)

### Side Effect
None.

