### PR TITLE
Faster draft loading

### DIFF
--- a/website/project/metadata/utils.py
+++ b/website/project/metadata/utils.py
@@ -1,5 +1,11 @@
 from framework import utils
 
+def serialize_initiator(initiator):
+    return {
+        'fullname': initiator.fullname,
+        'id': initiator._id
+    }
+
 def serialize_meta_schema(meta_schema):
     if not meta_schema:
         return None
@@ -26,7 +32,7 @@ def serialize_draft_registration(draft, auth=None):
     return {
         'pk': draft._id,
         'branched_from': serialize_node(node, auth),
-        'initiator': serialize_user(draft.initiator, full=True),
+        'initiator': serialize_initiator(draft.initiator),
         'registration_metadata': draft.registration_metadata,
         'registration_schema': serialize_meta_schema(draft.registration_schema),
         'initiated': utils.iso8601format(draft.datetime_initiated),

--- a/website/project/metadata/utils.py
+++ b/website/project/metadata/utils.py
@@ -24,7 +24,6 @@ def serialize_meta_schemas(meta_schemas):
     return [serialize_meta_schema(schema) for schema in (meta_schemas or [])]
 
 def serialize_draft_registration(draft, auth=None):
-    from website.profile.utils import serialize_user  # noqa
     from website.project.utils import serialize_node  # noqa
 
     node = draft.branched_from

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -1179,6 +1179,7 @@ RegistrationManager.prototype.init = function() {
                 return new MetaSchema(schema);
             })
         );
+        self.loading(false);
     });
 
     var getDraftRegistrations = self.getDraftRegistrations();
@@ -1190,10 +1191,6 @@ RegistrationManager.prototype.init = function() {
             return a.initiated.getTime() < b.initiated.getTime();
         });
         self.drafts(drafts);
-    });
-
-    var ready = $.when(getSchemas, getDraftRegistrations).done(function() {
-        self.loading(false);
     });
 
     var urlParams = $osf.urlParams();


### PR DESCRIPTION
# Purpose
 
Natasha noticed slowness when loading the project registrations pages, in particular with how long the "New Registration" button is disabled (this is done while the available MetaSchemas are loading). 

see: https://openscience.atlassian.net/browse/OSF-5466

# Changes

- Enable the "New Registration" button as soon as the MetaSchemas are loaded (don't wait for drafts too)
- Simplify Draft initiator serialization (this was the slowest part of draft serialization) 