### PR TITLE
take out multidashes from BAPI docs to appease swagger

### DIFF
--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -165,7 +165,10 @@ SWAGGER_SETTINGS = {
         'description':
         """
         Welcome to the fine documentation for the Open Science Framework's API!  Please click
-        on the <strong>GET /v2/</strong> link below to get started.""",
+        on the <strong>GET /v2/</strong> link below to get started.
+
+        For the most recent docs, please check out our <a href="/v2/">Browsable API</a>.
+        """,
         'title': 'OSF APIv2 Documentation',
     },
     'doc_expansion': 'list',

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -359,7 +359,7 @@ def root(request, format=None):
     ###OSF Node Categories
 
         value                 description
-        ------------------------------------------
+        ==========================================
         project               Project
         hypothesis            Hypothesis
         methods and measures  Methods and Measures
@@ -373,7 +373,7 @@ def root(request, format=None):
     ###OSF Node Permission keys
 
         value        description
-        ------------------------------------------
+        ==========================================
         read         Read-only access
         write        Write access (make changes, cannot delete)
         admin        Admin access (full write, create, delete, contributor add)
@@ -383,7 +383,7 @@ def root(request, format=None):
     Valid storage providers are:
 
         value        description
-        ------------------------------------------
+        ==========================================
         box          Box.com
         cloudfiles   Rackspace Cloud Files
         dataverse    Dataverse

--- a/api/collections/views.py
+++ b/api/collections/views.py
@@ -75,7 +75,7 @@ class CollectionList(JSONAPIBaseView, bulk_views.BulkUpdateJSONAPIView, bulk_vie
     OSF Organizer Collection entities have the "nodes" `type`.
 
         name           type               description
-        ---------------------------------------------------------------------------------
+        =================================================================================
         title          string             title of Organizer Collection
         date_created   iso8601 timestamp  timestamp that the collection was created
         date_modified  iso8601 timestamp  timestamp when the collection was last updated
@@ -215,7 +215,7 @@ class CollectionDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, C
     OSF Organizer Collection entities have the "nodes" `type`.
 
         name           type               description
-        ---------------------------------------------------------------------------------
+        =================================================================================
         title          string             title of Organizer Collection
         date_created   iso8601 timestamp  timestamp that the collection was created
         date_modified  iso8601 timestamp  timestamp when the collection was last updated
@@ -321,7 +321,7 @@ class LinkedNodesList(JSONAPIBaseView, generics.ListAPIView, CollectionMixin):
     OSF Node entities have the "nodes" `type`.
 
         name           type               description
-        ---------------------------------------------------------------------------------
+        =================================================================================
         title          string             title of project or component
         description    string             description of the node
         category       string             node category, must be one of the allowed values

--- a/api/comments/views.py
+++ b/api/comments/views.py
@@ -110,7 +110,7 @@ class CommentDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, Comm
     OSF comment entities have the "comments" `type`.
 
         name           type               description
-        ---------------------------------------------------------------------------------
+        =================================================================================
         content        string             content of the comment
         date_created   iso8601 timestamp  timestamp that the comment was created
         date_modified  iso8601 timestamp  timestamp when the comment was last updated
@@ -232,7 +232,7 @@ class CommentReportsList(JSONAPIBaseView, generics.ListCreateAPIView, CommentMix
     OSF comment report entities have the "comment_reports" `type`.
 
         name           type               description
-        -------------------------------------------------------------------------------------
+        =====================================================================================
         category        string            the type of spam, must be one of the allowed values
         message         string            description of why the comment was reported
 
@@ -306,7 +306,7 @@ class CommentReportDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView
     OSF comment report entities have the "comment_reports" `type`.
 
         name           type               description
-        -------------------------------------------------------------------------------------
+        =====================================================================================
         category        string            the type of spam, must be one of the allowed values
         message         string            description of why the comment was reported
 

--- a/api/files/views.py
+++ b/api/files/views.py
@@ -64,7 +64,7 @@ class FileDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView, FileMixin):
     ####File Entity
 
         name          type       description
-        -------------------------------------------------------------------------
+        =========================================================================
         name          string     name of the file
         path          string     unique identifier for this file entity for this
                                  project and storage provider. may not end with '/'
@@ -88,7 +88,7 @@ class FileDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView, FileMixin):
     ####Folder Entity
 
         name          type    description
-        ----------------------------------------------------------------------
+        ======================================================================
         name          string  name of the folder
         path          string  unique identifier for this folder entity for this
                               project and storage provider. must end with '/'
@@ -107,7 +107,7 @@ class FileDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView, FileMixin):
     null for folders.  A list of storage provider keys can be found [here](/v2/#storage-providers).
 
         name          type               description
-        ---------------------------------------------------------------------------------------------------
+        ===================================================================================================
         name              string             name of the file or folder; used for display
         kind              string             "file" or "folder"
         path              string             same as for corresponding WaterButler entity
@@ -331,7 +331,7 @@ class FileVersionsList(JSONAPIBaseView, generics.ListAPIView, FileMixin):
     For an OSF FileVersion entity the API `type` is "file_versions".
 
         name          type     description
-        ---------------------------------------------------------------------------------
+        =================================================================================
         size          integer  size of file in bytes
         content_type  string   MIME content-type for the file. May be null if unavailable.
 
@@ -390,7 +390,7 @@ class FileVersionDetail(JSONAPIBaseView, generics.RetrieveAPIView, FileMixin):
     For an OSF FileVersion entity the API `type` is "file_versions".
 
         name          type     description
-        ---------------------------------------------------------------------------------
+        =================================================================================
         size          integer  size of file in bytes
         content_type  string   MIME content-type for the file. May be null if unavailable.
 

--- a/api/institutions/views.py
+++ b/api/institutions/views.py
@@ -40,7 +40,7 @@ class InstitutionList(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin):
     OSF Institutions have the "institutions" `type`.
 
         name           type               description
-        -------------------------------------------------------------------------
+        =========================================================================
         name           string             title of the institution
         id             string             unique identifier in the OSF
         logo_path      string             a path to the institution's static logo
@@ -79,7 +79,7 @@ class InstitutionDetail(JSONAPIBaseView, generics.RetrieveAPIView, InstitutionMi
     OSF Institutions have the "institutions" `type`.
 
         name           type               description
-        -------------------------------------------------------------------------
+        =========================================================================
         name           string             title of the institution
         id             string             unique identifier in the OSF
         logo_path      string             a path to the institution's static logo

--- a/api/logs/views.py
+++ b/api/logs/views.py
@@ -65,7 +65,7 @@ class LogNodeList(JSONAPIBaseView, generics.ListAPIView, LogMixin, ODMFilterMixi
     OSF Node entities have the "nodes" `type`.
 
         name           type               description
-        ---------------------------------------------------------------------------------
+        =================================================================================
         title          string             title of project or component
         description    string             description of the node
         category       string             node category, must be one of the allowed values
@@ -142,7 +142,7 @@ class NodeLogDetail(JSONAPIBaseView, generics.RetrieveAPIView, LogMixin):
     OSF Node entities have the "nodes" `type`.
 
         name           type               description
-        ---------------------------------------------------------------------------------
+        =================================================================================
         title          string             title of project or component
         description    string             description of the node
         category       string             node category, must be one of the allowed values
@@ -216,7 +216,7 @@ class NodeLogContributors(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin,
     OSF User entities have the "users" `type`.
 
         name               type               description
-        ----------------------------------------------------------------------------------------
+        ========================================================================================
         full_name          string             full name of the user; used for display
         given_name         string             given name of the user; for bibliographic citations
         middle_names       string             middle name of user; for bibliographic citations

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -132,7 +132,7 @@ class NodeList(JSONAPIBaseView, bulk_views.BulkUpdateJSONAPIView, bulk_views.Bul
     OSF Node entities have the "nodes" `type`.
 
         name           type               description
-        ---------------------------------------------------------------------------------
+        =================================================================================
         title          string             title of project or component
         description    string             description of the node
         category       string             node category, must be one of the allowed values
@@ -327,7 +327,7 @@ class NodeDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, NodeMix
     OSF Node entities have the "nodes" `type`.
 
         name           type               description
-        ---------------------------------------------------------------------------------
+        =================================================================================
         title          string             title of project or component
         description    string             description of the node
         category       string             node category, must be one of the allowed values
@@ -466,7 +466,7 @@ class NodeContributorsList(JSONAPIBaseView, bulk_views.BulkUpdateJSONAPIView, bu
     `type` is "contributors"
 
         name           type     description
-        ------------------------------------------------------------------------------------------------------
+        ======================================================================================================
         bibliographic  boolean  Whether the user will be included in citations for this node. Default is true.
         permission     string   User permission level. Must be "read", "write", or "admin". Default is "write".
 
@@ -619,7 +619,7 @@ class NodeContributorDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIVi
     `type` is "contributors"
 
         name           type     description
-        ------------------------------------------------------------------------------------------------------
+        ======================================================================================================
         bibliographic  boolean  Whether the user will be included in citations for this node. Default is true.
         permission     string   User permission level. Must be "read", "write", or "admin". Default is "write".
 
@@ -731,7 +731,7 @@ class NodeRegistrationsList(JSONAPIBaseView, generics.ListAPIView, NodeMixin):
     Registrations have the "registrations" `type`.
 
         name               type               description
-        ---------------------------------------------------------------------------------
+        =================================================================================
         title              string             title of the registered project or component
         description        string             description of the registered node
         category           string             node category, must be one of the allowed values
@@ -800,7 +800,7 @@ class NodeChildrenList(JSONAPIBaseView, bulk_views.ListBulkCreateJSONAPIView, No
     OSF Node entities have the "nodes" `type`.
 
         name           type               description
-        ---------------------------------------------------------------------------------
+        =================================================================================
         title          string             title of project or component
         description    string             description of the node
         category       string             node category, must be one of the allowed values
@@ -1100,7 +1100,7 @@ class NodeFilesList(JSONAPIBaseView, generics.ListAPIView, WaterButlerMixin, Lis
     ####File Entity
 
         name          type       description
-        -------------------------------------------------------------------------
+        =========================================================================
         name          string     name of the file
         path          string     unique identifier for this file entity for this
                                  project and storage provider. may not end with '/'
@@ -1124,7 +1124,7 @@ class NodeFilesList(JSONAPIBaseView, generics.ListAPIView, WaterButlerMixin, Lis
     ####Folder Entity
 
         name          type    description
-        ----------------------------------------------------------------------
+        ======================================================================
         name          string  name of the folder
         path          string  unique identifier for this folder entity for this
                               project and storage provider. must end with '/'
@@ -1144,7 +1144,7 @@ class NodeFilesList(JSONAPIBaseView, generics.ListAPIView, WaterButlerMixin, Lis
     found [here](/v2/#storage-providers).
 
         name          type               description
-        ---------------------------------------------------------------------------------------------------
+        ===================================================================================================
         name              string             name of the file or folder; used for display
         kind              string             "file" or "folder"
         path              string             same as for corresponding WaterButler entity
@@ -1414,7 +1414,7 @@ class NodeProvidersList(JSONAPIBaseView, generics.ListAPIView, NodeMixin):
     ####File Entity
 
         name          type       description
-        -------------------------------------------------------------------------
+        =========================================================================
         name          string     name of the file
         path          string     unique identifier for this file entity for this
                                  project and storage provider. may not end with '/'
@@ -1438,7 +1438,7 @@ class NodeProvidersList(JSONAPIBaseView, generics.ListAPIView, NodeMixin):
     ####Folder Entity
 
         name          type    description
-        ----------------------------------------------------------------------
+        ======================================================================
         name          string  name of the folder
         path          string  unique identifier for this folder entity for this
                               project and storage provider. must end with '/'
@@ -1453,7 +1453,7 @@ class NodeProvidersList(JSONAPIBaseView, generics.ListAPIView, NodeMixin):
     `type` is "files"
 
         name      type    description
-        ---------------------------------------------------------------------------------
+        =================================================================================
         name      string  name of the provider
         kind      string  type of this file/folder.  always "folder"
         path      path    relative path of this folder within the provider filesys. always "/"
@@ -1650,7 +1650,7 @@ class NodeLogList(JSONAPIBaseView, generics.ListAPIView, NodeMixin, ODMFilterMix
     * 'pointer_created': A Pointer is created
     * 'pointer_forked': A Pointer is forked
     * 'pointer_removed': A Pointer is removed
-    ---
+    ===
     * 'made_public': A Node is made public
     * 'made_private': A Node is made private
     * 'tag_added': A tag is added to a Node
@@ -1659,20 +1659,20 @@ class NodeLogList(JSONAPIBaseView, generics.ListAPIView, NodeMixin, ODMFilterMix
     * 'edit_description': A Node's description is changed
     * 'updated_fields': One or more of a Node's fields are changed
     * 'external_ids_added': An external identifier is added to a Node (e.g. DOI, ARK)
-    ---
+    ===
     * 'contributor_added': A Contributor is added to a Node
     * 'contributor_removed': A Contributor is removed from a Node
     * 'contributors_reordered': A Contributor's position is a Node's biliography is changed
     * 'permissions_update': A Contributor's permissions on a Node are changed
     * 'made_contributor_visible': A Contributor is made bibliographically visible on a Node
     * 'made_contributor_invisible': A Contributor is made bibliographically invisible on a Node
-    ---
+    ===
     * 'wiki_updated': A Node's wiki is updated
     * 'wiki_deleted': A Node's wiki is deleted
     * 'wiki_renamed': A Node's wiki is renamed
     * 'made_wiki_public': A Node's wiki is made public
     * 'made_wiki_private': A Node's wiki is made private
-    ---
+    ===
     * 'addon_added': An add-on is linked to a Node
     * 'addon_removed': An add-on is unlinked from a Node
     * 'addon_file_moved': A File in a Node's linked add-on is moved
@@ -1683,11 +1683,11 @@ class NodeLogList(JSONAPIBaseView, generics.ListAPIView, NodeMixin, ODMFilterMix
     * 'file_updated': A File is updated on a Node's linked add-on
     * 'file_removed': A File is removed from a Node's linked add-on
     * 'file_restored': A File is restored in a Node's linked add-on
-    ---
+    ===
     * 'comment_added': A Comment is added to some item
     * 'comment_removed': A Comment is removed from some item
     * 'comment_updated': A Comment is updated on some item
-    ---
+    ===
     * 'embargo_initiated': An embargoed Registration is proposed on a Node
     * 'embargo_approved': A proposed Embargo of a Node is approved
     * 'embargo_cancelled': A proposed Embargo of a Node is cancelled
@@ -1698,7 +1698,7 @@ class NodeLogList(JSONAPIBaseView, generics.ListAPIView, NodeMixin, ODMFilterMix
     * 'registration_initiated': A Registration of a Node is proposed
     * 'registration_approved': A proposed Registration is approved
     * 'registration_cancelled': A proposed Registration is cancelled
-    ---
+    ===
     * 'node_created': A Node is created (_deprecated_)
     * 'node_forked': A Node is forked (_deprecated_)
     * 'node_removed': A Node is dele (_deprecated_)
@@ -1710,7 +1710,7 @@ class NodeLogList(JSONAPIBaseView, generics.ListAPIView, NodeMixin, ODMFilterMix
     OSF Log entities have the "logs" `type`.
 
         name           type                   description
-        ----------------------------------------------------------------------------
+        ============================================================================
         date           iso8601 timestamp      timestamp of Log creation
         action         string                 Log action (see list above)
 
@@ -1787,7 +1787,7 @@ class NodeCommentsList(JSONAPIBaseView, generics.ListCreateAPIView, ODMFilterMix
     OSF comment entities have the "comments" `type`.
 
         name           type               description
-        ---------------------------------------------------------------------------------
+        =================================================================================
         content        string             content of the comment
         date_created   iso8601 timestamp  timestamp that the comment was created
         date_modified  iso8601 timestamp  timestamp when the comment was last updated
@@ -1946,7 +1946,7 @@ class NodeInstitutionDetail(JSONAPIBaseView, generics.RetrieveAPIView, NodeMixin
     OSF Institutions have the "institutions" `type`.
 
         name           type               description
-        -------------------------------------------------------------------------
+        =========================================================================
         name           string             title of the institution
         id             string             unique identifier in the OSF
         logo_path      string             a path to the institution's static logo

--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -69,7 +69,7 @@ class RegistrationList(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin):
     Registrations have the "registrations" `type`.
 
         name                            type               description
-        -------------------------------------------------------------------------------------------------------
+        =======================================================================================================
         title                           string             title of the registered project or component
         description                     string             description of the registered node
         category                        string             node category, must be one of the allowed values
@@ -175,7 +175,7 @@ class RegistrationDetail(JSONAPIBaseView, generics.RetrieveAPIView, Registration
     Registrations have the "registrations" `type`.
 
         name                            type               description
-        -------------------------------------------------------------------------------------------------------
+        =======================================================================================================
         title                           string             title of the registered project or component
         description                     string             description of the registered node
         category                        string             node category, must be one of the allowed values

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -67,7 +67,7 @@ class UserList(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin):
     OSF User entities have the "users" `type`.
 
         name               type               description
-        ----------------------------------------------------------------------------------------
+        ========================================================================================
         full_name          string             full name of the user; used for display
         given_name         string             given name of the user; for bibliographic citations
         middle_names       string             middle name of user; for bibliographic citations
@@ -141,7 +141,7 @@ class UserDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView, UserMixin):
     OSF User entities have the "users" `type`.
 
         name               type               description
-        ----------------------------------------------------------------------------------------
+        ========================================================================================
         full_name          string             full name of the user; used for display
         given_name         string             given name of the user; for bibliographic citations
         middle_names       string             middle name of user; for bibliographic citations
@@ -243,7 +243,7 @@ class UserNodes(JSONAPIBaseView, generics.ListAPIView, UserMixin, ODMFilterMixin
     OSF Node entities have the "nodes" `type`.
 
         name           type               description
-        ---------------------------------------------------------------------------------
+        =================================================================================
         title          string             title of project or component
         description    string             description of the node
         category       string             node category, must be one of the allowed values
@@ -352,7 +352,7 @@ class UserRegistrations(UserNodes):
     Registrations have the "registrations" `type`.
 
         name                            type               description
-        -------------------------------------------------------------------------------------------------------
+        =======================================================================================================
         title                           string             title of the registered project or component
         description                     string             description of the registered node
         category                        string             node category, must be one of the allowed values


### PR DESCRIPTION
swagger thinks three or more dashes on their own line indicates the
beginning of a YAML document.  It then dies when the content after
isn't valid YAML.  Replace the dash strings we were using as ascii art
with equal strings to appease swagger.

Also add a note that the BAPI docs are the current preferred doc source.