### PR TITLE
[Ready to Review] Feature/separate date_last_login and date_last_request

### DIFF
--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -372,8 +372,11 @@ class User(GuidStoredObject, AddonModelMixin):
     # hashed password used to authenticate to Piwik
     piwik_token = fields.StringField()
 
-    # date the user last sent a request
+    # date user last authenticated with CAS
     date_last_login = fields.DateTimeField()
+
+    # date the user last sent a request
+    date_last_request = fields.DateTimeField()
 
     # date the user first successfully confirmed an email address
     date_confirmed = fields.DateTimeField(index=True)

--- a/framework/sessions/__init__.py
+++ b/framework/sessions/__init__.py
@@ -177,7 +177,7 @@ def before_request():
         except itsdangerous.BadData:
             return
         if session.data.get('auth_user_id'):
-            database['user'].update({'_id': session.data.get('auth_user_id')}, {'$set': {'date_last_login': datetime.utcnow()}}, w=0)
+            database['user'].update({'_id': session.data.get('auth_user_id')}, {'$set': {'date_last_request': datetime.utcnow()}}, w=0)
         set_session(session)
 
 def after_request(response):

--- a/scripts/migration/migrate_date_last_request_for_current_users.py
+++ b/scripts/migration/migrate_date_last_request_for_current_users.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 def main(dry=True):
     init_app(routes=False)
     users = models.User.find(Q('date_last_request', 'eq', None))
-    logger.warn('All active users will have a date_last_request field added and set equal to date_last_login.')
+    logger.info('All active users will have a date_last_request field added and set equal to date_last_login.')
 
     for user in users:
         if user.is_active:

--- a/scripts/migration/migrate_date_last_request_for_current_users.py
+++ b/scripts/migration/migrate_date_last_request_for_current_users.py
@@ -1,0 +1,34 @@
+"""
+Used to add users date_last_request, value set equal to date_last_login.
+"""
+
+import sys
+import logging
+from modularodm import Q
+from website.app import init_app
+from website import models
+from scripts import utils as script_utils
+from framework.transactions.context import TokuTransaction
+
+logger = logging.getLogger(__name__)
+
+
+def main(dry=True):
+    init_app(routes=False)
+    users = models.User.find(Q('date_last_request', 'eq', None))
+    logger.warn('All active users will have a date_last_request field added and set equal to date_last_login.')
+
+    for user in users:
+        with TokuTransaction():
+            if user.is_active:
+                user.date_last_request = user.date_last_login
+                if not dry:
+                    user.save()
+                    logger.info('User {0} "date_last_request" added'.format(user._id))
+
+if __name__ == '__main__':
+    dry_run = 'dry' in sys.argv
+    if not dry_run:
+        script_utils.add_file_logger(logger, __file__)
+    main(dry=dry_run)
+

--- a/scripts/migration/migrate_date_last_request_for_current_users.py
+++ b/scripts/migration/migrate_date_last_request_for_current_users.py
@@ -31,5 +31,5 @@ if __name__ == '__main__':
     if not dry_run:
         script_utils.add_file_logger(logger, __file__)
     with TokuTransaction():
-        main(dry=True)
+        main(dry=dry_run)
 

--- a/scripts/migration/migrate_date_last_request_for_current_users.py
+++ b/scripts/migration/migrate_date_last_request_for_current_users.py
@@ -19,16 +19,17 @@ def main(dry=True):
     logger.warn('All active users will have a date_last_request field added and set equal to date_last_login.')
 
     for user in users:
-        with TokuTransaction():
-            if user.is_active:
-                user.date_last_request = user.date_last_login
-                if not dry:
-                    user.save()
-                    logger.info('User {0} "date_last_request" added'.format(user._id))
+        if user.is_active:
+            user.date_last_request = user.date_last_login
+            user.save()
+            logger.info('User {0} "date_last_request" added'.format(user._id))
+    if dry:
+        raise RuntimeError('Dry run -- transaction rolled back')
 
 if __name__ == '__main__':
     dry_run = 'dry' in sys.argv
     if not dry_run:
         script_utils.add_file_logger(logger, __file__)
-    main(dry=dry_run)
+    with TokuTransaction():
+        main(dry=True)
 

--- a/scripts/tests/test_migrate_date_last_request_for_current_users.py
+++ b/scripts/tests/test_migrate_date_last_request_for_current_users.py
@@ -1,0 +1,44 @@
+from nose.tools import *
+
+from datetime import datetime
+from tests.base import OsfTestCase
+from tests import factories
+from website import models
+
+from scripts.migration.migrate_date_last_request_for_current_users import main
+
+
+class TestMigrateDateLastRequest(OsfTestCase):
+    def setUp(self):
+        super(TestMigrateDateLastRequest, self).setUp()
+        self.user = factories.UserFactory()
+        self.user2 = factories.UserFactory()
+        self.user3 = factories.UserFactory()
+
+        self.users = [self.user, self.user2, self.user3]
+
+        for user in self.users:
+            user.__setattr__('date_last_login', datetime.utcnow())
+            user.save()
+
+
+    def tearDown(self):
+        super(TestMigrateDateLastRequest, self).tearDown()
+        models.User.remove()
+
+    def test_get_users(self):
+        assert_equal(self.user.date_last_request, None)
+        assert_equal(self.user2.date_last_request, None)
+        assert_equal(self.user3.date_last_request, None)
+        assert_not_equal(self.user.date_last_request, self.user.date_last_login)
+        assert_not_equal(self.user2.date_last_request, self.user2.date_last_login)
+        assert_not_equal(self.user3.date_last_request, self.user3.date_last_login)
+
+        main(dry=False)
+
+        for user in self.users:
+            user.reload()
+
+        assert_equal(self.user.date_last_request, self.user.date_last_login)
+        assert_equal(self.user2.date_last_request, self.user2.date_last_login)
+        assert_equal(self.user3.date_last_request, self.user3.date_last_login)

--- a/scripts/tests/test_migrate_date_last_request_for_current_users.py
+++ b/scripts/tests/test_migrate_date_last_request_for_current_users.py
@@ -1,6 +1,6 @@
 from nose.tools import *
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from tests.base import OsfTestCase
 from tests import factories
 from website import models
@@ -21,6 +21,9 @@ class TestMigrateDateLastRequest(OsfTestCase):
             user.__setattr__('date_last_login', datetime.utcnow())
             user.save()
 
+        self.user3.date_last_request = (datetime.utcnow() + timedelta(hours=24))
+        self.user3.save()
+
 
     def tearDown(self):
         super(TestMigrateDateLastRequest, self).tearDown()
@@ -29,7 +32,8 @@ class TestMigrateDateLastRequest(OsfTestCase):
     def test_get_users(self):
         assert_equal(self.user.date_last_request, None)
         assert_equal(self.user2.date_last_request, None)
-        assert_equal(self.user3.date_last_request, None)
+        assert_not_equal(self.user3.date_last_request, None)
+
         assert_not_equal(self.user.date_last_request, self.user.date_last_login)
         assert_not_equal(self.user2.date_last_request, self.user2.date_last_login)
         assert_not_equal(self.user3.date_last_request, self.user3.date_last_login)
@@ -41,4 +45,4 @@ class TestMigrateDateLastRequest(OsfTestCase):
 
         assert_equal(self.user.date_last_request, self.user.date_last_login)
         assert_equal(self.user2.date_last_request, self.user2.date_last_login)
-        assert_equal(self.user3.date_last_request, self.user3.date_last_login)
+        assert_not_equal(self.user3.date_last_request, self.user3.date_last_login)

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -303,6 +303,7 @@ class TestUserMerging(base.OsfTestCase):
             'date_confirmed',
             'date_disabled',
             'date_last_login',
+            'date_last_request',
             'date_registered',
             'family_name',
             'fullname',


### PR DESCRIPTION
# Purpose

Issue: https://openscience.atlassian.net/browse/OSF-5523

We have a user field called `date_last_login`, but it actually is the date the user last sent a request.  So currently, we are not actually tracking `date_last_login`. `date_last_login` and `date_last_request` should be separated.  Tracking `date_last_request` separately will allow `date_last_login` to be used for things like loading the number of comments on your project since you last logged in.

# Changes
- Adds a User field called `date_last_request` which will track what `date_last_login` is tracking
- Restricts `date_last_login` to be updated only when a user authenticates with CAS and on initial confirmation
- `date_last_request` is updated when a user makes a request
- Adds script to add `date_last_request` field, initially set equal to `date_last_login`

# Side Effects

Requires a migration.