### PR TITLE
[hotfix] Fix approval/disapproval links for component admins

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -247,7 +247,7 @@ class RegistrationFactory(AbstractNodeFactory):
             else:
                 reg.require_approval(reg.creator)
             reg.save()
-            reg.sanction.add_authorizer(reg.creator)
+            reg.sanction.add_authorizer(reg.creator, reg)
             reg.sanction.save()
 
         if archive:

--- a/tests/test_registrations/test_embargoes.py
+++ b/tests/test_registrations/test_embargoes.py
@@ -640,7 +640,7 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
         assert_true(self.registration.is_pending_embargo)
         assert_equal(res.status_code, 400)
 
-    def test_GET_disapprove_with_valid_token_returns_redirect_to_parent(self):
+    def test_GET_disapprove_with_valid(self):
         project = ProjectFactory(creator=self.user)
         registration = RegistrationFactory(project=project)
         registration.embargo_registration(
@@ -651,18 +651,18 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
         assert_true(registration.is_pending_embargo)
 
         rejection_token = registration.embargo.approval_state[self.user._id]['rejection_token']
+
         res = self.app.get(
-            registration.web_url_for('view_project', token=rejection_token),
+            registration.registered_from.web_url_for('view_project', token=rejection_token),
             auth=self.user.auth,
         )
         registration.embargo.reload()
         assert_equal(registration.embargo.state, Embargo.REJECTED)
         assert_false(registration.is_pending_embargo)
-        assert_equal(res.status_code, 302)
-        assert_true(project._id in res.location)
+        assert_equal(res.status_code, 200)
+        assert_equal(project.web_url_for('view_project'), res.request.path)
 
-    @mock.patch('flask.redirect')
-    def test_GET_disapprove_for_existing_registration_with_valid_token_redirects_to_registration(self, mock_redirect):
+    def test_GET_disapprove_for_existing_registration_returns_200(self):
         self.registration.embargo_registration(
             self.user,
             datetime.datetime.utcnow() + datetime.timedelta(days=10),
@@ -679,7 +679,8 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
         self.registration.embargo.reload()
         assert_equal(self.registration.embargo.state, Embargo.REJECTED)
         assert_false(self.registration.is_pending_embargo)
-        assert_true(mock_redirect.called_with(self.registration.web_url_for('view_project')))
+        assert_equal(res.status_code, 200)
+        assert_equal(res.request.path, self.registration.web_url_for('view_project'))
 
 
 class RegistrationEmbargoViewsTestCase(OsfTestCase):

--- a/tests/test_registrations/test_registration_approvals.py
+++ b/tests/test_registrations/test_registration_approvals.py
@@ -69,7 +69,9 @@ class RegistrationApprovalModelTestCase(OsfTestCase):
 
         grandchild = NodeFactory(creator=grandchild_admin, parent=child)  # noqa
 
-        approval = project._initiate_approval(project.creator)
+        registration = RegistrationFactory(project=project)
+
+        approval = registration._initiate_approval(registration.creator)
         assert_in(project_admin._id, approval.approval_state)
         assert_in(child_admin._id, approval.approval_state)
         assert_in(grandchild_admin._id, approval.approval_state)

--- a/website/archiver/tasks.py
+++ b/website/archiver/tasks.py
@@ -386,4 +386,6 @@ def archive_success(dst_pk, job_pk):
     job = ArchiveJob.load(job_pk)
     job.sent = True
     job.save()
-    dst.sanction.ask(dst.active_contributors())
+    admins = [user for (user, _) in
+              dst.get_admin_contributors_recursive()]
+    dst.sanction.ask(admins)

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -375,7 +375,6 @@ def configure_comments(node, **kwargs):
 @must_be_contributor_or_public
 @process_token_or_pass
 def view_project(auth, node, **kwargs):
-
     primary = '/api/v1' not in request.path
     ret = _view_project(node, auth, primary=primary)
 

--- a/website/project/views/register.py
+++ b/website/project/views/register.py
@@ -104,7 +104,9 @@ def node_registration_retraction_post(auth, node, **kwargs):
     try:
         node.retract_registration(auth.user, data.get('justification', None))
         node.save()
-        node.retraction.ask(node.active_contributors())
+        admins = [user for (user, _) in
+                  node.get_admin_contributors_recursive()]
+        node.retraction.ask(admins)
     except NodeStateError as err:
         raise HTTPError(http.FORBIDDEN, data=dict(message_long=err.message))
 

--- a/website/tokens/__init__.py
+++ b/website/tokens/__init__.py
@@ -68,7 +68,7 @@ def process_token_or_pass(func):
         if encoded_token:
             handler = TokenHandler.from_string(encoded_token)
             try:
-                return handler.to_response()
+                res = handler.to_response()
             except TokenHandlerNotFound as e:
                 raise HTTPError(
                     http.BAD_REQUEST,
@@ -77,6 +77,8 @@ def process_token_or_pass(func):
                         'message_long': 'No token handler for action: {} found'.format(e.action)
                     }
                 )
+            if res:
+                return res
         return func(*args, **kwargs)
     return wrapper
 

--- a/website/tokens/handlers.py
+++ b/website/tokens/handlers.py
@@ -5,7 +5,6 @@ from modularodm import Q
 from framework.auth.decorators import must_be_logged_in
 from framework.exceptions import HTTPError, PermissionsError
 from framework import status
-from framework.flask import redirect
 
 from website.tokens.exceptions import UnsupportedSanctionHandlerKind, TokenError
 
@@ -14,30 +13,24 @@ def registration_approval_handler(action, registration, registered_from):
         'approve': 'Your registration approval has been accepted.',
         'reject': 'Your disapproval has been accepted and the registration has been cancelled.',
     }[action], kind='success', trust=False)
-    if action == 'approve':
-        return redirect(registration.web_url_for('view_project'))
-    else:
-        return redirect(registered_from.web_url_for('view_project'))
+    # Allow decorated view function to return response
+    return None
 
 def embargo_handler(action, registration, registered_from):
     status.push_status_message({
         'approve': 'Your embargo approval has been accepted.',
         'reject': 'Your disapproval has been accepted and the embargo has been cancelled.',
     }[action], kind='success', trust=False)
-    if action == 'approve':
-        return redirect(registration.web_url_for('view_project'))
-    else:
-        return redirect(registered_from.web_url_for('view_project'))
+    # Allow decorated view function to return response
+    return None
 
 def retraction_handler(action, registration, registered_from):
     status.push_status_message({
         'approve': 'Your retraction approval has been accepted.',
         'reject': 'Your disapproval has been accepted and the retraction has been cancelled.'
     }[action], kind='success', trust=False)
-    if action == 'approve':
-        return redirect(registered_from.web_url_for('view_project'))
-    elif action == 'reject':
-        return redirect(registration.web_url_for('view_project'))
+    # Allow decorated view function to return response
+    return None
 
 @must_be_logged_in
 def sanction_handler(kind, action, payload, encoded_token, auth, **kwargs):


### PR DESCRIPTION
- Approval links go to registered node
- Disapproval links go to original node
- Allow registered components to be made public when initiator
doesn't have access to private components (as long as component
    admins approve)

paired with @samchrisinger