### PR TITLE
Send mail takes to_addr as first arg

### DIFF
--- a/tests/test_sanctions.py
+++ b/tests/test_sanctions.py
@@ -209,14 +209,16 @@ class TestEmailApprovableSanction(SanctionsTestCase):
         self.sanction.ask(group)
         authorizer = group.pop(0)
         mock_send.assert_any_call(
-            authorizer,
+            authorizer.username,
             self.sanction.AUTHORIZER_NOTIFY_EMAIL_TEMPLATE,
+            user=authorizer,
             **{}
         )
         for user in group:
             mock_send.assert_any_call(
-                user,
+                user.username,
                 self.sanction.NON_AUTHORIZER_NOTIFY_EMAIL_TEMPLATE,
+                user=user,
                 **{}
             )
 

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -3100,7 +3100,7 @@ class EmailApprovableSanction(Sanction):
 
     def _send_approval_request_email(self, user, template, context):
         mails.send_mail(
-            user,
+            user.username,
             template,
             user=user,
             **context


### PR DESCRIPTION
# Purpose
We were both using and testing the wrong usage of website.mails.send_mail. 

# Changes
Pass send_mail to address as the first argument, and update tests to reflect this.