### PR TITLE
[Ready to Review] Do not send merged users mailchimp unsubscribe email

### DIFF
--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -1192,7 +1192,7 @@ class User(GuidStoredObject, AddonModelMixin):
             signals.user_merged.send(self, list_name=key, subscription=subscription)
 
             # clear subscriptions for merged user
-            signals.user_merged.send(user, list_name=key, subscription=False)
+            signals.user_merged.send(user, list_name=key, subscription=False, send_goodbye=False)
 
         for node_id, timestamp in user.comments_viewed_timestamp.iteritems():
             if not self.comments_viewed_timestamp.get(node_id):

--- a/tests/test_mailchimp.py
+++ b/tests/test_mailchimp.py
@@ -78,29 +78,5 @@ class TestMailChimpHelpers(OsfTestCase):
         list_id = mailchimp_utils.get_list_id_from_name(list_name)
         mailchimp_utils.unsubscribe_mailchimp(list_name, user._id)
         handlers.celery_teardown_request()
-        mock_client.lists.unsubscribe.assert_called_with(id=list_id, email={'email': user.username})
+        mock_client.lists.unsubscribe.assert_called_with(id=list_id, email={'email': user.username}, send_goodbye=True)
 
-    @mock.patch('website.mailchimp_utils.get_mailchimp_api')
-    def test_unsubscribe_email_not_sent_to_merged_user(self, mock_get_mailchimp_api):
-        list_name = 'foo'
-        user = UserFactory()
-        user.mailchimp_mailing_lists['foo'] = True
-        user.save()
-
-        merge_user = UserFactory()
-        merge_user_email = merge_user.username
-        merge_user.mailchimp_mailing_lists['foo'] = True
-        merge_user.save()
-
-        mock_client = mock.MagicMock()
-        mock_get_mailchimp_api.return_value = mock_client
-        mock_client.lists.list.return_value = {'data': [{'id': 1, 'list_name': list_name}]}
-        list_id = mailchimp_utils.get_list_id_from_name(list_name)
-
-        user.merge_user(merge_user)
-        handlers.celery_teardown_request()
-        mock_client.lists.unsubscribe.assert_called_with(
-            id=list_id,
-            email={'email': merge_user_email},
-            send_goodbye=False,
-        )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -961,7 +961,7 @@ class TestMergingUsers(OsfTestCase):
         list_id = mailchimp_utils.get_list_id_from_name(list_name)
         self._merge_dupe()
         handlers.celery_teardown_request()
-        mock_client.lists.unsubscribe.assert_called_with(id=list_id, email={'email': username})
+        mock_client.lists.unsubscribe.assert_called_with(id=list_id, email={'email': username}, send_goodbye=False)
         assert_false(self.dupe.mailchimp_mailing_lists[list_name])
 
     def test_inherits_projects_contributed_by_dupe(self):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1495,7 +1495,8 @@ class TestUserProfile(OsfTestCase):
 
         mock_client.lists.unsubscribe.assert_called_with(
             id=list_id,
-            email={'email': self.user.username}
+            email={'email': self.user.username},
+            send_goodbye=True
         )
         mock_client.lists.subscribe.assert_called_with(
             id=list_id,

--- a/website/mailchimp_utils.py
+++ b/website/mailchimp_utils.py
@@ -67,7 +67,7 @@ def subscribe_mailchimp(list_name, user_id):
 @queued_task
 @app.task
 @transaction()
-def unsubscribe_mailchimp(list_name, user_id, username=None):
+def unsubscribe_mailchimp(list_name, user_id, username=None, send_goodbye=True):
     """Unsubscribe a user from a mailchimp mailing list given its name.
 
     :param str list_name: mailchimp mailing list name
@@ -79,7 +79,7 @@ def unsubscribe_mailchimp(list_name, user_id, username=None):
     user = User.load(user_id)
     m = get_mailchimp_api()
     list_id = get_list_id_from_name(list_name=list_name)
-    m.lists.unsubscribe(id=list_id, email={'email': username or user.username})
+    m.lists.unsubscribe(id=list_id, email={'email': username or user.username}, send_goodbye=send_goodbye)
 
     # Update mailing_list user field
     if user.mailchimp_mailing_lists is None:

--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -461,7 +461,7 @@ def user_choose_mailing_lists(auth, **kwargs):
 
 
 @user_merged.connect
-def update_mailchimp_subscription(user, list_name, subscription):
+def update_mailchimp_subscription(user, list_name, subscription, send_goodbye=True):
     """ Update mailing list subscription in mailchimp.
 
     :param obj user: current user
@@ -472,7 +472,7 @@ def update_mailchimp_subscription(user, list_name, subscription):
         mailchimp_utils.subscribe_mailchimp(list_name, user._id)
     else:
         try:
-            mailchimp_utils.unsubscribe_mailchimp(list_name, user._id, username=user.username)
+            mailchimp_utils.unsubscribe_mailchimp(list_name, user._id, username=user.username, send_goodbye=send_goodbye)
         except mailchimp_utils.mailchimp.ListNotSubscribedError:
             raise HTTPError(http.BAD_REQUEST,
                 data=dict(message_short="ListNotSubscribedError",


### PR DESCRIPTION
Purpose
-----------
Fixes JIRA ticket [OSF-5031]

If User A merges with User B (who is subscribed to the OSF general mailing list), User A is subscribed if they are not already and User B is unsubscribed. However, User B receives the mailchimp unsubscribe email. 

Changes
------------
Set `send_goodbye` to `False` when unsubscribing due to merging user accounts to prevent the merged user from receiving an email.