### PR TITLE
Don't provided explict log_date for registration success logs

### DIFF
--- a/website/project/model.py
+++ b/website/project/model.py
@@ -3463,7 +3463,6 @@ class RegistrationApproval(EmailApprovableSanction):
                 'registration': node._primary_key,
             },
             auth=Auth(user),
-            log_date=node.registered_date,
             save=False
         )
         src.save()


### PR DESCRIPTION
# PURPOSE
- Registration completion logs were given an explicit log_data, causing logs to appear out of order.

# Chnages
- Remove log_date constructor from NodeLog constructor