### PR TITLE
[FEATURE]Add permission groups through migration

### DIFF
--- a/admin/README.md
+++ b/admin/README.md
@@ -20,8 +20,8 @@
 If you need to do prereg work then you need to add a group and add an OSF id to your admin user's profile.
 
 - Navigate to `localhost:8001/admin/django_admin/`
-- ~~ Go to groups and add `prereg_group` without any other permissions ~~
-- ~~ save ~~ These should already be populated if `migrate` was run above
+- ~~Go to groups and add `prereg_group` without any other permissions~~
+- ~~save~~ These should already be populated if `migrate` was run above
 - Go to **My users** and go into the user that needs to be a prereg admin
 - Add an existing user id to **Osf id**
 - Select **prereg_group** from the groups list and add it to **Chosen groups**

--- a/admin/README.md
+++ b/admin/README.md
@@ -20,8 +20,8 @@
 If you need to do prereg work then you need to add a group and add an OSF id to your admin user's profile.
 
 - Navigate to `localhost:8001/admin/django_admin/`
-- Go to groups and add `prereg_group` without any other permissions
-- save
+- ~~ Go to groups and add `prereg_group` without any other permissions ~~
+- ~~ save ~~ These should already be populated if `migrate` was run above
 - Go to **My users** and go into the user that needs to be a prereg admin
 - Add an existing user id to **Osf id**
 - Select **prereg_group** from the groups list and add it to **Chosen groups**

--- a/admin/base/migrations/0001_groups.py
+++ b/admin/base/migrations/0001_groups.py
@@ -13,6 +13,9 @@ def add_groups(*args):
     group, created = Group.objects.get_or_create(name='prereg_group')
     if created:
         logger.info('prereg_group created')
+    group, created = Group.objects.get_or_create(name='osf_admin')
+    if created:
+        logger.info('osf_admin group created')
     group, created = Group.objects.get_or_create(name='osf_group')
     if created:
         logger.info('osf_group created')

--- a/admin/base/migrations/0001_groups.py
+++ b/admin/base/migrations/0001_groups.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.contrib.auth.models import Group
+import logging
+
+logger = logging.getLogger(__file__)
+
+
+def add_groups(*args):
+    print args
+    group, created = Group.objects.get_or_create(name='prereg_group')
+    if created:
+        logger.info('prereg_group created')
+    group, created = Group.objects.get_or_create(name='osf_group')
+    if created:
+        logger.info('osf_group created')
+
+
+class Migration(migrations.Migration):
+
+    operations = [
+        migrations.RunPython(add_groups),
+    ]

--- a/admin/base/migrations/0001_groups.py
+++ b/admin/base/migrations/0001_groups.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from django.db import models, migrations
+from django.db import migrations
 from django.contrib.auth.models import Group
 import logging
 

--- a/admin/common_auth/migrations/0001_initial.py
+++ b/admin/common_auth/migrations/0001_initial.py
@@ -2,20 +2,13 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
-from django.contrib.auth.models import Group
 import datetime
-
-
-def add_groups():
-    Group.objects.get_or_create(name='prereg_group')
-    Group.objects.get_or_create(name='osf_group')
 
 
 class Migration(migrations.Migration):
 
     dependencies = [
         ('auth', '0006_require_contenttypes_0002'),
-        ('auth', '0001_initial'),
     ]
 
     operations = [
@@ -42,5 +35,4 @@ class Migration(migrations.Migration):
                 'ordering': ['email'],
             },
         ),
-        migrations.RunPython(add_groups),
     ]

--- a/admin/common_auth/migrations/0001_initial.py
+++ b/admin/common_auth/migrations/0001_initial.py
@@ -2,13 +2,20 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
+from django.contrib.auth.models import Group
 import datetime
+
+
+def add_groups():
+    Group.objects.get_or_create(name='prereg_group')
+    Group.objects.get_or_create(name='osf_group')
 
 
 class Migration(migrations.Migration):
 
     dependencies = [
         ('auth', '0006_require_contenttypes_0002'),
+        ('auth', '0001_initial'),
     ]
 
     operations = [
@@ -35,4 +42,5 @@ class Migration(migrations.Migration):
                 'ordering': ['email'],
             },
         ),
+        migrations.RunPython(add_groups),
     ]


### PR DESCRIPTION
## Proposal
Add permission groups such as `prereg_group` through a migration script.

## Repercussions
Should make it slightly easier to start a new server with permissions groups rather than having to add groups by hand. Also this will be a basis for several subsequent PRs that add in required login and group permissions for each view.