### PR TITLE
Make sure pending registrations cannot be made public

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1410,6 +1410,22 @@ class TestNode(OsfTestCase):
         with assert_raises(PermissionsError):
             project.set_privacy('private', Auth(non_contrib))
 
+    def test_set_privacy_pending_embargo(self):
+        project = ProjectFactory(creator=self.user, is_public=False)
+        with mock_archive(project, embargo=True, autocomplete=True) as registration:
+            assert_true(registration.embargo.is_pending_approval)
+            assert_true(registration.is_pending_embargo)
+            with assert_raises(NodeStateError):
+                registration.set_privacy('public', Auth(project.creator))
+
+    def test_set_privacy_pending_registration(self):
+        project = ProjectFactory(creator=self.user, is_public=False)
+        with mock_archive(project, embargo=False, autocomplete=True) as registration:
+            assert_true(registration.registration_approval.is_pending_approval)
+            assert_true(registration.is_pending_registration)
+            with assert_raises(NodeStateError):
+                registration.set_privacy('public', Auth(project.creator))
+
     def test_get_aggregate_logs_queryset_doesnt_return_hidden_logs(self):
         n_orig_logs = len(self.parent.get_aggregate_logs_queryset(Auth(self.user)))
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,7 @@
 import contextlib
 import functools
 import mock
+import datetime
 
 from django.http import HttpRequest
 from nose import SkipTest
@@ -70,11 +71,13 @@ def assert_not_logs(log_action, node_key, index=-1):
 
 @contextlib.contextmanager
 def mock_archive(project, schema=None, auth=None, data=None, parent=None,
+                 embargo=False, embargo_end_date=None,
                  autocomplete=True, autoapprove=False):
     """ A context manager for registrations. When you want to call Node#register_node in
     a test but do not want to deal with any of this side effects of archiver, this
     helper allows for creating a registration in a safe fashion.
 
+    :param bool embargo: embargo the registration (rather than RegistrationApproval)
     :param bool autocomplete: automatically finish archival?
     :param bool autoapprove: automatically approve registration approval?
 
@@ -107,7 +110,16 @@ def mock_archive(project, schema=None, auth=None, data=None, parent=None,
             data=data,
             parent=parent,
         )
-    registration.root.require_approval(project.creator)
+    if embargo:
+        embargo_end_date = embargo_end_date or (
+            datetime.datetime.now() + datetime.timedelta(days=20)
+        )
+        registration.root.embargo_registration(
+            project.creator,
+            embargo_end_date
+        )
+    else:
+        registration.root.require_approval(project.creator)
     if autocomplete:
         root_job = registration.root.archive_job
         root_job.status = ARCHIVER_SUCCESS

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2817,6 +2817,8 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
             if self.is_registration:
                 if self.is_pending_embargo:
                     raise NodeStateError("A registration with an unapproved embargo cannot be made public.")
+                elif self.is_pending_registration:
+                    raise NodeStateError("An unapproved registration cannot be made public.")
                 if self.embargo_end_date and not self.is_pending_embargo:
                     self.embargo.state = Embargo.REJECTED
                     self.embargo.save()

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -32,7 +32,7 @@
                     <div class="btn-group">
                     % if not node["is_public"]:
                         <button class='btn btn-default disabled'>Private</button>
-                        % if 'admin' in user['permissions'] and not node['is_pending_embargo']:
+                        % if 'admin' in user['permissions'] and not node['is_registration']:
                             <a class="btn btn-default" data-bind="click: makePublic">Make Public</a>
                         % endif
                     % else:


### PR DESCRIPTION
# Purpose
Fixes: https://openscience.atlassian.net/browse/OSF-5429

# Changes
- disable set_privacy UI in project.mako if Node is_registration
- raise NodeStateError in Node#set_privacy if Node
  is_pending_registration
- Update mock_archive to support Emabargoes
- Add tests for Node#set_privacy behavior