### PR TITLE
[hotfix] dataverse timeout

### DIFF
--- a/website/addons/dataverse/client.py
+++ b/website/addons/dataverse/client.py
@@ -5,6 +5,7 @@ from dataverse.exceptions import ConnectionError, UnauthorizedError, OperationFa
 
 from framework.exceptions import HTTPError
 
+from website.addons.dataverse import settings
 
 def _connect(host, token):
     try:
@@ -78,13 +79,13 @@ def publish_dataset(dataset):
 def get_datasets(dataverse):
     if dataverse is None:
         return []
-    return dataverse.get_datasets()
+    return dataverse.get_datasets(timeout=settings.REQUEST_TIMEOUT)
 
 
 def get_dataset(dataverse, doi):
     if dataverse is None:
         return
-    dataset = dataverse.get_dataset_by_doi(doi)
+    dataset = dataverse.get_dataset_by_doi(doi, timeout=settings.REQUEST_TIMEOUT)
     try:
         if dataset and dataset.get_state() == 'DEACCESSIONED':
             raise HTTPError(http.GONE, data=dict(

--- a/website/addons/dataverse/requirements.txt
+++ b/website/addons/dataverse/requirements.txt
@@ -1,1 +1,4 @@
--e git+https://github.com/IQSS/dataverse-client-python.git@b6aec5bc3fd1cc3199e3c97ac9c71705b54c3d11#egg=dataverse
+# Allow for optional timeout parameter.
+# https://github.com/IQSS/dataverse-client-python/pull/27
+#-e git+https://github.com/IQSS/dataverse-client-python.git@b6aec5bc3fd1cc3199e3c97ac9c71705b54c3d11#egg=dataverse
+-e git+https://github.com/CenterForOpenScience/dataverse-client-python.git@master#egg=dataverse

--- a/website/addons/dataverse/settings/defaults.py
+++ b/website/addons/dataverse/settings/defaults.py
@@ -3,3 +3,5 @@ DEFAULT_HOSTS = [
     'dataverse-demo.iq.harvard.edu',    # Harvard DEMO server
     'apitest.dataverse.org',            # Dataverse TEST server
 ]
+
+REQUEST_TIMEOUT = 15

--- a/website/addons/dataverse/tests/test_client.py
+++ b/website/addons/dataverse/tests/test_client.py
@@ -14,6 +14,7 @@ from website.addons.dataverse.client import (
     connect_from_settings_or_401,
 )
 from website.addons.dataverse.model import AddonDataverseNodeSettings
+from website.addons.dataverse import settings
 
 
 class TestClient(DataverseAddonTestCase):
@@ -145,7 +146,7 @@ class TestClient(DataverseAddonTestCase):
         ]
 
         datasets = get_datasets(self.mock_dataverse)
-        self.mock_dataverse.get_datasets.assert_called_once_with()
+        assert_is(self.mock_dataverse.get_datasets.assert_called_once_with(timeout=settings.REQUEST_TIMEOUT), None)
         assert_in(mock_dataset1, datasets)
         assert_in(mock_dataset2, datasets)
         assert_in(mock_dataset3, datasets)
@@ -159,7 +160,7 @@ class TestClient(DataverseAddonTestCase):
         self.mock_dataverse.get_dataset_by_doi.return_value = self.mock_dataset
 
         s = get_dataset(self.mock_dataverse, 'My hdl')
-        self.mock_dataverse.get_dataset_by_doi.assert_called_once_with('My hdl')
+        assert_is(self.mock_dataverse.get_dataset_by_doi.assert_called_once_with('My hdl', timeout=settings.REQUEST_TIMEOUT), None)
 
         assert_equal(s, self.mock_dataset)
 
@@ -174,7 +175,7 @@ class TestClient(DataverseAddonTestCase):
 
         with assert_raises(Exception) as e:
             get_dataset(dataverse, 'My hdl')
-        assert_is(mock_requests.get.assert_called_once_with('123', auth='me', timeout=15), None)
+        assert_is(mock_requests.get.assert_called_once_with('123', auth='me', timeout=settings.REQUEST_TIMEOUT), None)
         assert_equal(e.exception.message, 'Done Testing')
 
     def test_get_deaccessioned_dataset(self):
@@ -184,7 +185,7 @@ class TestClient(DataverseAddonTestCase):
         with assert_raises(HTTPError) as e:
             s = get_dataset(self.mock_dataverse, 'My hdl')
 
-        self.mock_dataverse.get_dataset_by_doi.assert_called_once_with('My hdl')
+        assert_is(self.mock_dataverse.get_dataset_by_doi.assert_called_once_with('My hdl', timeout=settings.REQUEST_TIMEOUT), None)
         assert_equal(e.exception.code, 410)
 
     def test_get_bad_dataset(self):
@@ -194,7 +195,7 @@ class TestClient(DataverseAddonTestCase):
 
         with assert_raises(HTTPError) as e:
             s = get_dataset(self.mock_dataverse, 'My hdl')
-        self.mock_dataverse.get_dataset_by_doi.assert_called_once_with('My hdl')
+        assert_is(self.mock_dataverse.get_dataset_by_doi.assert_called_once_with('My hdl', timeout=settings.REQUEST_TIMEOUT), None)
         assert_equal(e.exception.code, 406)
 
     def test_get_dataverses(self):

--- a/website/addons/dataverse/tests/utils.py
+++ b/website/addons/dataverse/tests/utils.py
@@ -86,9 +86,9 @@ def create_mock_dataverse(title='Example Dataverse 0'):
         create_mock_dataset('DVN/00003'),
     ]
 
-    def _get_dataset_by_doi(doi):
+    def _get_dataset_by_doi(doi, timeout=None):
         return next((
-            dataset for dataset in mock_dataverse.get_datasets()
+            dataset for dataset in mock_dataverse.get_datasets(timeout=timeout)
             if dataset.doi == doi), None
         )
 


### PR DESCRIPTION
Dataverse client will need to be updated.

```
pip install --no-deps -e git+https://github.com/CenterForOpenScience/dataverse-client-python.git@master#egg=dataverse
```