### PR TITLE
[READY for REVIEW] Standardize langauge for registration/embargo/retraction emails

### DIFF
--- a/website/project/model.py
+++ b/website/project/model.py
@@ -3335,8 +3335,12 @@ class Retraction(EmailApprovableSanction):
             disapproval_link = urls.get('reject', '')
             approval_time_span = settings.RETRACTION_PENDING_TIME.days * 24
 
+            registration = Node.find_one(Q('retraction', 'eq', self))
+
             return {
+                'is_initiator': self.initiated_by == user,
                 'initiated_by': self.initiated_by.fullname,
+                'project_name': registration.title,
                 'registration_link': registration_link,
                 'approval_link': approval_link,
                 'disapproval_link': disapproval_link,

--- a/website/templates/emails/pending_embargo_admin.txt.mako
+++ b/website/templates/emails/pending_embargo_admin.txt.mako
@@ -1,15 +1,17 @@
 Hello ${user.fullname},
 
-We just wanted to let you know that ${initiated_by} has requested an embargoed registration for a project you administer.
-
-The proposed registration can be reviewed here: ${registration_link}.
+% if is_initiator:
+You initiated an embargoed registration of ${project_name}. The proposed registration can be viewed here: ${registration_link}.
+% else:
+${initiated_by} initiated an embargoed registration of ${project_name}. The proposed registration can be viewed here: ${registration_link}.
+% endif 
 
 If approved, a registration will be created for the project and it will remain private until it is retracted, manually
 made public, or the embargo end date has passed on ${embargo_end_date.date()}.
 
-To approve this action click the following link: ${approval_link}.
+To approve this embargo, click the following link: ${approval_link}.
 
-To disapprove this action, click the following link: ${disapproval_link}.
+To cancel this embargo, click the following link: ${disapproval_link}.
 
 Note: Clicking the disapproval link will immediately cancel the pending embargo and the registration will
 be deleted. If you neither approve nor disapprove the embargo within ${approval_time_span} hours from

--- a/website/templates/emails/pending_embargo_non_admin.txt.mako
+++ b/website/templates/emails/pending_embargo_non_admin.txt.mako
@@ -1,6 +1,6 @@
 Hello ${user.fullname},
 
-We just wanted to let you know that ${initiated_by} has requested an embargoed registration for a project you contribute to.
+We just wanted to let you know that ${initiated_by} has initiated an embargoed registration for the following pending registration: ${registration_link}.
 
 If approved, a registration will be created for the project, viewable here: ${registration_link}, and it will remain
 private until it is retracted, manually made public, or the embargo end date has passed on ${embargo_end_date.date()}.

--- a/website/templates/emails/pending_registration_admin.txt.mako
+++ b/website/templates/emails/pending_registration_admin.txt.mako
@@ -1,16 +1,20 @@
 Hello ${user.fullname},
 
 % if is_initiator:
-You initiated a registration of your project ${project_name}. The pending registration can be viewed here: ${registration_link}.
+You initiated a registration of your project ${project_name}. The proposed registration can be viewed here: ${registration_link}.
 % else:
-${initiated_by} has initiated a registration of your project ${project_name}. The pending registration can be viewed here: ${registration_link}.
+${initiated_by} has initiated a registration of your project ${project_name}. The proposed registration can be viewed here: ${registration_link}.
 % endif 
+
+If approved, a registration will be created for the project and will be publicly visible immediately.
 
 To approve this registration, click the following link: ${approval_link}
 
-To immediately cancel this registration, click the following link: ${disapproval_link}
+To cancel this registration, click the following link: ${disapproval_link}
 
-Note: If you take no action within ${approval_time_span} hours, the registration will be automatically approved. This operation is irreversible.
+Note: Clicking the disapproval link will immediately cancel the pending registration and the registration will
+be deleted. If you neither approve nor cancel the registration within ${approval_time_span} hours from
+midnight tonight (EDT) the registration will be automatically approved and made public. This operation is irreversible.
 
 Sincerely yours,
 

--- a/website/templates/emails/pending_registration_non_admin.txt.mako
+++ b/website/templates/emails/pending_registration_non_admin.txt.mako
@@ -2,6 +2,9 @@ Hello ${user.fullname},
 
 We just wanted to let you know that ${initiated_by} has initiated the following pending registration: ${registration_link}.
 
+If approved, a registration will be created for the project, viewable here: ${registration_link}, and it will remain
+public until it is retracted.
+
 Sincerely yours,
 
 The OSF Robots

--- a/website/templates/emails/pending_retraction_admin.txt.mako
+++ b/website/templates/emails/pending_retraction_admin.txt.mako
@@ -1,15 +1,18 @@
 Hello ${user.fullname},
 
+% if is_initiator:
+You initiated a registration of your project ${project_name}. The proposed registration can be viewed here: ${registration_link}.
+% else:
+${initiated_by} has initiated a registration of your project ${project_name}. The proposed registration can be viewed here: ${registration_link}.
+% endif
 
-We just wanted to let you know that ${initiated_by} has initiated a retraction for the following registration: ${registration_link}
+If approved, the registration will be marked as retracted. Its content will be removed from the OSF, but leave basic metadata behind. The title of a retracted registration and its contributor list will remain, as will justification or explanation of the retraction, should you wish to provide it.
 
-To approve this action click the following link: ${approval_link}
+To approve this retraction, click the following link: ${approval_link}.
 
-To disapprove this action, click the following link: ${disapproval_link}
+To cancel this retraction, click the following link: ${disapproval_link}.
 
-Note: Clicking the disapproval link will immediately cancel the pending retraction. If you neither approve nor disapprove
-the retraction within ${approval_time_span} hours of midnight tonight (EDT) the registration will become retracted. This operation is irreversible.
-
+Note: Clicking the disapproval link will immediately cancel the pending retraction. If you neither approve nor disapprove the retraction within ${approval_time_span} hours of midnight tonight (EDT) the registration will become retracted. This operation is irreversible.
 Sincerely yours,
 
 The OSF Robots

--- a/website/templates/emails/pending_retraction_non_admin.txt.mako
+++ b/website/templates/emails/pending_retraction_non_admin.txt.mako
@@ -2,6 +2,8 @@ Hello ${user.fullname},
 
 We just wanted to let you know that ${initiated_by} has requested a retraction for the following registration: ${registration_link}.
 
+If approved, the registration will be marked as retracted. Its content will be removed from the OSF, but leave basic metadata behind. The title of a retracted registration and its contributor list will remain, as will justification or explanation of the retraction, if provided.
+
 Sincerely yours,
 
 The OSF Robots


### PR DESCRIPTION
# Purpose

The language in our registration/embargo/retraction emails varied unnecessarily. 

# Changes

Standardize the language. 