### PR TITLE
[Ready to Review] Feature/500 error when accessing log detail

### DIFF
--- a/api/logs/permissions.py
+++ b/api/logs/permissions.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from rest_framework import permissions
+
+from website.models import Node, NodeLog
+
+from api.nodes.permissions import ContributorOrPublic
+from api.base.utils import get_object_or_error
+
+
+class ContributorOrPublicForLogs(permissions.BasePermission):
+
+    def has_object_permission(self, request, view, obj):
+        assert isinstance(obj, (NodeLog)), 'obj must be a NodeLog, got {}'.format(obj)
+
+        for node_id in obj._backrefs['logged']['node']['logs']:
+            node = get_object_or_error(Node, node_id, display_name='node')
+            if ContributorOrPublic().has_object_permission(request, view, node):
+                return True
+        return False

--- a/api/logs/permissions.py
+++ b/api/logs/permissions.py
@@ -12,8 +12,14 @@ class ContributorOrPublicForLogs(permissions.BasePermission):
     def has_object_permission(self, request, view, obj):
         assert isinstance(obj, (NodeLog)), 'obj must be a NodeLog, got {}'.format(obj)
 
-        for node_id in obj._backrefs['logged']['node']['logs']:
-            node = get_object_or_error(Node, node_id, display_name='node')
-            if ContributorOrPublic().has_object_permission(request, view, node):
+        if obj._backrefs.get('logged'):
+            for node_id in obj._backrefs['logged']['node']['logs']:
+                node = get_object_or_error(Node, node_id, display_name='node')
+                if ContributorOrPublic().has_object_permission(request, view, node):
+                    return True
+
+        if getattr(obj, 'node'):
+            if ContributorOrPublic().has_object_permission(request, view, obj.node):
                 return True
+
         return False

--- a/api/logs/views.py
+++ b/api/logs/views.py
@@ -5,13 +5,13 @@ from modularodm import Q
 from framework.auth.core import User
 from framework.auth.oauth_scopes import CoreScopes
 
-from website.models import NodeLog, Node
-from api.nodes.permissions import (
-    ContributorOrPublic,
+from website.models import NodeLog
+from api.logs.permissions import (
+    ContributorOrPublicForLogs
 )
 
 from api.base.filters import ODMFilterMixin
-from api.base.utils import get_user_auth, get_object_or_error
+from api.base.utils import get_user_auth
 from api.base import permissions as base_permissions
 from api.nodes.serializers import NodeSerializer
 from api.users.serializers import UserSerializer
@@ -31,23 +31,8 @@ class LogMixin(object):
                 detail='No log matching that log_id could be found.'
             )
 
-        self.check_log_permission(log)
+        self.check_object_permissions(self.request, log)
         return log
-
-    def check_log_permission(self, log):
-        """
-        Cycles through nodes on log backrefs.  If user can view any of the nodes pertaining to the log, this means
-        the log itself can be viewed.
-        """
-        auth_user = get_user_auth(self.request)
-        log_nodes = []
-
-        for node_id in log._backrefs['logged']['node']['logs']:
-            node = get_object_or_error(Node, node_id, display_name='node')
-            log_nodes.append(node)
-            if node.can_view(auth_user):
-                return
-        self.check_object_permissions(self.request, log_nodes[0])  # will raise 401 or 403, as appropriate
 
 
 class LogNodeList(JSONAPIBaseView, generics.ListAPIView, LogMixin, ODMFilterMixin):
@@ -105,7 +90,7 @@ class LogNodeList(JSONAPIBaseView, generics.ListAPIView, LogMixin, ODMFilterMixi
     permission_classes = (
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
-        ContributorOrPublic
+        ContributorOrPublicForLogs
     )
 
     required_read_scopes = [CoreScopes.NODE_LOG_READ]
@@ -181,7 +166,7 @@ class NodeLogDetail(JSONAPIBaseView, generics.RetrieveAPIView, LogMixin):
     permission_classes = (
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
-        ContributorOrPublic
+        ContributorOrPublicForLogs
     )
 
     required_read_scopes = [CoreScopes.NODE_LOG_READ]
@@ -252,7 +237,7 @@ class NodeLogContributors(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin,
     permission_classes = (
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
-        ContributorOrPublic
+        ContributorOrPublicForLogs
     )
 
     required_read_scopes = [CoreScopes.USERS_READ]

--- a/api_tests/logs/views/test_log_detail.py
+++ b/api_tests/logs/views/test_log_detail.py
@@ -32,3 +32,9 @@ class TestLogDetail(LogsTestCase):
         assert_equal(res.status_code, 200)
         json_data = res.json['data']
         assert_equal(json_data['id'], self.public_log._id)
+
+    def test_log_detail_data_format_api(self):
+        res = self.app.get(self.public_log_detail + '?format=api', auth=self.user.auth)
+        assert_equal(res.status_code, 200)
+        assert_in(self.public_log._id, res.body)
+


### PR DESCRIPTION
# Purpose

Issue https://openscience.atlassian.net/browse/OSF-5777

Accessing log detail `/v2/logs/{log_id}/` for a project's logs gives a 500.  

This issue blocks https://openscience.atlassian.net/browse/OSF-5471

# Changes

Instead of using ContributorOrPublic method on log views (which was built for nodes), created a ContributorOrPublicForLogs method which then calls ContributorOrPublic for each of the nodes on the log's backref to see if the user has permission to access the log.

(Will be modified slightly when backrefs are eliminated between nodes and nodelogs).

Tests were already written for these endpoints and were now failing locally before this change.  Are these running on Travis?




