### PR TITLE
[WIP][Feature] Upgrade API to 1.9

### DIFF
--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -284,7 +284,7 @@ class ODMFilterMixin(FilterMixin):
         if self.request.parser_context['kwargs'].get('is_embedded'):
             param_query = None
         else:
-            param_query = self.query_params_to_odm_query(self.request.QUERY_PARAMS)
+            param_query = self.query_params_to_odm_query(self.request.query_params)
         default_query = self.get_default_odm_query()
 
         if param_query:
@@ -340,8 +340,8 @@ class ListFilterMixin(FilterMixin):
 
     def get_queryset_from_request(self):
         default_queryset = self.get_default_queryset()
-        if not self.kwargs.get('is_embedded') and self.request.QUERY_PARAMS:
-            param_queryset = self.param_queryset(self.request.QUERY_PARAMS, default_queryset)
+        if not self.kwargs.get('is_embedded') and self.request.query_params:
+            param_queryset = self.param_queryset(self.request.query_params, default_queryset)
             return param_queryset
         else:
             return default_queryset

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,8 +48,8 @@ raven==5.1.1
 webcolors==1.4
 
 # API requirements
-Django==1.8
-djangorestframework==3.1.1
+Django==1.9
+djangorestframework==3.3.2
 django-cors-headers==1.1.0
 django-rest-swagger==0.3.2
 djangorestframework-bulk==0.2.1


### PR DESCRIPTION
## Proposal

Upgrade the API from Django 1.8 to 1.9.

## Repercussions

Although I have started this process there are a few catches that might not be great:
- `api.base.serializer` ~443 has a line that gets back what looks to be a dictionary, but is actually a string.
- `hasattr` is used a few times in the API, but might be causing significant recursion.

Hopefully other issues are related to these, so fixing them will fix many other test failures.