### PR TITLE
Feature/fix deleting and restoring comments

### DIFF
--- a/api/comments/serializers.py
+++ b/api/comments/serializers.py
@@ -87,12 +87,7 @@ class CommentSerializer(JSONAPISerializer):
                     comment.edit(content, auth=auth, save=True)
                 except PermissionsError:
                     raise PermissionDenied('Not authorized to edit this comment.')
-            if validated_data.get('is_deleted', None) is True:
-                try:
-                    comment.delete(auth, save=True)
-                except PermissionsError:
-                    raise PermissionDenied('Not authorized to delete this comment.')
-            elif comment.is_deleted:
+            if validated_data.get('is_deleted', None) is False and comment.is_deleted:
                 try:
                     comment.undelete(auth, save=True)
                 except PermissionsError:

--- a/api/comments/views.py
+++ b/api/comments/views.py
@@ -170,9 +170,17 @@ class CommentDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, Comm
     and `deleted` fields are mandatory if you PUT and optional if you PATCH. Non-string values will be accepted and
     stringified, but we make no promises about the stringification output.  So don't do that.
 
-    To delete a comment, issue a PATCH request against the `/links/self` URL, with `deleted: True`:
+    To restore a deleted comment, issue a PATCH request against the `/links/self` URL, with `deleted: False`.
 
-    To undelete a comment, issue a PATCH request against the `/links/self` URL, with `deleted: False`.
+    ###Delete
+
+        Method:        DELETE
+        URL:           /links/self
+        Query Params:  <none>
+        Success:       204 No Content
+
+    To delete a comment send a DELETE request to the `/links/self` URL.  Nothing will be returned in the response
+    body. Attempting to delete an already deleted comment will result in a 400 Bad Request response.
 
     ##Query Params
 

--- a/website/static/js/comment.js
+++ b/website/static/js/comment.js
@@ -511,7 +511,7 @@ CommentModel.prototype.submitUndelete = function() {
     var self = this;
     var url = osfHelpers.apiV2Url('comments/' + self.id() + '/', {});
     var request = osfHelpers.ajaxJSON(
-        'PATCH',
+        'PUT',
         url,
         {
             'isCors': true,
@@ -520,6 +520,7 @@ CommentModel.prototype.submitUndelete = function() {
                     'id': self.id(),
                     'type': 'comments',
                     'attributes': {
+                        'content': self.content(),
                         'deleted': false
                     }
                 }

--- a/website/static/js/comment.js
+++ b/website/static/js/comment.js
@@ -474,20 +474,10 @@ CommentModel.prototype.submitDelete = function() {
     var self = this;
     var url = osfHelpers.apiV2Url('comments/' + self.id() + '/', {});
     var request = osfHelpers.ajaxJSON(
-        'PATCH',
+        'DELETE',
         url,
-        {
-            'isCors': true,
-            'data': {
-                'data': {
-                    'id': self.id(),
-                    'type': 'comments',
-                    'attributes': {
-                        'deleted': true
-                    }
-                }
-            }
-        });
+        {'isCors': true}
+    );
     request.done(function() {
         self.isDeleted(true);
         self.deleting(false);


### PR DESCRIPTION
Purpose
------------
Addresses issue where comments cannot be deleted when using IE10/11:
https://openscience.atlassian.net/browse/OSF-4938

Changes
------------
Use DELETE instead of PATCH to delete comments
- Add delete view function
- Remove ability to delete comments via PUT/PATCH
- Update API tests  

Use PUT instead of PATCH to restore comments