### PR TITLE
[Ready for Review] Allow making nodes private/public

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -141,14 +141,15 @@ class NodeSerializer(JSONAPISerializer):
             node.add_tag(new_tag, auth=auth)
         for deleted_tag in (old_tags - current_tags):
             node.remove_tag(deleted_tag, auth=auth)
-        if validated_data:
-            if 'is_public' in validated_data:
-                privacy_key = 'public' if validated_data.pop('is_public') else 'private'
-                try:
-                    node.set_privacy(privacy_key, auth=auth, log=True, save=True)
-                except PermissionsError:
-                    raise exceptions.PermissionDenied
 
+        if 'is_public' in validated_data:
+            privacy_key = 'public' if validated_data.pop('is_public') else 'private'
+            try:
+                node.set_privacy(privacy_key, auth=auth, log=True, save=True)
+            except PermissionsError:
+                raise exceptions.PermissionDenied
+
+        if validated_data:
             try:
                 node.update(validated_data, auth=auth)
             except ValidationValueError as e:

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -1,9 +1,9 @@
 from rest_framework import serializers as ser
 from rest_framework import exceptions
-
 from modularodm.exceptions import ValidationValueError
 
 from framework.auth.core import Auth
+from framework.exceptions import PermissionsError
 
 from website.models import Node, User
 from website.exceptions import NodeStateError
@@ -53,7 +53,9 @@ class NodeSerializer(JSONAPISerializer):
     collection = ser.BooleanField(read_only=True, source='is_folder')
     dashboard = ser.BooleanField(read_only=True, source='is_dashboard')
     tags = ser.ListField(child=NodeTagField(), required=False)
-    public = ser.BooleanField(source='is_public', read_only=True,
+
+    # Public is only write-able by admins--see update method
+    public = ser.BooleanField(source='is_public', required=False,
                               help_text='Nodes that are made public will give read-only access '
                                         'to everyone. Private nodes require explicit read '
                                         'permission. Write and admin access are the same for '
@@ -140,10 +142,18 @@ class NodeSerializer(JSONAPISerializer):
         for deleted_tag in (old_tags - current_tags):
             node.remove_tag(deleted_tag, auth=auth)
         if validated_data:
+            if 'is_public' in validated_data:
+                privacy_key = 'public' if validated_data.pop('is_public') else 'private'
+                try:
+                    node.set_privacy(privacy_key, auth=auth, log=True, save=True)
+                except PermissionsError:
+                    raise exceptions.PermissionDenied
+
             try:
                 node.update(validated_data, auth=auth)
             except ValidationValueError as e:
                 raise InvalidModelValueError(detail=e.message)
+
         return node
 
 

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -697,7 +697,7 @@ class TestNodeUpdate(NodeCRUDTestCase):
         assert_equal(res.status_code, 400)
         assert_equal(res.json['errors'][0]['detail'], "Malformed request.")
 
-    @assert_not_logs(NodeLog.UPDATED_FIELDS, 'private_project')
+    @assert_not_logs(NodeLog.MADE_PUBLIC, 'private_project')
     def test_cannot_make_project_public_if_non_contributor(self):
         non_contrib = AuthUserFactory()
         res = self.app.patch_json(
@@ -725,7 +725,7 @@ class TestNodeUpdate(NodeCRUDTestCase):
         self.private_project.reload()
         assert_false(self.private_project.is_public)
 
-    @assert_logs(NodeLog.UPDATED_FIELDS, 'private_project')
+    @assert_logs(NodeLog.MADE_PUBLIC, 'private_project')
     def test_can_make_project_public_if_admin_contributor(self):
         res = self.app.patch_json_api(
             self.private_url,

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -727,10 +727,17 @@ class TestNodeUpdate(NodeCRUDTestCase):
 
     @assert_logs(NodeLog.MADE_PUBLIC, 'private_project')
     def test_can_make_project_public_if_admin_contributor(self):
+        admin_user = AuthUserFactory()
+        self.private_project.add_contributor(
+            admin_user,
+            permissions=(permissions.READ, permissions.WRITE, permissions.ADMIN),
+            auth=Auth(self.private_project.creator)
+        )
+        self.private_project.save()
         res = self.app.patch_json_api(
             self.private_url,
             make_node_payload(self.private_project, {'public': True}),
-            auth=self.user.auth  # self.user is creator/admin
+            auth=admin_user.auth  # self.user is creator/admin
         )
         assert_equal(res.status_code, 200)
         self.private_project.reload()

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -677,6 +677,14 @@ class NodeCRUDTestCase(ApiTestCase):
 
         self.fake_url = '/{}nodes/{}/'.format(API_BASE, '12345')
 
+def make_node_payload(node, attributes):
+    return {
+        'data': {
+            'id': node._id,
+            'type': 'nodes',
+            'attributes': attributes,
+        }
+    }
 
 class TestNodeUpdate(NodeCRUDTestCase):
 
@@ -689,6 +697,40 @@ class TestNodeUpdate(NodeCRUDTestCase):
         assert_equal(res.status_code, 400)
         assert_equal(res.json['errors'][0]['detail'], "Malformed request.")
 
+    @assert_not_logs(NodeLog.UPDATED_FIELDS, 'private_project')
+    def test_cannot_make_project_public_if_non_contributor(self):
+        non_contrib = AuthUserFactory()
+        res = self.app.patch_json(
+            self.private_url,
+            make_node_payload(self.private_project, {'public': True}),
+            auth=non_contrib.auth, expect_errors=True
+        )
+        assert_equal(res.status_code, 403)
+
+    def test_cannot_make_project_public_if_non_admin_contributor(self):
+        non_admin = AuthUserFactory()
+        self.private_project.add_contributor(non_admin, auth=Auth(self.private_project.creator))
+        self.private_project.save()
+        res = self.app.patch_json(
+            self.private_url,
+            make_node_payload(self.private_project, {'public': True}),
+            auth=non_admin.auth, expect_errors=True
+        )
+        assert_equal(res.status_code, 403)
+
+        self.private_project.reload()
+        assert_false(self.private_project.is_public)
+
+    @assert_logs(NodeLog.UPDATED_FIELDS, 'private_project')
+    def test_can_make_project_public_if_admin_contributor(self):
+        res = self.app.patch_json_api(
+            self.private_url,
+            make_node_payload(self.private_project, {'public': True}),
+            auth=self.user.auth
+        )
+        assert_equal(res.status_code, 200)
+        self.private_project.reload()
+        assert_true(self.private_project.is_public)
 
     def test_update_project_properties_not_nested(self):
         res = self.app.put_json_api(self.public_url, {
@@ -830,7 +872,7 @@ class TestNodeUpdate(NodeCRUDTestCase):
                     'title': fake.catch_phrase(),
                     'description': fake.bs(),
                     'category': 'hypothesis',
-                 'public': True
+                    'public': True
                 }
             }
         }, auth=self.user.auth, expect_errors=True)
@@ -947,22 +989,6 @@ class TestNodeUpdate(NodeCRUDTestCase):
         }, auth=self.user_two.auth, expect_errors=True)
         assert_equal(res.status_code, 403)
         assert_in('detail', res.json['errors'][0])
-
-    @assert_not_logs(NodeLog.UPDATED_FIELDS, 'public_project')
-    def test_write_to_public_field_does_not_update(self):
-        # Test creator writing to public field (supposed to be read-only)
-        res = self.app.patch_json_api(self.public_url, {
-            'data': {
-                'id': self.public_project._id,
-                'type': 'nodes',
-                'attributes': {
-                    'public': False,
-                }
-            }
-        }, auth=self.user.auth, expect_errors=True)
-        assert_true(res.json['data']['attributes']['public'])
-        # django returns a 200 on PATCH to read only field, even though it does not update the field.
-        assert_equal(res.status_code, 200)
 
     def test_partial_update_public_project_logged_out(self):
         res = self.app.patch_json_api(self.public_url, {

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -709,7 +709,11 @@ class TestNodeUpdate(NodeCRUDTestCase):
 
     def test_cannot_make_project_public_if_non_admin_contributor(self):
         non_admin = AuthUserFactory()
-        self.private_project.add_contributor(non_admin, auth=Auth(self.private_project.creator))
+        self.private_project.add_contributor(
+            non_admin,
+            permissions=(permissions.READ, permissions.WRITE),
+            auth=Auth(self.private_project.creator)
+        )
         self.private_project.save()
         res = self.app.patch_json(
             self.private_url,
@@ -726,7 +730,7 @@ class TestNodeUpdate(NodeCRUDTestCase):
         res = self.app.patch_json_api(
             self.private_url,
             make_node_payload(self.private_project, {'public': True}),
-            auth=self.user.auth
+            auth=self.user.auth  # self.user is creator/admin
         )
         assert_equal(res.status_code, 200)
         self.private_project.reload()

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -260,10 +260,11 @@ class SanctionFactory(ModularOdmFactory):
 
     @classmethod
     def _create(cls, target_class, approve=False, *args, **kwargs):
-        user = UserFactory()
+        user = kwargs.get('user') or UserFactory()
         sanction = ModularOdmFactory._create(target_class, initiated_by=user, *args, **kwargs)
         reg_kwargs = {
-            'owner': user,
+            'creator': user,
+            'user': user,
             sanction.SHORT_NAME: sanction
         }
         RegistrationFactory(**reg_kwargs)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1370,6 +1370,18 @@ class TestNode(OsfTestCase):
         self.parent = ProjectFactory(creator=self.user)
         self.node = NodeFactory(creator=self.user, parent=self.parent)
 
+    def test_set_privacy_checks_admin_permissions(self):
+        non_contrib = UserFactory()
+        project = ProjectFactory(creator=self.user, is_public=True)
+        with assert_raises(PermissionsError):
+            project.set_privacy('public', Auth(non_contrib))
+
+        project.set_privacy('public', Auth(project.creator))
+        project.save()
+
+        with assert_raises(PermissionsError):
+            project.set_privacy('public', Auth(non_contrib))
+
     def test_validate_categories(self):
         with assert_raises(ValidationError):
             Node(category='invalid').save()  # an invalid category

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1372,15 +1372,17 @@ class TestNode(OsfTestCase):
 
     def test_set_privacy_checks_admin_permissions(self):
         non_contrib = UserFactory()
-        project = ProjectFactory(creator=self.user, is_public=True)
+        project = ProjectFactory(creator=self.user, is_public=False)
+        # Non-contrib can't make project public
         with assert_raises(PermissionsError):
             project.set_privacy('public', Auth(non_contrib))
 
         project.set_privacy('public', Auth(project.creator))
         project.save()
 
+        # Non-contrib can't make project private
         with assert_raises(PermissionsError):
-            project.set_privacy('public', Auth(non_contrib))
+            project.set_privacy('private', Auth(non_contrib))
 
     def test_validate_categories(self):
         with assert_raises(ValidationError):

--- a/tests/test_registration_embargoes.py
+++ b/tests/test_registration_embargoes.py
@@ -3,6 +3,8 @@ import datetime
 import httplib as http
 import json
 
+from modularodm import Q
+
 import mock
 from nose.tools import *  # noqa
 from tests.base import fake, OsfTestCase
@@ -76,7 +78,8 @@ class RegistrationEmbargoModelsTestCase(OsfTestCase):
         )
         self.registration.save()
         self.registration.reload()
-        assert_equal(len(self.user.embargo__embargoed), 1)
+        assert_equal(len(self.user.embargo__embargoed),
+            Embargo.find(Q('initiated_by', 'eq', self.user)).count())
 
     # Node#embargo_registration tests
     def test_embargo_from_non_admin_raises_PermissionsError(self):

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -23,7 +23,7 @@ REJECTED_MSG = "This registration {0} has been rejected."
 class MockAuth(object):
 
     def __init__(self, user):
-        self.user = user        
+        self.user = user
         self.logged_in = True
 
 mock_auth = lambda user: mock.patch('framework.auth.Auth.from_kwargs', mock.Mock(return_value=MockAuth(user)))

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2561,7 +2561,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
         :param auth: All the auth information including user, API key.
         :param bool log: Whether to add a NodeLog for the privacy change.
         """
-        if not self.has_permission(auth.user, ADMIN):
+        if auth and not self.has_permission(auth.user, ADMIN):
             raise PermissionsError('Must be an admin to change privacy settings.')
         if permissions == 'public' and not self.is_public:
             if self.is_registration:

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2561,6 +2561,8 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
         :param auth: All the auth information including user, API key.
         :param bool log: Whether to add a NodeLog for the privacy change.
         """
+        if not self.has_permission(auth.user, ADMIN):
+            raise PermissionsError('Must be an admin to change privacy settings.')
         if permissions == 'public' and not self.is_public:
             if self.is_registration:
                 if self.is_pending_embargo:

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -1087,8 +1087,16 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
         return self.is_contributor(auth.user)
 
     def update(self, fields, auth=None, save=True):
+        """Update the node with the given fields.
+
+        :param dict fields: Dictionary of field_name:value pairs.
+        :param Auth auth: Auth object for the user making the update.
+        :param bool save: Whether to save after updating the object.
+        """
         if self.is_registration:
             raise NodeUpdateError(reason="Registered content cannot be updated")
+        if not fields:  # Bail out early if there are no fields to update
+            return False
         values = {}
         for key, value in fields.iteritems():
             if key not in self.WRITABLE_WHITELIST:


### PR DESCRIPTION
Allows nodes to be made public/private through the API.

A node can be made public with the following request:

```
http -a sloria1@gmail.com:password PATCH :8000/v2/nodes/nx9d8/  data:='{"id": "nx9d8", "type": "nodes", "attributes": {"public": true}}'
```

Multiple PATCH requests with the same privacy setting will do nothing (no extra logs).

### Ticket

https://openscience.atlassian.net/browse/OSF-4306