### PR TITLE
[feature] bump pyrax version to fix dependency

### DIFF
--- a/requirements/release.txt
+++ b/requirements/release.txt
@@ -3,6 +3,6 @@
 # Requirements to be installed on server deployments
 
 # scripts osfstorage
-pyrax==1.9.4
+pyrax==1.9.5
 # multipart uploads (https://github.com/boto/boto/issues/2603)
 boto==2.31.1


### PR DESCRIPTION
pyrax v1.9.5 corrects issue with python-novaclient import issue.

https://github.com/rackspace/pyrax/issues/575