### PR TITLE
[Hotfix] more Search tags

### DIFF
--- a/website/static/js/search.js
+++ b/website/static/js/search.js
@@ -211,7 +211,7 @@ var ViewModel = function(params) {
         var dirty = false;
         while (matches.length) {
             var match = matches.pop();
-            if (match.match(tagName).length) {
+            if ((match.match(tagName) || []).length) {
                 query = query.replace(match, '');   
                 dirty = true;
             }


### PR DESCRIPTION
# Purpose

A JS bug prevented users from removing tags when more than one tag filter is active

# Changes

Allow matches to be null

# Resolves

https://trello.com/c/uk52BtZA/74-adding-removing-search-tags-works