### PR TITLE
[Hotfix] Add File Download functionality for Prereg-admins

### DIFF
--- a/admin/base/urls.py
+++ b/admin/base/urls.py
@@ -10,6 +10,7 @@ base_pattern = '^{}'.format(ADMIN_BASE)
 
 urlpatterns = [
     ### ADMIN ###
+    url(r'^project/', include('admin.pre_reg.urls', namespace='pre_reg')),
     url(base_pattern,
         include(patterns('',
                          url(r'^$', views.home, name='home'),

--- a/admin/pre_reg/urls.py
+++ b/admin/pre_reg/urls.py
@@ -7,5 +7,6 @@ urlpatterns = [
     url(r'^drafts/(?P<draft_pk>[0-9a-z]+)/$', views.view_draft, name='view_draft'),
     url(r'^drafts/(?P<draft_pk>[0-9a-z]+)/update/$', views.update_draft, name='update_draft'),
     url(r'^drafts/(?P<draft_pk>[0-9a-z]+)/approve/$', views.approve_draft, name='approve_draft'),
-    url(r'^drafts/(?P<draft_pk>[0-9a-z]+)/reject/$', views.reject_draft, name='reject_draft')
+    url(r'^drafts/(?P<draft_pk>[0-9a-z]+)/reject/$', views.reject_draft, name='reject_draft'),
+    url(r'^(?P<node_id>[a-zA-Z0-9]{5})/files/(?P<provider>.+?)/(?P<file_id>.+)/?', views.view_file, name='view_file')
 ]

--- a/admin/pre_reg/views.py
+++ b/admin/pre_reg/views.py
@@ -1,27 +1,25 @@
 import functools
+import httplib as http
+import json
 import operator
 from copy import deepcopy
 
-from django.http import HttpResponseBadRequest
 from django.contrib.auth.decorators import login_required, user_passes_test
-from django.views.decorators.csrf import csrf_exempt
-from django.shortcuts import render, redirect
-from django.http import JsonResponse
 from django.core.paginator import Paginator, EmptyPage
 from django.core.urlresolvers import reverse
-
-import json
-import httplib as http
-
-from modularodm import Q
+from django.http import HttpResponseBadRequest
+from django.http import JsonResponse
+from django.shortcuts import render, redirect
+from django.views.decorators.csrf import csrf_exempt
 
 from admin.pre_reg import serializers
 from admin.pre_reg.forms import DraftRegistrationForm
-
-from framework.mongo.utils import get_or_http_error
 from framework.exceptions import HTTPError
-from website.project.model import MetaSchema, DraftRegistration
+from framework.mongo.utils import get_or_http_error
+from modularodm import Q
 from website.exceptions import NodeStateError
+from website.files.models import FileNode
+from website.project.model import MetaSchema, DraftRegistration
 
 get_draft_or_error = functools.partial(get_or_http_error, DraftRegistration)
 
@@ -94,6 +92,13 @@ def view_draft(request, draft_pk):
         'draft': serializers.serialize_draft_registration(draft)
     }
     return render(request, 'pre_reg/edit_draft_registration.html', context)
+
+@login_required
+@user_passes_test(is_in_prereg_group)
+def view_file(request, node_id, provider, file_id):
+    file = FileNode.load(file_id)
+    wb_url = file.generate_waterbutler_url()
+    return redirect(wb_url)
 
 @csrf_exempt
 @login_required

--- a/website/addons/base/views.py
+++ b/website/addons/base/views.py
@@ -10,6 +10,7 @@ from flask import request
 from flask import redirect
 from flask import make_response
 from modularodm.exceptions import NoResultsFound
+from modularodm import Q
 
 from framework import sentry
 from framework.auth import cas
@@ -30,6 +31,7 @@ from website.addons.base import exceptions
 from website.addons.base import signals as file_signals
 from website.addons.base import StorageAddonBase
 from website.models import User, Node, NodeLog
+from website.project.model import DraftRegistration, MetaSchema
 from website.util import rubeus
 from website.profile.utils import get_gravatar
 from website.project.decorators import must_be_valid_project, must_be_contributor_or_public
@@ -139,6 +141,26 @@ def check_access(node, auth, action, cas_resp):
             if parent.can_edit(auth):
                 return True
             parent = parent.parent_node
+
+    # Users with the PREREG_ADMIN_TAG should be allowed to download files
+    # from prereg challenge draft registrations.
+    try:
+        prereg_schema = MetaSchema.find_one(
+            Q('name', 'eq', 'Prereg Challenge') &
+            Q('schema_version', 'eq', 2)
+        )
+        prereg_draft_registration = DraftRegistration.find(
+            Q('branched_from', 'eq', node) &
+            Q('registration_schema', 'eq', prereg_schema)
+        )
+
+        if action == 'download' and \
+                    auth.user is not None and \
+                    prereg_draft_registration.count() > 0 and \
+                    settings.PREREG_ADMIN_TAG in auth.user.system_tags:
+            return True
+    except NoResultsFound:
+        pass
 
     raise HTTPError(httplib.FORBIDDEN if auth.user else httplib.UNAUTHORIZED)
 


### PR DESCRIPTION
This PR modifies the `website.addons.views.check_access` method allowing users with the `settings.PREREG_ADMIN_TAG` system_tag to **download** files associated with DraftRegistrations of the Prereg Challenge Metaschema that they otherwise would not have permission to download.

It also creates a route and view that redirects to the proper waterbutler URL for a referenced file.