### PR TITLE
Share fix for filters duplicating results

### DIFF
--- a/website/static/js/share/results.js
+++ b/website/static/js/share/results.js
@@ -156,11 +156,15 @@ var Contributor = {
                     if (givenNameLength <= 0 && familyNameLength <= 0) {
                         utils.updateFilter(vm, 'match:contributors.name:' + contributor.name, true);
                     } else {
+                        var filters = [];
                         if (givenNameLength > 0) {
-                            utils.updateFilter(vm, 'match:contributors.givenName:' + contributor.givenName, true);
+                            filters.push('match:contributors.givenName:' + contributor.givenName);
                         }
                         if (familyNameLength > 0) {
-                            utils.updateFilter(vm, 'match:contributors.familyName:' + contributor.familyName, true);
+                            filters.push('match:contributors.familyName:' + contributor.familyName);
+                        }
+                        if(filters.length>0){
+                           utils.updateFilter(vm, filters, true);
                         }
                     }
                 }

--- a/website/static/js/share/utils.js
+++ b/website/static/js/share/utils.js
@@ -236,9 +236,8 @@ utils.updateFilter = function (vm, filter, required) {
 utils.wrapFilter = function(filter){
     if( typeof filter === 'string' ) {
         return [filter];
-    }else{
-        return filter;
     }
+    return filter;
 };
 
 /* Removes a filter from the list of filters */

--- a/website/static/js/share/utils.js
+++ b/website/static/js/share/utils.js
@@ -221,12 +221,24 @@ utils.maybeQuashEvent = function (event) {
 
 /* Adds a filter to the list of filters if it doesn't already exist */
 utils.updateFilter = function (vm, filter, required) {
-    if (required && vm.requiredFilters.indexOf(filter) === -1) {
-        vm.requiredFilters.push(filter);
-    } else if (vm.optionalFilters.indexOf(filter) === -1 && !required) {
-        vm.optionalFilters.push(filter);
-    }
+    filters = utils.wrapFilter(filter);
+    filters.forEach(function(f){
+        if (required && vm.requiredFilters.indexOf(f) === -1) {
+            vm.requiredFilters.push(f);
+        } else if (vm.optionalFilters.indexOf(f) === -1 && !required) {
+            vm.optionalFilters.push(f);
+        }
+    });
     utils.search(vm);
+};
+
+/* Helper function to accept string or array of strings for updateFilter */
+utils.wrapFilter = function(filter){
+    if( typeof filter === 'string' ) {
+        return [filter];
+    }else{
+        return filter;
+    }
 };
 
 /* Removes a filter from the list of filters */


### PR DESCRIPTION
# [OSF-4463]
## Purpose
Clicking Share page filters caused duplication of the results. This PR fixes the duplication bug.

## Changes
updateFilters in share/utils.js now accepts a list of strings of a single string. 

The problem was that names are sometimes split into a first and last name as separate filters. Clicking a name filter made two separate updateFilter calls, which was chained to a search call, which called updateVm (updateFilter -> search ->updateVm (data added here). When the second updateFilter was called it reran the chain adding the data a second time. 

Now clicking the name filter adds the filters to an array and updateFilter is called a single time with that array. 

## Side Effects

It is possible that changing the way updateFilter works could break the other filters. I didn't see any problems, but it is worth checking with more data. 

## QA Testing Considerations
1. Test that clicking name filters do not duplicate data.
2. Test that other filters (like the data provider) properly filter the data
3. Test that the sidebar where the current filter are applied show accurate data (no weird double filters). For example a bad filter might say "givenName:MartinfamilyName:Culpepper." instead of "givenName:Martin" and "familyName:Culpepper." as distinct filters.
