### PR TITLE
[Feature] Fix permissions regression

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -188,8 +188,10 @@ function resolveIconView(item) {
         var template = m('span', { 'class' : iconType});
         return template;
     }
-    if (!item.data.permissions.view) {
-        return m('span', { 'class' : iconmap.private });
+    if (item.data.permissions){
+        if (!item.data.permissions.view) {
+            return m('span', { 'class' : iconmap.private });
+        }
     }
     if (item.data.isDashboard) {
         return returnView('collection');


### PR DESCRIPTION
Purpose
=======
Fix https://trello.com/c/ObhQKy9w/36-project-settings-page-is-broken-for-add-on-and-notifications-configuration

The issue arised because two different types of `item` will be checked there: `object` and `event`. An `object` has associated `permissions`, an `event` does not.

Changes
=======
Check for `item.data.permissions` to avoid a regression-causing `TypeError`

Side Effects
=========
None