### PR TITLE
[Feature][Fix][Ready for Review] Escape " in clicked tags with \" using regex

### DIFF
--- a/website/static/js/search.js
+++ b/website/static/js/search.js
@@ -189,7 +189,7 @@ var ViewModel = function(params) {
     };
 
     self._makeTagString = function(tagName) {
-        return 'tags:("' + tagName + '")';        
+        return 'tags:("' + tagName.replace(/"/g, '\\\"') + '")';        
     };
     self.addTag = function(tagName) {
         var tagString = self._makeTagString(tagName);


### PR DESCRIPTION
Purpose
=======
Closes https://github.com/CenterForOpenScience/osf.io/issues/1502

Changes
=======
Use regex to escape quotes when building the tag's querystring

Side Effects
=========
Escaped strings appear in search bar, may confuse user.

<img width="775" alt="screen shot 2015-08-27 at 17 19 20" src="https://cloud.githubusercontent.com/assets/5659262/9533404/d1e0a58a-4cdf-11e5-8e4c-2d0a0e401755.png">

