### PR TITLE
[RFR] [Feature] s3 bucket exception handling

### DIFF
--- a/website/addons/s3/settings/defaults.py
+++ b/website/addons/s3/settings/defaults.py
@@ -11,19 +11,12 @@ MAX_RENDER_SIZE = (1024 ** 2) * 3
 
 ALLOWED_ORIGIN = '*'
 
-# These bucket locations are valid, but not currently used to create a bucket by the
-# front end of the OSF.  Since we are expecting the API v2 to handle this in the future,
-# we will leave them in.
-BUCKET_LOCATIONS = {
-    "us-east-1": "US Standard",
-    "EU": "Europe Standard"
-}
-
+BUCKET_LOCATIONS = {}
 ENCRYPT_UPLOADS_DEFAULT = True
 # Load S3 settings used in both front and back end
 with open(os.path.join(STATIC_PATH, 'settings.json')) as fp:
     settings = json.load(fp)
-    BUCKET_LOCATIONS.update(settings.get('bucketLocations', {}))
+    BUCKET_LOCATIONS = settings.get('bucketLocations', {})
     ENCRYPT_UPLOADS_DEFAULT = settings.get('encryptUploads', True)
 
 OSF_USER = 'osf-user{0}'

--- a/website/addons/s3/settings/defaults.py
+++ b/website/addons/s3/settings/defaults.py
@@ -11,12 +11,16 @@ MAX_RENDER_SIZE = (1024 ** 2) * 3
 
 ALLOWED_ORIGIN = '*'
 
-BUCKET_LOCATIONS = {}
+BUCKET_LOCATIONS = {
+    "us-east-1": "US Standard",
+    "EU": "Europe Standard"
+}
+
 ENCRYPT_UPLOADS_DEFAULT = True
 # Load S3 settings used in both front and back end
 with open(os.path.join(STATIC_PATH, 'settings.json')) as fp:
     settings = json.load(fp)
-    BUCKET_LOCATIONS = settings.get('bucketLocations', {})
+    BUCKET_LOCATIONS.update(settings.get('bucketLocations', {}))
     ENCRYPT_UPLOADS_DEFAULT = settings.get('encryptUploads', True)
 
 OSF_USER = 'osf-user{0}'

--- a/website/addons/s3/settings/defaults.py
+++ b/website/addons/s3/settings/defaults.py
@@ -11,6 +11,9 @@ MAX_RENDER_SIZE = (1024 ** 2) * 3
 
 ALLOWED_ORIGIN = '*'
 
+# These bucket locations are valid, but not currently used to create a bucket by the
+# front end of the OSF.  Since we are expecting the API v2 to handle this in the future,
+# we will leave them in.
 BUCKET_LOCATIONS = {
     "us-east-1": "US Standard",
     "EU": "Europe Standard"

--- a/website/addons/s3/static/s3NodeConfig.js
+++ b/website/addons/s3/static/s3NodeConfig.js
@@ -124,7 +124,7 @@ ViewModel.prototype.selectBucket = function() {
     self.loading(true);
 
     var ret = $.Deferred();
-    if (!isValidBucketName(self.selectedBucket(), false)) {
+    if (!isValidBucketName(self.selectedBucket(), true)) {
         self.loading(false);
         bootbox.alert({
             title: 'Invalid bucket name',

--- a/website/addons/s3/static/s3NodeConfig.js
+++ b/website/addons/s3/static/s3NodeConfig.js
@@ -92,14 +92,30 @@ ViewModel.prototype.updateBucketList = function(){
         });
 };
 
-var isValidBucketName = function(bucketName, allowPeriods) {
-    var isValidBucket;
-
-    if (allowPeriods === true) {
-        isValidBucket = /^(?!.*(\.\.|-\.))[^.][a-z0-9\d.-]{2,61}[^.]$/;
-    } else {isValidBucket = /^(?!.*(\.\.|-\.))[^.][a-z0-9\d-]{2,61}[^.]$/;}
-
-    return isValidBucket.test(bucketName);
+/**
+ * Tests if the given string is a valid Amazon S3 bucket name.  Supports two modes: strict and lax.
+ * Strict is for bucket creation and follows the guidelines at:
+ *
+ *   http://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html#bucketnamingrules
+ *
+ * However, the US East (N. Virginia) region currently permits much laxer naming rules.  The S3
+ * docs claim this will be changed at some point, but to support our user's already existing
+ * buckets, we provide the lax mode checking.
+ *
+ * Strict checking is the default.
+ *
+ * @param {String} bucketName user-provided name of bucket to validate
+ * @param {Boolean} laxChecking whether to use the more permissive validation
+ */
+var isValidBucketName = function(bucketName, laxChecking) {
+    if (laxChecking === true) {
+        return /^[a-zA-Z0-9.\-_]{1,255}$/.test(bucketName);
+    }
+    var label = '[a-z0-9]+(?:[a-z0-9\-]*[a-z0-9])?';
+    var strictBucketName = new RegExp('^' + label + '(?:\\.' + label + ')*$');
+    var isIpAddress = /^[0-9]+(?:\.[0-9]+){3}$/;
+    return bucketName.length >= 3 && bucketName.length <= 63 &&
+        strictBucketName.test(bucketName) && !isIpAddress.test(bucketName);
 };
 
 ViewModel.prototype.selectBucket = function() {
@@ -112,7 +128,7 @@ ViewModel.prototype.selectBucket = function() {
         self.loading(false);
         bootbox.alert({
             title: 'Invalid bucket name',
-            message: 'Sorry, the S3 addon only supports bucket names without periods.'
+            message: 'Sorry, the S3 addon only supports bucket names with letters, numbers, periods, and hyphens.'
         });
         ret.reject();
     } else {
@@ -302,8 +318,6 @@ ViewModel.prototype.createBucket = function(bucketName, bucketLocation) {
 ViewModel.prototype.openCreateBucket = function() {
     var self = this;
 
-    var isValidBucket = /^(?!.*(\.\.|-\.))[^.][a-z0-9\d.-]{2,61}[^.]$/;
-
     // Generates html options for key-value pairs in BUCKET_LOCATION_MAP
     function generateBucketOptions(locations) {
         var options = '';
@@ -358,10 +372,11 @@ ViewModel.prototype.openCreateBucket = function() {
                         errorMessage.text('Bucket name cannot be empty');
                         errorMessage[0].classList.add('text-danger');
                         return false;
-                    } else if (!isValidBucketName(bucketName, true)) {
+                    } else if (!isValidBucketName(bucketName, false)) {
                         bootbox.confirm({
                             title: 'Invalid bucket name',
-                            message: 'Sorry, that\'s not a valid bucket name. Try another name?',
+                            message: 'Amazon S3 buckets can contain lowercase letters, numbers, and hyphens, and' +
+                            ' periods.  Please try another name.',
                             callback: function (result) {
                                 if (result) {
                                     self.openCreateBucket();

--- a/website/addons/s3/static/s3NodeConfig.js
+++ b/website/addons/s3/static/s3NodeConfig.js
@@ -128,7 +128,8 @@ ViewModel.prototype.selectBucket = function() {
         self.loading(false);
         bootbox.alert({
             title: 'Invalid bucket name',
-            message: 'Sorry, the S3 addon only supports bucket names with letters, numbers, periods, and hyphens.'
+            message: 'Amazon S3 buckets can contain lowercase letters, numbers, and hyphens, seperated by' +
+            ' periods.  Please try another name.',
         });
         ret.reject();
     } else {
@@ -375,7 +376,7 @@ ViewModel.prototype.openCreateBucket = function() {
                     } else if (!isValidBucketName(bucketName, false)) {
                         bootbox.confirm({
                             title: 'Invalid bucket name',
-                            message: 'Amazon S3 buckets can contain lowercase letters, numbers, and hyphens, and' +
+                            message: 'Amazon S3 buckets can contain lowercase letters, numbers, and hyphens, seperated by' +
                             ' periods.  Please try another name.',
                             callback: function (result) {
                                 if (result) {

--- a/website/addons/s3/static/settings.json
+++ b/website/addons/s3/static/settings.json
@@ -1,10 +1,12 @@
 {
     "bucketLocations": {
         "": "US Standard",
-        "EU": "Europe Standard",
+        "eu-central-1": "Frankfurt",
+        "eu-west-1": "Ireland",
         "us-west-1": "California",
         "us-west-2": "Oregon",
         "ap-northeast-1": "Tokyo",
+        "ap-northeast-2": "Seoul",
         "ap-southeast-1": "Singapore",
         "ap-southeast-2": "Sydney",
         "sa-east-1": "Sao Paulo"

--- a/website/addons/s3/static/settings.json
+++ b/website/addons/s3/static/settings.json
@@ -1,8 +1,6 @@
 {
     "bucketLocations": {
         "": "US Standard",
-        "us-east-1": "US Standard",
-        "EU": "Europe Standard",
         "eu-central-1": "Frankfurt",
         "eu-west-1": "Ireland",
         "us-west-1": "California",

--- a/website/addons/s3/static/settings.json
+++ b/website/addons/s3/static/settings.json
@@ -1,6 +1,8 @@
 {
     "bucketLocations": {
         "": "US Standard",
+        "us-east-1": "US Standard",
+        "EU": "Europe Standard",
         "eu-central-1": "Frankfurt",
         "eu-west-1": "Ireland",
         "us-west-1": "California",

--- a/website/addons/s3/static/tests/s3NodeConfig.test.js
+++ b/website/addons/s3/static/tests/s3NodeConfig.test.js
@@ -80,16 +80,87 @@ var s3ViewModelSettings = {
 
 describe('s3NodeConfigViewModel', () => {
     describe('isValidBucketName', () => {
-        assert.isTrue(isValidBucketName('valid'));
-        assert.isFalse(isValidBucketName('not.valid', false));
-        assert.isFalse(isValidBucketName('no'));
-        assert.isFalse(isValidBucketName(''));
-        var chars = [];
-        for (var i = 0, len = 64; i < len; i++) {
-            chars.push('a');
-        }
-        var tooLong = chars.join('');
-        assert.isFalse(isValidBucketName(tooLong));
+    var chars = [];
+    for (var i = 0; i < 63; i++) {
+        chars.push('a');
+    }
+        var longName = chars.join('');
+
+    var moreChars = [];
+    for (var j = 0; j < 255; j++) {
+        moreChars.push('a');
+    }
+    var reallyLongName = moreChars.join('');
+
+        it('allows these names in strict mode', (done) => {
+            assert.isTrue(isValidBucketName('valid'), 'basic label');
+            assert.isTrue(isValidBucketName('also.valid'), 'two labels');
+            assert.isTrue(isValidBucketName('pork.beef.chicken'), 'three labels');
+            assert.isTrue(isValidBucketName('a-o.valid'), 'label w/ hyphen');
+            assert.isTrue(isValidBucketName('11.12.m'), 'numbers as labels');
+            assert.isTrue(isValidBucketName('aa.22.cc'), 'mixed label types');
+            assert.isTrue(isValidBucketName('a------a'), 'multiple hypens');
+            assert.isTrue(isValidBucketName(longName), 'name up to 63 characters');
+            done();
+        });
+
+        it('DOES NOT allow these names in strict mode', (done) => {
+            assert.isFalse(isValidBucketName(''), 'empty');
+            assert.isFalse(isValidBucketName('no'), 'too short');
+            assert.isFalse(isValidBucketName(longName + 'a'), 'too long');
+            assert.isFalse(isValidBucketName(' aaa'), 'leading space');
+            assert.isFalse(isValidBucketName('aaa '), 'trailing space');
+            assert.isFalse(isValidBucketName('aaa.'), 'trailing period');
+            assert.isFalse(isValidBucketName('.aaa'), 'leading period');
+            assert.isFalse(isValidBucketName('aaa-'), 'trailing hyphen');
+            assert.isFalse(isValidBucketName('-aaa'), 'leading hyphen');
+            assert.isFalse(isValidBucketName('aAa'), 'mixed case');
+            assert.isFalse(isValidBucketName('Aaa'), 'capital first letter');
+            assert.isFalse(isValidBucketName('aaA'), 'capital last letter');
+            assert.isFalse(isValidBucketName('a..b'), 'empty label');
+            assert.isFalse(isValidBucketName('a-.b'), 'label cannot end with hyphen');
+            assert.isFalse(isValidBucketName('a.-b'), 'label cannot begin with hyphen');
+            assert.isFalse(isValidBucketName('8.8.8.8'), 'label cannot look like IP addr');
+            assert.isFalse(isValidBucketName('600.9000.0.28'), '  ..not even a fake IP addr');
+            done();
+        });
+
+        it('allows these names in lax mode', (done) => {
+            assert.isTrue(isValidBucketName('valid', true), 'basic label');
+            assert.isTrue(isValidBucketName('also.valid', true), 'two labels');
+            assert.isTrue(isValidBucketName('pork.beef.chicken', true), 'three labels');
+            assert.isTrue(isValidBucketName('a-o.valid', true), 'label w/ hyphen');
+            assert.isTrue(isValidBucketName('11.12.m', true), 'numbers as labels');
+            assert.isTrue(isValidBucketName('aa.22.cc', true), 'mixed label types');
+            assert.isTrue(isValidBucketName('a------a', true), 'multiple hypens');
+            assert.isTrue(isValidBucketName('.aaa', true), 'leading period');
+            assert.isTrue(isValidBucketName('aaa.', true), 'trailing period');
+            assert.isTrue(isValidBucketName('a_a', true), 'underscore');
+            assert.isTrue(isValidBucketName('a..b', true), 'empty label');
+            assert.isTrue(isValidBucketName('a______a', true), 'multiple underscores');
+            assert.isTrue(isValidBucketName(reallyLongName, true), 'name up to 255 characters');
+            assert.isTrue(isValidBucketName('no', true), 'too short');
+            assert.isTrue(isValidBucketName('aaa-', true), 'trailing hyphen');
+            assert.isTrue(isValidBucketName('-aaa', true), 'leading hyphen');
+            assert.isTrue(isValidBucketName('bBb', true), 'mixed case');
+            assert.isTrue(isValidBucketName('a-.b', true), 'label cannot end with hyphen');
+            assert.isTrue(isValidBucketName('a.-b', true), 'label cannot begin with hyphen');
+            assert.isTrue(isValidBucketName('8.8.8.8', true), 'label cannot look like IP addr');
+            assert.isTrue(isValidBucketName('600.9000.0.28', true), '  ..not even a fake IP addr');
+            done();
+        });
+
+        it('DOES NOT allow these names in lax mode', (done) => {
+            assert.isFalse(isValidBucketName('', true), 'empty');
+            assert.isFalse(isValidBucketName(reallyLongName + 'a', true), 'too long');
+            assert.isFalse(isValidBucketName(' aaa', true), 'leading space');
+            assert.isFalse(isValidBucketName('aaa ', true), 'trailing space');
+            assert.isFalse(isValidBucketName(':aa', true), 'colon leading character');
+            assert.isFalse(isValidBucketName('aa;', true), 'semicolon trailing');
+            assert.isFalse(isValidBucketName('space middle', true), 'space in the middle');
+            done();
+        });
+
     });
 
     describe('ViewModel', () => {
@@ -353,18 +424,6 @@ describe('s3NodeConfigViewModel', () => {
                         assert.equal(vm.currentBucket(), bucket, 'currentBucket not equal to ' + bucket);
                         done();
                     });
-                });
-        });
-        it('alerts the user that the S3 addon does not support bucket names containing periods', (done) => {
-            var vm = new s3NodeConfigVM('', {url: '/api/v1/12345/s3/settings/'});
-            var spy = sinon.spy(bootbox, 'alert');
-            vm.updateFromData()
-                .always(function () {
-                    vm.selectedBucket('pew.pew.pew');
-                    vm.selectBucket();
-                    assert(spy.calledOnce);
-                    spy.restore();
-                    done();
                 });
         });
     });

--- a/website/addons/s3/static/tests/s3NodeConfig.test.js
+++ b/website/addons/s3/static/tests/s3NodeConfig.test.js
@@ -122,6 +122,9 @@ describe('s3NodeConfigViewModel', () => {
             assert.isFalse(isValidBucketName('a.-b'), 'label cannot begin with hyphen');
             assert.isFalse(isValidBucketName('8.8.8.8'), 'label cannot look like IP addr');
             assert.isFalse(isValidBucketName('600.9000.0.28'), '  ..not even a fake IP addr');
+            assert.isFalse(isValidBucketName(':aa', true), 'colon leading character');
+            assert.isFalse(isValidBucketName('aa;', true), 'semicolon trailing');
+            assert.isFalse(isValidBucketName('space middle', true), 'space in the middle');
             done();
         });
 

--- a/website/addons/s3/static/tests/s3NodeConfig.test.js
+++ b/website/addons/s3/static/tests/s3NodeConfig.test.js
@@ -107,7 +107,7 @@ describe('s3NodeConfigViewModel', () => {
         it('DOES NOT allow these names in strict mode', (done) => {
             assert.isFalse(isValidBucketName(''), 'empty');
             assert.isFalse(isValidBucketName('no'), 'too short');
-            assert.isFalse(isValidBucketName(longName + 'a'), 'too long');
+            assert.isFalse(isValidBucketName(longName + 'a'), '64 characters, too long');
             assert.isFalse(isValidBucketName(' aaa'), 'leading space');
             assert.isFalse(isValidBucketName('aaa '), 'trailing space');
             assert.isFalse(isValidBucketName('aaa.'), 'trailing period');
@@ -143,16 +143,16 @@ describe('s3NodeConfigViewModel', () => {
             assert.isTrue(isValidBucketName('aaa-', true), 'trailing hyphen');
             assert.isTrue(isValidBucketName('-aaa', true), 'leading hyphen');
             assert.isTrue(isValidBucketName('bBb', true), 'mixed case');
-            assert.isTrue(isValidBucketName('a-.b', true), 'label cannot end with hyphen');
-            assert.isTrue(isValidBucketName('a.-b', true), 'label cannot begin with hyphen');
-            assert.isTrue(isValidBucketName('8.8.8.8', true), 'label cannot look like IP addr');
+            assert.isTrue(isValidBucketName('a-.b', true), 'label can end with hyphen');
+            assert.isTrue(isValidBucketName('a.-b', true), 'label can begin with hyphen');
+            assert.isTrue(isValidBucketName('8.8.8.8', true), 'label can look like IP addr');
             assert.isTrue(isValidBucketName('600.9000.0.28', true), '  ..not even a fake IP addr');
             done();
         });
 
         it('DOES NOT allow these names in lax mode', (done) => {
             assert.isFalse(isValidBucketName('', true), 'empty');
-            assert.isFalse(isValidBucketName(reallyLongName + 'a', true), 'too long');
+            assert.isFalse(isValidBucketName(reallyLongName + 'a', true), ' 256 characters, too long');
             assert.isFalse(isValidBucketName(' aaa', true), 'leading space');
             assert.isFalse(isValidBucketName('aaa ', true), 'trailing space');
             assert.isFalse(isValidBucketName(':aa', true), 'colon leading character');

--- a/website/addons/s3/tests/test_view.py
+++ b/website/addons/s3/tests/test_view.py
@@ -397,6 +397,7 @@ class TestS3ViewsConfig(OsfTestCase):
         res = self.app.post(url, auth=unauthorized.auth, expect_errors=True)
         assert_equal(res.status_code, 403)
 
+
 class TestCreateBucket(OsfTestCase):
 
     def setUp(self):
@@ -423,19 +424,38 @@ class TestCreateBucket(OsfTestCase):
         self.node_settings.save()
 
     def test_bad_names(self):
-        assert_false(validate_bucket_name('bogus naMe'))
         assert_false(validate_bucket_name(''))
         assert_false(validate_bucket_name('no'))
+        assert_false(validate_bucket_name('a' * 64))
+        assert_false(validate_bucket_name(' leadingspace'))
+        assert_false(validate_bucket_name('trailingspace '))
+        assert_false(validate_bucket_name('bogus naMe'))
         assert_false(validate_bucket_name('.cantstartwithp'))
         assert_false(validate_bucket_name('or.endwith.'))
         assert_false(validate_bucket_name('..nodoubles'))
         assert_false(validate_bucket_name('no_unders_in'))
+        assert_false(validate_bucket_name('-leadinghyphen'))
+        assert_false(validate_bucket_name('trailinghyphen-'))
+        assert_false(validate_bucket_name('Mixedcase'))
+        assert_false(validate_bucket_name('empty..label'))
+        assert_false(validate_bucket_name('label-.trailinghyphen'))
+        assert_false(validate_bucket_name('label.-leadinghyphen'))
+        assert_false(validate_bucket_name('8.8.8.8'))
+        assert_false(validate_bucket_name('600.9000.0.28'))
+        assert_false(validate_bucket_name('no_underscore'))
+        assert_false(validate_bucket_name('_nounderscoreinfront'))
+        assert_false(validate_bucket_name('no-underscore-in-back_'))
+        assert_false(validate_bucket_name('no-underscore-in_the_middle_either'))
 
     def test_names(self):
         assert_true(validate_bucket_name('imagoodname'))
         assert_true(validate_bucket_name('still.passing'))
         assert_true(validate_bucket_name('can-have-dashes'))
         assert_true(validate_bucket_name('kinda.name.spaced'))
+        assert_true(validate_bucket_name('a-o.valid'))
+        assert_true(validate_bucket_name('11.12.m'))
+        assert_true(validate_bucket_name('a--------a'))
+        assert_true(validate_bucket_name('a' * 63))
 
     def test_bad_locations(self):
         assert_false(validate_bucket_location('Venus'))

--- a/website/addons/s3/tests/test_view.py
+++ b/website/addons/s3/tests/test_view.py
@@ -472,6 +472,8 @@ class TestCreateBucket(OsfTestCase):
         assert_true(validate_bucket_location('ap-southeast-1'))
         assert_true(validate_bucket_location('ap-southeast-2'))
         assert_true(validate_bucket_location('sa-east-1'))
+        assert_true(validate_bucket_location('eu-west-1'))
+
 
     @mock.patch('website.addons.s3.views.crud.utils.create_bucket')
     @mock.patch('website.addons.s3.views.crud.utils.get_bucket_names')

--- a/website/addons/s3/tests/test_view.py
+++ b/website/addons/s3/tests/test_view.py
@@ -464,8 +464,14 @@ class TestCreateBucket(OsfTestCase):
 
     def test_locations(self):
         assert_true(validate_bucket_location(''))
-        assert_true(validate_bucket_location('EU'))
+        assert_true(validate_bucket_location('eu-central-1'))
         assert_true(validate_bucket_location('us-west-1'))
+        assert_true(validate_bucket_location('us-west-2'))
+        assert_true(validate_bucket_location('ap-northeast-1'))
+        assert_true(validate_bucket_location('ap-northeast-2'))
+        assert_true(validate_bucket_location('ap-southeast-1'))
+        assert_true(validate_bucket_location('ap-southeast-2'))
+        assert_true(validate_bucket_location('sa-east-1'))
 
     @mock.patch('website.addons.s3.views.crud.utils.create_bucket')
     @mock.patch('website.addons.s3.views.crud.utils.get_bucket_names')

--- a/website/addons/s3/utils.py
+++ b/website/addons/s3/utils.py
@@ -37,8 +37,16 @@ def validate_bucket_location(location):
 
 
 def validate_bucket_name(name):
-    validate_name = re.compile('^(?!.*(\.\.|-\.))[^.][a-z0-9\d.-]{2,61}[^.]$')
-    return bool(validate_name.match(name))
+    """Make sure the bucket name conforms to Amazon's expectations as described at:
+    http://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html#bucketnamingrules
+    The laxer rules for US East (N. Virginia) are not supported.
+    """
+    label = '[a-z0-9]+(?:[a-z0-9\-]*[a-z0-9])?'
+    validate_name = re.compile('^' + label + '(?:\\.' + label + ')*$')
+    is_ip_address = re.compile('^[0-9]+(?:\.[0-9]+){3}$')
+    return (
+        len(name) >= 3 and len(name) <= 63 and bool(validate_name.match(name)) and not bool(is_ip_address.match(name))
+    )
 
 
 def create_bucket(user_settings, bucket_name, location=''):

--- a/website/addons/s3/utils.py
+++ b/website/addons/s3/utils.py
@@ -17,7 +17,7 @@ def connect_s3(access_key=None, secret_key=None, user_settings=None):
     """
     if user_settings is not None:
         access_key, secret_key = user_settings.access_key, user_settings.secret_key
-    connection = S3Connection(access_key, secret_key)
+    connection = S3Connection(access_key, secret_key, calling_format=OrdinaryCallingFormat())
     return connection
 
 


### PR DESCRIPTION
Jira Issue OSF-5442

This is a resubmission of github PR #4851

Purpose
-----------
Periods in buckets are currently not allowed in Amazon s3 buckets on the OSF, although they are allowed by Amazon s3, because of restrictions in boto.  (for example "mybucket.with.periods") The new version of boto, currently in staging, will allow buckets with periods to be created, but not linked.  This will create a 500 error on the server and disrupts our error messaging.  The workaround is to set calling_format=OrdinaryCallingFormat() in S3Connection.  We already do this in bucket_exists.  (Thanks to @felliott for exploring this and being amazing).

Changes
------------

1.  set calling_format=OrdinaryCallingFormat() in S3Connection
2.  set that periods are allowed in the exception handling.

Things to check
---------------------
1.  Buckets with and without periods should be added and linked.
2.  Check case sensitivity for buckets, which should already be supported but just make sure.