### PR TITLE
[hotfix] Different formatting of project description logged in vs. logged out

### DIFF
--- a/website/static/css/pages/project-page.css
+++ b/website/static/css/pages/project-page.css
@@ -134,3 +134,11 @@
 .table-addon-terms td:first-child {
     word-break: normal;
 }
+
+
+/* Project Description */
+
+span#nodeDescriptionEditable{
+    white-space:nowrap;
+}
+


### PR DESCRIPTION
# Purpose: 
- There is different formatting of project description logged in versus logged out. It is expected that there should be no formatting associated with the description. 

# Changes: 
-Changes in project-page.css

# Side Effects:
None

# Notes: 
Closes: 
- https://github.com/CenterForOpenScience/osf.io/issues/4097
- JIRA ticket: https://openscience.atlassian.net/browse/OSF-4155
