### PR TITLE
Markupsafe-3 bugfixes for view file page

### DIFF
--- a/website/addons/base/views.py
+++ b/website/addons/base/views.py
@@ -453,7 +453,7 @@ def addon_view_file(auth, node, node_addon, guid_file, extras):
         },
         # Note: must be called after get_or_start_render. This is really only for github
         'size': size,
-        'extra': json.dumps(getattr(guid_file, 'extra', {})),
+        'extra': getattr(guid_file, 'extra', {}),
         #NOTE: get_or_start_render must be called first to populate name
         'file_name': getattr(guid_file, 'name', os.path.split(guid_file.waterbutler_path)[1]),
         'materialized_path': getattr(guid_file, 'materialized', guid_file.waterbutler_path),

--- a/website/addons/base/views.py
+++ b/website/addons/base/views.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import os
-import json
 import uuid
 import httplib
 import functools

--- a/website/templates/project/view_file.mako
+++ b/website/templates/project/view_file.mako
@@ -160,10 +160,10 @@
     <script type="text/javascript">
       window.contextVars = $.extend(true, {}, window.contextVars, {
         file: {
-            size: ${size},
-            extra: ${extra},
+            size: ${size | sjson, n },
+            extra: ${extra | sjson, n },
             error: ${ error | sjson, n },
-            privateRepo: ${private | sjson, n},
+            privateRepo: ${ private | sjson, n },
             name: ${ file_name | sjson, n },
             path: ${ file_path | sjson, n },
             provider: ${ provider | sjson, n },
@@ -182,7 +182,7 @@
             docId: ${ sharejs_uuid | sjson, n },
             userId: ${ user['id'] | sjson, n },
             userName: ${ user['fullname'] | sjson, n },
-            userUrl: ${ '/' + user['id'] + '/' | sjson, n },
+            userUrl: ${ '/' + (user['id'] or '') + '/' | sjson, n },
             userGravatar: ${ urls['gravatar'].replace('&amp;', '&') | sjson, n }
         },
         node: {
@@ -192,7 +192,7 @@
         },
         panelsUsed: ['edit', 'view'],
         currentUser: {
-          canEdit: ${int(user['can_edit'])}
+          canEdit: ${ int(user['can_edit']) | sjson, n }
         }
       });
     </script>

--- a/website/templates/project/view_file.mako
+++ b/website/templates/project/view_file.mako
@@ -182,7 +182,7 @@
             docId: ${ sharejs_uuid | sjson, n },
             userId: ${ user['id'] | sjson, n },
             userName: ${ user['fullname'] | sjson, n },
-            userUrl: ${ '/' + (user['id'] or '') + '/' | sjson, n },
+            userUrl: ${ ('/' + user['id'] + '/') if user['id'] else None | sjson, n },
             userGravatar: ${ urls['gravatar'].replace('&amp;', '&') | sjson, n }
         },
         node: {


### PR DESCRIPTION
## Purpose
Fix two bugs that were causing file views to fail after the conversion to markupsafe, per report by @jinluyuan on Trello. One issue was triggered by files in Github addon storage, and the other was caused by viewing a file detail page when not logged in.

## Summary of changes
1. Move JSON conversion to mako template for consistency (`addon_view_file` does not seem to be used anywhere other than this view)

2. Check that all variables in `window.contextVars` are subject to the `sjson, n` filter in the template (but not in other functions)

3. Handle a case where strings constructed in Python should handle a user id value of "None", resulting in a mako error when viewing page while logged out.

## Side effects/ other notes
The method of dealing with `user['id']= None` is a bit of a kludge, because the function (`website.project.views.node._view_project`) is used elsewhere.

An alternative would be to only fill in those JS fields at all if the user were logged in, eg line 183 would become:

```javascript
        % if user['id']:
            userId: ${ user['id'] | sjson, n },
            userName: ${ user['fullname'] | sjson, n },
            userUrl: ${ '/' + (user['id'] or '') + '/' | sjson, n },
            userGravatar: ${ urls['gravatar'].replace('&amp;', '&') | sjson, n }
        % endif
        },
```

I chose the more lightweight approach due to lack of familiarity with the editor functionality, but it's worth noting that in the absence of a user ID, the editor section (and especially the fields generated from user data, like `userUrl`) are meaningless anyway.