### PR TITLE
[Hotfix] strip share query down

### DIFF
--- a/website/static/js/share/searchBar.js
+++ b/website/static/js/share/searchBar.js
@@ -72,8 +72,11 @@ SearchBar.controller = function(vm) {
 
     /* Dumps the json query for elasticsearch to a URI formatted string */
     self.atomParams = function(){
+        var query = utils.buildQuery(vm);
+        delete query.aggregations;
+        delete query.highlight;
         return $.param({
-            jsonQuery: encodeURIComponent(JSON.stringify(utils.buildQuery(vm)))
+            jsonQuery: encodeURIComponent(JSON.stringify(query))
         });
     };
 

--- a/website/static/js/share/utils.js
+++ b/website/static/js/share/utils.js
@@ -166,13 +166,17 @@ utils.buildURLParams = function(vm){
 utils.buildQuery = function (vm) {
     var must = $.map(vm.requiredFilters, utils.parseFilter);
     var should = $.map(vm.optionalFilters, utils.parseFilter);
+    var from = (vm.page - 1) * 10;
     var sort = {};
 
     if (vm.sortMap[vm.sort()]) {
         sort[vm.sortMap[vm.sort()]] = 'desc';
+    } else {
+        sort = null;
     }
 
-    return {
+    // size defaults to 10, left out intentionally
+    var ret = {
         'query' : {
             'filtered': {
                 'query': (vm.query().length > 0 && (vm.query() !== '*')) ? utils.commonQuery(vm.query()) : utils.matchAllQuery(),
@@ -180,9 +184,6 @@ utils.buildQuery = function (vm) {
             }
         },
         'aggregations': vm.loadStats ? utils.buildStatsAggs(vm) : {},
-        'from': (vm.page - 1) * 10,
-        'size': 10,
-        'sort': [sort],
         'highlight': {
             'fields': {
                 'title': {'fragment_size': 2000},
@@ -192,6 +193,13 @@ utils.buildQuery = function (vm) {
         }
     };
 
+    if (sort) {
+        ret.sort = sort;
+    }
+    if (from !== 0) {
+        ret.from = from;
+    }
+    return ret;
 };
 
 utils.maybeQuashEvent = function (event) {
@@ -312,13 +320,26 @@ utils.rangeFilter = function (fieldName, gte, lte) {
 
 /* Creates a bool query */
 utils.boolQuery = function (must, mustNot, should, minimum) {
-    var ret = {
-        'bool': {
-            'must': (must || []),
-            'must_not': (mustNot || []),
-            'should': (should || [])
-        }
-    };
+    var ret = {};
+    var mustProvided = must && (must.length > 0);
+    var mustNotProvided = mustNot && (mustNot.length > 0);
+    var shouldProvided = should && (should.length > 0);
+
+    if (!mustProvided && !mustNotProvided && !shouldProvided) {
+        return ret;
+    } else {
+        ret.bool = {};
+    }
+
+    if (mustProvided) {
+        ret.bool.must = must;
+    }
+    if (mustNotProvided) {
+        ret.bool.must_not = mustNot;
+    }
+    if (shouldProvided) {
+        ret.bool.should = should;
+    }
     if (minimum) {
         ret.bool.minimum_should_match = minimum;
     }

--- a/website/static/js/share/utils.js
+++ b/website/static/js/share/utils.js
@@ -168,6 +168,17 @@ utils.buildQuery = function (vm) {
     var should = $.map(vm.optionalFilters, utils.parseFilter);
     var from = (vm.page - 1) * 10;
     var sort = {};
+    var query = (vm.query().length > 0 && (vm.query() !== '*')) ? utils.commonQuery(vm.query()) : utils.matchAllQuery();
+    var builtQuery = {};
+    var filters = utils.boolQuery(must, null, should);
+    if (Object.keys(filters).length === 0) {
+        builtQuery = query;
+    } else {
+        builtQuery.filtered = {
+            query: query,
+            filter: filters
+        };
+    }
 
     if (vm.sortMap[vm.sort()]) {
         sort[vm.sortMap[vm.sort()]] = 'desc';
@@ -177,12 +188,7 @@ utils.buildQuery = function (vm) {
 
     // size defaults to 10, left out intentionally
     var ret = {
-        'query' : {
-            'filtered': {
-                'query': (vm.query().length > 0 && (vm.query() !== '*')) ? utils.commonQuery(vm.query()) : utils.matchAllQuery(),
-                'filter': utils.boolQuery(must, null, should)
-            }
-        },
+        'query' : builtQuery,
         'aggregations': vm.loadStats ? utils.buildStatsAggs(vm) : {},
         'highlight': {
             'fields': {

--- a/website/static/js/tests/share/utils.test.js
+++ b/website/static/js/tests/share/utils.test.js
@@ -154,8 +154,8 @@ describe('share/utils', () => {
         });
 
         it('creates match query filters for required filters', () => {
-            vm.requiredFilters.push('_all:1');
-            vm.requiredFilters.push('_all:2');
+            vm.requiredFilters.push('match:_all:1');
+            vm.requiredFilters.push('match:_all:2');
             var built = utils.buildQuery(vm);
 
             assert.equal('bool', Object.keys(built.query.filtered.filter)[0]);
@@ -166,8 +166,8 @@ describe('share/utils', () => {
         });
 
         it('creates a list of should filters for the optional filters', () => {
-            vm.requiredFilters.push('_all:1');
-            vm.requiredFilters.push('_all:2');
+            vm.optionalFilters.push('match:_all:1');
+            vm.optionalFilters.push('match:_all:2');
             var built = utils.buildQuery(vm);
 
             $.map(built.query.filtered.filter.bool.should, function (item) {

--- a/website/static/js/tests/share/utils.test.js
+++ b/website/static/js/tests/share/utils.test.js
@@ -139,18 +139,18 @@ describe('share/utils', () => {
             var built;
             query = '';
             built = utils.buildQuery(vm);
-            assert.equal('match_all', Object.keys(built.query.filtered.query)[0]);
+            assert.equal('match_all', Object.keys(built.query)[0]);
 
             query = '*';
             built = utils.buildQuery(vm);
-            assert.equal('match_all', Object.keys(built.query.filtered.query)[0]);
+            assert.equal('match_all', Object.keys(built.query)[0]);
 
             query = 'toast';
         });
 
         it('creates a common terms query otherwise', () => {
             var built = utils.buildQuery(vm);
-            assert.equal('common', Object.keys(built.query.filtered.query)[0]);
+            assert.equal('common', Object.keys(built.query)[0]);
         });
 
         it('creates match query filters for required filters', () => {


### PR DESCRIPTION
Purpose
-----------
When visiting the SHARE atom feed, even with a short query (like "cats"), the url that is generated is 1800+ characters long. Much of that is cruft that is either default values, or not used in the atom feed.

Changes
-------------
Change query building logic to only add fields when they are not set to the default value, and removes unused fields when generating the SHARE atom feed URL. Shortens the json dumped URL significantly.

Side-effects
----------------
Changed all of SHARE query building logic, so could affect any searches/tags. 
Should make Atom feed quite a bit faster.

Example
-------------
a query for cats, which currently produces:

https://osf.io/share/atom/?jsonQuery=%257B%2522query%2522%253A%257B%2522filtered%2522%253A%257B%2522query%2522%253A%257B%2522common%2522%253A%257B%2522_all%2522%253A%257B%2522query%2522%253A%2522cats%2522%257D%257D%257D%252C%2522filter%2522%253A%257B%2522bool%2522%253A%257B%2522must%2522%253A%255B%255D%252C%2522must_not%2522%253A%255B%255D%252C%2522should%2522%253A%255B%255D%257D%257D%257D%257D%252C%2522aggregations%2522%253A%257B%2522sourcesByTimes%2522%253A%257B%2522terms%2522%253A%257B%2522field%2522%253A%2522_type%2522%252C%2522size%2522%253A0%252C%2522exclude%2522%253A%2522of%257Cand%257Cor%2522%252C%2522min_doc_count%2522%253A0%257D%252C%2522aggregations%2522%253A%257B%2522articlesOverTime%2522%253A%257B%2522filter%2522%253A%257B%2522range%2522%253A%257B%2522providerUpdatedDateTime%2522%253A%257B%2522gte%2522%253A1432221676544%252C%2522lte%2522%253A1440170476544%257D%257D%257D%252C%2522aggregations%2522%253A%257B%2522articlesOverTime%2522%253A%257B%2522date_histogram%2522%253A%257B%2522field%2522%253A%2522providerUpdatedDateTime%2522%252C%2522interval%2522%253A%2522week%2522%252C%2522min_doc_count%2522%253A0%252C%2522extended_bounds%2522%253A%257B%2522min%2522%253A1432221676544%252C%2522max%2522%253A1440170476544%257D%257D%257D%257D%257D%257D%257D%252C%2522sources%2522%253A%257B%2522terms%2522%253A%257B%2522field%2522%253A%2522_type%2522%252C%2522size%2522%253A0%252C%2522exclude%2522%253A%2522of%257Cand%257Cor%2522%252C%2522min_doc_count%2522%253A0%257D%257D%257D%252C%2522from%2522%253A0%252C%2522size%2522%253A10%252C%2522sort%2522%253A%255B%257B%257D%255D%252C%2522highlight%2522%253A%257B%2522fields%2522%253A%257B%2522title%2522%253A%257B%2522fragment_size%2522%253A2000%257D%252C%2522description%2522%253A%257B%2522fragment_size%2522%253A2000%257D%252C%2522contributors.name%2522%253A%257B%2522fragment_size%2522%253A2000%257D%257D%257D%257D (1877 characters)

would produce

http://osf.io/share/atom/?jsonQuery=%257B%2522query%2522%253A%257B%2522common%2522%253A%257B%2522_all%2522%253A%257B%2522query%2522%253A%2522cats%2522%257D%257D%257D%257D (170 characters)

instead (and if you follow those two URLs, you can see they are equally valid)

