### PR TITLE
SHARE search page Postgres API Display Updates

### DIFF
--- a/website/static/js/share/results.js
+++ b/website/static/js/share/results.js
@@ -247,12 +247,20 @@ var RawNormalizedData = {
             m('.col-md-12',
                 m('div', [
                     m('ul', {className: 'nav nav-tabs'}, [
-                        m('li', m('a', {href: '#raw' + divID, 'data-toggle': 'tab'}, 'Raw')),
-                        m('li', m('a', {href: '#normalized' + divID, 'data-toggle': 'tab'}, 'Normalized'))
+                        m('li', m('a', {href: '#normalized' + divID, 'data-toggle': 'tab'}, 'Normalized')),
+                        m('li', m('a', {href: '#raw' + divID, 'data-toggle': 'tab'}, 'Raw'))
                     ]),
                     m('div', {className: 'tab-content'},
                         m('div',
-                            {className: 'tab-pane active', id:'raw' + divID},
+                            {className: 'tab-pane active', id:'normalized' + divID},
+                            m('pre',
+                                (function(){
+                                    return JSON.stringify(result.normalized, undefined, 2);
+                                }())
+                            )
+                        ),
+                        m('div',
+                            {className: 'tab-pane', id:'raw' + divID},
                             m('pre',
                                 (function(){
                                     if (result.rawfiletype === 'xml') {
@@ -262,14 +270,6 @@ var RawNormalizedData = {
                                         var rawjson = JSON.parse(result.raw);
                                         return JSON.stringify(rawjson, undefined, 2);
                                     }
-                                }())
-                            )
-                        ),
-                        m('div',
-                            {className: 'tab-pane', id:'normalized' + divID},
-                            m('pre',
-                                (function(){
-                                    return JSON.stringify(result.normalized, undefined, 2);
                                 }())
                             )
                         )

--- a/website/static/js/share/results.js
+++ b/website/static/js/share/results.js
@@ -242,12 +242,12 @@ var Footer = {
 var RawNormalizedData = {
     view: function(ctrl, params) {
         var result = params.result || params.missingError;
-        var divID = params.missingError ? '' : (result.normalized.shareProperties.docID + result.normalized.shareProperties.source).replace( /(:|\.|\[|\]|,)/g, '-' );
+        var divID = params.missingError ? '' : (result.normalized.shareProperties.docID + result.normalized.shareProperties.source).replace( /(:|\.|\[|\]|,|\/)/g, '-' );
         return m('.row', [
             m('.col-md-12',
                 m('div', [
                     m('ul', {className: 'nav nav-tabs'}, [
-                        m('li', m('a', {href: '#normalized' + divID, 'data-toggle': 'tab'}, 'Normalized')),
+                        m('li', {className: 'active'}, m('a', {href: '#normalized' + divID, 'data-toggle': 'tab'}, 'Normalized')),
                         m('li', m('a', {href: '#raw' + divID, 'data-toggle': 'tab'}, 'Raw'))
                     ]),
                     m('div', {className: 'tab-content'},


### PR DESCRIPTION
## Notes
This PR won't do anything until the new SHARE Postgres backend and forward facing API are in place. This will be soon but not yet!

## Purpose

This fixes one small issue with creating div IDs for documents with complicated names, swaps the location of raw and normalized tabs, and highlights the current Normalized tab when the data display is revealed for the first time

## Changes
- add "/" to the list of items in the share docID that's replaced when generating divs to be clicked in the dropdown display
- Swap tab location and active setting of the Raw and Normalized Document tabs

![screen shot 2015-09-04 at 11 50 26 am](https://cloud.githubusercontent.com/assets/801594/9688100/30e774b6-52fb-11e5-8d95-cd9da6cfbc55.png)

## Side Effects
Very minor change, so should not be any