### PR TITLE
Fix broken archiver

### DIFF
--- a/website/app.py
+++ b/website/app.py
@@ -148,5 +148,3 @@ def apply_middlewares(flask_app, settings):
         flask_app.wsgi_app = ProxyFix(flask_app.wsgi_app)
 
     return flask_app
-
-from website.archiver import listeners  # noqa

--- a/website/settings/celeryconfig.py
+++ b/website/settings/celeryconfig.py
@@ -31,5 +31,6 @@ CELERY_IMPORTS = (
     'framework.email.tasks',
     'framework.analytics.tasks',
     'website.mailchimp_utils',
-    'website.notifications.tasks'
+    'website.notifications.tasks',
+    'website.archiver.tasks'
 )


### PR DESCRIPTION
## Purpose:

Resolve an issue resulting in registrations getting stuck in the archiving process.
    
Something happened during the addition of Celery Beat and changing how we setup our Celery workers that caused a circular import with Archiver as well as stopped `website.archiver.tasks` from being imported into the the task pool.
    
## Changes:

- Remove import in `website.app` causing a circular import
- Add `website.archiver.tasks` to CELERY_IMPORTS

## Notes:
    
Resolves-issue: [#OSF-4378](https://openscience.atlassian.net/browse/OSF-4378)
