### PR TITLE
Only show "published" option in dataverse fangorn toolbar when there is a published version

### DIFF
--- a/website/addons/dataverse/static/dataverseFangornConfig.js
+++ b/website/addons/dataverse/static/dataverseFangornConfig.js
@@ -111,9 +111,11 @@ var _dataverseItemButtons = {
         }
         if (item.data.addonFullname) {
             var options = [
-                m('option', {selected: item.data.version === 'latest-published', value: 'latest-published'}, 'Published'),
                 m('option', {selected: item.data.version === 'latest', value: 'latest'}, 'Draft')
             ];
+            if (item.data.dataverseIsPublished) {
+                options.push(m('option', {selected: item.data.version === 'latest-published', value: 'latest-published'}, 'Published'));
+            }
             buttons.push(
                 m.component(Fangorn.Components.dropdown, {
                     'label': 'Version: ',


### PR DESCRIPTION
Purpose
------------
Fixes [#OSF-4451]

In the files toolbar for dataverse, the version menu includes the option to select the "Published" version even if the study does not have a published version. Choosing that option causes the select box to disappear and an error message pops up:  
![Uploading Screen Shot 2015-09-11 at 4.56.44 PM.png…]()


Changes
------------
Only provide "Published" as an option in the dataverse version select box if the connected dataverse study has a published version. 