### PR TITLE
[RfR] Fix Search license filter pagination bug

### DIFF
--- a/website/static/js/search.js
+++ b/website/static/js/search.js
@@ -103,6 +103,7 @@ var ViewModel = function(params) {
         $.map(licenses, function(license) {
             var l = new License(license.name, license.id, 0);
             l.active.subscribe(function() {
+                self.currentPage(1);
                 self.search();
             });
             return l;


### PR DESCRIPTION
# Purpose
QA discovered that if a user navigates to page 2 or beyond of a search result, then clicks a license filter with less than one page of results, they get trapped on that later page without the ability to go back or forward a page.

# Changes
Set currentPage = 1 when search license filter changes