### PR TITLE
[Ready] Fix for scrolling width of revisions table 

### DIFF
--- a/website/static/js/filepage/revisions.js
+++ b/website/static/js/filepage/revisions.js
@@ -132,7 +132,7 @@ var FileRevisionsTable = {
     view: function(ctrl) {
         return m('#revisionsPanel.panel.panel-default', [
                 m('.panel-heading.clearfix', m('h3.panel-title', 'Revisions')),
-                m('.panel-body', {style:{'padding-right': '0','padding-left':'0', 'padding-bottom' : '0'}}, (function() {
+                m('.panel-body', {style:{'padding-right': '0','padding-left':'0', 'padding-bottom' : '0', 'overflow': 'auto'}}, (function() {
                     if (!model.loaded()) {
                         return util.Spinner;
                     }
@@ -140,7 +140,7 @@ var FileRevisionsTable = {
                         return m('.alert.alert-warning', {style:{margin: '10px'}}, model.errorMessage);
                     }
 
-                    return m('table.table',{style: {marginBottom: '0'}}, [
+                    return m('table.table.table-responsive',{style: {marginBottom: '0'}}, [
                         ctrl.getTableHead(),
                         m('tbody', model.revisions.map(ctrl.makeTableRow))
                     ]);


### PR DESCRIPTION
## Purpose
This PR is a temporary fix to the issue #3787 , it's temporary in the sense that a Proposal for revising this section will be sent. In the meantime the fix itself is standard across the web and not a hack. It follows Jeff's suggestion in the discussion. 

## Changes
Force non-responsiveness on revision when table is in narrow window view. It maintains responsiveness in bigger windows. 

## Side Effects
This will hide the download button from immediate view which is not ideal but otherwise it would be stretched outside the window anyway. 

## Screenshot
![screen shot 2015-08-11 at 3 23 36 pm](https://cloud.githubusercontent.com/assets/1314003/9207673/f5b76106-403c-11e5-98b5-c953e8eb21f3.png)
