### PR TITLE
Feature/api/authed public noncontrib current user perms

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -171,9 +171,11 @@ class NodeSerializer(JSONAPISerializer):
     def get_current_user_permissions(self, obj):
         user = self.context['request'].user
         if user.is_anonymous():
-            return ["read"]
-        else:
-            return obj.get_permissions(user=user)
+            return ['read']
+        permissions = obj.get_permissions(user=user)
+        if not permissions:
+            permissions = ['read']
+        return permissions
 
     class Meta:
         type_ = 'nodes'

--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -53,7 +53,7 @@ class TestNodeDetail(ApiTestCase):
         assert_equal(res.json['data']['attributes']['category'], self.public_project.category)
         assert_items_equal(res.json['data']['attributes']['current_user_permissions'], self.read_permissions)
 
-    def test_return_public_project_details_logged_in(self):
+    def test_return_public_project_details_contributor_logged_in(self):
         res = self.app.get(self.public_url, auth=self.user.auth)
         assert_equal(res.status_code, 200)
         assert_equal(res.content_type, 'application/vnd.api+json')
@@ -61,6 +61,15 @@ class TestNodeDetail(ApiTestCase):
         assert_equal(res.json['data']['attributes']['description'], self.public_project.description)
         assert_equal(res.json['data']['attributes']['category'], self.public_project.category)
         assert_items_equal(res.json['data']['attributes']['current_user_permissions'], self.admin_permissions)
+
+    def test_return_public_project_details_non_contributor_logged_in(self):
+        res = self.app.get(self.public_url, auth=self.user_two.auth)
+        assert_equal(res.status_code, 200)
+        assert_equal(res.content_type, 'application/vnd.api+json')
+        assert_equal(res.json['data']['attributes']['title'], self.public_project.title)
+        assert_equal(res.json['data']['attributes']['description'], self.public_project.description)
+        assert_equal(res.json['data']['attributes']['category'], self.public_project.category)
+        assert_items_equal(res.json['data']['attributes']['current_user_permissions'], self.read_permissions)
 
     def test_return_private_project_details_logged_out(self):
         res = self.app.get(self.private_url, expect_errors=True)

--- a/api_tests/nodes/views/test_view_only_query_parameter.py
+++ b/api_tests/nodes/views/test_view_only_query_parameter.py
@@ -66,6 +66,7 @@ class TestNodeDetailViewOnlyLinks(ViewOnlyTestCase):
         assert_equal(res_normal.status_code, 200)
         res_linked = self.app.get(self.private_node_one_url, {'view_only': self.private_node_one_private_link.key})
         assert_equal(res_linked.status_code, 200)
+        assert_items_equal(res_linked.json['data']['attributes']['current_user_permissions'], ['read'])
         assert_equal(res_linked.json, res_normal.json)
 
     def test_private_node_with_link_unauthorized_when_not_using_link(self):


### PR DESCRIPTION
Purpose
------------
Fix https://openscience.atlassian.net/browse/OSF-5546?focusedCommentId=28809&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-28809

Logged in non-contributors were getting [] for permissions, rather than ['read']. This tests that condition and ensures that the default permissions are ['read'] for situations where the model isn't returning permissions. The assumption being, if you can serialize the node, one way or another you have permission to read. If you can't, you should be getting an error before you hit serialization.

Changes
------------
1) Tests
2) Return ['read'] if the model returns a falsy value in get_permissions()

Side effects
---------------
If, for some reason, the model returns a falsy value for a user that has higher-than-read permission, this will report the user as having read permission. However, this would still be more correct than what the model would be returning, so it's probably the best side effect under the circumstances. I do not know of any situation where that would happen.
