### PR TITLE
[hotfix] Fix Multiple Registration Approval Emails 

### DIFF
--- a/website/archiver/tasks.py
+++ b/website/archiver/tasks.py
@@ -392,6 +392,6 @@ def archive_success(dst_pk, job_pk):
 
     job = ArchiveJob.load(job_pk)
     if not job.sent:
-        dst.sanction.ask(dst.get_active_contributors_recursive(unique_users=True))
         job.sent = True
         job.save()
+        dst.sanction.ask(dst.get_active_contributors_recursive(unique_users=True))


### PR DESCRIPTION
##### Purpose
- Multiple approval emails were being sent to project admins and contributors after registering a parent project with components and files (i.e. when multiple celery worker threads were running to archive the files in multiple components). 

##### Changes
- This PR resolves the issue by marking a job as complete before the approval emails are sent, so that emails cannot be sent more than once. 

##### JIRA
- [OSF-5820]