### PR TITLE
Remove restore comment confirmation

### DIFF
--- a/website/static/js/comment.js
+++ b/website/static/js/comment.js
@@ -319,7 +319,6 @@ var CommentModel = function(data, $parent, $root) {
 
     self.reporting = ko.observable(false);
     self.deleting = ko.observable(false);
-    self.unreporting = ko.observable(false);
 
     self.abuseCategory = ko.observable('spam');
     self.abuseText = ko.observable('');
@@ -327,8 +326,7 @@ var CommentModel = function(data, $parent, $root) {
     self.editing = ko.observable(false);
 
     exclusifyGroup(
-        self.editing, self.replying, self.reporting, self.deleting,
-        self.unreporting
+        self.editing, self.replying, self.reporting, self.deleting
     );
 
     self.isVisible = ko.pureComputed(function() {
@@ -539,9 +537,6 @@ CommentModel.prototype.submitUndelete = function() {
     return request;
 };
 
-CommentModel.prototype.startUnreportAbuse = function() {
-    this.unreporting(true);
-};
 
 CommentModel.prototype.submitUnreportAbuse = function() {
     var self = this;
@@ -555,7 +550,6 @@ CommentModel.prototype.submitUnreportAbuse = function() {
         self.isAbuse(false);
     });
     request.fail(function(xhr, status, error) {
-        self.unreporting(false);
         Raven.captureMessage('Error unreporting comment', {
             url: url,
             status: status,
@@ -564,10 +558,6 @@ CommentModel.prototype.submitUnreportAbuse = function() {
 
     });
     return request;
-};
-
-CommentModel.prototype.cancelUnreportAbuse = function() {
-    this.unreporting(false);
 };
 
 

--- a/website/static/js/comment.js
+++ b/website/static/js/comment.js
@@ -320,7 +320,6 @@ var CommentModel = function(data, $parent, $root) {
     self.reporting = ko.observable(false);
     self.deleting = ko.observable(false);
     self.unreporting = ko.observable(false);
-    self.undeleting = ko.observable(false);
 
     self.abuseCategory = ko.observable('spam');
     self.abuseText = ko.observable('');
@@ -329,7 +328,7 @@ var CommentModel = function(data, $parent, $root) {
 
     exclusifyGroup(
         self.editing, self.replying, self.reporting, self.deleting,
-        self.unreporting, self.undeleting
+        self.unreporting
     );
 
     self.isVisible = ko.pureComputed(function() {
@@ -508,10 +507,6 @@ CommentModel.prototype.cancelDelete = function() {
     this.deleting(false);
 };
 
-CommentModel.prototype.startUndelete = function() {
-    this.undeleting(true);
-};
-
 CommentModel.prototype.submitUndelete = function() {
     var self = this;
     var url = osfHelpers.apiV2Url('comments/' + self.id() + '/', {});
@@ -534,7 +529,6 @@ CommentModel.prototype.submitUndelete = function() {
         self.isDeleted(false);
     });
     request.fail(function(xhr, status, error) {
-        self.undeleting(false);
         Raven.captureMessage('Error undeleting comment', {
             url: url,
             status: status,
@@ -543,10 +537,6 @@ CommentModel.prototype.submitUndelete = function() {
 
     });
     return request;
-};
-
-CommentModel.prototype.cancelUndelete = function() {
-    this.undeleting(false);
 };
 
 CommentModel.prototype.startUnreportAbuse = function() {

--- a/website/templates/include/comment_template.mako
+++ b/website/templates/include/comment_template.mako
@@ -17,13 +17,7 @@
                         </span>
                     </div>
                     <div data-bind="if: canEdit">
-                        <a data-bind="click: startUndelete">Restore</a>
-                        <div class="clearfix" data-bind="if: undeleting">
-                            <div class="pull-right">
-                                <a class="btn btn-default btn-sm" data-bind="click: cancelUndelete">Cancel</a>
-                                <a class="btn btn-success btn-sm" data-bind="click: submitUndelete">Save</a>
-                            </div>
-                        </div>
+                        <a data-bind="click: submitUndelete">Restore</a>
                     </div>
                 </div>
 

--- a/website/templates/include/comment_template.mako
+++ b/website/templates/include/comment_template.mako
@@ -28,13 +28,7 @@
                         </span>
                         Comment reported.
                     </div>
-                    <a data-bind="click: startUnreportAbuse">Not abuse</a>
-                    <div class="clearfix" data-bind="if: unreporting">
-                        <div class="pull-right">
-                        <a class="btn btn-default btn-sm" data-bind="click: cancelUnreportAbuse">Cancel</a>
-                        <a class="btn btn-success btn-sm" data-bind="click: submitUnreportAbuse">Save</a>
-                        </div>
-                    </div>
+                    <a data-bind="click: submitUnreportAbuse">Not abuse</a>
                 </div>
 
                 <div data-bind="if: isVisible">


### PR DESCRIPTION
Purpose
-----------
Addresses https://github.com/CenterForOpenScience/osf.io/pull/4806#issuecomment-168773334 

Changes
------------
When a user clicks "Restore" for a deleted comment, remove the additional confirmation step. 