### PR TITLE
[Feature] API exception handle project delete with components

### DIFF
--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -109,8 +109,13 @@ class NodeDetail(generics.RetrieveUpdateDestroyAPIView, NodeMixin):
         user = self.request.user
         auth = Auth(user)
         node = self.get_object()
-        node.remove_node(auth=auth)
-        node.save()
+        nodes = self.get_node().nodes
+        # If there are no children, then allow the node to be removed, otherwise give a 403 error.
+        if len(nodes) == 0:
+            node.remove_node(auth=auth)
+            node.save()
+        else:
+            raise PermissionDenied(detail='Any child components must be deleted prior to deleting this project.')
 
 
 class NodeContributorsList(generics.ListAPIView, ListFilterMixin, NodeMixin):

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -2,7 +2,7 @@ import requests
 
 from modularodm import Q
 from rest_framework import generics, permissions as drf_permissions
-from rest_framework.exceptions import PermissionDenied, ValidationError
+from rest_framework.exceptions import PermissionDenied, ValidationError, ParseError
 
 from framework.auth.core import Auth
 from website.models import Node, Pointer
@@ -12,6 +12,7 @@ from api.base.utils import get_object_or_404, waterbutler_url_for
 from .serializers import NodeSerializer, NodePointersSerializer, NodeFilesSerializer
 from .permissions import ContributorOrPublic, ReadOnlyIfRegistration, ContributorOrPublicForPointers
 from website.exceptions import NodeStateError
+from framework.exceptions import PermissionsError
 
 
 class NodeMixin(object):
@@ -114,7 +115,10 @@ class NodeDetail(generics.RetrieveUpdateDestroyAPIView, NodeMixin):
         try:
             node.remove_node(auth=auth)
         except NodeStateError:
+            raise ParseError(detail="Any child components must be deleted prior to deleting this project.")
+        except PermissionsError:
             raise PermissionDenied()
+
         node.save()
 
 

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -111,11 +111,12 @@ class NodeDetail(generics.RetrieveUpdateDestroyAPIView, NodeMixin):
         user = self.request.user
         auth = Auth(user)
         node = self.get_object()
-        # If there are no children, then allow the node to be removed, otherwise give a 403 error.
         try:
             node.remove_node(auth=auth)
+        # If there are no children, then allow the node to be removed, otherwise give a 400 error.
         except NodeStateError:
             raise ParseError(detail="Any child components must be deleted prior to deleting this project.")
+        # Catch unauthorized deletions and return a 403 error.
         except PermissionsError:
             raise PermissionDenied()
 

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -646,6 +646,20 @@ class TestNodeDelete(ApiTestCase):
         assert_equal(res.status_code, 403)
         assert_equal(self.public_project.is_deleted, False)
 
+    def test_deletes_public_project_node_if_child(self):
+        self.component = NodeFactory(parent=self.public_project, creator=self.user)
+        res = self.app.delete_json(self.public_url, auth=self.user.auth, expect_errors=True)
+        self.public_project.reload()
+        assert_equal(res.status_code, 403)
+        assert_equal(self.public_project.is_deleted, False)
+
+    def test_deletes_private_project_node_if_child(self):
+        self.component = NodeFactory(parent=self.project, creator=self.user)
+        res = self.app.delete_json(self.private_url, auth=self.user.auth, expect_errors=True)
+        self.project.reload()
+        assert_equal(res.status_code, 403)
+        assert_equal(self.project.is_deleted, False)
+
     def test_deletes_public_node_succeeds_as_owner(self):
         res = self.app.delete_json(self.public_url, auth=self.user.auth, expect_errors=True)
         self.public_project.reload()

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -646,14 +646,14 @@ class TestNodeDelete(ApiTestCase):
         assert_equal(res.status_code, 403)
         assert_equal(self.public_project.is_deleted, False)
 
-    def test_deletes_public_project_node_if_child(self):
+    def test_fails_to_delete_public_project_node_with_child(self):
         self.component = NodeFactory(parent=self.public_project, creator=self.user)
         res = self.app.delete_json(self.public_url, auth=self.user.auth, expect_errors=True)
         self.public_project.reload()
         assert_equal(res.status_code, 403)
         assert_equal(self.public_project.is_deleted, False)
 
-    def test_deletes_private_project_node_if_child(self):
+    def test_fails_to_delete_private_project_node_with_child(self):
         self.component = NodeFactory(parent=self.project, creator=self.user)
         res = self.app.delete_json(self.private_url, auth=self.user.auth, expect_errors=True)
         self.project.reload()

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -650,14 +650,14 @@ class TestNodeDelete(ApiTestCase):
         self.component = NodeFactory(parent=self.public_project, creator=self.user)
         res = self.app.delete_json(self.public_url, auth=self.user.auth, expect_errors=True)
         self.public_project.reload()
-        assert_equal(res.status_code, 403)
+        assert_equal(res.status_code, 400)
         assert_equal(self.public_project.is_deleted, False)
 
     def test_fails_to_delete_private_project_node_with_child(self):
         self.component = NodeFactory(parent=self.project, creator=self.user)
         res = self.app.delete_json(self.private_url, auth=self.user.auth, expect_errors=True)
         self.project.reload()
-        assert_equal(res.status_code, 403)
+        assert_equal(res.status_code, 400)
         assert_equal(self.project.is_deleted, False)
 
     def test_deletes_public_node_succeeds_as_owner(self):


### PR DESCRIPTION
Fixes #3969

Purpose
-------

Trying to delete a node that has children is not allowed.  Currently, the API returns a 500 error.  After the change, it will return a 403 response with the message "Any child components must be deleted prior to deleting this project." 

Changes
------------

Within the NodeDetail class, the perform_destroy method now has logic to test if the the node has children.  If so, an exception is raised.

### Before

![screen shot 2015-08-12 at 4 33 15 pm](https://cloud.githubusercontent.com/assets/6232068/9235973/0e132bd0-4110-11e5-8ef3-55d739b93bb5.png)

### After

![screen shot 2015-08-12 at 4 33 30 pm](https://cloud.githubusercontent.com/assets/6232068/9235979/151cd926-4110-11e5-95b1-fa88e4a4f5da.png)
