### PR TITLE
[Ready for Review] Feature/api/profile pic

### DIFF
--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -1,7 +1,8 @@
 from rest_framework import serializers as ser
-from api.base.serializers import JSONAPISerializer, LinksField, JSONAPIHyperlinkedIdentityField
+
 from website.models import User
 
+from api.base.serializers import JSONAPISerializer, LinksField, JSONAPIHyperlinkedIdentityField
 
 class UserSerializer(JSONAPISerializer):
     filterable_fields = frozenset([
@@ -18,7 +19,12 @@ class UserSerializer(JSONAPISerializer):
     family_name = ser.CharField(required=False, allow_blank=True, help_text='For bibliographic citations')
     suffix = ser.CharField(required=False, allow_blank=True, help_text='For bibliographic citations')
     date_registered = ser.DateTimeField(read_only=True)
-    gravatar_url = ser.URLField(required=False, read_only=True, help_text='URL for the icon used to identify the user. Relies on http://gravatar.com ')
+
+    profile_image_url = ser.SerializerMethodField(required=False, read_only=True)
+
+    def get_profile_image_url(self, user):
+        size = self.context['request'].query_params.get('profile_image_size')
+        return user.profile_image_url(size=size)
 
     # Social Fields are broken out to get around DRF complex object bug and to make API updating more user friendly.
     gitHub = ser.CharField(required=False, label='GitHub', source='social.github', allow_blank=True, help_text='GitHub Handle')

--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -938,12 +938,22 @@ class User(GuidStoredObject, AddonModelMixin):
     def deep_url(self):
         return '/profile/{}/'.format(self._primary_key)
 
-    @property
-    def gravatar_url(self):
+    def profile_image_url(self, size=None):
+        """A generalized method for getting a user's profile picture urls.
+        We may choose to use some service other than gravatar in the future,
+        and should not commit ourselves to using a specific service (mostly
+        an API concern).
+
+        As long as we use gravatar, this is just a proxy to User.gravatar_url
+        """
+        size = size or settings.PROFILE_IMAGE_MEDIUM
+        return self._gravatar_url(size)
+
+    def _gravatar_url(self, size=None):
         return filters.gravatar(
             self,
             use_ssl=True,
-            size=settings.GRAVATAR_SIZE_ADD_CONTRIBUTOR
+            size=size
         )
 
     def get_activity_points(self, db=None):

--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -949,7 +949,7 @@ class User(GuidStoredObject, AddonModelMixin):
         size = size or settings.PROFILE_IMAGE_MEDIUM
         return self._gravatar_url(size)
 
-    def _gravatar_url(self, size=None):
+    def _gravatar_url(self, size):
         return filters.gravatar(
             self,
             use_ssl=True,

--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -946,7 +946,6 @@ class User(GuidStoredObject, AddonModelMixin):
 
         As long as we use gravatar, this is just a proxy to User.gravatar_url
         """
-        size = size or settings.PROFILE_IMAGE_MEDIUM
         return self._gravatar_url(size)
 
     def _gravatar_url(self, size):

--- a/tests/api_tests/users/test_views.py
+++ b/tests/api_tests/users/test_views.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import urlparse
 from nose.tools import *  # flake8: noqa
 
 from website.models import Node
@@ -71,6 +72,15 @@ class TestUsers(ApiTestCase):
         assert_not_in(self.user_one._id, ids)
         assert_not_in(self.user_two._id, ids)
 
+    def test_users_list_takes_profile_image_size_param(self):
+        size = 42
+        url = "/{}users/?profile_image_size={}".format(API_BASE, size)
+        res = self.app.get(url)
+        user_json = res.json['data']
+        for user in user_json:
+            profile_image_url = user['attributes']['profile_image_url']
+            query_dict = urlparse.parse_qs(urlparse.urlparse(profile_image_url).query)
+            assert_equal(int(query_dict.get('size')[0]), size)
 
 class TestUserDetail(ApiTestCase):
 
@@ -110,7 +120,15 @@ class TestUserDetail(ApiTestCase):
         user_json = res.json['data']
         assert_not_equal(user_json['attributes']['fullname'], self.user_one.fullname)
         assert_equal(user_json['attributes']['fullname'], self.user_two.fullname)
-
+        
+    def test_user_detail_takes_profile_image_size_param(self):
+        size = 42
+        url = "/{}users/{}/?profile_image_size={}".format(API_BASE, self.user_one._id, size)
+        res = self.app.get(url)
+        user_json = res.json['data']
+        profile_image_url = user_json['attributes']['profile_image_url']
+        query_dict = urlparse.parse_qs(urlparse.urlparse(profile_image_url).query)
+        assert_equal(int(query_dict.get('size')[0]), size)
 
 class TestUserNodes(ApiTestCase):
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -615,13 +615,13 @@ class TestUser(OsfTestCase):
             urlparse.urljoin(settings.DOMAIN, '/{0}/'.format(self.user._primary_key))
         )
 
-    def test_gravatar_url(self):
+    def test_profile_image_url(self):
         expected = filters.gravatar(
             self.user,
             use_ssl=True,
-            size=settings.GRAVATAR_SIZE_ADD_CONTRIBUTOR
+            size=settings.PROFILE_IMAGE_MEDIUM
         )
-        assert_equal(self.user.gravatar_url, expected)
+        assert_equal(self.user.profile_image_url(), expected)
 
     def test_activity_points(self):
         assert_equal(self.user.get_activity_points(db=self.db),

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -649,7 +649,7 @@ class TestUser(OsfTestCase):
         gravatar = filters.gravatar(
             user,
             use_ssl=True,
-            size=settings.GRAVATAR_SIZE_PROFILE
+            size=settings.PROFILE_IMAGE_LARGE
         )
         assert_equal(d['id'], user._primary_key)
         assert_equal(d['url'], user.url)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -621,7 +621,16 @@ class TestUser(OsfTestCase):
             use_ssl=True,
             size=settings.PROFILE_IMAGE_MEDIUM
         )
+        assert_equal(self.user.profile_image_url(settings.PROFILE_IMAGE_MEDIUM), expected)
+
+    def test_profile_image_url_has_no_default_size(self):
+        expected = filters.gravatar(
+            self.user,
+            use_ssl=True,
+        )
         assert_equal(self.user.profile_image_url(), expected)
+        size = urlparse.parse_qs(urlparse.urlparse(self.user.profile_image_url()).query).get('size')
+        assert_equal(size, None)
 
     def test_activity_points(self):
         assert_equal(self.user.get_activity_points(db=self.db),

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -832,7 +832,7 @@ class TestSendEmails(OsfTestCase):
 
         users = [factories.UserFactory() for i in range(5)]
         context = dict(
-            gravatar_url=self.user.gravatar_url,
+            gravatar_url=self.user.profile_image_url(),
             content='',
             target_user=None,
             parent_comment='',
@@ -856,7 +856,7 @@ class TestSendEmails(OsfTestCase):
 
         users = [factories.UserFactory() for i in range(5)]
         context = dict(
-            gravatar_url=self.user.gravatar_url,
+            gravatar_url=self.user.profile_image_url(),
             content='',
             target_user=None,
             parent_comment='',
@@ -1070,7 +1070,7 @@ class TestSendEmails(OsfTestCase):
     #     emails.send([self.user], 'email_transactional', self.project._id, 'comments',
     #                 timestamp=datetime.datetime.utcnow(),
     #                 user=self.project.creator,
-    #                 gravatar_url=self.user.gravatar_url,
+    #                 gravatar_url=self.user.profile_image_url(),
     #                 content='',
     #                 parent_comment='',
     #                 title=self.project.title,
@@ -1089,7 +1089,7 @@ class TestSendEmails(OsfTestCase):
             user=self.project.creator,
             node=self.project,
             timestamp=timestamp,
-            gravatar_url=self.user.gravatar_url,
+            gravatar_url=self.user.profile_image_url(),
             content='',
             parent_comment='',
             title=self.project.title,
@@ -1098,7 +1098,7 @@ class TestSendEmails(OsfTestCase):
         subject = Template(emails.EMAIL_SUBJECT_MAP['comments']).render(
             timestamp=timestamp,
             user=self.project.creator,
-            gravatar_url=self.user.gravatar_url,
+            gravatar_url=self.user.profile_image_url(),
             content='',
             parent_comment='',
             title=self.project.title,
@@ -1108,7 +1108,7 @@ class TestSendEmails(OsfTestCase):
             'comments.html.mako',
             timestamp=timestamp,
             user=self.project.creator,
-            gravatar_url=self.user.gravatar_url,
+            gravatar_url=self.user.profile_image_url(),
             content='',
             parent_comment='',
             title=self.project.title,
@@ -1136,7 +1136,7 @@ class TestSendEmails(OsfTestCase):
                             user=self.user,
                             node=self.project,
                             timestamp=datetime.datetime.utcnow().replace(tzinfo=pytz.utc),
-                            gravatar_url=self.user.gravatar_url,
+                            gravatar_url=self.user.profile_image_url(),
                             content='',
                             parent_comment='',
                             title=self.project.title,
@@ -1152,7 +1152,7 @@ class TestSendEmails(OsfTestCase):
                             user=self.user,
                             node=self.project,
                             timestamp=datetime.datetime.utcnow().replace(tzinfo=pytz.utc),
-                            gravatar_url=self.user.gravatar_url,
+                            gravatar_url=self.user.profile_image_url(),
                             content='',
                             parent_comment='',
                             title=self.project.title,

--- a/website/profile/utils.py
+++ b/website/profile/utils.py
@@ -27,7 +27,7 @@ def get_public_projects(user):
 
 def get_gravatar(user, size=None):
     if size is None:
-        size = settings.GRAVATAR_SIZE_PROFILE
+        size = settings.PROFILE_IMAGE_LARGE
     return gravatar(
         user, use_ssl=True,
         size=size
@@ -50,7 +50,7 @@ def serialize_user(user, node=None, admin=False, full=False):
         'shortname': fullname if len(fullname) < 50 else fullname[:23] + "..." + fullname[-23:],
         'gravatar_url': gravatar(
             user, use_ssl=True,
-            size=settings.GRAVATAR_SIZE_ADD_CONTRIBUTOR
+            size=settings.PROFILE_IMAGE_MEDIUM
         ),
         'active': user.is_active,
     }
@@ -106,7 +106,7 @@ def serialize_user(user, node=None, admin=False, full=False):
             'activity_points': user.get_activity_points(),
             'gravatar_url': gravatar(
                 user, use_ssl=True,
-                size=settings.GRAVATAR_SIZE_PROFILE
+                size=settings.PROFILE_IMAGE_LARGE
             ),
             'is_merged': user.is_merged,
             'merged_by': merged_by,
@@ -156,7 +156,7 @@ def add_contributor_json(user, current_user=None):
         'active': user.is_active,
         'gravatar_url': gravatar(
             user, use_ssl=True,
-            size=settings.GRAVATAR_SIZE_ADD_CONTRIBUTOR
+            size=settings.PROFILE_IMAGE_MEDIUM
         ),
         'profile_url': user.profile_url
     }
@@ -171,7 +171,7 @@ def serialize_unregistered(fullname, email):
             'registered': False,
             'active': False,
             'gravatar': gravatar(email, use_ssl=True,
-                                 size=settings.GRAVATAR_SIZE_ADD_CONTRIBUTOR),
+                                 size=settings.PROFILE_IMAGE_MEDIUM),
             'email': email,
         }
     else:

--- a/website/project/views/comment.py
+++ b/website/project/views/comment.py
@@ -62,7 +62,7 @@ def comment_discussion(auth, node, **kwargs):
                 'isContributor': node.is_contributor(user),
                 'gravatarUrl': privacy_info_handle(
                     gravatar(
-                        user, use_ssl=True, size=settings.GRAVATAR_SIZE_DISCUSSION,
+                        user, use_ssl=True, size=settings.PROFILE_IMAGE_SMALL
                     ),
                     anonymous
                 ),
@@ -85,7 +85,7 @@ def serialize_comment(comment, auth, anonymous=False):
             'gravatarUrl': privacy_info_handle(
                 gravatar(
                     comment.user, use_ssl=True,
-                    size=settings.GRAVATAR_SIZE_DISCUSSION
+                    size=settings.PROFILE_IMAGE_SMALL
                 ),
                 anonymous
             ),

--- a/website/project/views/comment.py
+++ b/website/project/views/comment.py
@@ -149,7 +149,7 @@ def add_comment(auth, node, **kwargs):
     comment.save()
 
     context = dict(
-        gravatar_url=auth.user.gravatar_url,
+        gravatar_url=auth.user.profile_image_url(),
         content=content,
         target_user=target.user if is_reply(target) else None,
         parent_comment=target.content if is_reply(target) else "",

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -494,7 +494,7 @@ def search_contributor(query, page=0, size=10, exclude=None, current_user=None):
                 'gravatar_url': gravatar(
                     user,
                     use_ssl=True,
-                    size=settings.GRAVATAR_SIZE_ADD_CONTRIBUTOR,
+                    size=settings.PROFILE_IMAGE_MEDIUM
                 ),
                 'profile_url': user.profile_url,
                 'registered': user.is_registered,

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -136,16 +136,16 @@ SESSION_HISTORY_IGNORE_RULES = [
 
 # TODO: Configuration should not change between deploys - this should be dynamic.
 CANONICAL_DOMAIN = 'openscienceframework.org'
-COOKIE_DOMAIN = '.openscienceframework.org' # Beaker
+COOKIE_DOMAIN = '.openscienceframework.org'  # Beaker
 SHORT_DOMAIN = 'osf.io'
 
 # TODO: Combine Python and JavaScript config
 COMMENT_MAXLENGTH = 500
 
-# Gravatar options
-GRAVATAR_SIZE_PROFILE = 70
-GRAVATAR_SIZE_ADD_CONTRIBUTOR = 40
-GRAVATAR_SIZE_DISCUSSION = 20
+# Profile image options
+PROFILE_IMAGE_LARGE = 70
+PROFILE_IMAGE_MEDIUM = 40
+PROFILE_IMAGE_SMALL = 20
 
 # Conference options
 CONFERNCE_MIN_COUNT = 5


### PR DESCRIPTION
# Purpose 

brianjgeiger reports:

> We had a brief discussion on this issue, and it's leading to the following proposed changes:
1) v2 serializer uses profile_image_url instead of gravatar_url because we may not always use gravatar;
2) modify the user view to accept a query parameter to set the profile_image_size.
By default, it will still return a specified size.

# Changes

- Update V2 user serializer to use profile_image_url instead of gravatar_url
- Let user list and detail views take profile_image_size query param
  - write tests to document this
- Update User model to have a profile_image_url method, and replace usages of User.gravatar_url property with new method
- Update profile image size constants in settings to have more general names

# Side Effects 

We should track down all gravatar specific references and replace them with the generalized profile_image_url method. 
