### PR TITLE
Remove dashboard node creation from depth_use count

### DIFF
--- a/scripts/analytics/depth_users.py
+++ b/scripts/analytics/depth_users.py
@@ -28,8 +28,13 @@ def count_user_logs(user, query=None):
         query &= Q('user', 'eq', user._id)
     else:
         query = Q('user', 'eq', user._id)
-    items = [item for item in NodeLog.find(query) if item.action != 'project_created' or not item.node.is_dashboard]
-    return len(items)
+    logs = NodeLog.find(query)
+    length = logs.count()
+    if length > 0:
+        item = logs[0]
+        if item.action == 'project_created' and item.node.is_dashboard:
+            length -= 1
+    return length
 
 
 def get_depth_users(users):

--- a/scripts/analytics/depth_users.py
+++ b/scripts/analytics/depth_users.py
@@ -28,7 +28,8 @@ def count_user_logs(user, query=None):
         query &= Q('user', 'eq', user._id)
     else:
         query = Q('user', 'eq', user._id)
-    return NodeLog.find(query).count()
+    items = [item for item in NodeLog.find(query) if item.action != 'project_created' or not item.node.is_dashboard]
+    return len(items)
 
 
 def get_depth_users(users):


### PR DESCRIPTION
Purpose
-----------
Make depth_use statistics more accurate.
Closes https://openscience.atlassian.net/browse/OSF-5032

Changes
------------
In the analytics script, no longer count the creation of a dashboard collection towards the depth_use statistic if the dashboard creation is the user's first NodeLog, since all it really means is that the user logged in after some date in the Autumn of 2014. 

Running the script locally, before the change I had
```
fullname         email                logs
---------------  -----------------  ------
Brian J. Geiger  bgeiger@pobox.com      48
```

after the change
```
fullname         email                logs
---------------  -----------------  ------
Brian J. Geiger  bgeiger@pobox.com      47
```

Side effects
----------------
The user's activity points will be different from the analytics script that is run for depth use, but those numbers are never compared, so it's unlikely that it will be noticed by anyone who isn't explicitly looking for it. If we ever want to use activity points for anything meaningful, then a more robust change will have to be made.

The downside of this approach is that there are some people who will be counted incorrectly as depth users. Those would be easy to figure out. Also, there will be a little variation between the number of log entries in some cases. However, nobody cares about any of these cases. This should take a little longer to run than the version currently in use, but it shouldn't be a significant problem. If need be, we could either make this more accurate or a little faster, but this is probably a fine set of compromises for our current needs.