### PR TITLE
Fix anonymized comments

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -21,6 +21,15 @@ from modularodm import Q
 from modularodm.exceptions import NoResultsFound
 
 
+def hide_view_when_anonymous(view_name):
+    # TODO: add node_views.NodeForkList when it gets added to the node serializer (this is being tested now)
+    views_to_hide = [
+        'users:user-detail',
+        'nodes:node-registrations',
+    ]
+    return view_name in views_to_hide
+
+
 def format_relationship_links(related_link=None, self_link=None, rel_meta=None, self_meta=None):
     """
     Properly handles formatting of self and related links according to JSON API.
@@ -48,6 +57,7 @@ def format_relationship_links(related_link=None, self_link=None, rel_meta=None, 
 
     return ret
 
+
 def is_anonymized(request):
     is_anonymous = False
     private_key = request.query_params.get('view_only', None)
@@ -59,10 +69,6 @@ def is_anonymized(request):
         if link is not None:
             is_anonymous = link.anonymous
     return is_anonymous
-
-
-class DoNotRelateWhenAnonymous(object):
-    pass
 
 
 class HideIfRegistration(ser.Field):
@@ -775,7 +781,7 @@ class JSONAPISerializer(ser.Serializer):
                     try:
                         if not (is_anonymous and
                                 hasattr(field, 'view_name') and
-                                isinstance(field.root, DoNotRelateWhenAnonymous)):
+                                hide_view_when_anonymous(field.view_name)):
                             data['relationships'][field.field_name] = field.to_representation(attribute)
                     except SkipField:
                         continue

--- a/api/logs/serializers.py
+++ b/api/logs/serializers.py
@@ -5,7 +5,6 @@ from api.base.serializers import (
     RelationshipField,
     RestrictedDictSerializer,
     LinksField,
-    DoNotRelateWhenAnonymous,
 )
 from api.base.utils import absolute_reverse
 
@@ -52,7 +51,7 @@ class NodeLogParamsSerializer(RestrictedDictSerializer):
     version = ser.CharField(read_only=True)
 
 
-class NodeLogSerializer(JSONAPISerializer, DoNotRelateWhenAnonymous):
+class NodeLogSerializer(JSONAPISerializer):
 
     filterable_fields = frozenset(['action', 'date'])
     non_anonymized_fields = [

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -7,12 +7,12 @@ from api.base.serializers import AllowMissing
 from website.models import User
 
 from api.base.serializers import (
-    JSONAPISerializer, LinksField, RelationshipField, DevOnly, IDField, TypeField, DoNotRelateWhenAnonymous
+    JSONAPISerializer, LinksField, RelationshipField, DevOnly, IDField, TypeField
 )
 from api.base.utils import add_dev_only_items
 
 
-class UserSerializer(DoNotRelateWhenAnonymous, JSONAPISerializer):
+class UserSerializer(JSONAPISerializer):
     filterable_fields = frozenset([
         'full_name',
         'given_name',

--- a/api_tests/comments/views/test_comment_detail.py
+++ b/api_tests/comments/views/test_comment_detail.py
@@ -83,7 +83,7 @@ class TestCommentDetailView(ApiTestCase):
         private_link = PrivateLinkFactory(anonymous=True)
         private_link.nodes.append(self.private_project)
         private_link.save()
-        res = self.app.get('/{}comments/{}/'.format(API_BASE, self.comment._id), {'view_only': private_link.key}, expect_errors=True)
+        res = self.app.get('/{}comments/{}/'.format(API_BASE, self.comment._id), {'view_only': private_link.key})
         assert_equal(res.status_code, 200)
         assert_equal(self.comment._id, res.json['data']['id'])
         assert_equal(self.comment.content, res.json['data']['attributes']['content'])

--- a/api_tests/nodes/views/test_view_only_query_parameter.py
+++ b/api_tests/nodes/views/test_view_only_query_parameter.py
@@ -161,6 +161,21 @@ class TestNodeDetailViewOnlyLinks(ViewOnlyTestCase):
         assert_not_in(self.contributing_read_user._id, body)
         assert_not_in(self.creation_user._id, body)
 
+    def test_private_project_with_anonymous_link_does_not_expose_registrations_or_forks(self):
+        res = self.app.get(self.private_node_one_url, {
+            'view_only': self.private_node_one_anonymous_link.key,
+        })
+        assert_equal(res.status_code, 200)
+        relationships = res.json['data']['relationships']
+        if 'embeds' in res.json['data']:
+            embeds = res.json['data']['embeds']
+        else:
+            embeds = {}
+        assert_not_in('registrations', relationships)
+        assert_not_in('forks', relationships)
+        assert_not_in('registrations', embeds)
+        assert_not_in('forks', embeds)
+
     def test_bad_view_only_link_does_not_modify_permissions(self):
         res = self.app.get(self.private_node_one_url+'logs/', {
             'view_only': 'thisisnotarealprivatekey',

--- a/api_tests/nodes/views/test_view_only_query_parameter.py
+++ b/api_tests/nodes/views/test_view_only_query_parameter.py
@@ -172,9 +172,9 @@ class TestNodeDetailViewOnlyLinks(ViewOnlyTestCase):
         else:
             embeds = {}
         assert_not_in('registrations', relationships)
-        assert_not_in('forks', relationships)
+        assert_not_in('forks', relationships, 'Add forks view to blacklist in hide_view_when_anonymous().')
         assert_not_in('registrations', embeds)
-        assert_not_in('forks', embeds)
+        assert_not_in('forks', embeds, 'Add forks view to blacklist in hide_view_when_anonymous().')
 
     def test_bad_view_only_link_does_not_modify_permissions(self):
         res = self.app.get(self.private_node_one_url+'logs/', {


### PR DESCRIPTION
@sloria this fixes the broken test on staging. https://openscience.atlassian.net/browse/OSF-5488

Purpose
-----------
Ensure all use of a relationship to user:user-detail and nodes:node-registrations are prevented from being exposed when anonymized.

Changes
------------
Replaces broken mixin with a blacklist feature.

Side effects
---------------
Shouldn't be any. There's a test to ensure when forks are added, if they are called 'forks', will need to be added to the blacklist.