### PR TITLE
Feature/read more link wiki

### DIFF
--- a/website/addons/wiki/templates/wiki_widget.mako
+++ b/website/addons/wiki/templates/wiki_widget.mako
@@ -9,6 +9,12 @@
     % endif
 </div>
 
+<div id="more_link">
+    % if more:
+        <a href="${node['url']}${short_name}/">Read More</a>
+    % endif
+</div>
+
 <% import json %>
 <script>
     window.contextVars = $.extend(true, {}, window.contextVars, {

--- a/website/addons/wiki/tests/test_wiki.py
+++ b/website/addons/wiki/tests/test_wiki.py
@@ -424,6 +424,15 @@ class TestWikiViews(OsfTestCase):
         assert_in('...', res.json['wiki_content'])
         assert_true(res.json['more'])
 
+    def test_wiki_widget_with_multiple_short_pages_has_more(self):
+        project = ProjectFactory(is_public=True, creator=self.user)
+        short_content = 'a' * 150
+        project.update_node_wiki('home', short_content, Auth(self.user))
+        project.update_node_wiki('andanotherone', short_content, Auth(self.user))
+        url = project.api_url_for('wiki_widget', wid='home')
+        res = self.app.get(url, auth=self.user.auth)
+        assert_true(res.json['more'])
+
     @mock.patch('website.addons.wiki.model.NodeWikiPage.rendered_before_update', new_callable=mock.PropertyMock)
     def test_wiki_widget_use_python_render(self, mock_rendered_before_update):
         # New pages use js renderer

--- a/website/addons/wiki/views.py
+++ b/website/addons/wiki/views.py
@@ -144,8 +144,8 @@ def wiki_widget(**kwargs):
     use_python_render = False
     if wiki_page and wiki_page.html(node):
         wiki_html = wiki_page.html(node)
-        if len(wiki_html) > 500:
-            wiki_html = BeautifulSoup(wiki_html[:500] + '...', 'html.parser')
+        if len(wiki_html) > 400:
+            wiki_html = BeautifulSoup(wiki_html[:400] + '...', 'html.parser')
             more = True
         else:
             wiki_html = BeautifulSoup(wiki_html)

--- a/website/addons/wiki/views.py
+++ b/website/addons/wiki/views.py
@@ -140,7 +140,7 @@ def wiki_widget(**kwargs):
     wiki = node.get_addon('wiki')
     wiki_page = node.get_wiki_page('home')
 
-    more = False
+    more = True if len(node.wiki_pages_current.keys()) >= 2 else False
     use_python_render = False
     if wiki_page and wiki_page.html(node):
         wiki_html = wiki_page.html(node)
@@ -149,7 +149,6 @@ def wiki_widget(**kwargs):
             more = True
         else:
             wiki_html = BeautifulSoup(wiki_html)
-            more = False
         use_python_render = wiki_page.rendered_before_update
     else:
         wiki_html = None


### PR DESCRIPTION
Relates to https://openscience.atlassian.net/browse/OSF-5450

# Purpose 
Previously, when a wiki was too long to be rendered, the text would be truncated and had a '...' appended to the end. 

This PR adds a "Read More" link to wikis that have additonal content on the home page, OR wikis that  have additional content on pages other than the home page.

A "Read More" link is not present when there is additional content in a component's wiki - this was to avoid blank parent wikis with a confusing "Read More" link when their components had wiki content.

# Changes
- wiki_widget.mako:
    - Add new div with the "Read More" link.
        - I added a new div instead of placing it in the ```markdownRender``` div to avoid the ReadMore link being replaced when the content is re-rendered by js in ```project-dashboard-page.js```
- wiki/views.py:
     - Set the ```more``` variable up front if there are more wiki pages on the current component
     - update cutoff variable from 500 to 400 to match later JS rendering of truncated text