### PR TITLE
Feature/api node children create

### DIFF
--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -167,7 +167,7 @@ class NodeRegistrationsList(generics.ListAPIView, NodeMixin):
         return registrations
 
 
-class NodeChildrenList(generics.ListAPIView, NodeMixin):
+class NodeChildrenList(generics.ListCreateAPIView, NodeMixin):
     """Children of the current node.
 
     This will get the next level of child nodes for the selected node if the current user has read access for those
@@ -192,6 +192,11 @@ class NodeChildrenList(generics.ListAPIView, NodeMixin):
             auth = Auth(user)
         children = [node for node in nodes if node.can_view(auth) and node.primary]
         return children
+
+    # overrides ListCreateAPIView
+    def perform_create(self, serializer):
+        user = self.request.user
+        serializer.save(creator=user, parent=self.get_node())
 
 
 class NodePointersList(generics.ListCreateAPIView, NodeMixin):

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -1010,6 +1010,24 @@ class TestNodeChildCreate(ApiTestCase):
         assert_equal(res.json['data']['description'], self.private_child['description'])
         assert_equal(res.json['data']['category'], self.private_child['category'])
 
+    def test_creates_private_child_write_contributor(self):
+        self.project.add_contributor(self.user_two, permissions=['read', 'write'], auth=Auth(self.user), save=True)
+        self.project.reload()
+
+        res = self.app.post_json(self.url, self.private_child, auth=self.basic_auth_two)
+        assert_equal(res.status_code, 201)
+
+    def test_creates_private_child_read_contributor(self):
+        self.project.add_contributor(self.user_two, permissions=['read'], auth=Auth(self.user), save=True)
+        self.project.reload()
+
+        res = self.app.post_json(self.url, self.private_child, auth=self.basic_auth_two, expect_errors=True)
+        assert_equal(res.status_code, 403)
+
+    def test_creates_private_child_non_contributor(self):
+        res = self.app.post_json(self.url, self.private_child, auth=self.basic_auth_two, expect_errors=True)
+        assert_equal(res.status_code, 403)
+
     def test_creates_child_creates_child_and_sanitizes_html(self):
         title = '<em>Cool</em> <strong>Project</strong>'
         description = 'An <script>alert("even cooler")</script> child'

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -16,7 +16,8 @@ from tests.factories import (
     NodeFactory,
     ProjectFactory,
     RegistrationFactory,
-    UserFactory
+    UserFactory,
+    AuthUserFactory
 )
 
 class TestWelcomeToApi(ApiTestCase):
@@ -955,10 +956,8 @@ class TestNodeChildCreate(ApiTestCase):
 
     def setUp(self):
         super(TestNodeChildCreate, self).setUp()
-        self.user = UserFactory.build()
-        self.user.set_password('justapoorboy')
-        self.user.save()
-        self.basic_auth = (self.user.username, 'justapoorboy')
+        self.user = AuthUserFactory()
+        self.user_two = AuthUserFactory()
 
         self.project = ProjectFactory(creator=self.user, is_publc=True)
 
@@ -967,11 +966,6 @@ class TestNodeChildCreate(ApiTestCase):
         self.title = 'Cool Project'
         self.description = 'A Properly Cool Project'
         self.category = 'data'
-
-        self.user_two = UserFactory.build()
-        self.user_two.set_password('justapoorboy')
-        self.user_two.save()
-        self.basic_auth_two = (self.user_two.username, 'justapoorboy')
 
         self.public_child = {'title': self.title,
                              'description': self.description,
@@ -982,50 +976,53 @@ class TestNodeChildCreate(ApiTestCase):
                               'category': self.category,
                               'public': False}
 
-    def test_creates_public_child_logged_out(self):
+    def test_creates_public_child_logged_out_owner(self):
         res = self.app.post_json(self.url, self.public_child, expect_errors=True)
         # This is 403 instead of 401 because basic authentication is only for unit tests and, in order to keep from
         # presenting a basic authentication dialog box in the front end. We may change this as we understand CAS
         # a little better
         assert_equal(res.status_code, 403)
 
-    def test_creates_public_child_logged_in(self):
-        res = self.app.post_json(self.url, self.public_child, auth=self.basic_auth)
+    def test_creates_public_child_logged_in_owner(self):
+        res = self.app.post_json(self.url, self.public_child, auth=self.user.auth)
         assert_equal(res.status_code, 201)
         assert_equal(res.json['data']['title'], self.public_child['title'])
         assert_equal(res.json['data']['description'], self.public_child['description'])
         assert_equal(res.json['data']['category'], self.public_child['category'])
 
-    def test_creates_private_child_logged_out(self):
+    def test_creates_private_child_logged_out_owner(self):
         res = self.app.post_json(self.url, self.private_child, expect_errors=True)
         # This is 403 instead of 401 because basic authentication is only for unit tests and, in order to keep from
         # presenting a basic authentication dialog box in the front end. We may change this as we understand CAS
         # a little better
         assert_equal(res.status_code, 403)
 
-    def test_creates_private_child_logged_in_contributor(self):
-        res = self.app.post_json(self.url, self.private_child, auth=self.basic_auth)
+    def test_creates_private_child_logged_in_owner(self):
+        res = self.app.post_json(self.url, self.private_child, auth=self.user.auth)
         assert_equal(res.status_code, 201)
         assert_equal(res.json['data']['title'], self.private_child['title'])
         assert_equal(res.json['data']['description'], self.private_child['description'])
         assert_equal(res.json['data']['category'], self.private_child['category'])
 
-    def test_creates_private_child_write_contributor(self):
+    def test_creates_private_child_logged_in_write_contributor(self):
         self.project.add_contributor(self.user_two, permissions=['read', 'write'], auth=Auth(self.user), save=True)
         self.project.reload()
 
-        res = self.app.post_json(self.url, self.private_child, auth=self.basic_auth_two)
+        res = self.app.post_json(self.url, self.private_child, auth=self.user_two.auth)
         assert_equal(res.status_code, 201)
+        assert_equal(res.json['data']['title'], self.private_child['title'])
+        assert_equal(res.json['data']['description'], self.private_child['description'])
+        assert_equal(res.json['data']['category'], self.private_child['category'])
 
-    def test_creates_private_child_read_contributor(self):
+    def test_creates_private_child_logged_in_read_contributor(self):
         self.project.add_contributor(self.user_two, permissions=['read'], auth=Auth(self.user), save=True)
         self.project.reload()
 
-        res = self.app.post_json(self.url, self.private_child, auth=self.basic_auth_two, expect_errors=True)
+        res = self.app.post_json(self.url, self.private_child, auth=self.user_two.auth, expect_errors=True)
         assert_equal(res.status_code, 403)
 
-    def test_creates_private_child_non_contributor(self):
-        res = self.app.post_json(self.url, self.private_child, auth=self.basic_auth_two, expect_errors=True)
+    def test_creates_private_child_logged_in_non_contributor(self):
+        res = self.app.post_json(self.url, self.private_child, auth=self.user_two.auth, expect_errors=True)
         assert_equal(res.status_code, 403)
 
     def test_creates_child_creates_child_and_sanitizes_html(self):
@@ -1037,12 +1034,12 @@ class TestNodeChildCreate(ApiTestCase):
             'description': description,
             'category': self.category,
             'public': True,
-        }, auth=self.basic_auth)
+        }, auth=self.user.auth)
         child_id = res.json['data']['id']
         assert_equal(res.status_code, 201)
         url = '/{}nodes/{}/'.format(API_BASE, child_id)
 
-        res = self.app.get(url, auth=self.basic_auth)
+        res = self.app.get(url, auth=self.user.auth)
         assert_equal(res.json['data']['title'], strip_html(title))
         assert_equal(res.json['data']['description'], strip_html(description))
         assert_equal(res.json['data']['category'], self.category)

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -976,7 +976,7 @@ class TestNodeChildCreate(ApiTestCase):
                               'category': self.category,
                               'public': False}
 
-    def test_creates_public_child_logged_out_owner(self):
+    def test_creates_public_child_logged_out_user(self):
         res = self.app.post_json(self.url, self.public_child, expect_errors=True)
         # This is 403 instead of 401 because basic authentication is only for unit tests and, in order to keep from
         # presenting a basic authentication dialog box in the front end. We may change this as we understand CAS
@@ -990,7 +990,7 @@ class TestNodeChildCreate(ApiTestCase):
         assert_equal(res.json['data']['description'], self.public_child['description'])
         assert_equal(res.json['data']['category'], self.public_child['category'])
 
-    def test_creates_private_child_logged_out_owner(self):
+    def test_creates_private_child_logged_out_user(self):
         res = self.app.post_json(self.url, self.private_child, expect_errors=True)
         # This is 403 instead of 401 because basic authentication is only for unit tests and, in order to keep from
         # presenting a basic authentication dialog box in the front end. We may change this as we understand CAS
@@ -1025,7 +1025,7 @@ class TestNodeChildCreate(ApiTestCase):
         res = self.app.post_json(self.url, self.private_child, auth=self.user_two.auth, expect_errors=True)
         assert_equal(res.status_code, 403)
 
-    def test_creates_child_creates_child_and_sanitizes_html(self):
+    def test_creates_child_creates_child_and_sanitizes_html_logged_in_owner(self):
         title = '<em>Cool</em> <strong>Project</strong>'
         description = 'An <script>alert("even cooler")</script> child'
 

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -990,7 +990,6 @@ class TestNodeChildCreate(ApiTestCase):
 
     def test_creates_child_logged_in_write_contributor(self):
         self.project.add_contributor(self.user_two, permissions=['read', 'write'], auth=Auth(self.user), save=True)
-        self.project.reload()
 
         res = self.app.post_json(self.url, self.child, auth=self.user_two.auth)
         assert_equal(res.status_code, 201)
@@ -1036,6 +1035,9 @@ class TestNodeChildCreate(ApiTestCase):
         assert_equal(res.json['data']['title'], strip_html(title))
         assert_equal(res.json['data']['description'], strip_html(description))
         assert_equal(res.json['data']['category'], 'project')
+
+        self.project.reload()
+        assert_equal(res.json['data']['id'], self.project.nodes[0]._id)
 
 
 class TestNodePointersList(ApiTestCase):

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -962,68 +962,61 @@ class TestNodeChildCreate(ApiTestCase):
         self.project = ProjectFactory(creator=self.user, is_publc=True)
 
         self.url = '/{}nodes/{}/children/'.format(API_BASE, self.project._id)
+        self.child = {
+            'title': 'child',
+            'description': 'this is a child project',
+            'category': 'project',
+        }
 
-        self.title = 'Cool Project'
-        self.description = 'A Properly Cool Project'
-        self.category = 'data'
-
-        self.public_child = {'title': self.title,
-                             'description': self.description,
-                             'category': self.category,
-                             'public': True}
-        self.private_child = {'title': self.title,
-                              'description': self.description,
-                              'category': self.category,
-                              'public': False}
-
-    def test_creates_public_child_logged_out_user(self):
-        res = self.app.post_json(self.url, self.public_child, expect_errors=True)
+    def test_creates_child_logged_out_user(self):
+        res = self.app.post_json(self.url, self.child, expect_errors=True)
         # This is 403 instead of 401 because basic authentication is only for unit tests and, in order to keep from
         # presenting a basic authentication dialog box in the front end. We may change this as we understand CAS
         # a little better
         assert_equal(res.status_code, 403)
 
-    def test_creates_public_child_logged_in_owner(self):
-        res = self.app.post_json(self.url, self.public_child, auth=self.user.auth)
+        self.project.reload()
+        assert_equal(len(self.project.nodes), 0)
+
+    def test_creates_child_logged_in_owner(self):
+        res = self.app.post_json(self.url, self.child, auth=self.user.auth)
         assert_equal(res.status_code, 201)
-        assert_equal(res.json['data']['title'], self.public_child['title'])
-        assert_equal(res.json['data']['description'], self.public_child['description'])
-        assert_equal(res.json['data']['category'], self.public_child['category'])
+        assert_equal(res.json['data']['title'], self.child['title'])
+        assert_equal(res.json['data']['description'], self.child['description'])
+        assert_equal(res.json['data']['category'], self.child['category'])
 
-    def test_creates_private_child_logged_out_user(self):
-        res = self.app.post_json(self.url, self.private_child, expect_errors=True)
-        # This is 403 instead of 401 because basic authentication is only for unit tests and, in order to keep from
-        # presenting a basic authentication dialog box in the front end. We may change this as we understand CAS
-        # a little better
-        assert_equal(res.status_code, 403)
+        self.project.reload()
+        assert_equal(res.json['data']['id'], self.project.nodes[0]._id)
 
-    def test_creates_private_child_logged_in_owner(self):
-        res = self.app.post_json(self.url, self.private_child, auth=self.user.auth)
-        assert_equal(res.status_code, 201)
-        assert_equal(res.json['data']['title'], self.private_child['title'])
-        assert_equal(res.json['data']['description'], self.private_child['description'])
-        assert_equal(res.json['data']['category'], self.private_child['category'])
-
-    def test_creates_private_child_logged_in_write_contributor(self):
+    def test_creates_child_logged_in_write_contributor(self):
         self.project.add_contributor(self.user_two, permissions=['read', 'write'], auth=Auth(self.user), save=True)
         self.project.reload()
 
-        res = self.app.post_json(self.url, self.private_child, auth=self.user_two.auth)
+        res = self.app.post_json(self.url, self.child, auth=self.user_two.auth)
         assert_equal(res.status_code, 201)
-        assert_equal(res.json['data']['title'], self.private_child['title'])
-        assert_equal(res.json['data']['description'], self.private_child['description'])
-        assert_equal(res.json['data']['category'], self.private_child['category'])
+        assert_equal(res.json['data']['title'], self.child['title'])
+        assert_equal(res.json['data']['description'], self.child['description'])
+        assert_equal(res.json['data']['category'], self.child['category'])
 
-    def test_creates_private_child_logged_in_read_contributor(self):
+        self.project.reload()
+        assert_equal(res.json['data']['id'], self.project.nodes[0]._id)
+
+    def test_creates_child_logged_in_read_contributor(self):
         self.project.add_contributor(self.user_two, permissions=['read'], auth=Auth(self.user), save=True)
         self.project.reload()
 
-        res = self.app.post_json(self.url, self.private_child, auth=self.user_two.auth, expect_errors=True)
+        res = self.app.post_json(self.url, self.child, auth=self.user_two.auth, expect_errors=True)
         assert_equal(res.status_code, 403)
 
-    def test_creates_private_child_logged_in_non_contributor(self):
-        res = self.app.post_json(self.url, self.private_child, auth=self.user_two.auth, expect_errors=True)
+        self.project.reload()
+        assert_equal(len(self.project.nodes), 0)
+
+    def test_creates_child_logged_in_non_contributor(self):
+        res = self.app.post_json(self.url, self.child, auth=self.user_two.auth, expect_errors=True)
         assert_equal(res.status_code, 403)
+
+        self.project.reload()
+        assert_equal(len(self.project.nodes), 0)
 
     def test_creates_child_creates_child_and_sanitizes_html_logged_in_owner(self):
         title = '<em>Cool</em> <strong>Project</strong>'
@@ -1032,7 +1025,7 @@ class TestNodeChildCreate(ApiTestCase):
         res = self.app.post_json(self.url, {
             'title': title,
             'description': description,
-            'category': self.category,
+            'category': 'project',
             'public': True,
         }, auth=self.user.auth)
         child_id = res.json['data']['id']
@@ -1042,7 +1035,7 @@ class TestNodeChildCreate(ApiTestCase):
         res = self.app.get(url, auth=self.user.auth)
         assert_equal(res.json['data']['title'], strip_html(title))
         assert_equal(res.json['data']['description'], strip_html(description))
-        assert_equal(res.json['data']['category'], self.category)
+        assert_equal(res.json['data']['category'], 'project')
 
 
 class TestNodePointersList(ApiTestCase):


### PR DESCRIPTION
# Purpose
Allow api post request to add node children

# Changes
Changed node children view to ListCreateAPIView.  Overrode perform create method to view.

# Side Effects
User may now append children to nodes through API requests

https://github.com/CenterForOpenScience/osf.io/issues/3854