### PR TITLE
[RfR] Registration links; Serializer tests

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -79,14 +79,18 @@ class NodeSerializer(JSONAPISerializer):
     node_links = DevOnly(JSONAPIHyperlinkedIdentityField(view_name='nodes:node-pointers', lookup_field='pk', link_type='related',
                                                   lookup_url_kwarg='node_id', meta={'count': 'get_pointers_count'}))
 
-    parent = JSONAPIHyperlinkedIdentityField(view_name='nodes:node-detail', lookup_field='parent_id', link_type='self',
+    parent = JSONAPIHyperlinkedIdentityField(view_name='nodes:node-detail', lookup_field='parent_id', link_type='related',
                                               lookup_url_kwarg='node_id')
 
     registrations = DevOnly(JSONAPIHyperlinkedIdentityField(view_name='nodes:node-registrations', lookup_field='pk', link_type='related',
                                                      lookup_url_kwarg='node_id', meta={'count': 'get_registration_count'}))
 
-
-    # TODO: forked_from
+    forked_from = JSONAPIHyperlinkedIdentityField(
+        view_name='nodes:node-detail',
+        lookup_field='forked_from_id',
+        link_type='related',
+        lookup_url_kwarg='node_id'
+    )
 
     class Meta:
         type_ = 'nodes'

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -50,6 +50,7 @@ class NodeSerializer(JSONAPISerializer):
     date_created = ser.DateTimeField(read_only=True)
     date_modified = ser.DateTimeField(read_only=True)
     registration = ser.BooleanField(read_only=True, source='is_registration')
+    fork = ser.BooleanField(read_only=True, source='is_fork')
     collection = ser.BooleanField(read_only=True, source='is_folder')
     dashboard = ser.BooleanField(read_only=True, source='is_dashboard')
     tags = ser.ListField(child=NodeTagField(), required=False)
@@ -83,6 +84,9 @@ class NodeSerializer(JSONAPISerializer):
 
     registrations = DevOnly(JSONAPIHyperlinkedIdentityField(view_name='nodes:node-registrations', lookup_field='pk', link_type='related',
                                                      lookup_url_kwarg='node_id', meta={'count': 'get_registration_count'}))
+
+
+    # TODO: forked_from
 
     class Meta:
         type_ = 'nodes'

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -264,6 +264,21 @@ class NodeRegistrationSerializer(NodeSerializer):
 
     retracted = ser.BooleanField(source='is_retracted', read_only=True,
         help_text='Whether this registration has been retracted.')
+    date_registered = ser.DateTimeField(source='registered_date', read_only=True, help_text='Date time of registration.')
+
+    registered_by = JSONAPIHyperlinkedIdentityField(
+        view_name='users:user-detail',
+        lookup_field='registered_user_id',
+        link_type='related',
+        lookup_url_kwarg='user_id'
+    )
+
+    registered_from = JSONAPIHyperlinkedIdentityField(
+        view_name='nodes:node-detail',
+        lookup_field='registered_from_id',
+        link_type='related',
+        lookup_url_kwarg='node_id'
+    )
 
     # TODO: Finish me
 

--- a/tests/api_tests/nodes/test_serializers.py
+++ b/tests/api_tests/nodes/test_serializers.py
@@ -6,9 +6,9 @@ from django.http import HttpRequest
 from dateutil.parser import parse as parse_date
 
 from tests.base import DbTestCase, ApiTestCase, assert_datetime_equal
-from tests.factories import UserFactory, RegistrationFactory
+from tests.factories import UserFactory, NodeFactory, RegistrationFactory
 
-from api.nodes.serializers import NodeRegistrationSerializer
+from api.nodes.serializers import NodeSerializer, NodeRegistrationSerializer
 from api.base.settings.defaults import API_BASE
 
 def make_test_request():
@@ -18,6 +18,38 @@ def make_test_request():
     http_request.META['SERVER_PORT'] = 8000
     # A DRF Request wraps a Django HttpRequest
     return Request(http_request)
+
+
+class TestNodeSerializer(DbTestCase):
+
+    def test_serialization(self):
+        user = UserFactory()
+        node = NodeFactory()
+        req = make_test_request()
+        result = NodeSerializer(node, context={'request': req}).data
+        data = result['data']
+        assert_equal(data['id'], node._id)
+        assert_equal(data['type'], 'nodes')
+
+        # Attributes
+        attributes = data['attributes']
+        assert_equal(attributes['title'], node.title)
+        assert_equal(attributes['description'], node.description)
+        assert_equal(attributes['public'], node.is_public)
+        assert_equal(attributes['tags'], [str(each) for each in node.tags])
+        assert_equal(attributes['category'], node.category)
+        assert_equal(attributes['registration'], node.is_registration)
+        assert_equal(attributes['fork'], node.is_fork)
+        assert_equal(attributes['collection'], node.is_fork)
+
+        # Relationships
+        relationships = data['relationships']
+        assert_in('children', relationships)
+        assert_in('contributors', relationships)
+        assert_in('files', relationships)
+        assert_in('parent', relationships)
+        assert_in('registrations', relationships)
+
 
 class TestNodeRegistrationSerializer(DbTestCase):
 

--- a/tests/api_tests/nodes/test_serializers.py
+++ b/tests/api_tests/nodes/test_serializers.py
@@ -2,24 +2,15 @@
 from urlparse import urlparse
 
 from nose.tools import *  # flake8: noqa
-from django.http import HttpRequest
 from dateutil.parser import parse as parse_date
 
 from tests.base import DbTestCase, ApiTestCase, assert_datetime_equal
+from tests.utils import make_drf_request
 from tests.factories import UserFactory, NodeFactory, RegistrationFactory, ProjectFactory
 
 from framework.auth import Auth
 from api.nodes.serializers import NodeSerializer, NodeRegistrationSerializer
 from api.base.settings.defaults import API_BASE
-
-
-def make_test_request():
-    from rest_framework.request import Request
-    http_request = HttpRequest()
-    http_request.META['SERVER_NAME'] = 'localhost'
-    http_request.META['SERVER_PORT'] = 8000
-    # A DRF Request wraps a Django HttpRequest
-    return Request(http_request)
 
 
 class TestNodeSerializer(DbTestCase):
@@ -31,7 +22,7 @@ class TestNodeSerializer(DbTestCase):
     def test_node_serialization(self):
         parent = ProjectFactory(creator=self.user)
         node = NodeFactory(creator=self.user, parent=parent)
-        req = make_test_request()
+        req = make_drf_request()
         result = NodeSerializer(node, context={'request': req}).data
         data = result['data']
         assert_equal(data['id'], node._id)
@@ -68,7 +59,7 @@ class TestNodeSerializer(DbTestCase):
     def test_fork_serialization(self):
         node = NodeFactory(creator=self.user)
         fork = node.fork_node(auth=Auth(user=node.creator))
-        result = NodeSerializer(fork, context={'request': make_test_request()}).data
+        result = NodeSerializer(fork, context={'request': make_drf_request()}).data
         data = result['data']
 
         # Relationships
@@ -83,7 +74,7 @@ class TestNodeRegistrationSerializer(DbTestCase):
 
     def test_serialization(self):
         user = UserFactory()
-        req = make_test_request()
+        req = make_drf_request()
         reg = RegistrationFactory(creator=user)
         result = NodeRegistrationSerializer(reg, context={'request': req}).data
         data = result['data']

--- a/tests/api_tests/nodes/test_serializers.py
+++ b/tests/api_tests/nodes/test_serializers.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+from urlparse import urlparse
+
+from nose.tools import *  # flake8: noqa
+from django.http import HttpRequest
+from dateutil.parser import parse as parse_date
+
+from tests.base import DbTestCase, ApiTestCase, assert_datetime_equal
+from tests.factories import UserFactory, RegistrationFactory
+
+from api.nodes.serializers import NodeRegistrationSerializer
+from api.base.settings.defaults import API_BASE
+
+def make_test_request():
+    from rest_framework.request import Request
+    http_request = HttpRequest()
+    http_request.META['SERVER_NAME'] = 'localhost'
+    http_request.META['SERVER_PORT'] = 8000
+    # A DRF Request wraps a Django HttpRequest
+    return Request(http_request)
+
+class TestNodeRegistrationSerializer(DbTestCase):
+
+    def test_serialization(self):
+        user = UserFactory()
+        req = make_test_request()
+        reg = RegistrationFactory(creator=user)
+        result = NodeRegistrationSerializer(reg, context={'request': req}).data
+        data = result['data']
+        assert_equal(data['id'], reg._id)
+        assert_equal(data['type'], 'nodes')
+
+        # Attributes
+        attributes = data['attributes']
+        assert_datetime_equal(
+            parse_date(attributes['date_registered']),
+            reg.registered_date
+        )
+        assert_equal(attributes['retracted'], reg.is_retracted)
+
+        # Relationships
+        relationships = data['relationships']
+        assert_in('registered_by', relationships)
+        registered_by = relationships['registered_by']['links']['related']['href']
+        assert_equal(
+            urlparse(registered_by).path,
+            '/{}users/{}/'.format(API_BASE, user._id)
+        )
+        assert_in('registered_from', relationships)
+        registered_from = relationships['registered_from']['links']['related']['href']
+        assert_equal(
+            urlparse(registered_from).path,
+            '/{}nodes/{}/'.format(API_BASE, reg.registered_from._id)
+        )

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -587,7 +587,7 @@ class TestNodeDetail(ApiTestCase):
     def test_top_level_project_has_no_parent(self):
         res = self.app.get(self.public_url)
         assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['relationships']['parent']['links']['self']['href'], None)
+        assert_equal(res.json['data']['relationships']['parent']['links']['related']['href'], None)
         assert_equal(res.content_type, 'application/vnd.api+json')
 
     def test_child_project_has_parent(self):
@@ -595,7 +595,7 @@ class TestNodeDetail(ApiTestCase):
         public_component_url = '/{}nodes/{}/'.format(API_BASE, public_component._id)
         res = self.app.get(public_component_url)
         assert_equal(res.status_code, 200)
-        url = res.json['data']['relationships']['parent']['links']['self']['href']
+        url = res.json['data']['relationships']['parent']['links']['related']['href']
         assert_equal(urlparse(url).path, self.public_url)
 
     def test_node_has_children_link(self):
@@ -3265,7 +3265,7 @@ class TestExceptionFormatting(ApiTestCase):
         errors = res.json['errors']
         assert(isinstance(errors, list))
         assert_equal(errors[0], {'detail': 'Not found.'})
-    
+
     def test_forbidden_formatting(self):
         res = self.app.get(self.private_url, auth=self.non_contrib.auth, expect_errors=True)
         errors = res.json['errors']

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,6 +6,7 @@ from nose.tools import assert_equal, assert_not_equal
 
 from framework.auth import Auth
 
+from django.http import HttpRequest
 from website.archiver import listeners as archiver_listeners
 from website.archiver import ARCHIVER_SUCCESS
 
@@ -116,3 +117,13 @@ def mock_archive(project, schema=None, auth=None, template=None, data=None, pare
         sanction = registration.root.sanction
         sanction._on_complete(project.creator)
     yield registration
+
+def make_drf_request(*args, **kwargs):
+    from rest_framework.request import Request
+    http_request = HttpRequest()
+    # The values here don't matter; they just need
+    # to be present
+    http_request.META['SERVER_NAME'] = 'localhost'
+    http_request.META['SERVER_PORT'] = 8000
+    # A DRF Request wraps a Django HttpRequest
+    return Request(http_request, *args, **kwargs)

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2164,6 +2164,12 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
         return None
 
     @property
+    def forked_from_id(self):
+        if self.forked_from:
+            return self.forked_from._id
+        return None
+
+    @property
     def project_or_component(self):
         return 'project' if self.category == 'project' else 'component'
 

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -626,6 +626,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
     is_registration = fields.BooleanField(default=False, index=True)
     registered_date = fields.DateTimeField(index=True)
     registered_user = fields.ForeignField('user', backref='registered')
+
     registered_schema = fields.ForeignField('metaschema', backref='registered')
     registered_meta = fields.DictionaryField()
     registration_approval = fields.ForeignField('registrationapproval')
@@ -729,6 +730,23 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
     def category_display(self):
         """The human-readable representation of this node's category."""
         return self.CATEGORY_MAP[self.category]
+
+    # We need the following 2 properties in order to serialize related links in NodeRegistrationSerializer
+    @property
+    def registered_user_id(self):
+        """The ID of the user who registered this node if this is a registration, else None.
+        """
+        if self.registered_user:
+            return self.registered_user._id
+        return None
+
+    @property
+    def registered_from_id(self):
+        """The ID of the user who registered this node if this is a registration, else None.
+        """
+        if self.registered_from:
+            return self.registered_from._id
+        return None
 
     @property
     def sanction(self):


### PR DESCRIPTION
### Purpose/Changes

- Add initial unit tests for serializers 
- Add a few missing links and attributes to NodeSerializer and NodeRegistrationSerializer (partially addresses OSF-4436)
- Change NodeSerializer.parent to a `related` link rather than a `self` link (verified with Dawn that this is correct).

### Tickets

https://openscience.atlassian.net/browse/OSF-4771
Partially addresses https://openscience.atlassian.net/browse/OSF-4436