### PR TITLE
Update and clarify the instructions for running the Box Add-on 

### DIFF
--- a/website/addons/box/README.md
+++ b/website/addons/box/README.md
@@ -2,8 +2,8 @@
 
 Enabling the addon for development
 
-1. In `website/settings/local.py` add, `"box"` to `ADDONS_REQUESTED`.
-2. Create a local box settings file with `cp website/addons/box/settings/local-dist.py website/addons/box/setings/local.py`
-3. Create an app and get a key and secret from https://app.box.com/developers/services/edit/.
-5. At the Box app console, add http://localhost:5000/api/v1/addons/box/oauth/finish/ to your list of Oauth2 redirect URIs.
-4. Enter your key and secret in `website/addons/box/settings/local.py`. 
+1. In `website/settings/local.py` add, `"box"` to the `ADDONS_REQUESTED` list.
+2. If `website/addons/box/settings/local.py` does not yet exist, create a local box settings file with `cp website/addons/box/settings/local-dist.py website/addons/box/settings/local.py`
+3. Create an app and get a key and secret  (listed as `client_id` and `client_secret`) from <https://app.box.com/developers/services/edit/>.  
+4. At the Box app console, add <http://localhost:5000/oauth/callback/box/> to your list of Oauth2 `redirect_uri`.
+5. Enter your Box `client_id` and `client_secret` as `BOX_KEY` and `BOX_SECRET` in `website/addons/box/settings/local.py`. 


### PR DESCRIPTION
The instructions in the README.md for local development needs updating.  The most important change is updating the OAuth2 `redirect_uri`