### PR TITLE
[Feature] Download citations as .rtf

### DIFF
--- a/website/static/js/citationGrid.js
+++ b/website/static/js/citationGrid.js
@@ -381,7 +381,7 @@ CitationGrid.prototype.getCitation = function(item) {
 CitationGrid.prototype.parseRTF = function(item) {
     if (item.children.length) {
         for (var i = 0; i < item.children.length; i++){
-            return self.parseRTF(item.childNodes[0])
+            return self.parseRTF(item.childNodes[i])
         }
     }
 

--- a/website/static/js/citationGrid.js
+++ b/website/static/js/citationGrid.js
@@ -379,9 +379,10 @@ CitationGrid.prototype.getCitation = function(item) {
 };
 
 CitationGrid.prototype.parseRTF = function(item) {
+    var self = this;
     if (item.children.length) {
         for (var i = 0; i < item.children.length; i++){
-            return self.parseRTF(item.childNodes[i])
+            return self.parseRTF(item.childNodes[i]);
         }
     }
 
@@ -399,12 +400,13 @@ CitationGrid.prototype.parseRTF = function(item) {
 
 CitationGrid.prototype.getRTFCitation = function(item) {
     //Change HTML tags in each citation item to .rtf tags, for exporting
+    var self = this;
     var citation = this.getBibliography(item.parent())[item.data.csl.id];
     var htmlCitation = $.parseHTML(citation)[0];
     var rtfCitation = '';
 
     for(var i = 0; i < htmlCitation.childNodes.length; i++) {
-        rtfCitation += self.parseRTF(htmlCitation.childNodes[i])
+        rtfCitation += self.parseRTF(htmlCitation.childNodes[i]);
     }
 
     return rtfCitation.replace('\n', '').trim() + '\\';

--- a/website/static/js/citationGrid.js
+++ b/website/static/js/citationGrid.js
@@ -356,7 +356,7 @@ CitationGrid.prototype.makeBibliography = function(folder, format) {
         })
     );
     if (!format) {
-        format = 'html'
+        format = 'html';
     }
     var citeproc = citations.makeCiteproc(this.styleXml, data, format);
     var bibliography = citeproc.makeBibliography();

--- a/website/static/js/citationGrid.js
+++ b/website/static/js/citationGrid.js
@@ -219,6 +219,12 @@ var renderActions = function(item, col) {
             css: 'btn btn-default btn-xs',
             tooltip: 'Download citations',
             config: function(elm, isInit, ctx) {
+                // In JS, double-backlashes escape in-string backslashes,
+                // Quick overview of RTF file formatting (see https://msdn.microsoft.com/en-us/library/aa140284%28v=office.10%29.aspx for more):
+                // "{\rtf1\ansi             <- RTF headers indicating RTF version and char encoding, other headers possible but unecessary
+                //  [content line 1]\       <- Trailing backlash indicating newline in displayed file, \n otherwise ignored for display
+                //  [content line 2]        <- Trailing backslash not strictly necessary for final line, but doesn't hurt
+                //  }"                      <- Closing brace indicates EOF for display purposes
                 var text = '{\\rtf1\\ansi\n' + self.getCitations(item, 'rtf').join('\\\n') + '\n}';
                 $(elm).parent('a')
                     .attr('href', 'data:text/enriched;charset=utf-8,' + encodeURIComponent(text))
@@ -355,9 +361,7 @@ CitationGrid.prototype.makeBibliography = function(folder, format) {
             return child.data.csl;
         })
     );
-    if (!format) {
-        format = 'html';
-    }
+    format = format || 'html';
     var citeproc = citations.makeCiteproc(this.styleXml, data, format);
     var bibliography = citeproc.makeBibliography();
     if (bibliography[0].entry_ids) {


### PR DESCRIPTION
Purpose
======
Closes https://github.com/CenterForOpenScience/osf.io/issues/3951

Changes
=======
Function to parse the HTML version of citations to `rtf` formatting added.

Side Effects
=========
None