### PR TITLE
Feature/json pointers for describing object paths

### DIFF
--- a/api/base/views.py
+++ b/api/base/views.py
@@ -80,9 +80,10 @@ def root(request, format=None):
     all request bodies must be wrapped with some metadata.  Each request body must be an object with a `data` key
     containing at least a `type` member.  The value of the `type` member must agree with the `type` of the entities
     represented by the endpoint.  If not, a 409 Conflict will be returned.  The request should also contain an
-    `attributes` member with an object containing the key-value pairs to be created/updated.  PUT/PATCH requests must
-    also have an `id` key that matches the id part of the endpoint.  If the `id` key does not match the id path part, a
-    409 Conflict error will be returned.
+    `attributes` member with an object containing the key-value pairs to be created/updated. If creating a relationship
+    with another object, a `relationships` object with the `type` and `id` of the connecting object should be included.
+    PUT/PATCH requests must also have an `id` key that matches the id part of the endpoint.  If the `id` key does not match
+    the id path part, a 409 Conflict error will be returned.
 
     ####Example 1: Creating a Node via POST
 
@@ -172,7 +173,7 @@ def root(request, format=None):
             }
         }
 
-    If there are no related entities, `href` will be null.
+    If there are no related entities, `href` will be {}.
 
     + `links`
 

--- a/api/files/views.py
+++ b/api/files/views.py
@@ -78,11 +78,11 @@ class FileDetail(generics.RetrieveUpdateAPIView, FileMixin):
         size          integer    size of file in bytes
         extra         object     may contain additional data beyond what's describe here,
                                  depending on the provider
-          version     integer    version number of file. will be 1 on initial upload
-          downloads   integer    count of the number times the file has been downloaded
-          hashes      object
-            md5       string     md5 hash of file
-            sha256    string     SHA-256 hash of file
+        version     integer    version number of file. will be 1 on initial upload
+        downloads   integer    count of the number times the file has been downloaded
+        hashes      object
+        md5         string     md5 hash of file
+        sha256      string     SHA-256 hash of file
 
     ####Folder Entity
 
@@ -144,7 +144,7 @@ class FileDetail(generics.RetrieveUpdateAPIView, FileMixin):
     ###Get Info (*files, folders*)
 
         Method:   GET
-        URL:      links.info
+        URL:      /links/info
         Params:   <none>
         Success:  200 OK + file representation
 
@@ -154,7 +154,7 @@ class FileDetail(generics.RetrieveUpdateAPIView, FileMixin):
     ###Download (*files*)
 
         Method:   GET
-        URL:      links.download
+        URL:      /links/download
         Params:   <none>
         Success:  200 OK + file body
 
@@ -164,7 +164,7 @@ class FileDetail(generics.RetrieveUpdateAPIView, FileMixin):
     ###Create Subfolder (*folders*)
 
         Method:       PUT
-        URL:          links.new_folder
+        URL:          /links/new_folder
         Query Params: ?kind=folder&name={new_folder_name}
         Body:         <empty>
         Success:      201 Created + new folder representation
@@ -178,7 +178,7 @@ class FileDetail(generics.RetrieveUpdateAPIView, FileMixin):
     ###Upload New File (*folders*)
 
         Method:       PUT
-        URL:          links.upload
+        URL:          /links/upload
         Query Params: ?kind=file&name={new_file_name}
         Body (Raw):   <file data (not form-encoded)>
         Success:      201 Created or 200 OK + new file representation
@@ -192,7 +192,7 @@ class FileDetail(generics.RetrieveUpdateAPIView, FileMixin):
     ###Update Existing File (*file*)
 
         Method:       PUT
-        URL:          links.upload
+        URL:          /links/upload
         Query Params: ?kind=file
         Body (Raw):   <file data (not form-encoded)>
         Success:      200 OK + updated file representation
@@ -204,7 +204,7 @@ class FileDetail(generics.RetrieveUpdateAPIView, FileMixin):
     ###Rename (*files, folders*)
 
         Method:        POST
-        URL:           links.move
+        URL:           /links/move
         Query Params:  <none>
         Body (JSON):   {
                         "action": "rename",
@@ -219,7 +219,7 @@ class FileDetail(generics.RetrieveUpdateAPIView, FileMixin):
     ###Move & Copy (*files, folders*)
 
         Method:        POST
-        URL:           links.move
+        URL:           /links/move
         Query Params:  <none>
         Body (JSON):   {
                         // mandatory
@@ -253,7 +253,7 @@ class FileDetail(generics.RetrieveUpdateAPIView, FileMixin):
     ###Delete (*file, folders*)
 
         Method:        DELETE
-        URL:           links.delete
+        URL:           /links/delete
         Query Params:  <none>
         Success:       204 No Content
 

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -285,22 +285,40 @@ class NodeDetail(generics.RetrieveUpdateDestroyAPIView, NodeMixin):
 
     ###Children
 
-    List of nodes that are children of this node.  New child nodes may be added through this endpoint.
+    List of nodes that are children of this node.  New child nodes may be added through this endpoint,
+    `/children/links/related/href`.
 
     ###Contributors
 
     List of users who are contributors to this node.  Contributors may have "read", "write", or "admin" permissions.  A
-    node must always have at least one "admin" contributor.  Contributors may be added via this endpoint.
+    node must always have at least one "admin" contributor.  Contributors may be added via this endpoint,
+    `/contributors/links/related/href`.
 
     ###Files
 
-    List of top-level folders (actually cloud-storage providers) associated with this node. This is the starting point
-    for accessing the actual files stored within this node.
+    List of top-level folders (actually cloud-storage providers) associated with this node. `/files/links/related/href`
+    is the starting point for accessing the actual files stored within this node.
+
+    ###Forked From
+
+    If this node is a fork of another node, the original node will be available in
+    `/forked_from/links/related/href`. Otherwise, it will be null.
+
+    ###Node-Links
+
+    List of node links, or pointers from the current node to other nodes.  New links to other nodes can be added through
+    this endpoint, `/node_links/links/related/href`.
 
     ###Parent
 
-    If this node is a child node of another node, the parent's canonical endpoint will be available in the
-    `/parent/links/related/href` key.  Otherwise, it will be null.
+    If this node is a child node of another node, the parent's canonical endpoint will be available in
+    `/parent/links/related/href`.  Otherwise, it will be null.
+
+    ###Registrations
+
+    List of registrations of the current node. Registrations can be accessed through this endpoint,
+    `/registrations/links/related/href`.
+
 
     ##Links
 
@@ -415,7 +433,7 @@ class NodeContributorsList(generics.ListCreateAPIView, ListFilterMixin, NodeMixi
 
     ###Users
 
-    This endpoint shows the contributor user detail.
+    This endpoint, `/users/links/related/href` shows the contributor user detail.
     ##Actions
 
     ###Adding Contributors
@@ -530,7 +548,7 @@ class NodeContributorDetail(generics.RetrieveUpdateDestroyAPIView, NodeMixin, Us
 
     ###Users
 
-    This endpoint shows the contributor user detail.
+    This endpoint, `/users/links/related/href`, shows the contributor's user detail.
 
     ##Links
 
@@ -558,7 +576,7 @@ class NodeContributorDetail(generics.RetrieveUpdateDestroyAPIView, NodeMixin, Us
         Success:       200 OK + node representation
 
     To update a contributor's bibliographic preferences or access permissions for the node, issue a PUT request to the
-    `self` link. Since this endpoint has no mandatory attributes, PUT and PATCH are functionally the same.  If the given
+    `/links/self` link. Since this endpoint has no mandatory attributes, PUT and PATCH are functionally the same.  If the given
     user is not already in the contributor list, a 404 Not Found error will be returned.  A node must always have at
     least one admin, and any attempt to downgrade the permissions of a sole admin will result in a 400 Bad Request
     error.
@@ -570,7 +588,7 @@ class NodeContributorDetail(generics.RetrieveUpdateDestroyAPIView, NodeMixin, Us
         Query Params:  <none>
         Success:       204 No Content
 
-    To remove a contributor from a node, issue a DELETE request to the `self` link.  Attempting to remove the only admin
+    To remove a contributor from a node, issue a DELETE request to the `/links/self` link.  Attempting to remove the only admin
     from a node will result in a 400 Bad Request response.  This request will only remove the relationship between the
     node and the user, not the user itself.
 
@@ -649,14 +667,15 @@ class NodeRegistrationsList(generics.ListAPIView, NodeMixin):
 
 
     ##Relationships
+    ###Inherits all fields from Node Detail
 
     ###Registered from
 
-    The registration is branched from this node.
+    The registration is branched from this node. The source can be found at `/registered_from/links/related/href`.
 
     ###Registered by
 
-    The registration was initiated by this user.
+    The registration was initiated by this user, accessed at `/registered_by/links/related/href`.
 
     ##Links
 

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -683,7 +683,7 @@ class NodeRegistrationsList(generics.ListAPIView, NodeMixin):
     Registrations are read-only snapshots of a project. This view is a list of all the registrations of the current node.
 
     Each resource contains the full representation of the registration, meaning additional requests to an individual
-    registrations's detail view are not necessary.
+    registration's detail view are not necessary.
 
     ##Registration Attributes
 
@@ -706,8 +706,7 @@ class NodeRegistrationsList(generics.ListAPIView, NodeMixin):
         date_registered    iso8601 timestamp  timestamp that the registration was created
 
 
-    ##Relationships
-    ###Inherits all fields from Node Detail
+    ##Registration Relationships
 
     ###Registered from
 
@@ -717,6 +716,7 @@ class NodeRegistrationsList(generics.ListAPIView, NodeMixin):
 
     The registration was initiated by this user, accessed at `/registered_by/links/related/href`.
 
+    ### (+) all relationships from Node Detail
     ##Links
 
     See the [JSON-API spec regarding pagination](http://jsonapi.org/format/1.0/#fetching-pagination).
@@ -769,10 +769,49 @@ class NodeChildrenList(generics.ListCreateAPIView, NodeMixin, ODMFilterMixin):
         date_created   iso8601 timestamp  timestamp that the node was created
         date_modified  iso8601 timestamp  timestamp when the node was last updated
         tags           array of strings   list of tags that describe the node
+        fork           boolean            is this node a fork?
         registration   boolean            has this project been registered?
         collection     boolean            is this node a collection of other nodes?
         dashboard      boolean            is this node visible on the user dashboard?
         public         boolean            has this node been made publicly-visible?
+
+    ##Node Relationships
+
+    ###Children
+
+    List of nodes that are children of this node.  New child nodes may be added through this endpoint,
+    `/children/links/related/href`.
+
+    ###Contributors
+
+    List of users who are contributors to this node.  Contributors may have "read", "write", or "admin" permissions.  A
+    node must always have at least one "admin" contributor.  Contributors may be added via this endpoint,
+    `/contributors/links/related/href`.
+
+    ###Files
+
+    List of top-level folders (actually cloud-storage providers) associated with this node. `/files/links/related/href`
+    is the starting point for accessing the actual files stored within this node.
+
+    ###Forked From
+
+    If this node is a fork of another node, the original node will be available in
+    `/forked_from/links/related/href`. Otherwise, it will be null.
+
+    ###Node-Links
+
+    List of node links, or pointers from the current node to other nodes.  New links to other nodes can be added through
+    this endpoint, `/node_links/links/related/href`.
+
+    ###Parent
+
+    The parent's canonical endpoint will be available in `/parent/links/related/href`.
+
+    ###Registrations
+
+    List of registrations of the current node. Registrations can be accessed through this endpoint,
+    `/registrations/links/related/href`.
+
 
     ##Links
 
@@ -802,7 +841,7 @@ class NodeChildrenList(generics.ListCreateAPIView, NodeMixin, ODMFilterMixin):
 
     To create a child node of the current node, issue a POST request to this endpoint.  The `title` and `category`
     fields are mandatory. `category` must be one of the [permitted node categories](/v2/#osf-node-categories).  If the
-    node creation is successful the API will return a 201 response with the respresentation of the new node in the body.
+    node creation is successful the API will return a 201 response with the representation of the new node in the body.
     For the new node's canonical URL, see the `/links/self` field of the response.
 
     ##Query Params
@@ -813,10 +852,10 @@ class NodeChildrenList(generics.ListCreateAPIView, NodeMixin, ODMFilterMixin):
 
     <!--- Copied Query Params from NodeList -->
 
-    Nodes may be filtered by their `title`, `category`, `description`, `public`, `registration`, or `tags`.  `title`,
-    `description`, and `category` are string fields and will be filtered using simple substring matching.  `public` and
-    `registration` are booleans, and can be filtered using truthy values, such as `true`, `false`, `0`, or `1`.  Note
-    that quoting `true` or `false` in the query will cause the match to fail regardless.  `tags` is an array of simple strings.
+    Nodes may be filtered by their `title`, `category`, `description`, `public`, or `tags`.  `title`, `description`, and
+    `category` are string fields and will be filtered using simple substring matching.  `public` is a boolean,
+    and can be filtered using truthy values, such as `true`, `false`, `0`, or `1`.  Note that quoting `true`
+    or `false` in the query will cause the match to fail regardless.  `tags` is an array of simple strings.
 
     #This Request/Response
 

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -300,7 +300,7 @@ class NodeDetail(generics.RetrieveUpdateDestroyAPIView, NodeMixin):
     ###Parent
 
     If this node is a child node of another node, the parent's canonical endpoint will be available in the
-    `/parent/links/self/href` key.  Otherwise, it will be null.
+    `/parent/links/related/href` key.  Otherwise, it will be null.
 
     ##Links
 

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1101,11 +1101,11 @@ class NodeFilesList(generics.ListAPIView, WaterButlerMixin, ListFilterMixin, Nod
         size          integer    size of file in bytes
         extra         object     may contain additional data beyond what's describe here,
                                  depending on the provider
-          version     integer    version number of file. will be 1 on initial upload
-          downloads   integer    count of the number times the file has been downloaded
-          hashes      object
-            md5       string     md5 hash of file
-            sha256    string     SHA-256 hash of file
+        version     integer    version number of file. will be 1 on initial upload
+        downloads   integer    count of the number times the file has been downloaded
+        hashes      object
+        md5         string     md5 hash of file
+        sha256      string     SHA-256 hash of file
 
     ####Folder Entity
 
@@ -1389,11 +1389,11 @@ class NodeProvidersList(generics.ListAPIView, NodeMixin):
         size          integer    size of file in bytes
         extra         object     may contain additional data beyond what's describe here,
                                  depending on the provider
-          version     integer    version number of file. will be 1 on initial upload
-          downloads   integer    count of the number times the file has been downloaded
-          hashes      object
-            md5       string     md5 hash of file
-            sha256    string     SHA-256 hash of file
+        version       integer    version number of file. will be 1 on initial upload
+        downloads     integer    count of the number times the file has been downloaded
+        hashes        object
+        md5           string     md5 hash of file
+        sha256        string     SHA-256 hash of file
 
     ####Folder Entity
 
@@ -1419,6 +1419,11 @@ class NodeProvidersList(generics.ListAPIView, NodeMixin):
         path      path    relative path of this folder within the provider filesys. always "/"
         node      string  node this provider belongs to
         provider  string  provider id, same as "name"
+
+    ##Provider Relationships
+
+    ### Files
+    This endpoint `/relationships/files/links/related/href` is a list of all files from the provider.
 
     ##Links
 

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -469,7 +469,7 @@ class NodeContributorsList(generics.ListCreateAPIView, ListFilterMixin, NodeMixi
 
     ###Users
 
-    This endpoint, `/users/links/related/href` shows the contributor user detail.
+    This endpoint, `/users/links/related/href`, shows the contributor user detail.
 
     ##Links
 
@@ -515,7 +515,7 @@ class NodeContributorsList(generics.ListCreateAPIView, ListFilterMixin, NodeMixi
 
     + `filter[<fieldname>]=<Str>` -- fields and values to filter the search results on.
 
-    NodeContributors may be filtered by `bibliographic`, or `permission` attributes.  `bibliographic` is a boolean, and
+    NodeContributors may be filtered by `bibliographic` or `permission` attributes.  `bibliographic` is a boolean, and
     can be filtered using truthy values, such as `true`, `false`, `0`, or `1`.  Note that quoting `true` or `false` in
     the query will cause the match to fail regardless.
 

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -917,15 +917,15 @@ class NodeLinksList(generics.ListCreateAPIView, NodeMixin):
 
         None
 
-    ##Links
-
-    See the [JSON-API spec regarding pagination](http://jsonapi.org/format/1.0/#fetching-pagination).
-
-    ##Relationships
+    ##Node Link Relationships
 
     ### Target Node
 
-    This endpoint shows the target node detail.
+    This endpoint, `/target_node/links/related/href`, shows the target node detail.
+
+    ##Links
+
+    See the [JSON-API spec regarding pagination](http://jsonapi.org/format/1.0/#fetching-pagination).
 
     ##Actions
 
@@ -1000,17 +1000,15 @@ class NodeLinksDetail(generics.RetrieveDestroyAPIView, NodeMixin):
 
         None
 
+    ##Relationships
+
+    ### Target Node
+
+    This endpoint, `/target_node/links/related/href`, shows the target node detail.
+
     ##Links
 
         self:  the detail url for this node link
-        html:  this node's page on the OSF website
-        profile_image: this contributor's gravatar
-
-    ##Relationships
-
-    ###Target node
-
-    This endpoint shows the target node detail.
 
     ##Actions
 

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -129,7 +129,7 @@ class WaterButlerMixin(object):
 class NodeList(generics.ListCreateAPIView, ODMFilterMixin):
     """Nodes that represent projects and components. *Writeable*.
 
-    Paginated list of nodes ordered by their `date_modified`.  Each resource contains the full representation of the
+    Paginated list of nodes are ordered by their `date_modified`.  Each resource contains the full representation of the
     node, meaning additional requests to an individual node's detail view are not necessary.
 
     <!--- Copied Spiel from NodeDetail -->
@@ -155,11 +155,50 @@ class NodeList(generics.ListCreateAPIView, ODMFilterMixin):
         date_created   iso8601 timestamp  timestamp that the node was created
         date_modified  iso8601 timestamp  timestamp when the node was last updated
         tags           array of strings   list of tags that describe the node
-        registration   boolean            is this is a registration?
+        registration   boolean            has this project been registered?
+        fork           boolean            is this node a fork?
         collection     boolean            is this node a collection of other nodes?
         dashboard      boolean            is this node visible on the user dashboard?
         public         boolean            has this node been made publicly-visible?
 
+    ##Node Relationships
+
+    ###Children
+
+    List of nodes that are children of this node.  New child nodes may be added through this endpoint,
+    `/children/links/related/href`.
+
+    ###Contributors
+
+    List of users who are contributors to this node.  Contributors may have "read", "write", or "admin" permissions.  A
+    node must always have at least one "admin" contributor.  Contributors may be added via this endpoint,
+    `/contributors/links/related/href`.
+
+    ###Files
+
+    List of top-level folders (actually cloud-storage providers) associated with this node. `/files/links/related/href`
+    is the starting point for accessing the actual files stored within this node.
+
+    ###Forked From
+
+    If this node is a fork of another node, the original node will be available in
+    `/forked_from/links/related/href`. Otherwise, it will be null.
+
+    ###Node-Links
+
+    List of node links, or pointers from the current node to other nodes.  New links to other nodes can be added through
+    this endpoint, `/node_links/links/related/href`.
+
+    ###Parent
+
+    If this node is a child node of another node, the parent's canonical endpoint will be available in
+    `/parent/links/related/href`.  Otherwise, it will be null.
+
+    ###Registrations
+
+    List of registrations of the current node. Registrations can be accessed through this endpoint,
+    `/registrations/links/related/href`.
+    
     ##Links
 
     See the [JSON-API spec regarding pagination](http://jsonapi.org/format/1.0/#fetching-pagination).
@@ -197,10 +236,10 @@ class NodeList(generics.ListCreateAPIView, ODMFilterMixin):
 
     + `filter[<fieldname>]=<Str>` -- fields and values to filter the search results on.
 
-    Nodes may be filtered by their `title`, `category`, `description`, `public`, `registration`, or `tags`.  `title`,
-    `description`, and `category` are string fields and will be filtered using simple substring matching.  `public` and
-    `registration` are booleans, and can be filtered using truthy values, such as `true`, `false`, `0`, or `1`.  Note
-    that quoting `true` or `false` in the query will cause the match to fail regardless.  `tags` is an array of simple strings.
+    Nodes may be filtered by their `title`, `category`, `description`, `public` or `tags`.  `title`,
+    `description`, and `category` are string fields and will be filtered using simple substring matching.  `public` is
+    a boolean, and can be filtered using truthy values, such as `true`, `false`, `0`, or `1`.  Note that quoting `true`
+    or `false` in the query will cause the match to fail regardless.  `tags` is an array of simple strings.
 
     #This Request/Response
 
@@ -277,6 +316,7 @@ class NodeDetail(generics.RetrieveUpdateDestroyAPIView, NodeMixin):
         date_modified  iso8601 timestamp  timestamp when the node was last updated
         tags           array of strings   list of tags that describe the node
         registration   boolean            has this project been registered?
+        fork           boolean            is this node a fork?
         collection     boolean            is this node a collection of other nodes?
         dashboard      boolean            is this node visible on the user dashboard?
         public         boolean            has this node been made publicly-visible?

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -169,7 +169,7 @@ class NodeList(generics.ListCreateAPIView, ODMFilterMixin):
     ###Creating New Nodes
 
         Method:        POST
-        URL:           links.self
+        URL:           /links/self
         Query Params:  <none>
         Body (JSON):   {
                          "data": {
@@ -189,7 +189,7 @@ class NodeList(generics.ListCreateAPIView, ODMFilterMixin):
     mandatory. `category` must be one of the [permitted node categories](/v2/#osf-node-categories).  `public` defaults
     to false.  All other fields not listed above will be ignored.  If the node creation is successful the API will
     return a 201 response with the representation of the new node in the body.  For the new node's canonical URL, see
-    the `links.self` field of the response.
+    the `/links/self` field of the response.
 
     ##Query Params
 
@@ -300,7 +300,7 @@ class NodeDetail(generics.RetrieveUpdateDestroyAPIView, NodeMixin):
     ###Parent
 
     If this node is a child node of another node, the parent's canonical endpoint will be available in the
-    `parent.links.self.href` key.  Otherwise, it will be null.
+    `/parent/links/self/href` key.  Otherwise, it will be null.
 
     ##Links
 
@@ -312,7 +312,7 @@ class NodeDetail(generics.RetrieveUpdateDestroyAPIView, NodeMixin):
     ###Update
 
         Method:        PUT / PATCH
-        URL:           links.self
+        URL:           /links/self
         Query Params:  <none>
         Body (JSON):   {
                          "data": {
@@ -329,7 +329,7 @@ class NodeDetail(generics.RetrieveUpdateDestroyAPIView, NodeMixin):
                        }
         Success:       200 OK + node representation
 
-    To update a node, issue either a PUT or a PATCH request against the `links.self` URL.  The `title` and `category`
+    To update a node, issue either a PUT or a PATCH request against the `/links/self` URL.  The `title` and `category`
     fields are mandatory if you PUT and optional if you PATCH.  The `tags` parameter must be an array of strings.
     Non-string values will be accepted and stringified, but we make no promises about the stringification output.  So
     don't do that.
@@ -337,11 +337,11 @@ class NodeDetail(generics.RetrieveUpdateDestroyAPIView, NodeMixin):
     ###Delete
 
         Method:   DELETE
-        URL:      links.self
+        URL:      /links/self
         Params:   <none>
         Success:  204 No Content
 
-    To delete a node, issue a DELETE request against `links.self`.  A successful delete will return a 204 No Content
+    To delete a node, issue a DELETE request against `/links/self`.  A successful delete will return a 204 No Content
     response. Attempting to delete a node you do not own will result in a 403 Forbidden.
 
     ##Query Params
@@ -421,7 +421,7 @@ class NodeContributorsList(generics.ListCreateAPIView, ListFilterMixin, NodeMixi
     ###Adding Contributors
 
         Method:        POST
-        URL:           links.self
+        URL:           /links/self
         Query Params:  <none>
         Body (JSON): {
                       "data": {
@@ -449,7 +449,7 @@ class NodeContributorsList(generics.ListCreateAPIView, ListFilterMixin, NodeMixi
     with a "data" member, containing the user `type` and user `id` must be included.  The id must be a valid user id.
     All other fields not listed above will be ignored.  If the request is successful the API will return
     a 201 response with the representation of the new node contributor in the body.  For the new node contributor's
-    canonical URL, see the `links.self` field of the response.
+    canonical URL, see the `/links/self` field of the response.
 
     ##Query Params
 
@@ -543,7 +543,7 @@ class NodeContributorDetail(generics.RetrieveUpdateDestroyAPIView, NodeMixin, Us
     ###Update Contributor
 
         Method:        PUT / PATCH
-        URL:           links.self
+        URL:           /links/self
         Query Params:  <none>
         Body (JSON):   {
                          "data": {
@@ -566,7 +566,7 @@ class NodeContributorDetail(generics.RetrieveUpdateDestroyAPIView, NodeMixin, Us
     ###Remove Contributor
 
         Method:        DELETE
-        URL:           links.self
+        URL:           /links/self
         Query Params:  <none>
         Success:       204 No Content
 
@@ -726,7 +726,7 @@ class NodeChildrenList(generics.ListCreateAPIView, NodeMixin, ODMFilterMixin):
     <!--- Copied Creating New Node from NodeList -->
 
         Method:        POST
-        URL:           links.self
+        URL:           /links/self
         Query Params:  <none>
         Body (JSON):   {
                          "data": {
@@ -744,7 +744,7 @@ class NodeChildrenList(generics.ListCreateAPIView, NodeMixin, ODMFilterMixin):
     To create a child node of the current node, issue a POST request to this endpoint.  The `title` and `category`
     fields are mandatory. `category` must be one of the [permitted node categories](/v2/#osf-node-categories).  If the
     node creation is successful the API will return a 201 response with the respresentation of the new node in the body.
-    For the new node's canonical URL, see the `links.self` field of the response.
+    For the new node's canonical URL, see the `/links/self` field of the response.
 
     ##Query Params
 
@@ -833,7 +833,7 @@ class NodeLinksList(generics.ListCreateAPIView, NodeMixin):
 
     ###Adding Node Links
         Method:        POST
-        URL:           links.self
+        URL:           /links/self
         Query Params:  <none>
         Body (JSON): {
                        "data": {
@@ -919,7 +919,7 @@ class NodeLinksDetail(generics.RetrieveDestroyAPIView, NodeMixin):
     ###Remove Node Link
 
         Method:        DELETE
-        URL:           links.self
+        URL:           /links/self
         Query Params:  <none>
         Success:       204 No Content
 
@@ -975,7 +975,7 @@ class NodeFilesList(generics.ListAPIView, WaterButlerMixin, ListFilterMixin, Nod
     This gives a list of all of the files and folders that are attached to your project for the given storage provider.
     If the provider is not "osfstorage", the metadata for the files in the storage will be retrieved and cached whenever
     this endpoint is accessed.  To see the cached metadata, GET the endpoint for the file directly (available through
-    its `links.info` attribute).
+    its `/links/info` attribute).
 
     When a create/update/delete action is performed against the file or folder, the action is handled by an external
     service called WaterButler.  The WaterButler response format differs slightly from the OSF's.
@@ -1059,7 +1059,7 @@ class NodeFilesList(generics.ListAPIView, WaterButlerMixin, ListFilterMixin, Nod
     ###Get Info (*files, folders*)
 
         Method:   GET
-        URL:      links.info
+        URL:      /links/info
         Params:   <none>
         Success:  200 OK + file representation
 
@@ -1069,7 +1069,7 @@ class NodeFilesList(generics.ListAPIView, WaterButlerMixin, ListFilterMixin, Nod
     ###Download (*files*)
 
         Method:   GET
-        URL:      links.download
+        URL:      /links/download
         Params:   <none>
         Success:  200 OK + file body
 
@@ -1079,7 +1079,7 @@ class NodeFilesList(generics.ListAPIView, WaterButlerMixin, ListFilterMixin, Nod
     ###Create Subfolder (*folders*)
 
         Method:       PUT
-        URL:          links.new_folder
+        URL:          /links/new_folder
         Query Params: ?kind=folder&name={new_folder_name}
         Body:         <empty>
         Success:      201 Created + new folder representation
@@ -1093,7 +1093,7 @@ class NodeFilesList(generics.ListAPIView, WaterButlerMixin, ListFilterMixin, Nod
     ###Upload New File (*folders*)
 
         Method:       PUT
-        URL:          links.upload
+        URL:          /links/upload
         Query Params: ?kind=file&name={new_file_name}
         Body (Raw):   <file data (not form-encoded)>
         Success:      201 Created or 200 OK + new file representation
@@ -1107,7 +1107,7 @@ class NodeFilesList(generics.ListAPIView, WaterButlerMixin, ListFilterMixin, Nod
     ###Update Existing File (*file*)
 
         Method:       PUT
-        URL:          links.upload
+        URL:          /links/upload
         Query Params: ?kind=file
         Body (Raw):   <file data (not form-encoded)>
         Success:      200 OK + updated file representation
@@ -1119,7 +1119,7 @@ class NodeFilesList(generics.ListAPIView, WaterButlerMixin, ListFilterMixin, Nod
     ###Rename (*files, folders*)
 
         Method:        POST
-        URL:           links.move
+        URL:           /links/move
         Query Params:  <none>
         Body (JSON):   {
                         "action": "rename",
@@ -1134,7 +1134,7 @@ class NodeFilesList(generics.ListAPIView, WaterButlerMixin, ListFilterMixin, Nod
     ###Move & Copy (*files, folders*)
 
         Method:        POST
-        URL:           links.move
+        URL:           /links/move
         Query Params:  <none>
         Body (JSON):   {
                         // mandatory
@@ -1168,7 +1168,7 @@ class NodeFilesList(generics.ListAPIView, WaterButlerMixin, ListFilterMixin, Nod
     ###Delete (*file, folders*)
 
         Method:        DELETE
-        URL:           links.delete
+        URL:           /links/delete
         Query Params:  <none>
         Success:       204 No Content
 
@@ -1264,7 +1264,7 @@ class NodeProvidersList(generics.ListAPIView, NodeMixin):
 
     In the OSF filesystem model, providers are treated as folders, but with special properties that distinguish them
     from regular folders.  Every provider folder is considered a root folder, and may not be deleted through the regular
-    file API.  To see the contents of the provider, issue a GET request to the `relationships.files.links.related.href`
+    file API.  To see the contents of the provider, issue a GET request to the `/relationships/files/links/related/href`
     attribute of the provider resource.  The `new_folder` and `upload` actions are handled by another service called
     WaterButler, whose response format differs slightly from the OSF's.
 
@@ -1335,7 +1335,7 @@ class NodeProvidersList(generics.ListAPIView, NodeMixin):
     ###Create Subfolder (*folders*)
 
         Method:       PUT
-        URL:          links.new_folder
+        URL:          /link/new_folder
         Query Params: ?kind=folder&name={new_folder_name}
         Body:         <empty>
         Success:      201 Created + new folder representation
@@ -1349,7 +1349,7 @@ class NodeProvidersList(generics.ListAPIView, NodeMixin):
     ###Upload New File (*folders*)
 
         Method:       PUT
-        URL:          links.upload
+        URL:          /links/upload
         Query Params: ?kind=file&name={new_file_name}
         Body (Raw):   <file data (not form-encoded)>
         Success:      201 Created or 200 OK + new file representation

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -198,7 +198,7 @@ class NodeList(generics.ListCreateAPIView, ODMFilterMixin):
 
     List of registrations of the current node. Registrations can be accessed through this endpoint,
     `/registrations/links/related/href`.
-    
+
     ##Links
 
     See the [JSON-API spec regarding pagination](http://jsonapi.org/format/1.0/#fetching-pagination).
@@ -465,17 +465,17 @@ class NodeContributorsList(generics.ListCreateAPIView, ListFilterMixin, NodeMixi
         bibliographic  boolean  Whether the user will be included in citations for this node. Default is true.
         permission     string   User permission level. Must be "read", "write", or "admin". Default is "write".
 
-    ##Links
-
-    See the [JSON-API spec regarding pagination](http://jsonapi.org/format/1.0/#fetching-pagination).
-
-    ##Relationships
+    ##Node Contributor Relationships
 
     ###Users
 
     This endpoint, `/users/links/related/href` shows the contributor user detail.
-    ##Actions
 
+    ##Links
+
+    See the [JSON-API spec regarding pagination](http://jsonapi.org/format/1.0/#fetching-pagination).
+
+    ##Actions
     ###Adding Contributors
 
         Method:        POST

--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -59,11 +59,13 @@ class RegistrationList(generics.ListAPIView, ODMFilterMixin):
 
     ###Registered from
 
-    The registration is branched from this node.
+    The registration is branched from this node. The source can be found at `/registered_from/links/related/href`.
 
     ###Registered by
 
-    The registration was initiated by this user.
+    The registration was initiated by this user, accessed at `/registered_by/links/related/href`.
+
+    ### (+) all relationships from Node Detail
 
     ##Links
 
@@ -134,11 +136,13 @@ class RegistrationDetail(generics.RetrieveAPIView, RegistrationMixin):
 
     ###Registered from
 
-    The registration is branched from this node.
+    The registration is branched from this node. The source can be found at `/registered_from/links/related/href`.
 
     ###Registered by
 
-    The registration was initiated by this user.
+    The registration was initiated by this user, accessed at `/registered_by/links/related/href`.
+
+    ### (+) all relationships from Node Detail
 
     ##Links
 

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -67,6 +67,11 @@ class UserList(generics.ListAPIView, ODMFilterMixin):
         suffix             string             suffix of user's name for bibliographic citations
         date_registered    iso8601 timestamp  timestamp when the user's account was created
 
+    ##User Relationships
+
+    ###Nodes
+    A list of all nodes the user has contributed to. The Node List can be retrieved at `/nodes/links/related/href`.
+
     ##Links
 
     See the [JSON-API spec regarding pagination](http://jsonapi.org/format/1.0/#fetching-pagination).
@@ -137,8 +142,9 @@ class UserDetail(generics.RetrieveUpdateAPIView, UserMixin):
 
     ###Nodes
 
-    A list of all nodes the user has contributed to.  If the user id in the path is the same as the logged-in user, all
-    nodes will be visible.  Otherwise, you will only be able to see the other user's publicly-visible nodes.
+    A list of all nodes the user has contributed to, `/nodes/links/related/href`.  If the user id in the path is the
+    same as the logged-in user, all nodes will be visible.  Otherwise, you will only be able to see the other user's
+    publicly-visible nodes.
 
     ##Links
 
@@ -150,7 +156,7 @@ class UserDetail(generics.RetrieveUpdateAPIView, UserMixin):
     ###Update
 
         Method:        PUT / PATCH
-        URL:           links.self
+        URL:           /links/self
         Query Params:  <none>
         Body (JSON):   {
                          "data": {
@@ -168,7 +174,7 @@ class UserDetail(generics.RetrieveUpdateAPIView, UserMixin):
         Success:       200 OK + node representation
 
     To update your user profile, issue a PUT request to either the canonical URL of your user resource (as given in
-    `links.self`) or to `/users/me/`.  Only the `full_name` attribute is required.  Unlike at signup, the given, middle,
+    `/links/self`) or to `/users/me/`.  Only the `full_name` attribute is required.  Unlike at signup, the given, middle,
     and family names will not be inferred from the `full_name`.  Currently, only `full_name`, `given_name`,
     `middle_names`, `family_name`, and `suffix` are updateable.
 


### PR DESCRIPTION
# Purpose
Issue https://openscience.atlassian.net/browse/OSF-4654

Small API docs fix: Use JSON pointers to describe object paths https://tools.ietf.org/html/rfc6901
# Changes

Replaces object paths with JSONPointer.

Example:  links.self --> `/links/self`
Example:   parent.links.related.href --> `/parent/links/related/href`

Also, added more JSONPointers and some fixed inconsistencies, typos, and grammar issues in docs.


