### PR TITLE
Hotfix/Transaction middleware

### DIFF
--- a/api/base/middleware.py
+++ b/api/base/middleware.py
@@ -38,11 +38,12 @@ class TokuTransactionsMiddleware(object):
         """Commit transaction if it exists, rolling back in an
         exception occurs.
         """
-        if response.status_code >= 400:
-            commands.rollback()
 
         try:
-            commands.commit()
+            if response.status_code >= 400:
+                commands.rollback()
+            else:
+                commands.commit()
         except OperationFailure as err:
             message = utils.get_error_message(err)
             if messages.NO_TRANSACTION_TO_COMMIT_ERROR not in message:

--- a/api/base/middleware.py
+++ b/api/base/middleware.py
@@ -38,6 +38,9 @@ class TokuTransactionsMiddleware(object):
         """Commit transaction if it exists, rolling back in an
         exception occurs.
         """
+        if response.status_code >= 400:
+            commands.rollback()
+
         try:
             commands.commit()
         except OperationFailure as err:

--- a/tests/api_tests/base/test_middleware.py
+++ b/tests/api_tests/base/test_middleware.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+from tests.base import ApiTestCase, fake
+
+import mock
+from nose.tools import *  # flake8: noqa
+
+from api.base.middleware import TokuTransactionsMiddleware
+from tests.base import ApiTestCase
+
+class TestMiddlewareRollback(ApiTestCase):
+    
+    @mock.patch('api.base.middleware.commands')
+    def test_400_error_causes_rollback(self, mock_commands):
+
+        middleware = TokuTransactionsMiddleware()
+        mock_response = mock.Mock()
+        mock_response.status_code = 400
+        middleware.process_response(mock.Mock(), mock_response)
+
+        assert_is(mock_commands.rollback.assert_called_once_with(), None)
+

--- a/tests/api_tests/base/test_middleware.py
+++ b/tests/api_tests/base/test_middleware.py
@@ -9,14 +9,25 @@ from api.base.middleware import TokuTransactionsMiddleware
 from tests.base import ApiTestCase
 
 class TestMiddlewareRollback(ApiTestCase):
+    def setUp(self):
+        super(TestMiddlewareRollback, self).setUp()
+        self.middleware = TokuTransactionsMiddleware()
+        self.mock_response = mock.Mock()
     
     @mock.patch('api.base.middleware.commands')
     def test_400_error_causes_rollback(self, mock_commands):
 
-        middleware = TokuTransactionsMiddleware()
-        mock_response = mock.Mock()
-        mock_response.status_code = 400
-        middleware.process_response(mock.Mock(), mock_response)
+        self.mock_response.status_code = 400
+        self.middleware.process_response(mock.Mock(), self.mock_response)
 
-        assert_is(mock_commands.rollback.assert_called_once_with(), None)
+        assert_true(mock_commands.rollback.called)
+
+    @mock.patch('api.base.middleware.commands')
+    def test_200_OK_causes_commit(self, mock_commands):
+
+        self.mock_response.status_code = 200
+        self.middleware.process_response(mock.Mock(), self.mock_response)
+
+        assert_true(mock_commands.commit.called)
+
 


### PR DESCRIPTION
# Purpose

https://openscience.atlassian.net/browse/OSF-4759
Issue interfering with transactional requests. If there is an exception thrown, the TokuTransactionMiddleware is skipping commands.rollback. If anything is written to the database before the exception, it is committed.

DRF creates a nice, properly formatted response if there is an exception.  Since the response is not None, the process_exception in the TokuTransactionMiddleware is never being called. 

# Changes

Checks to see if an exception is thrown (by looking at the status_code).  If it's greater than or equal to 400, the transaction is rolled back.  Otherwise, the transaction is committed.