### PR TITLE
Feature/api/remove registrations from nodes dashboard

### DIFF
--- a/api/collections/views.py
+++ b/api/collections/views.py
@@ -137,7 +137,7 @@ class CollectionList(JSONAPIBaseView, bulk_views.BulkUpdateJSONAPIView, bulk_vie
         user = self.request.user
         permission_query = Q('is_public', 'eq', True)
         if not user.is_anonymous():
-            permission_query = (Q('is_public', 'eq', True) | Q('contributors', 'icontains', user._id))
+            permission_query = (Q('is_public', 'eq', True) | Q('contributors', 'eq', user._id))
 
         query = base_query & permission_query
         return query

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -242,7 +242,7 @@ class NodeList(JSONAPIBaseView, bulk_views.BulkUpdateJSONAPIView, bulk_views.Bul
         user = self.request.user
         permission_query = Q('is_public', 'eq', True)
         if not user.is_anonymous():
-            permission_query = (permission_query | Q('contributors', 'icontains', user._id))
+            permission_query = (permission_query | Q('contributors', 'eq', user._id))
 
         query = base_query & permission_query
         return query

--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -129,7 +129,7 @@ class RegistrationList(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin):
         user = self.request.user
         permission_query = Q('is_public', 'eq', True)
         if not user.is_anonymous():
-            permission_query = (permission_query | Q('contributors', 'icontains', user._id))
+            permission_query = (permission_query | Q('contributors', 'eq', user._id))
 
         query = base_query & permission_query
         return query
@@ -260,7 +260,7 @@ class RegistrationChildrenList(NodeChildrenList, RegistrationMixin):
         user = self.request.user
         permission_query = Q('is_public', 'eq', True)
         if not user.is_anonymous():
-            permission_query = (permission_query | Q('contributors', 'icontains', user._id))
+            permission_query = (permission_query | Q('contributors', 'eq', user._id))
 
         query = base_query & permission_query
         return query

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -297,7 +297,7 @@ class UserNodes(JSONAPIBaseView, generics.ListAPIView, UserMixin, ODMFilterMixin
 
         permission_query = Q('is_public', 'eq', True)
         if not current_user.is_anonymous():
-            permission_query = (permission_query | Q('contributors', 'icontains', current_user._id))
+            permission_query = (permission_query | Q('contributors', 'eq', current_user._id))
         query = (query & permission_query)
         return query
 
@@ -399,10 +399,10 @@ class UserRegistrations(UserNodes):
             Q('is_collection', 'ne', True) &
             Q('is_deleted', 'ne', True) &
             Q('is_registration', 'eq', True) &
-            Q('contributors', 'icontains', user._id)
+            Q('contributors', 'eq', user._id)
         )
         permission_query = Q('is_public', 'eq', True)
         if not current_user.is_anonymous():
-            permission_query = (permission_query | Q('contributors', 'icontains', current_user._id))
+            permission_query = (permission_query | Q('contributors', 'eq', current_user._id))
         query = query & permission_query
         return query

--- a/website/project/__init__.py
+++ b/website/project/__init__.py
@@ -69,7 +69,7 @@ def new_bookmark_collection(user):
 
     """
     existing_bookmark_collection = Node.find(
-        Q('is_bookmark_collection', 'eq', True) & Q('contributors', 'icontains', user._id)
+        Q('is_bookmark_collection', 'eq', True) & Q('contributors', 'eq', user._id)
     )
 
     if existing_bookmark_collection.count() > 0:

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -1346,7 +1346,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
 
         if first_save and self.is_bookmark_collection:
             existing_bookmark_collections = Node.find(
-                Q('is_bookmark_collection', 'eq', True) & Q('contributors', 'icontains', self.creator._id)
+                Q('is_bookmark_collection', 'eq', True) & Q('contributors', 'eq', self.creator._id)
             )
             if existing_bookmark_collections.count() > 0:
                 raise NodeStateError("Only one bookmark collection allowed per user.")

--- a/website/views.py
+++ b/website/views.py
@@ -107,7 +107,7 @@ def index(auth):
 
 
 def find_bookmark_collection(user):
-    bookmark_collection = Node.find(Q('is_bookmark_collection', 'eq', True) & Q('contributors', 'icontains', user._id))
+    bookmark_collection = Node.find(Q('is_bookmark_collection', 'eq', True) & Q('contributors', 'eq', user._id))
 
     if bookmark_collection.count() == 0:
         new_bookmark_collection(user)


### PR DESCRIPTION
Purpose
-----------
Improve efficiency for queries for contributors. Response to Steve's code review from https://openscience.atlassian.net/browse/OSF-5555 / https://github.com/CenterForOpenScience/osf.io/pull/4906/

Changes
------------
Modify contributor queries across the site that use 'icontains' to instead use 'eq'

Side effects
----------------
If anyone to_upper()'s a user id, it's going to fail, but that would be ridiculous, so nobody should be doing that.