### PR TITLE
Fix data-binding heirarchy on registrations.mako

### DIFF
--- a/website/static/js/pages/project-base-page.js
+++ b/website/static/js/pages/project-base-page.js
@@ -8,9 +8,6 @@ var $osf = require('js/osfHelpers');
 // NodeActions is needed for rendering recent logs in nodelists (e.g. regsitrations and forks
 // pages
 require('js/project');
-
-require('js/registerNode');
-
 require('js/licensePicker');
 
 var node = window.contextVars.node;

--- a/website/static/js/pages/project-registrations-page.js
+++ b/website/static/js/pages/project-registrations-page.js
@@ -18,7 +18,7 @@ $(document).ready(function() {
         $(this).tab('show');
     });
 
-    var draftManager = new RegistrationManager(node, '#registrationsListScope', {
+    var draftManager = new RegistrationManager(node, '#draftRegistrationsScope', {
         list: node.urls.api + 'drafts/',
         // TODO: uncomment when we support draft submission for review
         //submit: node.urls.api + 'draft/{draft_pk}/submit/',
@@ -26,7 +26,7 @@ $(document).ready(function() {
         schemas: '/api/v1/project/drafts/schemas/',
         edit: node.urls.web + 'drafts/{draft_pk}/',
         create: node.urls.web + 'registrations/'
-    });
+    }, $('#registerNode'));
     draftManager.init();
 
 });

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -760,7 +760,7 @@ RegistrationEditor.prototype.saveForLater = function () {
  * @param {String} urls.edit:
  * @param {String} urls.schemas:
  **/
-var RegistrationManager = function(node, draftsSelector, urls) {
+var RegistrationManager = function(node, draftsSelector, urls, createButton) {
     var self = this;
 
     self.node = node;
@@ -788,6 +788,10 @@ var RegistrationManager = function(node, draftsSelector, urls) {
     // bound functions
     self.getDraftRegistrations = $.getJSON.bind(null, self.urls.list);
     self.getSchemas = $.getJSON.bind(null, self.urls.schemas);
+
+    if (createButton) {
+        createButton.on('click', self.createDraftModal.bind(self));
+    }
 };
 RegistrationManager.prototype.init = function() {
     var self = this;

--- a/website/templates/project/registrations.mako
+++ b/website/templates/project/registrations.mako
@@ -1,12 +1,6 @@
 <%inherit file="project/project_base.mako"/>
 <%def name="title()">${node['title']} Registrations</%def>
 <div id="registrationsListScope">
-  <form id="newDraftRegistrationForm" method="POST" style="display:none">
-    <!-- ko if: selectedSchema() -->
-    <input type="hidden" name="schema_name" data-bind="value: selectedSchema().name">
-    <input type="hidden" name="schema_version" data-bind="value: selectedSchema().version">
-    <!-- /ko -->
-  </form>
 <ul id="registrationsTabs" class="nav nav-tabs" role="tablist">
   <li role="presentation" class="active">
     <a id="registrationsControl" aria-controls="registrations" href="#registrations">Registrations</a>
@@ -49,18 +43,23 @@
         To register the entire project "${parent_node['title']}" instead, click <a href="${parent_node['registrations_url']}">here.</a>
         %endif
       </div>
-
-        % if 'admin' in user['permissions'] and not disk_saving_mode:
-            <div class="col-md-3">
+      % if 'admin' in user['permissions'] and not disk_saving_mode:
+      <div class="col-md-3">
         <a data-bind="click: createDraftModal, css: {disabled: loading}" id="registerNode" class="btn btn-default" type="button">
           New Registration
         </a>
-            </div>
-        % endif
+      </div>
+      % endif
     </div>
   </div>
   <div role="tabpanel" class="tab-pane" id="drafts">
-    <div class="row" style="min-height: 150px;padding-top:20px;">
+    <div id="draftRegistrationsScope" class="row" style="min-height: 150px;padding-top:20px;">
+      <form id="newDraftRegistrationForm" method="POST" style="display:none">
+        <!-- ko if: selectedSchema() -->
+        <input type="hidden" name="schema_name" data-bind="value: selectedSchema().name">
+        <input type="hidden" name="schema_version" data-bind="value: selectedSchema().version">
+        <!-- /ko -->
+      </form>
       <div data-bind="visible: !preview()">
         <div class="col-md-9">
           <div class="scripted" data-bind="foreach: drafts">
@@ -111,6 +110,7 @@
           </div>
         </div>
       </div>
+      <!--
       <div data-bind="if: preview">
         <br />
         <button data-bind="click: preview.bind($root, false)"
@@ -172,6 +172,7 @@
         <div class="row" data-bind="template: {data: previewSchema, name: 'registrationPreview'}">
         </div>
       </div>
+      -->
     </div>
   </div>
 </div>


### PR DESCRIPTION
# Purpose 

registrations.mako got mangled at some point and the KO data-binding hierarchy was broken. This PR moves all components to their correct homes and makes the page work again.  

# Changes

- Pass RegistrationManager an option create button to listen for clicks
  on
- move components into the correct binding scope