### PR TITLE
Release/0.63.0/templating permissions

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -225,11 +225,18 @@ class NodeSerializer(JSONAPISerializer):
 
     def create(self, validated_data):
         if 'template_from' in validated_data:
+            request = self.context['request']
+            user = request.user
             template_from = validated_data.pop('template_from')
             template_node = Node.load(key=template_from)
+            if template_node is None:
+                raise exceptions.NotFound
+            if not template_node.has_permission(user, 'read', check_parent=False):
+                raise exceptions.PermissionDenied
+
             validated_data.pop('creator')
             changed_data = {template_from: validated_data}
-            node = template_node.use_as_template(auth=self.get_user_auth(self.context['request']), changes=changed_data)
+            node = template_node.use_as_template(auth=self.get_user_auth(request), changes=changed_data)
         else:
             node = Node(**validated_data)
         try:

--- a/api_tests/nodes/views/test_node_list.py
+++ b/api_tests/nodes/views/test_node_list.py
@@ -610,7 +610,7 @@ class TestNodeCreate(ApiTestCase):
             }
         }
         res = self.app.post_json_api(self.url, templated_project_data, auth=self.user_one.auth, expect_errors=True)
-        assert_equal(res.status_code, 404)
+        assert_equal(res.status_code, 403)
 
     def test_creates_project_creates_project_and_sanitizes_html(self):
         title = '<em>Cool</em> <strong>Project</strong>'

--- a/api_tests/nodes/views/test_node_list.py
+++ b/api_tests/nodes/views/test_node_list.py
@@ -580,6 +580,37 @@ class TestNodeCreate(ApiTestCase):
         assert_equal(len(new_project.nodes), len(template_from.nodes))
         assert_equal(new_project.nodes[0].title, template_component.title)
 
+    def test_404_on_create_from_template_of_nonexistent_project(self):
+        template_from_id = 'thisisnotavalidguid'
+        templated_project_data = {
+            'data': {
+                'type': 'nodes',
+                'attributes':
+                    {
+                        'title': 'No title',
+                        'category': 'project',
+                        'template_from': template_from_id,
+                    }
+            }
+        }
+        res = self.app.post_json_api(self.url, templated_project_data, auth=self.user_one.auth, expect_errors=True)
+        assert_equal(res.status_code, 404)
+
+    def test_403_on_create_from_template_of_unauthorized_project(self):
+        template_from = ProjectFactory(creator=self.user_two, is_public=True)
+        templated_project_data = {
+            'data': {
+                'type': 'nodes',
+                'attributes':
+                    {
+                        'title': 'No permission',
+                        'category': 'project',
+                        'template_from': template_from._id,
+                    }
+            }
+        }
+        res = self.app.post_json_api(self.url, templated_project_data, auth=self.user_one.auth, expect_errors=True)
+        assert_equal(res.status_code, 404)
 
     def test_creates_project_creates_project_and_sanitizes_html(self):
         title = '<em>Cool</em> <strong>Project</strong>'


### PR DESCRIPTION
Purpose
-----------
Fixes issues found in https://openscience.atlassian.net/browse/OSF-5631

Because changes for templating were happening in the serializer rather than the views, it wasn't going through the normal permission/missing-object checks. This PR adds checks into the create method to ensure proper handling.

Changes
-----------
In the serializer's create method, ensure that the node exists and also that the user has permission for the top-level node. The model will handle permissions for everything after that. Also tests.

Side effects
---------------
None.

Note: At some point we'll probably want to abstract out a way to get a node from the serializer so that it checks existence and permissions properly and automatically, but that's a potentially bigger project.