### PR TITLE
on SHARE Search Page, also escape / for creating data divIDs

### DIFF
--- a/website/static/js/share/results.js
+++ b/website/static/js/share/results.js
@@ -256,7 +256,7 @@ var Footer = {
 var RawNormalizedData = {
     view: function(ctrl, params) {
         var result = params.result || params.missingError;
-        var divID = params.missingError ? '' : (result.normalized.shareProperties.docID + result.normalized.shareProperties.source).replace( /(:|\.|\[|\]|,)/g, '-' );
+        var divID = params.missingError ? '' : (result.normalized.shareProperties.docID + result.normalized.shareProperties.source).replace( /(:|\.|\[|\]|,|\/)/g, '-' );
         return m('.row', [
             m('.col-md-12',
                 m('div', [


### PR DESCRIPTION
## Purpose
When loading data from the SHARE Postgres API, we use the document ID from the SHARE document to create a unique div ID, so that clicking show and hide, and switching between tabs, only affects the one shown tab. This changes that div ID to also escape and replace forward slashes

## Changes
Include forward slashes in the list of characters to be replaced with dashes when generating unique div IDs for retrieved SHARE data

## Side effects
None anticipated, as it is only for generating div IDs for SHARE data

[#SHARE-204]