### PR TITLE
Keep nodes from showing in any of the registration views

### DIFF
--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -43,7 +43,7 @@ class RegistrationMixin(NodeMixin):
         )
         # Nodes that are folders/collections are treated as a separate resource, so if the client
         # requests a collection through a node endpoint, we return a 404
-        if node.is_folder:
+        if node.is_folder or not node.is_registration:
             raise NotFound
         # May raise a permission denied
         if check_object_permissions:

--- a/api_tests/registrations/views/test_registration_detail.py
+++ b/api_tests/registrations/views/test_registration_detail.py
@@ -67,8 +67,14 @@ class TestRegistrationDetail(ApiTestCase):
     def test_do_not_return_node_detail(self):
         url = '/{}registrations/{}/'.format(API_BASE, self.public_project._id)
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, 400)
-        assert_equal(res.json['errors'][0]['detail'], "This is not a registration.")
+        assert_equal(res.status_code, 404)
+        assert_equal(res.json['errors'][0]['detail'], "Not found.")
+
+    def test_do_not_return_node_detail_in_sub_view(self):
+        url = '/{}registrations/{}/contributors/'.format(API_BASE, self.public_project._id)
+        res = self.app.get(url, auth=self.user.auth, expect_errors=True)
+        assert_equal(res.status_code, 404)
+        assert_equal(res.json['errors'][0]['detail'], "Not found.")
 
     def test_do_not_return_registration_in_node_detail(self):
         url = '/{}nodes/{}/'.format(API_BASE, self.public_registration._id)


### PR DESCRIPTION
Purpose
-----------
Fixes [https://openscience.atlassian.net/browse/OSF-5491]. Ensures /registrations/ views require the node to be a registration rather than just catching it elsewhere

Changes
-------------
* In get_node() for the registration mixin, verify that the node is a registration and raise a NotFound error otherwise.
* Fix the test that was checking for that to the new way of saying the node is not available here
* Add another test for a subview

Side effects
---------------
One (unrelated) test will still fail due to failing test in develop - fixed in #4844.