### PR TITLE
[Ready for Review] Add decaching to read comment count timestamp update view

### DIFF
--- a/website/project/views/comment.py
+++ b/website/project/views/comment.py
@@ -1,8 +1,13 @@
 # -*- coding: utf-8 -*-
+from functools import partial
+
 import pytz
 import markdown
 from datetime import datetime
 from flask import request
+
+from api.caching.tasks import ban_url
+from framework.postcommit_tasks.handlers import enqueue_postcommit_task
 from modularodm import Q
 
 from framework.auth.decorators import must_be_logged_in
@@ -135,6 +140,7 @@ def _update_comments_timestamp(auth, node, page=Comment.OVERVIEW, root_id=None):
         if not node_timestamp:
             user_timestamp[node._id] = dict()
         timestamps = auth.user.comments_viewed_timestamp[node._id]
+        enqueue_postcommit_task(partial(ban_url, node, []))
 
         # update node timestamp
         if page == Comment.OVERVIEW:


### PR DESCRIPTION
This fixes the comment count not being decached when users open the comment slide-out by decaching the users' url. 

The core problem is that the URL that is used to retrieve the users comment count is inside the /v2/nodes namespace and the URL to set/reset the comment count is in the /v1/api/user namespace. When a user posts their comment read timestamp to their /v1/api I purge their user, this PR makes it also purge the Node in question.

@sloria @nicipfeiffer