### PR TITLE
Make parent pending registration private

### DIFF
--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2793,6 +2793,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
             auth=Auth(user),
             save=True,
         )
+
         if self.is_public:
             self.set_privacy('private', Auth(user))
 
@@ -2828,7 +2829,9 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
             auth=Auth(user),
             save=True,
         )
-        # TODO make private?
+
+        if self.is_public:
+            self.set_privacy('private', Auth(user))
 
 @Node.subscribe('before_save')
 def validate_permissions(schema, instance):


### PR DESCRIPTION
# Purpose

Registration approvals did not behave like embargoes in the sense that the root node of registration hierarchies was not made private

# Changes

Make the root node private

# Resolves 

https://trello.com/c/koNpA4L1/67-public-immediately-pending-registrations-are-private-until-approval