### PR TITLE
Hotfix/Transaction middleware

### DIFF
--- a/api/base/middleware.py
+++ b/api/base/middleware.py
@@ -38,11 +38,12 @@ class TokuTransactionsMiddleware(object):
         """Commit transaction if it exists, rolling back in an
         exception occurs.
         """
-        if response.status_code >= 400:
-            commands.rollback()
 
         try:
-            commands.commit()
+            if response.status_code >= 400:
+                commands.rollback()
+            else:
+                commands.commit()
         except OperationFailure as err:
             message = utils.get_error_message(err)
             if messages.NO_TRANSACTION_TO_COMMIT_ERROR not in message:

--- a/api/base/middleware.py
+++ b/api/base/middleware.py
@@ -38,6 +38,9 @@ class TokuTransactionsMiddleware(object):
         """Commit transaction if it exists, rolling back in an
         exception occurs.
         """
+        if response.status_code >= 400:
+            commands.rollback()
+
         try:
             commands.commit()
         except OperationFailure as err:

--- a/tests/api_tests/base/test_middleware.py
+++ b/tests/api_tests/base/test_middleware.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+from tests.base import ApiTestCase, fake
+
+import mock
+from nose.tools import *  # flake8: noqa
+
+from api.base.middleware import TokuTransactionsMiddleware
+from tests.base import ApiTestCase
+
+class TestMiddlewareRollback(ApiTestCase):
+    
+    @mock.patch('api.base.middleware.commands')
+    def test_400_error_causes_rollback(self, mock_commands):
+
+        middleware = TokuTransactionsMiddleware()
+        mock_response = mock.Mock()
+        mock_response.status_code = 400
+        middleware.process_response(mock.Mock(), mock_response)
+
+        assert_is(mock_commands.rollback.assert_called_once_with(), None)
+


### PR DESCRIPTION
# Purpose

If there is an exception thrown, the TokuTransactionMiddleware is not running commands.rollback. If anything is written to the database before an exception is thrown, it is committed to the database.

DRF creates a nice, properly formatted response if there is an exception.  Since the response is not None, the process_exception in the TokuTransactionMiddleware was never being called. 

# Changes

Checks to see if an exception was thrown(by looking at the status_code).  If it's greater than or equal to 400, the transaction is rolled back.  Otherwise, the transaction is committed.