### PR TITLE
[Feature Fix] Affix Nav bar box gets bigger when scrolled down

### DIFF
--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -233,6 +233,9 @@ a {
  * affix scrolling into columns on small devices/affix
  * needs to be relative any smaller. See above @media.
  */
+.osf-affix {
+    display: none;
+}
 @media (min-width: 769px) {
     .osf-affix.profile-affix {
         top: 80px;

--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -659,12 +659,13 @@ var fixAffixWidth = function() {
 };
 
 var initializeResponsiveAffix = function (){
+    // Set nav-box width based on screem
     fixAffixWidth();
+    // Show the nav box
     $('.osf-affix').each(function (){
         $(this).show();
     });
     $(window).resize(debounce(fixAffixWidth, 20, true));
-    $('.osf-affix').one('affix.bs.affix', fixAffixWidth);
 };
 
 // Thanks to https://stackoverflow.com/questions/10420352/converting-file-size-in-bytes-to-human-readable

--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -659,6 +659,7 @@ var fixAffixWidth = function() {
 };
 
 var initializeResponsiveAffix = function (){
+    fixAffixWidth();
     $(window).resize(debounce(fixAffixWidth, 20, true));
     $('.osf-affix').one('affix.bs.affix', fixAffixWidth);
 };

--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -660,6 +660,9 @@ var fixAffixWidth = function() {
 
 var initializeResponsiveAffix = function (){
     fixAffixWidth();
+    $('.osf-affix').each(function (){
+        $(this).show();
+    });
     $(window).resize(debounce(fixAffixWidth, 20, true));
     $('.osf-affix').one('affix.bs.affix', fixAffixWidth);
 };


### PR DESCRIPTION
## Purpose
Fix the issue that on get-start page, FAQ page, and setting page, affix Nav bar box gets bigger when scrolled down. 

Resolved [#OSF-4550]
## Changes
Add init for nav-bar width when page refreshes
**Before Change:**
![issue-nav](https://cloud.githubusercontent.com/assets/5420789/9995042/1bde0ad4-604e-11e5-830a-f715ee43570e.gif)
**After Change:**
![issue-nav-good](https://cloud.githubusercontent.com/assets/5420789/9995047/22fb022c-604e-11e5-8cd7-f478b52d8222.gif)

## Side Effect
When refreshing the page, the change of width of nav box is still visible when loading the page. But user will not be unexpected change of nav box size when user do any actions. 

----Updates----
 After commit --`Fix side effect width change visible`,  side effect is resolved.
But the solution here is to hidden all the osf-affix firstly, and then show all of them when the width is got based calculation of the screen.
