### PR TITLE
[Feature] Small bug fix for contrib page

### DIFF
--- a/website/static/js/pages/sharing-page.js
+++ b/website/static/js/pages/sharing-page.js
@@ -48,8 +48,8 @@ $(function() {
 
 $(window).load(function() {
     cm.viewModel.onWindowResize();
-    privateLinkTable.viewModel.onWindowResize();
-    if (linkTable !== undefined) {
+    if (!!privateLinkTable){
+        privateLinkTable.viewModel.onWindowResize();
         rt.responsiveTable(linkTable[0]);
     }
     $('table.responsive-table td:first-child a,button').on('click', function(e) {
@@ -58,6 +58,8 @@ $(window).load(function() {
 });
 
 $(window).resize(function() {
-    privateLinkTable.viewModel.onWindowResize();
+    if (!!privateLinkTable) {
+        privateLinkTable.viewModel.onWindowResize();
+    }
     cm.viewModel.onWindowResize();
 });


### PR DESCRIPTION
Purpose
-
There was a bug in which the responsive table/cards didn't work if the user was not an admin

Changes
-
Previously the window load and resize functions called `privateLinkTable.viewModel.onWindowResize();`
however `privateLinkTable` is only defined if the user is an admin.  To fix this I wrapped the calls with 
`if (!!privateLinkTable)`

Side Effects
-
Should be none