### PR TITLE
[RFR] Put IE fix back in for changing nodes privacy.

### DIFF
--- a/website/static/js/nodesPrivacy.js
+++ b/website/static/js/nodesPrivacy.js
@@ -4,7 +4,7 @@
 'use strict';
 
 var $ = require('jquery');
-var $3 = $;
+var $3 = window.$3;
 var ko = require('knockout');
 var Raven = require('raven-js');
 var $osf = require('./osfHelpers');

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -264,7 +264,7 @@
     <!-- JQuery 3 for IE Patching -->
     <script type="text/javascript" src="/static/vendor/jquery-compat-git/jquery-compat-git.js"></script>
     <script type="text/javascript">
-        var window.$3 = jQuery.noConflict(true);
+        var $3 = jQuery.noConflict(true);
     </script>
     ## NOTE: We load vendor bundle  at the top of the page because contains
     ## the webpack runtime and a number of necessary stylesheets which should be loaded before the user sees

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -264,7 +264,7 @@
     <!-- JQuery 3 for IE Patching -->
     <script type="text/javascript" src="/static/vendor/jquery-compat-git/jquery-compat-git.js"></script>
     <script type="text/javascript">
-        var $3 = jQuery.noConflict(true);
+        var window.$3 = jQuery.noConflict(true);
     </script>
     ## NOTE: We load vendor bundle  at the top of the page because contains
     ## the webpack runtime and a number of necessary stylesheets which should be loaded before the user sees

--- a/website/templates/project/nodes_privacy.mako
+++ b/website/templates/project/nodes_privacy.mako
@@ -110,7 +110,7 @@
                     <a class="btn btn-primary" data-bind="click:confirmWarning">Continue</a>
                 </span>
 
-                <span data-bind="if: page() == CONFIRM">
+                <span data-bind="if: page() == CONFIRM && (nodesChangedPublic().length + nodesChangedPrivate().length <= 100)">
                     <a href="#" class="btn btn-primary" data-bind="click: confirmChanges, visible: nodesChanged()" data-dismiss="modal">Confirm</a>
                 </span>
 


### PR DESCRIPTION
Allow me to reintroduce myself, my name is jQuery 3, which works when patching Internet Explorer.  This was accidentally removed, and we are putting it back in.  

Also, added logic to allow confirm to disappear when there are more then 100 nodes to change (the limit for bulk api)