### PR TITLE
Add alternative citation routes for registrations

### DIFF
--- a/api/registrations/urls.py
+++ b/api/registrations/urls.py
@@ -16,6 +16,8 @@ urlpatterns = [
     url(r'^(?P<node_id>\w+)/files/$', views.RegistrationProvidersList.as_view(), name=views.RegistrationProvidersList.view_name),
     url(r'^(?P<node_id>\w+)/files/(?P<provider>\w+)(?P<path>/(?:.*/)?)$', views.RegistrationFilesList.as_view(), name=views.RegistrationFilesList.view_name),
     url(r'^(?P<node_id>\w+)/files/(?P<provider>\w+)(?P<path>/.+[^/])$', views.RegistrationFileDetail.as_view(), name=views.RegistrationFileDetail.view_name),
+    url(r'^(?P<node_id>\w+)/citations/$', views.RegistrationAlternativeCitationsList.as_view(), name=views.RegistrationAlternativeCitationsList.view_name),
+    url(r'^(?P<node_id>\w+)/citations/(?P<citation_id>\w+)/$', views.RegistrationAlternativeCitationDetail.as_view(), name=views.RegistrationAlternativeCitationDetail.view_name),
     url(r'^(?P<node_id>\w+)/comments/$', views.RegistrationCommentsList.as_view(), name=views.RegistrationCommentsList.view_name),
 ]
 

--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -16,7 +16,8 @@ from api.registrations.serializers import (
 from api.nodes.views import (
     NodeMixin, ODMFilterMixin, NodeContributorsList, NodeRegistrationsList,
     NodeChildrenList, NodeCommentsList, NodeProvidersList, NodeLinksList,
-    NodeContributorDetail, NodeFilesList, NodeLinksDetail, NodeFileDetail)
+    NodeContributorDetail, NodeFilesList, NodeLinksDetail, NodeFileDetail,
+    NodeAlternativeCitationsList, NodeAlternativeCitationDetail)
 
 from api.nodes.permissions import (
     ContributorOrPublic,
@@ -258,3 +259,11 @@ class RegistrationFilesList(NodeFilesList):
 class RegistrationFileDetail(NodeFileDetail):
     view_category = 'registrations'
     view_name = 'registration-file-detail'
+
+class RegistrationAlternativeCitationsList(NodeAlternativeCitationsList):
+    view_category = 'registrations'
+    view_name = 'registration-alternative-citations'
+
+class RegistrationAlternativeCitationDetail(NodeAlternativeCitationDetail):
+    view_category = 'registrations'
+    view_name = 'registration-alternative-citation-detail'

--- a/api_tests/nodes/views/test_node_alternative_citation_list.py
+++ b/api_tests/nodes/views/test_node_alternative_citation_list.py
@@ -50,13 +50,17 @@ def create_project(creator, public=True, contrib=None, citation=False, registrat
 class TestCreateAlternativeCitations(ApiTestCase):
     def request(self, data, errors=False, is_admin=False, is_contrib=True, logged_out=False, **kwargs):
         admin = AuthUserFactory()
+        registration = kwargs.get('registration', None)
         if is_admin:
             user = admin
         elif not logged_out:
             user = AuthUserFactory()
             kwargs['contrib'] = user if is_contrib else None
         project = create_project(admin, **kwargs)
-        project_url = '/{}nodes/{}/citations/'.format(API_BASE, project._id)
+        if registration:
+            project_url = '/{}registrations/{}/citations/'.format(API_BASE, project._id)
+        else:
+            project_url = '/{}nodes/{}/citations/'.format(API_BASE, project._id)
         if not logged_out:
             res = self.app.post_json_api(project_url, data, auth=user.auth, expect_errors=errors)
         else:

--- a/api_tests/nodes/views/test_node_alternative_citations.py
+++ b/api_tests/nodes/views/test_node_alternative_citations.py
@@ -37,10 +37,12 @@ def set_up_citation_and_project(admin, public=True, registration=False, contrib=
         citation2 = AlternativeCitationFactory(name='name2', text='text2')
         project.alternative_citations.append(citation2)
     project.save()
+    slug = 1 if bad else citation._id
     if registration:
         project = RegistrationFactory(project=project, is_public=public)
-    slug = 1 if bad else citation._id
-    citation_url = '/{}nodes/{}/citations/{}/'.format(API_BASE, project._id, slug)
+        citation_url = '/{}registrations/{}/citations/{}/'.format(API_BASE, project._id, slug)
+    else:
+        citation_url = '/{}nodes/{}/citations/{}/'.format(API_BASE, project._id, slug)
     if for_delete:
         return project, citation_url
     return citation, citation_url


### PR DESCRIPTION
Purpose
------------
Update alternative citations to be consistent with #4728, which creates separate endpoints for registrations.

Changes
------------
Added routes for viewing list/detail for alternative citations on registrations and updated tests.