### PR TITLE
[Ready to Review] Incorrect permissions and links for node links 

### DIFF
--- a/api/nodes/permissions.py
+++ b/api/nodes/permissions.py
@@ -60,7 +60,7 @@ class ContributorOrPublicForPointers(permissions.BasePermission):
             has_auth = public or (has_parent_auth and has_pointer_auth)
             return has_auth
         else:
-            has_auth = parent_node.can_edit(auth) and pointer_node.can_edit(auth)
+            has_auth = parent_node.can_edit(auth)
             return has_auth
 
 class ReadOnlyIfRegistration(permissions.BasePermission):

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -294,7 +294,6 @@ class NodeLinksSerializer(JSONAPISerializer):
         'self': 'get_absolute_url'
     })
 
-
     def get_absolute_url(self, obj):
         node_id = self.context['request'].parser_context['kwargs']['node_id']
         return absolute_reverse(

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -164,6 +164,7 @@ class NodeDetailSerializer(NodeSerializer):
     """
     id = IDField(source='_id', required=True)
 
+
 class NodeContributorsSerializer(JSONAPISerializer):
     """ Separate from UserSerializer due to necessity to override almost every field as read only
     """
@@ -277,23 +278,32 @@ class NodeLinksSerializer(JSONAPISerializer):
 
     id = IDField(source='_id', read_only=True)
     type = TypeField()
-    target_node_id = ser.CharField(source='node._id', help_text='The ID of the node that this Node Link points to')
+    target_node_id = ser.CharField(write_only=True, source='node._id', help_text='The ID of the node that this Node Link points to')
 
     # TODO: We don't show the title because the current user may not have access to this node. We may want to conditionally
     # include this field in the future.
     # title = ser.CharField(read_only=True, source='node.title', help_text='The title of the node that this Node Link '
     #                                                                      'points to')
 
+    target_node = JSONAPIHyperlinkedIdentityField(view_name='nodes:node-detail', lookup_field='pk', link_type='related',
+                                              lookup_url_kwarg='node_id')
     class Meta:
         type_ = 'node_links'
 
     links = LinksField({
-        'html': 'get_absolute_url',
+        'self': 'get_absolute_url'
     })
 
+
     def get_absolute_url(self, obj):
-        pointer_node = Node.load(obj.node._id)
-        return pointer_node.absolute_url
+        node_id = self.context['request'].parser_context['kwargs']['node_id']
+        return absolute_reverse(
+            'nodes:node-pointer-detail',
+            kwargs={
+                'node_id': node_id,
+                'node_link_id': obj._id
+            }
+        )
 
     def create(self, validated_data):
         request = self.context['request']

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -278,7 +278,7 @@ class NodeLinksSerializer(JSONAPISerializer):
 
     id = IDField(source='_id', read_only=True)
     type = TypeField()
-    target_node_id = ser.CharField(write_only=True, source='node._id', help_text='The ID of the node that this Node Link points to')
+    target_node_id = ser.CharField(source='node._id', help_text='The ID of the node that this Node Link points to')
 
     # TODO: We don't show the title because the current user may not have access to this node. We may want to conditionally
     # include this field in the future.

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -278,7 +278,7 @@ class NodeLinksSerializer(JSONAPISerializer):
 
     id = IDField(source='_id', read_only=True)
     type = TypeField()
-    target_node_id = ser.CharField(source='node._id', help_text='The ID of the node that this Node Link points to')
+    target_node_id = ser.CharField(write_only=True, source='node._id', help_text='The ID of the node that this Node Link points to')
 
     # TODO: We don't show the title because the current user may not have access to this node. We may want to conditionally
     # include this field in the future.

--- a/api/nodes/urls.py
+++ b/api/nodes/urls.py
@@ -21,6 +21,6 @@ urlpatterns = [
 if settings.DEV_MODE:
     urlpatterns.extend([
         url(r'^(?P<node_id>\w+)/node_links/$', views.NodeLinksList.as_view(), name='node-pointers'),
-        url(r'^(?P<node_id>\w+)/node_links/(?P<node_link_id>\w+)', views.NodeLinksDetail.as_view(), name='node-pointer-detail'),
+        url(r'^(?P<node_id>\w+)/node_links/(?P<node_link_id>\w+)/', views.NodeLinksDetail.as_view(), name='node-pointer-detail'),
         url(r'^(?P<node_id>\w+)/registrations/$', views.NodeRegistrationsList.as_view(), name='node-registrations'),
     ])

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -61,6 +61,7 @@ class NodeMixin(object):
             self.check_object_permissions(self.request, node)
         return node
 
+
 class WaterButlerMixin(object):
 
     path_lookup_url_kwarg = 'path'

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -2447,8 +2447,9 @@ class TestNodeLinksList(ApiTestCase):
         res_json = res.json['data']
         assert_equal(len(res_json), 1)
         assert_equal(res.status_code, 200)
-        assert_in(res_json[0]['attributes']['target_node_id'], self.public_pointer_project._id)
         assert_equal(res.content_type, 'application/vnd.api+json')
+        url = res.json['data'][0]['relationships']['target_node']['links']['related']['href']
+        assert_in('/{}nodes/{}/'.format(API_BASE, self.public_pointer_project._id), url)
 
     def test_return_public_node_pointers_logged_in(self):
         res = self.app.get(self.public_url, auth=self.user_two.auth)
@@ -2456,7 +2457,8 @@ class TestNodeLinksList(ApiTestCase):
         assert_equal(len(res_json), 1)
         assert_equal(res.status_code, 200)
         assert_equal(res.content_type, 'application/vnd.api+json')
-        assert_in(res_json[0]['attributes']['target_node_id'], self.public_pointer_project._id)
+        url = res_json[0]['relationships']['target_node']['links']['related']['href']
+        assert_in('/{}nodes/{}/'.format(API_BASE, self.public_pointer_project._id), url)
 
     def test_return_private_node_pointers_logged_out(self):
         res = self.app.get(self.private_url, expect_errors=True)
@@ -2469,7 +2471,8 @@ class TestNodeLinksList(ApiTestCase):
         assert_equal(res.status_code, 200)
         assert_equal(res.content_type, 'application/vnd.api+json')
         assert_equal(len(res_json), 1)
-        assert_in(res_json[0]['attributes']['target_node_id'], self.pointer_project._id)
+        url = res_json[0]['relationships']['target_node']['links']['related']['href']
+        assert_in('/{}nodes/{}/'.format(API_BASE, self.pointer_project._id), url)
 
     def test_return_private_node_pointers_logged_in_non_contributor(self):
         res = self.app.get(self.private_url, auth=self.user_two.auth, expect_errors=True)
@@ -2656,7 +2659,8 @@ class TestNodeLinkCreate(ApiTestCase):
         res = self.app.post_json_api(self.public_url, self.public_payload, auth=self.user.auth)
         assert_equal(res.status_code, 201)
         assert_equal(res.content_type, 'application/vnd.api+json')
-        assert_equal(res.json['data']['attributes']['target_node_id'], self.public_pointer_project._id)
+        url = res.json['data']['relationships']['target_node']['links']['related']['href']
+        assert_in('/{}nodes/{}/'.format(API_BASE, self.public_pointer_project._id), url)
 
     def test_creates_private_node_pointer_logged_out(self):
         res = self.app.post_json_api(self.private_url, self.private_payload, expect_errors=True)
@@ -2666,7 +2670,8 @@ class TestNodeLinkCreate(ApiTestCase):
     def test_creates_private_node_pointer_logged_in_contributor(self):
         res = self.app.post_json_api(self.private_url, self.private_payload, auth=self.user.auth)
         assert_equal(res.status_code, 201)
-        assert_equal(res.json['data']['attributes']['target_node_id'], self.pointer_project._id)
+        url = res.json['data']['relationships']['target_node']['links']['related']['href']
+        assert_in('/{}nodes/{}/'.format(API_BASE, self.pointer_project._id), url)
         assert_equal(res.content_type, 'application/vnd.api+json')
 
     def test_creates_private_node_pointer_logged_in_non_contributor(self):
@@ -2684,7 +2689,8 @@ class TestNodeLinkCreate(ApiTestCase):
         res = self.app.post_json_api(self.private_url, self.user_two_payload, auth=self.user.auth)
         assert_equal(res.status_code, 201)
         assert_equal(res.content_type, 'application/vnd.api+json')
-        assert_equal(res.json['data']['attributes']['target_node_id'], self.user_two_project._id)
+        url = res.json['data']['relationships']['target_node']['links']['related']['href']
+        assert_in('/{}nodes/{}/'.format(API_BASE, self.user_two_project._id), url)
 
     def test_create_pointer_non_contributing_node_to_fake_node(self):
         res = self.app.post_json_api(self.private_url, self.fake_payload, auth=self.user_two.auth, expect_errors=True)
@@ -2710,7 +2716,8 @@ class TestNodeLinkCreate(ApiTestCase):
         res = self.app.post_json_api(self.public_url, self.point_to_itself_payload, auth=self.user.auth)
         assert_equal(res.status_code, 201)
         assert_equal(res.content_type, 'application/vnd.api+json')
-        assert_equal(res.json['data']['attributes']['target_node_id'], self.public_project._id)
+        url = res.json['data']['relationships']['target_node']['links']['related']['href']
+        assert_in('/{}nodes/{}/'.format(API_BASE, self.public_project._id), url)
 
     def test_create_node_pointer_to_itself_unauthorized(self):
         res = self.app.post_json_api(self.public_url, self.point_to_itself_payload, auth=self.user_two.auth, expect_errors=True)
@@ -2722,7 +2729,8 @@ class TestNodeLinkCreate(ApiTestCase):
         res = self.app.post_json_api(self.public_url, self.public_payload, auth=self.user.auth)
         assert_equal(res.status_code, 201)
         assert_equal(res.content_type, 'application/vnd.api+json')
-        assert_equal(res.json['data']['attributes']['target_node_id'], self.public_pointer_project._id)
+        url = res.json['data']['relationships']['target_node']['links']['related']['href']
+        assert_in('/{}nodes/{}/'.format(API_BASE, self.public_pointer_project._id), url)
 
         res = self.app.post_json_api(self.public_url, self.public_payload, auth=self.user.auth, expect_errors=True)
         assert_equal(res.status_code, 400)
@@ -3034,15 +3042,16 @@ class TestNodeLinkDetail(ApiTestCase):
         res = self.app.get(self.public_url)
         assert_equal(res.status_code, 200)
         assert_equal(res.content_type, 'application/vnd.api+json')
-        res_json = res.json['data']
-        assert_equal(res_json['attributes']['target_node_id'], self.public_pointer_project._id)
+        url = res.json['data']['relationships']['target_node']['links']['related']['href']
+        assert_in('/{}nodes/{}/'.format(API_BASE, self.public_pointer_project._id), url)
 
     def test_returns_public_node_pointer_detail_logged_in(self):
         res = self.app.get(self.public_url, auth=self.user.auth)
         res_json = res.json['data']
         assert_equal(res.status_code, 200)
         assert_equal(res.content_type, 'application/vnd.api+json')
-        assert_equal(res_json['attributes']['target_node_id'], self.public_pointer_project._id)
+        url = res.json['data']['relationships']['target_node']['links']['related']['href']
+        assert_in('/{}nodes/{}/'.format(API_BASE, self.public_pointer_project._id), url)
 
     def test_returns_private_node_pointer_detail_logged_out(self):
         res = self.app.get(self.private_url, expect_errors=True)
@@ -3054,7 +3063,8 @@ class TestNodeLinkDetail(ApiTestCase):
         res_json = res.json['data']
         assert_equal(res.status_code, 200)
         assert_equal(res.content_type, 'application/vnd.api+json')
-        assert_equal(res_json['attributes']['target_node_id'], self.pointer_project._id)
+        url = res.json['data']['relationships']['target_node']['links']['related']['href']
+        assert_in('/{}nodes/{}/'.format(API_BASE, self.pointer_project._id), url)
 
     def test_returns_private_node_pointer_detail_logged_in_non_contributor(self):
         res = self.app.get(self.private_url, auth=self.user_two.auth, expect_errors=True)

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -2424,6 +2424,8 @@ class TestNodeChildCreate(ApiTestCase):
         assert_equal(res.json['errors'][0]['detail'], 'Request must include /data/attributes.')
         assert_equal(res.json['errors'][0]['source']['pointer'], '/data/attributes')
 
+node_url_for = lambda n_id: '/{}nodes/{}/'.format(API_BASE, n_id)
+
 
 class TestNodeLinksList(ApiTestCase):
 
@@ -2448,8 +2450,9 @@ class TestNodeLinksList(ApiTestCase):
         assert_equal(len(res_json), 1)
         assert_equal(res.status_code, 200)
         assert_equal(res.content_type, 'application/vnd.api+json')
-        url = res.json['data'][0]['relationships']['target_node']['links']['related']['href']
-        assert_in('/{}nodes/{}/'.format(API_BASE, self.public_pointer_project._id), url)
+        expected_path = node_url_for(self.public_pointer_project._id)
+        actual_path = urlparse(res_json[0]['relationships']['target_node']['links']['related']['href']).path
+        assert_equal(expected_path, actual_path)
 
     def test_return_public_node_pointers_logged_in(self):
         res = self.app.get(self.public_url, auth=self.user_two.auth)
@@ -2457,8 +2460,9 @@ class TestNodeLinksList(ApiTestCase):
         assert_equal(len(res_json), 1)
         assert_equal(res.status_code, 200)
         assert_equal(res.content_type, 'application/vnd.api+json')
-        url = res_json[0]['relationships']['target_node']['links']['related']['href']
-        assert_in('/{}nodes/{}/'.format(API_BASE, self.public_pointer_project._id), url)
+        expected_path = node_url_for(self.public_pointer_project._id)
+        actual_path = urlparse(res_json[0]['relationships']['target_node']['links']['related']['href']).path
+        assert_equal(expected_path, actual_path)
 
     def test_return_private_node_pointers_logged_out(self):
         res = self.app.get(self.private_url, expect_errors=True)
@@ -2471,8 +2475,9 @@ class TestNodeLinksList(ApiTestCase):
         assert_equal(res.status_code, 200)
         assert_equal(res.content_type, 'application/vnd.api+json')
         assert_equal(len(res_json), 1)
-        url = res_json[0]['relationships']['target_node']['links']['related']['href']
-        assert_in('/{}nodes/{}/'.format(API_BASE, self.pointer_project._id), url)
+        expected_path = node_url_for(self.pointer_project._id)
+        actual_path = urlparse(res_json[0]['relationships']['target_node']['links']['related']['href']).path
+        assert_equal(expected_path, actual_path)
 
     def test_return_private_node_pointers_logged_in_non_contributor(self):
         res = self.app.get(self.private_url, auth=self.user_two.auth, expect_errors=True)
@@ -2659,8 +2664,10 @@ class TestNodeLinkCreate(ApiTestCase):
         res = self.app.post_json_api(self.public_url, self.public_payload, auth=self.user.auth)
         assert_equal(res.status_code, 201)
         assert_equal(res.content_type, 'application/vnd.api+json')
-        url = res.json['data']['relationships']['target_node']['links']['related']['href']
-        assert_in('/{}nodes/{}/'.format(API_BASE, self.public_pointer_project._id), url)
+        res_json = res.json['data']
+        expected_path = node_url_for(self.public_pointer_project._id)
+        actual_path = urlparse(res_json['relationships']['target_node']['links']['related']['href']).path
+        assert_equal(expected_path, actual_path)
 
     def test_creates_private_node_pointer_logged_out(self):
         res = self.app.post_json_api(self.private_url, self.private_payload, expect_errors=True)
@@ -2670,8 +2677,10 @@ class TestNodeLinkCreate(ApiTestCase):
     def test_creates_private_node_pointer_logged_in_contributor(self):
         res = self.app.post_json_api(self.private_url, self.private_payload, auth=self.user.auth)
         assert_equal(res.status_code, 201)
-        url = res.json['data']['relationships']['target_node']['links']['related']['href']
-        assert_in('/{}nodes/{}/'.format(API_BASE, self.pointer_project._id), url)
+        res_json = res.json['data']
+        expected_path = node_url_for(self.pointer_project._id)
+        actual_path = urlparse(res_json['relationships']['target_node']['links']['related']['href']).path
+        assert_equal(expected_path, actual_path)
         assert_equal(res.content_type, 'application/vnd.api+json')
 
     def test_creates_private_node_pointer_logged_in_non_contributor(self):
@@ -2689,8 +2698,10 @@ class TestNodeLinkCreate(ApiTestCase):
         res = self.app.post_json_api(self.private_url, self.user_two_payload, auth=self.user.auth)
         assert_equal(res.status_code, 201)
         assert_equal(res.content_type, 'application/vnd.api+json')
-        url = res.json['data']['relationships']['target_node']['links']['related']['href']
-        assert_in('/{}nodes/{}/'.format(API_BASE, self.user_two_project._id), url)
+        res_json = res.json['data']
+        expected_path = node_url_for(self.user_two_project._id)
+        actual_path = urlparse(res_json['relationships']['target_node']['links']['related']['href']).path
+        assert_equal(expected_path, actual_path)
 
     def test_create_pointer_non_contributing_node_to_fake_node(self):
         res = self.app.post_json_api(self.private_url, self.fake_payload, auth=self.user_two.auth, expect_errors=True)
@@ -2714,10 +2725,12 @@ class TestNodeLinkCreate(ApiTestCase):
     @assert_logs(NodeLog.POINTER_CREATED, 'public_project')
     def test_create_node_pointer_to_itself(self):
         res = self.app.post_json_api(self.public_url, self.point_to_itself_payload, auth=self.user.auth)
+        res_json = res.json['data']
         assert_equal(res.status_code, 201)
         assert_equal(res.content_type, 'application/vnd.api+json')
-        url = res.json['data']['relationships']['target_node']['links']['related']['href']
-        assert_in('/{}nodes/{}/'.format(API_BASE, self.public_project._id), url)
+        expected_path = node_url_for(self.public_project._id)
+        actual_path = urlparse(res_json['relationships']['target_node']['links']['related']['href']).path
+        assert_equal(expected_path, actual_path)
 
     def test_create_node_pointer_to_itself_unauthorized(self):
         res = self.app.post_json_api(self.public_url, self.point_to_itself_payload, auth=self.user_two.auth, expect_errors=True)
@@ -2729,8 +2742,10 @@ class TestNodeLinkCreate(ApiTestCase):
         res = self.app.post_json_api(self.public_url, self.public_payload, auth=self.user.auth)
         assert_equal(res.status_code, 201)
         assert_equal(res.content_type, 'application/vnd.api+json')
-        url = res.json['data']['relationships']['target_node']['links']['related']['href']
-        assert_in('/{}nodes/{}/'.format(API_BASE, self.public_pointer_project._id), url)
+        res_json = res.json['data']
+        expected_path = node_url_for(self.public_pointer_project._id)
+        actual_path = urlparse(res_json['relationships']['target_node']['links']['related']['href']).path
+        assert_equal(expected_path, actual_path)
 
         res = self.app.post_json_api(self.public_url, self.public_payload, auth=self.user.auth, expect_errors=True)
         assert_equal(res.status_code, 400)
@@ -3042,16 +3057,19 @@ class TestNodeLinkDetail(ApiTestCase):
         res = self.app.get(self.public_url)
         assert_equal(res.status_code, 200)
         assert_equal(res.content_type, 'application/vnd.api+json')
-        url = res.json['data']['relationships']['target_node']['links']['related']['href']
-        assert_in('/{}nodes/{}/'.format(API_BASE, self.public_pointer_project._id), url)
+        res_json = res.json['data']
+        expected_path = node_url_for(self.public_pointer_project._id)
+        actual_path = urlparse(res_json['relationships']['target_node']['links']['related']['href']).path
+        assert_equal(expected_path, actual_path)
 
     def test_returns_public_node_pointer_detail_logged_in(self):
         res = self.app.get(self.public_url, auth=self.user.auth)
         res_json = res.json['data']
         assert_equal(res.status_code, 200)
         assert_equal(res.content_type, 'application/vnd.api+json')
-        url = res.json['data']['relationships']['target_node']['links']['related']['href']
-        assert_in('/{}nodes/{}/'.format(API_BASE, self.public_pointer_project._id), url)
+        expected_path = node_url_for(self.public_pointer_project._id)
+        actual_path = urlparse(res_json['relationships']['target_node']['links']['related']['href']).path
+        assert_equal(expected_path, actual_path)
 
     def test_returns_private_node_pointer_detail_logged_out(self):
         res = self.app.get(self.private_url, expect_errors=True)
@@ -3063,8 +3081,9 @@ class TestNodeLinkDetail(ApiTestCase):
         res_json = res.json['data']
         assert_equal(res.status_code, 200)
         assert_equal(res.content_type, 'application/vnd.api+json')
-        url = res.json['data']['relationships']['target_node']['links']['related']['href']
-        assert_in('/{}nodes/{}/'.format(API_BASE, self.pointer_project._id), url)
+        expected_path = node_url_for(self.pointer_project._id)
+        actual_path = urlparse(res_json['relationships']['target_node']['links']['related']['href']).path
+        assert_equal(expected_path, actual_path)
 
     def test_returns_private_node_pointer_detail_logged_in_non_contributor(self):
         res = self.app.get(self.private_url, auth=self.user_two.auth, expect_errors=True)

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -3119,9 +3119,13 @@ class TestDeleteNodeLink(ApiTestCase):
     def test_delete_node_link_no_permissions_for_target_node(self):
         pointer_project = ProjectFactory(creator=self.user_two, is_public=False)
         pointer = self.public_project.add_pointer(pointer_project, auth=Auth(self.user), save=True)
+        assert_in(pointer, self.public_project.nodes)
         url = '/{}nodes/{}/node_links/{}/'.format(API_BASE, self.public_project._id, pointer._id)
         res = self.app.delete_json_api(url, auth=self.user.auth, expect_errors=True)
         assert_equal(res.status_code, 204)
+
+        self.public_project.reload()
+        assert_not_in(pointer, self.public_project.nodes)
 
     def test_cannot_delete_if_registration(self):
         registration = RegistrationFactory(project=self.public_project)


### PR DESCRIPTION
# Purpose
Issue OSF-4630

The Node Link serialization isn't correct:
"self" link should point to the Node Link Detail URL, not the target node's URL.
The target node's url should go in /data/relationships/node/links/related/href

The DELETE behavior for NodeLinkDetail is also incorrect:
The user only needs permission to remove the node link; not edit permissions for the target node
Note: Node link endpoints are currently dev-only, but this is a blocker for the public stable release.

# Changes
![screen shot 2015-10-08 at 10 19 25 am](https://cloud.githubusercontent.com/assets/9755598/10369094/7d684098-6da6-11e5-913d-23d2270e4ae4.png)

This PR 1) makes self link pointing to Node Link Detail URL 2) moves target node's url under relationships 3)  Changes permissions for deleting node-link 4) For now, makes target_node_id write-only.  

Separate PR https://openscience.atlassian.net/browse/OSF-4804 will change how node links are created.