### PR TITLE
[Feature][Ready for Review] Migration script: GoogleDriveOauthSettings -> ExternalAccounts

### DIFF
--- a/scripts/googledrive/migrate_to_external_account.py
+++ b/scripts/googledrive/migrate_to_external_account.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Script to migrate GoogleDrive credentials from user settings object to external
+account objects.
+
+Changes:
+ - Create external account for authorized user settings
+ - Attach external account to user settings
+ - Attach external account to all node settings
+"""
+
+import sys
+import logging
+from modularodm import Q
+from modularodm.storage.base import KeyExistsException
+
+from website.app import init_app
+from scripts import utils as script_utils
+from framework.transactions.context import TokuTransaction
+
+from website.addons.googledrive.model import GoogleDriveUserSettings
+from website.addons.googledrive.model import GoogleDriveNodeSettings
+from website.oauth.models import ExternalAccount
+
+logger = logging.getLogger(__name__)
+
+
+def do_migration(records, dry):
+    for user_addon in records:
+        user = user_addon.owner
+        old_account = user_addon.oauth_settings
+
+        logger.info('Record found for user {}'.format(user._id))
+
+        if not dry:
+            # Create/load external account and append to user
+            try:
+                account = ExternalAccount(
+                    provider='googledrive',
+                    provider_name='Google Drive',
+                    display_name=old_account.username,
+                    oauth_key=old_account.access_token,
+                    refresh_token=old_account.refresh_token,
+                    provider_id=old_account.user_id,
+                    expires_at=old_account.expires_at,
+                )
+                account.save()
+            except KeyExistsException:
+                # ... or get the old one
+                account = ExternalAccount.find_one(
+                    Q('provider', 'eq', 'googledrive') &
+                    Q('provider_id', 'eq', old_account.user_id)
+                )
+                assert account is not None
+            user.external_accounts.append(account)
+            user.save()
+
+            # Remove oauth_settings from user settings object
+            user_addon.clear()
+            user_addon.save()
+
+            logger.info('Added external account {0} to user {1}'.format(
+                account._id, user._id,
+            ))
+
+            # Add external account to authorized nodes
+            for node_addon in get_authorized_node_settings(user_addon):
+                node_addon.set_auth(account, user)
+                node_addon.drive_folder_name = node_addon.folder_name
+                node_addon.drive_folder_id = node_addon.folder_id
+                node_addon.folder_name = None
+                node_addon.folder_id = None
+                node_addon.save()
+
+                logger.info('Added external account {0} to node {1}'.format(
+                    account._id, node_addon.owner._id,
+                ))
+
+        if dry:
+            logger.info('[Dry] Creating Google Drive ExternalAccount:\n\tdisplay_name={0}\n\toauth_key={1}\n\trefresh_token={2}\n\tprovider_id={3}'.format(
+                old_account.username, old_account.access_token, old_account.refresh_token, old_account.user_id
+            ))
+            logger.info('[Dry] Added external account to user {0}'.format(
+                user._id,
+            ))
+
+            for node_addon in get_authorized_node_settings(user_addon):
+                logger.info('[Dry] Added external account to node {0}'.format(
+                    node_addon.owner._id,
+                ))
+
+
+
+def get_targets():
+    return GoogleDriveUserSettings.find(
+        Q('oauth_settings', 'ne', None)
+    )
+
+
+def get_authorized_node_settings(user_addon):
+    """Returns node settings authorized by a given user settings object"""
+    return GoogleDriveNodeSettings.find(
+        Q('user_settings', 'eq', user_addon)
+    )
+
+
+def main(dry=True):
+    init_app(set_backends=True, routes=False)  # Sets the storage backends on all models
+    with TokuTransaction():
+        do_migration(get_targets(), dry=dry)
+
+
+if __name__ == '__main__':
+    dry = 'dry' in sys.argv
+    if not dry:
+        script_utils.add_file_logger(logger, __file__)
+    main(dry=dry)

--- a/scripts/googledrive/migrate_to_external_account.py
+++ b/scripts/googledrive/migrate_to_external_account.py
@@ -8,11 +8,6 @@ Changes:
  - Create external account for authorized user settings
  - Attach external account to user settings
  - Attach external account to all node settings
-
-First, run the following in a mongo shell:
-    db.getCollection('googledrivenodesettings').update({'user_settings': {'$type': 2}}, {$rename: { user_settings: 'foreign_user_settings'}}, {multi: true})
-
-Then change the user_settings field of GoogleDriveNodeSettings to foreign_user_settings
 """
 
 import sys
@@ -23,6 +18,7 @@ from modularodm.storage.base import KeyExistsException
 from website.app import init_app
 from scripts import utils as script_utils
 from framework.transactions.context import TokuTransaction
+from framework.mongo import database
 
 from website.addons.googledrive.model import GoogleDriveUserSettings
 from website.addons.googledrive.model import GoogleDriveNodeSettings
@@ -32,6 +28,8 @@ logger = logging.getLogger(__name__)
 
 
 def do_migration(records):
+    database['googledrivenodesettings'].update({'user_settings': {'$type': 2}}, {'$rename': { 'user_settings': 'foreign_user_settings'}}, multi=True)
+
     for user_addon in records:
         user = user_addon.owner
         old_account = user_addon.oauth_settings

--- a/scripts/googledrive/migrate_to_external_account.py
+++ b/scripts/googledrive/migrate_to_external_account.py
@@ -8,6 +8,11 @@ Changes:
  - Create external account for authorized user settings
  - Attach external account to user settings
  - Attach external account to all node settings
+
+First, run the following in a mongo shell:
+    db.getCollection('boxnodesettings').update({'user_settings': {'$type': 2}}, {$rename: { user_settings: 'foreign_user_settings'}}, {multi: true})
+
+Then change the user_settings field of BoxNodeSettings to foreign_user_settings
 """
 
 import sys
@@ -33,64 +38,43 @@ def do_migration(records, dry):
 
         logger.info('Record found for user {}'.format(user._id))
 
-        if not dry:
-            # Create/load external account and append to user
-            try:
-                account = ExternalAccount(
-                    provider='googledrive',
-                    provider_name='Google Drive',
-                    display_name=old_account.username,
-                    oauth_key=old_account.access_token,
-                    refresh_token=old_account.refresh_token,
-                    provider_id=old_account.user_id,
-                    expires_at=old_account.expires_at,
-                )
-                account.save()
-            except KeyExistsException:
-                # ... or get the old one
-                account = ExternalAccount.find_one(
-                    Q('provider', 'eq', 'googledrive') &
-                    Q('provider_id', 'eq', old_account.user_id)
-                )
-                assert account is not None
-            user.external_accounts.append(account)
-            user.save()
+        # Create/load external account and append to user
+        try:
+            account = ExternalAccount(
+                provider='googledrive',
+                provider_name='Google Drive',
+                display_name=old_account.username,
+                oauth_key=old_account.access_token,
+                refresh_token=old_account.refresh_token,
+                provider_id=old_account.user_id,
+                expires_at=old_account.expires_at,
+            )
+            account.save()
+        except KeyExistsException:
+            # ... or get the old one
+            account = ExternalAccount.find_one(
+                Q('provider', 'eq', 'googledrive') &
+                Q('provider_id', 'eq', old_account.user_id)
+            )
+            assert account is not None
+        user.external_accounts.append(account)
+        user.save()
 
-            # Remove oauth_settings from user settings object
-            user_addon.clear()
-            user_addon.save()
+        # Remove oauth_settings from user settings object
+        user_addon.oauth_settings = None
+        user_addon.save()
 
-            logger.info('Added external account {0} to user {1}'.format(
-                account._id, user._id,
-            ))
+        logger.info('Added external account {0} to user {1}'.format(
+            account._id, user._id,
+        ))
 
-            # Add external account to authorized nodes
-            for node_addon in get_authorized_node_settings(user_addon):
-                node_addon.set_auth(account, user)
-                node_addon.drive_folder_name = node_addon.folder_name
-                node_addon.drive_folder_id = node_addon.folder_id
-                node_addon.folder_name = None
-                node_addon.folder_id = None
-                node_addon.save()
-
-                logger.info('Added external account {0} to node {1}'.format(
-                    account._id, node_addon.owner._id,
-                ))
-
-        if dry:
-            logger.info('[Dry] Creating Google Drive ExternalAccount:\n\tdisplay_name={0}\n\toauth_key={1}\n\trefresh_token={2}\n\tprovider_id={3}'.format(
-                old_account.username, old_account.access_token, old_account.refresh_token, old_account.user_id
-            ))
-            logger.info('[Dry] Added external account to user {0}'.format(
-                user._id,
-            ))
-
-            for node_addon in get_authorized_node_settings(user_addon):
-                logger.info('[Dry] Added external account to node {0}'.format(
-                    node_addon.owner._id,
-                ))
-
-
+    # Add external account to authorized nodes
+    for node_addon in GoogleDriveNodeSettings.find():
+        if node.foreign_user_settings is None:
+            continue
+        logger.info('Migrating user_settings for googledrive {}'.format(node._id))
+        node.user_settings = node.foreign_user_settings
+        node.save()
 
 def get_targets():
     return GoogleDriveUserSettings.find(
@@ -98,17 +82,12 @@ def get_targets():
     )
 
 
-def get_authorized_node_settings(user_addon):
-    """Returns node settings authorized by a given user settings object"""
-    return GoogleDriveNodeSettings.find(
-        Q('user_settings', 'eq', user_addon)
-    )
-
-
 def main(dry=True):
     init_app(set_backends=True, routes=False)  # Sets the storage backends on all models
     with TokuTransaction():
-        do_migration(get_targets(), dry=dry)
+        do_migration(get_targets())
+        if dry:
+            raise Exception('Abort Transaction - Dry Run')
 
 
 if __name__ == '__main__':

--- a/scripts/googledrive/migrate_to_external_account.py
+++ b/scripts/googledrive/migrate_to_external_account.py
@@ -10,9 +10,9 @@ Changes:
  - Attach external account to all node settings
 
 First, run the following in a mongo shell:
-    db.getCollection('boxnodesettings').update({'user_settings': {'$type': 2}}, {$rename: { user_settings: 'foreign_user_settings'}}, {multi: true})
+    db.getCollection('googledrivenodesettings').update({'user_settings': {'$type': 2}}, {$rename: { user_settings: 'foreign_user_settings'}}, {multi: true})
 
-Then change the user_settings field of BoxNodeSettings to foreign_user_settings
+Then change the user_settings field of GoogleDriveNodeSettings to foreign_user_settings
 """
 
 import sys
@@ -31,7 +31,7 @@ from website.oauth.models import ExternalAccount
 logger = logging.getLogger(__name__)
 
 
-def do_migration(records, dry):
+def do_migration(records):
     for user_addon in records:
         user = user_addon.owner
         old_account = user_addon.oauth_settings
@@ -69,7 +69,7 @@ def do_migration(records, dry):
         ))
 
     # Add external account to authorized nodes
-    for node_addon in GoogleDriveNodeSettings.find():
+    for node in GoogleDriveNodeSettings.find():
         if node.foreign_user_settings is None:
             continue
         logger.info('Migrating user_settings for googledrive {}'.format(node._id))

--- a/scripts/tests/test_googledrive_migrate_to_external_account.py
+++ b/scripts/tests/test_googledrive_migrate_to_external_account.py
@@ -1,0 +1,95 @@
+from nose.tools import *
+
+from scripts.googledrive.migrate_to_external_account import do_migration, get_targets
+
+from framework.auth import Auth
+
+from tests.base import OsfTestCase
+from tests.factories import ProjectFactory, UserFactory
+
+from website.addons.googledrive.model import GoogleDriveUserSettings
+from website.addons.googledrive.tests.factories import GoogleDriveOAuthSettingsFactory
+
+
+class TestGoogleDriveMigration(OsfTestCase):
+    # Note: GoogleDriveUserSettings.user_settings has to be changed to foreign_user_settings (model and mongo). See migration instructions
+
+    def test_migration_no_project(self):
+
+        user = UserFactory()
+
+        user.add_addon('googledrive')
+        user_addon = user.get_addon('googledrive')
+        user_addon.oauth_settings = GoogleDriveOAuthSettingsFactory()
+        user_addon.save()
+
+        do_migration([user_addon])
+        user_addon.reload()
+
+        assert_is_none(user_addon.oauth_settings)
+        assert_equal(len(user.external_accounts), 1)
+
+        account = user.external_accounts[0]
+        assert_equal(account.provider, 'googledrive')
+        assert_equal(account.oauth_key, 'abcdef1')
+
+    def test_migration_removes_targets(self):
+        GoogleDriveUserSettings.remove()
+
+        user = UserFactory()
+        project = ProjectFactory(creator=user)
+
+
+        user.add_addon('googledrive', auth=Auth(user))
+        user_addon = user.get_addon('googledrive')
+        user_addon.oauth_settings = GoogleDriveOAuthSettingsFactory()
+        user_addon.save()
+
+
+        project.add_addon('googledrive', auth=Auth(user))
+        node_addon = project.get_addon('googledrive')
+        node_addon.foreign_user_settings = user_addon
+        node_addon.save()
+
+        assert_equal(get_targets().count(), 1)
+
+        do_migration([user_addon])
+        user_addon.reload()
+
+        assert_equal(get_targets().count(), 0)
+
+    def test_migration_multiple_users(self):
+        user1 = UserFactory()
+        user2 = UserFactory()
+        oauth_settings = GoogleDriveOAuthSettingsFactory()
+
+        user1.add_addon('googledrive')
+        user1_addon = user1.get_addon('googledrive')
+        user1_addon.oauth_settings = oauth_settings
+        user1_addon.save()
+
+        user2.add_addon('googledrive')
+        user2_addon = user2.get_addon('googledrive')
+        user2_addon.oauth_settings = oauth_settings
+        user2_addon.save()
+
+        do_migration([user1_addon, user2_addon])
+        user1_addon.reload()
+        user2_addon.reload()
+
+        assert_equal(
+            user1.external_accounts[0],
+            user2.external_accounts[0],
+        )
+
+    def test_get_targets(self):
+        GoogleDriveUserSettings.remove()
+        addons = [
+            GoogleDriveUserSettings(),
+            GoogleDriveUserSettings(oauth_settings=GoogleDriveOAuthSettingsFactory()),
+        ]
+        for addon in addons:
+            addon.save()
+        targets = get_targets()
+        assert_equal(targets.count(), 1)
+        assert_equal(targets[0]._id, addons[-1]._id)

--- a/website/addons/googledrive/model.py
+++ b/website/addons/googledrive/model.py
@@ -164,7 +164,7 @@ class GoogleDriveNodeSettings(StorageAddonBase, AddonNodeSettingsBase):
     folder_id = fields.StringField(default=None)
     folder_path = fields.StringField(default=None)
 
-    user_settings = fields.ForeignField(
+    foreign_user_settings = fields.ForeignField(
         'googledriveusersettings', backref='authorized'
     )
 


### PR DESCRIPTION
Purpose
=======
Adds script to migrate `GoogleDriveOAuthSettings` objects to `ExternalAccount` objects.

Note
=====
Must go in and be migrated before #4261  

Migration Steps
============
* Ensure that the `user_settings` field of GoogleDriveNodeSettings has been changed to `foreign_user_settings`
```
python -m scripts.googledrive.migrate_to_external_account
```
* [Merge 4261]
* Again, ensure that the `user_settings` field of GoogleDriveNodeSettings has been changed to `foreign_user_settings`
```
python -m scripts.googledrive.connect_external_accounts
```

[#OSF-2272]