### PR TITLE
Feature: remove Node.commented_files

### DIFF
--- a/api/comments/views.py
+++ b/api/comments/views.py
@@ -67,7 +67,6 @@ class CommentMixin(object):
                     )
                 except NoResultsFound:
                     Comment.update(Q('root_target', 'eq', root_target), data={'root_target': None})
-                    del comment.node.commented_files[root_target._id]
                     raise NotFound
             else:
                 if referent.provider == 'dropbox':

--- a/api/comments/views.py
+++ b/api/comments/views.py
@@ -70,6 +70,7 @@ class CommentMixin(object):
                     raise NotFound
             else:
                 if referent.provider == 'dropbox':
+                    # referent.path is the absolute path for the db file, but wb requires the relative path
                     referent = DropboxFile.load(referent._id)
                 url = waterbutler_api_url_for(comment.node._id, referent.provider, referent.path, meta=True)
                 waterbutler_request = requests.get(

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -215,27 +215,10 @@ class NodeSerializer(JSONAPISerializer):
     def get_unread_comments_count(self, obj):
         user = self.get_user_auth(self.context['request']).user
         node_comments = Comment.find_n_unread(user=user, node=obj, page='node')
-        file_comments = self.get_unread_file_comments(obj)
 
         return {
-            'total': node_comments + file_comments,
-            'node': node_comments,
-            'files': file_comments
+            'node': node_comments
         }
-
-    def get_unread_file_comments(self, obj):
-        user = self.get_user_auth(self.context['request']).user
-        n_unread = 0
-        commented_file_guids = Guid.find(Q('_id', 'in', obj.commented_files.keys()))
-        for target in commented_file_guids:
-            file_obj = FileNode.resolve_class(target.referent.provider, FileNode.FILE).load(target.referent._id)
-            if obj.get_addon(file_obj.provider):
-                try:
-                    get_file_object(node=obj, path=file_obj.path, provider=file_obj.provider, request=self.context['request'])
-                except (exceptions.NotFound, exceptions.PermissionDenied):
-                    continue
-                n_unread += Comment.find_n_unread(user, obj, page='files', root_id=target._id)
-        return n_unread
 
     def create(self, validated_data):
         if 'template_from' in validated_data:

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -7,15 +7,12 @@ from modularodm.exceptions import ValidationValueError
 
 from framework.auth.core import Auth
 from framework.exceptions import PermissionsError
-from framework.guid.model import Guid
 
 from website.models import Node, User, Comment, Institution
 from website.exceptions import NodeStateError, UserNotAffiliatedError
-from website.files.models.base import FileNode
 from website.util import permissions as osf_permissions
 from website.project.model import NodeUpdateError
 
-from api.nodes.utils import get_file_object
 from api.base.utils import get_object_or_error, absolute_reverse
 from api.base.serializers import (JSONAPISerializer, WaterbutlerLink, NodeFileHyperLinkField, IDField, TypeField,
                                   TargetTypeField, JSONAPIListField, LinksField, RelationshipField, DevOnly,

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1904,6 +1904,7 @@ class NodeCommentsList(JSONAPIBaseView, generics.ListCreateAPIView, ODMFilterMix
             else:
                 referent = root_target.referent
                 if referent.provider == 'dropbox':
+                    # referent.path is the absolute path for the db file, but wb requires the relative path
                     referent = DropboxFile.load(root_target.referent._id)
                 url = waterbutler_api_url_for(self.get_node()._id, referent.provider, referent.path, meta=True)
                 waterbutler_request = requests.get(

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1901,8 +1901,6 @@ class NodeCommentsList(JSONAPIBaseView, generics.ListCreateAPIView, ODMFilterMix
                     )
                 except NoResultsFound:
                     Comment.update(Q('root_target', 'eq', root_target), data={'root_target': None})
-                    del root_target.referent.node.commented_files[root_target._id]
-
             else:
                 referent = root_target.referent
                 if referent.provider == 'dropbox':

--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -155,24 +155,8 @@ class TestNodeDetail(ApiTestCase):
         comment = CommentFactory(node=self.public_project, user=contributor, page='node')
         res = self.app.get(self.public_url + '?related_counts=True', auth=self.user.auth)
         unread = res.json['data']['relationships']['comments']['links']['related']['meta']['unread']
-        unread_comments_total = unread['total']
         unread_comments_node = unread['node']
-        assert_equal(unread_comments_total, 1)
         assert_equal(unread_comments_node, 1)
-
-    def test_node_has_correct_unread_file_comments_count(self):
-        contributor = AuthUserFactory()
-        self.public_project.add_contributor(contributor=contributor, auth=Auth(self.user))
-        test_file = test_utils.create_test_file(self.public_project, self.user)
-        comment = CommentFactory(node=self.public_project, target=test_file.get_guid(), user=contributor, page='files')
-        comment.node.commented_files[comment.root_target._id] = 1
-        self.public_project.save()
-        res = self.app.get(self.public_url + '?related_counts=True', auth=self.user.auth)
-        unread = res.json['data']['relationships']['comments']['links']['related']['meta']['unread']
-        unread_comments_total = unread['total']
-        unread_comments_files = unread['files']
-        assert_equal(unread_comments_total, 1)
-        assert_equal(unread_comments_files, 1)
 
     def test_node_properties(self):
         res = self.app.get(self.public_url)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -495,9 +495,6 @@ class CommentFactory(ModularOdmFactory):
             instance.root_target = target.referent.root_target
         else:
             instance.root_target = target
-            if isinstance(instance.root_target.referent, StoredFileNode):
-                file_id = instance.root_target._id
-                instance.node.commented_files[file_id] = instance.node.commented_files.get(file_id, 0) + 1
         return instance
 
     @classmethod
@@ -517,10 +514,6 @@ class CommentFactory(ModularOdmFactory):
             instance.root_target = target.referent.root_target
         else:
             instance.root_target = target
-            if isinstance(instance.root_target.referent, StoredFileNode):
-                file_id = instance.root_target._id
-                instance.node.commented_files[file_id] = instance.node.commented_files.get(file_id, 0) + 1
-                instance.node.save()
         instance.save()
         return instance
 

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -894,11 +894,13 @@ class TestOsfstorageFileCommentMoveRename(FileCommentMoveRenameTestMixin, OsfTes
         file_comments = Comment.find(Q('root_target', 'eq', self.guid._id))
         assert_equal(file_comments.count(), 1)
 
+    @unittest.skip
     def test_comments_move_when_file_moved_to_osfstorage(self):
-        pass
+        super(TestOsfstorageFileCommentMoveRename, self).test_comments_move_when_file_moved_to_osfstorage()
 
+    @unittest.skip
     def test_comments_move_when_folder_moved_to_osfstorage(self):
-        pass
+        super(TestOsfstorageFileCommentMoveRename, self).test_comments_move_when_folder_moved_to_osfstorage()
 
 
 class TestBoxFileCommentMoveRename(FileCommentMoveRenameTestMixin, OsfTestCase):

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -238,7 +238,7 @@ class TestCommentModel(OsfTestCase):
             comment.get_content(auth=None)
 
     def test_find_unread_is_zero_when_no_comments(self):
-        n_unread = Comment.find_n_unread(user=UserFactory(), node=ProjectFactory())
+        n_unread = Comment.find_n_unread(user=UserFactory(), node=ProjectFactory(), page='node')
         assert_equal(n_unread, 0)
 
     def test_find_unread_new_comments(self):
@@ -247,7 +247,7 @@ class TestCommentModel(OsfTestCase):
         project.add_contributor(user)
         project.save()
         comment = CommentFactory(node=project, user=project.creator)
-        n_unread = Comment.find_n_unread(user=user, node=project)
+        n_unread = Comment.find_n_unread(user=user, node=project, page='node')
         assert_equal(n_unread, 1)
 
     def test_find_unread_includes_comment_replies(self):
@@ -257,7 +257,7 @@ class TestCommentModel(OsfTestCase):
         project.save()
         comment = CommentFactory(node=project, user=user)
         reply = CommentFactory(node=project, target=Guid.load(comment._id), user=project.creator)
-        n_unread = Comment.find_n_unread(user=user, node=project)
+        n_unread = Comment.find_n_unread(user=user, node=project, page='node')
         assert_equal(n_unread, 1)
 
     # Regression test for https://openscience.atlassian.net/browse/OSF-5193
@@ -272,7 +272,7 @@ class TestCommentModel(OsfTestCase):
         payload = {'page': 'node', 'rootId': project._id}
         res = self.app.put_json(url, payload, auth=user.auth)
         user.reload()
-        n_unread = Comment.find_n_unread(user=user, node=project)
+        n_unread = Comment.find_n_unread(user=user, node=project, page='node')
         assert_equal(n_unread, 0)
 
         # Edit previously read comment
@@ -281,7 +281,7 @@ class TestCommentModel(OsfTestCase):
             content='edited',
             save=True
         )
-        n_unread = Comment.find_n_unread(user=user, node=project)
+        n_unread = Comment.find_n_unread(user=user, node=project, page='node')
         assert_equal(n_unread, 1)
 
     def test_find_unread_does_not_include_deleted_comments(self):
@@ -290,7 +290,7 @@ class TestCommentModel(OsfTestCase):
         project.add_contributor(user)
         project.save()
         comment = CommentFactory(node=project, user=project.creator, is_deleted=True)
-        n_unread = Comment.find_n_unread(user=user, node=project)
+        n_unread = Comment.find_n_unread(user=user, node=project, page='node')
         assert_equal(n_unread, 0)
 
 

--- a/tests/test_websitefiles.py
+++ b/tests/test_websitefiles.py
@@ -127,7 +127,6 @@ class TestFileNodeObj(FilesTestCase):
         created.save()
         file_guids = TestFile.get_file_guids(materialized_path=created.materialized_path,
                                              provider=created.provider,
-                                             guids=[],
                                              node=self.node)
         assert_in(created.get_guid()._id, file_guids)
 
@@ -139,7 +138,6 @@ class TestFileNodeObj(FilesTestCase):
         created.save()
         file_guids = TestFile.get_file_guids(materialized_path='folder/',
                                              provider=created.provider,
-                                             guids=[],
                                              node=self.node)
         assert_in(created.get_guid()._id, file_guids)
 
@@ -152,7 +150,6 @@ class TestFileNodeObj(FilesTestCase):
         created.delete()
         file_guids = TestFile.get_file_guids(materialized_path='folder/',
                                              provider=created.provider,
-                                             guids=[],
                                              node=self.node)
         assert_not_in(guid._id, file_guids)
 

--- a/website/files/models/base.py
+++ b/website/files/models/base.py
@@ -427,9 +427,6 @@ class FileNode(object):
         """
         trashed = self._create_trashed(user=user, parent=parent)
         self._repoint_guids(trashed)
-        guid = self.get_guid()
-        if guid and guid._id in self.node.commented_files:
-            del self.node.commented_files[guid._id]
         self.node.save()
         StoredFileNode.remove_one(self.stored_object)
         return trashed

--- a/website/files/models/base.py
+++ b/website/files/models/base.py
@@ -251,7 +251,8 @@ class FileNode(object):
             return cls.create(node=node, path=path)
 
     @classmethod
-    def get_file_guids(cls, materialized_path, provider, guids, node):
+    def get_file_guids(cls, materialized_path, provider, node, guids=None):
+        guids = guids or []
         materialized_path = '/' + materialized_path.lstrip('/')
         if materialized_path.endswith('/'):
             folder_children = cls.find(Q('provider', 'eq', provider) &

--- a/website/files/models/osfstorage.py
+++ b/website/files/models/osfstorage.py
@@ -35,7 +35,8 @@ class OsfStorageFileNode(FileNode):
         return cls.create(node=node, path=path)
 
     @classmethod
-    def get_file_guids(cls, materialized_path, provider, guids, node=None):
+    def get_file_guids(cls, materialized_path, provider, node=None, guids=None):
+        guids = guids or []
         path = materialized_path.strip('/')
         file_obj = cls.load(path)
         if not file_obj:

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -10,10 +10,8 @@ from dateutil.parser import parse as parse_date
 import urlparse
 from collections import OrderedDict
 import warnings
-import requests
 
 import pytz
-from flask import request
 from django.core.urlresolvers import reverse
 
 from modularodm import Q
@@ -53,7 +51,7 @@ from website.exceptions import (
 )
 from website.citations.utils import datetime_to_csl
 from website.identifiers.model import IdentifierMixin
-from website.files.models.base import FileNode, StoredFileNode
+from website.files.models.base import StoredFileNode
 from website.util.permissions import expand_permissions
 from website.util.permissions import CREATOR_PERMISSIONS, DEFAULT_CONTRIBUTOR_PERMISSIONS, ADMIN
 from website.project.metadata.schemas import OSF_META_SCHEMAS

--- a/website/project/views/comment.py
+++ b/website/project/views/comment.py
@@ -85,8 +85,6 @@ def find_and_create_file_from_metadata(children, source, destination, destinatio
 
 def update_comment_node(root_target_id, source_node, destination_node):
     Comment.update(Q('root_target', 'eq', root_target_id), data={'node': destination_node})
-    destination_node.commented_files[root_target_id] = source_node.commented_files[root_target_id]
-    del source_node.commented_files[root_target_id]
     source_node.save()
     destination_node.save()
 

--- a/website/project/views/comment.py
+++ b/website/project/views/comment.py
@@ -28,7 +28,6 @@ def update_file_guid_referent(self, node, event_type, payload, user=None):
         file_guids = FileNode.resolve_class(source['provider'], FileNode.ANY).get_file_guids(
             materialized_path=source['materialized'] if source['provider'] != 'osfstorage' else source['path'],
             provider=source['provider'],
-            guids=[],
             node=source_node)
 
         if event_type == 'addon_file_renamed' and source['provider'] in settings.ADDONS_BASED_ON_IDS:


### PR DESCRIPTION
Purpose
------------
The `commented_files` field is used to easily calculate the total unread file comments, but updating the field causes the Node to lock. Since the total unread file comments are not being displayed anywhere, this code can be removed for now. 

Changes
------------
- Remove all usages of `Node.commented_files`
- Simplify `Comment.find_n_unread`
- Address code review comments from #5059, mainly minor refactoring