### PR TITLE
[Ready to Review] Uncaught 500 error when request contains non-dictionary data

### DIFF
--- a/api/base/parsers.py
+++ b/api/base/parsers.py
@@ -1,4 +1,5 @@
 from rest_framework.parsers import JSONParser
+from rest_framework.exceptions import ValidationError
 
 from api.base.renderers import JSONAPIRenderer
 from api.base.exceptions import JSONAPIException
@@ -15,16 +16,18 @@ class JSONAPIParser(JSONParser):
         Parses the incoming bytestream as JSON and returns the resulting data
         """
         result = super(JSONAPIParser, self).parse(stream, media_type=media_type, parser_context=parser_context)
+        if not isinstance(result, dict):
+            raise ValidationError("Invalid data. Expected a dictionary but got {}".format(type(result)))
         data = result.get('data', {})
 
         if data:
             if 'attributes' not in data:
                 raise JSONAPIException(source={'pointer': '/data/attributes'}, detail='This field is required.')
             id = data.get('id')
-            type = data.get('type')
+            object_type = data.get('type')
             attributes = data.get('attributes')
 
-            parsed = {'id': id, 'type': type}
+            parsed = {'id': id, 'type': object_type}
             parsed.update(attributes)
 
             return parsed

--- a/api/base/parsers.py
+++ b/api/base/parsers.py
@@ -1,5 +1,5 @@
 from rest_framework.parsers import JSONParser
-from rest_framework.exceptions import ValidationError
+from rest_framework.exceptions import ParseError
 
 from api.base.renderers import JSONAPIRenderer
 from api.base.exceptions import JSONAPIException
@@ -17,7 +17,7 @@ class JSONAPIParser(JSONParser):
         """
         result = super(JSONAPIParser, self).parse(stream, media_type=media_type, parser_context=parser_context)
         if not isinstance(result, dict):
-            raise ValidationError("Invalid data. Expected a dictionary but got {}".format(type(result)))
+            raise ParseError()
         data = result.get('data', {})
 
         if data:

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -402,6 +402,14 @@ class TestNodeCreate(ApiTestCase):
                 }
             }
         }
+    def test_node_create_invalid_data(self):
+        res = self.app.post_json_api(self.url, "Incorrect data", auth=self.user_one.auth, expect_errors=True)
+        assert_equal(res.status_code, 400)
+        assert_equal(res.json['errors'][0]['detail'], "Invalid data. Expected a dictionary but got <type 'unicode'>")
+
+        res = self.app.post_json_api(self.url, ["Incorrect data"], auth=self.user_one.auth, expect_errors=True)
+        assert_equal(res.status_code, 400)
+        assert_equal(res.json['errors'][0]['detail'], "Invalid data. Expected a dictionary but got <type 'list'>")
 
     def test_creates_public_project_logged_out(self):
         res = self.app.post_json_api(self.url, self.public_project, expect_errors=True)
@@ -655,6 +663,16 @@ class NodeCRUDTestCase(ApiTestCase):
 
 
 class TestNodeUpdate(NodeCRUDTestCase):
+
+    def test_node_update_invalid_data(self):
+        res = self.app.put_json_api(self.public_url, "Incorrect data", auth=self.user.auth, expect_errors=True)
+        assert_equal(res.status_code, 400)
+        assert_equal(res.json['errors'][0]['detail'], "Invalid data. Expected a dictionary but got <type 'unicode'>")
+
+        res = self.app.put_json_api(self.public_url, ["Incorrect data"], auth=self.user.auth, expect_errors=True)
+        assert_equal(res.status_code, 400)
+        assert_equal(res.json['errors'][0]['detail'], "Invalid data. Expected a dictionary but got <type 'list'>")
+
 
     def test_update_project_properties_not_nested(self):
         res = self.app.put_json_api(self.public_url, {
@@ -1289,6 +1307,15 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
             }
         }
 
+    def test_contributor_update_invalid_data(self):
+        res = self.app.post_json_api(self.public_url, "Incorrect data", auth=self.user_three.auth, expect_errors=True)
+        assert_equal(res.status_code, 400)
+        assert_equal(res.json['errors'][0]['detail'], "Invalid data. Expected a dictionary but got <type 'unicode'>")
+
+        res = self.app.post_json_api(self.public_url, ["Incorrect data"], auth=self.user_three.auth, expect_errors=True)
+        assert_equal(res.status_code, 400)
+        assert_equal(res.json['errors'][0]['detail'], "Invalid data. Expected a dictionary but got <type 'list'>")
+
     def test_add_contributor_no_type(self):
         data = {
             'data': {
@@ -1589,6 +1616,15 @@ class TestNodeContributorUpdate(ApiTestCase):
 
         self.url_creator = '/{}nodes/{}/contributors/{}/'.format(API_BASE, self.project._id, self.user._id)
         self.url_contributor = '/{}nodes/{}/contributors/{}/'.format(API_BASE, self.project._id, self.user_two._id)
+
+    def test_node_update_invalid_data(self):
+        res = self.app.put_json_api(self.url_creator, "Incorrect data", auth=self.user.auth, expect_errors=True)
+        assert_equal(res.status_code, 400)
+        assert_equal(res.json['errors'][0]['detail'], "Invalid data. Expected a dictionary but got <type 'unicode'>")
+
+        res = self.app.put_json_api(self.url_creator, ["Incorrect data"], auth=self.user.auth, expect_errors=True)
+        assert_equal(res.status_code, 400)
+        assert_equal(res.json['errors'][0]['detail'], "Invalid data. Expected a dictionary but got <type 'list'>")
 
     def test_change_contributor_no_id(self):
         data = {

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -405,11 +405,11 @@ class TestNodeCreate(ApiTestCase):
     def test_node_create_invalid_data(self):
         res = self.app.post_json_api(self.url, "Incorrect data", auth=self.user_one.auth, expect_errors=True)
         assert_equal(res.status_code, 400)
-        assert_equal(res.json['errors'][0]['detail'], "Invalid data. Expected a dictionary but got <type 'unicode'>")
+        assert_equal(res.json['errors'][0]['detail'], "Malformed request.")
 
         res = self.app.post_json_api(self.url, ["Incorrect data"], auth=self.user_one.auth, expect_errors=True)
         assert_equal(res.status_code, 400)
-        assert_equal(res.json['errors'][0]['detail'], "Invalid data. Expected a dictionary but got <type 'list'>")
+        assert_equal(res.json['errors'][0]['detail'], "Malformed request.")
 
     def test_creates_public_project_logged_out(self):
         res = self.app.post_json_api(self.url, self.public_project, expect_errors=True)
@@ -667,11 +667,11 @@ class TestNodeUpdate(NodeCRUDTestCase):
     def test_node_update_invalid_data(self):
         res = self.app.put_json_api(self.public_url, "Incorrect data", auth=self.user.auth, expect_errors=True)
         assert_equal(res.status_code, 400)
-        assert_equal(res.json['errors'][0]['detail'], "Invalid data. Expected a dictionary but got <type 'unicode'>")
+        assert_equal(res.json['errors'][0]['detail'], "Malformed request.")
 
         res = self.app.put_json_api(self.public_url, ["Incorrect data"], auth=self.user.auth, expect_errors=True)
         assert_equal(res.status_code, 400)
-        assert_equal(res.json['errors'][0]['detail'], "Invalid data. Expected a dictionary but got <type 'list'>")
+        assert_equal(res.json['errors'][0]['detail'], "Malformed request.")
 
 
     def test_update_project_properties_not_nested(self):


### PR DESCRIPTION
# Purpose
Issue OSF-4629, https://openscience.atlassian.net/browse/OSF-4629

New parser added to handle new JSON request formatting can only handle dictionary data.  If other type of data like a "list" or "string" is sent, there is an uncaught 500 exception because the code tries to call `.get` on a string, for example.
![screen shot 2015-09-24 at 1 14 12 pm](https://cloud.githubusercontent.com/assets/9755598/10080577/6236927c-62be-11e5-8f30-44616f8ce49c.png)


# Changes
Raises ValidationError if data is not a dictionary.

![screen shot 2015-09-24 at 1 17 11 pm](https://cloud.githubusercontent.com/assets/9755598/10080611/8bf11146-62be-11e5-82a4-f8a861604be7.png)

