### PR TITLE
[feature fix] Handle Sanctions after Archiver failures

### DIFF
--- a/scripts/approve_registrations.py
+++ b/scripts/approve_registrations.py
@@ -32,6 +32,12 @@ def main(dry_run=True):
                 .format(registration_approval._id, pending_registration._id)
             )
             if not dry_run:
+                if pending_registration.is_deleted:
+                    # Clean up any registration failures during archiving
+                    registration_approval.forcibly_reject()
+                    registration_approval.save()
+                    continue
+
                 with TokuTransaction():
                     try:
                         # Ensure no `User` is associated with the final approval

--- a/scripts/embargo_registrations.py
+++ b/scripts/embargo_registrations.py
@@ -32,6 +32,12 @@ def main(dry_run=True):
                 .format(embargo._id, parent_registration._id)
             )
             if not dry_run:
+                if parent_registration.is_deleted:
+                    # Clean up any registration failures during archiving
+                    embargo.forcibly_reject()
+                    embargo.save()
+                    continue
+
                 with TokuTransaction():
                     try:
                         embargo.state = models.Embargo.APPROVED
@@ -61,6 +67,12 @@ def main(dry_run=True):
                 .format(embargo._id, parent_registration._id)
             )
             if not dry_run:
+                if parent_registration.is_deleted:
+                    # Clean up any registration failures during archiving
+                    embargo.forcibly_reject()
+                    embargo.save()
+                    continue
+
                 with TokuTransaction():
                     try:
                         parent_registration.set_privacy('public')

--- a/website/archiver/utils.py
+++ b/website/archiver/utils.py
@@ -70,6 +70,8 @@ def handle_archive_fail(reason, src, dst, user, result):
         send_archiver_size_exceeded_mails(src, user, result)
     else:  # reason == ARCHIVER_UNCAUGHT_ERROR
         send_archiver_uncaught_error_mails(src, user, result)
+    dst.root.sanction.forcibly_reject()
+    dst.root.sanction.save()
     dst.root.delete_registration_tree(save=True)
 
 

--- a/website/exceptions.py
+++ b/website/exceptions.py
@@ -33,4 +33,4 @@ class InvalidSanctionApprovalToken(TokenError):
      or associated with another admin authorizer
     """
     message_short = "Invalid Token"
-    message_long = "This disapproval link is invalid. Are you logged into the correct account?"
+    message_long = "This approval link is invalid. Are you logged into the correct account?"

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -3038,6 +3038,9 @@ class Sanction(StoredObject):
         self.state = Sanction.REJECTED
         self._on_reject(user, token)
 
+    def forcibly_reject(self):
+        self.state = Sanction.REJECTED
+
     def _notify_authorizer(self, user):
         pass
 


### PR DESCRIPTION
## Purpose: 
If Archiver fails, the registration is deleted. However, the respective Sanction is untouched. This ensures that they are rejected either by the Archiver callback or by the scripts checking Sanctions.

## Changes:
- Updated Archiver failure callback to forcibly reject Sanctions
- Updated scripts to forcibly reject Sanctions for this case