### PR TITLE
Feature/s3 empty bucket name

### DIFF
--- a/website/addons/s3/static/s3NodeConfig.js
+++ b/website/addons/s3/static/s3NodeConfig.js
@@ -348,7 +348,7 @@ ViewModel.prototype.openCreateBucket = function() {
                     if (!bucketName) {
                         var errorMessage = $('#errorMessage');
                         errorMessage.text('Bucket name cannot be empty');
-                        errorMessage[0].classList.add('text-warning');
+                        errorMessage[0].classList.add('text-error');
                         return false;
                     } else if (isValidBucketName(bucketName, true)) {
                         bootbox.confirm({

--- a/website/addons/s3/static/s3NodeConfig.js
+++ b/website/addons/s3/static/s3NodeConfig.js
@@ -317,6 +317,9 @@ ViewModel.prototype.openCreateBucket = function() {
                                 '<label class="col-md-4 control-label" for="bucketName">Bucket Name</label> ' +
                                 '<div class="col-md-8"> ' +
                                     '<input id="bucketName" name="bucketName" type="text" placeholder="Enter bucket name" class="form-control" autofocus> ' +
+                                    '<div>' +
+                                        '<span id="errorMessage" ></span>' +
+                                    '</div>'+
                                 '</div>' +
                             '</div>' +
                             '<div class="form-group"> ' +
@@ -343,7 +346,10 @@ ViewModel.prototype.openCreateBucket = function() {
                     var bucketLocation = $('#bucketLocation').val();
 
                     if (!bucketName) {
-                        return;
+                        var errorMessage = $('#errorMessage');
+                        errorMessage.text('Bucket name cannot be empty');
+                        errorMessage[0].classList.add('text-warning');
+                        return false;
                     } else if (isValidBucketName(bucketName, true)) {
                         bootbox.confirm({
                             title: 'Invalid bucket name',
@@ -354,7 +360,7 @@ ViewModel.prototype.openCreateBucket = function() {
                                 }
                             },
                             buttons: {
-                                success: {
+                                confirm: {
                                     label: 'Try again'
                                 }
                             }

--- a/website/addons/s3/static/s3NodeConfig.js
+++ b/website/addons/s3/static/s3NodeConfig.js
@@ -318,7 +318,7 @@ ViewModel.prototype.openCreateBucket = function() {
                                 '<div class="col-md-8"> ' +
                                     '<input id="bucketName" name="bucketName" type="text" placeholder="Enter bucket name" class="form-control" autofocus> ' +
                                     '<div>' +
-                                        '<span id="errorMessage" ></span>' +
+                                        '<span id="bucketModalErrorMessage" ></span>' +
                                     '</div>'+
                                 '</div>' +
                             '</div>' +
@@ -346,7 +346,7 @@ ViewModel.prototype.openCreateBucket = function() {
                     var bucketLocation = $('#bucketLocation').val();
 
                     if (!bucketName) {
-                        var errorMessage = $('#errorMessage');
+                        var errorMessage = $('bucketModalErrorMessage');
                         errorMessage.text('Bucket name cannot be empty');
                         errorMessage[0].classList.add('text-danger');
                         return false;

--- a/website/addons/s3/static/s3NodeConfig.js
+++ b/website/addons/s3/static/s3NodeConfig.js
@@ -348,7 +348,7 @@ ViewModel.prototype.openCreateBucket = function() {
                     if (!bucketName) {
                         var errorMessage = $('#errorMessage');
                         errorMessage.text('Bucket name cannot be empty');
-                        errorMessage[0].classList.add('text-error');
+                        errorMessage[0].classList.add('text-danger');
                         return false;
                     } else if (isValidBucketName(bucketName, true)) {
                         bootbox.confirm({


### PR DESCRIPTION
<b>Purpose</b>
Add warning for creating S3 bucket with an empty bucket name. Closes https://github.com/CenterForOpenScience/osf.io/issues/3957

<b>Changes</b>
Before Change:
There is no warning or anything happen when you click the submit button with no bucket name.
After Change:
![screen shot 2015-08-06 at 12 13 02 pm](https://cloud.githubusercontent.com/assets/4974056/9116845/866baf98-3c34-11e5-890e-5966fa04c1e4.png)
