### PR TITLE
[Ready for review] Rename scopes to use underscores, not plus signs

### DIFF
--- a/framework/auth/oauth_scopes.py
+++ b/framework/auth/oauth_scopes.py
@@ -174,4 +174,5 @@ def normalize_scopes(scopes):
 
 if __name__ == '__main__':
     from pprint import pprint as pp
-    pp(public_scopes)
+    pp({k: v.parts
+        for k, v in public_scopes.iteritems()})

--- a/framework/auth/oauth_scopes.py
+++ b/framework/auth/oauth_scopes.py
@@ -17,29 +17,29 @@ class CoreScopes(object):
     """
     The smallest units of permission that can be granted- all other scopes are built out of these.
     Each named constant is a single string."""
-    USERS_READ = 'users+read'
-    USERS_WRITE = 'users+write'
+    USERS_READ = 'users_read'
+    USERS_WRITE = 'users_write'
 
-    NODE_BASE_READ = 'nodes.base+read'
-    NODE_BASE_WRITE = 'nodes.base+write'
+    NODE_BASE_READ = 'nodes.base_read'
+    NODE_BASE_WRITE = 'nodes.base_write'
 
-    NODE_CHILDREN_READ = 'nodes.children+read'
-    NODE_CHILDREN_WRITE = 'nodes.children+write'
+    NODE_CHILDREN_READ = 'nodes.children_read'
+    NODE_CHILDREN_WRITE = 'nodes.children_write'
 
-    NODE_CONTRIBUTORS_READ = 'nodes.contributors+read'
-    NODE_CONTRIBUTORS_WRITE = 'nodes.contributors+write'
+    NODE_CONTRIBUTORS_READ = 'nodes.contributors_read'
+    NODE_CONTRIBUTORS_WRITE = 'nodes.contributors_write'
 
-    NODE_FILE_READ = 'nodes.files+read'
-    NODE_FILE_WRITE = 'nodes.files+write'
+    NODE_FILE_READ = 'nodes.files_read'
+    NODE_FILE_WRITE = 'nodes.files_write'
 
-    NODE_LINKS_READ = 'nodes.links+read'
-    NODE_LINKS_WRITE = 'nodes.links+write'
+    NODE_LINKS_READ = 'nodes.links_read'
+    NODE_LINKS_WRITE = 'nodes.links_write'
 
-    NODE_REGISTRATIONS_READ = 'nodes.registrations+read'
-    NODE_REGISTRATIONS_WRITE = 'nodes.registrations+write'
+    NODE_REGISTRATIONS_READ = 'nodes.registrations_read'
+    NODE_REGISTRATIONS_WRITE = 'nodes.registrations_write'
 
-    APPLICATIONS_READ = 'applications+read'
-    APPLICATIONS_WRITE = 'applications+write'
+    APPLICATIONS_READ = 'applications_read'
+    APPLICATIONS_WRITE = 'applications_write'
 
 
 class ComposedScopes(object):
@@ -87,11 +87,11 @@ class ComposedScopes(object):
 #   Return as sets to enable fast comparisons of provided scopes vs those required by a given node
 # These are the ***only*** scopes that will be recognized from CAS
 public_scopes = {
-    'osf.full+read': scope(parts=frozenset(ComposedScopes.FULL_READ),
+    'osf.full_read': scope(parts=frozenset(ComposedScopes.FULL_READ),
                            description='View all information associated with this account, including for '
                                        'private projects.',
                            is_public=True),
-    'osf.full+write': scope(parts=frozenset(ComposedScopes.FULL_WRITE),
+    'osf.full_write': scope(parts=frozenset(ComposedScopes.FULL_WRITE),
                             description='View and edit all information associated with this account, including for '
                                         'private projects.',
                             is_public=True),
@@ -99,48 +99,48 @@ public_scopes = {
 
 if settings.DEV_MODE:
     public_scopes.update({
-        'osf.users.all+read': scope(parts=frozenset(ComposedScopes.USERS_READ),
+        'osf.users.all_read': scope(parts=frozenset(ComposedScopes.USERS_READ),
                                     description='Read your profile data',
                                     is_public=True),
-        'osf.users.all+write': scope(parts=frozenset(ComposedScopes.USERS_WRITE),
+        'osf.users.all_write': scope(parts=frozenset(ComposedScopes.USERS_WRITE),
                                      description='Read and edit your profile data',
                                      is_public=True),
 
-        'osf.nodes.metadata+read': scope(parts=frozenset(ComposedScopes.NODE_METADATA_READ),
+        'osf.nodes.metadata_read': scope(parts=frozenset(ComposedScopes.NODE_METADATA_READ),
                                          description='Read a list of all public and private nodes accessible to this '
                                                      'account, and view associated metadata such as project descriptions '
                                                      'and titles',
                                          is_public=True),
-        'osf.nodes.metadata+write': scope(parts=frozenset(ComposedScopes.NODE_METADATA_WRITE),
+        'osf.nodes.metadata_write': scope(parts=frozenset(ComposedScopes.NODE_METADATA_WRITE),
                                           description='Read a list of all public and private nodes accessible to this '
                                                       'account, and view and edit associated metadata such as project '
                                                       'descriptions and titles',
                                           is_public=True),
 
-        'osf.nodes.data+read': scope(parts=frozenset(ComposedScopes.NODE_DATA_READ),
+        'osf.nodes.data_read': scope(parts=frozenset(ComposedScopes.NODE_DATA_READ),
                                      description='List and view files associated with any public or private projects '
                                                  'accessible to this account.',
                                      is_public=True),
-        'osf.nodes.data+write': scope(parts=frozenset(ComposedScopes.NODE_DATA_WRITE),
+        'osf.nodes.data_write': scope(parts=frozenset(ComposedScopes.NODE_DATA_WRITE),
                                       description='List, view, and update files associated with any public or private '
                                                   'projects accessible to this account.',
                                       is_public=True),
 
-        'osf.nodes.access+read': scope(parts=frozenset(ComposedScopes.NODE_ACCESS_READ),
+        'osf.nodes.access_read': scope(parts=frozenset(ComposedScopes.NODE_ACCESS_READ),
                                        description='View the contributors list and any established registrations '
                                                    'associated with public or private projects',
                                        is_public=True),
-        'osf.nodes.access+write': scope(parts=frozenset(ComposedScopes.NODE_ACCESS_WRITE),
+        'osf.nodes.access_write': scope(parts=frozenset(ComposedScopes.NODE_ACCESS_WRITE),
                                         description='View and edit the contributors list associated with public or '
                                                     'private projects accessible to this account. Also view and create '
                                                     'registrations.',
                                         is_public=True),  # TODO: Language: Does registrations endpoint allow creation of registrations? Is that planned?
 
-        'osf.nodes.all+read': scope(parts=frozenset(ComposedScopes.NODE_ALL_READ),
+        'osf.nodes.all_read': scope(parts=frozenset(ComposedScopes.NODE_ALL_READ),
                                     description='View all metadata, files, and access rights associated with all public '
                                                 'and private projects accessible to this account.',
                                     is_public=True),
-        'osf.nodes.all+write': scope(parts=frozenset(ComposedScopes.NODE_ALL_WRITE),
+        'osf.nodes.all_write': scope(parts=frozenset(ComposedScopes.NODE_ALL_WRITE),
                                      description='View and edit all metadata, files, and access rights associated with '
                                                  'all public and private projects accessible to this account.',
                                      is_public=True),

--- a/framework/auth/oauth_scopes.py
+++ b/framework/auth/oauth_scopes.py
@@ -173,6 +173,8 @@ def normalize_scopes(scopes):
 
 
 if __name__ == '__main__':
+    # Print some data to console, to help audit what views/core scopes map to a given public/composed scope
+    # Although represented internally as a set, print as a sorted list for readability.
     from pprint import pprint as pp
-    pp({k: v.parts
+    pp({k: sorted(v.parts)
         for k, v in public_scopes.iteritems()})

--- a/tests/api_tests/base/test_auth.py
+++ b/tests/api_tests/base/test_auth.py
@@ -38,7 +38,7 @@ class TestOAuthValidation(ApiTestCase):
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_invalid_token_fails(self, mock_user_info):
         mock_user_info.return_value = cas.CasResponse(authenticated=False, user=None,
-                                                      attributes={'accessTokenScope': ['osf.full+read']})
+                                                      attributes={'accessTokenScope': ['osf.full_read']})
 
         res = self.app.get(self.reachable_url, auth='invalid_token', auth_type='jwt', expect_errors=True)
         assert_equal(res.status_code, 401, msg=res.json)
@@ -46,7 +46,7 @@ class TestOAuthValidation(ApiTestCase):
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_valid_token_returns_unknown_user_thus_fails(self, mock_user_info):
         mock_user_info.return_value = cas.CasResponse(authenticated=True, user='fail',
-                                                      attributes={'accessTokenScope': ['osf.full+read']})
+                                                      attributes={'accessTokenScope': ['osf.full_read']})
 
         res = self.app.get(self.reachable_url, auth='some_valid_token', auth_type='jwt', expect_errors=True)
         assert_equal(res.status_code, 401, msg=res.json)
@@ -54,7 +54,7 @@ class TestOAuthValidation(ApiTestCase):
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_valid_token_authenticates_and_has_permissions(self, mock_user_info):
         mock_user_info.return_value = cas.CasResponse(authenticated=True, user=self.user1._id,
-                                                      attributes={'accessTokenScope': ['osf.full+read']})
+                                                      attributes={'accessTokenScope': ['osf.full_read']})
 
         res = self.app.get(self.reachable_url, auth='some_valid_token', auth_type='jwt')
         assert_equal(res.status_code, 200, msg=res.json)
@@ -62,7 +62,7 @@ class TestOAuthValidation(ApiTestCase):
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_valid_token_authenticates_but_user_lacks_object_permissions(self, mock_user_info):
         mock_user_info.return_value = cas.CasResponse(authenticated=True, user=self.user1._id,
-                                                      attributes={'accessTokenScope': ['osf.full+read']})
+                                                      attributes={'accessTokenScope': ['osf.full_read']})
 
         res = self.app.get(self.unreachable_url, auth='some_valid_token', auth_type='jwt', expect_errors=True)
         assert_equal(res.status_code, 403, msg=res.json)
@@ -83,14 +83,14 @@ class TestOAuthScopedAccess(ApiTestCase):
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_user_read_scope_can_read_user_view(self, mock_user_info):
-        mock_user_info.return_value = self._scoped_response(['osf.users.all+read'])
+        mock_user_info.return_value = self._scoped_response(['osf.users.all_read'])
         url = api_v2_url('users/me/', base_route='/', base_prefix='v2/')
         res = self.app.get(url, auth='some_valid_token', auth_type='jwt', expect_errors=True)
         assert_equal(res.status_code, 200)
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_user_read_scope_cant_write_user_view(self, mock_user_info):
-        mock_user_info.return_value = self._scoped_response(['osf.users.all+read'])
+        mock_user_info.return_value = self._scoped_response(['osf.users.all_read'])
         url = api_v2_url('users/me/', base_route='/', base_prefix='v2/')
         payload = {u'suffix': u'VIII'}
 
@@ -100,14 +100,14 @@ class TestOAuthScopedAccess(ApiTestCase):
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_user_write_scope_implies_read_permissions_for_user_view(self, mock_user_info):
-        mock_user_info.return_value = self._scoped_response(['osf.users.all+write'])
+        mock_user_info.return_value = self._scoped_response(['osf.users.all_write'])
         url = api_v2_url('users/me/', base_route='/', base_prefix='v2/')
         res = self.app.get(url, auth='some_valid_token', auth_type='jwt', expect_errors=True)
         assert_equal(res.status_code, 200)
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_user_write_scope_can_write_user_view(self, mock_user_info):
-        mock_user_info.return_value = self._scoped_response(['osf.users.all+write'])
+        mock_user_info.return_value = self._scoped_response(['osf.users.all_write'])
         url = api_v2_url('users/me/', base_route='/', base_prefix='v2/')
         payload = {u'suffix': u'VIII'}
 
@@ -119,7 +119,7 @@ class TestOAuthScopedAccess(ApiTestCase):
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_node_write_scope_cant_read_user_view(self, mock_user_info):
-        mock_user_info.return_value = self._scoped_response(['osf.nodes.all+write'])
+        mock_user_info.return_value = self._scoped_response(['osf.nodes.all_write'])
         url = api_v2_url('users/me/', base_route='/', base_prefix='v2/')
         payload = {u'suffix': u'VIII'}
 

--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -426,7 +426,7 @@ class TestCheckOAuth(OsfTestCase):
         component_admin = AuthUserFactory()
         component = ProjectFactory(creator=component_admin, is_public=True, parent=self.node)
         cas_resp = cas.CasResponse(authenticated=True, status=None, user=self.user._id,
-                                   attributes={'accessTokenScope': {'osf.users.all+read'}})
+                                   attributes={'accessTokenScope': {'osf.users.all_read'}})
 
         assert_false(component.has_permission(self.user, 'write'))
         res = views.check_access(component, Auth(user=self.user), 'download', cas_resp)
@@ -436,7 +436,7 @@ class TestCheckOAuth(OsfTestCase):
         component_admin = AuthUserFactory()
         component = ProjectFactory(creator=component_admin, is_public=False, parent=self.node)
         cas_resp = cas.CasResponse(authenticated=True, status=None, user=self.user._id,
-                                   attributes={'accessTokenScope': {'osf.users.all+read'}})
+                                   attributes={'accessTokenScope': {'osf.users.all_read'}})
 
         assert_false(component.has_permission(self.user, 'write'))
         with assert_raises(HTTPError) as exc_info:
@@ -449,7 +449,7 @@ class TestCheckOAuth(OsfTestCase):
         cas_resp = cas.CasResponse(authenticated=True, status=None, user=self.user._id,
                                    attributes={'accessTokenScope': {
                                        'decommissioned.scope+write',
-                                       'osf.nodes.data+read',
+                                       'osf.nodes.data_read',
                                    }})
 
         assert_false(component.has_permission(self.user, 'write'))
@@ -460,7 +460,7 @@ class TestCheckOAuth(OsfTestCase):
         component_admin = AuthUserFactory()
         component = ProjectFactory(creator=component_admin, is_public=False, parent=self.node)
         cas_resp = cas.CasResponse(authenticated=True, status=None, user=self.user._id,
-                                   attributes={'accessTokenScope': {'osf.nodes.data+write'}})
+                                   attributes={'accessTokenScope': {'osf.nodes.data_write'}})
 
         assert_false(component.has_permission(self.user, 'write'))
         res = views.check_access(component, Auth(user=self.user), 'download', cas_resp)
@@ -469,7 +469,7 @@ class TestCheckOAuth(OsfTestCase):
     def test_has_permission_read_scope_write_action_forbidden(self):
         component = ProjectFactory(creator=self.user, is_public=False, parent=self.node)
         cas_resp = cas.CasResponse(authenticated=True, status=None, user=self.user._id,
-                                   attributes={'accessTokenScope': {'osf.nodes.data+read'}})
+                                   attributes={'accessTokenScope': {'osf.nodes.data_read'}})
 
         assert_true(component.has_permission(self.user, 'write'))
         with assert_raises(HTTPError) as exc_info:


### PR DESCRIPTION
References [#OSF-4574]

## Purpose
Some OAuth tools have trouble dealing with proper encoding of scope names. This changes the + character (which has special meaning and requires encoding) to an underscore (which should pass through without problems)

## Summary of changes
- Rename all scopes (internal and public facing) to separate permissions from scope name using an underscore (instead of a plus sign).
- Fix the feature that pretty-prints a list of what views/ core scopes go with what publicly available/composed scope
- Updated all unit tests accordingly. Times like this that I wish I'd used named constants....