### PR TITLE
[ready for review] Update OAuth app reg to work with recent API changes

### DIFF
--- a/api/applications/serializers.py
+++ b/api/applications/serializers.py
@@ -10,7 +10,8 @@ class ApiOAuth2ApplicationSerializer(JSONAPISerializer):
     """Serialize data about a registered OAuth2 application"""
     id = ser.CharField(help_text='The client ID for this application (automatically generated)',
                        read_only=True,
-                       source='client_id')
+                       source='client_id',
+                       label='ID')
     client_id = ser.CharField(help_text='The client ID for this application (automatically generated)',
                               read_only=True)
 
@@ -33,11 +34,13 @@ class ApiOAuth2ApplicationSerializer(JSONAPISerializer):
 
     home_url = ser.CharField(help_text="The full URL to this application's homepage.",
                              required=True,
-                             validators=[URLValidator()])
+                             validators=[URLValidator()],
+                             label="Home URL")
 
     callback_url = ser.CharField(help_text='The callback URL for this application (refer to OAuth documentation)',
                                  required=True,
-                                 validators=[URLValidator()])
+                                 validators=[URLValidator()],
+                                 label="Callback URL")
 
     class Meta:
         type_ = 'applications'

--- a/api/applications/serializers.py
+++ b/api/applications/serializers.py
@@ -8,31 +8,34 @@ from api.base.serializers import JSONAPISerializer, LinksField
 
 class ApiOAuth2ApplicationSerializer(JSONAPISerializer):
     """Serialize data about a registered OAuth2 application"""
-    client_id = ser.CharField(help_text="The client ID for this application (automatically generated)",
+    id = ser.CharField(help_text='The client ID for this application (automatically generated)',
+                       read_only=True,
+                       source='client_id')
+    client_id = ser.CharField(help_text='The client ID for this application (automatically generated)',
                               read_only=True)
 
-    client_secret = ser.CharField(help_text="The client secret for this application (automatically generated)",
+    client_secret = ser.CharField(help_text='The client secret for this application (automatically generated)',
                                   read_only=True)  # TODO: May change this later
 
-    owner = ser.CharField(help_text="The id of the user who owns this application",
+    owner = ser.CharField(help_text='The id of the user who owns this application',
                           read_only=True,  # Don't let user register an application in someone else's name
                           source='owner._id')
 
-    name = ser.CharField(help_text="A short, descriptive name for this application",
+    name = ser.CharField(help_text='A short, descriptive name for this application',
                          required=True)
 
-    description = ser.CharField(help_text="An optional description displayed to all users of this application",
+    description = ser.CharField(help_text='An optional description displayed to all users of this application',
                                 required=False,
                                 allow_blank=True)
 
-    date_created = ser.DateTimeField(help_text="The date this application was generated (automatically filled in)",
+    date_created = ser.DateTimeField(help_text='The date this application was generated (automatically filled in)',
                                      read_only=True)
 
     home_url = ser.CharField(help_text="The full URL to this application's homepage.",
                              required=True,
                              validators=[URLValidator()])
 
-    callback_url = ser.CharField(help_text="The callback URL for this application (refer to OAuth documentation)",
+    callback_url = ser.CharField(help_text='The callback URL for this application (refer to OAuth documentation)',
                                  required=True,
                                  validators=[URLValidator()])
 

--- a/api/applications/views.py
+++ b/api/applications/views.py
@@ -78,7 +78,7 @@ class ApplicationDetail(generics.RetrieveUpdateDestroyAPIView):
         """Instance is not actually deleted from DB- just flagged as inactive, which hides it from list views"""
         obj = self.get_object()
         try:
-            obj.deactivate()
+            obj.deactivate(save=True)
         except cas.CasHTTPError:
             raise APIException("Could not revoke application auth tokens; please try again later")
 

--- a/api/applications/views.py
+++ b/api/applications/views.py
@@ -34,7 +34,7 @@ class ApplicationList(generics.ListCreateAPIView, ODMFilterMixin):
         user_id = self.request.user._id
         return (
             Q('owner', 'eq', user_id) &
-            Q('active', 'eq', True)
+            Q('is_active', 'eq', True)
         )
 
     # overrides ListAPIView
@@ -68,7 +68,7 @@ class ApplicationDetail(generics.RetrieveUpdateDestroyAPIView):
     def get_object(self):
         obj = get_object_or_error(ApiOAuth2Application,
                                   Q('client_id', 'eq', self.kwargs['client_id']) &
-                                  Q('active', 'eq', True))
+                                  Q('is_active', 'eq', True))
 
         self.check_object_permissions(self.request, obj)
         return obj

--- a/tests/api_tests/applications/test_views.py
+++ b/tests/api_tests/applications/test_views.py
@@ -196,7 +196,7 @@ class TestApplicationDetail(ApiTestCase):
         mock_method.return_value(True)
         res = self.app.delete(self.user1_app_url, auth=self.user1.auth)
         self.user1_app.reload()
-        assert_false(self.user1_app.active)
+        assert_false(self.user1_app.is_active)
 
     def tearDown(self):
         super(TestApplicationDetail, self).tearDown()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1049,7 +1049,7 @@ class TestApiOAuth2Application(OsfTestCase):
     @mock.patch('framework.auth.cas.CasClient.revoke_application_tokens')
     def test_active_set_to_false_upon_successful_deletion(self, mock_method):
         mock_method.return_value(True)
-        self.api_app.deactivate()
+        self.api_app.deactivate(save=True)
         self.api_app.reload()
         assert_false(self.api_app.is_active)
 
@@ -1057,7 +1057,7 @@ class TestApiOAuth2Application(OsfTestCase):
     def test_active_remains_true_when_cas_token_deletion_fails(self, mock_method):
         mock_method.side_effect = cas.CasHTTPError("CAS can't revoke tokens", 400, 'blank', 'blank')
         with assert_raises(cas.CasHTTPError):
-            self.api_app.deactivate()
+            self.api_app.deactivate(save=True)
         self.api_app.reload()
         assert_true(self.api_app.is_active)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1010,7 +1010,7 @@ class TestApiOAuth2Application(OsfTestCase):
         assert_greater(len(self.api_app.client_secret), 0)
 
     def test_new_app_is_not_flagged_as_deleted(self):
-        assert_true(self.api_app.active)
+        assert_true(self.api_app.is_active)
 
     def test_user_backref_updates_when_app_created(self):
         u = UserFactory()
@@ -1051,7 +1051,7 @@ class TestApiOAuth2Application(OsfTestCase):
         mock_method.return_value(True)
         self.api_app.deactivate()
         self.api_app.reload()
-        assert_false(self.api_app.active)
+        assert_false(self.api_app.is_active)
 
     @mock.patch('framework.auth.cas.CasClient.revoke_application_tokens')
     def test_active_remains_true_when_cas_token_deletion_fails(self, mock_method):
@@ -1059,7 +1059,7 @@ class TestApiOAuth2Application(OsfTestCase):
         with assert_raises(cas.CasHTTPError):
             self.api_app.deactivate()
         self.api_app.reload()
-        assert_true(self.api_app.active)
+        assert_true(self.api_app.is_active)
 
 
 class TestNodeWikiPage(OsfTestCase):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1034,6 +1034,18 @@ class TestApiOAuth2Application(OsfTestCase):
             api_app = ApiOAuth2ApplicationFactory(callback_url="itms://itunes.apple.com/us/app/apple-store/id375380948?mt=8")
             api_app.save()
 
+    def test_long_name_raises_exception(self):
+        long_name = ('JohnJacobJingelheimerSchmidtHisNameIsMyN' * 5) + 'a'
+        with assert_raises(ValidationError):
+            api_app = ApiOAuth2ApplicationFactory(name=long_name)
+            api_app.save()
+
+    def test_long_description_raises_exception(self):
+        long_desc = ('JohnJacobJingelheimerSchmidtHisNameIsMyN' * 25) + 'a'
+        with assert_raises(ValidationError):
+            api_app = ApiOAuth2ApplicationFactory(description=long_desc)
+            api_app.save()
+
     @mock.patch('framework.auth.cas.CasClient.revoke_application_tokens')
     def test_active_set_to_false_upon_successful_deletion(self, mock_method):
         mock_method.return_value(True)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1540,7 +1540,7 @@ class TestUserProfileApplicationsPage(OsfTestCase):
         assert_equal(res.status_code, http.FORBIDDEN)
 
     def test_owner_cant_access_deleted_application(self):
-        self.platform_app.active = False
+        self.platform_app.is_active = False
         self.platform_app.save()
         res = self.app.get(self.detail_url, auth=self.user.auth, expect_errors=True)
         assert_equal(res.status_code, http.GONE)

--- a/website/oauth/models/__init__.py
+++ b/website/oauth/models/__init__.py
@@ -394,7 +394,7 @@ class ApiOAuth2Application(StoredObject):
     callback_url = fields.StringField(required=True,
                                       validate=URLValidator())
 
-    def deactivate(self):
+    def deactivate(self, save=True):
         """
         Deactivate an ApiOAuth2Application
 
@@ -405,7 +405,9 @@ class ApiOAuth2Application(StoredObject):
         resp = client.revoke_application_tokens(self.client_id, self.client_secret)  # noqa
 
         self.is_active = False
-        self.save()
+
+        if save:
+            self.save()
         return True
 
     @property

--- a/website/oauth/models/__init__.py
+++ b/website/oauth/models/__init__.py
@@ -394,7 +394,7 @@ class ApiOAuth2Application(StoredObject):
     callback_url = fields.StringField(required=True,
                                       validate=URLValidator())
 
-    def deactivate(self, save=True):
+    def deactivate(self, save=False):
         """
         Deactivate an ApiOAuth2Application
 

--- a/website/oauth/models/__init__.py
+++ b/website/oauth/models/__init__.py
@@ -374,8 +374,8 @@ class ApiOAuth2Application(StoredObject):
                                    index=True)
     client_secret = fields.StringField(default=generate_client_secret)
 
-    active = fields.BooleanField(default=True,  # Set to False if application is deactivated
-                                 index=True)
+    is_active = fields.BooleanField(default=True,  # Set to False if application is deactivated
+                                    index=True)
 
     owner = fields.ForeignField('User',
                                 backref='created',
@@ -404,7 +404,7 @@ class ApiOAuth2Application(StoredObject):
         # Will raise a CasHttpError if deletion fails, which will also stop setting of active=False.
         resp = client.revoke_application_tokens(self.client_id, self.client_secret)  # noqa
 
-        self.active = False
+        self.is_active = False
         self.save()
         return True
 

--- a/website/oauth/models/__init__.py
+++ b/website/oauth/models/__init__.py
@@ -14,7 +14,7 @@ from requests.exceptions import HTTPError as RequestsHTTPError
 
 from modularodm import fields, Q
 from modularodm.storage.base import KeyExistsException
-from modularodm.validators import URLValidator
+from modularodm.validators import MaxLengthValidator, URLValidator
 from requests_oauthlib import OAuth1Session
 from requests_oauthlib import OAuth2Session
 
@@ -383,8 +383,8 @@ class ApiOAuth2Application(StoredObject):
                                 required=True)
 
     # User-specified application descriptors
-    name = fields.StringField(index=True, required=True)
-    description = fields.StringField(required=False)
+    name = fields.StringField(index=True, required=True, validate=MaxLengthValidator(200))
+    description = fields.StringField(required=False, validate=MaxLengthValidator(1000))
 
     date_created = fields.DateTimeField(auto_now_add=datetime.datetime.utcnow,
                                         editable=False)

--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -408,7 +408,7 @@ def oauth_application_detail(auth, **kwargs):
         raise HTTPError(http.NOT_FOUND)
     if record.owner != auth.user:
         raise HTTPError(http.FORBIDDEN)
-    if record.active is False:
+    if record.is_active is False:
         raise HTTPError(http.GONE)
 
     app_detail_url = api_v2_url("applications/{}/".format(client_id))  # Send request to this URL

--- a/website/static/js/apiApplication.js
+++ b/website/static/js/apiApplication.js
@@ -63,7 +63,7 @@ var ApplicationData = oop.defclass({
     serialize: function () {
         return { // Convert data to JSON-serializable format consistent with API
             name: this.name(),
-            description: this.description(),
+            description: this.description() || '',
             home_url: this.homeUrl(),
             callback_url: this.callbackUrl(),
             client_id: this.clientId,

--- a/website/static/js/apiApplication.js
+++ b/website/static/js/apiApplication.js
@@ -25,18 +25,20 @@ var language = require('js/osfLanguage');
 var ApplicationData = oop.defclass({
     constructor: function (data) {  // Read in API data and store as object
         data = data || {};
+        var attributes = data.attributes || {};
 
         // User-editable fields
-        this.name = ko.observable(data.name)
-            .extend({required: true});
-        this.description = ko.observable(data.description);
-        this.homeUrl = ko.observable(data.home_url)
+        this.name = ko.observable(attributes.name)
+            .extend({required: true, maxLength:200});
+        this.description = ko.observable(attributes.description)
+            .extend({maxLength: 1000});
+        this.homeUrl = ko.observable(attributes.home_url)
             .extend({
                 url: true,
                 ensureHttp: true,
                 required: true
             });
-        this.callbackUrl = ko.observable(data.callback_url)
+        this.callbackUrl = ko.observable(attributes.callback_url)
             .extend({
                 url: true,
                 ensureHttp: true,
@@ -44,9 +46,9 @@ var ApplicationData = oop.defclass({
             });
 
         // Other fields. Owner and client ID should never change within this view.
-        this.owner = data.owner;
-        this.clientId = data.client_id;
-        this.clientSecret = ko.observable(data.client_secret);
+        this.owner = attributes.owner;
+        this.clientId = attributes.client_id;
+        this.clientSecret = ko.observable(attributes.client_secret);
         this.webDetailUrl = data.links ? data.links.html : undefined;
         this.apiDetailUrl = data.links ? data.links.self : undefined;
 

--- a/website/static/js/tests/apiApplication.test.js
+++ b/website/static/js/tests/apiApplication.test.js
@@ -13,14 +13,16 @@ describe('apiApplicationsInternals', () => {
         var vmd;
         // Sample data returned by an API call
         var sampleData = {
-            client_id: '0123456789abcdef0123456789abcdef',
-            client_secret: 'abcdefghij0123456789abcdefghij0123456789',
-            owner: '14abc',
-            name: 'Of course it has a name',
-            description: 'Always nice to have this',
-            date_created: '2015-07-21T16:28:28.037000',
-            home_url: 'http://tumblr.com',
-            callback_url: 'http://goodwill.org',
+            attributes: {
+                client_id: '0123456789abcdef0123456789abcdef',
+                client_secret: 'abcdefghij0123456789abcdefghij0123456789',
+                owner: '14abc',
+                name: 'Of course it has a name',
+                description: 'Always nice to have this',
+                date_created: '2015-07-21T16:28:28.037000',
+                home_url: 'http://tumblr.com',
+                callback_url: 'http://goodwill.org'
+            },
             links: {
                 self: 'http://localhost:8000/v2/users/14abc/applications/0123456789abcdef0123456789abcdef/',
                 html: 'http://localhost:5000/settings/applications/0123456789abcdef0123456789abcdef/'
@@ -35,14 +37,15 @@ describe('apiApplicationsInternals', () => {
         // TODO: Test that changing to incorrect data makes us fail validation
 
         it('loads data into the specified fields', () => {
-            assert.equal(sampleData.name, vmd.name());
-            assert.equal(sampleData.description, vmd.description());
-            assert.equal(sampleData.home_url, vmd.homeUrl());
-            assert.equal(sampleData.callback_url, vmd.callbackUrl());
+            var attributes = sampleData.attributes;
+            assert.equal(attributes.name, vmd.name());
+            assert.equal(attributes.description, vmd.description());
+            assert.equal(attributes.home_url, vmd.homeUrl());
+            assert.equal(attributes.callback_url, vmd.callbackUrl());
 
-            assert.equal(sampleData.owner, vmd.owner);
-            assert.equal(sampleData.client_id, vmd.clientId);
-            assert.equal(sampleData.client_secret, vmd.clientSecret());
+            assert.equal(attributes.owner, vmd.owner);
+            assert.equal(attributes.client_id, vmd.clientId);
+            assert.equal(attributes.client_secret, vmd.clientSecret());
 
             // TODO: May change when links field changes
             assert.equal(sampleData.links.html, vmd.webDetailUrl);


### PR DESCRIPTION
## Purpose
Improvements to OAuth2 app registration functionality, including fixes to accommodate recent changes.

## Summary of changes
- Updates Knockout to work with JSONAPI formatted data (fix breakage due to recent change) [#OSF-4313]
- Rename `active` field on ApiOAuth2Application model to `is_active` (requested previously, possible due to recent CAS change) [#OSF-4317]
- Add front and backend validators for max field length: 200 characters for application name and 1k for application description. [#OSF-4282]