### PR TITLE
Feature/s3 calling format update

### DIFF
--- a/website/addons/s3/static/s3NodeConfig.js
+++ b/website/addons/s3/static/s3NodeConfig.js
@@ -108,7 +108,7 @@ ViewModel.prototype.selectBucket = function() {
     self.loading(true);
 
     var ret = $.Deferred();
-    if (!isValidBucketName(self.selectedBucket(), false)) {
+    if (!isValidBucketName(self.selectedBucket(), true)) {
         self.loading(false);
         bootbox.alert({
             title: 'Invalid bucket name',

--- a/website/addons/s3/static/s3NodeConfig.js
+++ b/website/addons/s3/static/s3NodeConfig.js
@@ -108,6 +108,7 @@ ViewModel.prototype.selectBucket = function() {
     self.loading(true);
 
     var ret = $.Deferred();
+    //true is to allow periods in bucket names
     if (!isValidBucketName(self.selectedBucket(), true)) {
         self.loading(false);
         bootbox.alert({

--- a/website/addons/s3/utils.py
+++ b/website/addons/s3/utils.py
@@ -17,7 +17,7 @@ def connect_s3(access_key=None, secret_key=None, user_settings=None):
     """
     if user_settings is not None:
         access_key, secret_key = user_settings.access_key, user_settings.secret_key
-    connection = S3Connection(access_key, secret_key)
+    connection = S3Connection(access_key, secret_key, calling_format=OrdinaryCallingFormat())
     return connection
 
 


### PR DESCRIPTION
Jira Issue OSF-5442

Purpose
-----------
Periods in buckets are currently not allowed in Amazon s3 buckets on the OSF, although they are allowed by Amazon s3, because of restrictions in boto.  (for example "mybucket.with.periods") The new version of boto, currently in staging, will allow buckets with periods to be created, but not linked.  This will create a 500 error on the server and disrupts our error messaging.  The workaround is to set calling_format=OrdinaryCallingFormat() in S3Connection.  We already do this in bucket_exists.  (Thanks to @felliott for exploring this and being amazing).

Changes
------------

1.  set calling_format=OrdinaryCallingFormat() in S3Connection
2.  set that periods are allowed in the exception handling.

Things to check
---------------------
1.  Buckets with and without periods should be added and linked.
2.  Check case sensitivity for buckets, which should already be supported but just make sure.