### PR TITLE
Do not show Registration and Fork links for anonymized projects

### DIFF
--- a/website/templates/project/project_header.mako
+++ b/website/templates/project/project_header.mako
@@ -53,11 +53,14 @@
                             <li><a href="${node['url']}analytics/">Analytics</a></li>
                         % endif
 
-                        % if not node['is_registration']:
+                        % if not node['is_registration'] and not node['anonymous']:
                             <li><a href="${node['url']}registrations/">Registrations</a></li>
                         % endif
 
-                        <li><a href="${node['url']}forks/">Forks</a></li>
+                        % if not node['anonymous']:
+                            <li><a href="${node['url']}forks/">Forks</a></li>
+                        %endif
+                        
                         % if user['is_contributor']:
                             <li><a href="${node['url']}contributors/">Contributors</a></li>
                         % endif


### PR DESCRIPTION
#OSF-4851
## Purpose
No longer show project header bar "Registrations" and "Forks" links for projects that are anonymized.

## Changes
Add logic to check for anonymous links to project_header.mako

## Side Effects
None known

## QA


![header_bar](https://cloud.githubusercontent.com/assets/1322421/10494283/78df4a8a-7283-11e5-96ca-d7cd05fe6e2f.png)
Test:

Situation - Can Reg and Forks be seen on header bar?
 - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Anonymous private link - No
Not-Anonymous private link - Yes
Normal link - Yes

