### PR TITLE
Fix broken registration pages

### DIFF
--- a/website/templates/metadata/register_1.mako
+++ b/website/templates/metadata/register_1.mako
@@ -62,7 +62,7 @@
     window.contextVars.node.urls = window.contextVars.node.urls || {};
     window.contextVars.node.urls.api = ${ node['api_url'] | sjson, n };
     window.contextVars.node.id = ${ str(node['id']) | sjson, n };
-    window.contextVars.node.children = ${[str(each) for each in children_ids]};
+    window.contextVars.node.children = ${ [str(each) for each in children_ids] | sjson, n };
     window.contextVars.regTemplate = ${ template_name or '' | sjson, n };
     window.contextVars.regSchema = ${ schema | n };
     window.contextVars.regPayload = ${ payload | sjson, n };


### PR DESCRIPTION
## Purpose

Fix error reported by @NatashaRichter on Trello: registration templates were failing to render because one variable was not being markup-escaped.

## Side effects
Should be none.

Registration pages behave a bit oddly, so please keep me apprised of any other breakages. (it's worth checking a few different schemas as well due to [inconsistent](https://github.com/abought/osf.io/blob/fix/3910-registration-js_err/website/project/views/register.py#L356-356) separation of concerns)