### PR TITLE
make currentUser.id globally available via base.mako

### DIFF
--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -145,7 +145,10 @@
                 waterbutlerURL: ${ waterbutler_url if waterbutler_url.endswith('/') else waterbutler_url + '/' | sjson, n },
                 cookieName: ${ cookie_name | sjson, n },
                 apiV2Prefix: ${ api_v2_base | sjson, n },
-                registerUrl: ${ api_url_for('register_user') | sjson, n}
+                registerUrl: ${ api_url_for('register_user') | sjson, n},
+                currentUser: {
+                    id: ${ user_id | sjson, n }
+                }
             });
         </script>
 

--- a/website/templates/dashboard.mako
+++ b/website/templates/dashboard.mako
@@ -92,13 +92,6 @@
 </%def>
 
 <%def name="javascript_bottom()">
-<script>
-    window.contextVars = $.extend(true, {}, window.contextVars, {
-        currentUser: {
-            'id': '${user_id}'
-        }
-    });
-</script>
 <script src=${"/static/public/js/dashboard-page.js" | webpack_asset}></script>
 
 </%def>

--- a/website/templates/project/project_base.mako
+++ b/website/templates/project/project_base.mako
@@ -70,7 +70,6 @@
         currentUser: {
             ## TODO: Abstract me
             username: ${ user['username'] | sjson, n },
-            id: ${ user_id | sjson, n },
             urls: {
                 api: userApiUrl,
                 profile: ${user_url | sjson, n}


### PR DESCRIPTION
Analytics always needs the current user id. Set it in base.mako so
it's available on all pages, including /.  Stop setting it
specifically in sub-templates.