### PR TITLE
JSON API valid URI's fix 

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -84,7 +84,7 @@ def _url_val(val, obj, serializer, **kwargs):
     else:
         url = val
 
-    if not url and url !=0:
+    if not url and url != 0:
         raise SkipField
     else:
         return url

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -84,7 +84,7 @@ def _url_val(val, obj, serializer, **kwargs):
     else:
         url = val
 
-    if not url and not url == 0:
+    if not url and url !=0:
         raise SkipField
     else:
         return url

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -83,7 +83,7 @@ def _url_val(val, obj, serializer, **kwargs):
     else:
         url = val
 
-    if not url:
+    if not url and not url == 0:
         raise SkipField
     else:
         return url

--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -115,10 +115,10 @@ class TestNodeDetail(ApiTestCase):
         expected_url = self.public_url + 'files/'
         assert_equal(urlparse(url).path, expected_url)
 
-    def test_node_does_not_have_comments_link(self):
+    def test_node_has_comments_link(self):
         res = self.app.get(self.public_url)
         assert_equal(res.status_code, 200)
-        assert_not_in('comments', res.json['data']['relationships'].keys())
+        assert_in('comments', res.json['data']['relationships'].keys())
 
     def test_node_has_correct_unread_comments_count(self):
         contributor = AuthUserFactory()


### PR DESCRIPTION
# Purpose

Solves issue https://openscience.atlassian.net/browse/OSF-5249

Corrects bug caused by https://github.com/CenterForOpenScience/osf.io/pull/4629

Above PR raises SkipField in multiple places when URL is none.  However, this causes comments relationships link to disappear.  When going to fetch `get_unread_comments`, if there are 0 comments on a node, URL is none and SkipField is raised.  The comments relationships link disappears.

# Changes

Small change to `def _url_val`. 

`if not url and url != 0:`  ==>  comment link is restored.

![screen shot 2015-11-23 at 10 38 43 am](https://cloud.githubusercontent.com/assets/9755598/11341043/b24031ee-91ce-11e5-8048-943b328ce7b0.png)
