### PR TITLE
[feature] Notify contributors when added to a component whose parent project is private

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1765,11 +1765,8 @@ class TestAddingContributorViews(OsfTestCase):
     @mock.patch('website.mails.send_mail')
     def test_add_contributors_post_only_sends_one_email_to_registered_user(self, mock_send_mail):
         # Project has components
-        comp1, comp2 = NodeFactory(
-            creator=self.creator), NodeFactory(creator=self.creator)
-        self.project.nodes.append(comp1)
-        self.project.nodes.append(comp2)
-        self.project.save()
+        comp1 = NodeFactory(creator=self.creator, parent=self.project)
+        comp2 = NodeFactory(creator=self.creator, parent=self.project)
 
         # A registered user is added to the project AND its components
         user = UserFactory()
@@ -1792,6 +1789,34 @@ class TestAddingContributorViews(OsfTestCase):
 
         # send_mail should only have been called once
         assert_equal(mock_send_mail.call_count, 1)
+
+    @mock.patch('website.mails.send_mail')
+    def test_add_contributors_post_sends_email_if_user_not_contributor_on_parent_node(self, mock_send_mail):
+        # Project has a component with a sub-component
+        component = NodeFactory(creator=self.creator, parent=self.project)
+        sub_component = NodeFactory(creator=self.creator, parent=component)
+
+        # A registered user is added to the project and the sub-component, but NOT the component
+        user = UserFactory()
+        user_dict = {
+            'id': user._id,
+            'fullname': user.fullname,
+            'email': user.username,
+            'permission': 'write',
+            'visible': True}
+
+        payload = {
+            'users': [user_dict],
+            'node_ids': [sub_component._primary_key]
+        }
+
+        # send request
+        url = self.project.api_url_for('project_contributors_post')
+        assert self.project.can_edit(user=self.creator)
+        self.app.post_json(url, payload, auth=self.creator.auth)
+
+        # send_mail is called for both the project and the sub-component
+        assert_equal(mock_send_mail.call_count, 2)
 
 
     @mock.patch('website.project.views.contributor.send_claim_email')

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2308,8 +2308,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
             if save:
                 self.save()
 
-            if not self.parent_node or not self.parent_node.is_contributor(contributor):
-                project_signals.contributor_added.send(self, contributor=contributor)
+            project_signals.contributor_added.send(self, contributor=contributor)
 
             return True
 

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2308,7 +2308,8 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
             if save:
                 self.save()
 
-            project_signals.contributor_added.send(self, contributor=contributor)
+            if not self.parent_node or not self.parent_node.is_contributor(contributor):
+                project_signals.contributor_added.send(self, contributor=contributor)
 
             return True
 

--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -347,9 +347,8 @@ def project_contributors_post(auth, node, **kwargs):
     node.add_contributors(contributors=contribs, auth=auth)
     node.save()
 
-    # Disconnect listeners to avoid multiple invite or notification emails
+    # Disconnect listener to avoid multiple invite emails
     unreg_contributor_added.disconnect(finalize_invitation)
-    contributor_added.disconnect(notify_added_contributor)
 
     for child_id in node_ids:
         child = Node.load(child_id)
@@ -361,7 +360,7 @@ def project_contributors_post(auth, node, **kwargs):
         child.save()
     # Reconnect listeners
     unreg_contributor_added.connect(finalize_invitation)
-    contributor_added.connect(notify_added_contributor)
+
     return {'status': 'success'}, 201
 
 

--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -526,7 +526,7 @@ def notify_added_contributor(node, contributor, throttle=None):
     # via 'add_contributor' but does not need to get notified.
     # Only email users for projects, or for components where they are not contributors on the parent node.
     if (contributor.is_registered and not node.template_node and not node.is_fork
-            and not node.parent_node or not node.parent_node.is_contributor(contributor)):
+            and not node.parent_node or (node.parent_node and not node.parent_node.is_contributor(contributor))):
         contributor_record = contributor.contributor_added_email_records.get(node._id, {})
         if contributor_record:
             timestamp = contributor_record.get('last_sent', None)

--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -522,9 +522,11 @@ def send_claim_email(email, user, node, notify=True, throttle=24 * 3600):
 def notify_added_contributor(node, contributor, throttle=None):
     throttle = throttle or settings.CONTRIBUTOR_ADDED_EMAIL_THROTTLE
 
-    # Exclude forks and templates because the user forking/templating the project
-    # gets added via 'add_contributor' but does not need to get notified
-    if contributor.is_registered and not node.template_node and not node.is_fork:
+    # Exclude forks and templates because the user forking/templating the project gets added
+    # via 'add_contributor' but does not need to get notified.
+    # Only email users for projects, or for components where they are not contributors on the parent node.
+    if (contributor.is_registered and not node.template_node and not node.is_fork
+            and not node.parent_node or not node.parent_node.is_contributor(contributor)):
         contributor_record = contributor.contributor_added_email_records.get(node._id, {})
         if contributor_record:
             timestamp = contributor_record.get('last_sent', None)


### PR DESCRIPTION
Continuation of https://github.com/CenterForOpenScience/osf.io/pull/3385

Purpose
----------
If a project has a component with a sub-component, and a user is added to both the top-level project and the sub-component but not the component, the user would only receive one email about being added to the project. However, when viewing the project page, they will just see a private component and may not realize that they were also added to a sub-component in that private component.

Changes
------------
Notify contributors if they have been added to a component if the parent project is private. So in the example above, the user would receive two emails: one for the top-level project and another for the sub-component.
