### PR TITLE
[Feature Fix] Add more padding on home page after sign-up

### DIFF
--- a/website/static/js/signUp.js
+++ b/website/static/js/signUp.js
@@ -71,7 +71,7 @@ var ViewModel = function(submitUrl) {
             self.timeout = setTimeout(
                 function() {
                     message('');
-                    messageClass('text-info');
+                    messageClass('');
                 },
                 timeout
             );
@@ -87,7 +87,7 @@ var ViewModel = function(submitUrl) {
             self.flashMessage,
             self.flashMessageClass,
             response.message,
-            'text-info'
+            'text-info p-xs'
         );
         self.submitted(true);
     };
@@ -97,7 +97,7 @@ var ViewModel = function(submitUrl) {
             self.flashMessage,
             self.flashMessageClass,
             xhr.responseJSON.message_long,
-            'text-danger',
+            'text-danger p-xs',
             5000,
             self.flashTimeout
         );


### PR DESCRIPTION
### Purpose
Resolved https://trello.com/c/QJIJ15HB/63-more-padding-on-home-page-after-sign-up

### Change
Before:
![Image] (https://trello-attachments.s3.amazonaws.com/55dc8d054490af5dea27fc58/565x65/7cd8a3f3f0b2cd691c1b99d7c919091d/staging_message.png)
After:
![screenshot 2015-08-26 11 30 10](https://cloud.githubusercontent.com/assets/5420789/9498484/1b12caba-4be8-11e5-840b-7a991857bddf.png)

### Side Effect 
I don't know why the text-info class is added after timeout. But if we clear all the message, it is better to clear the text-info class. As a result, it will not influence the new update message

And also I tried to use css binding in knockout and put the padding class in html. But it will create visible bar. So I have to put `p-xs` in javascript and add them dynamically.
![screenshot 2015-08-26 11 54 02](https://cloud.githubusercontent.com/assets/5420789/9499024/d3d5ebfc-4bea-11e5-8483-2de7e60e5495.png)
 

