### PR TITLE
Do not embed empty relationships

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -1051,6 +1051,3 @@ def relationship_diff(current_items, new_items):
         'remove': {k: current_items[k] for k in (set(current_items.keys()) - set(new_items.keys()))}
     }
 
-
-def skip_field():
-    raise SkipField

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -1050,4 +1050,3 @@ def relationship_diff(current_items, new_items):
         'add': {k: new_items[k] for k in (set(new_items.keys()) - set(current_items.keys()))},
         'remove': {k: current_items[k] for k in (set(current_items.keys()) - set(new_items.keys()))}
     }
-

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -905,7 +905,12 @@ class JSONAPISerializer(ser.Serializer):
                         except SkipField:
                             continue
                     else:
-                        result = self.context['embed'][field.field_name](obj)
+                        try:
+                            # If a field has an empty representation, it should not be embedded.
+                            field.to_representation(attribute)
+                            result = self.context['embed'][field.field_name](obj)
+                        except SkipField:
+                            result = None
 
                     if result:
                         data['embeds'][field.field_name] = result

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -6,7 +6,7 @@ from api.base.utils import absolute_reverse
 from api.nodes.serializers import NodeSerializer
 from api.nodes.serializers import NodeLinksSerializer
 from api.nodes.serializers import NodeContributorsSerializer
-from api.base.serializers import IDField, RelationshipField, LinksField, HideIfRetraction, DevOnly
+from api.base.serializers import IDField, RelationshipField, LinksField, HideIfRetraction, DevOnly, HideIfRegistration
 
 
 class RegistrationSerializer(NodeSerializer):
@@ -90,6 +90,10 @@ class RegistrationSerializer(NodeSerializer):
         related_view='registrations:registration-institution-detail',
         related_view_kwargs={'node_id': '<pk>'}
     )
+    registrations = HideIfRegistration(RelationshipField(
+        related_view='nodes:node-registrations',
+        related_view_kwargs={'node_id': '<pk>'}
+    ))
 
     # TODO: Finish me
 

--- a/api_tests/files/views/test_file_detail.py
+++ b/api_tests/files/views/test_file_detail.py
@@ -47,24 +47,19 @@ class TestFileView(ApiTestCase):
         self.file.versions[-1].reload()
         assert_equal(res.status_code, 200)
         assert_equal(res.json.keys(), ['data'])
-        assert_equal(res.json['data']['attributes'], {
-            'path': self.file.path,
-            'kind': self.file.kind,
-            'name': self.file.name,
-            'materialized_path': self.file.materialized_path,
-            'last_touched': None,
-            'provider': self.file.provider,
-            'size': self.file.versions[-1].size,
-            # HACK: odm's dates are weird
-            'date_modified': _dt_to_iso8601(self.file.versions[-1].date_created.replace(tzinfo=pytz.utc)),
-            'date_created': _dt_to_iso8601(self.file.versions[0].date_created.replace(tzinfo=pytz.utc)),
-            'extra': {
-                'hashes': {
-                    'md5': None,
-                    'sha256': None,
-                },
-            },
-        })
+        attributes = res.json['data']['attributes']
+        assert_equal(attributes['path'], self.file.path)
+        assert_equal(attributes['kind'], self.file.kind)
+        assert_equal(attributes['name'], self.file.name)
+        assert_equal(attributes['materialized_path'], self.file.materialized_path)
+        assert_equal(attributes['last_touched'], None)
+        assert_equal(attributes['provider'], self.file.provider)
+        assert_equal(attributes['size'], self.file.versions[-1].size)
+        assert_equal(attributes['date_modified'], _dt_to_iso8601(self.file.versions[-1].date_created.replace(tzinfo=pytz.utc)))
+        assert_equal(attributes['date_created'], _dt_to_iso8601(self.file.versions[0].date_created.replace(tzinfo=pytz.utc)))
+        assert_equal(attributes['extra']['hashes']['md5'], None)
+        assert_equal(attributes['extra']['hashes']['sha256'], None)
+
 
     def test_file_has_comments_link(self):
         res = self.app.get('/{}files/{}/'.format(API_BASE, self.file._id), auth=self.user.auth)

--- a/api_tests/nodes/views/test_node_embeds.py
+++ b/api_tests/nodes/views/test_node_embeds.py
@@ -47,6 +47,13 @@ class TestNodeEmbeds(ApiTestCase):
         embeds = res.json['data']['embeds']
         assert_equal(embeds['parent']['data']['id'], self.root_node._id)
 
+    def test_embed_no_parent(self):
+        url = '/{0}nodes/{1}/?embed=parent'.format(API_BASE, self.root_node._id)
+
+        res = self.app.get(url, auth=self.user.auth)
+        data = res.json['data']
+        assert_not_in('embeds', data)
+
     def test_embed_contributors(self):
         url = '/{0}nodes/{1}/?embed=contributors'.format(API_BASE, self.child1._id)
 

--- a/api_tests/registrations/views/test_registration_detail.py
+++ b/api_tests/registrations/views/test_registration_detail.py
@@ -92,8 +92,8 @@ class TestRegistrationDetail(ApiTestCase):
         registration = self.retraction_registration
         res = self.app.get(self.retraction_url, auth=self.user.auth)
         assert_equal(res.status_code, 200)
-
-        assert_items_equal(res.json['data']['attributes'], {
+        attributes = res.json['data']['attributes']
+        expected_attributes = {
             'title': registration.title,
             'description': registration.description,
             'date_created': registration.date_created,
@@ -102,7 +102,7 @@ class TestRegistrationDetail(ApiTestCase):
             'public': None,
             'category': None,
             'date_modified': None,
-            "registration": True,
+            'registration': True,
             'fork': None,
             'collection': None,
             'dashboard': None,
@@ -111,11 +111,13 @@ class TestRegistrationDetail(ApiTestCase):
             'pending_retraction': None,
             'pending_registration_approval': None,
             'pending_embargo_approval': None,
-            "embargo_end_date": None,
-            "registered_meta": None,
+            'embargo_end_date': None,
+            'registered_meta': None,
             'current_user_permissions': None,
-            "registration_supplement": registration.registered_meta.keys()[0]
-        })
+            'registration_supplement': registration.registered_meta.keys()[0]
+        }
+
+        assert_items_equal(attributes, expected_attributes)
 
         contributors = urlparse(res.json['data']['relationships']['contributors']['links']['related']['href']).path
         assert_equal(contributors, '/{}registrations/{}/contributors/'.format(API_BASE, registration._id))


### PR DESCRIPTION
Purpose
-----------
Fix [https://openscience.atlassian.net/browse/OSF-5373] in which embedding a parent field for a top-level resource would embed an error rather than skipping the field.

Changes
------------
1. Add a test for the problem case
2. Check for the field representation early and, if it doesn't have a representation, bail out early
3. Cache the representation and use it later on when necessary
4. Fix a problem test from the Files views
5. Modify the HideIfRegistration and HideIfRetraction functions to raise SkipField if it's a registration, because the logic isn't always catching None's anymore depending
6. Explicitly skip the registrations field on registrations so it doesn't get serialized incorrectly

Side effects
----------------
Checking to verify the representation is potentially a little cumbersome, but some tests with profiling seems to indicate that it's faster more than it's slower, so that's good.

I'm also a little concerned that we might get some relationship fields added to attributes as None if I did this wrong, but I *think* we're okay there.