### PR TITLE
[Fix] Do not show deleted children in node children

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -83,7 +83,7 @@ class NodeSerializer(JSONAPISerializer):
 
     def get_node_count(self, obj):
         auth = self.get_user_auth(self.context['request'])
-        nodes = [node for node in obj.nodes if node.can_view(auth) and node.primary]
+        nodes = [node for node in obj.nodes if node.can_view(auth) and node.primary and not node.is_deleted]
         return len(nodes)
 
     def get_contrib_count(self, obj):

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -190,7 +190,7 @@ class NodeChildrenList(generics.ListCreateAPIView, NodeMixin):
             auth = Auth(None)
         else:
             auth = Auth(user)
-        children = [node for node in nodes if node.can_view(auth) and node.primary]
+        children = [node for node in nodes if node.can_view(auth) and node.primary and not node.is_deleted]
         return children
 
     # overrides ListCreateAPIView

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -848,9 +848,6 @@ class TestNodeChildrenList(ApiTestCase):
 
         self.user_two = AuthUserFactory()
 
-        self.deleted_project = NodeFactory(parent=self.public_project, is_deleted=True, creator=self.user)
-        self.deleted_project.save()
-
     def test_node_children_list_does_not_include_pointers(self):
         res = self.app.get(self.private_project_url, auth=self.user.auth)
         assert_equal(len(res.json['data']), 1)
@@ -890,6 +887,9 @@ class TestNodeChildrenList(ApiTestCase):
         assert_equal(len(res.json['data']), 1)
 
     def test_node_children_list_does_not_include_deleted(self):
+        deleted_project = NodeFactory(parent=self.public_project, is_deleted=True, creator=self.user)
+        deleted_project.save()
+
         res = self.app.get(self.public_project_url, auth=self.user.auth)
         assert_equal(res.status_code, 200)
         ids = [node['id'] for node in res.json['data']]

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -887,13 +887,22 @@ class TestNodeChildrenList(ApiTestCase):
         assert_equal(len(res.json['data']), 1)
 
     def test_node_children_list_does_not_include_deleted(self):
-        deleted_project = NodeFactory(parent=self.public_project, is_deleted=True, creator=self.user)
-        deleted_project.save()
+        child_project = NodeFactory(parent=self.public_project, creator=self.user)
+        child_project.save()
 
         res = self.app.get(self.public_project_url, auth=self.user.auth)
         assert_equal(res.status_code, 200)
         ids = [node['id'] for node in res.json['data']]
-        assert_not_in(self.deleted_project._id, ids)
+        assert_in(child_project._id, ids)
+        assert_equal(2, len(ids))
+
+        child_project.is_deleted = True
+        child_project.save()
+
+        res = self.app.get(self.public_project_url, auth=self.user.auth)
+        assert_equal(res.status_code, 200)
+        ids = [node['id'] for node in res.json['data']]
+        assert_not_in(child_project._id, ids)
         assert_equal(1, len(ids))
 
 

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -848,6 +848,9 @@ class TestNodeChildrenList(ApiTestCase):
 
         self.user_two = AuthUserFactory()
 
+        self.deleted_project = NodeFactory(parent=self.public_project, is_deleted=True, creator=self.user)
+        self.deleted_project.save()
+
     def test_node_children_list_does_not_include_pointers(self):
         res = self.app.get(self.private_project_url, auth=self.user.auth)
         assert_equal(len(res.json['data']), 1)
@@ -885,6 +888,14 @@ class TestNodeChildrenList(ApiTestCase):
         private_component = NodeFactory(parent=self.project)
         res = self.app.get(self.private_project_url, auth=self.user.auth)
         assert_equal(len(res.json['data']), 1)
+
+    def test_node_children_list_does_not_include_deleted(self):
+        res = self.app.get(self.public_project_url, auth=self.user.auth)
+        assert_equal(res.status_code, 200)
+        ids = [node['id'] for node in res.json['data']]
+        assert_not_in(self.deleted_project._id, ids)
+        assert_equal(1, len(ids))
+
 
 
 class TestNodeChildCreate(ApiTestCase):


### PR DESCRIPTION
# Purpose
Prevent deleted children from showing in the `NodeChildrenList`
# Changes
* Add a conditional in the list comprehension for the view to remove nodes that are deleted as well as tests in TestNodeChildrenList
* Addresses #4154

# Side effects

None