### PR TITLE
Remove link from embargo cancellation log template

### DIFF
--- a/website/templates/log_templates.mako
+++ b/website/templates/log_templates.mako
@@ -17,7 +17,7 @@ Embargo for
 
 <script type="text/html" id="embargo_cancelled">
 cancelled embargo of
-<a class="log-node-title-link overflow" data-bind="text: nodeTitle, attr: {href: nodeUrl}"></a>
+<span class="log-node-title-link overflow" data-bind="text: nodeTitle"></span>
 </script>
 
 <script type="text/html" id="embargo_completed">


### PR DESCRIPTION
# Purpose
Links never got removed from embargo cancellation logs

# Changes
Convert link to span
