### PR TITLE
Update syntax to avoid celery.chord usage

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1930,7 +1930,7 @@ class TestAddonCallbacks(OsfTestCase):
                 self.node, fork, self.user
             )
 
-    @mock.patch('website.archiver.tasks.archive.si')
+    @mock.patch('website.archiver.tasks.archive')
     def test_register_callback(self, mock_archive):
         registration = self.node.register_node(
             None, self.consolidate_auth, '', '',
@@ -2470,7 +2470,7 @@ class TestProject(OsfTestCase):
         project = ProjectFactory()
         assert_false(project.is_fork_of(self.project))
 
-    @mock.patch('website.archiver.tasks.archive.si')
+    @mock.patch('website.archiver.tasks.archive')
     def test_is_registration_of(self, mock_archive):
         project = ProjectFactory()
         reg1 = project.register_node(None, Auth(user=project.creator), '', None)
@@ -2478,7 +2478,7 @@ class TestProject(OsfTestCase):
         assert_true(reg1.is_registration_of(project))
         assert_true(reg2.is_registration_of(project))
 
-    @mock.patch('website.archiver.tasks.archive.si')
+    @mock.patch('website.archiver.tasks.archive')
     def test_is_registration_of_false(self, mock_archive):
         project = ProjectFactory()
         to_reg = ProjectFactory()
@@ -2491,7 +2491,7 @@ class TestProject(OsfTestCase):
         with assert_raises(PermissionsError):
             project.register_node(None, Auth(user=user), '', None)
 
-    @mock.patch('website.archiver.tasks.archive.si')
+    @mock.patch('website.archiver.tasks.archive')
     def test_admin_can_register_private_children(self, mock_archive):
         user = UserFactory()
         project = ProjectFactory(creator=user)
@@ -3470,7 +3470,7 @@ class TestPointer(OsfTestCase):
         registered = self.pointer.fork_node()
         self._assert_clone(self.pointer, registered)
 
-    @mock.patch('website.archiver.tasks.archive.si')
+    @mock.patch('website.archiver.tasks.archive')
     def test_register_with_pointer_to_registration(self, mock_archive):
         pointee = RegistrationFactory()
         project = ProjectFactory()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -546,7 +546,7 @@ class TestProjectViews(OsfTestCase):
         assert_equal("tag_removed", self.project.logs[-1].action)
         assert_equal("foo'ta#@%#%^&g?", self.project.logs[-1].params['tag'])
 
-    @mock.patch('website.archiver.tasks.archive.si')
+    @mock.patch('website.archiver.tasks.archive')
     def test_register_template_page(self, mock_archive):
         url = "/api/v1/project/{0}/register/Replication_Recipe_(Brandt_et_al.,_2013):_Post-Completion/".format(
             self.project._primary_key)
@@ -560,7 +560,7 @@ class TestProjectViews(OsfTestCase):
         reg = Node.load(self.project.node__registrations[-1])
         assert_true(reg.is_registration)
 
-    @mock.patch('website.archiver.tasks.archive.si')
+    @mock.patch('website.archiver.tasks.archive')
     def test_register_template_with_embargo_creates_embargo(self, mock_archive):
         url = "/api/v1/project/{0}/register/Replication_Recipe_(Brandt_et_al.,_2013):_Post-Completion/".format(
             self.project._primary_key)
@@ -602,7 +602,7 @@ class TestProjectViews(OsfTestCase):
 
 
     # Regression test for https://github.com/CenterForOpenScience/osf.io/issues/1478
-    @mock.patch('website.archiver.tasks.archive.si')
+    @mock.patch('website.archiver.tasks.archive')
     def test_registered_projects_contributions(self, mock_archive):
         # register a project
         self.project.register_node(None, Auth(user=self.project.creator), '', None)
@@ -1900,7 +1900,7 @@ class TestAddingContributorViews(OsfTestCase):
         project.use_as_template(auth=Auth(project.creator))
         assert_false(send_mail.called)
 
-    @mock.patch('website.archiver.tasks.archive.si')
+    @mock.patch('website.archiver.tasks.archive')
     @mock.patch('website.mails.send_mail')
     def test_registering_project_does_not_send_contributor_added_email(self, send_mail, mock_archive):
         project = ProjectFactory()

--- a/website/addons/dataverse/tests/test_model.py
+++ b/website/addons/dataverse/tests/test_model.py
@@ -307,7 +307,7 @@ class TestNodeSettingsCallbacks(DataverseAddonTestCase):
         assert_true(self.node_settings.dataset_doi is None)
         assert_true(self.node_settings.dataset is None)
 
-    @mock.patch('website.archiver.tasks.archive.si')
+    @mock.patch('website.archiver.tasks.archive')
     def test_does_not_get_copied_to_registrations(self, mock_archive):
         registration = self.project.register_node(
             schema=None,

--- a/website/addons/dropbox/tests/test_models.py
+++ b/website/addons/dropbox/tests/test_models.py
@@ -336,7 +336,7 @@ class TestDropboxNodeSettingsModel(OsfTestCase):
             path,
         )
 
-    @mock.patch('website.archiver.tasks.archive.si')
+    @mock.patch('website.archiver.tasks.archive')
     def test_does_not_get_copied_to_registrations(self, mock_archive):
         registration = self.project.register_node(
             schema=None,

--- a/website/addons/figshare/tests/test_models.py
+++ b/website/addons/figshare/tests/test_models.py
@@ -358,7 +358,7 @@ class TestCallbacks(OsfTestCase):
         assert_true(self.node_settings.figshare_type is None)
         assert_true(self.node_settings.figshare_title is None)
 
-    @mock.patch('website.archiver.tasks.archive.si')
+    @mock.patch('website.archiver.tasks.archive')
     @mock.patch('website.addons.figshare.model.AddonFigShareNodeSettings.archive_errors')
     def test_does_not_get_copied_to_registrations(self, mock_errors, mock_archive):
         registration = self.project.register_node(

--- a/website/addons/github/tests/test_models.py
+++ b/website/addons/github/tests/test_models.py
@@ -294,7 +294,7 @@ class TestCallbacks(OsfTestCase):
         self.node_settings.reload()
         assert_true(self.node_settings.user_settings is None)
 
-    @mock.patch('website.archiver.tasks.archive.si')
+    @mock.patch('website.archiver.tasks.archive')
     def test_does_not_get_copied_to_registrations(self, mock_archive):
         registration = self.project.register_node(
             schema=None,

--- a/website/addons/googledrive/tests/test_models.py
+++ b/website/addons/googledrive/tests/test_models.py
@@ -521,7 +521,7 @@ class TestNodeSettingsCallbacks(OsfTestCase):
         assert_true(self.node_settings.folder_path is None)
         assert_true(self.node_settings.user_settings is None)
 
-    @mock.patch('website.archiver.tasks.archive.si')
+    @mock.patch('website.archiver.tasks.archive')
     def test_does_not_get_copied_to_registrations(self, mock_archive):
         registration = self.project.register_node(
             schema=None,

--- a/website/addons/s3/tests/test_model.py
+++ b/website/addons/s3/tests/test_model.py
@@ -224,7 +224,7 @@ class TestCallbacks(OsfTestCase):
         assert_true(self.node_settings.user_settings is None)
         assert_true(self.node_settings.bucket is None)
 
-    @mock.patch('website.archiver.tasks.archive.si')
+    @mock.patch('website.archiver.tasks.archive')
     def test_does_not_get_copied_to_registrations(self, mock_archive):
         registration = self.project.register_node(
             schema=None,

--- a/website/archiver/listeners.py
+++ b/website/archiver/listeners.py
@@ -2,7 +2,7 @@ import celery
 
 from framework.tasks import handlers
 
-from website.archiver.tasks import archive
+from website.archiver import tasks
 from website.archiver import utils as archiver_utils
 from website.archiver import (
     ARCHIVER_UNCAUGHT_ERROR,
@@ -23,8 +23,10 @@ def after_register(src, dst, user):
     archiver_utils.before_archive(dst, user)
     if dst.root != dst:  # if not top-level registration
         return
-    archive_tasks = celery.chain(archive(job_pk=t.archive_job._id) for t in dst.node_and_primary_descendants())
-    handlers.enqueue_task(archive_tasks)
+    archive_tasks = [tasks.archive(job_pk=t.archive_job._id) for t in dst.node_and_primary_descendants()]
+    handlers.enqueue_task(
+        celery.chain(archive_tasks)
+    )
 
 
 @project_signals.archive_callback.connect

--- a/website/archiver/listeners.py
+++ b/website/archiver/listeners.py
@@ -23,10 +23,8 @@ def after_register(src, dst, user):
     archiver_utils.before_archive(dst, user)
     if dst.root != dst:  # if not top-level registration
         return
-    archive_tasks = [archive.si(job_pk=t.archive_job._id) for t in dst.node_and_primary_descendants()]
-    handlers.enqueue_task(
-        celery.chain(*archive_tasks)
-    )
+    archive_tasks = celery.chain(archive(job_pk=t.archive_job._id) for t in dst.node_and_primary_descendants())
+    handlers.enqueue_task(archive_tasks)
 
 
 @project_signals.archive_callback.connect

--- a/website/archiver/tasks.py
+++ b/website/archiver/tasks.py
@@ -239,9 +239,7 @@ def archive_node(stat_results, job_pk):
         project_signals.archive_callback.send(dst)
 
 
-@celery_app.task(bind=True, base=ArchiverTask, name='archiver.archive')
-@logged('archive')
-def archive(self, job_pk):
+def archive(job_pk):
     """Starts a celery.chord that runs stat_addon for each
     complete addon attached to the Node, then runs
     #archive_node with the result
@@ -254,7 +252,7 @@ def archive(self, job_pk):
     src, dst, user = job.info()
     logger = get_task_logger(__name__)
     logger.info("Received archive task for Node: {0} into Node: {1}".format(src._id, dst._id))
-    celery.chain(
+    return celery.chain(
         [
             celery.group(
                 stat_addon.si(
@@ -267,4 +265,4 @@ def archive(self, job_pk):
                 job_pk=job_pk
             )
         ]
-    )()
+    )

--- a/website/archiver/tasks.py
+++ b/website/archiver/tasks.py
@@ -200,7 +200,7 @@ def archive_addon(addon_short_name, job_pk, stat_result):
 
 @celery_app.task(base=ArchiverTask, name="archiver.archive_node")
 @logged('archive_node')
-def archive_node(stat_result, job_pk):
+def archive_node(stat_results, job_pk):
     """First use the results of #stat_node to check disk usage of the
     initiated registration, then either fail the registration or
     create a celery.group group of subtasks to archive addons
@@ -213,6 +213,14 @@ def archive_node(stat_result, job_pk):
     job = ArchiveJob.load(job_pk)
     src, dst, user = job.info()
     logger.info("Archiving node: {0}".format(src._id))
+
+    if not isinstance(stat_results, list):
+        stat_results = [stat_results]
+    stat_result = AggregateStatResult(
+        dst._id,
+        dst.title,
+        targets=stat_results
+    )
     if (NO_ARCHIVE_LIMIT not in job.initiator.system_tags) and (stat_result.disk_usage > settings.MAX_ARCHIVE_SIZE):
         raise ArchiverSizeExceeded(result=stat_result)
     else:
@@ -246,18 +254,17 @@ def archive(self, job_pk):
     src, dst, user = job.info()
     logger = get_task_logger(__name__)
     logger.info("Received archive task for Node: {0} into Node: {1}".format(src._id, dst._id))
-    results = celery.group(
-        stat_addon.si(
-            addon_short_name=target.name,
-            job_pk=job_pk,
-        )
-        for target in job.target_addons
-    )().get()
-    archive_node.s(
-        AggregateStatResult(
-            dst._id,
-            dst.title,
-            targets=results
-        ),
-        job_pk=job_pk
+    celery.chain(
+        [
+            celery.group(
+                stat_addon.si(
+                    addon_short_name=target.name,
+                    job_pk=job_pk,
+                )
+                for target in job.target_addons
+            ),
+            archive_node.s(
+                job_pk=job_pk
+            )
+        ]
     )()

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -3221,6 +3221,7 @@ class Embargo(EmailApprovableSanction):
                 'registration_link': registration_link,
                 'approval_link': approval_link,
                 'disapproval_link': disapproval_link,
+                'registration_link': registration_link,
                 'embargo_end_date': self.end_date,
                 'approval_time_span': approval_time_span,
             }

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -3216,10 +3216,12 @@ class Embargo(EmailApprovableSanction):
             disapproval_link = urls.get('reject', '')
             approval_time_span = settings.RETRACTION_PENDING_TIME.days * 24
 
+            registration = Node.find_one(Q('embargo', 'eq', self))
+
             return {
                 'initiated_by': self.initiated_by.fullname,
-                'registration_link': registration_link,
                 'approval_link': approval_link,
+                'project_name': registration.title,
                 'disapproval_link': disapproval_link,
                 'registration_link': registration_link,
                 'embargo_end_date': self.end_date,


### PR DESCRIPTION
# Purpose
Replacing https://github.com/CenterForOpenScience/osf.io/pull/4165, based on discussions:
- https://github.com/celery/celery/issues/2554
- https://github.com/celery/celery/issues/2554
- https://github.com/celery/celery/issues/2219

Some users have issues using the chord pattern. 

# Changes

Update proposed fix to avoid celery.chord usage.