### PR TITLE
Changes made in Search Mako

### DIFF
--- a/website/templates/search.mako
+++ b/website/templates/search.mako
@@ -27,7 +27,6 @@
                                                 <a data-bind="click: $parent.filter.bind($data)">{{ display }}<span class="badge pull-right">{{count}}</span></a>
                                             </li>
                                         <!-- /ko -->
-
                                 </ul>
                             </div>
                         </div>
@@ -91,11 +90,8 @@
                             <li data-bind="css: {disabled: !nextPageExists()}">
                                 <a href="#" data-bind="click: pageNext"> Next Page</a>
                             </li>
-
                         </ul>
                         <!-- /ko -->
-
-
                         <div class="buffer"></div>
                     </div><!--col-->
                 </div><!--row-->


### PR DESCRIPTION
Made change to prevent lengthy tags from extending in Firefox browser
Tags now get hyphenated and displayed within the Div width

[#OSF-4505]