### PR TITLE
[Ready to Review] Feature/tags should be an array

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -79,6 +79,14 @@ class TypeField(ser.CharField):
         return super(TypeField, self).to_internal_value(data)
 
 
+class JSONAPIListField(ser.ListField):
+    def to_internal_value(self, data):
+        if not isinstance(data, list):
+            self.fail('not_a_list', input_type=type(data).__name__)
+
+        return super(JSONAPIListField, self).to_internal_value(data)
+
+
 class JSONAPIHyperlinkedIdentityField(ser.HyperlinkedIdentityField):
     """
     HyperlinkedIdentityField that returns a nested dict with url,

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -11,7 +11,7 @@ from website.util import permissions as osf_permissions
 
 from api.base.utils import get_object_or_error, absolute_reverse, add_dev_only_items
 from api.base.serializers import LinksField, JSONAPIHyperlinkedIdentityField, DevOnly
-from api.base.serializers import JSONAPISerializer, WaterbutlerLink, NodeFileHyperLink, IDField, TypeField
+from api.base.serializers import JSONAPISerializer, WaterbutlerLink, NodeFileHyperLink, IDField, TypeField, JSONAPIListField
 from api.base.exceptions import InvalidModelValueError
 
 
@@ -52,7 +52,7 @@ class NodeSerializer(JSONAPISerializer):
     registration = ser.BooleanField(read_only=True, source='is_registration')
     collection = ser.BooleanField(read_only=True, source='is_folder')
     dashboard = ser.BooleanField(read_only=True, source='is_dashboard')
-    tags = ser.ListField(child=NodeTagField(), required=False)
+    tags = JSONAPIListField(child=NodeTagField(), required=False)
 
     # Public is only write-able by admins--see update method
     public = ser.BooleanField(source='is_public', required=False,

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -2603,6 +2603,26 @@ class TestNodeTags(ApiTestCase):
         assert_equal(res.status_code, 200)
         assert_equal(len(res.json['data']['attributes']['tags']), 0)
 
+    def test_tags_post_object_instead_of_list(self):
+        url = '/{}nodes/'.format(API_BASE)
+        payload = {'data': {
+            'type': 'nodes',
+            'attributes': {
+                'title': 'new title',
+                'category': 'project',
+                'tags': {'foo': 'bar'}
+            }
+        }}
+        res = self.app.post_json_api(url, payload, auth=self.user.auth, expect_errors=True)
+        assert_equal(res.status_code, 400)
+        assert_equal(res.json['errors'][0]['detail'], 'Expected a list of items but got type "dict".')
+
+    def test_tags_patch_object_instead_of_list(self):
+        self.one_new_tag_json['data']['attributes']['tags'] = {'foo': 'bar'}
+        res = self.app.patch_json_api(self.public_url, self.one_new_tag_json, auth=self.user.auth, expect_errors=True)
+        assert_equal(res.status_code, 400)
+        assert_equal(res.json['errors'][0]['detail'], 'Expected a list of items but got type "dict".')
+
 
 class TestNodeLinkCreate(ApiTestCase):
 


### PR DESCRIPTION
# Purpose

Issue https://openscience.atlassian.net/browse/OSF-4602

When creating/updating a node, a dictionary is allowed as input.  We need to enforce that the type is an array.

PUTting {"tags": {"foo":"bar", "baz":"quux"}} into /v2/nodes/$node_id results in the keys of the object ("foo", "baz") being used as the tags and the values being ignored. 

# Changes
Creates new ListField which overrides to_internal_value, enforcing that the data type is a list. 

# For QA
Try to create a node, fill in all required fields.  For tags, put a dictionary.  
![screen shot 2015-10-09 at 2 22 53 pm](https://cloud.githubusercontent.com/assets/9755598/10402081/2390c31a-6e91-11e5-9d97-664e8512e336.png)
Expected response:
![screen shot 2015-10-09 at 2 23 36 pm](https://cloud.githubusercontent.com/assets/9755598/10402092/34f57182-6e91-11e5-93f3-3dacfb5a1230.png)

And if tags are the correct format, a list, node will be created successfully with tags.
![screen shot 2015-10-09 at 2 25 21 pm](https://cloud.githubusercontent.com/assets/9755598/10402126/72ec465a-6e91-11e5-8a77-d28a83eec509.png)
