### PR TITLE
Fix Word Wrap and Crowded "Disconnect Account" link

### DIFF
--- a/website/addons/dataverse/templates/dataverse_user_settings.mako
+++ b/website/addons/dataverse/templates/dataverse_user_settings.mako
@@ -14,12 +14,12 @@
     </h4>
 
     <!-- ko foreach: accounts -->
+    <a data-bind="click: $root.askDisconnect" class="text-danger pull-right default-authorized-by">Disconnect Account</a>
     <div class="m-h-lg">
         <table class="table table-hover">
             <thead>
                 <tr class="user-settings-addon-auth">
                     <th class="text-muted default-authorized-by">Authorized on <a data-bind="attr.href: dataverseUrl"><em>{{ dataverseHost }}</em></a></th>
-                    <th><a data-bind="click: $root.askDisconnect" class="text-danger pull-right default-authorized-by">Disconnect Account</a></th>
                 </tr>
             </thead>
             <!-- ko if: connectedNodes().length > 0 -->

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -407,6 +407,10 @@ a {
     max-height: 140px;
     overflow-y: hidden;
 }
+.table-hover {
+    word-break: break-all;
+
+}
 select {
     word-wrap: normal;
 }

--- a/website/templates/profile/user_settings_default.mako
+++ b/website/templates/profile/user_settings_default.mako
@@ -10,12 +10,13 @@
       </small>
     </h4>
     <!-- ko foreach: accounts -->
+    <a data-bind="click: $root.askDisconnect" class="text-danger pull-right default-authorized-by">Disconnect Account</a>
+
     <div class="m-h-lg">
         <table class="table table-hover">
             <thead>
                 <tr class="user-settings-addon-auth">
                     <th class="text-muted default-authorized-by">Authorized by <em><span data-bind="text: name"></span></em></th>
-                    <th><a data-bind="click: $root.askDisconnect" class="text-danger pull-right default-authorized-by">Disconnect Account</a></th>
                 </tr>
             </thead>
             <!-- ko if: connectedNodes().length > 0 -->


### PR DESCRIPTION
<h1> Purpose </h1>
Stops project titles from overflowing tables on user settings page addons and prevents the "Disconnect Account" link from becoming crowded in table heading. Closes #3804.
<h1> Changes </h1>
Simple CSS and moves link outside table.
<h1> Side Effects </h1>
None.