### PR TITLE
[Bug Fix]Zotero/Mendeley fix rework

### DIFF
--- a/website/addons/citations/provider.py
+++ b/website/addons/citations/provider.py
@@ -20,9 +20,12 @@ class CitationsProvider(object):
     def check_credentials(self, node_addon):
         valid = True
         try:
-            node_addon.api.client()
-        except HTTPError:
-            valid = False
+            node_addon.api.client
+        except HTTPError as err:
+            if err.code == 403:
+                valid = False
+            else:
+                raise err
         return valid
 
     def user_accounts(self, user):

--- a/website/addons/citations/provider.py
+++ b/website/addons/citations/provider.py
@@ -17,6 +17,14 @@ class CitationsProvider(object):
     def serializer(self):
         pass
 
+    def check_credentials(self, node_addon):
+        valid = True
+        try:
+            node_addon.api.client()
+        except HTTPError:
+            valid = False
+        return valid
+
     def user_accounts(self, user):
         """ Gets a list of the accounts authorized by 'user' """
         return {

--- a/website/addons/mendeley/tests/test_views.py
+++ b/website/addons/mendeley/tests/test_views.py
@@ -71,8 +71,10 @@ class MendeleyViewsTestCase(OsfTestCase):
         self.id_patcher.stop()
         self.secret_patcher.stop()
 
-    def test_serialize_settings_authorizer(self):
+    @mock.patch('website.addons.mendeley.views.MendeleyCitationsProvider.check_credentials')
+    def test_serialize_settings_authorizer(self, mock_credentials):
         #"""dict: a serialized version of user-specific addon settings"""
+        mock_credentials.return_value = True
         res = self.app.get(
             self.project.api_url_for('mendeley_get_config'),
             auth=self.user.auth,
@@ -81,6 +83,7 @@ class MendeleyViewsTestCase(OsfTestCase):
         assert_true(result['nodeHasAuth'])
         assert_true(result['userHasAuth'])
         assert_true(result['userIsOwner'])
+        assert_true(res.json['validCredentials'])
         assert_equal(result['folder'], {'name': ''})
         assert_equal(result['ownerName'], self.user.fullname)
         assert_true(result['urls']['auth'])
@@ -90,8 +93,10 @@ class MendeleyViewsTestCase(OsfTestCase):
         assert_true(result['urls']['importAuth'])
         assert_true(result['urls']['settings'])
 
-    def test_serialize_settings_non_authorizer(self):
+    @mock.patch('website.addons.mendeley.views.MendeleyCitationsProvider.check_credentials')
+    def test_serialize_settings_non_authorizer(self, mock_credentials):
         #"""dict: a serialized version of user-specific addon settings"""
+        mock_credentials.return_value = True
         non_authorizing_user = AuthUserFactory()
         self.project.add_contributor(non_authorizing_user, save=True)
         res = self.app.get(

--- a/website/addons/mendeley/tests/test_views.py
+++ b/website/addons/mendeley/tests/test_views.py
@@ -107,6 +107,7 @@ class MendeleyViewsTestCase(OsfTestCase):
         assert_true(result['nodeHasAuth'])
         assert_false(result['userHasAuth'])
         assert_false(result['userIsOwner'])
+        assert_true(res.json['validCredentials'])
         assert_equal(result['folder'], {'name': ''})
         assert_equal(result['ownerName'], self.user.fullname)
         assert_true(result['urls']['auth'])

--- a/website/addons/mendeley/views.py
+++ b/website/addons/mendeley/views.py
@@ -20,7 +20,7 @@ def mendeley_get_user_accounts(auth):
 
     provider = MendeleyCitationsProvider()
     return provider.serializer(
-        user_settings=auth.user.get_addon('mendeley')
+        user_settings=auth.user.get_addon('mendeley'),
     ).serialized_user_settings
 
 
@@ -34,8 +34,9 @@ def mendeley_get_config(auth, node_addon, **kwargs):
     return {
         'result': provider.serializer(
             node_addon,
-            auth.user.get_addon('mendeley')
-        ).serialized_node_settings
+            auth.user.get_addon('mendeley'),
+        ).serialized_node_settings,
+        'validCredentials': provider.check_credentials(node_addon)
     }
 
 @must_have_permission('write')

--- a/website/addons/zotero/tests/test_models.py
+++ b/website/addons/zotero/tests/test_models.py
@@ -64,11 +64,12 @@ class ZoteroProviderTestCase(OsfTestCase):
             'Fake Key'
         )
 
-    def test_zotero_has_access(self):
-        mock_client = mock.Mock()
+    @mock.patch('website.addons.zotero.provider.ZoteroCitationsProvider')
+    @mock.patch('website.addons.zotero.model.Zotero.client')
+    def test_check_credentials(self, mock_client, mock_citations_provider):
         mock_client.collections.return_value = UserNotAuthorised
         self.provider._client = mock_client
-        self.provider._client
+        mock_citations_provider.check_credentials()
         assert_raises(HTTPError(403))
 
 class ZoteroNodeSettingsTestCase(OsfTestCase):

--- a/website/addons/zotero/tests/test_views.py
+++ b/website/addons/zotero/tests/test_views.py
@@ -103,6 +103,7 @@ class ZoteroViewsTestCase(OsfTestCase):
         assert_true(result['nodeHasAuth'])
         assert_false(result['userHasAuth'])
         assert_false(result['userIsOwner'])
+        assert_true(res.json['validCredentials'])
         assert_equal(result['folder'], {'name': ''})
         assert_equal(result['ownerName'], self.user.fullname)
         assert_true(result['urls']['auth'])

--- a/website/addons/zotero/tests/test_views.py
+++ b/website/addons/zotero/tests/test_views.py
@@ -67,8 +67,10 @@ class ZoteroViewsTestCase(OsfTestCase):
         self.id_patcher.stop()
         self.secret_patcher.stop()
 
-    def test_serialize_settings_authorizer(self):
+    @mock.patch('website.addons.zotero.provider.ZoteroCitationsProvider')
+    def test_serialize_settings_authorizer(self, mock_citations_provider):
         #"""dict: a serialized version of user-specific addon settings"""
+        mock_citations_provider.check_credentials.return_value = True
         res = self.app.get(
             self.project.api_url_for('zotero_get_config'),
             auth=self.user.auth,
@@ -77,6 +79,7 @@ class ZoteroViewsTestCase(OsfTestCase):
         assert_true(result['nodeHasAuth'])
         assert_true(result['userHasAuth'])
         assert_true(result['userIsOwner'])
+        assert_true(result['validCredentials'])
         assert_equal(result['folder'], {'name': ''})
         assert_equal(result['ownerName'], self.user.fullname)
         assert_true(result['urls']['auth'])

--- a/website/addons/zotero/views.py
+++ b/website/addons/zotero/views.py
@@ -33,7 +33,8 @@ def zotero_get_config(auth, node_addon, **kwargs):
         'result': provider.serializer(
             node_settings=node_addon,
             user_settings=auth.user.get_addon('zotero'),
-        ).serialized_node_settings
+        ).serialized_node_settings,
+        'validCredentials': provider.check_credentials(node_addon)
     }
 
 @must_have_permission('write')

--- a/website/static/js/citationGrid.js
+++ b/website/static/js/citationGrid.js
@@ -287,7 +287,6 @@ CitationGrid.prototype.initTreebeard = function() {
                 return self.resolveRowAux.call(self, arguments);
             },
             ondataloaderror: function(err) {
-                $osf.handleAddonApiHTTPError(err);
                 $(self.gridSelector).html(errorPage);
             }
         },

--- a/website/static/js/citationsNodeConfig.js
+++ b/website/static/js/citationsNodeConfig.js
@@ -60,22 +60,6 @@ var CitationsFolderPickerViewModel = oop.extend(FolderPickerViewModel, {
                     return item.kind === 'folder';
                     });
                 },
-                ondataloaderror: function(err){
-                    self.loading(false);
-                    self.destroyPicker();
-                    if (err.status === 403) {
-                        var message;
-                        if (self.userIsOwner()) {
-                            message = self.messages.invalidCredOwner();
-                        }
-                        else {
-                            message = self.messages.invalidCredNotOwner();
-                        }
-                        self.changeMessage(message, 'text-danger');
-                    } else {
-                        self.changeMessage(self.messages.connectError(), 'text-danger');
-                    }
-                }.bind(this),
                 resolveLazyloadUrl: function(item) {
                     return this.urls().folders + item.data.id + '/?view=folders';
                 }.bind(this)
@@ -138,7 +122,9 @@ var CitationsFolderPickerViewModel = oop.extend(FolderPickerViewModel, {
         ).then(self.onImportSuccess.bind(self), self.onImportError.bind(self));
     },
     _updateCustomFields: function(settings){
-        this.userAccountId(settings.userAccountId);
+        var self = this;
+        self.userAccountId(settings.userAccountId);
+        self.validCredentials(settings.validCredentials);
     },
     _serializeSettings: function(){
         return {
@@ -193,6 +179,19 @@ var CitationsFolderPickerViewModel = oop.extend(FolderPickerViewModel, {
                     });
                 }
             });
+    },
+    afterUpdate: function() {
+        var self = this;
+        if (self.nodeHasAuth() && !self.validCredentials()) {
+            var message;
+            if (self.userIsOwner()) {
+                message = self.messages.invalidCredOwner();
+            }
+            else {
+                message = self.messages.invalidCredNotOwner();
+            }
+            self.changeMessage(message, 'text-danger');
+        }
     }
 });
 // Public API

--- a/website/static/js/folderPickerNodeConfig.js
+++ b/website/static/js/folderPickerNodeConfig.js
@@ -89,7 +89,7 @@ var FolderPickerViewModel = oop.defclass({
             }),
             invalidCredNotOwner: ko.pureComputed(function() {
                 return 'Could not retrieve ' + self.addonName + ' settings at ' +
-                    'this time. The credentials' + self.addonName + ' addon credentials may no longer be valid.' +
+                    'this time. The ' + self.addonName + ' addon credentials may no longer be valid.' +
                     ' Contact ' + self.ownerName() + ' to verify.';
             }),
             cantRetrieveSettings: ko.pureComputed(function() {

--- a/website/templates/project/addon/node_settings_default.mako
+++ b/website/templates/project/addon/node_settings_default.mako
@@ -8,7 +8,7 @@
                     {{ownerName}}
                 </a>
                 % if not is_registration:
-                    <a data-bind="click: deauthorize"
+                    <a data-bind="click: deauthorize, visible: validCredentials"
                         class="text-danger pull-right addon-auth">Disconnect Account</a>
                 % endif
             </span>


### PR DESCRIPTION
# Purpose
Redo Zotero/Mendeley API fix so that project settings nodes cannot be used if credentials are wrong. User must now to go User Settings and fix before they can be used again. Took out growl box from project page.

# Side Effects
Disables node use in project settings until error is fixed.