### PR TITLE
[blocked] Update developer app reg UI to work with JSONAPI formatting changes

### DIFF
--- a/website/static/js/apiApplication.js
+++ b/website/static/js/apiApplication.js
@@ -47,7 +47,6 @@ var ApplicationData = oop.defclass({
 
         // Other fields. Owner and client ID should never change within this view.
         this.id = data.id;
-        this.type = data.type;
 
         this.owner = attributes.owner;
         this.clientId = attributes.client_id;
@@ -67,7 +66,7 @@ var ApplicationData = oop.defclass({
         return { // Convert data to JSON-serializable format consistent with JSON API v1.0 spec
             data: {
                 id: this.id,
-                type: this.type,
+                type: 'applications',
                 attributes: {
                     name: this.name(),
                     description: this.description() || '',

--- a/website/static/js/apiApplication.js
+++ b/website/static/js/apiApplication.js
@@ -46,6 +46,9 @@ var ApplicationData = oop.defclass({
             });
 
         // Other fields. Owner and client ID should never change within this view.
+        this.id = data.id;
+        this.type = data.type;
+
         this.owner = attributes.owner;
         this.clientId = attributes.client_id;
         this.clientSecret = ko.observable(attributes.client_secret);
@@ -61,14 +64,20 @@ var ApplicationData = oop.defclass({
     },
 
     serialize: function () {
-        return { // Convert data to JSON-serializable format consistent with API
-            name: this.name(),
-            description: this.description() || '',
-            home_url: this.homeUrl(),
-            callback_url: this.callbackUrl(),
-            client_id: this.clientId,
-            client_secret: this.clientSecret(),
-            owner: this.owner
+        return { // Convert data to JSON-serializable format consistent with JSON API v1.0 spec
+            data: {
+                id: this.id,
+                type: this.type,
+                attributes: {
+                    name: this.name(),
+                    description: this.description() || '',
+                    home_url: this.homeUrl(),
+                    callback_url: this.callbackUrl(),
+                    client_id: this.clientId,
+                    client_secret: this.clientSecret(),
+                    owner: this.owner
+                }
+            }
         };
     }
 });

--- a/website/static/js/tests/apiApplication.test.js
+++ b/website/static/js/tests/apiApplication.test.js
@@ -13,31 +13,32 @@ describe('apiApplicationsInternals', () => {
         var vmd;
         // Sample data returned by an API call
         var sampleData = {
+            id: '0123456789abcdef0123456789abcdef',
+            type: 'applications',
             attributes: {
                 client_id: '0123456789abcdef0123456789abcdef',
                 client_secret: 'abcdefghij0123456789abcdefghij0123456789',
                 owner: '14abc',
-                name: 'Of course it has a name',
-                description: 'Always nice to have this',
+                name: 'Soda Bunny\'s new outfit',
+                description: 'This field is optional',
                 date_created: '2015-07-21T16:28:28.037000',
-                home_url: 'http://tumblr.com',
+                home_url: 'http://sodabunnyadventures.tumblr.com/',
                 callback_url: 'http://goodwill.org'
             },
             links: {
                 self: 'http://localhost:8000/v2/users/14abc/applications/0123456789abcdef0123456789abcdef/',
                 html: 'http://localhost:5000/settings/applications/0123456789abcdef0123456789abcdef/'
-            },
-            type: 'applications'
+            }
         };
 
         beforeEach(() => {
             vmd = new apiApp._ApplicationData(sampleData);
         });
-        // TODO: Test data populates and test serializer serializes
-        // TODO: Test that changing to incorrect data makes us fail validation
 
         it('loads data into the specified fields', () => {
             var attributes = sampleData.attributes;
+            assert.equal(sampleData.id, vmd.id);
+            assert.equal(sampleData.type, vmd.type);
             assert.equal(attributes.name, vmd.name());
             assert.equal(attributes.description, vmd.description());
             assert.equal(attributes.home_url, vmd.homeUrl());
@@ -47,7 +48,6 @@ describe('apiApplicationsInternals', () => {
             assert.equal(attributes.client_id, vmd.clientId);
             assert.equal(attributes.client_secret, vmd.clientSecret());
 
-            // TODO: May change when links field changes
             assert.equal(sampleData.links.html, vmd.webDetailUrl);
             assert.equal(sampleData.links.self, vmd.apiDetailUrl);
         });

--- a/website/static/js/tests/apiApplication.test.js
+++ b/website/static/js/tests/apiApplication.test.js
@@ -38,7 +38,6 @@ describe('apiApplicationsInternals', () => {
         it('loads data into the specified fields', () => {
             var attributes = sampleData.attributes;
             assert.equal(sampleData.id, vmd.id);
-            assert.equal(sampleData.type, vmd.type);
             assert.equal(attributes.name, vmd.name());
             assert.equal(attributes.description, vmd.description());
             assert.equal(attributes.home_url, vmd.homeUrl());


### PR DESCRIPTION
Refs [#OSF-4720].


## Purpose
Fix an issue where recent JSONAPI format changes caused data to be rejected by the server. Ensure that data is correctly serialized so that developer apps can be registered and updated.

## Summary of changes
- Change serialization method in data model
- Update unit tests to check additional fields

This issue was not caught because there are not presently any integration tests between the frontend and APIv2. If this issue continues to crop up in the future, we may need to revisit that strategy.

## Blockers
Will require further testing once id field issue is resolved ([#OSF-4725]); difficult to fully test as that issue is blocking data submission to server. Candidate fix for review in #4392 .