### PR TITLE
Fixes to DraftRegistrationApproval flow

### DIFF
--- a/website/prereg/__init__.py
+++ b/website/prereg/__init__.py
@@ -1,0 +1,1 @@
+from views import *  # noqa

--- a/website/prereg/utils.py
+++ b/website/prereg/utils.py
@@ -1,0 +1,9 @@
+from modularodm import Q
+
+def get_prereg_schema():
+    from website.models import MetaSchema  # noqa
+
+    return MetaSchema.find_one(
+        Q('name', 'eq', 'Prereg Challenge') &
+        Q('schema_version', 'eq', 2)
+    )

--- a/website/prereg/views.py
+++ b/website/prereg/views.py
@@ -12,18 +12,17 @@ from modularodm import Q
 
 from framework.auth import decorators
 from framework.utils import iso8601format
-from website import models
 from website.util import permissions
+from website.prereg.utils import get_prereg_schema
 
 def drafts_for_user(user):
+    from website import models  # noqa
+
     user_projects = models.Node.find(
         Q('is_deleted', 'eq', False) &
         Q('permissions.{0}'.format(user._id), 'in', [permissions.ADMIN])
     )
-    PREREG_CHALLENGE_METASCHEMA = models.MetaSchema.find_one(
-        Q('name', 'eq', 'Prereg Challenge') &
-        Q('schema_version', 'eq', 2)
-    )
+    PREREG_CHALLENGE_METASCHEMA = get_prereg_schema()
     return models.DraftRegistration.find(
         Q('registration_schema', 'eq', PREREG_CHALLENGE_METASCHEMA) &
         Q('approval', 'eq', None) &

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -63,7 +63,7 @@ from website.project.licenses import (
     NodeLicenseRecord,
 )
 from website.project import signals as project_signals
-from website.prereg import uitls as prereg_utils
+from website.prereg import utils as prereg_utils
 
 logger = logging.getLogger(__name__)
 
@@ -3689,12 +3689,18 @@ class PreregCallbackMixin(object):
     def _notify_initiator(self):
         registration = self._get_registration()
         prereg_schema = prereg_utils.get_prereg_schema()
+
+        draft = DraftRegistration.find_one(
+            Q('registered_node', 'eq', registration)
+        )
+
         if prereg_schema in registration.registered_schema:
             mails.send_mail(
-                self.initiator.username,
-                template=mails.PREREG_CHALLENGE_ACCEPTED,
-                user=self.initiator,
-                registration_url=registration.url
+                draft.initiator.username,
+                mails.PREREG_CHALLENGE_ACCEPTED,
+                user=draft.initiator,
+                registration_url=registration.absolute_url,
+                mimetype='html'
             )
 
 class Embargo(PreregCallbackMixin, EmailApprovableSanction):

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -63,6 +63,7 @@ from website.project.licenses import (
     NodeLicenseRecord,
 )
 from website.project import signals as project_signals
+from website.prereg import uitls as prereg_utils
 
 logger = logging.getLogger(__name__)
 
@@ -3687,7 +3688,8 @@ class PreregCallbackMixin(object):
 
     def _notify_initiator(self):
         registration = self._get_registration()
-        if registration.registered_schema.name == 'Prereg Challenge':
+        prereg_schema = prereg_utils.get_prereg_schema()
+        if prereg_schema in registration.registered_schema:
             mails.send_mail(
                 self.initiator.username,
                 template=mails.PREREG_CHALLENGE_ACCEPTED,
@@ -4109,7 +4111,9 @@ class DraftRegistrationApproval(Sanction):
 
     def _send_rejection_email(self, user, draft):
         schema = draft.registration_schema
-        if schema.name == 'Prereg Challenge':
+        prereg_schema = prereg_utils.get_prereg_schema()
+
+        if schema._id == prereg_schema:
             mails.send_mail(
                 user.username,
                 mails.PREREG_CHALLENGE_REJECTED,

--- a/website/templates/emails/prereg_challenge_accepted.html.mako
+++ b/website/templates/emails/prereg_challenge_accepted.html.mako
@@ -4,7 +4,7 @@ We are happy to let you know that your research plan has been verified for compl
 
 What happens now?
 
-<strong>Conduct your study:</strong> It’s time to start your study and its analysis exactly as specified in your preregistration. 
+<strong>Conduct your study:</strong> It's time to start your study and its analysis exactly as specified in your preregistration. 
 
 <strong>Publish your study:</strong> In order to remain eligible for the Preregistration Challenge, any deviations from your preregistration (e.g. sample size, timing, analysis) must be documented and appear in the final publication. Any additional analyses must be noted separately from the registered, confirmatory, hypothesis testing analyses. Such new analyses must be described as hypothesis generating or exploratory tests. You must also refer to your preregistration in the publication by using its URL: <a href="${registration_url}">${registration_url}</a>. Publication must occur in an <a href="https://cos.io/preregjournals">eligible journal</a>.
 


### PR DESCRIPTION
# Purpose

Since Node.registered_schema became a list field some of the Prereg code had not been updated.

Also there was a non-acii character in the prereg_challenge_accepted email template.