### PR TITLE
[Ready] Icon and view consistency for private items in file browser 

### DIFF
--- a/website/static/css/fangorn.css
+++ b/website/static/css/fangorn.css
@@ -115,6 +115,12 @@
     vertical-align: middle;
 }
 
+.tb-private-row {
+    color: #888;
+}
+.fangorn-selected.tb-private-row {
+    color: #CCC;
+}
 .tb-expand-icon-holder > i {
 	font-size: 14px;
 	padding-left: 2px;

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -228,7 +228,7 @@ function resolveIconView(item) {
  * @private
  */
 function _fangornResolveIcon(item) {
-    var privateFolder =  m('div.file-extension._folder_delete', ' '),
+    var privateFolder =  m('i.fa.fa-lock', ' '),
         pointerFolder = m('i.fa.fa-link', ' '),
         openFolder  = m('i.fa.fa-folder-open', ' '),
         closedFolder = m('i.fa.fa-folder', ' '),

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -188,6 +188,9 @@ function resolveIconView(item) {
         var template = m('span', { 'class' : iconType});
         return template;
     }
+    if (!item.data.permissions.view) {
+        return m('span', { 'class' : iconmap.private });
+    }
     if (item.data.isDashboard) {
         return returnView('collection');
     }

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1170,7 +1170,7 @@ function _fangornResolveRows(item) {
         item.css = 'fangorn-selected';
     }
 
-    if(!item.data.permissions.view){
+    if(item.data.permissions && !item.data.permissions.view){
         item.css += ' tb-private-row';
     }
 

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1170,6 +1170,10 @@ function _fangornResolveRows(item) {
         item.css = 'fangorn-selected';
     }
 
+    if(!item.data.permissions.view){
+        item.css += ' tb-private-row';
+    }
+
     if(item.data.uploadState && (item.data.uploadState() === 'pending' || item.data.uploadState() === 'uploading')){
         return uploadRowTemplate.call(tb, item);
     }

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1121,7 +1121,7 @@ function _fangornTitleColumn(item, col) {
             }
         }, item.data.name);
     }
-    if ((item.data.nodeType === 'project') || (item.data.nodeType ==='component')) {
+    if ((item.data.nodeType === 'project' || item.data.nodeType ==='component') && item.data.permissions.view) {
         return m('a.fg-file-links',{ href: '/' + item.data.nodeID.toString() + '/'},
                 item.data.name);
     }

--- a/website/static/js/fileViewTreebeard.js
+++ b/website/static/js/fileViewTreebeard.js
@@ -88,7 +88,9 @@ function FileViewTreebeard(data) {
                 item.css = 'fangorn-selected';
                 tb.multiselected([item]);
             }
-
+            if(item.data.permissions && !item.data.permissions.view){
+                item.css += ' tb-private-row';
+            }
             var defaultColumns = [
                 {
                     data: 'name',

--- a/website/static/js/iconmap.js
+++ b/website/static/js/iconmap.js
@@ -23,5 +23,6 @@ module.exports = {
     },
     info: 'fa fa-info-circle',
     smaller: 'iconmap-smaller',
-    clickable: 'iconmap-clickable'
+    clickable: 'iconmap-clickable',
+    private : 'fa fa-lock'
 };

--- a/website/static/js/pages/project-dashboard-page.js
+++ b/website/static/js/pages/project-dashboard-page.js
@@ -83,6 +83,9 @@ $(document).ready(function () {
                     if(tb.isMultiselected(item.id)){
                         item.css = 'fangorn-selected';
                     }
+                    if(!item.data.permissions.view){
+                        item.css += ' tb-private-row';
+                    }
                     var defaultColumns = [
                                 {
                                 data: 'name',

--- a/website/static/js/pages/project-dashboard-page.js
+++ b/website/static/js/pages/project-dashboard-page.js
@@ -83,7 +83,7 @@ $(document).ready(function () {
                     if(tb.isMultiselected(item.id)){
                         item.css = 'fangorn-selected';
                     }
-                    if(!item.data.permissions.view){
+                    if(item.data.permissions && !item.data.permissions.view){
                         item.css += ' tb-private-row';
                     }
                     var defaultColumns = [


### PR DESCRIPTION
## Purpose
This PR addresses the concerns of issue #3619 and creates a uniform look for private items

## Changes
- Removes links from private items so the names are not clickable
- changes the yellow folder icon to Font Awesome lock icon
- Adds lock icon to all items that are private
- Makes the private items look muted in text color

## Side Effects
This only applies to OSF related items so no changes were made in addons. As far as I know this is correct but it would help to have confirmation
I checked in all instances of files, Files Page, project overview Page, File Detail Page. I checked Wiki to make sure nothing is broken. 
Because there are changes in view logic testing needs to validate that treebeard view works fine, i.e the rows load and the private items look like they should in this change and the change does not effect non-private items.

## Screenshots
**BEFORE**
![4f982ffa-2aff-11e5-8111-0384f8a3d8fc](https://cloud.githubusercontent.com/assets/1314003/9202548/6d048f62-4020-11e5-8d92-9b26e2879c88.png)

**AFTER**

![screen shot 2015-08-11 at 11 49 36 am](https://cloud.githubusercontent.com/assets/1314003/9202568/7de359e4-4020-11e5-87c5-abee2a979e91.png)
