### PR TITLE
Add script to migrate metadata for Prereg submissions

### DIFF
--- a/scripts/prereg/migrate_metadata_for_uploaders.py
+++ b/scripts/prereg/migrate_metadata_for_uploaders.py
@@ -3,7 +3,7 @@ a script to migrate draft registration metadata on Prereg Challenge submissions.
 has changed to include optional file uploads, and existing file upload values need to be updated.
 """
 import sys
-imort logging
+import logging
 from modularodm import Q
 from modularodm.exceptions import NoResultsFound
 import re

--- a/scripts/prereg/migrate_metadata_for_uploaders.py
+++ b/scripts/prereg/migrate_metadata_for_uploaders.py
@@ -66,6 +66,8 @@ def migrate_draft_metadata(draft, test=False):
                 continue  # no file selected
             extra = metadata_value.get('extra')
             if extra:
+                if not extra.get('viewUrl'):
+                    continue
                 node_id, path = parse_view_url(extra.get('viewUrl', ''))
                 sha256 = get_file_sha256(node_id, path)
                 file_name = extra.get('selectedFileName')
@@ -109,6 +111,8 @@ def migrate_draft_metadata(draft, test=False):
                         del old_value['value'][uid]
                         old_value['value']['uploader'] = {}
                     else:
+                        if not extra.get('viewUrl'):
+                            continue
                         node_id, path = parse_view_url(extra.get('viewUrl', ''))
                         sha256 = get_file_sha256(node_id, path)
                         file_name = extra.get('selectedFileName')

--- a/scripts/prereg/migrate_metadata_for_uploaders.py
+++ b/scripts/prereg/migrate_metadata_for_uploaders.py
@@ -1,0 +1,132 @@
+"""
+A script to migrate draft registration metadata on Prereg Challenge submissions. The structure of some schema items
+has changed to include optional file uploads, and existing file upload values need to be updated.
+"""
+from modularodm import Q
+from modularodm.exceptions import NoResultsFound
+import re
+from copy import deepcopy
+
+from framework.transactions.context import TokuTransaction
+
+from website.models import (
+    MetaSchema,
+    DraftRegistration,
+    Node
+)
+from website.files.models import osfstorage
+
+PREREG_SCHEMA = MetaSchema.find_one(
+    Q('name', 'eq', 'Prereg Challenge') &
+    Q('schema_version', 'eq', 2)
+)
+PREREG_QUESTIONS = ()
+for page in PREREG_SCHEMA.schema['pages']:
+    PREREG_QUESTIONS = PREREG_QUESTIONS + tuple(page['questions'])
+
+def get_file_sha256(node_id, path):
+    node = Node.load(node_id)
+
+    try:
+        file_node = osfstorage.OsfStorageFileNode.get(path, node)
+    except NoResultsFound:
+        raise RuntimeError("Couldn't find OsfStorageFile on node {0} with path {1}. Maybe it was moved or deleted?".format(node_id, path))
+    latest_version = file_node.get_version()
+    return latest_version.metadata.get('sha256')
+
+def parse_view_url(view_url):
+    match = re.search(
+        r'/project/(?P<node_id>\w+)/files/osfstorage/(?P<path>\w+)$',
+        view_url
+    )
+    if not match:
+        raise RuntimeError
+    else:
+        items = match.groupdict()
+        return items['node_id'], items['path']
+
+def migrate_draft_metadata(draft):
+    for question in PREREG_QUESTIONS:
+        qid = question['qid']
+        qtype = question['type']
+        metadata_value = deepcopy(draft.registration_metadata.get(qid, {}))
+        if qtype == 'osf-upload':
+            if not metadata_value['value']:
+                continue  # no file selected
+            extra = metadata_value.get('extra')
+            if extra:
+                node_id, path = parse_view_url(extra.get('viewUrl', ''))
+                sha256 = get_file_sha256(node_id, path)
+                file_name = extra.get('selectedFileName')
+                old_value = deepcopy(draft.registration_metadata[qid])
+                old_value['extra'] = {
+                    'sha256': sha256,
+                    'selectedFileName': file_name,
+                    'nodeId': node_id,
+                    'viewUrl': old_value['extra']['viewUrl']
+                }
+                draft.update_metadata(
+                    {
+                        qid: old_value
+                    }
+                )
+            else:
+                pass  # no metadata, skipping
+        elif 'properties' in question:
+            if not isinstance(metadata_value['value'], dict):  # uploader added to question
+                metadata_value['value'] = {
+                    'question': {
+                        'value': metadata_value['value']
+                    }
+                }
+                draft.update_metadata({
+                    qid: metadata_value
+                })
+                continue
+            for prop in question['properties']:
+                if prop['type'] == 'osf-upload':
+                    value = metadata_value.get('value', {})
+                    if not value:
+                        continue  # no file selected
+                    try:
+                        uid, uploader = [(k, v) for k, v in value.items() if 'uploader' in k][0]
+                    except IndexError:
+                        pass  # TODO
+                    extra = uploader.get('extra')
+                    old_value = deepcopy(draft.registration_metadata[qid])
+                    if not extra:
+                        del old_value['value'][uid]
+                        old_value['value']['uploader'] = {}
+                    else:
+                        node_id, path = parse_view_url(extra.get('viewUrl', ''))
+                        sha256 = get_file_sha256(node_id, path)
+                        file_name = extra.get('selectedFileName')
+                        old_value['value']['uploader'] = old_value['value'][uid]
+                        del old_value['value'][uid]
+                        old_value['value']['uploader']['extra'].update({
+                            'sha256': sha256,
+                            'selectedFileName': file_name,
+                            'nodeId': node_id
+                        })
+                    draft.update_metadata(
+                        {
+                            qid: old_value
+                        }
+                    )
+    draft.save()
+
+def main(dry_run=False):
+    with TokuTransaction():
+        prereg_drafts = DraftRegistration.find(
+            Q('registration_schema', 'eq', PREREG_SCHEMA)
+        )
+        for draft in prereg_drafts:
+            migrate_draft_metadata(draft)
+        if dry_run:
+            raise RuntimeError("Dry run, rolling back transaction")
+
+if __name__ == '__main__':
+    import sys
+    init_app(set_backends=True, routes=False)
+    dry = 'dry' in sys.argv
+    main(dry)

--- a/scripts/prereg/migrate_metadata_for_uploaders.py
+++ b/scripts/prereg/migrate_metadata_for_uploaders.py
@@ -3,6 +3,7 @@ a script to migrate draft registration metadata on Prereg Challenge submissions.
 has changed to include optional file uploads, and existing file upload values need to be updated.
 """
 import sys
+imort logging
 from modularodm import Q
 from modularodm.exceptions import NoResultsFound
 import re
@@ -19,6 +20,8 @@ from website.models import (
 from website.files.models import osfstorage
 
 init_app(set_backends=True, routes=False)
+
+logger = logging.getLogger(__name__)
 
 PREREG_SCHEMA = MetaSchema.find_one(
     Q('name', 'eq', 'Prereg Challenge') &
@@ -146,5 +149,7 @@ def main(dry_run=False, test=False):
 
 if __name__ == '__main__':
     dry = 'dry' in sys.argv
+    if not dry:
+        script_utils.add_file_logger(logger, __file__)
     test = 'test' in sys.argv
     main(dry, test)

--- a/scripts/prereg/migrate_metadata_for_uploaders.py
+++ b/scripts/prereg/migrate_metadata_for_uploaders.py
@@ -19,6 +19,8 @@ from website.models import (
 )
 from website.files.models import osfstorage
 
+from scripts import utils as script_utils
+
 init_app(set_backends=True, routes=False)
 
 logger = logging.getLogger(__name__)

--- a/scripts/prereg/migrate_metadata_for_uploaders.py
+++ b/scripts/prereg/migrate_metadata_for_uploaders.py
@@ -43,11 +43,11 @@ def get_file_sha256(node_id, path):
 
 def parse_view_url(view_url):
     match = re.search(
-        r'/project/(?P<node_id>\w+)/files/osfstorage/(?P<path>\w+)$',
+        r'/project/(?P<node_id>\w+)/files/osfstorage/(?P<path>\w+)/?$',
         view_url
     )
     if not match:
-        raise RuntimeError
+        raise RuntimeError('Invalid view URL: {0}'.format(view_url))
     else:
         items = match.groupdict()
         return items['node_id'], items['path']

--- a/scripts/tests/test_migrate_metadata_for_uploaders.py
+++ b/scripts/tests/test_migrate_metadata_for_uploaders.py
@@ -238,12 +238,17 @@ OTHER_QUESTIONS = set(SCHEMA_DATA.keys()) - EXISTING_UPLOADERS - EXISTING_OPTION
 def check_migration(orig_data, draft):
     # check for uploader added
     for qid in UPLOADERS_ADDED:
-        assert_equal(
-            orig_data[qid]['value'],
-            draft.registration_metadata[qid]['value']['question']['value']
-        )
+        if qid not in orig_data:
+            continue
+        if orig_data[qid]['value']:
+            assert_equal(
+                orig_data[qid]['value'],
+                draft.registration_metadata[qid]['value']['question']['value']
+            )
     # check for regular uploader type
     for qid in EXISTING_UPLOADERS:
+        if qid not in orig_data:
+            continue
         assert_equal(
             orig_data[qid]['value'],
             draft.registration_metadata[qid]['value']
@@ -265,12 +270,14 @@ def check_migration(orig_data, draft):
                 )
     # check for properties on object type
     for qid in EXISTING_OPTIONAL_UPLOADERS:
+        if qid not in orig_data:
+            continue
         uid = [k for k in orig_data[qid]['value'].keys() if 'uploader' in k][0]
         assert_equal(
             orig_data[qid]['value'][uid].get('value'),
-            draft.registration_metadata[qid]['value']['uploader'].get('value', '')
+            draft.registration_metadata[qid]['value']['uploader'].get('value')
         )
-        if orig_data[qid]['value'][uid]['extra']:
+        if orig_data[qid]['value'][uid].get('extra'):
             assert_equal(
                 orig_data[qid]['value'][uid]['extra'].get('selectedFileName'),
                 draft.registration_metadata[qid]['value']['uploader'].get('extra', {}).get('selectedFileName'),
@@ -288,6 +295,8 @@ def check_migration(orig_data, draft):
                 )
     # check everything else
     for qid in OTHER_QUESTIONS:
+        if qid not in orig_data:
+            continue
         assert_equal(
             orig_data[qid]['value'],
             draft.registration_metadata[qid]['value']

--- a/scripts/tests/test_migrate_metadata_for_uploaders.py
+++ b/scripts/tests/test_migrate_metadata_for_uploaders.py
@@ -1,0 +1,318 @@
+from copy import deepcopy
+
+import mock
+from nose.tools import *  # noqa
+
+from tests import factories
+from tests.base import OsfTestCase, fake
+from tests.utils import unique
+
+from scripts.prereg.migrate_metadata_for_uploaders import migrate_draft_metadata
+
+from website.files.models import osfstorage
+
+file_name_factory = unique(fake.file_name)
+ean8_factory = unique(fake.ean8)
+sha256_factory = unique(fake.sha256)
+
+FILE_ONE = {
+    "name": file_name_factory(),
+    "path": '/' + ean8_factory(),
+    "sha256": sha256_factory()
+}
+FILE_TWO = {
+    "name": file_name_factory(),
+    "path": '/' + ean8_factory(),
+    "sha256": sha256_factory()
+}
+FILE_MAP = {
+    FILE_ONE['path'].lstrip('/'): FILE_ONE,
+    FILE_TWO['path'].lstrip('/'): FILE_TWO,
+}
+
+class FakeVersion(object):
+    def __init__(self, metadata):
+        self.metadata = metadata
+
+class FakeFileNode(object):
+
+    def __init__(self, sha256):
+        self.sha256 = sha256
+
+    @classmethod
+    def get(cls, path, node):
+        file_obj = FILE_MAP[path]
+        return cls(file_obj['sha256'])
+
+    def get_version(self):
+        return FakeVersion({
+            'sha256': self.sha256
+        })
+
+NODE_ID = ean8_factory()
+
+SCHEMA_DATA = {
+    "q20": {
+        "comments": [],
+        "value": "The Effect of sugar on brownie tastiness does not require any additional transformations. However, if it were using a regression analysis and each level of sweet had been categorically described (e.g. not sweet, somewhat sweet, sweet, and very sweet), sweet could be dummy coded with not sweet as the reference category.",
+        "extra": {}
+    },
+    "q21": {
+        "comments": [],
+        "value": "If the the ANOVA indicates that the mean taste perceptions are significantly different (p&lt;.05), then we will use a Tukey-Kramer HSD test to conduct all possible pairwise comparison.",
+        "extra": {}
+    },
+    "q22": {
+        "comments": [],
+        "value": "We will use the standard p&lt;.05 criteria for determining if the ANOVA and the post hoc test suggest that the results are significantly different from those expected if the null hypothesis were correct. The post-hoc Tukey-Kramer test adjusts for multiple comparisons.",
+        "extra": {}
+    },
+    "q23": {
+        "comments": [],
+        "value": "No checks will be performed to determine eligibility for inclusion besides verification that each subject answered each of the three tastiness indices. Outliers will be included in the analysis",
+        "extra": {}
+    },
+    "q24": {
+        "comments": [],
+        "value": "If a subject does not complete any of the three indices of tastiness, that subject will not be included in the analysis.",
+        "extra": {}
+    },
+    "q25": {
+        "comments": [],
+        "value": "",
+        "extra": {}
+    },
+    "q26": {
+        "comments": [],
+        "value": "sugar_taste.R",
+        "extra": {
+            "viewUrl": "/project/{0}/files/osfstorage{1}".format(
+                NODE_ID,
+                FILE_ONE['path']
+            ),
+            "hasSelectedFile": True,
+            "selectedFileName": FILE_ONE['name']
+        }
+    },
+    "q27": {
+        "comments": [],
+        "value": "",
+        "extra": {}
+    },
+    "q1": {
+        "comments": [],
+        "value": "Effect of sugar on brownie tastiness",
+        "extra": {}
+    },
+    "q3": {
+        "comments": [],
+        "value": "Though there is strong evidence to suggest that sugar affects taste preferences, the effect has never been demonstrated in brownies. Therefore, we will measure taste preference for four different levels of sugar concentration in a standard brownie recipe to determine if the effect exists in this pastry. ",
+        "extra": {}
+    },
+    "q2": {
+        "comments": [],
+        "value": "David Mellor, Jolene Esposito",
+        "extra": {}
+    },
+    "q5": {
+        "comments": [],
+        "value": "Registration prior to creation of data: As of the date of submission of this research plan for preregistration, the data have not yet been collected, created, or realized.",
+        "extra": {}
+    },
+    "q4": {
+        "comments": [],
+        "value": "If taste affects preference, then mean preference indices will be higher with higher concentrations of sugar.",
+        "extra": {}
+    },
+    "q7": {
+        "comments": [],
+        "value": {
+            "question": {
+                "comments": [],
+                "value": "Participants will be recruited through advertisements at local pastry shops. Participants will be paid $10 for agreeing to participate (raised to $30 if our sample size is not reached within 15 days of beginning recruitment). Participants must be at least 18 years old and be able to eat the ingredients of the pastries.",
+                "extra": {}
+            },
+            "uploader16": {
+                "comments": [],
+                "value": "",
+                "extra": {
+                    "viewUrl": "/project/{0}/files/osfstorage{1}".format(
+                        NODE_ID,
+                        FILE_TWO['path']
+                    ),
+                    "hasSelectedFile": True,
+                    "selectedFileName": FILE_TWO['name']
+                }
+            }
+        },
+        "extra": {}
+    },
+    "q6": {
+        "comments": [],
+        "value": "Data do not yet exist",
+        "extra": {}
+    },
+    "q9": {
+        "comments": [],
+        "value": "We used the software program G*Power to conduct a power analysis. Our goal was to obtain .95 power to detect a medium effect size of .25 at the standard .05 alpha error probability. ",
+        "extra": {}
+    },
+    "q8": {
+        "comments": [],
+        "value": "Our target sample size is 280 participants. We will attempt to recruit up to 320, assuming that not all will complete the total task. ",
+        "extra": {}
+    },
+    "q15": {
+        "comments": [],
+        "value": ["For studies that involve human subjects, they will not know the treatment group to which they have been assigned."],
+        "extra": {}
+    },
+    "q14": {
+        "comments": [],
+        "value": "Experiment - A researcher randomly assigns treatments to study subjects, this includes field or lab experiments. This is also known as an intervention experiment and includes randomized controlled trials.",
+        "extra": {}
+    },
+    "q17": {
+        "comments": [],
+        "value": "We will use block randomization, where each participant will be randomly assigned to one of the four equally sized, predetermined blocks. The random number list used to create these four blocks will be created using the web applications available at http://random.org. ",
+        "extra": {}
+    },
+    "q16": {
+        "comments": [],
+        "value": {
+            "question": {
+                "comments": [],
+                "value": "We have a between subjects design with 1 factor (sugar by mass) with 4 levels. ",
+                "extra": {}
+            },
+            "uploader16": {
+                "comments": [],
+                "value": "",
+                "extra": {}
+            }
+        },
+        "extra": {}
+    },
+    "q11": {
+        "comments": [],
+        "value": "We manipulated the percentage of sugar by mass added to brownies. The four levels of this categorical variable are: 15%, 20%, 25%, or 40% cane sugar by mass. ",
+        "extra": {}
+    },
+    "q10": {
+        "comments": [],
+        "value": "We will post participant sign-up slots by week on the preceding Friday night, with 20 spots posted per week. We will post 20 new slots each week if, on that Friday night, we are below 320 participants. ",
+        "extra": {}
+    },
+    "q13": {
+        "comments": [],
+        "value": "We will take the mean of the two questions above to create a single measure of brownie enjoyment.",
+        "extra": {}
+    },
+    "q12": {
+        "comments": [],
+        "value": "The single outcome variable will be the perceived tastiness of the single brownie each participant will eat. We will measure this by asking participants How much did you enjoy eating the brownie (on a scale of 1-7, 1 being not at all, 7 being a great deal) and How good did the brownie taste (on a scale of 1-7, 1 being very bad, 7 being very good). ",
+        "extra": {}
+    },
+    "q19": {
+        "comments": [],
+        "value": {
+            "q19a": {
+                "value": "We will use a one-way between subjects ANOVA to analyze our results. The manipulated, categorical independent variable is 'sugar' whereas the dependent variable is our taste index. ",
+                "extra": {}
+            },
+            "uploader19": {
+                "value": "",
+                "extra": {}
+            },
+        },
+        "extra": {}
+    }
+}
+
+EXISTING_UPLOADERS = set(('q26', ))
+EXISTING_OPTIONAL_UPLOADERS = set(('q7', 'q16', 'q19'))
+UPLOADERS_ADDED = set(('q11', 'q12', 'q13'))
+
+OTHER_QUESTIONS = set(SCHEMA_DATA.keys()) - EXISTING_UPLOADERS - EXISTING_OPTIONAL_UPLOADERS - UPLOADERS_ADDED
+
+class TestMigratePreregMetadata(OsfTestCase):
+
+    def setUp(self):
+        super(TestMigratePreregMetadata, self).setUp()
+
+        self.draft = factories.DraftRegistrationFactory(
+            registration_metadata=SCHEMA_DATA
+        )
+
+    @mock.patch.object(osfstorage, 'OsfStorageFileNode', FakeFileNode)
+    def test_migrate_draft_metadata(self):
+        orig_data = deepcopy(SCHEMA_DATA)
+        migrate_draft_metadata(self.draft)
+        # check for uploader added
+        for qid in UPLOADERS_ADDED:
+            assert_equal(
+                orig_data[qid]['value'],
+                self.draft.registration_metadata[qid]['value']['question']['value']
+            )
+        # check for regular uploader type
+        for qid in EXISTING_UPLOADERS:
+            assert_equal(
+                orig_data[qid]['value'],
+                self.draft.registration_metadata[qid]['value']
+            )
+            assert_equal(
+                orig_data[qid]['extra'].get('selectedFileName'),
+                self.draft.registration_metadata[qid]['extra'].get('selectedFileName'),
+            )
+            assert_equal(
+                orig_data[qid]['extra']['viewUrl'],
+                self.draft.registration_metadata[qid]['extra']['viewUrl'],
+            )
+            if qid == 'q26':
+                assert_equal(
+                    self.draft.registration_metadata[qid]['extra']['nodeId'],
+                    NODE_ID
+                )
+                assert_equal(
+                    self.draft.registration_metadata[qid]['extra']['sha256'],
+                    FILE_ONE['sha256']
+                )
+                assert_equal(
+                    self.draft.registration_metadata[qid]['extra']['selectedFileName'],
+                    FILE_ONE['name']
+                )
+        # check for properties on object type
+        for qid in EXISTING_OPTIONAL_UPLOADERS:
+            uid = [k for k in orig_data[qid]['value'].keys() if 'uploader' in k][0]
+            assert_equal(
+                orig_data[qid]['value'][uid].get('value'),
+                self.draft.registration_metadata[qid]['value']['uploader'].get('value', '')
+            )
+            assert_equal(
+                orig_data[qid]['value'][uid]['extra'].get('selectedFileName'),
+                self.draft.registration_metadata[qid]['value']['uploader'].get('extra', {}).get('selectedFileName'),
+            )
+            if qid == 'q7':
+                assert_equal(
+                    self.draft.registration_metadata[qid]['value']['uploader']['extra']['nodeId'],
+                    NODE_ID
+                )
+                assert_equal(
+                    self.draft.registration_metadata[qid]['value']['uploader']['extra']['sha256'],
+                    FILE_TWO['sha256']
+                )
+                assert_equal(
+                    self.draft.registration_metadata[qid]['value']['uploader']['extra']['selectedFileName'],
+                    FILE_TWO['name']
+                )
+                assert_equal(
+                    orig_data[qid]['value'][uid]['extra']['viewUrl'],
+                    self.draft.registration_metadata[qid]['value']['uploader']['extra']['viewUrl']
+                )
+
+        # check everything else
+        for qid in OTHER_QUESTIONS:
+            assert_equal(
+                orig_data[qid]['value'],
+                self.draft.registration_metadata[qid]['value']
+            )

--- a/tests/test_registrations/test_archiver.py
+++ b/tests/test_registrations/test_archiver.py
@@ -46,6 +46,8 @@ from tests import factories
 from tests.base import OsfTestCase, fake
 from tests import utils as test_utils
 
+from tests.utils import unique as _unique
+
 
 SILENT_LOGGERS = (
     'framework.tasks.utils',
@@ -53,21 +55,6 @@ SILENT_LOGGERS = (
 )
 for each in SILENT_LOGGERS:
     logging.getLogger(each).setLevel(logging.CRITICAL)
-
-def _unique(factory):
-    used = []
-    @functools.wraps(factory)
-    def wrapper():
-        item = factory()
-        over = 0
-        while item in used:
-            if over > 100:
-                raise RuntimeError('Tried 100 times to generate a unqiue value, stopping.')
-            item = factory()
-            over += 1
-        used.append(item)
-        return item
-    return wrapper
 
 sha256_factory = _unique(fake.sha256)
 name_factory = _unique(fake.word)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -143,3 +143,27 @@ class MockAuth(object):
         self.logged_in = True
 
 mock_auth = lambda user: mock.patch('framework.auth.Auth.from_kwargs', mock.Mock(return_value=MockAuth(user)))
+
+def unique(factory):
+    """
+    Turns a factory function into a new factory function that guarentees unique return
+    values. Note this uses regular item equivalence to check uniqueness, so this may not
+    behave as expected with factories with complex return values.
+
+    Example use:
+    unique_name_factory = unique(fake.name)
+    unique_name = unique_name_factory()
+    """
+    used = []
+    @functools.wraps(factory)
+    def wrapper():
+        item = factory()
+        over = 0
+        while item in used:
+            if over > 100:
+                raise RuntimeError('Tried 100 times to generate a unqiue value, stopping.')
+            item = factory()
+            over += 1
+        used.append(item)
+        return item
+    return wrapper

--- a/website/project/metadata/prereg-prize.json
+++ b/website/project/metadata/prereg-prize.json
@@ -141,7 +141,6 @@
     }, {
         "id": "page3",
         "title": "Variables",
-        "type": "object",
         "description": "In this section you can describe all variables (both manipulated and measured variables) that will later be used in your confirmatory analysis plan. In your analysis plan, you will have the opportunity to describe how each variable will be used. If you have variables which you are measuring for exploratory analyses, you are not required to list them, though you are permitted to do so.",
         "questions": [{
             "qid": "q11",
@@ -259,7 +258,6 @@
         }, {
             "qid": "q17",
             "nav": "Randomization",
-            "type": "object",
             "title": "Randomization",
             "description": "If you are doing a randomized study, how will you randomize, and at what level? ",
             "help": "We will use block randomization, where each participant will be randomly assigned to one of the four equally sized, predetermined blocks. The random number list used to create these four blocks will be created using the web applications available at http://random.org. <br /><br /> How responses will be evaluated: Typical randomization techniques include: simple, block, stratified, and adaptive covariate randomization. If randomization is required for the study, the method should be specified here, not simply the source of random numbers.",


### PR DESCRIPTION
# Purpose
Recent changes with the impl. of file uploaders in the Prereg registration schema require existing draft metadata to be supplemented. 

Additionally, some questions that did not previously have uploaders now have them, and consequently saved data for those questions needs to be updated.
