### PR TITLE
Let Failed Registration Drafts be deleted

### DIFF
--- a/scripts/populate_conferences.py
+++ b/scripts/populate_conferences.py
@@ -604,6 +604,16 @@ MEETING_DATA = {
         'poster': True,
         'talk': True,
     },
+    'Emergy2016': {
+        'name': '9th Biennial Emergy Research Conference',
+        'info_url': 'http://www.cep.ees.ufl.edu/emergy/conferences/ERC09_2016/index.shtml',
+        'logo_url': 'http://s12.postimg.org/uf9ioqmct/emergy.jpg',
+        'active': True,
+        'admins': [],
+        'public_projects': True,
+        'poster': True,
+        'talk': True,
+    },
 }
 
 

--- a/tests/test_conferences.py
+++ b/tests/test_conferences.py
@@ -419,24 +419,6 @@ class TestConferenceEmailViews(OsfTestCase):
         res = res.follow()
         assert_equal(res.request.path, '/meetings/')
 
-    def test_conference_submissions(self):
-        Node.remove()
-        conference1 = ConferenceFactory()
-        conference2 = ConferenceFactory()
-        # Create conference nodes
-        create_fake_conference_nodes(
-            3,
-            conference1.endpoint,
-        )
-        create_fake_conference_nodes(
-            2,
-            conference2.endpoint,
-        )
-
-        url = api_url_for('conference_submissions')
-        res = self.app.get(url)
-        assert_equal(len(res.json['submissions']), 5)
-
     def test_conference_plain_returns_200(self):
         conference = ConferenceFactory()
         url = web_url_for('conference_results__plain', meeting=conference.endpoint)

--- a/tests/test_registrations/test_views.py
+++ b/tests/test_registrations/test_views.py
@@ -530,3 +530,16 @@ class TestDraftRegistrationViews(RegistrationsTestBase):
             draft_views.check_draft_state(self.draft)
         except Exception:
             self.fail()
+
+    def test_check_draft_state_registered_and_deleted_and_approved(self):
+        reg = RegistrationFactory()
+        self.draft.registered_node = reg
+        self.draft.save()
+        reg.is_deleted = True
+        reg.save()
+
+        with mock.patch('website.project.model.DraftRegistration.is_approved', mock.PropertyMock(return_value=True)):
+            try:
+                draft_views.check_draft_state(self.draft)
+            except HTTPError:
+                self.fail()

--- a/tests/test_registrations/test_views.py
+++ b/tests/test_registrations/test_views.py
@@ -432,6 +432,19 @@ class TestDraftRegistrationViews(RegistrationsTestBase):
         res = self.app.delete(url, auth=self.user.auth, expect_errors=True)
         assert_equal(res.status_code, http.FORBIDDEN)
 
+    @mock.patch('website.archiver.tasks.archive')
+    def testn_delete_draft_registration_approved_and_registration_deleted(self, mock_register_draft):
+        self.draft.register(auth=self.auth, save=True)
+        self.draft.registered_node.is_deleted = True
+        self.draft.registered_node.save()
+
+        assert_equal(1, DraftRegistration.find().count())
+        url = self.node.api_url_for('delete_draft_registration', draft_id=self.draft._id)
+
+        res = self.app.delete(url, auth=self.user.auth)
+        assert_equal(res.status_code, http.NO_CONTENT)
+        assert_equal(0, DraftRegistration.find().count())
+
     def test_only_admin_can_delete_registration(self):
         non_admin = AuthUserFactory()
         assert_equal(1, DraftRegistration.find().count())

--- a/website/conferences/views.py
+++ b/website/conferences/views.py
@@ -14,7 +14,7 @@ from framework.transactions.context import TokuTransaction
 from framework.transactions.handlers import no_auto_transaction
 
 from website import settings
-from website.models import Node, Tag
+from website.models import Node
 from website.util import web_url_for
 from website.mails import send_mail
 from website.files.models import StoredFileNode
@@ -221,37 +221,6 @@ def conference_results(meeting):
         # Needed in order to use base.mako namespace
         'settings': settings,
     }
-
-def conference_submissions(**kwargs):
-    """Return data for all OSF4M submissions.
-
-    The total number of submissions for each meeting is calculated and cached
-    in the Conference.num_submissions field.
-    """
-    submissions = []
-    for conf in Conference.find():
-        # For efficiency, we filter by tag first, then node
-        # instead of doing a single Node query
-        projects = set()
-        for tag in Tag.find(Q('_id', 'iexact', conf.endpoint)):
-            for node in tag.node__tagged:
-                if not node:
-                    continue
-                if not node.is_public or node.is_deleted:
-                    continue
-                projects.add(node)
-
-        for idx, node in enumerate(projects):
-            submissions.append(_render_conference_node(node, idx, conf))
-        num_submissions = len(projects)
-        # Cache the number of submissions
-        conf.num_submissions = num_submissions
-        conf.save()
-        if num_submissions < settings.CONFERENCE_MIN_COUNT:
-            continue
-    submissions.sort(key=lambda submission: submission['dateCreated'], reverse=True)
-
-    return {'submissions': submissions}
 
 def conference_view(**kwargs):
     meetings = []

--- a/website/project/views/drafts.py
+++ b/website/project/views/drafts.py
@@ -88,17 +88,18 @@ def validate_registration_choice(registration_choice):
         )
 
 def check_draft_state(draft):
-    if draft.registered_node and not draft.registered_node.is_deleted:
+    registered_and_deleted = draft.registered_node and draft.registered_node.is_deleted
+    if draft.registered_node and not registered_and_deleted:
         raise HTTPError(http.FORBIDDEN, data={
             'message_short': 'This draft has already been registered',
             'message_long': 'This draft has already been registered and cannot be modified.'
         })
-    elif draft.is_pending_review:
+    if draft.is_pending_review:
         raise HTTPError(http.FORBIDDEN, data={
             'message_short': 'This draft is pending review',
             'message_long': 'This draft is pending review and cannot be modified.'
         })
-    elif draft.requires_approval and draft.is_approved:
+    if draft.requires_approval and draft.is_approved and (not registered_and_deleted):
         raise HTTPError(http.FORBIDDEN, data={
             'message_short': 'This draft has already been approved',
             'message_long': 'This draft has already been approved and cannot be modified.'

--- a/website/project/views/drafts.py
+++ b/website/project/views/drafts.py
@@ -310,7 +310,7 @@ def delete_draft_registration(auth, node, draft, *args, **kwargs):
     :return: None
     :rtype: NoneType
     """
-    if draft.registered_node:
+    if draft.registered_node and not draft.registered_node.is_deleted:
         raise HTTPError(
             http.FORBIDDEN,
             data={

--- a/website/routes.py
+++ b/website/routes.py
@@ -214,13 +214,6 @@ def make_url_map(app):
         ),
 
         Rule(
-            '/api/v1/meetings/submissions/',
-            'get',
-            conference_views.conference_submissions,
-            json_renderer,
-        ),
-
-        Rule(
             '/presentations/',
             'get',
             conference_views.redirect_to_meetings,

--- a/website/static/js/osfLanguage.js
+++ b/website/static/js/osfLanguage.js
@@ -20,6 +20,7 @@ module.exports = {
         beforeEditIsApproved: 'This draft registration is currently approved. Please note that if you make any changes (excluding comments) this approval status will be revoked and you will need to submit for approval again.',
         beforeEditIsPendingReview: 'This draft registration is currently pending review. Please note that if you make any changes (excluding comments) this request will be cancelled and you will need to submit for approval again.',
         loadDraftsFail: 'There was a problem loading draft registrations at this time. ' + REFRESH_OR_SUPPORT,
+        deleteDraftFail: 'There was a problem deleting this draft. ' + REFRESH_OR_SUPPORT,
         loadMetaSchemaFail: 'There was a problem loading registration templates at this time. ' + REFRESH_OR_SUPPORT
     },
     Addons: {

--- a/website/static/js/pages/meetings-page.js
+++ b/website/static/js/pages/meetings-page.js
@@ -1,14 +1,4 @@
 var $ = require('jquery');
 var Meetings = require('../meetings.js');
-var Submissions = require('../submissions.js');
 
 new Meetings(window.contextVars.meetings);
-
-var request = $.getJSON('/api/v1/meetings/submissions/');
-
-request.always(function() {
-    $('#allMeetingsLoader').hide();
-});
-request.done(function(data) {
-    new Submissions(data.submissions);
-});

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -1318,6 +1318,7 @@ RegistrationManager.prototype.init = function() {
 RegistrationManager.prototype.deleteDraft = function(draft) {
     var self = this;
 
+    var url = self.urls.delete.replace('{draft_pk}', draft.pk);
     bootbox.dialog({
         title: 'Please confirm',
         message: 'Are you sure you want to delete this draft registration?',
@@ -1332,12 +1333,19 @@ RegistrationManager.prototype.deleteDraft = function(draft) {
                 className: 'btn-danger',
                 callback: function() {
                     $.ajax({
-                        url: self.urls.delete.replace('{draft_pk}', draft.pk),
+                        url: url,
                         method: 'DELETE'
                     }).then(function() {
                         self.drafts.remove(function(item) {
                             return item.pk === draft.pk;
                         });
+                    }).fail(function(xhr, status, err) {
+                        Raven.captureMessage('Could not submit draft registration', {
+                            url: url,
+                            textStatus: status,
+                            error: err
+                        });
+                        $osf.growl('Error deleting draft', language.deleteDraftFail);
                     });
                 }
             }

--- a/website/templates/public/pages/meeting_landing.mako
+++ b/website/templates/public/pages/meeting_landing.mako
@@ -77,38 +77,12 @@
     <div class="container grey-background">
         <div class="row m-v-lg">
             <div class="col-md-12">
-                <div role="tabpanel">
-                    <!-- Nav tabs -->
-                    <ul class="nav nav-tabs m-b-md" role="tablist">
-                        <li role="presentation" class="active">
-                            <a href="#meetings" aria-controls="meetings" role="tab" data-toggle="tab">All meetings</a>
-                        </li>
-                        <li role="presentation">
-                            <a href="#submissions" aria-controls="submissions" role="tab" data-toggle="tab">All submissions</a>
-                        </li>
-                    </ul>
-                    <!-- Tab panes -->
-                    <div class="tab-content">
-                        <div role="tabpanel" class="tab-pane active" id="meetings">
-                            <p>
-                                <small>Only conferences with at least five submissions are displayed.</small>
-                            </p>
-                            <div id="meetings-grid"></div>
-                        </div>
-                        <div role="tabpanel" class="tab-pane" id="submissions">
-
-                            <div id="submissions-grid">
-                                <div id="allMeetingsLoader" class="spinner-loading-wrapper">
-                                    <div class="logo-spin logo-lg"></div>
-                                    <p class="m-t-sm fg-load-message"> Loading submissions...</p>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
-            </div>
-        </div>
+                <p>
+                    <small>Only conferences with at least five submissions are displayed.</small>
+                </p>
+                <div id="meetings-grid"></div>
+            </div><!-- end col-md-->
+        </div><!-- end row -->
 
         <div class="row icon-bar m-v-lg">
             <div class="col-md-4 col-sm-4 text-center ">


### PR DESCRIPTION
See: https://openscience.atlassian.net/browse/OSF-5520

# Purpose

Drafts with failed or rejected registrations could not be deleted. The server was giving a 403 response and the JS failed silently.

# Changes

- Let drafts with failed or rejected registrations be deleted
- Add unit test for this behavior
- Add .fail handler to deleteDraft JS call