### PR TITLE
OSF-4850 Removed warning messages in Contributors page and modal.

### DIFF
--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -468,10 +468,6 @@ def project_statistics_redirect(auth, node, **kwargs):
 @must_have_permission(ADMIN)
 def project_before_set_public(node, **kwargs):
     prompt = node.callback('before_make_public')
-    anonymous_link_warning = any(private_link.anonymous for private_link in node.private_links_active)
-    if anonymous_link_warning:
-        prompt.append('Anonymized view-only links <b>DO NOT</b> anonymize '
-                      'contributors after a project or component is made public.')
 
     return {
         'prompts': prompt
@@ -1060,12 +1056,6 @@ def project_generate_private_link_post(auth, node, **kwargs):
             data=dict(message_long=e.message)
         )
 
-    if anonymous and has_public_node:
-        status.push_status_message(
-            'Anonymized view-only links <b>DO NOT</b> '
-            'anonymize contributors of public projects or components.',
-            trust=True
-        )
 
     return new_link
 

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -1044,8 +1044,6 @@ def project_generate_private_link_post(auth, node, **kwargs):
 
     nodes = [Node.load(node_id) for node_id in node_ids]
 
-    has_public_node = any(node.is_public for node in nodes)
-
     try:
         new_link = new_private_link(
             name=name, user=auth.user, nodes=nodes, anonymous=anonymous
@@ -1055,7 +1053,6 @@ def project_generate_private_link_post(auth, node, **kwargs):
             http.BAD_REQUEST,
             data=dict(message_long=e.message)
         )
-
 
     return new_link
 


### PR DESCRIPTION
<h3>Purpose</h3>
Since public projects can be anonymous, warning messages in both the Contributors page and the "make public" modal should be removed. See screen shots.
![1](https://cloud.githubusercontent.com/assets/1566880/10548625/1a761568-740a-11e5-80f5-8e0ce1720baa.png)
<img width="613" alt="2" src="https://cloud.githubusercontent.com/assets/1566880/10548624/1a747866-740a-11e5-8c1b-a7e1674f4112.png">

<h3>Changes</h3>
In the node.py file, lines to show these warning messages are deleted. See screen shots for results. 
<img width="1135" alt="screen shot 2015-10-16 at 13 25 04" src="https://cloud.githubusercontent.com/assets/1566880/10548675/64e98968-740a-11e5-90bb-c700fb0cfaab.png">
<img width="621" alt="screen shot 2015-10-16 at 13 24 46" src="https://cloud.githubusercontent.com/assets/1566880/10548676/64f54e88-740a-11e5-9106-6e22099d5622.png">
