### PR TITLE
[Feature][Fix] Improve OAuth Architecture

### DIFF
--- a/website/oauth/models/__init__.py
+++ b/website/oauth/models/__init__.py
@@ -214,6 +214,9 @@ class ExternalProvider(object):
         to the OSF after authenticating on the external service.
         """
 
+        if 'error' in request.args:
+            return False
+
         # make sure the user has temporary credentials for this provider
         try:
             cached_credentials = session.data['oauth_states'][self.short_name]
@@ -301,6 +304,8 @@ class ExternalProvider(object):
         if self.account not in user.external_accounts:
             user.external_accounts.append(self.account)
             user.save()
+
+        return True
 
     def _default_handle_callback(self, data):
         """Parse as much out of the key exchange's response as possible.

--- a/website/oauth/models/__init__.py
+++ b/website/oauth/models/__init__.py
@@ -114,11 +114,11 @@ class ExternalProvider(object):
     # Default to OAuth v2.0.
     _oauth_version = OAUTH2
 
-    def __init__(self):
+    def __init__(self, account=None):
         super(ExternalProvider, self).__init__()
 
         # provide an unauthenticated session by default
-        self.account = None
+        self.account = account
 
     def __repr__(self):
         return '<{name}: {status}>'.format(

--- a/website/oauth/views.py
+++ b/website/oauth/views.py
@@ -44,7 +44,8 @@ def oauth_callback(service_name, auth):
     provider = get_service(service_name)
 
     # Retrieve permanent credentials from provider
-    provider.auth_callback(user=user)
+    if not provider.auth_callback(user=user):
+        return {}
 
     if provider.account not in user.external_accounts:
         user.external_accounts.append(provider.account)

--- a/website/static/js/addonSettings.js
+++ b/website/static/js/addonSettings.js
@@ -82,8 +82,13 @@ var OAuthAddonSettingsViewModel = oop.defclass({
     connectAccount: function() {
         var self = this;
         window.oauthComplete = function() {
-            self.updateAccounts();
-            self.setMessage('Add-on successfully authorized. To link this add-on to an OSF project, go to the settings page of the project, enable ' + self.properName + ', and choose content to connect.', 'text-success');
+            self.setMessage('');
+            var accountCount = self.accounts().length;
+            self.updateAccounts().done( function() {
+                (self.accounts().length > accountCount) ?
+                    self.setMessage('Add-on successfully authorized. To link this add-on to an OSF project, go to the settings page of the project, enable ' + self.properName + ', and choose content to connect.', 'text-success') :
+                    self.setMessage('Error while authorizing addon. Please log in to your ' + self.properName + ' account and grant access to the OSF to enable this addon.', 'text-failure')
+                });
         };
         window.open('/oauth/connect/' + self.name + '/');
     },
@@ -98,6 +103,7 @@ var OAuthAddonSettingsViewModel = oop.defclass({
             callback: function(confirm) {
                 if (confirm) {
                     self.disconnectAccount(account);
+                    self.setMessage('');
                 }
             },
             buttons:{

--- a/website/static/js/addonSettings.js
+++ b/website/static/js/addonSettings.js
@@ -87,7 +87,7 @@ var OAuthAddonSettingsViewModel = oop.defclass({
             self.updateAccounts().done( function() {
                 (self.accounts().length > accountCount) ?
                     self.setMessage('Add-on successfully authorized. To link this add-on to an OSF project, go to the settings page of the project, enable ' + self.properName + ', and choose content to connect.', 'text-success') :
-                    self.setMessage('Error while authorizing addon. Please log in to your ' + self.properName + ' account and grant access to the OSF to enable this addon.', 'text-failure')
+                    self.setMessage('Error while authorizing addon. Please log in to your ' + self.properName + ' account and grant access to the OSF to enable this addon.', 'text-failure');
                 });
         };
         window.open('/oauth/connect/' + self.name + '/');

--- a/website/static/js/folderPickerNodeConfig.js
+++ b/website/static/js/folderPickerNodeConfig.js
@@ -110,6 +110,9 @@ var FolderPickerViewModel = oop.defclass({
             connectAccountSuccess: ko.pureComputed(function() {
                 return 'Successfully connected a ' + self.addonName + ' account';
             }),
+            connectAccountDenied: ko.pureComputed(function() {
+                return 'Error while authorizing addon. Please log in to your ' + self.addonName + ' account and grant access to the OSF to enable this addon.';
+            }),
             submitSettingsSuccess: ko.pureComputed(function() {
                 throw new Error('Subclasses of FolderPickerViewModel must provide a message for successful settings updates. ' +
                                 'This should take the form: "Successfully linked \'{FOLDER_NAME}\'. Go to the <a href="{URL}"> ' +

--- a/website/static/js/oauthAddonNodeConfig.js
+++ b/website/static/js/oauthAddonNodeConfig.js
@@ -60,7 +60,7 @@ var OauthAddonFolderPickerViewModel = oop.extend(FolderPickerViewModel, {
 
                 window.oauthComplete = function(res) {
                     // Update view model based on response
-                    self.updateAccounts(function() {
+                    self.updateAccounts().done(function() {
                         try{
                             $osf.putJSON(
                                 self.urls().importAuth, {
@@ -110,7 +110,7 @@ var OauthAddonFolderPickerViewModel = oop.extend(FolderPickerViewModel, {
     importAuth: function(){
         var self = this;
 
-        self.updateAccounts(function() {
+        self.updateAccounts().done(function () {
             if (self.accounts().length > 1) {
                 bootbox.prompt({
                     title: 'Choose ' + self.addonName + ' Access Token to Import',
@@ -153,7 +153,7 @@ var OauthAddonFolderPickerViewModel = oop.extend(FolderPickerViewModel, {
         ).done(self.onImportSuccess.bind(self)
         ).fail(self.onImportError.bind(self));
     },
-    updateAccounts: function(callback) {
+    updateAccounts: function() {
         var self = this;
         var request = $.get(self.urls().accounts);
         request.done(function(data) {
@@ -163,7 +163,6 @@ var OauthAddonFolderPickerViewModel = oop.extend(FolderPickerViewModel, {
                     id: account.id
                 };
             }));
-            callback();
         });
         request.fail(function(xhr, textStatus, error) {
             self.changeMessage(self.messages.UPDATE_ACCOUNTS_ERROR(), 'text-warning');

--- a/website/static/js/oauthAddonNodeConfig.js
+++ b/website/static/js/oauthAddonNodeConfig.js
@@ -39,10 +39,6 @@ var OauthAddonFolderPickerViewModel = oop.extend(FolderPickerViewModel, {
         self.loadedEmails = ko.observable(false);
         // externalAccounts
         self.accounts = ko.observableArray();
-        // List of contributor emails as a comma-separated values
-        self.emailList = ko.pureComputed(function() {
-            return self.emails().join([', ']);
-        });
         self.selectedFolderType = ko.pureComputed(function() {
             var userHasAuth = self.userHasAuth();
             var selected = self.selected();
@@ -198,7 +194,7 @@ var OauthAddonFolderPickerViewModel = oop.extend(FolderPickerViewModel, {
 });
 
 OauthAddonFolderPickerViewModel.prototype.connectExistingAccount = function(account_id) {
-     var self = this;
+    var self = this;
 
     $osf.putJSON(
         self.urls().importAuth, {

--- a/website/static/js/oauthAddonNodeConfig.js
+++ b/website/static/js/oauthAddonNodeConfig.js
@@ -1,0 +1,252 @@
+/**
+ * Module that controls the addon node settings. Includes Knockout view-model
+ * for syncing data, and HGrid-folderpicker for selecting a folder.
+ */
+'use strict';
+
+var ko = require('knockout');
+require('knockout.punches');
+var $ = require('jquery');
+var Raven = require('raven-js');
+var bootbox = require('bootbox');
+
+
+var ZeroClipboard = require('zeroclipboard');
+ZeroClipboard.config('/static/vendor/bower_components/zeroclipboard/dist/ZeroClipboard.swf');
+var $osf = require('js/osfHelpers');
+var oop = require('js/oop');
+var FolderPickerViewModel = require('js/folderPickerNodeConfig');
+
+ko.punches.enableAll();
+
+/**
+ * View model to support instances of AddonNodeConfig (folder picker widget)
+ *
+ * @class AddonFolderPickerViewModel
+ * @param {String} addonName Full display name of the addon
+ * @param {String} url API url to initially fetch settings
+ * @param {String} selector CSS selector for containing div
+ * @param {String} folderPicker CSS selector for folderPicker div
+ * @param {Object} opts Optional overrides to the class' default treebeardOptions, in particular onPickFolder
+ */
+var OauthAddonFolderPickerViewModel = oop.extend(FolderPickerViewModel, {
+    constructor: function(addonName, url, selector, folderPicker, opts) {
+        var self = this;
+        self.super.constructor.call(self, addonName, url, selector, folderPicker);
+        // whether the auth token is valid
+        self.validCredentials = ko.observable(true);
+        // Emails of contributors, can only be populated by activating the share dialog
+        self.emails = ko.observableArray([]);
+        self.loading = ko.observable(false);
+        // Whether the contributor emails have been loaded from the server
+        self.loadedEmails = ko.observable(false);
+        // externalAccounts
+        self.accounts = ko.observableArray();
+        // List of contributor emails as a comma-separated values
+        self.emailList = ko.pureComputed(function() {
+            return self.emails().join([', ']);
+        });
+        self.selectedFolderType = ko.pureComputed(function() {
+            var userHasAuth = self.userHasAuth();
+            var selected = self.selected();
+            return (userHasAuth && selected) ? selected.type : '';
+        });
+        self.messages.submitSettingsSuccess =  ko.pureComputed(function() {
+            return 'Successfully linked "' + $osf.htmlEscape(self.folder().name) + '". Go to the <a href="' +
+                self.urls().files + '">Files page</a> to view your content.';
+        });
+        // Overrides
+        var defaults = {
+            onPickFolder: function(evt, item) {
+                evt.preventDefault();
+                var name = item.data.path !== '/' ? item.data.path : '/ (Full ' + self.addonName + ')';
+                self.selected({
+                    name: name,
+                    path: item.data.path,
+                    id: item.data.id
+                });
+                return false; // Prevent event propagation
+            },
+            /**
+             * Allows a user to create an access token from the nodeSettings page
+             */
+            connectAccount: function() {
+                var self = this;
+
+                window.oauthComplete = function(res) {
+                    // Update view model based on response
+                    self.updateAccounts(function() {
+                        try{
+                            $osf.putJSON(
+                                self.urls().importAuth, {
+                                    external_account_id: self.accounts()[0].id
+                                }
+                            ).done(self.onImportSuccess.bind(self)
+                            ).fail(self.onImportError.bind(self));
+
+                            self.changeMessage(self.messages.connectAccountSuccess(), 'text-success', 3000);
+                        }
+                        catch(err){
+                            self.changeMessage(self.messages.connectAccountDenied(), 'text-failure', 6000);
+                        }
+                    });
+                };
+                window.open(self.urls().auth);
+            }
+        };
+        // Overrides
+        self.options = $.extend({}, defaults, opts);
+        // Treebeard config
+        self.treebeardOptions = $.extend(
+            {},
+            FolderPickerViewModel.prototype.treebeardOptions,
+            {
+                onPickFolder: function(evt, item) {
+                    return this.options.onPickFolder.call(this, evt, item);
+                }.bind(this),
+                resolveLazyloadUrl: function(item) {
+                    return item.data.urls.folders;
+                }
+            }
+        );
+    },
+    toggleShare: function() {
+        if (this.currentDisplay() === this.SHARE) {
+            this.currentDisplay(null);
+        } else {
+            // Clear selection
+            this.cancelSelection();
+            this.currentDisplay(this.SHARE);
+            this.activateShare();
+        }
+    },
+    fetchEmailList: function(){
+        var self = this;
+
+        var ret = $.Deferred();
+        var promise = ret.promise();
+        if(!self.loadedEmails()){
+            $.ajax({
+                url: self.urls().emails,
+                type: 'GET',
+                dataType: 'json'
+            }).done(function(res){
+                self.loadedEmails(true);
+                ret.resolve(res.results.emails);
+            }).fail(function(xhr, status, error){
+                Raven.captureMessage('Could not GET ' + self.addonName + ' email list', {
+                    url: self.urls().emails,
+                    textStatus: status,
+                    error: error
+                });
+                ret.reject(xhr, status, error);
+            });
+        }
+        else{
+            ret.resolve(self.emails());
+        }
+        return promise;
+    },
+    activateShare: function() {
+        var self = this;
+        self.fetchEmailList()
+            .done(function(emails){
+                self.emails(emails);
+            });
+        var $copyBtn = $(self.selector).find('.copyBtn');
+        new ZeroClipboard($copyBtn);
+    },
+    _updateCustomFields: function(settings){
+        this.validCredentials(settings.validCredentials);
+    },
+     /**
+     * Allows a user to create an access token from the nodeSettings page
+     */
+    connectAccount: function() {
+        this.options.connectAccount.call(this);
+    },
+    importAuth: function(){
+        var self = this;
+
+        self.updateAccounts(function() {
+            if (self.accounts().length > 1) {
+                bootbox.prompt({
+                    title: 'Choose ' + self.addonName + ' Access Token to Import',
+                    inputType: 'select',
+                    inputOptions: ko.utils.arrayMap(
+                        self.accounts(),
+                        function(item) {
+                            return {
+                                text: item.name,
+                                value: item.id
+                            };
+                        }
+                    ),
+                    value: self.accounts()[0].id,
+                    callback: (self.connectExistingAccount.bind(self))
+                });
+            } else {
+                bootbox.confirm({
+                    title: 'Import ' + self.addonName + ' Access Token?',
+                    message: self.messages.confirmAuth(),
+                    callback: function(confirmed) {
+                        if (confirmed) {
+                            self.connectExistingAccount.call(self, (self.accounts()[0].id));
+                        }
+                    }
+                });
+            }
+        });
+    }
+});
+
+OauthAddonFolderPickerViewModel.prototype.connectExistingAccount = function(account_id) {
+     var self = this;
+
+    $osf.putJSON(
+        self.urls().importAuth, {
+            external_account_id: account_id
+        }
+    ).done(self.onImportSuccess.bind(self)
+    ).fail(self.onImportError.bind(self));
+};
+
+OauthAddonFolderPickerViewModel.prototype.updateAccounts = function(callback) {
+    var self = this;
+    var request = $.get(self.urls().accounts);
+    request.done(function(data) {
+        self.accounts(data.accounts.map(function(account) {
+            return {
+                name: account.display_name,
+                id: account.id
+            };
+        }));
+        callback();
+    });
+    request.fail(function(xhr, textStatus, error) {
+        self.changeMessage(self.messages.UPDATE_ACCOUNTS_ERROR(), 'text-warning');
+        Raven.captureMessage('Could not GET ' + self.addonName + ' accounts for user', {
+            url: self.url,
+            textStatus: textStatus,
+            error: error
+        });
+    });
+};
+
+// Public API
+function OauthAddonNodeConfig(addonName, selector, url, folderPicker, opts) {
+    var self = this;
+    self.url = url;
+    self.folderPicker = folderPicker;
+    if (typeof opts === 'undefined') {
+        opts = {};
+    }
+    self.viewModel = new OauthAddonFolderPickerViewModel(addonName, url, selector, folderPicker, opts);
+    self.viewModel.updateFromData();
+    $osf.applyBindings(self.viewModel, selector);
+}
+
+module.exports = {
+    OauthAddonNodeConfig: OauthAddonNodeConfig,
+    _OauthAddonNodeConfigViewModel: OauthAddonFolderPickerViewModel
+};

--- a/website/static/js/oauthAddonNodeConfig.js
+++ b/website/static/js/oauthAddonNodeConfig.js
@@ -33,11 +33,8 @@ var OauthAddonFolderPickerViewModel = oop.extend(FolderPickerViewModel, {
     constructor: function(addonName, url, selector, folderPicker, opts) {
         var self = this;
         self.super.constructor.call(self, addonName, url, selector, folderPicker);
-        // whether the auth token is valid
-        self.validCredentials = ko.observable(true);
         // Emails of contributors, can only be populated by activating the share dialog
         self.emails = ko.observableArray([]);
-        self.loading = ko.observable(false);
         // Whether the contributor emails have been loaded from the server
         self.loadedEmails = ko.observable(false);
         // externalAccounts

--- a/website/static/js/oauthAddonNodeConfig.js
+++ b/website/static/js/oauthAddonNodeConfig.js
@@ -10,9 +10,6 @@ var $ = require('jquery');
 var Raven = require('raven-js');
 var bootbox = require('bootbox');
 
-
-var ZeroClipboard = require('zeroclipboard');
-ZeroClipboard.config('/static/vendor/bower_components/zeroclipboard/dist/ZeroClipboard.swf');
 var $osf = require('js/osfHelpers');
 var oop = require('js/oop');
 var FolderPickerViewModel = require('js/folderPickerNodeConfig');
@@ -44,7 +41,6 @@ var OauthAddonFolderPickerViewModel = oop.extend(FolderPickerViewModel, {
             return 'Successfully linked "' + $osf.htmlEscape(self.folder().name) + '". Go to the <a href="' +
                 self.urls().files + '">Files page</a> to view your content.';
         });
-        // Overrides
         var defaults = {
             onPickFolder: function(evt, item) {
                 evt.preventDefault();

--- a/website/static/js/oauthAddonNodeConfig.js
+++ b/website/static/js/oauthAddonNodeConfig.js
@@ -60,7 +60,7 @@ var OauthAddonFolderPickerViewModel = oop.extend(FolderPickerViewModel, {
 
                 window.oauthComplete = function(res) {
                     // Update view model based on response
-                    self.updateAccounts().done(function() {
+                    self.updateAccounts().then(function() {
                         try{
                             $osf.putJSON(
                                 self.urls().importAuth, {
@@ -110,7 +110,7 @@ var OauthAddonFolderPickerViewModel = oop.extend(FolderPickerViewModel, {
     importAuth: function(){
         var self = this;
 
-        self.updateAccounts().done(function () {
+        self.updateAccounts().then(function () {
             if (self.accounts().length > 1) {
                 bootbox.prompt({
                     title: 'Choose ' + self.addonName + ' Access Token to Import',
@@ -156,15 +156,14 @@ var OauthAddonFolderPickerViewModel = oop.extend(FolderPickerViewModel, {
     updateAccounts: function() {
         var self = this;
         var request = $.get(self.urls().accounts);
-        request.done(function(data) {
+        return request.done(function(data) {
             self.accounts(data.accounts.map(function(account) {
                 return {
                     name: account.display_name,
                     id: account.id
                 };
             }));
-        });
-        request.fail(function(xhr, textStatus, error) {
+        }).fail(function(xhr, textStatus, error) {
             self.changeMessage(self.messages.UPDATE_ACCOUNTS_ERROR(), 'text-warning');
             Raven.captureMessage('Could not GET ' + self.addonName + ' accounts for user', {
                 url: self.url,

--- a/website/static/js/tests/addons/oauthAddonNodeConfig.test.js
+++ b/website/static/js/tests/addons/oauthAddonNodeConfig.test.js
@@ -1,0 +1,39 @@
+/*global describe, it, expect, example, before, after, beforeEach, afterEach, mocha, sinon*/
+'use strict';
+var assert = require('chai').assert;
+
+var utils = require('tests/utils');
+var faker = require('faker');
+
+var $ = require('jquery');
+var $osf = require('js/osfHelpers');
+var ZeroClipboard = require('zeroclipboard');
+var OauthAddonNodeConfigVM = require('js/oauthAddonNodeConfig.js')._OauthAddonNodeConfigViewModel;
+var testUtils = require('./folderPickerTestUtils.js');
+
+var makeEmailList = function(n) {
+    var ret = [];
+    for (var i = 0; i < n; i++){
+        ret.push(faker.internet.email());
+    }
+    return ret;
+};
+
+describe('OauthAddonNodeConfig', () => {
+    describe('OauthAddonFolderPickerViewModel', () => {
+        var settingsUrl = '/api/v1/12345/addon/config/';
+        var onPickFolderSpy = sinon.spy();
+        var connectAccountSpy = sinon.spy();
+        var opts = {
+            onPickFolder: onPickFolderSpy,
+        };
+        var vm = new OauthAddonNodeConfigVM('Fake Addon', settingsUrl, '#fakeAddonScope', '#fakeAddonPicker', opts);
+        
+        describe('#constructor', () => {
+            it('applies overrides from the opts param if supplied', () => {
+                vm.treebeardOptions.onPickFolder();
+                assert.calledOnce(opts.onPickFolder);
+            });
+        });
+    });
+});

--- a/website/static/js/tests/addons/oauthAddonNodeConfig.test.js
+++ b/website/static/js/tests/addons/oauthAddonNodeConfig.test.js
@@ -7,7 +7,6 @@ var faker = require('faker');
 
 var $ = require('jquery');
 var $osf = require('js/osfHelpers');
-var ZeroClipboard = require('zeroclipboard');
 var OauthAddonNodeConfigVM = require('js/oauthAddonNodeConfig.js')._OauthAddonNodeConfigViewModel;
 var testUtils = require('./folderPickerTestUtils.js');
 


### PR DESCRIPTION
Purpose
=======
Allow users to deny access after authorizing an addon without giving an error page.

Changes
=======
* `auth_callback`, called by `oauth_callback`, will now return True if it worked and False if it didn't work
* `oauth_callback` doesn't create things it shouldn't when `auth_callback` fails
* minor improvement to `ExternalProvider.__init__`

Side Effects
=========
Can create an authenticated `ExternalProvider` at initialization, but still defaults to unauthenticated