### PR TITLE
[hotfix] restore missing hashes to osfstorage file metadata

### DIFF
--- a/website/addons/osfstorage/views.py
+++ b/website/addons/osfstorage/views.py
@@ -122,7 +122,7 @@ def osfstorage_get_metadata(file_node, **kwargs):
         # TODO This should change to version as its internal it can be changed anytime
         version = int(request.args.get('revision'))
     except (ValueError, TypeError):  # If its not a number
-        version = -1
+        version = None
     return file_node.serialize(version=version, include_full=True)
 
 


### PR DESCRIPTION
The OSF was sending a bogus version of -1 to WB for file metadata
requests, causing WB to respond with null for the file hashes.  If not
provided, the version should default to None.