### PR TITLE
Filter by registration

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -37,7 +37,8 @@ class NodeSerializer(JSONAPISerializer):
         'tags',
         'category',
         'date_created',
-        'date_modified'
+        'date_modified',
+        'registration'
     ])
 
     id = IDField(source='_id', read_only=True)


### PR DESCRIPTION
Purpose
-----------
We are mixing in registrations to the nodes endpoint. We neglected to add the ability to filter those out. Add that ability back in. **Needed for OSF Offline**

Changes
------------
Add a line to the node serializers allowed filters

Side effects
----------------
None