### PR TITLE
OSF-5179 Strange wiki compare behavior.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "bower": "^1.3.12",
     "c3": "^0.4.10",
     "css-loader": "^0.9.1",
-    "diff": "~1.2.2",
+    "diff": "~2.2.2",
     "dropzone": "git://github.com/sloria/dropzone.git#accept-directory",
     "exports-loader": "^0.6.2",
     "express": "~4.10.0",

--- a/website/static/js/diffTool.js
+++ b/website/static/js/diffTool.js
@@ -11,16 +11,10 @@ function removeEmpty(array) {
     return ret;
 }
 
-// Custom differ that includes newlines and sentence breaks
-var wikiDiff =  new jsdiff.Diff();
-wikiDiff.tokenize = function (value) {
-    return removeEmpty(value.split(/(\S.+?[.!?\n])(?=\s+|$)/));
-};
-
 var diff = function(beforeText, afterText) {
     beforeText = beforeText.replace(/(?:\r\n|\r|\n)/g, '\n');
     afterText = afterText.replace(/(?:\r\n|\r|\n)/g, '\n');
-    var diffList = wikiDiff.diff(beforeText, afterText);
+    var diffList = jsdiff.diffLines(beforeText, afterText, newlineIsToken=true);
     var fragment = document.createDocumentFragment();
 
     diffList.forEach(function(part) {


### PR DESCRIPTION
<h3>
Purpose
</h3>
The original behavior of the compare function of project wiki was erratic in that it was not clear whether it was comparing texts word by word, line by line or otherwise. This PR make use of new features in diff 2.2.2 and compare wiki texts line by line.

<h3>
Changes
</h3>
Update the package.json file to use newest version of diff (2.2.2).
Change diffTool.js. Specifically, the custom wikiDiff object was deleted and make use of diffLines() in diff 2.2.2.