### PR TITLE
fix s3 bucket error message problem

### DIFF
--- a/website/addons/s3/static/s3NodeConfig.js
+++ b/website/addons/s3/static/s3NodeConfig.js
@@ -346,7 +346,7 @@ ViewModel.prototype.openCreateBucket = function() {
                     var bucketLocation = $('#bucketLocation').val();
 
                     if (!bucketName) {
-                        var errorMessage = $('bucketModalErrorMessage');
+                        var errorMessage = $('#bucketModalErrorMessage');
                         errorMessage.text('Bucket name cannot be empty');
                         errorMessage[0].classList.add('text-danger');
                         return false;


### PR DESCRIPTION
<b>Purpose</b>
Fix the problem that s3 create bucket error message doesn't work. Closes https://trello.com/c/ArmmahP3/10-no-error-message-when-clicking-create-with-blank-name-for-amazon-s3