### PR TITLE
[Feature] API Show New User Profile Fields

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -12,6 +12,7 @@ from website.util import waterbutler_api_url_for
 from api.base import utils
 from api.base.exceptions import InvalidQueryStringError, Conflict
 
+
 class AllowMissing(ser.Field):
 
     def __init__(self, field, **kwargs):

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -12,6 +12,33 @@ from website.util import waterbutler_api_url_for
 from api.base import utils
 from api.base.exceptions import InvalidQueryStringError, Conflict
 
+class AllowMissing(ser.Field):
+
+    def __init__(self, field, **kwargs):
+        super(AllowMissing, self).__init__(**kwargs)
+        self.field = field
+
+    def to_representation(self, value):
+        return self.field.to_representation(value)
+
+    def bind(self, field_name, parent):
+        super(AllowMissing, self).bind(field_name, parent)
+        self.field.bind(field_name, self)
+
+    def get_attribute(self, instance):
+        """
+        Overwrite the error message to return a blank value is if there is no existing value.
+        This allows the display of keys that do not exist in the DB (gitHub on a new OSF account for example.)
+        """
+        try:
+            return self.field.get_attribute(instance)
+        except SkipField:
+            return ''
+
+    def to_internal_value(self, data):
+        return self.field.to_internal_value(data)
+
+
 def _rapply(d, func, *args, **kwargs):
     """Apply a function to all values in a dictionary, recursively. Handles lists and dicts currently,
     as those are the only complex structures currently supported by DRF Serializer Fields."""

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers as ser
-
+from api.base.serializers import AllowMissing
 from website.models import User
 
 from api.base.serializers import (
@@ -24,20 +24,29 @@ class UserSerializer(JSONAPISerializer):
     suffix = ser.CharField(required=False, allow_blank=True, help_text='For bibliographic citations')
     date_registered = ser.DateTimeField(read_only=True)
 
-    # Social Fields are broken out to get around DRF complex object bug and to make API updating more user friendly.
-    gitHub = DevOnly(ser.CharField(required=False, label='GitHub', source='social.github', allow_blank=True, help_text='GitHub Handle'))
-    scholar = DevOnly(ser.CharField(required=False, source='social.scholar', allow_blank=True, help_text='Google Scholar Account'))
-    personal_website = DevOnly(ser.URLField(required=False, source='social.personal', allow_blank=True, help_text='Personal Website'))
-    twitter = DevOnly(ser.CharField(required=False, source='social.twitter', allow_blank=True, help_text='Twitter Handle'))
-    linkedIn = DevOnly(ser.CharField(required=False, source='social.linkedIn', allow_blank=True, help_text='LinkedIn Account'))
-    impactStory = DevOnly(ser.CharField(required=False, source='social.impactStory', allow_blank=True, help_text='ImpactStory Account'))
-    orcid = DevOnly(ser.CharField(required=False, label='ORCID', source='social.orcid', allow_blank=True, help_text='ORCID'))
-    researcherId = DevOnly(ser.CharField(required=False, label='ResearcherID', source='social.researcherId', allow_blank=True, help_text='ResearcherId Account'))
     profile_image_url = DevOnly(ser.SerializerMethodField(required=False, read_only=True))
 
     def get_profile_image_url(self, user):
         size = self.context['request'].query_params.get('profile_image_size')
         return user.profile_image_url(size=size)
+
+    # Social Fields are broken out to get around DRF complex object bug and to make API updating more user friendly.
+    gitHub = DevOnly(AllowMissing(ser.CharField(required=False, source='social.github',
+                                                allow_blank=True, help_text='GitHub Handle'), required=False, source='social.github'))
+    scholar = DevOnly(AllowMissing(ser.CharField(required=False, source='social.scholar',
+                                                 allow_blank=True, help_text='Google Scholar Account'), required=False, source='social.scholar'))
+    personal_website = DevOnly(AllowMissing(ser.URLField(required=False, source='social.personal',
+                                                         allow_blank=True, help_text='Personal Website'), required=False, source='social.personal'))
+    twitter = DevOnly(AllowMissing(ser.CharField(required=False, source='social.twitter',
+                                                 allow_blank=True, help_text='Twitter Handle'), required=False, source='social.twitter'))
+    linkedIn = DevOnly(AllowMissing(ser.CharField(required=False, source='social.linkedIn',
+                                                  allow_blank=True, help_text='LinkedIn Account'), required=False, source='social.linkedIn'))
+    impactStory = DevOnly(AllowMissing(ser.CharField(required=False, source='social.impactStory',
+                                                     allow_blank=True, help_text='ImpactStory Account'), required=False, source='social.impactStory'))
+    orcid = DevOnly(AllowMissing(ser.CharField(required=False, source='social.orcid',
+                                               allow_blank=True, help_text='ORCID'), required=False, source='social.orcid'))
+    researcherId = DevOnly(AllowMissing(ser.CharField(required=False, source='social.researcherId',
+                                                      allow_blank=True, help_text='ResearcherId Account'), required=False, source='social.researcherId'))
 
     links = LinksField({'html': 'absolute_url'})
     nodes = JSONAPIHyperlinkedIdentityField(view_name='users:user-nodes', lookup_field='pk', lookup_url_kwarg='user_id',

--- a/tests/api_tests/users/test_views.py
+++ b/tests/api_tests/users/test_views.py
@@ -115,6 +115,21 @@ class TestUserDetail(ApiTestCase):
         user_json = res.json['data']
         assert_not_equal(user_json['attributes']['full_name'], self.user_one.fullname)
 
+    def test_get_new_users(self):
+        url = "/{}users/{}/".format(API_BASE, self.user_two._id)
+        res = self.app.get(url)
+        assert_equal(res.status_code, 200)
+        user_json = res.json['data']['attributes']
+        assert_equal(user_json['full_name'], self.user_two.fullname)
+        assert_equal(user_json['gitHub'], '')
+        assert_equal(user_json['scholar'], '')
+        assert_equal(user_json['personal_website'], '')
+        assert_equal(user_json['twitter'], '')
+        assert_equal(user_json['linkedIn'], '')
+        assert_equal(user_json['impactStory'], '')
+        assert_equal(user_json['orcid'], '')
+        assert_equal(user_json['researcherId'], '')
+
     def test_get_incorrect_pk_user_not_logged_in(self):
         url = "/{}users/{}/".format(API_BASE, self.user_two._id)
         res = self.app.get(url, auth=self.user_one.auth)


### PR DESCRIPTION
Fixes bug #4203

Purpose
-----------
In the API, users that have not filled out the any social fields in their profile will not show social media fieldnames. There is just a blank dictionary labeled social_accounts.

![screen shot 2015-08-28 at 9 34 28 am](https://cloud.githubusercontent.com/assets/6232068/9547612/6a82f32c-4d69-11e5-9be3-f91abf4c97f8.png)

To provide consistent user experience and to encourage users to fill out their profiles, we will now show all social fields even if they do not exist on the database.  

Changes
------------
User fields are shown on new users and ones without any social media information filled out.

Side Effects
---------------
All User social fields are stored at the top level of the JSON object, not one level down in the social_accounts dictionary.

#### Before:  

![screen shot 2015-08-28 at 9 52 14 am](https://cloud.githubusercontent.com/assets/6232068/9547758/8124dc52-4d6a-11e5-879e-7043139269e6.png)


#### Now:

![screen shot 2015-08-28 at 9 37 42 am](https://cloud.githubusercontent.com/assets/6232068/9547766/8aa74918-4d6a-11e5-89b8-f2c2d4d2d3f3.png)
