### PR TITLE
Add loading indicator to contributor search

### DIFF
--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -62,6 +62,7 @@ var AddContributorViewModel = oop.extend(Paginator, {
         self.selection = ko.observableArray();
         self.notification = ko.observable('');
         self.inviteError = ko.observable('');
+        self.doneSearching = ko.observable(false);
         self.totalPages = ko.observable(0);
         self.nodes = ko.observableArray([]);
         self.nodesToChange = ko.observableArray();
@@ -71,7 +72,11 @@ var AddContributorViewModel = oop.extend(Paginator, {
         });
 
         self.noResults = ko.pureComputed(function() {
-            return self.query() && !self.results().length;
+            return self.query() && !self.results().length && self.doneSearching();
+        });
+
+        self.showLoading = ko.pureComputed(function() {
+            return !self.doneSearching() && !!self.query();
         });
 
         self.addAllVisible = ko.pureComputed(function() {
@@ -143,6 +148,7 @@ var AddContributorViewModel = oop.extend(Paginator, {
                         userData.added = (self.contributors().indexOf(userData.id) !== -1);
                         return new Contributor(userData);
                     });
+                    self.doneSearching(true);
                     self.results(contributors);
                     self.currentPage(result.page);
                     self.numberOfPages(result.pages);
@@ -153,6 +159,7 @@ var AddContributorViewModel = oop.extend(Paginator, {
             self.results([]);
             self.currentPage(0);
             self.totalPages(0);
+            self.doneSearching(true);
         }
     },
     getContributors: function() {

--- a/website/templates/project/modal_add_contributor.mako
+++ b/website/templates/project/modal_add_contributor.mako
@@ -119,10 +119,13 @@
                                         <a href="#"data-bind="click:gotoInvite">Add <strong><em>{{query}}</em></strong> as an unregistered contributor</a>.
                                     </p>
                                 </div>
-                                <div data-bind="if: noResults">
-                                    No results found. Try a more specific search or  <a href="#"
-                                    data-bind="click:gotoInvite">add <strong><em>{{query}}</em></strong> as an unregistered contributor</a>.
+                                <div data-bind="if: showLoading">
+                                    <p class="text-muted">Searching contributors...</p>
                                 </div>
+                                    <div data-bind="if: noResults">
+                                        No results found. Try a more specific search or
+                                        <a href="#" data-bind="click:gotoInvite">add <strong><em>{{query}}</em></strong> as an unregistered contributor</a>.
+                                    </div>
                             </div>
                         </div><!-- ./col-md -->
 


### PR DESCRIPTION
## Purpose
Before, the user would see 'No results found' even if the search wasn't over. They should know that contributors are still being searched.

## Changes

Add some extra logic to show 'Searching contributors...'

Had to stop it in the debugger to pull off a screenshot which is why it's dark:
![screen shot 2016-02-26 at 3 49 33 pm](https://cloud.githubusercontent.com/assets/8905795/13365016/9c32be40-dca0-11e5-83c7-fc3aac6f46de.png)

## Side effects

It occasionally will "flash" locally (where I have about 4 users to search through) but it's not too bad.


[OSF-5654]