### PR TITLE
Use enqueue_task to run ES update_node_async

### DIFF
--- a/website/search/search.py
+++ b/website/search/search.py
@@ -1,5 +1,7 @@
 import logging
 
+from framework.tasks.handlers import enqueue_task
+
 from website import settings
 from website.search import share_search
 
@@ -27,10 +29,11 @@ def search(query, index=None, doc_type=None):
 def update_node(node, index=None, bulk=False, async=True):
     if async:
         node_id = node._id
-        if settings.USE_CELERY:
-            search_engine.update_node_async.delay(node_id=node_id, index=index, bulk=bulk)
-        else:
-            search_engine.update_node_async(node_id=node_id, index=index, bulk=bulk)
+        # We need the transaction to be committed before trying to run celery tasks.
+        # For example, when updating a Node's privacy, is_public must be True in the
+        # database in order for method that updates the Node's elastic search document
+        # to run correctly.
+        enqueue_task(search_engine.update_node_async.s(node_id=node_id, index=index, bulk=bulk))
     else:
         index = index or settings.ELASTIC_INDEX
         return search_engine.update_node(node, index=index, bulk=bulk)


### PR DESCRIPTION
# Purpose

Calling update_node_async while still in a transaction context caused issues with celery tasks getting a stale version of a Node's state. In particular when adjusting privacy `is_public` was still False in the database and the ES document was not being created.

# Changes

Use `enqueue_task` to defer the celery task until after the transaction is committed.

# Side Effects

None