### PR TITLE
Add an index for the backref connecting NodeLogs to Nodes

### DIFF
--- a/website/project/model.py
+++ b/website/project/model.py
@@ -336,6 +336,13 @@ class NodeLog(StoredObject):
     action = fields.StringField(index=True)
     params = fields.DictionaryField()
     should_hide = fields.BooleanField(default=False)
+    __indices__ = [
+        {
+            'key_or_list': [
+                ('__backrefs.logged.node.logs.$', 1)
+            ],
+        }
+    ]
 
     was_connected_to = fields.ForeignField('node', list=True)
 


### PR DESCRIPTION
Purpose
-----------
NodeLogs is slower than it should be. One reason is because, whenever you get the aggregate logs for a node, it's doing an 'in' query on an unindexed field. This should fix that.  Functionality should be the same, but it should be faster. 

Changes
------------
Modified the NodeLogs model to include an extra index.

Side effects
---------------
If anything, it's *possible* that forking or registering large/complex projects will become slower.