### PR TITLE
[Feature Fix] Fix search bar occludes dropdown items

### DIFF
--- a/website/static/css/pages/search-page.css
+++ b/website/static/css/pages/search-page.css
@@ -106,3 +106,7 @@ div.search-result  {
 .search-contributor-links {
     padding-top: 10px;
 }
+
+.osf-search {
+    z-index: 1029 !important;
+}

--- a/website/static/css/pages/search-page.css
+++ b/website/static/css/pages/search-page.css
@@ -107,6 +107,6 @@ div.search-result  {
     padding-top: 10px;
 }
 
-.osf-search {
-    z-index: 1029 !important;
+#searchControls .osf-search {
+    z-index: 1029; /* No larger than 1030 */
 }

--- a/website/static/js/navbarControl.js
+++ b/website/static/js/navbarControl.js
@@ -42,6 +42,11 @@ var NavbarViewModel = function() {
        }
     };
 
+    $('.navbar .dropdown').on('show.bs.dropdown', function () {
+        self.showSearch(false);
+        self.searchCSS('');
+    });
+
 };
 
 function NavbarControl (selector, data, options) {


### PR DESCRIPTION
### Purpose
This PR will have the dropdown menu not hidden. The reason is because I changed z-index to solve the issue that search bar is hidden in small screen (Issue https://github.com/CenterForOpenScience/osf.io/issues/3881) . 

### Change
Before Change ---- Dropdown on search page -https://osf.io/search/
![old-search](https://cloud.githubusercontent.com/assets/5420789/9479410/4bc3e18c-4b4b-11e5-962e-bf44e32e5ce0.gif)

After Change  ---- Dropdown on search page
![new-search-page](https://cloud.githubusercontent.com/assets/5420789/9479431/5f3fa39a-4b4b-11e5-874d-89deea6532f2.gif)


Before Change ---- Dropdown on other pages:
![old-main](https://cloud.githubusercontent.com/assets/5420789/9479377/26f7e6aa-4b4b-11e5-967c-823876dafd0b.gif)

After Change ---- Dropdown on other pages -- For example -- -https://osf.io
![new-main](https://cloud.githubusercontent.com/assets/5420789/9479437/6ab1b736-4b4b-11e5-9861-e6aa607aa369.gif)

### Side Effect
Generally, Putting `!important;` is not a good practice. I am not sure put the code below is the best practice.

    $('.navbar .dropdown').on('show.bs.dropdown', function () {
           self.showSearch(false);
           self.searchCSS('');
     });
