### PR TITLE
Disallow making pending registrations public

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -51,7 +51,7 @@ from tests.factories import (
     ProjectFactory, NodeLogFactory, WatchConfigFactory,
     NodeWikiFactory, RegistrationFactory, UnregUserFactory,
     ProjectWithAddonFactory, UnconfirmedUserFactory, CommentFactory, PrivateLinkFactory,
-    AuthUserFactory, DashboardFactory, FolderFactory
+    AuthUserFactory, DashboardFactory, FolderFactory, RegistrationApprovalFactory
 )
 from tests.test_features import requires_piwik
 
@@ -2604,6 +2604,13 @@ class TestProject(OsfTestCase):
         assert_equal(registration.embargo.state, Embargo.REJECTED)
         assert_true(registration.is_public)
         assert_equal(self.project.logs[-1].action, NodeLog.EMBARGO_APPROVED)
+
+    def test_can_not_set_privacy_for_pending_registration(self):
+        approval = RegistrationApprovalFactory()
+        reg = Node.find_one(Q('registration_approval', 'eq', approval))
+        err = lambda: reg.set_privacy('public', auth=reg.creator.auth)
+        assert_raises(NodeStateError, err)
+        assert_false(reg.is_public)
 
     def test_set_description(self):
         old_desc = self.project.description

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2474,6 +2474,8 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
             if self.is_registration:
                 if self.is_pending_embargo:
                     raise NodeStateError("A registration with an unapproved embargo cannot be made public")
+                elif self.is_pending_registration:
+                    raise NodeStateError("A registration this is pending approval cannot be made public")
                 if self.embargo_end_date and not self.is_pending_embargo:
                     self.embargo.state = Embargo.REJECTED
                     self.embargo.save()

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -32,7 +32,7 @@
                     <div class="btn-group">
                     % if not node["is_public"]:
                         <button class='btn btn-default disabled'>Private</button>
-                        % if 'admin' in user['permissions'] and not node['is_pending_embargo']:
+                        % if 'admin' in user['permissions'] and not node['is_pending_embargo'] and not node['is_pending_registration']:
                             <a class="btn btn-default" data-bind="click: makePublic">Make Public</a>
                         % endif
                     % else:


### PR DESCRIPTION
# Purpose
see conversation here: 
https://trello.com/c/koNpA4L1/67-public-immediately-pending-registrations-are-private-until-approval

# Changes
- prevent pending registrations from being made public
- add test to document this behavior

# Resolves
https://trello.com/c/koNpA4L1/67-public-immediately-pending-registrations-are-private-until-approval
