### PR TITLE
Handle wb connection error

### DIFF
--- a/website/files/models/base.py
+++ b/website/files/models/base.py
@@ -529,6 +529,7 @@ class File(FileNode):
         headers = {}
         if auth_header:
             headers['Authorization'] = auth_header
+
         resp = requests.get(
             self.generate_waterbutler_url(revision=revision, meta=True, **kwargs),
             headers=headers,

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -10,6 +10,7 @@ from dateutil.parser import parse as parse_date
 import urlparse
 from collections import OrderedDict
 import warnings
+import requests
 
 import pytz
 from flask import request
@@ -280,8 +281,11 @@ class Comment(GuidStoredObject):
         commented_files = File.find(Q('_id', 'in', node.commented_files.keys()))
         for file_obj in commented_files:
             if node.get_addon(file_obj.provider):
-                exists = file_obj and file_obj.touch(request.headers.get('Authorization'),
-                                                     cookie=request.cookies.get(settings.COOKIE_NAME))
+                try:
+                    exists = file_obj and file_obj.touch(request.headers.get('Authorization'),
+                                                         cookie=request.cookies.get(settings.COOKIE_NAME))
+                except requests.ConnectionError:
+                    return 0
                 if not exists:
                     Comment.update(Q('root_target', 'eq', file_obj), data={'root_target': None})
                     continue


### PR DESCRIPTION
Purpose
-------------
Adding error handling for local development

Changes
------------
When calling File.touch, if waterbutler is not running, catch the `ConnectionError` and `return None` so that waterbutler does not always need to be running in order to view projects on the OSF.