### PR TITLE
[hotfix] Redirect to project registrations page after creating a new registration 

### DIFF
--- a/tests/test_registration_embargoes.py
+++ b/tests/test_registration_embargoes.py
@@ -720,6 +720,7 @@ class RegistrationEmbargoViewsTestCase(OsfTestCase):
         )
         public_project.reload()
         assert_equal(res.status_code, 201)
+        assert_equal(res.json['urls']['registrations'], public_project.web_url_for('node_registrations'))
 
         # Last node directly registered from self.project
         registration = Node.load(public_project.node__registrations[-1])
@@ -810,6 +811,7 @@ class RegistrationEmbargoViewsTestCase(OsfTestCase):
         )
         public_project.reload()
         assert_equal(res.status_code, 201)
+        assert_equal(res.json['urls']['registrations'], public_project.web_url_for('node_registrations'))
 
         # Last node directly registered from self.project
         registration = Node.load(public_project.node__registrations[-1])

--- a/website/project/views/register.py
+++ b/website/project/views/register.py
@@ -266,9 +266,9 @@ def node_register_template_page_post(auth, node, **kwargs):
         schema, auth, template, json.dumps(clean_data),
     )
     register.is_public = False
-    for node in register.get_descendants_recursive():
-        node.is_public = False
-        node.save()
+    for child in register.get_descendants_recursive():
+        child.is_public = False
+        child.save()
     try:
         if data.get('registrationChoice', 'immediate') == 'embargo':
             # Initiate embargo


### PR DESCRIPTION
Purpose
------------
Fixes [OSF-5094] - after finishing registration steps, page redirects to the last registered component

Changes
------------
Use a variable name other than `node` when iterating through node children so as to not reassign the node. 