### PR TITLE
[feature] OSF4M Analytics Links

### DIFF
--- a/website/routes.py
+++ b/website/routes.py
@@ -198,6 +198,7 @@ def make_url_map(app):
         Rule('/howosfworks/', 'get', website_views.redirect_howosfworks, json_renderer,),
         Rule('/faq/', 'get', {}, OsfWebRenderer('public/pages/faq.mako')),
         Rule('/getting-started/', 'get', {}, OsfWebRenderer('public/pages/getting_started.mako')),
+        Rule('/getting-started/email/', 'get', website_views.redirect_meetings_analytics_link, json_renderer),
         Rule('/explore/', 'get', {}, OsfWebRenderer('public/explore.mako')),
         Rule(['/messages/', '/help/'], 'get', {}, OsfWebRenderer('public/comingsoon.mako')),
 

--- a/website/templates/emails/conference_submitted.txt.mako
+++ b/website/templates/emails/conference_submitted.txt.mako
@@ -21,9 +21,9 @@ Get more from the OSF by enhancing your project with the following:
 * Collaborators/contributors to the submission
 * Charts, graphs, and data that didn't make it onto the submission
 * Links to related publications or reference lists
-* Connecting other accounts, like Dropbox, Google Drive, GitHub, figshare and Mendeley via add-on integration. Learn more and read the full list of available add-ons: http://osf.io/getting-started/#addons
+* Connecting other accounts, like Dropbox, Google Drive, GitHub, figshare and Mendeley via add-on integration. Learn more and read the full list of available add-ons: http://osf.io/getting-started/email#addons
 
-To learn more about the OSF, visit: http://osf.io/getting-started
+To learn more about the OSF, visit: http://osf.io/getting-started/email
 
 
 Sincerely yours,

--- a/website/views.py
+++ b/website/views.py
@@ -366,3 +366,7 @@ def redirect_about(**kwargs):
 
 def redirect_howosfworks(**kwargs):
     return redirect('/getting-started/')
+
+
+def redirect_meetings_analytics_link(**kwargs):
+    return redirect('/getting-started/?utm_source=osf4m&utm_medium=email&utm_campaign=success')


### PR DESCRIPTION
- Add link to OSF4M success email which redirects to a Google Analytics link.
- [OSF-4998]