### PR TITLE
Hides "Description" after registration if initially blank

### DIFF
--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -188,11 +188,14 @@
                 <span data-bind="css: icon"></span>
                 </p>
 
-                % if node['description'] or 'write' in user['permissions']:
-                    <p>
+
+                <p>
+                % if not node['description']:
+                    <span id="description">Description:</span> <span id="nodeDescriptionEditable" class="text-muted" data-type="textarea">${'No description'}</span>
+                % elif node['description'] or 'write' in user['permissions']:
                     <span id="description">Description:</span> <span id="nodeDescriptionEditable" class="node-description overflow" data-type="textarea">${node['description']}</span>
-                    </p>
                 % endif
+                </p>
                 % if ('admin' in user['permissions'] or node['license'].get('name', 'No license') != 'No license'):
                     <p>
                       <license-picker params="saveUrl: '${node['update_url']}',

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -189,11 +189,11 @@
                 </p>
 
                 % if not node['description']:
-                    <p></p>
+                    <% pass %>
                 % elif node['description'] or 'write' in user['permissions']:
-                <p>
-                    <span id="description">Description:</span> <span id="nodeDescriptionEditable" class="node-description overflow" data-type="textarea">${node['description']}</span>
-                </p>
+                    <p>
+                        <span id="description">Description:</span> <span id="nodeDescriptionEditable" class="node-description overflow" data-type="textarea">${node['description']}</span>
+                    </p>
                 % endif
                 % if ('admin' in user['permissions'] or node['license'].get('name', 'No license') != 'No license'):
                     <p>

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -188,14 +188,13 @@
                 <span data-bind="css: icon"></span>
                 </p>
 
-
-                <p>
                 % if not node['description']:
-                    <span id="description">Description:</span> <span id="nodeDescriptionEditable" class="text-muted" data-type="textarea">${'No description'}</span>
+                    <p></p>
                 % elif node['description'] or 'write' in user['permissions']:
+                <p>
                     <span id="description">Description:</span> <span id="nodeDescriptionEditable" class="node-description overflow" data-type="textarea">${node['description']}</span>
-                % endif
                 </p>
+                % endif
                 % if ('admin' in user['permissions'] or node['license'].get('name', 'No license') != 'No license'):
                     <p>
                       <license-picker params="saveUrl: '${node['update_url']}',


### PR DESCRIPTION
Instead of having grey helper text when the description field is left blank, now the description field is hidden from users when left blank. 