### PR TITLE
[RFR] update treebeard when select all or select none are clicked

### DIFF
--- a/website/static/js/nodesPrivacySettingsTreebeard.js
+++ b/website/static/js/nodesPrivacySettingsTreebeard.js
@@ -71,6 +71,8 @@ function NodesPrivacyTreebeard(divID, data, nodesState, nodesOriginal) {
             var columns = [];
             var id = item.data.node.id;
             var nodesStateLocal = ko.toJS(nodesState());
+            //this lets treebeard know when changes come from the knockout side (select all or select none)
+            item.data.node.is_public = nodesStateLocal[id].public;
             columns.push(
                 {
                     data : 'action',


### PR DESCRIPTION
Treebeard was going out of sync when select all or select none were pressed when changing nodes privacy.  Basically, treebeard could update knockout, but not vice versa. . .  . . . 

UNTIL NOW!!!!!!!!!


![tumblr_mzhqymq6ml1skwvu2o1_r7_250](https://cloud.githubusercontent.com/assets/6232068/12933168/b318afce-cf54-11e5-877d-4eaa0547297c.gif)
