### PR TITLE
[WIP] Feature/retractions causing 400 error when requesting specific related counts

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -356,12 +356,10 @@ class RelationshipField(ser.HyperlinkedIdentityField):
         field_counts_requested = [val for val in params.split(',')]
         countable_fields = {field for field in self.parent.fields if getattr(self.parent.fields[field], 'json_api_link', False)}
         for count_field in field_counts_requested:
+            # Some fields will hide relationships, e.g. HideIfRetraction
+            # Ignore related_counts for these fields
             fetched_field = self.parent.fields.get(count_field)
-            hidden = False
-            if fetched_field:
-                check = fetched_field.get_attribute(value)
-                if check is None:
-                    hidden = True
+            hidden = fetched_field and fetched_field.get_attribute(value) is None
 
             if not hidden and count_field not in countable_fields:
                 raise InvalidQueryStringError(

--- a/api_tests/registrations/views/test_registration_detail.py
+++ b/api_tests/registrations/views/test_registration_detail.py
@@ -28,6 +28,12 @@ class TestRegistrationDetail(ApiTestCase):
         self.public_url = '/{}registrations/{}/'.format(API_BASE, self.public_registration._id)
         self.private_url = '/{}registrations/{}/'.format(API_BASE, self.private_registration._id)
 
+        self.retraction_registration = RegistrationFactory(creator=self.user, project=self.public_project, public=True)
+        self.retraction_url = '/{}registrations/{}/'.format(API_BASE, self.retraction_registration._id)
+        retraction = RetractedRegistrationFactory(registration=self.retraction_registration, user=self.retraction_registration.creator)
+        retraction.justification = 'We made a major error.'
+        retraction.save()
+
     def test_return_public_registration_details_logged_out(self):
         res = self.app.get(self.public_url)
         assert_equal(res.status_code, 200)
@@ -83,12 +89,8 @@ class TestRegistrationDetail(ApiTestCase):
         assert_equal(res.json['errors'][0]['detail'], "Not found.")
 
     def test_retractions_display_limited_fields(self):
-        registration = RegistrationFactory(creator=self.user, project=self.public_project, public=True)
-        url = '/{}registrations/{}/'.format(API_BASE, registration._id)
-        retraction = RetractedRegistrationFactory(registration=registration, user=registration.creator)
-        retraction.justification = 'We made a major error.'
-        retraction.save()
-        res = self.app.get(url, auth=self.user.auth)
+        registration = self.retraction_registration
+        res = self.app.get(self.retraction_url, auth=self.user.auth)
         assert_equal(res.status_code, 200)
 
         assert_items_equal(res.json['data']['attributes'], {
@@ -129,21 +131,13 @@ class TestRegistrationDetail(ApiTestCase):
 
 
     def test_field_specific_related_counts_ignored_if_hidden_field_on_retraction(self):
-        registration = RegistrationFactory(creator=self.user, project=self.public_project, public=True)
-        url = '/{}registrations/{}/?related_counts=children'.format(API_BASE, registration._id)
-        retraction = RetractedRegistrationFactory(registration=registration, user=registration.creator)
-        retraction.justification = 'We made a major error.'
-        retraction.save()
+        url = '/{}registrations/{}/?related_counts=children'.format(API_BASE, self.retraction_registration._id)
         res = self.app.get(url, auth=self.user.auth)
         assert_equal(res.status_code, 200)
         assert_not_in('children', res.json['data']['relationships'])
 
     def test_field_specific_related_counts_retrieved_if_visible_field_on_retraction(self):
-        registration = RegistrationFactory(creator=self.user, project=self.public_project, public=True)
-        url = '/{}registrations/{}/?related_counts=contributors'.format(API_BASE, registration._id)
-        retraction = RetractedRegistrationFactory(registration=registration, user=registration.creator)
-        retraction.justification = 'We made a major error.'
-        retraction.save()
+        url = '/{}registrations/{}/?related_counts=contributors'.format(API_BASE, self.retraction_registration._id)
         res = self.app.get(url, auth=self.user.auth)
         assert_equal(res.status_code, 200)
         assert_equal(res.json['data']['relationships']['contributors']['links']['related']['meta']['count'], 1)


### PR DESCRIPTION
# Purpose

Fixes edge case found by @sloria in https://openscience.atlassian.net/browse/OSF-5725

As of OSF-5725, you can request specific related counts instead of fetching related counts for all the fields.  For example, a response to `v2/registrations/?related_counts=children` will only return counts for the registrations' children, not other countable fields like `contributors` and `node_links`.  However, we hide the majority of the fields for retracted registrations.  So if a retraction is in a list of registrations, `children` is a hidden field in a retraction, and a 400 error would be thrown. 

# Changes
Ignores related_counts for hidden fields.

