### PR TITLE
[Hotfix] Sanction email language fixes

### DIFF
--- a/website/templates/emails/pending_registration_admin.txt.mako
+++ b/website/templates/emails/pending_registration_admin.txt.mako
@@ -6,7 +6,7 @@ You initiated a registration of your project ${project_name}. The proposed regis
 ${initiated_by} has initiated a registration of your project ${project_name}. The proposed registration can be viewed here: ${registration_link}.
 % endif 
 
-If approved, a registration will be created for the project and will be publicly visible immediately.
+If approved, a registration will be created for the project and will be made public immediately.
 
 To approve this registration, click the following link: ${approval_link}
 

--- a/website/templates/emails/pending_retraction_admin.txt.mako
+++ b/website/templates/emails/pending_retraction_admin.txt.mako
@@ -1,9 +1,9 @@
 Hello ${user.fullname},
 
 % if is_initiator:
-You initiated a registration of your project ${project_name}. The proposed registration can be viewed here: ${registration_link}.
+You initiated a retraction of your registration ${project_name}. The registration can be viewed here: ${registration_link}.
 % else:
-${initiated_by} has initiated a registration of your project ${project_name}. The proposed registration can be viewed here: ${registration_link}.
+${initiated_by} initiated a retraction of your registration ${project_name}. The registration can be viewed here: ${registration_link}.
 % endif
 
 If approved, the registration will be marked as retracted. Its content will be removed from the OSF, but leave basic metadata behind. The title of a retracted registration and its contributor list will remain, as will justification or explanation of the retraction, should you wish to provide it.


### PR DESCRIPTION
# Purpose

There is a mistake in the pending retraction email. Also the language in the pending registration email stood to be improved. 

# Changes

Update retraction and pending registration emails

# Resolves

https://trello.com/c/CzphRlmk/94-retraction-email-has-incorrect-language

