### PR TITLE
[Feature Fix] Refine modal and margin on registration page

### DIFF
--- a/website/static/js/pages/register_1-page.js
+++ b/website/static/js/pages/register_1-page.js
@@ -131,8 +131,8 @@ $(document).ready(function() {
                     bootbox.confirm({
                         message: ($osf.joinPrompts(
                             response.errors,
-                            'Before you continue...'
-                        ) + '<br /><hr /> ' + language.registerSkipAddons),
+                            '<h4>Before you continue...</h4>'
+                        ) + '<hr /> ' + language.registerSkipAddons),
                         callback: function (result) {
                             if (result) {
                                 confirm();


### PR DESCRIPTION
### Purpose
This PR is to unify non-standard modal heading and reduce unnecessary margin.
Resolve https://github.com/CenterForOpenScience/osf.io/issues/4140

### Change
1) Add `h4` for title
2) Delete `br` tag

### Side Effect
None