### PR TITLE
[Fix] OSF-5320 file picker highlighting in prereg form

### DIFF
--- a/website/static/js/registrationEditorExtensions.js
+++ b/website/static/js/registrationEditorExtensions.js
@@ -105,6 +105,8 @@ var osfUploader = function(element, valueAccessor, allBindings, viewModel, bindi
                 if (viewModel.value()) {
                     if (item.data.name === viewModel.value()) {
                         item.css = 'fangorn-selected';
+                    } else if ( viewModel.value() === 'No file selected' && item.data.name === 'OSF Storage') {
+                        item.css = 'fangorn-selected';
                     }
                 }
 

--- a/website/static/js/registrationEditorExtensions.js
+++ b/website/static/js/registrationEditorExtensions.js
@@ -103,7 +103,7 @@ var osfUploader = function(element, valueAccessor, allBindings, viewModel, bindi
                 limitContents(item);
 
                 if (viewModel.value()) {
-                    if (item.data.path === viewModel.value()) {
+                    if (item.data.name === viewModel.value()) {
                         item.css = 'fangorn-selected';
                     }
                 }


### PR DESCRIPTION
## Purpose
Make the file picker in the prereg form behave consistently as it does elsewhere on the site.
* Have the folder picker open with the OSF storage root folder highlighted.
* When a file is selected for highlight, the highlight persists regardless of the mouse pointing.

## Changes
Changed check for row highlighting from `item.data.path` to `item.data.name`.
If nothing is selected than highlight OSF Storage.
## Side Effects
If nothing is selected than OSF Storage is highlighted.
If file is selected than the file is highlighted.