### PR TITLE
[Hotfix] Failed moves/copies file signals

### DIFF
--- a/website/addons/base/views.py
+++ b/website/addons/base/views.py
@@ -331,6 +331,12 @@ def create_waterbutler_log(payload, **kwargs):
                 source_addon=payload['source']['addon'],
                 destination_addon=payload['destination']['addon'],
             )
+
+        if payload.get('error'):
+            # Action failed but our function succeeded
+            # Bail out to avoid file_signals
+            return {'status': 'success'}
+
     else:
         try:
             metadata = payload['metadata']


### PR DESCRIPTION
Bail out early when a move or a copy failes to avoid file_signal calls