### PR TITLE
[Hotfix] removing the empty familyName filter that prevents events from showing up

### DIFF
--- a/website/static/js/share/results.js
+++ b/website/static/js/share/results.js
@@ -151,8 +151,18 @@ var Contributor = {
             m('a', {
                 href: '#',
                 onclick: function() {
-                    utils.updateFilter(vm, 'match:contributors.familyName:' + contributor.familyName, true);
-                    utils.updateFilter(vm, 'match:contributors.givenName:' + contributor.givenName, true);
+                    var glen = contributor.givenName ? contributor.givenName.length : 0;
+                    var flen = contributor.familyName ? contributor.familyName.length : 0;
+                    if (glen <= 0 && flen <= 0) {
+                        utils.updateFilter(vm, 'match:contributors.name:' + contributor.name, true);
+                    } else {
+                        if (glen > 0) {
+                            utils.updateFilter(vm, 'match:contributors.givenName:' + contributor.givenName, true);
+                        }
+                        if (flen > 0) {
+                            utils.updateFilter(vm, 'match:contributors.familyName:' + contributor.familyName, true);
+                        }
+                    }
                 }
             }, contributor.name)
         ]);

--- a/website/static/js/share/results.js
+++ b/website/static/js/share/results.js
@@ -151,15 +151,15 @@ var Contributor = {
             m('a', {
                 href: '#',
                 onclick: function() {
-                    var glen = contributor.givenName ? contributor.givenName.length : 0;
-                    var flen = contributor.familyName ? contributor.familyName.length : 0;
-                    if (glen <= 0 && flen <= 0) {
+                    var givenNameLength = contributor.givenName ? contributor.givenName.length : 0;
+                    var familyNameLength = contributor.familyName ? contributor.familyName.length : 0;
+                    if (givenNameLength <= 0 && familyNameLength <= 0) {
                         utils.updateFilter(vm, 'match:contributors.name:' + contributor.name, true);
                     } else {
-                        if (glen > 0) {
+                        if (givenNameLength > 0) {
                             utils.updateFilter(vm, 'match:contributors.givenName:' + contributor.givenName, true);
                         }
-                        if (flen > 0) {
+                        if (familyNameLength > 0) {
                             utils.updateFilter(vm, 'match:contributors.familyName:' + contributor.familyName, true);
                         }
                     }


### PR DESCRIPTION
Resolves [#OSF-4466].
Add a constraint so that the familyName filter is added only if the length of familyName of a contributor > 0.