### PR TITLE
[feature] API error handling when removing pointers and nodes

### DIFF
--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -249,7 +249,10 @@ class NodeLinksDetail(generics.RetrieveDestroyAPIView, NodeMixin):
         auth = Auth(user)
         node = self.get_node()
         pointer = self.get_object()
-        node.rm_pointer(pointer, auth)
+        try:
+            node.rm_pointer(pointer, auth=auth)
+        except ValueError as err:  # pointer doesn't belong to node
+            raise ValidationError(err.message)
         node.save()
 
 

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -23,11 +23,15 @@ class NodeMixin(object):
     node_lookup_url_kwarg = 'node_id'
 
     def get_node(self):
-        node = get_object_or_error(Node, self.kwargs[self.node_lookup_url_kwarg], 'node')
+        node = get_object_or_error(
+            Node,
+            self.kwargs[self.node_lookup_url_kwarg],
+            display_name='node'
+        )
         # Nodes that are folders/collections are treated as a separate resource, so if the client
         # requests a collection through a node endpoint, we return a 404
         if node.is_folder:
-            raise NotFound()
+            raise NotFound
         # May raise a permission denied
         self.check_object_permissions(self.request, node)
         return node

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -5,6 +5,7 @@ from rest_framework import generics, permissions as drf_permissions
 from rest_framework.exceptions import PermissionDenied, ValidationError
 
 from framework.auth.core import Auth
+from website.exceptions import NodeStateError
 from website.models import Node, Pointer
 from api.users.serializers import ContributorSerializer
 from api.base.filters import ODMFilterMixin, ListFilterMixin
@@ -106,7 +107,10 @@ class NodeDetail(generics.RetrieveUpdateDestroyAPIView, NodeMixin):
         user = self.request.user
         auth = Auth(user)
         node = self.get_object()
-        node.remove_node(auth=auth)
+        try:
+            node.remove_node(auth=auth)
+        except NodeStateError as err:
+            raise ValidationError(err.message)
         node.save()
 
 

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -801,13 +801,8 @@ class TestNodeDelete(ApiTestCase):
             auth=self.user.auth,
             expect_errors=True
         )
-        assert_equal(res.status_code, 400)
-        errors = res.json['errors']
-        assert_equal(len(errors), 1)
-        assert_equal(
-            errors[0]['detail'],
-            'Dashboards may not be deleted.'
-        )
+        # Dashboards are a folder, so a 404 is returned
+        assert_equal(res.status_code, 404)
 
 class TestNodeContributorList(ApiTestCase):
 

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -1650,6 +1650,20 @@ class TestDeleteNodeLink(ApiTestCase):
         res = self.app.get(self.private_url, auth=self.user.auth, expect_errors=True)
         assert_equal(res.status_code, 404)
 
+    # Regression test for https://openscience.atlassian.net/browse/OSF-4322
+    def test_delete_link_that_is_not_linked_to_correct_node(self):
+        project = ProjectFactory(creator=self.user)
+        # The node link belongs to a different project
+        res = self.app.delete(
+            '/{}nodes/{}/node_links/{}'.format(API_BASE, project._id, self.public_pointer._id),
+            auth=self.user.auth,
+            expect_errors=True
+        )
+        assert_equal(res.status_code, 400)
+        errors = res.json['errors']
+        assert_equal(len(errors), 1)
+        assert_equal(errors[0]['detail'], 'Node link does not belong to the requested node.')
+
 
 class TestReturnDeletedNode(ApiTestCase):
     def setUp(self):

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -481,6 +481,15 @@ class TestNodeDetail(ApiTestCase):
         assert_equal(res.json['data']['attributes']['dashboard'], False)
         assert_equal(res.json['data']['attributes']['tags'], [])
 
+    def test_requesting_folder_returns_error(self):
+        folder = NodeFactory(is_folder=True, creator=self.user)
+        res = self.app.get(
+            '/{}nodes/{}/'.format(API_BASE, folder._id),
+            auth=self.user.auth,
+            expect_errors=True
+        )
+        assert_equal(res.status_code, 404)
+
 
 class TestNodeUpdate(ApiTestCase):
 
@@ -1618,7 +1627,6 @@ class TestDeleteNodeLink(ApiTestCase):
         # a little better
         assert_equal(res.status_code, 403)
         assert 'detail' in res.json['errors'][0]
-
 
     def test_deletes_private_node_pointer_logged_in_contributor(self):
         res = self.app.delete(self.private_url, auth=self.user.auth)

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -1344,7 +1344,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
         :param Auth auth: Consolidated authorization
         """
         if pointer not in self.nodes:
-            raise ValueError
+            raise ValueError('Node link does not belong to the requested node.')
 
         # Remove `Pointer` object; will also remove self from `nodes` list of
         # parent node


### PR DESCRIPTION
## Purpose

There were uncaught errors being raised when the client:

- Tries to DELETE a node that has components
- Tries to delete a pointer that doesn't belong to the requested node

## Changes

Re-raise exceptions with correct DRF exception in order to return properly-formatted 400 responses to the client.

## Tickets

https://openscience.atlassian.net/browse/OSF-4322
https://openscience.atlassian.net/browse/OSF-4314