### PR TITLE
Ignore more celerybeat-schedule files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,7 +98,7 @@ scripts/hide_extra_registration_logs.json
 scripts/osfstorage/usage_whitelist.json
 
 # Celery dbs
-celerybeat-schedule.db
+celerybeat-schedule*
 celery_beat.py.db
 
 # Diff (used during merge resolution)


### PR DESCRIPTION
Since `celerybeat` uses `anydbm` (via `shelve`), its data file might have one of a number of file extensions. It's actually pretty hard to figure out what those file extensions might be, but it's easy enough to keep them out of git with a wildcard.

P.S. I don't know what the `celery_beat.py.db` file is about, so I'm not touching that.

Reticketed from https://github.com/zkraime/osf.io/commit/a6d27826a247615b5de4838d76bf27b714aa144f#commitcomment-16682405.