### PR TITLE
Feature/modify registration serializer fields

### DIFF
--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -9,19 +9,22 @@ from api.base.serializers import IDField, RelationshipField, LinksField, HideIfR
 
 class RegistrationSerializer(NodeSerializer):
 
-    retracted = ser.BooleanField(source='is_retracted', read_only=True,
-                                 help_text='Whether this registration has been retracted.')
-    date_registered = ser.DateTimeField(source='registered_date', read_only=True, help_text='Date time of registration.')
-    embargo_end_date = HideIfRetraction(ser.SerializerMethodField(help_text='When will embargo be lifted?'))
-    retraction_justification = ser.CharField(source='retraction.justification', read_only=True)
+    pending_embargo_approval = HideIfRetraction(ser.BooleanField(read_only=True, source='is_pending_embargo',
+        help_text='The associated Embargo is awaiting approval by project admins.'))
+    pending_registration_approval = HideIfRetraction(ser.BooleanField(source='is_pending_registration', read_only=True,
+        help_text='The associated RegistrationApproval is awaiting approval by project admins.'))
     pending_retraction = HideIfRetraction(ser.BooleanField(source='is_pending_retraction', read_only=True,
-        help_text='Is this registration pending retraction?'))
-    pending_registration_approval = HideIfRetraction(ser.BooleanField(source='sanction.is_pending_approval', read_only=True,
-        help_text='Does this registration have a sanction pending approval?'))
-    registered_meta = HideIfRetraction(ser.SerializerMethodField(
-        help_text='A dictionary with embargo end date, whether registration choice was immediate or embargoed,'
-                  ' and answers to supplemental registration questions'))
+        help_text='The registration is awaiting retraction approval by project admins.'))
+    retracted = ser.BooleanField(source='is_retracted', read_only=True,
+                                 help_text='The registration has been retracted.')
+
+    date_registered = ser.DateTimeField(source='registered_date', read_only=True, help_text='Date time of registration.')
+    embargo_end_date = HideIfRetraction(ser.SerializerMethodField(help_text='When the embargo on this registration will be lifted.'))
+
+    retraction_justification = ser.CharField(source='retraction.justification', read_only=True)
     registration_supplement = ser.SerializerMethodField()
+    registered_meta = HideIfRetraction(ser.SerializerMethodField(
+        help_text='A dictionary with supplemental registration questions and responses.'))
 
     registered_by = HideIfRetraction(RelationshipField(
         related_view='users:user-detail',

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -12,13 +12,12 @@ class RegistrationSerializer(NodeSerializer):
     retracted = ser.BooleanField(source='is_retracted', read_only=True,
                                  help_text='Whether this registration has been retracted.')
     date_registered = ser.DateTimeField(source='registered_date', read_only=True, help_text='Date time of registration.')
+    embargo_end_date = HideIfRetraction(ser.SerializerMethodField(help_text='When will embargo be lifted?'))
     retraction_justification = ser.CharField(source='retraction.justification', read_only=True)
     pending_retraction = HideIfRetraction(ser.BooleanField(source='is_pending_retraction', read_only=True,
         help_text='Is this registration pending retraction?'))
-    pending_registration_approval = HideIfRetraction(ser.BooleanField(source='sanction.pending_approval', read_only=True,
+    pending_registration_approval = HideIfRetraction(ser.BooleanField(source='sanction.is_pending_approval', read_only=True,
         help_text='Does this registration have a sanction pending approval?'))
-    pending_embargo = HideIfRetraction(ser.BooleanField(read_only=True, source='is_pending_embargo',
-        help_text='Is this registration pending embargo?'))
     registered_meta = HideIfRetraction(ser.SerializerMethodField(
         help_text='A dictionary with embargo end date, whether registration choice was immediate or embargoed,'
                   ' and answers to supplemental registration questions'))
@@ -93,6 +92,11 @@ class RegistrationSerializer(NodeSerializer):
                 return meta_values
             except ValueError:
                 return meta_values
+        return None
+
+    def get_embargo_end_date(self, obj):
+        if obj.embargo_end_date:
+            return obj.embargo_end_date
         return None
 
     def get_registration_supplement(self, obj):

--- a/api_tests/registrations/views/test_registration_detail.py
+++ b/api_tests/registrations/views/test_registration_detail.py
@@ -96,7 +96,7 @@ class TestRegistrationDetail(ApiTestCase):
             'retracted': True,
             'pending_retraction': None,
             'pending_registration_approval': None,
-            "pending_embargo": None,
+            "embargo_end_date": None,
             "registered_meta": None,
             "registration_supplement": registration.registered_meta.keys()[0]
         })

--- a/api_tests/registrations/views/test_registration_detail.py
+++ b/api_tests/registrations/views/test_registration_detail.py
@@ -96,6 +96,7 @@ class TestRegistrationDetail(ApiTestCase):
             'retracted': True,
             'pending_retraction': None,
             'pending_registration_approval': None,
+            'pending_embargo_approval': None,
             "embargo_end_date": None,
             "registered_meta": None,
             "registration_supplement": registration.registered_meta.keys()[0]


### PR DESCRIPTION
# Purpose

Issue: https://openscience.atlassian.net/browse/OSF-5398
Makes a few small changes to RegistrationSerializer.  One is an error found by Nici in https://openscience.atlassian.net/browse/OSF-5036.

# Changes

1) Adds field embargo_end_date.  If no embargo_end_date, returns null
2) Changes source of pending_registration_approval to match new registration changes and name to pending_registration.
3) Updates help text.

Embargo, awaiting approval by project admins:
![screen shot 2015-12-15 at 4 00 11 pm](https://cloud.githubusercontent.com/assets/9755598/11823946/fca9bd22-a344-11e5-8344-b76715c10cb8.png)

Embargo, approved by project admins:
![screen shot 2015-12-15 at 4 01 31 pm](https://cloud.githubusercontent.com/assets/9755598/11823976/29460c6e-a345-11e5-9721-19dda487ddb2.png)

