### PR TITLE
Fix Prereg "Unseen comments"

### DIFF
--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -77,7 +77,7 @@ function Comment(data) {
         }
     });
 
-    self.seenBy = ko.observableArray([self.user.id]);
+    self.seenBy = ko.observableArray(data.seenBy || [self.user.id]);
 
     /**
      * Returns true if the current user is the comment owner

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -140,7 +140,9 @@ Comment.prototype.delete = function(save) {
 Comment.prototype.viewComment = function(user) {
     if (this.seenBy.indexOf(user.id) === -1) {
         this.seenBy.push(user.id);
+        return true;
     }
+    return false;
 };
 
 /**
@@ -396,9 +398,11 @@ var Page = function(schemaPage, schemaData) {
 Page.prototype.viewComments = function() {
     var self = this;
     var comments = self.comments();
+    var viewed = false;
     $.each(comments, function(index, comment) {
-        comment.viewComment($osf.currentUser());
+        viewed = comment.viewComment($osf.currentUser()) || viewed;
     });
+    return viewed;
 };
 Page.prototype.getUnseenComments = function() {
     var self = this;
@@ -800,7 +804,9 @@ var RegistrationEditor = function(urls, editorId, preview) {
         page.comments.subscribe(function() {
             self.dirtyCount(self.dirtyCount() + 1);
         });
-        page.viewComments();
+        if(page.viewComments()) {
+            self.save();
+        }
     });
 
     self.hasValidationInfo = ko.computed(function() {


### PR DESCRIPTION
# Purpose

see: https://openscience.atlassian.net/browse/OSF-5506

The "Unseen comments" badge on the Draft Registration list was not going away, even when a user viewed the comments. 

![screen shot 2016-01-13 at 4 47 02 pm](https://cloud.githubusercontent.com/assets/2207561/12308809/4fa485c0-ba15-11e5-9273-8a8857e94847.png)

# Changes

- Actually use the saved comment data to populate Comment.seenBy
- When viewing the comments on a given page, save the drafts if some previously unseen comments are seen.