### PR TITLE
[Fix] Better alerts when forking projects

### DIFF
--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -260,6 +260,10 @@ def node_fork_page(auth, node, **kwargs):
             http.FORBIDDEN,
             redirect_url=node.url
         )
+    message = '{} has been successfully forked.'.format(
+        node.project_or_component.capitalize()
+    )
+    status.push_status_message(message, kind='success', trust=False)
     return fork.url
 
 
@@ -614,7 +618,7 @@ def component_remove(auth, node, **kwargs):
         )
     node.save()
 
-    message = '{} deleted'.format(
+    message = '{} has been successfully deleted.'.format(
         node.project_or_component.capitalize()
     )
     status.push_status_message(message, kind='success', trust=False)

--- a/website/static/js/project.js
+++ b/website/static/js/project.js
@@ -46,9 +46,7 @@ NodeActions.forkNode = function() {
             ctx.node.urls.api + 'fork/',
             {}
         ).done(function(response) {
-            $osf.growl('Success:', 'fork was succesfully created', 'success');
             window.location = response;
-
         }).fail(function(response) {
             $osf.unblock();
             if (response.status === 403) {


### PR DESCRIPTION
# Purpose
Fixes https://openscience.atlassian.net/browse/OSF-4209.

# Changes
Successfully forked projects now display a success alert on the fork page after redirecting such as when deleting a project. Altered wording for both deleting project and forking project alert's to be more in line with style guide.