### PR TITLE
[Fix] Prevent sending a timestamp-updating PUT if anonymous

### DIFF
--- a/website/project/views/comment.py
+++ b/website/project/views/comment.py
@@ -5,7 +5,6 @@ from datetime import datetime
 from flask import request
 from modularodm import Q
 
-from framework.auth.decorators import must_be_logged_in
 from framework.guid.model import Guid
 
 from website.addons.base.signals import file_updated

--- a/website/project/views/comment.py
+++ b/website/project/views/comment.py
@@ -153,7 +153,6 @@ def _update_comments_timestamp(auth, node, page=Comment.OVERVIEW, root_id=None):
     else:
         return {}
 
-@must_be_logged_in
 @must_be_contributor_or_public
 def update_comments_timestamp(auth, node, **kwargs):
     timestamp_info = request.get_json()

--- a/website/static/js/comment.js
+++ b/website/static/js/comment.js
@@ -630,7 +630,7 @@ CommentListModel.prototype.initListeners = function() {
 };
 
 var onOpen = function(page, rootId, nodeApiUrl) {
-    if (window.contextVars.node.anonymous){
+    if (osfHelpers.urlParams().view_only){
         return null;
     }
     var timestampUrl = nodeApiUrl + 'comments/timestamps/';

--- a/website/static/js/comment.js
+++ b/website/static/js/comment.js
@@ -630,6 +630,9 @@ CommentListModel.prototype.initListeners = function() {
 };
 
 var onOpen = function(page, rootId, nodeApiUrl) {
+    if (window.contextVars.node.anonymous){
+        return null;
+    }
     var timestampUrl = nodeApiUrl + 'comments/timestamps/';
     var request = osfHelpers.putJSON(
         timestampUrl,


### PR DESCRIPTION
Purpose
=======
https://trello.com/c/4B1JZCYG/39-anonymous-vol-non-contributor-is-unable-to-view-comments-on-add-ons

Changes
=======
Check `window.contextVars.node.anonymous` before making request

Side effects
=========
None