### PR TITLE
[Enhancement][OSF Meeting] Enable Search on OSF Meeting  Front Page 

### DIFF
--- a/website/static/js/meetings.js
+++ b/website/static/js/meetings.js
@@ -39,16 +39,19 @@ function Meetings(data) {
                 {
                     data : 'name',  // Data field name
                     sortInclude : true,
+                    filter : true,
                     custom : function() { return m('a', { href : item.data.url, target : '_blank' }, item.data.name ); }
 
                 },
                 {
                     data: 'count',
-                    sortInclude: true
+                    sortInclude: true,
+                    filter : false
                 },
                 {
                     data: 'active', // Data field name
                     sortInclude: true,
+                    filter : false,
                     custom: function() { return item.data.active ? 'Yes' : 'No'; }
                 }
             ];
@@ -58,7 +61,7 @@ function Meetings(data) {
             down : 'i.fa.fa-chevron-down'
         },
         hScroll: 'auto',
-        showFilter : false,     // Gives the option to filter by showing the filter box.
+        showFilter : true,     // Gives the option to filter by showing the filter box.
         allowMove : false,       // Turn moving on or off.
         hoverClass : 'fangorn-hover',
     };

--- a/website/static/js/submissions.js
+++ b/website/static/js/submissions.js
@@ -52,6 +52,7 @@ function Submissions(data) {
                 {
                     data : 'title',  // Data field name
                     sortInclude : true,
+                    filter : true,
                     custom : function() {
                         return m('a', { href : item.data.nodeUrl, target : '_blank' }, item.data.title ); }
 
@@ -59,12 +60,14 @@ function Submissions(data) {
                 {
                     data: 'author',  // Data field name
                     sortInclude: true,
+                    filter : true,
                     custom: function() { return m('a', {href: item.data.authorUrl}, item.data.author); }
                 },
 
                 {
                     data: 'dateCreated', // Data field name
                     sortInclude: true,
+                    filter : false,
                     custom: function() {
                         var dateCreated = new osfHelpers.FormattableDate(item.data.dateCreated);
                         return m('', dateCreated.local);
@@ -89,6 +92,7 @@ function Submissions(data) {
                 {
                     data: 'confName',
                     sortInclude: true,
+                    filter : true,
                     custom: function() { return m('a', {href: item.data.confUrl}, item.data.confName); }
                 }
             ];
@@ -98,7 +102,7 @@ function Submissions(data) {
             down : 'i.fa.fa-chevron-down'
         },
         hScroll: 'auto',
-        showFilter : false,     // Gives the option to filter by showing the filter box.
+        showFilter : true,     // Gives the option to filter by showing the filter box.
         allowMove : false,       // Turn moving on or off.
         hoverClass : 'fangorn-hover',
     };


### PR DESCRIPTION
## Purpose 
Enable search in OSF meeting front page

Resolve [OSF-4994]

## Changes
It is a simple change since treebeard has already implemented search. The thing we need to do is to config it. 
1) Set show filter as true
2) Select column that need to be searched

### Before Change:
![beforechange](https://cloud.githubusercontent.com/assets/5420789/10913900/f6ec30ba-821d-11e5-838a-338429a58f96.gif)

### After Change:
![afterchange](https://cloud.githubusercontent.com/assets/5420789/10913907/fecf3124-821d-11e5-9a45-dd062d23137a.gif)

## Side Effect
None