### PR TITLE
[Feature Fix] Convert string into date with moment()

### DIFF
--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -544,7 +544,7 @@ var UTC_DATEFORMAT = 'YYYY-MM-DD HH:mm UTC';
 var FormattableDate = function(date) {
 
     if (typeof date === 'string') {
-        this.date = moment.utc(dateTimeWithoutOffset(date) ? forceUTC(date) : date).toDate();
+        this.date = moment(dateTimeWithoutOffset(date) ? forceUTC(date) : date).utc().toDate();
     } else {
         this.date = date;
     }


### PR DESCRIPTION
## Purpose
In moment.js, `utc()` can't process the date format created by [Dropbox API](https://www.dropbox.com/developers-v1/core/docs) in Safari and IE. It is something like -- `Sat, 21 Aug 2010 22:31:20 +0000`. Therefore, it is shown as invalidate and not displayed.

Resolve [OSF-4294]

## Changes
After testing, I find  `moment()` is more stable to accept all kinds of string date, as it mentioned in docs, 

>When creating a moment from a string, we first check if the string matches known ISO 8601 formats, then fall back to new Date(string) if a known format is not found.

![screenshot 2015-11-03 16 46 50](https://cloud.githubusercontent.com/assets/5420789/10922874/ba8bd94e-824b-11e5-8bf2-cd0126a90a95.png)

So I choose to use `moment()` to create date object firstly and then apply `utc()` to get UTC time object. 

Related Stackoverflow question (Asked by me) -- http://stackoverflow.com/questions/33508049/moment-utc-doesnt-work-in-ie-and-safari

## Side Effect
Since it is helper function used in many other places, it is better to check most of it. In theory, it should be find, because `moment()` can process the date string that `utc()` can do in the past.
