### PR TITLE
[Hotfix] Ensure proper oauth deauthorization for all new-oauth addons

### DIFF
--- a/website/addons/base/__init__.py
+++ b/website/addons/base/__init__.py
@@ -806,6 +806,14 @@ class AddonOAuthNodeSettingsBase(AddonNodeSettingsBase):
 
         self.save()
 
+    def deauthorize(self, auth=None, add_log=False):
+        """Remove authorization from this node.
+
+        This method should be overridden for addon-specific behavior,
+        such as logging and clearing non-generalizable settings.
+        """
+        self.clear_auth()
+
     def clear_auth(self):
         """Disconnect the node settings from the user settings.
 

--- a/website/addons/mendeley/model.py
+++ b/website/addons/mendeley/model.py
@@ -320,6 +320,22 @@ class MendeleyNodeSettings(AddonOAuthNodeSettingsBase):
         self.mendeley_list_id = None
         return super(MendeleyNodeSettings, self).clear_auth()
 
+    def deauthorize(self, auth=None, add_log=True):
+        """Remove user authorization from this node and log the event."""
+        if add_log:
+            self.owner.add_log(
+                'mendeley_node_deauthorized',
+                params={
+                    'project': self.owner.parent_id,
+                    'node': self.owner._id,
+                },
+                auth=auth,
+            )
+
+        self.clear_auth()
+
+        self.save()
+
     def set_auth(self, *args, **kwargs):
         self.mendeley_list_id = None
         return super(MendeleyNodeSettings, self).set_auth(*args, **kwargs)

--- a/website/addons/mendeley/templates/log_templates.mako
+++ b/website/addons/mendeley/templates/log_templates.mako
@@ -2,3 +2,9 @@
 linked Mendeley folder /<span class="overflow">{{ params.folder_name }}</span> to
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
+
+<script type="text/html" id="mendeley_node_deauthorized">
+deauthorized the Mendeley addon for
+<a class="log-node-title-link overflow"
+    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+</script>

--- a/website/addons/mendeley/tests/test_models.py
+++ b/website/addons/mendeley/tests/test_models.py
@@ -157,6 +157,24 @@ class MendeleyNodeSettingsTestCase(OsfTestCase):
                 user=UserFactory()
             )
 
+    def test_deauthorize(self):
+        self.node_settings.external_account = ExternalAccountFactory()
+        self.node_settings.mendeley_list_id = 'something'
+        self.node_settings.user_settings = self.user_settings
+        self.node_settings.save()
+
+        assert_true(self.node_settings.mendeley_list_id)
+        self.node_settings.deauthorize(auth=Auth(self.user))
+        self.node_settings.save()
+        assert_is(self.node_settings.user_settings, None)
+        assert_is(self.node_settings.mendeley_list_id, None)
+
+        last_log = self.node.logs[-1]
+        assert_equal(last_log.action, 'mendeley_node_deauthorized')
+        params = last_log.params
+        assert_in('node', params)
+        assert_in('project', params)
+
     def test_clear_auth(self):
         self.node_settings.external_account = ExternalAccountFactory()
         self.node_settings.mendeley_list_id = 'something'

--- a/website/addons/zotero/model.py
+++ b/website/addons/zotero/model.py
@@ -181,6 +181,22 @@ class ZoteroNodeSettings(AddonOAuthNodeSettingsBase):
         self.zotero_list_id = None
         return super(ZoteroNodeSettings, self).clear_auth()
 
+    def deauthorize(self, auth=None, add_log=True):
+        """Remove user authorization from this node and log the event."""
+        if add_log:
+            self.owner.add_log(
+                'zotero_node_deauthorized',
+                params={
+                    'project': self.owner.parent_id,
+                    'node': self.owner._id,
+                },
+                auth=auth,
+            )
+
+        self.clear_auth()
+
+        self.save()
+
     def set_target_folder(self, zotero_list_id, zotero_list_name, auth):
         """Configure this addon to point to a Zotero folder
 

--- a/website/addons/zotero/templates/log_templates.mako
+++ b/website/addons/zotero/templates/log_templates.mako
@@ -2,3 +2,9 @@
 linked Zotero folder /<span class="overflow">{{ params.folder_name }}</span> to 
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
 </script>
+
+<script type="text/html" id="zotero_node_deauthorized">
+deauthorized the Zotero addon for
+<a class="log-node-title-link overflow"
+    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+</script>

--- a/website/addons/zotero/tests/test_models.py
+++ b/website/addons/zotero/tests/test_models.py
@@ -139,6 +139,24 @@ class ZoteroNodeSettingsTestCase(OsfTestCase):
                 user=UserFactory()
             )
 
+    def test_deauthorize(self):
+        self.node_settings.external_account = ExternalAccountFactory()
+        self.node_settings.zotero_list_id = 'something'
+        self.node_settings.user_settings = self.user_settings
+        self.node_settings.save()
+
+        assert_true(self.node_settings.zotero_list_id)
+        self.node_settings.deauthorize(auth=Auth(self.user))
+        self.node_settings.save()
+        assert_is(self.node_settings.user_settings, None)
+        assert_is(self.node_settings.zotero_list_id, None)
+
+        last_log = self.node.logs[-1]
+        assert_equal(last_log.action, 'zotero_node_deauthorized')
+        params = last_log.params
+        assert_in('node', params)
+        assert_in('project', params)
+
     def test_clear_auth(self):
         self.node_settings.external_account = ExternalAccountFactory()
         self.node_settings.zotero_list_id = 'something'


### PR DESCRIPTION
Purpose
=======
Fixes bug introduced in #4518 
Citations style addons didn't implement `[Addon]NodeSettings.deauthorize()`

Changes
=======
* `.deauthorize`, deauth logging added to citations addons
* Add basic `.deauthorize` to `website.addons.base.AddonOAuthNodeSettings`
* Add `.deauthorize` tests for citations addons

Side Effects
=========
None

[#OSF-5030]