### PR TITLE
More SHARE search bugfixes

### DIFF
--- a/website/static/js/share/results.js
+++ b/website/static/js/share/results.js
@@ -175,7 +175,7 @@ var Subjects = {
         return m('span', [
             subjectViews.slice(0, 5),
             m('br'),
-            m('div', m('a', {href: '#', onclick: function() {ctrl.showAll = !ctrl.showAll;}},'See All'))
+            m('div', m('a', {onclick: function() {ctrl.showAll = !ctrl.showAll;}},'See All'))
         ]);
 
     }

--- a/website/static/js/share/sideBar.js
+++ b/website/static/js/share/sideBar.js
@@ -23,8 +23,8 @@ var ActiveFiltersHeader = {
     view: function(ctrl, params) {
         var vm = params.vm;
 
-        return m('.sidebar-header',  ['Active filters:',
-            (vm.optionalFilters.length > 0 || vm.requiredFilters.length > 0) ? m('a', {
+        return m('.sidebar-header', (vm.optionalFilters.length > 0 || vm.requiredFilters.length > 0) ? ['Active filters:',
+             m('a', {
                 style: {
                     'float': 'right'
                 }, onclick: function(event){
@@ -32,7 +32,8 @@ var ActiveFiltersHeader = {
                     vm.requiredFilters = [];
                     utils.search(vm);
                     }
-            }, ['Clear ', m('i.fa.fa-close')]) : []]);
+            }, ['Clear ', m('i.fa.fa-close')])
+        ]:[]);
     }
 };
 

--- a/website/static/js/share/stats.js
+++ b/website/static/js/share/stats.js
@@ -28,6 +28,13 @@ function donutGraph(data, vm) {
         },
         legend: {
             show: false
+        },
+        tooltip: {
+            format: {
+                value: function (value, ratio, id) {
+                    return Math.round(ratio * 100) + '%';
+                }
+            }
         }
     });
 }


### PR DESCRIPTION
Thanks to @fabianvf for most of these fixes - 

## Purpose
QA Found a few bugs:
- Blank active filters is confusing on mobile
- Clicking "show more" tags jumps the user to the top of the page
- Tooltip labeling had rounding inconsistent with graph labels

## Changes
- Remove the "Active Filters" heading when there are no active filters
- Remove href from tags to keep the user in place when clicking
- Add same rounding math to tooltip labels as graph labels

## Side Effects
-  href was removed from tags, but now - when you click on a tag to filter results, and the resulting filtered results list is shorter, the page appears blank until you scroll back to the top of the new results list (as the page did not jump as a new filter)