### PR TITLE
[RfR] Feature/api/node serializer fixes

### DIFF
--- a/api/base/exceptions.py
+++ b/api/base/exceptions.py
@@ -99,3 +99,8 @@ class UnconfirmedAccountError(APIException):
 class DeactivatedAccountError(APIException):
     status_code = 400
     default_detail = 'Making API requests with credentials associated with a deactivated account is not allowed.'
+
+
+class InvalidModelValueError(JSONAPIException):
+    status_code = 400
+    default_detail = 'Invalid value in POST/PUT/PATCH request.'

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -158,7 +158,7 @@ class LinksField(ser.Field):
 
     def to_representation(self, obj):
         ret = _rapply(self.links, _url_val, obj=obj, serializer=self.parent)
-        if hasattr(obj, 'get_absolute_url'):
+        if hasattr(obj, 'get_absolute_url') and 'self' not in self.links:
             ret['self'] = obj.get_absolute_url()
         return ret
 

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -173,7 +173,10 @@ class NodeContributorsSerializer(JSONAPISerializer):
                                  default=osf_permissions.reduce_permissions(osf_permissions.DEFAULT_CONTRIBUTOR_PERMISSIONS),
                                  help_text='User permission level. Must be "read", "write", or "admin". Defaults to "write".')
 
-    links = LinksField({'html': 'absolute_url'})
+    links = LinksField({
+        'html': 'absolute_url',
+        'self': 'get_absolute_url'
+    })
     nodes = JSONAPIHyperlinkedIdentityField(view_name='users:user-nodes', lookup_field='pk', lookup_url_kwarg='user_id',
                                              link_type='related')
 

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -510,6 +510,22 @@ class TestNodeCreate(ApiTestCase):
         assert_equal(res.json['errors'][0]['detail'], 'This field is required.')
         assert_equal(res.json['errors'][0]['source']['pointer'], '/data/attributes')
 
+    def test_create_project_invalid_title(self):
+        project = {
+            'data': {
+                'type': 'nodes',
+                'attributes': {
+                    'title': 'A' * 201,
+                    'description': self.description,
+                    'category': self.category,
+                    'public': False,
+                }
+            }
+        }
+        res = self.app.post_json_api(self.url, project, auth=self.user_one.auth, expect_errors=True)
+        assert_equal(res.status_code, 400)
+        assert_equal(res.json['errors'][0]['detail'], 'Title cannot exceed 200 characters.')
+
 
 class TestNodeDetail(ApiTestCase):
     def setUp(self):
@@ -1074,6 +1090,21 @@ class TestNodeUpdate(NodeCRUDTestCase):
             }
         }, auth=self.user.auth, expect_errors=True)
         assert_equal(res.status_code, 400)
+
+    def test_update_project_invalid_title(self):
+        project = {
+            'data': {
+                'type': 'nodes',
+                'id': self.public_project._id,
+                'attributes': {
+                    'title': 'A' * 201,
+                    'category': 'project',
+                }
+            }
+        }
+        res = self.app.put_json_api(self.public_url, project, auth=self.user.auth, expect_errors=True)
+        assert_equal(res.status_code, 400)
+        assert_equal(res.json['errors'][0]['detail'], 'Title cannot exceed 200 characters.')
 
 
 class TestNodeDelete(NodeCRUDTestCase):


### PR DESCRIPTION
# Purpose

The Node Contributor view was incorrectly serializing it's 'self' link. I.e.
```   
"links": {
            "self": "http://localhost:8000/v2/user/xbd6f/",
            "html": "http://localhost:5000/xbd6f/"
        }
```
Which should be: 
```
"links": {
            "self": "http://localhost:8000/v2/nodes/26vq3/contributors/xbd6f/",
            "html": "http://localhost:5000/xbd6f/"
        }
```

# Changes

Make the Links class 'self' link overridable  

# Side effects

profit ??? 