### PR TITLE
add scripts/* to .coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,8 +1,9 @@
 [run]
 include =
     api/*
-    website/*
     framework/*
+    scripts/*
+    website/*
 omit =
     *tests/*
 [report]


### PR DESCRIPTION
The `scripts` directory is a Python module, it turns out. It should be possible to run coverage reports against it (e.g., https://github.com/CenterForOpenScience/osf.io/pull/5033/files#r54173051).

cf. #4965