### PR TITLE
Make API filtering on a charfield be case insensitive

### DIFF
--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -369,7 +369,7 @@ class ListFilterMixin(FilterMixin):
         elif isinstance(field, ser.CharField):
             return_val = [
                 item for item in default_queryset
-                if params['value'] in getattr(item, field_name, {}).lower()
+                if params['value'].lower() in getattr(item, field_name, {}).lower()
             ]
         else:
             return_val = [

--- a/api_tests/nodes/views/test_node_files_list.py
+++ b/api_tests/nodes/views/test_node_files_list.py
@@ -293,6 +293,13 @@ class TestNodeFilesListFiltering(ApiTestCase):
         assert_equal(len(res.json['data']), 1)  # filters out 'abc'
         assert_equal(res.json['data'][0]['attributes']['name'], 'xyz')
 
+    def test_node_files_filter_by_name_case_insensitive(self):
+        url = '/{}nodes/{}/files/github/?filter[name]=XYZ'.format(API_BASE, self.project._id)
+        res = self.app.get(url, auth=self.user.auth)
+        assert_equal(res.status_code, 200)
+        assert_equal(len(res.json['data']), 1)  # filters out 'abc', but finds 'xyz'
+        assert_equal(res.json['data'][0]['attributes']['name'], 'xyz')
+
     def test_node_files_are_filterable_by_path(self):
         url = '/{}nodes/{}/files/github/?filter[path]=abc'.format(API_BASE, self.project._id)
         res = self.app.get(url, auth=self.user.auth)


### PR DESCRIPTION
Reopening #5003 without all those merge develop commits

Relates to https://openscience.atlassian.net/browse/OSF-5029

# Purpose
Filtering by filename in the API fails if you don't use the correct case.

As described on Jira by @brianjgeiger:

https://staging-api.osf.io/v2/nodes/ck8hm/files/s3/?filter[name]=Renamed will always fail, even if there's a file named Renamed, but https://staging-api.osf.io/v2/nodes/ck8hm/files/s3/?filter[name]=renamed will succeed. 

# Changes
- When parsing the filter on a CharField, the API will make the query term lowercase
- Add test to make sure that a search of the incorrect case returns the desired results

# SideEffects
If any API filtering was relying on exact case of search terms for a charField, this will break.