### PR TITLE
[hotfix] rollback error handling to transaction middleware

### DIFF
--- a/framework/transactions/handlers.py
+++ b/framework/transactions/handlers.py
@@ -73,15 +73,14 @@ def transaction_teardown_request(error=None):
     Werkzeug debugger.
     """
     if view_has_annotation(NO_AUTO_TRANSACTION_ATTR):
-        return None
+        return
     if error is not None:
-        if not settings.DEBUG_MODE:
-            logger.error('Uncaught error in `transaction_teardown_request`; '
-                         'this should never happen with `DEBUG_MODE = True`')
-        # If we're testing, the before_request handlers may not have been executed
-        # e.g. when Flask#test_request_context() is used
-        if not current_app.testing:
+        try:
             commands.rollback()
+        except OperationFailure as error:
+            message = utils.get_error_message(error)
+            if messages.NO_TRANSACTION_ERROR not in message:
+                raise
 
 
 handlers = {

--- a/framework/transactions/handlers.py
+++ b/framework/transactions/handlers.py
@@ -8,8 +8,6 @@ from pymongo.errors import OperationFailure
 
 from framework.transactions import utils, commands, messages
 
-from website import settings
-
 
 LOCK_ERROR_CODE = httplib.BAD_REQUEST
 NO_AUTO_TRANSACTION_ATTR = '_no_auto_transaction'


### PR DESCRIPTION
Flask context is not guaranteed to exist, it might be running in a Django context.

https://sentry.cos.io/sentry/osf-j5/issues/915/

"RuntimeError: working outside of application context"
