### PR TITLE
Feature/password changing security updates

### DIFF
--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -657,20 +657,21 @@ class User(GuidStoredObject, AddonModelMixin):
         return '{base_url}user/{uid}/{project_id}/claim/?token={token}'\
                     .format(**locals())
 
-    def set_password(self, raw_password):
+    def set_password(self, raw_password, suppress_notification=False):
         """Set the password for this user to the hash of ``raw_password``.
         If this is a new user, we're done. If this is a password change,
         then email the user about the change and clear all the old sessions
         so that users will have to log in again with the new password.
 
         :param raw_password: the plaintext value of the new password
+        :param suppress_notification: Only meant for unit tests to keep extra notifications from being sent
         :rtype: list
         :returns: Changed fields from the user save
         """
         had_existing_password = bool(self.password)
         self.password = generate_password_hash(raw_password)
         return_value = self.save()
-        if had_existing_password:
+        if had_existing_password and not suppress_notification:
             mails.send_mail(
                 to_addr=self.username,
                 mail=mails.PASSWORD_RESET,

--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -670,7 +670,6 @@ class User(GuidStoredObject, AddonModelMixin):
         """
         had_existing_password = bool(self.password)
         self.password = generate_password_hash(raw_password)
-        return_value = self.save()
         if had_existing_password and notify:
             mails.send_mail(
                 to_addr=self.username,
@@ -679,7 +678,6 @@ class User(GuidStoredObject, AddonModelMixin):
                 user=self
             )
             remove_sessions_for_user(self)
-        return return_value
 
     def check_password(self, raw_password):
         """Return a boolean of whether ``raw_password`` was correct."""

--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -657,21 +657,21 @@ class User(GuidStoredObject, AddonModelMixin):
         return '{base_url}user/{uid}/{project_id}/claim/?token={token}'\
                     .format(**locals())
 
-    def set_password(self, raw_password, suppress_notification=False):
+    def set_password(self, raw_password, notify=True):
         """Set the password for this user to the hash of ``raw_password``.
         If this is a new user, we're done. If this is a password change,
         then email the user about the change and clear all the old sessions
         so that users will have to log in again with the new password.
 
         :param raw_password: the plaintext value of the new password
-        :param suppress_notification: Only meant for unit tests to keep extra notifications from being sent
+        :param notify: Only meant for unit tests to keep extra notifications from being sent
         :rtype: list
         :returns: Changed fields from the user save
         """
         had_existing_password = bool(self.password)
         self.password = generate_password_hash(raw_password)
         return_value = self.save()
-        if had_existing_password and not suppress_notification:
+        if had_existing_password and notify:
             mails.send_mail(
                 to_addr=self.username,
                 mail=mails.PASSWORD_RESET,

--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -49,7 +49,6 @@ def reset_password(auth, **kwargs):
         # new random verification key, allows CAS to authenticate the user w/o password one time only.
         user_obj.verification_key = security.random_string(20)
         user_obj.set_password(form.password.data)
-        user_obj.save()
         status.push_status_message('Password reset', 'success')
         # Redirect to CAS and authenticate the user with a verification key.
         return redirect(cas.get_login_url(

--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -49,6 +49,7 @@ def reset_password(auth, **kwargs):
         # new random verification key, allows CAS to authenticate the user w/o password one time only.
         user_obj.verification_key = security.random_string(20)
         user_obj.set_password(form.password.data)
+        user_obj.save()
         status.push_status_message('Password reset', 'success')
         # Redirect to CAS and authenticate the user with a verification key.
         return redirect(cas.get_login_url(

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -132,7 +132,7 @@ class AuthUserFactory(UserFactory):
 
     @post_generation
     def add_auth(self, create, extracted):
-        self.set_password('password', suppress_notification=True)
+        self.set_password('password', notify=False)
         self.save()
         self.auth = (self.username, 'password')
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -132,7 +132,7 @@ class AuthUserFactory(UserFactory):
 
     @post_generation
     def add_auth(self, create, extracted):
-        self.set_password('password')
+        self.set_password('password', suppress_notification=True)
         self.save()
         self.auth = (self.username, 'password')
 

--- a/tests/framework_tests/test_sessions.py
+++ b/tests/framework_tests/test_sessions.py
@@ -34,3 +34,11 @@ class SessionUtilsTestCase(DbTestCase):
 
         utils.remove_sessions_for_user(self.user)
         assert_equal(1, Session.find().count())
+
+    def test_password_change_clears_sessions(self):
+        factories.SessionFactory(user=self.user)
+        factories.SessionFactory(user=self.user)
+        factories.SessionFactory(user=self.user)
+        assert_equal(3, Session.find().count())
+        self.user.set_password('killerqueen')
+        assert_equal(0, Session.find().count())

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -105,6 +105,22 @@ class TestAuthUtils(OsfTestCase):
             auth.get_user(email=user.username, password='wrong')
         )
 
+    @mock.patch('framework.auth.views.mails.send_mail')
+    def test_password_change_sends_email(self, mock_mail):
+        user = UserFactory.build()
+        user.set_password('killerqueen')
+        assert_equal(len(mock_mail.call_args_list), 1)
+        empty, kwargs = mock_mail.call_args
+        kwargs['user'].reload()
+
+        assert_equal(empty, ())
+        assert_equal(kwargs, {
+            'user': user,
+            'mimetype': 'plain',
+            'mail': mails.PASSWORD_RESET,
+            'to_addr': user.username,
+        })
+
 
 class TestAuthObject(OsfTestCase):
 

--- a/website/mails/mails.py
+++ b/website/mails/mails.py
@@ -143,6 +143,7 @@ FORWARD_INVITE = Mail('forward_invite', subject='Please forward to ${fullname}')
 FORWARD_INVITE_REGISTERED = Mail('forward_invite_registered', subject='Please forward to ${fullname}')
 
 FORGOT_PASSWORD = Mail('forgot_password', subject='Reset Password')
+PASSWORD_RESET = Mail('password_reset', subject='Your OSF password has been reset')
 PENDING_VERIFICATION = Mail('pending_invite', subject='Your account is almost ready!')
 PENDING_VERIFICATION_REGISTERED = Mail('pending_registered', subject='Received request to be a contributor')
 

--- a/website/templates/emails/notify_base.mako
+++ b/website/templates/emails/notify_base.mako
@@ -60,7 +60,7 @@
                     <tbody>
                         <tr>
                             <td style="border-collapse: collapse;">
-                                <p class="text-smaller text-center" style="text-align: center;font-size: 12px;">Copyright &copy; 2015 Center For Open Science, All rights reserved.
+                                <p class="text-smaller text-center" style="text-align: center;font-size: 12px;">Copyright &copy; 2016 Center For Open Science, All rights reserved.
                                 ${self.footer()}
                                 </p>
                             </td>

--- a/website/templates/emails/password_reset.txt.mako
+++ b/website/templates/emails/password_reset.txt.mako
@@ -1,0 +1,4 @@
+DRAFT EMAIL MESSAGE - Do not go to production with this.
+
+Your password has been reset. If you did not reset your password, go to the Open Science Framework
+at https://osf.io/ and reset your password.

--- a/website/templates/emails/password_reset.txt.mako
+++ b/website/templates/emails/password_reset.txt.mako
@@ -1,4 +1,13 @@
-DRAFT EMAIL MESSAGE - Do not go to production with this.
+Hello ${user.fullname},
 
-Your password has been reset. If you did not reset your password, go to the Open Science Framework
-at https://osf.io/ and reset your password.
+The password for your OSF account has successfully changed. 
+
+If you did not request this action or you believe an unauthorized person has accessed your account, reset your password immediately by visiting:
+
+http://osf.io/settings/account/
+
+If you need additional help or have questions, let us know at contact@cos.io.
+
+Sincerely yours,
+
+The OSF Robot


### PR DESCRIPTION
Purpose
-----------
Fixes [sec-3] and [sec-4] by way of [https://openscience.atlassian.net/browse/OSF-5874]. Essentially, resetting a user's password should warn the user and should log out all existing sessions. 

Changes
------------

1. Test for removing sessions when changing password
2. Test for emailing user when changing password
3. Add a stub email template (real email waiting for feedback from community)
4. Move save of user to the change password model
5. Check to verify that this isn't the user's first time adding a password. If it's a change, then email the user and delete existing sessions

Side effects
----------------
Shouldn't be any, although I seem to have to log in twice, especially after the sessions are cleared. I'm not yet sure if that's something I did somehow or if it's just the way the OSF is being right now; possibly something in my local setup.