### PR TITLE
Changed button order according to [OSF-1086]

### DIFF
--- a/website/addons/github/templates/github_node_settings.mako
+++ b/website/addons/github/templates/github_node_settings.mako
@@ -54,10 +54,10 @@
 
             % if is_owner and not is_registration:
                 <div class="col-md-6 m-b-sm">
-                    <a id="githubCreateRepo" class="btn btn-success">Create Repo</a>
-                    <button class="btn btn-success addon-settings-submit pull-right">
+                    <button class="btn btn-success addon-settings-submit">
                         Save
                     </button>
+                    <a id="githubCreateRepo" class="btn btn-success pull-right">Create Repo</a>
                 </div>
             % endif
 


### PR DESCRIPTION
<b>Purpose</b>

The purpose of this change was to switch the button order for the "create repo" button and "save" button according to OSF-1086.

<b>Changes</b>

The change made was to switch the button order as mentioned above (the "create repo" button should be on the right and the "save" button should be on the left.)