### PR TITLE
[HOTFIX] Fix search tags

### DIFF
--- a/website/static/js/search.js
+++ b/website/static/js/search.js
@@ -13,8 +13,6 @@ ko.punches.enableAll();
 // Disable IE Caching of JSON
 $.ajaxSetup({ cache: false });
 
-//https://stackoverflow.com/questions/7731778/jquery-get-query-string-parameters
-
 var Category = function(name, count, display){
     var self = this;
 
@@ -190,27 +188,42 @@ var ViewModel = function(params) {
         }
     };
 
-    /** name of tag, action add or remove.*/
-    self.clickTag = function(name, action) {
-        // To handle passing from template vs. in main html
-        var tag = name;
-
-        if(typeof name.name !== 'undefined') {
-            tag = name.name;
-        }
-
-        self.currentPage(1);
-        var tagString = 'tags:("' + tag + '")';
-
-        if (self.query().indexOf(tagString) === -1) {
-            if (self.query() !== '' && action === 'add') {
-                self.query(self.query() + ' AND ');
-            } else if (self.query() !== '' && action === 'remove') {
-                self.query(self.query() + ' NOT ');
+    self._makeTagString = function(tagName) {
+        return 'tags:("' + tagName + '")';        
+    };
+    self.addTag = function(tagName) {
+        var tagString = self._makeTagString(tagName);
+        var query = self.query();
+        if (query.indexOf(tagString) === -1) {
+            if (self.query() !== '') {
+                query += ' AND ';
             }
-            self.query(self.query() + tagString);
-            self.category(new Category('total', 0, 'Total'));
+            query += tagString;
+            self.query(query); 
+            self.onUpdateTags();                      
+        }     
+    };
+    self.removeTag = function(tagName, _, e) {
+        e.stopPropagation();            
+        var query = self.query();
+        var tagRegExp = /(?:AND)?\s*tags\:\([\'\"](.+?)[\'\"]\)/g;
+        var matches = query.match(tagRegExp);
+        var dirty = false;
+        while (matches.length) {
+            var match = matches.pop();
+            if (match.match(tagName).length) {
+                query = query.replace(match, '');   
+                dirty = true;
+            }
         }
+        if (dirty) {
+            self.query(query);
+            self.onUpdateTags();
+        }
+    };
+    self.onUpdateTags = function() {
+        self.category(new Category('total', 0, 'Total'));
+        self.currentPage(1);
         self.search();
     };
 

--- a/website/templates/search.mako
+++ b/website/templates/search.mako
@@ -35,35 +35,35 @@
                         <div class="row">
                             <div class="col-md-12">
                                 <h4> Improve your search:</h4>
-                                <span class="tag-cloud" data-bind="foreach: tags">
+                                <span class="tag-cloud" data-bind="foreach: {data: tags, as: 'tag'}">
                                     <!-- ko if: count === $parent.tagMaxCount() && count > $parent.tagMaxCount()/2  -->
                                     <span class="tag tag-big tag-container"
-                                          data-bind="click: $root.clickTag.bind($parentContext, name, 'add')">
+                                          data-bind="click: $root.addTag.bind($parentContext, tag.name)">
                                         <span class="cloud-text">
                                             {{name}}
                                         </span>
                                         <i class="fa fa-times-circle remove-tag big"
-                                           data-bind="click: $root.clickTag.bind($parentContext, name, 'remove')"></i>
+                                           data-bind="click: $root.removeTag.bind($parentContext, tag.name)"></i>
                                     </span>
                                     <!-- /ko -->
                                     <!-- ko if: count < $parent.tagMaxCount() && count > $parent.tagMaxCount()/2 -->
                                     <span class="tag tag-med tag-container"
-                                          data-bind="click: $root.clickTag.bind($parentContext, name, 'add')">
+                                          data-bind="click: $root.addTag.bind($parentContext, tag.name)">
                                         <span class="cloud-text">
                                             {{name}}
                                         </span>
                                         <i class="fa fa-times-circle remove-tag med"
-                                           data-bind="click: $root.clickTag.bind($parentContext, name, 'remove')"></i>
+                                           data-bind="click: $root.removeTag.bind($parentContext, tag.name)"></i>
                                     </span>
                                     <!-- /ko -->
                                     <!-- ko if: count <= $parent.tagMaxCount()/2-->
                                     <span class="tag tag-sm tag-container"
-                                          data-bind="click: $root.clickTag.bind($parentContext, name, 'add')">
+                                          data-bind="click: $root.addTag.bind($parentContext, tag.name)">
                                         <span class="cloud-text">
                                             {{name}}
                                         </span>
                                         <i class="fa fa-times-circle remove-tag"
-                                           data-bind="click: $root.clickTag.bind($parentContext, name, 'remove')"></i>
+                                           data-bind="click: $root.removeTag.bind($parentContext, tag.name)"></i>
                                     </span>
                                     <!-- /ko -->
                                 </span>
@@ -270,10 +270,10 @@
         <p data-bind="visible: tags.length"><strong>Tags:</strong>
             <div data-bind="foreach: tags">
                 <span class="tag pointer tag-container"
-                      data-bind="click: $root.clickTag.bind($parentContext, $data, 'add')">
+                      data-bind="click: $root.addTag.bind($parentContext, $data)">
                     <span class="tag-text" data-bind="text: $data"></span>
                     <i class="fa fa-times-circle remove-tag"
-                       data-bind="click: $root.clickTag.bind($parentContext, $data, 'remove')"></i>
+                       data-bind="click: $root.removeTag.bind($parentContext, $data)"></i>
                 </span>
             </div>
         </p>


### PR DESCRIPTION
# Purpose

The UI for search tags was behaving badly. Clicking the little X on a tag did nothing.
![screen shot 2015-08-24 at 2 20 09 pm](https://cloud.githubusercontent.com/assets/2207561/9448563/519eafe6-4a6b-11e5-93f8-fb9fc72e159c.png)

This updates that UI to behave as expected, i.e.:
- when a tag is clicked, and it is not already part of the query, it is added (to the query string)
- when the little X on a tag is clicked, and it is part of the query, it is removed (from the query string)

# Changes

- Update search code relevant to tagging to be more readable and predictable

# Side effects

None