### PR TITLE
Update contact us email link

### DIFF
--- a/website/templates/emails/welcome.html.mako
+++ b/website/templates/emails/welcome.html.mako
@@ -35,7 +35,7 @@ GitHub, Dropbox, Google Drive, Box.com, Dataverse, figshare, Amazon S3, Mendeley
 Add your collaborators to have a shared environment for maintaining your research materials and data and never lose files again.<br>
 <br>
 <br>
-Learn more about the OSF at <a href="https://osf.io/getting-started/">the getting started page</a>, or <a href="mailto:contact@osf.io">email contact@osf.io</a> with questions for support.<br>
+Learn more about the OSF at the <a href="https://osf.io/getting-started/">getting started page</a>, or email <a href="mailto:contact@osf.io">contact@osf.io</a> with questions for support.<br>
 <br>
 Sincerely,<br>
 <br>


### PR DESCRIPTION
This closes issue [#OSF-4251] where the email link included too many words.