### PR TITLE
Improvement onto icon images: Added ARIA labels to social media icons

### DIFF
--- a/website/templates/footer.mako
+++ b/website/templates/footer.mako
@@ -29,11 +29,11 @@
             </div>
             <div class="col-sm-3 col-md-2">
                 <h4>Socialize</h4>
-                <a href="http://twitter.com/OSFramework"><i class="fa fa-twitter fa-2x"></i></a>
-                <a href="https://www.facebook.com/OpenScienceFramework"><i class="fa fa-facebook fa-2x"></i></a>
-                <a href="https://groups.google.com/forum/#!forum/openscienceframework"><i class="fa fa-group fa-2x"></i></a>
-                <a href="https://www.github.com/centerforopenscience"><i class="fa fa-github fa-2x"></i></a>
-                <a href="https://plus.google.com/103557785986281627994" rel="publisher"><i class="fa fa-google-plus fa-2x"></i></a>
+                <a href="http://twitter.com/OSFramework" aria-label="Twitter"><i class="fa fa-twitter fa-2x"></i></a>
+                <a href="https://www.facebook.com/OpenScienceFramework" aria-label="Facebook"><i class="fa fa-facebook fa-2x"></i></a>
+                <a href="https://groups.google.com/forum/#!forum/openscienceframework" aria-label="Google Group"><i class="fa fa-group fa-2x"></i></a>
+                <a href="https://www.github.com/centerforopenscience" aria-label="GitHub"><i class="fa fa-github fa-2x"></i></a>
+                <a href="https://plus.google.com/103557785986281627994" aria-label="Google Plus" rel="publisher"><i class="fa fa-google-plus fa-2x"></i></a>
             </div> <!-- column -->
         </div>
     </div>


### PR DESCRIPTION
# Purpose
Currently when VoiceOver reads the social media icons in the footer of the OSF pages it just reads "link" for each of them. It has no idea what they are and to a blind or visually impaired person this could be a major problem. This PR allows VoiceOver to read what social media sites the icons represent and relay that information to the user.

# Changes
Adds ARIA labels to the five icons listed under the header "Socialize" in the footer of the OSF. The labels simply state exactly what social media website the icon represents. For example, the icon for twitter has the ARIA label : "Twitter" . An attached image showcases what this looks like in VoiceOver. Additionally, as the label is an ARIA label it would not be visible to sighted users and would only become audible and visible to users using VoiceOver to access the OSF.

# Side Effects
As only 5 lines of code were changed and of those changes only ARIA labels were added, no side effects are anticipated.

![screen shot 2016-03-10 at 10 12 54 am](https://cloud.githubusercontent.com/assets/16869216/13673813/bdd6caac-e6a8-11e5-8c23-90dd8525d46f.png)
