### PR TITLE
[Feature Fix] Set proper debounce time for navbar update on setting pages

### DIFF
--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -625,7 +625,7 @@ var fixAffixWidth = function() {
 };
 
 var initializeResponsiveAffix = function (){
-    $(window).resize(debounce(fixAffixWidth, 80, true));
+    $(window).resize(debounce(fixAffixWidth, 20, true));
     $('.osf-affix').one('affix.bs.affix', fixAffixWidth);
 };
 


### PR DESCRIPTION
### Purpose
The PR is to solve the issue that navigation bar on setting pages doesn't update responsively when user changes the size of screen.
Resolved #3908

### Change
Reduce the debounce time. 

### Side Effect
Cost user's resource for updating the page
