### PR TITLE
Feature/reverse registration

### DIFF
--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -916,10 +916,14 @@ def _get_summary(node, auth, rescale_ratio, primary=True, link_id=None, show_pat
             'title': node.title,
             'category': node.category,
             'node_type': node.project_or_component,
+            'is_fork': node.is_fork,
             'is_registration': node.is_registration,
             'anonymous': has_anonymous_link(node, auth),
             'registered_date': node.registered_date.strftime('%Y-%m-%d %H:%M UTC')
             if node.is_registration
+            else None,
+            'forked_date': node.forked_date.strftime('%Y-%m-%d %H:%M UTC')
+            if node.is_fork
             else None,
             'nlogs': None,
             'ua_count': None,
@@ -999,7 +1003,8 @@ def get_folder_pointers(auth, node, **kwargs):
 
 @must_be_contributor_or_public
 def get_forks(auth, node, **kwargs):
-    return _render_nodes(nodes=node.forks, auth=auth)
+    fork_list = sorted(node.forks, key=lambda fork: fork.forked_date, reverse=True)
+    return _render_nodes(nodes=fork_list, auth=auth)
 
 
 @must_be_contributor_or_public

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -1004,7 +1004,7 @@ def get_forks(auth, node, **kwargs):
 
 @must_be_contributor_or_public
 def get_registrations(auth, node, **kwargs):
-    registrations = [n for n in node.node__registrations if not n.is_deleted]  # get all registrations, including archiving
+    registrations = [n for n in reversed(node.node__registrations) if not n.is_deleted]  # get all registrations, including archiving
     return _render_nodes(registrations, auth)
 
 

--- a/website/templates/util/render_node.mako
+++ b/website/templates/util/render_node.mako
@@ -39,9 +39,10 @@
                 <span class="f-w-lg">${summary['title']}</span>
             % endif
 
-
             % if summary['is_registration']:
                 | Registered: ${summary['registered_date']}
+            % elif summary['is_fork']:
+                | Forked: ${summary['forked_date']}
             % endif
             </span>
 


### PR DESCRIPTION
<b>Purpose</b>
Reverse the display order of registrations and also add the forked time display on forks in fork pages and make forks to be reverse time order to be consistent with the display order on registration page. Closes https://github.com/CenterForOpenScience/osf.io/issues/3925.

<b>Changes</b>
Before changes:
Registration page:
![screen shot 2015-08-04 at 3 28 33 pm](https://cloud.githubusercontent.com/assets/4974056/9070407/8197eedc-3abd-11e5-9027-9ad740182de9.png)
Fork Pages:
![screen shot 2015-08-04 at 3 29 12 pm](https://cloud.githubusercontent.com/assets/4974056/9070426/97dbf56c-3abd-11e5-8949-5a2159b17ee7.png)

After changes:
Registration page:
![screen shot 2015-08-04 at 3 30 02 pm](https://cloud.githubusercontent.com/assets/4974056/9070455/b5e32922-3abd-11e5-99be-c60fca2a547e.png)
Fork page:
![screen shot 2015-08-04 at 3 31 04 pm](https://cloud.githubusercontent.com/assets/4974056/9070488/e20491ee-3abd-11e5-9a63-ceffe7f0e0a1.png)

