### PR TITLE
Ensure users created as confirmed have populated 'emails' fields

### DIFF
--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -461,6 +461,7 @@ class User(GuidStoredObject, AddonModelMixin):
         user.is_registered = True
         user.is_claimed = True
         user.date_confirmed = user.date_registered
+        user.emails.append(username)
         return user
 
     @classmethod


### PR DESCRIPTION
Purpose
=======
Users created as 'confirmed' should have an email associated with their account, as they used it to 'confirm' their account.

Changes
=======
Email address used to confirm is added to newly created confirmed user.

Side Effects
=========
None

Notes
---------
To fix preexisting broken users, run 
`python -m scripts.migration.migrate_confirmed_user_emails` 

[#OSF-4876]