### PR TITLE
Collection Linked Nodes Relationship endpoint and Relationship API groundwork

### DIFF
--- a/api/base/pagination.py
+++ b/api/base/pagination.py
@@ -113,24 +113,3 @@ class JSONAPIPagination(pagination.PageNumberPagination):
 
         else:
             return super(JSONAPIPagination, self).paginate_queryset(queryset, request, view=None)
-
-class JSONApiRelationShipPagination(pagination.PageNumberPagination):
-    def paginate_queryset(self, queryset, request, view=None):
-        return queryset
-
-    def get_paginated_response(self, data):
-        """
-        Formats paginated response in accordance with JSON API.
-
-        Creates pagination links from the view_name if embedded resource,
-        rather than the location used in the request.
-        """
-
-        response_dict = OrderedDict([
-            ('data', data),
-            ('links', OrderedDict([
-                ('first', 'link2'),
-                ('last', 'link1'),
-            ])),
-        ])
-        return Response(response_dict)

--- a/api/base/pagination.py
+++ b/api/base/pagination.py
@@ -113,3 +113,24 @@ class JSONAPIPagination(pagination.PageNumberPagination):
 
         else:
             return super(JSONAPIPagination, self).paginate_queryset(queryset, request, view=None)
+
+class JSONApiRelationShipPagination(pagination.PageNumberPagination):
+    def paginate_queryset(self, queryset, request, view=None):
+        return queryset
+
+    def get_paginated_response(self, data):
+        """
+        Formats paginated response in accordance with JSON API.
+
+        Creates pagination links from the view_name if embedded resource,
+        rather than the location used in the request.
+        """
+
+        response_dict = OrderedDict([
+            ('data', data),
+            ('links', OrderedDict([
+                ('first', 'link2'),
+                ('last', 'link1'),
+            ])),
+        ])
+        return Response(response_dict)

--- a/api/base/parsers.py
+++ b/api/base/parsers.py
@@ -131,19 +131,18 @@ class JSONAPIRelationshipParser(JSONParser):
 
         if not isinstance(res, dict):
             raise ParseError('Request body must be dictionary')
-        datas = res.get('data')
+        data = res.get('data')
 
-        if datas:
-            for data in datas:
-                id_ = data.get('id')
-                type_ = data.get('type')
+        if data:
+            for value in data:
 
-                if id_ is None:
+                if value.get('id') is None:
                     raise JSONAPIException(source={'pointer': '/data/id'}, detail=NO_ID_ERROR)
 
-                if type_ is None:
+                if value.get('type') is None:
                     raise JSONAPIException(source={'pointer': '/data/type'}, detail=NO_TYPE_ERROR)
-            return {'data': datas}
+
+            return {'data': data}
 
         return {'data': []}
 

--- a/api/base/parsers.py
+++ b/api/base/parsers.py
@@ -119,3 +119,36 @@ class JSONAPIParserForRegularJSON(JSONAPIParser):
     Allows same processing as JSONAPIParser to occur for requests with application/json media type.
     """
     media_type = 'application/json'
+
+class JSONAPIRelationshipParser(JSONParser):
+    """
+    Parses JSON-serialized data for relationship endpoints. Overrides media_type.
+    """
+    media_type = 'application/vnd.api+json'
+
+    def parse(self, stream, media_type=None, parser_context=None):
+        res = super(JSONAPIRelationshipParser, self).parse(stream, media_type, parser_context)
+
+        if not isinstance(res, dict):
+            raise ParseError('Request body must be dictionary')
+        data = res.get('data')
+
+        if data:
+            id_ = data.get('id')
+            type_ = data.get('type')
+
+            if id_ is None:
+                raise JSONAPIException(source={'pointer': '/data/id'}, detail=NO_ID_ERROR)
+
+            if type_ is None:
+                raise JSONAPIException(source={'pointer': '/data/type'}, detail=NO_TYPE_ERROR)
+
+            return data
+
+        return {'type': None, 'id': None}
+
+class JSONAPIRelationshipParserForRegularJSON(JSONAPIRelationshipParser):
+    """
+    Allows same processing as JSONAPIRelationshipParser to occur for requests with application/json media type.
+    """
+    media_type = 'application/json'

--- a/api/base/parsers.py
+++ b/api/base/parsers.py
@@ -131,19 +131,19 @@ class JSONAPIRelationshipParser(JSONParser):
 
         if not isinstance(res, dict):
             raise ParseError('Request body must be dictionary')
-        data = res.get('data')
+        datas = res.get('data')
 
-        if data:
-            id_ = data.get('id')
-            type_ = data.get('type')
+        if datas:
+            for data in datas:
+                id_ = data.get('id')
+                type_ = data.get('type')
 
-            if id_ is None:
-                raise JSONAPIException(source={'pointer': '/data/id'}, detail=NO_ID_ERROR)
+                if id_ is None:
+                    raise JSONAPIException(source={'pointer': '/data/id'}, detail=NO_ID_ERROR)
 
-            if type_ is None:
-                raise JSONAPIException(source={'pointer': '/data/type'}, detail=NO_TYPE_ERROR)
-
-            return data
+                if type_ is None:
+                    raise JSONAPIException(source={'pointer': '/data/type'}, detail=NO_TYPE_ERROR)
+            return {'data': datas}
 
         return {'type': None, 'id': None}
 

--- a/api/base/parsers.py
+++ b/api/base/parsers.py
@@ -145,7 +145,7 @@ class JSONAPIRelationshipParser(JSONParser):
                     raise JSONAPIException(source={'pointer': '/data/type'}, detail=NO_TYPE_ERROR)
             return {'data': datas}
 
-        return {'type': None, 'id': None}
+        return {'data': []}
 
 class JSONAPIRelationshipParserForRegularJSON(JSONAPIRelationshipParser):
     """

--- a/api/base/parsers.py
+++ b/api/base/parsers.py
@@ -136,13 +136,13 @@ class JSONAPIRelationshipParser(JSONParser):
         if data:
             if not isinstance(data, list):
                 raise ParseError('Data must be an array')
-            for i in range(0, len(data)):
+            for i, datum in enumerate(data):
 
-                if data[i].get('id') is None:
-                    raise JSONAPIException(source={'pointer': '/data/' + str(i) + '/id'}, detail=NO_ID_ERROR)
+                if datum.get('id') is None:
+                    raise JSONAPIException(source={'pointer': '/data/{}/id'.format(str(i))}, detail=NO_ID_ERROR)
 
-                if data[i].get('type') is None:
-                    raise JSONAPIException(source={'pointer': '/data/' + str(i) + '/type'}, detail=NO_TYPE_ERROR)
+                if datum.get('type') is None:
+                    raise JSONAPIException(source={'pointer': '/data/{}/type'.format(str(i))}, detail=NO_TYPE_ERROR)
 
             return {'data': data}
 

--- a/api/base/parsers.py
+++ b/api/base/parsers.py
@@ -134,13 +134,15 @@ class JSONAPIRelationshipParser(JSONParser):
         data = res.get('data')
 
         if data:
-            for value in data:
+            if not isinstance(data, list):
+                raise ParseError('Data must be an array')
+            for i in range(0, len(data)):
 
-                if value.get('id') is None:
-                    raise JSONAPIException(source={'pointer': '/data/id'}, detail=NO_ID_ERROR)
+                if data[i].get('id') is None:
+                    raise JSONAPIException(source={'pointer': '/data/' + str(i) + '/id'}, detail=NO_ID_ERROR)
 
-                if value.get('type') is None:
-                    raise JSONAPIException(source={'pointer': '/data/type'}, detail=NO_TYPE_ERROR)
+                if data[i].get('type') is None:
+                    raise JSONAPIException(source={'pointer': '/data/' + str(i) + '/type'}, detail=NO_TYPE_ERROR)
 
             return {'data': data}
 

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -816,7 +816,7 @@ class JSONAPIRelationshipsSerializer(ser.Serializer):
         assert type_ is not None, 'Must define Meta.type_'
 
         relation_id_field = self.fields['id']
-
+        import ipdb; ipdb.set_trace()
         attribute = relation_id_field.get_attribute(obj)
         relationship = relation_id_field.to_representation(attribute)
 

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -815,15 +815,12 @@ class JSONAPIRelationshipsSerializer(ser.Serializer):
         type_ = getattr(meta, 'type_', None)
         assert type_ is not None, 'Must define Meta.type_'
 
-        data = collections.OrderedDict([
-            ('data', collections.OrderedDict()),
-            ('links', collections.OrderedDict()),
-        ])
         relation_id_field = self.fields['id']
 
+        attribute = relation_id_field.get_attribute(obj)
+        relationship = relation_id_field.to_representation(attribute)
 
-        data['data'] = [{'type': type_, 'id': relation_id_field.to_representation(relation_id_field.get_attribute(object))} for object in obj]
-        data['links'] = {key: val for key, val in self.fields.get('links').to_representation(obj).iteritems()}
+        data = {'type': type_, 'id': relationship} if relationship else None
 
         return data
 

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -803,7 +803,7 @@ class JSONAPISerializer(ser.Serializer):
 
         return ret
 
-class JSONAPIRelationshipSerializer(ser.Serializer):
+class JSONAPIRelationshipsSerializer(ser.Serializer):
     """Base Relationship serializer. Requires that a `type_` option is set on `class Meta`.
     Provides a simplified serialization of the relationship, allowing for simple update request
     bodies. Also provides links to itself and to the endpoint providing information about the related
@@ -821,10 +821,8 @@ class JSONAPIRelationshipSerializer(ser.Serializer):
         ])
         relation_id_field = self.fields['id']
 
-        attribute = relation_id_field.get_attribute(obj)
-        relationship = relation_id_field.to_representation(attribute)
 
-        data['data'] = {'type': type_, 'id': relationship} if relationship else None
+        data['data'] = [{'type': type_, 'id': relation_id_field.to_representation(relation_id_field.get_attribute(object))} for object in obj]
         data['links'] = {key: val for key, val in self.fields.get('links').to_representation(obj).iteritems()}
 
         return data

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -849,3 +849,24 @@ class RestrictedDictSerializer(ser.Serializer):
             else:
                 data[field.field_name] = field.to_representation(attribute)
         return data
+
+
+class RelationshipResourceIdObjectSerializer(JSONAPIRelationshipsSerializer):
+    id = ser.CharField(source='node._id', required=False, allow_null=True)
+    type = TypeField(required=False, allow_null=True)
+
+def relationship_diff(current_items, new_items):
+    """
+    To be used in POST and PUT/PATCH relationship requests, as, by JSON API specs,
+    in update requests, the 'remove' items' relationships would be deleted, and the
+    'add' would be added, while for create requests, only the 'add' would be added.
+
+    :param current_items: The current items in the relationship
+    :param new_items: The items passed in the request
+    :return:
+    """
+
+    return {
+        'add': {k: new_items[k] for k in (set(new_items.keys()) - set(current_items.keys()))},
+        'remove': {k: current_items[k] for k in (set(current_items.keys()) - set(new_items.keys()))}
+    }

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -816,13 +816,14 @@ class JSONAPIRelationshipsSerializer(ser.Serializer):
         assert type_ is not None, 'Must define Meta.type_'
 
         relation_id_field = self.fields['id']
-        import ipdb; ipdb.set_trace()
         attribute = relation_id_field.get_attribute(obj)
         relationship = relation_id_field.to_representation(attribute)
 
         data = {'type': type_, 'id': relationship} if relationship else None
 
         return data
+
+
 
 
 def DevOnly(field):

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -806,8 +806,7 @@ class JSONAPISerializer(ser.Serializer):
 class JSONAPIRelationshipsSerializer(ser.Serializer):
     """Base Relationship serializer. Requires that a `type_` option is set on `class Meta`.
     Provides a simplified serialization of the relationship, allowing for simple update request
-    bodies. Also provides links to itself and to the endpoint providing information about the related
-    object.
+    bodies.
     """
 
     def to_representation(self, obj):
@@ -822,8 +821,6 @@ class JSONAPIRelationshipsSerializer(ser.Serializer):
         data = {'type': type_, 'id': relationship} if relationship else None
 
         return data
-
-
 
 
 def DevOnly(field):

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -803,11 +803,13 @@ class JSONAPISerializer(ser.Serializer):
 
         return ret
 
-class JSONAPIRelationshipsSerializer(ser.Serializer):
+class JSONAPIRelationshipSerializer(ser.Serializer):
     """Base Relationship serializer. Requires that a `type_` option is set on `class Meta`.
     Provides a simplified serialization of the relationship, allowing for simple update request
     bodies.
     """
+    id = ser.CharField(source='node._id', required=False, allow_null=True)
+    type = TypeField(required=False, allow_null=True)
 
     def to_representation(self, obj):
         meta = getattr(self, 'Meta', None)
@@ -850,10 +852,6 @@ class RestrictedDictSerializer(ser.Serializer):
                 data[field.field_name] = field.to_representation(attribute)
         return data
 
-
-class RelationshipResourceIdObjectSerializer(JSONAPIRelationshipsSerializer):
-    id = ser.CharField(source='node._id', required=False, allow_null=True)
-    type = TypeField(required=False, allow_null=True)
 
 def relationship_diff(current_items, new_items):
     """

--- a/api/collections/serializers.py
+++ b/api/collections/serializers.py
@@ -126,10 +126,16 @@ class CollectionLinkedNodesRelationshipSerializer(ser.Serializer):
         pointers_to_delete = [pointer for pointer in instance['data'] if pointer.node._id not in new_pointer_ids]
         pointers_to_add = [node_id for node_id in new_pointer_ids if node_id not in [pointer.node._id for pointer in instance['data']]]
 
-        for pointer in pointers_to_delete:
-            collection.rm_pointer(pointer, auth)
+        nodes_to_add = []
         for node_id in pointers_to_add:
             node = Node.load(node_id)
+            if not node:
+                raise exceptions.NotFound
+            nodes_to_add.append(node)
+
+        for pointer in pointers_to_delete:
+            collection.rm_pointer(pointer, auth)
+        for node in nodes_to_add:
             collection.add_pointer(node, auth)
 
         return {'data': [
@@ -145,8 +151,14 @@ class CollectionLinkedNodesRelationshipSerializer(ser.Serializer):
 
         pointers_to_add = [val['node']['_id'] for val in validated_data['data'] if val['node']['_id'] not in [pointer.node._id for pointer in instance['data']]]
 
+        nodes_to_add = []
         for node_id in pointers_to_add:
             node = Node.load(node_id)
+            if not node:
+                raise exceptions.NotFound
+            nodes_to_add.append(node)
+
+        for node in nodes_to_add:
             collection.add_pointer(node, auth)
 
         return {'data': [

--- a/api/collections/serializers.py
+++ b/api/collections/serializers.py
@@ -5,7 +5,7 @@ from framework.exceptions import PermissionsError
 
 from website.models import Node
 from api.base.serializers import LinksField, RelationshipField, DevOnly
-from api.base.serializers import JSONAPISerializer, JSONAPIRelationshipSerializer, IDField, TypeField
+from api.base.serializers import JSONAPISerializer, JSONAPIRelationshipsSerializer, IDField, TypeField
 from api.base.exceptions import InvalidModelValueError
 from api.base.utils import absolute_reverse, get_user_auth
 from api.nodes.serializers import NodeLinksSerializer
@@ -95,7 +95,7 @@ class CollectionNodeLinkSerializer(NodeLinksSerializer):
             }
         )
 
-class CollectionLinkedNodesRelationshipSerializer(JSONAPIRelationshipSerializer):
+class CollectionLinkedNodesRelationshipSerializer(JSONAPIRelationshipsSerializer):
 
     id = ser.CharField(source='node._id', required=False, allow_null=True)
     type = TypeField(required=False, allow_null=True)
@@ -109,13 +109,15 @@ class CollectionLinkedNodesRelationshipSerializer(JSONAPIRelationshipSerializer)
         type_ = 'linked_nodes'
 
     def get_self_link(self, obj):
-        return 'link a'
+        node = self.context['view'].get_node()
+        return node.linked_nodes_self_url
 
     def get_related_link(self, obj):
-        return 'link b'
-        #return obj.institution_url()
+        node = self.context['view'].get_node()
+        return node.linked_nodes_related_url
 
     def update(self, instance, validated_data):
+        import ipdb; ipdb.set_trace()
         pass
 
     def destroy(self, instance):

--- a/api/collections/serializers.py
+++ b/api/collections/serializers.py
@@ -1,10 +1,9 @@
 from rest_framework import serializers as ser
 from rest_framework import exceptions
-from modularodm import Q
 from modularodm.exceptions import ValidationValueError
 from framework.exceptions import PermissionsError
 
-from website.models import Node, Pointer
+from website.models import Node
 from api.base.serializers import LinksField, RelationshipField, DevOnly, RelationshipResourceIdObjectSerializer
 from api.base.serializers import JSONAPISerializer, IDField, TypeField, relationship_diff
 from api.base.exceptions import InvalidModelValueError
@@ -144,10 +143,7 @@ class CollectionLinkedNodesRelationshipSerializer(ser.Serializer):
         collection = instance['self']
         auth = get_user_auth(self.context['request'])
 
-        add, remove = self.get_pointers_to_add_remove(
-                pointers=instance['data'],
-                new_pointers=validated_data['data']
-        )
+        add, remove = self.get_pointers_to_add_remove(pointers=instance['data'], new_pointers=validated_data['data'])
 
         for pointer in remove:
             collection.rm_pointer(pointer, auth)
@@ -161,10 +157,7 @@ class CollectionLinkedNodesRelationshipSerializer(ser.Serializer):
         auth = get_user_auth(self.context['request'])
         collection = instance['self']
 
-        add, remove = self.get_pointers_to_add_remove(
-                pointers=instance['data'],
-                new_pointers=validated_data['data']
-        )
+        add, remove = self.get_pointers_to_add_remove(pointers=instance['data'], new_pointers=validated_data['data'])
 
         for node in add:
             collection.add_pointer(node, auth)

--- a/api/collections/serializers.py
+++ b/api/collections/serializers.py
@@ -103,6 +103,7 @@ class SingleLinkedNode(JSONAPIRelationshipsSerializer):
     class Meta:
         type_ = 'linked_nodes'
 
+
 class CollectionLinkedNodesRelationshipSerializer(ser.Serializer):
 
     data = ser.ListField(child=SingleLinkedNode())

--- a/api/collections/serializers.py
+++ b/api/collections/serializers.py
@@ -138,9 +138,19 @@ class CollectionLinkedNodesRelationshipSerializer(ser.Serializer):
             if not pointer.node.is_deleted and not pointer.node.is_folder
         ], 'self': collection}
 
+    def create(self, validated_data):
+        instance = self.context['view'].get_object()
+        auth = get_user_auth(self.context['request'])
+        collection = instance['self']
 
-    def destroy(self, instance):
-        import ipdb; ipdb.set_trace()
+        pointers_to_add = [val['node']['_id'] for val in validated_data['data'] if val['node']['_id'] not in [pointer.node._id for pointer in instance['data']]]
 
-    def create(self, *args, **kwargs):
-        import ipdb; ipdb.set_trace()
+        for node_id in pointers_to_add:
+            node = Node.load(node_id)
+            collection.add_pointer(node, auth)
+
+        return {'data': [
+            pointer for pointer in
+            collection.nodes_pointer
+            if not pointer.node.is_deleted and not pointer.node.is_folder
+        ], 'self': collection}

--- a/api/collections/serializers.py
+++ b/api/collections/serializers.py
@@ -5,7 +5,7 @@ from framework.exceptions import PermissionsError
 
 from website.models import Node
 from api.base.serializers import LinksField, RelationshipField, DevOnly
-from api.base.serializers import JSONAPISerializer, IDField, TypeField
+from api.base.serializers import JSONAPISerializer, JSONAPIRelationshipSerializer, IDField, TypeField
 from api.base.exceptions import InvalidModelValueError
 from api.base.utils import absolute_reverse, get_user_auth
 from api.nodes.serializers import NodeLinksSerializer
@@ -94,3 +94,29 @@ class CollectionNodeLinkSerializer(NodeLinksSerializer):
                 'node_link_id': obj._id
             }
         )
+
+class CollectionLinkedNodesRelationshipSerializer(JSONAPIRelationshipSerializer):
+
+    id = ser.CharField(source='node._id', required=False, allow_null=True)
+    type = TypeField(required=False, allow_null=True)
+
+    links = LinksField({
+        'self': 'get_self_link',
+        'related': 'get_related_link',
+    })
+
+    class Meta:
+        type_ = 'linked_nodes'
+
+    def get_self_link(self, obj):
+        return 'link a'
+
+    def get_related_link(self, obj):
+        return 'link b'
+        #return obj.institution_url()
+
+    def update(self, instance, validated_data):
+        pass
+
+    def destroy(self, instance):
+        pass

--- a/api/collections/serializers.py
+++ b/api/collections/serializers.py
@@ -104,19 +104,19 @@ class CollectionLinkedNodesRelationshipSerializer(JSONAPIRelationshipsSerializer
         type_ = 'linked_nodes'
 
     def update(self, instance, validated_data):
-        auth = None
+        auth = get_user_auth(self.context['request'])
         data = self.context['request'].data['data']
         new_pointers = [val['id'] for val in data]
-        current_pointers = instance.nodes_pointers
-        pointers_to_delete = [pointer for pointer in current_pointers if pointer.node.id not in new_pointers]
+        current_pointers = instance.nodes_pointer
+        pointers_to_delete = [pointer for pointer in current_pointers if pointer.node._id not in new_pointers]
         for pointer in pointers_to_delete:
             instance.rm_pointer(pointer, auth)
-        current_linked_nodes = [pointer.node._id for pointer in instance.nodes_pointers]
+        current_linked_nodes = [pointer.node._id for pointer in instance.nodes_pointer]
         pointers_to_add = [pointer for pointer in new_pointers if pointer not in current_linked_nodes]
         for pointer in pointers_to_add:
             node = Node.load(pointer)
-            instance.add_pointer(node, auth)        
-        return instance
+            instance.add_pointer(node, auth)
+        return instance.nodes_pointer
 
     def destroy(self, instance):
         pass

--- a/api/collections/serializers.py
+++ b/api/collections/serializers.py
@@ -4,7 +4,7 @@ from modularodm.exceptions import ValidationValueError
 from framework.exceptions import PermissionsError
 
 from website.models import Node
-from api.base.serializers import LinksField, RelationshipField, DevOnly, RelationshipResourceIdObjectSerializer
+from api.base.serializers import LinksField, RelationshipField, DevOnly, JSONAPIRelationshipSerializer
 from api.base.serializers import JSONAPISerializer, IDField, TypeField, relationship_diff
 from api.base.exceptions import InvalidModelValueError
 from api.base.utils import absolute_reverse, get_user_auth
@@ -98,7 +98,7 @@ class CollectionNodeLinkSerializer(NodeLinksSerializer):
         )
 
 
-class LinkedNode(RelationshipResourceIdObjectSerializer):
+class LinkedNode(JSONAPIRelationshipSerializer):
     class Meta:
         type_ = 'linked_nodes'
 

--- a/api/collections/serializers.py
+++ b/api/collections/serializers.py
@@ -90,7 +90,7 @@ class CollectionNodeLinkSerializer(NodeLinksSerializer):
     def get_absolute_url(self, obj):
         node_id = self.context['request'].parser_context['kwargs']['collection_id']
         return absolute_reverse(
-            'collections:node-pointer-detail',
+        ''    'collections:node-pointer-detail',
             kwargs={
                 'collection_id': node_id,
                 'node_link_id': obj._id
@@ -128,7 +128,7 @@ class CollectionLinkedNodesRelationshipSerializer(ser.Serializer):
         for node_id in diff['add']:
             node = Node.load(node_id)
             if not node:
-                raise exceptions.NotFound
+                raise exceptions.NotFound(detail='Node with id "{}" was not found'.format(node_id))
             nodes_to_add.append(node)
 
         return nodes_to_add, diff['remove'].values()

--- a/api/collections/serializers.py
+++ b/api/collections/serializers.py
@@ -90,7 +90,7 @@ class CollectionNodeLinkSerializer(NodeLinksSerializer):
     def get_absolute_url(self, obj):
         node_id = self.context['request'].parser_context['kwargs']['collection_id']
         return absolute_reverse(
-        ''    'collections:node-pointer-detail',
+            'collections:node-pointer-detail',
             kwargs={
                 'collection_id': node_id,
                 'node_link_id': obj._id

--- a/api/collections/serializers.py
+++ b/api/collections/serializers.py
@@ -125,7 +125,7 @@ class CollectionLinkedNodesRelationshipSerializer(ser.Serializer):
         )
 
         nodes_to_add = []
-        for node_id in diff['add'].keys():
+        for node_id in diff['add']:
             node = Node.load(node_id)
             if not node:
                 raise exceptions.NotFound

--- a/api/collections/serializers.py
+++ b/api/collections/serializers.py
@@ -37,7 +37,9 @@ class CollectionSerializer(JSONAPISerializer):
     linked_nodes = DevOnly(RelationshipField(
         related_view='collections:linked-nodes',
         related_view_kwargs={'collection_id': '<pk>'},
-        related_meta={'count': 'get_node_links_count'}
+        related_meta={'count': 'get_node_links_count'},
+        self_view='collections:collection-node-pointer-relationship',
+        self_view_kwargs={'collection_id': '<pk>'}
     ))
 
     class Meta:

--- a/api/collections/urls.py
+++ b/api/collections/urls.py
@@ -8,4 +8,5 @@ urlpatterns = [
     url(r'^(?P<collection_id>\w+)/linked_nodes/$', views.LinkedNodesList.as_view(), name=views.LinkedNodesList.view_name),
     url(r'^(?P<collection_id>\w+)/node_links/$', views.NodeLinksList.as_view(), name=views.NodeLinksList.view_name),
     url(r'^(?P<collection_id>\w+)/node_links/(?P<node_link_id>\w+)/', views.NodeLinksDetail.as_view(), name=views.NodeLinksDetail.view_name),
+    url(r'^(?P<collection_id>\w+)/relationships/linked_nodes/$', views.CollectionLinkedNodesRelationship.as_view(), name=views.CollectionLinkedNodesRelationship.view_name),
 ]

--- a/api/collections/views.py
+++ b/api/collections/views.py
@@ -559,12 +559,14 @@ class CollectionLinkedNodesRelationship(JSONAPIBaseView, generics.RetrieveUpdate
 
 
     def get_object(self):
-        collection = self.get_node()
-        return {'data': [
+        collection = self.get_node(check_object_permissions=False)
+        obj = {'data': [
             pointer for pointer in
             collection.nodes_pointer
             if not pointer.node.is_deleted and not pointer.node.is_folder
         ], 'self': collection}
+        self.check_object_permissions(self.request, obj)
+        return obj
 
     def perform_destroy(self, instance):
         data = self.request.data['data']

--- a/api/collections/views.py
+++ b/api/collections/views.py
@@ -538,6 +538,9 @@ class NodeLinksDetail(JSONAPIBaseView, generics.RetrieveDestroyAPIView, Collecti
         node.save()
 
 class CollectionLinkedNodesRelationship(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, generics.CreateAPIView, CollectionMixin):
+    """
+    This is a docstring
+    """
     permission_classes = (
         ContributorOrPublicForRelationshipPointers,
         drf_permissions.IsAuthenticatedOrReadOnly,

--- a/api/collections/views.py
+++ b/api/collections/views.py
@@ -537,25 +537,25 @@ class NodeLinksDetail(JSONAPIBaseView, generics.RetrieveDestroyAPIView, Collecti
             raise ValidationError(err.message)
         node.save()
 
-class CollectionLinkedNodesRelationship(JSONAPIBaseView, generics.ListAPIView, generics.RetrieveUpdateDestroyAPIView, CollectionMixin):
+class CollectionLinkedNodesRelationship(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, CollectionMixin):
     permission_classes = ()
 
     required_read_scopes = []
     required_write_scopes = []
     serializer_class = CollectionLinkedNodesRelationshipSerializer
     parser_classes = (JSONAPIRelationshipParser, JSONAPIRelationshipParserForRegularJSON, )
-    pagination_class = JSONApiRelationShipPagination
-
 
     view_category = 'collections'
     view_name = 'collection-node-pointer-relationship'
 
-    def get_object(self):
-        return self.get_node()
 
-    def get_queryset(self):
-        return [
+    def get_object(self):
+        collection = self.get_node()
+        return {'data': [
             pointer for pointer in
-            self.get_node().nodes_pointer
+            collection.nodes_pointer
             if not pointer.node.is_deleted and not pointer.node.is_folder
-        ]
+        ], 'self': collection}
+
+    def perform_destroy(self):
+        return 'poo'

--- a/api/collections/views.py
+++ b/api/collections/views.py
@@ -14,6 +14,7 @@ from api.collections.serializers import (
     CollectionSerializer,
     CollectionDetailSerializer,
     CollectionNodeLinkSerializer,
+    CollectionLinkedNodesRelationshipSerializer
 )
 from api.nodes.serializers import NodeSerializer
 
@@ -533,3 +534,21 @@ class NodeLinksDetail(JSONAPIBaseView, generics.RetrieveDestroyAPIView, Collecti
         except ValueError as err:  # pointer doesn't belong to node
             raise ValidationError(err.message)
         node.save()
+
+class CollectionLinkedNodesRelationship(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, CollectionMixin):
+    permission_classes = ()
+
+    required_read_scopes = []
+    required_write_scopes = []
+    serializer_class = CollectionLinkedNodesRelationshipSerializer
+
+    view_category = 'collections'
+    view_name = 'collection-node-pointer-relationship'
+
+    def get_object(self):
+        import ipdb; ipdb.set_trace()
+        return [
+            pointer for pointer in
+            self.get_node().nodes_pointer
+            if not pointer.node.is_deleted and not pointer.node.is_folder
+        ][0]

--- a/api/collections/views.py
+++ b/api/collections/views.py
@@ -7,7 +7,6 @@ from framework.auth.oauth_scopes import CoreScopes
 
 from api.base import generic_bulk_views as bulk_views
 from api.base import permissions as base_permissions
-from api.base.pagination import JSONApiRelationShipPagination
 from api.base.filters import ODMFilterMixin
 from api.base.views import JSONAPIBaseView
 from api.base.parsers import JSONAPIRelationshipParser, JSONAPIRelationshipParserForRegularJSON

--- a/api/collections/views.py
+++ b/api/collections/views.py
@@ -546,9 +546,9 @@ class CollectionLinkedNodesRelationship(JSONAPIBaseView, generics.RetrieveUpdate
     view_name = 'collection-node-pointer-relationship'
 
     def get_object(self):
-        import ipdb; ipdb.set_trace()
+        #import ipdb; ipdb.set_trace()
         return [
             pointer for pointer in
             self.get_node().nodes_pointer
             if not pointer.node.is_deleted and not pointer.node.is_folder
-        ][0]
+        ]

--- a/api/collections/views.py
+++ b/api/collections/views.py
@@ -7,8 +7,10 @@ from framework.auth.oauth_scopes import CoreScopes
 
 from api.base import generic_bulk_views as bulk_views
 from api.base import permissions as base_permissions
+from api.base.pagination import JSONApiRelationShipPagination
 from api.base.filters import ODMFilterMixin
 from api.base.views import JSONAPIBaseView
+from api.base.parsers import JSONAPIRelationshipParser, JSONAPIRelationshipParserForRegularJSON
 from api.base.utils import get_object_or_error, is_bulk_request, get_user_auth
 from api.collections.serializers import (
     CollectionSerializer,
@@ -535,18 +537,23 @@ class NodeLinksDetail(JSONAPIBaseView, generics.RetrieveDestroyAPIView, Collecti
             raise ValidationError(err.message)
         node.save()
 
-class CollectionLinkedNodesRelationship(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, CollectionMixin):
+class CollectionLinkedNodesRelationship(JSONAPIBaseView, generics.ListAPIView, generics.RetrieveUpdateDestroyAPIView, CollectionMixin):
     permission_classes = ()
 
     required_read_scopes = []
     required_write_scopes = []
     serializer_class = CollectionLinkedNodesRelationshipSerializer
+    parser_classes = (JSONAPIRelationshipParser, JSONAPIRelationshipParserForRegularJSON, )
+    pagination_class = JSONApiRelationShipPagination
+
 
     view_category = 'collections'
     view_name = 'collection-node-pointer-relationship'
 
     def get_object(self):
-        #import ipdb; ipdb.set_trace()
+        return self.get_node()
+
+    def get_queryset(self):
         return [
             pointer for pointer in
             self.get_node().nodes_pointer

--- a/api/collections/views.py
+++ b/api/collections/views.py
@@ -23,6 +23,7 @@ from api.nodes.permissions import (
     ContributorOrPublic,
     ReadOnlyIfRegistration,
     ContributorOrPublicForPointers,
+    ContributorOrPublicForRelationshipPointers,
 )
 
 from website.exceptions import NodeStateError
@@ -538,7 +539,7 @@ class NodeLinksDetail(JSONAPIBaseView, generics.RetrieveDestroyAPIView, Collecti
 
 class CollectionLinkedNodesRelationship(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, generics.CreateAPIView, CollectionMixin):
     permission_classes = (
-        ContributorOrPublicForPointers,
+        ContributorOrPublicForRelationshipPointers,
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
         ReadOnlyIfRegistration,

--- a/api/collections/views.py
+++ b/api/collections/views.py
@@ -538,8 +538,68 @@ class NodeLinksDetail(JSONAPIBaseView, generics.RetrieveDestroyAPIView, Collecti
         node.save()
 
 class CollectionLinkedNodesRelationship(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, generics.CreateAPIView, CollectionMixin):
-    """
-    This is a docstring
+    """ Relationship Endpoint for Collection -> Linked Node relationships
+
+    Used to set, remove, update and retrieve the ids of the linked nodes attached to this collection. For each id, there
+    exists a node link that contains that node.
+
+    ##Actions
+
+    ###Create
+
+        Method:        POST
+        URL:           /links/self
+        Query Params:  <none>
+        Body (JSON):   {
+                         "data": [{
+                           "type": "linked_nodes",   # required
+                           "id": <node_id>   # required
+                         }]
+                       }
+        Success:       201
+
+    This requires both admin permission on the collection, and for the user that is
+    making the request to be able to read the nodes requested. Data can be contain any number of
+    node identifiers. This will create a node_link for all node_ids in the request that
+    do not currently have a corresponding node_link in this collection.
+
+    ###Update
+
+        Method:        PUT || PATCH
+        URL:           /links/self
+        Query Params:  <none>
+        Body (JSON):   {
+                         "data": [{
+                           "type": "linked_nodes",   # required
+                           "id": <node_id>   # required
+                         }]
+                       }
+        Success:       200
+
+    This requires both admin permission on the collection, and for the user that is
+    making the request to be able to read the nodes requested. Data can be contain any number of
+    node identifiers. This will replace the contents of the node_links for this collection with
+    the contents of the request. It will delete all node links that don't have a node_id in the data
+    array, create node links for the node_ids that don't currently have a node id, and do nothing
+    for node_ids that already have a corresponding node_link. This means a update request with
+    {"data": []} will remove all node_links in this collection
+
+    ###Destroy
+
+        Method:        DELETE
+        URL:           /links/self
+        Query Params:  <none>
+        Body (JSON):   {
+                         "data": [{
+                           "type": "linked_nodes",   # required
+                           "id": <node_id>   # required
+                         }]
+                       }
+        Success:       204
+
+    This requires admin permission on the node. This will delete any node_links that have a
+    corresponding node_id in the request.
+
     """
     permission_classes = (
         ContributorOrPublicForRelationshipPointers,
@@ -556,7 +616,6 @@ class CollectionLinkedNodesRelationship(JSONAPIBaseView, generics.RetrieveUpdate
 
     view_category = 'collections'
     view_name = 'collection-node-pointer-relationship'
-
 
     def get_object(self):
         collection = self.get_node(check_object_permissions=False)

--- a/api/collections/views.py
+++ b/api/collections/views.py
@@ -599,7 +599,6 @@ class CollectionLinkedNodesRelationship(JSONAPIBaseView, generics.RetrieveUpdate
 
     This requires admin permission on the node. This will delete any node_links that have a
     corresponding node_id in the request.
-
     """
     permission_classes = (
         ContributorOrPublicForRelationshipPointers,

--- a/api/collections/views.py
+++ b/api/collections/views.py
@@ -558,7 +558,7 @@ class CollectionLinkedNodesRelationship(JSONAPIBaseView, generics.RetrieveUpdate
                        }
         Success:       201
 
-    This requires both admin permission on the collection, and for the user that is
+    This requires both edit permission on the collection, and for the user that is
     making the request to be able to read the nodes requested. Data can be contain any number of
     node identifiers. This will create a node_link for all node_ids in the request that
     do not currently have a corresponding node_link in this collection.
@@ -576,7 +576,7 @@ class CollectionLinkedNodesRelationship(JSONAPIBaseView, generics.RetrieveUpdate
                        }
         Success:       200
 
-    This requires both admin permission on the collection, and for the user that is
+    This requires both edit permission on the collection, and for the user that is
     making the request to be able to read the nodes requested. Data can be contain any number of
     node identifiers. This will replace the contents of the node_links for this collection with
     the contents of the request. It will delete all node links that don't have a node_id in the data
@@ -597,7 +597,7 @@ class CollectionLinkedNodesRelationship(JSONAPIBaseView, generics.RetrieveUpdate
                        }
         Success:       204
 
-    This requires admin permission on the node. This will delete any node_links that have a
+    This requires edit permission on the node. This will delete any node_links that have a
     corresponding node_id in the request.
     """
     permission_classes = (
@@ -633,5 +633,5 @@ class CollectionLinkedNodesRelationship(JSONAPIBaseView, generics.RetrieveUpdate
         current_pointers = {pointer.node._id: pointer for pointer in instance['data']}
         collection = instance['self']
         for val in data:
-            if val['id'] in current_pointers.keys():
+            if val['id'] in current_pointers:
                 collection.rm_pointer(current_pointers[val['id']], auth)

--- a/api/nodes/permissions.py
+++ b/api/nodes/permissions.py
@@ -74,6 +74,21 @@ class ContributorOrPublicForPointers(permissions.BasePermission):
             has_auth = parent_node.can_edit(auth)
             return has_auth
 
+class ContributorOrPublicForRelationshipPointers(permissions.BasePermission):
+
+    def has_object_permission(self, request, view, obj):
+        auth = get_user_auth(request)
+        if request.method in permissions.SAFE_METHODS:
+            import ipdb; ipdb.set_trace()
+            has_parent_auth = parent_node.can_edit(auth) if isinstance(obj, Node) else parent_node['self'].can_edit(auth)
+            return obj.can_view(auth)
+        else:
+            import ipdb; ipdb.set_trace()
+            parent_node = obj
+            pointer_nodes = [Node.load(pointer['id']) for pointer in request.data.get('data', [])]
+            has_parent_auth = parent_node.can_edit(auth) if isinstance(obj, Node) else parent_node['self'].can_edit(auth)
+            has_pointer_auth = reduce(lambda x, y: x.can_view(auth) and y.can_view(auth), pointer_nodes, True)
+            return has_parent_auth and has_pointer_auth
 
 class ReadOnlyIfRegistration(permissions.BasePermission):
     """Makes PUT and POST forbidden for registrations."""

--- a/api/nodes/permissions.py
+++ b/api/nodes/permissions.py
@@ -77,15 +77,16 @@ class ContributorOrPublicForPointers(permissions.BasePermission):
 class ContributorOrPublicForRelationshipPointers(permissions.BasePermission):
 
     def has_object_permission(self, request, view, obj):
+        assert isinstance(obj, dict)
         auth = get_user_auth(request)
-        parent_node = obj if isinstance(obj, Node) else obj['self']
+        parent_node = obj['self']
 
         if request.method in permissions.SAFE_METHODS:
             return parent_node.can_view(auth)
         else:
             pointer_nodes = [Node.load(pointer['id']) for pointer in request.data.get('data', [])]
             has_parent_auth = parent_node.can_edit(auth)
-            has_pointer_auth = reduce(lambda x, y: x.can_view(auth) and y.can_view(auth), pointer_nodes, True)
+            has_pointer_auth = reduce(lambda x, y: x.can_view(auth) and y.can_view(auth), pointer_nodes) if pointer_nodes else True
             return has_parent_auth and has_pointer_auth
 
 class ReadOnlyIfRegistration(permissions.BasePermission):

--- a/api/nodes/permissions.py
+++ b/api/nodes/permissions.py
@@ -78,15 +78,13 @@ class ContributorOrPublicForRelationshipPointers(permissions.BasePermission):
 
     def has_object_permission(self, request, view, obj):
         auth = get_user_auth(request)
+        parent_node = obj if isinstance(obj, Node) else obj['self']
+
         if request.method in permissions.SAFE_METHODS:
-            import ipdb; ipdb.set_trace()
-            has_parent_auth = parent_node.can_edit(auth) if isinstance(obj, Node) else parent_node['self'].can_edit(auth)
-            return obj.can_view(auth)
+            return parent_node.can_view(auth)
         else:
-            import ipdb; ipdb.set_trace()
-            parent_node = obj
             pointer_nodes = [Node.load(pointer['id']) for pointer in request.data.get('data', [])]
-            has_parent_auth = parent_node.can_edit(auth) if isinstance(obj, Node) else parent_node['self'].can_edit(auth)
+            has_parent_auth = parent_node.can_edit(auth)
             has_pointer_auth = reduce(lambda x, y: x.can_view(auth) and y.can_view(auth), pointer_nodes, True)
             return has_parent_auth and has_pointer_auth
 

--- a/api/nodes/permissions.py
+++ b/api/nodes/permissions.py
@@ -83,11 +83,14 @@ class ContributorOrPublicForRelationshipPointers(permissions.BasePermission):
 
         if request.method in permissions.SAFE_METHODS:
             return parent_node.can_view(auth)
+        elif request.method == 'DELETE':
+            return parent_node.can_edit(auth)
         else:
             pointer_nodes = [Node.load(pointer['id']) for pointer in request.data.get('data', [])]
             has_parent_auth = parent_node.can_edit(auth)
-            has_pointer_auth = reduce(lambda x, y: x.can_view(auth) and y.can_view(auth), pointer_nodes) if pointer_nodes else True
+            has_pointer_auth = reduce(lambda x, y: x and y.can_view(auth), pointer_nodes, True) if pointer_nodes else True
             return has_parent_auth and has_pointer_auth
+
 
 class ReadOnlyIfRegistration(permissions.BasePermission):
     """Makes PUT and POST forbidden for registrations."""

--- a/api/nodes/permissions.py
+++ b/api/nodes/permissions.py
@@ -94,7 +94,11 @@ class ContributorOrPublicForRelationshipPointers(permissions.BasePermission):
                     raise exceptions.NotFound
                 pointer_nodes.append(node)
             has_parent_auth = parent_node.can_edit(auth)
-            has_pointer_auth = reduce(lambda x, y: x and y.can_view(auth), pointer_nodes, True) if pointer_nodes else True
+            has_pointer_auth = True
+            for pointer in pointer_nodes:
+                if not pointer.can_view(auth):
+                    has_pointer_auth = False
+                    break
             return has_parent_auth and has_pointer_auth
 
 

--- a/api/nodes/permissions.py
+++ b/api/nodes/permissions.py
@@ -90,7 +90,7 @@ class ContributorOrPublicForRelationshipPointers(permissions.BasePermission):
             pointer_nodes = []
             for pointer in request.data.get('data', []):
                 node = Node.load(pointer['id'])
-                if not node:
+                if not node or node.is_folder:
                     raise exceptions.NotFound
                 pointer_nodes.append(node)
             has_parent_auth = parent_node.can_edit(auth)

--- a/api/nodes/permissions.py
+++ b/api/nodes/permissions.py
@@ -87,19 +87,21 @@ class ContributorOrPublicForRelationshipPointers(permissions.BasePermission):
         elif request.method == 'DELETE':
             return parent_node.can_edit(auth)
         else:
+            has_parent_auth = parent_node.can_edit(auth)
+            if not has_parent_auth:
+                return False
             pointer_nodes = []
             for pointer in request.data.get('data', []):
                 node = Node.load(pointer['id'])
                 if not node or node.is_folder:
                     raise exceptions.NotFound
                 pointer_nodes.append(node)
-            has_parent_auth = parent_node.can_edit(auth)
             has_pointer_auth = True
             for pointer in pointer_nodes:
                 if not pointer.can_view(auth):
                     has_pointer_auth = False
                     break
-            return has_parent_auth and has_pointer_auth
+            return has_pointer_auth
 
 
 class ReadOnlyIfRegistration(permissions.BasePermission):

--- a/api/nodes/permissions.py
+++ b/api/nodes/permissions.py
@@ -94,7 +94,7 @@ class ContributorOrPublicForRelationshipPointers(permissions.BasePermission):
             for pointer in request.data.get('data', []):
                 node = Node.load(pointer['id'])
                 if not node or node.is_folder:
-                    raise exceptions.NotFound
+                    raise exceptions.NotFound(detail='Node with id "{}" was not found'.format(pointer['id']))
                 pointer_nodes.append(node)
             has_pointer_auth = True
             for pointer in pointer_nodes:

--- a/api_tests/collections/test_views.py
+++ b/api_tests/collections/test_views.py
@@ -1714,3 +1714,24 @@ class TestBulkDeleteCollectionNodeLinks(ApiTestCase):
         errors = res.json['errors']
         assert_equal(len(errors), 1)
         assert_equal(errors[0]['detail'], 'Node link does not belong to the requested node.')
+
+class TestCollectionRelationshipNodeLinks(ApiTestCase):
+
+    def setUp(self):
+        super(TestCollectionRelationshipNodeLinks, self).setUp()
+        self.user = AuthUserFactory()
+        self.user2 = AuthUserFactory()
+        self.auth = Auth(self.user)
+        self.collection = FolderFactory(creator=self.user)
+        self.admin_node = NodeFactory(creator=self.user)
+        self.contributor_node = NodeFactory(creator=self.user2)
+        self.contributor_node.add_contributor(user=self.user, auth=Auth(self.user2))
+        self.contributor_node.save()
+        self.other_node = NodeFactory()
+        self.linked_node = NodeFactory()
+        self.collection.add_pointer(self.linked_node, auth=self.auth)
+        self.collection.save()
+        self.url = '/{}collections/{}/relationships/linked_nodes/'.format(API_BASE, self.collection._id)
+        
+    def test_get_relationship_linked_nodes(self):
+        pass

--- a/api_tests/collections/test_views.py
+++ b/api_tests/collections/test_views.py
@@ -1910,7 +1910,7 @@ class TestCollectionRelationshipNodeLinks(ApiTestCase):
             expect_errors=True
         )
 
-        assert_equal(res.status_code, 400)
+        assert_equal(res.status_code, 404)
 
     def test_type_mistyped(self):
         res = self.app.post_json_api(

--- a/api_tests/collections/test_views.py
+++ b/api_tests/collections/test_views.py
@@ -2007,3 +2007,12 @@ class TestCollectionRelationshipNodeLinks(ApiTestCase):
         relationship_id = [data['id'] for data in res_relationship.json['data']]
 
         assert_equal(set(node_links_id), set(relationship_id))
+
+    def test_attempt_to_add_collection_to_collection(self):
+        other_collection = NodeFactory(creator=self.user, is_folder=True)
+        res = self.app.post_json_api(
+            self.url, self.payload([other_collection._id]),
+            auth=self.user.auth, expect_errors=True
+        )
+
+        assert_equal(res.status_code, 404)

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2317,6 +2317,14 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
         return '/project/{}/'.format(self._primary_key)
 
     @property
+    def linked_nodes_self_url(self):
+        return self.absolute_api_v2_url + 'relationships/linked_nodes/'
+
+    @property
+    def linked_nodes_related_url(self):
+        return self.absolute_api_v2_url + 'linked_nodes/'
+
+    @property
     def csl(self):  # formats node information into CSL format for citation parsing
         """a dict in CSL-JSON schema
 


### PR DESCRIPTION
### Ticket: https://openscience.atlassian.net/browse/OSF-5533

## Purpose
Lay down the groundwork for relationship endpoints as per JSON API specs and, more specifically, add the ` /collections/<collection_id>/relationships/linked_nodes/ ` endpoint to allow the creation, retrieval, update and destruction if node links in a collection. This is done in this manner:

### Create
```
        Method:        POST
        URL:           /links/self
        Query Params:  <none>
        Body (JSON):   {
                         "data": [{
                           "type": "linked_nodes",   # required
                           "id": <node_id>   # required
                         }]
                       }
        Success:       201
```
This requires both admin permission on the collection, and for the user that is
making the request to be able to read the nodes requested. Data can be contain any number of
node identifiers. This will create a node_link for all node_ids in the request that
do not currently have a corresponding node_link in this collection.

### Update
```
        Method:        PUT || PATCH
        URL:           /links/self
        Query Params:  <none>
        Body (JSON):   {
                         "data": [{
                           "type": "linked_nodes",   # required
                           "id": <node_id>   # required
                         }]
                       }
        Success:       200
```
This requires both admin permission on the collection, and for the user that is
making the request to be able to read the nodes requested. Data can be contain any number of
node identifiers. This will replace the contents of the node_links for this collection with
the contents of the request. It will delete all node links that don't have a node_id in the data
array, create node links for the node_ids that don't currently have a node id, and do nothing
for node_ids that already have a corresponding node_link. This means a update request with
{"data": []} will remove all node_links in this collection

### Destroy
```
        Method:        DELETE
        URL:           /links/self
        Query Params:  <none>
        Body (JSON):   {
                         "data": [{
                           "type": "linked_nodes",   # required
                           "id": <node_id>   # required
                         }]
                       }
        Success:       204
```
This requires admin permission on the node. This will delete any node_links that have a
corresponding node_id in the request.

This PR also adds tests for the intended behavior of this relationship endpoint.

## Changes
The addition of the endpoint, and base classes for one-to-many relationships

## Side Effects
None? (easier to interact with node_links via api)