### PR TITLE
[hotfix] Fix OSF Meeting Download URLs

### DIFF
--- a/website/conferences/views.py
+++ b/website/conferences/views.py
@@ -137,7 +137,7 @@ def _render_conference_node(node, idx):
 
         download_url = node.web_url_for(
             'addon_view_or_download_file',
-            path=record.path,
+            path=record.path.strip('/'),
             provider='osfstorage',
             action='download',
             _absolute=True,


### PR DESCRIPTION
##### Purpose
- On both staging and production, when downloading a talk or poster from an OSF Meeting, an extra ```/``` is included in the download URL. 
- Example: on production, the download URL for the most recent SPSP 2015 poster is ```https://osf.io/project/24rz6/files/osfstorage//553eacc28c5e4a21991b2a4e/?action=download```.
- This PR removes the additional ```/``` that is not currently stripped from the file path.