### PR TITLE
[feature] put fail at end of call for very large projects

### DIFF
--- a/website/static/js/nodesPrivacy.js
+++ b/website/static/js/nodesPrivacy.js
@@ -81,11 +81,6 @@ function patchNodesPrivacy(nodes) {
             return;
         }
         return patchNodesPrivacy(nodes);
-    }).fail(function(xhr, status, error) {
-        $osf.growl('Error', 'Unable to update project privacy');
-        Raven.captureMessage('Could not PATCH project settings.', {
-            url: nodesV2Url, status: status, error: error
-        });
     });
 }
 
@@ -208,6 +203,13 @@ var NodesPrivacyViewModel = function(parentIsPublic) {
             return node.changed;
         });
         patchNodesPrivacy(nodesChanged).then(function () {
+            window.location.reload();
+        }).fail(function(xhr, status, error) {
+            $osf.growl('Error', 'Unable to update project privacy');
+            Raven.captureMessage('Could not PATCH project settings.', {
+                url: window.contextVars.apiV2Prefix + 'nodes/', status: status, error: error
+            });
+            self.clear();
             window.location.reload();
         });
     };


### PR DESCRIPTION
I was failing out of bulk api calls, and I think it was causing some grief.  Now the fail method is at the end of all the requests.