### PR TITLE
[Ready to Review] Feature/API filter on `not equal`

### DIFF
--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -57,7 +57,7 @@ class FilterMixin(object):
     MATCH_OPERATORS = ('contains', 'icontains')
     MATCHABLE_FIELDS = (ser.CharField, ser.ListField)
 
-    DEFAULT_OPERATOR = 'eq'
+    DEFAULT_OPERATORS = ('eq', 'ne')
     DEFAULT_OPERATOR_OVERRIDES = {
         ser.CharField: 'icontains',
         ser.ListField: 'contains',
@@ -81,13 +81,13 @@ class FilterMixin(object):
             raise NotImplementedError()
 
     def _get_default_operator(self, field):
-        return self.DEFAULT_OPERATOR_OVERRIDES.get(type(field), self.DEFAULT_OPERATOR)
+        return self.DEFAULT_OPERATOR_OVERRIDES.get(type(field), 'eq')
 
     def _get_valid_operators(self, field):
         if isinstance(field, self.COMPARABLE_FIELDS):
-            return self.COMPARISON_OPERATORS + (self.DEFAULT_OPERATOR, )
+            return self.COMPARISON_OPERATORS + self.DEFAULT_OPERATORS
         elif isinstance(field, self.MATCHABLE_FIELDS):
-            return self.MATCH_OPERATORS + (self.DEFAULT_OPERATOR, )
+            return self.MATCH_OPERATORS + self.DEFAULT_OPERATORS
         else:
             return None
 
@@ -111,7 +111,7 @@ class FilterMixin(object):
         :raises InvalidFilterMatchType: If the query contains comparisons against non-string or non-list fields
         :raises InvalidFilterOperator: If the filter operator is not a member of self.COMPARISON_OPERATORS
         """
-        if op not in set(self.MATCH_OPERATORS + self.COMPARISON_OPERATORS + (self.DEFAULT_OPERATOR, )):
+        if op not in set(self.MATCH_OPERATORS + self.COMPARISON_OPERATORS + self.DEFAULT_OPERATORS):
             valid_operators = self._get_valid_operators(field)
             raise InvalidFilterOperator(value=op, valid_operators=valid_operators)
         if op in self.COMPARISON_OPERATORS:

--- a/api_tests/base/test_filters.py
+++ b/api_tests/base/test_filters.py
@@ -173,7 +173,7 @@ class TestFilterMixin(ApiTestCase):
             self.view.parse_query_params(query_params)
         except InvalidFilterOperator as err:
             ops = re.search(r'one of (?P<ops>.+)\.$', err.detail).groupdict()['ops']
-            assert_equal(ops, "gt, gte, lt, lte, eq")
+            assert_equal(ops, "gt, gte, lt, lte, eq, ne")
 
         query_params = {
             'filter[string_field][bar]': 'foo'

--- a/api_tests/base/test_filters.py
+++ b/api_tests/base/test_filters.py
@@ -182,7 +182,7 @@ class TestFilterMixin(ApiTestCase):
             self.view.parse_query_params(query_params)
         except InvalidFilterOperator as err:
             ops = re.search(r'one of (?P<ops>.+)\.$', err.detail).groupdict()['ops']
-            assert_equal(ops, "contains, icontains, eq")
+            assert_equal(ops, "contains, icontains, eq, ne")
 
 
     def test_parse_query_params_supports_multiple_filters(self):

--- a/api_tests/nodes/views/test_node_list.py
+++ b/api_tests/nodes/views/test_node_list.py
@@ -446,6 +446,34 @@ class TestNodeFiltering(ApiTestCase):
         public_root_nodes = Node.find(Q('is_public', 'eq', True) & Q('parent_node', 'eq', None))
         assert_equal(len(res.json['data']), public_root_nodes.count())
 
+    def test_filtering_on_title_not_equal(self):
+        url = '/{}nodes/?filter[title][ne]=Project%20One'.format(API_BASE)
+        res = self.app.get(url, auth=self.user_one.auth)
+        assert_equal(res.status_code, 200)
+        data = res.json['data']
+        assert_equal(len(data), 3)
+
+        titles = [each['attributes']['title'] for each in data]
+
+        assert_not_in(self.project_one.title, titles)
+        assert_in(self.project_two.title, titles)
+        assert_in(self.project_three.title, titles)
+        assert_in(self.private_project_user_one.title, titles)
+
+    def test_filtering_on_description_not_equal(self):
+        url = '/{}nodes/?filter[description][ne]=One%20Three'.format(API_BASE)
+        res = self.app.get(url, auth=self.user_one.auth)
+        assert_equal(res.status_code, 200)
+        data = res.json['data']
+        assert_equal(len(data), 3)
+
+        descriptions = [each['attributes']['description'] for each in data]
+
+        assert_not_in(self.project_two.description, descriptions)
+        assert_in(self.project_one.description, descriptions)
+        assert_in(self.project_three.description, descriptions)
+        assert_in(self.private_project_user_one.description, descriptions)
+
 
 class TestNodeCreate(ApiTestCase):
 

--- a/api_tests/nodes/views/test_node_logs.py
+++ b/api_tests/nodes/views/test_node_logs.py
@@ -130,3 +130,32 @@ class TestNodeLogList(ApiTestCase):
         retraction = RetractedRegistrationFactory(registration=registration, user=self.user)
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
         assert_equal(res.status_code, 404)
+
+
+class TestNodeLogFiltering(TestNodeLogList):
+
+    def test_filter_action_not_equal(self):
+        self.public_project.add_tag("Jeff Spies", auth=self.user_auth)
+        assert_equal("tag_added", self.public_project.logs[OSF_LATEST].action)
+        url = '/{}nodes/{}/logs/?filter[action][ne]=tag_added'.format(API_BASE, self.public_project._id)
+        res = self.app.get(url, auth=self.user.auth)
+        assert_equal(len(res.json['data']), 1)
+        assert_equal(res.json['data'][0]['attributes']['action'], 'project_created')
+
+    def test_filter_date_not_equal(self):
+        self.public_project.add_pointer(self.pointer, auth=Auth(self.user), save=True)
+        assert_equal('pointer_created', self.public_project.logs[OSF_LATEST].action)
+        assert_equal(len(self.public_project.logs), 2)
+        date_pointer_added = str(self.public_project.logs[1].date).replace(' ', 'T')
+
+        url = '/{}nodes/{}/logs/?filter[date][ne]={}'.format(API_BASE, self.public_project._id, date_pointer_added)
+        res = self.app.get(url, auth=self.user.auth)
+        assert_equal(res.status_code, 200)
+        assert_equal(len(res.json['data']), 1)
+        assert_equal(res.json['data'][0]['attributes']['action'], 'project_created')
+
+
+
+
+
+


### PR DESCRIPTION
# Purpose

Issue https://openscience.atlassian.net/browse/OSF-5469
Extends Sam's PR https://github.com/CenterForOpenScience/osf.io/pull/4246, to add 'not equal', `ne`, to list of comparison operators in filter.

# Changes

Allows filtering on `not equal`.  For example: 
`/v2/nodes/3e5vn/logs/?filter[action][ne]=comment_added`.

This gives me all log actions on node `3e5vn` whose action does not equal `comment_added`.
