### PR TITLE
Disable button for contributors

### DIFF
--- a/website/templates/project/modal_add_contributor.mako
+++ b/website/templates/project/modal_add_contributor.mako
@@ -63,11 +63,11 @@
                                                                click:$root.add,
                                                                tooltip: {title: 'Add contributor'}"
                                                 ><i class="fa fa-fw fa-plus"></i></a>
-                                            <a
-                                                class="btn btn-default contrib-button btn-mini"
-                                                data-bind="visible: contributor.added,
-                                                           tooltip: {title: 'Already added'}"
-                                                ><i class="fa fa-fw fa-check"></i></a>
+                                            <div data-bind="visible: contributor.added,
+                                                            tooltip: {title: 'Already added'}"
+                                                ><div
+                                                    class="btn btn-default contrib-button btn-mini disabled"
+                                                    ><i class="fa fa-fw fa-check"></i></div></div>
                                         </td>
                                         <td>
                                             <!-- height and width are explicitly specified for faster rendering -->


### PR DESCRIPTION
Move the tooltip into a wrapper that allows the tooltip to still function.

Repercussions: No more than original PR.