### PR TITLE
Update Prereg Emails

### DIFF
--- a/website/project/model.py
+++ b/website/project/model.py
@@ -4172,7 +4172,7 @@ class DraftRegistrationApproval(Sanction):
         draft = DraftRegistration.find_one(
             Q('approval', 'eq', self)
         )
-        self._send_rejection_email(user, draft)
+        self._send_rejection_email(draft.initiator, draft)
 
 
 class DraftRegistration(StoredObject):

--- a/website/templates/emails/prereg_challenge_accepted.html.mako
+++ b/website/templates/emails/prereg_challenge_accepted.html.mako
@@ -1,18 +1,25 @@
 Dear ${user.fullname},
-
+<br />
+<br />
 We are happy to let you know that your research plan has been verified for completeness and registered on the OSF at the following URL: <a href="${registration_url}">${registration_url}</a>.
-
+<br />
+<br />
 What happens now?
+<br />
+<br />
 
-<strong>Conduct your study:</strong> It’s time to start your study and its analysis exactly as specified in your preregistration. 
-
+<strong>Conduct your study:</strong> It's time to start your study and its analysis exactly as specified in your preregistration. 
+<br />
 <strong>Publish your study:</strong> In order to remain eligible for the Preregistration Challenge, any deviations from your preregistration (e.g. sample size, timing, analysis) must be documented and appear in the final publication. Any additional analyses must be noted separately from the registered, confirmatory, hypothesis testing analyses. Such new analyses must be described as hypothesis generating or exploratory tests. You must also refer to your preregistration in the publication by using its URL: <a href="${registration_url}">${registration_url}</a>. Publication must occur in an <a href="https://cos.io/preregjournals">eligible journal</a>.
-
+<br />
 <strong>Submit your article for review:</strong> We will review your final, published article once you submit it on the OSF. We will verify that your study and its analyses were conducted as specified in your preregistration. In order to avoid any unintended oversights, please reach out to us (<a href="mailto:prereg@cos.io">prereg@cos.io</a>) and refer to our guidelines and FAQ on our <a href="https://cos.io/prereg">website</a> when writing up your results.
-
+<br />
 <strong>Receive the prize!</strong> $1,000 rewards will be distributed to eligible entrants according to the schedule on our website.
-
+<br />
+<br />
 Thank you for entering the Preregistration Challenge. Feel free to submit another research plan at any time.
-
+<br />
+<br />
 Sincerely,
+<br />
 The team at the Center for Open Science

--- a/website/templates/emails/prereg_challenge_rejected.txt.mako
+++ b/website/templates/emails/prereg_challenge_rejected.txt.mako
@@ -9,4 +9,5 @@ Each submission must pass this review process in which the statistical methods o
 Prereg Challenge administrators and reviewers review the submitted study design and analysis descriptions, and determine whether all question fields are answered with enough detail to fully pre-specify the design and analysis plan, and follow the eligibility requirements. See https://osf.io/h4ga8/ to learn more about the guidelines that reviewers use when evaluating your submitted plans.
 
 Sincerely,
+
 The team at the Center for Open Science


### PR DESCRIPTION
# Purpose

The Prereg email formatting was broken. Also a bug in the rejection logic caused rejection emails to go to the Prereg admin rather than the draft initiator

# Changes

- fix email formatting
- send rejection email to draft initiator

# Side Effects

We should restart the celery worker.