### PR TITLE
[RfR] Allow viewing unconfirmed users

### DIFF
--- a/api/base/utils.py
+++ b/api/base/utils.py
@@ -58,12 +58,6 @@ def get_object_or_error(model_cls, query_or_pk, display_name=None):
                 raise Gone
             else:
                 raise Gone(detail='The requested {name} is no longer available.'.format(name=display_name))
-        if hasattr(obj, 'is_active'):
-            if not getattr(obj, 'is_active', False):
-                if display_name is None:
-                    raise Gone
-                else:
-                    raise Gone(detail='The requested {name} is no longer available.'.format(name=display_name))
         return obj
 
     except NoResultsFound:

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -9,7 +9,7 @@ from api.base.serializers import (
 
 class UserSerializer(JSONAPISerializer):
     filterable_fields = frozenset([
-        'fullname',
+        'full_name',
         'given_name',
         'middle_names',
         'family_name',
@@ -17,7 +17,7 @@ class UserSerializer(JSONAPISerializer):
     ])
     id = IDField(source='_id', read_only=True)
     type = TypeField()
-    fullname = ser.CharField(required=True, label='Full name', help_text='Display name used in the general user interface')
+    full_name = ser.CharField(required=True, label='Full name', help_text='Display name used in the general user interface', source='fullname')
     given_name = ser.CharField(required=False, allow_blank=True, help_text='For bibliographic citations')
     middle_names = ser.CharField(required=False, allow_blank=True, help_text='For bibliographic citations')
     family_name = ser.CharField(required=False, allow_blank=True, help_text='For bibliographic citations')


### PR DESCRIPTION
# Purpose

The API was returning 410's for unconfirmed users. These users should be readable. 

# Changes

- fullname -> full_name
- remove check that user is active in get_object_or_error
- update tests

# Side Effects

None
