### PR TITLE
[Hotfix] Preserve OAuth grant metadata when forking

### DIFF
--- a/website/addons/base/__init__.py
+++ b/website/addons/base/__init__.py
@@ -862,7 +862,7 @@ class AddonOAuthNodeSettingsBase(AddonNodeSettingsBase):
             "AddonOAuthNodeSettingsBase subclasses must expose a 'clear_settings' method."
         )
 
-    def set_auth(self, external_account, user, log=True):
+    def set_auth(self, external_account, user, metadata=None, log=True):
         """Connect the node addon to a user's external account.
 
         This method also adds the permission to use the account in the user's
@@ -872,8 +872,8 @@ class AddonOAuthNodeSettingsBase(AddonNodeSettingsBase):
         user_settings = user.get_or_add_addon(self.oauth_provider.short_name)
         user_settings.grant_oauth_access(
             node=self.owner,
-            external_account=external_account
-            # no metadata, because the node has access to no folders
+            external_account=external_account,
+            metadata=metadata  # metadata can be passed in when forking
         )
         user_settings.save()
 
@@ -961,7 +961,13 @@ class AddonOAuthNodeSettingsBase(AddonNodeSettingsBase):
             save=False,
         )
         if self.has_auth and self.user_settings.owner == user:
-            clone.set_auth(self.external_account, user, log=False)
+            metadata = None
+            if self.complete:
+                try:
+                    metadata = self.user_settings.oauth_grants[node._id][self.external_account._id]
+                except (KeyError, AttributeError):
+                    pass
+            clone.set_auth(self.external_account, user, metadata=metadata, log=False)
             message = '{addon} authorization copied to forked {category}.'.format(
                 addon=self.config.full_name,
                 category=fork.project_or_component,

--- a/website/addons/box/model.py
+++ b/website/addons/box/model.py
@@ -134,19 +134,6 @@ class BoxNodeSettings(StorageAddonBase, AddonOAuthNodeSettingsBase):
         self.folder_id = str(folder_id)
         self._update_folder_data()
         self.save()
-
-        """ TODO: see if implicit authorization is necessary
-        (or a good idea in general?)
-        if not self.complete:
-            self.user_settings.grant_oauth_access(
-                node=self.owner,
-                external_account=self.external_account,
-                metadata={'folder': self.folder_id}
-            )
-            self.user_settings.save()
-        """
-
-        # Add log to node
         self.nodelogger.log(action="folder_selected", save=True)
 
     def clear_settings(self):

--- a/website/addons/googledrive/model.py
+++ b/website/addons/googledrive/model.py
@@ -114,16 +114,12 @@ class GoogleDriveNodeSettings(StorageAddonBase, AddonOAuthNodeSettingsBase):
         self.folder_id = folder['id']
         self.folder_path = folder['path']
 
-        if not self.complete:
-            # Tell the user's addon settings that this node is connecting
-            self.user_settings.grant_oauth_access(
-                node=self.owner,
-                external_account=self.external_account,
-                metadata={'folder': self.folder_id}
-            )
-            self.user_settings.save()
-
-        # update this instance
+        # Tell the user's addon settings that this node is connecting
+        self.user_settings.grant_oauth_access(
+            node=self.owner,
+            external_account=self.external_account,
+            metadata={'folder': self.folder_id}
+        )  # Performs a save on self.user_settings
         self.save()
 
         self.owner.add_log(

--- a/website/addons/googledrive/model.py
+++ b/website/addons/googledrive/model.py
@@ -101,10 +101,6 @@ class GoogleDriveNodeSettings(StorageAddonBase, AddonOAuthNodeSettingsBase):
         self.folder_path = None
         return super(GoogleDriveNodeSettings, self).clear_auth()
 
-    def set_auth(self, *args, **kwargs):
-        self.folder_id = None
-        return super(GoogleDriveNodeSettings, self).set_auth(*args, **kwargs)
-
     def set_target_folder(self, folder, auth):
         """Configure this addon to point to a Google Drive folder
 


### PR DESCRIPTION
Purpose
=======
When forking a node with configured addons that support OAuth grants, the new node's grants should have the same metadata as the original grant. If this is not done, some functionality (e.g. viewing/downloading a file) can throw errors.

Changes
=======
* Preserve metadata
* Don't bother with `.complete` check, grant always needs to be updated on folder selection

Side Effects
=========
Duplicated code from #4949: stop clearing `folder_id` on `set_auth` for GDrive -- this is necessary for folder link to persist when forking.

[#OSF-5790]