### PR TITLE
Trash old addon stored file node after move/rename

### DIFF
--- a/website/project/views/comment.py
+++ b/website/project/views/comment.py
@@ -14,7 +14,7 @@ from framework.auth.decorators import must_be_logged_in
 from framework.guid.model import Guid
 
 from website.addons.base.signals import file_updated
-from website.files.models import FileNode
+from website.files.models import FileNode, TrashedFileNode
 from website.notifications.constants import PROVIDERS
 from website.notifications.emails import notify
 from website.models import Comment
@@ -48,8 +48,11 @@ def update_file_guid_referent(self, node, event_type, payload, user=None):
                 update_comment_node(guid, source_node, destination_node)
 
             if source['provider'] != destination['provider'] or source['provider'] != 'osfstorage':
+                old_file = FileNode.load(obj.referent._id)
                 obj.referent = create_new_file(obj, source, destination, destination_node)
                 obj.save()
+                if not TrashedFileNode.load(old_file._id):
+                    old_file.delete()
 
 
 def create_new_file(obj, source, destination, destination_node):


### PR DESCRIPTION
Purpose
-----------
Addresses a commenting issue where if you upload a box file, then move it to a different provider, then re-upload the same file to box & move it again -- that second move fails because there are now two box stored file nodes for that file.

Changes
------------
When an addon file is moved or renamed, after the Guid referent is replaced with a newly created
StoredFileNode, delete the old StoredFileNode so that it is not possible to have multiple records
for the same file.