### PR TITLE
change the recent activity log for retracted registration

### DIFF
--- a/website/static/js/logFeed.js
+++ b/website/static/js/logFeed.js
@@ -116,7 +116,6 @@ var LogsViewModel = oop.extend(Paginator, {
         self.loading = ko.observable(false);
         self.logs = ko.observableArray(logs);
         self.url = url;
-        self.anonymousUserName = '<em>A user</em>';
 
         self.tzname = ko.pureComputed(function() {
             var logs = self.logs();

--- a/website/templates/util/render_node.mako
+++ b/website/templates/util/render_node.mako
@@ -102,33 +102,37 @@
         % if not summary['archiving']:
         <div class="body hide" id="body-${summary['id']}" style="overflow:hidden;">
             <hr />
-            Recent Activity
-            <!-- ko stopBinding: true -->
-            <div id="logs-${summary['id']}" class="log-container" data-uri="${summary['api_url']}log/">
-                <dl class="dl-horizontal activity-log" data-bind="foreach: {data: logs, as: 'log'}">
-                    <dt><span class="date log-date" data-bind="text: log.date.local, tooltip: {title: log.date.utc}"></span></dt>
-                    <dd class="log-content">
-                        <span data-bind="if:log.anonymous">
-                           <span data-bind="html: $parent.anonymousUserName"></span>
-                        </span>
-                        <span data-bind="ifnot:log.anonymous">
-                            <a data-bind="text: log.userFullName || log.apiKey, attr: {href: log.userURL}"></a>
-                        </span>
+            % if summary['is_retracted']:
+                <h4>Recent activity information has been retracted.</h4>
+            % else:
+                Recent Activity
+                <!-- ko stopBinding: true -->
+                <div id="logs-${summary['id']}" class="log-container" data-uri="${summary['api_url']}log/">
+                    <dl class="dl-horizontal activity-log" data-bind="foreach: {data: logs, as: 'log'}">
+                        <dt><span class="date log-date" data-bind="text: log.date.local, tooltip: {title: log.date.utc}"></span></dt>
+                        <dd class="log-content">
+                            <span data-bind="if:log.anonymous">
+                               <span data-bind="html: $parent.anonymousUserName"></span>
+                            </span>
+                            <span data-bind="ifnot:log.anonymous">
+                                <a data-bind="text: log.userFullName || log.apiKey, attr: {href: log.userURL}"></a>
+                            </span>
 
-                        <!-- ko if: log.hasUser() -->
-                            <!-- log actions are the same as their template name -->
-                            <span data-bind="template: {name: log.action, data: log}"></span>
-                        <!-- /ko -->
+                            <!-- ko if: log.hasUser() -->
+                                <!-- log actions are the same as their template name -->
+                                <span data-bind="template: {name: log.action, data: log}"></span>
+                            <!-- /ko -->
 
-                        <!-- ko ifnot: log.hasUser() -->
-                            <!-- Log actions are the same as their template name  + no_user -->
-                            <span data-bind="template: {name: log.action + '_no_user', data: log}"></span>
-                        <!-- /ko -->
-                        </dd>
-                </dl><!-- end foreach logs -->
-            </div>
-            <!-- /ko -->
-         </div>
+                            <!-- ko ifnot: log.hasUser() -->
+                                <!-- Log actions are the same as their template name  + no_user -->
+                                <span data-bind="template: {name: log.action + '_no_user', data: log}"></span>
+                            <!-- /ko -->
+                            </dd>
+                    </dl><!-- end foreach logs -->
+                </div>
+                <!-- /ko -->
+            % endif
+        </div>
         % endif
     </li>
 

--- a/website/templates/util/render_node.mako
+++ b/website/templates/util/render_node.mako
@@ -127,7 +127,7 @@
                                 <!-- Log actions are the same as their template name  + no_user -->
                                 <span data-bind="template: {name: log.action + '_no_user', data: log}"></span>
                             <!-- /ko -->
-                            </dd>
+                        </dd>
                     </dl><!-- end foreach logs -->
                 </div>
                 <!-- /ko -->

--- a/website/templates/util/render_node.mako
+++ b/website/templates/util/render_node.mako
@@ -107,29 +107,30 @@
             % else:
                 Recent Activity
                 <!-- ko stopBinding: true -->
-                <div id="logs-${summary['id']}" class="log-container" data-uri="${summary['api_url']}log/">
-                    <dl class="dl-horizontal activity-log" data-bind="foreach: {data: logs, as: 'log'}">
-                        <dt><span class="date log-date" data-bind="text: log.date.local, tooltip: {title: log.date.utc}"></span></dt>
-                        <dd class="log-content">
-                            <span data-bind="if:log.anonymous">
-                               <span data-bind="html: $parent.anonymousUserName"></span>
-                            </span>
-                            <span data-bind="ifnot:log.anonymous">
-                                <a data-bind="text: log.userFullName || log.apiKey, attr: {href: log.userURL}"></a>
-                            </span>
+                    <div id="logs-${summary['id']}" class="log-container" data-uri="${summary['api_url']}log/">
+                        <dl class="dl-horizontal activity-log" data-bind="foreach: {data: logs, as: 'log'}">
+                            <dt><span class="date log-date" data-bind="text: log.date.local, tooltip: {title: log.date.utc}"></span></dt>
+                            <dd class="log-content">
+                                <!-- ko if: log.anonymous -->
+                                    <em>A user</em>
+                                <!-- /ko -->
 
-                            <!-- ko if: log.hasUser() -->
-                                <!-- log actions are the same as their template name -->
-                                <span data-bind="template: {name: log.action, data: log}"></span>
-                            <!-- /ko -->
+                                <!-- ko ifnot: log.anonymous -->
+                                    <a data-bind="text: log.userFullName, attr: {href: log.userURL}"></a>
+                                <!-- /ko -->
 
-                            <!-- ko ifnot: log.hasUser() -->
-                                <!-- Log actions are the same as their template name  + no_user -->
-                                <span data-bind="template: {name: log.action + '_no_user', data: log}"></span>
-                            <!-- /ko -->
-                        </dd>
-                    </dl><!-- end foreach logs -->
-                </div>
+                                <!-- ko if: log.hasUser() -->
+                                    <!-- log actions are the same as their template name -->
+                                    <span data-bind="template: {name: log.action, data: log}"></span>
+                                <!-- /ko -->
+
+                                <!-- ko ifnot: log.hasUser() -->
+                                    <!-- Log actions are the same as their template name  + no_user -->
+                                    <span data-bind="template: {name: log.action + '_no_user', data: log}"></span>
+                                <!-- /ko -->
+                            </dd>
+                        </dl><!-- end foreach logs -->
+                    </div>
                 <!-- /ko -->
             % endif
         </div>


### PR DESCRIPTION
<b>Purpose</b>
Change the recent activities field for retracted registration to be a warning instead of showing logs. Closes [#OSF-3969]

<b>Changes</b>
before:
![image](https://cloud.githubusercontent.com/assets/4974056/9691558/28b22406-5311-11e5-9b0a-0787acec61b2.png)
after:
![screen shot 2015-09-04 at 2 28 18 pm](https://cloud.githubusercontent.com/assets/4974056/9691566/39c7e032-5311-11e5-8c15-0504e40ccf0d.png)
