### PR TITLE
[Fix] Success alert for forks

### DIFF
--- a/website/static/js/project.js
+++ b/website/static/js/project.js
@@ -46,7 +46,9 @@ NodeActions.forkNode = function() {
             ctx.node.urls.api + 'fork/',
             {}
         ).done(function(response) {
-            window.location = response;
+            bootbox.alert('Fork successfully created!', function() {
+                window.location = response;
+            });
         }).fail(function(response) {
             $osf.unblock();
             if (response.status === 403) {

--- a/website/static/js/project.js
+++ b/website/static/js/project.js
@@ -46,9 +46,9 @@ NodeActions.forkNode = function() {
             ctx.node.urls.api + 'fork/',
             {}
         ).done(function(response) {
-            bootbox.alert('Fork successfully created!', function() {
-                window.location = response;
-            });
+            $osf.growl('Success:', 'fork was succesfully created', 'success');
+            window.location = response;
+
         }).fail(function(response) {
             $osf.unblock();
             if (response.status === 403) {


### PR DESCRIPTION
# Purpose
To give a more obvious visual notification that a fork was successfully created 

# Changes
* Add bootbox alert on a successful fork that redirects to the new fork after being closed or hitting 'OK'
* Addresses #4118

# Side effects

* User has to click before being redirected to their new fork