### PR TITLE
Fixed project settings layout

### DIFF
--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -105,16 +105,14 @@
                         </div>
                     % if 'admin' in user['permissions']:
                         <hr />
-                        <div class="panel-body">
                             <div class="help-block">
                                 A project cannot be deleted if it has any components within it.
                                 To delete a parent project, you must first delete all child components
                                 by visiting their settings pages.
                             </div>
                             <button id="deleteNode" class="btn btn-danger btn-delete-node">Delete ${node['node_type']}</button>
-                        </div>
                     % endif
-
+                    </div>
                 </div>
 
             % endif


### PR DESCRIPTION
Purpose
-
As noted on the [Jira Ticket][1], the layout on the project settings page was messed up and one panel was wrapping all of the other panels.  This PR fixes this layout issue.
![projectsettingslayout](https://cloud.githubusercontent.com/assets/8229937/11565021/22fc7658-99aa-11e5-860e-80128cde2e0d.png)

Changes
-
Added a missing </div> tag and slightly restructured the panel (it had two panel-body elements which created a bunch of dead white space) to make the top panel be separate from the others and to be aesthetically pleasing
<img width="1202" alt="screen shot 2015-12-03 at 10 36 17 am" src="https://cloud.githubusercontent.com/assets/8229937/11564949/cd1ea0ee-99a9-11e5-9ecb-b8b25781ce28.png">

Side Effects
-
Since this PR is so small there should be nothing.  The only one I can think of would be messing up the knockout binding but this should not be an issue as it just adds in two unbound elements to the existing binding.  These elements should not be messed up as a result of being bound however.

[1]: https://openscience.atlassian.net/browse/OSF-5192