### PR TITLE
[Hotfix] Specify webhook event type when creating a hook

### DIFF
--- a/website/addons/github/model.py
+++ b/website/addons/github/model.py
@@ -547,7 +547,8 @@ class AddonGitHubNodeSettings(StorageAddonBase, AddonNodeSettingsBase):
                     ),
                     'content_type': github_settings.HOOK_CONTENT_TYPE,
                     'secret': secret,
-                }
+                },
+                events=github_settings.HOOK_EVENTS,
             )
 
             if hook:

--- a/website/addons/github/settings/defaults.py
+++ b/website/addons/github/settings/defaults.py
@@ -11,6 +11,7 @@ SET_PRIVACY = False
 # GitHub hook domain
 HOOK_DOMAIN = None
 HOOK_CONTENT_TYPE = 'json'
+HOOK_EVENTS = ['push']  # Only log commits
 
 # Max render size in bytes; no max if None
 MAX_RENDER_SIZE = None


### PR DESCRIPTION
[#OSF-5577]

Purpose
=======
GitHub appears to have had a recent breaking API change, making `events` a required parameter for hook creation. Because we create hooks when linking repos, this prevents users from changing their selected repository. We only log file operations type events (`added`, `modified`, or `removed` -- see [this function](https://github.com/CenterForOpenScience/osf.io/blob/develop/website/addons/github/views/hooks.py#L66)), thus the only event we need to specify is a [PushEvent](https://developer.github.com/v3/activity/events/types/#pushevent).

Changes
=======
* Specify which event type(s) should trigger the hook

Side Effects
=========
May trivially conflict with #4853 