### PR TITLE
Add: Import contribs to prereg Authors section

### DIFF
--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -439,7 +439,7 @@ var RegistrationEditor = function(urls, editorId) {
     });
     self.showValidation = ko.observable(false);
 
-    self.contributors = ko.observable(self.getContributors());
+    self.contributors = self.getContributors();
 
     self.currentPages = ko.computed(function() {
         var draft = self.draft();
@@ -782,16 +782,25 @@ RegistrationEditor.prototype.save = function() {
     return true;
 };
 /**
+ * Makes ajax request for a project's contributors
+ */
+RegistrationEditor.prototype.makeContributorsRequest = function() {
+    var self = this;
+    var contributorsUrl = window.contextVars.node.urls.api + 'contributors_abbrev/';
+    return $osf.ajaxJSON('get', contributorsUrl);
+};
+/**
  * Returns the `user_fullname` of each contributor attached to a node.
  **/
 RegistrationEditor.prototype.getContributors = function() {
-    var contributorsUrl = window.contextVars.node.urls.api + 'contributors_abbrev/';
+    var self = this;
     var contributorNames = [];
-    $osf.ajaxJSON('get', contributorsUrl).done(function(data) {
-        $.each(data.contributors, function(idx, val) {
-            contributorNames.push(val.user_fullname);
+    self.makeContributorsRequest()
+        .done(function(data) {
+            $.map(data.contributors, function(val, i) {
+                contributorNames.push(val.user_fullname);
+            });
         });
-    });
     return contributorNames;
 };
 /**
@@ -812,15 +821,15 @@ RegistrationEditor.prototype.authorDialog = function() {
                 label: 'Import',
                 className: 'btn-primary pull-left',
                 callback: function() {
-                    var boxes = document.querySelectorAll('input[type="checkbox"]');
-                    var authorString = '';
+                    var boxes = document.querySelectorAll('#contribBoxes input[type="checkbox"]');
+                    var authors = [];
                     $.each(boxes, function(i, box) {
                         if( this.checked ) {
-                            authorString += this.value + ', ';
+                            authors.push(this.value);
                         }
                     });
-                    if ( authorString ) {
-                        self.currentQuestion().setValue( authorString );
+                    if ( authors ) {
+                        self.currentQuestion().setValue(authors.join(', '));
                         self.save();
                     }
                 }

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -439,7 +439,10 @@ var RegistrationEditor = function(urls, editorId) {
     });
     self.showValidation = ko.observable(false);
 
-    self.contributors = self.getContributors();
+    self.contributors = ko.observable([]);
+    self.getContributors().done(function(data) {
+        self.contributors(data);
+    });
 
     self.currentPages = ko.computed(function() {
         var draft = self.draft();
@@ -767,7 +770,7 @@ RegistrationEditor.prototype.save = function() {
                     comments: ko.toJS(question.comments())
                 };
             }
-        });
+         });
     });
 
     if (typeof self.draft().pk === 'undefined') {
@@ -787,25 +790,21 @@ RegistrationEditor.prototype.save = function() {
 RegistrationEditor.prototype.makeContributorsRequest = function() {
     var self = this;
     var contributorsUrl = window.contextVars.node.urls.api + 'contributors_abbrev/';
-    return $osf.ajaxJSON('get', contributorsUrl);
+    return $.getJSON(contributorsUrl);
 };
 /**
  * Returns the `user_fullname` of each contributor attached to a node.
  **/
 RegistrationEditor.prototype.getContributors = function() {
     var self = this;
-    var contributorNames = [];
-    self.makeContributorsRequest()
-        .done(function(data) {
-            $.map(data.contributors, function(val, i) {
-                contributorNames.push(val.user_fullname);
-            });
+    return self.makeContributorsRequest()
+        .then(function(data) {
+            return $.map(data.contributors, function(c) { return c.user_fullname; });
         }).fail(function() {
             $osf.growl('Could not retrieve contributors.', 'Please refresh the page or ' +
                        'contact <a href="mailto: support@cos.io">support@cos.io</a> if the ' +
                        'problem persists.');
         });
-    return contributorNames;
 };
 /**
  * Opens a bootbox dialog with a checkbox list of each contributor
@@ -840,6 +839,12 @@ RegistrationEditor.prototype.authorDialog = function() {
             }
 
         }
+    });
+};
+RegistrationEditor.prototype.setContributorBoxes = function(value) {
+    var boxes = document.querySelectorAll('#contribBoxes input[type="checkbox"]');
+    $.each(boxes, function(i, box) {
+        this.checked = value;
     });
 };
 /**

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -800,6 +800,10 @@ RegistrationEditor.prototype.getContributors = function() {
             $.map(data.contributors, function(val, i) {
                 contributorNames.push(val.user_fullname);
             });
+        }).fail(function() {
+            $osf.growl('Could not retrieve contributors.', 'Please refresh the page or ' +
+                       'contact <a href="mailto: support@cos.io">support@cos.io</a> if the ' +
+                       'problem persists.');
         });
     return contributorNames;
 };

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -782,40 +782,17 @@ RegistrationEditor.prototype.save = function() {
     return true;
 };
 /**
- * Returns the `user_display_name` of each contributor attached to a node.
+ * Returns the `user_fullname` of each contributor attached to a node.
  **/
 RegistrationEditor.prototype.getContributors = function() {
     var contributorsUrl = window.contextVars.node.urls.api + 'contributors_abbrev/';
     var contributorNames = [];
     $osf.ajaxJSON('get', contributorsUrl).done(function(data) {
         $.each(data.contributors, function(idx, val) {
-            contributorNames.push(val.user_display_name);
+            contributorNames.push(val.user_fullname);
         });
     });
     return contributorNames;
-};
-/**
- * Sets the value for the currentQuestion as all of the contributors
- * on a project. Currently, the only way for this to be invoked is
- * when the currentQuestion is the authorship question.
- **/
-RegistrationEditor.prototype.populateContributors = function() {
-    var self = this;
-    var uri = window.contextVars.node.urls.api + 'get_contributors';
-    var request = $osf.ajaxJSON('get', uri);
-
-    request.done(function(data) {
-        var authorString = '';
-        if (data.contributors.length === 1 ) {
-            authorString = data.contributors[0].fullname;
-        } else {
-            $.each(data.contributors, function(i, contrib) {
-                authorString += contrib.fullname + ', ';
-            });
-        }
-        self.currentQuestion().setValue(authorString);
-        self.save();
-    });
 };
 /**
  * Opens a bootbox dialog with a checkbox list of each contributor
@@ -831,22 +808,15 @@ RegistrationEditor.prototype.authorDialog = function() {
             ko.renderTemplate('importContributors', self, {}, this, 'replaceNode');
         },
         buttons: {
-            importAll: {
-                label: 'Import all',
-                className: 'btn-primary pull-right',
-                callback: function() {
-                    self.populateContributors();
-                }
-            },
             select: {
-                label: 'OK',
-                className: 'btn-success pull-left',
+                label: 'Import',
+                className: 'btn-primary pull-left',
                 callback: function() {
                     var boxes = document.querySelectorAll('input[type="checkbox"]');
                     var authorString = '';
                     $.each(boxes, function(i, box) {
                         if( this.checked ) {
-                            authorString += this.value + ' ';
+                            authorString += this.value + ', ';
                         }
                     });
                     if ( authorString ) {

--- a/website/templates/project/edit_draft_registration.mako
+++ b/website/templates/project/edit_draft_registration.mako
@@ -89,9 +89,7 @@
                                 click: $root.check" type="button" class="pull-right btn btn-success">Register
                   </a>
                 </span>
-                <button data-bind="click: authorDialog,
-                                   visible: currentQuestion().title === 'Authorship' && contributors().length > 1"  type="button" class="btn btn-primary">Import Contributors
-                </button>
+                
               </div>
             </div>
           </div>

--- a/website/templates/project/edit_draft_registration.mako
+++ b/website/templates/project/edit_draft_registration.mako
@@ -84,11 +84,14 @@
                 </button>
                 <span data-bind="tooltip: {
                                    title: canRegister() ? 'Register' : 'This draft requires approval before it can be registered'
-                                 }">                      
+                                 }">
                   <a data-bind="css: {'disabled': !canRegister()},
                                 click: $root.check" type="button" class="pull-right btn btn-success">Register
                   </a>
                 </span>
+                <button data-bind="click: authorDialog,
+                                   visible: currentQuestion().title === 'Authorship' && contributors().length > 1"  type="button" class="btn btn-primary">Import Contributors
+                </button>
               </div>
             </div>
           </div>

--- a/website/templates/project/registration_editor_templates.mako
+++ b/website/templates/project/registration_editor_templates.mako
@@ -154,8 +154,19 @@
     </div>
 </script>
 
-<script type="text/html" id="importContributors">
+<script>
+ function setAllBoxes(value) {
+     var boxes = document.querySelectorAll('input[type="checkbox"]');
+     $.each(boxes, function(i, box) {
+         this.checked = value;
+     });
+ }
+</script>
 
+<script type="text/html" id="importContributors">
+    <div col-lg-12>
+        <p>Select: <a onClick="setAllBoxes(true)">All</a> | <a onClick="setAllBoxes(false)">None</a></p>
+    </div>
     <div data-bind="foreach: {data: contributors, as: 'contrib'}">
         <div class="checkbox">
             <label>

--- a/website/templates/project/registration_editor_templates.mako
+++ b/website/templates/project/registration_editor_templates.mako
@@ -154,4 +154,17 @@
     </div>
 </script>
 
+<script type="text/html" id="importContributors">
+
+    <div data-bind="foreach: {data: contributors, as: 'contrib'}">
+        <div class="checkbox">
+            <label>
+                <input type="checkbox" data-bind="value: contrib">
+                <!-- ko text: contrib --> <!-- /ko -->
+            </label>
+        </div>
+    </div>
+    <p>If you would like to add contributors to your OSF project, you can do that on your <a href="${web_url_for('node_contributors', pid=node['root_id'])}">Contributors Page</a> </p>
+</script>
+
 <%include file="registration_editor_extensions.mako" />

--- a/website/templates/project/registration_editor_templates.mako
+++ b/website/templates/project/registration_editor_templates.mako
@@ -85,7 +85,7 @@
                   <div data-bind="template: {data: $data, name: type}"></div>
                   <br />
                   <button data-bind="click: $root.authorDialog,
-                                     visible: $root.currentQuestion().title === 'Authorship' && $root.contributors.length > 1"  type="button" class="btn btn-primary">Import Contributors
+                                     visible: $root.currentQuestion().title === 'Authorship' && $root.contributors().length > 1"  type="button" class="btn btn-primary">Import Contributors
                   </button>
                 </span>
               </div>
@@ -158,18 +158,9 @@
     </div>
 </script>
 
-<script>
- function setAllBoxes(value) {
-     var boxes = document.querySelectorAll('#contribBoxes input[type="checkbox"]');
-     $.each(boxes, function(i, box) {
-         this.checked = value;
-     });
- }
-</script>
-
 <script type="text/html" id="importContributors">
     <div col-lg-12>
-        <p>Select: <a onClick="setAllBoxes(true)">All</a> | <a onClick="setAllBoxes(false)">None</a></p>
+        <p>Select: <a data-bind="click: setContributorBoxes(true) " >All</a> | <a data-bind="click: setContributorBoxes(false)">None</a></p>
     </div>
     <div data-bind="foreach: {data: contributors, as: 'contrib'}">
         <div class="checkbox" id="contribBoxes">

--- a/website/templates/project/registration_editor_templates.mako
+++ b/website/templates/project/registration_editor_templates.mako
@@ -83,6 +83,10 @@
                     </ul>
                   </span>
                   <div data-bind="template: {data: $data, name: type}"></div>
+                  <br />
+                  <button data-bind="click: $root.authorDialog,
+                                     visible: $root.currentQuestion().title === 'Authorship' && $root.contributors.length > 1"  type="button" class="btn btn-primary">Import Contributors
+                  </button>
                 </span>
               </div>
           </div>
@@ -156,7 +160,7 @@
 
 <script>
  function setAllBoxes(value) {
-     var boxes = document.querySelectorAll('input[type="checkbox"]');
+     var boxes = document.querySelectorAll('#contribBoxes input[type="checkbox"]');
      $.each(boxes, function(i, box) {
          this.checked = value;
      });
@@ -168,14 +172,14 @@
         <p>Select: <a onClick="setAllBoxes(true)">All</a> | <a onClick="setAllBoxes(false)">None</a></p>
     </div>
     <div data-bind="foreach: {data: contributors, as: 'contrib'}">
-        <div class="checkbox">
+        <div class="checkbox" id="contribBoxes">
             <label>
                 <input type="checkbox" data-bind="value: contrib">
-                <!-- ko text: contrib --> <!-- /ko -->
+                <span data-bind="text: contrib"></span>
             </label>
         </div>
     </div>
-    <p>If you would like to add contributors to your OSF project, you can do that on your <a href="${web_url_for('node_contributors', pid=node['root_id'])}">Contributors Page</a> </p>
+    <p>If you would like to add contributors to your OSF project, you can do that on your <a href="${web_url_for('node_contributors', pid=node['id'])}">Contributors Page</a> </p>
 </script>
 
 <%include file="registration_editor_extensions.mako" />


### PR DESCRIPTION
[OSF-4346]

If a user has more than one contributor on a project, they will have the option to import all of their contributors or to select from a list of their contributors to fill the 'Authorship' question for the prereg challenge form. 

The form only appears when the user is on the Authorship question and there is more than one contributor on a project.

The button:

![screen shot 2015-10-27 at 10 07 32 am](https://cloud.githubusercontent.com/assets/8905795/10760523/58f4836a-7c93-11e5-9e2d-84d37c60ada2.png)


The modal:
![screen shot 2015-10-09 at 4 17 32 pm](https://cloud.githubusercontent.com/assets/8905795/10404531/4cce0bce-6ea1-11e5-8710-96ae38372067.png)


After selection:
![screen shot 2015-10-08 at 3 47 30 pm](https://cloud.githubusercontent.com/assets/8905795/10377904/eaac2e3a-6dd3-11e5-9055-0fdb07151360.png)

