### PR TITLE
OSF-4898 Anonymize public project if user is sharing that project through an anonymized link

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -113,8 +113,18 @@ class TestViewingProjectWithPrivateLink(OsfTestCase):
         assert_equal(res.status_code, 400)
         assert_in('Invalid link name.', res.body)
 
-    def test_not_anonymous_for_public_project(self):
+    def test_anonymous_for_anonymous_public_project(self):
         anonymous_link = PrivateLinkFactory(anonymous=True)
+        anonymous_link.nodes.append(self.project)
+        anonymous_link.save()
+        self.project.set_privacy('public')
+        self.project.save()
+        self.project.reload()
+        auth = Auth(user=self.user, private_key=anonymous_link.key)
+        assert_true(has_anonymous_link(self.project, auth))
+
+    def test_not_anonymous_for_not_anonymous_public_project(self):
+        anonymous_link = PrivateLinkFactory(anonymous=False)
         anonymous_link.nodes.append(self.project)
         anonymous_link.save()
         self.project.set_privacy('public')

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -70,8 +70,7 @@ def has_anonymous_link(node, auth):
     view_only_link = auth.private_key or request.args.get('view_only', '').strip('/')
     if not view_only_link:
         return False
-    if node.is_public:
-        return False
+
     return any(
         link.anonymous
         for link in node.private_links_active

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -107,7 +107,7 @@
                     Contributors:
                 % endif
 
-                % if node['anonymous'] and not node['is_public']:
+                % if node['anonymous']:
                     <ol>Anonymous Contributors</ol>
                 % else:
                     <ol>


### PR DESCRIPTION
<h3>Purpose</h3>
Anonymize public project in view-only link.

<h3>Changes</h3>
Delete lines in model.py that says "if a node is public, it is not anonymous"
Make the same change to the template file.