### PR TITLE
[WIP] Phase out usage of KO.punches

### DIFF
--- a/website/addons/box/templates/log_templates.mako
+++ b/website/addons/box/templates/log_templates.mako
@@ -1,60 +1,56 @@
 <script type="text/html" id="box_file_added">
 added file
-<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect">
-    {{ stripSlash(params.path) }}</a> to
+<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect, text: stripSlash(params.path)"></a> to
 Box in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="box_folder_created">
 created folder
-<span class="overflow log-folder">{{ stripSlash(params.path) }}</span> in
+<span class="overflow log-folder" data-bind="text: stripSlash(params.path)"></span> in
 Box in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="box_file_updated">
 updated file
-<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect">
-    {{ stripSlash(params.path) }}</a> to
+<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect, text: stripSlash(params.path)"></a> to
 Box in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 
 <script type="text/html" id="box_file_removed">
-removed {{ pathType(params.path) }} <span class="overflow">
-    {{ stripSlash(params.path) }}</span> from
+removed <span data-bind="text: pathType(params.path)"></span> <span class="overflow" data-bind="text: stripSlash(params.path)"></span> from
 Box in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 
 <script type="text/html" id="box_folder_selected">
 linked Box folder
-<span class="overflow">
-    {{ params.folder === 'All Files' ? '/ (Full Box)' : (params.folder || '').replace('All Files','')}}
-</span> to
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<span class="overflow"
+      data-bind="text: params.folder === 'All Files' ? '/ (Full Box)' : (params.folder || '').replace('All Files','')"></span> to
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 
 <script type="text/html" id="box_node_deauthorized">
 deauthorized the Box addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 
 <script type="text/html" id="box_node_authorized">
 authorized the Box addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="box_node_deauthorized_no_user">
 Box addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
     deauthorized
 </script>

--- a/website/addons/dataverse/templates/dataverse_credentials_modal.mako
+++ b/website/addons/dataverse/templates/dataverse_credentials_modal.mako
@@ -45,7 +45,7 @@
                                 <label for="apiToken">
                                     API Token
                                     <!-- Link to API token generation page -->
-                                    <a href="{{tokenUrl}}"
+                                    <a data-bind="attr: {href: tokenUrl}"
                                        target="_blank" class="text-muted addon-external-link">
                                         (Get from Dataverse <i class="fa fa-external-link-square"></i>)
                                     </a>

--- a/website/addons/dataverse/templates/dataverse_node_settings.mako
+++ b/website/addons/dataverse/templates/dataverse_node_settings.mako
@@ -4,14 +4,12 @@
     <%include file="dataverse_credentials_modal.mako"/>
 
     <h4 class="addon-title">
-        <img class="addon-icon" src=${addon_icon_url}></img>
+        <img class="addon-icon" src=${addon_icon_url}>
         ${addon_full_name}
 
         <small class="authorized-by">
             <span data-bind="if: nodeHasAuth">
-                authorized by <a data-bind="attr.href: urls().owner">
-                    {{ownerName}}
-                </a>
+                authorized by <a data-bind="attr.href: urls().owner, text: ownerName"></a>
                 % if not is_registration:
                     <a data-bind="click: deauthorize"
                         class="text-danger pull-right addon-auth">Disconnect Account</a>
@@ -43,7 +41,7 @@
                 <!-- The linked Dataverse Host -->
                 <p class="break-word">
                     <strong>Dataverse Repository:</strong>
-                    <a data-bind="attr.href: savedHostUrl()">{{ savedHost }}</a>
+                    <a data-bind="attr.href: savedHostUrl(), text: savedHost"></a>
                 </p>
 
                 <!-- The linked dataset -->
@@ -51,8 +49,8 @@
                     <strong>Current Dataset:</strong>
                     <span data-bind="ifnot: submitting">
                         <span data-bind="if: showLinkedDataset">
-                            <a data-bind="attr.href: savedDatasetUrl()"> {{ savedDatasetTitle }}</a> on
-                            <a data-bind="attr.href: savedDataverseUrl()"> {{ savedDataverseTitle }} Dataverse</a>.
+                            <a data-bind="attr.href: savedDatasetUrl(), text: savedDatasetTitle"></a> on
+                            <a data-bind="attr.href: savedDataverseUrl(), text: savedDataverseTitle || '' + Dataverse"></a>.
                         </span>
                         <span data-bind="ifnot: showLinkedDataset" class="text-muted">
                             None

--- a/website/addons/dataverse/templates/dataverse_node_settings.mako
+++ b/website/addons/dataverse/templates/dataverse_node_settings.mako
@@ -9,7 +9,7 @@
 
         <small class="authorized-by">
             <span data-bind="if: nodeHasAuth">
-                authorized by <a data-bind="attr.href: urls().owner, text: ownerName"></a>
+                authorized by <a data-bind="attr: {href: urls().owner}, text: ownerName"></a>
                 % if not is_registration:
                     <a data-bind="click: deauthorize"
                         class="text-danger pull-right addon-auth">Disconnect Account</a>
@@ -41,7 +41,7 @@
                 <!-- The linked Dataverse Host -->
                 <p class="break-word">
                     <strong>Dataverse Repository:</strong>
-                    <a data-bind="attr.href: savedHostUrl(), text: savedHost"></a>
+                    <a data-bind="attr: {href: savedHostUrl()}, text: savedHost"></a>
                 </p>
 
                 <!-- The linked dataset -->
@@ -49,8 +49,8 @@
                     <strong>Current Dataset:</strong>
                     <span data-bind="ifnot: submitting">
                         <span data-bind="if: showLinkedDataset">
-                            <a data-bind="attr.href: savedDatasetUrl(), text: savedDatasetTitle"></a> on
-                            <a data-bind="attr.href: savedDataverseUrl(), text: savedDataverseTitle || '' + Dataverse"></a>.
+                            <a data-bind="attr: {href: savedDatasetUrl()}, text: savedDatasetTitle"></a> on
+                            <a data-bind="attr: {href: savedDataverseUrl()}, text: savedDataverseTitle || '' + Dataverse"></a>.
                         </span>
                         <span data-bind="ifnot: showLinkedDataset" class="text-muted">
                             None
@@ -126,6 +126,6 @@
     </div>
     <!-- Flashed Messages -->
     <div class="help-block">
-        <p data-bind="html: message, attr.class: messageClass"></p>
+        <p data-bind="html: message, attr: {class: messageClass}"></p>
     </div>
 </div>

--- a/website/addons/dataverse/templates/dataverse_user_settings.mako
+++ b/website/addons/dataverse/templates/dataverse_user_settings.mako
@@ -20,14 +20,14 @@
             <table class="table table-hover">
                 <thead>
                     <tr class="user-settings-addon-auth">
-                        <th class="text-muted default-authorized-by">Authorized on <a data-bind="attr.href: dataverseUrl"><em data-bind="text: dataverseHost"></em></a></th>
+                        <th class="text-muted default-authorized-by">Authorized on <a data-bind="attr: {href: dataverseUrl}"><em data-bind="text: dataverseHost"></em></a></th>
                     </tr>
                 </thead>
                 <!-- ko if: connectedNodes().length > 0 -->
                 <tbody data-bind="foreach: connectedNodes()">
                     <tr>
                         <td class="authorized-nodes">
-                            <!-- ko if: title --><a data-bind="attr.href: urls.view, text: title"></a><!-- /ko -->
+                            <!-- ko if: title --><a data-bind="attr: {href: urls.view}, text: title"></a><!-- /ko -->
                             <!-- ko if: !title --><em>Private project</em><!-- /ko -->
                         </td>
                         <td>

--- a/website/addons/dataverse/templates/dataverse_user_settings.mako
+++ b/website/addons/dataverse/templates/dataverse_user_settings.mako
@@ -6,8 +6,8 @@
     <%include file="dataverse_credentials_modal.mako"/>
 
     <h4 class="addon-title">
-        <img class="addon-icon" src=${addon_icon_url}></img>
-        {{ properName }}
+        <img class="addon-icon" src=${addon_icon_url}>
+        <span data-bind="text: properName"></span> <!-- TODO: Can we use mako addon_full_name as some other addons do? -->
         <small>
             <a href="#dataverseInputCredentials" data-toggle="modal" class="pull-right text-primary">Connect Account</a>
         </small>
@@ -20,14 +20,14 @@
             <table class="table table-hover">
                 <thead>
                     <tr class="user-settings-addon-auth">
-                        <th class="text-muted default-authorized-by">Authorized on <a data-bind="attr.href: dataverseUrl"><em>{{ dataverseHost }}</em></a></th>
+                        <th class="text-muted default-authorized-by">Authorized on <a data-bind="attr.href: dataverseUrl"><em data-bind="text: dataverseHost"></em></a></th>
                     </tr>
                 </thead>
                 <!-- ko if: connectedNodes().length > 0 -->
                 <tbody data-bind="foreach: connectedNodes()">
                     <tr>
                         <td class="authorized-nodes">
-                            <!-- ko if: title --><a data-bind="attr.href: urls.view">{{ title }}</a><!-- /ko -->
+                            <!-- ko if: title --><a data-bind="attr.href: urls.view, text: title"></a><!-- /ko -->
                             <!-- ko if: !title --><em>Private project</em><!-- /ko -->
                         </td>
                         <td>

--- a/website/addons/dataverse/templates/dataverse_widget.mako
+++ b/website/addons/dataverse/templates/dataverse_widget.mako
@@ -10,16 +10,16 @@
                 <dl class="dl-horizontal dl-dataverse" style="white-space: normal">
 
                     <dt>Dataset</dt>
-                    <dd>{{ dataset }}</dd>
+                    <dd><span data-bind="text: dataset"></span></dd>
 
                     <dt>Global ID</dt>
-                    <dd><a data-bind="attr: {href: datasetUrl}">{{ doi }}</a></dd>
+                    <dd><a data-bind="attr: {href: datasetUrl}, text: doi"></a></dd>
 
                     <dt>Dataverse</dt>
-                    <dd><a data-bind="attr: {href: dataverseUrl}">{{ dataverse }} Dataverse</a></dd>
+                    <dd><a data-bind="attr: {href: dataverseUrl}, text: dataverse || '' + 'Dataverse'"></a></dd>
 
                     <dt>Citation</dt>
-                    <dd>{{ citation }}</dd>
+                    <dd><span data-bind="text: citation"></span></dd>
 
                 </dl>
             </span>
@@ -27,6 +27,7 @@
         </span>
 
         <div class="help-block">
+            <!-- Todo: verify html binding -->
             <p data-bind="html: message, attr: {class: messageClass}"></p>
         </div>
 

--- a/website/addons/dataverse/templates/log_templates.mako
+++ b/website/addons/dataverse/templates/log_templates.mako
@@ -1,61 +1,61 @@
 <script type="text/html" id="dataverse_file_added">
 added file
 <a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect, text: params.filename"></a> to
-Dataverse dataset <span class="overflow">{{ params.dataset }}</span>
+Dataverse dataset <span class="overflow" data-bind="text: params.dataset"></span>
 in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="dataverse_file_removed">
-removed file <span class="overflow">{{ params.filename }}</span> from
-Dataverse dataset <span class="overflow">{{ params.dataset }}</span>
+removed file <span class="overflow" data-bind="text: params.filename"></span> from
+Dataverse dataset <span class="overflow" data-bind="text: params.dataset"></span>
 in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="dataverse_dataset_linked">
 linked Dataverse dataset
-<span class="overflow">{{ params.dataset }}</span> to
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<span class="overflow" data-bind="text: params.dataset"></span> to
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <!-- Legacy version -->
 <script type="text/html" id="dataverse_study_linked">
 linked Dataverse dataset
-<span class="overflow">{{ params.study }}</span> to
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<span class="overflow" data-bind="text: params.study"></span> to
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="dataverse_dataset_published">
 published a new version of Dataverse dataset
-<span class="overflow">{{ params.dataset }}</span> to
+<span class="overflow" data-bind="text: params.dataset"></span> to
 for
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <!-- Legacy version -->
 <script type="text/html" id="dataverse_study_released">
 published a new version of Dataverse dataset
-<span class="overflow">{{ params.study }}</span> to
+<span class="overflow" data-bind="text: params.study"></span> to
 for
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="dataverse_node_authorized">
 authorized the Dataverse addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="dataverse_node_deauthorized">
 deauthorized the Dataverse addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="dataverse_node_deauthorized_no_user">
 Dataverse addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
     deauthorized
 </script>

--- a/website/addons/dropbox/templates/log_templates.mako
+++ b/website/addons/dropbox/templates/log_templates.mako
@@ -1,54 +1,54 @@
 <script type="text/html" id="dropbox_file_added">
 added file
-<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect">{{ params.path }}</a> to
+<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect, text: params.path"></a> to
 Dropbox in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="dropbox_folder_created">
 created folder
-<span class="overflow log-folder">{{ stripSlash(params.path) }}</span> in
+<span class="overflow log-folder" data-bind="text: stripSlash(params.path)"></span> in
 Dropbox in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="dropbox_file_updated">
 updated file
-<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect">{{ params.path }}</a> to
+<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect, text: params.path"></a> to
 Dropbox in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 
 <script type="text/html" id="dropbox_file_removed">
-removed {{ pathType(params.path) }} <span class="overflow">{{ stripSlash(params.path) }}</span> from
+removed <span data-bind="text: pathType(params.path)"></span> <span class="overflow" data-bind="text: stripSlash(params.path)"></span> from
 Dropbox in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 
 <script type="text/html" id="dropbox_folder_selected">
-linked Dropbox folder <span class="overflow">{{ params.folder === '/' ? '/ (Full Dropbox)' : params.folder }}</span> to
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+linked Dropbox folder <span class="overflow" data-bind="text: (params.folder === '/' ? '/ (Full Dropbox)' : params.folder)"></span> to
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 
 <script type="text/html" id="dropbox_node_deauthorized">
 deauthorized the Dropbox addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 
 <script type="text/html" id="dropbox_node_authorized">
 authorized the Dropbox addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="dropbox_node_deauthorized_no_user">
 Dropbox addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
     deauthorized
 </script>

--- a/website/addons/figshare/templates/log_templates.mako
+++ b/website/addons/figshare/templates/log_templates.mako
@@ -6,9 +6,9 @@ figshare <span data-bind="text: params.figshare.title"></span> in
 </script>
 
 <script type="text/html" id="figshare_file_removed">
-removed file <span class="overflow">{{ params.path }}</span> from
+removed file <span class="overflow" data-bind="text: params.path"></span> from
 figshare in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="figshare_content_linked">
@@ -24,18 +24,18 @@ unlinked figshare project /<span data-bind="text: params.figshare.title"></span>
 <script type="text/html" id="figshare_node_authorized">
 authorized the figshare addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="figshare_node_deauthorized">
 deauthorized the figshare addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="figshare_node_deauthorized_no_user">
 figshare addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
     deauthorized
 </script>

--- a/website/addons/forward/templates/forward_node_settings.mako
+++ b/website/addons/forward/templates/forward_node_settings.mako
@@ -47,7 +47,7 @@
 
             <div class="row">
                 <div class="col-md-10 overflow">
-                    <p data-bind="html: message, attr.class: messageClass"></p>
+                    <p data-bind="html: message, attr: {class: messageClass}"></p>
                 </div>
                 <div class="col-md-2">
                     <input type="submit"

--- a/website/addons/forward/templates/forward_widget.mako
+++ b/website/addons/forward/templates/forward_widget.mako
@@ -6,10 +6,10 @@
 
         <div>
             This project contains a forward to
-            <a data-bind="attr.href: url">{{ url }}</a>.
+            <a data-bind="attr.href: url, text: url"></a>.
         </div>
 
-        <p>You will be automatically forwarded in {{ timeLeft }} seconds.</p>
+        <p>You will be automatically forwarded in <span data-bind="text: timeLeft"></span> seconds.</p>
 
         <div class="spaced-buttons" data-bind="visible: redirecting">
             <a class="btn btn-default" data-bind="click: cancelRedirect">Cancel</a>
@@ -22,7 +22,7 @@
 
         <div>
             This project contains a forward to
-            <a data-bind="attr.href: url" target="_blank">{{ linkDisplay }}</a>.
+            <a data-bind="attr.href: url, text: linkDisplay" target="_blank"></a>.
         </div>
 
         <div class="spaced-buttons m-t-sm">

--- a/website/addons/forward/templates/forward_widget.mako
+++ b/website/addons/forward/templates/forward_widget.mako
@@ -6,7 +6,7 @@
 
         <div>
             This project contains a forward to
-            <a data-bind="attr.href: url, text: url"></a>.
+            <a data-bind="attr: {href: url}, text: url"></a>.
         </div>
 
         <p>You will be automatically forwarded in <span data-bind="text: timeLeft"></span> seconds.</p>
@@ -22,7 +22,7 @@
 
         <div>
             This project contains a forward to
-            <a data-bind="attr.href: url, text: linkDisplay" target="_blank"></a>.
+            <a data-bind="attr: {href: url}, text: linkDisplay" target="_blank"></a>.
         </div>
 
         <div class="spaced-buttons m-t-sm">

--- a/website/addons/forward/templates/log_templates.mako
+++ b/website/addons/forward/templates/log_templates.mako
@@ -1,6 +1,6 @@
 <script type="text/html" id="forward_url_changed">
 changed forward URL to
-<a target="_blank" class="overflow log-file-link" data-bind="attr.href: params.forward_url">{{ params.forward_url }}</a>
+<a target="_blank" class="overflow log-file-link" data-bind="attr.href: params.forward_url, text: params.forwardUrl"></a>
 in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>

--- a/website/addons/forward/templates/log_templates.mako
+++ b/website/addons/forward/templates/log_templates.mako
@@ -1,6 +1,6 @@
 <script type="text/html" id="forward_url_changed">
 changed forward URL to
-<a target="_blank" class="overflow log-file-link" data-bind="attr.href: params.forward_url, text: params.forwardUrl"></a>
+<a target="_blank" class="overflow log-file-link" data-bind="attr: {href: params.forward_url}, text: params.forwardUrl"></a>
 in
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>

--- a/website/addons/github/templates/log_templates.mako
+++ b/website/addons/github/templates/log_templates.mako
@@ -9,11 +9,11 @@ GitHub repo
 
 <script type="text/html" id="github_folder_created">
 created folder
-<span class="overflow log-folder">{{ stripSlash(params.path) }}</span> in
+<span class="overflow log-folder" data-bind="text: stripSlash(params.path)"></span> in
 GitHub repo
 <span data-bind="text: params.github.user"></span> /
 <span data-bind="text: params.github.repo"></span> in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="github_file_updated">
@@ -50,18 +50,18 @@ unlinked GitHub repo
 <script type="text/html" id="github_node_authorized">
 authorized the GitHub addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="github_node_deauthorized">
 deauthorized the GitHub addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="github_node_deauthorized_no_user">
 GitHub addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
     deauthorized
 </script>

--- a/website/addons/googledrive/templates/log_templates.mako
+++ b/website/addons/googledrive/templates/log_templates.mako
@@ -1,48 +1,48 @@
 <script type="text/html" id="googledrive_file_added">
 added file
-<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect">{{ decodeURIComponent(params.path) }}</a> to
+<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect, text: decodeURIComponent(params.path)"></a> to
 Google Drive in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="googledrive_folder_created">
 created folder
-<span class="overflow log-folder">{{ stripSlash(decodeURIComponent(params.path)) }}</span> in
+<span class="overflow log-folder" data-bind="text: stripSlash(decodeURIComponent(params.path))"></span> in
 Google Drive in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="googledrive_file_updated">
 updated file
-<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect">{{ decodeURIComponent(params.path) }}</a> to
+<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect, text: decodeURIComponent(params.path)"></a> to
 Google Drive in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 
 <script type="text/html" id="googledrive_file_removed">
-removed {{ pathType(params.path) }} <span class="overflow ">{{ stripSlash(decodeURIComponent(params.path)) }}</span> from
+removed <span data-bind="text: pathType(params.path) "></span> <span class="overflow" data-bind="text: stripSlash(decodeURIComponent(params.path))"></span> from
 Google Drive in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 
 <script type="text/html" id="googledrive_folder_selected">
-linked Google Drive folder /<span class="overflow">{{ params.folder === '/' ? '(Full Google Drive)' : decodeURIComponent(params.folder) }}</span> to
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+linked Google Drive folder /<span class="overflow" data-bind="text: (params.folder === '/' ? '(Full Google Drive)' : decodeURIComponent(params.folder))"></span> to
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 
 <script type="text/html" id="googledrive_node_deauthorized">
 deauthorized the Google Drive addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="googledrive_node_deauthorized">
 Google Drive addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
     deauthorized
 </script>
 
@@ -50,12 +50,12 @@ Google Drive addon for
 <script type="text/html" id="googledrive_node_authorized">
 authorized the Google Drive addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="googledrive_node_deauthorized_no_user">
 Google Drive addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
     deauthorized
 </script>

--- a/website/addons/mendeley/templates/log_templates.mako
+++ b/website/addons/mendeley/templates/log_templates.mako
@@ -1,16 +1,16 @@
 <script type="text/html" id="mendeley_folder_selected">
-linked Mendeley folder /<span class="overflow">{{ params.folder_name }}</span> to
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+linked Mendeley folder /<span class="overflow" data-bind="text: params.folder_name"></span> to
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="mendeley_node_deauthorized">
 deauthorized the Mendeley addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="mendeley_node_authorized">
 authorized the Mendeley addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>

--- a/website/addons/osfstorage/templates/log_templates.mako
+++ b/website/addons/osfstorage/templates/log_templates.mako
@@ -1,27 +1,25 @@
 <script type="text/html" id="osf_storage_file_added">
 added file
-<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect">
-    {{ stripSlash(params.path) }}</a> to OSF Storage in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect, text: stripSlash(params.path)"></a> to OSF Storage in
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="osf_storage_folder_created">
 created folder
-<span class="overflow log-folder">{{ stripSlash(params.path) }}</span> in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<span class="overflow log-folder" data-bind="text: stripSlash(params.path)"></span> in
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="osf_storage_file_updated">
 updated file
-<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect">
-    {{ stripSlash(params.path) }}</a> to OSF Storage in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect, text: stripSlash(params.path)"></a> to OSF Storage in
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="osf_storage_file_removed">
-  removed {{ pathType(params.path) }} <span class="overflow">
-      {{ stripSlash(params.path) }}</span> from OSF Storage in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+  removed <span data-bind="text: pathType(params.path)"></span> <span class="overflow" data-bind="stripSlash(params.path)"></span>
+  from OSF Storage in
+  <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 

--- a/website/addons/s3/templates/log_templates.mako
+++ b/website/addons/s3/templates/log_templates.mako
@@ -8,9 +8,9 @@ bucket
 
 <script type="text/html" id="s3_folder_created">
 created folder
-<span class="overflow log-folder">{{ stripSlash(params.path) }}</span> in
-bucket {{ params.bucket }} in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<span class="overflow log-folder" data-bind="text: stripSlash(params.path)"></span> in
+bucket <span data-bind="text: params.bucket"></span> in
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="s3_file_updated">
@@ -22,7 +22,7 @@ bucket
 </script>
 
 <script type="text/html" id="s3_file_removed">
-removed {{ pathType(params.path) }} <span class="overflow">{{ stripSlash(params.path) }}</span> from
+removed <span data-bind="text: pathType(params.path)"></span> <span class="overflow" data-bind="text: stripSlash(params.path)"></span> from
 bucket
 <span data-bind="text: params.bucket"></span> in
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
@@ -43,18 +43,18 @@ un-selected bucket
 <script type="text/html" id="s3_node_authorized">
 authorized the Amazon S3 addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="s3_node_deauthorized">
 deauthorized the Amazon S3 addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="s3_node_deauthorized_no_user">
 Amazon S3 addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
     deauthorized
 </script>

--- a/website/addons/s3/templates/s3_node_settings.mako
+++ b/website/addons/s3/templates/s3_node_settings.mako
@@ -4,7 +4,7 @@
         Amazon S3
         <small class="authorized-by">
             <span data-bind="if: nodeHasAuth">
-                authorized by <a data-bind="attr.href: urls().owner, text: ownerName"></a>
+                authorized by <a data-bind="attr: {href: urls().owner}, text: ownerName"></a>
                 % if not is_registration:
                     <a data-bind="click: deauthorizeNode" class="text-danger pull-right addon-auth">
                       Disconnect Account
@@ -26,13 +26,13 @@
           <span data-bind="ifnot: currentBucket">
             None
           </span>
-          <a data-bind="if: currentBucket, attr.href: urls().files, text: currentBucket"></a>
+          <a data-bind="if: currentBucket, attr: {href: urls().files}, text: currentBucket"></a>
         </p>
-        <div data-bind="attr.disabled: creating">
+        <div data-bind="attr: {disabled: creating}">
           <button data-bind="visible: canChange, click: toggleSelect,
                              css: {active: showSelect}" class="btn btn-primary">Change</button>
           <button data-bind="visible: showNewBucket, click: openCreateBucket,
-                             attr.disabled: creating" class="btn btn-success" id="newBucket">Create Bucket</button>
+                             attr: {disabled: creating}" class="btn btn-success" id="newBucket">Create Bucket</button>
         </div>
         <br />
         <br />
@@ -40,7 +40,7 @@
           <div class="form-group col-md-8">
             <select class="form-control" id="s3_bucket" name="s3_bucket"
                     data-bind="value: selectedBucket,
-                               attr.disabled: !loadedBucketList(),
+                               attr: {disabled: !loadedBucketList()},
                                options: bucketList"> </select>
           </div>
           ## Remove comments to enable user toggling of file upload encryption
@@ -50,7 +50,7 @@
           ## </div>
           <div class="col-md-2">
             <button data-bind="click: selectBucket,
-                               attr.disabled: !allowSelectBucket(),
+                               attr: {disabled: !allowSelectBucket()},
                                text: saveButtonText"
                     class="btn btn-success">
               Save
@@ -70,12 +70,12 @@
         <input data-bind="value: secretKey" type="password" class="form-control" id="secret_key" name="secret_key" />
       </div>
       <button data-bind="click: createCredentials,
-                         attr.disabled: creatingCredentials" class="btn btn-success addon-settings-submit">
+                         attr: {disabled: creatingCredentials}" class="btn btn-success addon-settings-submit">
         Save
       </button>
     </div>
     <!-- Flashed Messages -->
     <div class="help-block">
-        <p data-bind="html: message, attr.class: messageClass"></p>
+        <p data-bind="html: message, attr: {class: messageClass}"></p>
     </div>
 </div>

--- a/website/addons/s3/templates/s3_node_settings.mako
+++ b/website/addons/s3/templates/s3_node_settings.mako
@@ -1,12 +1,10 @@
  <div id="s3Scope" class="scripted">
     <h4 class="addon-title">
-        <img class="addon-icon" src="${addon_icon_url}"></img>
+        <img class="addon-icon" src="${addon_icon_url}">
         Amazon S3
         <small class="authorized-by">
             <span data-bind="if: nodeHasAuth">
-                authorized by <a data-bind="attr.href: urls().owner">
-                {{ownerName}}
-                </a>
+                authorized by <a data-bind="attr.href: urls().owner, text: ownerName"></a>
                 % if not is_registration:
                     <a data-bind="click: deauthorizeNode" class="text-danger pull-right addon-auth">
                       Disconnect Account
@@ -28,9 +26,7 @@
           <span data-bind="ifnot: currentBucket">
             None
           </span>
-          <a data-bind="if: currentBucket, attr.href: urls().files">
-            {{currentBucket}}
-          </a>
+          <a data-bind="if: currentBucket, attr.href: urls().files, text: currentBucket"></a>
         </p>
         <div data-bind="attr.disabled: creating">
           <button data-bind="visible: canChange, click: toggleSelect,

--- a/website/addons/twofactor/templates/twofactor_user_settings.mako
+++ b/website/addons/twofactor/templates/twofactor_user_settings.mako
@@ -37,7 +37,7 @@
             <input type="submit" value="Submit" class="btn btn-primary">
           </div>
           <div class="help-block">
-            <p data-bind="html: message, attr.class: messageClass"></p>
+            <p data-bind="html: message, attr: {class: messageClass}"></p>
           </div>
         </div>
       </form>

--- a/website/addons/zotero/templates/log_templates.mako
+++ b/website/addons/zotero/templates/log_templates.mako
@@ -1,16 +1,16 @@
 <script type="text/html" id="zotero_folder_selected">
-linked Zotero folder /<span class="overflow">{{ params.folder_name }}</span> to 
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+linked Zotero folder /<span class="overflow" data-bind="text: params.folder_name"></span> to
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="zotero_node_deauthorized">
 deauthorized the Zotero addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="zotero_node_authorized">
 authorized the Zotero addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>

--- a/website/templates/include/comment_pane_template.mako
+++ b/website/templates/include/comment_pane_template.mako
@@ -32,12 +32,12 @@
                         <div class="clearfix">
                             <div class="pull-right">
                                 <a class="btn btn-default btn-sm" data-bind="click: cancelReply, css: {disabled: submittingReply}">Cancel</a>
-                                <a class="btn btn-success btn-sm" data-bind="click: submitReply, css: {disabled: submittingReply}">{{commentButtonText}}</a>
+                                <a class="btn btn-success btn-sm" data-bind="click: submitReply, css: {disabled: submittingReply}, text: commentButtonText"></a>
                                 <span data-bind="text: replyErrorMessage" class="text-danger"></span>
                             </div>
                         </div>
                     </div>
-                    <div class="text-danger">{{errorMessage}}</div>
+                    <div class="text-danger" data-bind="text: errorMessage"></div>
                 </form>
             </div>
 

--- a/website/templates/include/comment_template.mako
+++ b/website/templates/include/comment_template.mako
@@ -83,7 +83,7 @@
 
                     <div>
 
-                        <span class="text-danger">{{errorMessage}}</span>
+                        <span class="text-danger" data-bind="text: errorMessage"></span>
 
                         <span>&nbsp;</span>
 
@@ -142,7 +142,7 @@
                     <div class="clearfix">
                         <div class="pull-right">
                             <a class="btn btn-default btn-sm" data-bind="click: cancelReply, css: {disabled: submittingReply}"> Cancel</a>
-                            <a class="btn btn-success btn-sm" data-bind="click: submitReply, visible: replyNotEmpty, css: {disabled: submittingReply}"> {{commentButtonText}}</a>
+                            <a class="btn btn-success btn-sm" data-bind="click: submitReply, visible: replyNotEmpty, css: {disabled: submittingReply}, text: commentButtonText"></a>
                             <span data-bind="text: replyErrorMessage" class="text-danger"></span>
                         </div>
                     </div>

--- a/website/templates/include/profile/jobs.mako
+++ b/website/templates/include/profile/jobs.mako
@@ -16,7 +16,7 @@
                 <div>
 
                     <div class="well well-sm sort-handle">
-                        <span>Position {{ $index() + 1 }}</span>
+                        <span>Position <span data-bind="text: $index() + 1"></span></span>
                         <span data-bind="visible: $parent.contentsLength() > 1">
                             [ drag to reorder ]
                         </span>
@@ -138,16 +138,20 @@
                         <div class="panel panel-default">
                             <div class="panel-heading card-heading" data-bind="click: toggle(), attr: {id: 'jobHeading' + $index(), href: '#jobCard' + $index()}" role="button" data-toggle="collapse" aria-controls="card" aria-expanded="false">
                                 <div class="header-content">
-                                    <h5 class="institution">{{ institution }}</h5>
-                                    <span data-bind="if: startYear()" class="subheading">{{ startMonth }} {{startYear }} - {{ endView }}</span>
+                                    <h5 class="institution" data-bind="text: institution"></h5>
+                                    <span data-bind="if: startYear()" class="subheading">
+                                        <span data-bind="text: startMonth"></span> <span data-bind="text: startYear"></span> - <span data-bind="text: endView"></span>
+                                    </span>
                                 </div>
                                 <span data-bind="attr: {class: expanded() ? 'fa toggle-icon fa-angle-down' : 'fa toggle-icon fa-angle-up'}"></span>
                             </div>
                             <div data-bind="attr: {id: 'jobCard' + $index(), aria-labelledby: 'jobHeading' + $index()}" class="panel-collapse collapse">
                                 <div class="panel-body">
-                                    <span data-bind="if: department().length"><h5>Department:</h5> {{ department }}</span>
-                                    <span data-bind="if: title().length"><h5>Title:</h5> {{ title }}</span>
-                                    <span data-bind="if: startYear()"><h5>Dates:</h5> {{ startMonth }} {{startYear }} - {{ endView }}</span>
+                                    <span data-bind="if: department().length"><h5>Department:</h5> <span data-bind="text: department"></span></span>
+                                    <span data-bind="if: title().length"><h5>Title:</h5> <span data-bind="text: title"></span></span>
+                                    <span data-bind="if: startYear()"><h5>Dates:</h5>
+                                        <span data-bind="text: startMonth"></span> <span data-bind="text: startYear"></span> - <span data-bind="text: endView"></span>
+                                    </span>
                                 </div>
                             </div>
                         </div>
@@ -156,7 +160,7 @@
                         <div class="panel panel-default">
                             <div class="panel-heading no-bottom-border">
                                 <div>
-                                    <h5>{{ institution }}</h5>
+                                    <h5 data-bind="text: institution"></h5>
                                 </div>
                             </div>
                         </div>

--- a/website/templates/include/profile/jobs.mako
+++ b/website/templates/include/profile/jobs.mako
@@ -117,7 +117,7 @@
 
             <!-- Flashed Messages -->
             <div class="help-block">
-                <p data-bind="html: message, attr.class: messageClass"></p>
+                <p data-bind="html: message, attr: {class: messageClass}"></p>
             </div>
 
         </form>

--- a/website/templates/include/profile/names.mako
+++ b/website/templates/include/profile/names.mako
@@ -80,7 +80,7 @@
 
         <!-- Flashed Messages -->
         <div class="help-block">
-            <p data-bind="html: message, attr.class: messageClass"></p>
+            <p data-bind="html: message, attr: {class: messageClass}"></p>
         </div>
 
     </form>

--- a/website/templates/include/profile/names.mako
+++ b/website/templates/include/profile/names.mako
@@ -54,11 +54,11 @@
             <tbody>
                 <tr>
                     <td>APA</td>
-                    <td class="overflow-block" width="30%">{{ citeApa }}</td>
+                    <td class="overflow-block" width="30%"><span data-bind="text: citeApa"></span></td>
                 </tr>
                 <tr>
                     <td>MLA</td>
-                    <td class="overflow-block" width="30%">{{ citeMla }}</td>
+                    <td class="overflow-block" width="30%"><span data-bind="citeMla"></span></td>
                 </tr>
             </tbody>
         </table>

--- a/website/templates/include/profile/schools.mako
+++ b/website/templates/include/profile/schools.mako
@@ -16,7 +16,7 @@
                 <div>
 
                     <div class="well well-sm sort-handle">
-                        <span>Position {{ $index() + 1 }}</span>
+                        <span>Position <span data-bind="$index() + 1"></span></span>
                         <span data-bind="visible: $parent.contentsLength() > 1">
                             [ drag to reorder ]
                         </span>
@@ -137,16 +137,20 @@
                         <div class="panel panel-default">
                             <div class="panel-heading card-heading" data-bind="click: toggle(), attr: {id: 'schoolHeading' + $index(), href: '#schoolCard' + $index()}" role="button" data-toggle="collapse" aria-controls="card" aria-expanded="false">
                                 <div class="header-content">
-                                    <h5 class="institution">{{ institution }}</h5>
-                                    <span data-bind="if: startYear()" class="subheading">{{ startMonth }} {{startYear }} - {{ endView }}</span>
+                                    <h5 class="institution" data-bind="institution"></h5>
+                                    <span data-bind="if: startYear()" class="subheading">
+                                        <span data-bind="text: startMonth"></span> <span data-bind="text: startYear"></span> - <span data-bind="text: endView"></span>
+                                    </span>
                                 </div>
                                 <span data-bind="attr: {class: expanded() ? 'fa toggle-icon fa-angle-down' : 'fa toggle-icon fa-angle-up'}"></span>
                             </div>
                             <div data-bind="attr: {id: 'schoolCard' + $index(), aria-labelledby: 'schoolHeading' + $index()}" class="panel-collapse collapse">
                                 <div class="panel-body">
-                                    <span data-bind="if: department().length"><h5>Department:</h5> {{ department }}</span>
-                                    <span data-bind="if: degree().length"><h5>Degree:</h5> {{ degree }}</span>
-                                    <span data-bind="if: startYear()"><h5>Dates:</h5> {{ startMonth }} {{startYear }} - {{ endView }}</span>
+                                    <span data-bind="if: department().length"><h5>Department:</h5> <span data-bind="text: department"></span></span>
+                                    <span data-bind="if: degree().length"><h5>Degree:</h5> <span data-bind="text: degree"></span></span>
+                                    <span data-bind="if: startYear()"><h5>Dates:</h5>
+                                        <span data-bind="text: startMonth"></span> <span data-bind="text: startYear"></span> - <span data-bind="text: endView"></span>
+                                    </span>
                                 </div>
                             </div>
                         </div>
@@ -155,7 +159,7 @@
                         <div class="panel panel-default">
                             <div class="panel-heading no-bottom-border">
                                 <div>
-                                    <h5>{{ institution }}</h5>
+                                    <h5 data-bind="text: institution"></h5>
                                 </div>
                             </div>
                         </div>

--- a/website/templates/include/profile/schools.mako
+++ b/website/templates/include/profile/schools.mako
@@ -117,7 +117,7 @@
 
             <!-- Flashed Messages -->
             <div class="help-block">
-                <p data-bind="html: message, attr.class: messageClass"></p>
+                <p data-bind="html: message, attr: {class: messageClass}"></p>
             </div>
 
         </form>

--- a/website/templates/include/profile/social.mako
+++ b/website/templates/include/profile/social.mako
@@ -151,14 +151,14 @@
                 <tr data-bind="if: hasProfileWebsites()">
                     <td data-bind="visible: profileWebsites().length > 1">Personal websites</td>
                     <td data-bind="visible: profileWebsites().length === 1">Personal website</td>
-                    <td data-bind="foreach: profileWebsites"><a target="_blank" data-bind="attr.href: $data">{{ $data }}</a></br></td>
+                    <td data-bind="foreach: profileWebsites"><a target="_blank" data-bind="attr.href: $data, text: $data"></a><br></td>
                 </tr>
             </tbody>
 
             <tbody data-bind="foreach: values">
                 <tr data-bind="if: value">
-                    <td>{{ label }}</td>
-                    <td><a target="_blank" data-bind="attr.href: value">{{ text }}</a></td>
+                    <td><span data-bind="text: label"></span></td>
+                    <td><a target="_blank" data-bind="attr.href: value, text: text"></a></td>
                 </tr>
             </tbody>
         </table>

--- a/website/templates/include/profile/social.mako
+++ b/website/templates/include/profile/social.mako
@@ -137,7 +137,7 @@
 
             <!-- Flashed Messages -->
             <div class="help-block">
-                <p data-bind="html: message, attr.class: messageClass"></p>
+                <p data-bind="html: message, attr: {class: messageClass}"></p>
             </div>
 
         </form>
@@ -151,14 +151,14 @@
                 <tr data-bind="if: hasProfileWebsites()">
                     <td data-bind="visible: profileWebsites().length > 1">Personal websites</td>
                     <td data-bind="visible: profileWebsites().length === 1">Personal website</td>
-                    <td data-bind="foreach: profileWebsites"><a target="_blank" data-bind="attr.href: $data, text: $data"></a><br></td>
+                    <td data-bind="foreach: profileWebsites"><a target="_blank" data-bind="attr: {href: $data}, text: $data"></a><br></td>
                 </tr>
             </tbody>
 
             <tbody data-bind="foreach: values">
                 <tr data-bind="if: value">
                     <td><span data-bind="text: label"></span></td>
-                    <td><a target="_blank" data-bind="attr.href: value, text: text"></a></td>
+                    <td><a target="_blank" data-bind="attr: {href: value}, text: text"></a></td>
                 </tr>
             </tbody>
         </table>

--- a/website/templates/index.mako
+++ b/website/templates/index.mako
@@ -70,7 +70,7 @@
 
                           <!-- Flashed Messages -->
                           <div class="help-block osf-box-lt" >
-                              <p data-bind="html: flashMessage, attr.class: flashMessageClass" class=""></p>
+                              <p data-bind="html: flashMessage, attr: {class: flashMessageClass}" class=""></p>
                           </div>
                           <!-- ko ifnot: submitted -->
                           <div>

--- a/website/templates/log_templates.mako
+++ b/website/templates/log_templates.mako
@@ -152,7 +152,7 @@ from
 <script type="text/html" id="edit_title">
 changed the title from <span class="overflow" data-bind="text: params.title_original"></span>
 to
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ params.title_new }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: params.title_new"></a>
 </script>
 
 <script type="text/html" id="project_registered">
@@ -215,105 +215,105 @@ from
 <script type="text/html" id="comment_added">
 added a comment
 to
-{{#if params.file}}
+<!-- ko if: params.file -->
 <a data-bind="attr: {href: params.file.url}, text: params.file.name"></a>
 in
-{{/if}}
+<!-- /ko -->
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="comment_updated">
 updated a comment
 on
-{{#if params.file}}
+<!-- ko if: params.file -->
 <a data-bind="attr: {href: params.file.url}, text: params.file.name"></a>
 in
-{{/if}}
+<!-- /ko -->
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="comment_removed">
 deleted a comment
 on
-{{#if params.file}}
+<!-- ko if: params.file -->
 <a data-bind="attr: {href: params.file.url}, text: params.file.name"></a>
 in
-{{/if}}
+<!-- /ko -->
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="comment_restored">
 restored a comment
 on
-{{#if params.file}}
+<!-- ko if: params.file -->
 <a data-bind="attr: {href: params.file.url}, text: params.file.name"></a>
 in
-{{/if}}
+<!-- /ko -->
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="made_contributor_visible">
-    {{#if log.anonymous}}
+    <!-- ko if: log.anonymous -->
         changed a non-bibliographic contributor to a bibliographic contributor on
-    {{/if}}
-    {{#ifnot log.anonymous}}
+    <!-- /ko -->
+    <!-- ko ifnot: log.anonymous -->
         made non-bibliographic contributor
         <span data-bind="html: displayContributors"></span>
         a bibliographic contributor on
-    {{/ifnot}}
+    <!-- /ko -->
     <a class="log-node-title-link overflow" data-bind="attr: {href: $parent.nodeUrl}, text: $parent.nodeTitle"></a>
 </script>
 
 <script type="text/html" id="made_contributor_invisible">
-    {{#if log.anonymous}}
+    <!-- ko if: log.anonymous -->
         changed a bibliographic contributor to a non-bibliographic contributor on
-    {{/if}}
-    {{#ifnot log.anonymous}}
+    <!-- /ko -->
+    <!-- ko ifnot: log.anonymous -->
         made bibliographic contributor
         <span data-bind="html: displayContributors"></span>
         a non-bibliographic contributor on
-    {{/ifnot}}
+    <!-- /ko -->
     <a class="log-node-title-link overflow" data-bind="attr: {href: $parent.nodeUrl}, text: $parent.nodeTitle"></a>
 </script>
 
 <script type="text/html" id="addon_file_copied">
-  {{#if params.source.materialized.endsWith('/')}}
-    copied <span class="overflow log-folder">{{ params.source.materialized }}</span> from {{ params.source.addon }} in
-    <a class="log-node-title-link overflow" href="{{ params.source.node.url }}">{{ params.source.node.title }}</a>
-    to <span class="overflow log-folder">{{ params.destination.materialized }}</span> in {{ params.destination.addon }} in
+  <!-- ko if: params.source.materialized.endsWith('/') -->
+    copied <span class="overflow log-folder" data-bind="text: params.source.materialized"></span> from <span data-bind="text: params.source.addon"></span> in
+    <a class="log-node-title-link overflow" data-bind="attr: {href: params.source.node.url}, text:params.source.node.title"></a>
+    to <span class="overflow log-folder" data-bind="text: params.destination.materialized"></span> in <span data-bind="text: params.destination.addon"></span> in
     <a class="log-node-title-link overflow" data-bind="attr: {href: $parent.nodeUrl}, text: $parent.nodeTitle"></a>
-  {{/if}}
-  {{#ifnot params.source.materialized.endsWith('/')}}
-    copied <a href="{{ params.source.url }}" class="overflow">{{ params.source.materialized }}</a> from {{ params.source.addon }} in
-    <a class="log-node-title-link overflow" href="{{ params.source.node.url }}">{{ params.source.node.title }}</a>
-    to <a href="{{ params.destination.url }}" class="overflow">{{ params.destination.materialized }}</a> in {{ params.destination.addon }} in
+  <!-- /ko -->
+  <!-- ko ifnot: params.source.materialized.endsWith('/') -->
+    copied <a data-bind="attr: {href: params.source.url}, text: params.source.materialized" class="overflow"></a> from <span data-bind="text: params.source.addon"></span> in
+    <a class="log-node-title-link overflow" data-bind="attr: {href: params.source.node.url}, text: params.source.node.title"></a>
+    to <a data-bind="attr: {href: params.destination.url}, text: params.destination.materialized" class="overflow"></a> in <span data-bind="text: params.destination.addon"></span> in
     <a class="log-node-title-link overflow" data-bind="attr: {href: $parent.nodeUrl}, text: $parent.nodeTitle"></a>
-  {{/ifnot}}
+  <!-- /ko -->
 </script>
 
 <script type="text/html" id="addon_file_moved">
-  {{#if params.source.materialized.endsWith('/')}}
-  moved <span class="overflow">{{ params.source.materialized }}</span> from {{ params.source.addon }} in
-  <a class="log-node-title-link overflow" href="{{ params.source.node.url }}">{{ params.source.node.title }}</a>
-  to <span class="overflow log-folder">{{ params.destination.materialized }}</span> in {{ params.destination.addon }} in
+  <!-- ko if: params.source.materialized.endsWith('/') -->
+  moved <span class="overflow" data-bind="text: params.source.materialized"></span> from <span data-bind="text: params.source.addon"></span> in
+  <a class="log-node-title-link overflow" data-bind="attr: {href: params.source.node.url}, text: params.source.node.title"></a>
+  to <span class="overflow log-folder" data-bind="text: params.destination.materialized"></span> in <span data-bind="text: params.destination.addon"></span> in
   <a class="log-node-title-link overflow" data-bind="attr: {href: $parent.nodeUrl}, text: $parent.nodeTitle"></a>
-  {{/if}}
-  {{#ifnot params.source.materialized.endsWith('/')}}
-  moved <span class="overflow">{{ params.source.materialized }}</span> from {{ params.source.addon }} in
-  <a class="log-node-title-link overflow" href="{{ params.source.node.url }}">{{ params.source.node.title }}</a>
-  to <a href="{{ params.destination.url }}" class="overflow">{{ params.destination.materialized }}</a> in {{ params.destination.addon }} in
+  <!-- /ko -->
+  <!-- ko ifnot: params.source.materialized.endsWith('/') -->
+  moved <span class="overflow" data-bind="text: params.source.materialized"></span> from <span data-bind="text: params.source.addon"></span> in
+  <a class="log-node-title-link overflow" data-bind="attr: {href: params.source.node.url}, text: params.source.node.title"></a>
+  to <a class="overflow" data-bind="attr: {href: params.destination.url}, text: params.destination.materialized"></a> in <span data-bind="text: params.destination.addon"></span> in
   <a class="log-node-title-link overflow" data-bind="attr: {href: $parent.nodeUrl}, text: $parent.nodeTitle"></a>
-  {{/ifnot}}
+  <!-- /ko -->
 </script>
 
 <script type="text/html" id="addon_file_renamed">
-    renamed <span class="overflow">{{ params.source.materialized }}</span>
-  {{#if params.source.materialized.endsWith('/')}}
-  to <span class="overflow log-folder">{{ params.destination.materialized }}</span> in {{ params.destination.addon }} in
-  {{/if}}
-  {{#ifnot params.source.materialized.endsWith('/')}}
-  to <a href="{{ params.destination.url }}" class="overflow">{{ params.destination.materialized }}</a> in {{ params.destination.addon }} in
-  {{/ifnot}}
+    renamed <span class="overflow" data-bind="text: params.source.materialized"></span>
+  <!-- ko if: params.source.materialized.endsWith('/') -->
+  to <span class="overflow log-folder" data-bind="text: params.destination.materialized"></span> in <span data-bind="text: params.destination.addon"></span> in
+  <!-- /ko -->
+  <!-- ko ifnot: params.source.materialized.endsWith('/') -->
+  to <a class="overflow" data-bind="attr: {href: params.destination.url}, text: params.destination.materialized"></a> in <span data-bind="text: params.destination.addon"></span>  in
+  <!-- /ko -->
     <a class="log-node-title-link overflow" data-bind="attr: {href: $parent.nodeUrl}, text: $parent.nodeTitle"></a>
 </script>
 
@@ -326,35 +326,35 @@ on
 </script>
 
 <script type="text/html" id="citation_added">
-added a citation ({{ params.citation.name }})
+added a citation (<span data-bind="text: params.citation.name"></span>)
 to
 <a class="log-node-title-link overflow" data-bind="attr: {href: $parent.nodeUrl}, text: $parent.nodeTitle"></a>
 </script>
 
 <script type="text/html" id="citation_edited">
-{{#if params.citation.new_name}}
-updated a citation name from {{ params.citation.name }} to <strong>{{ params.citation.new_name }}</strong>
-  {{#if params.citation.new_text}}
+<!-- ko if: params.citation.new_name -->
+updated a citation name from <span data-bind="text: params.citation.name"></span> to <strong data-bind="text: params.citation.new_name"></strong>
+  <!-- ko if: params.citation.new_text -->
     and edited its text
-  {{/if}}
-{{/if}}
-{{#ifnot params.citation.new_name}}
-edited the text of a citation ({{ params.citation.name }})
-{{/ifnot}}
+  <!-- /ko -->
+<!-- /ko -->
+<!-- ko ifnot: params.citation.new_name -->
+edited the text of a citation (<span data-bind="text: params.citation.name"></span>)
+<!-- /ko -->
 on
 <a class="log-node-title-link overflow" data-bind="attr: {href: $parent.nodeUrl}, text: $parent.nodeTitle"></a>
 </script>
 
 <script type="text/html" id="citation_removed">
-removed a citation ({{ params.citation.name }})
+removed a citation (<span data-bind="text: params.citation.name"></span>)
 from
 <a class="log-node-title-link overflow" data-bind="attr: {href: $parent.nodeUrl}, text: $parent.nodeTitle"></a>
 </script>
 
 <script type="text/html" id="primary_institution_changed">
-changed this node's primary institution from <strong>{{ params.previous_institution.name }}</strong> to <strong>{{ params.institution.name }}</strong>.
+changed this node's primary institution from <strong data-bind="text: params.previous_institution.name"></strong> to <strong data-bind="text: params.institution.name"></strong>.
 </script>
 
 <script type="text/html" id="primary_institution_removed">
-removed <strong>{{ params.institution.name }}</strong> as this node's primary institution.
+removed <strong data-bind="text: params.institution.name"></strong> as this node's primary institution.
 </script>

--- a/website/templates/profile/account.mako
+++ b/website/templates/profile/account.mako
@@ -28,7 +28,7 @@
                             </thead>
                             <tbody>
                                 <tr>
-                                    <td>{{ profile().primaryEmail().address }}</td>
+                                    <td><span data-bind="text: profile().primaryEmail().address"></span></td>
                                     <td></td>
                                 </tr>
                             </tbody>
@@ -42,7 +42,7 @@
                             </thead>
                             <tbody data-bind="foreach: profile().alternateEmails()">
                                 <tr>
-                                    <td style="word-break: break-all;">{{ $data.address }}</td>
+                                    <td style="word-break: break-all;"><span data-bind="text: $data.address"></span></td>
                                     <td style="width:150px;"><a data-bind="click: $parent.makeEmailPrimary">make&nbsp;primary</a></td>
                                     <td style="width:50px;"><a data-bind="click: $parent.removeEmail"><i class="fa fa-times text-danger"></i></a></td>
                                 </tr>
@@ -57,7 +57,7 @@
                             <tbody>
                                 <!-- ko foreach: profile().unconfirmedEmails() -->
                                 <tr>
-                                    <td style="word-break: break-all;">{{ $data.address }}</td>
+                                    <td style="word-break: break-all;"><span data-bind="text: $data.address"></span></td>
                                     <td style="width:150px;"><a data-bind="click: $parent.resendConfirmation">resend&nbsp;confirmation</a></td>
                                     <td style="width:50px;" ><a data-bind="click: $parent.removeEmail"><i class="fa fa-times text-danger"></i></a></td>
                                 </tr>

--- a/website/templates/profile/oauth_app_detail.mako
+++ b/website/templates/profile/oauth_app_detail.mako
@@ -76,7 +76,7 @@
 
                     <!-- Flashed Messages -->
                     <div class="help-block">
-                        <p data-bind="html: $root.message, attr.class: $root.messageClass"></p>
+                        <p data-bind="html: $root.message, attr: {class: $root.messageClass}"></p>
                     </div>
 
                     <div class="padded">

--- a/website/templates/profile/personal_tokens_detail.mako
+++ b/website/templates/profile/personal_tokens_detail.mako
@@ -54,7 +54,7 @@
 
                     <!-- Flashed Messages -->
                     <div class="help-block">
-                        <p data-bind="html: $root.message, attr.class: $root.messageClass"></p>
+                        <p data-bind="html: $root.message, attr: {class: $root.messageClass}"></p>
                     </div>
 
                     <div class="padded">

--- a/website/templates/profile/user_settings_default.mako
+++ b/website/templates/profile/user_settings_default.mako
@@ -24,7 +24,7 @@
                 <tbody data-bind="foreach: connectedNodes()">
                     <tr>
                         <td class="authorized-nodes">
-                            <!-- ko if: title --><a data-bind="attr.href: urls.view, text: title"></a><!-- /ko -->
+                            <!-- ko if: title --><a data-bind="attr: {href: urls.view}, text: title"></a><!-- /ko -->
                             <!-- ko if: !title --><em>Private project</em><!-- /ko -->
                         </td>
                         <td>

--- a/website/templates/project/addon/node_settings_default.mako
+++ b/website/templates/project/addon/node_settings_default.mako
@@ -4,9 +4,7 @@
         ${addon_full_name}
         <small class="authorized-by">
             <span data-bind="if: nodeHasAuth">
-                authorized by <a data-bind="attr.href: urls().owner">
-                    {{ownerName}}
-                </a>
+                authorized by <a data-bind="attr.href: urls().owner, text: ownerName"></a>
                 % if not is_registration:
                     <a data-bind="click: deauthorize, visible: validCredentials"
                         class="text-danger pull-right addon-auth">Disconnect Account</a>
@@ -41,9 +39,9 @@
             <div class="col-md-12">
                 <p class="break-word">
                     <strong>Current Folder:</strong>
-                    <a href="{{ urls().files }}" data-bind="if: folderName">
-                        {{ folderName }}
-                    </a>
+                    <span data-bind="if: folderName">
+                        <a data-bind="attr: {href: urls().files}, text: folderName"></a>
+                    </span>
                     <span class="text-muted" data-bind="ifnot: folderName">
                         None
                     </span>
@@ -65,7 +63,7 @@
                         <form data-bind="submit: submitSettings">
                             <div class="break-word">
                                 <div data-bind="if: selected" class="alert alert-info ${addon_short_name}-confirm-dlg">
-                                    Connect <b>&ldquo;{{ selectedFolderName }}&rdquo;</b>?
+                                    Connect <b>&ldquo;<span data-bind="text: selectedFolderName"></span>&rdquo;</b>?
                                 </div>
                             </div>
                             <div class="pull-right">

--- a/website/templates/project/addon/node_settings_default.mako
+++ b/website/templates/project/addon/node_settings_default.mako
@@ -1,10 +1,10 @@
 <div id="${addon_short_name}Scope" class="scripted">
     <h4 class="addon-title">
-        <img class="addon-icon" src=${addon_icon_url}></img>
+        <img class="addon-icon" src=${addon_icon_url}>
         ${addon_full_name}
         <small class="authorized-by">
             <span data-bind="if: nodeHasAuth">
-                authorized by <a data-bind="attr.href: urls().owner, text: ownerName"></a>
+                authorized by <a data-bind="attr: {href: urls().owner}, text: ownerName"></a>
                 % if not is_registration:
                     <a data-bind="click: deauthorize, visible: validCredentials"
                         class="text-danger pull-right addon-auth">Disconnect Account</a>
@@ -82,6 +82,6 @@
     </div>
     <!-- Flashed Messages -->
     <div class="help-block">
-        <p data-bind="html: message, attr.class: messageClass"></p>
+        <p data-bind="html: message, attr: {class: messageClass}"></p>
     </div>
 </div>

--- a/website/templates/project/contributors.mako
+++ b/website/templates/project/contributors.mako
@@ -360,7 +360,7 @@
         </div>
     % endif
         <div data-bind="foreach: messages">
-            <div data-bind="css: cssClass">{{ text }}</div>
+            <div data-bind="css: cssClass, text: text"></div>
         </div>
 </%def>
 

--- a/website/templates/project/edit_draft_registration.mako
+++ b/website/templates/project/edit_draft_registration.mako
@@ -33,7 +33,7 @@
                     <div data-bind="visible: hasRequiredQuestions" class="progress progress-bar-md">
                         <div data-bind="progress: completion"></div>
                         <div class="progress-bar progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100"
-                             data-bind="attr.aria-completion: completion,
+                             data-bind="attr: {aria-completion: completion},
                                         style: {width: completion() + '%'}">
                         </div>
                     </div>

--- a/website/templates/project/modal_add_contributor.mako
+++ b/website/templates/project/modal_add_contributor.mako
@@ -114,7 +114,7 @@
                                         <li data-bind="css: style"><a href="#" data-bind="click: handler, html: text"></a></li>
                                     </ul>
                                     <p>
-                                        <a href="#"data-bind="click:gotoInvite">Add <strong><em>{{query}}</em></strong> as an unregistered contributor</a>.
+                                        <a href="#"data-bind="click:gotoInvite">Add <strong><em data-bind="text: query"></em></strong> as an unregistered contributor</a>.
                                     </p>
                                 </div>
                                 <div data-bind="if: showLoading">
@@ -122,7 +122,7 @@
                                 </div>
                                     <div data-bind="if: noResults">
                                         No results found. Try a more specific search or
-                                        <a href="#" data-bind="click:gotoInvite">add <strong><em>{{query}}</em></strong> as an unregistered contributor</a>.
+                                        <a href="#" data-bind="click:gotoInvite">add <strong><em data-bind="text: query"></em></strong> as an unregistered contributor</a>.
                                     </div>
                             </div>
                         </div><!-- ./col-md -->

--- a/website/templates/project/modal_remove_contributor.mako
+++ b/website/templates/project/modal_remove_contributor.mako
@@ -13,7 +13,7 @@
                     <div data-bind='if:page() === REMOVE'>
                         <div class="form-group">
                             <span>Do you want to remove <b data-bind="text:removeSelf() ? 'yourself' : contributorToRemove()['fullname']"></b> from
-                                <b>{{title}}</b>, or from <b>{{title}}</b> and every component in it?</span>
+                                <b data-bind="text: title"></b>, or from <b data-bind="text: title"></b> and every component in it?</span>
                         </div>
                         <div id="remove-page-radio-buttons" class="col-md-8" align="left">
                             <div class="radio">
@@ -34,7 +34,7 @@
                     <!-- removeNoChildren page -->
                     <div data-bind='if:page() === REMOVE_NO_CHILDREN'>
                         <div class="form-group" data-bind="if:contributorToRemove">
-                            <span>Remove <b data-bind="text:removeSelf() ? 'yourself' : contributorToRemove()['fullname']"></b> from {{title}}?</span>
+                            <span>Remove <b data-bind="text:removeSelf() ? 'yourself' : contributorToRemove()['fullname']"></b> from <span data-bind="text: title"></span>?</span>
                         </div>
 
                     </div><!-- end removeNoChildren page -->

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -294,7 +294,7 @@
                             <span data-bind="text: chicago"></span>
                         <div data-bind="validationOptions: {insertMessages: false, messagesOnModified: false}, foreach: citations">
                             <!-- ko if: view() === 'view' -->
-                                <div class="f-w-xl m-t-md">{{name}}
+                                <div class="f-w-xl m-t-md"><span data-bind="text: name"></span>
                                     % if 'admin' in user['permissions'] and not node['is_registration']:
                                         <!-- ko ifnot: $parent.editing() -->
                                             <button class="btn btn-default btn-sm" data-bind="click: function() {edit($parent)}"><i class="fa fa-edit"></i> Edit</button>

--- a/website/templates/project/register.mako
+++ b/website/templates/project/register.mako
@@ -9,13 +9,13 @@
       <div class="col-md-2">
         <ul class="nav nav-stacked list-group" data-bind="foreach: {data: metaSchema.schema.pages, as: 'page'}, visible: metaSchema.schema.pages.length > 1">
           <li class="re-navbar">
-            <a class="registration-editor-page" id="top-nav" style="text-align: left; font-weight:bold;" data-bind="text: title, attr.href: '#' + page.id">
+            <a class="registration-editor-page" id="top-nav" style="text-align: left; font-weight:bold;" data-bind="text: title, attr: {href: '#' + page.id}">
             </a>
             <span class="btn-group-vertical" role="group">
               <ul class="list-group" data-bind="foreach: {data: Object.keys(page.questions), as: 'qid'}">
                 <span data-bind="with: page.questions[qid]">
                   <li class="registration-editor-question list-group-item">
-                    <a data-bind="text: nav, attr.href: '#' + qid"></a>
+                    <a data-bind="text: nav, attr: {href: '#' + qid}"></a>
                   </li>
                 </span>
               </ul>
@@ -25,11 +25,11 @@
       </div>
       <div class="col-md-9" style="padding-left: 30px">
         <div data-bind="foreach: {data: metaSchema.pages, as: 'page'}">
-          <h3 data-bind="attr.id: page.id, text: page.title"></h3>
+          <h3 data-bind="attr: {id: page.id}, text: page.title"></h3>
           <div class="row">
             <div data-bind="foreach: {data: page.questions, as: 'question'}">
               <div class="row">
-                <h4 data-bind="attr.id: question.id, text: question.title"></h4>
+                <h4 data-bind="attr: {id: question.id}, text: question.title"></h4>
                 <small><em data-bind="text: question.description"></em></small>
                 <div class="col-md-12 well">
                   <span data-bind="if: question.value()">

--- a/website/templates/project/register_draft.mako
+++ b/website/templates/project/register_draft.mako
@@ -12,10 +12,10 @@
     <div class="row">
       <div class="col-lg-12 large-12" style="padding-left: 30px">
          <div data-bind="foreach: {data: draft.pages, as: 'page'}">
-           <h3 data-bind="attr.id: page.id, text: page.title"></h3>
+           <h3 data-bind="attr: {id: page.id}, text: page.title"></h3>
              <div data-bind="foreach: {data: page.questions, as: 'question'}">
                <p>
-                 <strong data-bind="attr.id: question.id, text: question.title"></strong>:
+                 <strong data-bind="attr: {id: question.id}, text: question.title"></strong>:
                  <span data-bind="previewQuestion: $root.editor.context(question, $root.editor)"></span>
                </p>
              </div>

--- a/website/templates/project/registration_editor_extensions.mako
+++ b/website/templates/project/registration_editor_extensions.mako
@@ -11,7 +11,7 @@
             style="margin-left: 5px;"
             class="btn btn-xs btn-danger fa fa-times"></button>
   </div>
-  <div data-bind="attr.id: $data.uid, osfUploader">
+  <div data-bind="attr: {id: $data.uid}, osfUploader"><!-- TODO: osfUploader attribute may not connect to anything? -->
     <div class="spinner-loading-wrapper">
       <div class="logo-spin logo-lg"></div>
       <p class="m-t-sm fg-load-message"> Loading files...  </p>
@@ -29,7 +29,7 @@
   </div>
   <a data-bind="click: toggleUploader">Attach File</a>
   <span data-bind="visible: showUploader">
-    <div data-bind="attr.id: $data.uid, osfUploader">
+    <div data-bind="attr: {id: $data.uid}, osfUploader">
       <div class="container">
 	<p class="m-t-sm fg-load-message">
           <span class="logo-spin logo-sm"></span>  Loading files...

--- a/website/templates/project/registration_editor_templates.mako
+++ b/website/templates/project/registration_editor_templates.mako
@@ -11,7 +11,7 @@
 <script type="text/html" id="match">
   <input data-bind="valueUpdate: 'keyup',
                     value: value,
-                    attr.placeholder: match" type="text" class="form-control" />
+                    attr: {placeholder: match}" type="text" class="form-control" />
 </script>
 <script type="text/html" id="textarea">
   <textarea data-bind="valueUpdate: 'keyup',
@@ -45,13 +45,13 @@
 <script type="text/html" id="multiselect">
   <div class="col-md-12" data-bind="foreach: {data: options, as: 'option'}">
     <p data-bind="if: !Boolean(option.tooltip)">
-      <input type="checkbox" data-bind="attr.value: option,
+      <input type="checkbox" data-bind="attr: {value: option},
                                         checked: $parent.value,
                                         checkedValue: option" />
       <span data-bind="text: option"></span>
     </p>
-    <p data-bind="if: Boolean(option.tooltip)">
-      <input type="checkbox" data-bind="attr.value: option.text,
+    <p data-bind="if: Boolean(option.tooltip)"> <!-- TODO: Verify checkboxes -->
+      <input type="checkbox" data-bind="attr: {value: option.text},
                                         checked: $parent.value,
                                         checkedValue: option">
       <span data-bind="text: option.text, tooltip: {title: option.tooltip}"></span>

--- a/website/templates/project/registration_editor_templates.mako
+++ b/website/templates/project/registration_editor_templates.mako
@@ -37,7 +37,7 @@
     <p data-bind="if: Boolean(option.tooltip)">
       <input type="radio" data-bind="checked: $parent.value,
                                      value: option.text"/>
-        {{option.text}}
+        <label data-bind="text: option.text"></label>
       <span data-bind="tooltip: {title: option.tooltip}" class="fa fa-info-circle"></span>
     </p>
   </div>
@@ -53,7 +53,7 @@
     <p data-bind="if: Boolean(option.tooltip)">
       <input type="checkbox" data-bind="attr.value: option.text,
                                         checked: $parent.value,
-                                        checkedValue: option"
+                                        checkedValue: option">
       <span data-bind="text: option.text, tooltip: {title: option.tooltip}"></span>
     </p>
   </div>

--- a/website/templates/project/registration_preview.mako
+++ b/website/templates/project/registration_preview.mako
@@ -4,13 +4,13 @@
           <!-- <div class="span8 col-md-2 columns eight large-8">
           <ul class="nav nav-stacked list-group" data-bind="foreach: {data: schema.pages, as: 'page'}">
           <li class="re-navbar">
-          <a class="registration-editor-page" id="top-nav" style="text-align: left; font-weight:bold;" data-bind="text: title, attr.href: '#' + page.id">
+          <a class="registration-editor-page" id="top-nav" style="text-align: left; font-weight:bold;" data-bind="text: title, attr: {href: '#' + page.id}">
           </a>
           <span class="btn-group-vertical" role="group">
           <ul class="list-group" data-bind="foreach: {data: Object.keys(page.questions), as: 'qid'}">
           <span data-bind="with: page.questions[qid]">
           <li class="registration-editor-question list-group-item">
-          <a data-bind="text: nav, attr.href: '#' + qid"></a>
+          <a data-bind="text: nav, attr: {href: '#' + qid}"></a>
           </li>
           </span>
           </ul>
@@ -20,10 +20,10 @@
           </div> -->
       <div class="span8 col-md-9 columns eight large-8" style="padding-left: 30px">
         <div data-bind="foreach: {data: schema.pages, as: 'page'}">
-          <h3 data-bind="attr.id: page.id, text: page.title"></h3>
+          <h3 data-bind="attr: {id: page.id}, text: page.title"></h3>
           <div data-bind="foreach: {data: Object.keys(page.questions), as: 'qid'}">
             <span data-bind="with: $parent.questions[qid]">
-              <h4 data-bind="attr.id: qid, text: title"></h4>
+              <h4 data-bind="attr: {id: qid}, text: title"></h4>
               <span data-bind="text: qid.description"></span>
             </span>
           </div>

--- a/website/templates/project/registrations.mako
+++ b/website/templates/project/registrations.mako
@@ -142,7 +142,7 @@
         <label>
           <input type="radio" name="selectedDraftSchema"
                  data-bind="attr {value: id}, checked: $root.selectedSchemaId" />
-          {{ schema.title }}
+          <span data-bind="text: schema.title"></span>
           <!-- ko if: schema.description -->
           <i data-bind="tooltip: {title: schema.description}" class="fa fa-info-circle"> </i>
           <!-- /ko -->

--- a/website/templates/project/registrations.mako
+++ b/website/templates/project/registrations.mako
@@ -71,7 +71,7 @@
               <h4 class="list-group-item-heading">
                 <div data-bind="visible: hasRequiredQuestions" class="progress progress-bar-md">
                   <div class="progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100"
-                       data-bind="attr.aria-completion: completion,
+                       data-bind="attr: {aria-completion: completion},
                                   style: {width: completion() + '%'}">
                     <span class="sr-only"></span>
                   </div>
@@ -113,7 +113,7 @@
                     </span>
                     -->
                     <span data-bind="ifnot: requiresApproval">
-                     <a class="btn btn-success" data-bind="attr.href: urls.register_page,
+                     <a class="btn btn-success" data-bind="attr: {href: urls.register_page},
                                                            css: {'disabled': !isApproved}">Register</a>
                     </span>
                   </div>

--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -77,7 +77,7 @@
                     <div id="projectSettings" class="panel-body">
                         <div class="form-group">
                             <label>Category:</label>
-                            <select data-bind="attr.disabled: disabled, options: categoryOptions, optionsValue: 'value', optionsText: 'label', value: selectedCategory"></select>
+                            <select data-bind="attr: {disabled: disabled}, options: categoryOptions, optionsValue: 'value', optionsText: 'label', value: selectedCategory"></select>
                             <span data-bind="if: disabled" class="help-block">
                               A top-level project's category cannot be changed
                             </span>

--- a/website/templates/public/login.mako
+++ b/website/templates/public/login.mako
@@ -211,7 +211,7 @@
             </div>
             <!-- Flashed Messages -->
             <div class="help-block" >
-                <p data-bind="html: flashMessage, attr.class: flashMessageClass"></p>
+                <p data-bind="html: flashMessage, attr: {class: flashMessageClass}"></p>
             </div>
             <div>
                 <p> By clicking "Create account", you agree to our <a href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/TERMS_OF_USE.md">Terms</a> and that you have read our <a href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/PRIVACY_POLICY.md">Privacy Policy</a>, including our information on <a href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/PRIVACY_POLICY.md#f-cookies">Cookie Use</a>.</p>

--- a/website/templates/search.mako
+++ b/website/templates/search.mako
@@ -112,11 +112,11 @@
 
     <script type="text/html" id="SHARE">
         <!-- ko if: $data.links -->
-            <h4><a data-bind="attr.href: links[0].url, text: title"></a></h4>
+            <h4><a data-bind="attr: {href: links[0].url}, text: title"></a></h4>
         <!-- /ko -->
 
         <!-- ko ifnot: $data.links -->
-            <h4><a data-bind="attr.href: id.url, text: title"></a></h4>
+            <h4><a data-bind="attr: {href: id.url}, text: title"></a></h4>
         <!-- /ko -->
 
         <!-- TODO: Add a "trimText" filter to replace the one we're losing from KO.punches; this display value should be a 500 char max limit-->
@@ -143,9 +143,9 @@
     <script type="text/html" id="file">
         <h4><a data-bind="attr: {href: deep_url}, text: name"></a> (<span data-bind="if: is_registration">Registration </span>File)</h4>
         <h5>
-            <!-- ko if: parent_url --> From: <a data-bind="attr.href: parent_url, text: parent_title || '' + ' /'"></a> <!-- /ko -->
+            <!-- ko if: parent_url --> From: <a data-bind="attr: {href: parent_url}, text: parent_title || '' + ' /'"></a> <!-- /ko -->
             <!-- ko if: !parent_url --> From: <span data-bind="if: parent_title"><span data-bind="text: parent_title"></span> /</span> <!-- /ko -->
-            <a data-bind="attr.href: node_url, text: node_title"></a>
+            <a data-bind="attr: {href: node_url}, text: node_title"></a>
         </h5>
         <!-- ko if: tags.length > 0 --> <div data-bind="template: 'tag-cloud'"></div> <!-- /ko -->
     </script>
@@ -153,10 +153,10 @@
 
         <div class="row">
             <div class="col-md-2">
-                <img class="social-gravatar" data-bind="visible: gravatarUrl(), attr.src: gravatarUrl()">
+                <img class="social-gravatar" data-bind="visible: gravatarUrl(), attr: {src: gravatarUrl()}">
             </div>
             <div class="col-md-10">
-                <h4><a data-bind="attr.href: url, text: user"></a></h4>
+                <h4><a data-bind="attr: {href: url}, text: user"></a></h4>
                 <p>
                     <span data-bind="visible: job_title, text: job_title"></span><!-- ko if: job_title && job --> at <!-- /ko -->
                     <span data-bind="visible: job, text: job"></span><!-- ko if: job_title || job --><br /><!-- /ko -->
@@ -166,58 +166,58 @@
                 <!-- ko if: social -->
                 <ul class="list-inline">
                     <li data-bind="visible: social.personal">
-                        <a data-bind="attr.href: social.personal">
+                        <a data-bind="attr: {href: social.personal}">
                             <i class="fa fa-globe social-icons" data-toggle="tooltip" title="Personal Website"></i>
                         </a>
                     </li>
 
                     <li data-bind="visible: social.twitter">
-                        <a data-bind="attr.href: social.twitter">
+                        <a data-bind="attr: {href: social.twitter}">
                             <i class="fa fa-twitter social-icons" data-toggle="tooltip" title="Twitter"></i>
                         </a>
                     </li>
                     <li data-bind="visible: social.github">
-                        <a data-bind="attr.href: social.github">
+                        <a data-bind="attr: {href: social.github}">
                             <i class="fa fa-github-alt social-icons" data-toggle="tooltip" title="Github"></i>
                         </a>
                     </li>
                     <li data-bind="visible: social.linkedIn">
-                        <a data-bind="attr.href: social.linkedIn">
+                        <a data-bind="attr: {href: social.linkedIn}">
                             <i class="fa fa-linkedin social-icons" data-toggle="tooltip" title="LinkedIn"></i>
                         </a>
                     </li>
                     <li data-bind="visible: social.scholar">
-                        <a data-bind="attr.href: social.scholar">
+                        <a data-bind="attr: {href: social.scholar}">
                             <img class="social-icons" src="/static/img/googlescholar.png"data-toggle="tooltip" title="Google Scholar">
                         </a>
                     </li>
                     <li data-bind="visible: social.impactStory">
-                        <a data-bind="attr.href: social.impactStory">
+                        <a data-bind="attr: {href: social.impactStory}">
                             <i class="fa fa-info-circle social-icons" data-toggle="tooltip" title="ImpactStory"></i>
                         </a>
                     </li>
                     <li data-bind="visible: social.orcid">
-                        <a data-bind="attr.href: social.orcid">
+                        <a data-bind="attr: {href: social.orcid}">
                             <i class="fa social-icons" data-toggle="tooltip" title="ORCiD">iD</i>
                         </a>
                     </li>
                     <li data-bind="visible: social.researcherId">
-                        <a data-bind="attr.href: social.researcherId">
+                        <a data-bind="attr: {href: social.researcherId}">
                             <i class="fa social-icons" data-toggle="tooltip" title="ResearcherID">R</i>
                         </a>
                     </li>
                     <li data-bind="visible: social.researchGate">
-                        <a data-bind="attr.href: social.researchGate">
+                        <a data-bind="attr: {href: social.researchGate}">
                             <img class="social-icons" src="/static/img/researchgate.jpg" style="PADDING-BOTTOM: 7px" data-toggle="tooltip" title="ResearchGate"></i>
                         </a>
                     </li>
                     <li data-bind="visible: social.academiaInstitution + social.academiaProfileID">
-                        <a data-bind="attr.href: social.academiaInstitution + social.academiaProfileID">
+                        <a data-bind="attr: {href: social.academiaInstitution + social.academiaProfileID}">
                             <i class="fa social-icons" data-toggle="tooltip" title="Academia">A</i>
                         </a>
                     </li>
                     <li data-bind="visible: social.baiduScholar">
-                        <a data-bind="attr.href: social.baiduScholar">
+                        <a data-bind="attr: {href: social.baiduScholar}">
                             <img class="social-icons" src="/static/img/baiduscholar.png"data-toggle="tooltip" style="PADDING-BOTTOM: 5px" title="Baidu Scholar">
                         </a>
                     </li>
@@ -229,10 +229,10 @@
     </script>
     <script type="text/html" id="node">
       <!-- ko if: parent_url -->
-      <h4><a data-bind="attr.href: parent_url, text: parent_title"></a> / <a data-bind="attr.href: url, text: title"></a></h4>
+      <h4><a data-bind="attr: {href: parent_url}, text: parent_title"></a> / <a data-bind="attr: {href: url}, text: title"></a></h4>
         <!-- /ko -->
         <!-- ko if: !parent_url -->
-        <h4><span data-bind="if: parent_title"><span data-bind="text: parent_title"></span> /</span> <a data-bind="attr.href: url, text: title"></a></h4>
+        <h4><span data-bind="if: parent_title"><span data-bind="text: parent_title"></span> /</span> <a data-bind="attr: {href: url}, text: title"></a></h4>
         <!-- /ko -->
 
         <!-- TODO: Write and use a replacement for the trimText filter here. Limit 500 characters -->
@@ -242,7 +242,7 @@
         <p>
             <strong>Contributors:</strong> <span data-bind="foreach: contributors">
                 <!-- ko if: url -->
-                    <a data-bind="attr.href: url, text: fullname"></a>
+                    <a data-bind="attr: {href: url}, text: fullname"></a>
                 <!-- /ko-->
                 <!-- ko ifnot: url -->
                     <span data-bind="text: fullname"></span>
@@ -256,9 +256,9 @@
         <!-- /ko -->
         <p><strong>Jump to:</strong>
             <!-- ko if: n_wikis > 0 -->
-            <a data-bind="attr.href: wikiUrl">Wiki</a> -
+            <a data-bind="attr: {href: wikiUrl}">Wiki</a> -
             <!-- /ko -->
-            <a data-bind="attr.href: filesUrl">Files</a>
+            <a data-bind="attr: {href: filesUrl}">Files</a>
         </p>
     </script>
     <script type="text/html" id="project">
@@ -269,10 +269,10 @@
     </script>
     <script type="text/html" id="registration">
         <!-- ko if: parent_url -->
-        <h4><a data-bind="attr.href: parent_url, text: parent_title"></a> / <a data-bind="attr.href: url, text: title"></a>  (<span class="text-danger" data-bind="if: is_retracted">Retracted </span>Registration)</h4>
+        <h4><a data-bind="attr: {href: parent_url}, text: parent_title"></a> / <a data-bind="attr: {href: url}, text: title"></a>  (<span class="text-danger" data-bind="if: is_retracted">Retracted </span>Registration)</h4>
         <!-- /ko -->
         <!-- ko if: !parent_url -->
-        <h4><span data-bind="if: parent_title"><span data-bind="text: parent_title"></span> /</span> <a data-bind="attr.href: url, text: title"></a>  (<span class="text-danger" data-bind="if: is_retracted">Retracted </span>Registration)</h4>
+        <h4><span data-bind="if: parent_title"><span data-bind="text: parent_title"></span> /</span> <a data-bind="attr: {href: url}, text: title"></a>  (<span class="text-danger" data-bind="if: is_retracted">Retracted </span>Registration)</h4>
         <!-- /ko -->
         <strong><span data-bind="text: 'Date Registered: ' + dateRegistered['local'], tooltip: {title: dateRegistered['utc']}"></span></strong>
 
@@ -283,7 +283,7 @@
         <p>
             <strong>Contributors:</strong> <span data-bind="foreach: contributors">
                 <!-- ko if: url -->
-                    <a data-bind="attr.href: url, text: fullname"></a>
+                    <a data-bind="attr: {href: url}, text: fullname"></a>
                 <!-- /ko-->
                 <!-- ko ifnot: url -->
                     <span data-bind="text: fullname"></span>
@@ -299,9 +299,9 @@
         <!-- /ko -->
         <p><strong>Jump to:</strong>
             <!-- ko if: n_wikis > 0 -->
-            <a data-bind="attr.href: wikiUrl">Wiki</a> -
+            <a data-bind="attr: {href: wikiUrl}">Wiki</a> -
             <!-- /ko -->
-            <a data-bind="attr.href: filesUrl">Files</a>
+            <a data-bind="attr: {href: filesUrl}">Files</a>
         </p>
     </script>
     <script id="tag-cloud" type="text/html">

--- a/website/templates/search.mako
+++ b/website/templates/search.mako
@@ -18,15 +18,15 @@
                                 <ul class="nav nav-pills nav-stacked" data-bind="foreach: allCategories">
 
                                     <!-- ko if: $parent.category().name === name -->
-                                            <li class="active">
-                                                <a data-bind="click: $parent.filter.bind($data)">{{ display }}<span class="badge pull-right">{{count}}</span></a>
-                                            </li>
-                                        <!-- /ko -->
-                                        <!-- ko if: $parent.category().name !== name -->
-                                            <li>
-                                                <a data-bind="click: $parent.filter.bind($data)">{{ display }}<span class="badge pull-right">{{count}}</span></a>
-                                            </li>
-                                        <!-- /ko -->
+                                        <li class="active"> <!-- TODO: simplify markup; only the active class really needs to be conditional -->
+                                            <a data-bind="click: $parent.filter.bind($data)"><span data-bind="text: display"></span><span class="badge pull-right" data-bind="text: count"></span></a>
+                                        </li>
+                                    <!-- /ko -->
+                                    <!-- ko if: $parent.category().name !== name -->
+                                        <li>
+                                            <a data-bind="click: $parent.filter.bind($data)"><span data-bind="text: display"></span><span class="badge pull-right" data-bind="text: count"></span></a>
+                                        </li>
+                                    <!-- /ko -->
                                 </ul>
                             </div>
                         </div>
@@ -38,9 +38,7 @@
                                     <!-- ko if: count === $parent.tagMaxCount() && count > $parent.tagMaxCount()/2  -->
                                     <span class="tag tag-big tag-container"
                                           data-bind="click: $root.addTag.bind($parentContext, tag.name)">
-                                        <span class="cloud-text">
-                                            {{name}}
-                                        </span>
+                                        <span class="cloud-text" data-bind="text: name"></span>
                                         <i class="fa fa-times-circle remove-tag big"
                                            data-bind="click: $root.removeTag.bind($parentContext, tag.name)"></i>
                                     </span>
@@ -48,9 +46,7 @@
                                     <!-- ko if: count < $parent.tagMaxCount() && count > $parent.tagMaxCount()/2 -->
                                     <span class="tag tag-med tag-container"
                                           data-bind="click: $root.addTag.bind($parentContext, tag.name)">
-                                        <span class="cloud-text">
-                                            {{name}}
-                                        </span>
+                                        <span class="cloud-text" data-bind="text: name"></span>
                                         <i class="fa fa-times-circle remove-tag med"
                                            data-bind="click: $root.removeTag.bind($parentContext, tag.name)"></i>
                                     </span>
@@ -58,9 +54,7 @@
                                     <!-- ko if: count <= $parent.tagMaxCount()/2-->
                                     <span class="tag tag-sm tag-container"
                                           data-bind="click: $root.addTag.bind($parentContext, tag.name)">
-                                        <span class="cloud-text">
-                                            {{name}}
-                                        </span>
+                                        <span class="cloud-text" data-bind="text: name"></span>
                                         <i class="fa fa-times-circle remove-tag"
                                            data-bind="click: $root.removeTag.bind($parentContext, tag.name)"></i>
                                     </span>
@@ -78,7 +72,7 @@
                                     data-bind="foreach: {data: licenses, as: 'license'}">
                                   <li data-bind="css: {'active': license.active(), 'disabled': !license.count()}">
                                     <a data-bind="click: license.toggleActive">
-                                      <span style="display: inline-block; max-width: 85%;">{{license.name}}</span>
+                                      <span style="display: inline-block; max-width: 85%;" data-bind="text: license.name"></span>
                                       <span data-bind="text: license.count" class="badge pull-right"></span>
                                     </a>
                                   </li>
@@ -118,26 +112,27 @@
 
     <script type="text/html" id="SHARE">
         <!-- ko if: $data.links -->
-            <h4><a data-bind="attr.href: links[0].url">{{ title }}</a></h4>
+            <h4><a data-bind="attr.href: links[0].url, text: title"></a></h4>
         <!-- /ko -->
 
         <!-- ko ifnot: $data.links -->
-            <h4><a data-bind="attr.href: id.url">{{ title }}</a></h4>
+            <h4><a data-bind="attr.href: id.url, text: title"></a></h4>
         <!-- /ko -->
 
-        <h5>Description: <small>{{ description | default:"No Description" | fit:500}}</small></h5>
+        <!-- TODO: Add a "trimText" filter to replace the one we're losing from KO.punches; this display value should be a 500 char max limit-->
+        <h5>Description: <small data-bind="text: description || 'No Description'"></small></h5>
 
         <!-- ko if: contributors.length > 0 -->
         <h5>
             Contributors: <small data-bind="foreach: contributors">
-                <span>{{ $data.given + " " + $data.family}}</span>
+                <span data-bind="text: $data.given + ' ' + $data.family"></span>
             <!-- ko if: ($index()+1) < ($parent.contributors.length) -->&nbsp;- <!-- /ko -->
             </small>
         </h5>
         <!-- /ko -->
 
         <!-- ko if: $data.source -->
-        <h5>Source: <small>{{ source }}</small></h5>
+        <h5>Source: <small data-bind="text: source"></small></h5>
         <!-- /ko -->
 
         <!-- ko if: $data.isResource -->
@@ -146,11 +141,11 @@
         <!-- /ko -->
     </script>
     <script type="text/html" id="file">
-        <h4><a href="{{ deep_url }}">{{ name }}</a> (<span data-bind="if: is_registration">Registration </span>File)</h4>
+        <h4><a data-bind="attr: {href: deep_url}, text: name"></a> (<span data-bind="if: is_registration">Registration </span>File)</h4>
         <h5>
-            <!-- ko if: parent_url --> From: <a data-bind="attr.href: parent_url">{{ parent_title }} /</a> <!-- /ko -->
-            <!-- ko if: !parent_url --> From: <span data-bind="if: parent_title">{{ parent_title }} /</span> <!-- /ko -->
-            <a data-bind="attr.href: node_url">{{ node_title }}</a>
+            <!-- ko if: parent_url --> From: <a data-bind="attr.href: parent_url, text: parent_title || '' + ' /'"></a> <!-- /ko -->
+            <!-- ko if: !parent_url --> From: <span data-bind="if: parent_title"><span data-bind="text: parent_title"></span> /</span> <!-- /ko -->
+            <a data-bind="attr.href: node_url, text: node_title"></a>
         </h5>
         <!-- ko if: tags.length > 0 --> <div data-bind="template: 'tag-cloud'"></div> <!-- /ko -->
     </script>
@@ -161,7 +156,7 @@
                 <img class="social-gravatar" data-bind="visible: gravatarUrl(), attr.src: gravatarUrl()">
             </div>
             <div class="col-md-10">
-                <h4><a data-bind="attr.href: url"><span>{{ user }}</span></a></h4>
+                <h4><a data-bind="attr.href: url, text: user"></a></h4>
                 <p>
                     <span data-bind="visible: job_title, text: job_title"></span><!-- ko if: job_title && job --> at <!-- /ko -->
                     <span data-bind="visible: job, text: job"></span><!-- ko if: job_title || job --><br /><!-- /ko -->
@@ -234,22 +229,23 @@
     </script>
     <script type="text/html" id="node">
       <!-- ko if: parent_url -->
-      <h4><a data-bind="attr.href: parent_url">{{ parent_title}}</a> / <a data-bind="attr.href: url">{{title }}</a></h4>
+      <h4><a data-bind="attr.href: parent_url, text: parent_title"></a> / <a data-bind="attr.href: url, text: title"></a></h4>
         <!-- /ko -->
         <!-- ko if: !parent_url -->
-        <h4><span data-bind="if: parent_title">{{ parent_title }} /</span> <a data-bind="attr.href: url">{{title }}</a></h4>
+        <h4><span data-bind="if: parent_title"><span data-bind="text: parent_title"></span> /</span> <a data-bind="attr.href: url, text: title"></a></h4>
         <!-- /ko -->
 
-        <p data-bind="visible: description"><strong>Description:</strong> {{ description | fit:500 }}</p>
+        <!-- TODO: Write and use a replacement for the trimText filter here. Limit 500 characters -->
+        <p data-bind="visible: description"><strong>Description:</strong> <span data-bind="text: description"></span></p>
 
         <!-- ko if: contributors.length > 0 -->
         <p>
             <strong>Contributors:</strong> <span data-bind="foreach: contributors">
                 <!-- ko if: url -->
-                    <a data-bind="attr.href: url">{{ fullname }}</a>
+                    <a data-bind="attr.href: url, text: fullname"></a>
                 <!-- /ko-->
                 <!-- ko ifnot: url -->
-                    {{ fullname }}
+                    <span data-bind="text: fullname"></span>
                 <!-- /ko -->
             <!-- ko if: ($index()+1) < ($parent.contributors.length) -->&nbsp;- <!-- /ko -->
             </span>
@@ -273,23 +269,24 @@
     </script>
     <script type="text/html" id="registration">
         <!-- ko if: parent_url -->
-        <h4><a data-bind="attr.href: parent_url">{{ parent_title}}</a> / <a data-bind="attr.href: url">{{ title }}</a>  (<span class="text-danger" data-bind="if: is_retracted">Retracted </span>Registration)</h4>
+        <h4><a data-bind="attr.href: parent_url, text: parent_title"></a> / <a data-bind="attr.href: url, text: title"></a>  (<span class="text-danger" data-bind="if: is_retracted">Retracted </span>Registration)</h4>
         <!-- /ko -->
         <!-- ko if: !parent_url -->
-        <h4><span data-bind="if: parent_title">{{ parent_title }} /</span> <a data-bind="attr.href: url">{{ title }}</a>  (<span class="text-danger" data-bind="if: is_retracted">Retracted </span>Registration)</h4>
+        <h4><span data-bind="if: parent_title"><span data-bind="text: parent_title"></span> /</span> <a data-bind="attr.href: url, text: title"></a>  (<span class="text-danger" data-bind="if: is_retracted">Retracted </span>Registration)</h4>
         <!-- /ko -->
         <strong><span data-bind="text: 'Date Registered: ' + dateRegistered['local'], tooltip: {title: dateRegistered['utc']}"></span></strong>
 
-        <p data-bind="visible: description"><strong>Description:</strong> {{ description | fit:500 }}</p>
+        <!-- TODO: Add trimText filter to restrict length to 500 chars -->
+        <p data-bind="visible: description"><strong>Description:</strong> <span data-bind="text: description>"></span></p>
 
         <!-- ko if: contributors.length > 0 -->
         <p>
             <strong>Contributors:</strong> <span data-bind="foreach: contributors">
                 <!-- ko if: url -->
-                    <a data-bind="attr.href: url">{{ fullname }}</a>
+                    <a data-bind="attr.href: url, text: fullname"></a>
                 <!-- /ko-->
                 <!-- ko ifnot: url -->
-                    {{ fullname }}
+                    <span data-bind="text: fullname"></span>
                 <!-- /ko -->
 
 


### PR DESCRIPTION
Refs https://openscience.atlassian.net/browse/OSF-5794

## Purpose
Phase out usage of knockout punches template helpers due to reported incompatibilities.

## Task list
- [x] Perform census of all pages affected, and plan best way to decompose this into different sections of the site
- [x] `{{ expression }}` should be replaced with `<!--ko text:expression--><!--/ko-->` or some equivalent
- [x] Remove usages of namespaced dynamic bindings (see the docs): https://mbest.github.io/knockout.punches/
- [ ] Convert pages that rely on wrapped event callbacks (by default, review `click`, `submit`, and `event` bindings)
- [ ] Replace ko.punches text filters (trim) with alternatives.
- [ ] Remove usages of `ko.punches.enableAll();`
- [ ] Remove ko-punches from vendor bundle

## Testing notes
### List of affected pages / sections
To be written

### Things to check
- Links should work
- Any text that used to be present should still be present (no fields are missing)
- Long description fields are still truncated
- Should be able to click all buttons on the affected pages