### PR TITLE
[Ready] Update style guide version to fix input multiple issue

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
     "locales": "https://github.com/citation-style-language/locales.git#d2b612f8a6f764cbd66e67238636fac3888a7736",
     "raven-js": "1.1.17",
     "zeroclipboard": "2.1.6",
-    "osf-style": "https://github.com/CenterForOpenScience/osf-style.git#0a6f466cdf3f585e18a32615ec5268de9880f851"
+    "osf-style": "https://github.com/CenterForOpenScience/osf-style.git#739bb46d59724d2214afefc5fd76ea297daf2e80"
 
   }
 }


### PR DESCRIPTION
## Purpose
Fixes this Trello issue: 
https://trello.com/c/vqwzwfpf

## Changes
The osf-style repo was updated to fix a quirk. This PR updates the installation. 

## Side effects 
break-word does not always apply and normal is the default so there shouldn't be any side effects