### PR TITLE
Fixes to SHARE Search Update

### DIFF
--- a/website/static/css/share-search.css
+++ b/website/static/css/share-search.css
@@ -137,11 +137,8 @@ stroke: #BAB5B5;
 
 .provider-footer {
     -moz-column-count: 2;
-    -moz-column-gap: 2.5em;
     -webkit-column-count: 2;
-    -webkit-column-gap: 2.5em;
     column-count: 2;
-    column-gap: 2.5em;
     list-style-type: none;
 }
 

--- a/website/static/js/share/footer.js
+++ b/website/static/js/share/footer.js
@@ -5,7 +5,7 @@ var MESSAGES = JSON.parse(require('raw!./messages.json'));
 var Footer = {
     view: function(ctrl, params) {
         return m('', [
-            m('.col-xs-12.col-lg-10.col-lg-offset-1', m.component(ProviderList, params)),
+            m('.row', m('.col-xs-12.col-lg-10.col-lg-offset-1', m.component(ProviderList, params))),
             m('.row', m('.col-md-12', {style: {paddingTop: '30px'}}, m('span', m.trust(MESSAGES.ABOUTSHARE))))
         ]);
     }

--- a/website/static/js/share/results.js
+++ b/website/static/js/share/results.js
@@ -228,8 +228,11 @@ var Footer = {
             m('span.pull-right', [
                 m('img', {src: vm.ProviderMap[result.shareProperties.source].favicon, alt: 'favicon for ' + result.shareProperties.source, style: {width: '16px', height: '16px'}}),
                 ' ',
-                m('a', {onclick: function() {utils.updateFilter(vm, 'match:shareProperties.source:' + result.shareProperties.source);}}, vm.ProviderMap[result.shareProperties.source].long_name),
-                m('br')
+                m('a', {
+                    onclick: function() {utils.updateFilter(vm, 'match:shareProperties.source:' + result.shareProperties.source);}
+                }, vm.ProviderMap[result.shareProperties.source].long_name),
+                m('br'),
+                m('hr')
             ]),
             ctrl.showRawNormalized() ? m.component(RawNormalizedData, {result: ctrl.cleanResult(), missingError: ctrl.missingError()}) : '',
         ]);


### PR DESCRIPTION
Builds on #3500.

# Purpose

Addresses 3 Bugs:
- On very small screens, the results were all crammed together and the long provider names cut out the hr between results. Now, the hr is preserved on small screens.
- On very small screens, on the SHARE index page, the provider links were unclickable. This puts them into their own HTML row so that the row below them does not take over on small screens - they're clickable on mobile now!
- The provider list was wrapping in a strange way - as noted in https://trello.com/c/KJRO3CxU/52-share-providers-list-column-vertical-wrapping-is-cut-off. This PR removes the column-gap css property that was causing the strange wrapping in Chrome

# Changes
- Updates footer to have provider list in their own row
- Adds hr to the result so that long  names don't overshaddow on mobile
- Removes column-gap in share-search.css 

# Side effects
As these are all cosmetic, none are anticipated.