### PR TITLE
[WIP] Make api lists ESI-based

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -793,6 +793,8 @@ class JSONAPISerializer(ser.Serializer):
                         pass
                 query_params.update(dict(format='jsonapi'))
                 return '<esi:include src="{}?{}"/>'.format(href, query_params.urlencode())
+        # failsafe, let python do it if something bad happened in the ESI construction
+        return super(JSONAPISerializer, self).to_representation(data)
 
     # overrides Serializer
     def to_representation(self, obj, envelope='data'):

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -780,7 +780,7 @@ class JSONAPISerializer(ser.Serializer):
         query_params_blacklist = ['page[size]', 'format']
         try:
             href = data.get_absolute_url()
-        except:
+        except AttributeError:
             representation = super(JSONAPISerializer, self).to_representation(data)
             return representation
         else:


### PR DESCRIPTION
This PR makes list views in the API use ESI. 

Instead of drawing out the full object in JSON the object is replaced by a varnish esi:include tag. This allows cache invalidation to work correctly because every part of the API now depends on a url for each individual object. 

#### Sample Data for http://localhost:8000/v2/nodes/?format=jsonapi&page[size]=3
```json
{
    "data":[
    <esi:include src="http://localhost:8000/v2/nodes/kxfsn/?format=jsonapi"/>,
    <esi:include src="http://localhost:8000/v2/nodes/bnscw/?format=jsonapi"/>,
    <esi:include src="http://localhost:8000/v2/nodes/r7myv/?format=jsonapi"/>
],
    "links":{
       "first":null,
        "last":"http://localhost:8000/v2/nodes/?format=jsonapi&page=115&page%5Bsize%5D=3",
        "prev":null,
        "next":"http://localhost:8000/v2/nodes/?format=jsonapi&page=2&page%5Bsize%5D=3",
        "meta":{"total":345,"per_page":3}}
}
```

#### Special Note
- For list esi:include tags the query parameters on the initial url are compared to a blacklist and appended to the esi url

  - For embed ESI:include tags the query parameters are **not** included because recursion