### PR TITLE
[Feature Fix] Fix update message disappear on safari

### DIFF
--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -705,6 +705,14 @@ var isIE = function(userAgent) {
 };
 
 /**
+*  Helper function to judge if the user browser is Safari
+*/
+var isSafari = function(userAgent) {
+    userAgent = userAgent || navigator.userAgent;
+    return (userAgent.search('Safari') >= 0 && userAgent.search('Chrome') < 0);
+};
+
+/**
   * Confirm a dangerous action by requiring the user to enter specific text
   *
   * This is an abstraction over bootbox, and passes most options through to
@@ -793,5 +801,6 @@ module.exports = window.$.osf = {
     initializeResponsiveAffix: initializeResponsiveAffix,
     humanFileSize: humanFileSize,
     confirmDangerousAction: confirmDangerousAction,
-    isIE: isIE
+    isIE: isIE,
+    isSafari:isSafari
 };

--- a/website/static/js/pages/project-settings-page.js
+++ b/website/static/js/pages/project-settings-page.js
@@ -71,9 +71,14 @@ $(document).ready(function() {
             ctx.node.urls.api + 'settings/comments/',
             {commentLevel: commentLevel}
         ).done(function() {
-            $commentMsg.addClass('text-success');
             $commentMsg.text('Successfully updated settings.');
-            setTimeout(function(){window.location.reload();}, 100);
+            $commentMsg.addClass('text-success');
+            if($osf.isSafari()){
+                setTimeout(function(){window.location.reload();}, 100);
+            } else {
+                window.location.reload();
+            }
+
         }).fail(function() {
             bootbox.alert({
                 message: 'Could not set commenting configuration. Please try again.',
@@ -112,7 +117,11 @@ $(document).ready(function() {
                 msgElm.text('Settings updated').fadeIn();
                 checkedOnLoad = $('#selectAddonsForm input:checked');
                 uncheckedOnLoad = $('#selectAddonsForm input:not(:checked)');
-                window.location.reload();
+                if($osf.isSafari()){
+                    setTimeout(function(){window.location.reload();}, 100);
+                } else {
+                    window.location.reload();
+                }
             }
         });
 

--- a/website/static/js/pages/project-settings-page.js
+++ b/website/static/js/pages/project-settings-page.js
@@ -73,7 +73,7 @@ $(document).ready(function() {
         ).done(function() {
             $commentMsg.addClass('text-success');
             $commentMsg.text('Successfully updated settings.');
-            window.location.reload();
+            setTimeout(function(){window.location.reload();}, 100);
         }).fail(function() {
             bootbox.alert({
                 message: 'Could not set commenting configuration. Please try again.',

--- a/website/static/js/pages/project-settings-page.js
+++ b/website/static/js/pages/project-settings-page.js
@@ -74,6 +74,7 @@ $(document).ready(function() {
             $commentMsg.text('Successfully updated settings.');
             $commentMsg.addClass('text-success');
             if($osf.isSafari()){
+                //Safari can't update jquery style change before reloading. So delay is applied here
                 setTimeout(function(){window.location.reload();}, 100);
             } else {
                 window.location.reload();
@@ -118,6 +119,7 @@ $(document).ready(function() {
                 checkedOnLoad = $('#selectAddonsForm input:checked');
                 uncheckedOnLoad = $('#selectAddonsForm input:not(:checked)');
                 if($osf.isSafari()){
+                    //Safari can't update jquery style change before reloading. So delay is applied here
                     setTimeout(function(){window.location.reload();}, 100);
                 } else {
                     window.location.reload();

--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -210,8 +210,8 @@
                     </div>
                     <form id="notificationSettings" class="osf-treebeard-minimal">
                         <div id="grid">
-                            <div class="notifications-loading">
-                                <i class="fa fa-spinner notifications-spin"></i>
+                            <div class="spinner-loading-wrapper">
+                                <div class="logo-spin text-center"><img src="/static/img/logo_spin.png" alt="loader"> </div>
                                 <p class="m-t-sm fg-load-message"> Loading notification settings...  </p>
                             </div>
                         </div>


### PR DESCRIPTION
### Purpose
In Safari, the updating message in addon setting will not show. It is because Safari will not update the style instantly. So In this PR, it adds delay before reloading the page. Therefore it will show the message.

Resolve https://github.com/CenterForOpenScience/osf.io/issues/4001

Another change is about the spinner in comment configuration. In this PR, it replaces the old spinner with the style guide spinner. 

### Changes
1) Add helper function for checking Safari Browser
2) Add setout delay for safari before reloading the page in project setting page
3) Replace with the style guide spinner

### Side Effect
Apply setout function in Safari and it will create 100 milliseconds delay.