### PR TITLE
Hotfix/fix pending registrations

### DIFF
--- a/tests/test_registration_embargoes.py
+++ b/tests/test_registration_embargoes.py
@@ -690,6 +690,22 @@ class RegistrationEmbargoViewsTestCase(OsfTestCase):
         assert_true(registration.is_registration)
         assert_not_equal(registration.registration_approval, None)
 
+    # Regression test for https://openscience.atlassian.net/browse/OSF-5039
+    def test_POST_register_make_public_immediately_creates_private_pending_registration_for_public_project(self):
+        public_project = ProjectFactory(is_public=True, creator=self.user)
+        res = self.app.post(
+            public_project.api_url_for('node_register_template_page_post', template=u'Open-Ended_Registration'),
+            self.valid_make_public_payload,
+            content_type='application/json',
+            auth=self.user.auth
+        )
+        assert_equal(res.status_code, 201)
+
+        registration = Node.find().sort('-registered_date')[0]
+
+        assert_true(registration.is_registration)
+        assert_false(registration.is_public)
+
     @mock.patch('framework.tasks.handlers.enqueue_task')
     def test_POST_register_make_public_does_not_make_children_public(self, mock_enqueue):
         component = NodeFactory(

--- a/tests/test_registration_embargoes.py
+++ b/tests/test_registration_embargoes.py
@@ -691,7 +691,8 @@ class RegistrationEmbargoViewsTestCase(OsfTestCase):
         assert_not_equal(registration.registration_approval, None)
 
     # Regression test for https://openscience.atlassian.net/browse/OSF-5039
-    def test_POST_register_make_public_immediately_creates_private_pending_registration_for_public_project(self):
+    @mock.patch('framework.tasks.handlers.enqueue_task')
+    def test_POST_register_make_public_immediately_creates_private_pending_registration_for_public_project(self, mock_enqueue):
         public_project = ProjectFactory(is_public=True, creator=self.user)
         res = self.app.post(
             public_project.api_url_for('node_register_template_page_post', template=u'Open-Ended_Registration'),

--- a/website/project/views/register.py
+++ b/website/project/views/register.py
@@ -271,6 +271,7 @@ def node_register_template_page_post(auth, node, **kwargs):
             embargo_end_date = parse_date(data['embargoEndDate'], ignoretz=True)
             register.embargo_registration(auth.user, embargo_end_date)
         else:
+            register.is_public = False
             register.require_approval(auth.user)
         register.save()
     except ValidationValueError as err:


### PR DESCRIPTION
Purpose
------------
Fixes [OSF-5039]

Pending registrations of public projects should be private until approved by administrators, or until 48 hours have passed since requesting the registration. 

Changes
------------
If the registration requires approval, make it private until approved.