### PR TITLE
[Ready for Review] Feature: Update add contributor email

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1702,6 +1702,7 @@ class TestAddingContributorViews(OsfTestCase):
         ensure_schemas()
         self.creator = AuthUserFactory()
         self.project = ProjectFactory(creator=self.creator)
+        self.auth = Auth(self.project.creator)
         # Authenticate all requests
         self.app.authenticate(*self.creator.auth)
         contributor_added.connect(notify_added_contributor)
@@ -1954,14 +1955,15 @@ class TestAddingContributorViews(OsfTestCase):
             'permissions': ['read', 'write']
         }]
         project = ProjectFactory()
-        project.add_contributors(contributors, auth=Auth(self.project.creator))
+        project.add_contributors(contributors, auth=self.auth)
         project.save()
         assert_true(send_mail.called)
         send_mail.assert_called_with(
             contributor.username,
             mails.CONTRIBUTOR_ADDED,
             user=contributor,
-            node=project)
+            node=project,
+            referrer_name=self.auth.user.fullname)
         assert_almost_equal(contributor.contributor_added_email_records[project._id]['last_sent'], int(time.time()), delta=1)
 
     @mock.patch('website.mails.send_mail')
@@ -2000,11 +2002,12 @@ class TestAddingContributorViews(OsfTestCase):
     def test_notify_contributor_email_does_not_send_before_throttle_expires(self, send_mail):
         contributor = UserFactory()
         project = ProjectFactory()
-        notify_added_contributor(project, contributor)
+        auth = Auth(project.creator)
+        notify_added_contributor(project, contributor, auth)
         assert_true(send_mail.called)
 
         # 2nd call does not send email because throttle period has not expired
-        notify_added_contributor(project, contributor)
+        notify_added_contributor(project, contributor, auth)
         assert_equal(send_mail.call_count, 1)
 
     @mock.patch('website.mails.send_mail')
@@ -2013,11 +2016,12 @@ class TestAddingContributorViews(OsfTestCase):
 
         contributor = UserFactory()
         project = ProjectFactory()
-        notify_added_contributor(project, contributor, throttle=throttle)
+        auth = Auth(project.creator)
+        notify_added_contributor(project, contributor, auth, throttle=throttle)
         assert_true(send_mail.called)
 
         time.sleep(1)  # throttle period expires
-        notify_added_contributor(project, contributor, throttle=throttle)
+        notify_added_contributor(project, contributor, auth, throttle=throttle)
         assert_equal(send_mail.call_count, 2)
 
     def test_add_multiple_contributors_only_adds_one_log(self):

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2561,7 +2561,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
             if save:
                 self.save()
 
-            project_signals.contributor_added.send(self, contributor=contributor)
+            project_signals.contributor_added.send(self, contributor=contributor, auth=auth)
 
             return True
 

--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -483,7 +483,7 @@ def send_claim_email(email, user, node, notify=True, throttle=24 * 3600):
 
 
 @contributor_added.connect
-def notify_added_contributor(node, contributor, throttle=None):
+def notify_added_contributor(node, contributor, auth=None, throttle=None):
     throttle = throttle or settings.CONTRIBUTOR_ADDED_EMAIL_THROTTLE
 
     # Exclude forks and templates because the user forking/templating the project gets added
@@ -505,7 +505,8 @@ def notify_added_contributor(node, contributor, throttle=None):
             contributor.username,
             mails.CONTRIBUTOR_ADDED,
             user=contributor,
-            node=node
+            node=node,
+            referrer_name=auth.user.fullname if auth else ''
         )
 
         contributor.contributor_added_email_records[node._id]['last_sent'] = get_timestamp()

--- a/website/templates/emails/contributor_added.txt.mako
+++ b/website/templates/emails/contributor_added.txt.mako
@@ -1,6 +1,6 @@
 Hello ${user.fullname},
 
-"${referrer.fullname}" has added you as a contributor to the project "${node.title}" on the Open Science Framework: ${node.absolute_url}
+${author} has added you as a contributor to the project "${node.title}" on the Open Science Framework: ${node.absolute_url}
 
 If you are erroneously being associated with "${node.title}," then you may visit the project's "Contributors" page and remove yourself as a contributor.
 

--- a/website/templates/emails/contributor_added.txt.mako
+++ b/website/templates/emails/contributor_added.txt.mako
@@ -1,6 +1,6 @@
 Hello ${user.fullname},
 
-${node.contributors[0]} has added you as a contributor to the project "${node.title}" on the Open Science Framework: ${node.absolute_url}
+${referrer_name + ' has added you' if referrer_name else 'You have been added'} as a contributor to the project "${node.title}" on the Open Science Framework: ${node.absolute_url}
 
 If you are erroneously being associated with "${node.title}," then you may visit the project's "Contributors" page and remove yourself as a contributor.
 

--- a/website/templates/emails/contributor_added.txt.mako
+++ b/website/templates/emails/contributor_added.txt.mako
@@ -1,6 +1,6 @@
 Hello ${user.fullname},
 
-${author} has added you as a contributor to the project "${node.title}" on the Open Science Framework: ${node.absolute_url}
+${node.contributors[0]} has added you as a contributor to the project "${node.title}" on the Open Science Framework: ${node.absolute_url}
 
 If you are erroneously being associated with "${node.title}," then you may visit the project's "Contributors" page and remove yourself as a contributor.
 

--- a/website/templates/emails/contributor_added.txt.mako
+++ b/website/templates/emails/contributor_added.txt.mako
@@ -1,6 +1,6 @@
 Hello ${user.fullname},
 
-You have been added as a contributor to the project "${node.title}" on the Open Science Framework: ${node.absolute_url}
+"${node.author}" has added you as a contributor to the project "${node.title}" on the Open Science Framework: ${node.absolute_url}
 
 If you are erroneously being associated with "${node.title}," then you may visit the project's "Contributors" page and remove yourself as a contributor.
 

--- a/website/templates/emails/contributor_added.txt.mako
+++ b/website/templates/emails/contributor_added.txt.mako
@@ -1,6 +1,6 @@
 Hello ${user.fullname},
 
-"${node.author}" has added you as a contributor to the project "${node.title}" on the Open Science Framework: ${node.absolute_url}
+"${referrer.fullname}" has added you as a contributor to the project "${node.title}" on the Open Science Framework: ${node.absolute_url}
 
 If you are erroneously being associated with "${node.title}," then you may visit the project's "Contributors" page and remove yourself as a contributor.
 


### PR DESCRIPTION
Continuation of PR #4638

Description from @njantrania: 

>Purpose

>The purpose of this was to change the email sent to registered contributors when notifying them about being added to a project so that the email would say who added them.

>Changes

>The change made was to add the name of the author of the project to the email so that the recipient could tell who added them.

![screen shot 2015-12-10 at 1 22 51 pm](https://cloud.githubusercontent.com/assets/6414394/11725202/6d4a6c8c-9f46-11e5-9802-acff4ffa10fe.png)


![screen shot 2015-12-10 at 1 24 55 pm](https://cloud.githubusercontent.com/assets/6414394/11725204/6d72a33c-9f46-11e5-8269-a29aa5c4b040.png)


Note: A user should only get this email if a user added them to a project. However, `add_contributor(s)` gets called in many places where we want to add contributors to a project automatically (e.g. OSF for meetings) so it's good to have a default message in case these emails get sent when they're not supposed to.