### PR TITLE
File comment fixes

### DIFF
--- a/website/addons/base/views.py
+++ b/website/addons/base/views.py
@@ -569,8 +569,6 @@ def addon_view_file(auth, node, file_node, version):
         'private': getattr(node.get_addon(file_node.provider), 'is_private', False),
         'file_tags': [tag._id for tag in file_node.tags],
         'file_id': file_node._id,
-        # Note: Comments are allowed for all addons that support waterbutler
-        'allow_comment': True
     })
 
     ret.update(rubeus.collect_addon_assets(node))

--- a/website/templates/include/comment_template.mako
+++ b/website/templates/include/comment_template.mako
@@ -8,11 +8,13 @@
 
             <div data-bind="ifnot: loading">
                 <div data-bind="if: isDeleted">
-                    <div class="text-muted">
-                        <span data-bind="if: hasChildren()">
+                    <div>
+                        <span class="text-muted">
+                            <em>Comment deleted.</em>
+                        </span>
+                        <span data-bind="if: hasChildren()" class="comment-actions pull-right">
                             <i data-bind="css: toggleIcon, click: toggle"></i>
                         </span>
-                        <em>Comment deleted.</em>
                     </div>
                     <div data-bind="if: canEdit">
                         <a data-bind="click: startUndelete">Restore</a>

--- a/website/templates/include/comment_template.mako
+++ b/website/templates/include/comment_template.mako
@@ -99,18 +99,18 @@
 
                         <!-- Action bar -->
                         <div style="display: inline">
-                            <div data-bind="ifnot: editing, event: {mouseover: setupToolTips('i')}" class="comment-actions pull-right">
+                            <div data-bind="ifnot: editing" class="comment-actions pull-right">
                                 <span data-bind="if: canEdit, click: edit">
-                                    <i data-toggle="tooltip" data-placement="bottom" title="Edit" class="fa fa-pencil"></i>
+                                    <i class="fa fa-pencil"></i>
                                 </span>
                                 <span data-bind="if: $root.canComment, click: showReply">
-                                    <i data-toggle="tooltip" data-placement="bottom" title="Reply" class="fa fa-reply"></i>
+                                    <i class="fa fa-reply"></i>
                                 </span>
                                 <span data-bind="if: canReport, click: reportAbuse">
-                                    <i data-toggle="tooltip" data-placement="bottom" title="Report" class="fa fa-warning"></i>
+                                    <i class="fa fa-warning"></i>
                                 </span>
                                 <span data-bind="if: canEdit, click: startDelete">
-                                    <i data-toggle="tooltip" data-placement="bottom" title="Delete" class="fa fa-trash-o"></i>
+                                    <i class="fa fa-trash-o"></i>
                                 </span>
                             </div>
                         </div>

--- a/website/templates/project/view_file.mako
+++ b/website/templates/project/view_file.mako
@@ -7,13 +7,7 @@
 <%def name="title()">${file_name | h}</%def>
 
 % if (user['can_comment'] or node['has_comments']):
-    % if allow_comment:
-        <%include file="include/comment_pane_template.mako"/>
-    % else:
-        <div class="alert alert-warning" role="alert">
-            Comments for this addon are not yet supported.
-        </div>
-    % endif
+    <%include file="include/comment_pane_template.mako"/>
 % endif
 
 <div class="row">


### PR DESCRIPTION
Purpose
----------
Address remaining non-blocking code review comments from #4856

Changes
------------
- Removed tooltips for comment action icons (edit, reply, delete and report) 
- Removed `allow_comment` flag
- UI fixes to the toggle comment replies button
  - Move "Comment deleted" text to the left and the "+" toggle to the right
  - Make the "+" black 
  - Make the cursor for the "+" a pointer
