### PR TITLE
rename sharing page to be contributors

### DIFF
--- a/tests/webtest_tests.py
+++ b/tests/webtest_tests.py
@@ -286,7 +286,7 @@ class TestRegistrations(OsfTestCase):
         res = self.app.get(self.project.url, auth=self.auth).maybe_follow()
         # Settings is not in the project navigation bar
         subnav = res.html.select('#projectSubnav')[0]
-        assert_in('Sharing', subnav.text)
+        assert_in('Contributors', subnav.text)
 
     def test_sees_registration_templates(self):
         # Browse to original project

--- a/website/templates/project/contributors.mako
+++ b/website/templates/project/contributors.mako
@@ -5,7 +5,7 @@
 <%include file="project/modal_add_contributor.mako"/>
 
 <div class="page-header  visible-xs">
-  <h2 class="text-300">Sharing</h2>
+  <h2 class="text-300">Contributors</h2>
 </div>
 
 <div class="row">

--- a/website/templates/project/project_header.mako
+++ b/website/templates/project/project_header.mako
@@ -59,7 +59,7 @@
 
                         <li><a href="${node['url']}forks/">Forks</a></li>
                         % if user['is_contributor']:
-                            <li><a href="${node['url']}contributors/">Sharing</a></li>
+                            <li><a href="${node['url']}contributors/">Contributors</a></li>
                         % endif
 
                         % if user['has_read_permissions'] and not node['is_registration'] or (node['is_registration'] and 'admin' in user['permissions']):


### PR DESCRIPTION
<b>Purpose</b>
Rename "Sharing" tab to be "Contributors". Closes https://github.com/CenterForOpenScience/osf.io/issues/4204.

<b>Changes</b>
Before change:
![image](https://cloud.githubusercontent.com/assets/4974056/9549795/c0de1dbc-4d75-11e5-8613-47ddda2723bc.png)
After change:
![screen shot 2015-08-28 at 11 12 46 am](https://cloud.githubusercontent.com/assets/4974056/9549805/c7f6ea16-4d75-11e5-84e2-0e9d563e4b7d.png)
