### PR TITLE
OSF-4475

### DIFF
--- a/website/addons/dataverse/static/dataverseFangornConfig.js
+++ b/website/addons/dataverse/static/dataverseFangornConfig.js
@@ -51,7 +51,7 @@ var _dataverseItemButtons = {
                 }, 'Publish ' + toPublish)
             ];
 
-            tb.modal.update(modalContent, modalActions, m('h3.break-word.modal-title', 'Publish this' + toPublish + '?'));
+            tb.modal.update(modalContent, modalActions, m('h3.break-word.modal-title', 'Publish this ' + toPublish + '?'));
 
             function publishDataset() {
                 tb.modal.dismiss();

--- a/website/addons/dataverse/static/dataverseFangornConfig.js
+++ b/website/addons/dataverse/static/dataverseFangornConfig.js
@@ -34,25 +34,24 @@ var _dataverseItemButtons = {
             var url = item.data.urls.publish;
             var toPublish = both ? 'Dataverse and dataset' : 'dataset';
             var modalContent = [
-                m('h3', 'Publish this ' + toPublish + '?'),
                 m('p.m-md', both ? 'This dataset cannot be published until ' + item.data.dataverse + ' Dataverse is published. ' : ''),
                 m('p.m-md', 'By publishing this ' + toPublish + ', all content will be made available through the Harvard Dataverse using their internal privacy settings, regardless of your OSF project settings. '),
                 m('p.font-thick.m-md', both ? 'Do you want to publish this Dataverse AND this dataset?' : 'Are you sure you want to publish this dataset?')
             ];
             var modalActions = [
-                m('button.btn.btn-default.m-sm', {
+                m('button.btn.btn-default', {
                     'onclick': function () {
                         tb.modal.dismiss();
                     }
                 }, 'Cancel'),
-                m('button.btn.btn-primary.m-sm', {
+                m('button.btn.btn-primary', {
                     'onclick': function () {
                         publishDataset();
                     }
                 }, 'Publish ' + toPublish)
             ];
 
-            tb.modal.update(modalContent, modalActions);
+            tb.modal.update(modalContent, modalActions, m('h3.break-word.modal-title', 'Publish this' + toPublish + '?'));
 
             function publishDataset() {
                 tb.modal.dismiss();
@@ -66,7 +65,7 @@ var _dataverseItemButtons = {
                         m('p.m-md', 'Your content has been published.')
                     ];
                     var modalActions = [
-                        m('button.btn.btn-primary.m-sm', {
+                        m('button.btn.btn-primary', {
                             'onclick': function () {
                                 tb.modal.dismiss();
                             }
@@ -99,7 +98,7 @@ var _dataverseItemButtons = {
                         m('p.m-md', message)
                     ];
                     var modalActions = [
-                        m('button.btn.btn-primary.m-sm', {
+                        m('button.btn.btn-primary', {
                             'onclick': function () {
                                 tb.modal.dismiss();
                             }

--- a/website/project/metadata/osf-standard-1.json
+++ b/website/project/metadata/osf-standard-1.json
@@ -9,9 +9,9 @@
                     {
                         "id": "datacompletion",
                         "type": "select",
-                        "label": "Is data collection for this project underway or complete?",
+                        "label": "Has data collection begun for this project?",
                         "caption": "Please choose",
-                        "options": ["No, no data has been collected", "Yes, data collection is underway or complete"]
+                        "options": ["No, data collection has not begun", "Yes, data collection is underway or complete"]
                     },
                     {
                         "id": "looked",


### PR DESCRIPTION
Fix the formatting for the dataverse modal (OSF-4475):
  1. The original code updates the title of the modal as the "modal content". Fixed.
  2. The original file (dataverseFangornConfig.js) use buttons with "m-sm" class, causing Cancel and Confirm buttons to not align correctly. Fixed.
  3. According to the style guide, default bootstrap buttons are used. So I remove the "m-sm" class from other buttons in this file (dataverseFangornConfig.js).

Change the language for data pre-registration (OSF-4660).
