### PR TITLE
Remove unread comment counts in project nav bar

### DIFF
--- a/website/project/model.py
+++ b/website/project/model.py
@@ -239,7 +239,7 @@ class Comment(GuidStoredObject):
         return self.content
 
     @classmethod
-    def find_n_unread(cls, user, node, page=None, root_id=None, check=False):
+    def find_n_unread(cls, user, node, page=None, root_id=None):
         if node.is_contributor(user):
             if not page:
                 return cls.n_unread_node_comments(user, node) + cls.n_unread_file_comments(user, node)
@@ -251,17 +251,12 @@ class Comment(GuidStoredObject):
                 else:
                     view_timestamp = user.get_node_comment_timestamps(node, page, file_id=root_id)
                     root_target = File.load(root_id)
-                    if check:
-                        if not (root_target and root_target.touch(request.headers.get('Authorization'),
-                                                                  cookie=request.cookies.get(settings.COOKIE_NAME))):
-                            return 0
-                    else:
-                        return Comment.find(Q('node', 'eq', node) &
-                                            Q('user', 'ne', user) &
-                                            Q('is_deleted', 'eq', False) &
-                                            (Q('date_created', 'gt', view_timestamp) |
-                                            Q('date_modified', 'gt', view_timestamp)) &
-                                            Q('root_target', 'eq', root_target)).count()
+                    return Comment.find(Q('node', 'eq', node) &
+                                        Q('user', 'ne', user) &
+                                        Q('is_deleted', 'eq', False) &
+                                        (Q('date_created', 'gt', view_timestamp) |
+                                        Q('date_modified', 'gt', view_timestamp)) &
+                                        Q('root_target', 'eq', root_target)).count()
 
         return 0
 

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -722,8 +722,6 @@ def _view_project(node, auth, primary=False):
             messages = addon.before_page_load(node, user) or []
             for message in messages:
                 status.push_status_message(message, kind='info', dismissible=False, trust=True)
-    n_unread_node = Comment.find_n_unread(user, node, page='node')
-    n_unread_files = Comment.find_n_unread(user, node, page='files')
     data = {
         'node': {
             'id': node._primary_key,
@@ -810,11 +808,6 @@ def _view_project(node, auth, primary=False):
             'can_comment': node.can_comment(auth),
             'show_wiki_widget': _should_show_wiki_widget(node, user),
             'dashboard_id': dashboard_id,
-            'unread_comments': {
-                'node': n_unread_node,
-                'files': n_unread_files,
-                'total': n_unread_node + n_unread_files
-            }
         },
         'badges': _get_badge(user),
         # TODO: Namespace with nested dicts

--- a/website/templates/project/project_header.mako
+++ b/website/templates/project/project_header.mako
@@ -32,18 +32,12 @@
                         <li>
                             <a href="${node['url']}"  class="project-title"> 
                                 ${ node['title'] }
-                                % if user['unread_comments']['node'] > 0:
-                                    <span class="badge">${user['unread_comments']['node']}</span>
-                                % endif
                             </a>
                         </li>
                     % if not node['is_retracted']:
                         <li id="projectNavFiles">
                             <a href="${node['url']}files/">
                                 Files
-                                % if user['unread_comments']['files'] > 0:
-                                    <span class="badge">${user['unread_comments']['files']}</span>
-                                % endif
                             </a>
                         </li>
                         <!-- Add-on tabs -->


### PR DESCRIPTION
Changes
-------------
- `find_n_unread` is never called with `check=True` so update `find_n_unread` to remove that unused code. 
- Take out calls to `find_n_unread` in `_view_project`. Getting `n_unread_files` requires a call to waterbutler for each commented file, which slows project loading times. 