### PR TITLE
[Ready] Add expand related attributes to addon files

### DIFF
--- a/website/addons/dataverse/templates/dataverse_user_settings.mako
+++ b/website/addons/dataverse/templates/dataverse_user_settings.mako
@@ -15,7 +15,7 @@
 
     <!-- ko foreach: accounts -->
     <a data-bind="click: $root.askDisconnect" class="text-danger pull-right default-authorized-by">Disconnect Account</a>
-    <div class="m-h-lg">
+    <div class="m-h-lg addon-auth-table" id="${addon_short_name}-header">
         <table class="table table-hover">
             <thead>
                 <tr class="user-settings-addon-auth">

--- a/website/templates/profile/user_settings_default.mako
+++ b/website/templates/profile/user_settings_default.mako
@@ -1,7 +1,7 @@
 <!-- Authorization -->
 <div class="addon-oauth"
      data-addon-short-name="${ addon_short_name }"
-     data-addon-name="${ addon_full_name }">  
+     data-addon-name="${ addon_full_name }">
     <h4 class="addon-title">
       <img class="addon-icon" src="${addon_icon_url}"></img>
       <span data-bind="text:properName"></span>
@@ -12,7 +12,7 @@
     <!-- ko foreach: accounts -->
     <a data-bind="click: $root.askDisconnect" class="text-danger pull-right default-authorized-by">Disconnect Account</a>
 
-    <div class="m-h-lg">
+    <div class="m-h-lg addon-auth-table" id="${addon_short_name}-header">
         <table class="table table-hover">
             <thead>
                 <tr class="user-settings-addon-auth">


### PR DESCRIPTION
## Purpose
Fixes Trello issue https://trello.com/c/c5hO4Spy
where expand/collapse feature does not apply to some add ons. Turns out this is because the mako file where the html is defined is not being used by all addons. 

## Changes
Added the pertinent sections to the addons that were missing these files

## Known Side effects
None. Adding further html attributes should not have any side effects. 