### PR TITLE
[WIP] NodeList is sorting by id and it thinks it's supposed to be sorting by date modified

### DIFF
--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -222,7 +222,7 @@ class NodeList(bulk_views.BulkUpdateJSONAPIView, bulk_views.BulkDestroyJSONAPIVi
 
     serializer_class = NodeSerializer
 
-    ordering = ('-date_modified', )  # default ordering
+    ordering = ('-date_created', )  # default ordering
 
     # overrides ODMFilterMixin
     def get_default_odm_query(self):

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -135,7 +135,7 @@ class WaterButlerMixin(object):
 class NodeList(bulk_views.BulkUpdateJSONAPIView, bulk_views.BulkDestroyJSONAPIView, bulk_views.ListBulkCreateJSONAPIView, ODMFilterMixin):
     """Nodes that represent projects and components. *Writeable*.
 
-    Paginated list of nodes ordered by their `date_modified`.  Each resource contains the full representation of the
+    Paginated list of nodes ordered by their `title`.  Each resource contains the full representation of the
     node, meaning additional requests to an individual node's detail view are not necessary.
 
     <!--- Copied Spiel from NodeDetail -->
@@ -222,7 +222,7 @@ class NodeList(bulk_views.BulkUpdateJSONAPIView, bulk_views.BulkDestroyJSONAPIVi
 
     serializer_class = NodeSerializer
 
-    ordering = ('-date_created', )  # default ordering
+    ordering = ('title', )  # default ordering
 
     # overrides ODMFilterMixin
     def get_default_odm_query(self):

--- a/api_tests/nodes/views/test_node_list.py
+++ b/api_tests/nodes/views/test_node_list.py
@@ -333,14 +333,15 @@ class TestNodeFiltering(ApiTestCase):
         assert_equal(len(errors), 1)
         assert_equal(errors[0]['detail'], "'notafield' is not a valid field for this endpoint.")
 
-    def test_default_ordering_on_date_created(self):
+    def test_default_ordering_on_title(self):
         url = '/{}nodes/'.format(API_BASE)
         res = self.app.get(url, auth=self.user_one.auth)
         data = res.json['data']
+        print res
         assert_equal(data[0]['id'], self.private_project_user_one._id)
-        assert_equal(data[1]['id'], self.project_three._id)
+        assert_equal(data[3]['id'], self.project_three._id)
         assert_equal(data[2]['id'], self.project_two._id)
-        assert_equal(data[3]['id'], self.project_one._id)
+        assert_equal(data[1]['id'], self.project_one._id)
 
 
 class TestNodeCreate(ApiTestCase):

--- a/api_tests/nodes/views/test_node_list.py
+++ b/api_tests/nodes/views/test_node_list.py
@@ -333,6 +333,15 @@ class TestNodeFiltering(ApiTestCase):
         assert_equal(len(errors), 1)
         assert_equal(errors[0]['detail'], "'notafield' is not a valid field for this endpoint.")
 
+    def test_default_ordering_on_date_created(self):
+        url = '/{}nodes/'.format(API_BASE)
+        res = self.app.get(url, auth=self.user_one.auth)
+        data = res.json['data']
+        assert_equal(data[0]['id'], self.private_project_user_one._id)
+        assert_equal(data[1]['id'], self.project_three._id)
+        assert_equal(data[2]['id'], self.project_two._id)
+        assert_equal(data[3]['id'], self.project_one._id)
+
 
 class TestNodeCreate(ApiTestCase):
 


### PR DESCRIPTION
# Purpose

Issue https://openscience.atlassian.net/browse/OSF-5173

NodeList is sorting by id and it thinks it's supposed to be sorting by date modified.  This is because `date_modified` is a property on the Node model, not an actual field.  You can't filter on properties because they are python code and the filtering takes place at the database level.

~~You can get around it by turning the node queryset into a list, and then sorting that, but I think this is too slow.~~

# Changes

~~Sorts by title instead of date_modified.~~
Decision made to make date_modified a field on Node.  NodeLogs should update date_modified when something is changed.