### PR TITLE
Feature/api/projects from templates

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -200,7 +200,7 @@ class NodeSerializer(JSONAPISerializer):
             template_node = Node.load(key=template_from)
             validated_data.pop('creator')
             changed_data = {template_from: validated_data}
-            node=template_node.use_as_template(auth=self.get_user_auth(self.context['request']), changes=changed_data)
+            node = template_node.use_as_template(auth=self.get_user_auth(self.context['request']), changes=changed_data)
         else:
             node = Node(**validated_data)
         try:

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -83,6 +83,7 @@ class NodeSerializer(JSONAPISerializer):
     collection = DevOnly(ser.BooleanField(read_only=True, source='is_folder'))
     dashboard = ser.BooleanField(read_only=True, source='is_dashboard')
     tags = JSONAPIListField(child=NodeTagField(), required=False)
+    template_from = ser.CharField(required=False, allow_blank=False, allow_null=False)
 
     # Public is only write-able by admins--see update method
     public = ser.BooleanField(source='is_public', required=False,
@@ -188,7 +189,14 @@ class NodeSerializer(JSONAPISerializer):
         return Comment.find_unread(user=user, node=obj)
 
     def create(self, validated_data):
-        node = Node(**validated_data)
+        if 'template_from' in validated_data:
+            template_from = validated_data.pop('template_from')
+            template_node = Node.load(key=template_from)
+            validated_data.pop('creator')
+            changed_data = {template_from: validated_data}
+            node=template_node.use_as_template(auth=self.get_user_auth(self.context['request']), changes=changed_data)
+        else:
+            node = Node(**validated_data)
         try:
             node.save()
         except ValidationValueError as e:

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -83,7 +83,13 @@ class NodeSerializer(JSONAPISerializer):
     collection = DevOnly(ser.BooleanField(read_only=True, source='is_folder'))
     dashboard = ser.BooleanField(read_only=True, source='is_dashboard')
     tags = JSONAPIListField(child=NodeTagField(), required=False)
-    template_from = ser.CharField(required=False, allow_blank=False, allow_null=False)
+    template_from = ser.CharField(required=False, allow_blank=False, allow_null=False,
+                                  help_text='Specify a node id for a node you would like to use as a template for the '
+                                            'new node. Templating is like forking, except that you do not copy the '
+                                            'files, only the project structure. Some information is changed on the top '
+                                            'level project by submitting the appropriate fields in the request body, '
+                                            'and some information will not change. By default, the description will '
+                                            'be cleared and the project will be made private.')
 
     # Public is only write-able by admins--see update method
     public = ser.BooleanField(source='is_public', required=False,

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -185,11 +185,12 @@ class NodeList(JSONAPIBaseView, bulk_views.BulkUpdateJSONAPIView, bulk_views.Bul
                          "data": {
                            "type": "nodes", # required
                            "attributes": {
-                             "title":       {title},          # required
-                             "category":    {category},       # required
-                             "description": {description},    # optional
-                             "tags":        [{tag1}, {tag2}], # optional
-                             "public":      true|false        # optional
+                             "title":         {title},          # required
+                             "category":      {category},       # required
+                             "description":   {description},    # optional
+                             "tags":          [{tag1}, {tag2}], # optional
+                             "public":        true|false        # optional
+                             "template_from": {node_id}         # optional
                            }
                          }
                        }

--- a/api_tests/nodes/views/test_node_list.py
+++ b/api_tests/nodes/views/test_node_list.py
@@ -552,6 +552,35 @@ class TestNodeCreate(ApiTestCase):
         project = Node.load(pid)
         assert_equal(project.logs[-1].action, NodeLog.PROJECT_CREATED)
 
+    def test_creates_project_from_template(self):
+        template_from = ProjectFactory(creator=self.user_one, is_public=True)
+        template_component = ProjectFactory(creator=self.user_one, is_public=True, parent=template_from)
+        templated_project_title = 'Templated Project'
+        templated_project_data = {
+            'data': {
+                'type': 'nodes',
+                'attributes':
+                    {
+                        'title': templated_project_title,
+                        'category': self.category,
+                        'template_from': template_from._id,
+                    }
+            }
+        }
+
+        res = self.app.post_json_api(self.url, templated_project_data, auth=self.user_one.auth)
+        assert_equal(res.status_code, 201)
+        json_data = res.json['data']
+
+        new_project_id = json_data['id']
+        new_project = Node.load(new_project_id)
+        assert_equal(new_project.title, templated_project_title)
+        assert_equal(new_project.description, None)
+        assert_false(new_project.is_public)
+        assert_equal(len(new_project.nodes), len(template_from.nodes))
+        assert_equal(new_project.nodes[0].title, template_component.title)
+
+
     def test_creates_project_creates_project_and_sanitizes_html(self):
         title = '<em>Cool</em> <strong>Project</strong>'
         description = 'An <script>alert("even cooler")</script> project'


### PR DESCRIPTION
Purpose
-----------
Closes https://openscience.atlassian.net/browse/OSF-5510

Allow API v2 to create projects from templates. This is not the best documented feature on the OSF, but I think I have it working at least well enough to match what we're doing on the onboarder within the API.

Changes
-------------
* Add API parameter to choose a node to template from on POST
* Unit tests to ensure that basic functionality works
* Documentation for the new parameter

Side effects and errata
----------------
Technically the templating allows for complex modification of the templated project during the creation, but that doesn't really work well with how the API is set up. Also, I'm not convinced anyone uses all the power available. So for now it's a minimal change to the API. That being said, it shouldn't break anything in the OSF nor on the API.