### PR TITLE
[Ready for Review] Fix inconsistencies between New Registration button and New Fork button

### DIFF
--- a/website/templates/project/registrations.mako
+++ b/website/templates/project/registrations.mako
@@ -14,7 +14,7 @@
 <div class="tab-content registrations-view">
   <div role="tabpanel" class="tab-pane active" id="registrations">
     <div class="row" style="min-height: 150px; padding-top:20px;">
-      <div class="col-md-9">
+      <div class="col-xs-9 col-sm-8">
         % if node["registration_count"]:
         <div mod-meta='{
             "tpl": "util/render_nodes.mako",
@@ -44,8 +44,8 @@
         %endif
       </div>
       % if 'admin' in user['permissions'] and not disk_saving_mode:
-      <div class="col-md-3">
-        <a id="registerNode" class="btn btn-default" type="button">
+      <div class="col-xs-3 col-sm-4">
+        <a id="registerNode" class="btn btn-success" type="button">
           New Registration
         </a>
       </div>


### PR DESCRIPTION
## Purpose
Fix inconsistencies between New Registration button and New Fork button
## Changes
- New Registration button stays in the top right on small screens
- New Registration button has btn-success like New Fork

Old:
![image](https://cloud.githubusercontent.com/assets/8905795/11566688/8244be70-99b1-11e5-9d4f-e101bbff977a.png)

New:
![screen shot 2015-12-03 at 11 34 51 am](https://cloud.githubusercontent.com/assets/8905795/11566783/ec98bb0a-99b1-11e5-94c8-f76504ccf3f3.png)


## Side effects
```python 
None 
```


[OSF-5178]