### PR TITLE
Hide "Description", remove whitespace 

### DIFF
--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -188,11 +188,14 @@
                 <span data-bind="css: icon"></span>
                 </p>
 
-                % if node['description'] or 'write' in user['permissions']:
-                    <p>
+
+                <p>
+                % if not node['description']:
+                    <span id="description">Description:</span> <span id="nodeDescriptionEditable" class="text-muted" data-type="textarea">${'No description'}</span>
+                % elif node['description'] or 'write' in user['permissions']:
                     <span id="description">Description:</span> <span id="nodeDescriptionEditable" class="node-description overflow" data-type="textarea">${node['description']}</span>
-                    </p>
                 % endif
+                </p>
                 % if ('admin' in user['permissions'] or node['license'].get('name', 'No license') != 'No license'):
                     <p>
                       <license-picker params="saveUrl: '${node['update_url']}',

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -189,11 +189,11 @@
                 </p>
 
                 % if not node['description']:
-                    <p></p>
+                    <% pass %>
                 % elif node['description'] or 'write' in user['permissions']:
-                <p>
-                    <span id="description">Description:</span> <span id="nodeDescriptionEditable" class="node-description overflow" data-type="textarea">${node['description']}</span>
-                </p>
+                    <p>
+                        <span id="description">Description:</span> <span id="nodeDescriptionEditable" class="node-description overflow" data-type="textarea">${node['description']}</span>
+                    </p>
                 % endif
                 % if ('admin' in user['permissions'] or node['license'].get('name', 'No license') != 'No license'):
                     <p>

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -192,7 +192,7 @@
                     <% pass %>
                 % elif node['description'] or 'write' in user['permissions']:
                     <p>
-                        <span id="description">Description:</span> <span id="nodeDescriptionEditable" class="node-description overflow" data-type="textarea">${node['description']}</span>
+                    <span id="description">Description:</span> <span id="nodeDescriptionEditable" class="node-description overflow" data-type="textarea">${node['description']}</span>
                     </p>
                 % endif
                 % if ('admin' in user['permissions'] or node['license'].get('name', 'No license') != 'No license'):

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -188,9 +188,7 @@
                 <span data-bind="css: icon"></span>
                 </p>
 
-                % if not node['description']:
-                    <% pass %>
-                % elif node['description'] or 'write' in user['permissions']:
+                % if node['description']:
                     <p>
                     <span id="description">Description:</span> <span id="nodeDescriptionEditable" class="node-description overflow" data-type="textarea">${node['description']}</span>
                     </p>

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -188,14 +188,13 @@
                 <span data-bind="css: icon"></span>
                 </p>
 
-
-                <p>
                 % if not node['description']:
-                    <span id="description">Description:</span> <span id="nodeDescriptionEditable" class="text-muted" data-type="textarea">${'No description'}</span>
+                    <p></p>
                 % elif node['description'] or 'write' in user['permissions']:
+                <p>
                     <span id="description">Description:</span> <span id="nodeDescriptionEditable" class="node-description overflow" data-type="textarea">${node['description']}</span>
-                % endif
                 </p>
+                % endif
                 % if ('admin' in user['permissions'] or node['license'].get('name', 'No license') != 'No license'):
                     <p>
                       <license-picker params="saveUrl: '${node['update_url']}',


### PR DESCRIPTION
Description field hidden from users after registration if left blank initially - extra whitespace created by previous code removed. 