### PR TITLE
[CR] api: add md5, sha256 hashes to FileDetails

### DIFF
--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -69,6 +69,7 @@ class FileSerializer(JSONAPISerializer):
     provider = ser.CharField(read_only=True, help_text='The Add-on service this file originates from')
     last_touched = ser.DateTimeField(read_only=True, help_text='The last time this file had information fetched about it via the OSF')
     date_modified = ser.SerializerMethodField(read_only=True, help_text='The size of this file at this version')
+    extra = ser.SerializerMethodField(read_only=True, help_text='Additional metadata about this file')
 
     files = NodeFileHyperLink(kind='folder', link_type='related', view_name='nodes:node-files', kwargs=('node_id', 'path', 'provider'))
     versions = NodeFileHyperLink(kind='file', link_type='related', view_name='files:file-versions', kwargs=(('file_id', '_id'), ))
@@ -98,6 +99,16 @@ class FileSerializer(JSONAPISerializer):
                 return obj.versions[-1].date_created
             return obj.versions[-1].date_modified
         return None
+
+    def get_extra(self, obj):
+        extras = {}
+        if obj.versions:
+            metadata = obj.versions[-1].metadata
+            extras['hashes'] = {  # mimic waterbutler response
+                'md5': metadata.get('md5', None),
+                'sha256': metadata.get('sha256', None),
+            }
+        return extras
 
     def user_id(self, obj):
         # NOTE: obj is the user here, the meta field for

--- a/api/files/views.py
+++ b/api/files/views.py
@@ -76,7 +76,7 @@ class FileDetail(generics.RetrieveUpdateAPIView, FileMixin):
         provider      string     id of provider e.g. "osfstorage", "s3", "googledrive".
                                  equivalent to addon_short_name on the OSF
         size          integer    size of file in bytes
-        extra         object     may contain additional data beyond what's describe here,
+        extra         object     may contain additional data beyond what's described here,
                                  depending on the provider
           version     integer    version number of file. will be 1 on initial upload
           downloads   integer    count of the number times the file has been downloaded
@@ -116,6 +116,13 @@ class FileDetail(generics.RetrieveUpdateAPIView, FileMixin):
                                          for Box.com.
         last_touched  iso8601 timestamp  last time the metadata for the file was retrieved. only applies to non-OSF
                                          storage providers.
+        date_modified iso8601 timestamp  timestamp of when this file was last updated
+        extra         object             may contain additional data beyond what's described here, depending on
+                                         the provider
+          hashes      object
+            md5       string             md5 hash of file, null for folders
+            sha256    string             SHA-256 hash of file, null for folders
+
 
     ##Relationships
 

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1099,7 +1099,7 @@ class NodeFilesList(generics.ListAPIView, WaterButlerMixin, ListFilterMixin, Nod
         provider      string     id of provider e.g. "osfstorage", "s3", "googledrive".
                                  equivalent to addon_short_name on the OSF
         size          integer    size of file in bytes
-        extra         object     may contain additional data beyond what's describe here,
+        extra         object     may contain additional data beyond what's described here,
                                  depending on the provider
           version     integer    version number of file. will be 1 on initial upload
           downloads   integer    count of the number times the file has been downloaded
@@ -1140,6 +1140,12 @@ class NodeFilesList(generics.ListAPIView, WaterButlerMixin, ListFilterMixin, Nod
                                          for Box.com.
         last_touched  iso8601 timestamp  last time the metadata for the file was retrieved. only applies to non-OSF
                                          storage providers.
+        date_modified iso8601 timestamp  timestamp of when this file was last updated
+        extra         object             may contain additional data beyond what's described here, depending on
+                                         the provider
+          hashes      object
+            md5       string             md5 hash of file, null for folders
+            sha256    string             SHA-256 hash of file, null for folders
 
     ##Links
 
@@ -1392,7 +1398,7 @@ class NodeProvidersList(generics.ListAPIView, NodeMixin):
         provider      string     id of provider e.g. "osfstorage", "s3", "googledrive".
                                  equivalent to addon_short_name on the OSF
         size          integer    size of file in bytes
-        extra         object     may contain additional data beyond what's describe here,
+        extra         object     may contain additional data beyond what's described here,
                                  depending on the provider
           version     integer    version number of file. will be 1 on initial upload
           downloads   integer    count of the number times the file has been downloaded

--- a/api_tests/files/views/test_file_detail.py
+++ b/api_tests/files/views/test_file_detail.py
@@ -57,7 +57,13 @@ class TestFileView(ApiTestCase):
             'provider': self.file.provider,
             'size': self.file.versions[-1].size,
             # HACK: odm's dates are weird
-            'date_modified': self.file.versions[-1].date_created.isoformat()[:-3]
+            'date_modified': self.file.versions[-1].date_created.isoformat()[:-3],
+            'extra': {
+                'hashes': {
+                    'md5': None,
+                    'sha256': None,
+                },
+            },
         })
 
     def test_checkout(self):


### PR DESCRIPTION
OSF Offline needs the hashes of files stored on osfstorage.  Add a new
'extra' object to the file serializer, with a 'hashes' object
containing them.  This mimics the response format of waterbutler.
Hashes are currently only provided for files stored on
osfstorage. Folders and other providers will return null.

[#OSF-5200]