### PR TITLE
Fix node contributors querysets

### DIFF
--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -179,6 +179,7 @@ class ListFilterMixin(FilterMixin):
     def get_filtered_queryset(self, field_name, value, default_queryset):
         """filters default queryset based on the serializer field type"""
         field = self.serializer_class._declared_fields[field_name]
+        field_name = field.source or field_name
 
         if isinstance(field, ser.SerializerMethodField):
             return_val = [item for item in default_queryset if self.get_serializer_method(field_name)(item) == self.convert_value(value, field_name)]

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -157,9 +157,9 @@ class NodeContributorsSerializer(JSONAPISerializer):
     """ Separate from UserSerializer due to necessity to override almost every field as read only
     """
     filterable_fields = frozenset([
-        'fullname',
+        'full_name',
         'given_name',
-        'middle_name',
+        'middle_names',
         'family_name',
         'id',
         'bibliographic',
@@ -171,7 +171,7 @@ class NodeContributorsSerializer(JSONAPISerializer):
 
     full_name = ser.CharField(source='fullname', read_only=True, help_text='Display name used in the general user interface')
     given_name = ser.CharField(read_only=True, help_text='For bibliographic citations')
-    middle_name = ser.CharField(read_only=True, source='middle_names', help_text='For bibliographic citations')
+    middle_names = ser.CharField(read_only=True, help_text='For bibliographic citations')
     family_name = ser.CharField(read_only=True, help_text='For bibliographic citations')
     suffix = ser.CharField(read_only=True, help_text='For bibliographic citations')
     date_registered = ser.DateTimeField(read_only=True)


### PR DESCRIPTION
# OSF-4652
## Purpose
Makes query fields for node contributors consistent with query fields for users
## Changes
middle_name changed to middle_names, fullname changed to full_name, get field name properly for queryset in base filters
## Side Effects
None known
