### PR TITLE
[Feature] [Ready for Code Review] Consolidate expand/collapse use in two locations

### DIFF
--- a/website/static/css/pages/contributor-page.css
+++ b/website/static/css/pages/contributor-page.css
@@ -11,11 +11,6 @@
     margin-left: 7px;
 }
 
-.list-overflow{
-    max-height: 200px;
-    overflow-y: auto;
-}
-
 #privateLinkTable .tooltip{
     word-wrap: break-word;
 }

--- a/website/static/js/addonPermissions.js
+++ b/website/static/js/addonPermissions.js
@@ -9,6 +9,8 @@ var $ = require('jquery');
 var bootbox = require('bootbox');
 
 var $osf = require('js/osfHelpers');
+require('js/osfToggleHeight');
+
 
 var AddonPermissionsTable = {
     init: function(addonShortName, addonFullname) {
@@ -51,7 +53,8 @@ var AddonPermissionsTable = {
                     }
                 }
             });
-    });
+        });
+        $('#' + addonShortName + '-header').osfToggleHeight({height: 140});
     }
 };
 

--- a/website/static/js/addonPermissions.js
+++ b/website/static/js/addonPermissions.js
@@ -52,17 +52,6 @@ var AddonPermissionsTable = {
                 }
             });
     });
-
-    $('#' + addonShortName + '-more').on('click', function (event) {
-        $('#' + addonShortName + '-header').removeClass('table-less');
-        $('#' + addonShortName + '-more').hide();
-        $('#' + addonShortName + '-less').show();
-    });
-    $('#' + addonShortName + '-less').on('click', function (event) {
-        $('#' + addonShortName + '-header').addClass('table-less');
-        $('#' + addonShortName + '-less').hide();
-        $('#' + addonShortName + '-more').show();
-    });
     }
 };
 

--- a/website/static/js/osfToggleHeight.js
+++ b/website/static/js/osfToggleHeight.js
@@ -1,7 +1,6 @@
 
 /**
 * A simple UI component to use with divs that need to be collapsed or expanded.
-* Requires html element to have an ID set and have display block rule, (preferably a div tag).
 *
 * Usage:
 *
@@ -38,9 +37,9 @@ ToggleHeight.prototype.init =  function () {
     var self = this;
     self.collapsed = true;
     self.showToggle = false;
-    self.gradientDiv = $('<div id="' + self.element.id + '-gradient" class="toggle-height-gradient" style="display:none"></div>').appendTo(self.element);
-    self.toggleDiv = $('<div id="' + self.element.id + '-toggle" class="toggle-height-toggle text-center" style="display:none"></div>').insertAfter(self.element);
-    $('#' + self.element.id + '-toggle.toggle-height-toggle').click(self.toggle.bind(this));
+    self.gradientDiv = $('<div class="toggle-height-gradient" style="display:none"></div>').appendTo(self.element);
+    self.toggleDiv = $('<div class="toggle-height-toggle text-center" style="display:none"></div>').insertAfter(self.element);
+    self.toggleDiv.click(self.toggle.bind(this));
     self.checkCollapse();
     $(window).resize(self.checkCollapse.bind(this));
 };

--- a/website/static/js/privateLinkTable.js
+++ b/website/static/js/privateLinkTable.js
@@ -148,7 +148,6 @@ function ViewModel(url, nodeIsPublic) {
         $tr.find('.remove-private-link').tooltip();
         setupEditable(elm, data);
         $('.private-link-list').osfToggleHeight({height: 50});
-        $('.toggle-height-gradient').css('left', '0');
     };
 
 }

--- a/website/static/js/privateLinkTable.js
+++ b/website/static/js/privateLinkTable.js
@@ -147,7 +147,8 @@ function ViewModel(url, nodeIsPublic) {
         clipboard(target[0]);
         $tr.find('.remove-private-link').tooltip();
         setupEditable(elm, data);
-        $('.private-link-list').osfToggleHeight({height: 25});
+        $('.private-link-list').osfToggleHeight({height: 50});
+        $('.toggle-height-gradient').css('left', '0');
     };
 
 }

--- a/website/static/js/privateLinkTable.js
+++ b/website/static/js/privateLinkTable.js
@@ -10,7 +10,6 @@ require('js/osfToggleHeight');
 require('bootstrap-editable');
 
 var ctx = window.contextVars;
-//var LINK_CUTOFF = 2;
 
 var setupEditable = function(elm, data) {
     var $elm = $(elm);

--- a/website/static/js/privateLinkTable.js
+++ b/website/static/js/privateLinkTable.js
@@ -9,7 +9,7 @@ var clipboard = require('./clipboard');
 require('bootstrap-editable');
 
 var ctx = window.contextVars;
-var LINK_CUTOFF = 2;
+//var LINK_CUTOFF = 2;
 
 var setupEditable = function(elm, data) {
     var $elm = $(elm);
@@ -44,22 +44,16 @@ function LinkViewModel(data, $root) {
     self.$root = $root;
     $.extend(self, data);
 
-    self.collapse = 'Collapse';
     self.name = ko.observable(data.name);
     self.readonly = 'readonly';
     self.selectText = 'this.setSelectionRange(0, this.value.length);';
 
-    self.collapseNode = ko.observable(false);
     self.dateCreated = new $osf.FormattableDate(data.date_created);
     self.linkUrl = ko.computed(function() {
         return self.$root.nodeUrl() + '?view_only=' + data.key;
     });
-    self.nodesList = ko.observableArray(data.nodes.slice(0, LINK_CUTOFF));
-    self.moreNode = ko.observable(data.nodes.length > LINK_CUTOFF);
+    self.nodesList = ko.observableArray(data.nodes);
     self.removeLink = 'Remove this link';
-    self.hasMoreText = ko.computed(function(){
-        return 'Show ' + (data.nodes.length - LINK_CUTOFF).toString() + ' more...';
-    });
 
     self.anonymousDisplay = ko.computed(function() {
         var openTag = '<span>';
@@ -77,17 +71,6 @@ function LinkViewModel(data, $root) {
         }
         return [openTag, text, closeTag].join('');
     });
-
-    self.displayAllNodes = function() {
-        self.nodesList(data.nodes);
-        self.moreNode(false);
-        self.collapseNode(true);
-    };
-    self.displayDefaultNodes = function() {
-        self.nodesList(data.nodes.slice(0, LINK_CUTOFF));
-        self.moreNode(true);
-        self.collapseNode(false);
-    };
 
 }
 

--- a/website/static/js/privateLinkTable.js
+++ b/website/static/js/privateLinkTable.js
@@ -5,6 +5,7 @@ var ko = require('knockout');
 var bootbox = require('bootbox');
 var $osf = require('./osfHelpers');
 var clipboard = require('./clipboard');
+require('js/osfToggleHeight');
 
 require('bootstrap-editable');
 
@@ -146,6 +147,7 @@ function ViewModel(url, nodeIsPublic) {
         clipboard(target[0]);
         $tr.find('.remove-private-link').tooltip();
         setupEditable(elm, data);
+        $('.private-link-list').osfToggleHeight({height: 25});
     };
 
 }

--- a/website/templates/profile/addon_permissions.mako
+++ b/website/templates/profile/addon_permissions.mako
@@ -24,12 +24,7 @@
             % endfor
         </table>
     </div>
-    %if len(nodes) > 3:
-        <div class="text-center" >
-            <i id="${addon_short_name}-more" class="fa fa-angle-double-down fa-lg collapse-button"></i>
-            <i style="display: none;" id="${addon_short_name}-less" class="fa fa-angle-double-up fa-lg collapse-button"></i>
-        </div>
-    %endif
+
     <script>
         window.contextVars = $.extend(true, {}, window.contextVars, {
             addonsWithNodes: {

--- a/website/templates/project/contributors.mako
+++ b/website/templates/project/contributors.mako
@@ -136,7 +136,7 @@
                             </div>
                         </td>
                         <td class="col-sm-4">
-                           <ul class="private-link-list narrow-list list-overflow" data-bind="foreach: nodesList, attr: {id: 'private-link-list-' + $index() }">
+                           <ul class="private-link-list narrow-list" data-bind="foreach: nodesList, attr: {id: 'private-link-list-' + $index() }">
                                <li data-bind="style:{marginLeft: $data.scale}">
                                   <span data-bind="getIcon: $data.category"></span>
                                   <a data-bind="text:$data.title, attr: {href: $data.url}"></a>

--- a/website/templates/project/contributors.mako
+++ b/website/templates/project/contributors.mako
@@ -136,7 +136,7 @@
                             </div>
                         </td>
                         <td class="col-sm-4">
-                           <ul class="private-link-list narrow-list" data-bind="foreach: nodesList, attr: {id: 'private-link-list-' + $index() }">
+                           <ul class="private-link-list narrow-list" data-bind="foreach: nodesList">
                                <li data-bind="style:{marginLeft: $data.scale}">
                                   <span data-bind="getIcon: $data.category"></span>
                                   <a data-bind="text:$data.title, attr: {href: $data.url}"></a>

--- a/website/templates/project/contributors.mako
+++ b/website/templates/project/contributors.mako
@@ -142,8 +142,7 @@
                                   <a data-bind="text:$data.title, attr: {href: $data.url}"></a>
                                </li>
                            </ul>
-                           <button class="btn btn-default btn-mini more-link-node" data-bind="text:hasMoreText, visible: moreNode, click: displayAllNodes"></button>
-                           <button class="btn btn-default btn-mini more-link-node" data-bind="text:collapse, visible:collapseNode, click: displayDefaultNodes"></button>
+
                         </td>
 
                         <td class="col-sm-2">

--- a/website/templates/project/contributors.mako
+++ b/website/templates/project/contributors.mako
@@ -136,7 +136,7 @@
                             </div>
                         </td>
                         <td class="col-sm-4">
-                           <ul class="private-link-list narrow-list list-overflow" data-bind="foreach: nodesList">
+                           <ul class="private-link-list narrow-list list-overflow" data-bind="foreach: nodesList, attr: {id: 'private-link-list-' + $index() }">
                                <li data-bind="style:{marginLeft: $data.scale}">
                                   <span data-bind="getIcon: $data.category"></span>
                                   <a data-bind="text:$data.title, attr: {href: $data.url}"></a>

--- a/website/templates/project/contributors.mako
+++ b/website/templates/project/contributors.mako
@@ -136,7 +136,7 @@
                             </div>
                         </td>
                         <td class="col-sm-4">
-                           <ul class="narrow-list list-overflow" data-bind="foreach: nodesList">
+                           <ul class="private-link-list narrow-list list-overflow" data-bind="foreach: nodesList">
                                <li data-bind="style:{marginLeft: $data.scale}">
                                   <span data-bind="getIcon: $data.category"></span>
                                   <a data-bind="text:$data.title, attr: {href: $data.url}"></a>


### PR DESCRIPTION
## Purpose
Based on issue #3689 this PR replaces the expand/collapse functionality of two locations
- View Only Link table in Sharing page
- Addon active projects list in user settings page

closes #3689 

## Changes
Removes existing expand collapse logic and markup from the two locations and replaces with the osfToggleHeight plugin. 

## Known Side Effects
None

## Screenshots of New Implementation
(see issue #3689 for originals)

![screen shot 2015-08-20 at 3 12 25 pm](https://cloud.githubusercontent.com/assets/1314003/9393123/4c168d16-474e-11e5-8683-58fd427bf195.png)

![screen shot 2015-08-20 at 2 35 58 pm](https://cloud.githubusercontent.com/assets/1314003/9393136/5286378c-474e-11e5-8658-bff4aa48cce7.png)

 