### PR TITLE
[Hotfix] Download as Zip button appears for open and closed folders

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1527,7 +1527,7 @@ var FGItemButtons = {
                         ])
                     );
                 }
-            } else if (item.data.provider && item.children.length !== 0) {
+            } else if (item.data.provider && item.open.length !== 0) {
                 rowButtons.push(
                     m.component(FGButton, {
                         onclick: function (event) { _downloadZipEvent.call(tb, event, item); },


### PR DESCRIPTION
# Purpose: 
-For a non-empty folder, the "Download as zip" button should appear when the folder is highlighted- whether the folder is open or closed. 
# Changes: 
- Changes in website/static/js/fanghorn.js
# Side Effects:
None.
# Notes: 
- Closes issue:
https://github.com/CenterForOpenScience/osf.io/issues/3388