### PR TITLE
[Feature Fix] Refine break word in whole site

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
     "locales": "https://github.com/citation-style-language/locales.git#d2b612f8a6f764cbd66e67238636fac3888a7736",
     "raven-js": "1.1.17",
     "zeroclipboard": "2.1.6",
-    "osf-style": "https://github.com/CenterForOpenScience/osf-style.git#7864d222e69b274a42de17d88dc326e405347a87"
+    "osf-style": "https://github.com/CenterForOpenScience/osf-style.git#0a6f466cdf3f585e18a32615ec5268de9880f851"
 
   }
 }

--- a/framework/addons/templates/capabilities.mako
+++ b/framework/addons/templates/capabilities.mako
@@ -1,6 +1,6 @@
 <h3>${full_name} Add-on Terms</h3>
 
-<table class="table table-bordered">
+<table class="table table-bordered table-addon-terms">
 
     <thead>
         <tr>

--- a/website/static/css/pages/project-page.css
+++ b/website/static/css/pages/project-page.css
@@ -114,3 +114,8 @@
     word-break: break-all;
     word-break: break-word; /* Non standard for webkit*/
 }
+
+/* Disable word-break in project addon-settings table */
+.table-addon-terms td:first-child {
+    word-break: normal;
+}

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -506,10 +506,6 @@ select {
     cursor: pointer;
 }
 
-tr a, b, em, td {
-    word-break: break-word;
-}
-
 .btn-link.project-toggle {
     padding-top: 0;
     padding-bottom:0;


### PR DESCRIPTION
### Purpose
Resolved Trello Cards:
1. Text overflow in add-on terms modals
https://trello.com/c/NH16HOUi/67-text-overflow-in-add-on-terms-modals
3. Tags overflow in Search if they are too long
https://trello.com/c/kQnwKTWa/63-tags-overflow-in-search-if-they-are-too-long

### Change:
1) Delete word-break code in style.css and update style guide version ( Add word break there https://github.com/CenterForOpenScience/osf-style/pull/76)

Apply refined word break to `p, a, span, em, td ` and class `break-word`

     word-break: break-word; /* Only WebKit/Blink browsers Support */
     word-wrap: break-word; }

2) Disable `word-break:break-word` in the first column of add-on terms table 

### Side Effect
Because the new word break will apply the whole site. So maybe there are also other special cases we need to deal with.