### PR TITLE
[Fix] Ensure rejected embargoes children components are cleaned up

### DIFF
--- a/tests/test_registration_embargoes.py
+++ b/tests/test_registration_embargoes.py
@@ -280,6 +280,33 @@ class RegistrationEmbargoModelsTestCase(OsfTestCase):
         assert_equal(self.registration.embargo.state, Embargo.REJECTED)
         assert_true(self.registration.is_deleted)
 
+    def test_cancelling_embargo_deletes_component_registrations(self):
+        component = NodeFactory(
+            creator=self.user,
+            parent=self.project,
+            title='Component'
+        )
+        subcomponent = NodeFactory(
+            creator=self.user,
+            parent=component,
+            title='Subcomponent'
+        )
+        project_registration = RegistrationFactory(project=self.project)
+        component_registration = project_registration.nodes[0]
+        subcomponent_registration = component_registration.nodes[0]
+        project_registration.embargo_registration(
+            self.user,
+            datetime.datetime.utcnow() + datetime.timedelta(days=10)
+        )
+        project_registration.save()
+
+        rejection_token = project_registration.embargo.approval_state[self.user._id]['rejection_token']
+        project_registration.embargo.disapprove_embargo(self.user, rejection_token)
+        assert_equal(project_registration.embargo.state, Embargo.REJECTED)
+        assert_true(project_registration.is_deleted)
+        assert_true(component_registration.is_deleted)
+        assert_true(subcomponent_registration.is_deleted)
+
     def test_cancelling_embargo_for_existing_registration_does_not_delete_registration(self):
         self.registration.embargo_registration(
             self.user,
@@ -292,6 +319,35 @@ class RegistrationEmbargoModelsTestCase(OsfTestCase):
         self.registration.embargo.disapprove_embargo(self.user, rejection_token)
         assert_equal(self.registration.embargo.state, Embargo.REJECTED)
         assert_false(self.registration.is_deleted)
+
+    def test_rejecting_embargo_for_existing_registration_does_not_deleted_component_registrations(self):
+        component = NodeFactory(
+            creator=self.user,
+            parent=self.project,
+            title='Component'
+        )
+        subcomponent = NodeFactory(
+            creator=self.user,
+            parent=component,
+            title='Subcomponent'
+        )
+        project_registration = RegistrationFactory(project=self.project)
+        component_registration = project_registration.nodes[0]
+        subcomponent_registration = component_registration.nodes[0]
+        project_registration.embargo_registration(
+            self.user,
+            datetime.datetime.utcnow() + datetime.timedelta(days=10),
+            for_existing_registration=True
+        )
+
+        rejection_token = project_registration.embargo.approval_state[self.user._id]['rejection_token']
+        project_registration.embargo.disapprove_embargo(self.user, rejection_token)
+        project_registration.save()
+        assert_equal(project_registration.embargo.state, Embargo.REJECTED)
+        assert_false(project_registration.is_deleted)
+        assert_false(component_registration.is_deleted)
+        assert_false(subcomponent_registration.is_deleted)
+
 
     # Embargo property tests
     def test_new_registration_is_pending_registration(self):

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2961,6 +2961,7 @@ class PrivateLink(StoredObject):
             "anonymous": self.anonymous
         }
 
+
 class Sanction(StoredObject):
     """Sanction object is a generic way to track approval states"""
 
@@ -3098,6 +3099,7 @@ class Sanction(StoredObject):
             else:
                 self._notify_non_authorizer(contrib)
 
+
 class EmailApprovableSanction(Sanction):
 
     AUTHORIZER_NOTIFY_EMAIL_TEMPLATE = None
@@ -3175,6 +3177,7 @@ class EmailApprovableSanction(Sanction):
             'reject': self._rejection_url(user._id)
         }
         self.save()
+
 
 class Embargo(EmailApprovableSanction):
     """Embargo object for registrations waiting to go public."""
@@ -3313,12 +3316,12 @@ class Embargo(EmailApprovableSanction):
             },
             auth=Auth(self.initiated_by),
         )
-        self.state == self.COMPLETED
         self.save()
 
     def approve_embargo(self, user, token):
         """Add user to approval list if user is admin and token verifies."""
         self.approve(user, token)
+
 
 class Retraction(EmailApprovableSanction):
     """Retraction object for public registrations."""
@@ -3441,7 +3444,6 @@ class Retraction(EmailApprovableSanction):
         # so that retracted subrojects/components don't appear in search
         for node in parent_registration.get_descendants_recursive():
             node.update_search()
-        self.state == self.APPROVED
         self.save()
 
     def approve_retraction(self, user, token):
@@ -3449,6 +3451,7 @@ class Retraction(EmailApprovableSanction):
 
     def disapprove_retraction(self, user, token):
         self.reject(user, token)
+
 
 class RegistrationApproval(EmailApprovableSanction):
 
@@ -3548,7 +3551,6 @@ class RegistrationApproval(EmailApprovableSanction):
         for node in register.root.node_and_primary_descendants():
             self._add_success_logs(node, user)
             node.update_search()  # update search if public
-        self.state = self.APPROVED
         self.save()
 
     def _on_reject(self, user, token):

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -3282,8 +3282,7 @@ class Embargo(EmailApprovableSanction):
 
     def _on_reject(self, user, token):
         parent_registration = Node.find_one(Q('embargo', 'eq', self))
-        registered_from = parent_registration.registered_from
-        registered_from.add_log(
+        parent_registration.registered_from.add_log(
             action=NodeLog.EMBARGO_CANCELLED,
             params={
                 'node': parent_registration._id,

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -3282,7 +3282,8 @@ class Embargo(EmailApprovableSanction):
 
     def _on_reject(self, user, token):
         parent_registration = Node.find_one(Q('embargo', 'eq', self))
-        parent_registration.registered_from.add_log(
+        registered_from = parent_registration.registered_from
+        registered_from.add_log(
             action=NodeLog.EMBARGO_CANCELLED,
             params={
                 'node': parent_registration._id,
@@ -3292,6 +3293,7 @@ class Embargo(EmailApprovableSanction):
         )
         # Remove backref to parent project if embargo was for a new registration
         if not self.for_existing_registration:
+            parent_registration.delete_registration_tree(save=True)
             parent_registration.registered_from = None
         # Delete parent registration if it was created at the time the embargo was initiated
         if not self.for_existing_registration:


### PR DESCRIPTION
## Purpose
If an embargo is rejected, its registration along with its component
registrations should be deleted if they did not exist prior to the
request for the embargo.

## Changes
- Call Node#delete_registration_tree upon Embargo#_on_reject
- Modify delete_registration_tree to not delete the root registration
if it existed prior to the embargo.

[#OSF-4316]