### PR TITLE
[Ready for Review] Cascade view_only qs param to ESI requests

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -465,7 +465,10 @@ class RelationshipField(ser.HyperlinkedIdentityField):
             if href and not href == '{}':
                 if self.always_embed:
                     envelope = 'data'
-                esi_url = extend_querystring_params(href, dict(format=['jsonapi', ], envelope=[envelope, ]))
+                query_dict = dict(format=['jsonapi', ], envelope=[envelope, ])
+                if 'view_only' in self.parent.context['request'].query_params.keys():
+                    query_dict.update(view_only=[self.parent.context['request'].query_params['view_only']])
+                esi_url = extend_querystring_params(href, query_dict)
                 return '<esi:include src="{}"/>'.format(esi_url)
         else:
             raise SkipField

--- a/website/project/views/comment.py
+++ b/website/project/views/comment.py
@@ -1,8 +1,13 @@
 # -*- coding: utf-8 -*-
+from functools import partial
+
 import pytz
 import markdown
 from datetime import datetime
 from flask import request
+
+from api.caching.tasks import ban_url
+from framework.postcommit_tasks.handlers import enqueue_postcommit_task
 from modularodm import Q
 
 from framework.auth.decorators import must_be_logged_in
@@ -135,6 +140,7 @@ def _update_comments_timestamp(auth, node, page=Comment.OVERVIEW, root_id=None):
         if not node_timestamp:
             user_timestamp[node._id] = dict()
         timestamps = auth.user.comments_viewed_timestamp[node._id]
+        enqueue_postcommit_task(partial(ban_url, node, []))
 
         # update node timestamp
         if page == Comment.OVERVIEW:


### PR DESCRIPTION
This takes the view_only qs parameter, if it's in the original requesting url, and passes it to all child requests. This should fix the problem @samanehsan was seeing where certain comments in a list would appear as errors when requesting with a view_only qs parameter.

@sloria I apologize for there being two commits, completely unrelated in this PR. I broke my working copy and my fork something awful. If you merge #5206 before you merge this it'll be fine. Or just close  #5206 and merge this, it has both sets of changes. I will never ever make a PR without a feature branch again. Sorry for the inconvenience. :disappointed: 