### PR TITLE
Point registration logs to registrations collection

### DIFF
--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -72,13 +72,18 @@ class RegistrationSerializer(NodeSerializer):
     )))
 
     parent = HideIfRetraction(RelationshipField(
-        related_view='nodes:node-detail',
+        related_view='registrations:registration-detail',
         related_view_kwargs={'node_id': '<parent_id>'}
     ))
 
     logs = HideIfRetraction(RelationshipField(
-        related_view='nodes:node-logs',
+        related_view='registrations:registration-logs',
         related_view_kwargs={'node_id': '<pk>'},
+    ))
+
+    root = HideIfRetraction(RelationshipField(
+        related_view='registrations:registration-detail',
+        related_view_kwargs={'node_id': '<root._id>'}
     ))
 
     # TODO: Finish me

--- a/api/registrations/urls.py
+++ b/api/registrations/urls.py
@@ -19,6 +19,7 @@ urlpatterns = [
     url(r'^(?P<node_id>\w+)/citations/$', views.RegistrationAlternativeCitationsList.as_view(), name=views.RegistrationAlternativeCitationsList.view_name),
     url(r'^(?P<node_id>\w+)/citations/(?P<citation_id>\w+)/$', views.RegistrationAlternativeCitationDetail.as_view(), name=views.RegistrationAlternativeCitationDetail.view_name),
     url(r'^(?P<node_id>\w+)/comments/$', views.RegistrationCommentsList.as_view(), name=views.RegistrationCommentsList.view_name),
+    url(r'^(?P<node_id>\w+)/logs/$', views.RegistrationLogList.as_view(), name=views.RegistrationLogList.view_name),
 ]
 
 # Routes only active in local/staging environments

--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -17,7 +17,7 @@ from api.nodes.views import (
     NodeMixin, ODMFilterMixin, NodeContributorsList, NodeRegistrationsList,
     NodeChildrenList, NodeCommentsList, NodeProvidersList, NodeLinksList,
     NodeContributorDetail, NodeFilesList, NodeLinksDetail, NodeFileDetail,
-    NodeAlternativeCitationsList, NodeAlternativeCitationDetail)
+    NodeAlternativeCitationsList, NodeAlternativeCitationDetail, NodeLogList)
 
 from api.registrations.serializers import RegistrationNodeLinksSerializer
 
@@ -257,6 +257,11 @@ class RegistrationChildrenList(NodeChildrenList, RegistrationMixin):
 class RegistrationCommentsList(NodeCommentsList, RegistrationMixin):
     view_category = 'registrations'
     view_name = 'registration-comments'
+
+
+class RegistrationLogList(NodeLogList, RegistrationMixin):
+    view_category = 'registrations'
+    view_name = 'registration-logs'
 
 
 class RegistrationProvidersList(NodeProvidersList, RegistrationMixin):

--- a/api_tests/nodes/serializers/test_serializers.py
+++ b/api_tests/nodes/serializers/test_serializers.py
@@ -79,6 +79,10 @@ class TestNodeRegistrationSerializer(DbTestCase):
         data = result['data']
         assert_equal(data['id'], reg._id)
         assert_equal(data['type'], 'registrations')
+        should_not_relate_to_registrations = [
+            'registered_from',
+            'registered_by'
+        ]
 
         # Attributes
         attributes = data['attributes']
@@ -90,6 +94,9 @@ class TestNodeRegistrationSerializer(DbTestCase):
 
         # Relationships
         relationships = data['relationships']
+        relationship_urls = {}
+        for relationship in relationships:
+            relationship_urls[relationship]=relationships[relationship]['links']['related']['href']
         assert_in('registered_by', relationships)
         registered_by = relationships['registered_by']['links']['related']['href']
         assert_equal(
@@ -102,3 +109,9 @@ class TestNodeRegistrationSerializer(DbTestCase):
             urlparse(registered_from).path,
             '/{}nodes/{}/'.format(API_BASE, reg.registered_from._id)
         )
+        for relationship in relationship_urls:
+            if relationship in should_not_relate_to_registrations:
+                assert_not_in('/{}registrations/'.format(API_BASE), relationship_urls[relationship])
+            else:
+                assert_in('/{}registrations/'.format(API_BASE), relationship_urls[relationship],
+                          'For key {}'.format(relationship))


### PR DESCRIPTION
Purpose
-----------
Fix registrations api v2 endpoint so new relationships point to registrations rather than nodes. This will make the new Dashboard work better.

Closes https://openscience.atlassian.net/browse/OSF-5556 

Changes
------------
* Point parent, logs, and root to their registrations urls instead of nodes urls
* Modify registration serializer test to try to catch these cases beforehand. The serializer test could stand to be upgraded to have a more complicated test registration, but it's a lot better than it was before. Currently it is a standalone registration, and something that is a child of a foked templated project would be better. Other variations would help as well. 

Side effects
----------------
None