### PR TITLE
[ko-1] Remove ko template syntax from non-project pages

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -203,3 +203,23 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+Helper functions adapted from Knockout.punches
+================================================
+
+Copyright (c) 2016 Michael Best
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/website/addons/dataverse/static/dataverseNodeConfig.js
+++ b/website/addons/dataverse/static/dataverseNodeConfig.js
@@ -5,14 +5,12 @@
 
 var ko = require('knockout');
 var bootbox = require('bootbox');
-require('knockout.punches');
 var Raven = require('raven-js');
 
 var $osf = require('js/osfHelpers');
 
 var $modal = $('#dataverseInputCredentials');
 
-ko.punches.enableAll();
 
 function ViewModel(url) {
     var self = this;

--- a/website/addons/dataverse/static/dataverseUserConfig.js
+++ b/website/addons/dataverse/static/dataverseUserConfig.js
@@ -4,8 +4,6 @@
 */
 
 var ko = require('knockout');
-require('knockout.punches');
-ko.punches.enableAll();
 var $ = require('jquery');
 var Raven = require('raven-js');
 var bootbox = require('bootbox');

--- a/website/addons/dataverse/templates/dataverse_credentials_modal.mako
+++ b/website/addons/dataverse/templates/dataverse_credentials_modal.mako
@@ -45,7 +45,7 @@
                                 <label for="apiToken">
                                     API Token
                                     <!-- Link to API token generation page -->
-                                    <a href="{{tokenUrl}}"
+                                    <a data-bind="attr: {href: tokenUrl}"
                                        target="_blank" class="text-muted addon-external-link">
                                         (Get from Dataverse <i class="fa fa-external-link-square"></i>)
                                     </a>

--- a/website/addons/dataverse/templates/dataverse_node_settings.mako
+++ b/website/addons/dataverse/templates/dataverse_node_settings.mako
@@ -4,14 +4,12 @@
     <%include file="dataverse_credentials_modal.mako"/>
 
     <h4 class="addon-title">
-        <img class="addon-icon" src=${addon_icon_url}></img>
+        <img class="addon-icon" src=${addon_icon_url}>
         ${addon_full_name}
 
         <small class="authorized-by">
             <span data-bind="if: nodeHasAuth">
-                authorized by <a data-bind="attr.href: urls().owner">
-                    {{ownerName}}
-                </a>
+                authorized by <a data-bind="attr: {href: urls().owner}, text: ownerName"></a>
                 % if not is_registration:
                     <a data-bind="click: deauthorize"
                         class="text-danger pull-right addon-auth">Disconnect Account</a>
@@ -43,7 +41,7 @@
                 <!-- The linked Dataverse Host -->
                 <p class="break-word">
                     <strong>Dataverse Repository:</strong>
-                    <a data-bind="attr.href: savedHostUrl()">{{ savedHost }}</a>
+                    <a data-bind="attr: {href: savedHostUrl()}, text: savedHost"></a>
                 </p>
 
                 <!-- The linked dataset -->
@@ -51,8 +49,8 @@
                     <strong>Current Dataset:</strong>
                     <span data-bind="ifnot: submitting">
                         <span data-bind="if: showLinkedDataset">
-                            <a data-bind="attr.href: savedDatasetUrl()"> {{ savedDatasetTitle }}</a> on
-                            <a data-bind="attr.href: savedDataverseUrl()"> {{ savedDataverseTitle }} Dataverse</a>.
+                            <a data-bind="attr: {href: savedDatasetUrl()}, text: savedDatasetTitle"></a> on
+                            <a data-bind="attr: {href: savedDataverseUrl()}, text: savedDataverseTitle || '' + Dataverse"></a>.
                         </span>
                         <span data-bind="ifnot: showLinkedDataset" class="text-muted">
                             None
@@ -128,6 +126,6 @@
     </div>
     <!-- Flashed Messages -->
     <div class="help-block">
-        <p data-bind="html: message, attr.class: messageClass"></p>
+        <p data-bind="html: message, attr: {class: messageClass}"></p>
     </div>
 </div>

--- a/website/addons/dataverse/templates/dataverse_user_settings.mako
+++ b/website/addons/dataverse/templates/dataverse_user_settings.mako
@@ -6,8 +6,8 @@
     <%include file="dataverse_credentials_modal.mako"/>
 
     <h4 class="addon-title">
-        <img class="addon-icon" src=${addon_icon_url}></img>
-        {{ properName }}
+        <img class="addon-icon" src=${addon_icon_url}>
+        <span data-bind="text: properName"></span> <!-- TODO: Can we use mako addon_full_name as some other addons do? -->
         <small>
             <a href="#dataverseInputCredentials" data-toggle="modal" class="pull-right text-primary">Connect Account</a>
         </small>
@@ -20,14 +20,14 @@
             <table class="table table-hover">
                 <thead>
                     <tr class="user-settings-addon-auth">
-                        <th class="text-muted default-authorized-by">Authorized on <a data-bind="attr.href: dataverseUrl"><em>{{ dataverseHost }}</em></a></th>
+                        <th class="text-muted default-authorized-by">Authorized on <a data-bind="attr: {href: dataverseUrl}"><em data-bind="text: dataverseHost"></em></a></th>
                     </tr>
                 </thead>
                 <!-- ko if: connectedNodes().length > 0 -->
                 <tbody data-bind="foreach: connectedNodes()">
                     <tr>
                         <td class="authorized-nodes">
-                            <!-- ko if: title --><a data-bind="attr.href: urls.view">{{ title }}</a><!-- /ko -->
+                            <!-- ko if: title --><a data-bind="attr: {href: urls.view}, text: title"></a><!-- /ko -->
                             <!-- ko if: !title --><em>Private project</em><!-- /ko -->
                         </td>
                         <td>

--- a/website/addons/forward/templates/forward_node_settings.mako
+++ b/website/addons/forward/templates/forward_node_settings.mako
@@ -47,7 +47,7 @@
 
             <div class="row">
                 <div class="col-md-10 overflow">
-                    <p data-bind="html: message, attr.class: messageClass"></p>
+                    <p data-bind="html: message, attr: {class: messageClass}"></p>
                 </div>
                 <div class="col-md-2">
                     <input type="submit"

--- a/website/addons/s3/static/s3NodeConfig.js
+++ b/website/addons/s3/static/s3NodeConfig.js
@@ -1,6 +1,5 @@
 'use strict';
 var ko = require('knockout');
-require('knockout.punches');
 var $ = require('jquery');
 var bootbox = require('bootbox');
 var Raven = require('raven-js');
@@ -8,8 +7,6 @@ var Raven = require('raven-js');
 var $osf = require('js/osfHelpers');
 
 var s3Settings = require('json!./settings.json');
-
-ko.punches.enableAll();
 
 var defaultSettings = {
     url: '',

--- a/website/addons/s3/templates/s3_node_settings.mako
+++ b/website/addons/s3/templates/s3_node_settings.mako
@@ -1,12 +1,10 @@
  <div id="s3Scope" class="scripted">
     <h4 class="addon-title">
-        <img class="addon-icon" src="${addon_icon_url}"></img>
+        <img class="addon-icon" src="${addon_icon_url}">
         Amazon S3
         <small class="authorized-by">
             <span data-bind="if: nodeHasAuth">
-                authorized by <a data-bind="attr.href: urls().owner">
-                {{ownerName}}
-                </a>
+                authorized by <a data-bind="attr: {href: urls().owner}, text: ownerName"></a>
                 % if not is_registration:
                     <a data-bind="click: deauthorizeNode" class="text-danger pull-right addon-auth">
                       Disconnect Account
@@ -28,15 +26,13 @@
           <span data-bind="ifnot: currentBucket">
             None
           </span>
-          <a data-bind="if: currentBucket, attr.href: urls().files">
-            {{currentBucket}}
-          </a>
+          <a data-bind="if: currentBucket, attr: {href: urls().files}, text: currentBucket"></a>
         </p>
-        <div data-bind="attr.disabled: creating">
+        <div data-bind="attr: {disabled: creating}">
           <button data-bind="visible: canChange, click: toggleSelect,
                              css: {active: showSelect}" class="btn btn-primary">Change</button>
           <button data-bind="visible: showNewBucket, click: openCreateBucket,
-                             attr.disabled: creating" class="btn btn-success" id="newBucket">Create Bucket</button>
+                             attr: {disabled: creating}" class="btn btn-success" id="newBucket">Create Bucket</button>
         </div>
         <br />
         <br />
@@ -44,7 +40,7 @@
           <div class="form-group col-md-8">
             <select class="form-control" id="s3_bucket" name="s3_bucket"
                     data-bind="value: selectedBucket,
-                               attr.disabled: !loadedBucketList(),
+                               attr: {disabled: !loadedBucketList()},
                                options: bucketList"> </select>
           </div>
           ## Remove comments to enable user toggling of file upload encryption
@@ -54,7 +50,7 @@
           ## </div>
           <div class="col-md-2">
             <button data-bind="click: selectBucket,
-                               attr.disabled: !allowSelectBucket(),
+                               attr: {disabled: !allowSelectBucket()},
                                text: saveButtonText"
                     class="btn btn-success">
               Save
@@ -74,12 +70,12 @@
         <input data-bind="value: secretKey" type="password" class="form-control" id="secret_key" name="secret_key" />
       </div>
       <button data-bind="click: createCredentials,
-                         attr.disabled: creatingCredentials" class="btn btn-success addon-settings-submit">
+                         attr: {disabled: creatingCredentials}" class="btn btn-success addon-settings-submit">
         Save
       </button>
     </div>
     <!-- Flashed Messages -->
     <div class="help-block">
-        <p data-bind="html: message, attr.class: messageClass"></p>
+        <p data-bind="html: message, attr: {class: messageClass}"></p>
     </div>
 </div>

--- a/website/addons/twofactor/templates/twofactor_user_settings.mako
+++ b/website/addons/twofactor/templates/twofactor_user_settings.mako
@@ -37,7 +37,7 @@
             <input type="submit" value="Submit" class="btn btn-primary">
           </div>
           <div class="help-block">
-            <p data-bind="html: message, attr.class: messageClass"></p>
+            <p data-bind="html: message, attr: {class: messageClass}"></p>
           </div>
         </div>
       </form>

--- a/website/static/js/accountSettings.js
+++ b/website/static/js/accountSettings.js
@@ -8,9 +8,6 @@ var oop = require('js/oop');
 var Raven = require('raven-js');
 var ChangeMessageMixin = require('js/changeMessage');
 
-require('knockout.punches');
-ko.punches.enableAll();
-
 
 var UserEmail = oop.defclass({
     constructor: function(params) {

--- a/website/static/js/addonNodeConfig.js
+++ b/website/static/js/addonNodeConfig.js
@@ -5,7 +5,6 @@
 'use strict';
 
 var ko = require('knockout');
-require('knockout.punches');
 var $ = require('jquery');
 var Raven = require('raven-js');
 
@@ -15,7 +14,6 @@ var $osf = require('js/osfHelpers');
 var oop = require('js/oop');
 var FolderPickerViewModel = require('js/folderPickerNodeConfig');
 
-ko.punches.enableAll();
 
 /**
  * View model to support instances of AddonNodeConfig (folder picker widget)

--- a/website/static/js/citationsNodeConfig.js
+++ b/website/static/js/citationsNodeConfig.js
@@ -5,7 +5,6 @@
 'use strict';
 
 var ko = require('knockout');
-require('knockout.punches');
 var $ = require('jquery');
 var Raven = require('raven-js');
 var bootbox = require('bootbox');
@@ -15,7 +14,6 @@ var $osf = require('js/osfHelpers');
 var oop = require('js/oop');
 var FolderPickerViewModel = require('js/folderPickerNodeConfig');
 
-ko.punches.enableAll();
 
 /**
  * View model to support instances of CitationsNodeConfig (folder picker widget)

--- a/website/static/js/folderPickerNodeConfig.js
+++ b/website/static/js/folderPickerNodeConfig.js
@@ -5,7 +5,6 @@
 'use strict';
 require('css/addon_folderpicker.css');
 var ko = require('knockout');
-require('knockout.punches');
 var $ = require('jquery');
 var bootbox = require('bootbox');
 var Raven = require('raven-js');
@@ -19,7 +18,6 @@ var $osf = require('js/osfHelpers');
 
 var oop = require('js/oop');
 
-ko.punches.enableAll();
 
 /**
  * @class FolderPickerViewModel

--- a/website/static/js/koHelpers.js
+++ b/website/static/js/koHelpers.js
@@ -209,6 +209,46 @@ ko.bindingHandlers.fadeVisible = {
     }
 };
 
+var fitHelper = function(value, length, replacement, trimWhere) {
+    if (length && ('' + value).length > length) {
+        replacement = '' + (replacement || '...');
+        length = length - replacement.length;
+        value = '' + value;
+        switch (trimWhere) {
+            case 'left':
+                return replacement + value.slice(-length);
+            case 'middle':
+                var leftLen = Math.ceil(length / 2);
+                return value.substr(0, leftLen) + replacement + value.slice(leftLen-length);
+            default:
+                return value.substr(0, length) + replacement;
+        }
+    } else {
+        return value;
+    }
+};
+/**
+    Trim the text to a specified width. Adapted from knockout.punches "fit" filter
+    Behavior can be modified by the presence of additional related bindings on the same element:
+
+ // TODO: Document hash of inputs
+    - fitLength : specifies the maximum number of characters to include (default no limit)
+    - fitReplacement : Specifies the sequence to use in place of trimmed characters (default `...`)
+    - fitTrimWhere : Trim extra characters from the left, middle, or right side. (default right)
+*/
+ko.bindingHandlers.fitText = {
+    update: function(element, valueAccessor, allBindings) {
+        var value = ko.unwrap(valueAccessor());
+        var trimValue = fitHelper(
+            value.text,
+            value.length,
+            value.replacement,
+            value.trimWhere
+        );
+        $(element).text(trimValue);
+    }
+};
+
 var tooltip = function(el, valueAccessor) {
     var params = valueAccessor();
     $(el).tooltip(params);
@@ -433,6 +473,7 @@ ko.virtualElements.allowedBindings.stopBinding = true;
 module.exports = {
     makeExtender: makeExtender,
     addExtender: addExtender,
+    _fitHelper: fitHelper,
     makeRegexValidator: makeRegexValidator,
     sanitizedObservable: sanitizedObservable,
     mapJStoKO: mapJStoKO

--- a/website/static/js/koHelpers.js
+++ b/website/static/js/koHelpers.js
@@ -230,11 +230,11 @@ var fitHelper = function(value, length, replacement, trimWhere) {
 /**
     Trim the text to a specified width. Adapted from knockout.punches "fit" filter
     Behavior can be modified by the presence of additional related bindings on the same element:
-
- // TODO: Document hash of inputs
-    - fitLength : specifies the maximum number of characters to include (default no limit)
-    - fitReplacement : Specifies the sequence to use in place of trimmed characters (default `...`)
-    - fitTrimWhere : Trim extra characters from the left, middle, or right side. (default right)
+    @param value {Object} A hash of options describing the text to truncate, and how
+    @param value.text {String} The string to truncate
+    @param value.length {Integer}  Specifies the maximum length of the truncated string (default no limit)
+    @param [value.replacement='...'] {String} Specifies the sequence to use in place of trimmed characters
+    @param [value.trimWhere='right'] {String} Trim extra characters from the left, middle, or right side
 */
 ko.bindingHandlers.fitText = {
     update: function(element, valueAccessor, allBindings) {

--- a/website/static/js/notificationsConfig.js
+++ b/website/static/js/notificationsConfig.js
@@ -1,10 +1,9 @@
 'use strict';
 
 var ko = require('knockout');
-require('knockout.punches');
 var $ = require('jquery');
 var $osf = require('js/osfHelpers');
-ko.punches.enableAll();
+
 
 var ViewModel = function(list) {
     var self = this;

--- a/website/static/js/oauthAddonNodeConfig.js
+++ b/website/static/js/oauthAddonNodeConfig.js
@@ -5,7 +5,6 @@
 'use strict';
 
 var ko = require('knockout');
-require('knockout.punches');
 var $ = require('jquery');
 var Raven = require('raven-js');
 var bootbox = require('bootbox');
@@ -14,7 +13,6 @@ var $osf = require('js/osfHelpers');
 var oop = require('js/oop');
 var FolderPickerViewModel = require('js/folderPickerNodeConfig');
 
-ko.punches.enableAll();
 
 /**
  * View model to support instances of AddonNodeConfig (folder picker widget)

--- a/website/static/js/pages/profile-settings-addons-page.js
+++ b/website/static/js/pages/profile-settings-addons-page.js
@@ -10,8 +10,6 @@ var $osf = require('js/osfHelpers');
 var AddonPermissionsTable = require('js/addonPermissions');
 var addonSettings = require('js/addonSettings');
 
-ko.punches.enableAll();
-
 
 // Show capabilities modal on selecting an addon; unselect if user
 // rejects terms

--- a/website/static/js/profile.js
+++ b/website/static/js/profile.js
@@ -6,7 +6,6 @@ var ko = require('knockout');
 var bootbox = require('bootbox');
 require('knockout.validation');
 require('knockout.punches');
-ko.punches.enableAll();
 require('knockout-sortable');
 
 var $osf = require('./osfHelpers');

--- a/website/static/js/search.js
+++ b/website/static/js/search.js
@@ -12,8 +12,7 @@ var DEFAULT_LICENSE = siteLicenses.DEFAULT_LICENSE;
 var OTHER_LICENSE = siteLicenses.OTHER_LICENSE;
 
 var $osf = require('js/osfHelpers');
-// Enable knockout punches
-ko.punches.enableAll();
+
 
 // Disable IE Caching of JSON
 $.ajaxSetup({ cache: false });

--- a/website/static/js/signUp.js
+++ b/website/static/js/signUp.js
@@ -2,12 +2,10 @@
 
 var ko = require('knockout');
 require('knockout.validation');
-require('knockout.punches');
 var $ = require('jquery');
 
 var $osf = require('./osfHelpers');
 
-ko.punches.enableAll();
 
 var ViewModel = function(submitUrl, campaign) {
 

--- a/website/static/js/tests/koHelpers.test.js
+++ b/website/static/js/tests/koHelpers.test.js
@@ -18,6 +18,23 @@ describe('koHelpers', () => {
         });
     });
 
+    describe('fitTextHelper', () => {
+        it('correctly processes various strings', () => {
+            // Test the underlying method; adapted from https://github.com/mbest/knockout.punches/blob/master/spec/textFilterSpec.js#L78
+            var cases = [
+                [{text: 'someText', length: 8}, 'someText'],
+                [{text: 'someText', length: 7}, 'some...'],
+                [{text: 'someText', length: 7, replacement: '!'}, 'someTe!'],
+                [{text: 'someText', length: 7, trimWhere: 'left'}, '...Text'],
+                [{text: 'someText', length: 7, trimWhere: 'middle'}, 'so...xt']
+            ];
+            cases.forEach(([{text, length, replacement, trimWhere}, expectedResult]) => {
+                let actualResult = koHelpers._fitHelper(text, length, replacement, trimWhere);
+                assert.equal(actualResult, expectedResult, text + ' is truncated correctly');
+            });
+        });
+    });
+
     // TODO: test custom validators
 
     describe('mapJStoKO', () => {

--- a/website/templates/include/profile/jobs.mako
+++ b/website/templates/include/profile/jobs.mako
@@ -16,7 +16,7 @@
                 <div>
 
                     <div class="well well-sm sort-handle">
-                        <span>Position {{ $index() + 1 }}</span>
+                        <span>Position <span data-bind="text: $index() + 1"></span></span>
                         <span data-bind="visible: $parent.contentsLength() > 1">
                             [ drag to reorder ]
                         </span>
@@ -117,7 +117,7 @@
 
             <!-- Flashed Messages -->
             <div class="help-block">
-                <p data-bind="html: message, attr.class: messageClass"></p>
+                <p data-bind="html: message, attr: {class: messageClass}"></p>
             </div>
 
         </form>
@@ -138,16 +138,20 @@
                         <div class="panel panel-default">
                             <div class="panel-heading card-heading" data-bind="click: toggle(), attr: {id: 'jobHeading' + $index(), href: '#jobCard' + $index()}" role="button" data-toggle="collapse" aria-controls="card" aria-expanded="false">
                                 <div class="header-content">
-                                    <h5 class="institution">{{ institution }}</h5>
-                                    <span data-bind="if: startYear()" class="subheading">{{ startMonth }} {{startYear }} - {{ endView }}</span>
+                                    <h5 class="institution" data-bind="text: institution"></h5>
+                                    <span data-bind="if: startYear()" class="subheading">
+                                        <span data-bind="text: startMonth"></span> <span data-bind="text: startYear"></span> - <span data-bind="text: endView"></span>
+                                    </span>
                                 </div>
                                 <span data-bind="attr: {class: expanded() ? 'fa toggle-icon fa-angle-down' : 'fa toggle-icon fa-angle-up'}"></span>
                             </div>
                             <div data-bind="attr: {id: 'jobCard' + $index(), aria-labelledby: 'jobHeading' + $index()}" class="panel-collapse collapse">
                                 <div class="panel-body">
-                                    <span data-bind="if: department().length"><h5>Department:</h5> {{ department }}</span>
-                                    <span data-bind="if: title().length"><h5>Title:</h5> {{ title }}</span>
-                                    <span data-bind="if: startYear()"><h5>Dates:</h5> {{ startMonth }} {{startYear }} - {{ endView }}</span>
+                                    <span data-bind="if: department().length"><h5>Department:</h5> <span data-bind="text: department"></span></span>
+                                    <span data-bind="if: title().length"><h5>Title:</h5> <span data-bind="text: title"></span></span>
+                                    <span data-bind="if: startYear()"><h5>Dates:</h5>
+                                        <span data-bind="text: startMonth"></span> <span data-bind="text: startYear"></span> - <span data-bind="text: endView"></span>
+                                    </span>
                                 </div>
                             </div>
                         </div>
@@ -156,7 +160,7 @@
                         <div class="panel panel-default">
                             <div class="panel-heading no-bottom-border">
                                 <div>
-                                    <h5>{{ institution }}</h5>
+                                    <h5 data-bind="text: institution"></h5>
                                 </div>
                             </div>
                         </div>

--- a/website/templates/include/profile/names.mako
+++ b/website/templates/include/profile/names.mako
@@ -54,11 +54,11 @@
             <tbody>
                 <tr>
                     <td>APA</td>
-                    <td class="overflow-block" width="30%">{{ citeApa }}</td>
+                    <td class="overflow-block" width="30%"><span data-bind="text: citeApa"></span></td>
                 </tr>
                 <tr>
                     <td>MLA</td>
-                    <td class="overflow-block" width="30%">{{ citeMla }}</td>
+                    <td class="overflow-block" width="30%"><span data-bind="citeMla"></span></td>
                 </tr>
             </tbody>
         </table>
@@ -80,7 +80,7 @@
 
         <!-- Flashed Messages -->
         <div class="help-block">
-            <p data-bind="html: message, attr.class: messageClass"></p>
+            <p data-bind="html: message, attr: {class: messageClass}"></p>
         </div>
 
     </form>

--- a/website/templates/include/profile/names.mako
+++ b/website/templates/include/profile/names.mako
@@ -58,7 +58,7 @@
                 </tr>
                 <tr>
                     <td>MLA</td>
-                    <td class="overflow-block" width="30%"><span data-bind="citeMla"></span></td>
+                    <td class="overflow-block" width="30%"><span data-bind="text: citeMla"></span></td>
                 </tr>
             </tbody>
         </table>

--- a/website/templates/include/profile/schools.mako
+++ b/website/templates/include/profile/schools.mako
@@ -16,7 +16,7 @@
                 <div>
 
                     <div class="well well-sm sort-handle">
-                        <span>Position {{ $index() + 1 }}</span>
+                        <span>Position <span data-bind="$index() + 1"></span></span>
                         <span data-bind="visible: $parent.contentsLength() > 1">
                             [ drag to reorder ]
                         </span>
@@ -117,7 +117,7 @@
 
             <!-- Flashed Messages -->
             <div class="help-block">
-                <p data-bind="html: message, attr.class: messageClass"></p>
+                <p data-bind="html: message, attr: {class: messageClass}"></p>
             </div>
 
         </form>
@@ -137,16 +137,20 @@
                         <div class="panel panel-default">
                             <div class="panel-heading card-heading" data-bind="click: toggle(), attr: {id: 'schoolHeading' + $index(), href: '#schoolCard' + $index()}" role="button" data-toggle="collapse" aria-controls="card" aria-expanded="false">
                                 <div class="header-content">
-                                    <h5 class="institution">{{ institution }}</h5>
-                                    <span data-bind="if: startYear()" class="subheading">{{ startMonth }} {{startYear }} - {{ endView }}</span>
+                                    <h5 class="institution" data-bind="institution"></h5>
+                                    <span data-bind="if: startYear()" class="subheading">
+                                        <span data-bind="text: startMonth"></span> <span data-bind="text: startYear"></span> - <span data-bind="text: endView"></span>
+                                    </span>
                                 </div>
                                 <span data-bind="attr: {class: expanded() ? 'fa toggle-icon fa-angle-down' : 'fa toggle-icon fa-angle-up'}"></span>
                             </div>
                             <div data-bind="attr: {id: 'schoolCard' + $index(), aria-labelledby: 'schoolHeading' + $index()}" class="panel-collapse collapse">
                                 <div class="panel-body">
-                                    <span data-bind="if: department().length"><h5>Department:</h5> {{ department }}</span>
-                                    <span data-bind="if: degree().length"><h5>Degree:</h5> {{ degree }}</span>
-                                    <span data-bind="if: startYear()"><h5>Dates:</h5> {{ startMonth }} {{startYear }} - {{ endView }}</span>
+                                    <span data-bind="if: department().length"><h5>Department:</h5> <span data-bind="text: department"></span></span>
+                                    <span data-bind="if: degree().length"><h5>Degree:</h5> <span data-bind="text: degree"></span></span>
+                                    <span data-bind="if: startYear()"><h5>Dates:</h5>
+                                        <span data-bind="text: startMonth"></span> <span data-bind="text: startYear"></span> - <span data-bind="text: endView"></span>
+                                    </span>
                                 </div>
                             </div>
                         </div>
@@ -155,7 +159,7 @@
                         <div class="panel panel-default">
                             <div class="panel-heading no-bottom-border">
                                 <div>
-                                    <h5>{{ institution }}</h5>
+                                    <h5 data-bind="text: institution"></h5>
                                 </div>
                             </div>
                         </div>

--- a/website/templates/include/profile/schools.mako
+++ b/website/templates/include/profile/schools.mako
@@ -16,7 +16,7 @@
                 <div>
 
                     <div class="well well-sm sort-handle">
-                        <span>Position <span data-bind="$index() + 1"></span></span>
+                        <span>Position <span data-bind="text: $index() + 1"></span></span>
                         <span data-bind="visible: $parent.contentsLength() > 1">
                             [ drag to reorder ]
                         </span>
@@ -137,7 +137,7 @@
                         <div class="panel panel-default">
                             <div class="panel-heading card-heading" data-bind="click: toggle(), attr: {id: 'schoolHeading' + $index(), href: '#schoolCard' + $index()}" role="button" data-toggle="collapse" aria-controls="card" aria-expanded="false">
                                 <div class="header-content">
-                                    <h5 class="institution" data-bind="institution"></h5>
+                                    <h5 class="institution" data-bind="text: institution"></h5>
                                     <span data-bind="if: startYear()" class="subheading">
                                         <span data-bind="text: startMonth"></span> <span data-bind="text: startYear"></span> - <span data-bind="text: endView"></span>
                                     </span>

--- a/website/templates/include/profile/social.mako
+++ b/website/templates/include/profile/social.mako
@@ -137,7 +137,7 @@
 
             <!-- Flashed Messages -->
             <div class="help-block">
-                <p data-bind="html: message, attr.class: messageClass"></p>
+                <p data-bind="html: message, attr: {class: messageClass}"></p>
             </div>
 
         </form>
@@ -151,14 +151,14 @@
                 <tr data-bind="if: hasProfileWebsites()">
                     <td data-bind="visible: profileWebsites().length > 1">Personal websites</td>
                     <td data-bind="visible: profileWebsites().length === 1">Personal website</td>
-                    <td data-bind="foreach: profileWebsites"><a target="_blank" data-bind="attr.href: $data">{{ $data }}</a></br></td>
+                    <td data-bind="foreach: profileWebsites"><a target="_blank" data-bind="attr: {href: $data}, text: $data"></a><br></td>
                 </tr>
             </tbody>
 
             <tbody data-bind="foreach: values">
                 <tr data-bind="if: value">
-                    <td>{{ label }}</td>
-                    <td><a target="_blank" data-bind="attr.href: value">{{ text }}</a></td>
+                    <td><span data-bind="text: label"></span></td>
+                    <td><a target="_blank" data-bind="attr: {href: value}, text: text"></a></td>
                 </tr>
             </tbody>
         </table>

--- a/website/templates/index.mako
+++ b/website/templates/index.mako
@@ -70,7 +70,7 @@
 
                           <!-- Flashed Messages -->
                           <div class="help-block osf-box-lt" >
-                              <p data-bind="html: flashMessage, attr.class: flashMessageClass" class=""></p>
+                              <p data-bind="html: flashMessage, attr: {class: flashMessageClass}" class=""></p>
                           </div>
                           <!-- ko ifnot: submitted -->
                           <div>

--- a/website/templates/profile/account.mako
+++ b/website/templates/profile/account.mako
@@ -28,7 +28,7 @@
                             </thead>
                             <tbody>
                                 <tr>
-                                    <td>{{ profile().primaryEmail().address }}</td>
+                                    <td><span data-bind="text: profile().primaryEmail().address"></span></td>
                                     <td></td>
                                 </tr>
                             </tbody>
@@ -42,7 +42,7 @@
                             </thead>
                             <tbody data-bind="foreach: profile().alternateEmails()">
                                 <tr>
-                                    <td style="word-break: break-all;">{{ $data.address }}</td>
+                                    <td style="word-break: break-all;"><span data-bind="text: $data.address"></span></td>
                                     <td style="width:150px;"><a data-bind="click: $parent.makeEmailPrimary">make&nbsp;primary</a></td>
                                     <td style="width:50px;"><a data-bind="click: $parent.removeEmail"><i class="fa fa-times text-danger"></i></a></td>
                                 </tr>
@@ -57,7 +57,7 @@
                             <tbody>
                                 <!-- ko foreach: profile().unconfirmedEmails() -->
                                 <tr>
-                                    <td style="word-break: break-all;">{{ $data.address }}</td>
+                                    <td style="word-break: break-all;"><span data-bind="text: $data.address"></span></td>
                                     <td style="width:150px;"><a data-bind="click: $parent.resendConfirmation">resend&nbsp;confirmation</a></td>
                                     <td style="width:50px;" ><a data-bind="click: $parent.removeEmail"><i class="fa fa-times text-danger"></i></a></td>
                                 </tr>

--- a/website/templates/profile/oauth_app_detail.mako
+++ b/website/templates/profile/oauth_app_detail.mako
@@ -76,7 +76,7 @@
 
                     <!-- Flashed Messages -->
                     <div class="help-block">
-                        <p data-bind="html: $root.message, attr.class: $root.messageClass"></p>
+                        <p data-bind="html: $root.message, attr: {class: $root.messageClass}"></p>
                     </div>
 
                     <div class="padded">

--- a/website/templates/profile/personal_tokens_detail.mako
+++ b/website/templates/profile/personal_tokens_detail.mako
@@ -54,7 +54,7 @@
 
                     <!-- Flashed Messages -->
                     <div class="help-block">
-                        <p data-bind="html: $root.message, attr.class: $root.messageClass"></p>
+                        <p data-bind="html: $root.message, attr: {class: $root.messageClass}"></p>
                     </div>
 
                     <div class="padded">

--- a/website/templates/profile/user_settings_default.mako
+++ b/website/templates/profile/user_settings_default.mako
@@ -24,7 +24,7 @@
                 <tbody data-bind="foreach: connectedNodes()">
                     <tr>
                         <td class="authorized-nodes">
-                            <!-- ko if: title --><a data-bind="attr.href: urls.view, text: title"></a><!-- /ko -->
+                            <!-- ko if: title --><a data-bind="attr: {href: urls.view}, text: title"></a><!-- /ko -->
                             <!-- ko if: !title --><em>Private project</em><!-- /ko -->
                         </td>
                         <td>

--- a/website/templates/project/addon/node_settings_default.mako
+++ b/website/templates/project/addon/node_settings_default.mako
@@ -1,12 +1,10 @@
 <div id="${addon_short_name}Scope" class="scripted">
     <h4 class="addon-title">
-        <img class="addon-icon" src=${addon_icon_url}></img>
+        <img class="addon-icon" src=${addon_icon_url}>
         ${addon_full_name}
         <small class="authorized-by">
             <span data-bind="if: nodeHasAuth">
-                authorized by <a data-bind="attr.href: urls().owner">
-                    {{ownerName}}
-                </a>
+                authorized by <a data-bind="attr: {href: urls().owner}, text: ownerName"></a>
                 % if not is_registration:
                     <a data-bind="click: deauthorize, visible: validCredentials"
                         class="text-danger pull-right addon-auth">Disconnect Account</a>
@@ -41,9 +39,9 @@
             <div class="col-md-12">
                 <p class="break-word">
                     <strong>Current Folder:</strong>
-                    <a href="{{ urls().files }}" data-bind="if: folderName">
-                        {{ folderName }}
-                    </a>
+                    <span data-bind="if: folderName">
+                        <a data-bind="attr: {href: urls().files}, text: folderName"></a>
+                    </span>
                     <span class="text-muted" data-bind="ifnot: folderName">
                         None
                     </span>
@@ -65,7 +63,7 @@
                         <form data-bind="submit: submitSettings">
                             <div class="break-word">
                                 <div data-bind="if: selected" class="alert alert-info ${addon_short_name}-confirm-dlg">
-                                    Connect <b>&ldquo;{{ selectedFolderName }}&rdquo;</b>?
+                                    Connect <b>&ldquo;<span data-bind="text: selectedFolderName"></span>&rdquo;</b>?
                                 </div>
                             </div>
                             <div class="pull-right">
@@ -84,6 +82,6 @@
     </div>
     <!-- Flashed Messages -->
     <div class="help-block">
-        <p data-bind="html: message, attr.class: messageClass"></p>
+        <p data-bind="html: message, attr: {class: messageClass}"></p>
     </div>
 </div>

--- a/website/templates/project/edit_draft_registration.mako
+++ b/website/templates/project/edit_draft_registration.mako
@@ -33,7 +33,7 @@
                     <div data-bind="visible: hasRequiredQuestions" class="progress progress-bar-md">
                         <div data-bind="progress: completion"></div>
                         <div class="progress-bar progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100"
-                             data-bind="attr.aria-completion: completion,
+                             data-bind="attr: {aria-completion: completion},
                                         style: {width: completion() + '%'}">
                         </div>
                     </div>

--- a/website/templates/project/edit_draft_registration.mako
+++ b/website/templates/project/edit_draft_registration.mako
@@ -33,7 +33,7 @@
                     <div data-bind="visible: hasRequiredQuestions" class="progress progress-bar-md">
                         <div data-bind="progress: completion"></div>
                         <div class="progress-bar progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100"
-                             data-bind="attr: {aria-completion: completion},
+                             data-bind="attr: {'aria-completion': completion},
                                         style: {width: completion() + '%'}">
                         </div>
                     </div>

--- a/website/templates/project/register.mako
+++ b/website/templates/project/register.mako
@@ -9,13 +9,13 @@
       <div class="col-md-2">
         <ul class="nav nav-stacked list-group" data-bind="foreach: {data: metaSchema.schema.pages, as: 'page'}, visible: metaSchema.schema.pages.length > 1">
           <li class="re-navbar">
-            <a class="registration-editor-page" id="top-nav" style="text-align: left; font-weight:bold;" data-bind="text: title, attr.href: '#' + page.id">
+            <a class="registration-editor-page" id="top-nav" style="text-align: left; font-weight:bold;" data-bind="text: title, attr: {href: '#' + page.id}">
             </a>
             <span class="btn-group-vertical" role="group">
               <ul class="list-group" data-bind="foreach: {data: Object.keys(page.questions), as: 'qid'}">
                 <span data-bind="with: page.questions[qid]">
                   <li class="registration-editor-question list-group-item">
-                    <a data-bind="text: nav, attr.href: '#' + qid"></a>
+                    <a data-bind="text: nav, attr: {href: '#' + qid}"></a>
                   </li>
                 </span>
               </ul>
@@ -25,11 +25,11 @@
       </div>
       <div class="col-md-9" style="padding-left: 30px">
         <div data-bind="foreach: {data: metaSchema.pages, as: 'page'}">
-          <h3 data-bind="attr.id: page.id, text: page.title"></h3>
+          <h3 data-bind="attr: {id: page.id}, text: page.title"></h3>
           <div class="row">
             <div data-bind="foreach: {data: page.questions, as: 'question'}">
               <div class="row">
-                <h4 data-bind="attr.id: question.id, text: question.title"></h4>
+                <h4 data-bind="attr: {id: question.id}, text: question.title"></h4>
                 <small><em data-bind="text: question.description"></em></small>
                 <div class="col-md-12 well">
                   <span data-bind="if: question.value()">

--- a/website/templates/project/register_draft.mako
+++ b/website/templates/project/register_draft.mako
@@ -12,10 +12,10 @@
     <div class="row">
       <div class="col-lg-12 large-12" style="padding-left: 30px">
          <div data-bind="foreach: {data: draft.pages, as: 'page'}">
-           <h3 data-bind="attr.id: page.id, text: page.title"></h3>
+           <h3 data-bind="attr: {id: page.id}, text: page.title"></h3>
              <div data-bind="foreach: {data: page.questions, as: 'question'}">
                <p>
-                 <strong data-bind="attr.id: question.id, text: question.title"></strong>:
+                 <strong data-bind="attr: {id: question.id}, text: question.title"></strong>:
                  <span data-bind="previewQuestion: $root.editor.context(question, $root.editor)"></span>
                </p>
              </div>

--- a/website/templates/project/registration_editor_extensions.mako
+++ b/website/templates/project/registration_editor_extensions.mako
@@ -11,7 +11,7 @@
             style="margin-left: 5px;"
             class="btn btn-xs btn-danger fa fa-times"></button>
   </div>
-  <div data-bind="attr.id: $data.uid, osfUploader">
+  <div data-bind="attr: {id: $data.uid}, osfUploader"><!-- TODO: osfUploader attribute may not connect to anything? -->
     <div class="spinner-loading-wrapper">
       <div class="logo-spin logo-lg"></div>
       <p class="m-t-sm fg-load-message"> Loading files...  </p>
@@ -29,7 +29,7 @@
   </div>
   <a data-bind="click: toggleUploader">Attach File</a>
   <span data-bind="visible: showUploader">
-    <div data-bind="attr.id: $data.uid, osfUploader">
+    <div data-bind="attr: {id: $data.uid}, osfUploader">
       <div class="container">
 	<p class="m-t-sm fg-load-message">
           <span class="logo-spin logo-sm"></span>  Loading files...

--- a/website/templates/project/registration_editor_templates.mako
+++ b/website/templates/project/registration_editor_templates.mako
@@ -11,7 +11,7 @@
 <script type="text/html" id="match">
   <input data-bind="valueUpdate: 'keyup',
                     value: value,
-                    attr.placeholder: match" type="text" class="form-control" />
+                    attr: {placeholder: match}" type="text" class="form-control" />
 </script>
 <script type="text/html" id="textarea">
   <textarea data-bind="valueUpdate: 'keyup',
@@ -37,7 +37,7 @@
     <p data-bind="if: Boolean(option.tooltip)">
       <input type="radio" data-bind="checked: $parent.value,
                                      value: option.text"/>
-        {{option.text}}
+        <label data-bind="text: option.text"></label>
       <span data-bind="tooltip: {title: option.tooltip}" class="fa fa-info-circle"></span>
     </p>
   </div>
@@ -45,15 +45,15 @@
 <script type="text/html" id="multiselect">
   <div class="col-md-12" data-bind="foreach: {data: options, as: 'option'}">
     <p data-bind="if: !Boolean(option.tooltip)">
-      <input type="checkbox" data-bind="attr.value: option,
+      <input type="checkbox" data-bind="attr: {value: option},
                                         checked: $parent.value,
                                         checkedValue: option" />
       <span data-bind="text: option"></span>
     </p>
-    <p data-bind="if: Boolean(option.tooltip)">
-      <input type="checkbox" data-bind="attr.value: option.text,
+    <p data-bind="if: Boolean(option.tooltip)"> <!-- TODO: Verify checkboxes -->
+      <input type="checkbox" data-bind="attr: {value: option.text},
                                         checked: $parent.value,
-                                        checkedValue: option"
+                                        checkedValue: option">
       <span data-bind="text: option.text, tooltip: {title: option.tooltip}"></span>
     </p>
   </div>

--- a/website/templates/project/registration_preview.mako
+++ b/website/templates/project/registration_preview.mako
@@ -4,13 +4,13 @@
           <!-- <div class="span8 col-md-2 columns eight large-8">
           <ul class="nav nav-stacked list-group" data-bind="foreach: {data: schema.pages, as: 'page'}">
           <li class="re-navbar">
-          <a class="registration-editor-page" id="top-nav" style="text-align: left; font-weight:bold;" data-bind="text: title, attr.href: '#' + page.id">
+          <a class="registration-editor-page" id="top-nav" style="text-align: left; font-weight:bold;" data-bind="text: title, attr: {href: '#' + page.id}">
           </a>
           <span class="btn-group-vertical" role="group">
           <ul class="list-group" data-bind="foreach: {data: Object.keys(page.questions), as: 'qid'}">
           <span data-bind="with: page.questions[qid]">
           <li class="registration-editor-question list-group-item">
-          <a data-bind="text: nav, attr.href: '#' + qid"></a>
+          <a data-bind="text: nav, attr: {href: '#' + qid}"></a>
           </li>
           </span>
           </ul>
@@ -20,10 +20,10 @@
           </div> -->
       <div class="span8 col-md-9 columns eight large-8" style="padding-left: 30px">
         <div data-bind="foreach: {data: schema.pages, as: 'page'}">
-          <h3 data-bind="attr.id: page.id, text: page.title"></h3>
+          <h3 data-bind="attr: {id: page.id}, text: page.title"></h3>
           <div data-bind="foreach: {data: Object.keys(page.questions), as: 'qid'}">
             <span data-bind="with: $parent.questions[qid]">
-              <h4 data-bind="attr.id: qid, text: title"></h4>
+              <h4 data-bind="attr: {id: qid}, text: title"></h4>
               <span data-bind="text: qid.description"></span>
             </span>
           </div>

--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -77,7 +77,7 @@
                     <div id="projectSettings" class="panel-body">
                         <div class="form-group">
                             <label>Category:</label>
-                            <select data-bind="attr.disabled: disabled, options: categoryOptions, optionsValue: 'value', optionsText: 'label', value: selectedCategory"></select>
+                            <select data-bind="attr: {disabled: disabled}, options: categoryOptions, optionsValue: 'value', optionsText: 'label', value: selectedCategory"></select>
                             <span data-bind="if: disabled" class="help-block">
                               A top-level project's category cannot be changed
                             </span>

--- a/website/templates/public/login.mako
+++ b/website/templates/public/login.mako
@@ -211,7 +211,7 @@
             </div>
             <!-- Flashed Messages -->
             <div class="help-block" >
-                <p data-bind="html: flashMessage, attr.class: flashMessageClass"></p>
+                <p data-bind="html: flashMessage, attr: {class: flashMessageClass}"></p>
             </div>
             <div>
                 <p> By clicking "Create account", you agree to our <a href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/TERMS_OF_USE.md">Terms</a> and that you have read our <a href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/PRIVACY_POLICY.md">Privacy Policy</a>, including our information on <a href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/PRIVACY_POLICY.md#f-cookies">Cookie Use</a>.</p>

--- a/website/templates/search.mako
+++ b/website/templates/search.mako
@@ -120,7 +120,7 @@
         <!-- /ko -->
 
         <!-- TODO: Add a "trimText" filter to replace the one we're losing from KO.punches; this display value should be a 500 char max limit-->
-        <h5>Description: <small data-bind="text: description || 'No Description'"></small></h5>
+        <h5>Description: <small data-bind="fitText: {text: description || 'No Description', length: 500}"></small></h5>
 
         <!-- ko if: contributors.length > 0 -->
         <h5>
@@ -235,8 +235,7 @@
         <h4><span data-bind="if: parent_title"><span data-bind="text: parent_title"></span> /</span> <a data-bind="attr: {href: url}, text: title"></a></h4>
         <!-- /ko -->
 
-        <!-- TODO: Write and use a replacement for the trimText filter here. Limit 500 characters -->
-        <p data-bind="visible: description"><strong>Description:</strong> <span data-bind="text: description"></span></p>
+        <p data-bind="visible: description"><strong>Description:</strong> <span data-bind="fitText: {text: description, length: 500}"></span></p>
 
         <!-- ko if: contributors.length > 0 -->
         <p>
@@ -276,8 +275,7 @@
         <!-- /ko -->
         <strong><span data-bind="text: 'Date Registered: ' + dateRegistered['local'], tooltip: {title: dateRegistered['utc']}"></span></strong>
 
-        <!-- TODO: Add trimText filter to restrict length to 500 chars -->
-        <p data-bind="visible: description"><strong>Description:</strong> <span data-bind="text: description>"></span></p>
+        <p data-bind="visible: description"><strong>Description:</strong> <span data-bind="fitText: {text: description, length: 500}"></span></p>
 
         <!-- ko if: contributors.length > 0 -->
         <p>

--- a/website/templates/search.mako
+++ b/website/templates/search.mako
@@ -18,15 +18,15 @@
                                 <ul class="nav nav-pills nav-stacked" data-bind="foreach: allCategories">
 
                                     <!-- ko if: $parent.category().name === name -->
-                                            <li class="active">
-                                                <a data-bind="click: $parent.filter.bind($data)">{{ display }}<span class="badge pull-right">{{count}}</span></a>
-                                            </li>
-                                        <!-- /ko -->
-                                        <!-- ko if: $parent.category().name !== name -->
-                                            <li>
-                                                <a data-bind="click: $parent.filter.bind($data)">{{ display }}<span class="badge pull-right">{{count}}</span></a>
-                                            </li>
-                                        <!-- /ko -->
+                                        <li class="active"> <!-- TODO: simplify markup; only the active class really needs to be conditional -->
+                                            <a data-bind="click: $parent.filter.bind($data)"><span data-bind="text: display"></span><span class="badge pull-right" data-bind="text: count"></span></a>
+                                        </li>
+                                    <!-- /ko -->
+                                    <!-- ko if: $parent.category().name !== name -->
+                                        <li>
+                                            <a data-bind="click: $parent.filter.bind($data)"><span data-bind="text: display"></span><span class="badge pull-right" data-bind="text: count"></span></a>
+                                        </li>
+                                    <!-- /ko -->
                                 </ul>
                             </div>
                         </div>
@@ -38,9 +38,7 @@
                                     <!-- ko if: count === $parent.tagMaxCount() && count > $parent.tagMaxCount()/2  -->
                                     <span class="tag tag-big tag-container"
                                           data-bind="click: $root.addTag.bind($parentContext, tag.name)">
-                                        <span class="cloud-text">
-                                            {{name}}
-                                        </span>
+                                        <span class="cloud-text" data-bind="text: name"></span>
                                         <i class="fa fa-times-circle remove-tag big"
                                            data-bind="click: $root.removeTag.bind($parentContext, tag.name)"></i>
                                     </span>
@@ -48,9 +46,7 @@
                                     <!-- ko if: count < $parent.tagMaxCount() && count > $parent.tagMaxCount()/2 -->
                                     <span class="tag tag-med tag-container"
                                           data-bind="click: $root.addTag.bind($parentContext, tag.name)">
-                                        <span class="cloud-text">
-                                            {{name}}
-                                        </span>
+                                        <span class="cloud-text" data-bind="text: name"></span>
                                         <i class="fa fa-times-circle remove-tag med"
                                            data-bind="click: $root.removeTag.bind($parentContext, tag.name)"></i>
                                     </span>
@@ -58,9 +54,7 @@
                                     <!-- ko if: count <= $parent.tagMaxCount()/2-->
                                     <span class="tag tag-sm tag-container"
                                           data-bind="click: $root.addTag.bind($parentContext, tag.name)">
-                                        <span class="cloud-text">
-                                            {{name}}
-                                        </span>
+                                        <span class="cloud-text" data-bind="text: name"></span>
                                         <i class="fa fa-times-circle remove-tag"
                                            data-bind="click: $root.removeTag.bind($parentContext, tag.name)"></i>
                                     </span>
@@ -78,7 +72,7 @@
                                     data-bind="foreach: {data: licenses, as: 'license'}">
                                   <li data-bind="css: {'active': license.active(), 'disabled': !license.count()}">
                                     <a data-bind="click: license.toggleActive">
-                                      <span style="display: inline-block; max-width: 85%;">{{license.name}}</span>
+                                      <span style="display: inline-block; max-width: 85%;" data-bind="text: license.name"></span>
                                       <span data-bind="text: license.count" class="badge pull-right"></span>
                                     </a>
                                   </li>
@@ -118,26 +112,27 @@
 
     <script type="text/html" id="SHARE">
         <!-- ko if: $data.links -->
-            <h4><a data-bind="attr.href: links[0].url">{{ title }}</a></h4>
+            <h4><a data-bind="attr: {href: links[0].url}, text: title"></a></h4>
         <!-- /ko -->
 
         <!-- ko ifnot: $data.links -->
-            <h4><a data-bind="attr.href: id.url">{{ title }}</a></h4>
+            <h4><a data-bind="attr: {href: id.url}, text: title"></a></h4>
         <!-- /ko -->
 
-        <h5>Description: <small>{{ description | default:"No Description" | fit:500}}</small></h5>
+        <!-- TODO: Add a "trimText" filter to replace the one we're losing from KO.punches; this display value should be a 500 char max limit-->
+        <h5>Description: <small data-bind="text: description || 'No Description'"></small></h5>
 
         <!-- ko if: contributors.length > 0 -->
         <h5>
             Contributors: <small data-bind="foreach: contributors">
-                <span>{{ $data.given + " " + $data.family}}</span>
+                <span data-bind="text: $data.given + ' ' + $data.family"></span>
             <!-- ko if: ($index()+1) < ($parent.contributors.length) -->&nbsp;- <!-- /ko -->
             </small>
         </h5>
         <!-- /ko -->
 
         <!-- ko if: $data.source -->
-        <h5>Source: <small>{{ source }}</small></h5>
+        <h5>Source: <small data-bind="text: source"></small></h5>
         <!-- /ko -->
 
         <!-- ko if: $data.isResource -->
@@ -146,11 +141,11 @@
         <!-- /ko -->
     </script>
     <script type="text/html" id="file">
-        <h4><a href="{{ deep_url }}">{{ name }}</a> (<span data-bind="if: is_registration">Registration </span>File)</h4>
+        <h4><a data-bind="attr: {href: deep_url}, text: name"></a> (<span data-bind="if: is_registration">Registration </span>File)</h4>
         <h5>
-            <!-- ko if: parent_url --> From: <a data-bind="attr.href: parent_url">{{ parent_title }} /</a> <!-- /ko -->
-            <!-- ko if: !parent_url --> From: <span data-bind="if: parent_title">{{ parent_title }} /</span> <!-- /ko -->
-            <a data-bind="attr.href: node_url">{{ node_title }}</a>
+            <!-- ko if: parent_url --> From: <a data-bind="attr: {href: parent_url}, text: parent_title || '' + ' /'"></a> <!-- /ko -->
+            <!-- ko if: !parent_url --> From: <span data-bind="if: parent_title"><span data-bind="text: parent_title"></span> /</span> <!-- /ko -->
+            <a data-bind="attr: {href: node_url}, text: node_title"></a>
         </h5>
         <!-- ko if: tags.length > 0 --> <div data-bind="template: 'tag-cloud'"></div> <!-- /ko -->
     </script>
@@ -158,10 +153,10 @@
 
         <div class="row">
             <div class="col-md-2">
-                <img class="social-gravatar" data-bind="visible: gravatarUrl(), attr.src: gravatarUrl()">
+                <img class="social-gravatar" data-bind="visible: gravatarUrl(), attr: {src: gravatarUrl()}">
             </div>
             <div class="col-md-10">
-                <h4><a data-bind="attr.href: url"><span>{{ user }}</span></a></h4>
+                <h4><a data-bind="attr: {href: url}, text: user"></a></h4>
                 <p>
                     <span data-bind="visible: job_title, text: job_title"></span><!-- ko if: job_title && job --> at <!-- /ko -->
                     <span data-bind="visible: job, text: job"></span><!-- ko if: job_title || job --><br /><!-- /ko -->
@@ -171,58 +166,58 @@
                 <!-- ko if: social -->
                 <ul class="list-inline">
                     <li data-bind="visible: social.personal">
-                        <a data-bind="attr.href: social.personal">
+                        <a data-bind="attr: {href: social.personal}">
                             <i class="fa fa-globe social-icons" data-toggle="tooltip" title="Personal Website"></i>
                         </a>
                     </li>
 
                     <li data-bind="visible: social.twitter">
-                        <a data-bind="attr.href: social.twitter">
+                        <a data-bind="attr: {href: social.twitter}">
                             <i class="fa fa-twitter social-icons" data-toggle="tooltip" title="Twitter"></i>
                         </a>
                     </li>
                     <li data-bind="visible: social.github">
-                        <a data-bind="attr.href: social.github">
+                        <a data-bind="attr: {href: social.github}">
                             <i class="fa fa-github-alt social-icons" data-toggle="tooltip" title="Github"></i>
                         </a>
                     </li>
                     <li data-bind="visible: social.linkedIn">
-                        <a data-bind="attr.href: social.linkedIn">
+                        <a data-bind="attr: {href: social.linkedIn}">
                             <i class="fa fa-linkedin social-icons" data-toggle="tooltip" title="LinkedIn"></i>
                         </a>
                     </li>
                     <li data-bind="visible: social.scholar">
-                        <a data-bind="attr.href: social.scholar">
+                        <a data-bind="attr: {href: social.scholar}">
                             <img class="social-icons" src="/static/img/googlescholar.png"data-toggle="tooltip" title="Google Scholar">
                         </a>
                     </li>
                     <li data-bind="visible: social.impactStory">
-                        <a data-bind="attr.href: social.impactStory">
+                        <a data-bind="attr: {href: social.impactStory}">
                             <i class="fa fa-info-circle social-icons" data-toggle="tooltip" title="ImpactStory"></i>
                         </a>
                     </li>
                     <li data-bind="visible: social.orcid">
-                        <a data-bind="attr.href: social.orcid">
+                        <a data-bind="attr: {href: social.orcid}">
                             <i class="fa social-icons" data-toggle="tooltip" title="ORCiD">iD</i>
                         </a>
                     </li>
                     <li data-bind="visible: social.researcherId">
-                        <a data-bind="attr.href: social.researcherId">
+                        <a data-bind="attr: {href: social.researcherId}">
                             <i class="fa social-icons" data-toggle="tooltip" title="ResearcherID">R</i>
                         </a>
                     </li>
                     <li data-bind="visible: social.researchGate">
-                        <a data-bind="attr.href: social.researchGate">
+                        <a data-bind="attr: {href: social.researchGate}">
                             <img class="social-icons" src="/static/img/researchgate.jpg" style="PADDING-BOTTOM: 7px" data-toggle="tooltip" title="ResearchGate"></i>
                         </a>
                     </li>
                     <li data-bind="visible: social.academiaInstitution + social.academiaProfileID">
-                        <a data-bind="attr.href: social.academiaInstitution + social.academiaProfileID">
+                        <a data-bind="attr: {href: social.academiaInstitution + social.academiaProfileID}">
                             <i class="fa social-icons" data-toggle="tooltip" title="Academia">A</i>
                         </a>
                     </li>
                     <li data-bind="visible: social.baiduScholar">
-                        <a data-bind="attr.href: social.baiduScholar">
+                        <a data-bind="attr: {href: social.baiduScholar}">
                             <img class="social-icons" src="/static/img/baiduscholar.png"data-toggle="tooltip" style="PADDING-BOTTOM: 5px" title="Baidu Scholar">
                         </a>
                     </li>
@@ -234,22 +229,23 @@
     </script>
     <script type="text/html" id="node">
       <!-- ko if: parent_url -->
-      <h4><a data-bind="attr.href: parent_url">{{ parent_title}}</a> / <a data-bind="attr.href: url">{{title }}</a></h4>
+      <h4><a data-bind="attr: {href: parent_url}, text: parent_title"></a> / <a data-bind="attr: {href: url}, text: title"></a></h4>
         <!-- /ko -->
         <!-- ko if: !parent_url -->
-        <h4><span data-bind="if: parent_title">{{ parent_title }} /</span> <a data-bind="attr.href: url">{{title }}</a></h4>
+        <h4><span data-bind="if: parent_title"><span data-bind="text: parent_title"></span> /</span> <a data-bind="attr: {href: url}, text: title"></a></h4>
         <!-- /ko -->
 
-        <p data-bind="visible: description"><strong>Description:</strong> {{ description | fit:500 }}</p>
+        <!-- TODO: Write and use a replacement for the trimText filter here. Limit 500 characters -->
+        <p data-bind="visible: description"><strong>Description:</strong> <span data-bind="text: description"></span></p>
 
         <!-- ko if: contributors.length > 0 -->
         <p>
             <strong>Contributors:</strong> <span data-bind="foreach: contributors">
                 <!-- ko if: url -->
-                    <a data-bind="attr.href: url">{{ fullname }}</a>
+                    <a data-bind="attr: {href: url}, text: fullname"></a>
                 <!-- /ko-->
                 <!-- ko ifnot: url -->
-                    {{ fullname }}
+                    <span data-bind="text: fullname"></span>
                 <!-- /ko -->
             <!-- ko if: ($index()+1) < ($parent.contributors.length) -->&nbsp;- <!-- /ko -->
             </span>
@@ -260,9 +256,9 @@
         <!-- /ko -->
         <p><strong>Jump to:</strong>
             <!-- ko if: n_wikis > 0 -->
-            <a data-bind="attr.href: wikiUrl">Wiki</a> -
+            <a data-bind="attr: {href: wikiUrl}">Wiki</a> -
             <!-- /ko -->
-            <a data-bind="attr.href: filesUrl">Files</a>
+            <a data-bind="attr: {href: filesUrl}">Files</a>
         </p>
     </script>
     <script type="text/html" id="project">
@@ -273,23 +269,24 @@
     </script>
     <script type="text/html" id="registration">
         <!-- ko if: parent_url -->
-        <h4><a data-bind="attr.href: parent_url">{{ parent_title}}</a> / <a data-bind="attr.href: url">{{ title }}</a>  (<span class="text-danger" data-bind="if: is_retracted">Retracted </span>Registration)</h4>
+        <h4><a data-bind="attr: {href: parent_url}, text: parent_title"></a> / <a data-bind="attr: {href: url}, text: title"></a>  (<span class="text-danger" data-bind="if: is_retracted">Retracted </span>Registration)</h4>
         <!-- /ko -->
         <!-- ko if: !parent_url -->
-        <h4><span data-bind="if: parent_title">{{ parent_title }} /</span> <a data-bind="attr.href: url">{{ title }}</a>  (<span class="text-danger" data-bind="if: is_retracted">Retracted </span>Registration)</h4>
+        <h4><span data-bind="if: parent_title"><span data-bind="text: parent_title"></span> /</span> <a data-bind="attr: {href: url}, text: title"></a>  (<span class="text-danger" data-bind="if: is_retracted">Retracted </span>Registration)</h4>
         <!-- /ko -->
         <strong><span data-bind="text: 'Date Registered: ' + dateRegistered['local'], tooltip: {title: dateRegistered['utc']}"></span></strong>
 
-        <p data-bind="visible: description"><strong>Description:</strong> {{ description | fit:500 }}</p>
+        <!-- TODO: Add trimText filter to restrict length to 500 chars -->
+        <p data-bind="visible: description"><strong>Description:</strong> <span data-bind="text: description>"></span></p>
 
         <!-- ko if: contributors.length > 0 -->
         <p>
             <strong>Contributors:</strong> <span data-bind="foreach: contributors">
                 <!-- ko if: url -->
-                    <a data-bind="attr.href: url">{{ fullname }}</a>
+                    <a data-bind="attr: {href: url}, text: fullname"></a>
                 <!-- /ko-->
                 <!-- ko ifnot: url -->
-                    {{ fullname }}
+                    <span data-bind="text: fullname"></span>
                 <!-- /ko -->
 
 
@@ -302,9 +299,9 @@
         <!-- /ko -->
         <p><strong>Jump to:</strong>
             <!-- ko if: n_wikis > 0 -->
-            <a data-bind="attr.href: wikiUrl">Wiki</a> -
+            <a data-bind="attr: {href: wikiUrl}">Wiki</a> -
             <!-- /ko -->
-            <a data-bind="attr.href: filesUrl">Files</a>
+            <a data-bind="attr: {href: filesUrl}">Files</a>
         </p>
     </script>
     <script id="tag-cloud" type="text/html">


### PR DESCRIPTION
Refs https://openscience.atlassian.net/browse/OSF-5794

## Purpose
Phase out usage of knockout punches template helpers due to reported incompatibilities.

This is the first of three planned PRs. The item touches on settings, profile, and some registration-related project pages. Addon widgets, nodelogs, and project dashboard items will be covered in a separate PR.

This replaces (and divides the work for) https://github.com/CenterForOpenScience/osf.io/pull/5216

## Task list
- [x] `{{ expression }}` should be replaced with `<!--ko text:expression--><!--/ko-->` or some equivalent
- [x] Replace text filters (`fit`) with alternative JS expressions
- [x] Remove usages of namespaced dynamic bindings (see the docs): https://mbest.github.io/knockout.punches/
- [x] Convert pages that rely on wrapped event callbacks (by default, review `click`, `submit`, and `event` bindings)
- [x] Replace ko.punches text filters (trim) with alternatives.
- [x] Remove usages of `ko.punches.enableAll();`

## Testing notes
### List of affected pages / sections
- [x] Project settings page: be able to connect and disconnect various addons. Be able to select folders, view contents on files page, and remove/disconnect addons. Confirm that the dataverse addon is configured via a modal and that all buttons and links work. (`http://localhost:5000/<project_id>/settings`). Go to email notifications.
- [x] User/profile settings (`http://localhost:5000/settings/`) (all four tabs)
- [x] Account settings `http://localhost:5000/settings/account/`, particularly 2FA addon (enable, refresh, disable). Also check notifications and addon config. (a few buttons work, email notifications clickable)
- [x] Draft registrations pages: create and edit a draft registration (any form should be fine to test this with)
- [x] Configure citations widgets (mendeley, zotero)
- [x] Log in and sign up for accounts
- [x] Search page (look at search results for both projects and profiles. No extra/missing icons, no links broken, no JS console errors)

### Things to check
- Links should work
- Any text that used to be present should still be present (no fields are missing)
- In search results, long project descriptions (>500 chars) are still truncated
- Should be able to click all buttons on the affected pages, and buttons should work as intended