### PR TITLE
[Feature][Fix]Delete associated addon node-settings  when revoking an external account

### DIFF
--- a/website/addons/base/__init__.py
+++ b/website/addons/base/__init__.py
@@ -377,6 +377,10 @@ class AddonOAuthUserSettingsBase(AddonUserSettingsBase):
             so it's not yet been implemented.
         """
         for key in self.oauth_grants:
+            addon_node_settings = Node.load(key).get_addon(self.oauth_provider.short_name)
+            if addon_node_settings is not None:
+                addon_node_settings.delete()
+                addon_node_settings.save()
             self.oauth_grants[key].pop(external_account._id, None)
 
         self.save()

--- a/website/addons/box/tests/test_models.py
+++ b/website/addons/box/tests/test_models.py
@@ -158,7 +158,7 @@ class TestBoxNodeSettingsModel(OsfTestCase):
     def test_complete_false(self):
         self.user_settings.revoke_oauth_access(self.external_account)
 
-        assert_true(self.node_settings.has_auth)
+        assert_false(self.node_settings.has_auth)
         assert_false(self.node_settings.complete)
 
     def test_complete_auth_false(self):


### PR DESCRIPTION
Purpose
=======
If a user disconnects an account from their user settings page and then reconnects it, node settings data (e.g. selected folder) should not persist, and must be manually reconfigured.

Changes
=======
Node settings for addon deleted if it exists

Side Effects
=========
Some addons may need to override `on_delete` to implement non-default behaviour

[#OSF-4963]