### PR TITLE
[hotfix] Potential OSF Authentication Loop

### DIFF
--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -146,9 +146,13 @@ def auth_login(auth, **kwargs):
 def auth_logout(redirect_url=None):
     """Log out and delete cookie.
     """
-    redirect_url = redirect_url or request.args.get('redirect_url')
+    redirect_url = redirect_url or request.args.get('redirect_url') or web_url_for('goodbye', _absolute=True)
     logout()
-    resp = redirect(cas.get_logout_url(redirect_url if redirect_url else web_url_for('goodbye', _absolute=True)))
+    if 'reauth' in request.args:
+        cas_endpoint = cas.get_login_url(redirect_url)
+    else:
+        cas_endpoint = cas.get_logout_url(redirect_url)
+    resp = redirect(cas_endpoint)
     resp.delete_cookie(settings.COOKIE_NAME)
     return resp
 

--- a/website/routes.py
+++ b/website/routes.py
@@ -73,7 +73,7 @@ def get_globals():
         'waterbutler_url': settings.WATERBUTLER_URL,
         'login_url': cas.get_login_url(request.url, auto=True),
         'access_token': session.data.get('auth_user_access_token') or '',
-        'auth_url': cas.get_login_url(request.url),
+        'reauth_url': util.web_url_for('auth_logout', redirect_url=request.url, reauth=True),
         'profile_url': cas.get_profile_url(),
     }
 

--- a/website/static/js/pages/base-page.js
+++ b/website/static/js/pages/base-page.js
@@ -122,9 +122,9 @@ $(function() {
                         error: error,
                         userId: window.contextVars.userId,
                         accessToken: window.contextVars.accessToken,
-                        authUrl: window.contextVars.authUrl
+                        reauthUrl: window.contextVars.reauthUrl
                     });
-                    window.document.location = window.contextVars.authUrl;
+                    window.document.location = window.contextVars.reauthUrl;
                 }
             }
         );

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -146,7 +146,7 @@
             % if access_token:
                 accessToken: ${ access_token | sjson, n },
                 userId: ${user_id | sjson, n},
-                authUrl: ${auth_url | sjson, n},
+                reauthUrl: ${reauth_url | sjson, n},
                 profileUrl: ${profile_url | sjson, n},
             % endif
                 cookieName: ${ cookie_name | sjson, n },


### PR DESCRIPTION
rename auth_url to reauth_url

send reauth attempt through standard logout endpoint so cookie can be cleared, thus preventing authentication loop