### PR TITLE
Add 'i' tooltips on existing data question

### DIFF
--- a/website/project/metadata/prereg-prize.json
+++ b/website/project/metadata/prereg-prize.json
@@ -75,23 +75,23 @@
             "format": "singleselect",
             "options": [
                 {
-                    "text": "Registration prior to creation of data",
+                    "text": "Registration prior to creation of data ",
                     "tooltip": "As of the date of submission of this research plan for preregistration, the data have not yet been collected, created, or realized."
                 },
                 {
-                    "text": "Registration prior to any human observation of the data",
+                    "text": "Registration prior to any human observation of the data ",
                     "tooltip": "As of the date of submission, the data exist but have not yet been quantified, constructed, observed, or reported by anyone - including individuals that are not associated with the proposed study. Examples include museum specimens that have not been measured and data that have been collected by non-human collectors and are inaccessible."
                 },
                 {
-                    "text": "Registration prior to accessing the data",
+                    "text": "Registration prior to accessing the data ",
                     "tooltip": "As of the date of submission, the data exist, but have not been accessed by you or your collaborators. Commonly, this includes data that has been collected by another researcher or institution."
                 },
                 {
-                    "text": "Registration prior to analysis of the data",
+                    "text": "Registration prior to analysis of the data ",
                     "tooltip": "As of the date of submission, the data exist and you have accessed it, though no analysis has been conducted related to the research plan (including calculation of summary statistics). A common situation for this scenario when a large dataset exists that is used for many different studies over time, or when a data set is randomly split into a sample for exploratory analyses, and the other section of data is reserved for later confirmatory data analysis."
                 },
                 {
-                   "text": "Registration following analysis of the data",
+                    "text": "Registration following analysis of the data ",
                     "tooltip": "As of the date of submission, you have accessed and analyzed some of the data relevant to the research plan. This includes preliminary analysis of variables, calculation of descriptive statistics, and observation of data distributions. Studies that fall into this category are ineligible for the Prereg Challenge. Please contact us (prereg@cos.io) and we will be happy to help you."
                 }
             ],

--- a/website/templates/project/registration_editor_templates.mako
+++ b/website/templates/project/registration_editor_templates.mako
@@ -37,7 +37,8 @@
     <p data-bind="if: Boolean(option.tooltip)">
       <input type="radio" data-bind="checked: $parent.value,
                                      value: option.text"/>
-      <span data-bind="text: option.text, tooltip: {title: option.tooltip}" class="fa fa-info-circle"></span>
+        {{option.text}}
+      <span data-bind="tooltip: {title: option.tooltip}" class="fa fa-info-circle"></span>
     </p>
   </div>
 </script>

--- a/website/templates/project/registration_editor_templates.mako
+++ b/website/templates/project/registration_editor_templates.mako
@@ -37,7 +37,7 @@
     <p data-bind="if: Boolean(option.tooltip)">
       <input type="radio" data-bind="checked: $parent.value,
                                      value: option.text"/>
-      <span data-bind="text: option.text, tooltip: {title: option.tooltip}"></span>
+      <span data-bind="text: option.text, tooltip: {title: option.tooltip}" class="fa fa-info-circle"></span>
     </p>
   </div>
 </script>


### PR DESCRIPTION
On pre-reg form, under 'Sampling Plan" and 'Existing Data', add an 'i' tooltip to the end of each option to indicate that there is more info (instead of linking the tooltip to the option text which is the current behavior)


[OSF-5492]