### PR TITLE
Make private parents not show name

### DIFF
--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -496,7 +496,7 @@ def create_index(index=None):
     all of which are applied to all projects, components, and registrations.
     '''
     index = index or INDEX
-    document_types = ['project', 'component', 'registration', 'user', 'files']
+    document_types = ['project', 'component', 'registration', 'user', 'file']
     project_like_types = ['project', 'component', 'registration']
     analyzed_fields = ['title', 'description']
 

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -444,7 +444,7 @@ def update_file(file_, index=None, delete=False):
         )
         return
 
-    file_deep_url = '/{node_id}/files/{provider}/{path}/'.format(
+    file_deep_url = '/{node_id}/files/{provider}{path}/'.format(
         node_id=file_.node._id,
         provider=file_.provider,
         path=file_.path,
@@ -452,6 +452,9 @@ def update_file(file_, index=None, delete=False):
     node_url = '/{node_id}/'.format(node_id=file_.node._id)
 
     parent_url = '/{}/'.format(file_.node.parent_node._id) if file_.node.parent_node else None,
+    if parent_url:
+        parent_url = parent_url if file_.node.parent_node.is_public else '-- private project --'
+
     file_doc = {
         'id': file_._id,
         'deep_url': file_deep_url,

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -454,8 +454,9 @@ def update_file(file_, index=None, delete=False):
     node_url = '/{node_id}/'.format(node_id=file_.node._id)
 
     parent_url = '/{}/'.format(file_.node.parent_node._id) if file_.node.parent_node else None,
-    if parent_url:
-        parent_url = parent_url if file_.node.parent_node.is_public else '-- private project --'
+    parent_title = file_.node.parent_node.title if file_.node.parent_node else None,
+    if parent_title:
+        parent_title = parent_title if file_.node.parent_node.is_public else '-- private project --'
 
     file_doc = {
         'id': file_._id,
@@ -466,7 +467,7 @@ def update_file(file_, index=None, delete=False):
         'node_url': node_url,
         'node_title': file_.node.title,
         'parent_url': parent_url if file_.node.parent_node.is_public else None,
-        'parent_title': file_.node.parent_node.title if file_.node.parent_node else None,
+        'parent_title': parent_title,
         'is_registration': file_.node.is_registration,
     }
 

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -465,7 +465,7 @@ def update_file(file_, index=None, delete=False):
         'category': 'file',
         'node_url': node_url,
         'node_title': file_.node.title,
-        'parent_url': parent_url,
+        'parent_url': parent_url if file_.node.parent_node.is_public else None,
         'parent_title': file_.node.parent_node.title if file_.node.parent_node else None,
         'is_registration': file_.node.is_registration,
     }

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -453,8 +453,8 @@ def update_file(file_, index=None, delete=False):
     )
     node_url = '/{node_id}/'.format(node_id=file_.node._id)
 
-    parent_url = '/{}/'.format(file_.node.parent_node._id) if file_.node.parent_node else None,
-    parent_title = file_.node.parent_node.title if file_.node.parent_node else None,
+    parent_url = '/{}/'.format(file_.node.parent_node._id) if file_.node.parent_node and file_.node.parent_node.is_public else None
+    parent_title = file_.node.parent_node.title if file_.node.parent_node else None
     if parent_title:
         parent_title = parent_title if file_.node.parent_node.is_public else '-- private project --'
 
@@ -466,7 +466,7 @@ def update_file(file_, index=None, delete=False):
         'category': 'file',
         'node_url': node_url,
         'node_title': file_.node.title,
-        'parent_url': parent_url if file_.node.parent_node.is_public else None,
+        'parent_url': parent_url,
         'parent_title': parent_title,
         'is_registration': file_.node.is_registration,
     }
@@ -495,7 +495,7 @@ def create_index(index=None):
     all of which are applied to all projects, components, and registrations.
     '''
     index = index or INDEX
-    document_types = ['project', 'component', 'registration', 'user']
+    document_types = ['project', 'component', 'registration', 'user', 'files']
     project_like_types = ['project', 'component', 'registration']
     analyzed_fields = ['title', 'description']
 

--- a/website/static/js/pages/file-page.js
+++ b/website/static/js/pages/file-page.js
@@ -36,4 +36,12 @@ $(function() {
             });
         }
     });
+    $('#fileTags_tag').attr('maxlength', '128');
+    if (!window.contextVars.currentUser.canEdit || window.contextVars.node.isRegistration) {
+        $('a[title="Removing tag"]').remove();
+        $('span.tag span').each(function(idx, elm) {
+            $(elm).text($(elm).text().replace(/\s*$/, ''));
+        });
+    }
+
 });


### PR DESCRIPTION
## Migration needed
` inv migrate_search ` needs to be run after this is merged, so that the mapping of tags for files can be updated.
## Purpose
This changes private parent nodes name to a not hyperlinked ` --private project-- `, and it adds NOT-ANALYZED to tags