### PR TITLE
Fix column sorting for meetings 

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "raw-loader": "^0.5.1",
     "share": "0.7.27",
     "style-loader": "^0.8.3",
-    "treebeard": "git://github.com/caneruguz/treebeard.git#9f1458a9f5961460dcd84c833b5da0180219f253",
+    "treebeard": "git://github.com/caneruguz/treebeard.git#50a71133305496a440586ed880ae63f0ac5edda8",
     "typeahead.js": "^0.10.5",
     "url-loader": "^0.5.5",
     "webpack": "^1.7.2",

--- a/website/static/js/submissions.js
+++ b/website/static/js/submissions.js
@@ -77,7 +77,7 @@ function Submissions(data) {
                     custom : function() {
                         if(item.data.downloadUrl){
                             return [ m('a', { href : item.data.downloadUrl }, [
-                                m('button.btn.btn-success.btn-xs', { style : 'margin-right : 10px;'},  m('i.fa.fa-download.fa-inverse')),
+                                m('button.btn.btn-success.btn-xs', { style : 'margin-right : 10px;'},  m('i.fa.fa-download.fa-inverse'))
 
                             ] ), item.data.download  ];
                         } else {


### PR DESCRIPTION
## Purpose 

Fixes JIRA ticket [#OSF-4262]  and [#OSF-4261] where sort comparisons for columns in treebeard were causing them to sort equals

## Changes
Main changes are in Treebeard but include
- correcting a section where comparison fallbcack to id was using < instead of - 
- handling cases where null or non-text/number/date examples are pushed into the comparison (there was a use case where a true/false was being sorted as text in OSF.)

## Known Side Effects
none 

P.S. Sorry for the git amend mixup.  