### PR TITLE
Pop-up added when navigating away from project settings page after editing title/description

### DIFF
--- a/website/static/js/pages/project-settings-page.js
+++ b/website/static/js/pages/project-settings-page.js
@@ -230,10 +230,10 @@ $(document).ready(function() {
           return 'The changes on addon setting are not submitted!';
       }
     /* Before closing the page, Check whether changes made to category, title or description are updated or not */
-      if ($('#titleID')[0].value !== (projectSettingsVM).titlePlaceholder  ||
-          $('#descriptionID')[0].value !== (projectSettingsVM).descriptionPlaceholder ||
-          $('#categoryID')[0].value !== (projectSettingsVM).categoryPlaceholder  ) {
-          return 'There are unsaved changes in your project section.';
+      if (projectSettingsVM.title() !== projectSettingsVM.titlePlaceholder ||
+          projectSettingsVM.description() !== projectSettingsVM.descriptionPlaceholder ||
+          projectSettingsVM.selectedCategory() !== projectSettingsVM.categoryPlaceholder) {
+          return 'There are unsaved changes in your project settings.';
       }
     });
 

--- a/website/static/js/pages/project-settings-page.js
+++ b/website/static/js/pages/project-settings-page.js
@@ -233,7 +233,7 @@ $(document).ready(function() {
       if ($('#titleID')[0].value != (projectSettingsVM).titlePlaceholder  ||
           $('#descriptionID')[0].value != (projectSettingsVM).descriptionPlaceholder ||
           $('#categoryID')[0].value != (projectSettingsVM).categoryPlaceholder  ) {
-          return "There are unsaved changes in your project section."
+          return "There are unsaved changes in your project section.";
       }
     });
 

--- a/website/static/js/pages/project-settings-page.js
+++ b/website/static/js/pages/project-settings-page.js
@@ -227,7 +227,13 @@ $(document).ready(function() {
       var unchecked = checkedOnLoad.filter('#selectAddonsForm input:not(:checked)');
 
       if(unchecked.length > 0 || checked.length > 0) {
-        return 'The changes on addon setting are not submitted!';
+          return 'The changes on addon setting are not submitted!';
+      }
+    /* Before closing the page, Check whether changes made to category, title or description are updated or not */
+      if ($('#titleID')[0].value != (projectSettingsVM).titlePlaceholder  ||
+          $('#descriptionID')[0].value != (projectSettingsVM).descriptionPlaceholder ||
+          $('#categoryID')[0].value != (projectSettingsVM).categoryPlaceholder  ) {
+          return "There are unsaved changes in your project section."
       }
     });
 

--- a/website/static/js/pages/project-settings-page.js
+++ b/website/static/js/pages/project-settings-page.js
@@ -230,10 +230,10 @@ $(document).ready(function() {
           return 'The changes on addon setting are not submitted!';
       }
     /* Before closing the page, Check whether changes made to category, title or description are updated or not */
-      if ($('#titleID')[0].value != (projectSettingsVM).titlePlaceholder  ||
-          $('#descriptionID')[0].value != (projectSettingsVM).descriptionPlaceholder ||
-          $('#categoryID')[0].value != (projectSettingsVM).categoryPlaceholder  ) {
-          return "There are unsaved changes in your project section.";
+      if ($('#titleID')[0].value !== (projectSettingsVM).titlePlaceholder  ||
+          $('#descriptionID')[0].value !== (projectSettingsVM).descriptionPlaceholder ||
+          $('#categoryID')[0].value !== (projectSettingsVM).categoryPlaceholder  ) {
+          return 'There are unsaved changes in your project section.';
       }
     });
 

--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -77,24 +77,20 @@
                     <div id="projectSettings" class="panel-body">
                         <div class="form-group">
                             <label>Category:</label>
-                            <select id = categoryID data-bind="attr.disabled: disabled,
-                                               options: categoryOptions,
-                                               optionsValue: 'value',
-                                               optionsText: 'label',
-                                               value: selectedCategory"></select>
+                            <select data-bind="attr.disabled: disabled, options: categoryOptions, optionsValue: 'value', optionsText: 'label', value: selectedCategory"></select>
                             <span data-bind="if: disabled" class="help-block">
                               A top-level project's category cannot be changed
                             </span>
                         </div>
                         <div class="form-group">
                             <label for="title">Title:</label>
-                            <input id= "titleID" class="form-control" type="text" maxlength="200" placeholder="Required" data-bind="value: title,
+                            <input class="form-control" type="text" maxlength="200" placeholder="Required" data-bind="value: title,
                                                                                                       valueUpdate: 'afterkeydown'">
                             <span class="text-danger" data-bind="validationMessage: title"></span>
                         </div>
                         <div class="form-group">
                             <label for="description">Description:</label>
-                              <textarea  id= descriptionID placeholder="Optional" data-bind="value: description,
+                            <textarea placeholder="Optional" data-bind="value: description,
                                              valueUpdate: 'afterkeydown'",
                             class="form-control resize-vertical"></textarea>
                         </div>

--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -77,24 +77,24 @@
                     <div id="projectSettings" class="panel-body">
                         <div class="form-group">
                             <label>Category:</label>
-                            <select data-bind="attr.disabled: disabled,
-                                                         options: categoryOptions,
-                                                         optionsValue: 'value',
-                                                         optionsText: 'label',
-                                                         value: selectedCategory"></select>
+                            <select id = categoryID data-bind="attr.disabled: disabled,
+                                               options: categoryOptions,
+                                               optionsValue: 'value',
+                                               optionsText: 'label',
+                                               value: selectedCategory"></select>
                             <span data-bind="if: disabled" class="help-block">
                               A top-level project's category cannot be changed
                             </span>
                         </div>
                         <div class="form-group">
                             <label for="title">Title:</label>
-                            <input class="form-control" type="text" maxlength="200" placeholder="Required" data-bind="value: title,
+                            <input id= "titleID" class="form-control" type="text" maxlength="200" placeholder="Required" data-bind="value: title,
                                                                                                       valueUpdate: 'afterkeydown'">
                             <span class="text-danger" data-bind="validationMessage: title"></span>
                         </div>
                         <div class="form-group">
                             <label for="description">Description:</label>
-                            <textarea placeholder="Optional" data-bind="value: description,
+                              <textarea  id= descriptionID placeholder="Optional" data-bind="value: description,
                                              valueUpdate: 'afterkeydown'",
                             class="form-control resize-vertical"></textarea>
                         </div>


### PR DESCRIPTION
**Issue:** https://openscience.atlassian.net/browse/OSF-5104 
# **Purpose**: 
Currently, when a user makes changes to either their category, title, or description in the project settings page and then tries to navigate to another page, their savings won't automatically be made nor are they alerted that they have unsaved changes on the page. This PR will show a pop-up alert when the user is navigating to another page without having saved their changes.

# **Changes**
Shows a pop-up window that tells the user they're leaving a page without having saved the changes made. There are two buttons on this pop-up, the first to 'stay on this page' with the implication that they can save their changes before navigating to another page, and the second to 'leave this page', anyways. This is only enacted if any or all of the following are altered without hitting 'save changes': title, category, description. 

# **Side Effects**
As very few lines of code were added (four lines including and if-statement with a return), no side effects are anticipated. 


