### PR TITLE
[hotfix] storedfilenode parent index

### DIFF
--- a/website/files/models/base.py
+++ b/website/files/models/base.py
@@ -107,14 +107,19 @@ class StoredFileNode(StoredObject):
             ('path', pymongo.ASCENDING),
             ('node', pymongo.ASCENDING),
             ('is_file', pymongo.ASCENDING),
-            ('provider', pymongo.ASCENDING)
+            ('provider', pymongo.ASCENDING),
         ]
     }, {
         'unique': False,
         'key_or_list': [
             ('node', pymongo.ASCENDING),
             ('is_file', pymongo.ASCENDING),
-            ('provider', pymongo.ASCENDING)
+            ('provider', pymongo.ASCENDING),
+        ]
+    }, {
+        'unique': False,
+        'key_or_list': [
+            ('parent', pymongo.ASCENDING),
         ]
     }]
 


### PR DESCRIPTION
Prevent full table scan when looking up parent storedfilenode items.

@sloria