### PR TITLE
Hotfix/fix pending registrations

### DIFF
--- a/tests/test_registration_embargoes.py
+++ b/tests/test_registration_embargoes.py
@@ -793,12 +793,14 @@ class RegistrationEmbargoViewsTestCase(OsfTestCase):
         subproject = ProjectFactory(
             creator=self.user,
             parent=public_project,
-            title='Subproject'
+            title='Subproject',
+            is_public=True
         )
         subproject_component = NodeFactory(
             creator=self.user,
             parent=subproject,
-            title='Subcomponent'
+            title='Subcomponent',
+            is_public=True
         )
         res = self.app.post(
             public_project.api_url_for('node_register_template_page_post', template=u'Open-Ended_Registration'),

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -1917,6 +1917,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
 
         registered = original.clone()
 
+        registered.is_public = False
         registered.is_registration = True
         registered.registered_date = when
         registered.registered_user = auth.user
@@ -1949,6 +1950,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
                 child_registration = node_contained.register_node(
                     schema, auth, template, data, parent=registered
                 )
+                child_registration.is_public = False
                 if child_registration and not child_registration.primary:
                     registered.nodes.append(child_registration)
 

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -1917,7 +1917,6 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
 
         registered = original.clone()
 
-        registered.is_public = False
         registered.is_registration = True
         registered.registered_date = when
         registered.registered_user = auth.user
@@ -1950,7 +1949,6 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
                 child_registration = node_contained.register_node(
                     schema, auth, template, data, parent=registered
                 )
-                child_registration.is_public = False
                 if child_registration and not child_registration.primary:
                     registered.nodes.append(child_registration)
 

--- a/website/project/views/register.py
+++ b/website/project/views/register.py
@@ -271,7 +271,6 @@ def node_register_template_page_post(auth, node, **kwargs):
             embargo_end_date = parse_date(data['embargoEndDate'], ignoretz=True)
             register.embargo_registration(auth.user, embargo_end_date)
         else:
-            register.is_public = False
             register.require_approval(auth.user)
         register.save()
     except ValidationValueError as err:

--- a/website/project/views/register.py
+++ b/website/project/views/register.py
@@ -265,6 +265,9 @@ def node_register_template_page_post(auth, node, **kwargs):
     register = node.register_node(
         schema, auth, template, json.dumps(clean_data),
     )
+    register.is_public = False
+    for node in register.nodes:
+        node.is_public = False
     try:
         if data.get('registrationChoice', 'immediate') == 'embargo':
             # Initiate embargo

--- a/website/project/views/register.py
+++ b/website/project/views/register.py
@@ -266,8 +266,9 @@ def node_register_template_page_post(auth, node, **kwargs):
         schema, auth, template, json.dumps(clean_data),
     )
     register.is_public = False
-    for node in register.nodes:
+    for node in register.get_descendants_recursive():
         node.is_public = False
+        node.save()
     try:
         if data.get('registrationChoice', 'immediate') == 'embargo':
             # Initiate embargo


### PR DESCRIPTION
Purpose
------------
Fixes https://openscience.atlassian.net/browse/OSF-5071

Changes
------------
Generalize fix for [OSF-5039] (registrations of public projects should be private until approved) so that whenever a registration is created it is private by default until it is approved/the embargo period ends.