### PR TITLE
Let Failed Registration Drafts be editable again

### DIFF
--- a/tests/test_registrations/test_views.py
+++ b/tests/test_registrations/test_views.py
@@ -530,3 +530,16 @@ class TestDraftRegistrationViews(RegistrationsTestBase):
             draft_views.check_draft_state(self.draft)
         except Exception:
             self.fail()
+
+    def test_check_draft_state_registered_and_deleted_and_approved(self):
+        reg = RegistrationFactory()
+        self.draft.registered_node = reg
+        self.draft.save()
+        reg.is_deleted = True
+        reg.save()
+
+        with mock.patch('website.project.model.DraftRegistration.is_approved', mock.PropertyMock(return_value=True)):
+            try:
+                draft_views.check_draft_state(self.draft)
+            except HTTPError:
+                self.fail()

--- a/website/project/views/drafts.py
+++ b/website/project/views/drafts.py
@@ -88,17 +88,18 @@ def validate_registration_choice(registration_choice):
         )
 
 def check_draft_state(draft):
-    if draft.registered_node and not draft.registered_node.is_deleted:
+    registered_and_deleted = draft.registered_node and draft.registered_node.is_deleted
+    if draft.registered_node and not registered_and_deleted:
         raise HTTPError(http.FORBIDDEN, data={
             'message_short': 'This draft has already been registered',
             'message_long': 'This draft has already been registered and cannot be modified.'
         })
-    elif draft.is_pending_review:
+    if draft.is_pending_review:
         raise HTTPError(http.FORBIDDEN, data={
             'message_short': 'This draft is pending review',
             'message_long': 'This draft is pending review and cannot be modified.'
         })
-    elif draft.requires_approval and draft.is_approved:
+    if draft.requires_approval and draft.is_approved and (not registered_and_deleted):
         raise HTTPError(http.FORBIDDEN, data={
             'message_short': 'This draft has already been approved',
             'message_long': 'This draft has already been approved and cannot be modified.'


### PR DESCRIPTION
# Purpose

Prereg challenge submissions that were approved but had failed registrations were not editable from the UI. 
![image](https://cloud.githubusercontent.com/assets/2207561/12244533/2b26c176-b872-11e5-9a2e-f152107eca9f.png)

# Changes

Modify `check_draft_state` to ignore the approval state of drafts with deleted registrations. 