### PR TITLE
[Feature Fix] Fix typo on unvalidated link 

### DIFF
--- a/website/addons/base/views.py
+++ b/website/addons/base/views.py
@@ -41,7 +41,7 @@ FILE_GONE_ERROR_MESSAGE = u'''
 .file-delete{{display: none;}}
 </style>
 <div class="alert alert-info" role="alert">
-This link to the file "{file_name}" is not longer valid.
+This link to the file "{file_name}" is no longer valid.
 </div>'''
 
 


### PR DESCRIPTION
##Purpose
Fix typo. Resolved issue -- [#OSF-4661]

## Change
Change `is not longer valid.` into `is no longer valid`

##Side Effect
None
