### PR TITLE
Updated CSS selector to fix menus not working

### DIFF
--- a/website/static/js/pages/sharing-page.js
+++ b/website/static/js/pages/sharing-page.js
@@ -52,7 +52,8 @@ $(window).load(function() {
         privateLinkTable.viewModel.onWindowResize();
         rt.responsiveTable(linkTable[0]);
     }
-    $('table.responsive-table td:first-child a,button').on('click', function(e) {
+    $('table.responsive-table td:first-child a,' +
+        'table.responsive-table td:first-child button').on('click', function(e) {
         e.stopImmediatePropagation();
     });
 });


### PR DESCRIPTION
Purpose
-
Menus were broken on the contributors page as a result of my PR.  This PR fixes that.

Changes
-
This was due to a bad CSS selector which effectively disabled buttons.  I fixed this CSS selector to only select the ones that were necessary.

Side Effects
-
Should be none