### PR TITLE
[Feature Fix] Refine modal button text and word break

### DIFF
--- a/website/addons/s3/static/s3NodeConfig.js
+++ b/website/addons/s3/static/s3NodeConfig.js
@@ -354,7 +354,7 @@ ViewModel.prototype.openCreateBucket = function() {
                                 }
                             },
                             buttons: {
-                                cancel: {
+                                success: {
                                     label: 'Try again'
                                 }
                             }

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -437,6 +437,10 @@ select {
     position: relative;
 }
 
+span.tag.tag-big.tag-container {
+    word-break: break-all;
+}
+
 .remove-tag
 {
     visibility: hidden;

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -507,7 +507,7 @@ select {
 }
 
 tr a, b, em, td {
-    word-break: break-word;
+    word-wrap: break-word;
 }
 
 .btn-link.project-toggle {

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -437,10 +437,6 @@ select {
     position: relative;
 }
 
-span.tag.tag-big.tag-container {
-    word-break: break-all;
-}
-
 .remove-tag
 {
     visibility: hidden;
@@ -511,7 +507,7 @@ span.tag.tag-big.tag-container {
 }
 
 tr a, b, em, td {
-    word-wrap: break-word;
+    word-break: break-word;
 }
 
 .btn-link.project-toggle {

--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -753,9 +753,8 @@ var confirmDangerousAction = function (options) {
         },
         message: ''
     };
-    options.buttons.success.callback = handleConfirmAttempt;
 
-    var bootboxOptions = $.extend({}, defaults, options);
+    var bootboxOptions = $.extend(true, {}, defaults, options);
 
     bootboxOptions.message += [
         '<p>Type the following to continue: <strong>',

--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -746,13 +746,14 @@ var confirmDangerousAction = function (options) {
                 className: 'btn-default'
             },
             success: {
-                label: options.confirmBtnLabel,
+                label: 'Confirm',
                 className: 'btn-danger',
                 callback: handleConfirmAttempt
             }
         },
         message: ''
     };
+    options.buttons.success.callback = handleConfirmAttempt
 
     var bootboxOptions = $.extend({}, defaults, options);
 

--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -746,7 +746,7 @@ var confirmDangerousAction = function (options) {
                 className: 'btn-default'
             },
             success: {
-                label: 'Confirm',
+                label: options.confirmBtnLabel,
                 className: 'btn-danger',
                 callback: handleConfirmAttempt
             }

--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -753,7 +753,7 @@ var confirmDangerousAction = function (options) {
         },
         message: ''
     };
-    options.buttons.success.callback = handleConfirmAttempt
+    options.buttons.success.callback = handleConfirmAttempt;
 
     var bootboxOptions = $.extend({}, defaults, options);
 

--- a/website/static/js/projectSettings.js
+++ b/website/static/js/projectSettings.js
@@ -138,7 +138,16 @@ ProjectSettings.getConfirmationCode = function(nodeType) {
             });
             request.fail($osf.handleJSONError);
         },
-        confirmBtnLabel: 'Delete'
+        buttons: {
+            cancel: {
+                label: 'Cancel',
+                className: 'btn-default'
+            },
+            success: {
+                label: 'Delete',
+                className: 'btn-danger'
+            }
+        }
     });
 };
 

--- a/website/static/js/projectSettings.js
+++ b/website/static/js/projectSettings.js
@@ -137,7 +137,8 @@ ProjectSettings.getConfirmationCode = function(nodeType) {
                 window.location.href = response.url;
             });
             request.fail($osf.handleJSONError);
-        }
+        },
+        confirmBtnLabel: 'Delete'
     });
 };
 

--- a/website/static/js/projectSettings.js
+++ b/website/static/js/projectSettings.js
@@ -139,13 +139,8 @@ ProjectSettings.getConfirmationCode = function(nodeType) {
             request.fail($osf.handleJSONError);
         },
         buttons: {
-            cancel: {
-                label: 'Cancel',
-                className: 'btn-default'
-            },
             success: {
-                label: 'Delete',
-                className: 'btn-danger'
+                label: 'Delete'
             }
         }
     });


### PR DESCRIPTION
### Purpose
Resolve Trello Card:
1. Delete Project modal button should say "delete"
https://trello.com/c/hKV9YuJM/58-delete-project-modal-button-should-say-delete
2. Invalid Bucket Name button options are wrong
https://trello.com/c/vIlsQfHO/54-invalid-bucket-name-button-options-are-wrong

### Changes
1. Deep copy to override the button label
2. Correct the button color

### Side Effects
None.