### PR TITLE
Update DraftReg

### DIFF
--- a/api_tests/nodes/views/test_node_registrations_list.py
+++ b/api_tests/nodes/views/test_node_registrations_list.py
@@ -19,12 +19,12 @@ class TestNodeRegistrationList(ApiTestCase):
         self.user = AuthUserFactory()
 
         self.project = ProjectFactory(is_public=False, creator=self.user)
-        self.registration_project = RegistrationFactory(creator=self.user, project=self.project)
+        self.registration_project = RegistrationFactory(creator=self.user, project=self.project, is_public=True)
         self.project.save()
         self.private_url = '/{}nodes/{}/registrations/'.format(API_BASE, self.project._id)
 
         self.public_project = ProjectFactory(is_public=True, creator=self.user)
-        self.public_registration_project = RegistrationFactory(creator=self.user, project=self.public_project)
+        self.public_registration_project = RegistrationFactory(creator=self.user, project=self.public_project, is_public=True)
         self.public_project.save()
         self.public_url = '/{}nodes/{}/registrations/'.format(API_BASE, self.public_project._id)
 

--- a/api_tests/registrations/views/test_registration_detail.py
+++ b/api_tests/registrations/views/test_registration_detail.py
@@ -20,7 +20,7 @@ class TestRegistrationDetail(ApiTestCase):
 
         self.public_project = ProjectFactory(title="Project One", is_public=True, creator=self.user)
         self.private_project = ProjectFactory(title="Project Two", is_public=False, creator=self.user)
-        self.public_registration = RegistrationFactory(project=self.public_project, creator=self.user)
+        self.public_registration = RegistrationFactory(project=self.public_project, creator=self.user, is_public=True)
         self.private_registration = RegistrationFactory(project=self.private_project, creator=self.user)
         self.public_url = '/{}registrations/{}/'.format(API_BASE, self.public_registration._id)
         self.private_url = '/{}registrations/{}/'.format(API_BASE, self.private_registration._id)

--- a/api_tests/registrations/views/test_registration_list.py
+++ b/api_tests/registrations/views/test_registration_list.py
@@ -24,7 +24,7 @@ class TestRegistrationList(ApiTestCase):
         self.url = '/{}registrations/'.format(API_BASE)
 
         self.public_project = ProjectFactory(is_public=True, creator=self.user)
-        self.public_registration_project = RegistrationFactory(creator=self.user, project=self.public_project)
+        self.public_registration_project = RegistrationFactory(creator=self.user, project=self.public_project, is_public=True)
         self.user_two = AuthUserFactory()
 
     def tearDown(self):

--- a/framework/tasks/handlers.py
+++ b/framework/tasks/handlers.py
@@ -26,7 +26,7 @@ def celery_teardown_request(error=None):
                 group(tasks).apply_async()
             else:
                 for task in tasks:
-                    task()
+                    task.apply()
     except AttributeError:
         if not settings.DEBUG_MODE:
             logger.error('Task queue not initialized')

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -203,9 +203,9 @@ class RegistrationFactory(AbstractNodeFactory):
 
     @classmethod
     def _create(cls, target_class, project=None, schema=None, user=None,
-                data=None, archive=False, embargo=None, registration_approval=None, retraction=None, *args, **kwargs):
+                data=None, archive=False, embargo=None, registration_approval=None, retraction=None, is_public=False,
+                *args, **kwargs):
         save_kwargs(**kwargs)
-
         # Original project to be registered
         project = project or target_class(*args, **kwargs)
         project.save()
@@ -254,6 +254,8 @@ class RegistrationFactory(AbstractNodeFactory):
             dst_node=reg,
             initiator=user,
         )
+        if is_public:
+            reg.is_public = True
         reg.save()
         return reg
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4325,12 +4325,14 @@ class TestDraftRegistration(OsfTestCase):
             data=self.draft.registration_metadata,
         )
 
+    @mock.patch('framework.tasks.handlers.celery_teardown_request', mock.Mock())
     def test_register_makes_registration_private(self):
         self.node.is_public = True
         self.node.save()
         registration = self.draft.register(Auth(self.user))
         assert_false(registration.is_public)
 
+    @mock.patch('framework.tasks.handlers.celery_teardown_request', mock.Mock())
     def test_register_makes_registration_children_private(self):
         self.node.is_public = True
         self.node.save()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4302,6 +4302,25 @@ class TestDraftRegistration(OsfTestCase):
             data=self.draft.registration_metadata,
         )
 
+    def test_register_makes_registration_private(self):
+        self.node.is_public = True
+        self.node.save()
+        registration = self.draft.register(Auth(self.user))
+        assert_false(registration.is_public)
+
+    def test_register_makes_registration_children_private(self):
+        self.node.is_public = True
+        self.node.save()
+        child = NodeFactory(parent=self.node)
+        child.is_public = True
+        child.save()
+        childchild = NodeFactory(parent=child)
+        childchild.is_public = True
+        childchild.save()
+        registration = self.draft.register(Auth(self.user))
+        for node in registration.node_and_primary_descendants():
+            assert_false(node.is_public)
+
     def test_update_metadata_tracks_changes(self):
         self.draft.registration_metadata = {
             'foo': {

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1878,6 +1878,29 @@ class TestNode(OsfTestCase):
         self.node.reload()
         assert_false(self.parent.nodes_active)
 
+    def test_register_node_makes_private_registration(self):
+        user = UserFactory()
+        node = NodeFactory(creator=user)
+        node.is_public = True
+        node.save()
+        registration = node.register_node(None, Auth(user), '', None)
+        assert_false(registration.is_public)
+
+    def test_register_node_makes_private_child_registrations(self):
+        user = UserFactory()
+        node = NodeFactory(creator=user)
+        node.is_public = True
+        node.save()
+        child = NodeFactory(parent=node)
+        child.is_public = True
+        child.save()
+        childchild = NodeFactory(parent=child)
+        childchild.is_public = True
+        childchild.save()
+        registration = node.register_node(None, Auth(user), '', None)
+        for node in registration.node_and_primary_descendants():
+            assert_false(node.is_public)
+
     @mock.patch('website.project.signals.after_create_registration')
     def test_register_node_propagates_schema_and_data_to_children(self, mock_signal):
         root = ProjectFactory(creator=self.user)
@@ -3523,7 +3546,7 @@ class TestRegisterNode(OsfTestCase):
         assert_false(self.registration.is_public)
         self.project.set_privacy('public')
         registration = RegistrationFactory(project=self.project)
-        assert_true(registration.is_public)
+        assert_false(registration.is_public)
 
     def test_contributors(self):
         assert_equal(self.registration.contributors, self.project.contributors)

--- a/tests/test_registration_retractions.py
+++ b/tests/test_registration_retractions.py
@@ -373,7 +373,7 @@ class RegistrationWithChildNodesRetractionModelTestCase(OsfTestCase):
             parent=self.subproject,
             title='Subcomponent'
         )
-        self.registration = RegistrationFactory(project=self.project)
+        self.registration = RegistrationFactory(project=self.project, is_public=True)
         # Reload the registration; else tests won't catch failures to svae
         self.registration.reload()
 
@@ -662,7 +662,7 @@ class RegistrationRetractionViewsTestCase(OsfTestCase):
         super(RegistrationRetractionViewsTestCase, self).setUp()
         self.user = AuthUserFactory()
         self.registered_from = ProjectFactory(creator=self.user, is_public=True)
-        self.registration = RegistrationFactory(project=self.registered_from)
+        self.registration = RegistrationFactory(project=self.registered_from, is_public=True)
 
         self.retraction_post_url = self.registration.api_url_for('node_registration_retraction_post')
         self.retraction_get_url = self.registration.web_url_for('node_registration_retraction_get')

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4953,6 +4953,8 @@ class TestDraftRegistrationViews(OsfTestCase):
         self.node.is_public = True
         self.node.save()
         reg = RegistrationFactory(project=self.node)
+        reg.is_public = True
+        reg.save()
         url = reg.web_url_for('node_register_page')
         res = self.app.get(url, auth=None)
         assert_equal(res.status_code, http.OK)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4895,13 +4895,13 @@ class TestDraftRegistrationViews(OsfTestCase):
         url = self.node.api_url_for('update_draft_registration', draft_id=self.draft._id)
 
         res = self.app.put_json(url, payload, auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, http.BAD_REQUEST)
+        assert_equal(res.status_code, http.FORBIDDEN)
 
     def test_edit_draft_registration_page_already_registered(self):
         self.draft.register(Auth(self.user), save=True)
         url = self.node.web_url_for('edit_draft_registration_page', draft_id=self.draft._id)
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, http.BAD_REQUEST)
+        assert_equal(res.status_code, http.FORBIDDEN)
 
     def test_delete_draft_registration(self):
         assert_equal(1, DraftRegistration.find().count())

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4881,6 +4881,28 @@ class TestDraftRegistrationViews(OsfTestCase):
         assert_equal(open_ended_schema, self.draft.registration_schema)
         assert_equal(metadata, self.draft.registration_metadata)
 
+    def test_update_draft_registration_cant_update_registered(self):
+        metadata = {
+            'summary': {'value': 'updated'}
+        }
+        assert_not_equal(metadata, self.draft.registration_metadata)
+        payload = {
+            'schema_data': metadata,
+            'schema_name': 'OSF-Standard Pre-Data Collection Registration',
+            'schema_version': 1
+        }
+        self.draft.register(Auth(self.user), save=True)
+        url = self.node.api_url_for('update_draft_registration', draft_id=self.draft._id)
+
+        res = self.app.put_json(url, payload, auth=self.user.auth, expect_errors=True)
+        assert_equal(res.status_code, http.BAD_REQUEST)
+
+    def test_edit_draft_registration_page_already_registered(self):
+        self.draft.register(Auth(self.user), save=True)
+        url = self.node.web_url_for('edit_draft_registration_page', draft_id=self.draft._id)
+        res = self.app.get(url, auth=self.user.auth, expect_errors=True)
+        assert_equal(res.status_code, http.BAD_REQUEST)
+
     def test_delete_draft_registration(self):
         assert_equal(1, DraftRegistration.find().count())
         url = self.node.api_url_for('delete_draft_registration', draft_id=self.draft._id)

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -3945,7 +3945,7 @@ class DraftRegistrationApproval(Sanction):
         pass  # draft approval state gets loaded dynamically from this record
 
 
-class DraftRegistration(AddonModelMixin, StoredObject):
+class DraftRegistration(StoredObject):
 
     _id = fields.StringField(primary=True, default=lambda: str(ObjectId()))
 

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -3805,15 +3805,16 @@ class Retraction(EmailApprovableSanction):
             )
             parent_registration.embargo.save()
         # Ensure retracted registration is public
-        if not parent_registration.is_public:
-            parent_registration.set_privacy('public')
-        parent_registration.update_search()
+        auth = Auth(self.initiated_by)
+        for node in parent_registration.node_and_primary_descendants():
+            node.set_privacy('public', auth=auth, save=True)
+            node.update_search()
+        # parent_registration.update_search()
         # Retraction status is inherited from the root project, so we
         # need to recursively update search for every descendant node
         # so that retracted subrojects/components don't appear in search
-        for node in parent_registration.get_descendants_recursive():
-            node.update_search()
-        self.save()
+        # for node in parent_registration.get_descendants_recursive():
+        #    node.update_search()
 
     def approve_retraction(self, user, token):
         self.approve(user, token)

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2081,6 +2081,10 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
         registered.node_license = original.license.copy() if original.license else None
 
         registered.save()
+        registered.is_public = False
+        for node in registered.get_descendants_recursive():
+            node.is_public = False
+            node.save()
 
         if parent:
             registered.parent_node = parent

--- a/website/project/views/drafts.py
+++ b/website/project/views/drafts.py
@@ -77,7 +77,6 @@ def register_draft_registration(auth, node, draft, *args, **kwargs):
     :return: success message; url to registrations page
     :rtype: dict
     """
-
     data = request.get_json()
     register = draft.register(auth)
     draft.save()
@@ -210,6 +209,11 @@ def edit_draft_registration_page(auth, node, draft, **kwargs):
     :return: serialized DraftRegistration
     :rtype: dict
     """
+    if draft.registered_node:
+        raise HTTPError(http.BAD_REQUEST, data={
+            'message_short': 'This draft has already been registered.',
+            'message_long': 'This draft has already been registered and cannot be modified.'
+        })
     ret = project_utils.serialize_node(node, auth, primary=True)
     ret['draft'] = serialize_draft_registration(draft, auth)
     return ret
@@ -224,6 +228,11 @@ def update_draft_registration(auth, node, draft, *args, **kwargs):
     :rtype: dict
     :raises: HTTPError
     """
+    if draft.registered_node:
+        raise HTTPError(http.BAD_REQUEST, data={
+            'message_short': 'This draft has already been registered.',
+            'message_long': 'This draft has already been registered and cannot be modified.'
+        })
     data = request.get_json()
 
     schema_data = data.get('schema_data', {})

--- a/website/project/views/drafts.py
+++ b/website/project/views/drafts.py
@@ -210,7 +210,7 @@ def edit_draft_registration_page(auth, node, draft, **kwargs):
     :rtype: dict
     """
     if draft.registered_node:
-        raise HTTPError(http.BAD_REQUEST, data={
+        raise HTTPError(http.FORBIDDEN, data={
             'message_short': 'This draft has already been registered.',
             'message_long': 'This draft has already been registered and cannot be modified.'
         })
@@ -229,7 +229,7 @@ def update_draft_registration(auth, node, draft, *args, **kwargs):
     :raises: HTTPError
     """
     if draft.registered_node:
-        raise HTTPError(http.BAD_REQUEST, data={
+        raise HTTPError(http.FORBIDDEN, data={
             'message_short': 'This draft has already been registered.',
             'message_long': 'This draft has already been registered and cannot be modified.'
         })

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -552,9 +552,11 @@ RegistrationEditor.prototype.toPreview = function () {
 RegistrationEditor.prototype.check = function() {
     var self = this;
 
+    var valid = true;
     ko.utils.arrayMap(self.draft().pages(), function(page) {
         ko.utils.arrayMap(page.questions(), function(question) {
             if (question.required && !question.value.isValid()) {
+                valid = false;
                 // Validation for a question failed
                 bootbox.dialog({
                     title: 'Registration Not Complete',
@@ -569,12 +571,12 @@ RegistrationEditor.prototype.check = function() {
                         }
                     }
                 });
-                return;
             }
-            // Validation passed for all applicable questions
-            self.toPreview();
         });
     });
+    if (valid) {
+        self.toPreview();
+    }
 };
 /**
  * Select a page, selecting the first question on that page

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -693,7 +693,9 @@ RegistrationEditor.prototype.save = function() {
         });
     }
     self.lastSaveRequest = request;
-    request.fail($osf.growl.bind(null, 'There was a problem saving this draft. Please try again, and if the problem persists please contact ' + SUPPORT_LINK + '.'));
+    request.fail(function() {
+        $osf.growl('Problem saving draft', 'There was a problem saving this draft. Please try again, and if the problem persists please contact ' + SUPPORT_LINK + '.');
+    });
     return request;
 };
 

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -126,8 +126,10 @@
                     </p>
                 % endif
                 % if node['is_registration']:
-                    <br />Registration Supplement:
+                    <p>
+                    Registration Supplement:
                     <a href="${node['url']}register/">${node['registered_schema']['schema']['title']}</a>
+                    </p>
                 % endif
                 % if node['is_registration']:
                     <p>


### PR DESCRIPTION
# Purpose

There are a couple conditions where while a user is editing a draft they will receive errors from the server: 
  -- the user is no longer an admin on the project (permissions changed, removed from project, etc)
  -- the draft is registered by another admin
  in these cases the user's requests will error can a growlbox error should appear. No description was being passed to the GrowlBox constructor, and consequently the growl was appearing without a background. 

This required two changes:
  - give a title/description to the growlbox constructor
  - check that the draft is not registered on `edit_draft_registration_page` and `update_draft_registration`

Also, remove AddonModelMixin from DraftRegistration as it is unused

Additionally, the Draft Reg views never respected the HF in https://github.com/CenterForOpenScience/osf.io/pull/4571. See https://github.com/CenterForOpenScience/osf.io/commit/158b120eceb3b89d366cb31d04a5a67dc13e9fb9 for details. 