### PR TITLE
Add get_absolute_html_url method to base serializer and encourage usage

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -931,6 +931,9 @@ class JSONAPISerializer(ser.Serializer):
     def get_absolute_url(self, obj):
         raise NotImplementedError()
 
+    def get_absolute_html_url(self, obj):
+        return obj.absolute_url
+
     # overrides Serializer: Add HTML-sanitization similar to that used by APIv1 front-end views
     def is_valid(self, clean_html=True, **kwargs):
         """

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -104,7 +104,7 @@ class NodeSerializer(JSONAPISerializer):
                                         'public and private nodes. Administrators on a parent '
                                         'node have implicit read permissions for all child nodes')
 
-    links = LinksField({'html': 'get_absolute_url'})
+    links = LinksField({'html': 'get_absolute_html_url'})
     # TODO: When we have osf_permissions.ADMIN permissions, make this writable for admins
 
     children = RelationshipField(

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -95,7 +95,7 @@ class RegistrationSerializer(NodeSerializer):
 
     # TODO: Override create?
 
-    links = LinksField({'self': 'get_registration_url', 'html': 'get_absolute_url'})
+    links = LinksField({'self': 'get_registration_url', 'html': 'get_absolute_html_url'})
 
     def get_registration_url(self, obj):
         return absolute_reverse('registrations:registration-detail', kwargs={'node_id': obj._id})


### PR DESCRIPTION
This fixes the html api urls pointing to the api instead of osf.