### PR TITLE
[FeatureFix] Share charts with full date

### DIFF
--- a/website/static/js/share/stats.js
+++ b/website/static/js/share/stats.js
@@ -76,7 +76,7 @@ function timeGraph(data, vm) {
                     position: 'outer-center'
                 },
                 tick: {
-                    format: function (d) {return Stats.timeSinceEpochInMsToMMYY(d); }
+                    format: function (d) {return Stats.timeSinceEpochInMsToDDMMYY(d); }
                 }
             },
             y: {
@@ -127,7 +127,7 @@ Stats.sourcesByDatesAgg = function () {
 };
 
 /* Helper function for dealing with epoch times returned by elasticsearch */
-Stats.timeSinceEpochInMsToMMYY = function (timeSinceEpochInMs) {
+Stats.timeSinceEpochInMsToDDMMYY = function (timeSinceEpochInMs) {
     var d = new Date(timeSinceEpochInMs);
     return (d.getDate()+1).toString() + '/' + (d.getMonth()+1).toString() +
         '/' + d.getFullYear().toString().substring(2); 

--- a/website/static/js/share/stats.js
+++ b/website/static/js/share/stats.js
@@ -128,9 +128,9 @@ Stats.sourcesByDatesAgg = function () {
 
 /* Helper function for dealing with epoch times returned by elasticsearch */
 Stats.timeSinceEpochInMsToMMYY = function (timeSinceEpochInMs) {
-    var d = new Date(0);
-    d.setUTCSeconds(timeSinceEpochInMs / 1000);
-    return d.getMonth().toString() + '/' + d.getFullYear().toString().substring(2);
+    var d = new Date(timeSinceEpochInMs);
+    return (d.getDate()+1).toString() + '/' + (d.getMonth()+1).toString() +
+        '/' + d.getFullYear().toString().substring(2); 
 };
 
 /* Parses elasticsearch data so that it can be fed into a c3 donut graph */


### PR DESCRIPTION
Fix for trello issue: 
SHARE - Line graph's x-axis dates are in Month/Year format and repeat themselves