### PR TITLE
[Ready]Feature/Ensure hidden relationship fields are showing up in countable fields

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -354,14 +354,13 @@ class RelationshipField(ser.HyperlinkedIdentityField):
             return params
 
         field_counts_requested = [val for val in params.split(',')]
-        countable_fields = {field for field in self.parent.fields if getattr(self.parent.fields[field], 'json_api_link', False)}
+        countable_fields = {field for field in self.parent.fields if getattr(self.parent.fields[field], 'json_api_link', False) or
+                            getattr(getattr(self.parent.fields[field], 'field', None), 'json_api_link', None)}
         for count_field in field_counts_requested:
             # Some fields will hide relationships, e.g. HideIfRetraction
             # Ignore related_counts for these fields
             fetched_field = self.parent.fields.get(count_field)
             hidden = fetched_field and fetched_field.get_attribute(value) is None
-            if fetched_field is not hidden and fetched_field not in countable_fields:
-                countable_fields.add(fetched_field.field_name)
 
             if not hidden and count_field not in countable_fields:
                 raise InvalidQueryStringError(

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -360,6 +360,8 @@ class RelationshipField(ser.HyperlinkedIdentityField):
             # Ignore related_counts for these fields
             fetched_field = self.parent.fields.get(count_field)
             hidden = fetched_field and fetched_field.get_attribute(value) is None
+            if fetched_field is not hidden and fetched_field not in countable_fields:
+                countable_fields.add(fetched_field.field_name)
 
             if not hidden and count_field not in countable_fields:
                 raise InvalidQueryStringError(

--- a/api_tests/registrations/views/test_registration_detail.py
+++ b/api_tests/registrations/views/test_registration_detail.py
@@ -129,6 +129,12 @@ class TestRegistrationDetail(ApiTestCase):
         assert_not_in('files', res.json['data']['relationships'])
         assert_not_in('logs', res.json['data']['relationships'])
 
+    def test_registration_shows_specific_related_counts(self):
+        url = '/{}registrations/{}/?related_counts=children'.format(API_BASE, self.private_registration._id)
+        res = self.app.get(url, auth=self.user.auth)
+        assert_equal(res.status_code, 200)
+        assert_equal(res.json['data']['relationships']['children']['links']['related']['meta']['count'], 0)
+        assert_equal(res.json['data']['relationships']['contributors']['links']['related']['meta'], {})
 
     def test_field_specific_related_counts_ignored_if_hidden_field_on_retraction(self):
         url = '/{}registrations/{}/?related_counts=children'.format(API_BASE, self.retraction_registration._id)


### PR DESCRIPTION
# Purpose

Continued fix on  https://openscience.atlassian.net/browse/OSF-5725.
Related to PR https://github.com/CenterForOpenScience/osf.io/pull/5044

The changes to the last PR ^ that made countable fields more generic, made Retractions work, but not Registrations.

If we have a HideIfRetractionField or HideIfRegistrationField, for example, these fields wrap RelationshipFields.  So on a registration, no fields will be hidden, but there will be a limited subset of "countable_fields" because the RelationshipFields are wrapped.

# Changes

When populating countable fields (so looking for fields that are relationship fields, not attributes, as indicated by `json_api_link` is true), check for json_api_link in nested fields like HideIfRetraction or HideIfRegistration as well.