### PR TITLE
Do not show contributor gravatar when commenting with anonymous link

### DIFF
--- a/website/static/js/comment.js
+++ b/website/static/js/comment.js
@@ -282,23 +282,21 @@ var CommentModel = function(data, $parent, $root) {
     self.canEdit = ko.observable(data.attributes.can_edit);
     self.hasChildren = ko.observable(data.attributes.has_children);
 
-    if ('embeds' in data && 'user' in data.embeds) {
+    if (window.contextVars.node.anonymous) {
+        self.author = {
+            'id': null,
+            'url': '',
+            'fullname': 'A User',
+            'gravatarUrl': ''
+        };
+    } else if ('embeds' in data && 'user' in data.embeds) {
         var userData = data.embeds.user.data;
-        if (userData.id !== '') {
-            self.author = {
-                'id': userData.id,
-                'url': userData.links.html,
-                'fullname': userData.attributes.full_name,
-                'gravatarUrl': userData.links.profile_image
-            };
-        } else {
-            self.author = {
-                'id': null,
-                'url': '',
-                'fullname': 'A User',
-                'gravatarUrl': ''
-            };
-        }
+        self.author = {
+            'id': userData.id,
+            'url': userData.links.html,
+            'fullname': userData.attributes.full_name,
+            'gravatarUrl': userData.links.profile_image
+        };
     } else {
         self.author = self.$root.author;
     }


### PR DESCRIPTION
Purpose
-----------
Addresses the issue reported in https://openscience.atlassian.net/browse/OSF-23. 

If a user is logged in and is viewing a project that they are a contributor on using an anonymous VOL, all of the commenters are anonymized. But when the user comments, their name and gravatar appear until refreshing the page.

Changes
-----------
If a contributor is logged in and is viewing his own project through an anonymous VOL, if the user leaves a comment, anonymize their name and do not show their gravatar.