### PR TITLE
[Ready for Review] Resolves misspointed url for registration contributors

### DIFF
--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -157,7 +157,7 @@ class RegistrationContributorsSerializer(NodeContributorsSerializer):
     def get_absolute_url(self, obj):
         node_id = self.context['request'].parser_context['kwargs']['node_id']
         return absolute_reverse(
-            'registrations:node-contributor-detail',
+            'registrations:registration-contributor-detail',
             kwargs={
                 'node_id': node_id,
                 'user_id': obj._id

--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -243,6 +243,9 @@ class RegistrationContributorsList(NodeContributorsList, RegistrationMixin):
     view_category = 'registrations'
     view_name = 'registration-contributors'
 
+    def get_serializer_class(self):
+        return RegistrationContributorsSerializer
+
 
 class RegistrationContributorDetail(NodeContributorDetail, RegistrationMixin):
     view_category = 'registrations'


### PR DESCRIPTION
The urls for registration contributors were pointing to /v2/node/{node_id}/contributors/{contributor_id}/ which did not resolve. This changes them to point to /v2/registrations/{registration_id}/contributors/{contributor_id}/.

In prod the only issue would be that links.self would have been pointing at the wrong place. In staging, with varnish esi enabled, the issue would be that registration contributors would have become `{"errors":[{"title":"Not Found"}]}`.

@caneruguz This should fix your problem.