### PR TITLE
[Feature Fix] Add properate column number for sm

### DIFF
--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -7,7 +7,7 @@
 <div id="projectScope">
     <header class="subhead" id="overview">
         <div class="row">
-            <div class="col-sm-6 col-md-7 cite-container">
+            <div class="col-sm-5 col-md-7 cite-container">
                 % if parent_node['exists']:
                     % if parent_node['can_view'] or parent_node['is_public'] or parent_node['is_contributor']:
                         <h2 class="node-parent-title">
@@ -23,7 +23,7 @@
                     <span id="nodeTitleEditable" class="overflow">${node['title']}</span>
                 </h2>
             </div>
-            <div class="col-sm-6 col-md-5">
+            <div class="col-sm-7 col-md-5">
                 <div class="btn-toolbar node-control pull-right"
                     % if not user_name:
                         data-bind="tooltip: {title: 'Log-in or create an account to watch/duplicate this project', placement: 'bottom'}"


### PR DESCRIPTION
### Purpose
Leave enough space for button group when it comes to small screen
Resolved https://github.com/CenterForOpenScience/osf.io/issues/4139

### Change
Change the column number in small screen.
Before Change:
![before-break](https://cloud.githubusercontent.com/assets/5420789/9451386/5c3f109c-4a7c-11e5-9c9d-aa7dec68cfa3.gif)

After Change:
![no-break](https://cloud.githubusercontent.com/assets/5420789/9451362/2b2b4976-4a7c-11e5-8a89-598b9318ad16.gif)

### Side effect
It may leave less space for project title. but it could be broken. So,it still looks OK.

