### PR TITLE
Allow single node deletion

### DIFF
--- a/website/static/js/contribRemover.js
+++ b/website/static/js/contribRemover.js
@@ -178,6 +178,9 @@ var RemoveContributorViewModel = oop.extend(Paginator, {
 
         self.nodeIDsToRemove = ko.computed(function() {
             var nodeIDsToRemove = [];
+            if (!self.deleteAll()) {
+                return [self.nodeId];
+            }
             for (var key in self.nodesOriginal()) {
                 if (self.nodesOriginal().hasOwnProperty(key) && self.canRemoveNodes()[key]) {
                     var node = self.nodesOriginal()[key];


### PR DESCRIPTION
This fixes a bug found by Todd Sacco.  The logic for the toggle to remove a contributor from one vs all nodes was removed at some point.  Now it's back, and this time. . . . . 

It's Personal.