### PR TITLE
Only use VOL token if project is private

### DIFF
--- a/website/static/js/comment.js
+++ b/website/static/js/comment.js
@@ -123,7 +123,7 @@ BaseComment.prototype.fetch = function() {
     if (self.comments().length === 0) {
         var urlParams = osfHelpers.urlParams();
         var query = 'embed=user';
-        if (urlParams.view_only) {
+        if (urlParams.view_only && !window.contextVars.node.isPublic) {
             query += '&view_only=' + urlParams.view_only;
         }
         if (self.id() !== undefined) {


### PR DESCRIPTION
Fixes issue where comment info was anonymized (viewing through anonymous link) but the project
was public.