### PR TITLE
Fix circular import in Archiver

### DIFF
--- a/website/archiver/listeners.py
+++ b/website/archiver/listeners.py
@@ -2,7 +2,6 @@ import celery
 
 from framework.tasks import handlers
 
-from website.archiver import tasks
 from website.archiver import utils as archiver_utils
 from website.archiver import (
     ARCHIVER_UNCAUGHT_ERROR,
@@ -21,6 +20,7 @@ def after_register(src, dst, user):
     :param user: registration initiator
     """
     archiver_utils.before_archive(dst, user)
+    from website.archiver import tasks  # Avoid circular import in app.py
     if dst.root != dst:  # if not top-level registration
         return
     archive_tasks = [tasks.archive(job_pk=t.archive_job._id) for t in dst.node_and_primary_descendants()]

--- a/website/settings/celeryconfig.py
+++ b/website/settings/celeryconfig.py
@@ -31,5 +31,6 @@ CELERY_IMPORTS = (
     'framework.email.tasks',
     'framework.analytics.tasks',
     'website.mailchimp_utils',
-    'website.notifications.tasks'
+    'website.notifications.tasks',
+    'website.archiver.tasks'
 )


### PR DESCRIPTION
## Purpose
Per icereval the circular import we removed will cause problems when
our uwsgi workers restart. This should resolve the circular import,
and ensure that Archivers tasks can be run by Celery.

[#OSF-3278]