### PR TITLE
Only append comments if actually saved

### DIFF
--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -291,16 +291,22 @@ var Question = function(questionSchema, data) {
  *
  * @param {function}: save: save function for the current registrationDraft
  **/
-Question.prototype.addComment = function(save) {
+Question.prototype.addComment = function(save, page, event) {
     var self = this;
 
     var comment = new Comment({
         value: self.nextComment()
     });
     comment.seenBy.push($osf.currentUser().id);
-    self.comments.push(comment);
-    self.nextComment('');
-    save();
+
+    var $comments = $(event.target).closest('.registration-editor-comments');
+    $osf.block('Saving...', $comments);
+    save()
+        .always($osf.unblock.bind(null, $comments))
+        .then(function () {
+            self.comments.push(comment);
+            self.nextComment('');
+        });
 };
 /**
  * Shows/hides the Question example
@@ -768,6 +774,9 @@ var RegistrationEditor = function(urls, editorId, preview) {
             question.value.subscribe(function() {
                 self.dirtyCount(self.dirtyCount() + 1);
             });
+        });
+        page.comments.subscribe(function() {
+            self.dirtyCount(self.dirtyCount() + 1);
         });
         page.viewComments();
     });

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -301,9 +301,9 @@ Question.prototype.addComment = function(save, page, event) {
 
     var $comments = $(event.target).closest('.registration-editor-comments');
     $osf.block('Saving...', $comments);
-    save()
+    return save()
         .always($osf.unblock.bind(null, $comments))
-        .then(function () {
+        .done(function () {
             self.comments.push(comment);
             self.nextComment('');
         });

--- a/website/static/js/tests/registrationUtils.test.js
+++ b/website/static/js/tests/registrationUtils.test.js
@@ -438,12 +438,27 @@ describe('Question', () => {
         });
     });
     describe('#addComment', () => {
-        it('creates a new Comment using the value of Question.nextComment, and clears Question.nextComment', () => {
+        before(() => {
+            sinon.stub($osf, 'block');
+            sinon.stub($osf, 'unblock');
+        });
+        after(() => {
+            $osf.block.restore();
+            $osf.unblock.restore();
+        });
+        it('creates a new Comment using the value of Question.nextComment, and clears Question.nextComment', (done) => {
             assert.equal(q.comments().length, 0);
             q.nextComment('A good comment');
-            q.addComment(function() {});
-            assert.equal(q.comments().length, 1);
-            assert.equal(q.nextComment(), '');
+            var ret = $.Deferred();
+            var saved = q.addComment(function() {
+                return ret.promise();
+            }, {}, {target: null});
+            ret.resolve();
+            saved.always(function() {
+                assert.equal(q.comments().length, 1);
+                assert.equal(q.nextComment(), '');
+                done();
+            });
         });
         it('calls the provided save function'), () => {
             var mock = new sinon.spy();
@@ -835,4 +850,3 @@ describe('RegistrationEditor', () => {
         });
     });
 });
-

--- a/website/templates/project/registration_editor_templates.mako
+++ b/website/templates/project/registration_editor_templates.mako
@@ -129,6 +129,7 @@
 
 <!-- Commentable -->
 <script type="text/html" id="commentable">
+  <div class="registration-editor-comments">
     <h4> Comments </h4>
     <ul class="list-group" id="commentList" data-bind="foreach: {data: comments, as: 'comment'}">
         <li class="list-group-item">
@@ -179,9 +180,13 @@
                         valueUpdate: 'keyup'" />
       <span class="input-group-btn">
         <button class="btn btn-primary"
-                data-bind="click: currentQuestion.addComment.bind(currentQuestion, $root.save.bind($root)),
+                data-bind="click: currentQuestion.addComment.bind(
+                             currentQuestion, 
+                             $root.save.bind($root)
+                           ),
                            enable: currentQuestion.allowAddNext">Add</button>
       </span>
     </div>
+  </div>
 </script>
 <%include file="registration_editor_extensions.mako" />


### PR DESCRIPTION
# Purpose

There was a general lack of user feedback when adding/saving comments.

# Changes

- only add a comment to the UI once saved sucessfully
- block the commenting UI while a comment is saving