### PR TITLE
Stop Single Visible Contributor Alerts From Piling Up

### DIFF
--- a/website/static/js/contribManager.js
+++ b/website/static/js/contribManager.js
@@ -274,6 +274,8 @@ var ContributorsViewModel = function(contributors, adminContributors, user, isRe
                     'error'
                 )
             );
+        } else {
+            self.messages([]);
         }
     });
 


### PR DESCRIPTION
<h1> Purpose </h1>
Stops unwarranted 'single visible contributor' alerts from piling up, like so:

<img width="952" alt="screen shot 2015-08-13 at 2 30 59 pm" src="https://cloud.githubusercontent.com/assets/9688518/9258182/00a3b13c-41c8-11e5-930f-380c8101f40d.png">

This also fixes this trello card: https://trello.com/c/uSTPAeg5/61-sharing-tab-still-seeing-the-incorrect-error-while-rearranging-contributors
<h1> Changes </h1>
Simple JS change clears message observable.