### PR TITLE
Add tooltip to '(required)' text on Prereg schema

### DIFF
--- a/website/project/metadata/prereg-prize.json
+++ b/website/project/metadata/prereg-prize.json
@@ -309,8 +309,8 @@
             "format": "textarea"
         }, {
             "qid": "q25",
-            "nav": "Assumptions (Optional)",
-            "title": "Assumptions (Optional)",
+            "nav": "Assumptions",
+            "title": "Assumptions",
             "description": "If you are planning on testing the assumptions of the statistical tests included in your analysis plan, which assumptions will you test, how will you test them, what criteria will you use to make decisions based on that test, and what alternative statistical tests will you use? This may be an item where a decision tree could be helpful to plan and communicate the possibilities.",
             "help": "We will test the assumption of the ANOVA on equal group variance using the Bartlett test and use a Kruskal-Wallis as an alternative to the ANOVA if p<.05.<br /><br /> How responses will be evaluated: Again, any reasonable answer here is acceptable, meaning that you are free to follow or ignore the assumptions of the test as they see fit.",
             "type": "string",
@@ -324,7 +324,7 @@
         "questions": [{
             "qid": "q26",
             "nav": "Script",
-            "title": "(Optional) Upload an analysis script with clear comments",
+            "title": "Upload an analysis script with clear comments",
             "type": "osf-upload",
             "format": "osf-upload-open",
             "description": "This optional step is helpful in order to create a process that is completely transparent and increase the likelihood that your analysis can be replicated. We recommend that you run the code on a simulated dataset in order to check that it will run without errors."

--- a/website/templates/project/registration_editor_templates.mako
+++ b/website/templates/project/registration_editor_templates.mako
@@ -61,8 +61,11 @@
       <div class="col-md-12">
         <div class="form-group">
           <label class="control-label" data-bind="text: title"></label>
-          <span class="text-muted" data-bind="if: required">
+          <span class="text-muted" data-bind="if: required, tooltip: {title: 'This field is required for submission. If this field is not applicable to your study, you may state so.'}">
             (required)
+          </span>
+          <span class="text-muted" data-bind="ifnot: required">
+            (optional)
           </span>
           <p class="help-block" data-bind="text: description"></p>
           <span data-bind="if: help" class="example-block">


### PR DESCRIPTION
# :dolphin: 

resolves: https://openscience.atlassian.net/browse/OSF-5329

# Changes
Explicitly mark questions as optional or required, and add tooltip to required questions. 