### PR TITLE
[Ready to Review] Bulk GET special case filtering on ID

### DIFF
--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -155,8 +155,12 @@ class FilterMixin(object):
         If url contained `/nodes/?filter[id]=12345, abcde`, the returned values would be:
         [u'12345', u'abcde']
         """
+        if value[0] == '[' and value[-1] == ']':
+            value = value.replace('[', '').replace(']', '')
         separated_values = value.split(',')
-        cleaned_values = [re.sub(r"[^\w\s]+]", '', val).strip() for val in separated_values]
+        cleaned_values = []
+        for val in separated_values:
+            cleaned_values.append(val.strip())
         values = [self.convert_value(val, field) for val in cleaned_values]
         return values
 

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -188,7 +188,7 @@ class FilterMixin(object):
                 # Special case date(time)s to allow for ambiguous date matches
                 if isinstance(field, self.DATE_FIELDS):
                     query[field_name].extend(self._parse_date_param(field, field_name, op, value))
-                elif not isinstance(value, int) and len(value.split(',')) > 1:
+                elif not isinstance(value, int) and field_name == '_id':
                     query[field_name].append({
                         'op': 'in',
                         'value': self.bulk_get_values(value, field)

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -148,6 +148,18 @@ class FilterMixin(object):
                 'value': stop
             }]
 
+    def bulk_get_values(self, value, field):
+        """
+        Returns list of values from query_param for IN query
+
+        If url contained `/nodes/?filter[id]=12345, abcde`, the returned values would be:
+        [u'12345', u'abcde']
+        """
+        separated_values = value.split(',')
+        cleaned_values = [re.sub(re.compile(r'\W'), '', val) for val in separated_values]
+        values = [self.convert_value(val, field) for val in cleaned_values]
+        return values
+
     def parse_query_params(self, query_params):
         """Maps query params to a dict useable for filtering
         :param dict query_params:

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -158,10 +158,7 @@ class FilterMixin(object):
         if value[0] == '[' and value[-1] == ']':
             value = value.replace('[', '').replace(']', '')
         separated_values = value.split(',')
-        cleaned_values = []
-        for val in separated_values:
-            cleaned_values.append(val.strip())
-        values = [self.convert_value(val, field) for val in cleaned_values]
+        values = [self.convert_value(val.strip(), field) for val in separated_values]
         return values
 
     def parse_query_params(self, query_params):

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -155,8 +155,7 @@ class FilterMixin(object):
         If url contained `/nodes/?filter[id]=12345, abcde`, the returned values would be:
         [u'12345', u'abcde']
         """
-        if value[0] == '[' and value[-1] == ']':
-            value = value.lstrip('[').rstrip(']')
+        value = value.lstrip('[').rstrip(']')
         separated_values = value.split(',')
         values = [self.convert_value(val.strip(), field) for val in separated_values]
         return values

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -189,10 +189,16 @@ class FilterMixin(object):
                 if isinstance(field, self.DATE_FIELDS):
                     query[field_name].extend(self._parse_date_param(field, field_name, op, value))
                 else:
-                    query[field_name].append({
-                        'op': op,
-                        'value': self.convert_value(value, field)
-                    })
+                    if len(value.split(',')) > 1:
+                        query[field_name].append({
+                            'op': 'in',
+                            'value': self.bulk_get_values(value, field)
+                        })
+                    else:
+                        query[field_name].append({
+                            'op': op,
+                            'value': self.convert_value(value, field)
+                        })
         return query
 
     def convert_key(self, field_name, field):

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -189,7 +189,7 @@ class FilterMixin(object):
                 if isinstance(field, self.DATE_FIELDS):
                     query[field_name].extend(self._parse_date_param(field, field_name, op, value))
                 else:
-                    if len(value.split(',')) > 1:
+                    if not isinstance(value, int) and len(value.split(',')) > 1:
                         query[field_name].append({
                             'op': 'in',
                             'value': self.bulk_get_values(value, field)

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -156,7 +156,7 @@ class FilterMixin(object):
         [u'12345', u'abcde']
         """
         separated_values = value.split(',')
-        cleaned_values = [re.sub(re.compile(r'\W'), '', val) for val in separated_values]
+        cleaned_values = [re.sub(r"[^\w\s]+]", '', val).strip() for val in separated_values]
         values = [self.convert_value(val, field) for val in cleaned_values]
         return values
 

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -99,11 +99,12 @@ class IDField(ser.CharField):
 
     # Overrides CharField
     def to_internal_value(self, data):
-        request = self.context['request']
-        if request.method in utils.UPDATE_METHODS and not utils.is_bulk_request(request):
-            id_field = getattr(self.root.instance, self.source, '_id')
-            if id_field != data:
-                raise Conflict()
+        request = self.context.get('request')
+        if request:
+            if request.method in utils.UPDATE_METHODS and not utils.is_bulk_request(request):
+                id_field = getattr(self.root.instance, self.source, '_id')
+                if id_field != data:
+                    raise Conflict()
         return super(IDField, self).to_internal_value(data)
 
 

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -7,6 +7,7 @@ from api.users.serializers import UserSerializer
 from website import settings
 from .utils import absolute_reverse
 
+
 class JSONAPIBaseView(generics.GenericAPIView):
 
     def __init__(self, **kwargs):
@@ -122,6 +123,10 @@ def root(request, format=None):
     Boolean fields should be queried with `true` or `false`.
 
         /nodes/?filter[registered]=true
+
+    You can request multiple resources through filtering.
+
+        /nodes/?filter[id]=aegu6,me23a
 
     ###Embedding
 

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -124,7 +124,7 @@ def root(request, format=None):
 
         /nodes/?filter[registered]=true
 
-    You can request multiple resources through filtering.
+    You can request multiple resources with comma-separated values in your query parameter.
 
         /nodes/?filter[id]=aegu6,me23a
 

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -124,7 +124,7 @@ def root(request, format=None):
 
         /nodes/?filter[registered]=true
 
-    You can request multiple resources with comma-separated values in your query parameter.
+    You can request multiple resources by filtering on id and placing comma-separated values in your query parameter.
 
         /nodes/?filter[id]=aegu6,me23a
 

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -30,6 +30,7 @@ class NodeSerializer(JSONAPISerializer):
     # handle blank choices properly. Currently DRF ChoiceFields ignore blank options, which is incorrect in this
     # instance
     filterable_fields = frozenset([
+        'id',
         'title',
         'description',
         'public',

--- a/api_tests/base/test_filters.py
+++ b/api_tests/base/test_filters.py
@@ -1,17 +1,13 @@
 # -*- coding: utf-8 -*-
 import datetime
-import re
 from dateutil import parser
 
 from nose.tools import *  # flake8: noqa
-import mock
 
 from rest_framework import serializers as ser
 
 from tests.base import ApiTestCase
-from tests import factories
 
-from api.base.settings.defaults import API_BASE
 from api.base.filters import FilterMixin
 
 from api.base.exceptions import (
@@ -19,8 +15,7 @@ from api.base.exceptions import (
     InvalidFilterOperator,
     InvalidFilterComparisonType,
     InvalidFilterMatchType,
-    InvalidFilterValue,
-    InvalidFilterFieldError
+
 )
 
 class FakeSerializer(ser.Serializer):

--- a/api_tests/base/test_filters.py
+++ b/api_tests/base/test_filters.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import datetime
+import re
 from dateutil import parser
 
 from nose.tools import *  # flake8: noqa
@@ -15,7 +16,6 @@ from api.base.exceptions import (
     InvalidFilterOperator,
     InvalidFilterComparisonType,
     InvalidFilterMatchType,
-
 )
 
 class FakeSerializer(ser.Serializer):

--- a/api_tests/nodes/views/test_node_list.py
+++ b/api_tests/nodes/views/test_node_list.py
@@ -144,7 +144,7 @@ class TestNodeFiltering(ApiTestCase):
         assert_not_in(self.private_project_user_two._id, ids)
         assert_equal(len(ids), 1)
 
-    def test_filtering_by_multiple_ids_incorrect_syntax_in_query_params(self):
+    def test_filtering_by_multiple_ids_brackets_in_query_params(self):
         url = '/{}nodes/?filter[id]=[{},   {}]'.format(API_BASE, self.project_one._id, self.project_two._id)
         res = self.app.get(url, auth=self.user_one.auth)
         assert_equal(res.status_code, 200)

--- a/api_tests/nodes/views/test_node_list.py
+++ b/api_tests/nodes/views/test_node_list.py
@@ -108,6 +108,45 @@ class TestNodeFiltering(ApiTestCase):
         super(TestNodeFiltering, self).tearDown()
         Node.remove()
 
+    def test_filtering_by_id(self):
+        url = '/{}nodes/?filter[id]={}'.format(API_BASE, self.project_one._id)
+        res = self.app.get(url, auth=self.user_one.auth)
+        assert_equal(res.status_code, 200)
+        ids = [each['id'] for each in res.json['data']]
+
+        assert_in(self.project_one._id, ids)
+        assert_equal(len(ids), 1)
+
+    def test_filtering_by_multiple_ids(self):
+        url = '/{}nodes/?filter[id]={},{}'.format(API_BASE, self.project_one._id, self.project_two._id)
+        res = self.app.get(url, auth=self.user_one.auth)
+        assert_equal(res.status_code, 200)
+        ids = [each['id'] for each in res.json['data']]
+
+        assert_in(self.project_one._id, ids)
+        assert_in(self.project_two._id, ids)
+        assert_equal(len(ids), 2)
+
+    def test_filtering_by_multiple_ids_one_private(self):
+        url = '/{}nodes/?filter[id]={},{}'.format(API_BASE, self.project_one._id, self.private_project_user_two._id)
+        res = self.app.get(url, auth=self.user_one.auth)
+        assert_equal(res.status_code, 200)
+        ids = [each['id'] for each in res.json['data']]
+
+        assert_in(self.project_one._id, ids)
+        assert_not_in(self.private_project_user_two._id, ids)
+        assert_equal(len(ids), 1)
+
+    def test_filtering_by_multiple_ids_incorrect_syntax_in_query_params(self):
+        url = '/{}nodes/?filter[id]=[{},   {}]'.format(API_BASE, self.project_one._id, self.project_two._id)
+        res = self.app.get(url, auth=self.user_one.auth)
+        assert_equal(res.status_code, 200)
+        ids = [each['id'] for each in res.json['data']]
+
+        assert_in(self.project_one._id, ids)
+        assert_in(self.project_two._id, ids)
+        assert_equal(len(ids), 2)
+
     def test_filtering_by_category(self):
         project = ProjectFactory(creator=self.user_one, category='hypothesis')
         project2 = ProjectFactory(creator=self.user_one, category='procedure')

--- a/api_tests/nodes/views/test_node_list.py
+++ b/api_tests/nodes/views/test_node_list.py
@@ -166,29 +166,6 @@ class TestNodeFiltering(ApiTestCase):
         assert_in(project._id, ids)
         assert_not_in(project2._id, ids)
 
-    def test_filtering_by_multiple_categories(self):
-        instrumentation = ProjectFactory(category='instrumentation', creator=self.user_one)
-        hypothesis = ProjectFactory(creator=self.user_one, category='hypothesis')
-
-        url = '/{}nodes/?filter[category]={},{}'.format(API_BASE, 'hypothesis', 'instrumentation')
-        res = self.app.get(url, auth=self.user_one.auth)
-        assert_equal(res.status_code, 200)
-        ids = [each['id'] for each in res.json['data']]
-
-        assert_in(instrumentation._id, ids)
-        assert_in(hypothesis._id, ids)
-        assert_equal(len(ids), 2)
-
-    def test_filtering_by_multiple_titles(self):
-        url = '/{}nodes/?filter[title]={},{}'.format(API_BASE, 'Project One', 'Project Two')
-        res = self.app.get(url, auth=self.user_one.auth)
-        assert_equal(res.status_code, 200)
-        ids = [each['id'] for each in res.json['data']]
-
-        assert_in(self.project_one._id, ids)
-        assert_in(self.project_two._id, ids)
-        assert_equal(len(ids), 2)
-
     def test_filtering_by_public(self):
         project = ProjectFactory(creator=self.user_one, is_public=True)
         project2 = ProjectFactory(creator=self.user_one, is_public=False)
@@ -240,17 +217,6 @@ class TestNodeFiltering(ApiTestCase):
         ids = [each['id'] for each in node_json]
         assert_in(self.project_one._id, ids)
         assert_not_in(self.project_two._id, ids)
-
-    def test_filtering_multiple_tags(self):
-        url = '/{}nodes/?filter[tags]={},{}'.format(API_BASE, self.tag1, self.tag2)
-
-        res = self.app.get(url, auth=self.project_one.creator.auth)
-        node_json = res.json['data']
-
-        ids = [each['id'] for each in node_json]
-        assert_in(self.project_one._id, ids)
-        assert_in(self.project_two._id, ids)
-        assert_equal(len(ids), 2)
 
     def test_get_all_projects_with_no_filter_logged_in(self):
         res = self.app.get(self.url, auth=self.user_one.auth)
@@ -381,19 +347,6 @@ class TestNodeFiltering(ApiTestCase):
         assert_not_in(self.private_project_user_two._id, ids)
         assert_not_in(self.folder._id, ids)
         assert_not_in(self.dashboard._id, ids)
-
-    def test_filtering_by_multiple_descriptions(self):
-        project = ProjectFactory(description='hello there', creator=self.user_one)
-        project_two = ProjectFactory(description='hi', creator=self.user_one)
-
-        url = "/{}nodes/?filter[description]={},{}".format(API_BASE, 'hi', 'hello there')
-        res = self.app.get(url, auth=self.user_one.auth)
-        assert_equal(res.status_code, 200)
-        ids = [each['id'] for each in res.json['data']]
-
-        assert_in(project._id, ids)
-        assert_in(project_two._id, ids)
-        assert_equal(len(ids), 2)
 
     def test_alternate_filtering_field_not_logged_in(self):
         url = "/{}nodes/?filter[description]=Three".format(API_BASE)

--- a/api_tests/nodes/views/test_node_list.py
+++ b/api_tests/nodes/views/test_node_list.py
@@ -104,6 +104,13 @@ class TestNodeFiltering(ApiTestCase):
 
         self.url = "/{}nodes/".format(API_BASE)
 
+        self.tag1, self.tag2 = 'tag1', 'tag2'
+        self.project_one.add_tag(self.tag1, Auth(self.project_one.creator), save=False)
+        self.project_one.add_tag(self.tag2, Auth(self.project_one.creator), save=False)
+        self.project_one.save()
+
+        self.project_two.add_tag(self.tag1, Auth(self.project_two.creator), save=True)
+
     def tearDown(self):
         super(TestNodeFiltering, self).tearDown()
         Node.remove()
@@ -159,6 +166,29 @@ class TestNodeFiltering(ApiTestCase):
         assert_in(project._id, ids)
         assert_not_in(project2._id, ids)
 
+    def test_filtering_by_multiple_categories(self):
+        instrumentation = ProjectFactory(category='instrumentation', creator=self.user_one)
+        hypothesis = ProjectFactory(creator=self.user_one, category='hypothesis')
+
+        url = '/{}nodes/?filter[category]={},{}'.format(API_BASE, 'hypothesis', 'instrumentation')
+        res = self.app.get(url, auth=self.user_one.auth)
+        assert_equal(res.status_code, 200)
+        ids = [each['id'] for each in res.json['data']]
+
+        assert_in(instrumentation._id, ids)
+        assert_in(hypothesis._id, ids)
+        assert_equal(len(ids), 2)
+
+    def test_filtering_by_multiple_titles(self):
+        url = '/{}nodes/?filter[title]={},{}'.format(API_BASE, 'Project One', 'Project Two')
+        res = self.app.get(url, auth=self.user_one.auth)
+        assert_equal(res.status_code, 200)
+        ids = [each['id'] for each in res.json['data']]
+
+        assert_in(self.project_one._id, ids)
+        assert_in(self.project_two._id, ids)
+        assert_equal(len(ids), 2)
+
     def test_filtering_by_public(self):
         project = ProjectFactory(creator=self.user_one, is_public=True)
         project2 = ProjectFactory(creator=self.user_one, is_public=False)
@@ -190,15 +220,8 @@ class TestNodeFiltering(ApiTestCase):
         assert_in(project._id, ids)
 
     def test_filtering_tags(self):
-        tag1, tag2 = 'tag1', 'tag2'
-        self.project_one.add_tag(tag1, Auth(self.project_one.creator), save=False)
-        self.project_one.add_tag(tag2, Auth(self.project_one.creator), save=False)
-        self.project_one.save()
-
-        self.project_two.add_tag(tag1, Auth(self.project_two.creator), save=True)
-
         # both project_one and project_two have tag1
-        url = '/{}nodes/?filter[tags]={}'.format(API_BASE, tag1)
+        url = '/{}nodes/?filter[tags]={}'.format(API_BASE, self.tag1)
 
         res = self.app.get(url, auth=self.project_one.creator.auth)
         node_json = res.json['data']
@@ -209,7 +232,7 @@ class TestNodeFiltering(ApiTestCase):
 
         # filtering two tags
         # project_one has both tags; project_two only has one
-        url = '/{}nodes/?filter[tags]={}&filter[tags]={}'.format(API_BASE, tag1, tag2)
+        url = '/{}nodes/?filter[tags]={}&filter[tags]={}'.format(API_BASE, self.tag1, self.tag2)
 
         res = self.app.get(url, auth=self.project_one.creator.auth)
         node_json = res.json['data']
@@ -217,6 +240,17 @@ class TestNodeFiltering(ApiTestCase):
         ids = [each['id'] for each in node_json]
         assert_in(self.project_one._id, ids)
         assert_not_in(self.project_two._id, ids)
+
+    def test_filtering_multiple_tags(self):
+        url = '/{}nodes/?filter[tags]={},{}'.format(API_BASE, self.tag1, self.tag2)
+
+        res = self.app.get(url, auth=self.project_one.creator.auth)
+        node_json = res.json['data']
+
+        ids = [each['id'] for each in node_json]
+        assert_in(self.project_one._id, ids)
+        assert_in(self.project_two._id, ids)
+        assert_equal(len(ids), 2)
 
     def test_get_all_projects_with_no_filter_logged_in(self):
         res = self.app.get(self.url, auth=self.user_one.auth)
@@ -347,6 +381,19 @@ class TestNodeFiltering(ApiTestCase):
         assert_not_in(self.private_project_user_two._id, ids)
         assert_not_in(self.folder._id, ids)
         assert_not_in(self.dashboard._id, ids)
+
+    def test_filtering_by_multiple_descriptions(self):
+        project = ProjectFactory(description='hello there', creator=self.user_one)
+        project_two = ProjectFactory(description='hi', creator=self.user_one)
+
+        url = "/{}nodes/?filter[description]={},{}".format(API_BASE, 'hi', 'hello there')
+        res = self.app.get(url, auth=self.user_one.auth)
+        assert_equal(res.status_code, 200)
+        ids = [each['id'] for each in res.json['data']]
+
+        assert_in(project._id, ids)
+        assert_in(project_two._id, ids)
+        assert_equal(len(ids), 2)
 
     def test_alternate_filtering_field_not_logged_in(self):
         url = "/{}nodes/?filter[description]=Three".format(API_BASE)


### PR DESCRIPTION
# Purpose

Issue https://openscience.atlassian.net/browse/OSF-5041
Allows for the equivalent of a bulk GET request through filtering (for example, if I want to request two nodes, specifically).  The reason we are not doing bulk GET requests is that putting JSON in the request body of a GET request is discouraged.  So for bulk GET capacity, we are implementing filtering on multiple ids.

# Changes
Allows return of multiple resources via a comma-separated list of values in the query_param.

For example, the following two node id's are requested in the following URL:
`/v2/nodes/?filter[id]=3z4tf,vatpw`

This turns into the query, `'_id', 'in', ['3z4tf, 'vatpw']`

The response will contain representations of the two nodes, `3z4tf` and `vatpw`.

**Example:**

url = `v2/nodes/?filter[id]=69wkq, y3mxq, aegu6,12345`

The first three are nodes, the fourth node DNE.

Response (most serializer fields removed for conciseness):

The three nodes that exist (and the user has permissions for) are returned.

![screen shot 2015-12-02 at 3 09 36 pm](https://cloud.githubusercontent.com/assets/9755598/11542656/58cd006c-9906-11e5-94a7-82ba6b9d7fd2.png)

:star: Also, this filtering on multiple resources extends to other fields and endpoints.  

so for example, you could filter on multiple user fullnames
   `v2/users/?filter[family_name]=Pattison,Jackson`
Will return all users with either a surname of Pattison or Jackson

Or, you could filter of multiple log actions:
   `/v2/nodes/x2qrm/logs/?filter[action]=comment_added,project_created`
Will return all logs on node `x2qrm` with action of `comment_added` or `project_created`.

