### PR TITLE
[Feature] Add click support for onboarder dropzone in IE

### DIFF
--- a/website/static/js/onboarder.js
+++ b/website/static/js/onboarder.js
@@ -597,8 +597,9 @@ function OBUploaderViewModel(params) {
     };
     self.dropzone = new Dropzone(self.selector, dropzoneOpts);
 
+    //Drag & drop is non-functional in IE; change instructional header to indicate this to the user.
     if($osf.isIE()){
-        $('h4:contains(1. Drop file (or click below))').replaceWith('<h4>1. Click below to select file</h4>');
+        $('#obDropzone-header').replaceWith('<h4 id=\'obDropzone-header\'>1. Click below to select file</h4>');
     }
 
     //stop user from leaving if file is staged for upload

--- a/website/static/js/onboarder.js
+++ b/website/static/js/onboarder.js
@@ -519,6 +519,7 @@ function OBUploaderViewModel(params) {
             };
         },
 
+        clickable: '#obDropzone',
         url: '/', // specified per upload
         autoProcessQueue: false,
         createImageThumbnails: false,
@@ -595,6 +596,10 @@ function OBUploaderViewModel(params) {
         }
     };
     self.dropzone = new Dropzone(self.selector, dropzoneOpts);
+
+    if($osf.isIE()){
+        $("h4:contains(1. Drop file (or click below))").replaceWith("<h4>1. Click below to select file</h4>");
+    }
 
     //stop user from leaving if file is staged for upload
     $(window).on('beforeunload', function() {

--- a/website/static/js/onboarder.js
+++ b/website/static/js/onboarder.js
@@ -598,7 +598,7 @@ function OBUploaderViewModel(params) {
     self.dropzone = new Dropzone(self.selector, dropzoneOpts);
 
     if($osf.isIE()){
-        $("h4:contains(1. Drop file (or click below))").replaceWith("<h4>1. Click below to select file</h4>");
+        $('h4:contains(1. Drop file (or click below))').replaceWith('<h4>1. Click below to select file</h4>');
     }
 
     //stop user from leaving if file is staged for upload

--- a/website/templates/components/dashboard_templates.mako
+++ b/website/templates/components/dashboard_templates.mako
@@ -103,7 +103,7 @@
     <div class="panel-body">
         <div class="row">
             <div class="col-md-12">
-                <h4>1. Drop file (or click below)</h4>
+                <h4 id="obDropzone-header">1. Drop file (or click below)</h4>
 
                 <!-- Dropzone -->
                 <div data-bind="click: clearMessages(), visible: enableUpload()" id="obDropzone" class="osf-box box-round ob-dropzone ob-dropzone-box osf-box box-round box-lt pull-left"></div>


### PR DESCRIPTION
Purpose
=======
Partial fix for https://github.com/CenterForOpenScience/osf.io/issues/1669
Adds click-to-upload functionality, does not add drag&drop functionality. There's something weird about IE's event system, preventing drag&drop related events from being registered. It may be due to an interaction with knockout, but I've found no evidence for or against that.

Changes
=======
* One `dropzoneOpts` key-value pair added
* Change the header above the dropzone (to `"Click below to select file"`) iff IE

Side Effects
=========
May fix similar issue for Safari 7.0.3 (untested). See https://github.com/CenterForOpenScience/osf.io/issues/1250
If so, header will not change in Safari.