### PR TITLE
Prevent rejection for approved sanctions

### DIFF
--- a/tests/test_registration_retractions.py
+++ b/tests/test_registration_retractions.py
@@ -522,7 +522,7 @@ class RegistrationRetractionApprovalDisapprovalViewsTestCase(OsfTestCase):
         )
         assert_equal(res.status_code, http.UNAUTHORIZED)
 
-    def test_GET_approve_registration_without_retraction_returns_HTTPError_GONE(self):
+    def test_GET_approve_registration_without_retraction_returns_HTTPError_BAD_REQUEST(self):
         assert_true(self.registration.is_pending_retraction)
         self.registration.retraction.reject(self.user, self.rejection_token)
         assert_false(self.registration.is_pending_retraction)
@@ -533,7 +533,7 @@ class RegistrationRetractionApprovalDisapprovalViewsTestCase(OsfTestCase):
             auth=self.user.auth,
             expect_errors=True
         )
-        assert_equal(res.status_code, http.GONE)
+        assert_equal(res.status_code, http.BAD_REQUEST)
 
     def test_GET_approve_with_invalid_token_returns_HTTPError_BAD_REQUEST(self):
         res = self.app.get(
@@ -572,7 +572,7 @@ class RegistrationRetractionApprovalDisapprovalViewsTestCase(OsfTestCase):
         )
         assert_equal(res.status_code, http.UNAUTHORIZED)
 
-    def test_GET_disapprove_registration_without_retraction_returns_HTTPError_GONE(self):
+    def test_GET_disapprove_registration_without_retraction_returns_HTTPError_BAD_REQUEST(self):
         assert_true(self.registration.is_pending_retraction)
         self.registration.retraction.reject(self.user, self.rejection_token)
         assert_false(self.registration.is_pending_retraction)
@@ -583,7 +583,7 @@ class RegistrationRetractionApprovalDisapprovalViewsTestCase(OsfTestCase):
             auth=self.user.auth,
             expect_errors=True
         )
-        assert_equal(res.status_code, http.GONE)
+        assert_equal(res.status_code, http.BAD_REQUEST)
 
     def test_GET_disapprove_with_invalid_token_HTTPError_BAD_REQUEST(self):
         res = self.app.get(

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -3392,7 +3392,7 @@ class Retraction(EmailApprovableSanction):
 class RegistrationApproval(EmailApprovableSanction):
 
     DISPLAY_NAME = 'Registration Approval'
-    SHORT_NAME = 'registration_approval'
+    SHORT_NAME = 'approval'
 
     AUTHORIZER_NOTIFY_EMAIL_TEMPLATE = mails.PENDING_REGISTRATION_ADMIN
     NON_AUTHORIZER_NOTIFY_EMAIL_TEMPLATE = mails.PENDING_REGISTRATION_NON_ADMIN

--- a/website/templates/project/project_header.mako
+++ b/website/templates/project/project_header.mako
@@ -89,7 +89,7 @@
               <div class="alert alert-info">This ${node['node_type']} is a registration of <a class="link-solid" href="${node['registered_from_url']}">this ${node['node_type']}</a>; the content of the ${node['node_type']} has been frozen and cannot be edited.</div>
 
            % else:
-              <div class="alert alert-info">This is a pending registration of <a class="link-solid" href="${node['registered_from_url']}">this project</a>, awaiting approval from project administrators. This registration will be final when all project administrators approve the registration or 48 hours pass, whichever comes first.</div>
+              <div class="alert alert-info">This is a pending registration of <a class="link-solid" href="${node['registered_from_url']}">this ${node['node_type']}</a>, awaiting approval from project administrators. This registration will be final when all project administrators approve the registration or 48 hours pass, whichever comes first.</div>
            % endif
 
            <style type="text/css">

--- a/website/tokens/handlers.py
+++ b/website/tokens/handlers.py
@@ -57,12 +57,15 @@ def sanction_handler(kind, action, payload, encoded_token, auth, **kwargs):
     if not sanction:
         raise HTTPError(http.BAD_REQUEST, data={
             'message_short': 'Bad request',
-            'message_long': 'There is no sanction associated with this token'
+            'message_long': 'There is no {0} associated with this token.'.format(kind)
         })
-
+    if sanction.is_approved:
+        raise HTTPError(http.BAD_REQUEST, data=dict(
+            message_long="This registration is not pending {0}.".format(sanction.short_name)
+        ))
     if sanction.is_rejected:
         raise HTTPError(http.GONE, data=dict(
-            message_long="This registration has been rejected"
+            message_long="This registration {0} has been rejected.".format(sanction.short_name)
         ))
     do_action = getattr(sanction, action, None)
     if do_action:

--- a/website/tokens/handlers.py
+++ b/website/tokens/handlers.py
@@ -59,10 +59,10 @@ def sanction_handler(kind, action, payload, encoded_token, auth, **kwargs):
     if not sanction:
         err_code = http.BAD_REQUEST
         err_message = 'There is no {0} associated with this token.'.format(kind)
-    if sanction.is_approved:
+    elif sanction.is_approved:
         err_code = http.BAD_REQUEST if kind in ['registration', 'embargo'] else http.GONE
         err_message = "This registration is not pending {0}.".format(sanction.SHORT_NAME)
-    if sanction.is_rejected:
+    elif sanction.is_rejected:
         err_code = http.GONE if kind in ['registration', 'embargo'] else http.BAD_REQUEST
         err_message = "This registration {0} has been rejected.".format(sanction.SHORT_NAME)
     if err_code:

--- a/website/tokens/handlers.py
+++ b/website/tokens/handlers.py
@@ -54,19 +54,22 @@ def sanction_handler(kind, action, payload, encoded_token, auth, **kwargs):
     sanction_id = payload.get('sanction_id', None)
     sanction = Model.load(sanction_id)
 
+    err_code = None
+    err_message = None
     if not sanction:
-        raise HTTPError(http.BAD_REQUEST, data={
-            'message_short': 'Bad request',
-            'message_long': 'There is no {0} associated with this token.'.format(kind)
-        })
+        err_code = http.BAD_REQUEST
+        err_message = 'There is no {0} associated with this token.'.format(kind)
     if sanction.is_approved:
-        raise HTTPError(http.BAD_REQUEST, data=dict(
-            message_long="This registration is not pending {0}.".format(sanction.short_name)
-        ))
+        err_code = http.BAD_REQUEST if kind in ['registration', 'embargo'] else http.GONE
+        err_message = "This registration is not pending {0}.".format(sanction.short_name)
     if sanction.is_rejected:
-        raise HTTPError(http.GONE, data=dict(
-            message_long="This registration {0} has been rejected.".format(sanction.short_name)
+        err_code = http.GONE if kind in ['registration', 'embargo'] else http.BAD_REQUEST
+        err_message = "This registration {0} has been rejected.".format(sanction.short_name)
+    if err_code:
+        raise HTTPError(err_code, data=dict(
+            message_long=err_message
         ))
+
     do_action = getattr(sanction, action, None)
     if do_action:
         registration = Node.find_one(Q(sanction.SHORT_NAME, 'eq', sanction))

--- a/website/tokens/handlers.py
+++ b/website/tokens/handlers.py
@@ -61,10 +61,10 @@ def sanction_handler(kind, action, payload, encoded_token, auth, **kwargs):
         err_message = 'There is no {0} associated with this token.'.format(kind)
     if sanction.is_approved:
         err_code = http.BAD_REQUEST if kind in ['registration', 'embargo'] else http.GONE
-        err_message = "This registration is not pending {0}.".format(sanction.short_name)
+        err_message = "This registration is not pending {0}.".format(sanction.SHORT_NAME)
     if sanction.is_rejected:
         err_code = http.GONE if kind in ['registration', 'embargo'] else http.BAD_REQUEST
-        err_message = "This registration {0} has been rejected.".format(sanction.short_name)
+        err_message = "This registration {0} has been rejected.".format(sanction.SHORT_NAME)
     if err_code:
         raise HTTPError(err_code, data=dict(
             message_long=err_message


### PR DESCRIPTION
# Purpose
Disallow sanction token actions if the sanction has been approved

# Changes
Check if a sanction has been approved in the handler, raise a 400 if so.

# Fixes: 
- https://trello.com/c/YZFj2bAk/55-users-can-cancel-embargo-registrations-retractions-after-they-are-already-approved
- https://trello.com/c/bd4b6MPQ/54-alert-at-top-of-screen-incorrectly-refers-to-a-component-as-a-project-for-immediately-public-registrations
