### PR TITLE
[feature fix] Update fangorn error upload message

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -763,7 +763,11 @@ function _fangornDropzoneError(treebeard, file, message, xhr) {
         }
     }
     if (msgText !== 'Upload canceled.') {
-        $osf.growl('Error', msgText);
+        $osf.growl(
+            'Error',
+            'Unable to reach the provider, please try again later. If the ' +
+            'problem persists, please contact <a href="mailto:support@osf.io">support@osf.io</a>.'
+            );
     }
     treebeard.options.uploadInProgress = false;
 }


### PR DESCRIPTION
## Purpose:
Provide users with a generic error message.

## Changes:
- Add generic upload error message.
  - Old message:
![screen shot 2015-08-06 at 10 23 28 am](https://cloud.githubusercontent.com/assets/2614670/9113934/343e40f0-3c25-11e5-8f57-fa4d439f1215.png)

  - New message:
![screen shot 2015-08-06 at 10 22 09 am](https://cloud.githubusercontent.com/assets/2614670/9113922/221f4680-3c25-11e5-8bd8-7efb07563ea4.png)


## Side Effects:
None.

## Notes:
We should add provider specific information to the Water Butler exception handler to build more useful error messages with fangorn.
Closes-issue: https://trello.com/c/jegKrdQ5/75-improve-error-message-to-users-when-file-uploads-fail