### PR TITLE
add regression test for node contributor filtering to ensure fullname…

### DIFF
--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -1357,7 +1357,7 @@ class TestNodeContributorFiltering(ApiTestCase):
         # regression test for changes in filter fields
         # fullname is now full_name
         url_fullname = '/{}nodes/{}/contributors/?filter[fullname]=foo'.format(API_BASE, self.project._id)
-        res = self.app.get(url, auth=self.user.auth, expect_errors=True)
+        res = self.app.get(url_fullname, auth=self.user.auth, expect_errors=True)
         assert_equal(res.status_code, 400)
         errors = res.json['errors']
         assert_equal(len(errors), 1)
@@ -1365,11 +1365,11 @@ class TestNodeContributorFiltering(ApiTestCase):
 
         # middle_name is now middle_names
         url_middle_name = '/{}nodes/{}/contributors/?filter[middle_name]=foo'.format(API_BASE, self.project._id)
-        res = self.app.get(url, auth=self.user.auth, expect_errors=True)
+        res = self.app.get(url_middle_name, auth=self.user.auth, expect_errors=True)
         assert_equal(res.status_code, 400)
         errors = res.json['errors']
         assert_equal(len(errors), 1)
-        assert_equal(errors[0]['detail'], 'Query string contains an invalid filter.')        
+        assert_equal(errors[0]['detail'], 'Query string contains an invalid filter.')
 
 class TestNodeContributorAdd(NodeCRUDTestCase):
 

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -1353,6 +1353,23 @@ class TestNodeContributorFiltering(ApiTestCase):
         assert_equal(len(errors), 1)
         assert_equal(errors[0]['detail'], 'Query string contains an invalid filter.')
 
+    def test_filtering_on_obsolete_fields(self):
+        # regression test for changes in filter fields
+        # fullname is now full_name
+        url_fullname = '/{}nodes/{}/contributors/?filter[fullname]=foo'.format(API_BASE, self.project._id)
+        res = self.app.get(url, auth=self.user.auth, expect_errors=True)
+        assert_equal(res.status_code, 400)
+        errors = res.json['errors']
+        assert_equal(len(errors), 1)
+        assert_equal(errors[0]['detail'], 'Query string contains an invalid filter.')        
+
+        # middle_name is now middle_names
+        url_middle_name = '/{}nodes/{}/contributors/?filter[middle_name]=foo'.format(API_BASE, self.project._id)
+        res = self.app.get(url, auth=self.user.auth, expect_errors=True)
+        assert_equal(res.status_code, 400)
+        errors = res.json['errors']
+        assert_equal(len(errors), 1)
+        assert_equal(errors[0]['detail'], 'Query string contains an invalid filter.')        
 
 class TestNodeContributorAdd(NodeCRUDTestCase):
 


### PR DESCRIPTION
# [OSF-4706]
## Purpose
Regression test for node contributor filtering. Tests that fullname and middle_name do not filter anymore.

## Changes
Regression test added for change in OSF-4652

## Side Effects
None