### PR TITLE
Fix Long Tags Jumping Past Cursor

### DIFF
--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -469,6 +469,10 @@ select {
     overflow-y: auto;
 }
 
+.tagsinput div {
+    float: left;
+}
+
 .tagsinput span.tag {
     float: left;
     padding: 5px;


### PR DESCRIPTION
<h1> Purpose </h1>
Fix problem created when long tags cause cursor to get stuck between tags. Relevant Trello card: https://trello.com/c/tSoW9G6c/65-tag-input-box-jumps-around-when-alternately-adding-short-and-long-tags

<h1> Changes </h1>
Change to .tagsinput div ensures cursor will always trail last tag.

<h1> Side Effects </h1>
None that I know of.