### PR TITLE
Update contributors list if using ContribAdder in asnyc mode

### DIFF
--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -315,6 +315,9 @@ var AddContributorViewModel = oop.extend(Paginator, {
             }
         ).done(function(response) {
             if (self.async) {
+                self.contributors($.map(response.contributors, function(contrib) {
+                    return contrib.id;
+                }));
                 self.hide();
                 $osf.unblock();
                 if (self.callback) {


### PR DESCRIPTION
# Purpose
When using the ContribAdder in async mode the list of current contributors was not being updated, and consequently you could "add" a contributor more than once (if the page is not reloaded). 

# Changes
Update the list of current contributors so newly added contributors appear added in the UI. 