### PR TITLE
Update search tag removal logic.

### DIFF
--- a/website/static/js/search.js
+++ b/website/static/js/search.js
@@ -208,12 +208,13 @@ var ViewModel = function(params) {
         e.stopPropagation();
         var query = self.query();
         var tagRegExp = /(?:AND)?\s*tags\:\([\'\"](.+?)[\'\"]\)/g;
-        var matches = query.match(tagRegExp);
         var dirty = false;
-        while (matches.length) {
-            var match = matches.pop();
-            if ((match.match(tagName) || []).length) {
-                query = query.replace(match, '');
+        while (tagRegExp.test(query)) {
+            var match = tagRegExp.exec(query);
+            var block = match.shift();
+            var tag = match.shift().trim();
+            if (tag === tagName) {
+                query = query.replace(block, '').trim();
                 dirty = true;
             }
         }


### PR DESCRIPTION
# Purpose

Due to a bug in the search tag removal logic, if a user tried to remove a tag that is was a substring of another currently active tag (e.g. 'bio' and 'biosphere'), clicking remove on the substring tag would remove the active tag. (Clicking X on 'bio' removes 'biosphere')

# Changes
- use regexp capture group to check actual tag equiavalence rather than
  just a substring match

[#OSF-5084]