### PR TITLE
[Hotfix] Non-file addons in file endpoints

### DIFF
--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -566,6 +566,20 @@ class TestAddonFileViews(OsfTestCase):
 
         assert_equals(resp.status_code, 401)
 
+    def test_nonstorage_addons_raise(self):
+        resp = self.app.get(
+            self.project.web_url_for(
+                'addon_view_or_download_file',
+                path='sillywiki',
+                provider='wiki',
+                action='download'
+            ),
+            auth=self.user.auth,
+            expect_errors=True
+        )
+
+        assert_equals(resp.status_code, 400)
+
     def test_head_returns_url(self):
         path = 'the little engine that couldnt'
         guid, _ = self.node_addon.find_or_create_file_guid('/' + path)

--- a/website/addons/base/views.py
+++ b/website/addons/base/views.py
@@ -21,6 +21,7 @@ from website import mails
 from website import settings
 from website.project import decorators
 from website.addons.base import exceptions
+from website.addons.base import StorageAddonBase
 from website.models import User, Node, NodeLog
 from website.util import rubeus
 from website.profile.utils import get_gravatar
@@ -360,7 +361,7 @@ def addon_view_or_download_file(auth, path, provider, **kwargs):
     if not path:
         raise HTTPError(httplib.BAD_REQUEST)
 
-    if not node_addon:
+    if not isinstance(node_addon, StorageAddonBase):
         raise HTTPError(httplib.BAD_REQUEST, {
             'message_short': 'Bad Request',
             'message_long': 'The add-on containing this file is no longer connected to the {}.'.format(node.project_or_component)


### PR DESCRIPTION
Require node_addon to be a subclass of StorageAddonBase
  Wiki node_settings would sometimes make it to this route causing 500s
  as they do not implement find_or_create_file_guid.