### PR TITLE
[WIP] Make sure username is always added to email list

### DIFF
--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -861,7 +861,7 @@ class User(GuidStoredObject, AddonModelMixin):
 
         # log to sentry if somehow the username isn't in the email list
         # This is for data gathering purposes, so we can find when this is happening
-        if username.lower() not in self.emails:
+        if self.username.lower() not in self.emails:
             log_message('Username not added to list of emails.')
 
         return True

--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -844,6 +844,9 @@ class User(GuidStoredObject, AddonModelMixin):
         if email not in self.emails:
             self.emails.append(email)
 
+        if self.username not in self.emails:
+            self.emails.append(self.username.lower())
+
         # Complete registration if primary email
         if email.lower() == self.username.lower():
             self.register(self.username)

--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -24,7 +24,7 @@ from framework.bcrypt import generate_password_hash, check_password_hash
 from framework.exceptions import PermissionsError
 from framework.guid.model import GuidStoredObject
 from framework.mongo.validators import string_required
-from framework.sentry import log_exception
+from framework.sentry import log_exception, log_message
 from framework.sessions import session
 from framework.sessions.model import Session
 from framework.sessions.utils import remove_sessions_for_user
@@ -858,6 +858,11 @@ class User(GuidStoredObject, AddonModelMixin):
         self.save()
 
         self.update_search_nodes()
+
+        # log to sentry if somehow the username isn't in the email list
+        # This is for data gathering purposes, so we can find when this is happening
+        if username.lower() not in self.emails:
+            log_message('Username not added to list of emails.')
 
         return True
 

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -83,6 +83,7 @@ class TestUser(base.OsfTestCase):
 
         assert_not_in('foo@bar.com', self.user.unconfirmed_emails)
         assert_in('foo@bar.com', self.user.emails)
+        assert_in(self.user.username, self.user.emails)
 
     def test_confirm_email_comparison_is_case_insensitive(self):
         u = factories.UnconfirmedUserFactory.build(

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -119,6 +119,7 @@ class TestUser(base.OsfTestCase):
         assert_equal(email, self.user._get_unconfirmed_email_for_token(token2))
         with assert_raises(exceptions.InvalidTokenError):
             self.user._get_unconfirmed_email_for_token(token1)
+        assert_in(email, self.user.unconfirmed_emails)
 
 
 class TestUserMerging(base.OsfTestCase):

--- a/tests/test_conferences.py
+++ b/tests/test_conferences.py
@@ -567,6 +567,7 @@ class TestConferenceIntegration(ContextTestCase):
         assert_absolute(call_kwargs['profile_url'])
         assert_absolute(call_kwargs['file_url'])
         assert_absolute(call_kwargs['node_url'])
+        assert_in(username, users[0].emails)
 
     @mock.patch('website.conferences.views.send_mail')
     def test_integration_inactive(self, mock_send_mail):
@@ -607,3 +608,6 @@ class TestConferenceIntegration(ContextTestCase):
             call_kwargs['presentations_url'],
             web_url_for('conference_view', _absolute=True),
         )
+        user = User.find_one(Q('username', 'eq', username))
+        assert_in(username, user[0].emails)
+

--- a/tests/test_conferences.py
+++ b/tests/test_conferences.py
@@ -608,5 +608,3 @@ class TestConferenceIntegration(ContextTestCase):
             call_kwargs['presentations_url'],
             web_url_for('conference_view', _absolute=True),
         )
-        user = User.find_one(Q('username', 'eq', username))
-

--- a/tests/test_conferences.py
+++ b/tests/test_conferences.py
@@ -609,5 +609,4 @@ class TestConferenceIntegration(ContextTestCase):
             web_url_for('conference_view', _absolute=True),
         )
         user = User.find_one(Q('username', 'eq', username))
-        assert_in(username, user[0].emails)
 


### PR DESCRIPTION
Relates to https://openscience.atlassian.net/browse/OSF-5462

# Purpose
There were 50 users on the OSF whose usernames weren't added to their list of emails
Hard to find a pattern, so just added some extra checks.

Stats:
- There are 50 registered
- There are 50 claimed
- There are 0 invited
- There are 0 merged
- There are 0 disabled accounts
- There are 10 with osf4m system tags, coming from OSF for meetings

# Changes
- Add tests that check when an email is confirmed
- Add sentry log message to gather when a username isn't added when an email is confirmed

# Side effects
- Shouldn't be any, as this is just testing and a bit of extra logging and tests