### PR TITLE
[Ready to Review] Restore self link using get_absolute_url method.

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -221,6 +221,7 @@ class NodeContributorsSerializer(JSONAPISerializer):
 
     links = LinksField(add_dev_only_items({
         'html': 'absolute_url',
+        'self': 'get_absolute_url'
 
     }, {
         'profile_image': 'profile_image_url',

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -219,23 +219,15 @@ class NodeContributorsSerializer(JSONAPISerializer):
                                  default=osf_permissions.reduce_permissions(osf_permissions.DEFAULT_CONTRIBUTOR_PERMISSIONS),
                                  help_text='User permission level. Must be "read", "write", or "admin". Defaults to "write".')
 
-    links = LinksField(add_dev_only_items({
-        'html': 'absolute_url',
+    links = LinksField({
         'self': 'get_absolute_url'
-
-    }, {
-        'profile_image': 'profile_image_url',
-    }))
+    })
 
     users = RelationshipField(
         related_view='users:user-detail',
         related_view_kwargs={'user_id': '<pk>'},
         always_embed=True
     )
-
-    def profile_image_url(self, user):
-        size = self.context['request'].query_params.get('profile_image_size')
-        return user.profile_image_url(size=size)
 
     class Meta:
         type_ = 'contributors'

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -9,7 +9,7 @@ from website.models import Node, User, Comment
 from website.exceptions import NodeStateError
 from website.util import permissions as osf_permissions
 
-from api.base.utils import get_object_or_error, absolute_reverse, add_dev_only_items
+from api.base.utils import get_object_or_error, absolute_reverse
 from api.base.serializers import (JSONAPISerializer, WaterbutlerLink, NodeFileHyperLinkField, IDField, TypeField,
                                   TargetTypeField, JSONAPIListField, LinksField, RelationshipField, DevOnly)
 from api.base.exceptions import InvalidModelValueError


### PR DESCRIPTION
# Purpose
Issue https://openscience.atlassian.net/browse/OSF-5284
The self link had been removed in NodeContributorSerializer, so it used the default, obj.get_absolute_url() to formulate the self link. When embedding, this caused the embedded user and the contributor self links to be the same.

# Changes
Restoring `'self': 'get_absolute_url'` to node contributors links will allow the self-link to be generated properly.