### PR TITLE
[Feature][Fix] Box - UI Fixes

### DIFF
--- a/website/addons/box/model.py
+++ b/website/addons/box/model.py
@@ -100,7 +100,7 @@ class BoxNodeSettings(StorageAddonBase, AddonOAuthNodeSettingsBase):
 
     def fetch_folder_name(self):
         self._update_folder_data()
-        return self.folder_name
+        return self.folder_name.replace('All Files', '/ (Full Box)')
 
     def fetch_full_folder_path(self):
         self._update_folder_data()
@@ -121,7 +121,7 @@ class BoxNodeSettings(StorageAddonBase, AddonOAuthNodeSettingsBase):
             self.folder_name = self._folder_data['name']
             self.folder_path = '/'.join(
                 [x['name'] for x in self._folder_data['path_collection']['entries']]
-                + [self.fetch_folder_name()]
+                + [self._folder_data['name']]
             )
             self.save()
 

--- a/website/static/js/folderPickerNodeConfig.js
+++ b/website/static/js/folderPickerNodeConfig.js
@@ -184,6 +184,7 @@ var FolderPickerViewModel = oop.defclass({
             var userIsOwner = self.userIsOwner();
             var selected = self.selected();
             var name = selected.name || 'None';
+            name = name.replace('All Files', 'Full ' + addonName);
             return userIsOwner ? name : '';
         });
 


### PR DESCRIPTION
Purpose
=======
Ensure 'All Files' is not displayed to the user

Changes
=======
* `replace` 'All Files' with '/ (Full Box)'
* Make sure root folder is not automatically deselected in `folderPicker` if already selected

Side Effects
=========
None