### PR TITLE
[WIP] Pass growl timeout variable

### DIFF
--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -22,8 +22,8 @@ var GrowlBox = require('js/growlBox');
  * @param {String} type One of 'success', 'info', 'warning', or 'danger'. Defaults to danger.
  *
  */
-var growl = function(title, message, type) {
-    new GrowlBox(title, message, type || 'danger');
+var growl = function(title, message, type, delay) {
+    new GrowlBox(title, message, type || 'danger', delay);
 };
 
 


### PR DESCRIPTION
trello ticket: https://trello.com/c/bswdkmZw/66-growl-box-error-for-adding-project-to-collection-it-s-already-in-should-not-persist

Our implementation of growl in osfHelpers did not pass the timeout variable to growl.  Now it does!!!!

This allows control of the persistence of different types of growl messages.