### PR TITLE
Wiki Editor - Disable Live Auto Complete OSF-2096

### DIFF
--- a/website/addons/wiki/static/ShareJSDoc.js
+++ b/website/addons/wiki/static/ShareJSDoc.js
@@ -24,13 +24,38 @@ var ShareJSDoc = function(url, metadata, viewText, editor) {
     self.editor.getSession().setUseWrapMode(true);   // Wraps text
     self.editor.renderer.setShowGutter(false);       // Hides line number
     self.editor.setShowPrintMargin(false);           // Hides print margin
-    self.editor.commands.removeCommand('showSettingsMenu');  // Disable settings menu
+    //self.editor.commands.removeCommand('showSettingsMenu');  // Disable settings menu
     self.editor.setReadOnly(true); // Read only until initialized
+
+
+    var completions = [
+        {id: 'id1', 'value': 'value1'},
+        {id: 'id2', 'value': 'value2'}
+    ];
+    var autoCompleter = {
+        getCompletions: function(editor, session, pos, prefix, callback) {
+            if (prefix.length < 3) {
+                callback(null, []);
+                return;
+            }
+            callback(
+                null,
+                completions.map(function(c) {
+                        return {value: c.id, caption: c.value};
+                    })
+            );
+        }
+    };
+
+
     self.editor.setOptions({
-        enableBasicAutocompletion: [LanguageTools.snippetCompleter],
-        enableSnippets: true,
-        enableLiveAutocompletion: true
-    });
+            enableBasicAutocompletion: [LanguageTools.snippetCompleter],
+            enableSnippets: true,
+            enableLiveAutocompletion: [autoCompleter]
+        });
+
+
+
 
     if (!collaborative) {
         // Populate editor with most recent draft
@@ -94,10 +119,12 @@ var ShareJSDoc = function(url, metadata, viewText, editor) {
         socket.send(JSON.stringify(metadata));
     }
 
+
     function refreshMaybe() {
         if (allowRefresh && refreshTriggered) {
             if (canEdit) {
                 window.location.reload();
+
             } else {
                 window.location.replace(ctx.urls.page);
             }

--- a/website/addons/wiki/static/WikiEditor.js
+++ b/website/addons/wiki/static/WikiEditor.js
@@ -28,7 +28,7 @@ ko.bindingHandlers.ace = {
         var value = ko.unwrap(valueAccessor()); // Value from view model
         editor.setOptions({
             enableBasicAutocompletion: true,
-            enableLiveAutocompletion: true
+            enableLiveAutocompletion: false
         });
         // Updates the editor based on changes to the view model
         if (value !== undefined && content !== value) {

--- a/website/addons/wiki/static/WikiEditor.js
+++ b/website/addons/wiki/static/WikiEditor.js
@@ -17,7 +17,10 @@ var editor;
 ko.bindingHandlers.ace = {
     init: function (element, valueAccessor) {
         editor = ace.edit(element.id);  // jshint ignore: line
-
+        /*editor.setOptions({
+            enableBasicAutocompletion: true,
+            enableLiveAutocompletion: false
+        });*/
         // Updates the view model based on changes to the editor
         editor.getSession().on('change', function () {
             valueAccessor()(editor.getValue());
@@ -26,10 +29,6 @@ ko.bindingHandlers.ace = {
     update: function (element, valueAccessor) {
         var content = editor.getValue();        // Content of ace editor
         var value = ko.unwrap(valueAccessor()); // Value from view model
-        editor.setOptions({
-            enableBasicAutocompletion: true,
-            enableLiveAutocompletion: false
-        });
         // Updates the editor based on changes to the view model
         if (value !== undefined && content !== value) {
             var cursorPosition = editor.getCursorPosition();

--- a/website/addons/wiki/static/WikiEditor.js
+++ b/website/addons/wiki/static/WikiEditor.js
@@ -26,7 +26,10 @@ ko.bindingHandlers.ace = {
     update: function (element, valueAccessor) {
         var content = editor.getValue();        // Content of ace editor
         var value = ko.unwrap(valueAccessor()); // Value from view model
-
+        editor.setOptions({
+            enableBasicAutocompletion: true,
+            enableLiveAutocompletion: true
+        });
         // Updates the editor based on changes to the view model
         if (value !== undefined && content !== value) {
             var cursorPosition = editor.getCursorPosition();

--- a/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
+++ b/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
@@ -1680,6 +1680,10 @@
             buttons.redo = makeButton("wmd-redo-button", getStringAndKey("redo"), "-220px", null);
             buttons.redo.execute = function (manager) { inputBox.session.getUndoManager().redo(); };
 
+            buttons.autoComplete = makeButton("wmd-button", "AceEdit Cntrl+space", "-240px", bindCommand("doAutoComplete"));
+
+
+
             if (helpOptions) {
                 var helpButton = document.createElement("li");
                 var helpButtonImage = document.createElement("span");
@@ -1745,6 +1749,10 @@
 
     commandProto.doItalic = function (chunk, postProcessing) {
         return this.doBorI(chunk, postProcessing, 1, this.getString("italicexample"));
+    };
+
+    commandProto.doAutoComplete = function(chunk, postProcessing){
+        this.editor.setOptions({enableLiveAutocompletion: false});
     };
 
     // chunk: The selected region that will be enclosed with */**

--- a/website/addons/wiki/templates/edit.mako
+++ b/website/addons/wiki/templates/edit.mako
@@ -70,8 +70,8 @@
           <div data-osf-panel="View"
                class="${'col-sm-{0}'.format(12 / num_columns) | n}"
                style="${'' if 'view' in panels_used else 'display: none' | n}">
-              <div class="osf-panel panel panel-default no-border reset-height" data-bind="css: { 'no-border reset-height': $root.singleVis() === 'view', 'osf-panel-flex': $root.singleVis() !== 'view' }">
-                <div class="panel-heading wiki-single-heading reset-height" data-bind="css: { 'osf-panel-heading-flex': $root.singleVis() !== 'view', 'wiki-single-heading': $root.singleVis() === 'view' }">
+              <div class="osf-panel panel panel-default no-border" data-bind="css: { 'no-border reset-height': $root.singleVis() === 'view', 'osf-panel-flex': $root.singleVis() !== 'view' }">
+                <div class="panel-heading wiki-single-heading" data-bind="css: { 'osf-panel-heading-flex': $root.singleVis() !== 'view', 'wiki-single-heading': $root.singleVis() === 'view' }">
                     <div class="row">
                         <div class="col-sm-6">
                             <span class="panel-title" > <i class="fa fa-eye"> </i>  View</span>

--- a/website/addons/wiki/templates/edit.mako
+++ b/website/addons/wiki/templates/edit.mako
@@ -70,8 +70,8 @@
           <div data-osf-panel="View"
                class="${'col-sm-{0}'.format(12 / num_columns) | n}"
                style="${'' if 'view' in panels_used else 'display: none' | n}">
-              <div class="osf-panel panel panel-default no-border" data-bind="css: { 'no-border reset-height': $root.singleVis() === 'view', 'osf-panel-flex': $root.singleVis() !== 'view' }">
-                <div class="panel-heading wiki-single-heading" data-bind="css: { 'osf-panel-heading-flex': $root.singleVis() !== 'view', 'wiki-single-heading': $root.singleVis() === 'view' }">
+              <div class="osf-panel panel panel-default no-border reset-height" data-bind="css: { 'no-border reset-height': $root.singleVis() === 'view', 'osf-panel-flex': $root.singleVis() !== 'view' }">
+                <div class="panel-heading wiki-single-heading reset-height" data-bind="css: { 'osf-panel-heading-flex': $root.singleVis() !== 'view', 'wiki-single-heading': $root.singleVis() === 'view' }">
                     <div class="row">
                         <div class="col-sm-6">
                             <span class="panel-title" > <i class="fa fa-eye"> </i>  View</span>

--- a/website/static/css/pages/wiki-page.css
+++ b/website/static/css/pages/wiki-page.css
@@ -14,6 +14,7 @@
 
 .panel-collapsed {
     background: #F5F5F5;
+    height: auto;
 }
 .wiki-sidenav h4, .wiki-sidenav li>ul>.btn,  .osf-sidenav.wiki-sidenav ul>li .row{
     padding: 8px 15px;

--- a/website/static/css/pages/wiki-page.css
+++ b/website/static/css/pages/wiki-page.css
@@ -13,7 +13,6 @@
 
 .panel-collapsed {
     background: #F5F5F5;
-    height: auto;
 }
 .wiki-sidenav h4, .wiki-sidenav li>ul>.btn,  .osf-sidenav.wiki-sidenav ul>li .row{
     padding: 8px 15px;

--- a/website/static/css/pages/wiki-page.css
+++ b/website/static/css/pages/wiki-page.css
@@ -13,7 +13,8 @@
 
 .panel-collapsed {
     background: #F5F5F5;
-    height: auto;
+    height: 551px;
+    /* height: auto; -- this causes the menu to change heights when expanded or collapsed*/
 }
 .wiki-sidenav h4, .wiki-sidenav li>ul>.btn,  .osf-sidenav.wiki-sidenav ul>li .row{
     padding: 8px 15px;

--- a/website/static/css/pages/wiki-page.css
+++ b/website/static/css/pages/wiki-page.css
@@ -4,7 +4,6 @@
 
 .markdown-it-view {
     padding: 10px;
-    height: auto;
 }
 
 .wiki-compare-view {

--- a/website/static/css/pages/wiki-page.css
+++ b/website/static/css/pages/wiki-page.css
@@ -132,7 +132,9 @@
     -ms-flex: 3 0 auto;
     flex: 3 0 auto;
     height: 500px; /* this will get overwritten by flex box */
+
 }
+
 
 /* Make wiki images responsive */
 .wiki img{

--- a/website/static/css/pages/wiki-page.css
+++ b/website/static/css/pages/wiki-page.css
@@ -4,6 +4,7 @@
 
 .markdown-it-view {
     padding: 10px;
+    height: auto;
 }
 
 .wiki-compare-view {
@@ -13,8 +14,6 @@
 
 .panel-collapsed {
     background: #F5F5F5;
-    height: 551px;
-    /* height: auto; -- this causes the menu to change heights when expanded or collapsed*/
 }
 .wiki-sidenav h4, .wiki-sidenav li>ul>.btn,  .osf-sidenav.wiki-sidenav ul>li .row{
     padding: 8px 15px;

--- a/website/static/css/pages/wiki-page.css
+++ b/website/static/css/pages/wiki-page.css
@@ -13,6 +13,7 @@
 
 .panel-collapsed {
     background: #F5F5F5;
+    height: auto;
 }
 .wiki-sidenav h4, .wiki-sidenav li>ul>.btn,  .osf-sidenav.wiki-sidenav ul>li .row{
     padding: 8px 15px;


### PR DESCRIPTION
Purpose
--------
To disable Ace Auto Complete so that it does not pop up on the first character of every word that is typed.

Changes
------
Disabled Ace Live Auto complete. Ace Basic Auto Complete is still enabled, which means the feature is still there, but must be prompted each time by the user. 

Side Effects
------
Auto Complete no longer pops up for users that need it. It can still be accessed with 'control' + 'space', but for users that rely heavily on this feature, that can be tedious. 



