### PR TITLE
[#OSF-5856] Added ARIA Label for youtube link

### DIFF
--- a/website/templates/index.mako
+++ b/website/templates/index.mako
@@ -38,7 +38,7 @@
         <div id="hero-signup" class="container">
           <div class="row">
             <div class="col-sm-6 hidden-xs">
-              <a class="youtube" href="//www.youtube.com/watch?v=2TV21gOzfhw"><i class="icon icon-play"></i></a>
+              <a class="youtube" href="//www.youtube.com/watch?v=2TV21gOzfhw" aria-label="OSF YouTube Video"><i class="icon icon-play"></i></a>
               <img src="/static/img/front-page/screenshot.png" class="img-responsive" id="screenshot" alt="Screenshot of OSF" />
             </div>
             <div class="col-sm-6">


### PR DESCRIPTION
# Purpose
Currently when VoiceOver reads the YouTube link to the video "Getting Started With the Open Science Framework" it just reads "link" for it. It has no idea what that is and to a blind or visually impaired person this could be a major problem. This PR adds an ARIA label to the link so that a blind/visually impaired user would be able to access it easily. This link is found on the home page of the OSF. It is the link located on the screen shot of the OSF with the YouTube play button over it. This can more clearly be seen in the before and after images.

# Changes
Adds an ARIA label to the YouTube link to "Getting Started With the Open Science Framework". This label shows up in the links menu of VoiceOver and reads out "OSF YouTube Video" when the user scrolls to it. This label is not visible to sighted users. Attached are before and after images of how this appears in the VoiceOver menu.

# Side Effects
As only one line of code was changed no side effects are anticipated. 

## Before Image
![screen shot 2016-03-11 at 10 10 10 am](https://cloud.githubusercontent.com/assets/16869216/13706059/83b246ca-e771-11e5-88c3-763dc08f6fee.png)

## After Image
![screen shot 2016-03-11 at 10 13 39 am](https://cloud.githubusercontent.com/assets/16869216/13706189/0518feb6-e772-11e5-87d4-8040fe5c34f3.png)
