### PR TITLE
OSF-4846 Recent activity logs sometimes link to registration instead …

### DIFF
--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2889,6 +2889,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
             'api_url': self.api_url,
             'is_public': self.is_public,
             'is_registration': self.is_registration,
+            'registered_from_id': self.registered_from_id,
         }
 
     def _initiate_retraction(self, user, justification=None):

--- a/website/static/js/logFeed.js
+++ b/website/static/js/logFeed.js
@@ -173,10 +173,10 @@ var createLogs = function(logData){
             // The node type, either 'project' or 'component'
             // NOTE: This is NOT the component category (e.g. 'hypothesis')
             nodeType: item.node.is_registration ? 'registration': item.node.node_type,
-            projectUrl: item.node.node_type === 'project' ? '/' + item.node.registered_from_id + '/' : item.node.url,
             nodeCategory: item.node.category,
             contributors: item.contributors,
             nodeUrl: item.node.url,
+            projectUrl: item.node.node_type === 'project' ? '/' + item.node.registered_from_id + '/' : item.node.url,
             userFullName: item.user.fullname,
             userURL: item.user.url,
             params: item.params,

--- a/website/static/js/logFeed.js
+++ b/website/static/js/logFeed.js
@@ -173,7 +173,7 @@ var createLogs = function(logData){
             // The node type, either 'project' or 'component'
             // NOTE: This is NOT the component category (e.g. 'hypothesis')
             nodeType: item.node.is_registration ? 'registration': item.node.node_type,
-            projectUrl: item.node.node_type === 'project' ? '/'+item.node.registered_from_id+'/' : item.node.url,
+            projectUrl: item.node.node_type === 'project' ? '/' + item.node.registered_from_id + '/' : item.node.url,
             nodeCategory: item.node.category,
             contributors: item.contributors,
             nodeUrl: item.node.url,

--- a/website/static/js/logFeed.js
+++ b/website/static/js/logFeed.js
@@ -173,6 +173,7 @@ var createLogs = function(logData){
             // The node type, either 'project' or 'component'
             // NOTE: This is NOT the component category (e.g. 'hypothesis')
             nodeType: item.node.is_registration ? 'registration': item.node.node_type,
+            projectUrl: item.node.node_type === 'project' ? '/'+item.node.registered_from_id+'/' : item.node.url,
             nodeCategory: item.node.category,
             contributors: item.contributors,
             nodeUrl: item.node.url,

--- a/website/templates/log_templates.mako
+++ b/website/templates/log_templates.mako
@@ -6,7 +6,7 @@
 
 ## Embargo related logs
 <script type="text/html" id="embargo_approved">
-approved embargo of
+approved embargoed registration of
 <a class="log-node-title-link overflow" data-bind="text: nodeTitle, attr: {href: projectUrl}"></a>
 </script>
 
@@ -16,7 +16,7 @@ Embargo for
 </script>
 
 <script type="text/html" id="embargo_cancelled">
-cancelled embargo of
+cancelled embargoed registration of
 <span class="log-node-title-link overflow" data-bind="text: nodeTitle"></span>
 </script>
 
@@ -37,17 +37,17 @@ initiated an embargoed registration of
 
 ## Retraction related logs
 <script type="text/html" id="retraction_approved">
-approved retraction of
+approved retraction of registration of
 <a class="log-node-title-link overflow" data-bind="text: nodeTitle, attr: {href: projectUrl}"></a>
 </script>
 
 <script type="text/html" id="retraction_cancelled">
-cancelled retraction of
+cancelled retraction of registration of
 <span class="log-node-title-link overflow" data-bind="text: nodeTitle"></span>
 </script>
 
 <script type="text/html" id="retraction_initiated">
-initiated retraction of
+initiated retraction of registration of
 <a class="log-node-title-link overflow" data-bind="text: nodeTitle, attr: {href: projectUrl}"></a>
 </script>
 

--- a/website/templates/log_templates.mako
+++ b/website/templates/log_templates.mako
@@ -54,7 +54,7 @@ initiated retraction of
 ## Registration related Logs
 <script type="text/html" id="registration_initiated">
 initiated registration of
-<a class="log-node-title-link overflow" data-bind="text: nodeTitle, attr: {href: nodeUrl}"></a>
+<a class="log-node-title-link overflow" data-bind="text: nodeTitle, attr: {href: projectUrl}"></a>
 </script>
 
 <script type="text/html" id="registration_cancelled">

--- a/website/templates/log_templates.mako
+++ b/website/templates/log_templates.mako
@@ -7,7 +7,7 @@
 ## Embargo related logs
 <script type="text/html" id="embargo_approved">
 approved embargo of
-<a class="log-node-title-link overflow" data-bind="text: nodeTitle, attr: {href: nodeUrl}"></a>
+<a class="log-node-title-link overflow" data-bind="text: nodeTitle, attr: {href: projectUrl}"></a>
 </script>
 
 <script type="text/html" id="embargo_approved_no_user">
@@ -32,13 +32,13 @@ Embargo for
 
 <script type="text/html" id="embargo_initiated">
 initiated an embargoed registration of
-<a class="log-node-title-link overflow" data-bind="text: nodeTitle, attr: {href: nodeUrl}"></a>
+<a class="log-node-title-link overflow" data-bind="text: nodeTitle, attr: {href: projectUrl}"></a>
 </script>
 
 ## Retraction related logs
 <script type="text/html" id="retraction_approved">
 approved retraction of
-<a class="log-node-title-link overflow" data-bind="text: nodeTitle, attr: {href: nodeUrl}"></a>
+<a class="log-node-title-link overflow" data-bind="text: nodeTitle, attr: {href: projectUrl}"></a>
 </script>
 
 <script type="text/html" id="retraction_cancelled">
@@ -48,7 +48,7 @@ cancelled retraction of
 
 <script type="text/html" id="retraction_initiated">
 initiated retraction of
-<a class="log-node-title-link overflow" data-bind="text: nodeTitle, attr: {href: nodeUrl}"></a>
+<a class="log-node-title-link overflow" data-bind="text: nodeTitle, attr: {href: projectUrl}"></a>
 </script>
 
 ## Registration related Logs


### PR DESCRIPTION
Purpose: change the link of registrations in the recent activity logs so that it links to projects instead of registrations of projects.

Changes:
Add a new serialized field "registered_from_id" to identify the node being registered.
Add a new field "projectUrl" so that the user may click into the project instead of registration of the project from "Recent logs" panel.
Make respective change in the template.
