### PR TITLE
[Hotfix] Fix check for add contributor permissions

### DIFF
--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -104,7 +104,7 @@ class TestNodeSerializers(OsfTestCase):
                                        permissions=permissions.expand_permissions(permissions.WRITE))
         read_and_write.save()
         read_only = NodeFactory(parent=admin_project)
-        read_only.add_contributor(user, auth=Auth(read_and_write.creator),
+        read_only.add_contributor(user, auth=Auth(read_only.creator),
                                   permissions=permissions.expand_permissions(permissions.READ))
         read_only.save()
 

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -854,10 +854,8 @@ def private_link_table(node, **kwargs):
 
 @collect_auth
 @must_be_valid_project
+@must_have_permission(ADMIN)
 def get_editable_children(auth, node, **kwargs):
-
-    if not node.has_permission(auth.user, 'admin'):
-        return
 
     children = _get_children(node, auth)
 

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -827,7 +827,7 @@ def _get_children(node, auth, indent=0):
     children = []
 
     for child in node.nodes_primary:
-        if not child.is_deleted and child.can_edit(auth):
+        if not child.is_deleted and child.has_permission(auth.user, 'admin'):
             children.append({
                 'id': child._primary_key,
                 'title': child.title,
@@ -856,7 +856,7 @@ def private_link_table(node, **kwargs):
 @must_be_valid_project
 def get_editable_children(auth, node, **kwargs):
 
-    if not node.can_edit(auth):
+    if not node.has_permission(auth.user, 'admin'):
         return
 
     children = _get_children(node, auth)


### PR DESCRIPTION
Fixes https://openscience.atlassian.net/browse/OSF-4618

For the list of nodes returned when adding a contributor to a project with components, instead of checking whether a user can edit a node, check that they have admin permissions on the node.