### PR TITLE
Fix the 'x' icon next to 'Filter' in Files detail page to not overlap…

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1689,10 +1689,10 @@ var FGToolbar = {
                 icon : 'fa fa-times'
             }, '');
         templates[toolbarModes.FILTER] =  [
-            m('.col-xs-10', [
+            m('.col-xs-9', [
                 ctrl.tb.options.filterTemplate.call(ctrl.tb)
                 ]),
-                m('.col-xs-2.tb-buttons-col',
+                m('.col-xs-3.tb-buttons-col',
                     m('.fangorn-toolbar.pull-right', [dismissIcon])
                 )
             ];


### PR DESCRIPTION
…/disappear on page resize.

[OSF-5552]