### PR TITLE
Feature/remove forks and registrations from anonymized nodes

### DIFF
--- a/api/base/pagination.py
+++ b/api/base/pagination.py
@@ -9,6 +9,7 @@ from rest_framework.response import Response
 from rest_framework.utils.urls import (
     replace_query_param, remove_query_param
 )
+from api.base.serializers import is_anonymized
 
 class JSONAPIPagination(pagination.PageNumberPagination):
     """
@@ -82,6 +83,8 @@ class JSONAPIPagination(pagination.PageNumberPagination):
                 ]))
             ])),
         ])
+        if is_anonymized(self.request):
+            response_dict['meta'] = {'anonymous': True}
         return Response(response_dict)
 
     def paginate_queryset(self, queryset, request, view=None):

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -795,6 +795,8 @@ class JSONAPISerializer(ser.Serializer):
 
         if envelope:
             ret[envelope] = data
+            if is_anonymous:
+                ret['meta'] = {'anonymous': True}
         else:
             ret = data
         return ret

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -770,7 +770,7 @@ class JSONAPISerializer(ser.Serializer):
                 else:
                     try:
                         if not (is_anonymous and
-                                hasattr(field, 'view_name') and not
+                                hasattr(field, 'view_name') and
                                 isinstance(field.root, DoNotRelateWhenAnonymous)):
                             data['relationships'][field.field_name] = field.to_representation(attribute)
                     except SkipField:

--- a/api/logs/serializers.py
+++ b/api/logs/serializers.py
@@ -4,7 +4,9 @@ from api.base.serializers import (
     JSONAPISerializer,
     RelationshipField,
     RestrictedDictSerializer,
-    LinksField)
+    LinksField,
+    DoNotRelateWhenAnonymous,
+)
 from api.base.utils import absolute_reverse
 
 
@@ -50,9 +52,14 @@ class NodeLogParamsSerializer(RestrictedDictSerializer):
     version = ser.CharField(read_only=True)
 
 
-class NodeLogSerializer(JSONAPISerializer):
+class NodeLogSerializer(JSONAPISerializer, DoNotRelateWhenAnonymous):
 
     filterable_fields = frozenset(['action', 'date'])
+    non_anonymized_fields = [
+        'id',
+        'date',
+        'action',
+    ]
 
     id = ser.CharField(read_only=True, source='_id')
     date = ser.DateTimeField(read_only=True)

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -46,6 +46,27 @@ class NodeSerializer(JSONAPISerializer):
         'parent'
     ])
 
+    non_anonymized_fields = [
+        'id',
+        'title',
+        'description',
+        'category',
+        'date_created',
+        'date_modified',
+        'registration',
+        'tags',
+        'public',
+        'links',
+        'children',
+        'comments',
+        'contributors',
+        'files',
+        'node_links',
+        'parent',
+        'root',
+        'logs',
+    ]
+
     id = IDField(source='_id', read_only=True)
     type = TypeField()
 


### PR DESCRIPTION
Purpose
-----------
For https://openscience.atlassian.net/browse/OSF-4501

Registrations and forks are leaky for anonymized data, and were recently removed from the project view on the OSF. This matches that removal. Also, node_logs params were super-leaky, so we're applying strict anonymization to them as well while we're at it.

Note: This will not prevent people from going to the node's registration list URL. We can talk about if we really want to go that far, but as of the current implementation, it's just making it harder to do. But there are more ways for people to find anonymous data if they *really* want to, such as searching for registrations with the same name or similar, so if we want to get serious about this, we may have to re-think our approach.

Changes
------------
* Restrict fields in the node serializer so that registration links aren't serialized and, consequently, you can't embed registrations. When forks are added to the node serializer, we'll want to avoid whitelisting the forks field;
* Embed meta information to the API when data is anonymized (there is a meta dictionary at the same level as the top-level data dictionary. The meta dictionary will say `anonymous: true` if data is anonymized, otherwise it will not appear);
* Update logs so that nobody can accidentally add leaky information. This is done by restricting log information to id, date, and the type of action; no params or relationship links will show.

Side effects
----------------
The upcoming log renderer will need to handle the case of not having much information, and Henrique has been notified. 