### PR TITLE
[FeatureFix] Added padding to share chart so full x label shows

### DIFF
--- a/website/static/js/share/stats.js
+++ b/website/static/js/share/stats.js
@@ -90,6 +90,9 @@ function timeGraph(data, vm) {
                 }
             }
         },
+        padding: {
+          right: 15
+        },
         legend: {
             show: false
         },


### PR DESCRIPTION
X label was being cut off when date appeared on far right side. Padding in c3 setup added to fix.