### PR TITLE
[Feature] 2FA Messages

### DIFF
--- a/website/addons/twofactor/models.py
+++ b/website/addons/twofactor/models.py
@@ -5,7 +5,6 @@ from random import SystemRandom
 from modularodm.fields import BooleanField, StringField, IntegerField
 from oath import accept_totp
 
-from framework.status import push_status_message
 from website.addons.base import AddonUserSettingsBase
 
 class TwoFactorUserSettings(AddonUserSettingsBase):
@@ -50,18 +49,12 @@ class TwoFactorUserSettings(AddonUserSettingsBase):
     #############
 
     def on_add(self):
-        push_status_message('Please <u><a href="#TfaVerify">activate your'
-                            ' device</a></u> before continuing.', 'info')
         super(TwoFactorUserSettings, self).on_add()
         self.totp_secret = _generate_seed()
         self.totp_drift = 0
         self.is_confirmed = False
 
     def on_delete(self):
-        if self.is_confirmed:
-            push_status_message('Successfully deauthorized two-factor'
-                                ' authentication. Please delete the'
-                                ' verification code on your device.', 'success')
         super(TwoFactorUserSettings, self).on_delete()
         self.totp_secret = None
         self.totp_drift = 0

--- a/website/addons/twofactor/models.py
+++ b/website/addons/twofactor/models.py
@@ -5,7 +5,6 @@ from random import SystemRandom
 from modularodm.fields import BooleanField, StringField, IntegerField
 from oath import accept_totp
 
-from framework.status import push_status_message
 from website.addons.base import AddonUserSettingsBase
 
 class TwoFactorUserSettings(AddonUserSettingsBase):

--- a/website/addons/twofactor/models.py
+++ b/website/addons/twofactor/models.py
@@ -5,6 +5,7 @@ from random import SystemRandom
 from modularodm.fields import BooleanField, StringField, IntegerField
 from oath import accept_totp
 
+from framework.status import push_status_message
 from website.addons.base import AddonUserSettingsBase
 
 class TwoFactorUserSettings(AddonUserSettingsBase):

--- a/website/addons/twofactor/static/twoFactorUserConfig.js
+++ b/website/addons/twofactor/static/twoFactorUserConfig.js
@@ -107,10 +107,6 @@ ViewModel.prototype.disableTwofactorConfirm = function() {
             self.isEnabled(false);
             self.isConfirmed(false);
             $(self.qrCodeSelector).html('');
-            self.changeMessage(
-                'Successfully disabled two-factor authentication.',
-                'text-success',
-                5000);
         })
         .fail(function(xhr, status, error) {
             Raven.captureMessage('Failed to disable two-factor.', {
@@ -149,10 +145,6 @@ ViewModel.prototype.enableTwofactorConfirm = function() {
     var self = this;
     return osfHelpers.postJSON(self.urls.enable, {})
         .done(function(response) {
-            self.changeMessage(
-                'Successfully enabled two-factor authentication.',
-                'text-success',
-                5000);
             self.updateFromData(response.result);
         })
         .fail(function(xhr, status, error) {

--- a/website/addons/twofactor/tests/test_models.py
+++ b/website/addons/twofactor/tests/test_models.py
@@ -1,6 +1,5 @@
 from urlparse import urlparse, parse_qs
 
-import mock
 from nose.tools import *  # noqa
 
 from tests.base import OsfTestCase
@@ -8,23 +7,19 @@ from tests.factories import UserFactory
 from website.addons.twofactor.tests import _valid_code
 
 class TestCallbacks(OsfTestCase):
-    @mock.patch('website.addons.twofactor.models.push_status_message')
-    def setUp(self, mocked):
+    def setUp(self):
         super(TestCallbacks, self).setUp()
 
         self.user = UserFactory()
         self.user.add_addon('twofactor')
         self.user_settings = self.user.get_addon('twofactor')
-        self.on_add_called = mocked.called
 
     def test_add_to_user(self):
         assert_equal(self.user_settings.totp_drift, 0)
         assert_is_not_none(self.user_settings.totp_secret)
         assert_false(self.user_settings.is_confirmed)
-        assert_true(self.on_add_called)
 
-    @mock.patch('website.addons.twofactor.models.push_status_message')
-    def test_remove_from_unconfirmed_user(self, mocked):
+    def test_remove_from_unconfirmed_user(self):
         # drift defaults to 0. Change it so we can test it was changed back.
         self.user_settings.totp_drift = 1
         self.user_settings.save()
@@ -34,10 +29,8 @@ class TestCallbacks(OsfTestCase):
         assert_equal(self.user_settings.totp_drift, 0)
         assert_is_none(self.user_settings.totp_secret)
         assert_false(self.user_settings.is_confirmed)
-        assert_false(mocked.called)
 
-    @mock.patch('website.addons.twofactor.models.push_status_message')
-    def test_remove_from_confirmed_user(self, mocked):
+    def test_remove_from_confirmed_user(self):
         # drift defaults to 0. Change it so we can test it was changed back.
         self.user_settings.totp_drift = 1
         self.user_settings.is_confirmed = True
@@ -48,15 +41,12 @@ class TestCallbacks(OsfTestCase):
         assert_equal(self.user_settings.totp_drift, 0)
         assert_is_none(self.user_settings.totp_secret)
         assert_false(self.user_settings.is_confirmed)
-        assert_true(mocked.called)
-
 
 class TestUserSettingsModel(OsfTestCase):
     TOTP_SECRET = 'b8f85986068f8079aa9d'
     TOTP_SECRET_B32 = 'XD4FTBQGR6AHTKU5'
 
-    @mock.patch('website.addons.twofactor.models.push_status_message')
-    def setUp(self, mocked):
+    def setUp(self):
         super(TestUserSettingsModel, self).setUp()
 
         self.user = UserFactory()

--- a/website/addons/twofactor/tests/test_utils.py
+++ b/website/addons/twofactor/tests/test_utils.py
@@ -1,4 +1,3 @@
-import mock
 from nose.tools import *  # noqa
 
 from tests.base import OsfTestCase
@@ -11,8 +10,7 @@ from website.app import init_app
 from website.addons.twofactor.utils import serialize_settings, serialize_urls
 
 class TestUtils(OsfTestCase):
-    @mock.patch('website.addons.twofactor.models.push_status_message')
-    def setUp(self, mocked):
+    def setUp(self):
         super(TestUtils, self).setUp()
         self.user = AuthUserFactory()
         self.user_addon = self.user.get_or_add_addon('twofactor')

--- a/website/addons/twofactor/tests/test_views.py
+++ b/website/addons/twofactor/tests/test_views.py
@@ -1,4 +1,3 @@
-import mock
 from nose.tools import *  # noqa
 
 import httplib as http
@@ -15,8 +14,7 @@ from website.addons.twofactor.utils import serialize_settings
 
 
 class TestViews(OsfTestCase):
-    @mock.patch('website.addons.twofactor.models.push_status_message')
-    def setUp(self, mocked):
+    def setUp(self):
         super(TestViews, self).setUp()
         self.user = AuthUserFactory()
         self.user_addon = self.user.get_or_add_addon('twofactor')


### PR DESCRIPTION
Purpose
-
This PR addresses some no longer needed messages when enabling/disabling Two-Factor-Authentication.

Changes
-
Removed the calls that displayed the various messages.

Side Effects
-
There should be no side effects to this since all it does is cause messages to not display.

More
-
 1. When you enabled 2FA it would show green text underneath letting you know it was enabled
<img width="567" alt="screen shot 2015-11-06 at 10 31 46 am" src="https://cloud.githubusercontent.com/assets/8229937/11000774/aab31ab4-8471-11e5-8481-e82f6c92c101.png">

 2. When you have enabled 2FA but not entered your code and refreshed the page, it would display a message telling you to enter your code
<img width="1173" alt="screen shot 2015-11-06 at 10 34 01 am" src="https://cloud.githubusercontent.com/assets/8229937/11000864/1c894f14-8472-11e5-9c1d-0026e0134d5a.png">

 3. When you disabled 2FA after having verified, it would display a message at the top on page refresh 
<img width="1181" alt="screen shot 2015-11-06 at 10 37 06 am" src="https://cloud.githubusercontent.com/assets/8229937/11000929/733bd93a-8472-11e5-99d6-362598238deb.png">

 
[#OSF-2426]