### PR TITLE
Archiver Fixes

### DIFF
--- a/scripts/cleanup_failed_registrations.py
+++ b/scripts/cleanup_failed_registrations.py
@@ -5,7 +5,11 @@ import logging
 
 from modularodm import Q
 
-from website.archiver import ARCHIVER_UNCAUGHT_ERROR, ARCHIVER_FAILURE
+from website.archiver import (
+    ARCHIVER_UNCAUGHT_ERROR,
+    ARCHIVER_FAILURE,
+    ARCHIVER_INITIATED
+)
 from website.settings import ARCHIVE_TIMEOUT_TIMEDELTA
 from website.archiver.utils import handle_archive_fail
 from website.archiver.model import ArchiveJob
@@ -21,7 +25,8 @@ def find_failed_registrations():
     expired_if_before = datetime.utcnow() - ARCHIVE_TIMEOUT_TIMEDELTA
     jobs = ArchiveJob.find(
         Q('sent', 'eq', False) &
-        Q('datetime_initiated', 'lt', expired_if_before)
+        Q('datetime_initiated', 'lt', expired_if_before) &
+        Q('status', 'eq', ARCHIVER_INITIATED)
     )
     return {node.root for node in [job.dst_node for job in jobs] if node}
 

--- a/website/archiver/tasks.py
+++ b/website/archiver/tasks.py
@@ -1,5 +1,6 @@
 import requests
 import json
+import httplib as http
 
 import celery
 from celery.utils.log import get_task_logger
@@ -155,7 +156,9 @@ def make_copy_request(job_pk, url, data):
     src, dst, user = job.info()
     provider = data['source']['provider']
     logger.info("Sending copy request for addon: {0} on node: {1}".format(provider, dst._id))
-    requests.post(url, data=json.dumps(data))
+    res = requests.post(url, data=json.dumps(data))
+    if res.status_code not in (http.OK, http.CREATED, http.ACCEPTED):
+        raise HTTPError(res.status_code)
 
 
 def make_waterbutler_payload(src, dst, addon_short_name, rename, cookie, revision=None):


### PR DESCRIPTION
# Purpose

An uncaught non-20X response from the WB API when making a copy request in Archiver would allow failing copy requests to appear as successes. This in turn created registrations that were stuck 'archiving'. Later, when the `approve_registrations` script was run, it would auto-approve those registrations, creating approved (potentially public) registrations still stuck in archiving mode.

# Changes

Catch and raise a HTTPError for non-20X response from WB.