### PR TITLE
Allow Embargo.state to be COMPLETED

### DIFF
--- a/tests/test_registrations/test_embargoes.py
+++ b/tests/test_registrations/test_embargoes.py
@@ -48,6 +48,12 @@ class RegistrationEmbargoModelsTestCase(OsfTestCase):
         )
         assert_equal(Embargo.find().count(), initial_count + 1)
 
+    def test_state_can_be_set_to_complete(self):
+        embargo = EmbargoFactory()
+        embargo.state = Embargo.COMPLETED
+        embargo.save()  # should pass validation
+        assert_equal(embargo.state, Embargo.COMPLETED)
+
     def test__initiate_embargo_does_not_create_tokens_for_unregistered_admin(self):
         unconfirmed_user = UnconfirmedUserFactory()
         self.registration.contributors.append(unconfirmed_user)

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -3433,13 +3433,16 @@ class Sanction(StoredObject):
     APPROVED = 'approved'
     # Rejected by at least one person
     REJECTED = 'rejected'
+    # Embargo has been completed
+    COMPLETED = 'completed'
 
     state = fields.StringField(
         default=UNAPPROVED,
         validate=validators.choice_in((
             UNAPPROVED,
             APPROVED,
-            REJECTED
+            REJECTED,
+            COMPLETED,
         ))
     )
 
@@ -3757,7 +3760,6 @@ class PreregCallbackMixin(object):
 class Embargo(PreregCallbackMixin, EmailApprovableSanction):
     """Embargo object for registrations waiting to go public."""
 
-    COMPLETED = 'completed'
     DISPLAY_NAME = 'Embargo'
     SHORT_NAME = 'embargo'
 


### PR DESCRIPTION
Setting an Embargo's state to COMPLETED would fail validation;
this adds COMPLETED as a valid value