### PR TITLE
[Feature Fix] Fix icons not centered for information and x buttons 

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1394,10 +1394,12 @@ var FGButton = {
             opts['data-placement'] = 'bottom';
             opts.title = args.tooltip;
         }
-        return m('div', opts, [
-            m('i', {className: iconCSS}),
-            m('span', children)
-        ]);
+        var childrenElements = [];
+        childrenElements.push(m('i', {className: iconCSS}));
+        if(children) {
+            childrenElements.push(m('span', children));
+        }
+        return m('div', opts, childrenElements);
     }
 };
 


### PR DESCRIPTION
### Purpose
It adds margin to span tag. So when span tag is empty, it still has that margin. So we add if-statement for it. When span is empty, don't use that.

Resolve https://github.com/CenterForOpenScience/osf.io/issues/4137

### Change
Before Change:
![screenshot 2015-08-24 16 58 57](https://cloud.githubusercontent.com/assets/5420789/9452366/d2a51344-4a81-11e5-86fa-14997ecea2c4.png)
![screenshot 2015-08-24 16 59 18](https://cloud.githubusercontent.com/assets/5420789/9452365/d2848534-4a81-11e5-9bff-7ee7d4387398.png)

After Change:
![screenshot 2015-08-24 16 58 25](https://cloud.githubusercontent.com/assets/5420789/9452376/dd46665e-4a81-11e5-8637-b0f5e0eb6932.png)
![screenshot 2015-08-24 16 58 17](https://cloud.githubusercontent.com/assets/5420789/9452375/dd442772-4a81-11e5-8ff0-ef8a435628f7.png)

### Side Effect
None