### PR TITLE
fixed link to orcid.com in SOCIAL_FIELDS

### DIFF
--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -194,7 +194,7 @@ class User(GuidStoredObject, AddonModelMixin):
     #   search update for all nodes to which the user is a contributor.
 
     SOCIAL_FIELDS = {
-        'orcid': u'http://orcid.com/{}',
+        'orcid': u'http://orcid.org/{}',
         'github': u'http://github.com/{}',
         'scholar': u'http://scholar.google.com/citation?user={}',
         'twitter': u'http://twitter.com/{}',


### PR DESCRIPTION
On production search, clicking the ORCID icon for a user directs you to orcid.com instead of orcid.org