### PR TITLE
Fix: Timestamp in OSF4M Date Created in UTC time

### DIFF
--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -480,7 +480,7 @@ var UTC_DATEFORMAT = 'YYYY-MM-DD HH:mm UTC';
 var FormattableDate = function(date) {
 
     if (typeof date === 'string') {
-        this.date = moment(dateTimeWithoutOffset(date) ? forceUTC(date) : date).utc().toDate();
+        this.date = moment.utc(dateTimeWithoutOffset(date) ? forceUTC(date) : date).toDate();
     } else {
         this.date = date;
     }
@@ -797,7 +797,7 @@ var any = function(listOfBools, check) {
     return false;
 };
 
-/** 
+/**
  * A helper for creating a style-guide conformant bootbox modal. Returns a promise.
  * @param {String} title: 
  * @param {String} message:

--- a/website/static/js/submissions.js
+++ b/website/static/js/submissions.js
@@ -69,8 +69,6 @@ function Submissions(data) {
                     filter : false,
                     custom: function() {
                         var dateCreated = new osfHelpers.FormattableDate(item.data.dateCreated);
-                        // Assign dateCreated with the format of date usable in all browsers
-                        item.data.dateCreated = dateCreated.date;
                         return m('', dateCreated.local);
                     }
                 },


### PR DESCRIPTION
## Purpose 

Make the Date Created column in OSF4M consistent with the Date Created on the project page.

## Changes

In some cases, calling format on the `moment(this.date)` would cause the date to be converted to UTC then formatted. This was because of `moment(...).utc()` vs `moment.utc(...)`. 

![screen shot 2016-03-02 at 11 41 40 am](https://cloud.githubusercontent.com/assets/8905795/13467757/9fe1fd64-e06d-11e5-98db-2fb76c19bd32.png)



## Side effects

Looks like local and UTC dates elsewhere are still working as expected. 

Chrome, FFox, and Safari all display the same format. 

[OSF-5788]