### PR TITLE
Add categories to engagement emails for analytics; use Sendgrid API for sending mail

### DIFF
--- a/framework/email/tasks.py
+++ b/framework/email/tasks.py
@@ -4,50 +4,84 @@ from email.mime.text import MIMEText
 
 from framework.tasks import app
 from website import settings
+import sendgrid
 
 logger = logging.getLogger(__name__)
 
 
 @app.task
 def send_email(from_addr, to_addr, subject, message, mimetype='html', ttls=True, login=True,
-                username=None, password=None, mail_server=None):
+                username=None, password=None, mail_server=None, categories=None):
     """Send email to specified destination.
     Email is sent from the email specified in FROM_EMAIL settings in the
     settings module.
+
+    Uses the Sendgrid API if ``settings.SENDGRID_API_KEY`` is set.
 
     :param from_addr: A string, the sender email
     :param to_addr: A string, the recipient
     :param subject: subject of email
     :param message: body of message
+    :param tuple categories: Categories to add to the email using SendGrid's
+        SMTPAPI. Used for email analytics.
+        See https://sendgrid.com/docs/User_Guide/Statistics/categories.html
+        This parameter is only respected if using the Sendgrid API.
+        ``settings.SENDGRID_API_KEY`` must be set.
 
     :return: True if successful
     """
-    username = username or settings.MAIL_USERNAME
-    password = password or settings.MAIL_PASSWORD
-    mail_server = mail_server or settings.MAIL_SERVER
-
     if not settings.USE_EMAIL:
         return
-    if login and (username is None or password is None):
-        logger.error('Mail username and password not set; skipping send.')
-        return
+    if settings.SENDGRID_API_KEY:
+        return send_with_sendgrid(
+            from_addr=from_addr,
+            to_addr=to_addr,
+            subject=subject,
+            message=message,
+            mimetype=mimetype,
+            categories=categories
+        )
+    else:
+        username = username or settings.MAIL_USERNAME
+        password = password or settings.MAIL_PASSWORD
+        mail_server = mail_server or settings.MAIL_SERVER
 
-    msg = MIMEText(message, mimetype, _charset='utf-8')
-    msg['Subject'] = subject
-    msg['From'] = from_addr
-    msg['To'] = to_addr
+        if login and (username is None or password is None):
+            logger.error('Mail username and password not set; skipping send.')
+            return
 
-    s = smtplib.SMTP(mail_server)
-    s.ehlo()
-    if ttls:
-        s.starttls()
+        msg = MIMEText(message, mimetype, _charset='utf-8')
+        msg['Subject'] = subject
+        msg['From'] = from_addr
+        msg['To'] = to_addr
+
+        s = smtplib.SMTP(mail_server)
         s.ehlo()
-    if login:
-        s.login(username, password)
-    s.sendmail(
-        from_addr=from_addr,
-        to_addrs=[to_addr],
-        msg=msg.as_string()
-    )
-    s.quit()
-    return True
+        if ttls:
+            s.starttls()
+            s.ehlo()
+        if login:
+            s.login(username, password)
+        s.sendmail(
+            from_addr=from_addr,
+            to_addrs=[to_addr],
+            msg=msg.as_string()
+        )
+        s.quit()
+        return True
+
+def send_with_sendgrid(from_addr, to_addr, subject, message, mimetype='html', categories=None, client=None):
+    client = client or sendgrid.SendGridClient(settings.SENDGRID_API_KEY)
+    mail = sendgrid.Mail()
+    mail.set_from(from_addr)
+    mail.add_to(to_addr)
+    mail.set_subject(subject)
+    if mimetype == 'html':
+        mail.set_html(message)
+    else:
+        mail.set_text(message)
+    if categories:
+        mail.set_categories(categories)
+
+    status, msg = client.send(mail)
+    return status < 400

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,7 @@ git+https://github.com/CenterForOpenScience/modular-odm.git@develop
 # Issue: certifi-2015.9.6.1 and 2015.9.6.2 fail verification (https://github.com/certifi/python-certifi/issues/26)
 # MailChimp Ticket: LTK1218902287135X, Domain: https://us9.api.mailchimp.com
 certifi==2015.4.28
+sendgrid==1.5.13
 
 requests==2.5.3
 urllib3==1.10.4

--- a/tests/framework_tests/test_email.py
+++ b/tests/framework_tests/test_email.py
@@ -2,10 +2,13 @@
 import unittest
 import smtplib
 
-from nose.tools import *  # PEP8 asserts
+import mock
+from nose.tools import *  # flake8: noqa (PEP8 asserts)
+import sendgrid
 
-from framework.email.tasks import send_email
+from framework.email.tasks import send_email, send_with_sendgrid
 from website import settings
+from tests.base import fake
 
 # Check if local mail server is running
 SERVER_RUNNING = True
@@ -25,6 +28,52 @@ class TestEmail(unittest.TestCase):
     def test_sending_email(self):
         assert_true(send_email("foo@bar.com", "baz@quux.com", subject='no subject',
                                  message="<h1>Greetings!</h1>", ttls=False, login=False))
+
+    def test_send_with_sendgrid_success(self):
+        mock_client = mock.MagicMock()
+        mock_client.send.return_value = 200, 'success'
+        from_addr, to_addr = fake.email(), fake.email()
+        category1, category2 = fake.word(), fake.word()
+        subject = fake.bs()
+        message = fake.text()
+        ret = send_with_sendgrid(
+            from_addr=from_addr,
+            to_addr=to_addr,
+            subject=subject,
+            message=message,
+            mimetype='txt',
+            client=mock_client,
+            categories=(category1, category2)
+        )
+        assert_true(ret)
+
+        mock_client.send.assert_called_once()
+        # First call's argument should be a Mail object with
+        # the correct configuration
+        first_call_arg = mock_client.send.call_args[0][0]
+        assert_is_instance(first_call_arg, sendgrid.Mail)
+        assert_equal(first_call_arg.from_email, from_addr)
+        assert_equal(first_call_arg.to[0], to_addr)
+        assert_equal(first_call_arg.subject, subject)
+        assert_equal(first_call_arg.text, message)
+        # Categories are set
+        assert_equal(first_call_arg.smtpapi.data['category'], (category1, category2))
+
+    def test_send_with_sendgrid_failure_returns_false(self):
+        mock_client = mock.MagicMock()
+        mock_client.send.return_value = 400, 'failed'
+        from_addr, to_addr = fake.email(), fake.email()
+        subject = fake.bs()
+        message = fake.text()
+        ret = send_with_sendgrid(
+            from_addr=from_addr,
+            to_addr=to_addr,
+            subject=subject,
+            message=message,
+            mimetype='txt',
+            client=mock_client
+        )
+        assert_false(ret)
 
 
 if __name__ == '__main__':

--- a/website/mails/mails.py
+++ b/website/mails/mails.py
@@ -43,11 +43,15 @@ class Mail(object):
 
     :param str tpl_prefix: The template name prefix.
     :param str subject: The subject of the email.
+    :param iterable categories: Categories to add to the email using SendGrid's
+        SMTPAPI. Used for email analytics.
+        See https://sendgrid.com/docs/User_Guide/Statistics/categories.html
     """
 
-    def __init__(self, tpl_prefix, subject):
+    def __init__(self, tpl_prefix, subject, categories=None):
         self.tpl_prefix = tpl_prefix
         self._subject = subject
+        self.categories = categories
 
     def html(self, **context):
         """Render the HTML email message."""
@@ -70,7 +74,8 @@ def render_message(tpl_name, **context):
 
 
 def send_mail(to_addr, mail, mimetype='plain', from_addr=None, mailer=None,
-            username=None, password=None, mail_server=None, callback=None, **context):
+            username=None, password=None, mail_server=None, callback=None,
+            **context):
     """Send an email from the OSF.
     Example: ::
 
@@ -107,7 +112,8 @@ def send_mail(to_addr, mail, mimetype='plain', from_addr=None, mailer=None,
         login=login,
         username=username,
         password=password,
-        mail_server=mail_server
+        mail_server=mail_server,
+        categories=mail.categories,
     )
 
     if settings.USE_EMAIL:
@@ -122,7 +128,7 @@ def send_mail(to_addr, mail, mimetype='plain', from_addr=None, mailer=None,
 
 # Predefined Emails
 
-TEST = Mail('test', subject='A test email to ${name}')
+TEST = Mail('test', subject='A test email to ${name}', categories=['test'])
 
 CONFIRM_EMAIL = Mail('confirm', subject='Open Science Framework Account Verification')
 CONFIRM_MERGE = Mail('confirm_merge', subject='Confirm account merge')
@@ -136,7 +142,7 @@ FORWARD_INVITE = Mail('forward_invite', subject='Please forward to ${fullname}')
 FORWARD_INVITE_REGISTERED = Mail('forward_invite_registered', subject='Please forward to ${fullname}')
 
 FORGOT_PASSWORD = Mail('forgot_password', subject='Reset Password')
-PENDING_VERIFICATION = Mail('pending_invite', subject="Your account is almost ready!")
+PENDING_VERIFICATION = Mail('pending_invite', subject='Your account is almost ready!')
 PENDING_VERIFICATION_REGISTERED = Mail('pending_registered', subject='Received request to be a contributor')
 
 REQUEST_EXPORT = Mail('support_request', subject='[via OSF] Export Request')
@@ -155,8 +161,14 @@ CONFERENCE_FAILED = Mail(
     subject='Open Science Framework Error: No files attached',
 )
 
-DIGEST = Mail('digest', subject='OSF Notifications')
-TRANSACTIONAL = Mail('transactional', subject='OSF: ${subject}')
+DIGEST = Mail(
+    'digest', subject='OSF Notifications',
+    categories=['notifications', 'notifications-digest']
+)
+TRANSACTIONAL = Mail(
+    'transactional', subject='OSF: ${subject}',
+    categories=['notifications', 'notifications-transactional']
+)
 
 # Retraction related Mail objects
 PENDING_RETRACTION_ADMIN = Mail(

--- a/website/mails/queued_mails.py
+++ b/website/mails/queued_mails.py
@@ -38,7 +38,8 @@ class QueuedMail(StoredObject):
         presend = mail_struct['presend'](self)
         mail = Mail(
             mail_struct['template'],
-            subject=mail_struct['subject']
+            subject=mail_struct['subject'],
+            categories=mail_struct.get('categories', None)
         )
         self.data['osf_url'] = settings.DOMAIN
         if presend and self.user.is_active and self.user.osf_mailing_lists.get(settings.OSF_HELP_LIST):
@@ -95,6 +96,7 @@ def queue_mail(to_addr, mail, send_at, user, **context):
 #EMAIL_TYPE = {
 #    'template': the mako template used for email_type,
 #    'subject': subject used for the actual email,
+#    'categories': categories to attach to the email using Sendgrid's SMTPAPI.
 #    'presend': function undes presends that can modify mail.data and decides whether the email should be sent,
 #               by returning a boolean.
 #}
@@ -102,25 +104,29 @@ def queue_mail(to_addr, mail, send_at, user, **context):
 NO_ADDON = {
     'template': 'no_addon',
     'subject': 'Link an add-on to your OSF project',
-    'presend': presends.no_addon
+    'presend': presends.no_addon,
+    'categories': ['engagement', 'engagement-no-addon']
 }
 
 NO_LOGIN = {
     'template': 'no_login',
     'subject': 'What you\'re missing on the OSF',
-    'presend': presends.no_login
+    'presend': presends.no_login,
+    'categories': ['engagement', 'engagement-no-login']
 }
 
 NEW_PUBLIC_PROJECT = {
     'template': 'new_public_project',
     'subject': 'Now, public. Next, impact.',
-    'presend': presends.new_public_project
+    'presend': presends.new_public_project,
+    'categories': ['engagement', 'engagement-new-public-project']
 }
 
 WELCOME_OSF4M = {
     'template': 'welcome_osf4m',
     'subject': 'The benefits of sharing your presentation',
-    'presend': presends.welcome_osf4m
+    'presend': presends.welcome_osf4m,
+    'categories': ['engagement', 'engagement-welcome-osf4m']
 }
 
 NO_ADDON_TYPE = 'no_addon'

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -88,9 +88,15 @@ USE_CDN_FOR_CLIENT_LIBS = True
 USE_EMAIL = True
 FROM_EMAIL = 'openscienceframework-noreply@osf.io'
 SUPPORT_EMAIL = 'support@osf.io'
+
+# SMTP Settings
 MAIL_SERVER = 'smtp.sendgrid.net'
 MAIL_USERNAME = 'osf-smtp'
 MAIL_PASSWORD = ''  # Set this in local.py
+
+# OR, if using Sendgrid's API
+SENDGRID_API_KEY = None
+
 
 # Mandrill
 MANDRILL_USERNAME = None


### PR DESCRIPTION
### Changes

Emails are now sent via the SendGrid API (`settings.SENDGRID_API_KEY` must be set).

### Purpose

This allows us to easily add categories using Sendgrid's
SMTPAPI. We will use categories to calculate open rates
of engagement emails and other emails.

Categories have been added to all engagement and notifications
emails.

### Notes

Should be backwards-compatible for local dev environments. If `settings.SENDGRID_API_KEY` is not set, emails will be sent via SMTP.

### Ticket

https://openscience.atlassian.net/browse/OSF-4806

### Deployment considerations

- Must update Python requirements (to install `sendgrid`)
- Must set `settings.SENDGRID_API_KEY` in the `local.py` for all deployments