### PR TITLE
[Feature Fix] [OSF Meeting] Show full name when user don't set family name

### DIFF
--- a/website/conferences/views.py
+++ b/website/conferences/views.py
@@ -163,7 +163,7 @@ def _render_conference_node(node, idx, conf):
         'id': idx,
         'title': node.title,
         'nodeUrl': node.url,
-        'author': author.family_name,
+        'author': author.family_name if author.family_name else author.fullname,
         'authorUrl': node.creator.url,
         'category': 'talk' if 'talk' in node.system_tags else 'poster',
         'download': download_count,


### PR DESCRIPTION
## Purpose 
It is to show full name when user don't set family name. For some languages, such as Chinese and Japanese, people usually don't separate their family name and first name with space. In OSF, if there is no space within user name, it will assume there is no family name. 

Currently, OSF meeting only show author's family name. Therefore, for user who use those language, there is no name to be displayed (blank).

Resolve [OSF-4899]

## Changes
The change is simple here. Just show full name if there is no family name filed.

### Before Change:
![screenshot 2015-10-26 16 44 04](https://cloud.githubusercontent.com/assets/5420789/10742263/9b1ad35c-7c02-11e5-92ff-a75f3f3d1cd4.png)

### After Change:
![screenshot 2015-10-26 16 43 14](https://cloud.githubusercontent.com/assets/5420789/10742272/a94dc22c-7c02-11e5-8b31-00f57e74095c.png)

## Side Effect
None
