### PR TITLE
Fix limiting showed items by resetting natural scroll limit

### DIFF
--- a/website/static/js/notificationsTreebeard.js
+++ b/website/static/js/notificationsTreebeard.js
@@ -83,6 +83,7 @@ function ProjectNotifications(data) {
     var tbOptions = $.extend({}, projectSettingsTreebeardBase.defaults, {
         divID: 'grid',
         filesData: data,
+        naturalScrollLimit : 0,
         resolveRows: function notificationResolveRows(item){
             var columns = [];
             var iconcss = '';


### PR DESCRIPTION
## Purpose
Fixes [#OSF-4335] where the notifications treebeard instance did not draw more than first 16 columns

Treebeard should get rid of the naturalScrollLimit setting, I'll add as an issue