### PR TITLE
check for 200 on PATCH of read field and fix public field

### DIFF
--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -641,7 +641,7 @@ class TestNodeUpdate(ApiTestCase):
             'public': False,
         }, auth=self.user.auth, expect_errors=True)
         assert_true(res.json['data']['attributes']['public'])
-        # django returns a 200 on PATCH to read only field, it just doesn't change it.
+        # django returns a 200 on PATCH to read only field, even though it does not update the field.
         assert_equal(res.status_code, 200)
 
     def test_partial_update_public_project_logged_out(self):

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -631,18 +631,18 @@ class TestNodeUpdate(ApiTestCase):
         # Test non-contrib writing to public field
         url = '/{}nodes/{}/'.format(API_BASE, project._id)
         res = self.app.patch_json_api(url, {
-            'is_public': False,
+            'public': False,
         }, auth=self.user_two.auth, expect_errors=True)
         assert_equal(res.status_code, 403)
         assert 'detail' in res.json['errors'][0]
 
         # Test creator writing to public field (supposed to be read-only)
         res = self.app.patch_json_api(url, {
-            'is_public': False,
+            'public': False,
         }, auth=self.user.auth, expect_errors=True)
         assert_true(res.json['data']['attributes']['public'])
-        # TODO: Figure out why the validator isn't raising when attempting to write to a read-only field
-        # assert_equal(res.status_code, 403)
+        # django returns a 200 on PATCH to read only field, it just doesn't change it.
+        assert_equal(res.status_code, 200)
 
     def test_partial_update_public_project_logged_out(self):
         res = self.app.patch_json_api(self.public_url, {'title': self.new_title}, expect_errors=True)


### PR DESCRIPTION
Fixes #4086 and an update to #4132

Purpose
-------

Currently api_tests/nodes/test_views/test_writing_to_public_field has a commented out status code assertion.  That assertion is no longer needed as it is a feature of the django rest framework.

Also, in the same test, changes "public_field" (the mongo field) to "public" (the django rest framework field) 

Changes
------------

Remove commented out line 573 and 574 of test_views
change "public_field" to "public" twice in the test.  
