### PR TITLE
Uncomment hidden approval link from registration initiated email

### DIFF
--- a/website/templates/emails/pending_registration_admin.txt.mako
+++ b/website/templates/emails/pending_registration_admin.txt.mako
@@ -1,11 +1,10 @@
 Hello ${user.fullname},
 
 % if is_initiator:
-You initiated a registration of your project ${project_name}.
+You initiated a registration of your project ${project_name}. The pending registration can be viewed here: ${registration_link}.
 % else:
-${initiated_by} has initiated a registration of your project ${project_name}.
+${initiated_by} has initiated a registration of your project ${project_name}. The pending registration can be viewed here: ${registration_link}.
 % endif 
-The pending registration can be viewed here: ${registration_link}.
 
 To approve this registration, click the following link: ${approval_link}
 

--- a/website/templates/emails/pending_registration_admin.txt.mako
+++ b/website/templates/emails/pending_registration_admin.txt.mako
@@ -4,7 +4,8 @@ Hello ${user.fullname},
 You initiated a registration of your project ${project_name}.
 % else:
 ${initiated_by} has initiated a registration of your project ${project_name}.
-% endif The pending registration can be viewed here: ${registration_link}.
+% endif 
+The pending registration can be viewed here: ${registration_link}.
 
 To approve this registration, click the following link: ${approval_link}
 


### PR DESCRIPTION
# Purpose

The link to view registration for registration approval emails was blocked by mako's #endif.

# Changes

Reformat so the link is included inline for both branches.

# Side effects

None