### PR TITLE
[Hotfix] Restore Save and Cancel  in folderpicker on Chrome

### DIFF
--- a/website/static/js/folderpicker.js
+++ b/website/static/js/folderpicker.js
@@ -76,7 +76,7 @@ function treebeardSelectView(item) {
     var templateUnchecked = m('input', {
         type: 'radio',
         onclick: setTempPicked.bind(tb),
-        onchange: function(evt) {
+        onmousedown: function(evt) {
             tb.options.onPickFolder(evt, item);
         },
         name: '#' + tb.options.divID + INPUT_NAME


### PR DESCRIPTION
Fixes:  Jira issue OSF-4275 and OSF-4424

Purpose
-----------

In the latest version of the Chrome browser, any Add On that uses the Folder Picker (Box, Google Drive, Mendeley) will not allow a user to change folders.  The Save and Cancel button never appear.

Current:

![screen shot 2015-09-10 at 11 25 38 am](https://cloud.githubusercontent.com/assets/6232068/9793208/479811fa-57b2-11e5-9017-49dab7fa0347.png)

After fix:

![screen shot 2015-09-10 at 11 27 07 am](https://cloud.githubusercontent.com/assets/6232068/9793214/4e8d759a-57b2-11e5-9b57-2a54e6be116a.png)

Changes
------------

1.  The onChange event was happening twice, and was being lost during the redraw of the page.  I have changed the onChange event to an onMouseOver when a folder is selected.