### PR TITLE
[feature-fix] Add comma to contrib added email

### DIFF
--- a/website/templates/emails/contributor_added.txt.mako
+++ b/website/templates/emails/contributor_added.txt.mako
@@ -2,7 +2,7 @@ Hello ${user.fullname},
 
 You have been added as a contributor to the project "${node.title}" on the Open Science Framework: ${node.absolute_url}
 
-If you are erroneously being associated with "${node.title}" then you may visit the project sharing page and remove yourself as a contributor.
+If you are erroneously being associated with "${node.title}," then you may visit the project sharing page and remove yourself as a contributor.
 
 
 Sincerely,


### PR DESCRIPTION
Fixes https://trello.com/c/bfdUb6zf/73-contributor-notification-needs-a-comma-for-if-then-sentence