### PR TITLE
[hotfix] Download as zip button does not appear for closed folders

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1527,7 +1527,7 @@ var FGItemButtons = {
                         ])
                     );
                 }
-            } else if (item.data.provider && item.children.length !== 0) {
+            } else if (item.data.provider && item.open.length !== 0) {
                 rowButtons.push(
                     m.component(FGButton, {
                         onclick: function (event) { _downloadZipEvent.call(tb, event, item); },

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1527,7 +1527,7 @@ var FGItemButtons = {
                         ])
                     );
                 }
-            } else if (item.data.provider && item.open.length !== 0) {
+            } else if (item.data.provider) {
                 rowButtons.push(
                     m.component(FGButton, {
                         onclick: function (event) { _downloadZipEvent.call(tb, event, item); },


### PR DESCRIPTION
# Purpose: 
- When the user clicks on (but does not open) a closed folder that contains files it is expected that a "Download as zip" button should appear. 

# Changes: 
-Change in fanghorn.js

# Side Effects:
Users will be able to download empty folders. This side effect was discussed with @erinmayhood and the resulting issue is addressed in a new JIRA ticket: https://openscience.atlassian.net/browse/OSF-4549

# Notes: 
Closes: 
- https://github.com/CenterForOpenScience/osf.io/issues/3388
- JIRA ticket: https://openscience.atlassian.net/browse/OSF-3429

