### PR TITLE
Feature/api/do not clear node tags on patch

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -171,13 +171,15 @@ class NodeSerializer(JSONAPISerializer):
         """
         assert isinstance(node, Node), 'node must be a Node'
         auth = self.get_user_auth(self.context['request'])
-        tags = validated_data.get('tags')
-        if tags is not None:
+        old_tags = set([tag._id for tag in node.tags])
+        if 'tags' in validated_data:
+            current_tags = set(validated_data.get('tags'))
             del validated_data['tags']
-            current_tags = set(tags)
+        elif self.partial:
+            current_tags = set(old_tags)
         else:
             current_tags = set()
-        old_tags = set([tag._id for tag in node.tags])
+
         for new_tag in (current_tags - old_tags):
             node.add_tag(new_tag, auth=auth)
         for deleted_tag in (old_tags - current_tags):

--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -878,6 +878,7 @@ class TestNodeTags(ApiTestCase):
     def setUp(self):
         super(TestNodeTags, self).setUp()
         self.user = AuthUserFactory()
+        self.admin = AuthUserFactory()
         self.user_two = AuthUserFactory()
         self.read_only_contributor = AuthUserFactory()
 
@@ -885,6 +886,7 @@ class TestNodeTags(ApiTestCase):
         self.public_project.add_contributor(self.user, permissions=permissions.DEFAULT_CONTRIBUTOR_PERMISSIONS, save=True)
         self.private_project = ProjectFactory(title="Project Two", is_public=False, creator=self.user)
         self.private_project.add_contributor(self.user, permissions=permissions.DEFAULT_CONTRIBUTOR_PERMISSIONS, save=True)
+        self.private_project.add_contributor(self.admin, permissions=permissions.CREATOR_PERMISSIONS, save=True)
         self.public_url = '/{}nodes/{}/'.format(API_BASE, self.public_project._id)
         self.private_url = '/{}nodes/{}/'.format(API_BASE, self.private_project._id)
 
@@ -943,6 +945,27 @@ class TestNodeTags(ApiTestCase):
         reload_res = self.app.get(self.private_url, auth=self.user.auth)
         assert_equal(len(reload_res.json['data']['attributes']['tags']), 1)
         assert_equal(reload_res.json['data']['attributes']['tags'][0], 'new-tag')
+
+    def test_partial_update_project_does_not_clear_tags(self):
+        res = self.app.patch_json_api(self.private_url, self.private_payload, auth=self.admin.auth)
+        assert_equal(res.status_code, 200)
+        assert_equal(len(res.json['data']['attributes']['tags']), 1)
+        new_payload = {
+            'data': {
+                'id': self.private_project._id,
+                'type': 'nodes',
+                'attributes': {
+                    'public': True
+                }
+            }
+        }
+        res = self.app.patch_json_api(self.private_url, new_payload, auth=self.admin.auth)
+        assert_equal(res.status_code, 200)
+        assert_equal(len(res.json['data']['attributes']['tags']), 1)
+        new_payload['data']['attributes']['public'] = False
+        res = self.app.patch_json_api(self.private_url, new_payload, auth=self.admin.auth)
+        assert_equal(res.status_code, 200)
+        assert_equal(len(res.json['data']['attributes']['tags']), 1)
 
     def test_non_authenticated_user_cannot_add_tag_to_public_project(self):
         res = self.app.patch_json_api(self.public_url, self.one_new_tag_json, expect_errors=True, auth=None)


### PR DESCRIPTION
Purpose
-----------
Keep tags from clearing out when someone does a PATCH on /v2/nodes/{{node_id}}/ when no tags are included in the patch. Closes https://openscience.atlassian.net/browse/OSF-5403

Changes
------------
 - Check for the partial update condition in the update method and, in that case, make the tags equal to the original tags
 - Add a test for this situation

Side effects
-----------------
None