### PR TITLE
Fix OSF loader for DraftRegistrations

### DIFF
--- a/website/static/js/osfLanguage.js
+++ b/website/static/js/osfLanguage.js
@@ -18,7 +18,9 @@ module.exports = {
         registerFail: 'There was a problem completing your registration right now. Please try again later. If this should not have occurred and the issue persists, please report it to ' + SUPPORT_LINK,
         submitForReviewFail: 'There was a problem submitting this draft for review right now. Please try again later. If this should not have occurred and the issue persists, please report it to ' + SUPPORT_LINK,
         beforeEditIsApproved: 'This draft registration is currently approved. Please note that if you make any changes (excluding comments) this approval status will be revoked and you will need to submit for approval again.',
-        beforeEditIsPendingReview: 'This draft registration is currently pending review. Please note that if you make any changes (excluding comments) this request will be cancelled and you will need to submit for approval again.'
+        beforeEditIsPendingReview: 'This draft registration is currently pending review. Please note that if you make any changes (excluding comments) this request will be cancelled and you will need to submit for approval again.',
+        loadDraftsFail: 'There was a problem loading draft registrations at this time. ' + REFRESH_OR_SUPPORT,
+        loadMetaSchemaFail: 'There was a problem loading registration templates at this time. ' + REFRESH_OR_SUPPORT
     },
     Addons: {
         dataverse: {

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -1153,6 +1153,7 @@ var RegistrationManager = function(node, draftsSelector, urls, createButton) {
     self.loadingSchemas.subscribe(function(loading) {
         if (!loading) {
             createButton.removeClass('disabled');
+            createButton.text('New Registration');
         }
     });
     self.loadingDrafts = ko.observable(true);

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -1149,12 +1149,13 @@ var RegistrationManager = function(node, draftsSelector, urls, createButton) {
         return self.drafts().length > 0;
     });
 
-    self.loading = ko.observable(true);
-    self.loading.subscribe(function(loading) {
+    self.loadingSchemas = ko.observable(true);
+    self.loadingSchemas.subscribe(function(loading) {
         if (!loading) {
             createButton.removeClass('disabled');
         }
     });
+    self.loadingDrafts = ko.observable(true);
 
     self.preview = ko.observable(false);
 
@@ -1179,7 +1180,7 @@ RegistrationManager.prototype.init = function() {
                 return new MetaSchema(schema);
             })
         );
-        self.loading(false);
+        self.loadingSchemas(false);
     });
 
     var getDraftRegistrations = self.getDraftRegistrations();
@@ -1191,6 +1192,7 @@ RegistrationManager.prototype.init = function() {
             return a.initiated.getTime() < b.initiated.getTime();
         });
         self.drafts(drafts);
+        self.loadingDrafts(false);
     });
 
     var urlParams = $osf.urlParams();

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -1183,6 +1183,14 @@ RegistrationManager.prototype.init = function() {
         );
         self.loadingSchemas(false);
     });
+    getSchemas.fail(function(xhr, status, error) {
+        Raven.captureMessage('Could not load registration templates', {
+            url: self.urls.schemas,
+            textStatus: status,
+            error: error
+        });
+        $osf.growl('Error loading registration templates', language.loadMetaSchemaFail);
+    });
 
     var getDraftRegistrations = self.getDraftRegistrations();
     getDraftRegistrations.done(function(response) {
@@ -1194,6 +1202,14 @@ RegistrationManager.prototype.init = function() {
         });
         self.drafts(drafts);
         self.loadingDrafts(false);
+    });
+    getDraftRegistrations.fail(function(xhr, status, error) {
+        Raven.captureMessage('Could not load draft registrations', {
+            url: self.urls.list,
+            textStatus: status,
+            error: error
+        });
+        $osf.growl('Error loading draft registrations', language.loadDraftsFail);
     });
 
     var urlParams = $osf.urlParams();

--- a/website/templates/project/registrations.mako
+++ b/website/templates/project/registrations.mako
@@ -45,8 +45,8 @@
       </div>
       % if 'admin' in user['permissions'] and not disk_saving_mode:
       <div class="col-md-3">
-        <a id="registerNode" class="btn btn-default" type="button">
-          New Registration
+        <a id="registerNode" class="btn btn-default disabled" type="button">
+          Loading ...
         </a>
       </div>
       % endif

--- a/website/templates/project/registrations.mako
+++ b/website/templates/project/registrations.mako
@@ -54,7 +54,7 @@
   </div>
   <div role="tabpanel" class="tab-pane" id="drafts">
     <div id="draftRegistrationsScope" class="row scripted" style="min-height: 150px;padding-top:20px;">
-      <div data-bind="visible: loading" class="spinner-loading-wrapper">
+      <div data-bind="visible: loadingDrafts" class="spinner-loading-wrapper">
         <div class="logo-spin logo-lg"></div>
       </div>
       <form id="newDraftRegistrationForm" method="POST" style="display:none">


### PR DESCRIPTION
# Purpose

The changes I made in https://github.com/CenterForOpenScience/osf.io/pull/4805 cause the loading spinner to disappear prematurely from the "Draft Registrations" tab. This fixes that.

# Changes

Break loading into loadingSchemas and loadingDrafts to isolate the two states. Use loadingDrafts to control the visibility of the loading spinner. 

Also make the "New Registration" button text "Loading ..." while loading, and add fail callbacks to the requests to fetch DraftRegistrations and MetaSchemas