### PR TITLE
[Ready for Review ]Add template that differentiates between New Account makers and adding a new email to existing account

### DIFF
--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -245,8 +245,10 @@ def send_confirm_email(user, email):
         mail_template = mails.CONFIRM_MERGE
     elif campaign:
         mail_template = campaigns.email_template_for_campaign(campaign)
-    else:
+    elif user.is_active:
         mail_template = mails.CONFIRM_EMAIL
+    else:
+        mail_template = mails.INITIAL_CONFIRM_EMAIL
 
     mails.send_mail(
         email,

--- a/website/mails/mails.py
+++ b/website/mails/mails.py
@@ -128,7 +128,8 @@ def send_mail(to_addr, mail, mimetype='plain', from_addr=None, mailer=None,
 
 TEST = Mail('test', subject='A test email to ${name}', categories=['test'])
 
-CONFIRM_EMAIL = Mail('confirm', subject='Open Science Framework Account Verification')
+INITIAL_CONFIRM_EMAIL = Mail('initial_confirm', subject='Open Science Framework Account Verification')
+CONFIRM_EMAIL = Mail('confirm', subject='Open Science Framework Email Verification')
 CONFIRM_EMAIL_PREREG = Mail('confirm_prereg', subject='Open Science Framework Account Verification, Preregistration Challenge')
 
 CONFIRM_MERGE = Mail('confirm_merge', subject='Confirm account merge')

--- a/website/templates/emails/initial_confirm.txt.mako
+++ b/website/templates/emails/initial_confirm.txt.mako
@@ -1,0 +1,10 @@
+Hello ${user.fullname},
+
+Thank you for registering for an account on the Open Science Framework.
+
+Please verify your email address by visiting this link:
+
+${confirmation_url}
+
+The OSF Team
+Center for Open Science


### PR DESCRIPTION
Addresses https://openscience.atlassian.net/browse/OSF-5697

# Purpose 
Previous cherry-picked commit https://github.com/CenterForOpenScience/osf.io/commit/fee6ee687cd577de8dd2c5cafc2e0b39a76fc5ea modified the CONFIRM_EMAIL template to assume that you're confirming an email added to an existing account. @caileyfitz found that this email is also sent to new registratnt to the OSF. This PR adds a new category for email confirmation to be sent, that checks if this user is not active and sends a specific email then.

# Changes
- New email template that is sent when a person first enters their email into the account signup form
- Calling that email template from ```mails.py```
- Checking if a user is active, sending the simple CONFIRM_EMAIL in that case, and sending them their first ever "you've made an account with this email" if they're not active.

# Side effects
If another case used this generic CONFIRM EMAIL template, but I could not find one. 