### PR TITLE
support utf8 subscription keys

### DIFF
--- a/website/notifications/utils.py
+++ b/website/notifications/utils.py
@@ -45,7 +45,7 @@ def find_subscription_type(subscription):
 
 def to_subscription_key(uid, event):
     """Build the Subscription primary key for the given guid and event"""
-    return str(uid + '_' + event)
+    return u'{}_{}'.format(uid, event)
 
 
 def from_subscription_key(key):


### PR DESCRIPTION
When uploading or modifying files with utf8 characters in their names,
some providers will encounter 500 errors when posting to the waterbutler
logs endpoint.  This occurs because the file events notifier prepends
the file name to the event, and the `to_subscription_key` method in
`website/notification/utils.py` expects ascii-only events.  This patch
updates `to_subscription_key` to support utf8 events.