### PR TITLE
Feature/allow client to request specific related counts

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -343,6 +343,26 @@ class RelationshipField(ser.HyperlinkedIdentityField):
             )
         )
 
+    def process_related_counts_parameters(self, params):
+        """
+        Processes related_counts parameter.
+
+        Can either be a True/False value for fetching counts on all fields, or a comma-separated list for specifying
+        individual fields.  Ensures specified fields are allowed.
+        """
+        if utils.is_truthy(params) or utils.is_falsy(params):
+            return params
+
+        field_counts_requested = [val for val in params.split(',')]
+        for count_field in field_counts_requested:
+            if count_field not in [field for field in self.parent.fields if getattr(self.parent.fields[field], 'json_api_link', False)]:
+                raise InvalidQueryStringError(
+                    detail="Acceptable values for the related_counts query param are 'true' or 'false' or relationship fields; got '{0}'".format(params),
+                    parameter='related_counts'
+                )
+        return field_counts_requested
+
+
     def get_meta_information(self, meta_data, value):
         """
         For retrieving meta values, otherwise returns {}

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -357,7 +357,7 @@ class RelationshipField(ser.HyperlinkedIdentityField):
         for count_field in field_counts_requested:
             if count_field not in [field for field in self.parent.fields if getattr(self.parent.fields[field], 'json_api_link', False)]:
                 raise InvalidQueryStringError(
-                    detail="Acceptable values for the related_counts query param are 'true' or 'false' or relationship fields; got '{0}'".format(params),
+                    detail="Acceptable values for the related_counts query param are 'true', 'false', or any of the relationship fields; got '{0}'".format(params),
                     parameter='related_counts'
                 )
         return field_counts_requested
@@ -373,9 +373,12 @@ class RelationshipField(ser.HyperlinkedIdentityField):
                 show_related_counts = self.context['request'].query_params.get('related_counts', False)
                 field_counts_requested = self.process_related_counts_parameters(show_related_counts)
 
-                if utils.is_truthy(show_related_counts) or self.field_name in field_counts_requested:
+                if utils.is_truthy(show_related_counts):
                     meta[key] = website_utils.rapply(meta_data[key], _url_val, obj=value, serializer=self.parent)
-
+                elif utils.is_falsy(show_related_counts):
+                    continue
+                elif self.field_name in field_counts_requested:
+                    meta[key] = website_utils.rapply(meta_data[key], _url_val, obj=value, serializer=self.parent)
                 else:
                     continue
             else:

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -348,7 +348,7 @@ class RelationshipField(ser.HyperlinkedIdentityField):
         Processes related_counts parameter.
 
         Can either be a True/False value for fetching counts on all fields, or a comma-separated list for specifying
-        individual fields.  Ensures specified fields are allowed.
+        individual fields.  Ensures field for which we are requesting counts is a relationship field.
         """
         if utils.is_truthy(params) or utils.is_falsy(params):
             return params

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -362,7 +362,6 @@ class RelationshipField(ser.HyperlinkedIdentityField):
                 )
         return field_counts_requested
 
-
     def get_meta_information(self, meta_data, value):
         """
         For retrieving meta values, otherwise returns {}

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -372,14 +372,12 @@ class RelationshipField(ser.HyperlinkedIdentityField):
             if key == 'count' or key == 'unread':
                 show_related_counts = self.context['request'].query_params.get('related_counts', False)
                 field_counts_requested = self.process_related_counts_parameters(show_related_counts)
+
+                if utils.is_truthy(show_related_counts) or self.field_name in field_counts_requested:
                     meta[key] = website_utils.rapply(meta_data[key], _url_val, obj=value, serializer=self.parent)
-                elif utils.is_falsy(show_related_counts):
+
+                else:
                     continue
-                if not utils.is_truthy(show_related_counts):
-                    raise InvalidQueryStringError(
-                        detail="Acceptable values for the related_counts query param are 'true' or 'false'; got '{0}'".format(show_related_counts),
-                        parameter='related_counts'
-                    )
             else:
                 meta[key] = website_utils.rapply(meta_data[key], _url_val, obj=value, serializer=self.parent)
         return meta

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -371,7 +371,7 @@ class RelationshipField(ser.HyperlinkedIdentityField):
         for key in meta_data or {}:
             if key == 'count' or key == 'unread':
                 show_related_counts = self.context['request'].query_params.get('related_counts', False)
-                if utils.is_truthy(show_related_counts):
+                field_counts_requested = self.process_related_counts_parameters(show_related_counts)
                     meta[key] = website_utils.rapply(meta_data[key], _url_val, obj=value, serializer=self.parent)
                 elif utils.is_falsy(show_related_counts):
                     continue

--- a/api_tests/base/test_serializers.py
+++ b/api_tests/base/test_serializers.py
@@ -123,6 +123,21 @@ class TestApiBaseSerializers(ApiTestCase):
         assert_equal(res.status_code, http.BAD_REQUEST)
         assert_equal(res.json['errors'][0]['detail'], "The following fields are not embeddable: foo")
 
+    def test_counts_included_in_children_field_with_children_related_counts_query_param(self):
+
+        res = self.app.get(self.url, params={'related_counts': 'children'})
+        relationships = res.json['data']['relationships']
+        for key, relation in relationships.iteritems():
+            if relation == {}:
+                continue
+            field = NodeSerializer._declared_fields[key]
+            if getattr(field, 'field', None):
+                field = field.field
+            link = relation['links'].values()[0]
+            if (field.related_meta or {}).get('count') and key == 'children':
+                assert_in('count', link['meta'])
+            else:
+                assert_not_in('count', link['meta'])
 
 class TestRelationshipField(DbTestCase):
 

--- a/api_tests/base/test_serializers.py
+++ b/api_tests/base/test_serializers.py
@@ -154,6 +154,15 @@ class TestApiBaseSerializers(ApiTestCase):
                 assert_in('count', link['meta'])
             else:
                 assert_not_in('count', link['meta'])
+
+    def test_error_when_requesting_related_counts_for_attribute_field(self):
+
+        res = self.app.get(self.url, params={'related_counts': 'title'}, expect_errors=True)
+        assert_equal(res.status_code, http.BAD_REQUEST)
+        assert_equal(res.json['errors'][0]['detail'], "Acceptable values for the related_counts query param are 'true', 'false', or any of the relationship fields; got 'title'")
+
+
+
 class TestRelationshipField(DbTestCase):
 
     # We need a Serializer to test the Relationship field (needs context)

--- a/api_tests/base/test_serializers.py
+++ b/api_tests/base/test_serializers.py
@@ -139,6 +139,21 @@ class TestApiBaseSerializers(ApiTestCase):
             else:
                 assert_not_in('count', link['meta'])
 
+    def test_counts_included_in_children_and_contributors_fields_with_field_csv_related_counts_query_param(self):
+
+        res = self.app.get(self.url, params={'related_counts': 'children,contributors'})
+        relationships = res.json['data']['relationships']
+        for key, relation in relationships.iteritems():
+            if relation == {}:
+                continue
+            field = NodeSerializer._declared_fields[key]
+            if getattr(field, 'field', None):
+                field = field.field
+            link = relation['links'].values()[0]
+            if (field.related_meta or {}).get('count') and key == 'children' or key == 'contributors':
+                assert_in('count', link['meta'])
+            else:
+                assert_not_in('count', link['meta'])
 class TestRelationshipField(DbTestCase):
 
     # We need a Serializer to test the Relationship field (needs context)


### PR DESCRIPTION
# Purpose

Issue: https://openscience.atlassian.net/browse/OSF-5725

 `?related_counts` parameter should be modified to allow the client to request specific relationship accounts, passed as a comma-separated list.

To retain backwards-compat, i.e. passing a boolean should also still work.

# Changes

Modified relationship serializer.

The following now works: 
 - `?related_counts=children`
 - `?related_counts=children,comments`

The following still works:
 - `?related_counts=true`


