### PR TITLE
[feature] Treebeard OSF Meetings

### DIFF
--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -37,6 +37,7 @@ var entry = {
     'register_1-page': staticPath('js/pages/register_1-page.js'),
     'sharing-page': staticPath('js/pages/sharing-page.js'),
     'conference-page': staticPath('js/pages/conference-page.js'),
+    'meetings-page': staticPath('js/pages/meetings-page.js'),
     'view-file-tree-page': staticPath('js/pages/view-file-tree-page.js'),
     'project-settings-page': staticPath('js/pages/project-settings-page.js'),
     'search-page': staticPath('js/pages/search-page.js'),

--- a/website/conferences/views.py
+++ b/website/conferences/views.py
@@ -125,7 +125,7 @@ def add_poster_by_email(conference, message):
     )
 
 
-def _render_conference_node(node, idx):
+def _render_conference_node(node, idx, conf):
     storage_settings = node.get_addon('osfstorage')
     records = storage_settings.root_node.children
     try:
@@ -158,13 +158,16 @@ def _render_conference_node(node, idx):
         'category': 'talk' if 'talk' in node.system_tags else 'poster',
         'download': download_count,
         'downloadUrl': download_url,
+        'dateCreated': str(node.date_created),
+        'confName': conf.name,
+        'confUrl': web_url_for('conference_results', meeting=conf.endpoint),
         'tags': ' '.join(tags)
     }
 
 
 def conference_data(meeting):
     try:
-        Conference.find_one(Q('endpoint', 'iexact', meeting))
+        conf = Conference.find_one(Q('endpoint', 'iexact', meeting))
     except ModularOdmException:
         raise HTTPError(httplib.NOT_FOUND)
 
@@ -175,7 +178,7 @@ def conference_data(meeting):
     )
 
     ret = [
-        _render_conference_node(each, idx)
+        _render_conference_node(each, idx, conf)
         for idx, each in enumerate(nodes)
     ]
     return ret
@@ -207,8 +210,8 @@ def conference_results(meeting):
 
 
 def conference_view(**kwargs):
-
     meetings = []
+    submissions = []
     for conf in Conference.find():
         query = (
             Q('tags', 'iexact', conf.endpoint)
@@ -216,15 +219,19 @@ def conference_view(**kwargs):
             & Q('is_deleted', 'eq', False)
         )
         projects = Node.find(query)
-        submissions = projects.count()
-        if submissions < settings.CONFERNCE_MIN_COUNT:
+        for idx, node in enumerate(projects):
+            submissions.append(_render_conference_node(node, idx, conf))
+        num_submissions = projects.count()
+        if num_submissions < settings.CONFERNCE_MIN_COUNT:
             continue
         meetings.append({
             'name': conf.name,
             'active': conf.active,
             'url': web_url_for('conference_results', meeting=conf.endpoint),
-            'submissions': submissions,
+            'count': num_submissions,
         })
-    meetings.sort(key=lambda meeting: meeting['submissions'], reverse=True)
 
-    return {'meetings': meetings}
+    submissions.sort(key=lambda submission: submission['dateCreated'], reverse=True)
+    meetings.sort(key=lambda meeting: meeting['count'], reverse=True)
+
+    return {'meetings': meetings, 'submissions': submissions}

--- a/website/static/js/meetings.js
+++ b/website/static/js/meetings.js
@@ -1,0 +1,69 @@
+var $ = require('jquery');
+var m = require('mithril');
+var Treebeard = require('treebeard');
+
+
+function Meetings(data) {
+    //  Treebeard 'All Meetings' Grid
+    var tbOptions = {
+        divID: 'meetings-grid',
+        filesData: data,
+        rowHeight : 30,         // user can override or get from .tb-row height
+        paginate : false,       // Whether the applet starts with pagination or not.
+        paginateToggle : false, // Show the buttons that allow users to switch between scroll and paginate.
+        uploads : false,         // Turns dropzone on/off.
+        columnTitles : function() {
+             return [
+                {
+                    title: 'Name',
+                    width: '50%',
+                    sortType : 'text',
+                    sort : true
+                },
+                {
+                     title: 'Submissions',
+                     width : '25%',
+                     sortType : 'number',
+                     sort : true
+                },
+                {
+                    title: 'Accepting Submissions',
+                    width: '25%',
+                    sortType: 'text',
+                    sort: true
+                }
+            ];
+        },
+        resolveRows : function _conferenceResolveRows(item){
+            return [
+                {
+                    data : 'name',  // Data field name
+                    sortInclude : true,
+                    custom : function() { return m('a', { href : item.data.url, target : '_blank' }, item.data.name ); }
+
+                },
+                {
+                    data: 'count',
+                    sortInclude: true
+                },
+                {
+                    data: 'active', // Data field name
+                    sortInclude: true,
+                    custom: function() { return item.data.active ? 'Yes' : 'No'; }
+                }
+            ];
+        },
+        sortButtonSelector : {
+            up : 'i.fa.fa-chevron-up',
+            down : 'i.fa.fa-chevron-down'
+        },
+        hScroll: 'auto',
+        showFilter : false,     // Gives the option to filter by showing the filter box.
+        allowMove : false,       // Turn moving on or off.
+        hoverClass : 'fangorn-hover',
+    };
+
+    var grid = new Treebeard(tbOptions);
+}
+
+module.exports = Meetings;

--- a/website/static/js/pages/meetings-page.js
+++ b/website/static/js/pages/meetings-page.js
@@ -1,0 +1,5 @@
+var Meetings = require('../meetings.js');
+var Submissions = require('../submissions.js');
+
+new Meetings(window.contextVars.meetings);
+new Submissions(window.contextVars.submissions);

--- a/website/static/js/submissions.js
+++ b/website/static/js/submissions.js
@@ -1,0 +1,109 @@
+var $ = require('jquery');
+var m = require('mithril');
+var osfHelpers = require('js/osfHelpers');
+var Treebeard = require('treebeard');
+
+
+function Submissions(data) {
+    //  Treebeard 'All Submissions' Grid
+    var tbOptions = {
+        divID: 'submissions-grid',
+        filesData: data,
+        rowHeight : 30,         // user can override or get from .tb-row height
+        paginate : false,       // Whether the applet starts with pagination or not.
+        paginateToggle : false, // Show the buttons that allow users to switch between scroll and paginate.
+        uploads : false,         // Turns dropzone on/off.
+        columnTitles : function() {
+             return [
+                {
+                    title: 'Title',
+                    width: '30%',
+                    sortType : 'text',
+                    sort : true
+                },
+                {
+                     title: 'Author',
+                     width : '15%',
+                     sortType : 'number',
+                     sort : true
+                },
+                {
+                    title: 'Date Created',
+                    width: '15%',
+                    sortType: 'date',
+                    sort: true
+                },
+                {
+                    title: 'Downloads',
+                    width: '15%',
+                    sortType: 'date',
+                    sort: true
+                },
+                {
+                    title: 'Conference',
+                    width: '25%',
+                    sortType: 'text',
+                    sort: true
+                }
+            ];
+        },
+        resolveRows : function _conferenceResolveRows(item) {
+            return [
+                {
+                    data : 'title',  // Data field name
+                    sortInclude : true,
+                    custom : function() {
+                        return m('a', { href : item.data.nodeUrl, target : '_blank' }, item.data.title ); }
+
+                },
+                {
+                    data: 'author',  // Data field name
+                    sortInclude: true,
+                    custom: function() { return m('a', {href: item.data.authorUrl}, item.data.author); }
+                },
+
+                {
+                    data: 'dateCreated', // Data field name
+                    sortInclude: true,
+                    custom: function() {
+                        var dateCreated = new osfHelpers.FormattableDate(item.data.dateCreated);
+                        return m('', dateCreated.local);
+                    }
+                },
+                {
+                    data : 'download',  // Data field name
+                    folderIcons : false,
+                    filter : false,
+                    custom : function() {
+                        if(item.data.downloadUrl){
+                            return [ m('a', { href : item.data.downloadUrl }, [
+                                m('button.btn.btn-success.btn-xs', { style : 'margin-right : 10px;'},  m('i.fa.fa-download.fa-inverse')),
+
+                            ] ), item.data.download  ];
+                        } else {
+                            return '';
+                        }
+                    }
+
+                },
+                {
+                    data: 'confName',
+                    sortInclude: true,
+                    custom: function() { return m('a', {href: item.data.confUrl}, item.data.confName); }
+                }
+            ];
+        },
+        sortButtonSelector : {
+            up : 'i.fa.fa-chevron-up',
+            down : 'i.fa.fa-chevron-down'
+        },
+        hScroll: 'auto',
+        showFilter : false,     // Gives the option to filter by showing the filter box.
+        allowMove : false,       // Turn moving on or off.
+        hoverClass : 'fangorn-hover',
+    };
+
+    var grid = new Treebeard(tbOptions);
+}
+
+module.exports = Submissions;

--- a/website/templates/public/pages/meeting_landing.mako
+++ b/website/templates/public/pages/meeting_landing.mako
@@ -5,10 +5,9 @@
 <%def name="content()">
 
     <div class="row">
+        <div class="col-md-12">
 
-        <div class="col-md-8 col-md-offset-2">
-
-            <h1>OSF for Meetings</h1>
+            <h1 class="text-center">OSF for Meetings</h1>
 
             <p>
                 The OSF can host posters and talks for scholarly meetings.
@@ -17,7 +16,6 @@
                 link to your presentation, plus analytics about who has viewed and
                 downloaded your work.
             </p>
-
             <p>
                 OSF for Meetings is a product that we offer to
                 academic conferences at no cost. To request poster and talk hosting
@@ -26,36 +24,41 @@
                 and add your conference within one business day.
             </p>
 
-            <p>
-                <small>Only conferences with at least five submissions are displayed here.</small>
-            </p>
-
-            <table class="table table-striped" id="conferenceViewTable">
-                <tbody>
-                % for meeting in meetings:
-                    <tr>
-                        <td>
-                            <div style="font-size: 18px; font-weight: bold;">
-                                <a href="${meeting['url']}">
-                                    ${meeting['name']}
-                                </a>
-                            </div>
-                            <span
-                                % if not meeting['active']:
-                                    style="color: grey;"
-                                % endif
-                                >
-                                ${'Not a' if not meeting['active'] else 'A'}ccepting submissions
-                            </span>
-                        </td>
-                        <td>${meeting['submissions']} submission(s)</td>
-                    </tr>
-                % endfor
-                </tbody>
-            </table>
+            <div role="tabpanel">
+                <!-- Nav tabs -->
+                <ul class="nav nav-tabs m-b-md" role="tablist">
+                    <li role="presentation" class="active">
+                        <a href="#meetings" aria-controls="meetings" role="tab" data-toggle="tab">All Meetings</a>
+                    </li>
+                    <li role="presentation">
+                        <a href="#submissions" aria-controls="submissions" role="tab" data-toggle="tab">All Submissions</a>
+                    </li>
+                </ul>
+                <!-- Tab panes -->
+                <div class="tab-content">
+                    <div role="tabpanel" class="tab-pane active" id="meetings">
+                        <p>
+                            <small>Only conferences with at least five submissions are displayed here.</small>
+                        </p>
+                        <div id="meetings-grid"></div>
+                    </div>
+                    <div role="tabpanel" class="tab-pane" id="submissions">
+                        <div id="submissions-grid"></div>
+                    </div>
+                </div>
+            </div>
 
         </div>
-
     </div>
 
+</%def>
+
+<%def name="javascript_bottom()">
+    ${parent.javascript_bottom()}
+    <script type="text/javascript">
+        window.contextVars = window.contextVars || {};
+        window.contextVars.meetings = ${meetings | sjson, n};
+        window.contextVars.submissions = ${submissions | sjson, n};
+    </script>
+    <script src=${"/static/public/js/meetings-page.js" | webpack_asset}></script>
 </%def>


### PR DESCRIPTION
##### Purpose
- Per @JeffSpies' request, the main OSF Meetings page (```osf.io/meetings/```) will now use treebeard to display the list of meetings. 
- Additionally, a tabbed view of 'All Meetings' and 'All Submissions' has been added to the page so that users can toggle between a table of all meetings (ordered by highest number of submissions) and all submissions (ordered by the most recent submissions first). 

##### Screenshots 
- 'All Meetings' View
![screen shot 2015-08-13 at 10 39 17 am](https://cloud.githubusercontent.com/assets/7913604/9253355/60a16916-41ab-11e5-8647-44b7ad3db3e2.png)

- 'All Submissions' View
![screen shot 2015-08-13 at 11 06 02 am](https://cloud.githubusercontent.com/assets/7913604/9253358/6393f5bc-41ab-11e5-86bb-75a920a8795a.png)

Also pinging @AndrewSallans and @saradbowman for any comments.