### PR TITLE
swap the order of commenting panel and notification panel

### DIFF
--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -36,12 +36,14 @@
                                 <li><a href="#configureAddonsAnchor">Configure Add-ons</a></li>
                             % endif
 
+                            % if 'admin' in user['permissions']:
+                                <li><a href="#configureCommentingAnchor">Configure Commenting</a></li>
+                            % endif
+
                             <li><a href="#configureNotificationsAnchor">Configure Notifications</a></li>
                         % endif
 
-                        % if 'admin' in user['permissions']:
-                            <li><a href="#configureCommentingAnchor">Configure Commenting</a></li>
-                        % endif
+
 
 
                     % endif
@@ -196,37 +198,6 @@
             % endif
         % endif  ## End Select Addons
 
-        % if user['has_read_permissions']:  ## Begin Configure Notifications
-
-            % if not node['is_registration']:
-
-                <div class="panel panel-default">
-                    <span id="configureNotificationsAnchor" class="anchor"></span>
-                    <div class="panel-heading clearfix">
-                        <h3 class="panel-title">Configure Notifications</h3>
-                    </div>
-                    <div class="help-block" style="padding-left: 15px">
-                        <p class="text-info">These notification settings only apply to you. They do NOT affect any other contributor on this project.</p>
-                    </div>
-                    <form id="notificationSettings" class="osf-treebeard-minimal">
-                        <div id="grid">
-                            <div class="notifications-loading">
-                                <i class="fa fa-spinner notifications-spin"></i>
-                                <p class="m-t-sm fg-load-message"> Loading notification settings...  </p>
-                            </div>
-                        </div>
-                        <div class="help-block" style="padding-left: 15px">
-                            <p id="configureNotificationsMessage"></p>
-                        </div>
-                    </form>
-                </div>
-
-            %endif
-
-        % endif End Configure Notifications
-
-
-
         % if 'admin' in user['permissions']:  ## Begin Configure Commenting
 
             % if not node['is_registration']:
@@ -270,7 +241,34 @@
 
         % endif  ## End Configure Commenting
 
+        % if user['has_read_permissions']:  ## Begin Configure Notifications
 
+            % if not node['is_registration']:
+
+                <div class="panel panel-default">
+                    <span id="configureNotificationsAnchor" class="anchor"></span>
+                    <div class="panel-heading clearfix">
+                        <h3 class="panel-title">Configure Notifications</h3>
+                    </div>
+                    <div class="help-block" style="padding-left: 15px">
+                        <p class="text-info">These notification settings only apply to you. They do NOT affect any other contributor on this project.</p>
+                    </div>
+                    <form id="notificationSettings" class="osf-treebeard-minimal">
+                        <div id="grid">
+                            <div class="notifications-loading">
+                                <i class="fa fa-spinner notifications-spin"></i>
+                                <p class="m-t-sm fg-load-message"> Loading notification settings...  </p>
+                            </div>
+                        </div>
+                        <div class="help-block" style="padding-left: 15px">
+                            <p id="configureNotificationsMessage"></p>
+                        </div>
+                    </form>
+                </div>
+
+            %endif
+
+        % endif End Configure Notifications
 
         % if 'admin' in user['permissions']:  ## Begin Retract Registration
 


### PR DESCRIPTION
<b>Purpose</b>
Swap the order of configure commenting and configure notification. Closes https://github.com/CenterForOpenScience/osf.io/issues/3944.

<b>Changes</b>
Before changes:
![image](https://cloud.githubusercontent.com/assets/4974056/9088915/88575c3c-3b60-11e5-8e97-cbf39d8385ac.png)
After changes:
![screen shot 2015-08-05 at 10 54 04 am](https://cloud.githubusercontent.com/assets/4974056/9088922/913f9512-3b60-11e5-90d5-6aa640053513.png)
