### PR TITLE
Feature: Create trashed addon file nodes

### DIFF
--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -23,7 +23,7 @@ from tests import factories
 
 from website import settings
 from website.files import models
-from website.files.models.base import PROVIDER_MAP
+from website.files.models.base import PROVIDER_MAP, StoredFileNode, TrashedFileNode
 from website.project.model import MetaSchema, ensure_schemas
 from website.util import api_url_for, rubeus
 from website.project import new_private_link
@@ -586,6 +586,7 @@ class TestAddonFileViews(OsfTestCase):
         super(TestAddonFileViews, cls).tearDownClass()
         PROVIDER_MAP['github'] = [models.GithubFolder, models.GithubFile, models.GithubFileNode]
         del PROVIDER_MAP['test_addons']
+        TrashedFileNode.remove()
 
     def get_test_file(self):
         version = models.FileVersion(identifier='1')
@@ -799,6 +800,33 @@ class TestAddonFileViews(OsfTestCase):
         )
 
         assert_equals(resp.status_code, 401)
+
+    def test_delete_action_creates_trashed_file_node(self):
+        file_node = self.get_test_file()
+        payload = {
+            'provider': file_node.provider,
+            'metadata': {
+                'path': '/test/Test',
+                'materialized': '/test/Test'
+            }
+        }
+        views.addon_delete_file_node(self=None, node=self.project, event_type='file_removed', payload=payload)
+        assert_false(StoredFileNode.load(file_node._id))
+        assert_true(TrashedFileNode.load(file_node._id))
+
+    def test_delete_action_for_folder_creates_trashed_file_nodes(self):
+        file_node = self.get_test_file()
+        payload = {
+            'provider': file_node.provider,
+            'metadata': {
+                'path': '/test/',
+                'materialized': '/test/'
+            }
+        }
+        views.addon_delete_file_node(self=None, node=self.project, event_type='file_removed', payload=payload)
+        assert_false(StoredFileNode.load(file_node._id))
+        assert_true(TrashedFileNode.load(file_node._id))
+
 
 class TestLegacyViews(OsfTestCase):
 

--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -814,8 +814,16 @@ class TestAddonFileViews(OsfTestCase):
         assert_false(StoredFileNode.load(file_node._id))
         assert_true(TrashedFileNode.load(file_node._id))
 
-    def test_delete_action_for_folder_creates_trashed_file_nodes(self):
+    def test_delete_action_for_folder_deletes_subfolders_and_creates_trashed_file_nodes(self):
         file_node = self.get_test_file()
+        subfolder = TestFolder(
+            name='folder',
+            node=self.project,
+            path='/test/folder/',
+            materialized_path='/test/folder/',
+            versions=[]
+        )
+        subfolder.save()
         payload = {
             'provider': file_node.provider,
             'metadata': {
@@ -826,6 +834,7 @@ class TestAddonFileViews(OsfTestCase):
         views.addon_delete_file_node(self=None, node=self.project, event_type='file_removed', payload=payload)
         assert_false(StoredFileNode.load(file_node._id))
         assert_true(TrashedFileNode.load(file_node._id))
+        assert_false(StoredFileNode.load(subfolder._id))
 
 
 class TestLegacyViews(OsfTestCase):

--- a/website/addons/base/views.py
+++ b/website/addons/base/views.py
@@ -392,10 +392,10 @@ def addon_delete_file_node(self, node, event_type, payload, user=None):
         materialized_path = payload['metadata']['materialized']
         if path.endswith('/'):
             folder_children = FileNode.resolve_class(provider, FileNode.FILE).find(
-                                Q('provider', 'eq', provider) &
-                                Q('node', 'eq', node) &
-                                Q('materialized_path', 'startswith', materialized_path))
-
+                Q('provider', 'eq', provider) &
+                Q('node', 'eq', node) &
+                Q('materialized_path', 'startswith', materialized_path)
+            )
             for item in folder_children:
                 if item.kind == 'file' and not TrashedFileNode.load(item._id):
                     item.delete()

--- a/website/addons/base/views.py
+++ b/website/addons/base/views.py
@@ -396,7 +396,7 @@ def addon_delete_file_node(self, node, event_type, payload, user=None):
         path = payload['metadata']['path']
         materialized_path = payload['metadata']['materialized']
         if path.endswith('/'):
-            folder_children = FileNode.resolve_class(provider, FileNode.FILE).find(
+            folder_children = FileNode.resolve_class(provider, FileNode.ANY).find(
                 Q('provider', 'eq', provider) &
                 Q('node', 'eq', node) &
                 Q('materialized_path', 'startswith', materialized_path)
@@ -404,6 +404,8 @@ def addon_delete_file_node(self, node, event_type, payload, user=None):
             for item in folder_children:
                 if item.kind == 'file' and not TrashedFileNode.load(item._id):
                     item.delete()
+                elif item.kind == 'folder':
+                    StoredFileNode.remove_one(item.stored_object)
         else:
             try:
                 file_node = FileNode.resolve_class(provider, FileNode.FILE).find_one(

--- a/website/addons/base/views.py
+++ b/website/addons/base/views.py
@@ -386,7 +386,7 @@ def create_waterbutler_log(payload, **kwargs):
 
 @file_signals.file_updated.connect
 def addon_delete_file_node(self, node, event_type, payload, user=None):
-    if event_type == 'file_removed':
+    if event_type == 'file_removed' and payload.get('provider', None) != 'osfstorage':
         provider = payload['provider']
         path = payload['metadata']['path']
         materialized_path = payload['metadata']['materialized']


### PR DESCRIPTION
Purpose
-----------
When a folder is moved/renamed, the guids of all of the files are updated with the new StoredFileNode objects. However, there is no way to know whether the original StoredFileNode corresponds to a deleted addon file unless you make a request to waterbutler.

Changes
------------
- When a file is deleted, remove its StoredFileNode and create a TrashedFileNode.
- When resolving a file, if it no longer exists remove the StoredFileNode and create a TrashedFileNode (handles the case where a file is deleted through the addon)