### PR TITLE
[feature fix] Retraction approval emails were missing the approval inks

### DIFF
--- a/website/project/model.py
+++ b/website/project/model.py
@@ -3298,7 +3298,7 @@ class Retraction(EmailApprovableSanction):
             'node_id': registration._id
         }
 
-    def _approve_url_context(self, user_id):
+    def _approval_url_context(self, user_id):
         approval_token = self.approval_state.get(user_id, {}).get('approval_token')
         if approval_token:
             registration = Node.find_one(Q('retraction', 'eq', self))


### PR DESCRIPTION
## Purpose:
Ensure retraction approval emails have the approval link.

## Changes:
- Fix misnamed method.

## Notes:
Closes-issue: https://trello.com/c/Wd7C9Zr1/49-no-email-sent-upon-retracting-registration