### PR TITLE
[Ready] Enhancements to profile settings pages 

### DIFF
--- a/website/templates/include/profile/jobs.mako
+++ b/website/templates/include/profile/jobs.mako
@@ -107,7 +107,7 @@
                         type="button"
                         class="btn btn-default"
                         data-bind="click: cancel"
-                    >Discard Changes</button>
+                    >Discard changes</button>
 
                 <button
                         type="submit"

--- a/website/templates/include/profile/jobs.mako
+++ b/website/templates/include/profile/jobs.mako
@@ -107,7 +107,7 @@
                         type="button"
                         class="btn btn-default"
                         data-bind="click: cancel"
-                    >Cancel</button>
+                    >Discard Changes</button>
 
                 <button
                         type="submit"

--- a/website/templates/include/profile/names.mako
+++ b/website/templates/include/profile/names.mako
@@ -66,7 +66,7 @@
                     type="button"
                     class="btn btn-default"
                     data-bind="click: cancel"
-                >Discard Changes</button>
+                >Discard changes</button>
 
             <button
                     type="submit"

--- a/website/templates/include/profile/names.mako
+++ b/website/templates/include/profile/names.mako
@@ -66,7 +66,7 @@
                     type="button"
                     class="btn btn-default"
                     data-bind="click: cancel"
-                >Cancel</button>
+                >Discard Changes</button>
 
             <button
                     type="submit"

--- a/website/templates/include/profile/schools.mako
+++ b/website/templates/include/profile/schools.mako
@@ -107,7 +107,7 @@
                         type="button"
                         class="btn btn-default"
                         data-bind="click: cancel"
-                    >Discard Changes</button>
+                    >Discard changes</button>
 
                 <button
                         type="submit"

--- a/website/templates/include/profile/schools.mako
+++ b/website/templates/include/profile/schools.mako
@@ -107,7 +107,7 @@
                         type="button"
                         class="btn btn-default"
                         data-bind="click: cancel"
-                    >Cancel</button>
+                    >Discard Changes</button>
 
                 <button
                         type="submit"

--- a/website/templates/include/profile/settings_navpanel.mako
+++ b/website/templates/include/profile/settings_navpanel.mako
@@ -2,15 +2,16 @@
 
 <div class="osf-affix profile-affix panel panel-default" data-spy="affix" data-offset-top="70" data-offset-bottom="268">
   <ul class="nav nav-stacked nav-pills">
-      <li ${'class="active"' if current_page == 'profile' else ''}><a href="${ '#' if current_page == 'profile' else web_url_for('user_profile') }">Profile Information</a></li>
+      <li class="${'active' if current_page == 'profile' else ''}">
+        <a href="${ '#' if current_page == 'profile' else web_url_for('user_profile') }">Profile Information</a></li>
 
-      <li ${'class="active"' if current_page == 'account' else ''}>
+      <li class="${'active' if current_page == 'account' else ''}">
         <a href="${ '#' if current_page == 'account' else web_url_for('user_account') }">Account Settings</a></li>
 
-      <li ${'class="active"' if current_page == 'addons' else ''}>
+      <li class="${'active' if current_page == 'addons' else ''}">
         <a href="${ '#' if current_page == 'addons' else  web_url_for('user_addons') }">Configure Add-on Accounts</a></li>
 
-      <li ${'class="active"' if current_page == 'notifications' else ''}>
+      <li class="${'active' if current_page == 'notifications' else ''}">
         <a href="${ '#' if current_page == 'notifications' else web_url_for('user_notifications') }">Notifications</a></li>
   </ul>
 </div>

--- a/website/templates/include/profile/social.mako
+++ b/website/templates/include/profile/social.mako
@@ -80,7 +80,7 @@
                         type="button"
                         class="btn btn-default"
                         data-bind="click: cancel"
-                    >Discard Changes</button>
+                    >Discard changes</button>
 
                 <button
                         type="submit"

--- a/website/templates/include/profile/social.mako
+++ b/website/templates/include/profile/social.mako
@@ -80,7 +80,7 @@
                         type="button"
                         class="btn btn-default"
                         data-bind="click: cancel"
-                    >Cancel</button>
+                    >Discard Changes</button>
 
                 <button
                         type="submit"

--- a/website/templates/profile.mako
+++ b/website/templates/profile.mako
@@ -35,7 +35,7 @@
         </span>
         <span class="edit-profile-settings">
             % if user['is_profile']:
-                <a href="/settings/">Edit your profile</a>
+                <a href="/settings/"><i class="fa fa-pencil m-r-xs"></i> Edit your profile</a>
             % endif
         </span>
     </div>

--- a/website/templates/profile/account.mako
+++ b/website/templates/profile/account.mako
@@ -11,7 +11,7 @@
 <%def name="content()">
     <% from website import settings %>
     <div id="accountSettings">
-        <h2 class="page-header">Account Settings</h2>
+        <h2 class="page-header">Settings</h2>
         <div class="row">
             <div class="col-md-3 affix-parent">
               <%include file="include/profile/settings_navpanel.mako" args="current_page='account'"/>

--- a/website/templates/profile/addons.mako
+++ b/website/templates/profile/addons.mako
@@ -16,7 +16,7 @@
 </style>
 
 <% from website import settings %>
-<h2 class="page-header">Configure Add-on Accounts</h2>
+<h2 class="page-header">Settings</h2>
 
 
 <div id="addonSettings" class="row">

--- a/website/templates/profile/notifications.mako
+++ b/website/templates/profile/notifications.mako
@@ -8,7 +8,7 @@
 
 <%def name="content()">
 <% from website import settings%>
-<h2 class="page-header">Notifications</h2>
+<h2 class="page-header">Settings</h2>
 
 <div id="notificationSettings" class="row">
     <div class="col-sm-3 affix-parent">

--- a/website/templates/profile/settings.mako
+++ b/website/templates/profile/settings.mako
@@ -2,7 +2,11 @@
 <%def name="title()">Settings</%def>
 <%def name="content()">
 <% from website import settings %>
-<h2 class="page-header">Settings</h2>
+<h2 class="page-header">Settings
+    <div class="pull-right">
+        <a href="/profile" class="btn btn-link"><i class="fa fa-user m-r-sm"></i>View Profile </a>
+    </div>
+</h2>
 
 ## TODO: Review and un-comment
 ##<div class="row">

--- a/website/templates/profile/settings.mako
+++ b/website/templates/profile/settings.mako
@@ -2,7 +2,7 @@
 <%def name="title()">Settings</%def>
 <%def name="content()">
 <% from website import settings %>
-<h2 class="page-header">Profile Information</h2>
+<h2 class="page-header">Settings</h2>
 
 ## TODO: Review and un-comment
 ##<div class="row">

--- a/website/templates/profile/settings.mako
+++ b/website/templates/profile/settings.mako
@@ -38,23 +38,18 @@
             </ul>
 
             <div class="tab-content" id="containDrag">
-
                 <div class="m-t-md tab-pane active" id="names">
                     <div data-bind="template: {name: 'profileName'}"></div>
                 </div>
-
                 <div class="m-t-md tab-pane" id="social">
                     <div data-bind="template: {name: 'profileSocial'}"></div>
                 </div>
-
                 <div class="m-t-md tab-pane" id="jobs">
                     <div data-bind="template: {name: 'profileJobs'}"></div>
                 </div>
-
                 <div class="m-t-md tab-pane" id="schools">
                     <div data-bind="template: {name: 'profileSchools'}"></div>
                 </div>
-
             </div>
 
         </div>

--- a/website/templates/profile/settings.mako
+++ b/website/templates/profile/settings.mako
@@ -4,7 +4,7 @@
 <% from website import settings %>
 <h2 class="page-header">Settings
     <div class="pull-right">
-        <a href="/profile" class="btn btn-link"><i class="fa fa-user m-r-sm"></i>View Profile </a>
+        <a href="/profile" class="btn btn-link"><i class="fa fa-user m-r-sm"></i>View your profile </a>
     </div>
 </h2>
 


### PR DESCRIPTION
## Purpose
This PR makes minor edits to several settings pages to improve work flow and general use. 

## Changes
- All Settings pages headers are changed to Settings instead of their actual names. This allows the user to have a better context about where she is and links well to the Settings link on the navigation bar which says "Settings" when hovered over. 
- The active class in the navigation is fixed so that the user knows which of the settings pages she is at, thus eliminating need for a separate title for those settings page.
- There is now a link at Profile Information edit page to take users back to the profile page.
- The Cancel buttons in profile edit where renamed to "Discard Changes" which is the same as what the modals say when that button is clicked. 
- Icons were added to View Profile and Edit Your Profile links to allow them more visibility in an otherwise mostly white background. 

## Side Effects
No functional changes were made so there shouldn't be any side effects. 

![screen shot 2015-08-06 at 1 20 23 pm](https://cloud.githubusercontent.com/assets/1314003/9118384/f74cc216-3c3d-11e5-9544-b003b607291f.png)

![screen shot 2015-08-06 at 1 20 36 pm](https://cloud.githubusercontent.com/assets/1314003/9118387/fefa44a2-3c3d-11e5-80ed-b5bc6ea3ef45.png)
