### PR TITLE
[Ready] Meetings sorting fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "raw-loader": "^0.5.1",
     "share": "0.7.27",
     "style-loader": "^0.8.3",
-    "treebeard": "git://github.com/caneruguz/treebeard.git#1e15b4a15271670273bf28db6aa04dae1c3a25b0",
+    "treebeard": "git://github.com/caneruguz/treebeard.git#88d1339defd4adf76fa509546ca625831f4000f6",
     "typeahead.js": "^0.10.5",
     "url-loader": "^0.5.5",
     "webpack": "^1.7.2",

--- a/website/static/js/submissions.js
+++ b/website/static/js/submissions.js
@@ -30,8 +30,8 @@ function Submissions(data) {
                 {
                     title: 'Date Created',
                     width: '15%',
-                    sortType: 'number',
-                    sort: false
+                    sortType: 'date',
+                    sort: true
                 },
                 {
                     title: 'Downloads',

--- a/website/static/js/submissions.js
+++ b/website/static/js/submissions.js
@@ -24,19 +24,19 @@ function Submissions(data) {
                 {
                      title: 'Author',
                      width : '15%',
-                     sortType : 'number',
+                     sortType : 'text',
                      sort : true
                 },
                 {
                     title: 'Date Created',
                     width: '15%',
-                    sortType: 'date',
-                    sort: true
+                    sortType: 'number',
+                    sort: false
                 },
                 {
                     title: 'Downloads',
                     width: '15%',
-                    sortType: 'date',
+                    sortType: 'number',
                     sort: true
                 },
                 {


### PR DESCRIPTION
## Purpose
Fixes the following Trello bug about problems with sorting of date and author. 
https://trello.com/c/SM19wSbr

##  Changes
Part of the sort problem (with Author was because of a wrong sort type which was changed to 'text'
The other part of the problem was due to Treebeard not having date sorting as a feature, but the developer used it anyway without testing if date sorting works (which could also stem from the fact that all test items have the same dates which makes it hard to test locally). 
This update includes an update to treebeard with the date sorting feature added.

## Known Side Effects
Should not break anything else since the additions to treebeard kick in only if date sorting is used, and it's not used anywhere else on the OSF. 
 