### PR TITLE
[CR] Two Files API-related fixes

### DIFF
--- a/api/files/permissions.py
+++ b/api/files/permissions.py
@@ -6,6 +6,9 @@ from website.files.models import FileNode
 class CheckedOutOrAdmin(permissions.BasePermission):
     def has_object_permission(self, request, view, obj):
         assert isinstance(obj, FileNode), 'obj must be a FileNode, got {}'.format(obj)
+        if request.method in permissions.SAFE_METHODS:
+            return True
+
         auth = get_user_auth(request)
         # Limited to osfstorage for the moment
         if obj.provider != 'osfstorage':

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -67,13 +67,14 @@ class WaterButlerMixin(object):
     provider_lookup_url_kwarg = 'provider'
 
     def get_file_item(self, item):
+        attrs = item['attributes']
         file_node = FileNode.resolve_class(
-            item['provider'],
-            FileNode.FOLDER if item['kind'] == 'folder'
+            attrs['provider'],
+            FileNode.FOLDER if attrs['kind'] == 'folder'
             else FileNode.FILE
-        ).get_or_create(self.get_node(check_object_permissions=False), item['path'])
+        ).get_or_create(self.get_node(check_object_permissions=False), attrs['path'])
 
-        file_node.update(None, item, user=self.request.user)
+        file_node.update(None, attrs, user=self.request.user)
 
         self.check_object_permissions(self.request, file_node)
 

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -2790,11 +2790,16 @@ def prepare_mock_wb_response(
         data = [dict(default_file, **each) for each in files]
     else:
         data = [default_file]
+
+    jsonapi_data = []
+    for datum in data:
+        jsonapi_data.append({'attributes': datum})
+
     if not folder:
-        data = data[0]
+        jsonapi_data = jsonapi_data[0]
 
     body = json.dumps({
-        u'data': data
+        u'data': jsonapi_data
     })
     httpretty.register_uri(
         method,


### PR DESCRIPTION
The attached patches fix two separate issues with the files API.

1.) d181651 updates NodeFilesList to handle the new JSON-API conformant WaterButler responses.  Relevant: [#OSF-4667]

2.) d65c61d fixes a permissions bug for file checkouts.  It wasn't checking whether or not the request was safe and ergo declining all non-osfstorage files.  Relevant: [#OSF-4674]

The Jira ticket for this task is https://openscience.atlassian.net/browse/OSF-4674