### PR TITLE
hotfix/Update Getting Started language: statistics to analytics

### DIFF
--- a/website/templates/public/pages/help/statistics.mako
+++ b/website/templates/public/pages/help/statistics.mako
@@ -1,8 +1,8 @@
 <div class="col-sm-12">
     <span id="statistics" class="anchor"></span>
-    <h4 class="m-t-lg f-w-lg">Statistics</h4>
-    <p>Every project comes with a statistics page where you can see information on how many visitors your project has and what websites are referring them to your materials. </p>
-    <p>What types of information are displayed on the statistics page can be changed. From the Statistics tab of your project (found on the grey navigation bar), click on "Widgets & Dashboard." Select the widget you wish to add by clicking on the orange arrow to the right of the widget's name.</P>
+    <h4 class="m-t-lg f-w-lg">Analytics</h4>
+    <p>Every project comes with an analytics page where you can see information on how many visitors your project has and what websites are referring them to your materials. </p>
+    <p>What types of information are displayed on the analytics page can be changed. From the Analytics tab of your project (found on the grey navigation bar), click on "Widgets & Dashboard." Select the widget you wish to add by clicking on the orange arrow to the right of the widget's name.</P>
 
     <div class="row">
         <div class="col-md-8 col-md-offset-2 col-sm-12">


### PR DESCRIPTION
The "Statistics" tab has been renamed to "Analytics." This is updating the language on the Getting Started page.

I am not updating the anchor on the page because I'm concerned links point here and I don't want them to break. The entire Support/Getting Started page will be changed soon and I think we should deal with that issue then.