### PR TITLE
[hotfix] fix task queue race condition

### DIFF
--- a/framework/exceptions/__init__.py
+++ b/framework/exceptions/__init__.py
@@ -67,6 +67,9 @@ class HTTPError(FrameworkError):
             data=self.to_data(),
         )
 
+    def __str__(self):
+        return repr(self)
+
     def to_data(self):
 
         data = copy.deepcopy(self.data)

--- a/framework/tasks/__init__.py
+++ b/framework/tasks/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Asynchronous task queue module."""
-import threading
-
 from celery import Celery
 from celery.utils.log import get_task_logger
 
@@ -36,9 +34,3 @@ def error_handler(task_id, task_name):
     logger.error('#####FAILURE LOG BEGIN#####\n'
                 'Task {0} raised exception: {0}\n\{0}\n'
                 '#####FAILURE LOG STOP#####'.format(task_name, excep, result.traceback))
-
-
-# A common thread local for OSF, API, and Admin to push celery tasks into
-_task_queue = threading.local()
-_task_queue.queue = []
-queue = _task_queue.queue


### PR DESCRIPTION
Multiple threads were causing the tasks queue to be overwritten when a new request was created.

Though the queue was attached to a threading.local the attribute `queue` was attached directly to the module avoiding any use of the threading.local as it only works when the `__getattribute__` can provide the necessary scoping mechanism to evaluate the current thread and thus return the appropriate object.

Also HTTPError `__str__` now matches `__repr__`