### PR TITLE
Fixed issue with some image links being dead

### DIFF
--- a/website/addons/wiki/static/dragNDrop.js
+++ b/website/addons/wiki/static/dragNDrop.js
@@ -74,7 +74,7 @@ var remoteFileHandler = function(html, url, cm, init, fixupInputArea) {
         var ext = getExtension(imgURL);
         isImg = !!ext ? validImgExtensions.indexOf(ext.toLowerCase()) > -1 : false;
     }
-    cm.doLinkOrImage(init, fixupInputArea, isImg, url);
+    cm.doLinkOrImage(init, fixupInputArea, isImg, imgURL);
 };
 
 /**


### PR DESCRIPTION
Purpose
-
I made a rookie mistake and had the wrong variable name in one place that resulted in some dead image links.

Changes
-
Renamed the variable probably

Side Effects
-
Hopefully no more dead image renders