### PR TITLE
[Ready] Fix spinner problems for 0.46

### DIFF
--- a/website/templates/dashboard.mako
+++ b/website/templates/dashboard.mako
@@ -13,7 +13,12 @@
         </div><!-- end div -->
 
         <div class="project-organizer" id="projectOrganizerScope">
-            <div id="project-grid"></div>
+            <div id="project-grid">
+                <div class="spinner-loading-wrapper">
+                    <div class="logo-spin logo-lg"></div>
+                     <p class="m-t-sm fg-load-message"> Loading projects...  </p>
+                </div>
+            </div>
         </div><!-- end project-organizer -->
     </div><!-- end col -->
 

--- a/website/templates/log_list.mako
+++ b/website/templates/log_list.mako
@@ -29,7 +29,7 @@
                 </p>
                 <span data-bind="if: loading()">
                     <div class="spinner-loading-wrapper">
-		                <div class="logo-spin logo-xl"></div>
+		                <div class="logo-spin logo-lg"></div>
 	                	<p class="m-t-sm text-center"> Loading logs...  </p>
 	                </div>
                 </span>
@@ -79,7 +79,7 @@
                     </ul>
                 </div>
 
-            </div> 
+            </div>
         </div>
 </div>
 </div><!-- end #logScope -->

--- a/website/templates/profile/notifications.mako
+++ b/website/templates/profile/notifications.mako
@@ -48,7 +48,7 @@
                 <form id="selectNotifications" class="osf-treebeard-minimal">
                     <div id="grid">
                         <div class="spinner-loading-wrapper">
-                            <div class="logo-spin logo-xl"></div>
+                            <div class="logo-spin logo-lg"></div>
                             <p class="m-t-sm fg-load-message"> Loading notification settings... </p>
                         </div>
                     </div>

--- a/website/templates/project/files.mako
+++ b/website/templates/project/files.mako
@@ -7,8 +7,8 @@
 
 <div id="treeGrid">
 	<div class="spinner-loading-wrapper">
-		<div class="logo-spin logo-xl"></div>
-		<p class="m-t-sm fg-load-message"> Loading files...  </p> 
+		<div class="logo-spin logo-lg"></div>
+		<p class="m-t-sm fg-load-message"> Loading files...  </p>
 	</div>
 </div>
 

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -215,7 +215,7 @@
             <div class="panel-body">
                 <div id="treeGrid">
                     <div class="spinner-loading-wrapper">
-                        <div class="logo-spin logo-xl"></div>
+                        <div class="logo-spin logo-lg"></div>
                          <p class="m-t-sm fg-load-message"> Loading files...  </p>
                     </div>
                 </div>

--- a/website/templates/project/view_file.mako
+++ b/website/templates/project/view_file.mako
@@ -32,7 +32,7 @@
       <div class="osf-panel-body-flex file-page reset-height">
         <div id="grid">
           <div class="spinner-loading-wrapper">
-            <div class="logo-spin logo-xl"></div>
+            <div class="logo-spin logo-lg"></div>
             <p class="m-t-sm fg-load-message"> Loading files...  </p>
           </div>
         </div>

--- a/website/templates/project/view_file.mako
+++ b/website/templates/project/view_file.mako
@@ -47,6 +47,7 @@
     </div>
   </div>
 
+<!-- The osf-logo spinner here is from mfr code base -->
   <div id="fileViewPanelLeft" class="col-sm-9 panel-expand">
     <div class="row">
         <div id="externalView" class="col-sm-9"></div>


### PR DESCRIPTION
## Purpose
Fixes the following Trello bugs related to size of spinner by overall reverting to lg size
- Project Logs: https://trello.com/c/5J3lhaJy
- File Detail page: https://trello.com/c/9d61XxA2
- Project overview file widget https://trello.com/c/Oa3YLzdj
- Configure Notification https://trello.com/c/BvPQBnkV
- Added loader to project organizer
It does not fix MFR rendered section. 

## Changes
Spinner sizes were changed to logo-lg to fit their spaces and each other. These may be different than production, their relative size and fit in their white space is the check. 

## Side Effects
- Added loader to project organizer, which was not decided on, but it seems to make sense. 
