### PR TITLE
[rfr] Calling Node#update with same data doesn't generate multiple logs

### DIFF
--- a/tests/api_tests/nodes/test_views.py
+++ b/tests/api_tests/nodes/test_views.py
@@ -1086,6 +1086,24 @@ class TestNodeUpdate(NodeCRUDTestCase):
         assert_equal(res.status_code, 403)
         assert_in('detail', res.json['errors'][0])
 
+    def test_multiple_patch_requests_with_same_category_generates_one_log(self):
+        self.private_project.category = 'project'
+        self.private_project.save()
+        new_category = 'data'
+        payload = make_node_payload(self.private_project, attributes={'category': new_category})
+        original_n_logs = len(self.private_project.logs)
+
+        res = self.app.patch_json_api(self.private_url, payload, auth=self.user.auth)
+        self.private_project.reload()
+        assert_equal(self.private_project.category, new_category)
+        assert_equal(len(self.private_project.logs), original_n_logs + 1)  # sanity check
+
+        res = self.app.patch_json_api(self.private_url, payload, auth=self.user.auth)
+        self.private_project.reload()
+        assert_equal(self.private_project.category, new_category)
+        self.private_project.reload()
+        assert_equal(len(self.private_project.logs), original_n_logs + 1)
+
     def test_partial_update_invalid_id(self):
         res = self.app.patch_json_api(self.public_url, {
                 'data': {

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1941,6 +1941,24 @@ class TestNodeUpdate(OsfTestCase):
         # A new log is not created
         assert_equal(len(self.node.logs), original_n_logs + 1)
 
+    # Regression test for https://openscience.atlassian.net/browse/OSF-4664
+    def test_updating_category_twice_with_same_content_generates_one_log(self):
+        self.node.category = 'project'
+        self.node.save()
+        original_n_logs = len(self.node.logs)
+        new_category = 'data'
+
+        self.node.update({'category': new_category}, auth=Auth(self.user), save=True)
+        assert_equal(len(self.node.logs), original_n_logs + 1)  # sanity check
+        assert_equal(self.node.category, new_category)
+
+        # Call update with same category
+        self.node.update({'category': new_category}, auth=Auth(self.user), save=True)
+
+        # A new log is not created
+        assert_equal(len(self.node.logs), original_n_logs + 1)
+        assert_equal(self.node.category, new_category)
+
     # TODO: test permissions, non-writable fields
 
 

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -1167,11 +1167,13 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
                         if key == 'category':
                             self.delete_search_entry()
                         ###############
-                        values[key] = {
-                            'old': getattr(self, key),
-                            'new': value,
-                        }
-                        setattr(self, key, value)
+                        old_value = getattr(self, key)
+                        if old_value != value:
+                            values[key] = {
+                                'old': old_value,
+                                'new': value,
+                            }
+                            setattr(self, key, value)
                     except AttributeError:
                         raise NodeUpdateError(reason="Invalid value for attribute '{0}'".format(key), key=key)
                     except warnings.Warning:


### PR DESCRIPTION
### Purpose

Sending multiple `PATCH /v2/nodes/<nid>` requests with the same category generated multiple logs, which was inconsistent with the behavior for PATCHing title and description.

### Changes

Modify `Node#update` to only create a log when a field has been changed.

### Ticket

https://openscience.atlassian.net/browse/OSF-4664