### PR TITLE
[hotfix] Conferences: Allow additional sender email & name formats

### DIFF
--- a/tests/test_conferences.py
+++ b/tests/test_conferences.py
@@ -337,6 +337,7 @@ class TestMessage(ContextTestCase):
         names = [
             (' Fred', 'Fred'),
             (u'Me‰¨ü', u'Me‰¨ü'),
+            (u'fred@queen.com', u'fred@queen.com'),
             (u'Fred <fred@queen.com>', u'Fred'),
             (u'"Fred" <fred@queen.com>', u'Fred'),
         ]
@@ -607,3 +608,52 @@ class TestConferenceIntegration(ContextTestCase):
             call_kwargs['presentations_url'],
             web_url_for('conference_view', _absolute=True),
         )
+
+    @mock.patch('website.conferences.views.send_mail')
+    @mock.patch('website.conferences.utils.upload_attachments')
+    def test_integration_wo_full_name(self, mock_upload, mock_send_mail):
+        username = 'no_full_name@test.com'
+        title = 'no full name only email'
+        conference = ConferenceFactory()
+        body = 'dragon on my back'
+        content = 'dragon attack'
+        recipient = '{0}{1}-poster@osf.io'.format(
+            'test-' if settings.DEV_MODE else '',
+            conference.endpoint,
+        )
+        self.app.post(
+            api_url_for('meeting_hook'),
+            {
+                'X-Mailgun-Sscore': 0,
+                'timestamp': '123',
+                'token': 'secret',
+                'signature': hmac.new(
+                    key=settings.MAILGUN_API_KEY,
+                    msg='{}{}'.format('123', 'secret'),
+                    digestmod=hashlib.sha256,
+                ).hexdigest(),
+                'attachment-count': '1',
+                'X-Mailgun-Sscore': 0,
+                'from': username,
+                'recipient': recipient,
+                'subject': title,
+                'stripped-text': body,
+            },
+            upload_files=[
+                ('attachment-1', 'attachment-1', content),
+            ],
+        )
+        assert_true(mock_upload.called)
+        users = User.find(Q('username', 'eq', username))
+        assert_equal(users.count(), 1)
+        nodes = Node.find(Q('title', 'eq', title))
+        assert_equal(nodes.count(), 1)
+        node = nodes[0]
+        assert_equal(node.get_wiki_page('home').content, body)
+        assert_true(mock_send_mail.called)
+        call_args, call_kwargs = mock_send_mail.call_args
+        assert_absolute(call_kwargs['conf_view_url'])
+        assert_absolute(call_kwargs['set_password_url'])
+        assert_absolute(call_kwargs['profile_url'])
+        assert_absolute(call_kwargs['file_url'])
+        assert_absolute(call_kwargs['node_url'])

--- a/website/conferences/message.py
+++ b/website/conferences/message.py
@@ -109,15 +109,24 @@ class ConferenceMessage(object):
 
     @cached_property
     def sender_name(self):
-        name = ANGLE_BRACKETS_REGEX.sub('', self.sender)
-        name = name.strip().replace('"', '')
+        if '<' in self.sender:
+            # sender format: "some name" <email@domain.tld>
+            name = ANGLE_BRACKETS_REGEX.sub('', self.sender)
+            name = name.strip().replace('"', '')
+        else:
+            # sender format: email@domain.tld
+            name = self.sender
         return unicode(HumanName(name))
 
     @cached_property
     def sender_email(self):
         match = ANGLE_BRACKETS_REGEX.search(self.sender)
         if match:
+            # sender format: "some name" <email@domain.tld>
             return match.groups()[0]
+        elif '@' in self.sender:
+            # sender format: email@domain.tld
+            return self.sender
         raise ConferenceError('Could not extract sender email')
 
     @cached_property


### PR DESCRIPTION
e.g.

"some name" <email@domain.tld>
some name <email@domain.tld>
email@domain.tld