### PR TITLE
Test that every view has a base set of permission classes

### DIFF
--- a/api/base/exceptions.py
+++ b/api/base/exceptions.py
@@ -45,3 +45,13 @@ class Gone(APIException):
 class InvalidFilterError(ParseError):
     """Raised when client passes an invalid filter in the querystring."""
     default_detail = 'Querystring contains an invalid filter.'
+
+
+class UnconfirmedAccountError(APIException):
+    status_code = 400
+    default_detail = 'Please confirm your account before using the API.'
+
+
+class DeactivatedAccountError(APIException):
+    status_code = 400
+    default_detail = 'Making API requests with credentials associated with a deactivated account is not allowed.'

--- a/api/files/views.py
+++ b/api/files/views.py
@@ -62,7 +62,6 @@ class FileVersionsList(generics.ListAPIView, FileMixin):
     """
     permission_classes = (
         drf_permissions.IsAuthenticatedOrReadOnly,
-        ContributorOrPublic,
         base_permissions.TokenHasScope,
         PermissionWithGetter(ContributorOrPublic, 'node'),
     )

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -122,6 +122,7 @@ class NodeDetail(generics.RetrieveUpdateDestroyAPIView, NodeMixin):
     project, and children nodes may have a category of project.
     """
     permission_classes = (
+        drf_permissions.IsAuthenticatedOrReadOnly,
         ContributorOrPublic,
         ReadOnlyIfRegistration,
         base_permissions.TokenHasScope,

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -80,6 +80,7 @@ class UserDetail(generics.RetrieveUpdateAPIView, UserMixin):
     """Details about a specific user.
     """
     permission_classes = (
+        drf_permissions.IsAuthenticatedOrReadOnly,
         ReadOnlyOrCurrentUser,
         base_permissions.TokenHasScope,
     )

--- a/tests/api_tests/base/test_views.py
+++ b/tests/api_tests/base/test_views.py
@@ -1,11 +1,62 @@
 # -*- coding: utf-8 -*-
+import httplib as http
+import sys
+import inspect
+import pkgutil
+
+import mock
+
 from nose.tools import *  # flake8: noqa
 
 from tests.base import ApiTestCase
+from tests import factories
+
 from api.base.settings.defaults import API_BASE
+from rest_framework.permissions import IsAuthenticatedOrReadOnly, IsAuthenticated
+from api.base.permissions import TokenHasScope
+
+from framework.auth.oauth_scopes import CoreScopes
 
 class TestApiBaseViews(ApiTestCase):
 
     def test_root_returns_200(self):
         res = self.app.get('/{}'.format(API_BASE))
         assert_equal(res.status_code, 200)
+
+    def test_view_classes_have_minimal_set_of_permissions_classes(self):
+        base_permissions = [            
+            TokenHasScope,
+            (IsAuthenticated, IsAuthenticatedOrReadOnly)
+        ]
+        view_modules = [name for _, name, _ in pkgutil.iter_modules(['api'])]
+        for module in view_modules:
+            for name, view in inspect.getmembers(sys.modules['api.{}.views'.format(module)], inspect.isclass):
+                if hasattr(view, 'permission_classes'):
+                    for cls in base_permissions:
+                        if isinstance(cls, tuple):
+                            has_cls = any([c in view.permission_classes for c in cls])
+                            assert_true(has_cls, "{0} lacks the appropriate permission classes".format(name))
+                        else:
+                            assert_in(cls, view.permission_classes, "{0} lacks the appropriate permission classes".format(name))
+                        for key in ['read', 'write']:                            
+                            scopes = getattr(view, 'required_{}_scopes'.format(key), None)
+                            assert_true(bool(scopes))
+                            for scope in scopes:
+                                assert_is_not_none(scope)                        
+
+    @mock.patch('framework.auth.core.User.is_confirmed', mock.PropertyMock(return_value=False))
+    def test_unconfirmed_user_gets_error(self):
+
+        user = factories.AuthUserFactory()
+
+        res = self.app.get('/{}nodes/'.format(API_BASE), auth=user.auth, expect_errors=True)
+        assert_equal(res.status_code, http.BAD_REQUEST)
+        
+    @mock.patch('framework.auth.core.User.is_disabled', mock.PropertyMock(return_value=True))
+    def test_disabled_user_gets_error(self):
+
+        user = factories.AuthUserFactory()
+
+        res = self.app.get('/{}nodes/'.format(API_BASE), auth=user.auth, expect_errors=True)
+        assert_equal(res.status_code, http.BAD_REQUEST)
+        

--- a/tests/api_tests/users/test_views.py
+++ b/tests/api_tests/users/test_views.py
@@ -601,14 +601,14 @@ class TestDeactivatedUser(ApiTestCase):
         super(TestDeactivatedUser, self).setUp()
         self.user = AuthUserFactory()
 
-    def test_deactivated_user_returns_410_response(self):
+    def test_deactivated_user_returns_400_response(self):
         url = '/{}users/{}/'.format(API_BASE, self.user._id)
         res = self.app.get(url, auth=self.user.auth , expect_errors=False)
         assert_equal(res.status_code, 200)
         self.user.is_disabled = True
         self.user.save()
         res = self.app.get(url, auth=self.user.auth , expect_errors=True)
-        assert_equal(res.status_code, 410)
+        assert_equal(res.status_code, 400)
 
 class TestExceptionFormatting(ApiTestCase):
     def setUp(self):


### PR DESCRIPTION
Replaces https://github.com/CenterForOpenScience/osf.io/pull/4322

References [#OSF-4563]

# Purpose

QA discovered unconfirmed and deactivated users could access the API using HTTP basic auth.

Also fixes invalid node permissions check on file version view

# Changes

- Add UserIsConfirmed permissions class
- Add UserIsNotDeactivated permissions class
- Add OsfAPIViewMeta class to ensure ^ are added to all view class
- permissions
- Update and unit tests
- remove ContributorOrPublic from FileVersionsList

# Side Effects

???