### PR TITLE
[Ready] Tag style fixes 

### DIFF
--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -518,7 +518,7 @@ select {
     font-size:13px;
     padding:5px;
     border:1px solid transparent;
-    border-radius: 5px;
+    border-radius: 2px;
     cursor: pointer;
 }
 

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -422,6 +422,14 @@ select {
 .tag:hover > .remove-tag
 {
     visibility: visible;
+/* to make the center of the x not transparent */
+    background: -moz-radial-gradient(center, ellipse cover,  rgba(255,255,255,1) 35%, rgba(255,255,255,1) 44%, rgba(255,255,255,1) 53%, rgba(255,255,255,0) 64%, rgba(255,255,255,0) 72%); /* FF3.6+ */
+    background: -webkit-gradient(radial, center center, 0px, center center, 100%, color-stop(35%,rgba(255,255,255,1)), color-stop(44%,rgba(255,255,255,1)), color-stop(53%,rgba(255,255,255,1)), color-stop(64%,rgba(255,255,255,0)), color-stop(72%,rgba(255,255,255,0))); /* Chrome,Safari4+ */
+    background: -webkit-radial-gradient(center, ellipse cover,  rgba(255,255,255,1) 35%,rgba(255,255,255,1) 44%,rgba(255,255,255,1) 53%,rgba(255,255,255,0) 64%,rgba(255,255,255,0) 72%); /* Chrome10+,Safari5.1+ */
+    background: -o-radial-gradient(center, ellipse cover,  rgba(255,255,255,1) 35%,rgba(255,255,255,1) 44%,rgba(255,255,255,1) 53%,rgba(255,255,255,0) 64%,rgba(255,255,255,0) 72%); /* Opera 12+ */
+    background: -ms-radial-gradient(center, ellipse cover,  rgba(255,255,255,1) 35%,rgba(255,255,255,1) 44%,rgba(255,255,255,1) 53%,rgba(255,255,255,0) 64%,rgba(255,255,255,0) 72%); /* IE10+ */
+    background: radial-gradient(ellipse at center,  rgba(255,255,255,1) 35%,rgba(255,255,255,1) 44%,rgba(255,255,255,1) 53%,rgba(255,255,255,0) 64%,rgba(255,255,255,0) 72%); /* W3C */
+    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#ffffff', endColorstr='#00ffffff',GradientType=1 ); /* IE6-9 fallback on horizontal gradient */
 }
 .tag-big
 {

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -416,7 +416,7 @@ select {
     background-color: #337ab7;
     color: #E0EBF3;
 }
-.tag:hover > .tag-text
+.tag:hover > .tag-text, .tag:hover > a
 {
     color: #E0EBF3;
 }

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -503,7 +503,7 @@ select {
     color: #000;
     text-decoration:none;
     font-size: 11px;
-
+    vertical-align: top;
 }
 
 .tag {

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -414,6 +414,7 @@ select {
 .tag:hover
 {
     background-color: #337ab7;
+    color: #E0EBF3;
 }
 .tag:hover > .tag-text
 {

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -477,8 +477,8 @@ select {
     height:100px;
     overflow-y: auto;
 }
-#node-tags_tag {
-    outline: 0;
+#node-tags_tag:focus {
+    outline: 2px solid #DEF;
 }
 
 .tagsinput div {

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -477,6 +477,9 @@ select {
     height:100px;
     overflow-y: auto;
 }
+#node-tags_tag {
+    outline: 0;
+}
 
 .tagsinput div {
     float: left;


### PR DESCRIPTION
## Purpose
Makes fixes as suggested in issue #4019 to improve style of tags used. 

## Changes
- hover backgrounds are lighter color for readability
- X icon in search tags has radial white backgound to fix this (https://github.com/CenterForOpenScience/osf.io/pull/3843#issuecomment-126772678) 
- input focus outline is styled but kept for accesibility
- border radius is set to 2px 

## Side effects
I tested in search and  project overview pages, I don't know if these apply anywhere else. 

![screen shot 2015-08-13 at 10 39 09 am](https://cloud.githubusercontent.com/assets/1314003/9252985/676becf0-41a9-11e5-8c19-317e403994cd.png)

![screen shot 2015-08-13 at 10 52 45 am](https://cloud.githubusercontent.com/assets/1314003/9252995/7ed354c8-41a9-11e5-8ad8-8f7ecca42420.png)
