### PR TITLE
Fix Sanction emails

### DIFF
--- a/tests/test_sanctions.py
+++ b/tests/test_sanctions.py
@@ -200,6 +200,26 @@ class TestEmailApprovableSanction(SanctionsTestCase):
         args, kwargs = mock_send.call_args
         assert_true(self.user.username in args)
 
+    @mock.patch('website.mails.send_mail')
+    def test_ask(self, mock_send):
+        group = [self.user]
+        for i in range(5):
+            u = factories.UserFactory()
+            group.append(u)
+        self.sanction.ask(group)
+        authorizer = group.pop(0)
+        mock_send.assert_any_call(
+            authorizer,
+            self.sanction.AUTHORIZER_NOTIFY_EMAIL_TEMPLATE,
+            **{}
+        )
+        for user in group:
+            mock_send.assert_any_call(
+                user,
+                self.sanction.NON_AUTHORIZER_NOTIFY_EMAIL_TEMPLATE,
+                **{}
+            )
+
 
 class TestRegistrationApproval(OsfTestCase):
 

--- a/website/mails.py
+++ b/website/mails.py
@@ -105,7 +105,8 @@ def send_mail(to_addr, mail, mimetype='plain', from_addr=None, mailer=None,
         login=login,
         username=username,
         password=password,
-        mail_server=mail_server)
+        mail_server=mail_server
+    )
 
     if settings.USE_CELERY:
         return mailer.apply_async(kwargs=kwargs, link=callback)

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -3100,9 +3100,8 @@ class EmailApprovableSanction(Sanction):
 
     def _send_approval_request_email(self, user, template, context):
         mails.send_mail(
-            self.initiated_by.username,
+            user,
             template,
-            user=user,
             **context
         )
 


### PR DESCRIPTION
# Purpose
All sanction confirmation emails were getting sent to sanction initiator

# Changes
- Send emails to user rather than Sanction.initiated_by
- Add a regression test for the bug.

# Side effects
resolves https://trello.com/c/Ww5fUwir/37-the-admin-making-the-registration-gets-all-contributors-approval-emails