### PR TITLE
Fix 'node' in registration cancelled log to point to deleted reg

### DIFF
--- a/website/project/model.py
+++ b/website/project/model.py
@@ -3495,7 +3495,7 @@ class RegistrationApproval(EmailApprovableSanction):
         registered_from.add_log(
             action=NodeLog.REGISTRATION_APPROVAL_CANCELLED,
             params={
-                'node': registered_from._id,
+                'node': register,
                 'registration_approval_id': self._id,
             },
             auth=Auth(user),

--- a/website/templates/log_templates.mako
+++ b/website/templates/log_templates.mako
@@ -43,7 +43,7 @@ approved retraction of
 
 <script type="text/html" id="retraction_cancelled">
 cancelled retraction of
-<a class="log-node-title-link overflow" data-bind="text: nodeTitle, attr: {href: nodeUrl}"></a>
+<span class="log-node-title-link overflow" data-bind="text: nodeTitle"></span>
 </script>
 
 <script type="text/html" id="retraction_initiated">
@@ -59,7 +59,7 @@ initiated registration of
 
 <script type="text/html" id="registration_cancelled">
 cancelled registration of
-<a class="log-node-title-link overflow" data-bind="text: nodeTitle, attr: {href: nodeUrl}"></a>
+<span class="log-node-title-link overflow" data-bind="text: nodeTitle"></span>
 </script>
 
 <script type="text/html" id="registration_approved">


### PR DESCRIPTION
# Purpose
Inconsistent behavior of reg. initiated and reg. rejected logs
https://trello.com/c/Hnbt1RyW/45-project-title-does-not-link-to-resource-deleted-for-disapproval-logs

# Changes
Always refer to the registration in the log params.

Also convert cancellation links to plain text (don't expose url of potentially archiving node) 

# Side effects 
None