### PR TITLE
[hotfix] File Spinner Covers External Links

### DIFF
--- a/website/templates/project/view_file.mako
+++ b/website/templates/project/view_file.mako
@@ -49,8 +49,8 @@
 
   <div id="fileViewPanelLeft" class="col-sm-9 panel-expand">
     <div class="row">
-      <div id="mfrIframeParent" class="col-sm-9">
-        <div id="externalView"></div>
+        <div id="externalView" class="col-sm-9"></div>
+        <div id="mfrIframeParent" class="col-sm-9">
         <div id="mfrIframe" class="mfr mfr-file"></div>
       </div>
 


### PR DESCRIPTION
Closes [#3983](https://github.com/CenterForOpenScience/osf.io/issues/3983).