### PR TITLE
[RfR] Make 'self' link overridable for Links field

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -158,7 +158,7 @@ class LinksField(ser.Field):
 
     def to_representation(self, obj):
         ret = _rapply(self.links, _url_val, obj=obj, serializer=self.parent)
-        if hasattr(obj, 'get_absolute_url'):
+        if hasattr(obj, 'get_absolute_url') and 'self' not in self.links:
             ret['self'] = obj.get_absolute_url()
         return ret
 

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -173,7 +173,10 @@ class NodeContributorsSerializer(JSONAPISerializer):
                                  default=osf_permissions.reduce_permissions(osf_permissions.DEFAULT_CONTRIBUTOR_PERMISSIONS),
                                  help_text='User permission level. Must be "read", "write", or "admin". Defaults to "write".')
 
-    links = LinksField({'html': 'absolute_url'})
+    links = LinksField({
+        'html': 'absolute_url',
+        'self': 'get_absolute_url'
+    })
     nodes = JSONAPIHyperlinkedIdentityField(view_name='users:user-nodes', lookup_field='pk', lookup_url_kwarg='user_id',
                                              link_type='related')
 


### PR DESCRIPTION
# Purpose

The Node Contributor view was incorrectly serializing it's 'self' link. I.e.
```   
"links": {
            "self": "http://localhost:8000/v2/user/xbd6f/",
            "html": "http://localhost:5000/xbd6f/"
        }
```
Which should be: 
```
"links": {
            "self": "http://localhost:8000/v2/nodes/26vq3/contributors/xbd6f/",
            "html": "http://localhost:5000/xbd6f/"
        }
```

# Changes

Make the Links class 'self' link overridable  

# Side effects

profit ??? 