### PR TITLE
fix the share search thread appear twice

### DIFF
--- a/website/static/js/search.js
+++ b/website/static/js/search.js
@@ -75,7 +75,6 @@ var ViewModel = function(params) {
     self.categories = ko.observableArray([]);
     self.shareCategory = ko.observable('');
     self.searchStarted = ko.observable(false);
-    self.jsonData = ko.observable('');
     self.showSearch = true;
     self.showClose = false;
     self.searchCSS = ko.observable('active');
@@ -91,6 +90,8 @@ var ViewModel = function(params) {
             categoryList.push(self.shareCategory());
             return categoryList;
         }
+        categoryList.push(new Category('SHARE', 0, 'SHARE'));
+        return categoryList;
     });
 
     self.totalCount = ko.pureComputed(function() {

--- a/website/static/js/search.js
+++ b/website/static/js/search.js
@@ -85,6 +85,14 @@ var ViewModel = function(params) {
     self.toggleSearch = function() {
     };
 
+    self.allCategories = ko.pureComputed(function(){
+        var categoryList = self.categories();
+        if(self.shareCategory()){
+            categoryList.push(self.shareCategory());
+            return categoryList;
+        }
+    });
+
     self.totalCount = ko.pureComputed(function() {
         if (self.categories().length === 0 || self.categories()[0] === undefined) {
             return 0;
@@ -286,10 +294,6 @@ var ViewModel = function(params) {
             $osf.postJSON('/api/v1/share/search/?count&v=1', jsonData).success(function(data) {
                 self.shareCategory(new Category('SHARE', data.count, 'SHARE'));
             });
-
-            if (!(self.shareCategory() in self.categories())){
-                self.categories.push(self.shareCategory());
-            }
 
         }).fail(function(response){
             self.totalResults(0);

--- a/website/static/js/search.js
+++ b/website/static/js/search.js
@@ -73,6 +73,7 @@ var ViewModel = function(params) {
     self.searching = ko.observable(false);
     self.resultsPerPage = ko.observable(10);
     self.categories = ko.observableArray([]);
+    self.shareCategory = ko.observable('');
     self.searchStarted = ko.observable(false);
     self.jsonData = ko.observable('');
     self.showSearch = true;
@@ -232,6 +233,7 @@ var ViewModel = function(params) {
             self.tagMaxCount(1);
             self.results.removeAll();
             self.categories.removeAll();
+            self.shareCategory('');
 
             data.results.forEach(function(result){
                 if(result.category === 'user'){
@@ -282,18 +284,13 @@ var ViewModel = function(params) {
             }
 
             $osf.postJSON('/api/v1/share/search/?count&v=1', jsonData).success(function(data) {
-                var shareCheck = true;
-                for (var i = 0; i < self.categories.length; i++){
-                    if (self.categories[i].name === 'SHARE' && self.categories[i].count === data.count && self.jsonData() === jsonData){
-                        shareCheck = false;
-                        break;
-                    }
-                }
-                if(shareCheck) {
-                    self.categories.push(new Category('SHARE', data.count, 'SHARE'));
-                    self.jsonData(jsonData);
-                }
+                self.shareCategory(new Category('SHARE', data.count, 'SHARE'));
             });
+
+            if (!(self.shareCategory() in self.categories())){
+                self.categories.push(self.shareCategory());
+            }
+
         }).fail(function(response){
             self.totalResults(0);
             self.currentPage(0);

--- a/website/static/js/search.js
+++ b/website/static/js/search.js
@@ -85,13 +85,10 @@ var ViewModel = function(params) {
     };
 
     self.allCategories = ko.pureComputed(function(){
-        var categoryList = self.categories();
         if(self.shareCategory()){
-            categoryList.push(self.shareCategory());
-            return categoryList;
+            return self.categories().concat(self.shareCategory());
         }
-        categoryList.push(new Category('SHARE', 0, 'SHARE'));
-        return categoryList;
+        return self.categories().concat(new Category('SHARE', 0, 'SHARE'));
     });
 
     self.totalCount = ko.pureComputed(function() {

--- a/website/templates/search.mako
+++ b/website/templates/search.mako
@@ -15,7 +15,7 @@
                     <div class="col-md-3">
                         <div class="row">
                             <div class="col-md-12">
-                                <ul class="nav nav-pills nav-stacked" data-bind="foreach: categories">
+                                <ul class="nav nav-pills nav-stacked" data-bind="foreach: allCategories">
 
                                     <!-- ko if: $parent.category().name === name -->
                                             <li class="active">

--- a/website/templates/search.mako
+++ b/website/templates/search.mako
@@ -11,7 +11,7 @@
         <div class="row">
             <div class="col-md-12">
                 <div class="row m-t-md">
-                    <!-- ko if: categories().length > 0-->
+                    <!-- ko if: allCategories().length > 0-->
                     <div class="col-md-3">
                         <div class="row">
                             <div class="col-md-12">


### PR DESCRIPTION
<b>Purpose</b>
Fix the problem that share search thread can appear twice on search page. Closes https://trello.com/c/WTvShYqU/5-fix-in-search-results-page-share-displaying-twice-when-user-hits-enter-button-twice.