### PR TITLE
[hotfix] OSF4M: Remove "All Submissions" for now

### DIFF
--- a/tests/test_conferences.py
+++ b/tests/test_conferences.py
@@ -419,24 +419,6 @@ class TestConferenceEmailViews(OsfTestCase):
         res = res.follow()
         assert_equal(res.request.path, '/meetings/')
 
-    def test_conference_submissions(self):
-        Node.remove()
-        conference1 = ConferenceFactory()
-        conference2 = ConferenceFactory()
-        # Create conference nodes
-        create_fake_conference_nodes(
-            3,
-            conference1.endpoint,
-        )
-        create_fake_conference_nodes(
-            2,
-            conference2.endpoint,
-        )
-
-        url = api_url_for('conference_submissions')
-        res = self.app.get(url)
-        assert_equal(len(res.json['submissions']), 5)
-
     def test_conference_plain_returns_200(self):
         conference = ConferenceFactory()
         url = web_url_for('conference_results__plain', meeting=conference.endpoint)

--- a/website/conferences/views.py
+++ b/website/conferences/views.py
@@ -222,37 +222,6 @@ def conference_results(meeting):
         'settings': settings,
     }
 
-def conference_submissions(**kwargs):
-    """Return data for all OSF4M submissions.
-
-    The total number of submissions for each meeting is calculated and cached
-    in the Conference.num_submissions field.
-    """
-    submissions = []
-    for conf in Conference.find():
-        # For efficiency, we filter by tag first, then node
-        # instead of doing a single Node query
-        projects = set()
-        for tag in Tag.find(Q('_id', 'iexact', conf.endpoint)):
-            for node in tag.node__tagged:
-                if not node:
-                    continue
-                if not node.is_public or node.is_deleted:
-                    continue
-                projects.add(node)
-
-        for idx, node in enumerate(projects):
-            submissions.append(_render_conference_node(node, idx, conf))
-        num_submissions = len(projects)
-        # Cache the number of submissions
-        conf.num_submissions = num_submissions
-        conf.save()
-        if num_submissions < settings.CONFERENCE_MIN_COUNT:
-            continue
-    submissions.sort(key=lambda submission: submission['dateCreated'], reverse=True)
-
-    return {'submissions': submissions}
-
 def conference_view(**kwargs):
     meetings = []
     for conf in Conference.find():

--- a/website/routes.py
+++ b/website/routes.py
@@ -214,13 +214,6 @@ def make_url_map(app):
         ),
 
         Rule(
-            '/api/v1/meetings/submissions/',
-            'get',
-            conference_views.conference_submissions,
-            json_renderer,
-        ),
-
-        Rule(
             '/presentations/',
             'get',
             conference_views.redirect_to_meetings,

--- a/website/static/js/pages/meetings-page.js
+++ b/website/static/js/pages/meetings-page.js
@@ -1,14 +1,4 @@
 var $ = require('jquery');
 var Meetings = require('../meetings.js');
-var Submissions = require('../submissions.js');
 
 new Meetings(window.contextVars.meetings);
-
-var request = $.getJSON('/api/v1/meetings/submissions/');
-
-request.always(function() {
-    $('#allMeetingsLoader').hide();
-});
-request.done(function(data) {
-    new Submissions(data.submissions);
-});

--- a/website/templates/public/pages/meeting_landing.mako
+++ b/website/templates/public/pages/meeting_landing.mako
@@ -77,38 +77,12 @@
     <div class="container grey-background">
         <div class="row m-v-lg">
             <div class="col-md-12">
-                <div role="tabpanel">
-                    <!-- Nav tabs -->
-                    <ul class="nav nav-tabs m-b-md" role="tablist">
-                        <li role="presentation" class="active">
-                            <a href="#meetings" aria-controls="meetings" role="tab" data-toggle="tab">All meetings</a>
-                        </li>
-                        <li role="presentation">
-                            <a href="#submissions" aria-controls="submissions" role="tab" data-toggle="tab">All submissions</a>
-                        </li>
-                    </ul>
-                    <!-- Tab panes -->
-                    <div class="tab-content">
-                        <div role="tabpanel" class="tab-pane active" id="meetings">
-                            <p>
-                                <small>Only conferences with at least five submissions are displayed.</small>
-                            </p>
-                            <div id="meetings-grid"></div>
-                        </div>
-                        <div role="tabpanel" class="tab-pane" id="submissions">
-
-                            <div id="submissions-grid">
-                                <div id="allMeetingsLoader" class="spinner-loading-wrapper">
-                                    <div class="logo-spin logo-lg"></div>
-                                    <p class="m-t-sm fg-load-message"> Loading submissions...</p>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-            </div>
-        </div>
+                <p>
+                    <small>Only conferences with at least five submissions are displayed.</small>
+                </p>
+                <div id="meetings-grid"></div>
+            </div><!-- end col-md-->
+        </div><!-- end row -->
 
         <div class="row icon-bar m-v-lg">
             <div class="col-md-4 col-sm-4 text-center ">


### PR DESCRIPTION
The endpoint is too inefficient to be used in production at the
moment; requests for All Submissions are timing out. This removes
the UI and the route for viewing All Submissions

see OSF-4756