### PR TITLE
[Hotfix] Github double logs (kinda)

### DIFF
--- a/website/addons/github/utils.py
+++ b/website/addons/github/utils.py
@@ -13,6 +13,8 @@ from website.addons.github.api import GitHub
 MESSAGE_BASE = 'via the Open Science Framework'
 MESSAGES = {
     'add': 'Added {0}'.format(MESSAGE_BASE),
+    'move': 'Moved {0}'.format(MESSAGE_BASE),
+    'copy': 'Copied {0}'.format(MESSAGE_BASE),
     'update': 'Updated {0}'.format(MESSAGE_BASE),
     'delete': 'Deleted {0}'.format(MESSAGE_BASE),
 }


### PR DESCRIPTION
Add move and copy to github messages to prevent moves and copies from creating extra logs.
The core issue was fixed via waterbutler 0.10.2