### PR TITLE
[Feature] Hide delete button for published dataverse

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1587,6 +1587,8 @@ var FGToolbar = {
                 onclick: ctrl.dismissToolbar,
                 icon : 'fa fa-times'
             }, '');
+        var firstSelected = ctrl.tb.multiselected()[0];
+        var publishedDataverseSelected = (firstSelected.data.provider === 'dataverse' && firstSelected.parent().data.version === 'latest-published');
         templates[toolbarModes.SEARCH] =  [
             m('.col-xs-10', [
                 ctrl.tb.options.filterTemplate.call(ctrl.tb)
@@ -1675,7 +1677,7 @@ var FGToolbar = {
             );
         }
         //multiple selection icons
-        if(items.length > 1 && ctrl.tb.multiselected()[0].data.provider !== 'github' && ctrl.tb.options.placement !== 'fileview' && !(ctrl.tb.multiselected()[0].data.provider === 'dataverse' && ctrl.tb.multiselected()[0].parent().data.version === 'latest-published') ) {
+        if(items.length > 1 && firstSelected.data.provider !== 'github' && ctrl.tb.options.placement !== 'fileview' && !publishedDataverseSelected ) {
             var showDelete = false;
             // Only show delete button if user has edit permissions on at least one selected file
             for (var i = 0, len = items.length; i < len; i++) {

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1675,7 +1675,7 @@ var FGToolbar = {
             );
         }
         //multiple selection icons
-        if(items.length > 1 && ctrl.tb.multiselected()[0].data.provider !== 'github' && ctrl.tb.options.placement !== 'fileview') {
+        if(items.length > 1 && ctrl.tb.multiselected()[0].data.provider !== 'github' && ctrl.tb.options.placement !== 'fileview' && !(ctrl.tb.multiselected()[0].data.provider === 'dataverse' && ctrl.tb.multiselected()[0].parent().data.version === 'latest-published') ) {
             var showDelete = false;
             // Only show delete button if user has edit permissions on at least one selected file
             for (var i = 0, len = items.length; i < len; i++) {

--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -209,9 +209,9 @@ var FileViewPage = {
                 }, ctrl.editor.title);
             }
         };
-
         m.render(document.getElementById('toggleBar'), m('.btn-toolbar.m-t-md', [
-            ctrl.canEdit() ? m('.btn-group.m-l-xs.m-t-xs', [
+            // Special case whether or not to show the delete button for published Dataverse files
+            (ctrl.canEdit() && $(document).context.URL.indexOf('version=latest-published') < 0 ) ? m('.btn-group.m-l-xs.m-t-xs', [
                 m('button.btn.btn-sm.btn-danger.file-delete', {onclick: $(document).trigger.bind($(document), 'fileviewpage:delete')}, 'Delete')
             ]) : '',
             m('.btn-group.m-t-xs', [


### PR DESCRIPTION
Purpose
======
Hides buttons that will invariably return errors if pressed

Changes
=======
More ugly special cases for Dataverse added

Side Effects
=========
None