### PR TITLE
[Hotfix] Fix width of sign-up in narrows screens

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
     "locales": "https://github.com/citation-style-language/locales.git#d2b612f8a6f764cbd66e67238636fac3888a7736",
     "raven-js": "1.1.17",
     "zeroclipboard": "2.1.6",
-    "osf-style": "https://github.com/CenterForOpenScience/osf-style.git#dc4d695e7072bae03d9d731b2bcbdc5abd744cec"
+    "osf-style": "https://github.com/CenterForOpenScience/osf-style.git#ea27f1bf94f185c26c0f98bb5e1aebfe20489c05"
 
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
     "locales": "https://github.com/citation-style-language/locales.git#d2b612f8a6f764cbd66e67238636fac3888a7736",
     "raven-js": "1.1.17",
     "zeroclipboard": "2.1.6",
-    "osf-style": "https://github.com/CenterForOpenScience/osf-style.git#a3600019a60155b3787d776f3d5751b906cb68a8"
+    "osf-style": "https://github.com/CenterForOpenScience/osf-style.git#dc4d695e7072bae03d9d731b2bcbdc5abd744cec"
 
   }
 }

--- a/website/static/css/front-page.css
+++ b/website/static/css/front-page.css
@@ -575,18 +575,6 @@ footer {
     .student-image .main {
         font-size: 1.0em !important;
     }
-    .sign-in .btn-group {
-        width: 90%;
-        padding-left: 5%;
-    }
-    .sign-in .btn {
-        width: 100%;
-        margin-bottom: 20px;
-    }
-    #formLogin {
-        padding: 0;
-        width: 100%;
-    }
     .grey-pullout {
         padding-bottom: 90px;
     }

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -178,6 +178,14 @@ a {
         font-size: 20px;
     }
 
+    .sign-in .btn-group {
+        width: 90%;
+        padding-left: 5%;
+    }
+    .sign-in .btn {
+        width: 100%;
+        margin-bottom: 20px;
+    }
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
## Purpose
Fixes a regression error where the menu for login stayed at 300px in narrow screens. Makes sure this works in all pages and not just front-page. 

## Changes
- Updated the style guide css to include narrow version of menuLogin width
- moved the css for sign in to more general style.css since the login window appears in all logged out situations. 
- Removed #formLogin, doesn't seem to be used anywhere. 

## Side effects
I checked different withds and pages, seems to be none. 