### PR TITLE
Wiki menu - Collapsed menu is taller than expanded menu

### DIFF
--- a/website/addons/wiki/templates/edit.mako
+++ b/website/addons/wiki/templates/edit.mako
@@ -70,8 +70,8 @@
           <div data-osf-panel="View"
                class="${'col-sm-{0}'.format(12 / num_columns) | n}"
                style="${'' if 'view' in panels_used else 'display: none' | n}">
-              <div class="osf-panel panel panel-default no-border reset-height" data-bind="css: { 'no-border reset-height': $root.singleVis() === 'view', 'osf-panel-flex': $root.singleVis() !== 'view' }">
-                <div class="panel-heading wiki-single-heading reset-height" data-bind="css: { 'osf-panel-heading-flex': $root.singleVis() !== 'view', 'wiki-single-heading': $root.singleVis() === 'view' }">
+              <div class="osf-panel panel panel-default no-border" data-bind="css: { 'no-border reset-height': $root.singleVis() === 'view', 'osf-panel-flex': $root.singleVis() !== 'view' }">
+                <div class="panel-heading wiki-single-heading" data-bind="css: { 'osf-panel-heading-flex': $root.singleVis() !== 'view', 'wiki-single-heading': $root.singleVis() === 'view' }">
                     <div class="row">
                         <div class="col-sm-6">
                             <span class="panel-title" > <i class="fa fa-eye"> </i>  View</span>

--- a/website/addons/wiki/templates/edit.mako
+++ b/website/addons/wiki/templates/edit.mako
@@ -70,8 +70,8 @@
           <div data-osf-panel="View"
                class="${'col-sm-{0}'.format(12 / num_columns) | n}"
                style="${'' if 'view' in panels_used else 'display: none' | n}">
-              <div class="osf-panel panel panel-default no-border" data-bind="css: { 'no-border reset-height': $root.singleVis() === 'view', 'osf-panel-flex': $root.singleVis() !== 'view' }">
-                <div class="panel-heading wiki-single-heading" data-bind="css: { 'osf-panel-heading-flex': $root.singleVis() !== 'view', 'wiki-single-heading': $root.singleVis() === 'view' }">
+              <div class="osf-panel panel panel-default no-border reset-height" data-bind="css: { 'no-border reset-height': $root.singleVis() === 'view', 'osf-panel-flex': $root.singleVis() !== 'view' }">
+                <div class="panel-heading wiki-single-heading reset-height" data-bind="css: { 'osf-panel-heading-flex': $root.singleVis() !== 'view', 'wiki-single-heading': $root.singleVis() === 'view' }">
                     <div class="row">
                         <div class="col-sm-6">
                             <span class="panel-title" > <i class="fa fa-eye"> </i>  View</span>

--- a/website/static/css/pages/wiki-page.css
+++ b/website/static/css/pages/wiki-page.css
@@ -14,6 +14,7 @@
 
 .panel-collapsed {
     background: #F5F5F5;
+    height: auto;
 }
 .wiki-sidenav h4, .wiki-sidenav li>ul>.btn,  .osf-sidenav.wiki-sidenav ul>li .row{
     padding: 8px 15px;

--- a/website/static/css/pages/wiki-page.css
+++ b/website/static/css/pages/wiki-page.css
@@ -13,7 +13,8 @@
 
 .panel-collapsed {
     background: #F5F5F5;
-    height: auto;
+    height: 551px;
+    /* height: auto; -- this causes the menu to change heights when expanded or collapsed*/
 }
 .wiki-sidenav h4, .wiki-sidenav li>ul>.btn,  .osf-sidenav.wiki-sidenav ul>li .row{
     padding: 8px 15px;

--- a/website/static/css/pages/wiki-page.css
+++ b/website/static/css/pages/wiki-page.css
@@ -4,6 +4,7 @@
 
 .markdown-it-view {
     padding: 10px;
+    height: auto;
 }
 
 .wiki-compare-view {
@@ -13,8 +14,6 @@
 
 .panel-collapsed {
     background: #F5F5F5;
-    height: 551px;
-    /* height: auto; -- this causes the menu to change heights when expanded or collapsed*/
 }
 .wiki-sidenav h4, .wiki-sidenav li>ul>.btn,  .osf-sidenav.wiki-sidenav ul>li .row{
     padding: 8px 15px;

--- a/website/static/css/pages/wiki-page.css
+++ b/website/static/css/pages/wiki-page.css
@@ -13,6 +13,7 @@
 
 .panel-collapsed {
     background: #F5F5F5;
+    height: auto;
 }
 .wiki-sidenav h4, .wiki-sidenav li>ul>.btn,  .osf-sidenav.wiki-sidenav ul>li .row{
     padding: 8px 15px;


### PR DESCRIPTION
## Purpose
Jira ticket OSF-3830

The Wiki Menu was longer when collapsed than when expanded, which pushed the header down and created wasted space on the page.

## Changes
This only required one change, which was to make the height set to auto when the panel is collapsed.

## Side effects
The collapsed menu will still be a different height from expanded when the page has no content. 
