### PR TITLE
Remove extra "icon"

### DIFF
--- a/website/templates/log_list.mako
+++ b/website/templates/log_list.mako
@@ -34,7 +34,7 @@
 	                </div>
                 </span>
                 <p data-bind="if: !logs().length && !loading()" class="help-block">
-                    No logs to show. Click the watch icon (<i class="fa fa-eye"></i>) icon on a
+                    No logs to show. Click the watch icon (<i class="fa fa-eye"></i>) on a
                     project's page to get activity updates here.
                 </p>
                 <span data-bind="if: !loading()">


### PR DESCRIPTION
Empty watchlists show a sentence that reads "Click the watch icon icon on a..." This removes the extra "icon."