### PR TITLE
Feature/edit title error fix

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -100,7 +100,7 @@ class TestViewingProjectWithPrivateLink(OsfTestCase):
         link.nodes.append(node)
         link.save()
         url = node.api_url_for("project_private_link_edit")
-        res = self.app.post_json(url, {'pk': link._id, 'value': ''}, auth=self.user.auth, expect_errors=True)
+        res = self.app.put_json(url, {'pk': link._id, 'value': ''}, auth=self.user.auth, expect_errors=True)
         assert_equal(res.status_code, 400)
         assert_in('Title cannot be blank', res.body)
 
@@ -110,7 +110,7 @@ class TestViewingProjectWithPrivateLink(OsfTestCase):
         link.nodes.append(node)
         link.save()
         url = node.api_url_for("project_private_link_edit")
-        res = self.app.post_json(url, {'pk': link._id, 'value': '<a></a>'}, auth=self.user.auth, expect_errors=True)
+        res = self.app.put_json(url, {'pk': link._id, 'value': '<a></a>'}, auth=self.user.auth, expect_errors=True)
         assert_equal(res.status_code, 400)
         assert_in('Invalid link name.', res.body)
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -94,6 +94,26 @@ class TestViewingProjectWithPrivateLink(OsfTestCase):
         self.link.save()
         self.project_url = self.project.web_url_for('view_project')
 
+    def test_edit_private_link_empty(self):
+        node = ProjectFactory(creator=self.user)
+        link = PrivateLinkFactory()
+        link.nodes.append(node.project)
+        link.save()
+        url = node.api_url_for("project_private_link_edit")
+        res = self.app.post_json(url, {'pk': link._id, 'value': ''}, auth=self.user.auth, expect_errors=True)
+        assert_equal(res.status_code, 400)
+        assert_in('Title cannot be blank', res.body)
+
+    def test_edit_private_link_invalid(self):
+        node = ProjectFactory(creator=self.user)
+        link = PrivateLinkFactory()
+        link.nodes.append(node.project)
+        link.save()
+        url = node.api_url_for("project_private_link_edit")
+        res = self.app.post_json(url, {'pk': link._id, 'value': '<a></a>'}, auth=self.user.auth, expect_errors=True)
+        assert_equal(res.status_code, 400)
+        assert_in('Invalid link name.', res.body)
+
     def test_not_anonymous_for_public_project(self):
         anonymous_link = PrivateLinkFactory(anonymous=True)
         anonymous_link.nodes.append(self.project)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -97,7 +97,7 @@ class TestViewingProjectWithPrivateLink(OsfTestCase):
     def test_edit_private_link_empty(self):
         node = ProjectFactory(creator=self.user)
         link = PrivateLinkFactory()
-        link.nodes.append(node.project)
+        link.nodes.append(node)
         link.save()
         url = node.api_url_for("project_private_link_edit")
         res = self.app.post_json(url, {'pk': link._id, 'value': ''}, auth=self.user.auth, expect_errors=True)
@@ -107,7 +107,7 @@ class TestViewingProjectWithPrivateLink(OsfTestCase):
     def test_edit_private_link_invalid(self):
         node = ProjectFactory(creator=self.user)
         link = PrivateLinkFactory()
-        link.nodes.append(node.project)
+        link.nodes.append(node)
         link.save()
         url = node.api_url_for("project_private_link_edit")
         res = self.app.post_json(url, {'pk': link._id, 'value': '<a></a>'}, auth=self.user.auth, expect_errors=True)
@@ -211,7 +211,7 @@ class TestProjectViews(OsfTestCase):
         assert_in('Title cannot be blank', res.body)
 
     def test_edit_title_invalid(self):
-        node = ProjectFactory(creator=self.user)
+        node = ProjectFactory(creator=self.user1)
         url = node.api_url_for("edit_node")
         res = self.app.post_json(url, {'name': 'title', 'value': '<a></a>'}, auth=self.user1.auth, expect_errors=True)
         assert_equal(res.status_code, 400)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -94,20 +94,6 @@ class TestViewingProjectWithPrivateLink(OsfTestCase):
         self.link.save()
         self.project_url = self.project.web_url_for('view_project')
 
-    def test_edit_title_empty(self):
-        node = ProjectFactory(creator=self.user)
-        url = node.api_url_for("edit_node")
-        res = self.app.post_json(url, {'name': 'title', 'value': ''}, auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, 400)
-        assert_in('Title cannot be blank', res.body)
-
-    def test_edit_title_invalid(self):
-        node = ProjectFactory(creator=self.user)
-        url = node.api_url_for("edit_node")
-        res = self.app.post_json(url, {'name': 'title', 'value': '<a></a>'}, auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, 400)
-        assert_in('Invalid title.', res.body)
-
     def test_not_anonymous_for_public_project(self):
         anonymous_link = PrivateLinkFactory(anonymous=True)
         anonymous_link.nodes.append(self.project)
@@ -196,6 +182,20 @@ class TestProjectViews(OsfTestCase):
         )
         self.project.add_contributor(self.user2, auth=Auth(self.user1))
         self.project.save()
+
+    def test_edit_title_empty(self):
+        node = ProjectFactory(creator=self.user1)
+        url = node.api_url_for("edit_node")
+        res = self.app.post_json(url, {'name': 'title', 'value': ''}, auth=self.user1.auth, expect_errors=True)
+        assert_equal(res.status_code, 400)
+        assert_in('Title cannot be blank', res.body)
+
+    def test_edit_title_invalid(self):
+        node = ProjectFactory(creator=self.user)
+        url = node.api_url_for("edit_node")
+        res = self.app.post_json(url, {'name': 'title', 'value': '<a></a>'}, auth=self.user1.auth, expect_errors=True)
+        assert_equal(res.status_code, 400)
+        assert_in('Invalid title.', res.body)
 
     def test_cannot_remove_only_visible_contributor_before_remove_contributor(self):
         self.project.visible_contributor_ids.remove(self.user1._id)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -64,18 +64,24 @@ from tests.factories import (
 )
 from website.settings import ALL_MY_REGISTRATIONS_ID, ALL_MY_PROJECTS_ID
 
+
 class Addon(MockAddonNodeSettings):
     @property
     def complete(self):
         return True
+
     def archive_errors(self):
         return 'Error'
+
+
 class Addon2(MockAddonNodeSettings):
     @property
     def complete(self):
         return True
+
     def archive_errors(self):
         return 'Error'
+
 
 class TestViewingProjectWithPrivateLink(OsfTestCase):
 
@@ -87,6 +93,20 @@ class TestViewingProjectWithPrivateLink(OsfTestCase):
         self.link.nodes.append(self.project)
         self.link.save()
         self.project_url = self.project.web_url_for('view_project')
+
+    def test_edit_title_empty(self):
+        node = ProjectFactory(creator=self.user)
+        url = node.api_url_for("edit_node")
+        res = self.app.post_json(url, {'name': 'title', 'value': ''}, auth=self.user.auth, expect_errors=True)
+        assert_equal(res.status_code, 400)
+        assert_in('Title cannot be blank', res.body)
+
+    def test_edit_title_invalid(self):
+        node = ProjectFactory(creator=self.user)
+        url = node.api_url_for("edit_node")
+        res = self.app.post_json(url, {'name': 'title', 'value': '<a></a>'}, auth=self.user.auth, expect_errors=True)
+        assert_equal(res.status_code, 400)
+        assert_in('Invalid title.', res.body)
 
     def test_not_anonymous_for_public_project(self):
         anonymous_link = PrivateLinkFactory(anonymous=True)

--- a/website/project/__init__.py
+++ b/website/project/__init__.py
@@ -4,6 +4,7 @@ import uuid
 from .model import Node, PrivateLink
 from framework.mongo.utils import from_mongo
 from modularodm import Q
+from modularodm.exceptions import ValidationValueError
 from website.exceptions import NodeStateError
 from website.util.sanitize import strip_html
 
@@ -123,6 +124,8 @@ def new_private_link(name, user, nodes, anonymous):
     key = str(uuid.uuid4()).replace("-", "")
     if name:
         name = strip_html(name)
+        if name is None or not name.strip():
+            raise ValidationValueError('Invalid link name.')
     else:
         name = "Shared project link"
 

--- a/website/project/__init__.py
+++ b/website/project/__init__.py
@@ -6,6 +6,7 @@ from framework.forms.utils import sanitize
 from framework.mongo.utils import from_mongo
 from modularodm import Q
 from website.exceptions import NodeStateError
+from website.util.sanitize import strip_html
 
 def show_diff(seqm):
     """Unify operations between two compared strings
@@ -43,9 +44,9 @@ def new_node(category, title, user, description=None, parent=None):
 
     """
     category = category
-    title = sanitize(title.strip())
+    title = strip_html(title.strip())
     if description:
-        description = sanitize(description.strip())
+        description = strip_html(description.strip())
 
     node = Node(
         title=title,
@@ -96,7 +97,7 @@ def new_folder(title, user):
     :return Node: Created node
 
     """
-    title = sanitize(title.strip())
+    title = strip_html(title.strip())
 
     node = Node(
         title=title,
@@ -122,7 +123,7 @@ def new_private_link(name, user, nodes, anonymous):
     """
     key = str(uuid.uuid4()).replace("-", "")
     if name:
-        name = sanitize(name)
+        name = strip_html(name)
     else:
         name = "Shared project link"
 

--- a/website/project/__init__.py
+++ b/website/project/__init__.py
@@ -122,7 +122,7 @@ def new_private_link(name, user, nodes, anonymous):
     """
     key = str(uuid.uuid4()).replace("-", "")
     if name:
-        name = validate_title(name)
+        name = sanitize(name)
     else:
         name = "Shared project link"
 

--- a/website/project/__init__.py
+++ b/website/project/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import uuid
 
-from .model import Node, PrivateLink, validate_title
+from .model import Node, PrivateLink
 from framework.forms.utils import sanitize
 from framework.mongo.utils import from_mongo
 from modularodm import Q

--- a/website/project/__init__.py
+++ b/website/project/__init__.py
@@ -2,7 +2,6 @@
 import uuid
 
 from .model import Node, PrivateLink
-from framework.forms.utils import sanitize
 from framework.mongo.utils import from_mongo
 from modularodm import Q
 from website.exceptions import NodeStateError
@@ -17,8 +16,8 @@ seqm is a difflib.SequenceMatcher instance whose a & b are strings"""
     del_el = '<span style="background:#D16587; font-size:1.5em;">'
     del_el_close = '</span>'
     for opcode, a0, a1, b0, b1 in seqm.get_opcodes():
-        content_a = sanitize(seqm.a[a0:a1])
-        content_b = sanitize(seqm.b[b0:b1])
+        content_a = strip_html(seqm.a[a0:a1])
+        content_b = strip_html(seqm.b[b0:b1])
         if opcode == 'equal':
             output.append(content_a)
         elif opcode == 'insert':

--- a/website/project/__init__.py
+++ b/website/project/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import uuid
 
-from .model import Node, PrivateLink
+from .model import Node, PrivateLink, validate_title
 from framework.forms.utils import sanitize
 from framework.mongo.utils import from_mongo
 from modularodm import Q
@@ -59,6 +59,7 @@ def new_node(category, title, user, description=None, parent=None):
 
     return node
 
+
 def new_dashboard(user):
     """Create a new dashboard project.
 
@@ -108,6 +109,7 @@ def new_folder(title, user):
 
     return node
 
+
 def new_private_link(name, user, nodes, anonymous):
     """Create a new private link.
 
@@ -120,7 +122,7 @@ def new_private_link(name, user, nodes, anonymous):
     """
     key = str(uuid.uuid4()).replace("-", "")
     if name:
-        name = sanitize(name.strip())
+        name = validate_title(name)
     else:
         name = "Shared project link"
 

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -1594,7 +1594,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
         :param bool save: Save self after updating.
         """
         original = self.description
-        self.description = description
+        self.description = sanitize.strip_html(description)
         self.add_log(
             action=NodeLog.EDITED_DESCRIPTION,
             params={

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -514,7 +514,7 @@ def validate_title(value):
     if len(value) > 200:
         raise ValidationValueError('Title cannot exceed 200 characters.')
 
-    return value
+    return True
 
 
 def validate_user(value):
@@ -1567,10 +1567,10 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
         :param auth: All the auth information including user, API key.
         """
         #Called so validation does not have to wait until save.
-        new_title = validate_title(title)
+        validate_title(title)
 
         original_title = self.title
-        self.title = new_title
+        self.title = sanitize.strip_html(title)
         self.add_log(
             action=NodeLog.EDITED_TITLE,
             params={

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -503,7 +503,7 @@ def validate_title(value):
     above 200 characters.
     """
     if value is None or not value.strip():
-        raise ValidationValueError('Title cannot be blank')
+        raise ValidationValueError('Title cannot be blank.')
 
     value = sanitize.strip_html(value)
 

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -1566,10 +1566,10 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
         :param auth: All the auth information including user, API key.
         """
         #Called so validation does not have to wait until save.
-        validate_title(title)
+        new_title = validate_title(title)
 
         original_title = self.title
-        self.title = title
+        self.title = new_title
         self.add_log(
             action=NodeLog.EDITED_TITLE,
             params={

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -503,11 +503,18 @@ def validate_title(value):
     above 200 characters.
     """
     if value is None or not value.strip():
-        raise ValidationValueError('Title cannot be blank.')
+        raise ValidationValueError('Title cannot be blank')
+
+    value = sanitize.strip_html(value)
+
+    if value is None or not value.strip():
+        raise ValidationValueError('Invalid title.')
 
     if len(value) > 200:
         raise ValidationValueError('Title cannot exceed 200 characters.')
-    return True
+
+    return value
+
 
 def validate_user(value):
     if value != {}:
@@ -516,11 +523,13 @@ def validate_user(value):
             raise ValidationValueError('User does not exist.')
     return True
 
+
 class NodeUpdateError(Exception):
     def __init__(self, reason, key, *args, **kwargs):
         super(NodeUpdateError, self).__init__(*args, **kwargs)
         self.key = key
         self.reason = reason
+
 
 class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
 

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2962,7 +2962,7 @@ class PrivateLink(StoredObject):
             "id": self._id,
             "date_created": iso8601format(self.date_created),
             "key": self.key,
-            "name": self.name,
+            "name": sanitize.unescape_entities(self.name),
             "creator": {'fullname': self.creator.fullname, 'url': self.creator.profile_url},
             "nodes": [{'title': x.title, 'url': x.url, 'scale': str(self.node_scale(x)) + 'px', 'category': x.category}
                       for x in self.nodes if not x.is_deleted],

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -1071,16 +1071,18 @@ def project_private_link_edit(auth, **kwargs):
     try:
         validate_title(name)
     except ValidationValueError as e:
+        message = 'Invalid link name.' if e.message == 'Invalid title.' else e.message
         raise HTTPError(
             http.BAD_REQUEST,
-            data=dict(message_long=e.message)
+            data=dict(message_long=message)
         )
 
     private_link_id = request.json.get('pk', '')
     private_link = PrivateLink.load(private_link_id)
+
     if private_link:
         new_name = strip_html(name)
-        private_link.name = strip_html(new_name)
+        private_link.name = new_name
         private_link.save()
         return new_name
     else:

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -1063,7 +1063,7 @@ def project_generate_private_link_post(auth, node, **kwargs):
 def project_private_link_edit(auth, **kwargs):
     name = request.json.get('value', '')
     try:
-        new_name = validate_title(name)
+        validate_title(name)
     except ValidationValueError as e:
         raise HTTPError(
             http.BAD_REQUEST,
@@ -1073,7 +1073,8 @@ def project_private_link_edit(auth, **kwargs):
     private_link_id = request.json.get('pk', '')
     private_link = PrivateLink.load(private_link_id)
     if private_link:
-        private_link.name = new_name
+        new_name = strip_html(name)
+        private_link.name = strip_html(new_name)
         private_link.save()
         return new_name
     else:

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -1044,9 +1044,15 @@ def project_generate_private_link_post(auth, node, **kwargs):
 
     has_public_node = any(node.is_public for node in nodes)
 
-    new_link = new_private_link(
-        name=name, user=auth.user, nodes=nodes, anonymous=anonymous
-    )
+    try:
+        new_link = new_private_link(
+            name=name, user=auth.user, nodes=nodes, anonymous=anonymous
+        )
+    except ValidationValueError as e:
+        raise HTTPError(
+            http.BAD_REQUEST,
+            data=dict(message_long=e.message)
+        )
 
     if anonymous and has_public_node:
         status.push_status_message(

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -60,7 +60,7 @@ def edit_node(auth, node, **kwargs):
                 data=dict(message_long=e.message)
             )
     elif edited_field == 'description':
-        node.set_description(strip_html(value), auth=auth)
+        node.set_description(value, auth=auth)
     node.save()
     return {'status': 'success'}
 

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -32,7 +32,7 @@ from website.project.decorators import (
 from website.tokens import process_token_or_pass
 from website.util.permissions import ADMIN, READ, WRITE
 from website.util.rubeus import collect_addon_js
-from website.project.model import has_anonymous_link, get_pointer_parent, NodeUpdateError
+from website.project.model import has_anonymous_link, get_pointer_parent, NodeUpdateError, validate_title
 from website.project.forms import NewNodeForm
 from website.models import Node, Pointer, WatchConfig, PrivateLink
 from website import settings
@@ -49,7 +49,8 @@ logger = logging.getLogger(__name__)
 def edit_node(auth, node, **kwargs):
     post_data = request.json
     edited_field = post_data.get('name')
-    value = strip_html(post_data.get('value', ''))
+    value = post_data.get('value', '')
+
     if edited_field == 'title':
         try:
             node.set_title(value, auth=auth)
@@ -1060,10 +1061,11 @@ def project_generate_private_link_post(auth, node, **kwargs):
 @must_have_permission(ADMIN)
 def project_private_link_edit(auth, **kwargs):
     new_name = request.json.get('value', '')
+    name = validate_title(new_name)
     private_link_id = request.json.get('pk', '')
     private_link = PrivateLink.load(private_link_id)
     if private_link:
-        private_link.name = new_name
+        private_link.name = name
         private_link.save()
 
 

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -20,7 +20,6 @@ from website import language
 
 from website.util import paths
 from website.util import rubeus
-from website.util import sanitize
 from website.exceptions import NodeStateError
 from website.project import clean_template_name, new_node, new_private_link
 from website.project.decorators import (
@@ -1066,7 +1065,7 @@ def project_private_link_edit(auth, **kwargs):
     private_link_id = request.json.get('pk', '')
     private_link = PrivateLink.load(private_link_id)
     if private_link:
-        private_link.name = sanitize(new_name)
+        private_link.name = strip_html(new_name)
         private_link.save()
 
 

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -49,7 +49,7 @@ logger = logging.getLogger(__name__)
 def edit_node(auth, node, **kwargs):
     post_data = request.json
     edited_field = post_data.get('name')
-    value = strip_html(post_data.get('value', ''))
+    value = post_data.get('value', '')
 
     if edited_field == 'title':
         try:
@@ -60,7 +60,7 @@ def edit_node(auth, node, **kwargs):
                 data=dict(message_long=e.message)
             )
     elif edited_field == 'description':
-        node.set_description(value, auth=auth)
+        node.set_description(strip_html(value), auth=auth)
     node.save()
     return {'status': 'success'}
 

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -49,7 +49,7 @@ logger = logging.getLogger(__name__)
 def edit_node(auth, node, **kwargs):
     post_data = request.json
     edited_field = post_data.get('name')
-    value = post_data.get('value', '')
+    value = strip_html(post_data.get('value', ''))
 
     if edited_field == 'title':
         try:

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -33,7 +33,7 @@ from website.project.decorators import (
 from website.tokens import process_token_or_pass
 from website.util.permissions import ADMIN, READ, WRITE
 from website.util.rubeus import collect_addon_js
-from website.project.model import has_anonymous_link, get_pointer_parent, NodeUpdateError, validate_title
+from website.project.model import has_anonymous_link, get_pointer_parent, NodeUpdateError
 from website.project.forms import NewNodeForm
 from website.models import Node, Pointer, WatchConfig, PrivateLink
 from website import settings
@@ -1048,7 +1048,6 @@ def project_generate_private_link_post(auth, node, **kwargs):
     new_link = new_private_link(
         name=name, user=auth.user, nodes=nodes, anonymous=anonymous
     )
-
 
     if anonymous and has_public_node:
         status.push_status_message(

--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -168,7 +168,7 @@ var handleJSONError = function(response) {
 
 var handleEditableError = function(response) {
     Raven.captureMessage('Unexpected error occurred in an editable input');
-    return 'Unexpected error: ' + response.statusText;
+    return 'Error: ' + response.message_long;
 };
 
 var block = function(message) {

--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -168,7 +168,7 @@ var handleJSONError = function(response) {
 
 var handleEditableError = function(response) {
     Raven.captureMessage('Unexpected error occurred in an editable input');
-    return 'Error: ' + response.message_long;
+    return 'Error: ' + response.responseJSON.message_long;
 };
 
 var block = function(message) {

--- a/website/static/js/privateLinkManager.js
+++ b/website/static/js/privateLinkManager.js
@@ -3,6 +3,7 @@
 var $ = require('jquery');
 var ko = require('knockout');
 var $osf = require('./osfHelpers');
+var ChangeMessageMixin = require('js/changeMessage');
 
 var NODE_OFFSET = 25;
 
@@ -11,7 +12,7 @@ var nodeApiUrl = window.contextVars.node.urls.api;
 
 var PrivateLinkViewModel = function(url) {
     var self = this;
-
+    ChangeMessageMixin.call(self);
     self.url = url;
     self.title = ko.observable('');
     self.isPublic = ko.observable('');
@@ -24,10 +25,6 @@ var PrivateLinkViewModel = function(url) {
     self.nodesToChange = ko.observableArray();
     self.disableSubmit = ko.observable(false);
     self.submitText = ko.observable('Create');
-
-    self.isChildVisible = function(data) {
-        return (self.nodesToChange().indexOf(data.parent_id) !== -1 ||  data.parent_id === self.id());
-    };
 
     self.changingNodesCleaner = ko.computed(function(){
         self.nodesToChange();
@@ -79,6 +76,10 @@ var PrivateLinkViewModel = function(url) {
     // Initial fetch of data
     fetch();
 
+    self.isChildVisible = function(data) {
+        return (self.nodesToChange().indexOf(data.parent_id) !== -1 ||  data.parent_id === self.id());
+    };
+
     self.cantSelectNodes = function() {
         return self.nodesToChange().length === self.nodes().length;
     };
@@ -108,10 +109,10 @@ var PrivateLinkViewModel = function(url) {
             }
         ).done(function() {
             window.location.reload();
-        }).fail(function() {
-            $osf.growl('Error:','Failed to create a view-only link.');
+        }).fail(function(response) {
+            self.changeMessage(response.responseJSON.message_long, 'text-danger');
             self.disableSubmit(false);
-            self.submitText('Generate');
+            self.submitText('Create');
         });
     };
 
@@ -119,6 +120,7 @@ var PrivateLinkViewModel = function(url) {
         self.nodesToChange([]);
     };
 };
+$.extend(PrivateLinkViewModel.prototype, ChangeMessageMixin.prototype);
 
 
 function PrivateLinkManager (selector, url) {

--- a/website/static/js/privateLinkTable.js
+++ b/website/static/js/privateLinkTable.js
@@ -11,7 +11,7 @@ require('bootstrap-editable');
 
 var ctx = window.contextVars;
 
-var setupEditable = function(elm, data) {
+var setupEditable = function(elm, data, self) {
     var $elm = $(elm);
     var $editable = $elm.find('.link-name');
     $editable.editable({
@@ -30,8 +30,8 @@ var setupEditable = function(elm, data) {
             params.pk = data.id;
             return JSON.stringify(params);
         },
-        success: function(response, value) {
-            data.name(value);
+        success: function(response) {
+            data.name(response);
         },
         error: $osf.handleEditableError
     });
@@ -145,7 +145,7 @@ function ViewModel(url, nodeIsPublic) {
         var target = $tr.find('.copy-button');
         clipboard(target[0]);
         $tr.find('.remove-private-link').tooltip();
-        setupEditable(elm, data);
+        setupEditable(elm, data, self);
         $('.private-link-list').osfToggleHeight({height: 50});
     };
 

--- a/website/static/js/privateLinkTable.js
+++ b/website/static/js/privateLinkTable.js
@@ -11,7 +11,7 @@ require('bootstrap-editable');
 
 var ctx = window.contextVars;
 
-var setupEditable = function(elm, data, self) {
+var setupEditable = function(elm, data) {
     var $elm = $(elm);
     var $editable = $elm.find('.link-name');
     $editable.editable({
@@ -145,7 +145,7 @@ function ViewModel(url, nodeIsPublic) {
         var target = $tr.find('.copy-button');
         clipboard(target[0]);
         $tr.find('.remove-private-link').tooltip();
-        setupEditable(elm, data, self);
+        setupEditable(elm, data);
         $('.private-link-list').osfToggleHeight({height: 50});
     };
 

--- a/website/static/js/privateLinkTable.js
+++ b/website/static/js/privateLinkTable.js
@@ -11,32 +11,6 @@ require('bootstrap-editable');
 
 var ctx = window.contextVars;
 
-var setupEditable = function(elm, data) {
-    var $elm = $(elm);
-    var $editable = $elm.find('.link-name');
-    $editable.editable({
-        type: 'text',
-        url: ctx.node.urls.api + 'private_link/edit/',
-        placement: 'bottom',
-        ajaxOptions: {
-            type: 'PUT',
-            dataType: 'json',
-            contentType: 'application/json'
-        },
-        send: 'always',
-        title: 'Edit Link Name',
-        params: function(params){
-            // Send JSON data
-            params.pk = data.id;
-            return JSON.stringify(params);
-        },
-        success: function(response) {
-            data.name(response);
-        },
-        error: $osf.handleEditableError
-    });
-};
-
 function LinkViewModel(data, $root) {
 
     var self = this;
@@ -140,12 +114,39 @@ function ViewModel(url, nodeIsPublic) {
         });
     };
 
+    self.setupEditable = function(elm, data) {
+        var $elm = $(elm);
+        var $editable = $elm.find('.link-name');
+        $editable.editable({
+            type: 'text',
+            url: ctx.node.urls.api + 'private_link/edit/',
+            placement: 'bottom',
+            ajaxOptions: {
+                type: 'PUT',
+                dataType: 'json',
+                contentType: 'application/json'
+            },
+            send: 'always',
+            title: 'Edit Link Name',
+            params: function(params){
+                // Send JSON data
+                params.pk = data.id;
+                return JSON.stringify(params);
+            },
+            success: function(response) {
+                data.name(response);
+                fetch();
+            },
+            error: $osf.handleEditableError
+        });
+    };
+
     self.afterRenderLink = function(elm, data) {
         var $tr = $(elm);
         var target = $tr.find('.copy-button');
         clipboard(target[0]);
         $tr.find('.remove-private-link').tooltip();
-        setupEditable(elm, data);
+        self.setupEditable(elm, data);
         $('.private-link-list').osfToggleHeight({height: 50});
     };
 

--- a/website/static/js/tests/osfHelpers.test.js
+++ b/website/static/js/tests/osfHelpers.test.js
@@ -91,6 +91,32 @@ describe('osfHelpers', () => {
         });
     });
 
+    describe('handleEditableError', () => {
+
+        var ravenStub;
+        beforeEach(() => {
+            ravenStub = new sinon.stub(Raven, 'captureMessage');
+        });
+
+        afterEach(() => {
+            ravenStub.restore();
+        });
+        var response = {
+            responseJSON: {
+                message_short: 'Oh no!',
+                message_long: 'Something went wrong'
+            }
+        };
+        it('uses the response text if available', () => {
+            assert.equal('Error: ' + response.responseJSON.message_long, $osf.handleEditableError(response));
+        });
+
+        it('logs error with Raven', () => {
+            $osf.handleEditableError(response);
+            assert.called(ravenStub);
+        });
+    });
+
     describe('block', () => {
         var stub;
         beforeEach(() => {

--- a/website/templates/project/contributors.mako
+++ b/website/templates/project/contributors.mako
@@ -124,7 +124,7 @@
                     <tr>
                         <td class="col-sm-3">
                             <div>
-                                <span class="link-name m-b-xs" data-bind="text: name, tooltip: {title: 'Link name'}" style="display: block; width: 100%"></span>
+                                <span class="link-name m-b-xs" data-bind="html: name, tooltip: {title: 'Link name'}" style="display: block; width: 100%"></span>
                             </div>
 
                             <div class="btn-group">

--- a/website/templates/project/contributors.mako
+++ b/website/templates/project/contributors.mako
@@ -124,7 +124,7 @@
                     <tr>
                         <td class="col-sm-3">
                             <div>
-                                <span class="link-name m-b-xs" data-bind="html: name, tooltip: {title: 'Link name'}" style="display: block; width: 100%"></span>
+                                <span class="link-name m-b-xs" data-bind="text: name, tooltip: {title: 'Link name'}" style="display: block; width: 100%"></span>
                             </div>
 
                             <div class="btn-group">

--- a/website/templates/project/modal_generate_private_link.mako
+++ b/website/templates/project/modal_generate_private_link.mako
@@ -17,6 +17,9 @@
                                 class="form-control private-link-name"
                                 placeholder='Optional link name (e.g., For peer review, Sharing data, Share project)' />
                         </div>
+                        <div class="help-block">
+                            <p data-bind="html: message, attr: {class: messageClass}"></p>
+                        </div>
                     </div>
 
                     <hr />


### PR DESCRIPTION
<b>Purpose</b>
Change the error message of the edit title. Closes [#OSF-4022]
Fix the view-only link name dispaly escape html. Closes [#OSF-4097]
Fix the problem that View Only links sanitization inconsistent between initial naming and editing. Closes [#OSF-4090]

<b>Changes</b>
Before change:
![image](https://cloud.githubusercontent.com/assets/4974056/9616254/10594cf6-50cb-11e5-804f-a928d1441bdb.png)
After change:
![screen shot 2015-09-01 at 5 01 40 pm](https://cloud.githubusercontent.com/assets/4974056/9616263/2536cc16-50cb-11e5-85a8-15043b311f15.png)
