### PR TITLE
Fix hard-coded source in APIv2 IDField

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -62,7 +62,7 @@ class IDField(ser.CharField):
     def to_internal_value(self, data):
         update_methods = ['PUT', 'PATCH']
         if self.context['request'].method in update_methods:
-            id_field = getattr(self.root.instance, self.source)
+            id_field = getattr(self.root.instance, self.source, '_id')
             if id_field != data:
                 raise Conflict()
         return super(IDField, self).to_internal_value(data)

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -62,7 +62,8 @@ class IDField(ser.CharField):
     def to_internal_value(self, data):
         update_methods = ['PUT', 'PATCH']
         if self.context['request'].method in update_methods:
-            if self.root.instance._id != data:
+            id_field = getattr(self.root.instance, self.source)
+            if id_field != data:
                 raise Conflict()
         return super(IDField, self).to_internal_value(data)
 

--- a/tests/api_tests/applications/test_views.py
+++ b/tests/api_tests/applications/test_views.py
@@ -144,7 +144,7 @@ class TestApplicationDetail(ApiTestCase):
 
         self.missing_type = {
             'data': {
-                'id': self.user1_app._id,
+                'id': self.user1_app.client_id,
                 'attributes': {
                     'name': 'A shiny new application',
                     'home_url': 'http://osf.io',
@@ -167,7 +167,7 @@ class TestApplicationDetail(ApiTestCase):
 
         self.incorrect_type = {
             'data': {
-                'id': self.user1_app._id,
+                'id': self.user1_app.client_id,
                 'type': 'Wrong type.',
                 'attributes': {
                     'name': 'A shiny new application',
@@ -177,9 +177,9 @@ class TestApplicationDetail(ApiTestCase):
             }
         }
 
-        self.correct =  {
+        self.correct = {
             'data': {
-                'id': self.user1_app._id,
+                'id': self.user1_app.client_id,
                 'type': 'applications',
                 'attributes': {
                     'name': 'A shiny new application',
@@ -227,7 +227,7 @@ class TestApplicationDetail(ApiTestCase):
         res = self.app.patch_json_api(self.user1_app_url,
                              {'data': {'attributes':
                                   {'name': new_name},
-                              'id': self.user1_app._id,
+                              'id': self.user1_app.client_id,
                               'type': 'applications'
                              }}, auth=self.user1.auth, expect_errors=True)
         user1_app.reload()
@@ -248,7 +248,7 @@ class TestApplicationDetail(ApiTestCase):
         res = self.app.patch_json_api(self.user1_app_url,
                                       {'data': {
                                           'attributes': {"name": new_name},
-                                          'id': self.user1_app._id,
+                                          'id': self.user1_app.client_id,
                                           'type': 'applications'}}, auth=self.user1.auth)
         assert_equal(res.status_code, 200)
 
@@ -267,7 +267,6 @@ class TestApplicationDetail(ApiTestCase):
 
     def test_update_application(self):
         res = self.app.put_json_api(self.user1_app_url, self.correct, auth=self.user1.auth, expect_errors=True)
-        print res
         assert_equal(res.status_code, 200)
 
     def test_update_application_incorrect_type(self):
@@ -287,7 +286,7 @@ class TestApplicationDetail(ApiTestCase):
         assert_equal(res.status_code, 400)
 
     def test_update_application_no_attributes(self):
-        payload = {'id': self.user1_app._id, 'type': 'applications', 'name': 'The instance formerly known as Prince'}
+        payload = {'id': self.user1_app.client_id, 'type': 'applications', 'name': 'The instance formerly known as Prince'}
         res = self.app.put_json_api(self.user1_app_url, payload, auth=self.user1.auth, expect_errors=True)
         assert_equal(res.status_code, 400)
 
@@ -308,7 +307,13 @@ class TestApplicationDetail(ApiTestCase):
         assert_equal(res.status_code, 400)
 
     def test_partial_update_application_no_attributes(self):
-        payload = {'data': {'id': self.user1_app._id, 'type': 'applications', 'name': 'The instance formerly known as Prince'}}
+        payload = {
+            'data':
+                {'id': self.user1_app.client_id,
+                 'type': 'applications',
+                 'name': 'The instance formerly known as Prince'
+                 }
+        }
         res = self.app.patch_json_api(self.user1_app_url, payload, auth=self.user1.auth, expect_errors=True)
         assert_equal(res.status_code, 400)
 


### PR DESCRIPTION
Fix [#OSF-4725]

## Purpose
ID field is not always based on the _id attribute. Rely on what the user specifies instead of hard-coded assumption.

This PR is intended to fix issues with developer application registration, which uses `client_id` as the publicly facing identifier field.

## Summary of changes
- Allow ID field to respond to whatever the specified source is (rather than hardcoded `_id` field)
- Fix broken unit tests that were suppressing our ability to detect problems with developer app registration

## Testing notes
Once this and #4383 are merged, developer applications registration (`/v2/applications/`) should again work via the front-end.