### PR TITLE
[Feature] Fixed line break issues on employment/education cards

### DIFF
--- a/website/static/css/pages/profile-page.css
+++ b/website/static/css/pages/profile-page.css
@@ -52,11 +52,6 @@ table.table.table-plain th, table.table.table-plain td {
 
 /* Cards
 -------------------- */
-
-.panel-heading>.header-content {
-    word-break: break-all;
-}
-
 .card-heading {
     position: relative;
 }

--- a/website/templates/include/profile/jobs.mako
+++ b/website/templates/include/profile/jobs.mako
@@ -155,7 +155,7 @@
                     <!-- ko ifnot: expandable() -->
                         <div class="panel panel-default">
                             <div class="panel-heading no-bottom-border">
-                                <div class="header-content">
+                                <div>
                                     <h5>{{ institution }}</h5>
                                 </div>
                             </div>

--- a/website/templates/include/profile/schools.mako
+++ b/website/templates/include/profile/schools.mako
@@ -154,7 +154,7 @@
                     <!-- ko ifnot: expandable() -->
                         <div class="panel panel-default">
                             <div class="panel-heading no-bottom-border">
-                                <div class="header-content">
+                                <div>
                                     <h5>{{ institution }}</h5>
                                 </div>
                             </div>


### PR DESCRIPTION
Purpose
-
Fixes [OSF-5416][1].  Also, it looked odd to have a max width of 75% for non-expandable card titles so this was fixed as well

Changes
-
Removed `word-break: break-all` from the card headers.  Removed `class="header-content"` from unexpandable cards.

Side Effects
-
Its possible that this could cause slight UI issues but I highly doubt it and have not seen any.

[1]: https://openscience.atlassian.net/browse/OSF-5416