### PR TITLE
[Ready to Review] - Updated Employment Tab to say "Department / Institute"

### DIFF
--- a/website/templates/include/profile/jobs.mako
+++ b/website/templates/include/profile/jobs.mako
@@ -36,7 +36,7 @@
                     </div>
 
                     <div class="form-group">
-                        <label>Department</label>
+                        <label>Department / Institute</label>
                         <input class="form-control" data-bind="value: department" />
                     </div>
 


### PR DESCRIPTION
This JIRA Issue this corresponds to is : https://openscience.atlassian.net/browse/OFI-25

**Purpose** 
Currently on https://osf.io/settings/ in the employment tab the heading for where the user enters which department they are in merely says, "Department". However, simply having this term can be vague and hard to understand. Some clarification is necessary. 

**Changes**
Updated the employment tab so the heading for department now reads "Department / Institute". Attached is an image of how the employment tab will look with the updated heading.

**Side Effects**
As only one line of code for the heading was changed no side effects are anticipated.




![employtabupdate](https://cloud.githubusercontent.com/assets/16869216/13605800/3fa0f7a8-e517-11e5-9619-6d2f4f379844.jpg)

