### PR TITLE
Fix token handler messages and add tests to document behavior

### DIFF
--- a/framework/auth/decorators.py
+++ b/framework/auth/decorators.py
@@ -31,6 +31,7 @@ def must_be_logged_in(func):
     """
     @functools.wraps(func)
     def wrapped(*args, **kwargs):
+
         kwargs['auth'] = Auth.from_kwargs(request.args.to_dict(), kwargs)
         if kwargs['auth'].logged_in:
             return func(*args, **kwargs)

--- a/framework/auth/decorators.py
+++ b/framework/auth/decorators.py
@@ -31,7 +31,6 @@ def must_be_logged_in(func):
     """
     @functools.wraps(func)
     def wrapped(*args, **kwargs):
-
         kwargs['auth'] = Auth.from_kwargs(request.args.to_dict(), kwargs)
         if kwargs['auth'].logged_in:
             return func(*args, **kwargs)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -27,10 +27,9 @@ from website.oauth.models import ExternalAccount
 from website.oauth.models import ExternalProvider
 from website.project.model import (
     Node, NodeLog, WatchConfig, Tag, Pointer, Comment, PrivateLink,
-    Retraction, Embargo, Sanction
+    Retraction, Embargo, Sanction, RegistrationApproval
 )
 from website.notifications.model import NotificationSubscription, NotificationDigest
-from website.archiver import listeners as archiver_listeners
 from website.archiver.model import ArchiveTarget, ArchiveJob
 from website.archiver import ARCHIVER_SUCCESS
 
@@ -173,7 +172,7 @@ class RegistrationFactory(AbstractNodeFactory):
 
     @classmethod
     def _create(cls, target_class, project=None, schema=None, user=None,
-                template=None, data=None, archive=False, embargo=None, approval=None, *args, **kwargs):
+                template=None, data=None, archive=False, embargo=None, registration_approval=None, retraction=None, *args, **kwargs):
         save_kwargs(**kwargs)
 
         # Original project to be registered
@@ -197,17 +196,17 @@ class RegistrationFactory(AbstractNodeFactory):
         )
 
         def add_approval_step(reg):
-            target = None
             if embargo:
                 reg.embargo = embargo
-                target = embargo
-            if approval:
-                reg.registration_approval = approval
+            elif registration_approval:
+                reg.registration_approval = registration_approval
+            elif retraction:
+                reg.retraction = retraction
             else:
                 reg.require_approval(reg.creator)
-            if not embargo:
-                target = reg.registration_approval
-            target.save()
+            reg.save()
+            reg.sanction.add_authorizer(reg.creator)
+            reg.sanction.save()
 
         if archive:
             reg = register()
@@ -245,15 +244,36 @@ class WatchConfigFactory(ModularOdmFactory):
     node = SubFactory(NodeFactory)
 
 
-class RetractionFactory(ModularOdmFactory):
+class SanctionFactory(ModularOdmFactory):
+
+    ABSTRACT_FACTORY = True
+
+    @classmethod
+    def _create(cls, target_class, approve=False, *args, **kwargs):
+        user = UserFactory()
+        sanction = ModularOdmFactory._create(target_class, initiated_by=user, *args, **kwargs)
+        reg_kwargs = {
+            'owner': user,
+            sanction.SHORT_NAME: sanction
+        }
+        RegistrationFactory(**reg_kwargs)
+        if not approve:
+            sanction.state = Sanction.UNAPPROVED
+            sanction.save()
+        return sanction
+
+class RetractionFactory(SanctionFactory):
     FACTORY_FOR = Retraction
     user = SubFactory(UserFactory)
 
 
-class EmbargoFactory(ModularOdmFactory):
+class EmbargoFactory(SanctionFactory):
     FACTORY_FOR = Embargo
     user = SubFactory(UserFactory)
 
+class RegistrationApprovalFactory(SanctionFactory):
+    FACTORY_FOR = RegistrationApproval
+    user = SubFactory(UserFactory)
 
 
 class NodeWikiFactory(ModularOdmFactory):

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -1,19 +1,39 @@
 import jwt
+import httplib as http
 
 import mock
 from nose.tools import *  # noqa
+from nose.loader import TestLoader
+import nose
+
+from modularodm import Q
 
 from tests.base import OsfTestCase
+from tests import factories
+
+from framework.exceptions import HTTPError
 
 from website import settings
+from website.models import Node, Sanction, Embargo, RegistrationApproval, Retraction
 from website.tokens import decode, encode, TokenHandler
 from website.tokens.exceptions import TokenHandlerNotFound
 
+NO_SANCTION_MSG = 'There is no {0} associated with this token.'
+APPROVED_MSG = "This registration is not pending {0}."
+REJECTED_MSG = "This registration {0} has been rejected."
+
+class MockAuth(object):
+
+    def __init__(self, user):
+        self.user = user        
+        self.logged_in = True
+
+mock_auth = lambda user: mock.patch('framework.auth.Auth.from_kwargs', mock.Mock(return_value=MockAuth(user)))
 
 class TestTokenHandler(OsfTestCase):
 
-    def setUp(self):
-        super(TestTokenHandler, self).setUp()
+    def setUp(self, *args, **kwargs):
+        super(TestTokenHandler, self).setUp(*args, **kwargs)
 
         self.payload = {
             'user_id': 'abc123',
@@ -60,3 +80,87 @@ class TestTokenHandler(OsfTestCase):
                 self.encoded_token
             )
         )
+
+
+SANCTION_CLASS_MAP = {
+    'embargo': Embargo,
+    'registration_approval': RegistrationApproval,
+    'retraction': Retraction
+}
+SANCTION_FACTORY_MAP = {
+    'embargo': factories.EmbargoFactory,
+    'registration_approval': factories.RegistrationApprovalFactory,
+    'retraction': factories.RetractionFactory
+}
+
+def make_sanction_token_handler_case(kind):
+
+    def setUp(self, *args, **kwargs):
+        OsfTestCase.setUp(self, *args, **kwargs)
+        setattr(self, kind, SANCTION_FACTORY_MAP[kind]())
+        setattr(self, '{0}_reg'.format(kind), Node.find_one(Q(kind, 'eq', getattr(self, kind))))
+        setattr(self, '{0}_user'.format(kind), getattr(self, '{0}_reg'.format(kind)).creator)
+
+    @mock.patch('website.tokens.handlers.{0}_handler'.format(kind))
+    def test_sanction_handler(self, mock_handler):
+        approval_token = getattr(self, kind).approval_state[getattr(self, '{}_user'.format(kind))._id]['approval_token']
+        handler = TokenHandler.from_string(approval_token)
+        with mock_auth(getattr(self, '{0}_user'.format(kind))):
+            handler.to_response()
+            mock_handler.assert_called_with('approve', getattr(self, '{0}_reg'.format(kind)), getattr(self, '{0}_reg'.format(kind)).registered_from)
+
+    def test_sanction_handler_no_sanction(self):
+        approval_token = getattr(self, kind).approval_state[getattr(self, '{0}_user'.format(kind))._id]['approval_token']
+        handler = TokenHandler.from_string(approval_token)
+        SANCTION_CLASS_MAP[kind].remove_one(getattr(self, kind))
+        with mock_auth(getattr(self, '{0}_user'.format(kind))):
+            try:
+                handler.to_response()
+            except HTTPError as e:
+                assert_equal(e.code, http.BAD_REQUEST)
+                assert_equal(e.data['message_long'], NO_SANCTION_MSG.format(SANCTION_CLASS_MAP[kind].DISPLAY_NAME))
+
+    def test_sanction_handler_sanction_approved(self):
+        approval_token = getattr(self, kind).approval_state[getattr(self, '{0}_user'.format(kind))._id]['approval_token']
+        handler = TokenHandler.from_string(approval_token)
+        getattr(self, kind).state = Sanction.APPROVED
+        getattr(self, kind).save()
+        with mock_auth(getattr(self, '{0}_user'.format(kind))):
+            try:
+                handler.to_response()
+            except HTTPError as e:
+                assert_equal(e.code, http.BAD_REQUEST if kind in ['embargo', 'registration_approval'] else http.GONE)
+                assert_equal(e.data['message_long'], APPROVED_MSG.format(getattr(self, kind).DISPLAY_NAME))
+
+    def test_sanction_handler_sanction_rejected(self):
+        approval_token = getattr(self, kind).approval_state[getattr(self, '{0}_user'.format(kind))._id]['approval_token']
+        handler = TokenHandler.from_string(approval_token)
+        getattr(self, kind).state = Sanction.REJECTED
+        getattr(self, kind).save()
+        with mock_auth(getattr(self, '{0}_user'.format(kind))):
+            try:
+                handler.to_response()
+            except HTTPError as e:
+                assert_equal(e.code, http.GONE if kind in ['embargo', 'registration_approval'] else http.BAD_REQUEST)
+                assert_equal(e.data['message_long'], REJECTED_MSG.format(getattr(self, kind).DISPLAY_NAME))
+
+    return type(
+        'Test{0}TokenHandlers'.format(kind),
+        (OsfTestCase,),
+        {
+            'setUp': setUp,
+            'test_sanction_handler_{0}'.format(kind): test_sanction_handler,
+            'test_sanction_sanction_handler_no_{0}'.format(kind): test_sanction_handler_no_sanction,
+            'test_sanction_handler_{0}_approved'.format(kind): test_sanction_handler_sanction_approved,
+            'test_sanction_handler_{0}_rejected'.format(kind): test_sanction_handler_sanction_rejected
+        }
+    )
+
+global test_sanction_handler_embargo
+global test_sanction_handler_registration_appproval
+global test_sanction_handler_retraction
+for kind in ['embargo', 'registration_approval', 'retraction']:
+    globals()['test_sanction_handler_{0}'.format(kind)] = make_sanction_token_handler_case(kind)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -3,7 +3,6 @@ import httplib as http
 
 import mock
 from nose.tools import *  # noqa
-import unittest
 
 from modularodm import Q
 
@@ -80,89 +79,85 @@ class TestTokenHandler(OsfTestCase):
             )
         )
 
-
-SANCTION_CLASS_MAP = {
-    'embargo': Embargo,
-    'registration_approval': RegistrationApproval,
-    'retraction': Retraction
-}
-SANCTION_FACTORY_MAP = {
-    'embargo': factories.EmbargoFactory,
-    'registration_approval': factories.RegistrationApprovalFactory,
-    'retraction': factories.RetractionFactory
-}
-
 class SanctionTokenHandlerBase(OsfTestCase):
 
     kind = None
+    Model = None
+    Factory = None
 
     def setUp(self, *args, **kwargs):
         OsfTestCase.setUp(self, *args, **kwargs)
         if not self.kind:
             return
-        setattr(self, self.kind, SANCTION_FACTORY_MAP[self.kind]())
-        setattr(self, '{0}_reg'.format(self.kind), Node.find_one(Q(self.kind, 'eq', getattr(self, self.kind))))
-        setattr(self, '{0}_user'.format(self.kind), getattr(self, '{0}_reg'.format(self.kind)).creator)
+        self.sanction = self.Factory()
+        self.reg = Node.find_one(Q(self.Model.SHORT_NAME, 'eq', self.sanction))
+        self.user = self.reg.creator
 
     def test_sanction_handler(self):
         if not self.kind:
             return
-        approval_token = getattr(self, self.kind).approval_state[getattr(self, '{}_user'.format(self.kind))._id]['approval_token']
+        approval_token = self.sanction.approval_state[self.user._id]['approval_token']
         handler = TokenHandler.from_string(approval_token)
-        with mock_auth(getattr(self, '{0}_user'.format(self.kind))):
+        with mock_auth(self.user):
             with mock.patch('website.tokens.handlers.{0}_handler'.format(self.kind)) as mock_handler:
                 handler.to_response()
-                mock_handler.assert_called_with('approve', getattr(self, '{0}_reg'.format(self.kind)), getattr(self, '{0}_reg'.format(self.kind)).registered_from)
+                mock_handler.assert_called_with('approve', self.reg, self.reg.registered_from)
 
     def test_sanction_handler_no_sanction(self):
         if not self.kind:
             return
-        approval_token = getattr(self, self.kind).approval_state[getattr(self, '{0}_user'.format(self.kind))._id]['approval_token']
+        approval_token = self.sanction.approval_state[self.user._id]['approval_token']
         handler = TokenHandler.from_string(approval_token)
-        SANCTION_CLASS_MAP[self.kind].remove_one(getattr(self, self.kind))
-        with mock_auth(getattr(self, '{0}_user'.format(self.kind))):
+        self.Model.remove_one(self.sanction)
+        with mock_auth(self.user):
             try:
                 handler.to_response()
             except HTTPError as e:
                 assert_equal(e.code, http.BAD_REQUEST)
-                assert_equal(e.data['message_long'], NO_SANCTION_MSG.format(SANCTION_CLASS_MAP[self.kind].DISPLAY_NAME))
+                assert_equal(e.data['message_long'], NO_SANCTION_MSG.format(self.Model.DISPLAY_NAME))
 
     def test_sanction_handler_sanction_approved(self):
         if not self.kind:
             return
-        approval_token = getattr(self, self.kind).approval_state[getattr(self, '{0}_user'.format(self.kind))._id]['approval_token']
+        approval_token = self.sanction.approval_state[self.user._id]['approval_token']
         handler = TokenHandler.from_string(approval_token)
-        getattr(self, self.kind).state = Sanction.APPROVED
-        getattr(self, self.kind).save()
-        with mock_auth(getattr(self, '{0}_user'.format(self.kind))):
+        self.sanction.state = Sanction.APPROVED
+        self.sanction.save()
+        with mock_auth(self.user):
             try:
                 handler.to_response()
             except HTTPError as e:
                 assert_equal(e.code, http.BAD_REQUEST if self.kind in ['embargo', 'registration_approval'] else http.GONE)
-                assert_equal(e.data['message_long'], APPROVED_MSG.format(getattr(self, self.kind).DISPLAY_NAME))
+                assert_equal(e.data['message_long'], APPROVED_MSG.format(self.sanction.DISPLAY_NAME))
 
     def test_sanction_handler_sanction_rejected(self):
         if not self.kind:
             return
-        approval_token = getattr(self, self.kind).approval_state[getattr(self, '{0}_user'.format(self.kind))._id]['approval_token']
+        approval_token = self.sanction.approval_state[self.user._id]['approval_token']
         handler = TokenHandler.from_string(approval_token)
-        getattr(self, self.kind).state = Sanction.REJECTED
-        getattr(self, self.kind).save()
-        with mock_auth(getattr(self, '{0}_user'.format(self.kind))):
+        self.sanction.state = Sanction.REJECTED
+        self.sanction.save()
+        with mock_auth(self.user):
             try:
                 handler.to_response()
             except HTTPError as e:
                 assert_equal(e.code, http.GONE if self.kind in ['embargo', 'registration_approval'] else http.BAD_REQUEST)
-                assert_equal(e.data['message_long'], REJECTED_MSG.format(getattr(self, self.kind).DISPLAY_NAME))
+                assert_equal(e.data['message_long'], REJECTED_MSG.format(self.sanction.DISPLAY_NAME))
 
 class TestEmbargoTokenHandler(SanctionTokenHandlerBase):
 
     kind = 'embargo'
+    Model = Embargo
+    Factory = factories.EmbargoFactory
 
 class TestRegistrationApprovalTokenHandler(SanctionTokenHandlerBase):
 
     kind = 'registration_approval'
+    Model = RegistrationApproval
+    Factory = factories.RegistrationApprovalFactory
 
 class TestRetractionTokenHandler(SanctionTokenHandlerBase):
 
     kind = 'retraction'
+    Model = Retraction
+    Factory = factories.RetractionFactory

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -3402,7 +3402,7 @@ class Retraction(EmailApprovableSanction):
 
 class RegistrationApproval(EmailApprovableSanction):
 
-    DISPLAY_NAME = 'Registration Approval'
+    DISPLAY_NAME = 'Approval'
     SHORT_NAME = 'registration_approval'
 
     AUTHORIZER_NOTIFY_EMAIL_TEMPLATE = mails.PENDING_REGISTRATION_ADMIN

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -18,6 +18,7 @@ from modularodm import fields
 from modularodm.validators import MaxLengthValidator
 from modularodm.exceptions import ValidationTypeError
 from modularodm.exceptions import ValidationValueError
+from modularodm.exceptions import NoResultsFound
 
 from api.base.utils import absolute_reverse
 from framework import status
@@ -671,7 +672,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
 
     @property
     def sanction(self):
-        sanction = self.registration_approval or self.embargo
+        sanction = self.registration_approval or self.embargo or self.retraction
         if sanction:
             return sanction
         elif self.parent_node:
@@ -2929,6 +2930,8 @@ class Sanction(StoredObject):
     REJECTED = 'rejected'
 
     DISPLAY_NAME = 'Sanction'
+    # SHORT_NAME must correspond with the associated foreign field to query against,
+    # e.g. Node.find_one(Q(sanction.SHORT_NAME, 'eq', sanction))
     SHORT_NAME = 'sanction'
 
     APPROVAL_NOT_AUTHORIZED_MESSAGE = 'This user is not authorized to approve this {DISPLAY_NAME}'
@@ -3168,7 +3171,11 @@ class Embargo(EmailApprovableSanction):
         return not self.for_existing_registration and self.pending_approval
 
     def __repr__(self):
-        parent_registration = Node.find_one(Q('embargo', 'eq', self))
+        parent_registration = None
+        try:
+            parent_registration = Node.find_one(Q('embargo', 'eq', self))
+        except NoResultsFound:
+            pass
         return ('<Embargo(parent_registration={0}, initiated_by={1}, '
                 'end_date={2}) with _id {3}>').format(
             parent_registration,
@@ -3284,7 +3291,11 @@ class Retraction(EmailApprovableSanction):
     justification = fields.StringField(default=None, validate=MaxLengthValidator(2048))
 
     def __repr__(self):
-        parent_registration = Node.find_one(Q('retraction', 'eq', self))
+        parent_registration = None
+        try:
+            parent_registration = Node.find_one(Q('retraction', 'eq', self))
+        except NoResultsFound:
+            pass
         return ('<Retraction(parent_registration={0}, initiated_by={1}) '
                 'with _id {2}>').format(
             parent_registration,
@@ -3392,7 +3403,7 @@ class Retraction(EmailApprovableSanction):
 class RegistrationApproval(EmailApprovableSanction):
 
     DISPLAY_NAME = 'Registration Approval'
-    SHORT_NAME = 'approval'
+    SHORT_NAME = 'registration_approval'
 
     AUTHORIZER_NOTIFY_EMAIL_TEMPLATE = mails.PENDING_REGISTRATION_ADMIN
     NON_AUTHORIZER_NOTIFY_EMAIL_TEMPLATE = mails.PENDING_REGISTRATION_NON_ADMIN

--- a/website/tokens/handlers.py
+++ b/website/tokens/handlers.py
@@ -58,13 +58,13 @@ def sanction_handler(kind, action, payload, encoded_token, auth, **kwargs):
     err_message = None
     if not sanction:
         err_code = http.BAD_REQUEST
-        err_message = 'There is no {0} associated with this token.'.format(kind)
+        err_message = 'There is no {0} associated with this token.'.format(Model.DISPLAY_NAME)
     elif sanction.is_approved:
         err_code = http.BAD_REQUEST if kind in ['registration', 'embargo'] else http.GONE
-        err_message = "This registration is not pending {0}.".format(sanction.SHORT_NAME)
+        err_message = "This registration is not pending {0}.".format(sanction.DISPLAY_NAME)
     elif sanction.is_rejected:
         err_code = http.GONE if kind in ['registration', 'embargo'] else http.BAD_REQUEST
-        err_message = "This registration {0} has been rejected.".format(sanction.SHORT_NAME)
+        err_message = "This registration {0} has been rejected.".format(sanction.DISPLAY_NAME)
     if err_code:
         raise HTTPError(err_code, data=dict(
             message_long=err_message


### PR DESCRIPTION
# Purpose

Earlier the SHORT_NAME for registration approval got changed which broke the handler system for sanction tokens

# Changes
Fix this and add test coverage for sanction handlers. 

# Resolves
https://trello.com/c/YZFj2bAk/55-users-can-cancel-embargo-registrations-retractions-after-they-are-already-approved