### PR TITLE
[WIP] Migrate GoogleDrive files/folders to use unique IDs

### DIFF
--- a/scripts/migrate_googledrive_to_uid.py
+++ b/scripts/migrate_googledrive_to_uid.py
@@ -1,14 +1,16 @@
+import re
 import logging
+import requests
+from itertools import groupby
+
+from framework.transactions.context import TokuTransaction
+from modularodm.query.querydialect import DefaultQueryDialect as Q
+
 from website.app import init_app
+from scripts import utils as scripts_utils
 from website.files.models.base import FileNode
 from website.files.models.googledrive import GoogleDriveFileNode
 from website.addons.googledrive.model import GoogleDriveNodeSettings
-from scripts import utils as scripts_utils
-from framework.transactions.context import TokuTransaction
-from modularodm.query.querydialect import DefaultQueryDialect as Q
-from itertools import groupby
-import re
-import requests
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/migrate_googledrive_to_uid.py
+++ b/scripts/migrate_googledrive_to_uid.py
@@ -157,6 +157,17 @@ def update_node_files(current_node, gdrive_filenodes, dry=True):
 
         payload = {'alt': 'json', 'q':_build_query(parent_folders[filenode_root])}
         resp = requests.get(base_url, params=payload, headers=headers)
+
+        if resp.status_code != 200:
+            raise Exception(
+                "Not gonna lie, I wasn't expecting this. How did this happen? "
+                "I was trying to get a list of child entities of {} for node {}"
+                ", but when I asked Google about it, they handed me back a {}"
+                " response code.  What the hell, Google, I thought we were tight?!"
+                " Oh well, I guess I have no choice but to abort and investigate. "
+                "Thumbs down.".format(filenode_root, current_node, resp.status_code)
+            )
+
         items = resp.json()['items']
 
         metadata = [ _response_to_metadata(item, filenode_root) for item in items ]

--- a/scripts/migrate_googledrive_to_uid.py
+++ b/scripts/migrate_googledrive_to_uid.py
@@ -12,11 +12,10 @@ from modularodm.query.querydialect import DefaultQueryDialect as Q
 from website.app import init_app
 from scripts import utils as scripts_utils
 from website.files.models.base import FileNode
-from website.files.models.googledrive import GoogleDriveFileNode, GoogleDriveFile, GoogleDriveFolder
 from website.addons.googledrive.model import GoogleDriveNodeSettings
+from website.files.models.googledrive import GoogleDriveFileNode, GoogleDriveFile, GoogleDriveFolder
 
 logger = logging.getLogger(__name__)
-
 base_path_regex = re.compile('[^/]+/?$')
 FOLDER_MIME_TYPE = 'application/vnd.google-apps.folder'
 all_file_tally = collections.Counter()
@@ -41,7 +40,7 @@ def main():
     response, we'll throw an error and abort.  I'm not sure if there's a case where this is likely
     to happen.  Two possibilities: a user deletes a child folder at the exact time the migration
     is running, between when the child folder is identified and the child folder meta is retreived.
-    I suppose if a user has disabled their gdrive addon, it might cause an issue, but again,
+    I suppose if a user has disabled their gdrive addon it might cause an issue, but again,
     doesn't seem likely.
 
     What happens if the OAuth refresh fails?  This is low probability.  We refresh tokens regularly,
@@ -61,7 +60,6 @@ def main():
     args = parser.parse_args()
 
     logger.setLevel(logging.INFO if args.verbose == 1 else logging.DEBUG if args.verbose == 2 else logging.WARNING)
-
     scripts_utils.add_file_logger(logger, __file__)
     init_app(set_backends=True, routes=False)
 
@@ -174,7 +172,7 @@ def update_node_files(current_node, gdrive_filenodes, dry=True):
 
     node_file_tally = collections.Counter()
 
-    # how does one do a schwartzian transform in python?
+    # how does one do a schwartzian transform in python? each schwartz entry is [root, filenode]
     schwartz = [ [base_path_regex.sub('', x.path), x] for x in gdrive_filenodes ]
     ordered = sorted(schwartz, key=lambda x: x[0])
     for filenode_root, filenodes in itertools.groupby(ordered, lambda x: x[0]):

--- a/scripts/migrate_googledrive_to_uid.py
+++ b/scripts/migrate_googledrive_to_uid.py
@@ -1,0 +1,188 @@
+import logging
+from website.app import init_app
+from website.files.models.base import FileNode
+from website.files.models.googledrive import GoogleDriveFileNode
+from website.addons.googledrive.model import GoogleDriveNodeSettings
+from scripts import utils as scripts_utils
+from framework.transactions.context import TokuTransaction
+from modularodm.query.querydialect import DefaultQueryDialect as Q
+from itertools import groupby
+import re
+import requests
+
+logger = logging.getLogger(__name__)
+
+regex = re.compile('[^/]+/?$')
+FOLDER_MIME_TYPE = 'application/vnd.google-apps.folder'
+
+def main():
+    with TokuTransaction():
+
+        current_node = None
+        gdrive_filenodes = []
+        for file in GoogleDriveFileNode.find().sort('node'):
+            if current_node != file.node_id:
+                update_node(current_node, gdrive_filenodes)
+                gdrive_filenodes = []
+                current_node = file.node_id
+
+            gdrive_filenodes.append(file)
+
+        update_node(current_node, gdrive_filenodes)
+
+
+def _build_query(folder_id):
+    queries = [
+        "'{}' in parents".format(folder_id),
+        'trashed = false',
+        "mimeType != 'application/vnd.google-apps.form'",
+    ]
+    return ' and '.join(queries)
+
+
+def _response_to_metadata(response, parent):
+    is_folder = response.get('mimeType') == FOLDER_MIME_TYPE
+    name = response['title']
+
+    if not is_folder and is_docs_file(response):
+        ext = get_extension(response)
+        name += ext
+
+    extra = {
+        'revisionId': response.get('version')
+    }
+    if not is_folder:
+        if is_docs_file(response):
+            extra['downloadExt'] = get_download_extension(response)
+        extra['webView'] = response.get('alternateLink')
+
+    return {
+        'kind': 'folder' if is_folder else 'file',
+        'contentType': None if is_folder else response.get('mimeType'),
+        'name': name,
+        'materialized': parent + name + ('/' if is_folder else ''),
+        'modified': response.get('modifiedDate'),
+        'etag': response.get('version'),
+        'provider': 'googledrive',
+        'path': '/{}'.format(response.get('id')) + ('/' if is_folder else ''),
+        'size': response.get('fileSize'),
+        'extra': extra,
+    }
+
+def update_node(current_node, gdrive_filenodes):
+    if current_node is None:
+        return
+
+    node_settings = GoogleDriveNodeSettings.find_one(Q('owner', 'eq', current_node))
+    access_token = node_settings.fetch_access_token()
+    headers = {'authorization': 'Bearer {}'.format(access_token)}
+    base_url = 'https://www.googleapis.com/drive/v2/files'
+
+    logger.info(u'--Node: {}  (token:{})'.format(current_node, access_token))
+
+    parent_folders = { '/': node_settings.folder_id }
+    merp = map(lambda x: [regex.sub('', x.path), x], gdrive_filenodes)
+    ordered = sorted(list(merp), key=lambda x: x[0])
+    for filenode_root, filenodes in groupby(ordered, lambda x: x[0]):
+        logger.info(u'  --Root: {}'.format(filenode_root))
+
+        payload = {'alt': 'json', 'q':_build_query(parent_folders[filenode_root])}
+        resp = requests.get(base_url, params=payload, headers=headers)
+        items = resp.json()['items']
+
+        metadata = map(lambda x: _response_to_metadata(x, filenode_root), items)
+
+        lunch = sorted(list(filenodes), key=lambda x: x[1].path)
+
+        for pair in lunch:
+            storedfilenode = pair[1]
+            filenode = GoogleDriveFileNode(storedfilenode)
+
+            logger.info(u'    --File: {}'.format(filenode.path))
+            found = None
+            for metadatum in metadata:
+                if metadatum['name'] == filenode.name and (metadatum['kind'] == 'file') == filenode.is_file:
+                    found = metadatum
+                    break
+
+            if found is None:
+                filenode.delete()
+                continue
+
+            if not filenode.is_file:
+                parent_folders[filenode.path] = found['path'].strip('/')
+
+            filenode.path = found['path']
+            filenode.update(found['extra']['revisionId'], found)
+
+
+
+### EVERYTHING BELOW THIS COPIED FROM WATERBUTLER's googledrive/utils.py
+
+DOCS_FORMATS = [
+    {
+        'mime_type': 'application/vnd.google-apps.document',
+        'ext': '.gdoc',
+        'download_ext': '.docx',
+        'type': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    },
+    {
+        'mime_type': 'application/vnd.google-apps.drawing',
+        'ext': '.gdraw',
+        'download_ext': '.jpg',
+        'type': 'image/jpeg',
+    },
+    {
+        'mime_type': 'application/vnd.google-apps.spreadsheet',
+        'ext': '.gsheet',
+        'download_ext': '.xlsx',
+        'type': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    },
+    {
+        'mime_type': 'application/vnd.google-apps.presentation',
+        'ext': '.gslides',
+        'download_ext': '.pptx',
+        'type': 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    },
+]
+DOCS_DEFAULT_FORMAT = {
+    'ext': '',
+    'download_ext': '.pdf',
+    'type': 'application/pdf',
+}
+
+
+def is_docs_file(metadata):
+    """Only Docs files have the "exportLinks" key."""
+    return metadata.get('exportLinks')
+
+
+def get_format(metadata):
+    for format in DOCS_FORMATS:
+        if format['mime_type'] == metadata['mimeType']:
+            return format
+    return DOCS_DEFAULT_FORMAT
+
+
+def get_extension(metadata):
+    format = get_format(metadata)
+    return format['ext']
+
+
+def get_download_extension(metadata):
+    format = get_format(metadata)
+    return format['download_ext']
+
+
+def get_export_link(metadata):
+    format = get_format(metadata)
+    return metadata['exportLinks'][format['type']]
+
+### END of googledrive/utils.py
+
+
+if __name__ == '__main__':
+    scripts_utils.add_file_logger(logger, __file__)
+    init_app(set_backends=True, routes=False)
+    main()
+


### PR DESCRIPTION
## Purpose

The Google Drive storage addon currently uses the path of the files and folders to identify the stored entities.  When a file is moved or renamed, we don't have a way of tracking that.  GDrive provides unique ids in their metadata which would allow us to do this.  @TomBaxter has already written the WaterButler-side code to allow us to do this, and now we need to update the stored metadata in the OSF with these new IDs.  Since we do not currently track these IDs in the metadata at all, we have to use the users' refresh tokens to query GDrive and get the IDs.
## Changes

All StoredFileNodes with `"provider": "googledrive"` will be updated so that their `path` is set to their ID.  StoredFileNodes that cannot be matched to something currently stored in GDrive will be removed.  If a file is matched and has a new revision, the ID will be updated, and a new entry will be added to its history.  New files or folders will not be created, as that will happen on the next NodeFilesList access.
## Side Effects

After this migration is performed, WB needs to be updated with [this PR](https://github.com/CenterForOpenScience/waterbutler/pull/103).

Fixes: [#OSF-5205]
