### PR TITLE
[Ready] Fix project organizer saving expand/collapse state accurately

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "raw-loader": "^0.5.1",
     "share": "0.7.27",
     "style-loader": "^0.8.3",
-    "treebeard": "git://github.com/caneruguz/treebeard.git#e050802ff2ef55714c663716a3796ee15eb4c9d4",
+    "treebeard": "git://github.com/caneruguz/treebeard.git#c81b89ba6ed59e160ed5042c6208bc5fb1cc15aa",
     "typeahead.js": "^0.10.5",
     "url-loader": "^0.5.5",
     "webpack": "^1.7.2",

--- a/website/static/js/projectorganizer.js
+++ b/website/static/js/projectorganizer.js
@@ -187,7 +187,7 @@ function saveExpandState(item, callback) {
         expandUrl = item.apiURL + 'expand/';
         postAction = $osf.postJSON(expandUrl, {});
         postAction.done(function () {
-            item.expand = false;
+            item.expand = true;
             if (callback !== undefined) {
                 callback();
             }


### PR DESCRIPTION
## Purpose
Fixes the issue #2154 where in certain cases the expand/collapse state was not reliably setting. 

## Changes
- This includes treebeard change so installing assets is required. Treebeard had two invocations of the ontogglefolder function in certain cases which made the expand/collapse to be set twice. (https://github.com/caneruguz/treebeard/commit/c81b89ba6ed59e160ed5042c6208bc5fb1cc15aa)
- Existing expand/collapse state saved was wrong, although this does not really take effect for the page and is not relevant to the function but it's good to keep the server state and application state synchronizes in case we use them in the future. 

## Side effects
- Treebeard core was changed so all treebeard instances need to be tested to make sure they  **a) show content** and **b) toggle folders properly**
- Note that saving expand state is unique to Project Organizer so we don't expect that to function anywehere else in treebeard implementations. 
- Places to check
  - Project Organizer
  - File widget in project overview
  - Files tab
  - Notifications in Project settings page