### PR TITLE
[RfR] Allow viewing unconfirmed users

### DIFF
--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -174,9 +174,9 @@ SWAGGER_SETTINGS = {
         <p> Collections can be filtered by adding a query parameter in the form:</p>
         <pre>filter[&lt;fieldname&gt;]=&lt;matching information&gt;</pre>
         <p>For example, if you were trying to find <a href="http://en.wikipedia.org/wiki/Lise_Meitner">Lise Meitner</a>:</p>
-        <pre>/users?filter[fullname]=meitn</pre>
+        <pre>/users?filter[full_name]=meitn</pre>
         <p>You can filter on multiple fields, or the same field in different ways, by &-ing the query parameters together.</p>
-        <pre>/users?filter[fullname]=lise&filter[family_name]=mei</pre>
+        <pre>/users?filter[full_name]=lise&filter[family_name]=mei</pre>
         <h3>Links</h3>
         <p> Responses will generally have associated links which are helpers to keep you from having to construct URLs in
         your code or by hand. If you know the route to a high-level resource, you can go to that route. For example:</p>

--- a/api/base/utils.py
+++ b/api/base/utils.py
@@ -58,12 +58,6 @@ def get_object_or_error(model_cls, query_or_pk, display_name=None):
                 raise Gone
             else:
                 raise Gone(detail='The requested {name} is no longer available.'.format(name=display_name))
-        if hasattr(obj, 'is_active'):
-            if not getattr(obj, 'is_active', False):
-                if display_name is None:
-                    raise Gone
-                else:
-                    raise Gone(detail='The requested {name} is no longer available.'.format(name=display_name))
         return obj
 
     except NoResultsFound:

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -33,7 +33,7 @@ def root(request, format=None):
             filter[<fieldname>]=<matching information>
         For example, if you were trying to find [Lise Meitner](http://en.wikipedia.org/wiki/Lise_Meitner):
 
-            /users?filter[fullname]=meitn
+            /users?filter[full_name]=meitn
         You can filter on multiple fields, or the same field in different ways, by &-ing the query parameters together.
 
             /users?filter[fullname]=lise&filter[family_name]=mei

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -160,7 +160,7 @@ class NodeContributorsSerializer(JSONAPISerializer):
     id = IDField(source='_id', required=True)
     type = TypeField()
 
-    fullname = ser.CharField(read_only=True, help_text='Display name used in the general user interface')
+    full_name = ser.CharField(read_only=True, help_text='Display name used in the general user interface', source='fullname')
     given_name = ser.CharField(read_only=True, help_text='For bibliographic citations')
     middle_name = ser.CharField(read_only=True, source='middle_names', help_text='For bibliographic citations')
     family_name = ser.CharField(read_only=True, help_text='For bibliographic citations')

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -9,7 +9,7 @@ from api.base.serializers import (
 
 class UserSerializer(JSONAPISerializer):
     filterable_fields = frozenset([
-        'fullname',
+        'full_name',
         'given_name',
         'middle_names',
         'family_name',
@@ -17,7 +17,7 @@ class UserSerializer(JSONAPISerializer):
     ])
     id = IDField(source='_id', read_only=True)
     type = TypeField()
-    fullname = ser.CharField(required=True, label='Full name', help_text='Display name used in the general user interface')
+    full_name = ser.CharField(required=True, label='Full name', help_text='Display name used in the general user interface', source='fullname')
     given_name = ser.CharField(required=False, allow_blank=True, help_text='For bibliographic citations')
     middle_names = ser.CharField(required=False, allow_blank=True, help_text='For bibliographic citations')
     family_name = ser.CharField(required=False, allow_blank=True, help_text='For bibliographic citations')

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -47,7 +47,7 @@ class UserMixin(object):
 class UserList(generics.ListAPIView, ODMFilterMixin):
     """Users registered on the OSF.
 
-    You can filter on users by their id, fullname, given_name, middle_name, or family_name.
+    You can filter on users by their id, full_name, given_name, middle_name, or family_name.
     """
     permission_classes = (
         drf_permissions.IsAuthenticatedOrReadOnly,


### PR DESCRIPTION
# Purpose

The API was returning 410's for unconfirmed users. These users should be readable. 

# Changes

- fullname -> full_name
- remove check that user is active in get_object_or_error
- update tests

# Side Effects

None
