### PR TITLE
Button no longer disabled when URL field is empty on project settings page

### DIFF
--- a/website/addons/forward/static/forwardConfig.js
+++ b/website/addons/forward/static/forwardConfig.js
@@ -100,18 +100,36 @@ var ViewModel = function(url, nodeId) {
     self.fetchFromServer();
 
     function onSubmitSuccess() {
-        self.changeMessage(
-            'Successfully linked to <a href="' + self.url() + '">' + self.url() + '</a>.',
-            'text-success',
-            MESSAGE_TIMEOUT
-        );
+        if (self.url() == null) {
+            self.changeMessage(
+                'Please fill in the required field.',
+                'text-danger'
+            );
+        }
+        else {
+            self.changeMessage(
+                'Successfully linked to <a href="' + self.url() + '">' + self.url() + '</a>.',
+                'text-success',
+                MESSAGE_TIMEOUT
+            );
+        }
     }
 
     function onSubmitError(xhr, status) {
-        self.changeMessage(
-            'Could not change settings. Please try again later.',
-            'text-danger'
-        );
+        var re = /^(https?):\/{2}/;
+        var b = self.url().replace(re, '');
+        if (b == '') {
+            self.changeMessage(
+                'Please fill in the required field.',
+                'text-danger'
+            );
+        }
+        else {
+            self.changeMessage(
+                'Could not change settings. Please try again later.',
+                'text-danger'
+            );
+        }
     }
 
     /**

--- a/website/addons/forward/templates/forward_node_settings.mako
+++ b/website/addons/forward/templates/forward_node_settings.mako
@@ -17,7 +17,7 @@
                         class="form-control"
                         data-bind="value: url"
                         placeholder="Required"
-                        required />
+                        />
             </div>
 
             <div class="form-group">
@@ -53,7 +53,6 @@
                     <input type="submit"
                            class="btn btn-success pull-right"
                            value="Save"
-                           data-bind="disable: !validators.isValid()"
                     />
                 </div>
             </div>


### PR DESCRIPTION
On the project settings page, when "External Links" under "Select Add-ons" is enabled, the button is no longer disabled when the URL field is empty. A new error message consistent with other OSF pages now appears when the user clicks the button without entering anything into the URL field (previously, the default HTML5 form validation error appeared). 

Before:
<img width="911" alt="screen shot 2016-03-11 at 2 02 05 pm" src="https://cloud.githubusercontent.com/assets/17709643/13713329/7e076ba4-e796-11e5-97e6-047bff77f91b.png">

After:
<img width="891" alt="screen shot 2016-03-11 at 2 06 17 pm" src="https://cloud.githubusercontent.com/assets/17709643/13713348/8b4fe07a-e796-11e5-80ce-c74e7c4e3fdd.png">

[OSF-3546]