### PR TITLE
Allow pagination to have 0/0, fixing 1/0 case (when node has no tags)

### DIFF
--- a/website/static/js/fileBrowser.js
+++ b/website/static/js/fileBrowser.js
@@ -869,7 +869,7 @@ var MicroPagination = {
             args.currentPage() > 1 ? m('span.m-r-xs.arrow.left.live', { onclick : function(){
                     args.currentPage(args.currentPage() - 1);
                 }}, m('i.fa.fa-angle-left')) : m('span.m-r-xs.arrow.left', m('i.fa.fa-angle-left')),
-            m('span', args.currentPage() + '/' + args.totalPages()),
+            m('span', (args.totalPages() ? args.currentPage() : 0) + '/' + args.totalPages()),
             args.currentPage() < args.totalPages() ? m('span.m-l-xs.arrow.right.live', { onclick : function(){
                     args.currentPage(args.currentPage() + 1);
             }}, m('i.fa.fa-angle-right')) : m('span.m-l-xs.arrow.right', m('i.fa.fa-angle-right'))


### PR DESCRIPTION
When something in micropagination has no instances (if not tags are present, as the common example), pagination would show as 1/0. This makes it so if the total is 0, the page number will also be 0.