### PR TITLE
Remove registrations from nodes dashboard

### DIFF
--- a/api/base/utils.py
+++ b/api/base/utils.py
@@ -119,3 +119,11 @@ def add_dev_only_items(items, dev_only_items):
     if website_settings.DEV_MODE:
         items.update(dev_only_items)
     return items
+
+
+def default_node_list_query():
+    return (
+            Q('is_deleted', 'ne', True) &
+            Q('is_collection', 'ne', True) &
+            Q('is_registration', 'ne', True)
+        )

--- a/api/base/utils.py
+++ b/api/base/utils.py
@@ -123,7 +123,7 @@ def add_dev_only_items(items, dev_only_items):
 
 def default_node_list_query():
     return (
-            Q('is_deleted', 'ne', True) &
-            Q('is_collection', 'ne', True) &
-            Q('is_registration', 'ne', True)
-        )
+        Q('is_deleted', 'ne', True) &
+        Q('is_collection', 'ne', True) &
+        Q('is_registration', 'ne', True)
+    )

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -401,6 +401,7 @@ def root(request, format=None):
     }
     if settings.DEV_MODE:
         return_val["links"]["collections"] = absolute_reverse('collections:collection-list')
+        return_val["links"]["registrations"] = absolute_reverse('registrations:registration-list')
 
     return Response(return_val)
 

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -46,6 +46,7 @@ from website.files.models import OsfStorageFileNode
 from website.models import Node, Pointer, Comment, NodeLog
 from framework.auth.core import User
 from website.util import waterbutler_api_url_for
+from api.base.utils import default_node_list_query
 
 
 class NodeMixin(object):
@@ -867,10 +868,7 @@ class NodeChildrenList(JSONAPIBaseView, bulk_views.ListBulkCreateJSONAPIView, No
 
     # overrides ODMFilterMixin
     def get_default_odm_query(self):
-        return (
-            Q('is_deleted', 'ne', True) &
-            Q('is_collection', 'ne', True)
-        )
+        return default_node_list_query()
 
     # overrides ListBulkCreateJSONAPIView
     def get_queryset(self):

--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -250,6 +250,20 @@ class RegistrationContributorDetail(NodeContributorDetail, RegistrationMixin):
 class RegistrationChildrenList(NodeChildrenList, RegistrationMixin):
     view_category = 'registrations'
     view_name = 'registration-children'
+    serializer_class = RegistrationSerializer
+
+    def get_default_odm_query(self):
+        base_query = (
+            Q('is_deleted', 'ne', True) &
+            Q('is_registration', 'eq', True)
+        )
+        user = self.request.user
+        permission_query = Q('is_public', 'eq', True)
+        if not user.is_anonymous():
+            permission_query = (permission_query | Q('contributors', 'icontains', user._id))
+
+        query = base_query & permission_query
+        return query
 
 
 class RegistrationCommentsList(NodeCommentsList, RegistrationMixin):

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -61,6 +61,11 @@ class UserSerializer(DoNotRelateWhenAnonymous, JSONAPISerializer):
         related_view_kwargs={'user_id': '<pk>'},
     )
 
+    registrations = DevOnly(RelationshipField(
+        related_view='users:user-registrations',
+        related_view_kwargs={'user_id': '<pk>'},
+    ))
+
     class Meta:
         type_ = 'users'
 


### PR DESCRIPTION
Purpose
-----------
Ensures that the `/v2/users/{user}/nodes/` and `/v2/users/{user}/registrations/`include only the appropriate node types, especially to ensure that the nodes endpoint doesn't include registrations.

Closes https://openscience.atlassian.net/browse/OSF-5555

Changes
------------
* Made a common location for a standard nodes request, so if 'what a node is' changes, it will be updated both in the node list and the users node list.
* Added a /registrations/ link to the base view
* Ensured that the registrations/children view actually returned proper information

Side effects
---------------
List views for nodes and node-like things will not include components that a user sees only because they are the administrator on the node. They will still have access to the node, but won't see them in the list. This will be fixed in https://openscience.atlassian.net/browse/OSF-5563 at some point.