### PR TITLE
Convert public activity page to markupsafe rendering by default [markupsafe-extra]

### DIFF
--- a/website/routes.py
+++ b/website/routes.py
@@ -412,9 +412,12 @@ def make_url_map(app):
 
     process_rules(app, [
 
-        Rule('/explore/activity/', 'get', discovery_views.activity,
-             OsfWebRenderer('public/pages/active_nodes.mako')),
-
+        Rule(
+            '/explore/activity/',
+            'get',
+            discovery_views.activity,
+            OsfWebRenderer('public/pages/active_nodes.mako', trust=False)
+        ),
     ])
 
     ### Auth ###


### PR DESCRIPTION
## Purpose
A one-off conversion of the public activity page to reflect recent changes introduced in markupsafe-3 (#3910).

## Summary of changes
Turn on markupsafe rendering for the public `/explore/activity` page.

## Side effects
Should be none. However, best practice advises a quick round of QA using the same project names and test strings as for markupsafe-3. (#3910)