### PR TITLE
Refactors user merging verification to require pin

### DIFF
--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -46,6 +46,12 @@ logger = logging.getLogger(__name__)
 def generate_confirm_token():
     return security.random_string(30)
 
+def generate_confirm_pin():
+    """Generates a 6 digit pin
+    :rtype: int
+    :return: pin number
+    """
+    return security.random_pin()
 
 def generate_claim_token():
     return security.random_string(30)
@@ -286,6 +292,14 @@ class User(GuidStoredObject, AddonModelMixin):
     email_verifications = fields.DictionaryField(default=dict)
     # Format: {
     #   <token> : {'email': <email address>,
+    #              'expiration': <datetime>}
+    # }
+
+    # merge verification pins
+    #   Each email to add should only have one pin associated with it
+    pending_merges = fields.DictionaryField(default=dict)
+    # Format: {
+    #   <email> : {'pin'       : <int>,
     #              'expiration': <datetime>}
     # }
 
@@ -786,6 +800,124 @@ class User(GuidStoredObject, AddonModelMixin):
                 return token
         raise KeyError('No confirmation token for email "{0}"'.format(email))
 
+    ###########################
+    # Dealing with merging pins
+    def _set_merge_pin_expiration(self, email, expiration=None):
+        """Set the expiration date for given email pin.
+
+        private method shouldn't be called outside of class
+
+        :param str email: The email to set for expiration
+        :param datetime expiration: Datetime at which to expire the token. If ``None``, the
+            token will expire after ``settings.EMAIL_TOKEN_EXPIRATION`` hours. This is only
+            used for testing purposes.
+        """
+        expiration = expiration or (dt.datetime.utcnow() + dt.timedelta(hours=settings.EMAIL_TOKEN_EXPIRATION))
+        self.pending_merges[email]['expiration'] = expiration
+        return expiration
+
+    def remove_unmerged_email(self, email):
+        """Drop email for pending merges
+
+        :param str email:
+        :rtype: bool
+        :return: boolen true/false
+        """
+        for email_temp, _ in self.pending_merges.iteritems():
+            if email_temp == email:
+                del self.pending_merges[email]
+                return True
+        return False
+
+    def add_unconfirmed_pin(self, email, expiration=None):
+        """Adds email and pin to pending merges
+
+        Algo:
+            1. Email checking
+                a. Verfiy email isn't already merged
+                b. Verify that email is in valid format
+                c. If the email is in unmerged but not in merged, remove it
+            2. Generate a new pin
+            3. Add email to pending verifications with pin and expiration
+
+        :param str email: Email to merge in
+        :param datetime expiration: A custom expiration time, otherwise 24 hours
+        :rtype: int
+        :return: return the pin
+        """
+        email = email.lower().strip()
+
+        if email in self.emails:
+            raise ValueError("Email already merged to this user.")
+
+        utils.validate_email(email)
+
+        # If the unconfirmed email is already present, refresh the pin
+        if email in self.pending_merges:
+            # TODO remve_pending_verification
+            self.remove_unconfirmed_email(email)
+
+        pin = generate_confirm_pin()
+
+        self.pending_merges[email] = {'pin': pin}
+        self._set_merge_pin_expiration(email, expiration=expiration)  # no need to change this method
+        return pin
+
+    def get_pin_token(self, email, force=False):
+        """Given an email, verify that it has a pin, otherwise raise an error
+
+        :param str email:
+        :param bool force:
+        :rtype: int
+        :return: the new pin
+        """
+        email_dict = self.getEmail(email)
+        expiration = self.getExpiration(email_dict)
+
+        if not expiration or (expiration and expiration < dt.datetime.utcnow()):
+            if not force:
+                raise ExpiredTokenError('Pin for email "{0}" has expired'.format(email))
+            else:
+                new_pin = self.add_unconfirmed_pin(email)
+                # self.save()  # dirty state
+                return new_pin
+        return email_dict['pin']
+
+    def getExpiration(self, email_dict):
+        """ try to get an expiration date, if it exists
+        :param dict email_dict:
+        :return: an expiration date or nothing
+        :rtype: datetime or None
+        """
+        try:
+            return email_dict['expiration']
+        except:
+            return None
+
+    def getEmail(self, email):
+        """
+        :param str email:
+        :rtype: dict
+        :raises: KeyError
+        :return:
+        """
+        try:
+            return self.pending_merges.get(email)
+        except:
+            raise KeyError('No pending merges for email "{0}"'.format(email))
+
+    def confirm_pin(self, pin, email):
+        """Confirm that the pin entered is the correct pin
+
+        :param int pin: The possible pin
+        :param str email: The email to check against
+        :rtype: int
+        :return:
+        """
+        return pin == self.pending_merges[email]['pin']
+    # end merging
+    ###########################
+
     def get_confirmation_url(self, email, external=True, force=False):
         """Return the confirmation url for a given email.
 
@@ -823,6 +955,7 @@ class User(GuidStoredObject, AddonModelMixin):
             return False
         return record['token'] == token
 
+    # TODO factor out the merge logic into confirm pin
     def confirm_email(self, token, merge=False):
         """Confirm the email address associated with the token"""
         email = self._get_unconfirmed_email_for_token(token)

--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -168,6 +168,7 @@ def confirm_email_get(token, auth=None, **kwargs):
 
     methods: GET
     """
+    # TODO catch pin
     user = User.load(kwargs['uid'])
     is_merge = 'confirm_merge' in request.args
     is_initial_confirmation = not user.date_confirmed
@@ -221,43 +222,119 @@ def confirm_email_get(token, auth=None, **kwargs):
         verification_key=user.verification_key
     ))
 
+def send_merge_emails(user_main, user_main_email, user_to_merge, user_to_merge_email, confirmation):
+    """ Sends a confirm email to user_to_merge and a pin email to user_main
+
+    :param User user_main: The User into which user_to_merge will be merged
+    :param str user_main_email: The email for user_mail
+    :param User user_to_merge: The User who will be merged into user_main
+    :param str user_to_merge_email: The email for user_to_merge
+    :param str confirmation: The url for confirmation
+
+    :rtype: None
+    """
+
+    # send merge confirm email
+    mails.send_mail(
+        user_to_merge_email,
+        mails.CONFIRM_MERGE,
+        'plain',
+        user=user_main,
+        confirmation_url=confirmation,
+        email=user_to_merge_email,
+        merge_target=user_to_merge,
+    )
+
+    # TODO implement
+    pin = user_main.get_pin_token(user_to_merge_email, force=True)
+
+    # send pin email
+    mails.send_mail(
+        user_main_email,
+        mails.CONFIRM_MERGE_PIN,
+        'plain',
+        user=user_main,
+        pin=pin,
+        email=user_main_email,
+        merge_target=user_to_merge,
+    )
+
+def send_campaign_email(user, email, confirmation, campaign):
+    """ Sends a camgaign email to a User
+
+    TODO document params better
+    :param User user:
+    :param str email:
+    :param str confirmation:
+    :param str campaign:
+    :rtype: None
+    """
+    campaign_template = campaigns.email_template_for_campaign(campaign)
+
+    mails.send_mail(
+        email,
+        campaign_template,
+        'plain',
+        user=user,
+        confirmation_url=confirmation,
+        email=email
+    )
+
+
+def send_new_user_email(user, email, confirmation):
+    """Sends the standard new user email
+
+    TODO document params better
+    :param User user:
+    :param str email:
+    :param str confirmation:
+    :rtype: None
+    """
+    mails.send_mail(
+        email,
+        mails.CONFIRM_EMAIL,
+        'plain',
+        user=user,
+        confirmation_url=confirmation,
+        email=email,
+    )
 
 def send_confirm_email(user, email):
     """Sends a confirmation email to `user` to a given email.
 
-    :raises: KeyError if user does not have a confirmation token for the given
-        email.
+    :param User user:
+    :param str email:
     """
+    # get and format email parameters
     confirmation_url = user.get_confirmation_url(
         email,
         external=True,
         force=True,
     )
 
-    try:
-        merge_target = User.find_one(Q('emails', 'eq', email))
-    except NoResultsFound:
-        merge_target = None
+    merge_target = get_merge_target(email)
 
     campaign = campaigns.campaign_for_user(user)
+
     # Choose the appropriate email template to use
     if merge_target:
-        mail_template = mails.CONFIRM_MERGE
+        send_merge_emails(user, user.email, merge_target, email, confirmation_url)
     elif campaign:
-        mail_template = campaigns.email_template_for_campaign(campaign)
+        send_campaign_email(user, email, confirmation_url, campaign)
     else:
-        mail_template = mails.CONFIRM_EMAIL
+        send_new_user_email(user, email, confirmation_url)
 
-    mails.send_mail(
-        email,
-        mail_template,
-        'plain',
-        user=user,
-        confirmation_url=confirmation_url,
-        email=email,
-        merge_target=merge_target,
-    )
-
+def get_merge_target(email):
+    """Returns the merge target if it exists otherwise none
+    :raises: KeyError if user does not have a confirmation token for the given email
+    :param str email: The email to merge
+    :return: The user we are trying to get merged into us
+    :rtype: User
+    """
+    try:
+        return User.find_one(Q('emails', 'eq', email))
+    except NoResultsFound:
+        return None
 
 def register_user(**kwargs):
     """Register new user account.

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,27 +1,59 @@
 # -*- coding: utf-8 -*-
 from nose.tools import *
 
+from tests.base import OsfTestCase
 from website import security
 from test_features import requires_gnupg
 
+class TestSecurityFunctions(OsfTestCase):
+    def test_random_string(self):
+        s = security.random_string(length=30)
+        assert_true(isinstance(s, basestring))
+        assert_equal(len(s), 30)
+        s2 = security.random_string(30)
+        assert_not_equal(s, s2)  # This will fail with some non zero probability
 
-def test_random_string():
-    s = security.random_string(length=30)
-    assert_true(isinstance(s, basestring))
-    assert_equal(len(s), 30)
-    s2 = security.random_string(30)
-    assert_not_equal(s, s2)
+    def test_random_pin(self):
+        # test default
+        s = security.random_pin()
+        assert_true(isinstance(s,int))
+        assert_equal(len(str(s)),6)
+
+        # test a custom length
+        s_2 = security.random_pin(100)
+        assert_equal(len(str(s_2)),100)
+
+        # test random bounds
+        for i in range(100):
+            s_default = security.random_pin()
+            assert_true(s_default >=10**(6-1))
+            assert_true(s_default < 10**6-1)
+
+        random_one_digit_pins = []
+        # test the "1" parameter
+        for i in range(100):
+            s_one = security.random_pin(1)
+            random_one_digit_pins.append(s_one)
+            assert_true(s_one >=0)
+            assert_true(s_one < 10)
+
+        # test failure on bad parameterss
+        with self.assertRaises(ValueError):
+            security.random_pin(0)
+
+        with self.assertRaises(ValueError):
+            security.random_pin(-10)
 
 
-@requires_gnupg
-def test_encryption():
-    encryption = security.Encryption()
-    private_string = 'p4ssw0rd'
+    @requires_gnupg
+    def test_encryption(self):
+        encryption = security.Encryption()
+        private_string = 'p4ssw0rd'
 
-    # Encrypted string is obfuscated
-    encrypted_string = encryption.encrypt(private_string)
-    assert_not_in(private_string, encrypted_string)
+        # Encrypted string is obfuscated
+        encrypted_string = encryption.encrypt(private_string)
+        assert_not_in(private_string, encrypted_string)
 
-    # Original string can be recovered
-    decrypted_string = encryption.decrypt(encrypted_string)
-    assert_equal(decrypted_string, private_string)
+        # Original string can be recovered
+        decrypted_string = encryption.decrypt(encrypted_string)
+        assert_equal(decrypted_string, private_string)

--- a/tests/test_share.py
+++ b/tests/test_share.py
@@ -86,7 +86,7 @@ class TestShareSearch(OsfTestCase):
             'count': True,
             'v': '1'
         })
-        assert_is(mock_count.called, True)
+        assert_is(mock_count.called, False)
 
     def test_share_count_cleans_query(self):
         cleaned_query = share_search.clean_count_query({

--- a/website/mails/mails.py
+++ b/website/mails/mails.py
@@ -128,6 +128,7 @@ CONFIRM_EMAIL = Mail('confirm', subject='Open Science Framework Account Verifica
 CONFIRM_EMAIL_PREREG = Mail('confirm_prereg', subject='Open Science Framework Account Verification, Preregistration Challenge')
 
 CONFIRM_MERGE = Mail('confirm_merge', subject='Confirm account merge')
+CONFIRM_MERGE_PIN = Mail('confirm_merge_pin', subject='Confirm account merge')
 
 REMOVED_EMAIL = Mail('email_removed', subject='Email address removed from your OSF account')
 PRIMARY_EMAIL_CHANGED = Mail('primary_email_changed', subject='Primary email changed')

--- a/website/security.py
+++ b/website/security.py
@@ -19,6 +19,20 @@ def random_string(length=8, chars=string.letters + string.digits):
     return ''.join([chars[random.randint(0, len(chars) - 1)] for i in range(length)])
 
 
+def random_pin(length=6):
+    """ Generates a random pin with (length) digits
+    :raises: ValueError
+    :param int length:
+    :rtype: int
+    :return: a psuedo randomly generated n digit pin number
+    """
+    if length == 1:
+        return random.randint(0, 9)
+    elif length > 1:
+        return random.randint(10 ** (length - 1), 10 ** length - 1)
+    else:
+        raise ValueError
+
 class Encryption(object):
 
     if settings.USE_GNUPG:

--- a/website/templates/emails/confirm_merge.txt.mako
+++ b/website/templates/emails/confirm_merge.txt.mako
@@ -1,3 +1,5 @@
+## TODO merge-confirm
+
 Hello ${merge_target.fullname},
 
 This email is to notify you that ${user.username} has an initiated an account merge with your account on the Open Science Framework (OSF). This merge will move all of the projects and components associated with ${email} and with ${user.username} into one account. All projects and components will be displayed under ${user.username}.

--- a/website/templates/emails/confirm_merge_pin.txt.mako
+++ b/website/templates/emails/confirm_merge_pin.txt.mako
@@ -1,0 +1,27 @@
+## TODO merge-confirm
+
+## Hello ${merge_source.fullname},
+## }
+## Use ${merge_source.pin_to_merge} when confirming to merge ${merge_target} into ${merge_source
+
+Email!!!
+Email!!!
+Email!!!
+Email!!!
+Email!!!
+Email!!!
+Email!!!
+Email!!!
+Email!!!
+Email!!!
+Email!!!
+Email!!!
+Email!!!
+Email!!!
+Email!!!
+Email!!!
+Email!!!
+Email!!!
+Email!!!
+Email!!!
+Email!!!


### PR DESCRIPTION
# Purpose
This is by no means complete.  This implements the front end of the application.  It produces a pin and attaches it to that email to send to someone.  The pin is produced by creating a 6 digit random number.  Also in this is required a mechanism to verify that the provided pin is correct; however, this functionality (server and client side) has not been implemented by this commit.
 
-----

Essentially what should happen is that when two users (Agrippa and Brutus)  we need to should that Agrippa => Brutus and that Brutus => Agrippa.  To do that, we send Brutus and email with confirm token that directs Brutus to a confirm page that requires a pin to complete the merge.  Agrippa receives an email with a pin number regarding the merge.  If Brutus truly is Agrippa, Brutus will have the pin from Agrippa's email. Brutus will then be fully merged into Agrippa in the same way it works currently.

-----

Thus the original user cannot merge in a random user, and that random user cannot complete a merge without verifying that they initialized the merge.

# Changes
There are a significant number of changes.  The biggest is in framework/auth/core.py with a number of refactors elsewhere to deal with the new interface.  These can probably be simplified and there still needs to be the authorization on the other end but otherwise this functionality plays out.
# Interactions
There's one bug where the User object cannot be saved due to the additional field "pending merges"