### PR TITLE
Give the v2 API it's own _celery_tasks

### DIFF
--- a/api/base/api_globals.py
+++ b/api/base/api_globals.py
@@ -8,3 +8,6 @@ api_globals = threading.local()
 
 # Store a reference to the current Django request. Threads may be reused; empty after request.
 api_globals.request = None
+
+# Set _celery_tasks to be used in 'framework.tasks.enqueue_task'
+api_globals._celery_tasks = None

--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -166,3 +166,5 @@ SWAGGER_SETTINGS = {
 }
 
 DEBUG_TRANSACTIONS = DEBUG
+
+osf_settings.THREAD_LOCALS = 'api.base.api_globals'

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -326,3 +326,5 @@ WATERBUTLER_JWT_EXPIRATION = 15
 
 DRAFT_REGISTRATION_APPROVAL_PERIOD = datetime.timedelta(days=10)
 assert (DRAFT_REGISTRATION_APPROVAL_PERIOD > EMBARGO_END_DATE_MIN), 'The draft registration approval period should be more than the minimum embargo end date.'
+
+THREAD_LOCALS = 'flask.g'


### PR DESCRIPTION
The v2 API couldn't use Flask's thread locals, and consenquently calls
to framework.tasks.enqueue_task made in API threads were likely running
syncrhonously. This add a _celery_tasks to the API's thread locals and
then dynamically import the configured THREAD_LOCALS module in
framework.tasks.handlers.