### PR TITLE
Release/0.59.0 fixes

### DIFF
--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -1227,7 +1227,7 @@ RegistrationManager.prototype.init = function() {
             var preregSchema = self.schemas().filter(function(schema) {
                 return schema.name === 'Prereg Challenge';
             })[0];
-            preregSchema.askConsent().then(function() {
+            preregSchema.askConsent(true).then(function() {
                 self.selectedSchema(preregSchema);
                 $('#newDraftRegistrationForm').submit();
             });

--- a/website/templates/project/register_draft.mako
+++ b/website/templates/project/register_draft.mako
@@ -25,9 +25,7 @@
     <div class="row-md-12 scripted">
         <span data-bind="ifnot: draft.isPendingApproval">
           <a type="button" class="btn btn-default pull-left" href="${draft['urls']['edit']}">Continue editing</a>
-        </span>
 
-        <span data-bind="ifnot: draft.isPendingApproval">
           <button id="register-submit" type="button" class="btn btn-success pull-right"
                   style="margin-left: 5px;"
                   data-bind="visible: draft.requiresApproval,
@@ -35,6 +33,9 @@
                              enable: editor.canSubmit">
             Submit for review
           </button>
+        </span>
+        <span data-bind="if: draft.isPendingApproval">
+          <a type="button" class="btn btn-default pull-left" href="${web_url_for('node_registrations', pid=node['id'], tab='drafts')}"> Back </a>
         </span>
 
         <!-- TODO(samchrisinger): Enable when post-registration file path updating is in


### PR DESCRIPTION
# Fixes

- When using the prereg campaign flow to auto-select the Prereg Challenge schema (on the draft registrations page), a flag was not set to use the "pre" consent language (vs. the language just before submission) 
- Add back button to draft preview page if draft is pending approval