### PR TITLE
Update comments on file move

### DIFF
--- a/website/addons/osfstorage/tests/test_models.py
+++ b/website/addons/osfstorage/tests/test_models.py
@@ -4,7 +4,6 @@ import mock
 import unittest
 from nose.tools import *  # noqa
 
-from tests.base import capture_signals
 from tests.factories import ProjectFactory, NodeFactory, CommentFactory
 
 from website.addons.osfstorage.tests import factories
@@ -19,7 +18,6 @@ from website.files import models
 from website.addons.osfstorage import utils
 from website.addons.osfstorage import settings
 from website.files.exceptions import FileNodeCheckedOutError
-from website.project.signals import file_moved_node
 
 
 class TestOsfstorageFileNode(StorageTestCase):
@@ -284,27 +282,6 @@ class TestOsfstorageFileNode(StorageTestCase):
 
         assert_equal(to_move, moved)
         assert_equal(moved.parent, move_to)
-
-    def test_move_between_nodes_sends_file_moved_node_signal(self):
-        to_move = self.node_settings.get_root().append_file('file_to_move')
-        component = NodeFactory(parent=self.node)
-        component_settings = component.get_addon('osfstorage')
-        with capture_signals() as mock_signals:
-            moved = to_move.move_under(component_settings.get_root())
-        assert_equal(mock_signals.signals_sent(), set([file_moved_node]))
-
-    def test_comments_move_when_file_moved_to_component(self):
-        to_move = self.node_settings.get_root().append_file('file_to_move')
-        comment = CommentFactory(node=self.node, target=to_move)
-
-        component = NodeFactory(parent=self.node)
-        component_settings = component.get_addon('osfstorage')
-        moved = to_move.move_under(component_settings.get_root())
-        comment.reload()
-
-        assert_equal(to_move, moved)
-        assert_equal(to_move.node, moved.node)
-        assert_equal(comment.node, moved.node)
 
     def test_move_and_rename(self):
         to_move = self.node_settings.get_root().append_file('Carp')

--- a/website/files/models/base.py
+++ b/website/files/models/base.py
@@ -21,7 +21,6 @@ from framework.analytics import get_basic_counters
 from website import util
 from website.files import utils
 from website.files import exceptions
-from website.project import signals as project_signals
 
 
 __all__ = (
@@ -399,8 +398,6 @@ class FileNode(object):
 
     def move_under(self, destination_parent, name=None):
         self.name = name or self.name
-        if self.parent.node != destination_parent.node:
-            project_signals.file_moved_node.send(self, destination_node=destination_parent.node)
         self.parent = destination_parent.stored_object
         self._update_node(save=True)  # Trust _update_node to save us
 

--- a/website/project/signals.py
+++ b/website/project/signals.py
@@ -12,5 +12,3 @@ after_create_registration = signals.signal('post-create-registration')
 archive_callback = signals.signal('archive-callback')
 
 privacy_set_public = signals.signal('privacy_set_public')
-
-file_moved_node = signals.signal('file-moved-node')

--- a/website/project/views/comment.py
+++ b/website/project/views/comment.py
@@ -1,17 +1,53 @@
 # -*- coding: utf-8 -*-
 import pytz
+from datetime import datetime
 from flask import request
 from modularodm import Q
+from modularodm.exceptions import NoResultsFound
 
 from framework.auth.decorators import must_be_logged_in
+from framework.tasks import app
 
+from website.files.models import FileNode, TrashedFileNode
 from website.notifications.constants import PROVIDERS
 from website.notifications.emails import notify
 from website.models import Comment
-from website.project.decorators import must_be_contributor_or_public
+from website.project.decorators import must_be_contributor_or_public, must_have_permission
+from website.project.model import Node
 from website.project.signals import comment_added, file_moved_node
-from datetime import datetime
+from website import settings
 
+
+@app.task
+@must_be_logged_in
+@must_have_permission('write')
+def update_comment_root_target_file(auth, **kwargs):
+    data = request.get_json()
+    source = data.get('source')
+    destination = data.get('destination')
+    node = Node.load(source.get('nodeId'))
+    destination_node = Node.load(destination.get('nodeId'))
+
+    if source.get('provider') == 'osfstorage':
+        try:
+            old_file = TrashedFileNode.find_one(Q('provider', 'eq', source.get('provider')) &
+                                                Q('node', 'eq', node) &
+                                                Q('path', 'eq', source.get('path')))
+        except NoResultsFound:
+            old_file = FileNode.load(source.get('path').strip('/'))
+    else:
+        old_file = FileNode.resolve_class(source.get('provider'), FileNode.FILE).get_or_create(node, source.get('path'))
+
+    new_file = FileNode.resolve_class(destination.get('provider'), FileNode.FILE).get_or_create(destination_node, destination.get('path'))
+    new_file.touch(
+        request.headers.get('Authorization'),
+        cookie=request.cookies.get(settings.COOKIE_NAME)
+    )
+    if node._id != destination_node._id:
+        Comment.update(Q('root_target', 'eq', old_file), data={'node': destination_node})
+
+    Comment.update(Q('root_target', 'eq', old_file), data={'root_target': new_file})
+    Comment.update(Q('target', 'eq', old_file), data={'target': new_file})
 
 @file_moved_node.connect
 def update_comment_node(file_obj, destination_node):

--- a/website/project/views/comment.py
+++ b/website/project/views/comment.py
@@ -14,7 +14,7 @@ from website.notifications.emails import notify
 from website.models import Comment
 from website.project.decorators import must_be_contributor_or_public, must_have_permission
 from website.project.model import Node
-from website.project.signals import comment_added, file_moved_node
+from website.project.signals import comment_added
 from website import settings
 
 
@@ -49,9 +49,6 @@ def update_comment_root_target_file(auth, **kwargs):
     Comment.update(Q('root_target', 'eq', old_file), data={'root_target': new_file})
     Comment.update(Q('target', 'eq', old_file), data={'target': new_file})
 
-@file_moved_node.connect
-def update_comment_node(file_obj, destination_node):
-    Comment.update(Q('root_target', 'eq', file_obj._id), data={'node': destination_node})
 
 @comment_added.connect
 def send_comment_added_notification(comment, auth):

--- a/website/project/views/comment.py
+++ b/website/project/views/comment.py
@@ -44,10 +44,10 @@ def update_comment_root_target_file(auth, **kwargs):
         cookie=request.cookies.get(settings.COOKIE_NAME)
     )
     if node._id != destination_node._id:
-        Comment.update(Q('root_target', 'eq', old_file), data={'node': destination_node})
+        Comment.update(Q('root_target', 'eq', old_file._id), data={'node': destination_node})
 
-    Comment.update(Q('root_target', 'eq', old_file), data={'root_target': new_file})
-    Comment.update(Q('target', 'eq', old_file), data={'target': new_file})
+    Comment.update(Q('root_target', 'eq', old_file._id), data={'root_target': new_file})
+    Comment.update(Q('target', 'eq', old_file._id), data={'target': new_file})
 
 
 @comment_added.connect

--- a/website/routes.py
+++ b/website/routes.py
@@ -328,6 +328,16 @@ def make_url_map(app):
 
         Rule(
             [
+                '/project/<pid>/comments/update/',
+                '/project/<pid>/node/<nid>/comments/update/',
+            ],
+            'put',
+            project_views.comment.update_comment_root_target_file,
+            json_renderer,
+        ),
+
+        Rule(
+            [
                 '/project/<pid>/citation/',
                 '/project/<pid>/node/<nid>/citation/',
             ],

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -295,6 +295,7 @@ CELERY_IMPORTS = (
     'website.notifications.tasks',
     'website.archiver.tasks',
     'website.search.search',
+    'website.project.views.comment'
 )
 
 # celery.schedule will not be installed when running invoke requirements the first time.

--- a/website/signals.py
+++ b/website/signals.py
@@ -19,5 +19,4 @@ ALL_SIGNALS = [
     auth.unconfirmed_user_created,
     event.file_updated,
     conference.osf4m_user_created,
-    project.file_moved_node
 ]

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -407,6 +407,8 @@ function doItemOp(operation, to, from, rename, conflict) {
     var tb = this;
     tb.modal.dismiss();
     var ogParent = from.parentID;
+    var source = from.data;
+
     if (to.id === ogParent && (!rename || rename === from.data.name)){
       return;
     }
@@ -479,6 +481,11 @@ function doItemOp(operation, to, from, rename, conflict) {
         }
         // no need to redraw because fangornOrderFolder does it
         orderFolder.call(tb, from.parent());
+
+        if (operation === OPERATIONS.MOVE) {
+            updateCommentsOnMove(from.data.nodeApiUrl, source, resp);
+        }
+
     }).fail(function(xhr, textStatus) {
         if (to.data.provider === from.provider) {
             tb.pendingFileOps.pop();
@@ -517,6 +524,19 @@ function doItemOp(operation, to, from, rename, conflict) {
         orderFolder.call(tb, from.parent());
     });
 }
+
+function updateCommentsOnMove(nodeApiUrl, source, destination) {
+    var url = nodeApiUrl + 'comments/update/';
+    var request = $osf.putJSON(
+        url,
+        {
+            'source': source,
+            'destination': destination
+        }
+    );
+    return request;
+}
+
 
 /**
  * Find out what the upload URL is for each item


### PR DESCRIPTION
When files move within or between external providers and/or between nodes, update the file comments so that they move with the file. Comments do not move when a file gets copied. 