### PR TITLE
Change commenting defaults to any OSF user

### DIFF
--- a/api_tests/comments/views/test_comment_detail.py
+++ b/api_tests/comments/views/test_comment_detail.py
@@ -176,7 +176,7 @@ class TestCommentDetailView(ApiTestCase):
         assert_equal(res.status_code, 401)
 
     def test_public_node_non_contributor_commenter_can_update_comment(self):
-        project = ProjectFactory(is_public=True, comment_level='public')
+        project = ProjectFactory(is_public=True)
         comment = CommentFactory(node=project, target=project, user=self.non_contributor)
         url = '/{}comments/{}/'.format(API_BASE, comment._id)
         payload = {
@@ -400,7 +400,7 @@ class TestCommentDetailView(ApiTestCase):
         assert_equal(res.status_code, 401)
 
     def test_public_node_non_contributor_commenter_can_delete_comment(self):
-        project = ProjectFactory(is_public=True, comment_level='public')
+        project = ProjectFactory(is_public=True)
         comment = CommentFactory(node=project, target=project, user=self.non_contributor)
         url = '/{}comments/{}/'.format(API_BASE, comment._id)
         payload = {

--- a/api_tests/comments/views/test_comment_replies_list.py
+++ b/api_tests/comments/views/test_comment_replies_list.py
@@ -204,7 +204,7 @@ class TestCommentRepliesCreate(ApiTestCase):
         assert_equal(res.status_code, 401)
 
     def test_private_node_with_public_comment_level_non_contributor_cannot_reply(self):
-        project = ProjectFactory(is_public=False, comment_level='public')
+        project = ProjectFactory(is_public=False)
         comment = CommentFactory(node=project, user=self.user)
         reply = CommentFactory(node=project, target=comment, user=self.user)
         url = '/{}comments/{}/replies/'.format(API_BASE, reply._id)
@@ -212,7 +212,7 @@ class TestCommentRepliesCreate(ApiTestCase):
         assert_equal(res.status_code, 403)
 
     def test_public_node_contributor_can_reply(self):
-        project = ProjectFactory(is_public=True, comment_level='public')
+        project = ProjectFactory(is_public=True)
         comment = CommentFactory(node=project, user=self.user)
         reply = CommentFactory(node=project, target=comment, user=self.user)
         url = '/{}comments/{}/replies/'.format(API_BASE, reply._id)
@@ -221,7 +221,7 @@ class TestCommentRepliesCreate(ApiTestCase):
         assert_equal(res.json['data']['attributes']['content'], self.payload['data']['attributes']['content'])
 
     def test_public_node_any_logged_in_user_can_reply(self):
-        project = ProjectFactory(is_public=True, comment_level='public')
+        project = ProjectFactory(is_public=True)
         comment = CommentFactory(node=project, user=self.user)
         reply = CommentFactory(node=project, target=comment, user=self.user)
         url = '/{}comments/{}/replies/'.format(API_BASE, reply._id)
@@ -230,7 +230,7 @@ class TestCommentRepliesCreate(ApiTestCase):
         assert_equal(res.json['data']['attributes']['content'], self.payload['data']['attributes']['content'])
 
     def test_public_node_logged_out_user_cannot_reply(self):
-        project = ProjectFactory(is_public=True, comment_level='public')
+        project = ProjectFactory(is_public=True)
         comment = CommentFactory(node=project, user=self.user)
         reply = CommentFactory(node=project, target=comment, user=self.user)
         url = '/{}comments/{}/replies/'.format(API_BASE, reply._id)

--- a/api_tests/comments/views/test_comment_replies_list.py
+++ b/api_tests/comments/views/test_comment_replies_list.py
@@ -243,10 +243,10 @@ class TestCommentRepliesCreate(ApiTestCase):
         assert_equal(res.status_code, 201)
         assert_equal(res.json['data']['attributes']['content'], self.payload['data']['attributes']['content'])
 
-    def test_public_node_non_contributor_cannot_reply(self):
+    def test_public_node_non_contributor_can_reply(self):
         self._set_up_public_project_comment_reply()
         res = self.app.post_json_api(self.public_url, self.payload, auth=self.non_contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
+        assert_equal(res.status_code, 201)
 
 
 class TestCommentRepliesFiltering(ApiTestCase):

--- a/api_tests/comments/views/test_comment_report_detail.py
+++ b/api_tests/comments/views/test_comment_report_detail.py
@@ -33,6 +33,7 @@ class TestReportDetailView(ApiTestCase):
 
     def _set_up_public_project_comment_reports(self):
         self.public_project = ProjectFactory.build(is_public=True, creator=self.user)
+        self.public_project.comment_level = 'private'
         self.public_project.add_contributor(contributor=self.contributor, save=True)
         self.public_comment = CommentFactory.build(node=self.public_project, target=self.public_project, user=self.contributor)
         self.public_comment.reports = {self.user._id: {'category': 'spam', 'text': 'This is spam'}}
@@ -83,7 +84,7 @@ class TestReportDetailView(ApiTestCase):
         assert_equal(res.status_code, 401)
 
     def test_public_node_logged_in_non_contributor_reporter_can_view_report_detail(self):
-        project = ProjectFactory(is_public=True, comment_level='public')
+        project = ProjectFactory(is_public=True)
         comment = CommentFactory.build(node=project, user=project.creator)
         comment.reports = {self.non_contributor._id: {'category': 'spam', 'text': 'This is spam'}}
         comment.save()
@@ -137,7 +138,7 @@ class TestReportDetailView(ApiTestCase):
         assert_equal(res.status_code, 401)
 
     def test_public_node_logged_in_non_contributor_reporter_can_update_report_detail(self):
-        project = ProjectFactory(is_public=True, comment_level='public')
+        project = ProjectFactory(is_public=True)
         comment = CommentFactory.build(node=project, user=project.creator)
         comment.reports = {self.non_contributor._id: {'category': 'spam', 'text': 'This is spam'}}
         comment.save()
@@ -206,7 +207,7 @@ class TestReportDetailView(ApiTestCase):
         assert_equal(res.status_code, 401)
 
     def test_public_node_logged_in_non_contributor_reporter_can_delete_report_detail(self):
-        project = ProjectFactory(is_public=True, comment_level='public')
+        project = ProjectFactory(is_public=True)
         comment = CommentFactory.build(node=project, user=project.creator)
         comment.reports = {self.non_contributor._id: {'category': 'spam', 'text': 'This is spam'}}
         comment.save()

--- a/api_tests/comments/views/test_comment_report_list.py
+++ b/api_tests/comments/views/test_comment_report_list.py
@@ -86,11 +86,10 @@ class TestCommentReportsView(ApiTestCase):
         assert_equal(len(report_json), 0)
         assert_not_in(self.contributor._id, report_ids)
 
-    def test_public_node_non_contributor_does_not_see_report(self):
+    def test_public_node_non_contributor_does_see_report(self):
         self._set_up_public_project_comment_reports()
         res = self.app.get(self.public_url, auth=self.non_contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
-        assert_equal(res.json['errors'][0]['detail'], 'You do not have permission to perform this action.')
+        assert_equal(res.status_code, 200)
 
     def test_public_node_logged_out_user_cannot_view_reports(self):
         self._set_up_public_project_comment_reports()
@@ -218,10 +217,10 @@ class TestCommentReportsView(ApiTestCase):
         res = self.app.post_json_api(self.public_url, self.payload, expect_errors=True)
         assert_equal(res.status_code, 401)
 
-    def test_public_node_logged_in_non_contributor_cannot_report_comment(self):
+    def test_public_node_logged_in_non_contributor_can_report_comment(self):
         self._set_up_public_project_comment_reports()
         res = self.app.post_json_api(self.public_url, self.payload, auth=self.non_contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
+        assert_equal(res.status_code, 201)
 
     def test_public_node_contributor_can_report_comment(self):
         self._set_up_public_project_comment_reports()

--- a/api_tests/comments/views/test_comment_report_list.py
+++ b/api_tests/comments/views/test_comment_report_list.py
@@ -97,7 +97,7 @@ class TestCommentReportsView(ApiTestCase):
         assert_equal(res.status_code, 401)
 
     def test_public_node_non_contributor_reporter_can_view_report(self):
-        project = ProjectFactory(is_public=True, comment_level='public')
+        project = ProjectFactory(is_public=True)
         comment = CommentFactory.build(node=project, user=project.creator)
         comment.reports = comment.reports or {}
         comment.reports[self.non_contributor._id] = {'category': 'spam', 'text': 'This is spam.'}
@@ -236,7 +236,7 @@ class TestCommentReportsView(ApiTestCase):
             comment (comment_level == 'public), non-contributors
             can also report comments.
         """
-        project = ProjectFactory(is_public=True, comment_level='public')
+        project = ProjectFactory(is_public=True)
         comment = CommentFactory(node=project, user=project.creator)
         url = '/{}comments/{}/reports/'.format(API_BASE, comment._id)
 

--- a/api_tests/nodes/views/test_node_comments_list.py
+++ b/api_tests/nodes/views/test_node_comments_list.py
@@ -123,7 +123,6 @@ class TestNodeCommentCreate(ApiTestCase):
     def _set_up_public_project_with_public_comment_level(self):
         """ Public project configured so that any logged-in user can comment."""
         self.project_with_public_comment_level = ProjectFactory(is_public=True, creator=self.user)
-        self.project_with_public_comment_level.comment_level = 'public'
         self.project_with_public_comment_level.save()
         self.public_comments_url = '/{}nodes/{}/comments/'.format(API_BASE, self.project_with_public_comment_level._id)
 

--- a/api_tests/nodes/views/test_node_comments_list.py
+++ b/api_tests/nodes/views/test_node_comments_list.py
@@ -236,10 +236,10 @@ class TestNodeCommentCreate(ApiTestCase):
         assert_equal(res.status_code, 201)
         assert_equal(res.json['data']['attributes']['content'], self.payload['data']['attributes']['content'])
 
-    def test_public_node_non_contributor_cannot_comment(self):
+    def test_public_node_non_contributor_can_comment(self):
         self._set_up_public_project()
         res = self.app.post_json_api(self.public_url, self.payload, auth=self.non_contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
+        assert_equal(res.status_code, 201)
 
     def test_public_node_logged_out_user_cannot_comment(self):
         self._set_up_public_project()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4176,7 +4176,7 @@ class TestComments(OsfTestCase):
         project = ProjectFactory()
         user = UserFactory()
         project.set_privacy('private')
-        project.add_contributor(user, 'read')
+        project.add_contributor(user, ['read'])
         project.save()
 
         assert_true(project.can_comment(Auth(user=user)))

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -723,7 +723,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
 
     # One of 'public', 'private'
     # TODO: Add validator
-    comment_level = fields.StringField(default='private')
+    comment_level = fields.StringField(default='public')
 
     wiki_pages_current = fields.DictionaryField()
     wiki_pages_versions = fields.DictionaryField()


### PR DESCRIPTION
## Purpose
Change the default configuration to "any OSF user can comment." 

## Changes
Default `comment_level` field `'private'` => `'public'`

## Side effects
Any new, public project is commentable for any OSF user, not just contributors

[OSF-5002]