### PR TITLE
[RFR] Check to see if there are multiple contributors to remove

### DIFF
--- a/website/static/js/contribRemover.js
+++ b/website/static/js/contribRemover.js
@@ -128,7 +128,7 @@ var RemoveContributorViewModel = oop.extend(Paginator, {
 
         self.hasChildrenToRemove = ko.computed(function() {
             //if there is more then one node to remove, then show a simplified page
-            if (self.canRemoveNodesLength() > 1) {
+            if (self.canRemoveNodesLength() > 1 && self.titlesToRemove().length > 1) {
                 self.page(self.REMOVE);
                 return true;
             }


### PR DESCRIPTION
Related to #4799

This fixes a bug found by QA where if there are multiple nodes but the contributor is not on those nodes, then the multiple remove radio button is displayed.  It should not be.

Steps to Reproduce
---------------------------

1.  have a project with components
2.  add a contributor on the project and not on any of the children
3.  try and remove her

Before Fix
----------------------

![screen shot 2016-02-29 at 10 02 33 am](https://cloud.githubusercontent.com/assets/6232068/13398276/922b100a-decb-11e5-9368-6e7e9cad2b2d.png)

After Fix
----------

you see this dialog

![screen shot 2016-02-29 at 10 00 50 am](https://cloud.githubusercontent.com/assets/6232068/13398217/5e7aafea-decb-11e5-8952-6bedd5910e57.png)