### PR TITLE
Feature: Fix comment edit/delete permissions

### DIFF
--- a/api/comments/permissions.py
+++ b/api/comments/permissions.py
@@ -32,7 +32,7 @@ class CommentDetailPermissions(permissions.BasePermission):
         if request.method in permissions.SAFE_METHODS:
             return node.is_public or node.can_view(auth)
         else:
-            return comment.user._id == auth.user._id
+            return comment.user._id == auth.user._id and node.can_comment(auth)
 
 
 class CommentReportsPermissions(permissions.BasePermission):

--- a/api/comments/serializers.py
+++ b/api/comments/serializers.py
@@ -74,7 +74,7 @@ class CommentSerializer(JSONAPISerializer):
         user = self.context['request'].user
         if user.is_anonymous():
             return False
-        return obj.user._id == user._id
+        return obj.user._id == user._id and obj.node.can_comment(Auth(user))
 
     def get_has_children(self, obj):
         return Comment.find(Q('target', 'eq', obj)).count() > 0


### PR DESCRIPTION
Purpose:
------------
Fixes https://openscience.atlassian.net/browse/OSF-5681

If a project's comment level changes from public to private, non-contributors can still edit and delete any comments that they made while the comment level was public.

Changes:
------------
- The `can_edit` field on the CommentSerializer now checks if the user can comment on the project (not just if they are the author).
- The `CommentDetailPermissions.has_object_permission` also checks if the user can comment on the project.