### PR TITLE
include api module in coverage reports

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 include =
+    api/*
     website/*
     framework/*
 omit =


### PR DESCRIPTION
I don't find a way to run coverage reports on the `api` module from pytest without this configuration change. Coming from https://github.com/caneruguz/osf.io/pull/17#issuecomment-176989103.