### PR TITLE
fix grammar in view only link language

### DIFF
--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -1031,7 +1031,7 @@ def project_generate_private_link_post(auth, node, **kwargs):
     if anonymous and has_public_node:
         status.push_status_message(
             'Anonymized view-only links <b>DO NOT</b> '
-            'anonymize contributors of public project or component.'
+            'anonymize contributors of public projects or components.'
         )
 
     return new_link


### PR DESCRIPTION
<h1>Purpose</h1>

Fix grammar in view-only link change
<h1>Changes</h1>

Current language when you try to anonymize a public project/component:
"Anonymized view-only links DO NOT anonymize contributors of public project or component."

Changed to:
"Anonymized view-only links DO NOT anonymize contributors of public projects or components."