### PR TITLE
[Enhancement] [OSF Meeting] Open new tab after clicking conference or author

### DIFF
--- a/website/static/js/conference.js
+++ b/website/static/js/conference.js
@@ -55,7 +55,7 @@ function Meeting(data) {
                     folderIcons : false,
                     filter : true,
                     sortInclude : true,
-                    custom : function() { return m('a', { href : item.data.authorUrl }, item.data.author ); }
+                    custom : function() { return m('a', { href : item.data.authorUrl, target : '_blank'}, item.data.author ); }
                 },
                 {
                     data : 'category',  // Data field name

--- a/website/static/js/submissions.js
+++ b/website/static/js/submissions.js
@@ -59,7 +59,7 @@ function Submissions(data) {
                 {
                     data: 'author',  // Data field name
                     sortInclude: true,
-                    custom: function() { return m('a', {href: item.data.authorUrl}, item.data.author); }
+                    custom: function() { return m('a', {href: item.data.authorUrl, target : '_blank'}, item.data.author); }
                 },
 
                 {
@@ -89,7 +89,7 @@ function Submissions(data) {
                 {
                     data: 'confName',
                     sortInclude: true,
-                    custom: function() { return m('a', {href: item.data.confUrl}, item.data.confName); }
+                    custom: function() { return m('a', {href: item.data.confUrl, target : '_blank'}, item.data.confName); }
                 }
             ];
         },


### PR DESCRIPTION
## Purpose
Currently, for part of links  on  all submission and conference page, it will not open a new tab but some of them do.

When it comes to whether a new tab should be opened, there are a lot discussions. However, for this case, we would prefer to let all of them open new tab.
1. Be consistent
2. Based on the content,  we have many links on one page, opening a new tab will be easy and quick to let them back. Otherwise, It will take a lot time if  bring back the page with all the links(Treebeard table).

## Change
See target  attribute as "_blank" in author and conference name link.

## Side Effect
None