### PR TITLE
[RfR] Generalize <user_id> = me across API

### DIFF
--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -8,6 +8,7 @@ from framework.auth.core import Auth
 from api.files.serializers import FileSerializer
 from api.base.filters import ODMFilterMixin, ListFilterMixin
 from api.base.utils import get_object_or_error
+from api.users.views import UserMixin
 from api.nodes.serializers import (
     NodeSerializer,
     NodeLinksSerializer,
@@ -27,7 +28,7 @@ from api.nodes.permissions import (
 from website.exceptions import NodeStateError
 from website.files.models import FileNode
 from website.files.models import OsfStorageFileNode
-from website.models import Node, Pointer, User
+from website.models import Node, Pointer
 from website.util import waterbutler_api_url_for
 
 
@@ -173,7 +174,7 @@ class NodeContributorsList(generics.ListCreateAPIView, ListFilterMixin, NodeMixi
 
 
 # TODO: Support creating registrations
-class NodeContributorDetail(generics.RetrieveUpdateDestroyAPIView, NodeMixin):
+class NodeContributorDetail(generics.RetrieveUpdateDestroyAPIView, NodeMixin, UserMixin):
     """Detail of a contributor for a node.
 
     View, remove from, and change bibliographic and permissions for a given contributor on a given node.
@@ -190,7 +191,7 @@ class NodeContributorDetail(generics.RetrieveUpdateDestroyAPIView, NodeMixin):
     # overrides RetrieveAPIView
     def get_object(self):
         node = self.get_node()
-        user = get_object_or_error(User, self.kwargs['user_id'], display_name='user')
+        user = self.get_user()
         # May raise a permission denied
         self.check_object_permissions(self.request, user)
         if user not in node.contributors:


### PR DESCRIPTION
# Purpose

There was some discussion of how to generalize the <user_id> = me shortcut across the API. This PR explores how to do this with the node contributor detail view as a first use case.

# Changes

Apply UserMixin to NodeContributorDetail view, and use #get_user shortcut method. 

# Side Effects 

none