### PR TITLE
[hotfix] gevent wsgi patch

### DIFF
--- a/admin/base/wsgi.py
+++ b/admin/base/wsgi.py
@@ -6,10 +6,17 @@ It exposes the WSGI callable as a module-level variable named ``application``.
 For more information on this file, see
 https://docs.djangoproject.com/en/1.8/howto/deployment/wsgi/
 """
+from gevent import monkey
+monkey.patch_all()
 
-import os
-from django.core.wsgi import get_wsgi_application
-from website.app import init_app
+# PATCH: avoid deadlock on getaddrinfo, this patch is necessary while waiting for
+# the final gevent 1.1 release (https://github.com/gevent/gevent/issues/349)
+unicode('foo').encode('idna')  # noqa
+
+
+import os  # noqa
+from django.core.wsgi import get_wsgi_application  # noqa
+from website.app import init_app  # noqa
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'admin.base.settings')
 

--- a/api/base/wsgi.py
+++ b/api/base/wsgi.py
@@ -6,10 +6,17 @@ It exposes the WSGI callable as a module-level variable named ``application``.
 For more information on this file, see
 https://docs.djangoproject.com/en/1.8/howto/deployment/wsgi/
 """
+from gevent import monkey
+monkey.patch_all()
 
-import os
-from django.core.wsgi import get_wsgi_application
-from website.app import init_app
+# PATCH: avoid deadlock on getaddrinfo, this patch is necessary while waiting for
+# the final gevent 1.1 release (https://github.com/gevent/gevent/issues/349)
+unicode('foo').encode('idna')  # noqa
+
+
+import os  # noqa
+from django.core.wsgi import get_wsgi_application  # noqa
+from website.app import init_app  # noqa
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'api.base.settings')
 

--- a/main.py
+++ b/main.py
@@ -1,9 +1,17 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-import os
+from gevent import monkey
+monkey.patch_all()
 
-from website import settings
-from website.app import init_app
+# PATCH: avoid deadlock on getaddrinfo, this patch is necessary while waiting for
+# the final gevent 1.1 release (https://github.com/gevent/gevent/issues/349)
+unicode('foo').encode('idna')  # noqa
+
+
+import os  # noqa
+
+from website import settings  # noqa
+from website.app import init_app  # noqa
 
 app = init_app('website.settings', set_backends=True, routes=True)
 


### PR DESCRIPTION
Patching via uwsgi.ini configuration was only patching full module imports.

https://uwsgi-docs.readthedocs.org/en/latest/Gevent.html#monkey-patching

> Monkey patching
> uWSGI uses native gevent api, so it does not need monkey patching. That said, your code may need it, so remember to call gevent.monkey.patch_all() at the start of your app. As of uWSGI 1.9, the convenience option --gevent-monkey-patch will do that for you. Please note that uWSGI does monkey patching before your application starts, not before your application loads. So if you are loading other modules while loading your application you may still need to call gevent.monkey.patch_all() yourself.
> 
> A common example is using psycopg2_gevent with django. Django will make a connection to postgres for each thread (storing it in thread locals).
> 
> As the uWSGI gevent plugin runs on a single thread this approach will lead to a deadlock in psycopg. Enabling monkey patch will allow you to map thread locals to greenlets (though you could avoid full monkey patching and only call gevent.monkey.patch_thread()) and solves the issue:

Further a good example can be found here: http://zderadicka.eu/running-uwsgi-for-gevent-enabled-application/