### PR TITLE
[WIP] Handle file comments on move/rename file

### DIFF
--- a/addons.json
+++ b/addons.json
@@ -26,6 +26,13 @@
         "wiki": "full"
     },
     "addons_commentable": [
-        "osfstorage"
+        "osfstorage",
+        "box",
+        "dropbox",
+        "github",
+        "googledrive",
+        "s3",
+        "dataverse",
+        "figshare"
     ]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ mailchimp==2.0.9
 nameparser==0.3.3
 py-bcrypt==0.4
 pymongo==2.5.1
+pytest==2.8.7
 python-dateutil==2.4.2
 python-gnupg==0.3.6
 pytz==2014.9

--- a/website/project/views/comment.py
+++ b/website/project/views/comment.py
@@ -26,7 +26,7 @@ def update_comment_root_target_file(self, node, event_type, payload, user=None):
 
         if source.get('path').endswith('/'):
             if event_type == 'addon_file_moved' or (event_type == 'addon_file_renamed' and not (source['provider'] == 'osfstorage' or source['provider'] == 'box')):
-                folder_contents = destination['children']
+                folder_contents = destination.get('children', [destination])
                 update_file_records(folder_contents, source, source_node, destination, destination_node)
 
         else:

--- a/website/project/views/comment.py
+++ b/website/project/views/comment.py
@@ -68,7 +68,7 @@ def update_comment_root_target_file(self, node, event_type, payload, user=None):
 
             new_path = destination['path']
             if destination['provider'] == 'dropbox':  # prepend root folder
-                new_path = '/{}/{}'.format(destination_node.get_addon(destination['provider']).folder_name, new_path.strip('/'))
+                new_path = '{}/{}'.format(destination_node.get_addon(destination['provider']).folder, new_path.strip('/'))
 
             old_file.stored_object.path = new_path
             old_file.save()

--- a/website/project/views/comment.py
+++ b/website/project/views/comment.py
@@ -67,7 +67,7 @@ def update_comment_root_target_file(self, node, event_type, payload, user=None):
 
             new_path = destination['path']
             if destination['provider'] == 'dropbox':  # prepend root folder
-                new_path = '/{}/{}'.format(destination_node.get_addon(destination['provider']).folder, new_path.strip('/'))
+                new_path = '/{}/{}'.format(destination_node.get_addon(destination['provider']).folder_name, new_path.strip('/'))
 
             old_file.stored_object.path = new_path
             old_file.save()

--- a/website/project/views/comment.py
+++ b/website/project/views/comment.py
@@ -52,9 +52,10 @@ def update_comment_root_target_file(self, node, event_type, payload, user=None):
             else:
                 old_file = FileNode.resolve_class(source.get('provider'), FileNode.FILE).get_or_create(source_node, source.get('path'))
 
-            data = dict(destination)  # convert OrderedDict to dict
-            data['extra'] = dict(destination['extra'])
-            old_file.update(revision=None, data=data)
+            if source['provider'] != 'osfstorage':
+                data = dict(destination)  # convert OrderedDict to dict
+                data['extra'] = dict(destination['extra'])
+                old_file.update(revision=None, data=data)
 
             has_comments = Comment.find(Q('root_target', 'eq', old_file._id)).count()
             if source_node._id != destination_node._id:


### PR DESCRIPTION
Update existing FileNode objects with metadata returned from waterbutler. For files in nested folders, just update the path and if necessary, the node and provider.