### PR TITLE
[Ready for Review] Fix logging of title/description updates; improve Node.update

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -142,18 +142,13 @@ class NodeSerializer(JSONAPISerializer):
         for deleted_tag in (old_tags - current_tags):
             node.remove_tag(deleted_tag, auth=auth)
 
-        if 'is_public' in validated_data:
-            privacy_key = 'public' if validated_data.pop('is_public') else 'private'
-            try:
-                node.set_privacy(privacy_key, auth=auth, log=True, save=True)
-            except PermissionsError:
-                raise exceptions.PermissionDenied
-
         if validated_data:
             try:
                 node.update(validated_data, auth=auth)
             except ValidationValueError as e:
                 raise InvalidModelValueError(detail=e.message)
+            except PermissionsError:
+                raise exceptions.PermissionDenied
 
         return node
 

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -966,7 +966,7 @@ class TestNodeUpdate(NodeCRUDTestCase):
         assert_equal(res.json['data']['attributes']['title'], strip_html(new_title))
         assert_equal(res.json['data']['attributes']['description'], strip_html(new_description))
 
-    @assert_logs(NodeLog.UPDATED_FIELDS, 'public_project')
+    @assert_logs(NodeLog.EDITED_TITLE, 'public_project')
     def test_partial_update_project_updates_project_correctly_and_sanitizes_html(self):
         new_title = 'An <script>alert("even cooler")</script> project'
         res = self.app.patch_json_api(self.public_url, {
@@ -1014,7 +1014,7 @@ class TestNodeUpdate(NodeCRUDTestCase):
         assert_equal(res.status_code, 401)
         assert_in('detail', res.json['errors'][0])
 
-    @assert_logs(NodeLog.UPDATED_FIELDS, 'public_project')
+    @assert_logs(NodeLog.EDITED_TITLE, 'public_project')
     def test_partial_update_public_project_logged_in(self):
         res = self.app.patch_json_api(self.public_url, {
             'data': {
@@ -1057,7 +1057,7 @@ class TestNodeUpdate(NodeCRUDTestCase):
         assert_equal(res.status_code, 401)
         assert_in('detail', res.json['errors'][0])
 
-    @assert_logs(NodeLog.UPDATED_FIELDS, 'private_project')
+    @assert_logs(NodeLog.EDITED_TITLE, 'private_project')
     def test_partial_update_private_project_logged_in_contributor(self):
         res = self.app.patch_json_api(self.private_url, {
             'data': {

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1894,6 +1894,28 @@ class TestNodeUpdate(OsfTestCase):
         last_log = self.node.logs[-1]
         assert_equal(last_log.action, NodeLog.MADE_PRIVATE)
 
+    def test_updating_title_twice_with_same_title(self):
+        original_n_logs = len(self.node.logs)
+        new_title = fake.bs()
+        self.node.update({'title': new_title}, auth=Auth(self.user), save=True)
+        assert_equal(len(self.node.logs), original_n_logs + 1)  # sanity check
+
+        # Call update with same title
+        self.node.update({'title': new_title}, auth=Auth(self.user), save=True)
+        # A new log is not created
+        assert_equal(len(self.node.logs), original_n_logs + 1)
+
+    def test_updating_description_twice_with_same_content(self):
+        original_n_logs = len(self.node.logs)
+        new_desc = fake.bs()
+        self.node.update({'description': new_desc}, auth=Auth(self.user), save=True)
+        assert_equal(len(self.node.logs), original_n_logs + 1)  # sanity check
+
+        # Call update with same description
+        self.node.update({'description': new_desc}, auth=Auth(self.user), save=True)
+        # A new log is not created
+        assert_equal(len(self.node.logs), original_n_logs + 1)
+
     # TODO: test permissions, non-writable fields
 
 

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -1649,7 +1649,11 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
         validate_title(title)
 
         original_title = self.title
-        self.title = sanitize.strip_html(title)
+        new_title = sanitize.strip_html(title)
+        # Title hasn't changed after sanitzation, bail out
+        if original_title == new_title:
+            return False
+        self.title = new_title
         self.add_log(
             action=NodeLog.EDITED_TITLE,
             params={
@@ -1673,7 +1677,10 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
         :param bool save: Save self after updating.
         """
         original = self.description
-        self.description = sanitize.strip_html(description)
+        new_description = sanitize.strip_html(description)
+        if original == new_description:
+            return False
+        self.description = new_description
         self.add_log(
             action=NodeLog.EDITED_DESCRIPTION,
             params={


### PR DESCRIPTION
- Fixes a bug in logging title and description updates
- Consolidates node updating logic in `Node#update`. 
- Adds named constants `Node.PUBLIC` and `Node.PRIVATE`.
- Sending a PUT or PATCH to update title or description with the same content will not generate multiple logs

### Ticket

https://openscience.atlassian.net/browse/OSF-4668