### PR TITLE
[WIP] Convert misc pages to markupsafe (markupsafe-4)

### DIFF
--- a/framework/forms/__init__.py
+++ b/framework/forms/__init__.py
@@ -41,10 +41,11 @@ class BootstrapTextArea(TextArea):
 
 
 def push_errors_to_status(errors):
+    # TODO: Review whether errors contain custom HTML. If so this change might cause some display anomalies.
     if errors:
         for field, _ in errors.items():
             for error in errors[field]:
-                status.push_status_message(error)
+                status.push_status_message(error, trust=False)
 
 
 class NoHtmlCharacters(object):

--- a/website/conferences/views.py
+++ b/website/conferences/views.py
@@ -201,7 +201,7 @@ def conference_results(meeting):
     data = conference_data(meeting)
 
     return {
-        'data': json.dumps(data),
+        'data': data,
         'label': meeting,
         'meeting': conf.to_storage(),
         # Needed in order to use base.mako namespace

--- a/website/language.py
+++ b/website/language.py
@@ -22,7 +22,7 @@ REGISTRATION_SUCCESS = '''Registration successful. Please check {email} to confi
 # Shown if registration is turned off in website.settings
 REGISTRATION_UNAVAILABLE = 'Registration currently unavailable.'
 
-ALREADY_REGISTERED = '''The email <em>{email}</em> has already been registered.'''
+ALREADY_REGISTERED = u'The email <em>{email}</em> has already been registered.'
 
 # Shown if user tries to login with an email that is not yet confirmed
 UNCONFIRMED = ('This login email has been registered but not confirmed. Please check your email (and spam folder).'
@@ -48,7 +48,7 @@ LOGOUT = '''
 You have successfully logged out.
 '''
 
-EMAIL_NOT_FOUND = '''
+EMAIL_NOT_FOUND = u'''
 <strong>{email}</strong> was not found in our records.
 '''
 
@@ -75,10 +75,10 @@ MERGE_COMPLETE = 'Accounts successfully merged.'
 MERGE_CONFIRMATION_REQUIRED_SHORT = 'Confirmation Required: Merge Accounts'
 
 MERGE_CONFIRMATION_REQUIRED_LONG = (
-    '<p>This email is confirmed to another account. '
-    'Would you like to merge <em>{user_to_merge.username}</em> with the account '
-    '<em>{user.username}</em>?<p>'
-    '<a class="btn btn-primary" href="?confirm_merge">Confirm merge</a> '
+    u'<p>This email is confirmed to another account. '
+    u'Would you like to merge <em>{user_to_merge.username}</em> with the account '
+    u'<em>{user.username}</em>?<p>'
+    u'<a class="btn btn-primary" href="?confirm_merge">Confirm merge</a> '
 )
 
 # Node Actions
@@ -89,17 +89,17 @@ AFTER_REGISTER_ARCHIVING = (
 )
 
 BEFORE_REGISTER_HAS_POINTERS = (
-    'This {category} contains links to other projects. Links will be copied '
-    'into your registration, but the projects that they link to will not be '
-    'registered. If you wish to register the linked projects, you must fork '
-    'them from the original project before registering.'
+    u'This {category} contains links to other projects. Links will be copied '
+    u'into your registration, but the projects that they link to will not be '
+    u'registered. If you wish to register the linked projects, you must fork '
+    u'them from the original project before registering.'
 )
 
 BEFORE_FORK_HAS_POINTERS = (
-    'This {category} contains links to other projects. Links will be copied '
-    'into your fork, but the projects that they link to will not be forked. '
-    'If you wish to fork the linked projects, they need to be forked from the '
-    'original project.'
+    u'This {category} contains links to other projects. Links will be copied '
+    u'into your fork, but the projects that they link to will not be forked. '
+    u'If you wish to fork the linked projects, they need to be forked from the '
+    u'original project.'
 )
 
 REGISTRATION_INFO = '''
@@ -178,11 +178,11 @@ TEMPLATED_FROM_PREFIX = "Templated from "
 
 # MFR Error handling
 ERROR_PREFIX = "Unable to render. <a href='?action=download'>Download</a> file to view it."
-SUPPORT = "Contact support@osf.io for further assistance."
+SUPPORT = u"Contact support@osf.io for further assistance."
 
-# Custom Error Messages w/ support
-STATA_VERSION_ERROR = 'Version of given Stata file is not 104, 105, 108, 113 (Stata 8/9), 114 (Stata 10/11) or 115 (Stata 12)<p>{0}</p>'.format(SUPPORT)
-BLANK_OR_CORRUPT_TABLE_ERROR = 'Is this a valid instance of this file type?<p>{0}</p>'.format(SUPPORT)
+# Custom Error Messages w/ support  # TODO: Where are these used?
+STATA_VERSION_ERROR = u'Version of given Stata file is not 104, 105, 108, 113 (Stata 8/9), 114 (Stata 10/11) or 115 (Stata 12)<p>{0}</p>'.format(SUPPORT)
+BLANK_OR_CORRUPT_TABLE_ERROR = u'Is this a valid instance of this file type?<p>{0}</p>'.format(SUPPORT)
 
 #disk saving mode
 DISK_SAVING_MODE = 'Forks, registrations, and uploads to OSF Storage uploads are temporarily disabled while we are undergoing a server upgrade. These features will return shortly.'

--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -6,6 +6,7 @@ import httplib as http  # TODO: Inconsistent usage of aliased import
 from dateutil.parser import parse as parse_date
 
 from flask import request
+import markupsafe
 from modularodm.exceptions import ValidationError, NoResultsFound, MultipleResultsFound
 from modularodm import Q
 
@@ -343,9 +344,11 @@ def user_account_password(auth, **kwargs):
         user.change_password(old_password, new_password, confirm_password)
         user.save()
     except ChangePasswordError as error:
-        push_status_message('<br />'.join(error.messages) + '.', kind='warning')
+        # TODO: Why is this pushing one single message, instead of a separate message for each error? The <br> is the only reason we need to trust at all
+        safe_messages = [markupsafe.escape(m) for m in error.messages]
+        push_status_message(u'<br />'.join(safe_messages) + '.', kind='warning', trust=True)
     else:
-        push_status_message('Password updated successfully.', kind='success')
+        push_status_message('Password updated successfully.', kind='success', trust=False)
 
     return redirect(web_url_for('user_account'))
 

--- a/website/routes.py
+++ b/website/routes.py
@@ -745,11 +745,21 @@ def make_url_map(app):
 
     process_rules(app, [
 
-        Rule('/search/', 'get', {}, OsfWebRenderer('search.mako')),
-        Rule('/share/', 'get', {}, OsfWebRenderer('share_search.mako')),
-        Rule('/share/registration/', 'get', {'register': settings.SHARE_REGISTRATION_URL}, OsfWebRenderer('share_registration.mako')),
-        Rule('/share/help/', 'get', {'help': settings.SHARE_API_DOCS_URL}, OsfWebRenderer('share_api_docs.mako')),
-        Rule('/share_dashboard/', 'get', {}, OsfWebRenderer('share_dashboard.mako')),
+        Rule('/search/', 'get', {}, OsfWebRenderer('search.mako', trust=False)),
+        Rule('/share/', 'get', {}, OsfWebRenderer('share_search.mako', trust=False)),  # TODO: Couldn't test this locally
+        Rule(
+            '/share/registration/',
+            'get',
+            {'register': settings.SHARE_REGISTRATION_URL},
+            OsfWebRenderer('share_registration.mako', trust=False)
+        ),
+        Rule(  # TODO: This route/template is an iframe that loads a blank page (src='') on production
+            '/share/help/',
+            'get',
+            {'help': settings.SHARE_API_DOCS_URL},
+            OsfWebRenderer('share_api_docs.mako', trust=False)
+        ),
+        Rule('/share_dashboard/', 'get', {}, OsfWebRenderer('share_dashboard.mako', trust=False)),  # TODO: Dead route and template never existed; can be deleted
         Rule('/share/atom/', 'get', search_views.search_share_atom, xml_renderer),
         Rule('/api/v1/user/search/', 'get', search_views.search_contributor, json_renderer),
 
@@ -780,8 +790,8 @@ def make_url_map(app):
 
     process_rules(app, [
 
-        Rule('/', 'get', website_views.index, OsfWebRenderer('index.mako')),
-        Rule('/goodbye/', 'get', goodbye, OsfWebRenderer('index.mako')),
+        Rule('/', 'get', website_views.index, OsfWebRenderer('index.mako', trust=False)),
+        Rule('/goodbye/', 'get', goodbye, OsfWebRenderer('index.mako', trust=False)),
 
         Rule(
             [
@@ -835,7 +845,7 @@ def make_url_map(app):
             ],
             'post',
             project_views.node.project_set_privacy,
-            OsfWebRenderer('project/project.mako')  # TODO: Should this be notemplate? (post request)
+            OsfWebRenderer('project/project.mako', trust=False)  # TODO: Should this be notemplate? (post request)
         ),
 
         ### Logs ###
@@ -882,7 +892,6 @@ def make_url_map(app):
             OsfWebRenderer('project/registrations.mako', trust=False)
         ),
 
-        # TODO: Can't create a registration locally, so can't test this one..?
         Rule(
             [
                 '/project/<pid>/retraction/',
@@ -925,7 +934,6 @@ def make_url_map(app):
 
         # Note: Web endpoint for files view must pass `mode` = `page` to
         # include project view data and JS includes
-        # TODO: Start waterbutler to test
         Rule(
             [
                 '/project/<pid>/files/',

--- a/website/routes.py
+++ b/website/routes.py
@@ -133,10 +133,18 @@ def make_url_map(app):
 
     # Set default views to 404, using URL-appropriate renderers
     process_rules(app, [
-        Rule('/<path:_>', ['get', 'post'], HTTPError(http.NOT_FOUND),
-             OsfWebRenderer('', render_mako_string)),
-        Rule('/api/v1/<path:_>', ['get', 'post'],
-             HTTPError(http.NOT_FOUND), json_renderer),
+        Rule(
+            '/<path:_>',
+            ['get', 'post'],
+            HTTPError(http.NOT_FOUND),
+            notemplate
+        ),
+        Rule(
+            '/api/v1/<path:_>',
+            ['get', 'post'],
+            HTTPError(http.NOT_FOUND),
+            json_renderer
+        ),
     ])
 
     ### GUID ###
@@ -174,29 +182,43 @@ def make_url_map(app):
 
     process_rules(app, [
 
-        Rule('/dashboard/', 'get', website_views.dashboard, OsfWebRenderer('dashboard.mako')),
-        Rule('/reproducibility/', 'get',
-             website_views.reproducibility, OsfWebRenderer('', render_mako_string)),
+        Rule(
+            '/dashboard/',
+            'get',
+            website_views.dashboard,
+            OsfWebRenderer('dashboard.mako', trust=False)
+        ),
+        Rule(
+            '/reproducibility/',  # Redirect to RPP
+            'get',
+            website_views.reproducibility,
+            notemplate
+        ),
 
-        Rule('/about/', 'get', website_views.redirect_about, json_renderer,),
-        Rule('/howosfworks/', 'get', website_views.redirect_howosfworks, json_renderer,),
-        Rule('/faq/', 'get', {}, OsfWebRenderer('public/pages/faq.mako')),
-        Rule('/getting-started/', 'get', {}, OsfWebRenderer('public/pages/getting_started.mako')),
-        Rule('/explore/', 'get', {}, OsfWebRenderer('public/explore.mako')),
-        Rule(['/messages/', '/help/'], 'get', {}, OsfWebRenderer('public/comingsoon.mako')),
+        Rule('/about/', 'get', website_views.redirect_about, notemplate),
+        Rule('/howosfworks/', 'get', website_views.redirect_howosfworks, notemplate),
+        Rule('/faq/', 'get', {}, OsfWebRenderer('public/pages/faq.mako', trust=False)),
+        Rule('/getting-started/', 'get', {}, OsfWebRenderer('public/pages/getting_started.mako', trust=False)),
+        Rule('/explore/', 'get', {}, OsfWebRenderer('public/explore.mako', trust=False)),
+        Rule(
+            ['/messages/', '/help/'],
+            'get',
+            {},
+            OsfWebRenderer('public/comingsoon.mako', trust=False)
+        ),
 
         Rule(
             '/view/<meeting>/',
             'get',
             conference_views.conference_results,
-            OsfWebRenderer('public/pages/meeting.mako'),
+            OsfWebRenderer('public/pages/meeting.mako', trust=False),
         ),
 
         Rule(
             '/view/<meeting>/plain/',
             'get',
             conference_views.conference_results,
-            OsfWebRenderer('public/pages/meeting_plain.mako'),
+            OsfWebRenderer('public/pages/meeting_plain.mako', trust=False),
             endpoint_suffix='__plain',
         ),
 
@@ -211,18 +233,17 @@ def make_url_map(app):
             '/meetings/',
             'get',
             conference_views.conference_view,
-            OsfWebRenderer('public/pages/meeting_landing.mako'),
+            OsfWebRenderer('public/pages/meeting_landing.mako', trust=False),
         ),
 
         Rule(
             '/presentations/',
             'get',
             conference_views.redirect_to_meetings,
-            json_renderer,
+            notemplate,
         ),
 
-        Rule('/news/', 'get', {}, OsfWebRenderer('public/pages/news.mako')),
-
+        Rule('/news/', 'get', {}, OsfWebRenderer('public/pages/news.mako', trust=False)),
     ])
 
     # Site-wide API routes

--- a/website/templates/dashboard.mako
+++ b/website/templates/dashboard.mako
@@ -95,7 +95,7 @@
 <script>
     window.contextVars = $.extend(true, {}, window.contextVars, {
         currentUser: {
-            'id': '${user_id}'
+            id: ${ user_id | sjson, n }
         }
     });
 </script>

--- a/website/templates/public/pages/getting_started.mako
+++ b/website/templates/public/pages/getting_started.mako
@@ -72,6 +72,7 @@
                 </ul>
             </div>
         </div>
+    </div>  <!-- TODO Is this correct location for missing /div? -->
     <div class="col-sm-8 col-md-9">
 
         <div  id="start" class="p-t-xl">
@@ -121,49 +122,49 @@
                     </div>
                 </div>
             </div>
-        <div  id="structure" class="row p-t-xl">
-            <h2 class="text-center">Structuring Your Work</h2>
-            <div class="col-md-12">
-                <%include file="/public/pages/help/organizer.mako"/>
-                <%include file="/public/pages/help/dashboards.mako"/>
-                <%include file="/public/pages/help/user_profile.mako"/>
-                <%include file="/public/pages/help/projects.mako"/>
-                <%include file="/public/pages/help/components.mako"/>
-                <%include file="/public/pages/help/files.mako"/>
-                <%include file="/public/pages/help/links.mako"/>
-                <%include file="/public/pages/help/forks.mako"/>
-                <%include file="/public/pages/help/registrations.mako"/>
-                <%include file="/public/pages/help/wiki.mako"/>
+            <div  id="structure" class="row p-t-xl">
+                <h2 class="text-center">Structuring Your Work</h2>
+                <div class="col-md-12">
+                    <%include file="/public/pages/help/organizer.mako"/>
+                    <%include file="/public/pages/help/dashboards.mako"/>
+                    <%include file="/public/pages/help/user_profile.mako"/>
+                    <%include file="/public/pages/help/projects.mako"/>
+                    <%include file="/public/pages/help/components.mako"/>
+                    <%include file="/public/pages/help/files.mako"/>
+                    <%include file="/public/pages/help/links.mako"/>
+                    <%include file="/public/pages/help/forks.mako"/>
+                    <%include file="/public/pages/help/registrations.mako"/>
+                    <%include file="/public/pages/help/wiki.mako"/>
+                </div>
             </div>
-        </div>
 
-        <div id="sharing" class="row p-t-xl">
-            <h2 class="text-center">Sharing Your Work</h2>
-            <div class="col-md-12">
-                <%include file="/public/pages/help/contributors.mako"/>
-                <%include file="/public/pages/help/privacy.mako"/>
-                <%include file="/public/pages/help/citations.mako"/>
-                <%include file="/public/pages/help/view_only.mako"/>
-                <%include file="/public/pages/help/comments.mako"/>
+            <div id="sharing" class="row p-t-xl">
+                <h2 class="text-center">Sharing Your Work</h2>
+                <div class="col-md-12">
+                    <%include file="/public/pages/help/contributors.mako"/>
+                    <%include file="/public/pages/help/privacy.mako"/>
+                    <%include file="/public/pages/help/citations.mako"/>
+                    <%include file="/public/pages/help/view_only.mako"/>
+                    <%include file="/public/pages/help/comments.mako"/>
+                </div>
             </div>
-        </div>
 
-        <div id="addons" class="row p-t-xl">
-            <h2 class="text-center m-b-lg">OSF Add-ons</h2>
-            <div class="col-md-12">
-                <%include file="/public/pages/help/addons.mako"/>
+            <div id="addons" class="row p-t-xl">
+                <h2 class="text-center m-b-lg">OSF Add-ons</h2>
+                <div class="col-md-12">
+                    <%include file="/public/pages/help/addons.mako"/>
+                </div>
             </div>
-        </div>
 
-        <div id="metrics" class="row p-t-xl">
-            <h2 class="text-center">Metrics</h2>
-            <div class="col-md-12">
-                <%include file="/public/pages/help/statistics.mako"/>
-                <%include file="/public/pages/help/notifications.mako"/>
+            <div id="metrics" class="row p-t-xl">
+                <h2 class="text-center">Metrics</h2>
+                <div class="col-md-12">
+                    <%include file="/public/pages/help/statistics.mako"/>
+                    <%include file="/public/pages/help/notifications.mako"/>
+                </div>
             </div>
         </div>
     </div>
-</div>
 
 <script type="text/javascript" src="/static/vendor/youtube/youtube-loader.js"></script>
 </%def>

--- a/website/templates/public/pages/meeting.mako
+++ b/website/templates/public/pages/meeting.mako
@@ -14,7 +14,7 @@
     ${parent.javascript_bottom()}
     <script type="text/javascript">
         window.contextVars = window.contextVars || {};
-        window.contextVars.meetingData = ${data};
+        window.contextVars.meetingData = ${ data | sjson, n };
 
         $('#addLink').on('click', function(e) {
             e.preventDefault();

--- a/website/templates/public/pages/meeting_plain.mako
+++ b/website/templates/public/pages/meeting_plain.mako
@@ -45,7 +45,7 @@
 
     <script type="text/javascript">
         window.contextVars = window.contextVars || {};
-        window.contextVars.meetingData = ${data};
+        window.contextVars.meetingData = ${ data | sjson, n };
 
         $('#addLink').on('click', function(e) {
             e.preventDefault();

--- a/website/templates/share_registration.mako
+++ b/website/templates/share_registration.mako
@@ -10,7 +10,7 @@
         window.contextVars = $.extend(true, {}, window.contextVars, {
             share: {
                 urls: {
-                    register: '${register | js_str}'
+                    register: ${ register | sjson, n }
                 }
             }
         });

--- a/website/tokens/handlers.py
+++ b/website/tokens/handlers.py
@@ -10,6 +10,7 @@ from framework.flask import redirect
 from website.tokens.exceptions import UnsupportedSanctionHandlerKind, TokenError
 
 def registration_approval_handler(action, registration, registered_from):
+    # TODO: Unnecessary and duplicated dictionary.
     status.push_status_message({
         'approve': 'Your registration approval has been accepted.',
         'reject': 'Your disapproval has been accepted and the registration has been cancelled.',

--- a/website/util/sanitize.py
+++ b/website/util/sanitize.py
@@ -55,7 +55,7 @@ def escape_html(data):
     return data
 
 
-# FIXME: Not sure what this function is trying to accomplish. Candidate for deletion?
+# FIXME: Doesn't raise either type of exception expected, and can probably be deleted along with sole use
 def assert_clean(data):
     """Ensure that data is cleaned
 


### PR DESCRIPTION
Refs [#OSF-4426]

## Purpose
Continues the markupsafe series. This PR focuses on single / miscellaneous pages, including search, meetings, SHARE, login, and dashboard functionality. All testing notes from previous items in the series continue to apply.


## Summary of changes / routes affected
Some of these routes are static or otherwise make minimal use of mako variables. Routes particularly expected to be affected by this conversion are marked with a (*). 

TODO: Write list once conversion complete