### PR TITLE
Fix Visible Contributor Swap Bug

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1630,6 +1630,49 @@ class TestNode(OsfTestCase):
             self.node.set_visible(user=self.user, visible=False, auth=None)
             assert_equal(e.exception.message, 'Must have at least one visible contributor')
 
+    def test_contributor_manage_visibility(self):
+
+        reg_user1 = UserFactory()
+        #This makes sure manage_contributors uses set_visible so visibility for contributors is added before visibility
+        #for other contributors is removed ensuring there is always at least one visible contributor
+        self.node.add_contributor(contributor=self.user, permissions=['read', 'write','admin'], auth=self.consolidate_auth)
+        self.node.add_contributor(contributor=reg_user1, permissions=['read', 'write','admin'], auth=self.consolidate_auth)
+
+        self.node.manage_contributors(
+            user_dicts=[
+                    {'id': self.user._id, 'permission': 'admin', 'visible': True},
+                    {'id': reg_user1._id, 'permission': 'admin', 'visible': False},
+                ],
+            auth=self.consolidate_auth,
+            save=True
+        )
+        self.node.manage_contributors(
+            user_dicts=[
+                    {'id': self.user._id, 'permission': 'admin', 'visible': False},
+                    {'id': reg_user1._id, 'permission': 'admin', 'visible': True},
+            ],
+            auth=self.consolidate_auth,
+            save=True
+        )
+
+        assert_equal(len(self.node.visible_contributor_ids),1)
+
+    def test_contributor_set_visibility_validation(self):
+        reg_user1, reg_user2 = UserFactory(), UserFactory()
+        self.node.add_contributors(
+                        [
+                {'user': reg_user1, 'permissions': [
+                    'read', 'write', 'admin'], 'visible': True},
+                {'user': reg_user2, 'permissions': [
+                    'read', 'write', 'admin'], 'visible': False},
+            ]
+        )
+        print(self.node.visible_contributor_ids)
+        with assert_raises(ValueError) as e:
+            self.node.set_visible(user=reg_user1, visible=False, auth=None)
+            self.node.set_visible(user=self.user, visible=False, auth=None)
+            assert_equal(e.exception.message, 'Must have at least one visible contributor')
+
 class TestNodeTraversals(OsfTestCase):
 
     def setUp(self):

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -967,9 +967,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
             self.update_visible_ids(save=False)
         elif not visible and user._id in self.visible_contributor_ids:
             if len(self.visible_contributor_ids) == 1:
-                raise ValueError(
-                        'Must have at least one visible contributor'
-                    )
+                raise ValueError('Must have at least one visible contributor')
             self.visible_contributor_ids.remove(user._id)
         else:
             return

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -959,7 +959,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
         if save:
             self.save()
 
-    def set_visible(self, user, visible, log=True, auth=None, save=False):
+    def set_visible(self, user, visible, user_dicts=None, log=True, auth=None, save=False):
         if not self.is_contributor(user):
             raise ValueError(u'User {0} not in contributors'.format(user))
         if visible and user._id not in self.visible_contributor_ids:
@@ -967,9 +967,10 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
             self.update_visible_ids(save=False)
         elif not visible and user._id in self.visible_contributor_ids:
             if len(self.visible_contributor_ids) == 1:
-                raise ValueError(
-                    'Must have at least one visible contributor'
-                )
+                if user_dicts is None or all([contributor['visible'] is False for contributor in user_dicts]):
+                    raise ValueError(
+                        'Must have at least one visible contributor'
+                    )
             self.visible_contributor_ids.remove(user._id)
         else:
             return
@@ -2197,7 +2198,10 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
                 if set(permissions) != set(self.get_permissions(user)):
                     self.set_permissions(user, permissions, save=False)
                     permissions_changed[user._id] = permissions
-                self.set_visible(user, user_dict['visible'], auth=auth)
+                self.set_visible(user,
+                                 user_dict['visible'],
+                                 user_dicts,
+                                 auth=auth)
                 users.append(user)
                 user_ids.append(user_dict['id'])
 


### PR DESCRIPTION
<h1> Purpose </h1>
Fix bug where changing the first contributors visibility would raise unnecessary error. Close #3765.
<h1> Changes </h1>
set_visible now can accept a list of user dicts being modified and check against that to see whether an error should be raised.
<h1> Side Effects </h1>
None that I know of.