### PR TITLE
Add missing node logs parameters

### DIFF
--- a/api/logs/serializers.py
+++ b/api/logs/serializers.py
@@ -25,14 +25,29 @@ class NodeLogFileParamsSerializer(RestrictedDictSerializer):
 
 class NodeLogParamsSerializer(RestrictedDictSerializer):
 
-    tags = ser.CharField(read_only=True)
-    title_original = ser.CharField(read_only=True)
-    title_new = ser.CharField(read_only=True)
-    updated_fields = ser.ListField(read_only=True)
     addon = ser.CharField(read_only=True)
-    source = NodeLogFileParamsSerializer(read_only=True)
-    target = NodeLogFileParamsSerializer(read_only=True)
+    bucket = ser.CharField(read_only=True)
+    data_set = ser.CharField(read_only=True, source='dataset')
+    figshare_title = ser.CharField(read_only=True, source='figshare.title')
+    forward_url = ser.CharField(read_only=True)
+    github_user = ser.CharField(read_only=True, source='github.user')
+    github_repo = ser.CharField(read_only=True, source='github.repo')
+    filename = ser.CharField(read_only=True)
+    folder = ser.CharField(read_only=True)
+    folder_name = ser.CharField(read_only=True)
     identifiers = NodeLogIdentifiersSerializer(read_only=True)
+    old_page = ser.CharField(read_only=True)
+    page = ser.CharField(read_only=True)
+    path = ser.CharField(read_only=True)
+    source = NodeLogFileParamsSerializer(read_only=True)
+    study = ser.CharField(read_only=True)
+    tag = ser.CharField(read_only=True)
+    tags = ser.CharField(read_only=True)
+    target = NodeLogFileParamsSerializer(read_only=True)
+    title_new = ser.CharField(read_only=True)
+    title_original = ser.CharField(read_only=True)
+    updated_fields = ser.ListField(read_only=True)
+    version = ser.CharField(read_only=True)
 
 
 class NodeLogSerializer(JSONAPISerializer):
@@ -60,6 +75,10 @@ class NodeLogSerializer(JSONAPISerializer):
     linked_node = RelationshipField(
         related_view='nodes:node-detail',
         related_view_kwargs={'node_id': '<params.pointer.id>'}
+    )
+    template_node = RelationshipField(
+        related_view='nodes:node-detail',
+        related_view_kwargs={'node_id': '<params.template_node.id>'}
     )
 
     def get_absolute_url(self, obj):


### PR DESCRIPTION
Purpose
-----------
When /v2/nodes/logs was added, we didn't go too crazy with the params serialization. But in that I missed the addons params. This adds those params in. Closes https://openscience.atlassian.net/browse/OSF-5347

Changes
-----------
New fields mostly. A couple parameters are accessed differently than before, such as dataset becoming data_set, github.user becoming github_user, and so on. Templated node is a relationship link rather than having serialized data.

![screen shot 2015-12-07 at 12 44 04 pm](https://cloud.githubusercontent.com/assets/6599111/11634733/425b0594-9ce0-11e5-985d-125a422b8551.png)

Side effects
-------------
None