### PR TITLE
Ignore PhantomJS traffic on KeenIO

### DIFF
--- a/website/static/js/pages/base-page.js
+++ b/website/static/js/pages/base-page.js
@@ -115,6 +115,11 @@ $(function() {
         var params = {};
         params.currentUser = window.contextVars.currentUser;
         params.node = window.contextVars.node;
-        new KeenTracker(window.contextVars.keenProjectId, window.contextVars.keenWriteKey, params);
+
+        //Don't track PhantomJS visits with KeenIO
+        if(!(/PhantomJS/.test(navigator.userAgent))){
+            new KeenTracker(window.contextVars.keenProjectId, window.contextVars.keenWriteKey, params);
+        }
+
     }
 });


### PR DESCRIPTION
# Purpose
PhantomJS is being tracked by KeenIO on staging. This is skewing analytics and we need to ignore these calls.

# Side Effects
None