### PR TITLE
[Ready to Review] Dashboard/quick search while loading

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "list-of-licenses": "git://github.com/samchrisinger/list-of-licenses.git#1f1d9ca8a9aba56d57fca6e27df80b8298048cc8",
     "livedb": "~0.4.8",
     "livedb-mongo": "~0.4.1",
+    "loaders.css": "^0.1.2",
     "markdown-it": "~4.1.0",
     "markdown-it-ins-del": "^0.1.1",
     "markdown-it-sanitizer": "~0.3.0",

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -72,6 +72,7 @@ var entry = {
         'select2',
         'dropzone',
         'knockout-sortable',
+        'loaders.css',
         'treebeard',
         'jquery.cookie',
         'URIjs',

--- a/website/static/js/home-page/newAndNoteworthyPlugin.js
+++ b/website/static/js/home-page/newAndNoteworthyPlugin.js
@@ -9,6 +9,8 @@ var Raven = require('raven-js');
 
 // CSS
 require('css/new-and-noteworthy-plugin.css');
+require('loaders.css/loaders.min.css');
+
 
 // XHR config for apiserver connection
 var xhrconfig = function(xhr) {
@@ -91,7 +93,7 @@ var NewAndNoteworthy = {
         }
 
         if (!ctrl.someDataLoaded()) {
-            return m('.text-center', m('.logo-spin.logo-xl.m-v-xl'));
+            return m('.loader-inner.ball-scale.text-center.m-v-xl', m(''))
         }
 
         function newAndNoteworthyProjectsTemplate () {

--- a/website/static/js/home-page/newAndNoteworthyPlugin.js
+++ b/website/static/js/home-page/newAndNoteworthyPlugin.js
@@ -93,7 +93,7 @@ var NewAndNoteworthy = {
         }
 
         if (!ctrl.someDataLoaded()) {
-            return m('.loader-inner.ball-scale.text-center.m-v-xl', m(''))
+            return m('.loader-inner.ball-scale.text-center.m-v-xl', m(''));
         }
 
         function newAndNoteworthyProjectsTemplate () {

--- a/website/static/js/home-page/quickProjectSearchPlugin.js
+++ b/website/static/js/home-page/quickProjectSearchPlugin.js
@@ -306,10 +306,6 @@ var QuickSearchProject = {
             }
         };
 
-        // Onclick, directs user to project page
-        self.nodeDirect = function(node) {
-            location.href = '/'+ node.id;
-        };
     },
     view : function(ctrl) {
         if (ctrl.errorLoading()) {

--- a/website/static/js/home-page/quickProjectSearchPlugin.js
+++ b/website/static/js/home-page/quickProjectSearchPlugin.js
@@ -401,16 +401,9 @@ var QuickSearchProject = {
         }
 
         function searchBar() {
-            var searchClass = 'form-control disabled';
-            var searchPlaceholder = 'Loading projects for search...';
-
-            if (ctrl.loadingComplete()){
-                searchClass = 'form-control';
-                searchPlaceholder = 'Quick search projects';
-            }
-
             return m('div.m-v-sm.quick-search-input', [
-                m('input[type=search]', {'id': 'searchQuery', 'class': searchClass, placeholder: searchPlaceholder, onkeyup: function(search) {
+                ctrl.loadingComplete() ? m('.m-v-md') : m('.spinner-div.m-v-md', m('.logo-spin.logo-sm.m-r-sm'), 'Loading projects...'),
+                m('input[type=search]', {'id': 'searchQuery', 'class': 'form-control', placeholder: 'Quick search projects', onkeyup: function(search) {
                     ctrl.filter(search.target.value);
                     ctrl.quickSearch();
                 }})

--- a/website/static/js/home-page/quickProjectSearchPlugin.js
+++ b/website/static/js/home-page/quickProjectSearchPlugin.js
@@ -320,7 +320,7 @@ var QuickSearchProject = {
         }
 
         if (!ctrl.someDataLoaded()) {
-            return m('.loader-inner.ball-scale.text-center.m-v-xl', m(''))
+            return m('.loader-inner.ball-scale.text-center.m-v-xl', m(''));
         }
 
         function loadMoreButton(){

--- a/website/static/js/home-page/quickProjectSearchPlugin.js
+++ b/website/static/js/home-page/quickProjectSearchPlugin.js
@@ -81,7 +81,12 @@ var QuickSearchProject = {
                         self.nodes().push(node);
                         self.retrieveContributors(node);
                     });
-                self.populateEligibleNodes(self.eligibleNodes().length, self.nodes().length);
+                    if (self.filter()) {
+                        self.quickSearch();
+                    }
+                    else {
+                        self.populateEligibleNodes(self.eligibleNodes().length, self.nodes().length);
+                    }
                 self.next(result.links.next);
                 self.recursiveNodes(self.next());
                 }, function _error(result){

--- a/website/static/js/home-page/quickProjectSearchPlugin.js
+++ b/website/static/js/home-page/quickProjectSearchPlugin.js
@@ -8,6 +8,7 @@ var Raven = require('raven-js');
 
 // CSS
 require('css/quick-project-search-plugin.css');
+require('loaders.css/loaders.min.css');
 
 // XHR config for apiserver connection
 var xhrconfig = function(xhr) {
@@ -319,7 +320,7 @@ var QuickSearchProject = {
         }
 
         if (!ctrl.someDataLoaded()) {
-            return m('.text-center', m('.logo-spin.logo-xl.m-v-xl'));
+            return m('.loader-inner.ball-scale.text-center.m-v-xl', m(''))
         }
 
         function loadMoreButton(){
@@ -457,7 +458,7 @@ var QuickSearchProject = {
                             },
                             loadingComplete: ctrl.loadingComplete
                         }),
-                        !ctrl.loadingComplete() && ctrl.filter() ? m('.spinner-div.m-v-md.text-center', m('.logo-spin.logo-sm.m-r-sm'), 'Searching projects...') : m('.m-v-md') ,
+                        !ctrl.loadingComplete() && ctrl.filter() ? m('.loader-inner.ball-scale.text-center', m('')) : m('.m-v-md')
 
                     ]),
                     m('.text-center', loadMoreButton())

--- a/website/static/js/home-page/quickProjectSearchPlugin.js
+++ b/website/static/js/home-page/quickProjectSearchPlugin.js
@@ -271,10 +271,11 @@ var QuickSearchProject = {
         // Filtering on contrib
         self.contributorMatch = function (node) {
             var contributors = self.contributorMapping[node.id];
-            for (var c = 0; c < contributors.length; c++) {
+            if (contributors) {
+                for (var c = 0; c < contributors.length; c++) {
                 if (contributors[c].toUpperCase().indexOf(self.filter().toUpperCase()) !== -1){
                     return true;
-                }
+                }}
             }
             return false;
         };

--- a/website/static/js/home-page/quickProjectSearchPlugin.js
+++ b/website/static/js/home-page/quickProjectSearchPlugin.js
@@ -455,7 +455,8 @@ var QuickSearchProject = {
                             getFamilyName: ctrl.getFamilyName,
                             formatDate: function(node) {
                                 return ctrl.formatDate(node);
-                            }
+                            },
+                            loadingComplete: ctrl.loadingComplete
                         })
                     ]),
                     m('.text-center', loadMoreButton())
@@ -468,7 +469,7 @@ var QuickSearchProject = {
 
 var QuickSearchNodeDisplay = {
     view: function(ctrl, args) {
-        if (args.eligibleNodes().length === 0 && args.filter() != null) {
+        if (args.eligibleNodes().length === 0 && args.filter() != null && args.loadingComplete() === true) {
             return m('.row.m-v-sm', m('.col-sm-12',
                 m('.row',
                     m('.col-sm-12', m('em', 'No results found!'))

--- a/website/static/js/home-page/quickProjectSearchPlugin.js
+++ b/website/static/js/home-page/quickProjectSearchPlugin.js
@@ -402,7 +402,6 @@ var QuickSearchProject = {
 
         function searchBar() {
             return m('div.m-v-sm.quick-search-input', [
-                ctrl.loadingComplete() ? m('.m-v-md') : m('.spinner-div.m-v-md', m('.logo-spin.logo-sm.m-r-sm'), 'Loading projects...'),
                 m('input[type=search]', {'id': 'searchQuery', 'class': 'form-control', placeholder: 'Quick search projects', onkeyup: function(search) {
                     ctrl.filter(search.target.value);
                     ctrl.quickSearch();
@@ -457,7 +456,9 @@ var QuickSearchProject = {
                                 return ctrl.formatDate(node);
                             },
                             loadingComplete: ctrl.loadingComplete
-                        })
+                        }),
+                        !ctrl.loadingComplete() && ctrl.filter() ? m('.spinner-div.m-v-md.text-center', m('.logo-spin.logo-sm.m-r-sm'), 'Searching projects...') : m('.m-v-md') ,
+
                     ]),
                     m('.text-center', loadMoreButton())
                 ])


### PR DESCRIPTION
Issue https://openscience.atlassian.net/browse/OSF-5867

# Purpose

Currently, users must wait until all projects are loaded before they can begin to search.   This can be a long wait if the users have many projects.

# Changes

Allows user to search for projects before all projects are loaded in the background.  As new search results are found, they will be added to the list.  Sorting is still prevented until all nodes are loaded.

Also, adds ball-scale, instead of spinner while loading.  Just an experiment - we need to reach an agreement on the loader.
![out](https://cloud.githubusercontent.com/assets/9755598/13758043/b0e48232-e9fd-11e5-9b96-1dd6d3009f5e.gif)


