### PR TITLE
[Feature][Fix] Markdown rendering in comment emails

### DIFF
--- a/website/templates/emails/comment_replies.html.mako
+++ b/website/templates/emails/comment_replies.html.mako
@@ -8,7 +8,7 @@
                 <span class="title" style="font-style: italic; color: grey;"> ${page_title} </span>
             %endif
             <span class="timestamp" style="color: grey;"> at ${localized_timestamp}: </span>
-            <span class="content" style="display: block;padding: 6px 5px 0px 8px;font-size: 14px;">"${content}"</span>
+            <span class="content" style="display: block;padding: 6px 5px 0px 8px;font-size: 14px;">${content}</span>
         </td>
         <td class="link text-center" width="25" style="border-collapse: collapse;text-align: center;font-size: 18px;border-left: 1px solid #ddd;">
             <a href="${url}" style="padding: 0;margin: 0;border: none;list-style: none;color: #008de5;text-decoration: none;">&#10095;</a>

--- a/website/templates/emails/comment_replies.txt.mako
+++ b/website/templates/emails/comment_replies.txt.mako
@@ -1,3 +1,3 @@
-${user} replied to your comment "${parent_comment}" on your project "${title}": "${content}".
+${user} replied to your comment "${parent_comment}" on your project "${title}": ${content}.
 
 ${'\t'}To view this on the Open Science Framework, please visit: ${url}.

--- a/website/templates/emails/comments.html.mako
+++ b/website/templates/emails/comments.html.mako
@@ -10,7 +10,7 @@
                 <span class="title" style="font-style: italic; color: grey;"> ${page_title} </span>
             %endif
             <span class="timestamp" style="color: grey;"> at ${localized_timestamp}: </span>
-            <span class="content" style="display: block;padding: 6px 5px 0px 8px;font-size: 14px;">"${content}"</span>
+            <span class="content" style="display: block;padding: 6px 5px 0px 8px;font-size: 14px;">${content}</span>
         </td>
         <td class="link text-center" width="25" style="border-collapse: collapse;text-align: center;font-size: 18px;border-left: 1px solid #ddd;">
             <a href="${url}" style="padding: 0;margin: 0;border: none;list-style: none;color: #008de5;text-decoration: none;">&#10095;</a>

--- a/website/templates/emails/comments.txt.mako
+++ b/website/templates/emails/comments.txt.mako
@@ -1,3 +1,3 @@
-${user} at ${localized_timestamp}: "${content}".
+${user} at ${localized_timestamp}: ${content}.
 
 ${'\t'}To view this on the Open Science Framework, please visit: ${url}.


### PR DESCRIPTION
Purpose
======
Remove quotes around `comment.content` in email templates, it looks bad with markdown rendering.
See https://trello.com/c/ssDXjC4y/32-notifications-format-of-comment-email

Changes
=======
Quotation remarks removed.

Alternative approaches considered:
* `string[3:-4]` indexing to ignore `<p>[...]</p>`    - Bad
* BeautifulSoup/Bleach to strip tags           - Slow/Greedy

Side Effects
=========
None