### PR TITLE
Large number of files upload 

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "raw-loader": "^0.5.1",
     "share": "0.7.27",
     "style-loader": "^0.8.3",
-    "treebeard": "git://github.com/caneruguz/treebeard.git#02e5b770640b5e7410cab9685ae7536fac04c3de",
+    "treebeard": "git://github.com/caneruguz/treebeard.git#c62685d66f62e7ed893eea32e77094b19a438885",
     "typeahead.js": "^0.10.5",
     "url-loader": "^0.5.5",
     "webpack": "^1.7.2",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "raw-loader": "^0.5.1",
     "share": "0.7.27",
     "style-loader": "^0.8.3",
-    "treebeard": "git://github.com/caneruguz/treebeard.git#50a71133305496a440586ed880ae63f0ac5edda8",
+    "treebeard": "git://github.com/caneruguz/treebeard.git#02e5b770640b5e7410cab9685ae7536fac04c3de",
     "typeahead.js": "^0.10.5",
     "url-loader": "^0.5.5",
     "webpack": "^1.7.2",

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1998,20 +1998,24 @@ function _fangornQueueComplete(treebeard) {
     var fileStatus = treebeard.options.uploadStates;
     treebeard.options.uploadStates = [];
     if (fileStatus.length > 2) {
-        treebeard.modal.update(m('div', [
-            m('h3.break-word.modal-title', ['Upload Status', m('br')]),
-            m('div.container', [
+        treebeard.modal.update(m('', [
+            m('', [
                 fileStatus.map(function(status){
-                    if (status.link) {
-                        return m('', [m('.row.col-12', [ m('.col-xs-2', m(status.success ? '.fa.fa-check' : '.fa.fa-times')), m('a[href="' + status.link + '"].col-xs-8', status.name)]), m('hr.row.col-12')])
-                    } else {
-                        return m('', [m('.row.col-12', [m('.col-xs-2', m(status.success ? '.fa.fa-check' : '.fa.fa-times')), m('.col-xs-8', status.name)]), m('hr.row.col-12')])
-                        // return m('.row.col-12', [m('', status.name), m('.col-xs-2', m(status.success ? '.fa.fa-check' : '.fa.fa-times'))])
-                    }
+                    return m('',
+                        [
+                            m('.row', [
+                                m((status.link ? 'a[href="' + status.link + '"]' : status.name) + '.col-sm-10', status.name),
+                                m('.col-sm-2', m(status.success ? '.fa.fa-check' : '.fa.fa-times'))
+                            ]),
+                            m('hr')
+                        ]
+                    );
                 })
             ])
-            ])
-        );
+        ]), m('', [
+            m('a.btn.btn-primary', {onclick: function() {treebeard.modal.dismiss();}}, 'Done'), //jshint ignore:line
+        ]), m('h3.break-word.modal-title', 'Upload Status'));
+
     }
 }
 

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1997,10 +1997,13 @@ function _fangornOver(event, ui) {
 function _fangornQueueComplete(treebeard) {
     var fileStatus = treebeard.options.uploadStates;
     treebeard.options.uploadStates = [];
+    var total = fileStatus.length;
+    var failed = 0;
     if (fileStatus.length > 2) {
         treebeard.modal.update(m('', [
             m('', [
                 fileStatus.map(function(status){
+                    if (!status.success){ failed++; }
                     return m('',
                         [
                             m('.row', [
@@ -2015,7 +2018,7 @@ function _fangornQueueComplete(treebeard) {
             ])
         ]), m('', [
             m('a.btn.btn-primary', {onclick: function() {treebeard.modal.dismiss();}}, 'Done'), //jshint ignore:line
-        ]), m('h3.break-word.modal-title', 'Upload Status'));
+        ]), m('', [m('h3.break-word.modal-title', 'Upload Status'), m('p', total - failed + '/' + total + ' files succeeded.')]));
         $('[data-toggle="tooltip"]').tooltip();
     }
 }
@@ -2285,7 +2288,7 @@ tbOptions = {
         parallelUploads: 5,
         acceptDirectories: false,
         createImageThumbnails: false,
-        fallback: function(){}
+        fallback: function(){},
     },
     resolveIcon : _fangornResolveIcon,
     resolveToggle : _fangornResolveToggle,

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -767,7 +767,7 @@ function _fangornDropzoneError(treebeard, file, message, xhr) {
         msgText = 'Cannot upload file due to insufficient storage.';
     } else if (xhr && xhr.status === 0){
         msgText = 'Unable to reach the provider, please try again later. If the ' +
-                'problem persists, please contact <a href="mailto:support@osf.io">support@osf.io</a>.';
+                'problem persists, please contact support@osf.io.';
     } else {
         msgText = message.message || DEFAULT_ERROR_MESSAGE;
     }

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -2018,7 +2018,7 @@ function _fangornQueueComplete(treebeard) {
                         [
                             m('.row', [
                                 m((status.link ? 'a[href="' + status.link + '"]' : status.name) + '.col-sm-10', status.name),
-                                m('.col-sm-1', m(status.success ? '.fa.fa-check' : '.fa.fa-times')),
+                                m('.col-sm-1', m(status.success ? '.fa.fa-check[style="color: green"]' : '.fa.fa-times[style="color: red"]')),
                                 m('.col-sm-1', m(status.message ? '.fa.fa-info[data-toggle="tooltip"][data-placement="top"][title="'+ status.message +'"]' : ''))
                             ]),
                             m('hr')

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1999,7 +1999,7 @@ function _fangornQueueComplete(treebeard) {
     treebeard.options.uploadStates = [];
     var total = fileStatus.length;
     var failed = 0;
-    if (fileStatus.length > 2) {
+    if (fileStatus.length > 3) {
         treebeard.modal.update(m('', [
             m('', [
                 fileStatus.map(function(status){
@@ -2263,7 +2263,7 @@ tbOptions = {
                     item.notify.update(msgText, 'warning', undefined, 3000);
                     if (!treebeard.options.uploadStates) { treebeard.options.uploadStates = []; }
                     treebeard.options.uploadStates.push(
-                        {'name': file.name, 'success': false, 'link': false, 'message': 'File is too large. Max file size is' + item.data.accept.maxSize + ' MB.'}
+                        {'name': file.name, 'success': false, 'link': false, 'message': 'File is too large. Max file size is ' + item.data.accept.maxSize + ' MB.'}
                     );
                     return false;
                 }

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -745,7 +745,7 @@ function _fangornDropzoneSuccess(treebeard, file, response) {
     var u = item.data;
     var url = u.nodeUrl + 'files/' + u.provider + u.path;
     if (!treebeard.options.uploadStates) { treebeard.options.uploadStates = []; }
-    treebeard.options.uploadStates.push({'name': file.name, 'success': true, 'link': url, 'message': 'It worked'});
+    treebeard.options.uploadStates.push({'name': file.name, 'success': true, 'link': url, 'message': false});
     treebeard.redraw();
 }
 
@@ -793,7 +793,7 @@ function _fangornDropzoneError(treebeard, file, message, xhr) {
     }
     treebeard.options.uploadInProgress = false;
     if (!treebeard.options.uploadStates) { treebeard.options.uploadStates = []; }
-    treebeard.options.uploadStates.push({'name': file.name, 'success': false, 'link': false, 'message': 'Because you suck'});
+    treebeard.options.uploadStates.push({'name': file.name, 'success': false, 'link': false, 'message': msgText});
 
 }
 
@@ -2005,7 +2005,8 @@ function _fangornQueueComplete(treebeard) {
                         [
                             m('.row', [
                                 m((status.link ? 'a[href="' + status.link + '"]' : status.name) + '.col-sm-10', status.name),
-                                m('.col-sm-2', m(status.success ? '.fa.fa-check' : '.fa.fa-times'))
+                                m('.col-sm-1', m(status.success ? '.fa.fa-check' : '.fa.fa-times')),
+                                m('.col-sm-1', m(status.message ? '.fa.fa-info[data-toggle="tooltip"][data-placement="top"][title="'+ status.message +'"]' : ''))
                             ]),
                             m('hr')
                         ]
@@ -2015,7 +2016,7 @@ function _fangornQueueComplete(treebeard) {
         ]), m('', [
             m('a.btn.btn-primary', {onclick: function() {treebeard.modal.dismiss();}}, 'Done'), //jshint ignore:line
         ]), m('h3.break-word.modal-title', 'Upload Status'));
-
+        $('[data-toggle="tooltip"]').tooltip();
     }
 }
 
@@ -2258,7 +2259,9 @@ tbOptions = {
                     msgText = 'One of the files is too large (' + displaySize + ' MB). Max file size is ' + item.data.accept.maxSize + ' MB.';
                     item.notify.update(msgText, 'warning', undefined, 3000);
                     if (!treebeard.options.uploadStates) { treebeard.options.uploadStates = []; }
-                    treebeard.options.uploadStates.push({'name': file.name, 'success': false, 'link': false, 'message': 'Becayse you suck'});
+                    treebeard.options.uploadStates.push(
+                        {'name': file.name, 'success': false, 'link': false, 'message': 'File is too large. Max file size is' + item.data.accept.maxSize + ' MB.'}
+                    );
                     return false;
                 }
             }


### PR DESCRIPTION
https://openscience.atlassian.net/browse/OSF-4829

## Purpose
Provide a report of how many files were successfully uploaded, and why others weren't .
For this first iteration, the user will receive a modal showing which files uploaded successfully and which didn't if the total files uploaded exceeds 3. The modal is shown below.

1. The behavior is the same for all providers and will show the name of the file as it was uploaded, rather than potential rename (such as file.txt (1)). 
2. Files that fail will have an 'X' next to their names and a little 'i' that should show what caused the file to fail on tooltip when the icon is hovered. 
3. Files that succeed will have a check mark next to their names, and the name should be a hyperlink (blue) to the file detail page.

QA, I was unable to test for case when 'Replace one, keep both' modal is used, so please pay attention to that potential use case.
![screen shot 2015-11-23 at 10 20 59 am](https://cloud.githubusercontent.com/assets/6268982/11340449/eb940e46-91cb-11e5-9c46-9917e56f0762.png)
