### PR TITLE
Fix Visible Contributor Swap Bug and ContribManager.js TODOS

### DIFF
--- a/website/project/model.py
+++ b/website/project/model.py
@@ -966,7 +966,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
             self.visible_contributor_ids.append(user._id)
             self.update_visible_ids(save=False)
         elif not visible and user._id in self.visible_contributor_ids:
-            if len(self.visible_contributor_ids) == 1:
+            if len(self.visible_contributor_ids) == 0:
                 raise ValueError(
                     'Must have at least one visible contributor'
                 )

--- a/website/static/js/contribManager.js
+++ b/website/static/js/contribManager.js
@@ -306,8 +306,8 @@ var ContributorsViewModel = function(contributors, adminContributors, user, isRe
                 );
                 return false;
             }
-        }
-    )};
+        });
+    };
 
     self.init();
     self.initListeners();

--- a/website/static/js/contribManager.js
+++ b/website/static/js/contribManager.js
@@ -66,7 +66,7 @@ var ContributorModel = function(contributor, pageOwner, isRegistration, isAdmin)
     };
 
     self.canEdit = ko.computed(function() {
-      return self.currentUserCanEdit && !self.isAdmin;
+      return  $.inArray('admin', pageOwner.permissions) !== -1;
     });
 
     self.remove = function() {
@@ -278,10 +278,10 @@ var ContributorsViewModel = function(contributors, adminContributors, user, isRe
     self.init = function() {
         self.messages([]);
         self.contributors(self.original().map(function(item) {
-            return new ContributorModel(item, self.canEdit(), self.user(), isRegistration);
+            return new ContributorModel(item, self.user(), isRegistration);
         }));
         self.adminContributors = adminContributors.map(function(contributor) {
-          return new ContributorModel(contributor, self.canEdit(), self.user(), isRegistration, true);
+          return new ContributorModel(contributor, self.user(), isRegistration, true);
         });
     };
 

--- a/website/static/js/contribManager.js
+++ b/website/static/js/contribManager.js
@@ -35,9 +35,7 @@ var sortMap = {
     }
 };
 
-// TODO: We shouldn't need both pageOwner (the current user) and currentUserCanEdit. Separate
-// out the permissions-related functions and remove currentUserCanEdit.
-var ContributorModel = function(contributor, currentUserCanEdit, pageOwner, isRegistration, isAdmin) {
+var ContributorModel = function(contributor, pageOwner, isRegistration, isAdmin) {
 
     var self = this;
     $.extend(self, contributor);
@@ -56,7 +54,6 @@ var ContributorModel = function(contributor, currentUserCanEdit, pageOwner, isRe
         return self.permissionList[0];
     };
 
-    self.currentUserCanEdit = currentUserCanEdit;
     self.isAdmin = isAdmin;
     self.visible = ko.observable(contributor.visible);
     self.permission = ko.observable(contributor.permission);

--- a/website/static/js/contribManager.js
+++ b/website/static/js/contribManager.js
@@ -192,10 +192,9 @@ var ContributorsViewModel = function(contributors, adminContributors, user, isRe
     self.adminContributors = adminContributors;
 
     self.user = ko.observable(user);
-    // TODO: Does this need to be an observable?
-    self.userIsAdmin  = ko.observable($.inArray('admin', user.permissions) !== -1);
+    self.userIsAdmin  = $.inArray('admin', user.permissions) !== -1);
     self.canEdit = ko.computed(function() {
-        return (self.userIsAdmin()) && !isRegistration;
+        return (self.userIsAdmin) && !isRegistration;
     });
 
     self.messages = ko.observableArray([]);
@@ -303,10 +302,10 @@ var ContributorsViewModel = function(contributors, adminContributors, user, isRe
         // Warn on URL change if pending changes
         $(window).on('beforeunload', function() {
             if (self.changed() && !self.forceSubmit()) {
-                // TODO: Use GrowlBox.
-                return 'There are unsaved changes to your contributor ' +
-                    'settings. Are you sure you want to leave this page?';
-            }
+                $osf.growl('Error','There are unsaved changes to your contributor ' +
+                    'settings. Are you sure you want to leave this page?'
+            );
+            return false;
         });
     };
 

--- a/website/static/js/contribManager.js
+++ b/website/static/js/contribManager.js
@@ -192,7 +192,7 @@ var ContributorsViewModel = function(contributors, adminContributors, user, isRe
     self.adminContributors = adminContributors;
 
     self.user = ko.observable(user);
-    self.userIsAdmin  = $.inArray('admin', user.permissions) !== -1);
+    self.userIsAdmin  = $.inArray('admin', user.permissions) !== -1;
     self.canEdit = ko.computed(function() {
         return (self.userIsAdmin) && !isRegistration;
     });
@@ -304,10 +304,11 @@ var ContributorsViewModel = function(contributors, adminContributors, user, isRe
             if (self.changed() && !self.forceSubmit()) {
                 $osf.growl('Error','There are unsaved changes to your contributor ' +
                     'settings. Are you sure you want to leave this page?'
-            );
-            return false;
-        });
-    };
+                );
+                return false;
+            }
+        }
+    )};
 
     self.init();
     self.initListeners();

--- a/website/static/js/contribManager.js
+++ b/website/static/js/contribManager.js
@@ -270,6 +270,8 @@ var ContributorsViewModel = function(contributors, adminContributors, user, isRe
                     'error'
                 )
             );
+        } else {
+            self.messages([]);
         }
     });
 


### PR DESCRIPTION
<h1> Purpose </h1>
This PR addresses a few problems in ContribManager

A. It fixes issue #3765 which creates an unwarranted error when the first and only contributor swaps only visible contributor status with another contributor, I included some screenshots to illustrate this better.

![screen shot 2015-08-05 at 11 35 58 am](https://cloud.githubusercontent.com/assets/9688518/9090053/51bc3afc-3b66-11e5-9661-b7a5220c0374.png)

B. This makes self.userIsAdmin no longer an observable in accordance with TODO

C. Removes unnecessary self.currentUserCanEdit in accordance with TODO.

D. Unsaved changes error now uses growlbox in accordance with TODO.

E. Stops 'Must have at least one bibliographic contributor' messages from piling up. Pictured below:
![screen shot 2015-08-05 at 11 43 39 am](https://cloud.githubusercontent.com/assets/9688518/9090290/63df8102-3b67-11e5-9797-81982b086083.png)

<h1> Changes </h1>
A. Fixes check in model.py set_visible 

B. Simple fix, it just doesn't need to be observable.

C. Simple fix, this check done with ```$.inArray('admin', pageOwner.permissions) !== -1;``` instead of passing it as a parameter.

D. Now uses $osf.growl

E. Simple fix, clears message observable 

<h1> Side Effects </h1>
None that I know of.