### PR TITLE
Remove fail_archive_on_error decorator from archiver callback

### DIFF
--- a/website/archiver/listeners.py
+++ b/website/archiver/listeners.py
@@ -7,7 +7,6 @@ from website.archiver import utils as archiver_utils
 from website.archiver import (
     ARCHIVER_UNCAUGHT_ERROR,
 )
-from website.archiver.decorators import fail_archive_on_error
 from website.archiver import signals as archiver_signals
 
 from website.project import signals as project_signals
@@ -31,7 +30,6 @@ def after_register(src, dst, user):
 
 
 @project_signals.archive_callback.connect
-@fail_archive_on_error
 def archive_callback(dst):
     """Blinker listener for updates to the archive task. When the tree of ArchiveJob
     instances is complete, proceed to send success or failure mails


### PR DESCRIPTION
# Purpose
This decorator should have been removed but wasn't causing issues
before. Now, if an error gets raised in any of the Sanction#ask logic
two bad things happen:
- exception gets swallowed
- (possibly) two emails get sent to some admins; Sanction#ask loops
through a list of users. If one of those calls raises an Exception then
the registration initatior will get a second email telling them there
was an issue registering X.

# Changes
Remove the decorator