### PR TITLE
Update retraction template to account for new Node.registered_meta/schema format

### DIFF
--- a/website/templates/project/register.mako
+++ b/website/templates/project/register.mako
@@ -52,7 +52,7 @@
 
 <%def name="javascript_bottom()">
     ${parent.javascript_bottom()}
-    % if node.get('registered_schema'):
+    % if node.get('registered_schema') and not node.get('is_retracted'):
       <script type="text/javascript">
         window.contextVars.node.registrationMetaSchema = ${ node['registered_schema'] | sjson, n };
       </script>

--- a/website/templates/project/retracted_registration.mako
+++ b/website/templates/project/retracted_registration.mako
@@ -25,10 +25,15 @@
                     <br />Forked from <a class="node-forked-from" href="/${node['forked_from_id']}/">${node['forked_from_display_absolute_url']}</a> on
                     <span data-bind="text: dateForked.local, tooltip: {title: dateForked.utc}"></span>
                 % endif
-                % if node['is_registration'] and node['registered_meta']:
-                    <br />Registration Supplement:
-                    <span>${node['registered_schema']['schema']['title']}</span>
-                % endif
+                <p>
+                  Registration Supplement:
+                  % for meta_schema in node.get('registered_schemas', []):
+                  <span> ${meta_schema['schema_name']}</span>
+                  % if len(node['registered_schemas']) > 1:
+                  ,
+                  % endif
+                  % endfor
+                </p>
                 <br />
                 Date Created: <span data-bind="text: dateCreated.local, tooltip: {title: dateCreated.utc}" class="date node-date-created"></span>
                 | Date Registered:  <span data-bind="text: dateRegistered.local, tooltip: {title: dateRegistered.utc}" class="date node-date-registered"></span>


### PR DESCRIPTION
# Purpose

Draft Reg. changed the way Node.registered_meta and Node.registered_schema work, and consequently the mako templates for showing registration supplements was updated. The retraction mako templates duplicate this logic and were not updated.

# Changes

Update the retraction template logic
[#OSF-5247]