### PR TITLE
Changing a node's privacy setting removes all tags on the node

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -615,6 +615,11 @@ class JSONAPIListSerializer(ser.ListSerializer):
 
     # Overrides ListSerializer which doesn't support multiple update by default
     def update(self, instance, validated_data):
+
+        # if PATCH request, the child serializer's partial attribute needs to be True
+        if self.context['request'].method == 'PATCH':
+            self.child.partial = True
+
         if len(instance) != len(validated_data):
             raise exceptions.ValidationError({'non_field_errors': 'Could not find all objects to update.'})
 

--- a/api_tests/nodes/views/test_node_list.py
+++ b/api_tests/nodes/views/test_node_list.py
@@ -1168,6 +1168,15 @@ class TestNodeBulkPartialUpdate(ApiTestCase):
         assert_equal(res.json['errors'][0]['detail'], 'Bulk operation limit is 10, got 11.')
         assert_equal(res.json['errors'][0]['source']['pointer'], '/data')
 
+    def test_bulk_partial_update_privacy_has_no_effect_on_tags(self):
+        self.public_project.add_tag('tag1', Auth(self.public_project.creator), save=True)
+        payload = {'id': self.public_project._id, 'type': 'nodes', 'attributes': {'public': False}}
+        res = self.app.patch_json_api(self.url, {'data': [payload]}, auth=self.user.auth, bulk=True)
+        assert_equal(res.status_code, 200)
+        self.public_project.reload()
+        assert_equal(self.public_project.tags, ['tag1'])
+        assert_equal(self.public_project.is_public, False)
+
 
 class TestNodeBulkDelete(ApiTestCase):
 


### PR DESCRIPTION
# Purpose

Issue https://openscience.atlassian.net/browse/OSF-5403

When doing a bulk PATCH request, self.partial, a DRF thing, was set to False.  When the request hit the update method in the node serializer, self.partial, being set to False, acted as if this was a PUT request and deleted all the tags.

# Changes

In the JSONAPIListSerializer, if this is a bulk PATCH request, set the child serializer self.partial equal to True.

**Basically, the request is now correctly treated as a PATCH request instead of a PUT request when it comes to tags.**  PATCH was only broken for tags, because the tags logic was specifically looking for the self.partial flag.