### PR TITLE
Fix addon settings modal on project pages

### DIFF
--- a/website/templates/profile/addons.mako
+++ b/website/templates/profile/addons.mako
@@ -41,10 +41,6 @@
 </div><!-- end row -->
 
 
-% for name, capabilities in addon_capabilities.iteritems():
-    <script id="capabilities-${name}" type="text/html">${capabilities}</script>
-% endfor
-
 </%def>
 
 <%def name="render_user_settings(config)">

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -314,9 +314,6 @@
         </div><!-- end addon-widget-body -->
     </div><!-- end components -->
 %endif
-% for name, capabilities in addon_capabilities.iteritems():
-    <script id="capabilities-${name}" type="text/html">${capabilities}</script>
-% endfor
 
 </%def>
 

--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -335,7 +335,7 @@
 </%def>
 
 % for name, capabilities in addon_capabilities.iteritems():
-    <script id="capabilities-${name}" type="text/html">${capabilities}</script>
+    <script id="capabilities-${name}" type="text/html">${ capabilities | n }</script>
 % endfor
 
 


### PR DESCRIPTION
## Origins
Reported on Trello by WillBanner in associated with #3910.

## Purpose
When enabling an addon on project pages, the "Addon terms" modal incorrectly displays as raw code (rather than being rendered). This PR exempts that string from markupsafe rendering.

Additionally, the modal text is completely removed from several pages where it does not appear to be used at all.

## Summary of changes
- Fixed website/templates/project/settings.mako
- Removed text from  website/templates/project/project.mako 
- Removed text from  website/templates/profile/addons.mako 


## Side effects
Hopefully none: this modal text was removed from profile settings.

We are not sure why the text was *ever* in project pages; click a variety of addon related things and report any bugs.

Modal (on project settings) should look like this one:
<img width="497" alt="screen shot 2015-08-03 at 3 21 37 pm" src="https://cloud.githubusercontent.com/assets/2957073/9046736/d3948588-39fa-11e5-9dd9-19052b8e107a.png">
