### PR TITLE
[hold]  [feature]Hover description for MD5 and SHA2 for file revision

### DIFF
--- a/website/static/js/filepage/revisions.js
+++ b/website/static/js/filepage/revisions.js
@@ -90,6 +90,14 @@ var FileRevisionsTable = {
             });
         };
 
+
+        var popOver = function(element, isInit) {
+            if (!isInit) {
+                $(document.getElementById(element.id)).popover();
+            }
+
+        }
+
         self.getTableHead = function() {
             return m('thead', [
                 m('tr', [
@@ -97,11 +105,17 @@ var FileRevisionsTable = {
                     model.hasDate ? m('th', 'Date') : false,
                     model.hasUser ? m('th', 'User') : false,
                     m('th[colspan=2]', 'Download'),
-                    model.hasHashes ? m('th', 'MD5') : false,
-                    model.hasHashes ? m('th', 'SHA2') : false,
+                    model.hasHashes ? m('th', [
+                        'MD5 ', m('#md5pop.fa.fa-question-circle[data-content="Unique 32-digit code for the file."][rel="popover"]' +
+                            '[data-placement="top"][data-trigger="hover"]', {config: popOver}) ]) : false,
+                    model.hasHashes ? m('th', [
+                        'SHA2 ', m('#sha2pop.fa.fa-question-circle[data-content="Unique 64-digit code for the file."][rel="popover"]' +
+                            '[data-placement="top"][data-trigger="hover"]', {config: popOver}) ]) : false,
                 ].filter(TRUTHY))
             ]);
+
         };
+
 
         self.makeTableRow = function(revision, index) {
             var isSelected = index === model.selectedRevision;

--- a/website/static/js/filepage/revisions.js
+++ b/website/static/js/filepage/revisions.js
@@ -98,7 +98,7 @@ var FileRevisionsTable = {
                     model.hasUser ? m('th', 'User') : false,
                     m('th[colspan=2]', 'Download'),
                     model.hasHashes ? m('th', 'MD5') : false,
-                    model.hasHashes ? m('th', 'SHA2, testing testing testing') : false,
+                    model.hasHashes ? m('th', 'SHA2') : false,
                 ].filter(TRUTHY))
             ]);
         };

--- a/website/static/js/filepage/revisions.js
+++ b/website/static/js/filepage/revisions.js
@@ -93,10 +93,9 @@ var FileRevisionsTable = {
 
         var popOver = function(element, isInit) {
             if (!isInit) {
-                $(document.getElementById(element.id)).popover();
+                $(element).popover();
             }
-
-        }
+        };
 
         self.getTableHead = function() {
             return m('thead', [
@@ -106,16 +105,15 @@ var FileRevisionsTable = {
                     model.hasUser ? m('th', 'User') : false,
                     m('th[colspan=2]', 'Download'),
                     model.hasHashes ? m('th', [
-                        'MD5 ', m('#md5pop.fa.fa-question-circle[data-content="Unique 32-digit code for the file."][rel="popover"]' +
+                        'MD5 ', m('.fa.fa-question-circle[data-content="Unique 32-digit code for the file."][rel="popover"]' +
                             '[data-placement="top"][data-trigger="hover"]', {config: popOver}) ]) : false,
                     model.hasHashes ? m('th', [
-                        'SHA2 ', m('#sha2pop.fa.fa-question-circle[data-content="Unique 64-digit code for the file."][rel="popover"]' +
+                        'SHA2 ', m('.fa.fa-question-circle[data-content="Unique 64-digit code for the file."][rel="popover"]' +
                             '[data-placement="top"][data-trigger="hover"]', {config: popOver}) ]) : false,
                 ].filter(TRUTHY))
             ]);
 
         };
-
 
         self.makeTableRow = function(revision, index) {
             var isSelected = index === model.selectedRevision;

--- a/website/static/js/filepage/revisions.js
+++ b/website/static/js/filepage/revisions.js
@@ -98,7 +98,7 @@ var FileRevisionsTable = {
                     model.hasUser ? m('th', 'User') : false,
                     m('th[colspan=2]', 'Download'),
                     model.hasHashes ? m('th', 'MD5') : false,
-                    model.hasHashes ? m('th', 'SHA2, testing') : false,
+                    model.hasHashes ? m('th', 'SHA2, testing testing') : false,
                 ].filter(TRUTHY))
             ]);
         };

--- a/website/static/js/filepage/revisions.js
+++ b/website/static/js/filepage/revisions.js
@@ -98,7 +98,7 @@ var FileRevisionsTable = {
                     model.hasUser ? m('th', 'User') : false,
                     m('th[colspan=2]', 'Download'),
                     model.hasHashes ? m('th', 'MD5') : false,
-                    model.hasHashes ? m('th', 'SHA2') : false,
+                    model.hasHashes ? m('th', 'SHA2, testing') : false,
                 ].filter(TRUTHY))
             ]);
         };

--- a/website/static/js/filepage/revisions.js
+++ b/website/static/js/filepage/revisions.js
@@ -98,7 +98,7 @@ var FileRevisionsTable = {
                     model.hasUser ? m('th', 'User') : false,
                     m('th[colspan=2]', 'Download'),
                     model.hasHashes ? m('th', 'MD5') : false,
-                    model.hasHashes ? m('th', 'SHA2, testing testing') : false,
+                    model.hasHashes ? m('th', 'SHA2, testing testing testing') : false,
                 ].filter(TRUTHY))
             ]);
         };


### PR DESCRIPTION
## Purpose
The purpose of this pull request is to implement a feature to allow users to understand what the MD5 and SHA2 features are of the Revisions. By having this feature, the user is capable of making file comparisons as well as fully understanding what is provided on nearly half of the screen.

## Changes
Added a question-circle next to MD5 and SHA2. Hovering over the question-circle creates a hovering popup that shows the description of each. Implementation was done on revisions.js on lines 94-98 and 108-113.
![screen shot 2016-03-08 at 1 24 58 pm](https://cloud.githubusercontent.com/assets/16393184/13611585/4dbe0276-e531-11e5-8248-70eac26fb93e.png)

## Side Effects
Definitions/descriptions of MD5 and SHA2 must be taken into consideration.