### PR TITLE
[Feature][Ready for Review] Wiki version dropdowns with usernames and timestamps

### DIFF
--- a/website/addons/wiki/templates/edit.mako
+++ b/website/addons/wiki/templates/edit.mako
@@ -73,10 +73,10 @@
               <div class="osf-panel panel panel-default no-border" data-bind="css: { 'no-border reset-height': $root.singleVis() === 'view', 'osf-panel-flex': $root.singleVis() !== 'view' }">
                 <div class="panel-heading wiki-single-heading" data-bind="css: { 'osf-panel-heading-flex': $root.singleVis() !== 'view', 'wiki-single-heading': $root.singleVis() === 'view' }">
                     <div class="row">
-                        <div class="col-sm-6">
+                        <div class="col-sm-4">
                             <span class="panel-title" > <i class="fa fa-eye"> </i>  View</span>
                         </div>
-                        <div class="col-sm-6">
+                        <div class="col-sm-8">
 
                             <div class="pull-right">
                                 <!-- Version Picker -->

--- a/website/addons/wiki/templates/edit.mako
+++ b/website/addons/wiki/templates/edit.mako
@@ -84,7 +84,11 @@
                                     % if user['can_edit_wiki_body']:
                                         <option value="preview" ${'selected' if version_settings['view'] == 'preview' else ''}>Preview</option>
                                     % endif
-                                    <option value="current" ${'selected' if version_settings['view'] == 'current' else ''}>(Current) ${versions[0]['user_fullname']}: ${versions[0]['date']}</option>
+                                    % if len(versions) > 0:
+                                        <option value="current" ${'selected' if version_settings['view'] == 'current' else ''}>(Current) ${versions[0]['user_fullname']}: ${versions[0]['date']}</option>
+                                    % else:
+                                        <option value="current" ${'selected' if version_settings['view'] == 'current' else ''}>Current</option>
+                                    % endif
                                     % if len(versions) > 1:
                                         % for version in versions[1:]:
                                             <option value="${version['version']}" ${'selected' if version_settings['view'] == version['version'] else ''}>(${version['version']}) ${version['user_fullname']}: ${version['date']}</option>
@@ -197,7 +201,11 @@
                             <!-- Version Picker -->
                             <span class="compare-version-text"><i> <span data-bind="text: viewVersionDisplay"></span></i> to
                               <select class="form-control" data-bind="value: compareVersion" id="compareVersionSelect">
-                                  <option value="current" ${'selected' if version_settings['compare'] == 'current' else ''}>(Current) ${versions[0]['user_fullname']}: ${versions[0]['date']}</option>
+                                  % if len(versions) > 0:
+                                      <option value="current" ${'selected' if version_settings['compare'] == 'current' else ''}>(Current) ${versions[0]['user_fullname']}: ${versions[0]['date']}</option>
+                                  % else:
+                                      <option value="current" ${'selected' if version_settings['view'] == 'current' else ''}>Current</option>
+                                  % endif
                                   % if len(versions) > 1:
                                       % for version in versions[1:]:
                                           <option value="${version['version']}" ${'selected' if version_settings['compare'] == version['version'] else ''}>(${version['version']}) ${version['user_fullname']}: ${version['date']}</option>

--- a/website/addons/wiki/templates/edit.mako
+++ b/website/addons/wiki/templates/edit.mako
@@ -84,13 +84,12 @@
                                     % if user['can_edit_wiki_body']:
                                         <option value="preview" ${'selected' if version_settings['view'] == 'preview' else ''}>Preview</option>
                                     % endif
-                                    <option value="current" ${'selected' if version_settings['view'] == 'current' else ''}>Current</option>
+                                    <option value="current" ${'selected' if version_settings['view'] == 'current' else ''}>(Current) ${versions[0]['user_fullname']}: ${versions[0]['date']}</option>
                                     % if len(versions) > 1:
-                                        <option value="previous" ${'selected' if version_settings['view'] == 'previous' else ''}>Previous</option>
+                                        % for version in versions[1:]:
+                                            <option value="${version['version']}" ${'selected' if version_settings['view'] == version['version'] else ''}>(${version['version']}) ${version['user_fullname']}: ${version['date']}</option>
+                                        % endfor
                                     % endif
-                                    % for version in versions[2:]:
-                                        <option value="${version['version']}" ${'selected' if version_settings['view'] == version['version'] else ''}>Version ${version['version']}</option>
-                                    % endfor
                                 </select>
 
                             </div>
@@ -198,13 +197,13 @@
                             <!-- Version Picker -->
                             <span class="compare-version-text"><i> <span data-bind="text: viewVersionDisplay"></span></i> to
                               <select class="form-control" data-bind="value: compareVersion" id="compareVersionSelect">
-                                  <option value="current" ${'selected' if version_settings['compare'] == 'current' else ''}>Current</option>
+                                  <option value="current" ${'selected' if version_settings['compare'] == 'current' else ''}>(Current) ${versions[0]['user_fullname']}: ${versions[0]['date']}</option>
                                   % if len(versions) > 1:
-                                      <option value="previous" ${'selected' if version_settings['compare'] == 'previous' else ''}>Previous</option>
+                                      % for version in versions[1:]:
+                                          <option value="${version['version']}" ${'selected' if version_settings['compare'] == version['version'] else ''}>(${version['version']}) ${version['user_fullname']}: ${version['date']}</option>
+                                      % endfor
                                   % endif
-                                  % for version in versions[2:]:
-                                      <option value="${version['version']}" ${'selected' if version_settings['compare'] == version['version'] else ''}>Version ${version['version']}</option>
-                                  % endfor
+
                               </select></span>
 
                           </div>

--- a/website/addons/wiki/views.py
+++ b/website/addons/wiki/views.py
@@ -84,7 +84,7 @@ def _get_wiki_versions(node, name, anonymous=False):
         {
             'version': version.version,
             'user_fullname': privacy_info_handle(version.user.fullname, anonymous, name=True),
-            'date': version.date.replace(microsecond=0).isoformat(),
+            'date': '{} UTC'.format(version.date.replace(microsecond=0).isoformat().replace('T', ' ')),
         }
         for version in reversed(versions)
     ]

--- a/website/static/css/pages/wiki-page.css
+++ b/website/static/css/pages/wiki-page.css
@@ -314,7 +314,6 @@
 }
 
 select.form-control {
-    width: inherit;
     padding:1px;
     display: inline;
     height: 24px;


### PR DESCRIPTION
Purpose
=======
Give users more information regarding wiki version history

Changes
=======
* previously unused `date` formatted, exposed
* dropdown item format changed to:
     * `([# or 'Current']) [Firstname Lastname]: [YYYY-MM-DD HH:mm] UTC`

Side Effects
=========
None