### PR TITLE
[RFR] Redirect to project instead of component when creating new component

### DIFF
--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -202,7 +202,7 @@ def project_new_node(auth, node, **kwargs):
                 http.BAD_REQUEST,
                 data=dict(message_long=e.message)
             )
-        redirect_url = new_component.url
+        redirect_url = node.url
         message = (
             'Your component was created successfully. You can keep working on the component page below, '
             'or return to the <u><a href="{url}">project page</a></u>.'

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -205,19 +205,18 @@ def project_new_node(auth, node, **kwargs):
         redirect_url = node.url
         message = (
             'Your component was created successfully. You can keep working on the project page below, '
-            'or go to the new <u><a href=' + new_component.url +
-            '>component</a></u>.'
-        ).format(url=node.url)
+            'or go to the new <u><a href={component_url}>component</a></u>.'
+        ).format(component_url=new_component.url)
         if form.inherit_contributors.data and node.has_permission(user, ADMIN):
             for contributor in node.contributors:
                 new_component.add_contributor(contributor, permissions=node.get_permissions(contributor), auth=auth)
             new_component.save()
-            redirect_url = redirect_url + 'contributors/'
+            redirect_url = new_component.url + 'contributors/'
             message = (
                 'Your component was created successfully. You can edit the contributor permissions below, '
-                'work on your <u><a href=' + new_component.url +
-                '>component</a></u> or return to the <u><a href="{url}">project page</a></u>.'
-            ).format(url=node.url)
+                'work on your <u><a href={component_url}>component</a></u> or return to the <u> '
+                '<a href="{project_url}">project page</a></u>.'
+            ).format(component_url=new_component.url, project_url=node.url)
         status.push_status_message(message, kind='info', trust=True)
 
         return {

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -204,8 +204,9 @@ def project_new_node(auth, node, **kwargs):
             )
         redirect_url = node.url
         message = (
-            'Your component was created successfully. You can keep working on the component page below, '
-            'or return to the <u><a href="{url}">project page</a></u>.'
+            'Your component was created successfully. You can keep working on the project page below, '
+            'or go to the new <u><a href=' + new_component.url +
+            '>component</a></u>.'
         ).format(url=node.url)
         if form.inherit_contributors.data and node.has_permission(user, ADMIN):
             for contributor in node.contributors:


### PR DESCRIPTION
Jira Ticket:  https://openscience.atlassian.net/browse/OSF-5814

After creating a component, the OSF takes you into that component.  Usually this is not the preferred action, and leaves users confused.  Now users will stay on the project page they were originally working on.