### PR TITLE
[Ready for Review] strip_html correctly handles non-string input

### DIFF
--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -1,3 +1,4 @@
+import datetime
 import unittest
 from nose.tools import *  # flake8: noqa
 from website.util import sanitize
@@ -37,10 +38,20 @@ class TestSanitize(unittest.TestCase):
             sanitize.strip_html(b'<foo>bar</foo>'),
             'bar'
         )
+
+    def test_strip_html_on_non_strings_returns_original_value(self):
         assert_true(sanitize.strip_html(True))
         assert_false(sanitize.strip_html(False))
-        assert_equal(sanitize.strip_html({}), {})
-        assert_equal(sanitize.strip_html([]), [])
+
+        assert_equal(sanitize.strip_html(12), 12)
+        assert_equal(sanitize.strip_html(12.3), 12.3)
+
+        dtime = datetime.datetime.now()
+        assert_equal(sanitize.strip_html(dtime), dtime)
+
+    def test_strip_html_bleaches_collection_types(self):
+        assert_equal(sanitize.strip_html({'foo': '<b>bar</b>'}), "{'foo': 'bar'}")
+        assert_equal(sanitize.strip_html(['<em>baz</em>']), "['baz']")
 
     def test_unescape_html(self):
         assert_equal(

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -49,7 +49,7 @@ class TestSanitize(unittest.TestCase):
         dtime = datetime.datetime.now()
         assert_equal(sanitize.strip_html(dtime), dtime)
 
-    def test_strip_html_bleaches_collection_types(self):
+    def test_strip_html_sanitizes_collection_types_as_strings(self):
         assert_equal(sanitize.strip_html({'foo': '<b>bar</b>'}), "{'foo': 'bar'}")
         assert_equal(sanitize.strip_html(['<em>baz</em>']), "['baz']")
 

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -33,6 +33,14 @@ class TestSanitize(unittest.TestCase):
             sanitize.strip_html('<foo>bar</foo>'),
             'bar'
         )
+        assert_equal(
+            sanitize.strip_html(b'<foo>bar</foo>'),
+            'bar'
+        )
+        assert_true(sanitize.strip_html(True))
+        assert_false(sanitize.strip_html(False))
+        assert_equal(sanitize.strip_html({}), {})
+        assert_equal(sanitize.strip_html([]), [])
 
     def test_unescape_html(self):
         assert_equal(

--- a/website/util/sanitize.py
+++ b/website/util/sanitize.py
@@ -11,6 +11,10 @@ def strip_html(unclean):
     :return: stripped string
     :rtype: str
     """
+    # Handle non string inputs so this function can be used with higher-order
+    # functions, such as rapply (recursively applies a function to collections)
+    if not isinstance(unclean, basestring):
+        return unclean
     return bleach.clean(unclean, strip=True, tags=[], attributes=[], styles=[])
 
 

--- a/website/util/sanitize.py
+++ b/website/util/sanitize.py
@@ -11,9 +11,9 @@ def strip_html(unclean):
     :return: stripped string
     :rtype: str
     """
-    # Handle non string inputs so this function can be used with higher-order
+    # We make this noop for non-string, non-collection inputs so this function can be used with higher-order
     # functions, such as rapply (recursively applies a function to collections)
-    if not isinstance(unclean, basestring):
+    if not isinstance(unclean, basestring) and not is_iterable(unclean) and unclean is not None:
         return unclean
     return bleach.clean(unclean, strip=True, tags=[], attributes=[], styles=[])
 
@@ -31,9 +31,12 @@ def clean_tag(data):
     return escape_html(data).replace('"', '&quot;').replace("'", '&#39')
 
 
+def is_iterable(obj):
+    return hasattr(obj, '__iter__')
+
 def is_iterable_but_not_string(obj):
     """Return True if ``obj`` is an iterable object that isn't a string."""
-    return (hasattr(obj, '__iter__') and not hasattr(obj, 'strip'))
+    return (is_iterable(obj) and not hasattr(obj, 'strip'))
 
 
 def escape_html(data):

--- a/website/util/sanitize.py
+++ b/website/util/sanitize.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import collections
+
 import bleach
 import json
 
@@ -32,7 +34,7 @@ def clean_tag(data):
 
 
 def is_iterable(obj):
-    return hasattr(obj, '__iter__')
+    return isinstance(obj, collections.Iterable)
 
 def is_iterable_but_not_string(obj):
     """Return True if ``obj`` is an iterable object that isn't a string."""


### PR DESCRIPTION
### Purpose

Fixes a bug where `strip_html` turned non-string inputs into strings.

This is relevant to the API because we sanitize all user input here: https://github.com/CenterForOpenScience/osf.io/blob/84559c0f97084514b1de6f93cf199be79a7e2ffc/api/base/serializers.py#L306 . Using `_rapply` with `strip_html` resulted in boolean and other non-string inputs being stringified.

This is a blocker for https://openscience.atlassian.net/browse/OSF-4306 and any other API development that requires updating non-string fields.

### Ticket

https://openscience.atlassian.net/browse/OSF-4570
