### PR TITLE
[Ready for Review] Change which resources are automatically embedded.

### DIFF
--- a/api/base/requests.py
+++ b/api/base/requests.py
@@ -1,0 +1,33 @@
+from rest_framework.request import Request
+
+
+class EmbeddedRequest(Request):
+    """
+    Creates a Request for retrieving the embedded resource.
+
+    Enforces that the request method is 'GET' and user is the
+    authorized user from the original request.
+    """
+
+    def __init__(self, request, parsers=None, authenticators=None,
+                 negotiator=None, parser_context=None):
+         self.original_user = request.user
+         super(EmbeddedRequest, self).__init__(request, parsers, authenticators,
+                                               negotiator, parser_context)
+
+    @property
+    def method(self):
+        """
+        Overrides method to be 'GET'
+        """
+        return 'GET'
+
+    @property
+    def user(self):
+        """
+        Returns the user from the original request
+        """
+        return self.original_user
+
+
+

--- a/api/base/requests.py
+++ b/api/base/requests.py
@@ -8,12 +8,11 @@ class EmbeddedRequest(Request):
     Enforces that the request method is 'GET' and user is the
     authorized user from the original request.
     """
-
     def __init__(self, request, parsers=None, authenticators=None,
                  negotiator=None, parser_context=None):
-         self.original_user = request.user
-         super(EmbeddedRequest, self).__init__(request, parsers, authenticators,
-                                               negotiator, parser_context)
+        self.original_user = request.user
+        super(EmbeddedRequest, self).__init__(request, parsers, authenticators,
+                                              negotiator, parser_context)
 
     @property
     def method(self):
@@ -28,6 +27,3 @@ class EmbeddedRequest(Request):
         Returns the user from the original request
         """
         return self.original_user
-
-
-

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -6,6 +6,7 @@ from rest_framework import generics
 from api.users.serializers import UserSerializer
 from website import settings
 from .utils import absolute_reverse
+from .requests import EmbeddedRequest
 
 class JSONAPIBaseView(generics.GenericAPIView):
 
@@ -26,8 +27,9 @@ class JSONAPIBaseView(generics.GenericAPIView):
         def partial(item):
             # resolve must be implemented on the field
             view, view_args, view_kwargs = field.resolve(item)
+            request = EmbeddedRequest(self.request)
             view_kwargs.update({
-                'request': self.request,
+                'request': request,
                 'is_embedded': True
             })
             response = view(*view_args, **view_kwargs)

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -38,15 +38,15 @@ class JSONAPIBaseView(generics.GenericAPIView):
 
     def get_serializer_context(self):
         """Inject request into the serializer context. Additionally, inject partial functions
-        (request, object -> embed items) if the query string contains embeds, and this
-        is the topmost call to this method (the embed partials call view functions which has
-        the potential to create infinite recursion hence the inclusion of the is_embedded
-        view kwarg to prevent this).
+        (request, object -> embed items) if the query string contains embeds.  Allows
+         multiple levels of nesting.
         """
         context = super(JSONAPIBaseView, self).get_serializer_context()
         if self.kwargs.get('is_embedded'):
-            return context
-        embeds = self.request.query_params.getlist('embed')
+            embeds = []
+        else:
+            embeds = self.request.query_params.getlist('embed')
+
         fields = self.serializer_class._declared_fields
         for field in fields:
             if getattr(fields[field], 'always_embed', False) and field not in embeds:

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -2,6 +2,7 @@ from django.http import JsonResponse
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 from rest_framework import generics
+from rest_framework.mixins import ListModelMixin
 
 from api.users.serializers import UserSerializer
 from website import settings
@@ -27,6 +28,8 @@ class JSONAPIBaseView(generics.GenericAPIView):
         def partial(item):
             # resolve must be implemented on the field
             view, view_args, view_kwargs = field.resolve(item)
+            if issubclass(view.cls, ListModelMixin) and field.always_embed:
+                raise Exception("Cannot auto-embed a list view.")
             request = EmbeddedRequest(self.request)
             view_kwargs.update({
                 'request': request,

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -84,7 +84,6 @@ class NodeSerializer(JSONAPISerializer):
         related_view='nodes:node-contributors',
         related_view_kwargs={'node_id': '<pk>'},
         related_meta={'count': 'get_contrib_count'},
-        always_embed=True
     )
 
     files = RelationshipField(
@@ -101,7 +100,6 @@ class NodeSerializer(JSONAPISerializer):
         related_view='nodes:node-pointers',
         related_view_kwargs={'node_id': '<pk>'},
         related_meta={'count': 'get_pointers_count'},
-        always_embed=True
     ))
 
     parent = RelationshipField(
@@ -306,7 +304,9 @@ class NodeLinksSerializer(JSONAPISerializer):
 
     target_node = RelationshipField(
         related_view='nodes:node-detail',
-        related_view_kwargs={'node_id': '<pk>'}
+        related_view_kwargs={'node_id': '<pk>'},
+        always_embed=True
+
     )
     class Meta:
         type_ = 'node_links'

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -472,6 +472,7 @@ class NodeContributorsList(JSONAPIBaseView, bulk_views.BulkUpdateJSONAPIView, bu
     ###Users
 
     This endpoint shows the contributor user detail and is automatically embedded.
+
     ##Actions
 
     ###Adding Contributors
@@ -921,7 +922,7 @@ class NodeLinksList(JSONAPIBaseView, bulk_views.BulkDestroyJSONAPIView, bulk_vie
 
     ### Target Node
 
-    This endpoint shows the target node detail.
+    This endpoint shows the target node detail and is automatically embedded.
 
     ##Actions
 

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -343,9 +343,8 @@ class NodeDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, NodeMix
 
     ###Contributors
 
-    List of users who are contributors to this node. This endpoint is always embedded.  Contributors may have
-    "read", "write", or "admin" permissions.  A node must always have at least one "admin" contributor.  Contributors may
-    be added via this endpoint.
+    List of users who are contributors to this node. Contributors may have "read", "write", or "admin" permissions.
+    A node must always have at least one "admin" contributor.  Contributors may be added via this endpoint.
 
     ###Files
 
@@ -1018,7 +1017,7 @@ class NodeLinksDetail(JSONAPIBaseView, generics.RetrieveDestroyAPIView, NodeMixi
 
     ###Target node
 
-    This endpoint shows the target node detail.
+    This endpoint shows the target node detail and is automatically embedded.
 
     ##Actions
 

--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -93,15 +93,17 @@ class TestNodeDetail(ApiTestCase):
         expected_url = self.public_url + 'children/'
         assert_equal(urlparse(url).path, expected_url)
 
-    def test_node_contributors_embedded(self):
+    def test_node_has_contributors_link(self):
         res = self.app.get(self.public_url)
-        returned_id = res.json['data']['embeds']['contributors']['data'][0]['id']
-        assert_equal(returned_id, self.user._id)
+        url = res.json['data']['relationships']['contributors']['links']['related']['href']
+        expected_url = self.public_url + 'contributors/'
+        assert_equal(urlparse(url).path, expected_url)
 
-    def test_node_has_pointers_embedded(self):
+    def test_node_has_node_links_link(self):
         res = self.app.get(self.public_url)
-        returned_node_link = res.json['data']['embeds']['node_links']['data']
-        assert_equal(returned_node_link, [])
+        url = res.json['data']['relationships']['node_links']['links']['related']['href']
+        expected_url = self.public_url + 'node_links/'
+        assert_equal(urlparse(url).path, expected_url)
 
     def test_node_has_registrations_link(self):
         res = self.app.get(self.public_url)

--- a/api_tests/nodes/views/test_node_links_detail.py
+++ b/api_tests/nodes/views/test_node_links_detail.py
@@ -37,23 +37,21 @@ class TestNodeLinkDetail(ApiTestCase):
                                                               save=True)
         self.public_url = '/{}nodes/{}/node_links/{}/'.format(API_BASE, self.public_project._id, self.public_pointer._id)
 
-    def test_returns_public_node_pointer_detail_logged_out(self):
+    def test_returns_embedded_public_node_pointer_detail_logged_out(self):
         res = self.app.get(self.public_url)
         assert_equal(res.status_code, 200)
         assert_equal(res.content_type, 'application/vnd.api+json')
         res_json = res.json['data']
-        expected_path = node_url_for(self.public_pointer_project._id)
-        actual_path = urlparse(res_json['relationships']['target_node']['links']['related']['href']).path
-        assert_equal(expected_path, actual_path)
+        embedded = res_json['embeds']['target_node']['data']['id']
+        assert_equal(embedded, self.public_pointer_project._id)
 
     def test_returns_public_node_pointer_detail_logged_in(self):
         res = self.app.get(self.public_url, auth=self.user.auth)
         res_json = res.json['data']
         assert_equal(res.status_code, 200)
         assert_equal(res.content_type, 'application/vnd.api+json')
-        expected_path = node_url_for(self.public_pointer_project._id)
-        actual_path = urlparse(res_json['relationships']['target_node']['links']['related']['href']).path
-        assert_equal(expected_path, actual_path)
+        embedded = res_json['embeds']['target_node']['data']['id']
+        assert_equal(embedded, self.public_pointer_project._id)
 
     def test_returns_private_node_pointer_detail_logged_out(self):
         res = self.app.get(self.private_url, expect_errors=True)
@@ -65,9 +63,8 @@ class TestNodeLinkDetail(ApiTestCase):
         res_json = res.json['data']
         assert_equal(res.status_code, 200)
         assert_equal(res.content_type, 'application/vnd.api+json')
-        expected_path = node_url_for(self.pointer_project._id)
-        actual_path = urlparse(res_json['relationships']['target_node']['links']['related']['href']).path
-        assert_equal(expected_path, actual_path)
+        embedded = res_json['embeds']['target_node']['data']['id']
+        assert_equal(embedded, self.pointer_project._id)
 
     def test_returns_private_node_pointer_detail_logged_in_non_contributor(self):
         res = self.app.get(self.private_url, auth=self.user_two.auth, expect_errors=True)

--- a/api_tests/nodes/views/test_node_links_list.py
+++ b/api_tests/nodes/views/test_node_links_list.py
@@ -35,25 +35,24 @@ class TestNodeLinksList(ApiTestCase):
 
         self.user_two = AuthUserFactory()
 
-    def test_return_public_node_pointers_logged_out(self):
+    def test_return_embedded_public_node_pointers_logged_out(self):
         res = self.app.get(self.public_url)
         res_json = res.json['data']
         assert_equal(len(res_json), 1)
         assert_equal(res.status_code, 200)
         assert_equal(res.content_type, 'application/vnd.api+json')
-        expected_path = node_url_for(self.public_pointer_project._id)
-        actual_path = urlparse(res_json[0]['relationships']['target_node']['links']['related']['href']).path
-        assert_equal(expected_path, actual_path)
 
-    def test_return_public_node_pointers_logged_in(self):
+        embedded = res_json[0]['embeds']['target_node']['data']['id']
+        assert_equal(embedded, self.public_pointer_project._id)
+
+    def test_return_embedded_public_node_pointers_logged_in(self):
         res = self.app.get(self.public_url, auth=self.user_two.auth)
         res_json = res.json['data']
         assert_equal(len(res_json), 1)
         assert_equal(res.status_code, 200)
         assert_equal(res.content_type, 'application/vnd.api+json')
-        expected_path = node_url_for(self.public_pointer_project._id)
-        actual_path = urlparse(res_json[0]['relationships']['target_node']['links']['related']['href']).path
-        assert_equal(expected_path, actual_path)
+        embedded = res_json[0]['embeds']['target_node']['data']['id']
+        assert_equal(embedded, self.public_pointer_project._id)
 
     def test_return_private_node_pointers_logged_out(self):
         res = self.app.get(self.private_url, expect_errors=True)
@@ -66,9 +65,8 @@ class TestNodeLinksList(ApiTestCase):
         assert_equal(res.status_code, 200)
         assert_equal(res.content_type, 'application/vnd.api+json')
         assert_equal(len(res_json), 1)
-        expected_path = node_url_for(self.pointer_project._id)
-        actual_path = urlparse(res_json[0]['relationships']['target_node']['links']['related']['href']).path
-        assert_equal(expected_path, actual_path)
+        embedded = res_json[0]['embeds']['target_node']['data']['id']
+        assert_equal(embedded, self.pointer_project._id)
 
     def test_return_private_node_pointers_logged_in_non_contributor(self):
         res = self.app.get(self.private_url, auth=self.user_two.auth, expect_errors=True)
@@ -340,9 +338,8 @@ class TestNodeLinkCreate(ApiTestCase):
         assert_equal(res.status_code, 201)
         assert_equal(res.content_type, 'application/vnd.api+json')
         res_json = res.json['data']
-        expected_path = node_url_for(self.public_pointer_project._id)
-        actual_path = urlparse(res_json['relationships']['target_node']['links']['related']['href']).path
-        assert_equal(expected_path, actual_path)
+        embedded = res_json['embeds']['target_node']['data']['id']
+        assert_equal(embedded, self.public_pointer_project._id)
 
     def test_creates_private_node_pointer_logged_out(self):
         res = self.app.post_json_api(self.private_url, self.private_payload, expect_errors=True)
@@ -353,9 +350,8 @@ class TestNodeLinkCreate(ApiTestCase):
         res = self.app.post_json_api(self.private_url, self.private_payload, auth=self.user.auth)
         assert_equal(res.status_code, 201)
         res_json = res.json['data']
-        expected_path = node_url_for(self.pointer_project._id)
-        actual_path = urlparse(res_json['relationships']['target_node']['links']['related']['href']).path
-        assert_equal(expected_path, actual_path)
+        embedded = res_json['embeds']['target_node']['data']['id']
+        assert_equal(embedded, self.pointer_project._id)
         assert_equal(res.content_type, 'application/vnd.api+json')
 
     def test_creates_private_node_pointer_logged_in_non_contributor(self):
@@ -374,9 +370,8 @@ class TestNodeLinkCreate(ApiTestCase):
         assert_equal(res.status_code, 201)
         assert_equal(res.content_type, 'application/vnd.api+json')
         res_json = res.json['data']
-        expected_path = node_url_for(self.user_two_project._id)
-        actual_path = urlparse(res_json['relationships']['target_node']['links']['related']['href']).path
-        assert_equal(expected_path, actual_path)
+        embedded = res_json['embeds']['target_node']['data']['id']
+        assert_equal(embedded, self.user_two_project._id)
 
     def test_create_pointer_non_contributing_node_to_fake_node(self):
         res = self.app.post_json_api(self.private_url, self.fake_payload, auth=self.user_two.auth, expect_errors=True)
@@ -403,9 +398,8 @@ class TestNodeLinkCreate(ApiTestCase):
         res_json = res.json['data']
         assert_equal(res.status_code, 201)
         assert_equal(res.content_type, 'application/vnd.api+json')
-        expected_path = node_url_for(self.public_project._id)
-        actual_path = urlparse(res_json['relationships']['target_node']['links']['related']['href']).path
-        assert_equal(expected_path, actual_path)
+        embedded = res_json['embeds']['target_node']['data']['id']
+        assert_equal(embedded, self.public_project._id)
 
     def test_create_node_pointer_to_itself_unauthorized(self):
         res = self.app.post_json_api(self.public_url, self.point_to_itself_payload, auth=self.user_two.auth, expect_errors=True)
@@ -418,9 +412,8 @@ class TestNodeLinkCreate(ApiTestCase):
         assert_equal(res.status_code, 201)
         assert_equal(res.content_type, 'application/vnd.api+json')
         res_json = res.json['data']
-        expected_path = node_url_for(self.public_pointer_project._id)
-        actual_path = urlparse(res_json['relationships']['target_node']['links']['related']['href']).path
-        assert_equal(expected_path, actual_path)
+        embedded = res_json['embeds']['target_node']['data']['id']
+        assert_equal(embedded, self.public_pointer_project._id)
 
         res = self.app.post_json_api(self.public_url, self.public_payload, auth=self.user.auth, expect_errors=True)
         assert_equal(res.status_code, 400)
@@ -610,13 +603,12 @@ class TestNodeLinksBulkCreate(ApiTestCase):
         assert_equal(res.status_code, 201)
         assert_equal(res.content_type, 'application/vnd.api+json')
         res_json = res.json['data']
-        expected_path = node_url_for(self.public_pointer_project._id)
-        actual_path = urlparse(res_json[0]['relationships']['target_node']['links']['related']['href']).path
-        assert_equal(expected_path, actual_path)
+        embedded = res_json[0]['embeds']['target_node']['data']['id']
+        assert_equal(embedded, self.public_pointer_project._id)
 
-        expected_path = node_url_for(self.public_pointer_project_two._id)
-        actual_path = urlparse(res_json[1]['relationships']['target_node']['links']['related']['href']).path
-        assert_equal(expected_path, actual_path)
+        embedded = res_json[1]['embeds']['target_node']['data']['id']
+        assert_equal(embedded, self.public_pointer_project_two._id)
+
 
     def test_bulk_creates_private_node_pointers_logged_out(self):
         res = self.app.post_json_api(self.private_url, self.private_payload, expect_errors=True, bulk=True)
@@ -632,13 +624,11 @@ class TestNodeLinksBulkCreate(ApiTestCase):
         res = self.app.post_json_api(self.private_url, self.private_payload, auth=self.user.auth, bulk=True)
         assert_equal(res.status_code, 201)
         res_json = res.json['data']
-        expected_path = node_url_for(self.private_pointer_project._id)
-        actual_path = urlparse(res_json[0]['relationships']['target_node']['links']['related']['href']).path
-        assert_equal(expected_path, actual_path)
+        embedded = res_json[0]['embeds']['target_node']['data']['id']
+        assert_equal(embedded, self.private_pointer_project._id)
 
-        expected_path = node_url_for(self.private_pointer_project_two._id)
-        actual_path = urlparse(res_json[1]['relationships']['target_node']['links']['related']['href']).path
-        assert_equal(expected_path, actual_path)
+        embedded = res_json[1]['embeds']['target_node']['data']['id']
+        assert_equal(embedded, self.private_pointer_project_two._id)
         assert_equal(res.content_type, 'application/vnd.api+json')
 
     def test_bulk_creates_private_node_pointers_logged_in_non_contributor(self):
@@ -662,15 +652,13 @@ class TestNodeLinksBulkCreate(ApiTestCase):
         assert_equal(res.status_code, 201)
         assert_equal(res.content_type, 'application/vnd.api+json')
         res_json = res.json['data']
-        expected_path = node_url_for(self.user_two_project._id)
-        actual_path = urlparse(res_json[0]['relationships']['target_node']['links']['related']['href']).path
-        assert_equal(expected_path, actual_path)
+        embedded = res_json[0]['embeds']['target_node']['data']['id']
+        assert_equal(embedded, self.user_two_project._id)
 
         res = self.app.get(self.private_url, auth=self.user.auth)
         res_json = res.json['data']
-        expected_path = node_url_for(self.user_two_project._id)
-        actual_path = urlparse(res_json[0]['relationships']['target_node']['links']['related']['href']).path
-        assert_equal(expected_path, actual_path)
+        embedded = res_json[0]['embeds']['target_node']['data']['id']
+        assert_equal(embedded, self.user_two_project._id)
 
     def test_bulk_creates_pointers_non_contributing_node_to_fake_node(self):
         fake_payload = {'data': [{'type': 'node_links', 'relationships': {'nodes': {'data': {'id': 'fdxlq', 'type': 'nodes'}}}}]}
@@ -707,9 +695,8 @@ class TestNodeLinksBulkCreate(ApiTestCase):
         assert_equal(res.status_code, 201)
         assert_equal(res.content_type, 'application/vnd.api+json')
         res_json = res.json['data']
-        expected_path = node_url_for(self.public_project._id)
-        actual_path = urlparse(res_json[0]['relationships']['target_node']['links']['related']['href']).path
-        assert_equal(expected_path, actual_path)
+        embedded = res_json[0]['embeds']['target_node']['data']['id']
+        assert_equal(embedded, self.public_project._id)
 
     def test_bulk_creates_node_pointer_to_itself_unauthorized(self):
         point_to_itself_payload = {'data': [{'type': 'node_links', 'relationships': {'nodes': {'data': {'type': 'nodes', 'id': self.public_project._id}}}}]}
@@ -726,13 +713,11 @@ class TestNodeLinksBulkCreate(ApiTestCase):
         assert_equal(res.status_code, 201)
         assert_equal(res.content_type, 'application/vnd.api+json')
         res_json = res.json['data']
-        expected_path = node_url_for(self.public_pointer_project._id)
-        actual_path = urlparse(res_json[0]['relationships']['target_node']['links']['related']['href']).path
-        assert_equal(expected_path, actual_path)
+        embedded = res_json[0]['embeds']['target_node']['data']['id']
+        assert_equal(embedded, self.public_pointer_project._id)
 
-        expected_path = node_url_for(self.public_pointer_project_two._id)
-        actual_path = urlparse(res_json[1]['relationships']['target_node']['links']['related']['href']).path
-        assert_equal(expected_path, actual_path)
+        embedded_two = res_json[1]['embeds']['target_node']['data']['id']
+        assert_equal(embedded_two, self.public_pointer_project_two._id)
 
         res = self.app.post_json_api(self.public_url, self.public_payload, auth=self.user.auth, expect_errors=True, bulk=True)
         assert_equal(res.status_code, 400)


### PR DESCRIPTION
# Purpose

Issue https://openscience.atlassian.net/browse/OSF-5250 
- Auto-embeds should check to ensure that it's not auto-embedding a ListView 
- Only two resources auto embedded: contributors:user-detail and node-links:node-detail. 
- Auto-embeds should happen regardless of level.

# Changes

Node Contributors > user and Node Links > target node will be automatically embedded. 
Nodes > contributors and nodes > node links will NOT be automatically embedded.  

Users embedded in contributors:
![screen shot 2015-11-23 at 5 22 12 pm](https://cloud.githubusercontent.com/assets/9755598/11351775/8dc0d5de-9206-11e5-91c1-e5c2d85f000a.png)

Target node embedded in node links:
![screen shot 2015-11-23 at 5 27 05 pm](https://cloud.githubusercontent.com/assets/9755598/11351879/1987fbb0-9207-11e5-9e49-7164df677666.png)

Multiple levels of embeds:
`http://localhost:8000/v2/nodes/3fnkr/?embed=contributors` 

![screen shot 2015-11-23 at 6 11 42 pm](https://cloud.githubusercontent.com/assets/9755598/11352906/4226f228-920d-11e5-9822-d280aeaa47b0.png)

