### PR TITLE
remove redundant node text

### DIFF
--- a/website/static/js/myProjects.js
+++ b/website/static/js/myProjects.js
@@ -372,7 +372,6 @@ var MyProjects = {
                     }
                     if(showAddProject){
                         self.nonLoadTemplate(m('.db-non-load-template.m-md.p-md.osf-box.text-center', [
-                            'This project has no components.',
                             m.component(AddProject, {
                                 buttonTemplate : m('.btn.btn-link[data-toggle="modal"][data-target="#addSubcomponent"]', 'Add new component'),
                                 parentID : lastcrumb.data.id,
@@ -385,9 +384,6 @@ var MyProjects = {
                                 }
                             })
                         ]));
-                    } else {
-                        self.nonLoadTemplate(m('.db-non-load-template.m-md.p-md.osf-box',
-                            'This project has no components.'));
                     }
                 }
                 self.selected([]); // Empty selected


### PR DESCRIPTION
With the current text, the word component will be repeated 3 times, which, as I mentioned in the trello card, will invoke Beatlejuice.  No one wants that.  And its also redundant.  

Since the lack of components or projects is implied by the lack of components listed.  I propose we remove the text all together.

Before
---------
![screen shot 2016-03-16 at 3 39 28 pm](https://cloud.githubusercontent.com/assets/6232068/13827660/2f1480f2-eb94-11e5-87ff-352f3836e690.png)

After
-------

![screen shot 2016-03-16 at 4 30 36 pm](https://cloud.githubusercontent.com/assets/6232068/13827718/73e050e4-eb94-11e5-9a5e-e126146b286c.png)
