### PR TITLE
[Feature Fix] Align the display with alphabetical order

### DIFF
--- a/website/static/js/components/legend.js
+++ b/website/static/js/components/legend.js
@@ -3,6 +3,11 @@ var m = require('mithril');
 
 module.exports = {
     view: function(data, repr, opts) {
+        if(data[0].label){
+            data.sort(function(a, b) {
+                return a.label.localeCompare(b.label);
+            });
+        }
         return [
             m('div', {
                 className: 'legend-grid'

--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -989,7 +989,7 @@ function showLegend() {
     });
     var repr = function (item) {
         return [
-            m('span', {
+            m('span[style="width:18px"]', {
                 className: item.icon
             }),
             '  ',


### PR DESCRIPTION
### Purpose
Align the display with alphabetical order

The PR will resolve #3645 completely.

### Change
1) Add sorting function 
2) Align the text 

Before Change:
![screenshot 2015-08-14 10 33 14](https://cloud.githubusercontent.com/assets/5420789/9276093/ea0963e2-426f-11e5-88e8-047aa2f5760b.png)


After Change:
![screenshot 2015-08-14 10 29 43](https://cloud.githubusercontent.com/assets/5420789/9276040/8d9938bc-426f-11e5-98fa-071ed520407c.png)

### Side Effect
I don't know why I pull the request from cos develop branch. But it doesn't have the legend heading like staging.
![screenshot 2015-08-14 10 34 24](https://cloud.githubusercontent.com/assets/5420789/9276114/1297f332-4270-11e5-8025-9fe81f2c3683.png)
