### PR TITLE
[Ready] Fixes the osfToggleHeight initialization in user settings 

### DIFF
--- a/website/addons/dataverse/static/dataverseUserConfig.js
+++ b/website/addons/dataverse/static/dataverseUserConfig.js
@@ -76,7 +76,7 @@ function ViewModel(url) {
                 externalAccount.dataverseUrl = account.host_url;
                 return externalAccount;
             }));
-            $('.addon-auth-table').osfToggleHeight({height: 140});
+            $('#dataverse-header').osfToggleHeight({height: 140});
         });
         request.fail(function(xhr, status, error) {
             Raven.captureMessage('Error while updating addon account', {

--- a/website/static/js/addonSettings.js
+++ b/website/static/js/addonSettings.js
@@ -26,6 +26,7 @@ var ExternalAccount = oop.defclass({
         ko.utils.arrayMap(data.nodes, function(item) {
             self.connectedNodes.push(new ConnectedProject(item));
         });
+
     },
     _deauthorizeNodeConfirm: function(node) {
         var self = this;
@@ -135,6 +136,7 @@ var OAuthAddonSettingsViewModel = oop.defclass({
             self.accounts($.map(data.accounts, function(account) {
                 return new ExternalAccount(account);
             }));
+            $('#' + self.name + '-header').osfToggleHeight({height: 140});
         });
         request.fail(function(xhr, status, error) {
             Raven.captureMessage('Error while updating addon account', {

--- a/website/static/js/citationsNodeConfig.js
+++ b/website/static/js/citationsNodeConfig.js
@@ -71,7 +71,6 @@ var CitationsFolderPickerViewModel = oop.extend(FolderPickerViewModel, {
         var request = $.get(self.urls().accounts);
         request.then(function(data) {
             ret.resolve(data.accounts);
-            $('.addon-auth-table').osfToggleHeight({height: 140});
         });
         request.fail(function(xhr, textStatus, error) {
             self.changeMessage(self.messages.updateAccountsError(), 'text-danger');

--- a/website/static/js/pages/profile-settings-addons-page.js
+++ b/website/static/js/pages/profile-settings-addons-page.js
@@ -114,6 +114,14 @@ for (var i=0; i < addonEnabledSettings.length; i++) {
    }
 }
 
+$(document).ready(function(){
+    // Keep these separate since other addons have different methods of applying and this makes it easier to troubleshoot fixes and changes
+    var makoLoadedAddons = ['dropbox', 'github', 'box', 'figshare', 'googledrive', 's3'];
+    makoLoadedAddons.forEach(function(addon){
+        $('#'+ addon + '-header').osfToggleHeight({height: 140});
+    });
+});
+
 /* Before closing the page, Check whether the newly checked addon are updated or not */
 $(window).on('beforeunload',function() {
     //new checked items but not updated

--- a/website/static/js/pages/profile-settings-addons-page.js
+++ b/website/static/js/pages/profile-settings-addons-page.js
@@ -114,10 +114,6 @@ for (var i=0; i < addonEnabledSettings.length; i++) {
    }
 }
 
-$(document).ready(function(){
-    $('.addon-auth-table').osfToggleHeight({height: 140});
-});
-
 /* Before closing the page, Check whether the newly checked addon are updated or not */
 $(window).on('beforeunload',function() {
     //new checked items but not updated
@@ -135,6 +131,7 @@ $(window).on('beforeunload',function() {
 ****************/
 
 $('.addon-oauth').each(function(index, elem) {
+    // Applies to Mendeley, Zotero and Dataverse
     var viewModel = new addonSettings.OAuthAddonSettingsViewModel(
         $(elem).data('addon-short-name'),
         $(elem).data('addon-name')

--- a/website/static/js/pages/profile-settings-addons-page.js
+++ b/website/static/js/pages/profile-settings-addons-page.js
@@ -131,7 +131,7 @@ $(window).on('beforeunload',function() {
 ****************/
 
 $('.addon-oauth').each(function(index, elem) {
-    // Applies to Mendeley, Zotero and Dataverse
+    // Applies to Mendeley, Zotero.  There is a separate code for dataverse in DataverseUserConfig.js
     var viewModel = new addonSettings.OAuthAddonSettingsViewModel(
         $(elem).data('addon-short-name'),
         $(elem).data('addon-name')

--- a/website/static/js/pages/profile-settings-addons-page.js
+++ b/website/static/js/pages/profile-settings-addons-page.js
@@ -115,7 +115,7 @@ for (var i=0; i < addonEnabledSettings.length; i++) {
 }
 
 $(document).ready(function(){
-    // Keep these separate since other addons have different methods of applying and this makes it easier to troubleshoot fixes and changes
+    // Separately load addons whose data is loaded on the backend as opposed to async javascript.
     var makoLoadedAddons = ['dropbox', 'github', 'box', 'figshare', 'googledrive', 's3'];
     makoLoadedAddons.forEach(function(addon){
         $('#'+ addon + '-header').osfToggleHeight({height: 140});


### PR DESCRIPTION
## Purpose
Fixes JIRA issue: OSF-4265
Where the application of the osfToggleHeight plugin to addon node list was unreliable. 

## Changes 
There are two types of data load methods for addons
1. Those that get added by backend and mako file addon_permissions.mako
-- For these the document.ready function was used to apply
2. Asyncronous loading with ajax after load 
-- For these the initialization was added where nodes have been applied 

## Side effects
None 

![screen shot 2015-09-03 at 12 00 12 pm](https://cloud.githubusercontent.com/assets/1314003/9669801/51c24cd2-5257-11e5-941a-c06b078d0556.png)
