### PR TITLE
[Hotfix] Ensure oauth accounts are properly deauthorized when removed via user settings

### DIFF
--- a/website/addons/base/__init__.py
+++ b/website/addons/base/__init__.py
@@ -381,10 +381,11 @@ class AddonOAuthUserSettingsBase(AddonUserSettingsBase):
         for node in self.get_nodes_with_oauth_grants(external_account):
             try:
                 addon_settings = node.get_addon(external_account.provider)
-                addon_settings.deauthorize(auth=auth)
             except AttributeError:
                 # No associated addon settings despite oauth grant
                 pass
+            else:
+                addon_settings.deauthorize(auth=auth)
 
         for key in self.oauth_grants:
             self.oauth_grants[key].pop(external_account._id, None)

--- a/website/addons/box/tests/test_models.py
+++ b/website/addons/box/tests/test_models.py
@@ -156,7 +156,7 @@ class TestBoxNodeSettingsModel(OsfTestCase):
         assert_true(self.node_settings.complete)
 
     def test_complete_false(self):
-        self.user_settings.revoke_oauth_access(self.external_account)
+        self.user_settings.oauth_grants[self.node._id].pop(self.external_account._id)
 
         assert_true(self.node_settings.has_auth)
         assert_false(self.node_settings.complete)

--- a/website/oauth/views.py
+++ b/website/oauth/views.py
@@ -22,7 +22,15 @@ def oauth_disconnect(external_account_id, auth):
         HTTPError(http.FORBIDDEN)
 
     # iterate AddonUserSettings for addons
+    # iterate Nodes[].ProviderNodeSettings for AddonUserSettings
     for user_settings in user.get_oauth_addons():
+        for node in user_settings.get_nodes_with_oauth_grants(account):
+            try:
+                addon_settings = node.get_addon(account.provider)
+                addon_settings.deauthorize(auth=auth)
+            except AttributeError:
+                # No associated addon settings despite oauth grant
+                pass
         user_settings.revoke_oauth_access(account)
         user_settings.save()
 

--- a/website/oauth/views.py
+++ b/website/oauth/views.py
@@ -22,15 +22,7 @@ def oauth_disconnect(external_account_id, auth):
         HTTPError(http.FORBIDDEN)
 
     # iterate AddonUserSettings for addons
-    # iterate Nodes[].ProviderNodeSettings for AddonUserSettings
     for user_settings in user.get_oauth_addons():
-        for node in user_settings.get_nodes_with_oauth_grants(account):
-            try:
-                addon_settings = node.get_addon(account.provider)
-                addon_settings.deauthorize(auth=auth)
-            except AttributeError:
-                # No associated addon settings despite oauth grant
-                pass
         user_settings.revoke_oauth_access(account)
         user_settings.save()
 


### PR DESCRIPTION
Purpose
======
Iterate over all `[Provider]NodeSettings` objects and deauthorize when revoking access.

Changes
=======
deauth logic added 

Side Effects
=========
NodeLogs will be created when appropriate


[#OSF-4991]