### PR TITLE
Use file_updated signal to update comments on file move and rename

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -39,11 +39,13 @@ from website.project.model import (
 )
 from website import settings
 
+from website.addons.base.signals import file_updated
 from website.addons.wiki.model import NodeWikiPage
 
 import website.models
 from website.signals import ALL_SIGNALS
 from website.project.signals import contributor_added
+from website.project.views.comment import update_comment_root_target_file
 from website.app import init_app
 from website.addons.base import AddonConfig
 from website.project.views.contributor import notify_added_contributor
@@ -162,7 +164,8 @@ class AppTestCase(unittest.TestCase):
 
     DISCONNECTED_SIGNALS = {
         # disconnect notify_add_contributor so that add_contributor does not send "fake" emails in tests
-        contributor_added: [notify_added_contributor]
+        contributor_added: [notify_added_contributor],
+        file_updated: [update_comment_root_target_file]
     }
 
     def setUp(self):

--- a/website/project/views/comment.py
+++ b/website/project/views/comment.py
@@ -50,6 +50,12 @@ def update_comment_root_target_file(self, node, event_type, payload, user=None):
         Comment.update(Q('root_target', 'eq', old_file._id), data={'root_target': new_file})
         Comment.update(Q('target', 'eq', old_file._id), data={'target': new_file})
 
+        # update node record of commented files
+        if old_file._id in source_node.commented_files:
+            destination_node.commented_files[new_file._id] = source_node.commented_files[old_file._id]
+            del source_node.commented_files[old_file._id]
+            source_node.save()
+
 
 @comment_added.connect
 def send_comment_added_notification(comment, auth):

--- a/website/project/views/comment.py
+++ b/website/project/views/comment.py
@@ -7,45 +7,45 @@ from modularodm.exceptions import NoResultsFound
 
 from framework.auth.decorators import must_be_logged_in
 
+from website.addons.base.signals import file_updated
 from website.files.models import FileNode, TrashedFileNode
 from website.notifications.constants import PROVIDERS
 from website.notifications.emails import notify
 from website.models import Comment
-from website.project.decorators import must_be_contributor_or_public, must_have_permission
+from website.project.decorators import must_be_contributor_or_public
 from website.project.model import Node
 from website.project.signals import comment_added
 from website import settings
 
 
-@must_be_logged_in
-@must_have_permission('write')
-def update_comment_root_target_file(auth, **kwargs):
-    data = request.get_json()
-    source = data.get('source')
-    destination = data.get('destination')
-    node = Node.load(source.get('nodeId'))
-    destination_node = Node.load(destination.get('nodeId'))
+@file_updated.connect
+def update_comment_root_target_file(self, node, event_type, payload, user=None):
+    source = payload.get('source')
+    destination = payload.get('destination')
+    source_node = Node.load(source['node']['_id'])
+    destination_node = node
+    
+    if event_type == 'addon_file_moved':
+        if source.get('provider') == 'osfstorage':
+            try:
+                old_file = TrashedFileNode.find_one(Q('provider', 'eq', source.get('provider')) &
+                                                    Q('node', 'eq', source_node) &
+                                                    Q('path', 'eq', source.get('path')))
+            except NoResultsFound:
+                old_file = FileNode.load(source.get('path').strip('/'))
+        else:
+            old_file = FileNode.resolve_class(source.get('provider'), FileNode.FILE).get_or_create(source_node, source.get('path'))
 
-    if source.get('provider') == 'osfstorage':
-        try:
-            old_file = TrashedFileNode.find_one(Q('provider', 'eq', source.get('provider')) &
-                                                Q('node', 'eq', node) &
-                                                Q('path', 'eq', source.get('path')))
-        except NoResultsFound:
-            old_file = FileNode.load(source.get('path').strip('/'))
-    else:
-        old_file = FileNode.resolve_class(source.get('provider'), FileNode.FILE).get_or_create(node, source.get('path'))
+        new_file = FileNode.resolve_class(destination.get('provider'), FileNode.FILE).get_or_create(destination_node, destination.get('path'))
+        new_file.touch(
+            request.headers.get('Authorization'),
+            cookie=request.cookies.get(settings.COOKIE_NAME)
+        )
+        if source_node._id != destination_node._id:
+            Comment.update(Q('root_target', 'eq', old_file._id), data={'node': destination_node})
 
-    new_file = FileNode.resolve_class(destination.get('provider'), FileNode.FILE).get_or_create(destination_node, destination.get('path'))
-    new_file.touch(
-        request.headers.get('Authorization'),
-        cookie=request.cookies.get(settings.COOKIE_NAME)
-    )
-    if node._id != destination_node._id:
-        Comment.update(Q('root_target', 'eq', old_file._id), data={'node': destination_node})
-
-    Comment.update(Q('root_target', 'eq', old_file._id), data={'root_target': new_file})
-    Comment.update(Q('target', 'eq', old_file._id), data={'target': new_file})
+        Comment.update(Q('root_target', 'eq', old_file._id), data={'root_target': new_file})
+        Comment.update(Q('target', 'eq', old_file._id), data={'target': new_file})
 
 
 @comment_added.connect

--- a/website/project/views/comment.py
+++ b/website/project/views/comment.py
@@ -25,7 +25,7 @@ def update_comment_root_target_file(self, node, event_type, payload, user=None):
     source_node = Node.load(source['node']['_id'])
     destination_node = node
     
-    if event_type == 'addon_file_moved':
+    if event_type == 'addon_file_moved' or (event_type == 'addon_file_renamed' and source.get('provider') != 'osfstorage'):
         if source.get('provider') == 'osfstorage':
             try:
                 old_file = TrashedFileNode.find_one(Q('provider', 'eq', source.get('provider')) &

--- a/website/project/views/comment.py
+++ b/website/project/views/comment.py
@@ -20,12 +20,15 @@ from website import settings
 
 @file_updated.connect
 def update_comment_root_target_file(self, node, event_type, payload, user=None):
-    source = payload.get('source')
-    destination = payload.get('destination')
-    source_node = Node.load(source['node']['_id'])
-    destination_node = node
-    
-    if event_type == 'addon_file_moved' or (event_type == 'addon_file_renamed' and source.get('provider') != 'osfstorage'):
+    if event_type == 'addon_file_moved' or event_type == 'addon_file_renamed':
+        source = payload['source']
+        destination = payload['destination']
+        source_node = Node.load(source['node']['_id'])
+        destination_node = node
+
+        if event_type == 'addon_file_renamed' and source.get('provider') == 'osfstorage':
+            return
+
         if source.get('provider') == 'osfstorage':
             try:
                 old_file = TrashedFileNode.find_one(Q('provider', 'eq', source.get('provider')) &

--- a/website/routes.py
+++ b/website/routes.py
@@ -328,16 +328,6 @@ def make_url_map(app):
 
         Rule(
             [
-                '/project/<pid>/comments/target/',
-                '/project/<pid>/node/<nid>/comments/target/',
-            ],
-            'put',
-            project_views.comment.update_comment_root_target_file,
-            json_renderer,
-        ),
-
-        Rule(
-            [
                 '/project/<pid>/citation/',
                 '/project/<pid>/node/<nid>/citation/',
             ],

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -407,8 +407,6 @@ function doItemOp(operation, to, from, rename, conflict) {
     var tb = this;
     tb.modal.dismiss();
     var ogParent = from.parentID;
-    var source = from.data;
-
     if (to.id === ogParent && (!rename || rename === from.data.name)){
       return;
     }
@@ -481,11 +479,6 @@ function doItemOp(operation, to, from, rename, conflict) {
         }
         // no need to redraw because fangornOrderFolder does it
         orderFolder.call(tb, from.parent());
-
-        if (operation === OPERATIONS.MOVE) {
-            updateCommentsOnMove(from.data.nodeApiUrl, source, resp);
-        }
-
     }).fail(function(xhr, textStatus) {
         if (to.data.provider === from.provider) {
             tb.pendingFileOps.pop();
@@ -524,27 +517,6 @@ function doItemOp(operation, to, from, rename, conflict) {
         orderFolder.call(tb, from.parent());
     });
 }
-
-function updateCommentsOnMove(nodeApiUrl, source, destination) {
-    var url = nodeApiUrl + 'comments/target/';
-    var request = $osf.putJSON(
-        url,
-        {
-            'source': source,
-            'destination': destination
-        }
-    );
-    request.fail(function(xhr, textStatus) {
-        Raven.captureMessage('Failed to move or copy file', {
-            xhr: xhr,
-            url: url,
-            source: source,
-            destination: destination
-        });
-    });
-    return request;
-}
-
 
 /**
  * Find out what the upload URL is for each item


### PR DESCRIPTION
Purpose
-----------
- Refactor logic for updating comments on file move to use the `file_updated` signal sent when a waterbutler log is created on the OSF. 
- In addition to updating comments when a file moves, update comments when a file is renamed
- Update the `Node.commented_files` field with the new file id (fixes issue where comments on files that were moved could not be deleted)
