### PR TITLE
[RfR] add fields to V2 file serializer, improve non-osfstorage support

### DIFF
--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -140,13 +140,17 @@ class FileSerializer(JSONAPISerializer):
         return mod_dt and mod_dt.replace(tzinfo=pytz.utc)
 
     def get_extra(self, obj):
-        extras = {}
-        if obj.versions:
+        metadata = {}
+        if obj.provider == 'osfstorage' and obj.versions:
             metadata = obj.versions[-1].metadata
-            extras['hashes'] = {  # mimic waterbutler response
-                'md5': metadata.get('md5', None),
-                'sha256': metadata.get('sha256', None),
-            }
+        elif obj.provider != 'osfstorage' and obj.history:
+            metadata = obj.history[-1].get('extra', {})
+
+        extras = {}
+        extras['hashes'] = {  # mimic waterbutler response
+            'md5': metadata.get('md5', None),
+            'sha256': metadata.get('sha256', None),
+        }
         return extras
 
     def user_id(self, obj):

--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -83,6 +83,7 @@ class FileSerializer(JSONAPISerializer):
         'node',
         'kind',
         'path',
+        'materialized_path',
         'size',
         'provider',
         'last_touched',
@@ -95,6 +96,8 @@ class FileSerializer(JSONAPISerializer):
     path = ser.CharField(read_only=True, help_text='The unique path used to reference this object')
     size = ser.SerializerMethodField(read_only=True, help_text='The size of this file at this version')
     provider = ser.CharField(read_only=True, help_text='The Add-on service this file originates from')
+    materialized_path = ser.CharField(
+        read_only=True, help_text='The Unix-style path of this object relative to the provider root')
     last_touched = ser.DateTimeField(read_only=True, help_text='The last time this file had information fetched about it via the OSF')
     date_modified = ser.SerializerMethodField(read_only=True, help_text='Timestamp when the file was last modified')
     date_created = ser.SerializerMethodField(read_only=True, help_text='Timestamp when the file was created')

--- a/api/files/views.py
+++ b/api/files/views.py
@@ -107,23 +107,31 @@ class FileDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView, FileMixin):
     null for folders.  A list of storage provider keys can be found [here](/v2/#storage-providers).
 
         name          type               description
-        ---------------------------------------------------------------------------------
-        name          string             name of the file or folder; used for display
-        kind          string             "file" or "folder"
-        path          string             same as for corresponding WaterButler entity
-        size          integer            size of file in bytes, null for folders
-        provider      string             storage provider for this file. "osfstorage" if stored on the OSF.  Other
-                                         examples include "s3" for Amazon S3, "googledrive" for Google Drive, "box"
-                                         for Box.com.
-        last_touched  iso8601 timestamp  last time the metadata for the file was retrieved. only applies to non-OSF
-                                         storage providers.
-        date_modified iso8601 timestamp  timestamp of when this file was last updated
-        extra         object             may contain additional data beyond what's described here, depending on
-                                         the provider
-          hashes      object
-            md5       string             md5 hash of file, null for folders
-            sha256    string             SHA-256 hash of file, null for folders
+        ---------------------------------------------------------------------------------------------------
+        name              string             name of the file or folder; used for display
+        kind              string             "file" or "folder"
+        path              string             same as for corresponding WaterButler entity
+        materialized_path string             the unix-style path to the file relative to the provider root
+        size              integer            size of file in bytes, null for folders
+        provider          string             storage provider for this file. "osfstorage" if stored on the
+                                             OSF.  other examples include "s3" for Amazon S3, "googledrive"
+                                             for Google Drive, "box" for Box.com.
+        last_touched      iso8601 timestamp  last time the metadata for the file was retrieved. only
+                                             applies to non-OSF storage providers.
+        date_modified     iso8601 timestamp  timestamp of when this file was last updated*
+        date_created      iso8601 timestamp  timestamp of when this file was created*
+        extra             object             may contain additional data beyond what's described here,
+                                             depending on the provider
+          hashes          object
+            md5           string             md5 hash of file, null for folders
+            sha256        string             SHA-256 hash of file, null for folders
 
+    * A note on timestamps: for files stored in osfstorage, `date_created` refers to the time the file was
+    first uploaded to osfstorage, and `date_modified` is the time the file was last updated while in osfstorage.
+    Other providers may or may not provide this information, but if they do it will correspond to the provider's
+    semantics for created/modified times.  These timestamps may also be stale; metadata retrieved via the File Detail
+    endpoint is cached.  The `last_touched` field describes the last time the metadata was retrieved from the external
+    provider.  To force a metadata update, access the parent folder via its Node Files List endpoint.
 
     ##Relationships
 

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1146,22 +1146,31 @@ class NodeFilesList(JSONAPIBaseView, generics.ListAPIView, WaterButlerMixin, Lis
     found [here](/v2/#storage-providers).
 
         name          type               description
-        ---------------------------------------------------------------------------------
-        name          string             name of the file or folder; use for display
-        kind          string             "file" or "folder"
-        path          url path           unique path for this entity, used in "move" actions
-        size          integer            size of file in bytes, null for folders
-        provider      string             storage provider for this file. "osfstorage" if stored on the OSF.  Other
-                                         examples include "s3" for Amazon S3, "googledrive" for Google Drive, "box"
-                                         for Box.com.
-        last_touched  iso8601 timestamp  last time the metadata for the file was retrieved. only applies to non-OSF
-                                         storage providers.
-        date_modified iso8601 timestamp  timestamp of when this file was last updated
-        extra         object             may contain additional data beyond what's described here, depending on
-                                         the provider
-          hashes      object
-            md5       string             md5 hash of file, null for folders
-            sha256    string             SHA-256 hash of file, null for folders
+        ---------------------------------------------------------------------------------------------------
+        name              string             name of the file or folder; used for display
+        kind              string             "file" or "folder"
+        path              string             same as for corresponding WaterButler entity
+        materialized_path string             the unix-style path to the file relative to the provider root
+        size              integer            size of file in bytes, null for folders
+        provider          string             storage provider for this file. "osfstorage" if stored on the
+                                             OSF.  other examples include "s3" for Amazon S3, "googledrive"
+                                             for Google Drive, "box" for Box.com.
+        last_touched      iso8601 timestamp  last time the metadata for the file was retrieved. only
+                                             applies to non-OSF storage providers.
+        date_modified     iso8601 timestamp  timestamp of when this file was last updated*
+        date_created      iso8601 timestamp  timestamp of when this file was created*
+        extra             object             may contain additional data beyond what's described here,
+                                             depending on the provider
+          hashes          object
+            md5           string             md5 hash of file, null for folders
+            sha256        string             SHA-256 hash of file, null for folders
+
+    * A note on timestamps: for files stored in osfstorage, `date_created` refers to the time the file was
+    first uploaded to osfstorage, and `date_modified` is the time the file was last updated while in osfstorage.
+    Other providers may or may not provide this information, but if they do it will correspond to the provider's
+    semantics for created/modified times.  These timestamps may also be stale; metadata retrieved via the File Detail
+    endpoint is cached.  The `last_touched` field describes the last time the metadata was retrieved from the external
+    provider.  To force a metadata update, access the parent folder via its Node Files List endpoint.
 
     ##Links
 


### PR DESCRIPTION
Purpose
----
This PR fixes four minor closely-related tickets for changes to the V2 FileSerializer.  Two new attributes, `materialized_path` and `date_created`, were added.  Two existing attributes, `date_modified` and `extra.hashes`, were being pulled from the file versions, which non-osfstorage providers lack.  For these, we can use the metadata history to get this information.

*If desired I can split these up into separate PRs, but they're all pretty small, so I figured they'd be better together.*

Changes
----
* added `materialized_path` attribute to show unix-style path for entity relative to provider root.
* added `date_created` attribute. For osfstorage, `date_created` is the timestamp when the file was first uploaded to osfstorage.  For other providers, `date_created` is the `modified` field of the first entry in the file's metadata history.
* updated `date_modified` to work for non-osfstorage.  Returns the `modified` field of the most recent entry in the file's metadata history.
* updated `extras.hashes` to work with non-osfstorage providers, which have histories, rather than versions.  Only s3 currently provides md5.

Side Effects
----
Should be minimal, most changes are additions.  `date_modified` was updated to include a tz indicator, but datetime parsers should handle this, as we're just making explicit what was implicit before.

----------

**Fixes:** [#OSF-5417] - parent ticket, has testing information
**Sub-tasks:**
* [#OSF-5289] - add `date_created` to file serializer
* [#OSF-5346] - add `materialized_path` to file serializer
* [#OSF-5418] - update file serializer's `date_modified` to work for non-osfstorage
* [#OSF-5419] - update file serializer's `extra.hashes` to work for non-osfstorage