### PR TITLE
[ready for review] Fixes for OAuth2 application registration

### DIFF
--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -5,6 +5,7 @@ import urlparse
 import itertools
 import datetime as dt
 
+from framework.mongo.validators import string_required
 import bson
 import pytz
 import itsdangerous
@@ -48,11 +49,6 @@ def generate_confirm_token():
 
 def generate_claim_token():
     return security.random_string(30)
-
-
-def string_required(value):
-    if value is None or value == '':
-        raise ValidationValueError('Value must not be empty.')
 
 
 def validate_history_item(item):

--- a/framework/mongo/validators.py
+++ b/framework/mongo/validators.py
@@ -1,0 +1,9 @@
+"""
+Validators for use in ModularODM
+"""
+from modularodm.exceptions import ValidationValueError
+
+
+def string_required(value):
+    if value is None or value == '':
+        raise ValidationValueError('Value must not be empty.')

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1034,6 +1034,11 @@ class TestApiOAuth2Application(OsfTestCase):
             api_app = ApiOAuth2ApplicationFactory(callback_url="itms://itunes.apple.com/us/app/apple-store/id375380948?mt=8")
             api_app.save()
 
+    def test_name_cannot_be_blank(self):
+        with assert_raises(ValidationError):
+            api_app = ApiOAuth2ApplicationFactory(name='')
+            api_app.save()
+
     def test_long_name_raises_exception(self):
         long_name = ('JohnJacobJingelheimerSchmidtHisNameIsMyN' * 5) + 'a'
         with assert_raises(ValidationError):

--- a/website/oauth/models/__init__.py
+++ b/website/oauth/models/__init__.py
@@ -22,6 +22,7 @@ from framework.auth import cas
 from framework.exceptions import HTTPError, PermissionsError
 from framework.mongo import ObjectId, StoredObject
 from framework.mongo.utils import unique_on
+from framework.mongo.validators import string_required
 from framework.sessions import session
 from website import settings
 from website.oauth.utils import PROVIDER_LOOKUP
@@ -383,7 +384,7 @@ class ApiOAuth2Application(StoredObject):
                                 required=True)
 
     # User-specified application descriptors
-    name = fields.StringField(index=True, required=True, validate=MaxLengthValidator(200))
+    name = fields.StringField(index=True, required=True, validate=[string_required, MaxLengthValidator(200)])
     description = fields.StringField(required=False, validate=MaxLengthValidator(1000))
 
     date_created = fields.DateTimeField(auto_now_add=datetime.datetime.utcnow,

--- a/website/static/js/osfLanguage.js
+++ b/website/static/js/osfLanguage.js
@@ -77,7 +77,7 @@ module.exports = {
     apiOauth2Application: {
         discardUnchanged: 'Are you sure you want to discard your unsaved changes?',
         deactivateConfirm: 'Are you sure you want to deactivate this application for all users and revoke all access tokens? This cannot be reversed.',
-        deactivateError: 'Could not delete application. ' + REFRESH_OR_SUPPORT,
+        deactivateError: 'Could not deactivate application. Please wait a few minutes and try again, or contact ' + SUPPORT_LINK + ' if the problem persists.',
         dataFetchError: 'Data not loaded. ' + REFRESH_OR_SUPPORT,
         dataListFetchError: 'Could not load list of developer applications at this time. ' + REFRESH_OR_SUPPORT,
         dataSendError: 'Error sending data to the server: check that all fields are valid, or contact ' + SUPPORT_LINK + ' if the problem persists.',


### PR DESCRIPTION
Refs [#OSF-4430] and [#OSF-4433].

## Purpose
Addresses unclear or surprising behaviors when registering an OAuth2 Developer App on the OSF. This includes the case where an all-HTML name was blanked by the sanitizer, and the rare case where a user might want to deactivate a new OAuth2 application immediately.

## Summary of changes
- Move the `string_required` validator from `framework.auth.core` to a new centralized location, `framework.mongo.validators`
- Use the above validator in the `name` field of `ApiOAuth2Application`.
- Change the wording of the "deactivation failed" error message to specify that it may work if the user waits a few minutes 

New error message sample:
![screen shot 2015-09-10 at 10 13 39 am](https://cloud.githubusercontent.com/assets/2957073/9792380/db87ed9a-57ad-11e5-815c-a3c7d895d07e.png)

## Other
Cleaned up and reordered imports in `framework.auth.core`; auth exceptions were being imported in two different ways. I've separated the cleanup work into its own commit.