### PR TITLE
[discuss][WIP] Add fields to registration serializer

### DIFF
--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -10,12 +10,13 @@ class RegistrationSerializer(NodeSerializer):
 
     retracted = ser.BooleanField(source='is_retracted', read_only=True,
         help_text='Whether this registration has been retracted.')
+    pending_retraction = ser.BooleanField(source='is_pending_retraction', read_only=True)
+    pending_approval = ser.BooleanField(source='sanction.pending_approval')
+    pending_registration = ser.BooleanField(read_only=True, source='is_pending_registration')
     date_registered = ser.DateTimeField(source='registered_date', read_only=True, help_text='Date time of registration.')
-    embargoed = ser.BooleanField(read_only=True, source='embargo.state')
-    embargo_end_date = ser.DateTimeField(source='embargo.end_date', read_only=True)
-    registration_schema = ser.CharField(read_only=True, source='registered_schema')
-    registered_meta = ser.CharField(read_only=True)
-        
+    registration_approved = ser.BooleanField(source='is_registration_approved', read_only=True)
+    pending_embargo = ser.BooleanField(read_only=True, source='is_pending_embargo')
+    registered_meta = ser.DictField(read_only=True)
 
     registered_by = JSONAPIHyperlinkedIdentityField(
         view_name='users:user-detail',

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -10,7 +10,13 @@ class RegistrationSerializer(NodeSerializer):
 
     retracted = ser.BooleanField(source='is_retracted', read_only=True,
         help_text='Whether this registration has been retracted.')
+    pending_registration = ser.CharField(read_only=True, source='registration_approval')
     date_registered = ser.DateTimeField(source='registered_date', read_only=True, help_text='Date time of registration.')
+    embargoed = ser.BooleanField(read_only=True, source='embargo.state')
+    embargo_end_date = ser.DateTimeField(source='embargo.end_date', read_only=True)
+    registration_schema = ser.CharField(read_only=True)
+    registered_meta = ser.CharField(read_only=True)
+
 
     registered_by = JSONAPIHyperlinkedIdentityField(
         view_name='users:user-detail',

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -9,14 +9,17 @@ from api.base.serializers import IDField, JSONAPIHyperlinkedIdentityField, Links
 class RegistrationSerializer(NodeSerializer):
 
     retracted = ser.BooleanField(source='is_retracted', read_only=True,
-        help_text='Whether this registration has been retracted.')
-    pending_retraction = ser.BooleanField(source='is_pending_retraction', read_only=True)
-    pending_approval = ser.BooleanField(source='sanction.pending_approval')
-    pending_registration = ser.BooleanField(read_only=True, source='is_pending_registration')
-    date_registered = ser.DateTimeField(source='registered_date', read_only=True, help_text='Date time of registration.')
-    registration_approved = ser.BooleanField(source='is_registration_approved', read_only=True)
-    pending_embargo = ser.BooleanField(read_only=True, source='is_pending_embargo')
-    registered_meta = ser.DictField(read_only=True)
+        help_text='Has this registration has been retracted?')
+    pending_retraction = ser.BooleanField(source='is_pending_retraction', read_only=True,
+        help_text='Is this registration pending retraction?')
+    pending_approval = ser.BooleanField(source='sanction.pending_approval', read_only=True,
+        help_text='Does this registration have a sanction pending approval?')
+    date_registered = ser.DateTimeField(source='registered_date', read_only=True,
+        help_text='Date time of registration.')
+    pending_embargo = ser.BooleanField(read_only=True, source='is_pending_embargo',
+        help_text='Is this registration pending embargo?')
+    registered_meta = ser.DictField(read_only=True,
+        help_text='Includes a dictionary with registration schema, embargo end date, and supplemental registration questions')
 
     registered_by = JSONAPIHyperlinkedIdentityField(
         view_name='users:user-detail',

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -10,13 +10,12 @@ class RegistrationSerializer(NodeSerializer):
 
     retracted = ser.BooleanField(source='is_retracted', read_only=True,
         help_text='Whether this registration has been retracted.')
-    pending_registration = ser.CharField(read_only=True, source='registration_approval')
     date_registered = ser.DateTimeField(source='registered_date', read_only=True, help_text='Date time of registration.')
     embargoed = ser.BooleanField(read_only=True, source='embargo.state')
     embargo_end_date = ser.DateTimeField(source='embargo.end_date', read_only=True)
     registration_schema = ser.CharField(read_only=True, source='registered_schema')
     registered_meta = ser.CharField(read_only=True)
-
+        
 
     registered_by = JSONAPIHyperlinkedIdentityField(
         view_name='users:user-detail',

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -14,7 +14,7 @@ class RegistrationSerializer(NodeSerializer):
     date_registered = ser.DateTimeField(source='registered_date', read_only=True, help_text='Date time of registration.')
     embargoed = ser.BooleanField(read_only=True, source='embargo.state')
     embargo_end_date = ser.DateTimeField(source='embargo.end_date', read_only=True)
-    registration_schema = ser.CharField(read_only=True)
+    registration_schema = ser.CharField(read_only=True, source='registered_schema')
     registered_meta = ser.CharField(read_only=True)
 
 

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -12,7 +12,7 @@ class RegistrationSerializer(NodeSerializer):
         help_text='Has this registration has been retracted?')
     pending_retraction = ser.BooleanField(source='is_pending_retraction', read_only=True,
         help_text='Is this registration pending retraction?')
-    pending_approval = ser.BooleanField(source='sanction.pending_approval', read_only=True,
+    pending_registration_approval = ser.BooleanField(source='sanction.pending_approval', read_only=True,
         help_text='Does this registration have a sanction pending approval?')
     date_registered = ser.DateTimeField(source='registered_date', read_only=True,
         help_text='Date time of registration.')


### PR DESCRIPTION
# Purpose
Issue https://openscience.atlassian.net/browse/OSF-4436

The RegistrationSerializer is incomplete; it should include information about embargoes, pending state, registration template, etc. @brianjgeiger pointed out that we can always add, never remove.

# Changes 

Current Field:
- retracted
- date_registered
- registered_by
- registered_from

Added Fields:
- pending_retraction
- pending_registration_approval
- pending_embargo
- registered_meta - contains name of registration schema, embargo end date, and answers to supplemental registration questions