### PR TITLE
[Feature] Remove Project String from Project Name

### DIFF
--- a/tests/test_rubeus.py
+++ b/tests/test_rubeus.py
@@ -341,7 +341,7 @@ class TestSerializingNodeWithAddon(OsfTestCase):
             len(self.project.get_addons.return_value) + len(self.project.nodes)
         )
         assert_equal(ret['kind'], rubeus.FOLDER)
-        assert_equal(ret['name'], 'Project: {0}'.format(self.project.title))
+        assert_equal(ret['name'], self.project.title)
         assert_equal(
             ret['permissions'],
             {

--- a/tests/test_rubeus.py
+++ b/tests/test_rubeus.py
@@ -226,7 +226,7 @@ class TestRubeus(OsfTestCase):
         # Public (Can View)
         public_project = ProjectFactory(is_public=True)
         collector = rubeus.NodeFileCollector(node=public_project, auth=another_auth)
-        node_name = u'{0}: {1}'.format(public_project.project_or_component.capitalize(), sanitize.unescape_entities(public_project.title))
+        node_name =  sanitize.unescape_entities(public_project.title)
         assert_equal(collector._get_node_name(public_project), node_name)
 
         # Private  (Can't View)

--- a/website/util/rubeus.py
+++ b/website/util/rubeus.py
@@ -457,7 +457,7 @@ class NodeFileCollector(object):
         can_view = node.can_view(auth=self.auth)
 
         if can_view:
-            node_name = u'{0}: {1}'.format(node.project_or_component.capitalize(), sanitize.unescape_entities(node.title))
+            node_name = sanitize.unescape_entities(node.title)
         elif node.is_registration:
             node_name = u'Private Registration'
         elif node.is_fork:


### PR DESCRIPTION
This feature removes "Project: " and "Component: " before the project or component name when listed on the project page. 

Jira ticket: https://openscience.atlassian.net/browse/OSF-5834

## Before
![alt text](http://i.imgur.com/gBeB6dj.png)


## After
![alt text](http://i.imgur.com/V9YESkg.png)


