### PR TITLE
Fix reporting abuse error

### DIFF
--- a/website/static/js/comment.js
+++ b/website/static/js/comment.js
@@ -447,13 +447,14 @@ CommentModel.prototype.submitAbuse = function() {
                     'type': 'comment_reports',
                     'attributes': {
                         'category': self.abuseCategory(),
-                        'message': self.abuseText()
+                        'message': self.abuseText() || ''
                     }
                 }
             }
         });
     request.done(function() {
         self.isAbuse(true);
+        self.reporting(false);
     });
     request.fail(function(xhr, status, error) {
         self.errorMessage('Could not report abuse.');


### PR DESCRIPTION
Purpose
------------
When unreporting a comment and immediately reporting it again, the request fails because the message is null. Also, the form re-appears after unreporting a comment when it should not.

Changes
-------------
Make `self.abuseText` default to an empty string in the request payload. Also, set `self.reporting` to false after successfully reporting a comment so that the form does not re-appear when clicking unreport.