### PR TITLE
Provide choice_in validator for ModularODM models

### DIFF
--- a/framework/mongo/validators.py
+++ b/framework/mongo/validators.py
@@ -1,7 +1,8 @@
 """
 Validators for use in ModularODM
 """
-from modularodm.exceptions import ValidationValueError
+import collections
+from modularodm.exceptions import ValidationError, ValidationValueError
 
 
 def string_required(value):
@@ -27,6 +28,9 @@ def choice_in(choices, ignore_case=False):
         choice_set = frozenset(choices)
 
     def validator(value):
+
+        if not isinstance(value, collections.Hashable):
+            raise ValidationError('Must specify a single choice; value cannot be a collection')
         if ignore_case and isinstance(value, basestring):
             value = value.upper()
 

--- a/framework/mongo/validators.py
+++ b/framework/mongo/validators.py
@@ -10,24 +10,24 @@ def string_required(value):
     return True
 
 
-def choice_in(choices, match_case=True):
+def choice_in(choices, ignore_case=False):
     """
-    Validate that the option provided is from a restricted set of choices
+    Validate that the option provided is one of a restricted set of choices
 
     Returns a callable that can be used as a validator in ModularODM
     :param choices: An iterable of choices allowed for use
-    :param bool match_case: If false, perform case-insensitive comparison (for strings)
+    :param bool ignore_case: If True, perform case-insensitive comparison (for strings) and otherwise match as-is
     :return:
     """
 
-    if match_case:
-        choice_set = set(e.upper() if isinstance(e, basestring) else e
-                         for e in choices)
+    if ignore_case is True:
+        choice_set = frozenset(e.upper() if isinstance(e, basestring) else e
+                               for e in choices)
     else:
-        choice_set = set(choices)
+        choice_set = frozenset(choices)
 
     def validator(value):
-        if match_case is True and isinstance(value, basestring):
+        if ignore_case is True and isinstance(value, basestring):
             value = value.upper()
 
         if value in choice_set:

--- a/framework/mongo/validators.py
+++ b/framework/mongo/validators.py
@@ -20,14 +20,14 @@ def choice_in(choices, ignore_case=False):
     :return:
     """
 
-    if ignore_case is True:
+    if ignore_case:
         choice_set = frozenset(e.upper() if isinstance(e, basestring) else e
                                for e in choices)
     else:
         choice_set = frozenset(choices)
 
     def validator(value):
-        if ignore_case is True and isinstance(value, basestring):
+        if ignore_case and isinstance(value, basestring):
             value = value.upper()
 
         if value in choice_set:

--- a/framework/mongo/validators.py
+++ b/framework/mongo/validators.py
@@ -7,3 +7,31 @@ from modularodm.exceptions import ValidationValueError
 def string_required(value):
     if value is None or value == '':
         raise ValidationValueError('Value must not be empty.')
+    return True
+
+
+def choice_in(choices, match_case=True):
+    """
+    Validate that the option provided is from a restricted set of choices
+
+    Returns a callable that can be used as a validator in ModularODM
+    :param choices: An iterable of choices allowed for use
+    :param bool match_case: If false, perform case-insensitive comparison (for strings)
+    :return:
+    """
+
+    if match_case:
+        choice_set = set(e.upper() if isinstance(e, basestring) else e
+                         for e in choices)
+    else:
+        choice_set = set(choices)
+
+    def validator(value):
+        if match_case is True and isinstance(value, basestring):
+            value = value.upper()
+
+        if value in choice_set:
+            return True
+        else:
+            raise ValidationValueError('Value must be one of these options: {}'.format(choices))
+    return validator

--- a/tests/framework_tests/test_mongo.py
+++ b/tests/framework_tests/test_mongo.py
@@ -5,11 +5,16 @@ from unittest import TestCase
 
 from nose.tools import *  # flake8: noqa
 
-from modularodm.exceptions import ValidationValueError
+from modularodm.exceptions import ValidationError, ValidationValueError
 
 from framework.mongo import validators
 
 class TestValidators(TestCase):
+
+    def _choice_validator(self, ignore_case=False):
+        return validators.choice_in(('value1', 'value2', 'VaLuE3', 123),
+                                    ignore_case=ignore_case)
+
     def test_string_required_passes_with_string(self):
         assert_true(validators.string_required('Hi!'))
 
@@ -20,8 +25,7 @@ class TestValidators(TestCase):
             validators.string_required('')
 
     def test_choice_validator_finds_only_exact_match(self):
-        new_validator = validators.choice_in(('value1', 'value2', 'VaLuE3', 123),
-                                             ignore_case=False)
+        new_validator = self._choice_validator(ignore_case=False)
 
         assert_true(new_validator('value1'))
         assert_true(new_validator('VaLuE3'))
@@ -30,20 +34,31 @@ class TestValidators(TestCase):
         with assert_raises(ValidationValueError):
             new_validator('VALue2')
 
-    def choice_validator_fails_when_option_not_present(self):
-        new_validator = validators.choice_in(('value1', 'value2', 'VaLuE3', 123),
-                                             ignore_case=False)
+    def test_choice_validator_fails_when_option_not_present(self):
+        new_validator = self._choice_validator(ignore_case=False)
+
         with assert_raises(ValidationValueError):
             new_validator('You')
             new_validator('123')
             new_validator(456)
 
-    def choice_validator_case_insensitive(self):
-        new_validator = validators.choice_in(('value1', 'value2', 'VaLuE3', 123),
-                                             ignore_case=True)
+    def test_choice_validator_case_insensitive(self):
+        new_validator = self._choice_validator(ignore_case=True)
         assert_true(new_validator('VaLuE3'))
         assert_true(new_validator('value3'))
         assert_true(new_validator(123))
 
         with assert_raises(ValidationValueError):
             new_validator('123')
+
+    def test_choice_validator_fails_when_value_is_unhashable_list(self):
+        new_validator = self._choice_validator(ignore_case=False)
+
+        with assert_raises(ValidationError):
+            new_validator(['e', 'i', 'e', 'i', 'o'])
+
+    def test_choice_validator_fails_when_value_is_unhashable_dict(self):
+        new_validator = self._choice_validator(ignore_case=False)
+
+        with assert_raises(ValidationError):
+            new_validator({'k': 'v', 'k2': 'v2'})

--- a/tests/framework_tests/test_mongo.py
+++ b/tests/framework_tests/test_mongo.py
@@ -1,0 +1,44 @@
+"""
+Tests related to functions in framework.mongo
+"""
+from unittest import TestCase
+
+from nose.tools import *  # flake8: noqa
+
+from modularodm.exceptions import ValidationValueError
+
+from framework.mongo import validators
+
+class TestValidators(TestCase):
+    def test_string_required_passes_with_string(self):
+        assert_true(validators.string_required('Hi!'))
+
+    def test_string_required_fails_when_empty(self):
+
+        with assert_raises(ValidationValueError):
+            validators.string_required(None)
+            validators.string_required('')
+
+    def test_choice_validator_finds_only_exact_match(self):
+        new_validator = validators.choice_in(('value1', 'value2', 'VaLuE3'),
+                                             match_case=True)
+
+        assert_true(new_validator('value1'))
+        assert_true(new_validator('VaLuE3'))
+
+        with assert_raises(ValidationValueError):
+            new_validator('Value2')
+
+    def choice_validator_fails_when_option_not_present(self):
+        new_validator = validators.choice_in(('value1', 'value2', 'VaLuE3'),
+                                             match_case=True)
+        with assert_raises(ValidationValueError):
+            new_validator('You')
+            new_validator(123)
+
+    def choice_validator_case_insensitive(self):
+        new_validator = validators.choice_in(('value1', 'value2', 'VaLuE3'),
+                                             match_case=False)
+        assert_true(new_validator('VaLuE3'))
+        assert_true(new_validator('value3'))
+

--- a/tests/framework_tests/test_mongo.py
+++ b/tests/framework_tests/test_mongo.py
@@ -20,25 +20,30 @@ class TestValidators(TestCase):
             validators.string_required('')
 
     def test_choice_validator_finds_only_exact_match(self):
-        new_validator = validators.choice_in(('value1', 'value2', 'VaLuE3'),
-                                             match_case=True)
+        new_validator = validators.choice_in(('value1', 'value2', 'VaLuE3', 123),
+                                             ignore_case=False)
 
         assert_true(new_validator('value1'))
         assert_true(new_validator('VaLuE3'))
+        assert_true(new_validator(123))
 
         with assert_raises(ValidationValueError):
-            new_validator('Value2')
+            new_validator('VALue2')
 
     def choice_validator_fails_when_option_not_present(self):
-        new_validator = validators.choice_in(('value1', 'value2', 'VaLuE3'),
-                                             match_case=True)
+        new_validator = validators.choice_in(('value1', 'value2', 'VaLuE3', 123),
+                                             ignore_case=False)
         with assert_raises(ValidationValueError):
             new_validator('You')
-            new_validator(123)
+            new_validator('123')
+            new_validator(456)
 
     def choice_validator_case_insensitive(self):
-        new_validator = validators.choice_in(('value1', 'value2', 'VaLuE3'),
-                                             match_case=False)
+        new_validator = validators.choice_in(('value1', 'value2', 'VaLuE3', 123),
+                                             ignore_case=True)
         assert_true(new_validator('VaLuE3'))
         assert_true(new_validator('value3'))
+        assert_true(new_validator(123))
 
+        with assert_raises(ValidationValueError):
+            new_validator('123')


### PR DESCRIPTION
## Purpose
Presently, modularODM does not provide a way to restrict a field to a particular set of choices. There are some one-off validation functions, but I was not able to find a single reusable solution.

This adds a validator that accepts an iterable of choices, and returns a callable. It supports multiple datatypes, and provides an option for case-insensitive comparisons. Example use-cases include `Node.category` field and `Sanction.state` (a field in a pending PR).

## Summary of changes
- Add validator to restrict modularODM field to a set of pre-defined choices
- Also added unit tests for this and one other recently added validator.

## Sample usage
```
class Node(...):
    category = fields.StringField(validate=validators.choice_in(CATEGORY_MAP.keys()), index=True)
```

## Priority
Side task; need identified while reviewing prereg PR.