### PR TITLE
[Feature] Remove project settings addons apply button

### DIFF
--- a/website/static/js/pages/project-settings-page.js
+++ b/website/static/js/pages/project-settings-page.js
@@ -245,6 +245,8 @@ $(document).ready(function() {
                     callback: function(result) {
                         if (!result) {
                             $(that).attr('checked', false);
+                        } else {
+                            $('#selectAddonsForm').submit();
                         }
                     },
                     buttons:{
@@ -253,7 +255,11 @@ $(document).ready(function() {
                         }
                     }
                });
+            } else {
+                $('#selectAddonsForm').submit();
             }
+        } else {
+            $('#selectAddonsForm').submit();
         }
     });
 });

--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -167,9 +167,6 @@
 
                             <br />
 
-                            <button id="settings-submit" class="btn btn-success">
-                                Apply
-                            </button>
                             <div class="addon-settings-message text-success" style="padding-top: 10px;"></div>
 
                         </form>


### PR DESCRIPTION
On the project settings page, under the checkbox list of addons, there existed an 'Apply' button which was inconvenient for users. This feature removes the apply button and updates the page when the checkboxes are clicked.

Jira ticket: https://openscience.atlassian.net/browse/OSF-5854

## Before
![alt text](http://i.imgur.com/WhJB9i6.png)

## After
![alt text](http://i.imgur.com/KaDpBzH.png)