### PR TITLE
Feature/api/current user node permissions

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -83,6 +83,7 @@ class NodeSerializer(JSONAPISerializer):
     collection = DevOnly(ser.BooleanField(read_only=True, source='is_folder'))
     dashboard = ser.BooleanField(read_only=True, source='is_dashboard')
     tags = JSONAPIListField(child=NodeTagField(), required=False)
+    current_user_permissions = ser.SerializerMethodField()
 
     # Public is only write-able by admins--see update method
     public = ser.BooleanField(source='is_public', required=False,
@@ -149,6 +150,13 @@ class NodeSerializer(JSONAPISerializer):
         related_view='nodes:node-logs',
         related_view_kwargs={'node_id': '<pk>'},
     )
+
+    def get_current_user_permissions(self, obj):
+        user = self.context['request'].user
+        if user.is_anonymous():
+            return ["read"]
+        else:
+            return obj.get_permissions(user=user)
 
     class Meta:
         type_ = 'nodes'

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -83,7 +83,8 @@ class NodeSerializer(JSONAPISerializer):
     collection = DevOnly(ser.BooleanField(read_only=True, source='is_folder'))
     dashboard = ser.BooleanField(read_only=True, source='is_dashboard')
     tags = JSONAPIListField(child=NodeTagField(), required=False)
-    current_user_permissions = ser.SerializerMethodField()
+    current_user_permissions = ser.SerializerMethodField(help_text='List of strings representing the permissions '
+                                                                   'for the current user on this node.')
 
     # Public is only write-able by admins--see update method
     public = ser.BooleanField(source='is_public', required=False,

--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -22,7 +22,7 @@ from tests.factories import (
     RetractedRegistrationFactory
 )
 
-from tests.utils import assert_logs, assert_not_logs
+from tests.utils import assert_logs, assert_not_logs, assert_mutual_in
 
 
 class TestNodeDetail(ApiTestCase):
@@ -39,6 +39,9 @@ class TestNodeDetail(ApiTestCase):
 
         self.public_component = NodeFactory(parent=self.public_project, creator=self.user, is_public=True)
         self.public_component_url = '/{}nodes/{}/'.format(API_BASE, self.public_component._id)
+        self.read_permissions = ['read']
+        self.write_permissions = ['read', 'write']
+        self.admin_permissions = ['read', 'admin', 'write']
 
     def test_return_public_project_details_logged_out(self):
         res = self.app.get(self.public_url)
@@ -47,6 +50,7 @@ class TestNodeDetail(ApiTestCase):
         assert_equal(res.json['data']['attributes']['title'], self.public_project.title)
         assert_equal(res.json['data']['attributes']['description'], self.public_project.description)
         assert_equal(res.json['data']['attributes']['category'], self.public_project.category)
+        assert_mutual_in(res.json['data']['attributes']['current_user_permissions'], self.read_permissions)
 
     def test_return_public_project_details_logged_in(self):
         res = self.app.get(self.public_url, auth=self.user.auth)
@@ -55,19 +59,31 @@ class TestNodeDetail(ApiTestCase):
         assert_equal(res.json['data']['attributes']['title'], self.public_project.title)
         assert_equal(res.json['data']['attributes']['description'], self.public_project.description)
         assert_equal(res.json['data']['attributes']['category'], self.public_project.category)
+        assert_mutual_in(res.json['data']['attributes']['current_user_permissions'], self.admin_permissions)
 
     def test_return_private_project_details_logged_out(self):
         res = self.app.get(self.private_url, expect_errors=True)
         assert_equal(res.status_code, 401)
         assert_in('detail', res.json['errors'][0])
 
-    def test_return_private_project_details_logged_in_contributor(self):
+    def test_return_private_project_details_logged_in_admin_contributor(self):
         res = self.app.get(self.private_url, auth=self.user.auth)
         assert_equal(res.status_code, 200)
         assert_equal(res.content_type, 'application/vnd.api+json')
         assert_equal(res.json['data']['attributes']['title'], self.private_project.title)
         assert_equal(res.json['data']['attributes']['description'], self.private_project.description)
         assert_equal(res.json['data']['attributes']['category'], self.private_project.category)
+        assert_mutual_in(res.json['data']['attributes']['current_user_permissions'], self.admin_permissions)
+
+    def test_return_private_project_details_logged_in_write_contributor(self):
+        self.private_project.add_contributor(contributor=self.user_two, auth=Auth(self.user), save=True)
+        res = self.app.get(self.private_url, auth=self.user_two.auth)
+        assert_equal(res.status_code, 200)
+        assert_equal(res.content_type, 'application/vnd.api+json')
+        assert_equal(res.json['data']['attributes']['title'], self.private_project.title)
+        assert_equal(res.json['data']['attributes']['description'], self.private_project.description)
+        assert_equal(res.json['data']['attributes']['category'], self.private_project.category)
+        assert_mutual_in(res.json['data']['attributes']['current_user_permissions'], self.write_permissions)
 
     def test_return_private_project_details_logged_in_non_contributor(self):
         res = self.app.get(self.private_url, auth=self.user_two.auth, expect_errors=True)

--- a/api_tests/registrations/views/test_registration_detail.py
+++ b/api_tests/registrations/views/test_registration_detail.py
@@ -111,6 +111,7 @@ class TestRegistrationDetail(ApiTestCase):
             'pending_embargo_approval': None,
             "embargo_end_date": None,
             "registered_meta": None,
+            'current_user_permissions': None,
             "registration_supplement": registration.registered_meta.keys()[0]
         })
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,7 +5,7 @@ import datetime
 
 from django.http import HttpRequest
 from nose import SkipTest
-from nose.tools import assert_equal, assert_not_equal
+from nose.tools import assert_equal, assert_not_equal, assert_in
 
 from framework.auth import Auth
 from website.archiver import ARCHIVER_SUCCESS
@@ -178,3 +178,15 @@ def unique(factory):
         used.append(item)
         return item
     return wrapper
+
+
+def assert_mutual_in(list_one, list_two):
+    """Compare two lists to each other to ensure that they contain the same elements. More robust than assert_equal
+    because the lists do not have to be in the same order.
+    :param list_one:
+    :param list_two:
+    :return: True if lists contain the same elements. False if not
+    """
+    assert_equal(len(list_one), len(list_two))
+    for item in list_one:
+        assert_in(item, list_two)


### PR DESCRIPTION
Purpose
-----------
Create a node serializer field that tells you what the current user's permissions are for that node. If the user is not logged in, the permissions are ["read"]. If they don't have read permissions, they won't be able to serialize the node.

Closes https://openscience.atlassian.net/browse/OSF-5546

Changes
------------
* New serializer field current_user_permissions
* Tests
* Test utility to compare two lists and ensure they are the same. There was an assertion that seemed similar, but the docstring suggested it only did length comparison.

Side effects
---------------
None