### PR TITLE
[Feature] Remove remote grant during deauthorization if possible

### DIFF
--- a/tests/test_addons_oauth.py
+++ b/tests/test_addons_oauth.py
@@ -294,6 +294,23 @@ class TestUserSettings(OsfTestCase):
             }
         )
 
+    @mock.patch('tests.test_addons_oauth.MockUserSettings.revoke_remote_oauth_access')
+    @mock.patch('framework.auth.core._get_current_user')
+    def test_revoke_remote_access_called(self, mock_decorator, mock_revoke):
+        mock_decorator.return_value = self.user
+        self.user_settings.delete()
+        assert_equal(mock_revoke.call_count, 1)
+
+    @mock.patch('tests.test_addons_oauth.MockUserSettings.revoke_remote_oauth_access')
+    @mock.patch('framework.auth.core._get_current_user')
+    def test_revoke_remote_access_not_called(self, mock_decorator, mock_revoke):
+        mock_decorator.return_value = self.user
+        user2 = AuthUserFactory()
+        user2.external_accounts.append(self.external_account)
+        user2.save()
+        self.user_settings.delete()
+        assert_equal(mock_revoke.call_count, 0)
+
     def test_on_delete(self):
         node_settings = self.project.get_or_add_addon(
             MockUserSettings.oauth_provider.short_name,

--- a/website/addons/base/__init__.py
+++ b/website/addons/base/__init__.py
@@ -22,8 +22,7 @@ from framework.auth import Auth
 
 from website import settings
 from website.addons.base import serializer, logger
-from website.models import User
-from website.project.model import Node
+from website.project.model import Node, User
 from website.util import waterbutler_url_for
 
 from website.oauth.signals import oauth_complete

--- a/website/addons/base/__init__.py
+++ b/website/addons/base/__init__.py
@@ -22,6 +22,7 @@ from framework.auth import Auth
 
 from website import settings
 from website.addons.base import serializer, logger
+from website.models import User
 from website.project.model import Node
 from website.util import waterbutler_url_for
 
@@ -393,10 +394,26 @@ class AddonOAuthUserSettingsBase(AddonUserSettingsBase):
             else:
                 addon_settings.deauthorize(auth=auth)
 
+        if User.find(Q('external_accounts', 'contains', external_account._id)).count() == 1:
+            # Only this user is using the account, so revoke remote access as well.
+            self.revoke_remote_oauth_access(external_account)
+
         for key in self.oauth_grants:
             self.oauth_grants[key].pop(external_account._id, None)
         if save:
             self.save()
+
+    def revoke_remote_oauth_access(self, external_account):
+        """ Makes outgoing request to remove the remote oauth grant
+        stored by third-party provider.
+
+        Individual addons must override this method, as it is addon-specific behavior.
+        Not all addon providers support this through their API, but those that do
+        should also handle the case where this is called with an external_account
+        with invalid credentials, to prevent a user from being unable to disconnect
+        an account.
+        """
+        pass
 
     def verify_oauth_access(self, node, external_account, metadata=None):
         """Verify that access has been previously granted.

--- a/website/addons/box/model.py
+++ b/website/addons/box/model.py
@@ -4,6 +4,7 @@ import logging
 from box import CredentialsV2, BoxClient
 from box.client import BoxClientException
 from modularodm import fields
+import requests
 
 from framework.auth import Auth
 from framework.exceptions import HTTPError
@@ -58,6 +59,21 @@ class BoxUserSettings(AddonOAuthUserSettingsBase):
     """
     oauth_provider = Box
     serializer = BoxSerializer
+
+    def revoke_remote_oauth_access(self, external_account):
+        try:
+            # TODO: write client for box, stop using third-party lib
+            requests.request(
+                'POST',
+                settings.BOX_OAUTH_REVOKE_ENDPOINT,
+                params={
+                    'client_id': settings.BOX_KEY,
+                    'client_secret': settings.BOX_SECRET,
+                    'token': external_account.oauth_key,
+                }
+            )
+        except requests.HTTPError:
+            pass
 
 
 class BoxNodeSettings(StorageAddonBase, AddonOAuthNodeSettingsBase):

--- a/website/addons/box/settings/defaults.py
+++ b/website/addons/box/settings/defaults.py
@@ -6,3 +6,4 @@ REFRESH_TIME = 5 * 60  # 5 minutes
 
 BOX_OAUTH_TOKEN_ENDPOINT = 'https://www.box.com/api/oauth2/token'
 BOX_OAUTH_AUTH_ENDPOINT = 'https://www.box.com/api/oauth2/authorize'
+BOX_OAUTH_REVOKE_ENDPOINT = 'https://api.box.com/oauth2/revoke'

--- a/website/addons/box/tests/test_models.py
+++ b/website/addons/box/tests/test_models.py
@@ -47,6 +47,13 @@ class TestNodeSettings(models.OAuthAddonNodeSettingsTestSuiteMixin, OsfTestCase)
         mock_refresh.return_value = True
         super(TestNodeSettings, self).test_serialize_credentials()
 
+    @mock.patch(
+        'website.addons.box.model.BoxUserSettings.revoke_remote_oauth_access',
+        mock.PropertyMock()
+    )
+    def test_complete_has_auth_not_verified(self):
+        super(TestNodeSettings, self).test_complete_has_auth_not_verified()
+
 class TestUserSettings(models.OAuthAddonUserSettingTestSuiteMixin, OsfTestCase):
 
     short_name = 'box'

--- a/website/addons/box/tests/test_views.py
+++ b/website/addons/box/tests/test_views.py
@@ -41,6 +41,13 @@ class TestAuthViews(BoxAddonTestCase, testing.views.OAuthAddonAuthViewsTestCaseM
         self.mock_refresh.stop()
         super(TestAuthViews, self).tearDown()
 
+    @mock.patch(
+        'website.addons.box.model.BoxUserSettings.revoke_remote_oauth_access',
+        mock.PropertyMock()
+    )
+    def test_delete_external_account(self):
+        super(TestAuthViews, self).test_delete_external_account()
+
 
 class TestConfigViews(BoxAddonTestCase, testing.views.OAuthAddonConfigViewsTestCaseMixin):
 

--- a/website/addons/dropbox/model.py
+++ b/website/addons/dropbox/model.py
@@ -6,6 +6,7 @@ import logging
 from flask import request
 from modularodm import fields
 from dropbox.client import DropboxOAuth2Flow, DropboxClient
+from dropbox.rest import ErrorResponse
 
 from framework.auth import Auth
 from framework.exceptions import HTTPError
@@ -94,6 +95,17 @@ class DropboxUserSettings(AddonOAuthUserSettingsBase):
 
     oauth_provider = DropboxProvider
     serializer = DropboxSerializer
+
+    def revoke_remote_oauth_access(self, external_account):
+        """Overrides default behavior during external_account deactivation.
+
+        Tells DropBox to remove the grant for the OSF associated with this account.
+        """
+        client = DropboxClient(external_account.oauth_key)
+        try:
+            client.disable_access_token()
+        except ErrorResponse:
+            pass
 
 class DropboxNodeSettings(StorageAddonBase, AddonOAuthNodeSettingsBase):
 

--- a/website/addons/dropbox/tests/test_models.py
+++ b/website/addons/dropbox/tests/test_models.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import mock
 from nose.tools import *  # noqa (PEP8 asserts)
 
 from tests.base import OsfTestCase
@@ -31,6 +32,14 @@ class TestNodeSettings(testing.models.OAuthAddonNodeSettingsTestSuiteMixin, OsfT
         node_settings = DropboxNodeSettings(user_settings=self.user_settings)
         node_settings.save()
         assert_is_none(node_settings.folder)
+
+    @mock.patch(
+        'website.addons.dropbox.model.DropboxUserSettings.revoke_remote_oauth_access',
+        mock.PropertyMock()
+    )
+    def test_complete_has_auth_not_verified(self):
+        super(TestNodeSettings, self).test_complete_has_auth_not_verified()
+
 
 class TestUserSettings(testing.models.OAuthAddonUserSettingTestSuiteMixin, OsfTestCase):
 

--- a/website/addons/dropbox/tests/test_views.py
+++ b/website/addons/dropbox/tests/test_views.py
@@ -34,6 +34,13 @@ class TestAuthViews(DropboxAddonTestCase, views_testing.OAuthAddonAuthViewsTestC
     def test_oauth_start(self):
         super(TestAuthViews, self).test_oauth_start()
 
+    @mock.patch(
+        'website.addons.dropbox.model.DropboxUserSettings.revoke_remote_oauth_access',
+        mock.PropertyMock()
+    )
+    def test_delete_external_account(self):
+        super(TestAuthViews, self).test_delete_external_account()
+
 class TestConfigViews(DropboxAddonTestCase, views_testing.OAuthAddonConfigViewsTestCaseMixin):
 
     folder = {


### PR DESCRIPTION
[#OSF-5365]

Purpose
=======
Addons that follow the [OAuth RFC](http://tools.ietf.org/html/rfc6749) most closely provide an endpoint to revoke the oauth grant on their end, invalidating any access tokens that may have been discovered by a third-party. We should make use of this feature for addons with an API supporting it.

Changes
=======
* Method and call added to base class that will `pass` when tokens should be revoked.
* Above method overridden in addons that support token revocation (and have been migrated to the `ExternalAccount` architecture already.)
* #4853 has had this method preemptively overriden on the `GitHubUserSettings` model.

Side Effects
==========
None