### PR TITLE
[WIP] [hold] Restrict what OSF routes respond to OAuth2 tokens

### DIFF
--- a/api/base/authentication/drf.py
+++ b/api/base/authentication/drf.py
@@ -78,6 +78,7 @@ class OSFCASAuthentication(authentication.BaseAuthentication):
         if user is None:
             raise exceptions.AuthenticationFailed("Could not find the user associated with this token")
 
+        # TODO: Instead of just the token itself, store the CAS response, including list of associated scopes
         return user, auth_token
 
     def authenticate_header(self, request):

--- a/api/base/permissions.py
+++ b/api/base/permissions.py
@@ -1,0 +1,14 @@
+"""
+Permissions classes intended to be shared across all types of API endpoints
+"""
+
+from rest_framework import permissions
+
+class InternalOnly(permissions.BasePermission):
+    """
+    This route is intended for internal (OSF) consumption only, and access should be denied for OAuth2 requests
+    """
+    def has_permission(self, request, view):
+        """Identify OAuth consumers based on whether request.auth is set (eg whether the authentication class
+        returns two values from the authenticate() method"""
+        return request.auth is None  # TODO: Improve this check as more token data is stored.


### PR DESCRIPTION
Refs #3323 and provides functionality useful for #3082.

## Purpose
OAuth2 bearer tokens will allow third parties to access the OSF on behalf of users.

Certain routes (some on APIv2, and all on APIv1) are not intended to be accessible externally. This proof-of-concept PR demonstrates a simplistic way of restricting access.

Those routes may be required to respond to (token-like) strings from internal services such as waterbutler, so access is restricted, rather than removed.

## Summary of changes
- Add an `InternalOnly` permissions class that can be used for APIv2 routes (such as those to be introduced in #3082)
- Modify `before_request` to check that the bearer token is originating from an OSF-whitelisted address. (Currently only waterbutler communicates with the OSF in this way)

## Side effects
Will need more testing to ensure that these restrictions can't be side-stepped.

DRF permissions class may need to be modified once we add scopes to tokens, or if other types of authentication are added (in which case checking that `request.auth` is None might be insufficient). This relies on the fact that CAS auth returns two values from `authenticate()` (the second being set as `request.auth`)