### PR TITLE
[CR] typo fixes and feature updates to BAPI docs

### DIFF
--- a/api/base/views.py
+++ b/api/base/views.py
@@ -25,7 +25,7 @@ def root(request, format=None):
     #General API Usage
 
     The OSF API generally conforms to the [JSON-API v1.0 spec](http://jsonapi.org/format/1.0/).  Where exceptions
-    exists, they will be noted.  Each endpoint will have its own documentation, but there are some general principles.
+    exist, they will be noted.  Each endpoint will have its own documentation, but there are some general principles.
 
     ##Requests
 
@@ -133,12 +133,12 @@ def root(request, format=None):
     + `id`
 
     The identifier for the entity.  This MUST be included with [PUT and PATCH
-    requests](#formatting-post-put-patch-request-bodies).
+    requests](#formatting-postputpatch-request-bodies).
 
     + `type`
 
     The type identifier of this entity.  This MUST be included with [all create/update
-    requests](#formatting-post-put-patch-request-bodies).
+    requests](#formatting-postputpatch-request-bodies).
 
     + `attributes`
 
@@ -147,7 +147,7 @@ def root(request, format=None):
     + `relationships`
 
     Relationships are urls to other entities or entity collections that have a relationship to the entity. For example,
-    the node entity provides a `contributors` relationship that points to the endpoint to retreive all contributors to
+    the node entity provides a `contributors` relationship that points to the endpoint to retrieve all contributors to
     that node.  It is recommended to use these links rather than to id-filter general entity collection endpoints.
     They'll be faster, easier, and less error-prone.  Generally a relationship will have the following structure:
 
@@ -195,14 +195,14 @@ def root(request, format=None):
     succeeded without the updated attribute, it will still report as successful.  Likewise, if the request would have
     failed without the attribute update, the API will still report a failure.
 
-    Typoed or non-existant attributes will behave the same as non-updatable attributes and be silently
+    Typoed or non-existent attributes will behave the same as non-updatable attributes and be silently
     ignored. If a request is not working the way you expect, make sure to double check your spelling.
 
     ###Errors
 
     When a request fails for whatever reason, the OSF API will return an appropriate HTTP error code and include a
     descriptive error in the body of the response.  The response body will be an object with a key, `errors`, pointing
-    to an array of error objects.  Generally, these error object will consist of a `detail` key with a detailed error
+    to an array of error objects.  Generally, these error objects will consist of a `detail` key with a detailed error
     message, but may include additional information in accordance with the [JSON-API error
     spec](http://jsonapi.org/format/1.0/#error-objects).
 

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -75,7 +75,7 @@ def root(request, format=None):
 
     ###Formatting POST/PUT/PATCH request bodies
 
-    The OSF API follows the JSON-API spec for (create and update requests)[http://jsonapi.org/format/#crud].  This means
+    The OSF API follows the JSON-API spec for [create and update requests](http://jsonapi.org/format/1.0/#crud).  This means
     all request bodies must be wrapped with some metadata.  Each request body must be an object with a `data` key
     containing at least a `type` member.  The value of the `type` member must agree with the `type` of the entities
     represented by the endpoint.  If not, a 409 Conflict will be returned.  The request should also contain an

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -122,6 +122,17 @@ def root(request, format=None):
     PUT requests require all mandatory attributes to be set, even if their value is unchanged. PATCH requests may omit
     mandatory attributes, whose value will be unchanged.
 
+    ###Attribute Validation
+
+    Endpoints that allow creation or modification of entities generally limit updates to certain attributes of the
+    entity.  If you attempt to set an attribute that does not permit updates (such as a `date_created` timestamp), the
+    API will silently ignore that attribute.  This will not affect the response from the API: if the request would have
+    succeeded without the updated attribute, it will still report as successful.  Likewise, if the request would have
+    failed without the attribute update, the API will still report a failure.
+
+    Typoed or non-existent attributes will behave the same as non-updatable attributes and be silently ignored. If a
+    request is not working the way you expect, make sure to double check your spelling.
+
     ##Responses
 
     ###Entities
@@ -186,17 +197,6 @@ def root(request, format=None):
     The meta key contains the total number of entities available, as well as the current number of results displayed per
     page.  If there are only enough results to fill one page, the `first`, `last`, `prev`, and `next` values will be
     null.
-
-    ###Attribute Validation
-
-    Endpoints that allow creation or modification of entities generally limit updates to certain attributes of the
-    entity.  If you attempt to set an attribute that does not permit updates (such as a `date_created` timestamp), the
-    API will silently ignore that attribute.  This will not affect the response from the API: if the request would have
-    succeeded without the updated attribute, it will still report as successful.  Likewise, if the request would have
-    failed without the attribute update, the API will still report a failure.
-
-    Typoed or non-existent attributes will behave the same as non-updatable attributes and be silently
-    ignored. If a request is not working the way you expect, make sure to double check your spelling.
 
     ###Errors
 

--- a/api/files/views.py
+++ b/api/files/views.py
@@ -172,7 +172,8 @@ class FileDetail(generics.RetrieveUpdateAPIView, FileMixin):
     You can create a subfolder of an existing folder by issuing a PUT request against the `new_folder` link.  The
     `?kind=folder` portion of the query parameter is already included in the `new_folder` link.  The name of the new
     subfolder should be provided in the `name` query parameter.  The response will contain a [WaterButler folder
-    entity](#folder-entity).
+    entity](#folder-entity).  If a folder with that name already exists in the parent directory, the server will return
+    a 409 Conflict error response.
 
     ###Upload New File (*folders*)
 
@@ -180,11 +181,13 @@ class FileDetail(generics.RetrieveUpdateAPIView, FileMixin):
         URL:          links.upload
         Query Params: ?kind=file&name={new_file_name}
         Body (Raw):   <file data (not form-encoded)>
-        Success:      201 Created + new file representation
+        Success:      201 Created or 200 OK + new file representation
 
     To upload a file to a folder, issue a PUT request to the folder's `upload` link with the raw file data in the
     request body, and the `kind` and `name` query parameters set to `'file'` and the desired name of the file.  The
-    response will contain a [WaterButler file entity](#file-entity) that describes the new file.
+    response will contain a [WaterButler file entity](#file-entity) that describes the new file.  If a file with the
+    same name already exists in the folder, it will be considered a new version.  In this case, the response will be a
+    200 OK.
 
     ###Update Existing File (*file*)
 

--- a/api/files/views.py
+++ b/api/files/views.py
@@ -40,7 +40,7 @@ class FileDetail(generics.RetrieveUpdateAPIView, FileMixin):
     Welcome to the Files API.  Brace yourself, things are about to get *weird*.
 
     The Files API is the one place in the OSF API where we break hard from the JSON-API spec.  This is because most of
-    the behind-the-scenes moving, uploading, deleting, etc. of files and folders is actually be handled for us by a
+    the behind-the-scenes moving, uploading, deleting, etc. of files and folders is actually handled for us by a
     nifty piece of software called [WaterButler](https://github.com/CenterForOpenScience/waterbutler).  WaterButler lets
     us interact with files stored on different cloud storage platforms through a consistent API.  However, it uses
     different conventions for requests, responses, and URL-building, so pay close attention to the documentation for
@@ -52,7 +52,7 @@ class FileDetail(generics.RetrieveUpdateAPIView, FileMixin):
     metadata is cached and can be refreshed by GETting the file via the Node Files List endpoint.
 
     Both files and folders are available through the Files API and are distinguished by the `kind` attribute ("file" for
-    files, "folder" for folders).  Not all actions and relationships are relevent to both files and folders, so the
+    files, "folder" for folders).  Not all actions and relationships are relevant to both files and folders, so the
     applicable types are listed by each heading.
 
     ###Waterbutler Entities

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -414,9 +414,9 @@ class NodeContributorsList(generics.ListCreateAPIView, ListFilterMixin, NodeMixi
         Query Params:  <none>
         Body (JSON):   {
                          "data": {
-                           "type": "contributors", # required
+                           "type": "contributors",        # required
+                           "id":   {contributor_user_id}, # required
                            "attributes": {
-                             "id":            {user_id},             # required
                              "bibliographic": true|false,            # optional
                              "permission":    "read"|"write"|"admin" # optional
                            }

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -288,7 +288,7 @@ class NodeDetail(generics.RetrieveUpdateDestroyAPIView, NodeMixin):
     ###Files
 
     List of top-level folders (actually cloud-storage providers) associated with this node. This is the starting point
-    for accessing the actual files stored with this node.
+    for accessing the actual files stored within this node.
 
     ###Parent
 
@@ -849,7 +849,7 @@ class NodeFilesList(generics.ListAPIView, WaterButlerMixin, NodeMixin):
     """Files attached to a node for a given provider. *Read-only*.
 
     This gives a list of all of the files and folders that are attached to your project for the given storage provider.
-    If the provider is not "osfstorage", the metadata for the files in the storage will be retrieved and cached whenver
+    If the provider is not "osfstorage", the metadata for the files in the storage will be retrieved and cached whenever
     this endpoint is accessed.  To see the cached metadata, GET the endpoint for the file directly (available through
     its `links.info` attribute).
 
@@ -960,7 +960,7 @@ class NodeProvidersList(generics.ListAPIView, NodeMixin):
 
     Users of the OSF may access their data on a [number of cloud-storage](/v2/#storage-providers) services that have
     integratations with the OSF.  We call these "providers".  By default every node has access to the OSF-provided
-    storage but may use as many of the supported providers as desired.  This endpoint lists all of the providers are
+    storage but may use as many of the supported providers as desired.  This endpoint lists all of the providers that are
     configured for this node.  If you want to add more, you will need to do that in the Open Science Framework front end
     for now.
 

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -172,20 +172,21 @@ class NodeList(generics.ListCreateAPIView, ODMFilterMixin):
                          "data": {
                            "type": "nodes", # required
                            "attributes": {
-                             "title":       {title},         # required
-                             "category":    {category},      # required
-                             "description": {description},   # optional
-                             "tags":        [{tag1}, {tag2}] # optional
+                             "title":       {title},          # required
+                             "category":    {category},       # required
+                             "description": {description},    # optional
+                             "tags":        [{tag1}, {tag2}], # optional
+                             "public":      true|false        # optional
                            }
                          }
                        }
         Success:       201 CREATED + node representation
 
     New nodes are created by issuing a POST request to this endpoint.  The `title` and `category` fields are
-    mandatory. `category` must be one of the [permitted node categories](/v2/#osf-node-categories).  All other fields
-    not listed above will be ignored.  If the node creation is successful the API will return a 201 response with the
-    respresentation of the new node in the body.  For the new node's canonical URL, see the `links.self` field of the
-    response.
+    mandatory. `category` must be one of the [permitted node categories](/v2/#osf-node-categories).  `public` defaults
+    to false.  All other fields not listed above will be ignored.  If the node creation is successful the API will
+    return a 201 response with the respresentation of the new node in the body.  For the new node's canonical URL, see
+    the `links.self` field of the response.
 
     ##Query Params
 
@@ -199,6 +200,7 @@ class NodeList(generics.ListCreateAPIView, ODMFilterMixin):
     that quoting `true` or `false` in the query will cause the match to fail regardless.  `tags` is an array of simple strings.
 
     #This Request/Response
+
     """
     permission_classes = (
         drf_permissions.IsAuthenticatedOrReadOnly,
@@ -312,10 +314,11 @@ class NodeDetail(generics.RetrieveUpdateDestroyAPIView, NodeMixin):
                            "type": "nodes",   # required
                            "id":   {node_id}, # required
                            "attributes": {
-                             "title":       {title},         # mandatory
-                             "category":    {category},      # mandatory
-                             "description": {description},   # optional
-                             "tags":        [{tag1}, {tag2}] # optional
+                             "title":       {title},          # mandatory
+                             "category":    {category},       # mandatory
+                             "description": {description},    # optional
+                             "tags":        [{tag1}, {tag2}], # optional
+                             "public":      true|false        # optional
                            }
                          }
                        }

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -116,9 +116,9 @@ class UserList(generics.ListAPIView, ODMFilterMixin):
 class UserDetail(generics.RetrieveUpdateAPIView, UserMixin):
     """Details about a specific user. *Writeable*.
 
-    The User Detail endpoint retrieves information about for the user whose id is the final part of the path.  If `me`
+    The User Detail endpoint retrieves information about the user whose id is the final part of the path.  If `me`
     is given as the id, the record of the currently logged-in user will be returned.  The returned information includes
-    their bibliographic information and the date they registered.
+    the user's bibliographic information and the date the user registered.
 
     ##Attributes
 


### PR DESCRIPTION
This branch includes typo fixes caught by QA's proofreading, explanation of conflict behavior for the Create Subfolder and Upload File actions, and new docs for the Node privacy updates.