### PR TITLE
[hotfix] Update file move notification emails to show file name

### DIFF
--- a/website/addons/base/views.py
+++ b/website/addons/base/views.py
@@ -353,8 +353,8 @@ def create_waterbutler_log(payload, **kwargs):
                     action=payload['action'],
                     source_node=source_node,
                     destination_node=destination_node,
-                    source_path=payload['source']['path'],
-                    destination_path=payload['source']['path'],
+                    source_path=payload['source']['materialized'],
+                    destination_path=payload['source']['materialized'],
                     source_addon=payload['source']['addon'],
                     destination_addon=payload['destination']['addon'],
                 )


### PR DESCRIPTION
# Purpose

When a file move via the file browser takes too long, we let the user get back to browsing and then send them a notification when it's done. The notification email was showing the `path` of the moved file, which
is an identifier, not a human-readable filename.  Ex. if a file was moved from osfstorage to another provider, the email would read `The folder "56b3816a594d90018653919b” has been successfully moved`

# Changes

This PR updates `create_waterbutler_log` to pass the human-readable `materialized` property of the source and destination log payloads instead of the `path` property.

Fixes: [#OSF-5648]