### PR TITLE
[Hotfix] retraction mash

### DIFF
--- a/tests/test_registration_retractions.py
+++ b/tests/test_registration_retractions.py
@@ -784,6 +784,21 @@ class RegistrationRetractionViewsTestCase(OsfTestCase):
         assert_equal(len(self.registration.registered_from.logs), initial_project_logs + 1)
 
     @mock.patch('website.mails.send_mail')
+    def test_valid_POST_retraction_when_pending_retraction_raises_400(self, mock_send):
+        self.app.post_json(
+            self.retraction_post_url,
+            {'justification': ''},
+            auth=self.user.auth,
+        )
+        res = self.app.post_json(
+            self.retraction_post_url,
+            {'justification': ''},
+            auth=self.user.auth,
+            expect_errors=True
+        )
+        assert_equal(res.status_code, 400)
+
+    @mock.patch('website.mails.send_mail')
     def test_valid_POST_calls_send_mail_with_username(self, mock_send):
         self.app.post_json(
             self.retraction_post_url,

--- a/website/addons/s3/static/s3NodeConfig.js
+++ b/website/addons/s3/static/s3NodeConfig.js
@@ -106,15 +106,17 @@ ViewModel.prototype.selectBucket = function() {
     var self = this;
 
     self.loading(true);
-
+    
+    var ret = $.Deferred();
     if (isValidBucketName(self.selectedBucket(), false)) {
         self.loading(false);
         bootbox.alert({
             title: 'Invalid bucket name',
             message: 'Sorry, the S3 addon only supports bucket names without periods.'
         });
+        ret.reject();
     } else {
-        return $osf.postJSON(
+        $osf.postJSON(            
                 self.urls().set_bucket, {
                     's3_bucket': self.selectedBucket(),
                     'encrypt_uploads': self.encryptUploads()
@@ -125,6 +127,7 @@ ViewModel.prototype.selectBucket = function() {
                 self.changeMessage('Successfully linked S3 bucket "' + self.currentBucket() + '". Go to the <a href="' +
                     self.urls().files + '">Files page</a> to view your content.', 'text-success');
                 self.loading(false);
+                ret.resolve(response);
             })
             .fail(function (xhr, status, error) {
                 self.loading(false);
@@ -137,8 +140,10 @@ ViewModel.prototype.selectBucket = function() {
                     textStatus: status,
                     error: error
                 });
+                ret.reject();
             });
     }
+    return ret.promise();
 };
 
 ViewModel.prototype._deauthorizeNodeConfirm = function() {

--- a/website/project/views/register.py
+++ b/website/project/views/register.py
@@ -90,7 +90,11 @@ def node_registration_retraction_post(auth, node, **kwargs):
     :param auth: Authentication object for User
     :return: Redirect URL for successful POST
     """
-
+    if node.is_pending_retraction:
+        raise HTTPError(http.BAD_REQUEST, data={
+            'message_short': 'Invalid Request',
+            'message_long': 'This registration is already pending retraction'
+        })
     if not node.is_registration:
         raise HTTPError(http.BAD_REQUEST, data={
             'message_short': 'Invalid Request',

--- a/website/static/js/registrationRetraction.js
+++ b/website/static/js/registrationRetraction.js
@@ -41,8 +41,9 @@ var RegistrationRetractionViewModel = oop.extend(
                 required: true,
                 mustEqual: self.truncatedTitle
             });
-            self.valid = ko.pureComputed(function(){
-                return self.confirmationText.isValid();
+            self.disableSave = ko.observable(false);
+            self.valid = ko.computed(function(){
+                return !self.disableSave() && self.confirmationText.isValid();
             });
         },
         SUBMIT_ERROR_MESSAGE: 'Error submitting your retraction request, please try again. If the problem ' +
@@ -51,11 +52,12 @@ var RegistrationRetractionViewModel = oop.extend(
         JUSTIFICATON_ERROR_MESSAGE: 'Your justification is too long, please enter a justification with no more ' +
             'than 2048 characters long.',
         MESSAGE_ERROR_CLASS: 'text-danger',
-        onSubmitSuccess: function(response) {
+        onSubmitSuccess: function(response) {            
             window.location = response.redirectUrl;
         },
         onSubmitError: function(xhr, status, errorThrown) {
             var self = this;
+            self.disableSave(false);
             self.changeMessage(self.SUBMIT_ERROR_MESSAGE, self.MESSAGE_ERROR_CLASS);
             Raven.captureMessage('Could not submit registration retraction.', {
                 xhr: xhr,
@@ -65,6 +67,7 @@ var RegistrationRetractionViewModel = oop.extend(
         },
         submit: function() {
             var self = this;
+            self.disableSave(true);
             // Show errors if invalid
             if (!self.confirmationText.isValid()) {
                 self.changeMessage(self.CONFIRMATION_ERROR_MESSAGE, self.MESSAGE_ERROR_CLASS);


### PR DESCRIPTION
# Purpose

Cailey aka The Mash Master, managed to POST the retractions form more than once before page reload. This overwrote the previous retraction for that registration. This means multiple emails got sent, only the last of which actually works.

# Changes

- Prevent double form submission
- Disable retracting a pending retraction on the backend
- Add python test for this behavior

# Resolves
- https://trello.com/c/kCFNv2Ui/100-unable-to-resolve-when-clicking-retraction-approval-links
- https://trello.com/c/ZQlGVZ8l/99-duplicate-emalis-for-registration-retractions