### PR TITLE
Fix node files endpoint

### DIFF
--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -447,9 +447,11 @@ class NodeFilesList(generics.ListAPIView, NodeMixin):
             if self.kwargs['path'] == '/':
                 return list(self.get_node().get_addon('osfstorage').get_root().children)
 
-            fobj = OsfStorageFileNode.find_one(
+            fobj = get_object_or_error(
+                OsfStorageFileNode,
                 Q('node', 'eq', self.get_node()._id) &
-                Q('path', 'eq', self.kwargs['path'])
+                Q('_id', 'eq', self.kwargs['path'].strip('/')) &
+                Q('is_file', 'eq', not self.kwargs['path'].endswith('/'))
             )
 
             if fobj.is_file:

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -2664,6 +2664,24 @@ class TestNodeFilesList(ApiTestCase):
         assert_equal(res.content_type, 'application/vnd.api+json')
         assert_equal(res.json['data'][0]['attributes']['provider'], 'osfstorage')
 
+    def test_returns_file_data(self):
+        fobj = self.project.get_addon('osfstorage').get_root().append_file('NewFile')
+        fobj.save()
+        res = self.app.get('{}osfstorage/{}'.format(self.private_url, fobj._id), auth=self.user.auth)
+        assert_equal(res.status_code, 200)
+        assert_equal(len(res.json['data']), 1)
+        assert_equal(res.json['data'][0]['attributes']['kind'], 'file')
+        assert_equal(res.json['data'][0]['attributes']['name'], 'NewFile')
+        assert_equal(res.content_type, 'application/vnd.api+json')
+
+    def test_returns_folder_data(self):
+        fobj = self.project.get_addon('osfstorage').get_root().append_folder('NewFolder')
+        fobj.save()
+        res = self.app.get('{}osfstorage/{}/'.format(self.private_url, fobj._id), auth=self.user.auth)
+        assert_equal(res.status_code, 200)
+        assert_equal(len(res.json['data']), 0)
+        assert_equal(res.content_type, 'application/vnd.api+json')
+
     def test_returns_private_files_logged_out(self):
         res = self.app.get(self.private_url, expect_errors=True)
         assert_equal(res.status_code, 401)


### PR DESCRIPTION
Use get_object_or_error for osfstorage. Path is no longer stored in mongodb