### PR TITLE
Sanitize comment content with bleach.clean

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -815,7 +815,7 @@ class JSONAPISerializer(ser.Serializer):
         ret = super(JSONAPISerializer, self).is_valid(**kwargs)
 
         if clean_html is True:
-            self._validated_data = website_utils.rapply(self.validated_data, strip_html)
+            self._validated_data = self.sanitize_data()
 
         self._validated_data.pop('type', None)
         self._validated_data.pop('target_type', None)
@@ -825,6 +825,8 @@ class JSONAPISerializer(ser.Serializer):
 
         return ret
 
+    def sanitize_data(self):
+        return website_utils.rapply(self.validated_data, strip_html)
 
 def DevOnly(field):
     """Make a field only active in ``DEV_MODE``. ::

--- a/api/comments/serializers.py
+++ b/api/comments/serializers.py
@@ -1,3 +1,5 @@
+import bleach
+
 from rest_framework import serializers as ser
 from modularodm import Q
 from framework.auth.core import Auth
@@ -106,6 +108,14 @@ class CommentSerializer(JSONAPISerializer):
                 source={'pointer': '/data/relationships/target/links/related/meta/type'},
                 detail='Invalid comment target type.'
             )
+
+    def sanitize_data(self):
+        ret = super(CommentSerializer, self).sanitize_data()
+        content = self.validated_data.get('get_content', None)
+        if content:
+            ret['get_content'] = bleach.clean(content)
+        return ret
+
 
 class CommentCreateSerializer(CommentSerializer):
 

--- a/api_tests/nodes/views/test_node_comments_list.py
+++ b/api_tests/nodes/views/test_node_comments_list.py
@@ -527,7 +527,7 @@ class TestNodeCommentCreate(ApiTestCase):
         assert_equal(res.status_code, 400)
         assert_equal(res.json['errors'][0]['detail'], 'Comment cannot be empty.')
 
-    def test_create_comment_sanitizes_input(self):
+    def test_create_comment_with_allowed_tags(self):
         self._set_up_private_project()
         payload = {
             'data': {
@@ -547,7 +547,7 @@ class TestNodeCommentCreate(ApiTestCase):
         }
         res = self.app.post_json_api(self.private_url, payload, auth=self.user.auth)
         assert_equal(res.status_code, 201)
-        assert_equal(res.json['data']['attributes']['content'], strip_html(payload['data']['attributes']['content']))
+        assert_equal(res.json['data']['attributes']['content'], payload['data']['attributes']['content'])
 
     def test_create_comment_exceeds_max_length(self):
         self._set_up_private_project()


### PR DESCRIPTION
Purpose
-----------
Allow html tags supported by v1 for comments.

Changes
------------
Put sanitization in a method separate from `is_valid` (`sanitize_data`) and override in the comment serializer to use `bleach.clean` when sanitizing comment content (and `strip_html` for everything else).

ALLOWED_TAGS = [
    'a',
    'abbr',
    'acronym',
    'b',
    'blockquote',
    'code',
    'em',
    'i',
    'li',
    'ol',
    'strong',
    'ul',
]