### PR TITLE
[RFR] Block unconfirmed and deactivated user auth from API

### DIFF
--- a/api/applications/views.py
+++ b/api/applications/views.py
@@ -4,6 +4,7 @@ Views related to OAuth2 platform applications. Intended for OSF internal use onl
 from rest_framework.exceptions import APIException
 from rest_framework import generics
 from rest_framework import renderers
+from rest_framework import permissions as drf_permissions
 
 from modularodm import Q
 
@@ -26,6 +27,7 @@ class ApplicationList(generics.ListCreateAPIView, ODMFilterMixin):
     __metaclass__ = OsfAPIViewMeta
 
     permission_classes = (
+        drf_permissions.IsAuthenticated,
         OwnerOnly,
     )
 
@@ -62,8 +64,10 @@ class ApplicationDetail(generics.RetrieveUpdateDestroyAPIView):
     Should not return information if the application belongs to a different user
     """
     __metaclass__ = OsfAPIViewMeta
+
     permission_classes = (
         OwnerOnly,
+        drf_permissions.IsAuthenticated,
     )
 
     required_read_scopes = [CoreScopes.APPLICATIONS_READ]

--- a/api/applications/views.py
+++ b/api/applications/views.py
@@ -4,7 +4,6 @@ Views related to OAuth2 platform applications. Intended for OSF internal use onl
 from rest_framework.exceptions import APIException
 from rest_framework import generics
 from rest_framework import renderers
-from rest_framework import permissions as drf_permissions
 
 from modularodm import Q
 
@@ -15,7 +14,7 @@ from website.models import ApiOAuth2Application
 
 from api.base.filters import ODMFilterMixin
 from api.base.utils import get_object_or_error
-from api.base import permissions as base_permissions
+from api.base.views import OsfAPIViewMeta
 from api.applications.permissions import OwnerOnly
 from api.applications.serializers import ApiOAuth2ApplicationSerializer
 
@@ -24,10 +23,10 @@ class ApplicationList(generics.ListCreateAPIView, ODMFilterMixin):
     """
     Get a list of API applications (eg OAuth2) that the user has registered
     """
+    __metaclass__ = OsfAPIViewMeta
+
     permission_classes = (
-        drf_permissions.IsAuthenticated,
         OwnerOnly,
-        base_permissions.TokenHasScope,
     )
 
     required_read_scopes = [CoreScopes.APPLICATIONS_READ]
@@ -62,10 +61,9 @@ class ApplicationDetail(generics.RetrieveUpdateDestroyAPIView):
 
     Should not return information if the application belongs to a different user
     """
+    __metaclass__ = OsfAPIViewMeta
     permission_classes = (
-        drf_permissions.IsAuthenticated,
         OwnerOnly,
-        base_permissions.TokenHasScope,
     )
 
     required_read_scopes = [CoreScopes.APPLICATIONS_READ]

--- a/api/base/exceptions.py
+++ b/api/base/exceptions.py
@@ -45,3 +45,13 @@ class Gone(APIException):
 class InvalidFilterError(ParseError):
     """Raised when client passes an invalid filter in the querystring."""
     default_detail = 'Querystring contains an invalid filter.'
+
+
+class UnconfirmedAccountError(APIException):
+    status_code = 400
+    default_detail = 'Please confirm your account before using the API.'
+
+
+class DeactivatedAccountError(APIException):
+    status_code = 400
+    default_detail = 'Making API requests with credentials associated with a deactivated account is not allowed.'

--- a/api/base/exceptions.py
+++ b/api/base/exceptions.py
@@ -53,5 +53,5 @@ class UnconfirmedAccountError(APIException):
 
 
 class DeactivatedAccountError(APIException):
-    status_code = 410
+    status_code = 400
     default_detail = 'Making API requests with credentials associated with a deactivated account is not allowed.'

--- a/api/base/exceptions.py
+++ b/api/base/exceptions.py
@@ -53,5 +53,5 @@ class UnconfirmedAccountError(APIException):
 
 
 class DeactivatedAccountError(APIException):
-    status_code = 400
+    status_code = 410
     default_detail = 'Making API requests with credentials associated with a deactivated account is not allowed.'

--- a/api/base/permissions.py
+++ b/api/base/permissions.py
@@ -6,8 +6,6 @@ from rest_framework import exceptions, permissions
 from framework.auth import oauth_scopes
 from framework.auth.cas import CasResponse
 
-from api.base.exceptions import UnconfirmedAccountError, DeactivatedAccountError
-
 # Implementation built on django-oauth-toolkit, but  with more granular control over read+write permissions
 #   https://github.com/evonove/django-oauth-toolkit/blob/d45431ea0bf64fd31e16f429db1e902dbf30e3a8/oauth2_provider/ext/rest_framework/permissions.py#L15
 class TokenHasScope(permissions.BasePermission):
@@ -78,17 +76,3 @@ def PermissionWithGetter(Base, getter):
             obj = self.get_object(request, view, obj)
             return super(Perm, self).has_object_permission(request, view, obj)
     return Perm
-
-
-class OsfBasePermission(permissions.BasePermission):
-
-    def has_permission(self, request, view):
-        if request.user.is_anonymous():
-            return True
-        else:
-            if request.user.is_disabled:
-                raise DeactivatedAccountError
-            elif not request.user.is_confirmed:
-                raise UnconfirmedAccountError
-            else:
-                return True

--- a/api/base/permissions.py
+++ b/api/base/permissions.py
@@ -79,18 +79,16 @@ def PermissionWithGetter(Base, getter):
             return super(Perm, self).has_object_permission(request, view, obj)
     return Perm
 
-class UserIsConfirmed(permissions.BasePermission):
+
+class OsfBasePermission(permissions.BasePermission):
 
     def has_permission(self, request, view):
-        confirmed = request.user and request.user.is_confirmed
-        if not confirmed:
-            raise UnconfirmedAccountError
-        return True
-
-class UserIsNotDeactivated(permissions.BasePermission):
-
-    def has_permission(self, request, view):
-        deactivated = request.user and request.user.is_disabled
-        if deactivated:
-            raise DeactivatedAccountError
-        return True
+        if request.user.is_anonymous():
+            return True
+        else:
+            if request.user.is_disabled:
+                raise DeactivatedAccountError
+            elif not request.user.is_confirmed:
+                raise UnconfirmedAccountError
+            else:
+                return True

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -84,16 +84,16 @@ def root(request, format=None):
 class OsfAPIViewMeta(type):
     """Metaclass to ensure a base level of permissions are applied to all of our views
     """
-    def __new__(cls, name, bases, attributes):
+    def __init__(self, *args, **kwargs):
         permission_classes = set((
             drf_permissions.IsAuthenticatedOrReadOnly,
             base_permissions.TokenHasScope,
         ))
-        bases_permission_classes = attributes.get('permission_classes', tuple())
+        bases_permission_classes = getattr(self, 'permission_classes', tuple())
         try:
             iter(bases_permission_classes)
         except TypeError:
             bases_permission_classes = (bases_permission_classes, )
         bases_permission_classes = set(bases_permission_classes)
-        attributes['permission_classes'] = permission_classes | bases_permission_classes
-        return super(OsfAPIViewMeta, cls).__new__(cls, name, bases, attributes)
+        setattr(self, 'permission_classes', permission_classes | bases_permission_classes)
+        return super(OsfAPIViewMeta, self).__init__(*args, **kwargs)

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -6,10 +6,7 @@ from rest_framework import (
 
 from api.base.utils import absolute_reverse
 from api.users.serializers import UserSerializer
-from api.base.permissions import (
-    UserIsConfirmed,
-    UserIsNotDeactivated,
-)
+from api.base.permissions import OsfBasePermission
 
 @api_view(('GET',))
 def root(request, format=None):
@@ -90,8 +87,7 @@ class OsfAPIViewMeta(type):
     def __new__(cls, name, bases, attributes):
         permission_classes = set((
             drf_permissions.IsAuthenticatedOrReadOnly,
-            UserIsConfirmed,
-            UserIsNotDeactivated
+            OsfBasePermission
         ))
         bases_permission_classes = set(attributes.get('permission_classes', tuple()))
         attributes['permission_classes'] = permission_classes | bases_permission_classes

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -89,6 +89,11 @@ class OsfAPIViewMeta(type):
             drf_permissions.IsAuthenticatedOrReadOnly,
             base_permissions.TokenHasScope,
         ))
-        bases_permission_classes = set(attributes.get('permission_classes', tuple()))
+        bases_permission_classes = attributes.get('permission_classes', tuple())
+        try:
+            iter(bases_permission_classes)
+        except TypeError:
+            bases_permission_classes = (bases_permission_classes, )
+        bases_permission_classes = set(bases_permission_classes)
         attributes['permission_classes'] = permission_classes | bases_permission_classes
         return super(OsfAPIViewMeta, cls).__new__(cls, name, bases, attributes)

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -6,7 +6,7 @@ from rest_framework import (
 
 from api.base.utils import absolute_reverse
 from api.users.serializers import UserSerializer
-from api.base.permissions import OsfBasePermission
+from api.base import permissions as base_permissions
 
 @api_view(('GET',))
 def root(request, format=None):
@@ -87,7 +87,7 @@ class OsfAPIViewMeta(type):
     def __new__(cls, name, bases, attributes):
         permission_classes = set((
             drf_permissions.IsAuthenticatedOrReadOnly,
-            OsfBasePermission
+            base_permissions.TokenHasScope,
         ))
         bases_permission_classes = set(attributes.get('permission_classes', tuple()))
         attributes['permission_classes'] = permission_classes | bases_permission_classes

--- a/api/files/views.py
+++ b/api/files/views.py
@@ -1,5 +1,4 @@
 from rest_framework import generics
-from rest_framework import permissions as drf_permissions
 
 from framework.auth.oauth_scopes import CoreScopes
 
@@ -9,6 +8,7 @@ from website.files.models import FileVersion
 from api.base.permissions import PermissionWithGetter
 from api.base.utils import get_object_or_error
 from api.base import permissions as base_permissions
+from api.base.views import OsfAPIViewMeta
 from api.nodes.permissions import ContributorOrPublic
 from api.nodes.permissions import ReadOnlyIfRegistration
 from api.files.permissions import CheckedOutOrAdmin
@@ -36,8 +36,9 @@ class FileMixin(object):
 class FileDetail(generics.RetrieveUpdateAPIView, FileMixin):
     """Details about a specific file.
     """
+    __metaclass__ = OsfAPIViewMeta
+
     permission_classes = (
-        drf_permissions.IsAuthenticatedOrReadOnly,
         CheckedOutOrAdmin,
         base_permissions.TokenHasScope,
         PermissionWithGetter(ContributorOrPublic, 'node'),
@@ -60,8 +61,9 @@ class FileDetail(generics.RetrieveUpdateAPIView, FileMixin):
 class FileVersionsList(generics.ListAPIView, FileMixin):
     """List of versions for the file requested.
     """
+    __metaclass__ = OsfAPIViewMeta
+
     permission_classes = (
-        drf_permissions.IsAuthenticatedOrReadOnly,
         ContributorOrPublic,
         base_permissions.TokenHasScope,
         PermissionWithGetter(ContributorOrPublic, 'node'),
@@ -83,9 +85,10 @@ def node_from_version(request, view, obj):
 class FileVersionDetail(generics.RetrieveAPIView, FileMixin):
     """Details about a specific file version.
     """
+    __metaclass__ = OsfAPIViewMeta
+
     version_lookup_url_kwarg = 'version_id'
     permission_classes = (
-        drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
         PermissionWithGetter(ContributorOrPublic, node_from_version)
     )

--- a/api/files/views.py
+++ b/api/files/views.py
@@ -7,7 +7,6 @@ from website.files.models import FileVersion
 
 from api.base.permissions import PermissionWithGetter
 from api.base.utils import get_object_or_error
-from api.base import permissions as base_permissions
 from api.base.views import OsfAPIViewMeta
 from api.nodes.permissions import ContributorOrPublic
 from api.nodes.permissions import ReadOnlyIfRegistration
@@ -40,7 +39,6 @@ class FileDetail(generics.RetrieveUpdateAPIView, FileMixin):
 
     permission_classes = (
         CheckedOutOrAdmin,
-        base_permissions.TokenHasScope,
         PermissionWithGetter(ContributorOrPublic, 'node'),
         PermissionWithGetter(ReadOnlyIfRegistration, 'node'),
     )
@@ -65,7 +63,6 @@ class FileVersionsList(generics.ListAPIView, FileMixin):
 
     permission_classes = (
         ContributorOrPublic,
-        base_permissions.TokenHasScope,
         PermissionWithGetter(ContributorOrPublic, 'node'),
     )
 
@@ -89,7 +86,6 @@ class FileVersionDetail(generics.RetrieveAPIView, FileMixin):
 
     version_lookup_url_kwarg = 'version_id'
     permission_classes = (
-        base_permissions.TokenHasScope,
         PermissionWithGetter(ContributorOrPublic, node_from_version)
     )
 

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1,13 +1,12 @@
 import requests
 
 from modularodm import Q
-from rest_framework import generics, permissions as drf_permissions
 from rest_framework.exceptions import PermissionDenied, ValidationError, NotFound
+from rest_framework import generics
 
 from framework.auth.core import Auth
 from framework.auth.oauth_scopes import CoreScopes
 
-from api.base import permissions as base_permissions
 from api.base.views import OsfAPIViewMeta
 from api.base.filters import ODMFilterMixin, ListFilterMixin
 from api.base.utils import get_object_or_error
@@ -73,10 +72,6 @@ class NodeList(generics.ListCreateAPIView, ODMFilterMixin):
     """
     __metaclass__ = OsfAPIViewMeta
 
-    permission_classes = (
-        base_permissions.TokenHasScope,
-    )
-
     required_read_scopes = [CoreScopes.NODE_BASE_READ]
     required_write_scopes = [CoreScopes.NODE_BASE_WRITE]
 
@@ -128,7 +123,6 @@ class NodeDetail(generics.RetrieveUpdateDestroyAPIView, NodeMixin):
     permission_classes = (
         ContributorOrPublic,
         ReadOnlyIfRegistration,
-        base_permissions.TokenHasScope,
     )
 
     required_read_scopes = [CoreScopes.NODE_BASE_READ]
@@ -171,7 +165,6 @@ class NodeContributorsList(generics.ListCreateAPIView, ListFilterMixin, NodeMixi
     permission_classes = (
         AdminOrPublic,
         ReadOnlyIfRegistration,
-        base_permissions.TokenHasScope,
     )
 
     required_read_scopes = [CoreScopes.NODE_CONTRIBUTORS_READ]
@@ -204,9 +197,7 @@ class NodeContributorDetail(generics.RetrieveUpdateDestroyAPIView, NodeMixin, Us
 
     permission_classes = (
         ContributorDetailPermissions,
-        drf_permissions.IsAuthenticatedOrReadOnly,
         ReadOnlyIfRegistration,
-        base_permissions.TokenHasScope,
     )
 
     required_read_scopes = [CoreScopes.NODE_CONTRIBUTORS_READ]
@@ -249,7 +240,6 @@ class NodeRegistrationsList(generics.ListAPIView, NodeMixin):
 
     permission_classes = (
         ContributorOrPublic,
-        base_permissions.TokenHasScope,
     )
 
     required_read_scopes = [CoreScopes.NODE_REGISTRATIONS_READ]
@@ -283,7 +273,6 @@ class NodeChildrenList(generics.ListCreateAPIView, NodeMixin, ODMFilterMixin):
     permission_classes = (
         ContributorOrPublic,
         ReadOnlyIfRegistration,
-        base_permissions.TokenHasScope,
     )
 
     required_read_scopes = [CoreScopes.NODE_CHILDREN_READ]
@@ -336,7 +325,6 @@ class NodeLinksList(generics.ListCreateAPIView, NodeMixin):
     permission_classes = (
         ContributorOrPublic,
         ReadOnlyIfRegistration,
-        base_permissions.TokenHasScope,
     )
 
     required_read_scopes = [CoreScopes.NODE_LINKS_READ]
@@ -362,7 +350,6 @@ class NodeLinksDetail(generics.RetrieveDestroyAPIView, NodeMixin):
 
     permission_classes = (
         ContributorOrPublicForPointers,
-        base_permissions.TokenHasScope,
     )
 
     required_read_scopes = [CoreScopes.NODE_LINKS_READ]
@@ -427,7 +414,6 @@ class NodeFilesList(generics.ListAPIView, NodeMixin):
     permission_classes = (
         ContributorOrPublic,
         ReadOnlyIfRegistration,
-        base_permissions.TokenHasScope,
     )
 
     required_read_scopes = [CoreScopes.NODE_FILE_READ]
@@ -508,7 +494,6 @@ class NodeProvidersList(generics.ListAPIView, NodeMixin):
 
     permission_classes = (
         ContributorOrPublic,
-        base_permissions.TokenHasScope,
     )
 
     required_read_scopes = [CoreScopes.NODE_FILE_READ]

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -8,6 +8,7 @@ from framework.auth.core import Auth
 from framework.auth.oauth_scopes import CoreScopes
 
 from api.base import permissions as base_permissions
+from api.base.views import OsfAPIViewMeta
 from api.base.filters import ODMFilterMixin, ListFilterMixin
 from api.base.utils import get_object_or_error
 from api.files.serializers import FileSerializer
@@ -69,8 +70,9 @@ class NodeList(generics.ListCreateAPIView, ODMFilterMixin):
     By default, a GET will return a list of public nodes, sorted by date_modified. You can filter Nodes by their title,
     description, and public fields.
     """
+    __metaclass__ = OsfAPIViewMeta
+
     permission_classes = (
-        drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
     )
 
@@ -120,6 +122,8 @@ class NodeDetail(generics.RetrieveUpdateDestroyAPIView, NodeMixin):
     Node in the front-end UI and helps with search organization. Top-level Nodes may have a category other than
     project, and children nodes may have a category of project.
     """
+    __metaclass__ = OsfAPIViewMeta
+
     permission_classes = (
         ContributorOrPublic,
         ReadOnlyIfRegistration,
@@ -161,9 +165,10 @@ class NodeContributorsList(generics.ListCreateAPIView, ListFilterMixin, NodeMixi
     contributors. From a permissions standpoint, both are the same, but bibliographic contributors
     are included in citations, while non-bibliographic contributors are not included in citations.
     """
+    __metaclass__ = OsfAPIViewMeta
+
     permission_classes = (
         AdminOrPublic,
-        drf_permissions.IsAuthenticatedOrReadOnly,
         ReadOnlyIfRegistration,
         base_permissions.TokenHasScope,
     )
@@ -195,6 +200,8 @@ class NodeContributorDetail(generics.RetrieveUpdateDestroyAPIView, NodeMixin):
 
     View, remove from, and change bibliographic and permissions for a given contributor on a given node.
     """
+    __metaclass__ = OsfAPIViewMeta
+
     permission_classes = (
         ContributorDetailPermissions,
         drf_permissions.IsAuthenticatedOrReadOnly,
@@ -237,9 +244,10 @@ class NodeRegistrationsList(generics.ListAPIView, NodeMixin):
     Registrations are read-only snapshots of a project. This view lists all of the existing registrations
     created for the current node.
      """
+    __metaclass__ = OsfAPIViewMeta
+
     permission_classes = (
         ContributorOrPublic,
-        drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
     )
 
@@ -269,9 +277,10 @@ class NodeChildrenList(generics.ListCreateAPIView, NodeMixin, ODMFilterMixin):
     probably indicates private nodes that aren't being returned. That discrepancy should disappear before everything
     is finalized.
     """
+    __metaclass__ = OsfAPIViewMeta
+
     permission_classes = (
         ContributorOrPublic,
-        drf_permissions.IsAuthenticatedOrReadOnly,
         ReadOnlyIfRegistration,
         base_permissions.TokenHasScope,
     )
@@ -321,8 +330,9 @@ class NodeLinksList(generics.ListCreateAPIView, NodeMixin):
     Node Links act as pointers to other nodes. Unlike Forks, they are not copies of nodes;
     Node Links are a direct reference to the node that they point to.
     """
+    __metaclass__ = OsfAPIViewMeta
+
     permission_classes = (
-        drf_permissions.IsAuthenticatedOrReadOnly,
         ContributorOrPublic,
         ReadOnlyIfRegistration,
         base_permissions.TokenHasScope,
@@ -347,9 +357,10 @@ class NodeLinksDetail(generics.RetrieveDestroyAPIView, NodeMixin):
     Node Links act as pointers to other nodes. Unlike Forks, they are not copies of nodes;
     Node Links are a direct reference to the node that they point to.
     """
+    __metaclass__ = OsfAPIViewMeta
+
     permission_classes = (
         ContributorOrPublicForPointers,
-        drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
     )
 
@@ -410,8 +421,9 @@ class NodeFilesList(generics.ListAPIView, NodeMixin):
     the links as we provide them before you use them, and not to reverse engineer the structure of the links as they
     are at any given time.
     """
+    __metaclass__ = OsfAPIViewMeta
+
     permission_classes = (
-        drf_permissions.IsAuthenticatedOrReadOnly,
         ContributorOrPublic,
         ReadOnlyIfRegistration,
         base_permissions.TokenHasScope,
@@ -490,8 +502,10 @@ class NodeProvider(object):
 
 
 class NodeProvidersList(generics.ListAPIView, NodeMixin):
+
+    __metaclass__ = OsfAPIViewMeta
+
     permission_classes = (
-        drf_permissions.IsAuthenticatedOrReadOnly,
         ContributorOrPublic,
         base_permissions.TokenHasScope,
     )

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -9,7 +9,6 @@ from framework.auth.oauth_scopes import CoreScopes
 
 from website.models import User, Node
 
-from api.base import permissions as base_permissions
 from api.base.utils import get_object_or_error
 from api.base.filters import ODMFilterMixin
 from api.nodes.serializers import NodeSerializer
@@ -51,10 +50,6 @@ class UserList(generics.ListAPIView, ODMFilterMixin):
     """
     __metaclass__ = OsfAPIViewMeta
 
-    permission_classes = (
-        base_permissions.TokenHasScope,
-    )
-
     required_read_scopes = [CoreScopes.USERS_READ]
     required_write_scopes = [CoreScopes.USERS_WRITE]
 
@@ -84,7 +79,6 @@ class UserDetail(generics.RetrieveUpdateAPIView, UserMixin):
 
     permission_classes = (
         ReadOnlyOrCurrentUser,
-        base_permissions.TokenHasScope,
     )
 
     required_read_scopes = [CoreScopes.USERS_READ]
@@ -107,10 +101,6 @@ class UserNodes(generics.ListAPIView, UserMixin, ODMFilterMixin):
     Return a list of nodes that the user contributes to.
     """
     __metaclass__ = OsfAPIViewMeta
-
-    permission_classes = (
-        base_permissions.TokenHasScope,
-    )
 
     required_read_scopes = [CoreScopes.USERS_READ, CoreScopes.NODE_BASE_READ]
     required_write_scopes = [CoreScopes.USERS_WRITE, CoreScopes.NODE_BASE_WRITE]

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -1,5 +1,4 @@
 from rest_framework import generics
-from rest_framework import permissions as drf_permissions
 from rest_framework.exceptions import NotAuthenticated
 from django.contrib.auth.models import AnonymousUser
 
@@ -14,6 +13,7 @@ from api.base import permissions as base_permissions
 from api.base.utils import get_object_or_error
 from api.base.filters import ODMFilterMixin
 from api.nodes.serializers import NodeSerializer
+from api.base.views import OsfAPIViewMeta
 
 from .serializers import UserSerializer
 from .permissions import ReadOnlyOrCurrentUser
@@ -49,8 +49,9 @@ class UserList(generics.ListAPIView, ODMFilterMixin):
 
     You can filter on users by their id, fullname, given_name, middle_name, or family_name.
     """
+    __metaclass__ = OsfAPIViewMeta
+
     permission_classes = (
-        drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
     )
 
@@ -79,6 +80,8 @@ class UserList(generics.ListAPIView, ODMFilterMixin):
 class UserDetail(generics.RetrieveUpdateAPIView, UserMixin):
     """Details about a specific user.
     """
+    __metaclass__ = OsfAPIViewMeta
+
     permission_classes = (
         ReadOnlyOrCurrentUser,
         base_permissions.TokenHasScope,
@@ -103,8 +106,9 @@ class UserNodes(generics.ListAPIView, UserMixin, ODMFilterMixin):
     """Nodes belonging to a user.
     Return a list of nodes that the user contributes to.
     """
+    __metaclass__ = OsfAPIViewMeta
+
     permission_classes = (
-        drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
     )
 

--- a/tests/api_tests/base/test_views.py
+++ b/tests/api_tests/base/test_views.py
@@ -13,7 +13,7 @@ from tests import factories
 from api.base.settings.defaults import API_BASE
 from api.base.views import OsfAPIViewMeta
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
-from api.base.permissions import OsfBasePermission
+from api.base.permissions import TokenHasScope
 
 class TestApiBaseViews(ApiTestCase):
 
@@ -23,7 +23,7 @@ class TestApiBaseViews(ApiTestCase):
 
     def test_view_classes_have_minimal_set_of_permissions_classes(self):
         base_permissions = [
-            OsfBasePermission,
+            TokenHasScope,
             IsAuthenticatedOrReadOnly
         ]
         view_modules = ['nodes', 'users', 'files']

--- a/tests/api_tests/base/test_views.py
+++ b/tests/api_tests/base/test_views.py
@@ -1,11 +1,52 @@
 # -*- coding: utf-8 -*-
+import httplib as http
+import sys
+import inspect
+
+import mock
+
 from nose.tools import *  # flake8: noqa
 
 from tests.base import ApiTestCase
+from tests import factories
+
 from api.base.settings.defaults import API_BASE
+from api.base.views import OsfAPIViewMeta
+from rest_framework.permissions import IsAuthenticatedOrReadOnly
+from api.base.permissions import UserIsConfirmed, UserIsNotDeactivated
 
 class TestApiBaseViews(ApiTestCase):
 
     def test_root_returns_200(self):
         res = self.app.get('/{}'.format(API_BASE))
         assert_equal(res.status_code, 200)
+
+    def test_view_classes_have_minimal_set_of_permissions_classes(self):
+        base_permissions = [
+            UserIsConfirmed,
+            UserIsNotDeactivated
+        ]
+        view_modules = ['nodes', 'users', 'files']
+
+        for module in view_modules:
+            for name, obj in inspect.getmembers(sys.modules['api.{}.views'.format(module)], inspect.isclass):
+                if hasattr(obj, 'permission_classes'):
+                    for cls in base_permissions:
+                        assert_in(cls, obj.permission_classes)
+
+    @mock.patch('framework.auth.core.User.is_confirmed', mock.PropertyMock(return_value=False))
+    def test_unconfirmed_user_gets_error(self):
+
+        user = factories.AuthUserFactory()
+
+        res = self.app.get('/{}nodes/'.format(API_BASE), auth=user.auth, expect_errors=True)
+        assert_equal(res.status_code, http.BAD_REQUEST)
+        
+    @mock.patch('framework.auth.core.User.is_disabled', mock.PropertyMock(return_value=True))
+    def test_disabled_user_gets_error(self):
+
+        user = factories.AuthUserFactory()
+
+        res = self.app.get('/{}nodes/'.format(API_BASE), auth=user.auth, expect_errors=True)
+        assert_equal(res.status_code, http.BAD_REQUEST)
+        

--- a/tests/api_tests/base/test_views.py
+++ b/tests/api_tests/base/test_views.py
@@ -13,7 +13,7 @@ from tests import factories
 from api.base.settings.defaults import API_BASE
 from api.base.views import OsfAPIViewMeta
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
-from api.base.permissions import UserIsConfirmed, UserIsNotDeactivated
+from api.base.permissions import OsfBasePermission
 
 class TestApiBaseViews(ApiTestCase):
 
@@ -23,8 +23,8 @@ class TestApiBaseViews(ApiTestCase):
 
     def test_view_classes_have_minimal_set_of_permissions_classes(self):
         base_permissions = [
-            UserIsConfirmed,
-            UserIsNotDeactivated
+            OsfBasePermission,
+            IsAuthenticatedOrReadOnly
         ]
         view_modules = ['nodes', 'users', 'files']
 
@@ -48,5 +48,5 @@ class TestApiBaseViews(ApiTestCase):
         user = factories.AuthUserFactory()
 
         res = self.app.get('/{}nodes/'.format(API_BASE), auth=user.auth, expect_errors=True)
-        assert_equal(res.status_code, http.BAD_REQUEST)
+        assert_equal(res.status_code, http.GONE)
         

--- a/tests/api_tests/base/test_views.py
+++ b/tests/api_tests/base/test_views.py
@@ -37,8 +37,7 @@ class TestApiBaseViews(ApiTestCase):
                         assert_in(cls, view.permission_classes, "{0} lacks the appropriate permission classes".format(name))
                         for key in ['read', 'write']:                            
                             scopes = getattr(view, 'required_{}_scopes'.format(key), None)
-                            assert_is_not_none(scopes)
-                            assert_not_equal(scopes, [])
+                            assert_true(bool(scopes))
                             for scope in scopes:
                                 assert_is_not_none(scope)                        
 

--- a/tests/api_tests/users/test_views.py
+++ b/tests/api_tests/users/test_views.py
@@ -601,14 +601,14 @@ class TestDeactivatedUser(ApiTestCase):
         super(TestDeactivatedUser, self).setUp()
         self.user = AuthUserFactory()
 
-    def test_deactivated_user_returns_410_response(self):
+    def test_deactivated_user_returns_400_response(self):
         url = '/{}users/{}/'.format(API_BASE, self.user._id)
         res = self.app.get(url, auth=self.user.auth , expect_errors=False)
         assert_equal(res.status_code, 200)
         self.user.is_disabled = True
         self.user.save()
         res = self.app.get(url, auth=self.user.auth , expect_errors=True)
-        assert_equal(res.status_code, 410)
+        assert_equal(res.status_code, 400)
 
 class TestExceptionFormatting(ApiTestCase):
     def setUp(self):


### PR DESCRIPTION
References [#OSF-4563]

# Purpose

QA discovered unconfirmed and deactivated users could access the API using HTTP basic auth.

# Changes

- Add UserIsConfirmed permissions class
- Add UserIsNotDeactivated permissions class
- Add OsfAPIViewMeta class to ensure ^ are added to all view class
- permissions
- Update and unit tests

# Side Effects

???