### PR TITLE
Changed email notification to address [OSF-5026]

### DIFF
--- a/website/templates/emails/contributor_added.txt.mako
+++ b/website/templates/emails/contributor_added.txt.mako
@@ -1,6 +1,6 @@
 Hello ${user.fullname},
 
-"${referrer.fullname}" has added you as a contributor to the project "${node.title}" on the Open Science Framework: ${node.absolute_url}
+${author} has added you as a contributor to the project "${node.title}" on the Open Science Framework: ${node.absolute_url}
 
 If you are erroneously being associated with "${node.title}," then you may visit the project's "Contributors" page and remove yourself as a contributor.
 

--- a/website/templates/emails/contributor_added.txt.mako
+++ b/website/templates/emails/contributor_added.txt.mako
@@ -1,6 +1,6 @@
 Hello ${user.fullname},
 
-${author} has added you as a contributor to the project "${node.title}" on the Open Science Framework: ${node.absolute_url}
+${node.contributors[0]} has added you as a contributor to the project "${node.title}" on the Open Science Framework: ${node.absolute_url}
 
 If you are erroneously being associated with "${node.title}," then you may visit the project's "Contributors" page and remove yourself as a contributor.
 

--- a/website/templates/emails/contributor_added.txt.mako
+++ b/website/templates/emails/contributor_added.txt.mako
@@ -1,6 +1,6 @@
 Hello ${user.fullname},
 
-You have been added as a contributor to the project "${node.title}" on the Open Science Framework: ${node.absolute_url}
+"${node.author}" has added you as a contributor to the project "${node.title}" on the Open Science Framework: ${node.absolute_url}
 
 If you are erroneously being associated with "${node.title}," then you may visit the project's "Contributors" page and remove yourself as a contributor.
 

--- a/website/templates/emails/contributor_added.txt.mako
+++ b/website/templates/emails/contributor_added.txt.mako
@@ -1,6 +1,6 @@
 Hello ${user.fullname},
 
-"${node.author}" has added you as a contributor to the project "${node.title}" on the Open Science Framework: ${node.absolute_url}
+"${referrer.fullname}" has added you as a contributor to the project "${node.title}" on the Open Science Framework: ${node.absolute_url}
 
 If you are erroneously being associated with "${node.title}," then you may visit the project's "Contributors" page and remove yourself as a contributor.
 


### PR DESCRIPTION
<b>Purpose</b>

The purpose of this was to change the email sent to registered contributors when notifying them about being added to a project so that the email would say who added them.  

<b>Changes</b>

The change made was to add the name of the author of the project to the email so that the recipient could tell who added them.