### PR TITLE
[Ready to Review] Audit/fix bugs with filtering and permissions

### DIFF
--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -84,7 +84,7 @@ class ODMFilterMixin(FilterMixin):
 
     field_comparison_operators = {
         ser.CharField: 'icontains',
-        ser.ListField: 'in',
+        ser.ListField: 'contains',
     }
 
     def __init__(self, *args, **kwargs):

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -131,6 +131,19 @@ class NodeSerializer(JSONAPISerializer):
         return instance
 
 
+class NodeRegistrationSerializer(NodeSerializer):
+
+    retracted = ser.BooleanField(source='is_retracted', read_only=True,
+        help_text='Whether this registration has been retracted.')
+
+    # TODO: Finish me
+
+    # TODO: Override create?
+
+    def update(self, *args, **kwargs):
+        raise exceptions.ValidationError('Registrations cannot be modified.')
+
+
 class NodeLinksSerializer(JSONAPISerializer):
 
     id = ser.CharField(read_only=True, source='_id')

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -23,7 +23,14 @@ class NodeSerializer(JSONAPISerializer):
     # instance
     category_choices = Node.CATEGORY_MAP.keys()
     category_choices_string = ', '.join(["'{}'".format(choice) for choice in category_choices])
-    filterable_fields = frozenset(['title', 'description', 'public'])
+    filterable_fields = frozenset([
+        'title',
+        'description',
+        'public',
+        'registration',
+        'tags',
+        'category',
+    ])
 
     id = ser.CharField(read_only=True, source='_id', label='ID')
     title = ser.CharField(required=True)
@@ -40,10 +47,10 @@ class NodeSerializer(JSONAPISerializer):
     # TODO: When we have 'admin' permissions, make this writable for admins
     public = ser.BooleanField(source='is_public', read_only=True,
                               help_text='Nodes that are made public will give read-only access '
-                                                            'to everyone. Private nodes require explicit read '
-                                                            'permission. Write and admin access are the same for '
-                                                            'public and private nodes. Administrators on a parent '
-                                                            'node have implicit read permissions for all child nodes',
+                                        'to everyone. Private nodes require explicit read '
+                                        'permission. Write and admin access are the same for '
+                                        'public and private nodes. Administrators on a parent '
+                                        'node have implicit read permissions for all child nodes',
                               )
 
     children = JSONAPIHyperlinkedIdentityField(view_name='nodes:node-children', lookup_field='pk', link_type='related',

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -134,6 +134,7 @@ class NodeContributorsList(generics.ListAPIView, ListFilterMixin, NodeMixin):
     permission_classes = (
         drf_permissions.IsAuthenticatedOrReadOnly,
         ContributorOrPublic,
+        ReadOnlyIfRegistration,
     )
 
     serializer_class = ContributorSerializer
@@ -190,6 +191,7 @@ class NodeChildrenList(generics.ListCreateAPIView, NodeMixin, ODMFilterMixin):
     permission_classes = (
         ContributorOrPublic,
         drf_permissions.IsAuthenticatedOrReadOnly,
+        ReadOnlyIfRegistration,
     )
 
     serializer_class = NodeSerializer

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -10,7 +10,7 @@ from website.models import Node, Pointer
 from api.users.serializers import ContributorSerializer
 from api.base.filters import ODMFilterMixin, ListFilterMixin
 from api.base.utils import get_object_or_error, waterbutler_url_for
-from .serializers import NodeSerializer, NodeLinksSerializer, NodeFilesSerializer
+from .serializers import NodeSerializer, NodeLinksSerializer, NodeFilesSerializer, NodeRegistrationSerializer
 from .permissions import ContributorOrPublic, ReadOnlyIfRegistration, ContributorOrPublicForPointers
 
 
@@ -152,19 +152,22 @@ class NodeContributorsList(generics.ListAPIView, ListFilterMixin, NodeMixin):
         return self.get_queryset_from_request()
 
 
+# TODO: Support creating registrations
 class NodeRegistrationsList(generics.ListAPIView, NodeMixin):
     """Registrations of the current node.
 
     Registrations are read-only snapshots of a project. This view lists all of the existing registrations
-     created for the current node."""
+    created for the current node.
+     """
     permission_classes = (
         ContributorOrPublic,
         drf_permissions.IsAuthenticatedOrReadOnly,
     )
 
-    serializer_class = NodeSerializer
+    serializer_class = NodeRegistrationSerializer
 
     # overrides ListAPIView
+    # TODO: Filter out retractions by default
     def get_queryset(self):
         nodes = self.get_node().node__registrations
         user = self.request.user

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -208,6 +208,9 @@ class NodeChildrenList(generics.ListCreateAPIView, NodeMixin):
         serializer.save(creator=user, parent=self.get_node())
 
 
+# TODO: Make NodeLinks filterable. They currently aren't filterable because we have can't
+# currently query on a Pointer's node's attributes.
+# e.g. Pointer.find(Q('node.title', 'eq', ...)) doesn't work
 class NodeLinksList(generics.ListCreateAPIView, NodeMixin):
     """Node Links to other nodes.
 
@@ -222,8 +225,11 @@ class NodeLinksList(generics.ListCreateAPIView, NodeMixin):
     serializer_class = NodeLinksSerializer
 
     def get_queryset(self):
-        pointers = self.get_node().nodes_pointer
-        return pointers
+        return [
+            pointer for pointer in
+            self.get_node().nodes_pointer
+            if not pointer.node.is_deleted
+        ]
 
 
 class NodeLinksDetail(generics.RetrieveDestroyAPIView, NodeMixin):

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -239,6 +239,7 @@ class NodeLinksList(generics.ListCreateAPIView, NodeMixin):
     permission_classes = (
         drf_permissions.IsAuthenticatedOrReadOnly,
         ContributorOrPublic,
+        ReadOnlyIfRegistration,
     )
 
     serializer_class = NodeLinksSerializer
@@ -321,6 +322,7 @@ class NodeFilesList(generics.ListAPIView, NodeMixin):
     permission_classes = (
         drf_permissions.IsAuthenticatedOrReadOnly,
         ContributorOrPublic,
+        ReadOnlyIfRegistration,
     )
 
     def get_valid_self_link_methods(self, root_folder=False):

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -385,7 +385,7 @@ class TestNodeCreate(ApiTestCase):
     def test_creates_public_project_logged_out(self):
         res = self.app.post_json_api(self.url, self.public_project, expect_errors=True)
         assert_equal(res.status_code, 401)
-        assert 'detail' in res.json['errors'][0]
+        assert_in('detail', res.json['errors'][0])
 
     def test_creates_public_project_logged_in(self):
         res = self.app.post_json_api(self.url, self.public_project, auth=self.user_one.auth)
@@ -398,7 +398,7 @@ class TestNodeCreate(ApiTestCase):
     def test_creates_private_project_logged_out(self):
         res = self.app.post_json_api(self.url, self.private_project, expect_errors=True)
         assert_equal(res.status_code, 401)
-        assert 'detail' in res.json['errors'][0]
+        assert_in('detail', res.json['errors'][0])
 
     def test_creates_private_project_logged_in_contributor(self):
         res = self.app.post_json_api(self.url, self.private_project, auth=self.user_one.auth)
@@ -463,7 +463,7 @@ class TestNodeDetail(ApiTestCase):
     def test_return_private_project_details_logged_out(self):
         res = self.app.get(self.private_url, expect_errors=True)
         assert_equal(res.status_code, 401)
-        assert 'detail' in res.json['errors'][0]
+        assert_in('detail', res.json['errors'][0])
 
 
     def test_return_private_project_details_logged_in_contributor(self):
@@ -477,7 +477,7 @@ class TestNodeDetail(ApiTestCase):
     def test_return_private_project_details_logged_in_non_contributor(self):
         res = self.app.get(self.private_url, auth=self.user_two.auth, expect_errors=True)
         assert_equal(res.status_code, 403)
-        assert 'detail' in res.json['errors'][0]
+        assert_in('detail', res.json['errors'][0])
 
     def test_top_level_project_has_no_parent(self):
         res = self.app.get(self.public_url)
@@ -578,7 +578,7 @@ class TestNodeUpdate(ApiTestCase):
             'public': True,
         }, expect_errors=True)
         assert_equal(res.status_code, 401)
-        assert 'detail' in res.json['errors'][0]
+        assert_in('detail', res.json['errors'][0])
 
 
     def test_update_public_project_logged_in(self):
@@ -603,7 +603,7 @@ class TestNodeUpdate(ApiTestCase):
             'public': True,
         }, auth=self.user_two.auth, expect_errors=True)
         assert_equal(res.status_code, 403)
-        assert 'detail' in res.json['errors'][0]
+        assert_in('detail', res.json['errors'][0])
 
     def test_cannot_update_a_registration(self):
         registration = RegistrationFactory(project=self.public_project, creator=self.user)
@@ -629,7 +629,7 @@ class TestNodeUpdate(ApiTestCase):
             'public': False,
         }, expect_errors=True)
         assert_equal(res.status_code, 401)
-        assert 'detail' in res.json['errors'][0]
+        assert_in('detail', res.json['errors'][0])
 
     def test_update_private_project_logged_in_contributor(self):
         res = self.app.put_json_api(self.private_url, {
@@ -652,7 +652,7 @@ class TestNodeUpdate(ApiTestCase):
             'public': False,
         }, auth=self.user_two.auth, expect_errors=True)
         assert_equal(res.status_code, 403)
-        assert 'detail' in res.json['errors'][0]
+        assert_in('detail', res.json['errors'][0])
 
     def test_update_project_sanitizes_html_properly(self):
         """Post request should update resource, and any HTML in fields should be stripped"""
@@ -704,7 +704,7 @@ class TestNodeUpdate(ApiTestCase):
             'public': False,
         }, auth=self.user_two.auth, expect_errors=True)
         assert_equal(res.status_code, 403)
-        assert 'detail' in res.json['errors'][0]
+        assert_in('detail', res.json['errors'][0])
 
         # Test creator writing to public field (supposed to be read-only)
         res = self.app.patch_json_api(url, {
@@ -717,7 +717,7 @@ class TestNodeUpdate(ApiTestCase):
     def test_partial_update_public_project_logged_out(self):
         res = self.app.patch_json_api(self.public_url, {'title': self.new_title}, expect_errors=True)
         assert_equal(res.status_code, 401)
-        assert 'detail' in res.json['errors'][0]
+        assert_in('detail', res.json['errors'][0])
 
     def test_partial_update_public_project_logged_in(self):
         res = self.app.patch_json_api(self.public_url, {
@@ -734,12 +734,12 @@ class TestNodeUpdate(ApiTestCase):
             'title': self.new_title,
         }, auth=self.user_two.auth, expect_errors=True)
         assert_equal(res.status_code, 403)
-        assert 'detail' in res.json['errors'][0]
+        assert_in('detail', res.json['errors'][0])
 
     def test_partial_update_private_project_logged_out(self):
         res = self.app.patch_json_api(self.private_url, {'title': self.new_title}, expect_errors=True)
         assert_equal(res.status_code, 401)
-        assert 'detail' in res.json['errors'][0]
+        assert_in('detail', res.json['errors'][0])
 
     def test_partial_update_private_project_logged_in_contributor(self):
         res = self.app.patch_json_api(self.private_url, {'title': self.new_title}, auth=self.user.auth)
@@ -755,7 +755,7 @@ class TestNodeUpdate(ApiTestCase):
                                   auth=self.user_two.auth,
                                   expect_errors=True)
         assert_equal(res.status_code, 403)
-        assert 'detail' in res.json['errors'][0]
+        assert_in('detail', res.json['errors'][0])
 
 
 class TestNodeDelete(ApiTestCase):
@@ -1281,6 +1281,7 @@ class TestNodeLinksList(ApiTestCase):
         res_json = res.json['data']
         assert_equal(len(res_json), original_length - 1)
 
+
 class TestNodeTags(ApiTestCase):
     def setUp(self):
         super(TestNodeTags, self).setUp()
@@ -1371,9 +1372,11 @@ class TestNodeTags(ApiTestCase):
         assert_equal(res.status_code, 200)
         assert_equal(len(res.json['data']['attributes']['tags']), 0)
 
-class TestCreateNodeLink(ApiTestCase):
+
+class TestNodeLinkCreate(ApiTestCase):
+
     def setUp(self):
-        super(TestCreateNodeLink, self).setUp()
+        super(TestNodeLinkCreate, self).setUp()
         self.user = AuthUserFactory()
         self.project = ProjectFactory(is_public=False, creator=self.user)
         self.pointer_project = ProjectFactory(is_public=False, creator=self.user)
@@ -1395,12 +1398,12 @@ class TestCreateNodeLink(ApiTestCase):
     def test_creates_public_node_pointer_logged_out(self):
         res = self.app.post(self.public_url, self.public_payload, expect_errors=True)
         assert_equal(res.status_code, 401)
-        assert 'detail' in res.json['errors'][0]
+        assert_in('detail', res.json['errors'][0])
 
     def test_creates_public_node_pointer_logged_in(self):
         res = self.app.post(self.public_url, self.public_payload, auth=self.user_two.auth, expect_errors=True)
         assert_equal(res.status_code, 403)
-        assert 'detail' in res.json['errors'][0]
+        assert_in('detail', res.json['errors'][0])
 
         res = self.app.post(self.public_url, self.public_payload, auth=self.user.auth)
         assert_equal(res.status_code, 201)
@@ -1410,8 +1413,7 @@ class TestCreateNodeLink(ApiTestCase):
     def test_creates_private_node_pointer_logged_out(self):
         res = self.app.post(self.private_url, self.private_payload, expect_errors=True)
         assert_equal(res.status_code, 401)
-        assert 'detail' in res.json['errors'][0]
-
+        assert_in('detail', res.json['errors'][0])
 
     def test_creates_private_node_pointer_logged_in_contributor(self):
         res = self.app.post(self.private_url, self.private_payload, auth=self.user.auth)
@@ -1422,12 +1424,12 @@ class TestCreateNodeLink(ApiTestCase):
     def test_creates_private_node_pointer_logged_in_non_contributor(self):
         res = self.app.post(self.private_url, self.private_payload, auth=self.user_two.auth, expect_errors=True)
         assert_equal(res.status_code, 403)
-        assert 'detail' in res.json['errors'][0]
+        assert_in('detail', res.json['errors'][0])
 
     def test_create_node_pointer_non_contributing_node_to_contributing_node(self):
         res = self.app.post(self.private_url, self.user_two_payload, auth=self.user_two.auth, expect_errors=True)
         assert_equal(res.status_code, 403)
-        assert 'detail' in res.json['errors'][0]
+        assert_in('detail', res.json['errors'][0])
 
     def test_create_node_pointer_contributing_node_to_non_contributing_node(self):
         res = self.app.post(self.private_url, self.user_two_payload, auth=self.user.auth)
@@ -1438,26 +1440,26 @@ class TestCreateNodeLink(ApiTestCase):
     def test_create_pointer_non_contributing_node_to_fake_node(self):
         res = self.app.post(self.private_url, self.fake_payload, auth=self.user_two.auth, expect_errors=True)
         assert_equal(res.status_code, 403)
-        assert 'detail' in res.json['errors'][0]
+        assert_in('detail', res.json['errors'][0])
 
     def test_create_pointer_contributing_node_to_fake_node(self):
         res = self.app.post(self.private_url, self.fake_payload, auth=self.user.auth, expect_errors=True)
         assert_equal(res.status_code, 404)
-        assert 'detail' in res.json['errors'][0]
+        assert_in('detail', res.json['errors'][0])
 
     def test_create_fake_node_pointing_to_contributing_node(self):
         res = self.app.post(self.fake_url, self.private_payload, auth=self.user.auth, expect_errors=True)
         assert_equal(res.status_code, 404)
-        assert 'detail' in res.json['errors'][0]
+        assert_in('detail', res.json['errors'][0])
 
         res = self.app.post(self.fake_url, self.private_payload, auth=self.user_two.auth, expect_errors=True)
         assert_equal(res.status_code, 404)
-        assert 'detail' in res.json['errors'][0]
+        assert_in('detail', res.json['errors'][0])
 
     def test_create_node_pointer_to_itself(self):
         res = self.app.post(self.public_url, self.point_to_itself_payload, auth=self.user_two.auth, expect_errors=True)
         assert_equal(res.status_code, 403)
-        assert 'detail' in res.json['errors'][0]
+        assert_in('detail', res.json['errors'][0])
 
         res = self.app.post(self.public_url, self.point_to_itself_payload, auth=self.user.auth)
         assert_equal(res.status_code, 201)
@@ -1472,7 +1474,7 @@ class TestCreateNodeLink(ApiTestCase):
 
         res = self.app.post(self.public_url, self.public_payload, auth=self.user.auth, expect_errors=True)
         assert_equal(res.status_code, 400)
-        assert 'detail' in res.json['errors'][0]
+        assert_in('detail', res.json['errors'][0])
 
 
 class TestNodeFilesList(ApiTestCase):
@@ -1503,7 +1505,7 @@ class TestNodeFilesList(ApiTestCase):
     def test_returns_private_files_logged_out(self):
         res = self.app.get(self.private_url, expect_errors=True)
         assert_equal(res.status_code, 401)
-        assert 'detail' in res.json['errors'][0]
+        assert_in('detail', res.json['errors'][0])
 
     def test_returns_private_files_logged_in_contributor(self):
         res = self.app.get(self.private_url, auth=self.user.auth)
@@ -1515,7 +1517,7 @@ class TestNodeFilesList(ApiTestCase):
     def test_returns_private_files_logged_in_non_contributor(self):
         res = self.app.get(self.private_url, auth=self.user_two.auth, expect_errors=True)
         assert_equal(res.status_code, 403)
-        assert 'detail' in res.json['errors'][0]
+        assert_in('detail', res.json['errors'][0])
 
     def test_returns_addon_folders(self):
         user_auth = Auth(self.user)
@@ -1563,7 +1565,7 @@ class TestNodeFilesList(ApiTestCase):
         mock_waterbutler_request.return_value = mock_res
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
         assert_equal(res.status_code, 403)
-        assert 'detail' in res.json['errors'][0]
+        assert_in('detail', res.json['errors'][0])
 
 
     @mock.patch('api.nodes.views.requests.get')
@@ -1575,7 +1577,7 @@ class TestNodeFilesList(ApiTestCase):
         mock_waterbutler_request.return_value = mock_res
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
         assert_equal(res.status_code, 400)
-        assert 'detail' in res.json['errors'][0]
+        assert_in('detail', res.json['errors'][0])
 
     def test_files_list_does_not_contain_empty_relationships_object(self):
         res = self.app.get(self.public_url, auth=self.user.auth)
@@ -1619,7 +1621,7 @@ class TestNodeLinkDetail(ApiTestCase):
     def test_returns_private_node_pointer_detail_logged_out(self):
         res = self.app.get(self.private_url, expect_errors=True)
         assert_equal(res.status_code, 401)
-        assert 'detail' in res.json['errors'][0]
+        assert_in('detail', res.json['errors'][0])
 
     def test_returns_private_node_pointer_detail_logged_in_contributor(self):
         res = self.app.get(self.private_url, auth=self.user.auth)
@@ -1631,7 +1633,7 @@ class TestNodeLinkDetail(ApiTestCase):
     def returns_private_node_pointer_detail_logged_in_non_contributor(self):
         res = self.app.get(self.private_url, auth=self.user_two.auth, expect_errors=True)
         assert_equal(res.status_code, 403)
-        assert 'detail' in res.json['errors'][0]
+        assert_in('detail', res.json['errors'][0])
 
 
 class TestDeleteNodeLink(ApiTestCase):
@@ -1656,7 +1658,7 @@ class TestDeleteNodeLink(ApiTestCase):
     def test_deletes_public_node_pointer_logged_out(self):
         res = self.app.delete(self.public_url, expect_errors=True)
         assert_equal(res.status_code, 401)
-        assert 'detail' in res.json['errors'][0].keys()
+        assert_in('detail', res.json['errors'][0].keys())
 
     def test_deletes_public_node_pointer_fails_if_bad_auth(self):
         node_count_before = len(self.public_project.nodes_pointer)
@@ -1664,7 +1666,7 @@ class TestDeleteNodeLink(ApiTestCase):
         self.public_project.reload()
         # This is could arguably be a 405, but we don't need to go crazy with status codes
         assert_equal(res.status_code, 403)
-        assert 'detail' in res.json['errors'][0]
+        assert_in('detail', res.json['errors'][0])
 
         assert_equal(node_count_before, len(self.public_project.nodes_pointer))
 
@@ -1678,7 +1680,7 @@ class TestDeleteNodeLink(ApiTestCase):
     def test_deletes_private_node_pointer_logged_out(self):
         res = self.app.delete(self.private_url, expect_errors=True)
         assert_equal(res.status_code, 401)
-        assert 'detail' in res.json['errors'][0]
+        assert_in('detail', res.json['errors'][0])
 
     def test_deletes_private_node_pointer_logged_in_contributor(self):
         res = self.app.delete(self.private_url, auth=self.user.auth)
@@ -1689,7 +1691,7 @@ class TestDeleteNodeLink(ApiTestCase):
     def test_deletes_private_node_pointer_logged_in_non_contributor(self):
         res = self.app.delete(self.private_url, auth=self.user_two.auth, expect_errors=True)
         assert_equal(res.status_code, 403)
-        assert 'detail' in res.json['errors'][0]
+        assert_in('detail', res.json['errors'][0])
 
 
     def test_return_deleted_public_node_pointer(self):

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -1476,6 +1476,14 @@ class TestNodeLinkCreate(ApiTestCase):
         assert_equal(res.status_code, 400)
         assert_in('detail', res.json['errors'][0])
 
+    def test_cannot_add_link_to_registration(self):
+        registration = RegistrationFactory(creator=self.user)
+
+        url = '/{}nodes/{}/node_links/'.format(API_BASE, registration._id)
+        payload = {'target_node_id': self.public_pointer_project._id}
+        res = self.app.post(url, self.public_payload, auth=self.user.auth, expect_errors=True)
+        assert_equal(res.status_code, 403)
+
 
 class TestNodeFilesList(ApiTestCase):
 

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -990,6 +990,16 @@ class TestNodeRegistrationList(ApiTestCase):
         assert_equal(res.status_code, 403)
         assert 'detail' in res.json['errors'][0]
 
+class TestNodeRegistrationListFiltering(ApiTestCase):
+
+    def test_filtering_registrations_by_title(self):
+        user = AuthUserFactory()
+
+        project = ProjectFactory(creator=self.user)
+        registration = RegistrationFactory(creator=self.user, project=self.project)
+
+        url = '/{}nodes/{}/registrations/'.format(API_BASE, self.project._id)
+
 
 class TestNodeChildrenList(ApiTestCase):
     def setUp(self):

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -1194,7 +1194,7 @@ class TestNodeLinksList(ApiTestCase):
     def test_return_private_node_pointers_logged_out(self):
         res = self.app.get(self.private_url, expect_errors=True)
         assert_equal(res.status_code, 401)
-        assert 'detail' in res.json['errors'][0]
+        assert_in('detail', res.json['errors'][0])
 
     def test_return_private_node_pointers_logged_in_contributor(self):
         res = self.app.get(self.private_url, auth=self.user.auth)
@@ -1207,8 +1207,19 @@ class TestNodeLinksList(ApiTestCase):
     def test_return_private_node_pointers_logged_in_non_contributor(self):
         res = self.app.get(self.private_url, auth=self.user_two.auth, expect_errors=True)
         assert_equal(res.status_code, 403)
-        assert 'detail' in res.json['errors'][0]
+        assert_in('detail', res.json['errors'][0])
 
+    def test_deleted_links_not_returned(self):
+        res = self.app.get(self.public_url)
+        res_json = res.json['data']
+        original_length = len(res_json)
+
+        self.public_pointer_project.is_deleted = True
+        self.public_pointer_project.save()
+
+        res = self.app.get(self.public_url)
+        res_json = res.json['data']
+        assert_equal(len(res_json), original_length - 1)
 
 class TestNodeTags(ApiTestCase):
     def setUp(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1555,6 +1555,13 @@ class TestNode(OsfTestCase):
             }
         )
 
+    def test_add_pointer_fails_for_registrations(self):
+        node = ProjectFactory()
+        registration = RegistrationFactory(creator=self.user)
+
+        with assert_raises(NodeStateError):
+            registration.add_pointer(node, auth=self.consolidate_auth)
+
     def test_get_points_exclude_folders(self):
         user = UserFactory()
         pointer_project = ProjectFactory(is_public=True)  # project that points to another project

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -1298,6 +1298,9 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
                 'Pointer to node {0} already in list'.format(node._id)
             )
 
+        if self.is_registration:
+            raise NodeStateError('Cannot add a pointer to a registration')
+
         # If a folder, prevent more than one pointer to that folder. This will prevent infinite loops on the Dashboard.
         # Also, no pointers to the dashboard project, which could cause loops as well.
         already_pointed = node.pointed


### PR DESCRIPTION
### Purpose

The purpose of this PR is two-fold:

- Filtering nodes against `is_registration` and `tags` was broken (OSF-4323).
- Some actions on registrations should be disallowed but are currently allowed (OSF-4439).

### Changes

- Fix bug in filtering `ListFields`
- Make  `registration` and tags` filterable fields
- Make Node children filterable 
- Nodes, contributors 
- Expand test coverage for filtering and permissions

### Tickets

https://openscience.atlassian.net/browse/OSF-4323
https://openscience.atlassian.net/browse/OSF-4439

### TODO

- [x] Complete audit of filterable fields on all serializers
- [x] Complete audit of permissions classes fields on all view classes