### PR TITLE
[Feature Fix] Fix ContribAdder double-bind

### DIFF
--- a/website/static/js/registrationEditorExtensions.js
+++ b/website/static/js/registrationEditorExtensions.js
@@ -240,7 +240,7 @@ var AuthorImport = function(data, $root) {
             });
     };
     self.getContributors().done(function(data) {
-        self.value(data);
+        self.question.value(data);
     });
     self.preview = function() {
         return self.value();
@@ -248,6 +248,8 @@ var AuthorImport = function(data, $root) {
     var callback = function(data) {
         self.value(self.serializeContributors(data));
     };
+
+    ko.cleanNode($('#addContributors')[0]);
     var adder = new ContribAdder(
         '#addContributors',
         node.title,


### PR DESCRIPTION
# Purpose

Since the ContribAdder relies on a single static modal for rendering and the Prereg authorImport extension potentially instantiates the Adder multiple times, we were getting double-binding errors from KO.

# Changes

Clean the node before instantiating the ContribAdder in authorImport extension. 