### PR TITLE
Fix Datetimes on Search Page

### DIFF
--- a/website/static/js/search.js
+++ b/website/static/js/search.js
@@ -245,7 +245,7 @@ var ViewModel = function(params) {
                     self.results.push(result);
                 }
                 if(result.category === 'registration'){
-                    result.dateRegistered = new $osf.FormattableDate(result.registered_date);
+                    result.dateRegistered = new $osf.FormattableDate(result.date_created);
                 }
             });
 


### PR DESCRIPTION
<h1> Purpose </h1>
Make registration dates display the time they were created and not the current time. Address this trello card:
https://trello.com/c/PgBEhyUK/45-date-registered-displays-current-date-and-time

<h1>  Changes </h1>
Uses date_created attribute for the the time the registration was created opposed to the somewhat counter-intuitively date_registered which refers to the date the registration of project was created.
<h1> Side Effects </h1>
None that I know of.