### PR TITLE
[Ready to Review] User serializer showing user registrations link for user nodes relationship

### DIFF
--- a/api/users/views.py
+++ b/api/users/views.py
@@ -385,6 +385,8 @@ class UserRegistrations(UserNodes):
     required_write_scopes = [CoreScopes.USERS_WRITE, CoreScopes.NODE_REGISTRATIONS_WRITE]
 
     serializer_class = RegistrationSerializer
+    view_category = 'users'
+    view_name = 'user-registrations'
 
     # overrides ODMFilterMixin
     def get_default_odm_query(self):


### PR DESCRIPTION
# Purpose

Issue https://openscience.atlassian.net/browse/OSF-5356

Small fix - user serializer showing user registrations link for user nodes relationship

# Changes 

Added view_category and view_name to UserRegistrations view. 

Now user node link is returned for user nodes relationship.
![screen shot 2015-12-10 at 11 40 23 am](https://cloud.githubusercontent.com/assets/9755598/11721723/45f652a8-9f33-11e5-8f4d-38204888b042.png)

