### PR TITLE
Stop retracted registrations from showing up in public activity

### DIFF
--- a/website/project/utils.py
+++ b/website/project/utils.py
@@ -78,7 +78,8 @@ def recent_public_registrations(n=10):
     )
     registrations = Node.find(
         recent_query &
-        Q('is_registration', 'eq', True)
+        Q('is_registration', 'eq', True) &
+        Q('is_retracted', 'eq', False)
     ).sort(
         '-registered_date'
     )


### PR DESCRIPTION
<h1> Purpose </h1>
Stop retracted registrations from showing up in public activity feed. Close #3928.
<h1> Changes </h1>
Adds new search condition.