### PR TITLE
[RfR] APIv2: Filterable files

### DIFF
--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -102,7 +102,6 @@ class WaterButlerMixin(object):
             return obj
 
         url = waterbutler_api_url_for(node._id, provider, path, meta=True)
-
         waterbutler_request = requests.get(
             url,
             cookies=self.request.COOKIES,
@@ -848,7 +847,7 @@ class NodeLinksDetail(generics.RetrieveDestroyAPIView, NodeMixin):
         node.save()
 
 
-class NodeFilesList(generics.ListAPIView, WaterButlerMixin, NodeMixin):
+class NodeFilesList(generics.ListAPIView, WaterButlerMixin, ListFilterMixin, NodeMixin):
     """Files attached to a node for a given provider. *Read-only*.
 
     This gives a list of all of the files and folders that are attached to your project for the given storage provider.
@@ -1077,7 +1076,7 @@ class NodeFilesList(generics.ListAPIView, WaterButlerMixin, NodeMixin):
     required_read_scopes = [CoreScopes.NODE_FILE_READ]
     required_write_scopes = [CoreScopes.NODE_FILE_WRITE]
 
-    def get_queryset(self):
+    def get_default_queryset(self):
         # Don't bother going to waterbutler for osfstorage
         files_list = self.fetch_from_waterbutler()
 
@@ -1089,6 +1088,10 @@ class NodeFilesList(generics.ListAPIView, WaterButlerMixin, NodeMixin):
             raise NotFound
 
         return list(files_list.children)
+
+    # overrides ListAPIView
+    def get_queryset(self):
+        return self.get_queryset_from_request()
 
 
 class NodeFileDetail(generics.RetrieveAPIView, WaterButlerMixin, NodeMixin):

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -1,19 +1,20 @@
 # -*- coding: utf-8 -*-
-import mock
+import json
 import base64
 from urlparse import urlparse
+
+import mock
 from nose.tools import *  # flake8: noqa
+import httpretty
 
 from framework.auth.core import Auth
 
 from website.addons.github import model
 from website.models import Node, NodeLog
 from website.views import find_dashboard
-from website.util import permissions
+from website.util import permissions, waterbutler_api_url_for
 from website.util.sanitize import strip_html
-
 from api.base.settings.defaults import API_BASE
-
 from tests.base import ApiTestCase, fake
 from tests.factories import (
     DashboardFactory,
@@ -2762,6 +2763,12 @@ class TestNodeFilesList(ApiTestCase):
 
         self.public_project = ProjectFactory(creator=self.user, is_public=True)
         self.public_url = '/{}nodes/{}/files/'.format(API_BASE, self.public_project._id)
+        httpretty.enable()
+
+    def tearDown(self):
+        super(TestNodeFilesList, self).tearDown()
+        httpretty.disable()
+        httpretty.reset()
 
     def test_returns_public_files_logged_out(self):
         res = self.app.get(self.public_url, expect_errors=True)
@@ -2834,115 +2841,85 @@ class TestNodeFilesList(ApiTestCase):
         assert_in('github', providers)
         assert_in('osfstorage', providers)
 
-    @mock.patch('api.nodes.views.requests.get')
-    def test_returns_node_files_list(self, mock_waterbutler_request):
-        mock_res = mock.MagicMock()
-        mock_res.status_code = 200
-        mock_res.json.return_value = {
-            u'data': [{
-                u'contentType': None,
-                u'extra': {u'downloads': 0, u'version': 1},
-                u'kind': u'file',
-                u'modified': None,
-                u'name': u'NewFile',
-                u'path': u'/',
-                u'provider': u'github',
-                u'size': None,
-                u'materialized': '/',
-            }]
-        }
-        auth_header = 'Basic {}'.format(base64.b64encode(':'.join(self.user.auth)))
-        mock_waterbutler_request.return_value = mock_res
+    def _prepare_mock_wb_response(
+            self,
+            node=None,
+            provider='github',
+            files=None,
+            folder=True,
+            method=httpretty.GET,
+            status_code=200
+        ):
+        """Prepare a mock Waterbutler response with httpretty.
 
+        :param Node node:
+        :param str provider:
+        :param list files: Optional list of files. You can specify partial data; missing values
+            will have defaults.
+        :param int status_code:
+        """
+        node = node or self.project
+        files = files or []
+        wb_url = waterbutler_api_url_for(node._id, provider=provider, path='/', meta=True)
+
+        default_file = {
+            u'contentType': None,
+            u'extra': {u'downloads': 0, u'version': 1},
+            u'kind': u'file',
+            u'modified': None,
+            u'name': u'NewFile',
+            u'path': u'/',
+            u'provider': provider,
+            u'size': None,
+            u'materialized': '/',
+        }
+
+        if len(files):
+            data = [dict(default_file, **each) for each in files]
+        else:
+            data = [default_file]
+        if not folder:
+            data = data[0]
+        body = json.dumps({
+            u'data': data
+        })
+        httpretty.register_uri(
+            method,
+            wb_url,
+            body=body,
+            status=status_code
+        )
+
+    def test_returns_node_files_list(self):
+        self._prepare_mock_wb_response(provider='github', files=[{'name': 'NewFile'}])
         url = '/{}nodes/{}/files/github/'.format(API_BASE, self.project._id)
         res = self.app.get(url, auth=self.user.auth, headers={
             'COOKIE': 'foo=bar;'  # Webtests doesnt support cookies?
         })
         assert_equal(res.json['data'][0]['attributes']['name'], 'NewFile')
         assert_equal(res.json['data'][0]['attributes']['provider'], 'github')
-        mock_waterbutler_request.assert_called_once_with(
-            'http://localhost:7777/v1/resources/{}/providers/github/?meta=True'.format(self.project._id),
-            cookies={'foo':'bar'},
-            headers={'Authorization': auth_header}
-        )
 
-    @mock.patch('api.nodes.views.requests.get')
-    def test_returns_node_file(self, mock_waterbutler_request):
+    def test_returns_node_file(self):
+        self._prepare_mock_wb_response(provider='github', files=[{'name': 'NewFile'}])
         mock_res = mock.MagicMock()
-        mock_res.status_code = 200
-        mock_res.json.return_value = {
-            u'data': {
-                u'contentType': None,
-                u'extra': {u'downloads': 0, u'version': 1},
-                u'kind': u'file',
-                u'modified': None,
-                u'name': u'NewFile',
-                u'path': u'/NewFile',
-                u'provider': u'github',
-                u'size': None,
-                u'materialized': '/',
-            }
-        }
-        auth_header = 'Basic {}'.format(base64.b64encode(':'.join(self.user.auth)))
-        mock_waterbutler_request.return_value = mock_res
 
         url = '/{}nodes/{}/files/github/file'.format(API_BASE, self.project._id)
         res = self.app.get(url, auth=self.user.auth, headers={
-            'COOKIE': 'foo=bar;'  # Webtests doesnt support cookies?
+            'COOKIE': 'foo=bar;'
         })
         assert_equal(res.json['data']['attributes']['name'], 'NewFile')
         assert_equal(res.json['data']['attributes']['provider'], 'github')
-        mock_waterbutler_request.assert_called_once_with(
-            'http://localhost:7777/v1/resources/{}/providers/github/file?meta=True'.format(self.project._id),
-            cookies={'foo':'bar'},
-            headers={'Authorization': auth_header}
-        )
 
-    @mock.patch('api.nodes.views.requests.get')
-    def test_notfound_node_file_returns_folder(self, mock_waterbutler_request):
-        mock_res = mock.MagicMock()
-        mock_res.status_code = 200
-        mock_res.json.return_value = {
-            u'data': [{
-                u'contentType': None,
-                u'extra': {u'downloads': 0, u'version': 1},
-                u'kind': u'file',
-                u'modified': None,
-                u'name': u'NewFile',
-                u'path': u'/NewFile',
-                u'provider': u'github',
-                u'size': None,
-                u'materialized': '/',
-            }]
-        }
-        auth_header = 'Basic {}'.format(base64.b64encode(':'.join(self.user.auth)))
-        mock_waterbutler_request.return_value = mock_res
-
+    def test_notfound_node_file_returns_folder(self):
+        self._prepare_mock_wb_response(provider='github', files=[{'name': 'NewFile'}])
         url = '/{}nodes/{}/files/github/file'.format(API_BASE, self.project._id)
         res = self.app.get(url, auth=self.user.auth, expect_errors=True, headers={
             'COOKIE': 'foo=bar;'  # Webtests doesnt support cookies?
         })
         assert_equal(res.status_code, 404)
 
-    @mock.patch('api.nodes.views.requests.get')
-    def test_notfound_node_folder_returns_file(self, mock_waterbutler_request):
-        mock_res = mock.MagicMock()
-        mock_res.status_code = 200
-        mock_res.json.return_value = {
-            u'data': {
-                u'contentType': None,
-                u'extra': {u'downloads': 0, u'version': 1},
-                u'kind': u'file',
-                u'modified': None,
-                u'name': u'NewFile',
-                u'path': u'/NewFile',
-                u'provider': u'github',
-                u'size': None,
-                u'materialized': '/',
-            }
-        }
-        auth_header = 'Basic {}'.format(base64.b64encode(':'.join(self.user.auth)))
-        mock_waterbutler_request.return_value = mock_res
+    def test_notfound_node_folder_returns_file(self):
+        self._prepare_mock_wb_response(provider='github', files=[{'name': 'NewFile'}], folder=False)
 
         url = '/{}nodes/{}/files/github/'.format(API_BASE, self.project._id)
         res = self.app.get(url, auth=self.user.auth, expect_errors=True, headers={
@@ -2950,57 +2927,52 @@ class TestNodeFilesList(ApiTestCase):
         })
         assert_equal(res.status_code, 404)
 
-    @mock.patch('api.nodes.views.requests.get')
-    def test_waterbutler_server_error_returns_503(self, mock_waterbutler_request):
-        mock_res = mock.MagicMock()
-        mock_res.status_code = 500
-        mock_waterbutler_request.return_value = mock_res
+    def test_waterbutler_server_error_returns_503(self):
+        self._prepare_mock_wb_response(status_code=500)
         url = '/{}nodes/{}/files/github/'.format(API_BASE, self.project._id)
         res = self.app.get(url, auth=self.user.auth, expect_errors=True, headers={
             'COOKIE': 'foo=bar;'  # Webtests doesnt support cookies?
         })
         assert_equal(res.status_code, 503)
 
-    @mock.patch('api.nodes.views.requests.get')
-    def test_waterbutler_invalid_data_returns_503(self, mock_waterbutler_request):
-        mock_res = mock.MagicMock()
-        mock_res.status_code = 400
-        mock_res.json.return_value = {}  # no data
-        mock_waterbutler_request.return_value = mock_res
+    def test_waterbutler_invalid_data_returns_503(self):
+        wb_url = waterbutler_api_url_for(self.project._id, provider='github', path='/', meta=True)
+        httpretty.register_uri(
+            httpretty.GET,
+            wb_url,
+            body=json.dumps({}),
+            status=400
+        )
         url = '/{}nodes/{}/files/github/'.format(API_BASE, self.project._id)
         res = self.app.get(url, auth=self.user.auth, expect_errors=True, headers={
             'COOKIE': 'foo=bar;'  # Webtests doesnt support cookies?
         })
         assert_equal(res.status_code, 503)
 
-    @mock.patch('api.nodes.views.requests.get')
-    def test_handles_unauthenticated_waterbutler_request(self, mock_waterbutler_request):
+    def test_handles_unauthenticated_waterbutler_request(self):
+        self._prepare_mock_wb_response(status_code=401)
         url = '/{}nodes/{}/files/github/'.format(API_BASE, self.project._id)
-        mock_res = mock.MagicMock()
-        mock_res.status_code = 401
-        mock_waterbutler_request.return_value = mock_res
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
         assert_equal(res.status_code, 403)
         assert_in('detail', res.json['errors'][0])
 
-    @mock.patch('api.nodes.views.requests.get')
-    def test_handles_notfound_waterbutler_request(self, mock_waterbutler_request):
-        url = '/{}nodes/{}/files/gilkjadsflhub/'.format(API_BASE, self.project._id)
-        mock_res = mock.MagicMock()
-        mock_res.status_code = 404
-        mock_waterbutler_request.return_value = mock_res
+    def test_handles_notfound_waterbutler_request(self):
+        invalid_provider = 'gilkjadsflhub'
+        self._prepare_mock_wb_response(status_code=404, provider=invalid_provider)
+        url = '/{}nodes/{}/files/{}/'.format(API_BASE, self.project._id, invalid_provider)
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
         assert_equal(res.status_code, 404)
         assert_in('detail', res.json['errors'][0])
 
-
-    @mock.patch('api.nodes.views.requests.get')
-    def test_handles_bad_waterbutler_request(self, mock_waterbutler_request):
+    def test_handles_bad_waterbutler_request(self):
+        wb_url = waterbutler_api_url_for(self.project._id, provider='github', path='/', meta=True)
+        httpretty.register_uri(
+            httpretty.GET,
+            wb_url,
+            body=json.dumps({}),
+            status=418
+        )
         url = '/{}nodes/{}/files/github/'.format(API_BASE, self.project._id)
-        mock_res = mock.MagicMock()
-        mock_res.status_code = 418
-        mock_res.json.return_value = {}
-        mock_waterbutler_request.return_value = mock_res
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
         assert_equal(res.status_code, 503)
         assert_in('detail', res.json['errors'][0])
@@ -3265,7 +3237,7 @@ class TestExceptionFormatting(ApiTestCase):
         errors = res.json['errors']
         assert(isinstance(errors, list))
         assert_equal(errors[0], {'detail': 'Not found.'})
-    
+
     def test_forbidden_formatting(self):
         res = self.app.get(self.private_url, auth=self.non_contrib.auth, expect_errors=True)
         errors = res.json['errors']


### PR DESCRIPTION
### Changes

- Make NodeFilesList filterable
- Use httpretty rather than mocking requests.get for finer-grained control over mocked HTTP requests

### Ticket

https://openscience.atlassian.net/browse/OSF-4780