### PR TITLE
Vastly improve OSF4M load time

### DIFF
--- a/tests/test_conferences.py
+++ b/tests/test_conferences.py
@@ -419,6 +419,24 @@ class TestConferenceEmailViews(OsfTestCase):
         res = res.follow()
         assert_equal(res.request.path, '/meetings/')
 
+    def test_conference_submissions(self):
+        Node.remove()
+        conference1 = ConferenceFactory()
+        conference2 = ConferenceFactory()
+        # Create conference nodes
+        create_fake_conference_nodes(
+            3,
+            conference1.endpoint,
+        )
+        create_fake_conference_nodes(
+            2,
+            conference2.endpoint,
+        )
+
+        url = api_url_for('conference_submissions')
+        res = self.app.get(url)
+        assert_equal(len(res.json['submissions']), 5)
+
     def test_conference_plain_returns_200(self):
         conference = ConferenceFactory()
         url = web_url_for('conference_results__plain', meeting=conference.endpoint)

--- a/website/conferences/model.py
+++ b/website/conferences/model.py
@@ -41,6 +41,9 @@ class Conference(StoredObject):
         }
     )
 
+    # Cached number of submissions
+    num_submissions = fields.IntegerField(default=0)
+
     @classmethod
     def get_by_endpoint(cls, endpoint, active=True):
         query = Q('endpoint', 'iexact', endpoint)

--- a/website/conferences/views.py
+++ b/website/conferences/views.py
@@ -218,9 +218,12 @@ def conference_results(meeting):
         'settings': settings,
     }
 
+def conference_submissions(**kwargs):
+    """Return data for all OSF4M submissions.
 
-def conference_view(**kwargs):
-    meetings = []
+    The total number of submissions for each meeting is calculated and cached
+    in the Conference.num_submissions field.
+    """
     submissions = []
     for conf in Conference.find():
         # For efficiency, we filter by tag first, then node
@@ -237,16 +240,26 @@ def conference_view(**kwargs):
         for idx, node in enumerate(projects):
             submissions.append(_render_conference_node(node, idx, conf))
         num_submissions = len(projects)
+        # Cache the number of submissions
+        conf.num_submissions = num_submissions
+        conf.save()
         if num_submissions < settings.CONFERENCE_MIN_COUNT:
+            continue
+    submissions.sort(key=lambda submission: submission['dateCreated'], reverse=True)
+
+    return {'submissions': submissions}
+
+def conference_view(**kwargs):
+    meetings = []
+    for conf in Conference.find():
+        if conf.num_submissions < settings.CONFERENCE_MIN_COUNT:
             continue
         meetings.append({
             'name': conf.name,
             'active': conf.active,
             'url': web_url_for('conference_results', meeting=conf.endpoint),
-            'count': num_submissions,
+            'count': conf.num_submissions,
         })
 
-    submissions.sort(key=lambda submission: submission['dateCreated'], reverse=True)
     meetings.sort(key=lambda meeting: meeting['count'], reverse=True)
-
-    return {'meetings': meetings, 'submissions': submissions}
+    return {'meetings': meetings}

--- a/website/routes.py
+++ b/website/routes.py
@@ -213,6 +213,13 @@ def make_url_map(app):
         ),
 
         Rule(
+            '/api/v1/meetings/submissions/',
+            'get',
+            conference_views.conference_submissions,
+            json_renderer,
+        ),
+
+        Rule(
             '/presentations/',
             'get',
             conference_views.redirect_to_meetings,

--- a/website/static/js/pages/meetings-page.js
+++ b/website/static/js/pages/meetings-page.js
@@ -1,5 +1,14 @@
+var $ = require('jquery');
 var Meetings = require('../meetings.js');
 var Submissions = require('../submissions.js');
 
 new Meetings(window.contextVars.meetings);
-new Submissions(window.contextVars.submissions);
+
+var request = $.getJSON('/api/v1/meetings/submissions/');
+
+request.always(function() {
+    $('#allMeetingsLoader').hide();
+});
+request.done(function(data) {
+    new Submissions(data.submissions);
+});

--- a/website/templates/public/pages/meeting_landing.mako
+++ b/website/templates/public/pages/meeting_landing.mako
@@ -96,7 +96,13 @@
                             <div id="meetings-grid"></div>
                         </div>
                         <div role="tabpanel" class="tab-pane" id="submissions">
-                            <div id="submissions-grid"></div>
+
+                            <div id="submissions-grid">
+                                <div id="allMeetingsLoader" class="spinner-loading-wrapper">
+                                    <div class="logo-spin logo-lg"></div>
+                                    <p class="m-t-sm fg-load-message"> Loading submissions...</p>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -159,7 +165,6 @@
     <script type="text/javascript">
         window.contextVars = window.contextVars || {};
         window.contextVars.meetings = ${meetings | sjson, n};
-        window.contextVars.submissions = ${submissions | sjson, n};
     </script>
     <script src=${"/static/public/js/meetings-page.js" | webpack_asset}></script>
 </%def>


### PR DESCRIPTION
The meetings page was taking many seconds to load because all
submission records needed to be loaded before page loaded.
This patch adds an API endpoint for loading the data for the
All Submissions tab asynchronously. This improves the load time
~5x.

Also caches the number of submissions in Toku so they can be displayed
on the "All meetings" tab.

Partially addresses OSF-4989