### PR TITLE
Use APIv2 to fetch current list of contributors in contribAdder

### DIFF
--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -158,15 +158,22 @@ var AddContributorViewModel = oop.extend(Paginator, {
     getContributors: function() {
         var self = this;
         self.notification(false);
-        return $.getJSON(
-            self.nodeApiUrl + 'get_contributors/', {},
-            function(result) {
-                var contributors = result.contributors.map(function(userData) {
-                    return userData.id;
-                });
-                self.contributors(contributors);
-            }
-        );
+        var url = window.contextVars.apiV2Prefix + 'nodes/' + window.contextVars.node.id + '/contributors/';
+
+        return $.ajax({
+            url: url,
+            type: 'GET',
+            dataType: 'json',
+            contentType: 'application/vnd.api+json;',
+            crossOrigin: true,
+            xhrFields: {withCredentials: true},
+            processData: false
+        }).done(function(response) {
+            var contributors = response.data.map(function(user) {
+                return user.id;
+            });
+            self.contributors(contributors);
+        });
     },
     getEditableChildren: function() {
         var self = this;

--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -158,7 +158,7 @@ var AddContributorViewModel = oop.extend(Paginator, {
     getContributors: function() {
         var self = this;
         self.notification(false);
-        var url = window.contextVars.apiV2Prefix + 'nodes/' + window.contextVars.node.id + '/contributors/';
+        var url = $osf.apiV2Url('nodes/' + window.contextVars.node.id + '/contributors/');
 
         return $.ajax({
             url: url,


### PR DESCRIPTION
# Purpose

The v1 call to get_contributors was omitting non-bibliographic contribs,
and consequently those users were appearing as addable in the UI.

see: https://openscience.atlassian.net/browse/OSF-5461

# Changes

Use the v2 endpoint for fetching Node contributors. 