### PR TITLE
improve the reset password language

### DIFF
--- a/framework/auth/forms.py
+++ b/framework/auth/forms.py
@@ -121,8 +121,26 @@ confirm_password_field = PasswordField(
 
 
 class ResetPasswordForm(Form):
-    password = password_field
-    password2 = confirm_password_field
+    password = PasswordField('New Password',
+        [
+            validators.Required(message=u'Password is required'),
+            validators.Length(min=6, message=u'Password is too short. '
+                'Password should be at least 6 characters.'),
+            validators.Length(max=256, message=u'Password is too long. '
+                'Password should be at most 256 characters.'),
+        ],
+        filters=[stripped],
+        widget=BootstrapPasswordInput()
+    )
+
+    password2 = PasswordField(
+        'Verify New Password',
+        [
+            validators.EqualTo('password', message='Passwords must match')
+        ],
+        filters=[stripped],
+        widget=BootstrapPasswordInput()
+    )
 
 
 class SetEmailAndPasswordForm(ResetPasswordForm):


### PR DESCRIPTION
<b>Purpose</b>
Improve the language on reset  password page. Closes https://github.com/CenterForOpenScience/osf.io/issues/4098

<b>Changes</b>
Before change:
![image](https://cloud.githubusercontent.com/assets/4974056/9549564/a757efae-4d74-11e5-9017-44036c9c66f6.png)
After change:
![screen shot 2015-08-28 at 11 05 25 am](https://cloud.githubusercontent.com/assets/4974056/9549576/b9fbd42c-4d74-11e5-87e4-4d6b5d7ba32f.png)
