### PR TITLE
remove the unnecessary css

### DIFF
--- a/website/addons/dropbox/static/dropbox.css
+++ b/website/addons/dropbox/static/dropbox.css
@@ -1,6 +1,3 @@
-.dropbox-confirm-selection {
-    padding-top: 10px;
-}
 .dropbox-folder-picker {
     margin-top: 10px;
 }


### PR DESCRIPTION
<b>Purpose</b>
Remove the unnecessary css for the dropbox alert to keep consistent with other addons. Closes https://github.com/CenterForOpenScience/osf.io/issues/3924

<b>Changes</b>
Before change:
![image](https://cloud.githubusercontent.com/assets/4974056/9087066/648d488e-3b56-11e5-9c2e-93f46a7d8341.png)
After change:
![screen shot 2015-08-05 at 9 43 27 am](https://cloud.githubusercontent.com/assets/4974056/9087079/74192c46-3b56-11e5-9643-9fd0e78c6a56.png)
