### PR TITLE
Remove Tag Styling from Activity Log

### DIFF
--- a/website/templates/log_templates.mako
+++ b/website/templates/log_templates.mako
@@ -114,11 +114,11 @@ made
 
 <script type="text/html" id="tag_added">
 tagged
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a> as <a class='tag' data-bind="attr: {href: '/search/?q=%22' + params.tag + '%22'}, text: params.tag"></a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a> as <a data-bind="attr: {href: '/search/?q=%22' + params.tag + '%22'}, text: params.tag"></a>
 </script>
 
 <script type="text/html" id="tag_removed">
-removed tag <a class='tag' data-bind="attr: {href: '/search/?q=%22' + params.tag + '%22'}, text: params.tag"></a>
+removed tag <a data-bind="attr: {href: '/search/?q=%22' + params.tag + '%22'}, text: params.tag"></a>
 from
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>


### PR DESCRIPTION
<h1> Purpose </h1>
To complete complete the changes discussed in #3843, namely removing any special styling tags in the Log had. This should have been part of #3843, but I missed some of the tags in the log_templates.mako. Sorry!
<h1> Changes </h1>
Removes class='tag' tags from the log templates, so they appear as normal links.
<h1> Side Effects </h1>
None that I know of.