### PR TITLE
Update search tag removal (again)

### DIFF
--- a/website/static/js/search.js
+++ b/website/static/js/search.js
@@ -309,8 +309,8 @@ var ViewModel = function(params) {
         var query = self.query();
         var tagRegExp = /(?:AND)?\s*tags\:\([\'\"](.+?)[\'\"]\)/g;
         var dirty = false;
-        while (tagRegExp.test(query)) {
-            var match = tagRegExp.exec(query);
+        var match;
+        while ((match = tagRegExp.exec(query))) {
             var block = match.shift();
             var tag = match.shift().trim();
             if (tag === tagName) {


### PR DESCRIPTION
# Purpose

Interestingly, the 'g' flag for JS regexp causes the RegExp instance to
yeild matches at every call of ReExp#exec. This works by incrementing an
internal lastIndex count. Using RegExp#test also increments this counter
even though it returns nothing. So in this code, calling test was
incrementing the RegExp's match counter, and was causing the subsequent
exec call to return null under some circumstances.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec#Finding_successive_matches

# Changes
Use assignment as condition for the tag removal while loop. 