### PR TITLE
[Ready for Review] Make it so the revisions view can only be seen by itself

### DIFF
--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -196,7 +196,7 @@ var FileViewPage = {
             ]);
         }
 
-        var editPane = function() {
+        var editButton = function() {
             if (ctrl.editor) {
                 return m('button.btn' + (ctrl.editor.selected ? '.btn-primary' : '.btn-default'), {
                     onclick: function (e) {
@@ -234,7 +234,7 @@ var FileViewPage = {
                         }
                     }
                 }, 'View')
-            ).concat([editPane()])
+            ).concat([editButton()])
             ),
             m('.btn-group.m-t-xs', [
                 m('button.btn.btn-sm' + (ctrl.revisions.selected ? '.btn-primary': '.btn-default'), {onclick: function(){

--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -210,13 +210,7 @@ var FileViewPage = {
                 }, ctrl.editor.title);
             }
         };
-        var editDisplay = function() {
-            ctrl.triggerResize();
-            if (ctrl.editor && !ctrl.editor.selected) {
-                return m('[style="display:none"]', ctrl.editor);
-            }
-            return m('.col-sm-12', ctrl.editor);
-        };
+
         m.render(document.getElementById('toggleBar'), m('.btn-toolbar.m-t-md', [
             ctrl.canEdit() ? m('.btn-group.m-l-xs.m-t-xs', [
                 m('button.btn.btn-sm.btn-danger.file-delete', {onclick: $(document).trigger.bind($(document), 'fileviewpage:delete')}, 'Delete')
@@ -257,8 +251,10 @@ var FileViewPage = {
                 m('.row', ctrl.revisions)
             ]));
         }
+        var editDisplay = (ctrl.editor && !ctrl.editor.selected) ? 'display:none' : '' ;
+        ctrl.triggerResize();
         return m('.file-view-page', m('.panel-toggler', [
-            m('.row', {view: editDisplay})
+            m('.row[style="' + editDisplay + '"]', m('.col-sm-12', ctrl.editor))
         ]));
     }
 };

--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -233,8 +233,8 @@ var FileViewPage = {
                             ctrl.revisions.selected = true;
                         }
                     }
-                }, 'View')
-            ).concat([editButton()])
+                }, 'View'), [editButton()]
+            )
             ),
             m('.btn-group.m-t-xs', [
                 m('button.btn.btn-sm' + (ctrl.revisions.selected ? '.btn-primary': '.btn-default'), {onclick: function(){

--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -228,6 +228,9 @@ var FileViewPage = {
                         if (!ctrl.mfrIframeParent.is(':visible') || panelsShown > 1) {
                             ctrl.mfrIframeParent.toggle();
                             ctrl.revisions.selected = false;
+                        } else if (ctrl.mfrIframeParent.is(':visible') && !ctrl.editor){
+                            ctrl.mfrIframeParent.toggle();
+                            ctrl.revisions.selected = true;
                         }
                     }
                 }, 'View')
@@ -235,13 +238,24 @@ var FileViewPage = {
             ),
             m('.btn-group.m-t-xs', [
                 m('button.btn.btn-sm' + (ctrl.revisions.selected ? '.btn-primary': '.btn-default'), {onclick: function(){
-                    if (ctrl.mfrIframeParent.is(':visible')){
+                    var editable = ctrl.editor && ctrl.editor.selected,
+                        viewable = ctrl.mfrIframeParent.is(':visible');
+                    if (editable || viewable){
+                        if (viewable){
+                            ctrl.mfrIframeParent.toggle();
+                            flag = true;
+                        }
+                        if (editable) {
+                            ctrl.editor.selected = false;
+                            flag = true;
+                        }
+                        ctrl.revisions.selected = true;
+                    } else {
                         ctrl.mfrIframeParent.toggle();
-                        ctrl.revisions.selected = true;
-                    }
-                    if (ctrl.editor && ctrl.editor.selected) {
-                        ctrl.revisions.selected = true;
-                        ctrl.editor.selected = false;
+                        if (ctrl.editor) {
+                            ctrl.editor.selected = false;
+                        }
+                        ctrl.revisions.selected = false;
                     }
                 }}, 'Revisions')
             ])

--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -163,7 +163,10 @@ var FileViewPage = {
         //With other non-mithril components on the page
         ctrl.enableEditing();
 
-        var panelsShown = ((ctrl.editor && ctrl.editor.selected) ? 1 : 0) + (ctrl.mfrIframeParent.is(':visible') ? 1 : 0);
+        var panelsShown = (
+            ((ctrl.editor && ctrl.editor.selected) ? 1 : 0) + // Editor panel is active
+            (ctrl.mfrIframeParent.is(':visible') ? 1 : 0)    // View panel is active
+        );
         var mfrIframeParentLayout;
         var fileViewPanelsLayout;
 
@@ -221,7 +224,7 @@ var FileViewPage = {
             m('.btn-group.m-t-xs', [
                 m('.btn.btn-sm.btn-primary.file-download', {onclick: $(document).trigger.bind($(document), 'fileviewpage:download')}, 'Download')
             ]),
-            m('.btn-group.btn-group-sm.m-t-xs' + (ctrl.editor ? '.btn-group' : ''), [
+            m('.btn-group.btn-group-sm.m-t-xs', [
                ctrl.editor ? m( '.btn.btn-default.disabled', 'Toggle view: ') : null
             ].concat(
                 m('.btn' + (ctrl.mfrIframeParent.is(':visible') ? '.btn-primary' : '.btn-default'), {

--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -198,7 +198,7 @@ var FileViewPage = {
 
         var editPane = function() {
             if (ctrl.editor) {
-                return m('.btn' + (ctrl.editor.selected ? '.btn-primary' : '.btn-default'), {
+                return m('button.btn' + (ctrl.editor.selected ? '.btn-primary' : '.btn-default'), {
                     onclick: function (e) {
                         e.preventDefault();
                         // atleast one button must remain enabled.
@@ -219,15 +219,15 @@ var FileViewPage = {
         };
         m.render(document.getElementById('toggleBar'), m('.btn-toolbar.m-t-md', [
             ctrl.canEdit() ? m('.btn-group.m-l-xs.m-t-xs', [
-                m('.btn.btn-sm.btn-danger.file-delete', {onclick: $(document).trigger.bind($(document), 'fileviewpage:delete')}, 'Delete')
+                m('button.btn.btn-sm.btn-danger.file-delete', {onclick: $(document).trigger.bind($(document), 'fileviewpage:delete')}, 'Delete')
             ]) : '',
             m('.btn-group.m-t-xs', [
-                m('.btn.btn-sm.btn-primary.file-download', {onclick: $(document).trigger.bind($(document), 'fileviewpage:download')}, 'Download')
+                m('button.btn.btn-sm.btn-primary.file-download', {onclick: $(document).trigger.bind($(document), 'fileviewpage:download')}, 'Download')
             ]),
             m('.btn-group.btn-group-sm.m-t-xs', [
                ctrl.editor ? m( '.btn.btn-default.disabled', 'Toggle view: ') : null
             ].concat(
-                m('.btn' + (ctrl.mfrIframeParent.is(':visible') ? '.btn-primary' : '.btn-default'), {
+                m('button.btn' + (ctrl.mfrIframeParent.is(':visible') ? '.btn-primary' : '.btn-default'), {
                     onclick: function (e) {
                         e.preventDefault();
                         // at least one button must remain enabled.
@@ -240,7 +240,7 @@ var FileViewPage = {
             ).concat([editPane()])
             ),
             m('.btn-group.m-t-xs', [
-                m('.btn.btn-sm' + (ctrl.revisions.selected ? '.btn-primary': '.btn-default'), {onclick: function(){
+                m('button.btn.btn-sm' + (ctrl.revisions.selected ? '.btn-primary': '.btn-default'), {onclick: function(){
                     if (ctrl.mfrIframeParent.is(':visible')){
                         ctrl.mfrIframeParent.toggle();
                         ctrl.revisions.selected = true;

--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -238,8 +238,8 @@ var FileViewPage = {
             ),
             m('.btn-group.m-t-xs', [
                 m('button.btn.btn-sm' + (ctrl.revisions.selected ? '.btn-primary': '.btn-default'), {onclick: function(){
-                    var editable = ctrl.editor && ctrl.editor.selected,
-                        viewable = ctrl.mfrIframeParent.is(':visible');
+                    var editable = ctrl.editor && ctrl.editor.selected;
+                    var viewable = ctrl.mfrIframeParent.is(':visible');
                     if (editable || viewable){
                         if (viewable){
                             ctrl.mfrIframeParent.toggle();

--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -161,41 +161,22 @@ var FileViewPage = {
         //This code was abstracted into a panel toggler at one point
         //it was removed and shoved here due to issues with mithrils caching and interacting
         //With other non-mithril components on the page
-        var panels;
+        ctrl.enableEditing();
+        var panels, shown;
         if (ctrl.editor) {
-            panels = [ctrl.editor, ctrl.revisions];
+            panels = [ctrl.editor];
         } else {
-            panels = [ctrl.revisions];
+            panels = [];
         }
 
-        var shown = panels.reduce(function(accu, panel) {
-            return accu + (panel.selected ? 1 : 0);
-        }, 0);
-
-        var panelsShown = shown + (ctrl.mfrIframeParent.is(':visible') ? 1 : 0);
+        var panelsShown = ((ctrl.editor && ctrl.editor.selected) ? 1 : 0) + (ctrl.mfrIframeParent.is(':visible') ? 1 : 0);
         var mfrIframeParentLayout;
         var fileViewPanelsLayout;
 
-        if (panelsShown === 3) {
-            // view | edit | revisions
-            mfrIframeParentLayout = 'col-sm-4';
-            fileViewPanelsLayout = 'col-sm-8';
-        } else if (panelsShown === 2) {
-            if (ctrl.mfrIframeParent.is(':visible')) {
-                if (ctrl.revisions.selected) {
-                    // view | revisions
-                    mfrIframeParentLayout = 'col-sm-8';
-                    fileViewPanelsLayout = 'col-sm-4';
-                } else {
-                    // view | edit
-                    mfrIframeParentLayout = 'col-sm-6';
-                    fileViewPanelsLayout = 'col-sm-6';
-                }
-            } else {
-                // edit | revisions
-                mfrIframeParentLayout = '';
-                fileViewPanelsLayout = 'col-sm-12';
-            }
+        if (panelsShown === 2) {
+            // view | edit 
+            mfrIframeParentLayout = 'col-sm-6';
+            fileViewPanelsLayout = 'col-sm-6';
         } else {
             // view
             if (ctrl.mfrIframeParent.is(':visible')) {
@@ -225,8 +206,8 @@ var FileViewPage = {
             m('.btn-group.m-t-xs', [
                 m('.btn.btn-sm.btn-primary.file-download', {onclick: $(document).trigger.bind($(document), 'fileviewpage:download')}, 'Download')
             ]),
-            m('.btn-group.btn-group-sm.m-t-xs', [
-                m('.btn.btn-default.disabled', 'Toggle view: ')
+            m('.btn-group.btn-group-sm.m-t-xs' + (ctrl.editor ? '.btn-group' : ''), [
+               ctrl.editor ? m( '.btn.btn-default.disabled', 'Toggle view: ') : null
             ].concat(
                 m('.btn' + (ctrl.mfrIframeParent.is(':visible') ? '.btn-primary' : '.btn-default'), {
                     onclick: function (e) {
@@ -234,6 +215,7 @@ var FileViewPage = {
                         // atleast one button must remain enabled.
                         if (!ctrl.mfrIframeParent.is(':visible') || panelsShown > 1) {
                             ctrl.mfrIframeParent.toggle();
+                            ctrl.revisions.selected = false;
                         }
                     }
                 }, 'View')
@@ -243,15 +225,32 @@ var FileViewPage = {
                         onclick: function(e) {
                             e.preventDefault();
                             // atleast one button must remain enabled.
-                            if (!panel.selected || panelsShown > 1) {
+                            if ((!panel.selected || panelsShown > 1)) {
                                 panel.selected = !panel.selected;
+                                ctrl.revisions.selected = false;
                             }
                         }
                     }, panel.title);
                 })
-            ))
+            )),
+            m('.btn-group.m-t-xs', [
+                m('.btn.btn-sm' + (ctrl.revisions.selected ? '.btn-primary': '.btn-default'), {onclick: function(){
+                    if (ctrl.mfrIframeParent.is(':visible')){
+                        ctrl.mfrIframeParent.toggle();
+                        ctrl.revisions.selected = true;
+                    }
+                    if (ctrl.editor && ctrl.editor.selected) {
+                        ctrl.revisions.selected = true;
+                        ctrl.editor.selected = false;
+                    }
+                }}, 'Revisions')
+            ])
         ]));
-
+        if (ctrl.revisions.selected){
+            return m('.file-view-page', m('.panel-toggler', [
+                m('.row', ctrl.revisions)
+            ]));
+        }
         return m('.file-view-page', m('.panel-toggler', [
             m('.row', panels.map(function(pane, index) {
                 ctrl.triggerResize();

--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -162,12 +162,6 @@ var FileViewPage = {
         //it was removed and shoved here due to issues with mithrils caching and interacting
         //With other non-mithril components on the page
         ctrl.enableEditing();
-        var panels, shown;
-        if (ctrl.editor) {
-            panels = [ctrl.editor];
-        } else {
-            panels = [];
-        }
 
         var panelsShown = ((ctrl.editor && ctrl.editor.selected) ? 1 : 0) + (ctrl.mfrIframeParent.is(':visible') ? 1 : 0);
         var mfrIframeParentLayout;
@@ -199,6 +193,27 @@ var FileViewPage = {
             ]);
         }
 
+        var editPane = function() {
+            if (ctrl.editor) {
+                return m('.btn' + (ctrl.editor.selected ? '.btn-primary' : '.btn-default'), {
+                    onclick: function (e) {
+                        e.preventDefault();
+                        // atleast one button must remain enabled.
+                        if ((!ctrl.editor.selected || panelsShown > 1)) {
+                            ctrl.editor.selected = !ctrl.editor.selected;
+                            ctrl.revisions.selected = false;
+                        }
+                    }
+                }, ctrl.editor.title);
+            }
+        };
+        var editDisplay = function() {
+            ctrl.triggerResize();
+            if (ctrl.editor && !ctrl.editor.selected) {
+                return m('[style="display:none"]', ctrl.editor);
+            }
+            return m('.col-sm-12', ctrl.editor);
+        };
         m.render(document.getElementById('toggleBar'), m('.btn-toolbar.m-t-md', [
             ctrl.canEdit() ? m('.btn-group.m-l-xs.m-t-xs', [
                 m('.btn.btn-sm.btn-danger.file-delete', {onclick: $(document).trigger.bind($(document), 'fileviewpage:delete')}, 'Delete')
@@ -212,27 +227,15 @@ var FileViewPage = {
                 m('.btn' + (ctrl.mfrIframeParent.is(':visible') ? '.btn-primary' : '.btn-default'), {
                     onclick: function (e) {
                         e.preventDefault();
-                        // atleast one button must remain enabled.
+                        // at least one button must remain enabled.
                         if (!ctrl.mfrIframeParent.is(':visible') || panelsShown > 1) {
                             ctrl.mfrIframeParent.toggle();
                             ctrl.revisions.selected = false;
                         }
                     }
                 }, 'View')
-            ).concat(
-                panels.map(function(panel) {
-                    return m('.btn' + (panel.selected ? '.btn-primary' : '.btn-default'), {
-                        onclick: function(e) {
-                            e.preventDefault();
-                            // atleast one button must remain enabled.
-                            if ((!panel.selected || panelsShown > 1)) {
-                                panel.selected = !panel.selected;
-                                ctrl.revisions.selected = false;
-                            }
-                        }
-                    }, panel.title);
-                })
-            )),
+            ).concat([editPane()])
+            ),
             m('.btn-group.m-t-xs', [
                 m('.btn.btn-sm' + (ctrl.revisions.selected ? '.btn-primary': '.btn-default'), {onclick: function(){
                     if (ctrl.mfrIframeParent.is(':visible')){
@@ -252,13 +255,7 @@ var FileViewPage = {
             ]));
         }
         return m('.file-view-page', m('.panel-toggler', [
-            m('.row', panels.map(function(pane, index) {
-                ctrl.triggerResize();
-                if (!pane.selected) {
-                    return m('[style="display:none"]', pane);
-                }
-                return m('.col-sm-' + Math.floor(12/shown), pane);
-            }))
+            m('.row', {view: editDisplay})
         ]));
     }
 };


### PR DESCRIPTION
## Purpose
The revisions tab has a lot of information. This makes all the information cluttered and unreadable/unusable if revisions is open together with view, edit or both. This problem will become worse with more information being added to the revisions tab (like hashes in #3517). So revisions should only be seen as its own window/tab, without needing to share space with view or edit.

## Changes
Changes the file view page so that the revision tab can only be viewed by itself, while edit/view maintain the same behavior. Toggle view helper button only appears if toggle is available (meaning edit is available)
Makes it so when revision button is pressed it supersedes anythign else and becomes the only tab, and while on revision, pressing view/edit will show those only, without revision.

## Side-Effects
Not being able to view 3 tabs, or view the file and the revisions tab at the same time.

## Limitation
Besides not being able to use revision tab with any other tabs, a user can click on revision button to toggle between view and revision but it does not remember the state of the view||edit buttons when initially pressing revision (example, you have only the edit panel open, you click revision, which in turn opens revision only and closes edit, if you would click revision again, it would o back to view). Also, in 3 button mode (edit view revision), view does not toggle back to revision. 