### PR TITLE
Fix the project overview page contributor error

### DIFF
--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -111,7 +111,7 @@
                     Contributors:
                 % endif
 
-                % if node['anonymous'] and not node['is_public']:
+                % if node['anonymous']:
                     <ol>Anonymous Contributors</ol>
                 % else:
                     <ol>


### PR DESCRIPTION
<b>Purpose</b>
Fix the error that the contributors are not showing correctly in project overview page when it is a public project visited under anonymous private link.

Before fix:
![screen shot 2016-03-09 at 6 48 06 pm](https://cloud.githubusercontent.com/assets/4974056/13654650/804fda74-e627-11e5-9e0b-958ebff4c3a1.png)

After fix:
![screen shot 2016-03-09 at 6 48 31 pm](https://cloud.githubusercontent.com/assets/4974056/13654657/8a25ad26-e627-11e5-9b55-05b9ab5a3608.png)


Partially fix https://openscience.atlassian.net/browse/OSF-5824
