### PR TITLE
[feature fix] Approval emails for embargoes were missing their approval links

### DIFF
--- a/website/project/model.py
+++ b/website/project/model.py
@@ -3183,7 +3183,7 @@ class Embargo(EmailApprovableSanction):
             'node_id': registration._id
         }
 
-    def _approve_url_context(self, user_id):
+    def _approval_url_context(self, user_id):
         approval_token = self.approval_state.get(user_id, {}).get('approval_token')
         if approval_token:
             registration = Node.find_one(Q('embargo', 'eq', self))


### PR DESCRIPTION
## Purpose:
Resolve incomplete embargo emails missing approval links.

## Changes:
- Fix misnamed method

## Notes:
Closes-issue: https://trello.com/c/eRBnRPfa/32-no-link-to-approve-embargoed-registration