### PR TITLE
[Feature] fix esi for jsonapi

### DIFF
--- a/api/base/renderers.py
+++ b/api/base/renderers.py
@@ -1,21 +1,23 @@
 import re
 from rest_framework.renderers import JSONRenderer, BrowsableAPIRenderer
 
-class JSONAPIRenderer(JSONRenderer):
-    format = "jsonapi"
-    media_type = 'application/vnd.api+json'
+
+class JSONRendererWithESISupport(JSONRenderer):
+    format = 'json'
+    media_type = 'application/json'
 
     def render(self, data, accepted_media_type=None, renderer_context=None):
         #  TODO: There should be a way to do this that is conditional on esi being requested and
         #  TODO: In such a way that it doesn't use regex unless there's absolutely no other way.
-        initial_rendering = super(JSONAPIRenderer, self).render(data, accepted_media_type, renderer_context)
+        initial_rendering = super(JSONRendererWithESISupport, self).render(data, accepted_media_type, renderer_context)
         augmented_rendering = re.sub(r'"<esi:include src=\\"(.*?)\\"\/>"', r'<esi:include src="\1"/>', initial_rendering)
         return augmented_rendering
 
 
-class JSONRenderer(JSONAPIRenderer):
-    format = 'json'
-    media_type = 'application/json'
+class JSONAPIRenderer(JSONRendererWithESISupport):
+    format = "jsonapi"
+    media_type = 'application/vnd.api+json'
+
 
 class BrowsableAPIRendererNoForms(BrowsableAPIRenderer):
     """

--- a/api/base/renderers.py
+++ b/api/base/renderers.py
@@ -12,6 +12,11 @@ class JSONAPIRenderer(JSONRenderer):
         augmented_rendering = re.sub(r'"<esi:include src=\\"(.*?)\\"\/>"', r'<esi:include src="\1"/>', initial_rendering)
         return augmented_rendering
 
+
+class JSONRenderer(JSONAPIRenderer):
+    format = 'json'
+    media_type = 'application/json'
+
 class BrowsableAPIRendererNoForms(BrowsableAPIRenderer):
     """
     Renders browsable API but omits HTML forms

--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -65,7 +65,7 @@ REST_FRAMEWORK = {
     # https://github.com/marcgibbons/django-rest-swagger/issues/271 is resolved.
     'DEFAULT_RENDERER_CLASSES': (
         'api.base.renderers.JSONAPIRenderer',
-        'api.base.renderers.JSONRenderer',
+        'api.base.renderers.JSONRendererWithESISupport',
         'api.base.renderers.BrowsableAPIRendererNoForms',
     ),
     'DEFAULT_PARSER_CLASSES': (
@@ -172,3 +172,4 @@ DEBUG_TRANSACTIONS = DEBUG
 ENABLE_VARNISH = False
 ENABLE_ESI = False
 VARNISH_SERVERS = []  # This should be set in local.py or cache invalidation won't work
+ESI_MEDIA_TYPES = {'application/vnd.api+json', 'application/json'}

--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -65,7 +65,7 @@ REST_FRAMEWORK = {
     # https://github.com/marcgibbons/django-rest-swagger/issues/271 is resolved.
     'DEFAULT_RENDERER_CLASSES': (
         'api.base.renderers.JSONAPIRenderer',
-        'rest_framework.renderers.JSONRenderer',
+        'api.base.renderers.JSONRenderer',
         'api.base.renderers.BrowsableAPIRendererNoForms',
     ),
     'DEFAULT_PARSER_CLASSES': (

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -76,7 +76,7 @@ class JSONAPIBaseView(generics.GenericAPIView):
         context.update({
             'enable_esi': (
                 is_truthy(self.request.query_params.get('esi', django_settings.ENABLE_ESI)) and
-                self.request.accepted_media_type in {'application/vnd.api+json', 'application/json'}
+                self.request.accepted_media_type in django_settings.ESI_MEDIA_TYPES
             ),
             'embed': embeds_partials,
         })

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -76,7 +76,7 @@ class JSONAPIBaseView(generics.GenericAPIView):
         context.update({
             'enable_esi': (
                 is_truthy(self.request.query_params.get('esi', django_settings.ENABLE_ESI)) and
-                self.request.accepted_media_type == 'application/vnd.api+json'
+                self.request.accepted_media_type in {'application/vnd.api+json', 'application/json'}
             ),
             'embed': embeds_partials,
         })

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -74,7 +74,10 @@ class JSONAPIBaseView(generics.GenericAPIView):
             embeds_partials[embed] = self._get_embed_partial(embed, embed_field)
 
         context.update({
-            'enable_esi': is_truthy(self.request.query_params.get('esi', django_settings.ENABLE_ESI)),
+            'enable_esi': (
+                is_truthy(self.request.query_params.get('esi', django_settings.ENABLE_ESI)) and
+                self.request.accepted_media_type == 'application/vnd.api+json'
+            ),
             'embed': embeds_partials,
         })
         return context


### PR DESCRIPTION
This disables ESI in **all** cases except where the content-type is that of jsonapi. This can be forced for testing with ?format=jsonapi in the url or by passing the correct jsonapi vendor content type as a header.