### PR TITLE
[Feature Fix] GitHub show wrong branch file

### DIFF
--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -134,6 +134,18 @@ var FileViewPage = {
         });
 
         if ($osf.urlParams().branch) {
+            var newFileBranchUrl = waterbutler.buildMetadataUrl(self.file.path, self.file.provider, self.node.id, {branch : $osf.urlParams().branch});
+            $.ajax({
+                dataType: 'json',
+                async: true,
+                url: newFileBranchUrl,
+                beforeSend: $osf.setXHRAuthorization,
+                success:function(response) {
+                    window.contextVars.file.urls.external = response.data.extra.webView;
+                    console.log(response);
+                    console.log(response.data.extra.webView);
+                }
+            });
             self.file.urls.revisions = waterbutler.buildRevisionsUrl(self.file.path, self.file.provider, self.node.id, {sha: $osf.urlParams().branch});
             self.file.urls.content = waterbutler.buildDownloadUrl(self.file.path, self.file.provider, self.node.id, {accept_url: false, mode: 'render', branch: $osf.urlParams().branch});
         }

--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -134,16 +134,14 @@ var FileViewPage = {
         });
 
         if ($osf.urlParams().branch) {
-            var newFileBranchUrl = waterbutler.buildMetadataUrl(self.file.path, self.file.provider, self.node.id, {branch : $osf.urlParams().branch});
+            var fileWebViewUrl = waterbutler.buildMetadataUrl(self.file.path, self.file.provider, self.node.id, {branch : $osf.urlParams().branch});
             $.ajax({
                 dataType: 'json',
                 async: true,
-                url: newFileBranchUrl,
+                url: fileWebViewUrl,
                 beforeSend: $osf.setXHRAuthorization,
                 success:function(response) {
                     window.contextVars.file.urls.external = response.data.extra.webView;
-                    console.log(response);
-                    console.log(response.data.extra.webView);
                 }
             });
             self.file.urls.revisions = waterbutler.buildRevisionsUrl(self.file.path, self.file.provider, self.node.id, {sha: $osf.urlParams().branch});


### PR DESCRIPTION
## Purpose
When clicking view file on github, it will always lead user to the master file link. However, github has different branches, and therefore the file linked is not the one rendering in MFR.

In this PR, it will create the correct link url for file (with current branch).  

## Changes
Firstly, get the url for the branch. And then use ajax and get file object from waterbulter. The ajax ur is something like -- `http://localhost:7777/data?path=%2Fmain.py&provider=github&nid=9j5hu&branch=redesign` 
![screenshot 2015-11-11 11 02 24](https://cloud.githubusercontent.com/assets/5420789/11095621/e5fa0dd0-8863-11e5-9c75-5f5c2f2223fe.png)

In this object, we can get the webView url from file object.  Then assign it to  `window.contextVars.file.urls.external`

## Side Effect
None. This is limited to github. 
