### PR TITLE
[hotfix] Registration URL

### DIFF
--- a/website/static/js/onboarder.js
+++ b/website/static/js/onboarder.js
@@ -104,7 +104,7 @@ function serializeNode(node) {
         urls: {
             web: node.url,
             api: node.api_url,
-            register: node.url + 'register/',
+            register: node.url + 'register',
             files: node.url + 'files/',
             children: node.api_url + 'get_children/?permissions=write'
         }


### PR DESCRIPTION
Removes additional ```/``` from registration URLs.
Closes [#3875](https://github.com/CenterForOpenScience/osf.io/issues/3875).