### PR TITLE
[Hotfix] Approval consts

### DIFF
--- a/website/project/model.py
+++ b/website/project/model.py
@@ -3214,7 +3214,7 @@ class Embargo(EmailApprovableSanction):
         if is_authorizer:
             approval_link = urls.get('approve', '')
             disapproval_link = urls.get('reject', '')
-            approval_time_span = settings.RETRACTION_PENDING_TIME.days * 24
+            approval_time_span = settings.EMBARGO_PENDING_TIME.days * 24
 
             registration = Node.find_one(Q('embargo', 'eq', self))
 
@@ -3453,7 +3453,7 @@ class RegistrationApproval(EmailApprovableSanction):
             approval_link = urls.get('approve', '')
             disapproval_link = urls.get('reject', '')
 
-            approval_time_span = (24 * settings.REGISTRATION_APPROVAL_TIME.days) + (settings.REGISTRATION_APPROVAL_TIME.seconds / 60)
+            approval_time_span = settings.REGISTRATION_APPROVAL_TIME.days * 24
 
             registration = Node.find_one(Q('registration_approval', 'eq', self))
 


### PR DESCRIPTION
# Purpose

Turns out we weren't using the settings constants for Embargo expiration times. Also, RegistrationApproval was using some unnecessary manual timedelta -> num. hours conversion. 

# Changes
Fix this

# Side effects
None