### PR TITLE
[Feature] Prevents enter key from refreshing the page within the Create Bucket bootbox

### DIFF
--- a/website/addons/s3/static/s3NodeConfig.js
+++ b/website/addons/s3/static/s3NodeConfig.js
@@ -333,31 +333,29 @@ ViewModel.prototype.openCreateBucket = function() {
     bootbox.dialog({
         title: 'Create a new bucket',
         message:
-                '<form class="form-horizontal" onsubmit="return false"> ' +
-                    '<div class="row"> ' +
-                        '<div class="col-md-12"> ' +
-                            '<form class="form-horizontal"> ' +
-                                '<div class="form-group"> ' +
-                                    '<label class="col-md-4 control-label" for="bucketName">Bucket Name</label> ' +
-                                    '<div class="col-md-8"> ' +
-                                        '<input id="bucketName" name="bucketName" type="text" placeholder="Enter bucket name" class="form-control" autofocus> ' +
-                                        '<div>' +
-                                            '<span id="bucketModalErrorMessage" ></span>' +
-                                        '</div>'+
-                                    '</div>' +
+                '<div class="row"> ' +
+                    '<div class="col-md-12"> ' +
+                        '<form class="form-horizontal" onsubmit="return false"> ' +
+                            '<div class="form-group"> ' +
+                                '<label class="col-md-4 control-label" for="bucketName">Bucket Name</label> ' +
+                                '<div class="col-md-8"> ' +
+                                    '<input id="bucketName" name="bucketName" type="text" placeholder="Enter bucket name" class="form-control" autofocus> ' +
+                                    '<div>' +
+                                        '<span id="bucketModalErrorMessage" ></span>' +
+                                    '</div>'+
                                 '</div>' +
-                                '<div class="form-group"> ' +
-                                    '<label class="col-md-4 control-label" for="bucketLocation">Bucket Location</label> ' +
-                                    '<div class="col-md-8"> ' +
-                                        '<select id="bucketLocation" name="bucketLocation" class="form-control"> ' +
-                                            generateBucketOptions(self.settings.bucketLocations) +
-                                        '</select>' +
-                                    '</div>' +
+                            '</div>' +
+                            '<div class="form-group"> ' +
+                                '<label class="col-md-4 control-label" for="bucketLocation">Bucket Location</label> ' +
+                                '<div class="col-md-8"> ' +
+                                    '<select id="bucketLocation" name="bucketLocation" class="form-control"> ' +
+                                        generateBucketOptions(self.settings.bucketLocations) +
+                                    '</select>' +
                                 '</div>' +
-                            '</form>' +
-                        '</div>' +
-                    '</div>'+
-                '</form>',
+                            '</div>' +
+                        '</form>' +
+                    '</div>' +
+                '</div>',
         buttons: {
             cancel: {
                 label: 'Cancel',

--- a/website/addons/s3/static/s3NodeConfig.js
+++ b/website/addons/s3/static/s3NodeConfig.js
@@ -316,6 +316,17 @@ ViewModel.prototype.createBucket = function(bucketName, bucketLocation) {
     });
 };
 
+// Prevents return key from refreshing the page inside openCreateBucket
+function stopRKey(evt) {
+  var evt = (evt) ? evt : ((event) ? event : null);
+  var node = (evt.target) ? evt.target : ((evt.srcElement) ? evt.srcElement : null);
+  if ((evt.keyCode == 13) && (node.type=="text"))  {
+      return false;
+  }
+}
+
+document.onkeypress = stopRKey;
+
 ViewModel.prototype.openCreateBucket = function() {
     var self = this;
 

--- a/website/addons/s3/static/s3NodeConfig.js
+++ b/website/addons/s3/static/s3NodeConfig.js
@@ -316,17 +316,6 @@ ViewModel.prototype.createBucket = function(bucketName, bucketLocation) {
     });
 };
 
-// Prevents return key from refreshing the page inside openCreateBucket
-function stopRKey(evt) {
-  var evt = (evt) ? evt : ((event) ? event : null);
-  var node = (evt.target) ? evt.target : ((evt.srcElement) ? evt.srcElement : null);
-  if ((evt.keyCode == 13) && (node.type=="text"))  {
-      return false;
-  }
-}
-
-document.onkeypress = stopRKey;
-
 ViewModel.prototype.openCreateBucket = function() {
     var self = this;
 
@@ -344,29 +333,31 @@ ViewModel.prototype.openCreateBucket = function() {
     bootbox.dialog({
         title: 'Create a new bucket',
         message:
-                '<div class="row"> ' +
-                    '<div class="col-md-12"> ' +
-                        '<form class="form-horizontal"> ' +
-                            '<div class="form-group"> ' +
-                                '<label class="col-md-4 control-label" for="bucketName">Bucket Name</label> ' +
-                                '<div class="col-md-8"> ' +
-                                    '<input id="bucketName" name="bucketName" type="text" placeholder="Enter bucket name" class="form-control" autofocus> ' +
-                                    '<div>' +
-                                        '<span id="bucketModalErrorMessage" ></span>' +
-                                    '</div>'+
+                '<form class="form-horizontal" onsubmit="return false"> ' +
+                    '<div class="row"> ' +
+                        '<div class="col-md-12"> ' +
+                            '<form class="form-horizontal"> ' +
+                                '<div class="form-group"> ' +
+                                    '<label class="col-md-4 control-label" for="bucketName">Bucket Name</label> ' +
+                                    '<div class="col-md-8"> ' +
+                                        '<input id="bucketName" name="bucketName" type="text" placeholder="Enter bucket name" class="form-control" autofocus> ' +
+                                        '<div>' +
+                                            '<span id="bucketModalErrorMessage" ></span>' +
+                                        '</div>'+
+                                    '</div>' +
                                 '</div>' +
-                            '</div>' +
-                            '<div class="form-group"> ' +
-                                '<label class="col-md-4 control-label" for="bucketLocation">Bucket Location</label> ' +
-                                '<div class="col-md-8"> ' +
-                                    '<select id="bucketLocation" name="bucketLocation" class="form-control"> ' +
-                                        generateBucketOptions(self.settings.bucketLocations) +
-                                    '</select>' +
+                                '<div class="form-group"> ' +
+                                    '<label class="col-md-4 control-label" for="bucketLocation">Bucket Location</label> ' +
+                                    '<div class="col-md-8"> ' +
+                                        '<select id="bucketLocation" name="bucketLocation" class="form-control"> ' +
+                                            generateBucketOptions(self.settings.bucketLocations) +
+                                        '</select>' +
+                                    '</div>' +
                                 '</div>' +
-                            '</div>' +
-                        '</form>' +
-                    '</div>' +
-                '</div>',
+                            '</form>' +
+                        '</div>' +
+                    '</div>'+
+                '</form>',
         buttons: {
             cancel: {
                 label: 'Cancel',


### PR DESCRIPTION
Jira ticket: https://openscience.atlassian.net/browse/OSF-5553

When users enter a name in the S3 create bucket modal, if they hit the "return" key, the modal is dismissed.  This is not the expected behavior.  According to @billyhunt, since this form should be refactored, and fixing the behavior in a timely manner is important, this fix should be put in first to correct the unintended behavior.  
