### PR TITLE
[Feature][Ready for Review] Filter by a relationship field's object id

### DIFF
--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -19,6 +19,7 @@ from api.base.exceptions import (
     InvalidFilterFieldError
 )
 from api.base import utils
+from api.base.serializers import RelationshipField, TargetField
 
 def sort_multiple(fields):
     fields = list(fields)
@@ -214,6 +215,8 @@ class FilterMixin(object):
                     field_type='date'
                 )
         elif isinstance(field, self.LIST_FIELDS):
+            return value
+        elif isinstance(field, (RelationshipField, TargetField)):
             return value
         else:
             try:

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -73,6 +73,8 @@ class FilterMixin(object):
 
     LIST_FIELDS = (ser.ListField, )
 
+    RELATIONSHIP_FIELDS = (RelationshipField, TargetField)
+
     def __init__(self, *args, **kwargs):
         super(FilterMixin, self).__init__(*args, **kwargs)
         if not self.serializer_class:
@@ -214,9 +216,7 @@ class FilterMixin(object):
                     value=value,
                     field_type='date'
                 )
-        elif isinstance(field, self.LIST_FIELDS):
-            return value
-        elif isinstance(field, (RelationshipField, TargetField)):
+        elif isinstance(field, (self.LIST_FIELDS + self.RELATIONSHIP_FIELDS)):
             return value
         else:
             try:

--- a/api/comments/serializers.py
+++ b/api/comments/serializers.py
@@ -23,7 +23,8 @@ class CommentSerializer(JSONAPISerializer):
     filterable_fields = frozenset([
         'deleted',
         'date_created',
-        'date_modified'
+        'date_modified',
+        'target'
     ])
 
     id = IDField(source='_id', read_only=True)

--- a/api/comments/views.py
+++ b/api/comments/views.py
@@ -110,6 +110,11 @@ class CommentRepliesList(JSONAPIBaseView, generics.ListCreateAPIView, CommentMix
     operators include 'gt' (greater than), 'gte'(greater than or equal to), 'lt' (less than) and 'lte'
     (less than or equal to). The date must be in the format YYYY-MM-DD and the time is optional.
 
+    + `filter[target]=target_id` -- filter comments based on their target id.
+
+    The list of comments can be filtered by target id. For example, to get all comments with target = comment,
+    the target_id would be the comment_id.
+
     #This Request/Response
     """
 

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1696,6 +1696,11 @@ class NodeCommentsList(JSONAPIBaseView, generics.ListCreateAPIView, ODMFilterMix
     operators include 'gt' (greater than), 'gte'(greater than or equal to), 'lt' (less than) and 'lte'
     (less than or equal to). The date must be in the format YYYY-MM-DD and the time is optional.
 
+    + `filter[target]=target_id` -- filter comments based on their target id.
+
+    The list of comments can be filtered by target id. For example, to get all comments with target = project,
+    the target_id would be the project_id.
+
     #This Request/Response
     """
     permission_classes = (

--- a/api_tests/nodes/views/test_node_comments_list.py
+++ b/api_tests/nodes/views/test_node_comments_list.py
@@ -316,3 +316,14 @@ class TestCommentFiltering(ApiTestCase):
         url = self.base_url + '?filter[date_modified][gt]={}'.format(self.formatted_date_modified)
         res = self.app.get(url, auth=self.user.auth)
         assert_equal(len(res.json['data']), 0)
+
+    def test_filtering_by_target(self):
+        url = self.base_url + '?filter[target]=' + str(self.project._id)
+        res = self.app.get(url, auth=self.user.auth)
+        assert_equal(len(res.json['data']), 2)
+        assert_in(self.project._id, res.json['data'][0]['relationships']['target']['links']['related']['href'])
+
+    def test_filtering_by_target_no_results(self):
+        url = self.base_url + '?filter[target]=' + 'fakeid'
+        res = self.app.get(url, auth=self.user.auth)
+        assert_equal(len(res.json['data']), 0)


### PR DESCRIPTION
Purpose
-----------
Addresses JIRA [OSF-5330]

Add ability to filter by a relationship field's object id. This is required for incorporating the API v2 comments routes into the commenting feature in development. 

E.g. `/v2/nodes/node_id/comments/?filter[target]=target_id`

Changes
------------
- Update `filters.py` to handle `RelationshipField` and `TargetField` 
- Make comment `target` a filterable field
- Test that filtering by `target` works


I included comment filtering in this PR so that there could be something to test this filtering with. 

Note to QA: Right now, you can only filter by target=node_id, since the node comments endpoint only lists top-level comments on the node. With the commenting feature, this endpoint will return all comments and users will also be able to filter by target comment and file.
