### PR TITLE
Undo updating comments on file move/rename

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -39,13 +39,11 @@ from website.project.model import (
 )
 from website import settings
 
-from website.addons.base.signals import file_updated
 from website.addons.wiki.model import NodeWikiPage
 
 import website.models
 from website.signals import ALL_SIGNALS
 from website.project.signals import contributor_added
-from website.project.views.comment import update_comment_root_target_file
 from website.app import init_app
 from website.addons.base import AddonConfig
 from website.project.views.contributor import notify_added_contributor
@@ -164,8 +162,7 @@ class AppTestCase(unittest.TestCase):
 
     DISCONNECTED_SIGNALS = {
         # disconnect notify_add_contributor so that add_contributor does not send "fake" emails in tests
-        contributor_added: [notify_added_contributor],
-        file_updated: [update_comment_root_target_file]
+        contributor_added: [notify_added_contributor]
     }
 
     def setUp(self):

--- a/website/project/views/comment.py
+++ b/website/project/views/comment.py
@@ -2,59 +2,14 @@
 import pytz
 from datetime import datetime
 from flask import request
-from modularodm import Q
-from modularodm.exceptions import NoResultsFound
 
 from framework.auth.decorators import must_be_logged_in
 
-from website.addons.base.signals import file_updated
-from website.files.models import FileNode, TrashedFileNode
 from website.notifications.constants import PROVIDERS
 from website.notifications.emails import notify
 from website.models import Comment
 from website.project.decorators import must_be_contributor_or_public
-from website.project.model import Node
 from website.project.signals import comment_added
-from website import settings
-
-
-@file_updated.connect
-def update_comment_root_target_file(self, node, event_type, payload, user=None):
-    if event_type == 'addon_file_moved' or event_type == 'addon_file_renamed':
-        source = payload['source']
-        destination = payload['destination']
-        source_node = Node.load(source['node']['_id'])
-        destination_node = node
-
-        if event_type == 'addon_file_renamed' and source.get('provider') == 'osfstorage':
-            return
-
-        if source.get('provider') == 'osfstorage':
-            try:
-                old_file = TrashedFileNode.find_one(Q('provider', 'eq', source.get('provider')) &
-                                                    Q('node', 'eq', source_node) &
-                                                    Q('path', 'eq', source.get('path')))
-            except NoResultsFound:
-                old_file = FileNode.load(source.get('path').strip('/'))
-        else:
-            old_file = FileNode.resolve_class(source.get('provider'), FileNode.FILE).get_or_create(source_node, source.get('path'))
-
-        new_file = FileNode.resolve_class(destination.get('provider'), FileNode.FILE).get_or_create(destination_node, destination.get('path'))
-        new_file.touch(
-            request.headers.get('Authorization'),
-            cookie=request.cookies.get(settings.COOKIE_NAME)
-        )
-        if source_node._id != destination_node._id:
-            Comment.update(Q('root_target', 'eq', old_file._id), data={'node': destination_node})
-
-        Comment.update(Q('root_target', 'eq', old_file._id), data={'root_target': new_file})
-        Comment.update(Q('target', 'eq', old_file._id), data={'target': new_file})
-
-        # update node record of commented files
-        if old_file._id in source_node.commented_files:
-            destination_node.commented_files[new_file._id] = source_node.commented_files[old_file._id]
-            del source_node.commented_files[old_file._id]
-            source_node.save()
 
 
 @comment_added.connect


### PR DESCRIPTION
Remove updating comments on file move/rename due to inconsistencies with certain move/rename operations.