### PR TITLE
Let Failed Registration Drafts be deleted

### DIFF
--- a/tests/test_registrations/test_views.py
+++ b/tests/test_registrations/test_views.py
@@ -432,6 +432,19 @@ class TestDraftRegistrationViews(RegistrationsTestBase):
         res = self.app.delete(url, auth=self.user.auth, expect_errors=True)
         assert_equal(res.status_code, http.FORBIDDEN)
 
+    @mock.patch('website.archiver.tasks.archive')
+    def testn_delete_draft_registration_approved_and_registration_deleted(self, mock_register_draft):
+        self.draft.register(auth=self.auth, save=True)
+        self.draft.registered_node.is_deleted = True
+        self.draft.registered_node.save()
+
+        assert_equal(1, DraftRegistration.find().count())
+        url = self.node.api_url_for('delete_draft_registration', draft_id=self.draft._id)
+
+        res = self.app.delete(url, auth=self.user.auth)
+        assert_equal(res.status_code, http.NO_CONTENT)
+        assert_equal(0, DraftRegistration.find().count())
+
     def test_only_admin_can_delete_registration(self):
         non_admin = AuthUserFactory()
         assert_equal(1, DraftRegistration.find().count())

--- a/website/project/views/drafts.py
+++ b/website/project/views/drafts.py
@@ -310,7 +310,7 @@ def delete_draft_registration(auth, node, draft, *args, **kwargs):
     :return: None
     :rtype: NoneType
     """
-    if draft.registered_node:
+    if draft.registered_node and not draft.registered_node.is_deleted:
         raise HTTPError(
             http.FORBIDDEN,
             data={

--- a/website/static/js/osfLanguage.js
+++ b/website/static/js/osfLanguage.js
@@ -20,6 +20,7 @@ module.exports = {
         beforeEditIsApproved: 'This draft registration is currently approved. Please note that if you make any changes (excluding comments) this approval status will be revoked and you will need to submit for approval again.',
         beforeEditIsPendingReview: 'This draft registration is currently pending review. Please note that if you make any changes (excluding comments) this request will be cancelled and you will need to submit for approval again.',
         loadDraftsFail: 'There was a problem loading draft registrations at this time. ' + REFRESH_OR_SUPPORT,
+        deleteDraftFail: 'There was a problem deleting this draft. ' + REFRESH_OR_SUPPORT,
         loadMetaSchemaFail: 'There was a problem loading registration templates at this time. ' + REFRESH_OR_SUPPORT
     },
     Addons: {

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -1318,6 +1318,7 @@ RegistrationManager.prototype.init = function() {
 RegistrationManager.prototype.deleteDraft = function(draft) {
     var self = this;
 
+    var url = self.urls.delete.replace('{draft_pk}', draft.pk);
     bootbox.dialog({
         title: 'Please confirm',
         message: 'Are you sure you want to delete this draft registration?',
@@ -1332,12 +1333,19 @@ RegistrationManager.prototype.deleteDraft = function(draft) {
                 className: 'btn-danger',
                 callback: function() {
                     $.ajax({
-                        url: self.urls.delete.replace('{draft_pk}', draft.pk),
+                        url: url,
                         method: 'DELETE'
                     }).then(function() {
                         self.drafts.remove(function(item) {
                             return item.pk === draft.pk;
                         });
+                    }).fail(function(xhr, status, err) {
+                        Raven.captureMessage('Could not submit draft registration', {
+                            url: url,
+                            textStatus: status,
+                            error: err
+                        });
+                        $osf.growl('Error deleting draft', language.deleteDraftFail);
                     });
                 }
             }


### PR DESCRIPTION
See: https://openscience.atlassian.net/browse/OSF-5520

# Purpose

Drafts with failed or rejected registrations could not be deleted. The server was giving a 403 response and the JS failed silently.

# Changes

- Let drafts with failed or rejected registrations be deleted
- Add unit test for this behavior
- Add .fail handler to deleteDraft JS call