### PR TITLE
Update DraftReg

### DIFF
--- a/website/static/js/osfLanguage.js
+++ b/website/static/js/osfLanguage.js
@@ -4,6 +4,7 @@ var SUPPORT_LINK = '<a href="mailto:' + SUPPORT_EMAIL + '">' + SUPPORT_EMAIL +'<
 var REFRESH_OR_SUPPORT = 'Please refresh the page and try again or contact ' + SUPPORT_LINK + ' if the problem persists.';
 
 module.exports = {
+    SUPPORT_LINK: SUPPORT_LINK,
     // TODO
     makePublic: null,
     makePrivate: null,
@@ -104,5 +105,5 @@ module.exports = {
         updateErrorMessage400: 'Error updating project settings. Check that all fields are valid.',
         updateErrorMessage: 'Could not update project settings. ' + REFRESH_OR_SUPPORT,
         instantiationErrorMessage: 'Trying to instantiate ProjectSettings view model without an update URL'
-    },
+    }
 };

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -742,6 +742,14 @@ RegistrationEditor.prototype.putSaveData = function(payload) {
     return self.saveManager.save(payload).then(self.updateData.bind(self));
 };
 
+RegistrationEditor.prototype.saveForLater = function() {
+    var self = this;
+    $osf.block('Saving...');
+    self.save().then(function() {
+        window.location = self.urls.draftRegistrations;
+    }); // TODO(samchrisinger): on fail
+};
+
 /**
  * Save the current Draft
  **/

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -9,7 +9,9 @@ var URI = require('URIjs');
 require('js/koHelpers');
 
 var $osf = require('js/osfHelpers');
-var language = require('js/osfLanguage').registrations;
+var osfLanguage = require('js/osfLanguage');
+var SUPPORT_LINK = osfLanguage.SUPPORT_LINK;
+var language = osfLanguage.registrations;
 
 var SaveManager = require('js/saveManager');
 var editorExtensions = require('js/registrationEditorExtensions');
@@ -745,9 +747,14 @@ RegistrationEditor.prototype.putSaveData = function(payload) {
 RegistrationEditor.prototype.saveForLater = function() {
     var self = this;
     $osf.block('Saving...');
-    self.save().then(function() {
-        window.location = self.urls.draftRegistrations;
-    }); // TODO(samchrisinger): on fail
+    self.save()
+        .then(function() {
+            window.location = self.urls.draftRegistrations;
+        })
+        .fail(function() {
+            $osf.unblock();
+            $osf.growl('There was a problem saving this draft. Please try again, and if the problem persists please contact ' + SUPPORT_LINK + '.');
+        }); 
 };
 
 /**

--- a/website/static/js/saveManager.js
+++ b/website/static/js/saveManager.js
@@ -13,7 +13,6 @@ var SaveManager = function(url, method, xhrOpts, dirty, warn) {
     warn = warn || true;
 
     self.queued = null;
-    self.queuedPromise = null;
 
     self.blocking = null;
     if (warn) {
@@ -29,13 +28,11 @@ SaveManager.prototype.enqueue = function(opts, promise) {
     var self = this;
     if (self.queued) {
         self.queued = self.dequeue.bind(self, opts, promise);
-        self.queuedPromise = promise;
     }
     else {
         self.queued = function() {
             return self.dequeue(opts, promise);
         };
-        self.queuedPromise = promise;
     }
     return promise.promise();
 };


### PR DESCRIPTION
# Purpose

- Some koHelpers got deleted in a merge, and consequently tooltips were not working
- `saveForLater` was also deleted and needed to be added back

# Changes

- re-add koHelpers: `tooltip`, `onKeyPress`, `anchorScroll`, `listing`
- re-add `saveForLater`, and add error handling to that fn
- cleanup SaveManager
