### PR TITLE
[#OSF-4722] [Ready to Review] Fixed Add Button and Check Button Sizes

### DIFF
--- a/website/templates/project/modal_add_contributor.mako
+++ b/website/templates/project/modal_add_contributor.mako
@@ -62,12 +62,12 @@
                                                     data-bind="visible: !contributor.added,
                                                                click:$root.add,
                                                                tooltip: {title: 'Add contributor'}"
-                                                ><i class="fa fa-fw fa-plus"></i></a>
+                                                ><i class="fa fa-plus"></i></a>
                                             <div data-bind="visible: contributor.added,
                                                             tooltip: {title: 'Already added'}"
                                                 ><div
                                                     class="btn btn-default contrib-button btn-mini disabled"
-                                                    ><i class="fa fa-fw fa-check"></i></div></div>
+                                                    ><i class="fa fa-check"></i></div></div>
                                         </td>
                                         <td>
                                             <!-- height and width are explicitly specified for faster rendering -->


### PR DESCRIPTION
JIRA Ticket: https://openscience.atlassian.net/browse/OSF-4722

# Purpose
Currently when editing one of the projects for which the user has admin permission. In the project's Contributor's page when you try to add a contributor the plus button has a larger width than the minus button does. This PR makes the size of the buttons the same. This is more easily visible in the before and after images.

# Changes
Takes out the section in the plus button code where the width was fixed as the width of the minus button was not fixed. 

# Side Effects
No side effects anticipated. 

## Before
![unnamed](https://cloud.githubusercontent.com/assets/16869216/13714188/1914d844-e79b-11e5-81f0-883529246302.png)
![unnamed-1](https://cloud.githubusercontent.com/assets/16869216/13714195/247a6758-e79b-11e5-8243-b6f5a71b7c80.png)

The buttons are different sizes.

## After
![screen shot 2016-03-11 at 3 04 41 pm](https://cloud.githubusercontent.com/assets/16869216/13714168/fb275d48-e79a-11e5-82f5-faff2cca3159.png)
![screen shot 2016-03-11 at 3 05 00 pm](https://cloud.githubusercontent.com/assets/16869216/13714171/fda5eb0c-e79a-11e5-9fda-87f404f569e1.png)

The buttons are now the same size.