### PR TITLE
Fix anchor div blocking content and license spacing

### DIFF
--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -87,6 +87,8 @@ a {
     margin-top: -60px;
     padding-top: 60px;
     display: block;
+    z-index: -1;
+    position: relative;
 }
 
 .scripted {display: none;}

--- a/website/templates/public/pages/help/licenses.mako
+++ b/website/templates/public/pages/help/licenses.mako
@@ -1,5 +1,5 @@
 <div class="col-sm-12">
     <span id="licenses" class="anchor"></span>
     <h4 class="m-t-lg f-w-lg">Licenses</h4>
-    <p>You can add a license to your project to allow others to copy, distribute, and make use of your data while allowing you to retain copyright. On a project's Overview page, add a license by clicking the &ldquo;No license&rdquo; text below the project's description and choose from a selection of common license types or upload your own. Not sure what license to apply to your work? Get detailed information here:<a target="_blank" href="http://choosealicense.com/">http://choosealicense.com/</a></p>
+    <p>You can add a license to your project to allow others to copy, distribute, and make use of your data while allowing you to retain copyright. On a project's Overview page, add a license by clicking the &ldquo;No license&rdquo; text below the project's description and choose from a selection of common license types or upload your own. Not sure what license to apply to your work? Get detailed information here: <a target="_blank" href="http://choosealicense.com/">http://choosealicense.com/</a></p>
 </div>


### PR DESCRIPTION
## Purpose
The anchor layer is helping the anchor links not hide headers so it's pushed up but this ends up covering the layers above which leads to links not being clickable. This was an overall problem and not related to licenses but the z-index organization fixed the layering issue. 

## Changes
-Added z-index to anchor div css, this is the most unobtrusive method I can think of and should be a good long term solution
- Space was added between here: and link in licenses.mako

## Side effects
 I checked to see that the other div arrangements also still work after the anchor css change and that menu divs still work (for licenses and others) and bring the user to the proper location. 

Fixes issue talked about in here: https://github.com/CenterForOpenScience/osf.io/pull/4697
