### PR TITLE
[feature] Return 400 if client passes an invalid filter

### DIFF
--- a/api/base/exceptions.py
+++ b/api/base/exceptions.py
@@ -43,6 +43,6 @@ class Gone(APIException):
     default_detail = ('The requested resource is no longer available.')
 
 
-class InvalidFilter(ParseError):
+class InvalidFilterError(ParseError):
     """Raised when client passes an invalid filter in the querystring."""
     default_detail = 'Querystring contains an invalid filter.'

--- a/api/base/exceptions.py
+++ b/api/base/exceptions.py
@@ -1,6 +1,6 @@
 
 from rest_framework import status
-from rest_framework.exceptions import APIException
+from rest_framework.exceptions import APIException, ParseError
 
 
 def json_api_exception_handler(exc, context):
@@ -41,3 +41,8 @@ def json_api_exception_handler(exc, context):
 class Gone(APIException):
     status_code = status.HTTP_410_GONE
     default_detail = ('The requested resource is no longer available.')
+
+
+class InvalidFilter(ParseError):
+    """Raised when client passes an invalid filter in the querystring."""
+    default_detail = 'Querystring contains an invalid filter.'


### PR DESCRIPTION
## Purpose

In APIv2, if the client passed an invalid filter in the querystring, e.g. `?filter[not-a-field]=foo`, the invalid input passed silently.

## Changes

A 400 response with the message "Querystring contains an invalid filter." is returned to the client.

## Tickets

https://openscience.atlassian.net/browse/OSF-4325