### PR TITLE
[RfR] Component logs reflect inherited actions regarding license

### DIFF
--- a/tests/test_node_licenses.py
+++ b/tests/test_node_licenses.py
@@ -145,7 +145,7 @@ class TestNodeLicenses(OsfTestCase):
         )
         NEW_YEAR = '2014'
         COPYLEFT_HOLDERS = ['Richard Stallman']
-        self.node.set_node_license('GPL3', NEW_YEAR, COPYLEFT_HOLDERS, auth=Auth(self.user))
+        self.node.set_node_license('GPL3', NEW_YEAR, COPYLEFT_HOLDERS, auth=Auth(self.user), save=True)
         assert_equal(self.node.node_license.id, GPL3.id)
         assert_equal(self.node.node_license.name, GPL3.name)
         assert_equal(self.node.node_license.copyright_holders, COPYLEFT_HOLDERS)
@@ -157,3 +157,15 @@ class TestNodeLicenses(OsfTestCase):
         }
         with assert_raises(NodeStateError):
             self.node.set_node_license(invalid_license['id'], 'foo', [], auth=Auth(self.user))
+
+    def test_Node_set_node_license_children(self):
+        child = ProjectFactory(creator=self.user, parent=self.node)
+        GPL3 = NodeLicense.find_one(
+            Q('id', 'eq', 'GPL3')
+        )
+        NEW_YEAR = '2014'
+        COPYLEFT_HOLDERS = ['Richard Stallman']
+        self.node.set_node_license('GPL3', NEW_YEAR, COPYLEFT_HOLDERS, auth=Auth(self.user), save=True)
+        last_parent_log = self.node.logs[-1]
+        last_child_log = child.logs[-1]
+        assert_equal(last_parent_log.params['new_license'], last_child_log.params['new_license'])

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -1239,18 +1239,20 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
         record.copyright_holders = copyright_holders or []
         record.save()
         self.node_license = record
-        self.add_log(
-            action=NodeLog.CHANGED_LICENSE,
-            params={
-                'parent_node': self.parent_id,
-                'node': self._primary_key,
-                'new_license': node_license.name
-            },
-            auth=auth,
-            save=False,
-        )
-        if save:
-            self.save()
+
+        for node in self.node_and_primary_descendants():
+            node.add_log(
+                action=NodeLog.CHANGED_LICENSE,
+                params={
+                    'parent_node': node.parent_id,
+                    'node': node._primary_key,
+                    'new_license': node_license.name
+                },
+                auth=auth,
+                save=False,
+            )
+            if save:
+                node.save()
 
     def update(self, fields, auth=None, save=True):
         """Update the node with the given fields.

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -1287,7 +1287,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
                     value.get('year'),
                     value.get('copyright_holders'),
                     auth,
-                    save=False
+                    save=True
                 )
             else:
                 with warnings.catch_warnings():

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -1220,7 +1220,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
             )
         return self.is_contributor(auth.user)
 
-    def set_node_license(self, license_id, year, copyright_holders, auth, save=True):
+    def set_node_license(self, license_id, year, copyright_holders, auth, save=False):
         if not self.has_permission(auth.user, ADMIN):
             raise PermissionsError("Only admins can change a project's license.")
         try:
@@ -1251,8 +1251,11 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
                 auth=auth,
                 save=False,
             )
-            if save:
+            if node._id != self._id:
                 node.save()
+
+        if save:
+            self.save()
 
     def update(self, fields, auth=None, save=True):
         """Update the node with the given fields.

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -1290,7 +1290,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
                     value.get('year'),
                     value.get('copyright_holders'),
                     auth,
-                    save=True
+                    save=save
                 )
             else:
                 with warnings.catch_warnings():


### PR DESCRIPTION
## Purpose 
Since the license is inherited to all the components and nested components, the logs on those components should record the license actions.

## Changes

`add_log` called for each primary descendant of the updated node; trickle down license-omics. 

![screen shot 2015-12-03 at 10 02 10 am](https://cloud.githubusercontent.com/assets/8905795/11564052/fd5df3f4-99a4-11e5-998d-dd9bbb6f9fa7.png)


## Side effects
None apparent 


[OSF-5083]