### PR TITLE
Removes Broken Two-factor Auth Link

### DIFF
--- a/website/addons/twofactor/models.py
+++ b/website/addons/twofactor/models.py
@@ -50,8 +50,7 @@ class TwoFactorUserSettings(AddonUserSettingsBase):
     #############
 
     def on_add(self):
-        push_status_message('Please <u><a href="#TfaVerify">activate your'
-                            ' device</a></u> before continuing.', 'info')
+        push_status_message('Please activate your device before continuing.', 'info')
         super(TwoFactorUserSettings, self).on_add()
         self.totp_secret = _generate_seed()
         self.totp_drift = 0


### PR DESCRIPTION
<h1> Purpose </h1>
Remove unnecessary link for Two-factor Auth message. Close #3901.
<h1> Changes </h1>
Deletes link tag
<h1> Side Effect </h1>
None that I know of.