### PR TITLE
run scripts/tests/ at Travis

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -464,6 +464,11 @@ def test_api():
     test_module(module="api_tests/")
 
 @task
+def test_scripts():
+    """Run the test suite for scripts."""
+    test_module(module="scripts/tests/")
+
+@task
 def test_admin():
     """Run the Admin test suite."""
     # test_module(module="admin_tests/")
@@ -506,6 +511,7 @@ def test(all=False, syntax=False):
 
     test_osf()
     test_api()
+    test_scripts()
     test_admin()
 
     if all:
@@ -528,6 +534,7 @@ def test_travis_else():
     """
     test_addons()
     test_api()
+    test_scripts()
     test_admin()
     karma(single=True, browsers='PhantomJS')
 


### PR DESCRIPTION
I'm not sure if you want this @sloria (depends on how you manage the `scripts` directory, what the lifespan and workflow is for scripts), but over at https://github.com/pattisdr/osf.io/pull/2#issuecomment-191476364 I noticed that we're not actually running `scripts/tests/` at Travis. From the looks of it (and as one might expect), this test suite is in a broken state:

```
============================== 24 failed, 57 passed, 15 error in 142.83 seconds ===============================
```