### PR TITLE
small fix for margin at frontpage, probably looks better?

### DIFF
--- a/website/static/css/front-page.css
+++ b/website/static/css/front-page.css
@@ -87,7 +87,7 @@ h6 {
     position: relative;
 }
 #home-hero h2 {
-    margin-top: -50px;
+    margin-top: -10px;
     background-color: #ffffff;
     padding: 10px 0;
     color: #0A314A;


### PR DESCRIPTION
Hi, was that a bug with frontpage? ('Free, Get Started Today button')
<img width="1626" alt="screen shot 2015-10-09 at 02 32 03" src="https://cloud.githubusercontent.com/assets/5033274/10382682/236f5a20-6e2f-11e5-9196-544e55e67a95.png">
On Chrome it looks really strange, so shouldn't that be fixed with it?
<img width="1837" alt="screen shot 2015-10-09 at 02 35 01" src="https://cloud.githubusercontent.com/assets/5033274/10382688/3cc355e4-6e2f-11e5-8ed1-6ed8fc29b2c8.png">
