### PR TITLE
Only allow osfstorage file comments

### DIFF
--- a/addons.json
+++ b/addons.json
@@ -24,5 +24,8 @@
         "github": "partial",
         "s3": "partial",
         "wiki": "full"
-    }
+    },
+    "addons_commentable": [
+        "osfstorage"
+    ]
 }

--- a/api/comments/serializers.py
+++ b/api/comments/serializers.py
@@ -145,8 +145,8 @@ class CommentCreateSerializer(CommentSerializer):
             else:
                 raise ValueError('Cannot post reply to comment on another node.')
         elif target_file:
-            if target_file.provider != 'osfstorage':
-                raise ValueError('Cannot post comment to non-osfstorage file.')
+            if target_file.provider not in osf_settings.ADDONS_COMMENTABLE:
+                raise ValueError('Comments are not supported for this file provider.')
             elif target_file.node._id != node_id:
                 raise ValueError('Cannot post comment to file on another node.')
             else:

--- a/api/comments/serializers.py
+++ b/api/comments/serializers.py
@@ -145,10 +145,12 @@ class CommentCreateSerializer(CommentSerializer):
             else:
                 raise ValueError('Cannot post reply to comment on another node.')
         elif target_file:
-            if target_file.node._id == node_id:
-                return target_file
-            else:
+            if target_file.provider != 'osfstorage':
+                raise ValueError('Cannot post comment to non-osfstorage file.')
+            elif target_file.node._id != node_id:
                 raise ValueError('Cannot post comment to file on another node.')
+            else:
+                return target_file
         else:
             raise ValueError('Invalid comment target.')
 

--- a/website/addons/base/views.py
+++ b/website/addons/base/views.py
@@ -569,7 +569,7 @@ def addon_view_file(auth, node, file_node, version):
         'private': getattr(node.get_addon(file_node.provider), 'is_private', False),
         'file_tags': [tag._id for tag in file_node.tags],
         'file_id': file_node._id,
-        'allow_comments': file_node.provider == 'osfstorage'
+        'allow_comments': file_node.provider in settings.ADDONS_COMMENTABLE
     })
 
     ret.update(rubeus.collect_addon_assets(node))

--- a/website/addons/base/views.py
+++ b/website/addons/base/views.py
@@ -569,6 +569,7 @@ def addon_view_file(auth, node, file_node, version):
         'private': getattr(node.get_addon(file_node.provider), 'is_private', False),
         'file_tags': [tag._id for tag in file_node.tags],
         'file_id': file_node._id,
+        'allow_comments': file_node.provider == 'osfstorage'
     })
 
     ret.update(rubeus.collect_addon_assets(node))

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -192,6 +192,7 @@ with open(os.path.join(ROOT, 'addons.json')) as fp:
     addon_settings = json.load(fp)
     ADDONS_REQUESTED = addon_settings['addons']
     ADDONS_ARCHIVABLE = addon_settings['addons_archivable']
+    ADDONS_COMMENTABLE = addon_settings['addons_commentable']
 
 ADDON_CATEGORIES = [
     'documentation',

--- a/website/templates/project/view_file.mako
+++ b/website/templates/project/view_file.mako
@@ -6,7 +6,7 @@
 
 <%def name="title()">${file_name | h}</%def>
 
-% if (user['can_comment'] or node['has_comments']):
+% if (user['can_comment'] or node['has_comments']) and allow_comments:
     <%include file="include/comment_pane_template.mako"/>
 % endif
 


### PR DESCRIPTION
Only allow osfstorage file comments due to inconsistencies with making sure comments stay with addon files when they are moved or renamed.