### PR TITLE
[Feature Fix] Remove index from Node.contributors 

### DIFF
--- a/website/project/model.py
+++ b/website/project/model.py
@@ -747,6 +747,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
             'unique': False,
             'key_or_list': [
                 ('contributors', 1),
+                ('contributors.$', 1)
             ]
         }
     ]

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -743,13 +743,6 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin):
                 ('is_deleted', pymongo.ASCENDING),
             ]
         },
-        {
-            'unique': False,
-            'key_or_list': [
-                ('contributors', 1),
-                ('contributors.$', 1)
-            ]
-        }
     ]
 
     # Node fields that trigger an update to Solr on save


### PR DESCRIPTION
This removes an index from Node.contributors that was causing MultiKey errors in tokumx