### PR TITLE
[HOTFIX] Prevent duplicate archiver emails

### DIFF
--- a/website/archiver/tasks.py
+++ b/website/archiver/tasks.py
@@ -259,4 +259,4 @@ def archive(self, job_pk):
             )
             for target in job.target_addons
         )
-    )(archive_node.s(job_pk=job_pk))
+    )(archive_node.s(job_pk=job_pk)).get()


### PR DESCRIPTION
# Purpose

It appears an issue with inconsistent StoredObject instances for the same record was causing multiple emails to be sent for registrations callbacks.

# Changes

Force the celery task chain created in website/archiver/listeners.py#after_register to run sequentially (by making the website/archiver/tasks.py#archiver task wait until its chord call completes before returning).