### PR TITLE
Sanitize comment content with bleach.clean

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -805,7 +805,7 @@ class JSONAPISerializer(ser.Serializer):
         return ret
 
     # overrides Serializer: Add HTML-sanitization similar to that used by APIv1 front-end views
-    def is_valid(self, clean_html=True, **kwargs):
+    def is_valid(self, clean_html=True, excluded_fields=None, **kwargs):
         """
         After validation, scrub HTML from validated_data prior to saving (for create and update views)
 
@@ -815,7 +815,15 @@ class JSONAPISerializer(ser.Serializer):
         ret = super(JSONAPISerializer, self).is_valid(**kwargs)
 
         if clean_html is True:
+            # Remove fields from _validated_data to exclude from sanitization
+            excluded = {}
+            for field in excluded_fields:
+                excluded[field] = self._validated_data.pop(field, None)
+
             self._validated_data = website_utils.rapply(self.validated_data, strip_html)
+
+            for field in excluded:
+                self._validated_data[field] = excluded[field]
 
         self._validated_data.pop('type', None)
         self._validated_data.pop('target_type', None)

--- a/api/comments/serializers.py
+++ b/api/comments/serializers.py
@@ -1,3 +1,5 @@
+import bleach
+
 from rest_framework import serializers as ser
 from modularodm import Q
 from framework.auth.core import Auth
@@ -111,6 +113,13 @@ class CommentSerializer(JSONAPISerializer):
                 source={'pointer': '/data/relationships/target/links/related/meta/type'},
                 detail='Invalid comment target type.'
             )
+
+    def is_valid(self, **kwargs):
+        ret = super(CommentSerializer, self).is_valid(clean_html=True, excluded_fields=['get_content'], **kwargs)
+        content = self._validated_data.get('get_content', None)
+        self._validated_data['get_content'] = bleach.clean(content)
+        return ret
+
 
 class CommentCreateSerializer(CommentSerializer):
 

--- a/api_tests/nodes/views/test_node_comments_list.py
+++ b/api_tests/nodes/views/test_node_comments_list.py
@@ -14,7 +14,6 @@ from tests.factories import (
     CommentFactory,
     RetractedRegistrationFactory
 )
-from website.util.sanitize import strip_html
 
 
 class TestNodeCommentsList(ApiTestCase):
@@ -527,7 +526,7 @@ class TestNodeCommentCreate(ApiTestCase):
         assert_equal(res.status_code, 400)
         assert_equal(res.json['errors'][0]['detail'], 'Comment cannot be empty.')
 
-    def test_create_comment_sanitizes_input(self):
+    def test_create_comment_with_allowed_html_tags(self):
         self._set_up_private_project()
         payload = {
             'data': {
@@ -547,7 +546,7 @@ class TestNodeCommentCreate(ApiTestCase):
         }
         res = self.app.post_json_api(self.private_url, payload, auth=self.user.auth)
         assert_equal(res.status_code, 201)
-        assert_equal(res.json['data']['attributes']['content'], strip_html(payload['data']['attributes']['content']))
+        assert_equal(res.json['data']['attributes']['content'], payload['data']['attributes']['content'])
 
     def test_create_comment_exceeds_max_length(self):
         self._set_up_private_project()


### PR DESCRIPTION
Purpose
-----------
Previously, comments supported some html tags but DRF removes all html tags. 

Changes
------------
Instead of using default DRF sanitization for the content serializer field, skip it in `is_valid` and use `bleach.clean` (used in API v1) to allow certain html tags through that are expected to work with markdown.

ALLOWED_TAGS = [
    'a',
    'abbr',
    'acronym',
    'b',
    'blockquote',
    'code',
    'em',
    'i',
    'li',
    'ol',
    'strong',
    'ul',
]