### PR TITLE
Feature/api/valid error without source

### DIFF
--- a/api/base/exceptions.py
+++ b/api/base/exceptions.py
@@ -3,6 +3,7 @@ import httplib as http
 from rest_framework import status
 from rest_framework.exceptions import APIException, ParseError
 
+
 def json_api_exception_handler(exc, context):
     """ Custom exception handler that returns errors object as an array """
 
@@ -21,7 +22,7 @@ def json_api_exception_handler(exc, context):
         if isinstance(exc, JSONAPIException):
             errors.extend([
                 {
-                    'source': exc.source,
+                    'source': exc.source or {},
                     'detail': exc.detail,
                 }
             ])

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -534,6 +534,7 @@ class TestNodeCreate(ApiTestCase):
         res = self.app.post_json_api(self.url, project, auth=self.user_one.auth, expect_errors=True)
         assert_equal(res.status_code, 400)
         assert_equal(res.json['errors'][0]['detail'], 'Title cannot exceed 200 characters.')
+        assert_equal(res.json['errors'][0]['source'], {}, 'Source cannot be none per JSON API Spec')
 
 
 class TestNodeDetail(ApiTestCase):

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -534,7 +534,7 @@ class TestNodeCreate(ApiTestCase):
         res = self.app.post_json_api(self.url, project, auth=self.user_one.auth, expect_errors=True)
         assert_equal(res.status_code, 400)
         assert_equal(res.json['errors'][0]['detail'], 'Title cannot exceed 200 characters.')
-        assert_equal(res.json['errors'][0]['source'], {}, 'Source cannot be none per JSON API Spec')
+        assert_equal(res.json['errors'][0]['source'], {}, msg='Source cannot be none per JSON API Spec')
 
 
 class TestNodeDetail(ApiTestCase):

--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -534,7 +534,7 @@ class TestNodeCreate(ApiTestCase):
         res = self.app.post_json_api(self.url, project, auth=self.user_one.auth, expect_errors=True)
         assert_equal(res.status_code, 400)
         assert_equal(res.json['errors'][0]['detail'], 'Title cannot exceed 200 characters.')
-        assert_equal(res.json['errors'][0]['source'], {}, msg='Source cannot be none per JSON API Spec')
+        assert_not_equal(res.json['errors'][0]['source'], None)
 
 
 class TestNodeDetail(ApiTestCase):


### PR DESCRIPTION
Overview
-------------
Source fields in JSON API compliant APIs cannot be null/None. Replace with a valid return value.

Changes
------------
Now returning {} rather than None in the case of no source field. Added an assertion to a test that generated an error like this. 

Side effects
---------------
None

Fixes https://openscience.atlassian.net/browse/OSF-4653