### PR TITLE
[Feature] Add New Relic and pin uWSGI

### DIFF
--- a/requirements/release.txt
+++ b/requirements/release.txt
@@ -8,3 +8,5 @@ pyrax==1.9.5
 boto==2.31.1
 # newrelic APM agent
 newrelic==2.60.0.46
+# uwsgi
+uwsgi==2.0.12

--- a/requirements/release.txt
+++ b/requirements/release.txt
@@ -6,3 +6,5 @@
 pyrax==1.9.5
 # multipart uploads (https://github.com/boto/boto/issues/2603)
 boto==2.31.1
+# newrelic APM agent
+newrelic==2.60.0.46


### PR DESCRIPTION
This adds the requirement for New Relic to release.txt and also adds a pinned version of uWSGI. @icereval suggested moving uWSGI out of the docker build process into release.txt for the ease of updating.

This should have no effect other than upgrading uWSGI to the newest version. There are accompanying changes in other repos that enable the New Relic instrumenting on individual servers in different environments. Those deployments have a **hard** dependency on this being released prior **OR** @icereval just installing it by hand on the servers in question.