### PR TITLE
[Feature] Wiki Collaboration Preview Permissions

### DIFF
--- a/website/addons/wiki/templates/edit.mako
+++ b/website/addons/wiki/templates/edit.mako
@@ -81,7 +81,7 @@
                             <div class="pull-right">
                                 <!-- Version Picker -->
                                 <select class="form-control" data-bind="value:viewVersion" id="viewVersionSelect">
-                                    % if user['can_edit']:
+                                    % if user['can_edit_wiki_body']:
                                         <option value="preview" ${'selected' if version_settings['view'] == 'preview' else ''}>Preview</option>
                                     % endif
                                     <option value="current" ${'selected' if version_settings['view'] == 'current' else ''}>Current</option>


### PR DESCRIPTION
### Proposal
This gives the 'can_edit_wiki_body' check to the preview view of the wiki page. Used to be only 'can_edit'.

### Repercussions
There are a few more plain 'can_edit' checks in the mako template but they do not cover any of the functionality described in the ticket.