### PR TITLE
Add is_initiator to embargo email context

### DIFF
--- a/website/project/model.py
+++ b/website/project/model.py
@@ -3221,6 +3221,7 @@ class Embargo(EmailApprovableSanction):
             registration = Node.find_one(Q('embargo', 'eq', self))
 
             return {
+                'is_initiator': self.initiated_by == user,
                 'initiated_by': self.initiated_by.fullname,
                 'approval_link': approval_link,
                 'project_name': registration.title,


### PR DESCRIPTION
# Purpose
is_initiator was not being injected into the embargo admin email template context. This caused a conditional in that template to always follow the False branch.

# Changes
Add is_initiator to embargo email context.

# Resolves 
https://trello.com/c/B9JAJr4x/70-incorrect-wording-in-embargoed-registration-email

