### PR TITLE
Feautre/node archiving children display

### DIFF
--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -926,8 +926,7 @@ def _get_summary(node, auth, rescale_ratio, primary=True, link_id=None, show_pat
         'is_pending_retraction': node.is_pending_retraction,
         'embargo_end_date': node.embargo_end_date.strftime("%A, %b. %d, %Y") if node.embargo_end_date else False,
         'is_pending_embargo': node.is_pending_embargo,
-        'archiving': node.archiving,
-        'archive_tree_in_progress': node.root.archiving,
+        'archiving': node.archiving or node.root.archiving,
     }
 
     if node.can_view(auth):

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -927,6 +927,7 @@ def _get_summary(node, auth, rescale_ratio, primary=True, link_id=None, show_pat
         'embargo_end_date': node.embargo_end_date.strftime("%A, %b. %d, %Y") if node.embargo_end_date else False,
         'is_pending_embargo': node.is_pending_embargo,
         'archiving': node.archiving,
+        'archive_tree_in_progress': node.root.archiving,
     }
 
     if node.can_view(auth):

--- a/website/templates/util/render_node.mako
+++ b/website/templates/util/render_node.mako
@@ -29,15 +29,14 @@
                   % elif summary['is_pending_embargo']:
                     <span class="label label-info"><strong>Pending embargo</strong></span> |
                   % endif
-                  % if summary['archiving']:
+                  % if summary['archive_tree_in_progress']:
                     <span class="label label-primary"><strong>Archiving</strong></span> |
                   % endif
                 </span>
             <span data-bind="getIcon: '${summary['category']}'"></span>
-            % if not summary['archiving']:
+            % if not summary['archive_tree_in_progress']:
                 <a href="${summary['url']}">${summary['title']}</a>
-            % endif
-            % if summary['archiving']:
+            % else:
                 <span class="f-w-lg">${summary['title']}</span>
             % endif
 
@@ -49,7 +48,7 @@
             </span>
 
             <!-- Show/Hide recent activity log -->
-            % if not summary['archiving']:
+            % if not summary['archive_tree_in_progress']:
             <div class="pull-right">
                 % if not summary['primary'] and 'admin' in user['permissions'] and not node['is_registration']:
                     <i class="fa fa-times remove-pointer" data-id="${summary['id']}" data-toggle="tooltip" title="Remove link"></i>
@@ -99,7 +98,7 @@
             </div>
             <span class="text-muted">${summary['nlogs']} contributions</span>
         % endif
-        % if not summary['archiving']:
+        % if not summary['archive_tree_in_progress']:
         <div class="body hide" id="body-${summary['id']}" style="overflow:hidden;">
             <hr />
             % if summary['is_retracted']:

--- a/website/templates/util/render_node.mako
+++ b/website/templates/util/render_node.mako
@@ -29,12 +29,12 @@
                   % elif summary['is_pending_embargo']:
                     <span class="label label-info"><strong>Pending embargo</strong></span> |
                   % endif
-                  % if summary['archive_tree_in_progress']:
+                  % if summary['archiving']:
                     <span class="label label-primary"><strong>Archiving</strong></span> |
                   % endif
                 </span>
             <span data-bind="getIcon: '${summary['category']}'"></span>
-            % if not summary['archive_tree_in_progress']:
+            % if not summary['archiving']:
                 <a href="${summary['url']}">${summary['title']}</a>
             % else:
                 <span class="f-w-lg">${summary['title']}</span>
@@ -48,7 +48,7 @@
             </span>
 
             <!-- Show/Hide recent activity log -->
-            % if not summary['archive_tree_in_progress']:
+            % if not summary['archiving']:
             <div class="pull-right">
                 % if not summary['primary'] and 'admin' in user['permissions'] and not node['is_registration']:
                     <i class="fa fa-times remove-pointer" data-id="${summary['id']}" data-toggle="tooltip" title="Remove link"></i>
@@ -98,7 +98,7 @@
             </div>
             <span class="text-muted">${summary['nlogs']} contributions</span>
         % endif
-        % if not summary['archive_tree_in_progress']:
+        % if not summary['archiving']:
         <div class="body hide" id="body-${summary['id']}" style="overflow:hidden;">
             <hr />
             % if summary['is_retracted']:


### PR DESCRIPTION
https://openscience.atlassian.net/browse/OSF-5591

# Purpose
When registering a project, and a component, if the parent project gets stuck in archiving, the children are presented as being OK and no-longer archiving.

While this is the desired behavior on the backend (the child has a different archive job and so should in fact succeed on its own) it should not be presented this way as that might be confusing to a user who is checking the status of their registration. If the top level is still archiving and so appears "locked," the child registrations should appear to be in the same state.

# Changes
- Add ```archive_tree_in_progress``` to the ``` _get_summary``` method that will display if a node's root is currently still undergoing archiving.
- Use this ```archive_tree_in_progress``` to determine if the archiving badge displayed in the mako template to display instead of its own ```archiving``` property (which is properly reported as finished)
- Add an ```else``` instead of a second if statement in ```render_node.mako```, adjustment found while investigating this issue.

# Side effects
- A new property was added to the ``` _get_summary``` method and no existing code other than the template itself was modified, so things should still work the same
- Other mako templates can now use this provided ```archive_tree_in_progress``` information if they'd like to check the archiving status of the root node.