### PR TITLE
[feature fix] Add watermark to pending registration templates

### DIFF
--- a/website/templates/project/project_header.mako
+++ b/website/templates/project/project_header.mako
@@ -86,17 +86,19 @@
 
         % if not node['is_retracted']:
            % if not node['is_pending_registration']:
-              <div class="alert alert-info">This ${node['node_type']} is a registration of <a class="link-solid" href="${node['registered_from_url']}">this ${node['node_type']}</a>; the content of the ${node['node_type']} has been frozen and cannot be edited.</div>
-              <style type="text/css">
-              .watermarked {
-                  background-image:url('/static/img/read-only.png');
-                  background-repeat:repeat;
-              }
-              </style>
+              <div>
+               class="alert alert-info">This ${node['node_type']} is a registration of <a class="link-solid" href="${node['registered_from_url']}">this ${node['node_type']}</a>; the content of the ${node['node_type']} has been frozen and cannot be edited.</div>
+
            % else:
               <div class="alert alert-info">This is a pending registration of <a class="link-solid" href="${node['registered_from_url']}">this project</a>, awaiting approval from project administrators. This registration will be final when all project administrators approve the registration or 48 hours pass, whichever comes first.</div>
            % endif
 
+           <style type="text/css">
+              .watermarked {
+                  background-image:url('/static/img/read-only.png');
+                  background-repeat:repeat;
+              }
+           </style>
 
         % endif
 


### PR DESCRIPTION
## Purpose:
Ensure that all registration templates have a `read-only` watermark

## Notes:
Closes-issue: https://trello.com/c/cERml4ao/39-no-greyed-out-read-only-on-pending-registration