### PR TITLE
[hotfix] Notify non-admin contributors when a registration is initiated

### DIFF
--- a/website/archiver/tasks.py
+++ b/website/archiver/tasks.py
@@ -386,6 +386,4 @@ def archive_success(dst_pk, job_pk):
     job = ArchiveJob.load(job_pk)
     job.sent = True
     job.save()
-    admins = [user for (user, _) in
-              dst.get_admin_contributors_recursive(unique_users=True)]
-    dst.sanction.ask(admins)
+    dst.sanction.ask(dst.get_active_contributors_recursive(unique_users=True))

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -3272,6 +3272,23 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
         if self.is_public:
             self.set_privacy('private', Auth(user))
 
+    def get_active_contributors_recursive(self, unique_users=False, *args, **kwargs):
+        """Yield (admin, node) tuples for this node and
+        descendant nodes. Excludes contributors on node links and inactive users.
+
+        :param bool unique_users: If True, a given admin will only be yielded once
+            during iteration.
+        """
+        visited_user_ids = []
+        for node in self.node_and_primary_descendants(*args, **kwargs):
+            for contrib in node.active_contributors(*args, **kwargs):
+                if unique_users:
+                    if contrib._id not in visited_user_ids:
+                        visited_user_ids.append(contrib._id)
+                        yield (contrib, node)
+                else:
+                    yield (contrib, node)
+
     def get_admin_contributors_recursive(self, unique_users=False, *args, **kwargs):
         """Yield (admin, node) tuples for this node and
         descendant nodes. Excludes contributors on node links and inactive users.
@@ -3621,18 +3638,22 @@ class TokenApprovableSanction(Sanction):
         self.state = Sanction.REJECTED
         self._on_reject(user)
 
-    def _notify_authorizer(self, user):
+    def _notify_authorizer(self, user, node):
         pass
 
-    def _notify_non_authorizer(self, user):
+    def _notify_non_authorizer(self, user, node):
         pass
 
     def ask(self, group):
-        for contrib in group:
+        """
+        :param list group: List of (user, node) tuples containing contributors to notify about the
+        sanction.
+        """
+        for contrib, node in group:
             if contrib._id in self.approval_state:
-                self._notify_authorizer(contrib)
+                self._notify_authorizer(contrib, node)
             else:
-                self._notify_non_authorizer(contrib)
+                self._notify_non_authorizer(contrib, node)
 
 
 class EmailApprovableSanction(TokenApprovableSanction):
@@ -3668,10 +3689,10 @@ class EmailApprovableSanction(TokenApprovableSanction):
             return template.format(**context)
         return ''
 
-    def _view_url(self, user_id):
-        return self._format_or_empty(self.VIEW_URL_TEMPLATE, self._view_url_context(user_id))
+    def _view_url(self, user_id, node):
+        return self._format_or_empty(self.VIEW_URL_TEMPLATE, self._view_url_context(user_id, node))
 
-    def _view_url_context(self, user_id):
+    def _view_url_context(self, user_id, node):
         return None
 
     def _approval_url(self, user_id):
@@ -3694,18 +3715,18 @@ class EmailApprovableSanction(TokenApprovableSanction):
             **context
         )
 
-    def _email_template_context(self, user, is_authorizer=False):
+    def _email_template_context(self, user, node, is_authorizer=False):
         return {}
 
-    def _notify_authorizer(self, authorizer):
-        context = self._email_template_context(authorizer, is_authorizer=True)
+    def _notify_authorizer(self, authorizer, node):
+        context = self._email_template_context(authorizer, node, is_authorizer=True)
         if self.AUTHORIZER_NOTIFY_EMAIL_TEMPLATE:
             self._send_approval_request_email(authorizer, self.AUTHORIZER_NOTIFY_EMAIL_TEMPLATE, context)
         else:
             raise NotImplementedError
 
-    def _notify_non_authorizer(self, user):
-        context = self._email_template_context(user)
+    def _notify_non_authorizer(self, user, node):
+        context = self._email_template_context(user, node)
         if self.NON_AUTHORIZER_NOTIFY_EMAIL_TEMPLATE:
             self._send_approval_request_email(user, self.NON_AUTHORIZER_NOTIFY_EMAIL_TEMPLATE, context)
         else:
@@ -3714,7 +3735,7 @@ class EmailApprovableSanction(TokenApprovableSanction):
     def add_authorizer(self, user, node, **kwargs):
         super(EmailApprovableSanction, self).add_authorizer(user, node, **kwargs)
         self.stashed_urls[user._id] = {
-            'view': self._view_url(user._id),
+            'view': self._view_url(user._id, node),
             'approve': self._approval_url(user._id),
             'reject': self._rejection_url(user._id)
         }
@@ -3747,7 +3768,7 @@ class PreregCallbackMixin(object):
                 mimetype='html'
             )
 
-    def _email_template_context(self, user, is_authorizer=False, urls=None):
+    def _email_template_context(self, user, node, is_authorizer=False, urls=None):
         registration = self._get_registration()
         prereg_schema = prereg_utils.get_prereg_schema()
         if prereg_schema in registration.registered_schema:
@@ -3808,8 +3829,8 @@ class Embargo(PreregCallbackMixin, EmailApprovableSanction):
     def _get_registration(self):
         return Node.find_one(Q('embargo', 'eq', self))
 
-    def _view_url_context(self, user_id):
-        registration = self._get_registration()
+    def _view_url_context(self, user_id, node):
+        registration = node or self._get_registration()
         return {
             'node_id': registration._id
         }
@@ -3837,10 +3858,10 @@ class Embargo(PreregCallbackMixin, EmailApprovableSanction):
                 'token': rejection_token,
             }
 
-    def _email_template_context(self, user, is_authorizer=False, urls=None):
-        context = super(Embargo, self)._email_template_context(user, is_authorizer, urls)
+    def _email_template_context(self, user, node, is_authorizer=False, urls=None):
+        context = super(Embargo, self)._email_template_context(user, node, is_authorizer, urls)
         urls = urls or self.stashed_urls.get(user._id, {})
-        registration_link = urls.get('view', self._view_url(user._id))
+        registration_link = urls.get('view', self._view_url(user._id, node))
         if is_authorizer:
             approval_link = urls.get('approve', '')
             disapproval_link = urls.get('reject', '')
@@ -3936,7 +3957,7 @@ class Retraction(EmailApprovableSanction):
             self._id
         )
 
-    def _view_url_context(self, user_id):
+    def _view_url_context(self, user_id, node):
         registration = Node.find_one(Q('retraction', 'eq', self))
         return {
             'node_id': registration._id
@@ -3965,9 +3986,9 @@ class Retraction(EmailApprovableSanction):
                 'token': rejection_token,
             }
 
-    def _email_template_context(self, user, is_authorizer=False, urls=None):
+    def _email_template_context(self, user, node, is_authorizer=False, urls=None):
         urls = urls or self.stashed_urls.get(user._id, {})
-        registration_link = urls.get('view', self._view_url(user._id))
+        registration_link = urls.get('view', self._view_url(user._id, node))
         if is_authorizer:
             approval_link = urls.get('approve', '')
             disapproval_link = urls.get('reject', '')
@@ -4056,10 +4077,11 @@ class RegistrationApproval(PreregCallbackMixin, EmailApprovableSanction):
     def _get_registration(self):
         return Node.find_one(Q('registration_approval', 'eq', self))
 
-    def _view_url_context(self, user_id):
-        registration = self._get_registration()
+    def _view_url_context(self, user_id, node):
+        user_approval_state = self.approval_state.get(user_id, {})
+        node_id = user_approval_state.get('node_id', node._id)
         return {
-            'node_id': registration._id
+            'node_id': node_id
         }
 
     def _approval_url_context(self, user_id):
@@ -4085,10 +4107,10 @@ class RegistrationApproval(PreregCallbackMixin, EmailApprovableSanction):
                 'token': rejection_token,
             }
 
-    def _email_template_context(self, user, is_authorizer=False, urls=None):
-        context = super(RegistrationApproval, self)._email_template_context(user, is_authorizer, urls)
+    def _email_template_context(self, user, node, is_authorizer=False, urls=None):
+        context = super(RegistrationApproval, self)._email_template_context(user, node, is_authorizer, urls)
         urls = urls or self.stashed_urls.get(user._id, {})
-        registration_link = urls.get('view', self._view_url(user._id))
+        registration_link = urls.get('view', self._view_url(user._id, node))
         if is_authorizer:
             approval_link = urls.get('approve', '')
             disapproval_link = urls.get('reject', '')

--- a/website/project/views/register.py
+++ b/website/project/views/register.py
@@ -104,9 +104,7 @@ def node_registration_retraction_post(auth, node, **kwargs):
     try:
         node.retract_registration(auth.user, data.get('justification', None))
         node.save()
-        admins = [user for (user, _) in
-                  node.get_admin_contributors_recursive(unique_users=True)]
-        node.retraction.ask(admins)
+        node.retraction.ask(node.get_active_contributors_recursive(unique_users=True))
     except NodeStateError as err:
         raise HTTPError(http.FORBIDDEN, data=dict(message_long=err.message))
 


### PR DESCRIPTION
[OSF-5592]

- Add `Node#get_active_contributors_recursive`
- Changes the signature of multiple methods, e.g. `ask`, `_email_context`,
  etc. to receive the node of the user being notified

https://openscience.atlassian.net/browse/OSF-5592