### PR TITLE
Use ._id rather than model instance

### DIFF
--- a/website/project/model.py
+++ b/website/project/model.py
@@ -3498,7 +3498,7 @@ class RegistrationApproval(EmailApprovableSanction):
         registered_from.add_log(
             action=NodeLog.REGISTRATION_APPROVAL_CANCELLED,
             params={
-                'node': register,
+                'node': register._id,
                 'registration_approval_id': self._id,
             },
             auth=Auth(user),


### PR DESCRIPTION
# Purpose
Adding registration_approval rejection logs was erroring out

# Changes
Use node._id instead of node

