### PR TITLE
[WIP] feature/Add "Read More" link to wiki preview

### DIFF
--- a/website/addons/wiki/templates/wiki_widget.mako
+++ b/website/addons/wiki/templates/wiki_widget.mako
@@ -9,6 +9,12 @@
     % endif
 </div>
 
+<div id="more_link">
+    % if more:
+        <a href="${node['url']}${short_name}/">Read More</a>
+    % endif
+</div>
+
 <% import json %>
 <script>
     window.contextVars = $.extend(true, {}, window.contextVars, {

--- a/website/addons/wiki/templates/wiki_widget.mako
+++ b/website/addons/wiki/templates/wiki_widget.mako
@@ -2,9 +2,7 @@
 <%page expression_filter="h"/>
 
 <div id="markdownRender" class="break-word">
-    % if wiki_content:
-        ${wiki_content | n}
-    % else:
+    % if not wiki_content:
         <p><em>No wiki content</em></p>
     % endif
 </div>

--- a/website/addons/wiki/templates/wiki_widget.mako
+++ b/website/addons/wiki/templates/wiki_widget.mako
@@ -2,9 +2,6 @@
 <%page expression_filter="h"/>
 
 <div id="markdownRender" class="break-word">
-    % if not wiki_content:
-        <p><em>No wiki content</em></p>
-    % endif
 </div>
 
 <div id="more_link">

--- a/website/addons/wiki/templates/wiki_widget.mako
+++ b/website/addons/wiki/templates/wiki_widget.mako
@@ -2,6 +2,11 @@
 <%page expression_filter="h"/>
 
 <div id="markdownRender" class="break-word">
+    % if wiki_content:
+        ${wiki_content | n}
+    % else:
+        <p><em>No wiki content</em></p>
+    % endif
 </div>
 
 <div id="more_link">

--- a/website/addons/wiki/views.py
+++ b/website/addons/wiki/views.py
@@ -140,16 +140,13 @@ def wiki_widget(**kwargs):
     wiki = node.get_addon('wiki')
     wiki_page = node.get_wiki_page('home')
 
-    more = True if len(node.wiki_pages_current.keys()) >= 2 or len(wiki_html) > 400 else False
+    more = True if len(node.wiki_pages_current.keys()) >= 2 else False
 
     use_python_render = False
     if wiki_page and wiki_page.html(node):
         wiki_html = wiki_page.html(node)
         if len(wiki_html) > 400:
-            wiki_html = BeautifulSoup(wiki_html[:400] + '...', 'html.parser')
-        else:
-            wiki_html = BeautifulSoup(wiki_html)
-
+            more = True
         use_python_render = wiki_page.rendered_before_update
     else:
         wiki_html = None

--- a/website/addons/wiki/views.py
+++ b/website/addons/wiki/views.py
@@ -140,16 +140,16 @@ def wiki_widget(**kwargs):
     wiki = node.get_addon('wiki')
     wiki_page = node.get_wiki_page('home')
 
-    more = False
+    more = True if len(node.wiki_pages_current.keys()) >= 2 or len(wiki_html) > 400 else False
+
     use_python_render = False
     if wiki_page and wiki_page.html(node):
         wiki_html = wiki_page.html(node)
         if len(wiki_html) > 400:
             wiki_html = BeautifulSoup(wiki_html[:400] + '...', 'html.parser')
-            more = True
         else:
             wiki_html = BeautifulSoup(wiki_html)
-            more = False
+
         use_python_render = wiki_page.rendered_before_update
     else:
         wiki_html = None

--- a/website/addons/wiki/views.py
+++ b/website/addons/wiki/views.py
@@ -144,8 +144,8 @@ def wiki_widget(**kwargs):
     use_python_render = False
     if wiki_page and wiki_page.html(node):
         wiki_html = wiki_page.html(node)
-        if len(wiki_html) > 500:
-            wiki_html = BeautifulSoup(wiki_html[:500] + '...', 'html.parser')
+        if len(wiki_html) > 400:
+            wiki_html = BeautifulSoup(wiki_html[:400] + '...', 'html.parser')
             more = True
         else:
             wiki_html = BeautifulSoup(wiki_html)

--- a/website/addons/wiki/views.py
+++ b/website/addons/wiki/views.py
@@ -3,7 +3,6 @@
 import httplib as http
 import logging
 
-from bs4 import BeautifulSoup
 from flask import request
 
 from framework.mongo.utils import to_mongo_key

--- a/website/addons/wiki/views.py
+++ b/website/addons/wiki/views.py
@@ -141,16 +141,16 @@ def wiki_widget(**kwargs):
     wiki_page = node.get_wiki_page('home')
 
     more = True if len(node.wiki_pages_current.keys()) >= 2 else False
-
     use_python_render = False
     if wiki_page and wiki_page.html(node):
         wiki_html = wiki_page.html(node)
         if len(wiki_html) > 400:
             wiki_html = BeautifulSoup(wiki_html[:400] + '...', 'html.parser')
             more = True
+        else:
+            wiki_html = BeautifulSoup(wiki_html)
         use_python_render = wiki_page.rendered_before_update
     else:
-        wiki_html = BeautifulSoup(wiki_html)
         wiki_html = None
 
     ret = {

--- a/website/addons/wiki/views.py
+++ b/website/addons/wiki/views.py
@@ -3,6 +3,7 @@
 import httplib as http
 import logging
 
+from bs4 import BeautifulSoup
 from flask import request
 
 from framework.mongo.utils import to_mongo_key
@@ -145,9 +146,11 @@ def wiki_widget(**kwargs):
     if wiki_page and wiki_page.html(node):
         wiki_html = wiki_page.html(node)
         if len(wiki_html) > 400:
+            wiki_html = BeautifulSoup(wiki_html[:400] + '...', 'html.parser')
             more = True
         use_python_render = wiki_page.rendered_before_update
     else:
+        wiki_html = BeautifulSoup(wiki_html)
         wiki_html = None
 
     ret = {


### PR DESCRIPTION
Relates to https://openscience.atlassian.net/browse/OSF-5450

# Purpose 
Previously, when a wiki was too long to be rendered, the text would be truncated and had a '...' appended to the end. This PR refactors this process a bit, making it smoother and taking out some unnecessary  python HTML parsing before the text is rendered fully in javascript.

This PR adds a "Read More" link to wikis that have additonal content on the home page, OR wikis that  have additional content on pages other than the home page.

A "Read More" link is not present when there is additional content in a component's wiki - this was to avoid blank parent wikis with a confusing "Read More" link when their components had wiki content.

# Changes
- wiki_widget.mako:
    - Remove "pre-rendered" wiki html
        - WIki content was being rendered once, then the whole page jumped as javascript appropriately re-rendered wiki content with truncating and appropriate markdown. Removing this in the template prevents this jumping, and shows the content after it is done loading.
    - Add new div with the "Read More" link.
        - I added a new div instead of placing it in the ```markdownRender``` div to avoid the ReadMore link being replaced when the content is re-rendered by js in ```project-dashboard-page.js```
- wiki/views.py:
     - Set the ```more``` variable up front if there are more wiki pages on the current component
    - Remove unnecessary BeautifulSoup html parsing done in the view

# Side effects
- The wiki preview won't be rendered if javascript is disabled - since javascript is doing the rendering of the text