### PR TITLE
[ko-2] Remove ko template syntax from project pages

### DIFF
--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -62,7 +62,6 @@ var entry = {
         // Vendor libraries
         'knockout',
         'knockout.validation',
-        'knockout.punches',
         'moment',
         'bootstrap',
         'bootbox',

--- a/website/addons/box/templates/log_templates.mako
+++ b/website/addons/box/templates/log_templates.mako
@@ -1,60 +1,55 @@
 <script type="text/html" id="box_file_added">
 added file
-<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect">
-    {{ stripSlash(params.path) }}</a> to
+<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect, text: stripSlash(params.path)"></a> to
 Box in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="box_folder_created">
 created folder
-<span class="overflow log-folder">{{ stripSlash(params.path) }}</span> in
+<span class="overflow log-folder" data-bind="text: stripSlash(params.path)"></span> in
 Box in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="box_file_updated">
 updated file
-<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect">
-    {{ stripSlash(params.path) }}</a> to
+<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect, text: stripSlash(params.path)"></a> to
 Box in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 
 <script type="text/html" id="box_file_removed">
-removed {{ pathType(params.path) }} <span class="overflow">
-    {{ stripSlash(params.path) }}</span> from
+removed <span data-bind="text: pathType(params.path) "></span> <span class="overflow" data-bind="text: stripSlash(params.path)"></span> from
 Box in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 
 <script type="text/html" id="box_folder_selected">
 linked Box folder
-<span class="overflow">
-    {{ params.folder === 'All Files' ? '/ (Full Box)' : (params.folder || '').replace('All Files','')}}
-</span> to
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<span class="overflow" data-bind="text: (params.folder === 'All Files' ? '/ (Full Box)' : (params.folder || '').replace('All Files',''))"></span> to
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, title: nodeTitle"></a>
 </script>
 
 
 <script type="text/html" id="box_node_deauthorized">
 deauthorized the Box addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 
 <script type="text/html" id="box_node_authorized">
 authorized the Box addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="box_node_deauthorized_no_user">
 Box addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
     deauthorized
 </script>

--- a/website/addons/dataverse/static/dataverseWidget.js
+++ b/website/addons/dataverse/static/dataverseWidget.js
@@ -1,9 +1,6 @@
 'use strict';
 var ko = require('knockout');
-require('knockout.punches');
 var $ = require('jquery');
-
-ko.punches.enableAll();
 
 var $osf = require('js/osfHelpers');
 var language = require('js/osfLanguage').Addons.dataverse;

--- a/website/addons/dataverse/templates/dataverse_widget.mako
+++ b/website/addons/dataverse/templates/dataverse_widget.mako
@@ -10,16 +10,16 @@
                 <dl class="dl-horizontal dl-dataverse" style="white-space: normal">
 
                     <dt>Dataset</dt>
-                    <dd>{{ dataset }}</dd>
+                    <dd data-bind="text: dataset"></dd>
 
                     <dt>Global ID</dt>
-                    <dd><a data-bind="attr: {href: datasetUrl}">{{ doi }}</a></dd>
+                    <dd><a data-bind="attr: {href: datasetUrl}, text: doi"></a></dd>
 
                     <dt>Dataverse</dt>
-                    <dd><a data-bind="attr: {href: dataverseUrl}">{{ dataverse }} Dataverse</a></dd>
+                    <dd><a data-bind="attr: {href: dataverseUrl}"><span data-bind="text: dataverse"></span> Dataverse</a></dd>
 
                     <dt>Citation</dt>
-                    <dd>{{ citation }}</dd>
+                    <dd data-bind="text: citation"></dd>
 
                 </dl>
             </span>

--- a/website/addons/dataverse/templates/log_templates.mako
+++ b/website/addons/dataverse/templates/log_templates.mako
@@ -1,61 +1,61 @@
 <script type="text/html" id="dataverse_file_added">
 added file
 <a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect, text: params.filename"></a> to
-Dataverse dataset <span class="overflow">{{ params.dataset }}</span>
+Dataverse dataset <span class="overflow" data-bind="text: params.dataset"></span>
 in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="dataverse_file_removed">
-removed file <span class="overflow">{{ params.filename }}</span> from
-Dataverse dataset <span class="overflow">{{ params.dataset }}</span>
+removed file <span class="overflow" data-bind="text: params.filename"></span> from
+Dataverse dataset <span class="overflow" data-bind="text: params.dataset"></span>
 in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="dataverse_dataset_linked">
 linked Dataverse dataset
-<span class="overflow">{{ params.dataset }}</span> to
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<span class="overflow" data-bind="text: params.dataset"></span> to
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <!-- Legacy version -->
 <script type="text/html" id="dataverse_study_linked">
 linked Dataverse dataset
-<span class="overflow">{{ params.study }}</span> to
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<span class="overflow" data-bind="params.study"></span> to
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="dataverse_dataset_published">
 published a new version of Dataverse dataset
-<span class="overflow">{{ params.dataset }}</span> to
+<span class="overflow" data-bind="text: params.dataset"></span> to
 for
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <!-- Legacy version -->
 <script type="text/html" id="dataverse_study_released">
 published a new version of Dataverse dataset
-<span class="overflow">{{ params.study }}</span> to
+<span class="overflow" data-bind="text: params.study"></span> to
 for
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="dataverse_node_authorized">
 authorized the Dataverse addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="dataverse_node_deauthorized">
 deauthorized the Dataverse addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="dataverse_node_deauthorized_no_user">
 Dataverse addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
     deauthorized
 </script>

--- a/website/addons/dropbox/templates/log_templates.mako
+++ b/website/addons/dropbox/templates/log_templates.mako
@@ -1,54 +1,54 @@
 <script type="text/html" id="dropbox_file_added">
 added file
-<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect">{{ params.path }}</a> to
+<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect, text: params.path"></a> to
 Dropbox in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="dropbox_folder_created">
 created folder
-<span class="overflow log-folder">{{ stripSlash(params.path) }}</span> in
+<span class="overflow log-folder" data-bind="text: stripSlash(params.path)"></span> in
 Dropbox in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="dropbox_file_updated">
 updated file
-<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect">{{ params.path }}</a> to
+<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect, text: params.path"></a> to
 Dropbox in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 
 <script type="text/html" id="dropbox_file_removed">
-removed {{ pathType(params.path) }} <span class="overflow">{{ stripSlash(params.path) }}</span> from
+removed <span data-bind="text: pathType(params.path)"></span> <span class="overflow" data-bind="text: stripSlash(params.path)"></span> from
 Dropbox in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 
 <script type="text/html" id="dropbox_folder_selected">
-linked Dropbox folder <span class="overflow">{{ params.folder === '/' ? '/ (Full Dropbox)' : params.folder }}</span> to
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+linked Dropbox folder <span class="overflow" data-bind="text: params.folder === '/' ? '/ (Full Dropbox)' : params.folder"></span> to
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 
 <script type="text/html" id="dropbox_node_deauthorized">
 deauthorized the Dropbox addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 
 <script type="text/html" id="dropbox_node_authorized">
 authorized the Dropbox addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="dropbox_node_deauthorized_no_user">
 Dropbox addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
     deauthorized
 </script>

--- a/website/addons/figshare/templates/log_templates.mako
+++ b/website/addons/figshare/templates/log_templates.mako
@@ -6,9 +6,9 @@ figshare <span data-bind="text: params.figshare.title"></span> in
 </script>
 
 <script type="text/html" id="figshare_file_removed">
-removed file <span class="overflow">{{ params.path }}</span> from
+removed file <span class="overflow" data-bind="text: params.path"></span> from
 figshare in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="figshare_content_linked">
@@ -24,18 +24,18 @@ unlinked figshare project /<span data-bind="text: params.figshare.title"></span>
 <script type="text/html" id="figshare_node_authorized">
 authorized the figshare addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="figshare_node_deauthorized">
 deauthorized the figshare addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="figshare_node_deauthorized_no_user">
 figshare addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
     deauthorized
 </script>

--- a/website/addons/forward/static/forwardConfig.js
+++ b/website/addons/forward/static/forwardConfig.js
@@ -1,13 +1,10 @@
 'use strict';
 
 var ko = require('knockout');
-require('knockout.punches');
 var $ = require('jquery');
 var Raven = require('raven-js');
 var koHelpers = require('js/koHelpers');
 var $osf = require('js/osfHelpers');
-
-ko.punches.enableAll();
 
 var MESSAGE_TIMEOUT = 5000;
 var MIN_FORWARD_TIME = 5;

--- a/website/addons/forward/static/forwardWidget.js
+++ b/website/addons/forward/static/forwardWidget.js
@@ -1,11 +1,8 @@
 'use strict';
 
 var ko = require('knockout');
-require('knockout.punches');
 var $ = require('jquery');
 var $osf = require('js/osfHelpers');
-
-ko.punches.enableAll();
 
 /**
  * Knockout view model for the Forward node settings widget.

--- a/website/addons/forward/templates/forward_widget.mako
+++ b/website/addons/forward/templates/forward_widget.mako
@@ -6,10 +6,10 @@
 
         <div>
             This project contains a forward to
-            <a data-bind="attr.href: url">{{ url }}</a>.
+            <a data-bind="attr: {href: url}, text: url"></a>.
         </div>
 
-        <p>You will be automatically forwarded in {{ timeLeft }} seconds.</p>
+        <p>You will be automatically forwarded in <span data-bind="text: timeLeft"></span> seconds.</p>
 
         <div class="spaced-buttons" data-bind="visible: redirecting">
             <a class="btn btn-default" data-bind="click: cancelRedirect">Cancel</a>
@@ -22,7 +22,7 @@
 
         <div>
             This project contains a forward to
-            <a data-bind="attr.href: url" target="_blank">{{ linkDisplay }}</a>.
+            <a data-bind="attr: {href: url}, text: linkDisplay" target="_blank"></a>.
         </div>
 
         <div class="spaced-buttons m-t-sm">

--- a/website/addons/forward/templates/log_templates.mako
+++ b/website/addons/forward/templates/log_templates.mako
@@ -1,6 +1,6 @@
 <script type="text/html" id="forward_url_changed">
 changed forward URL to
-<a target="_blank" class="overflow log-file-link" data-bind="attr.href: params.forward_url">{{ params.forward_url }}</a>
+<a target="_blank" class="overflow log-file-link" data-bind="attr: {href: params.forward_url}, text: params.forwardUrl"></a>
 in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>

--- a/website/addons/forward/templates/log_templates.mako
+++ b/website/addons/forward/templates/log_templates.mako
@@ -1,6 +1,6 @@
 <script type="text/html" id="forward_url_changed">
 changed forward URL to
-<a target="_blank" class="overflow log-file-link" data-bind="attr: {href: params.forward_url}, text: params.forwardUrl"></a>
+<a target="_blank" class="overflow log-file-link" data-bind="attr: {href: params.forward_url}, text: params.forward_url"></a>
 in
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>

--- a/website/addons/github/templates/log_templates.mako
+++ b/website/addons/github/templates/log_templates.mako
@@ -9,11 +9,11 @@ GitHub repo
 
 <script type="text/html" id="github_folder_created">
 created folder
-<span class="overflow log-folder">{{ stripSlash(params.path) }}</span> in
+<span class="overflow log-folder" data-bind="text: stripSlash(params.path)"></span> in
 GitHub repo
 <span data-bind="text: params.github.user"></span> /
 <span data-bind="text: params.github.repo"></span> in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="github_file_updated">
@@ -50,18 +50,18 @@ unlinked GitHub repo
 <script type="text/html" id="github_node_authorized">
 authorized the GitHub addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="github_node_deauthorized">
 deauthorized the GitHub addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="github_node_deauthorized_no_user">
 GitHub addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
     deauthorized
 </script>

--- a/website/addons/googledrive/templates/log_templates.mako
+++ b/website/addons/googledrive/templates/log_templates.mako
@@ -1,48 +1,48 @@
 <script type="text/html" id="googledrive_file_added">
 added file
-<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect">{{ decodeURIComponent(params.path) }}</a> to
+<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect, text: decodeURIComponent(params.path)"></a> to
 Google Drive in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="googledrive_folder_created">
 created folder
-<span class="overflow log-folder">{{ stripSlash(decodeURIComponent(params.path)) }}</span> in
+<span class="overflow log-folder" data-bind="text: stripSlash(decodeURIComponent(params.path))"></span> in
 Google Drive in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="googledrive_file_updated">
 updated file
-<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect">{{ decodeURIComponent(params.path) }}</a> to
+<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect, text: decodeURIComponent(params.path)"></a> to
 Google Drive in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 
 <script type="text/html" id="googledrive_file_removed">
-removed {{ pathType(params.path) }} <span class="overflow ">{{ stripSlash(decodeURIComponent(params.path)) }}</span> from
+removed <span data-bind="text: pathType(params.path) "></span> <span class="overflow" data-bind="text: stripSlash(decodeURIComponent(params.path))"></span> from
 Google Drive in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 
 <script type="text/html" id="googledrive_folder_selected">
-linked Google Drive folder /<span class="overflow">{{ params.folder === '/' ? '(Full Google Drive)' : decodeURIComponent(params.folder) }}</span> to
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+linked Google Drive folder /<span class="overflow" data-bind="text: (params.folder === '/' ? '(Full Google Drive)' : decodeURIComponent(params.folder))"></span> to
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 
 <script type="text/html" id="googledrive_node_deauthorized">
 deauthorized the Google Drive addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="googledrive_node_deauthorized">
 Google Drive addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
     deauthorized
 </script>
 
@@ -50,12 +50,12 @@ Google Drive addon for
 <script type="text/html" id="googledrive_node_authorized">
 authorized the Google Drive addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="googledrive_node_deauthorized_no_user">
 Google Drive addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
     deauthorized
 </script>

--- a/website/addons/mendeley/templates/log_templates.mako
+++ b/website/addons/mendeley/templates/log_templates.mako
@@ -1,16 +1,16 @@
 <script type="text/html" id="mendeley_folder_selected">
-linked Mendeley folder /<span class="overflow">{{ params.folder_name }}</span> to
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+linked Mendeley folder /<span class="overflow" data-bind="text: params.folder_name"></span> to
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="mendeley_node_deauthorized">
 deauthorized the Mendeley addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="mendeley_node_authorized">
 authorized the Mendeley addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>

--- a/website/addons/osfstorage/templates/log_templates.mako
+++ b/website/addons/osfstorage/templates/log_templates.mako
@@ -1,27 +1,25 @@
 <script type="text/html" id="osf_storage_file_added">
 added file
-<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect">
-    {{ stripSlash(params.path) }}</a> to OSF Storage in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect, text: stripSlash(params.path)"></a> to OSF Storage in
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="osf_storage_folder_created">
 created folder
-<span class="overflow log-folder">{{ stripSlash(params.path) }}</span> in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<span class="overflow log-folder" data-bind="text: stripSlash(params.path)"></span> in
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="osf_storage_file_updated">
 updated file
-<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect">
-    {{ stripSlash(params.path) }}</a> to OSF Storage in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<a class="overflow log-file-link" data-bind="click: NodeActions.addonFileRedirect, text: stripSlash(params.path)"></a> to OSF Storage in
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="osf_storage_file_removed">
-  removed {{ pathType(params.path) }} <span class="overflow">
-      {{ stripSlash(params.path) }}</span> from OSF Storage in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+  removed <span data-bind="text: pathType(params.path)"></span> <span class="overflow" data-bind="stripSlash(params.path)"></span>
+  from OSF Storage in
+  <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 

--- a/website/addons/s3/templates/log_templates.mako
+++ b/website/addons/s3/templates/log_templates.mako
@@ -8,9 +8,9 @@ bucket
 
 <script type="text/html" id="s3_folder_created">
 created folder
-<span class="overflow log-folder">{{ stripSlash(params.path) }}</span> in
-bucket {{ params.bucket }} in
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+<span class="overflow log-folder" data-bind="text: stripSlash(params.path)"></span> in
+bucket <span data-bind="text: params.bucket"></span> in
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="s3_file_updated">
@@ -22,7 +22,7 @@ bucket
 </script>
 
 <script type="text/html" id="s3_file_removed">
-removed {{ pathType(params.path) }} <span class="overflow">{{ stripSlash(params.path) }}</span> from
+removed <span data-bind="text: pathType(params.path)"></span> <span class="overflow" data-bind="text: stripSlash(params.path)"></span> from
 bucket
 <span data-bind="text: params.bucket"></span> in
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
@@ -43,18 +43,18 @@ un-selected bucket
 <script type="text/html" id="s3_node_authorized">
 authorized the Amazon S3 addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="s3_node_deauthorized">
 deauthorized the Amazon S3 addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="s3_node_deauthorized_no_user">
 Amazon S3 addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
     deauthorized
 </script>

--- a/website/addons/zotero/templates/log_templates.mako
+++ b/website/addons/zotero/templates/log_templates.mako
@@ -1,16 +1,16 @@
 <script type="text/html" id="zotero_folder_selected">
-linked Zotero folder /<span class="overflow">{{ params.folder_name }}</span> to 
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+linked Zotero folder /<span class="overflow" data-bind="text: params.folder_name"></span> to
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="zotero_node_deauthorized">
 deauthorized the Zotero addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="zotero_node_authorized">
 authorized the Zotero addon for
 <a class="log-node-title-link overflow"
-    data-bind="attr: {href: nodeUrl}">{{ nodeTitle }}</a>
+    data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>

--- a/website/static/js/comment.js
+++ b/website/static/js/comment.js
@@ -8,9 +8,7 @@ var ko = require('knockout');
 var moment = require('moment');
 var Raven = require('raven-js');
 var koHelpers = require('./koHelpers');
-require('knockout.punches');
 require('jquery-autosize');
-ko.punches.enableAll();
 
 var osfHelpers = require('js/osfHelpers');
 var CommentPane = require('js/commentpane');

--- a/website/static/js/logFeed.js
+++ b/website/static/js/logFeed.js
@@ -8,12 +8,9 @@ var $ = require('jquery');
 var moment = require('moment');
 var Paginator = require('js/paginator');
 var oop = require('js/oop');
-require('knockout.punches');
 
 var $osf = require('js/osfHelpers');  // Injects 'listing' binding handler to to Knockout
 var nodeCategories = require('json!built/nodeCategories.json');
-
-ko.punches.enableAll();  // Enable knockout punches
 
 /**
   * Log model.

--- a/website/static/js/nodeControl.js
+++ b/website/static/js/nodeControl.js
@@ -10,8 +10,6 @@ var ko = require('knockout');
 var bootbox = require('bootbox');
 var Raven = require('raven-js');
 require('bootstrap-editable');
-require('knockout.punches');
-ko.punches.enableAll();
 
 var osfHelpers = require('js/osfHelpers');
 var NodeActions = require('js/project.js');

--- a/website/templates/include/comment_pane_template.mako
+++ b/website/templates/include/comment_pane_template.mako
@@ -32,12 +32,12 @@
                         <div class="clearfix">
                             <div class="pull-right">
                                 <a class="btn btn-default btn-sm" data-bind="click: cancelReply, css: {disabled: submittingReply}">Cancel</a>
-                                <a class="btn btn-success btn-sm" data-bind="click: submitReply, css: {disabled: submittingReply}">{{commentButtonText}}</a>
+                                <a class="btn btn-success btn-sm" data-bind="click: submitReply, css: {disabled: submittingReply}, text: commentButtonText"></a>
                                 <span data-bind="text: replyErrorMessage" class="text-danger"></span>
                             </div>
                         </div>
                     </div>
-                    <div class="text-danger">{{errorMessage}}</div>
+                    <div class="text-danger" data-bind="text: errorMessage"></div>
                 </form>
             </div>
 

--- a/website/templates/include/comment_template.mako
+++ b/website/templates/include/comment_template.mako
@@ -36,7 +36,7 @@
                     <div class="comment-info">
                         <form class="form-inline">
                             <span data-bind="if: author.gravatarUrl">
-                                <img data-bind="css: {comment-gravatar: author.gravatarUrl}, attr: {src: author.gravatarUrl}"/>
+                                <img data-bind="css: {'comment-gravatar': author.gravatarUrl}, attr: {src: author.gravatarUrl}"/>
                             </span>
                             <span data-bind="if: author.id">
                                 <a class="comment-author" data-bind="text: author.fullname, attr: {href: author.url}"></a>

--- a/website/templates/include/comment_template.mako
+++ b/website/templates/include/comment_template.mako
@@ -83,7 +83,7 @@
 
                     <div>
 
-                        <span class="text-danger">{{errorMessage}}</span>
+                        <span class="text-danger" data-bind="text: errorMessage"></span>
 
                         <span>&nbsp;</span>
 
@@ -142,7 +142,7 @@
                     <div class="clearfix">
                         <div class="pull-right">
                             <a class="btn btn-default btn-sm" data-bind="click: cancelReply, css: {disabled: submittingReply}"> Cancel</a>
-                            <a class="btn btn-success btn-sm" data-bind="click: submitReply, visible: replyNotEmpty, css: {disabled: submittingReply}"> {{commentButtonText}}</a>
+                            <a class="btn btn-success btn-sm" data-bind="click: submitReply, visible: replyNotEmpty, css: {disabled: submittingReply}, text: commentButtonText"></a>
                             <span data-bind="text: replyErrorMessage" class="text-danger"></span>
                         </div>
                     </div>

--- a/website/templates/log_templates.mako
+++ b/website/templates/log_templates.mako
@@ -35,6 +35,7 @@ initiated an embargoed registration of
 <!-- ko if: !registrationCancelled -->
 <a class="log-node-title-link overflow" data-bind="text: nodeTitle, attr: {href: projectUrl}"></a>
 <!-- /ko -->
+
 <!-- ko if: registrationCancelled -->
 <span class="log-node-title-link overflow" data-bind="text: nodeTitle"></span>
 <!-- /ko -->
@@ -59,14 +60,16 @@ initiated retraction of registration of
 ## Registration related Logs
 <script type="text/html" id="registration_initiated">
 initiated registration of
-<a class="log-node-title-link overflow" data-bind="text: nodeTitle, attr: {href: projectUrl}"></a>
 <!-- ko if: !registrationCancelled -->
-</script>
+<a class="log-node-title-link overflow" data-bind="text: nodeTitle, attr: {href: projectUrl}"></a>
 <!-- /ko -->
-<script type="text/html" id="registration_cancelled">
+
 <!-- ko if: registrationCancelled -->
 <span class="log-node-title-link overflow" data-bind="text: nodeTitle"></span>
 <!-- /ko -->
+</script>
+
+<script type="text/html" id="registration_cancelled">
 cancelled registration of
 <span class="log-node-title-link overflow" data-bind="text: nodeTitle"></span>
 </script>

--- a/website/templates/log_templates.mako
+++ b/website/templates/log_templates.mako
@@ -32,13 +32,7 @@ Embargo for
 
 <script type="text/html" id="embargo_initiated">
 initiated an embargoed registration of
-<!-- ko if: !registrationCancelled -->
 <a class="log-node-title-link overflow" data-bind="text: nodeTitle, attr: {href: projectUrl}"></a>
-<!-- /ko -->
-
-<!-- ko if: registrationCancelled -->
-<span class="log-node-title-link overflow" data-bind="text: nodeTitle"></span>
-<!-- /ko -->
 </script>
 
 ## Retraction related logs
@@ -60,13 +54,7 @@ initiated retraction of registration of
 ## Registration related Logs
 <script type="text/html" id="registration_initiated">
 initiated registration of
-<!-- ko if: !registrationCancelled -->
 <a class="log-node-title-link overflow" data-bind="text: nodeTitle, attr: {href: projectUrl}"></a>
-<!-- /ko -->
-
-<!-- ko if: registrationCancelled -->
-<span class="log-node-title-link overflow" data-bind="text: nodeTitle"></span>
-<!-- /ko -->
 </script>
 
 <script type="text/html" id="registration_cancelled">
@@ -164,7 +152,7 @@ from
 <script type="text/html" id="edit_title">
 changed the title from <span class="overflow" data-bind="text: params.title_original"></span>
 to
-<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}">{{ params.title_new }}</a>
+<a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: params.title_new"></a>
 </script>
 
 <script type="text/html" id="project_registered">
@@ -227,105 +215,105 @@ from
 <script type="text/html" id="comment_added">
 added a comment
 to
-{{#if params.file}}
+<!-- ko if: params.file -->
 <a data-bind="attr: {href: params.file.url}, text: params.file.name"></a>
 in
-{{/if}}
+<!-- /ko -->
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="comment_updated">
 updated a comment
 on
-{{#if params.file}}
+<!-- ko if: params.file -->
 <a data-bind="attr: {href: params.file.url}, text: params.file.name"></a>
 in
-{{/if}}
+<!-- /ko -->
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="comment_removed">
 deleted a comment
 on
-{{#if params.file}}
+<!-- ko if: params.file -->
 <a data-bind="attr: {href: params.file.url}, text: params.file.name"></a>
 in
-{{/if}}
+<!-- /ko -->
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="comment_restored">
 restored a comment
 on
-{{#if params.file}}
+<!-- ko if: params.file -->
 <a data-bind="attr: {href: params.file.url}, text: params.file.name"></a>
 in
-{{/if}}
+<!-- /ko -->
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 
 <script type="text/html" id="made_contributor_visible">
-    {{#if log.anonymous}}
+    <!-- ko if: log.anonymous -->
         changed a non-bibliographic contributor to a bibliographic contributor on
-    {{/if}}
-    {{#ifnot log.anonymous}}
+    <!-- /ko -->
+    <!-- ko ifnot: log.anonymous -->
         made non-bibliographic contributor
         <span data-bind="html: displayContributors"></span>
         a bibliographic contributor on
-    {{/ifnot}}
+    <!-- /ko -->
     <a class="log-node-title-link overflow" data-bind="attr: {href: $parent.nodeUrl}, text: $parent.nodeTitle"></a>
 </script>
 
 <script type="text/html" id="made_contributor_invisible">
-    {{#if log.anonymous}}
+    <!-- ko if: log.anonymous -->
         changed a bibliographic contributor to a non-bibliographic contributor on
-    {{/if}}
-    {{#ifnot log.anonymous}}
+    <!-- /ko -->
+    <!-- ko ifnot: log.anonymous -->
         made bibliographic contributor
         <span data-bind="html: displayContributors"></span>
         a non-bibliographic contributor on
-    {{/ifnot}}
+    <!-- /ko -->
     <a class="log-node-title-link overflow" data-bind="attr: {href: $parent.nodeUrl}, text: $parent.nodeTitle"></a>
 </script>
 
 <script type="text/html" id="addon_file_copied">
-  {{#if params.source.materialized.endsWith('/')}}
-    copied <span class="overflow log-folder">{{ params.source.materialized }}</span> from {{ params.source.addon }} in
-    <a class="log-node-title-link overflow" href="{{ params.source.node.url }}">{{ params.source.node.title }}</a>
-    to <span class="overflow log-folder">{{ params.destination.materialized }}</span> in {{ params.destination.addon }} in
+  <!-- ko if: params.source.materialized.endsWith('/') -->
+    copied <span class="overflow log-folder" data-bind="text: params.source.materialized"></span> from <span data-bind="text: params.source.addon"></span> in
+    <a class="log-node-title-link overflow" data-bind="attr: {href: params.source.node.url}, text:params.source.node.title"></a>
+    to <span class="overflow log-folder" data-bind="text: params.destination.materialized"></span> in <span data-bind="text: params.destination.addon"></span> in
     <a class="log-node-title-link overflow" data-bind="attr: {href: $parent.nodeUrl}, text: $parent.nodeTitle"></a>
-  {{/if}}
-  {{#ifnot params.source.materialized.endsWith('/')}}
-    copied <a href="{{ params.source.url }}" class="overflow">{{ params.source.materialized }}</a> from {{ params.source.addon }} in
-    <a class="log-node-title-link overflow" href="{{ params.source.node.url }}">{{ params.source.node.title }}</a>
-    to <a href="{{ params.destination.url }}" class="overflow">{{ params.destination.materialized }}</a> in {{ params.destination.addon }} in
+  <!-- /ko -->
+  <!-- ko ifnot: params.source.materialized.endsWith('/') -->
+    copied <a data-bind="attr: {href: params.source.url}, text: params.source.materialized" class="overflow"></a> from <span data-bind="text: params.source.addon"></span> in
+    <a class="log-node-title-link overflow" data-bind="attr: {href: params.source.node.url}, text: params.source.node.title"></a>
+    to <a data-bind="attr: {href: params.destination.url}, text: params.destination.materialized" class="overflow"></a> in <span data-bind="text: params.destination.addon"></span> in
     <a class="log-node-title-link overflow" data-bind="attr: {href: $parent.nodeUrl}, text: $parent.nodeTitle"></a>
-  {{/ifnot}}
+  <!-- /ko -->
 </script>
 
 <script type="text/html" id="addon_file_moved">
-  {{#if params.source.materialized.endsWith('/')}}
-  moved <span class="overflow">{{ params.source.materialized }}</span> from {{ params.source.addon }} in
-  <a class="log-node-title-link overflow" href="{{ params.source.node.url }}">{{ params.source.node.title }}</a>
-  to <span class="overflow log-folder">{{ params.destination.materialized }}</span> in {{ params.destination.addon }} in
+  <!-- ko if: params.source.materialized.endsWith('/') -->
+  moved <span class="overflow" data-bind="text: params.source.materialized"></span> from <span data-bind="text: params.source.addon"></span> in
+  <a class="log-node-title-link overflow" data-bind="attr: {href: params.source.node.url}, text: params.source.node.title"></a>
+  to <span class="overflow log-folder" data-bind="text: params.destination.materialized"></span> in <span data-bind="text: params.destination.addon"></span> in
   <a class="log-node-title-link overflow" data-bind="attr: {href: $parent.nodeUrl}, text: $parent.nodeTitle"></a>
-  {{/if}}
-  {{#ifnot params.source.materialized.endsWith('/')}}
-  moved <span class="overflow">{{ params.source.materialized }}</span> from {{ params.source.addon }} in
-  <a class="log-node-title-link overflow" href="{{ params.source.node.url }}">{{ params.source.node.title }}</a>
-  to <a href="{{ params.destination.url }}" class="overflow">{{ params.destination.materialized }}</a> in {{ params.destination.addon }} in
+  <!-- /ko -->
+  <!-- ko ifnot: params.source.materialized.endsWith('/') -->
+  moved <span class="overflow" data-bind="text: params.source.materialized"></span> from <span data-bind="text: params.source.addon"></span> in
+  <a class="log-node-title-link overflow" data-bind="attr: {href: params.source.node.url}, text: params.source.node.title"></a>
+  to <a class="overflow" data-bind="attr: {href: params.destination.url}, text: params.destination.materialized"></a> in <span data-bind="text: params.destination.addon"></span> in
   <a class="log-node-title-link overflow" data-bind="attr: {href: $parent.nodeUrl}, text: $parent.nodeTitle"></a>
-  {{/ifnot}}
+  <!-- /ko -->
 </script>
 
 <script type="text/html" id="addon_file_renamed">
-    renamed <span class="overflow">{{ params.source.materialized }}</span>
-  {{#if params.source.materialized.endsWith('/')}}
-  to <span class="overflow log-folder">{{ params.destination.materialized }}</span> in {{ params.destination.addon }} in
-  {{/if}}
-  {{#ifnot params.source.materialized.endsWith('/')}}
-  to <a href="{{ params.destination.url }}" class="overflow">{{ params.destination.materialized }}</a> in {{ params.destination.addon }} in
-  {{/ifnot}}
+    renamed <span class="overflow" data-bind="text: params.source.materialized"></span>
+  <!-- ko if: params.source.materialized.endsWith('/') -->
+  to <span class="overflow log-folder" data-bind="text: params.destination.materialized"></span> in <span data-bind="text: params.destination.addon"></span> in
+  <!-- /ko -->
+  <!-- ko ifnot: params.source.materialized.endsWith('/') -->
+  to <a class="overflow" data-bind="attr: {href: params.destination.url}, text: params.destination.materialized"></a> in <span data-bind="text: params.destination.addon"></span>  in
+  <!-- /ko -->
     <a class="log-node-title-link overflow" data-bind="attr: {href: $parent.nodeUrl}, text: $parent.nodeTitle"></a>
 </script>
 
@@ -338,35 +326,35 @@ on
 </script>
 
 <script type="text/html" id="citation_added">
-added a citation ({{ params.citation.name }})
+added a citation (<span data-bind="text: params.citation.name"></span>)
 to
 <a class="log-node-title-link overflow" data-bind="attr: {href: $parent.nodeUrl}, text: $parent.nodeTitle"></a>
 </script>
 
 <script type="text/html" id="citation_edited">
-{{#if params.citation.new_name}}
-updated a citation name from {{ params.citation.name }} to <strong>{{ params.citation.new_name }}</strong>
-  {{#if params.citation.new_text}}
+<!-- ko if: params.citation.new_name -->
+updated a citation name from <span data-bind="text: params.citation.name"></span> to <strong data-bind="text: params.citation.new_name"></strong>
+  <!-- ko if: params.citation.new_text -->
     and edited its text
-  {{/if}}
-{{/if}}
-{{#ifnot params.citation.new_name}}
-edited the text of a citation ({{ params.citation.name }})
-{{/ifnot}}
+  <!-- /ko -->
+<!-- /ko -->
+<!-- ko ifnot: params.citation.new_name -->
+edited the text of a citation (<span data-bind="text: params.citation.name"></span>)
+<!-- /ko -->
 on
 <a class="log-node-title-link overflow" data-bind="attr: {href: $parent.nodeUrl}, text: $parent.nodeTitle"></a>
 </script>
 
 <script type="text/html" id="citation_removed">
-removed a citation ({{ params.citation.name }})
+removed a citation (<span data-bind="text: params.citation.name"></span>)
 from
 <a class="log-node-title-link overflow" data-bind="attr: {href: $parent.nodeUrl}, text: $parent.nodeTitle"></a>
 </script>
 
 <script type="text/html" id="primary_institution_changed">
-changed this node's primary institution from <strong>{{ params.previous_institution.name }}</strong> to <strong>{{ params.institution.name }}</strong>.
+changed this node's primary institution from <strong data-bind="text: params.previous_institution.name"></strong> to <strong data-bind="text: params.institution.name"></strong>.
 </script>
 
 <script type="text/html" id="primary_institution_removed">
-removed <strong>{{ params.institution.name }}</strong> as this node's primary institution.
+removed <strong data-bind="text: params.institution.name"></strong> as this node's primary institution.
 </script>

--- a/website/templates/log_templates.mako
+++ b/website/templates/log_templates.mako
@@ -32,7 +32,12 @@ Embargo for
 
 <script type="text/html" id="embargo_initiated">
 initiated an embargoed registration of
+<!-- ko if: !registrationCancelled -->
 <a class="log-node-title-link overflow" data-bind="text: nodeTitle, attr: {href: projectUrl}"></a>
+<!-- /ko -->
+<!-- ko if: registrationCancelled -->
+<span class="log-node-title-link overflow" data-bind="text: nodeTitle"></span>
+<!-- /ko -->
 </script>
 
 ## Retraction related logs
@@ -55,9 +60,13 @@ initiated retraction of registration of
 <script type="text/html" id="registration_initiated">
 initiated registration of
 <a class="log-node-title-link overflow" data-bind="text: nodeTitle, attr: {href: projectUrl}"></a>
+<!-- ko if: !registrationCancelled -->
 </script>
-
+<!-- /ko -->
 <script type="text/html" id="registration_cancelled">
+<!-- ko if: registrationCancelled -->
+<span class="log-node-title-link overflow" data-bind="text: nodeTitle"></span>
+<!-- /ko -->
 cancelled registration of
 <span class="log-node-title-link overflow" data-bind="text: nodeTitle"></span>
 </script>

--- a/website/templates/project/contributors.mako
+++ b/website/templates/project/contributors.mako
@@ -182,7 +182,7 @@
             <div>
                 <div class="btn-group">
                     <button title="Copy to clipboard" class="btn btn-default btn-sm m-r-xs copy-button"
-                            data-bind="attr: {data-clipboard-text: linkUrl}" >
+                            data-bind="attr: {'data-clipboard-text': linkUrl}" >
                         <i class="fa fa-copy"></i>
                     </button>
                     <input class="link-url" type="text" data-bind="value: linkUrl, attr:{readonly: readonly}, click: toggle, clickBubble: false"  />
@@ -317,7 +317,7 @@
                             options: $parents[1].permissionList,
                             value: permission,
                             optionsText: optionsText.bind(permission),
-                             style: { font-weight: permissionChange() ? 'normal' : 'bold' }"
+                             style: { 'font-weight': permissionChange() ? 'normal' : 'bold' }"
                         >
                         </select>
                     </span>

--- a/website/templates/project/contributors.mako
+++ b/website/templates/project/contributors.mako
@@ -360,7 +360,7 @@
         </div>
     % endif
         <div data-bind="foreach: messages">
-            <div data-bind="css: cssClass">{{ text }}</div>
+            <div data-bind="css: cssClass, text: text"></div>
         </div>
 </%def>
 

--- a/website/templates/project/modal_add_contributor.mako
+++ b/website/templates/project/modal_add_contributor.mako
@@ -58,7 +58,7 @@
                                             <a
                                                     class="btn btn-success contrib-button btn-mini"
                                                     data-bind="visible: !contributor.added,
-                                                               click:$root.add,
+                                                               click:$root.add.bind($root),
                                                                tooltip: {title: 'Add contributor'}"
                                                 ><i class="fa fa-plus"></i></a>
                                             <div data-bind="visible: contributor.added,
@@ -114,7 +114,7 @@
                                         <li data-bind="css: style"><a href="#" data-bind="click: handler, html: text"></a></li>
                                     </ul>
                                     <p>
-                                        <a href="#"data-bind="click:gotoInvite">Add <strong><em data-bind="text: query"></em></strong> as an unregistered contributor</a>.
+                                        <a href="#" data-bind="click:gotoInvite">Add <strong><em data-bind="text: query"></em></strong> as an unregistered contributor</a>.
                                     </p>
                                 </div>
                                 <div data-bind="if: showLoading">

--- a/website/templates/project/modal_add_contributor.mako
+++ b/website/templates/project/modal_add_contributor.mako
@@ -114,7 +114,7 @@
                                         <li data-bind="css: style"><a href="#" data-bind="click: handler, html: text"></a></li>
                                     </ul>
                                     <p>
-                                        <a href="#"data-bind="click:gotoInvite">Add <strong><em>{{query}}</em></strong> as an unregistered contributor</a>.
+                                        <a href="#"data-bind="click:gotoInvite">Add <strong><em data-bind="text: query"></em></strong> as an unregistered contributor</a>.
                                     </p>
                                 </div>
                                 <div data-bind="if: showLoading">
@@ -122,7 +122,7 @@
                                 </div>
                                     <div data-bind="if: noResults">
                                         No results found. Try a more specific search or
-                                        <a href="#" data-bind="click:gotoInvite">add <strong><em>{{query}}</em></strong> as an unregistered contributor</a>.
+                                        <a href="#" data-bind="click:gotoInvite">add <strong><em data-bind="text: query"></em></strong> as an unregistered contributor</a>.
                                     </div>
                             </div>
                         </div><!-- ./col-md -->

--- a/website/templates/project/modal_remove_contributor.mako
+++ b/website/templates/project/modal_remove_contributor.mako
@@ -13,7 +13,7 @@
                     <div data-bind='if:page() === REMOVE'>
                         <div class="form-group">
                             <span>Do you want to remove <b data-bind="text:removeSelf() ? 'yourself' : contributorToRemove()['fullname']"></b> from
-                                <b>{{title}}</b>, or from <b>{{title}}</b> and every component in it?</span>
+                                <b data-bind="text: title"></b>, or from <b data-bind="text: title"></b> and every component in it?</span>
                         </div>
                         <div id="remove-page-radio-buttons" class="col-md-8" align="left">
                             <div class="radio">
@@ -34,7 +34,7 @@
                     <!-- removeNoChildren page -->
                     <div data-bind='if:page() === REMOVE_NO_CHILDREN'>
                         <div class="form-group" data-bind="if:contributorToRemove">
-                            <span>Remove <b data-bind="text:removeSelf() ? 'yourself' : contributorToRemove()['fullname']"></b> from {{title}}?</span>
+                            <span>Remove <b data-bind="text:removeSelf() ? 'yourself' : contributorToRemove()['fullname']"></b> from <span data-bind="text: title"></span>?</span>
                         </div>
 
                     </div><!-- end removeNoChildren page -->

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -294,7 +294,7 @@
                             <span data-bind="text: chicago"></span>
                         <div data-bind="validationOptions: {insertMessages: false, messagesOnModified: false}, foreach: citations">
                             <!-- ko if: view() === 'view' -->
-                                <div class="f-w-xl m-t-md">{{name}}
+                                <div class="f-w-xl m-t-md"><span data-bind="text: name"></span>
                                     % if 'admin' in user['permissions'] and not node['is_registration']:
                                         <!-- ko ifnot: $parent.editing() -->
                                             <button class="btn btn-default btn-sm" data-bind="click: function() {edit($parent)}"><i class="fa fa-edit"></i> Edit</button>

--- a/website/templates/project/registrations.mako
+++ b/website/templates/project/registrations.mako
@@ -71,7 +71,7 @@
               <h4 class="list-group-item-heading">
                 <div data-bind="visible: hasRequiredQuestions" class="progress progress-bar-md">
                   <div class="progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100"
-                       data-bind="attr: {aria-completion: completion},
+                       data-bind="attr: {'aria-completion': completion},
                                   style: {width: completion() + '%'}">
                     <span class="sr-only"></span>
                   </div>

--- a/website/templates/project/registrations.mako
+++ b/website/templates/project/registrations.mako
@@ -71,7 +71,7 @@
               <h4 class="list-group-item-heading">
                 <div data-bind="visible: hasRequiredQuestions" class="progress progress-bar-md">
                   <div class="progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100"
-                       data-bind="attr.aria-completion: completion,
+                       data-bind="attr: {aria-completion: completion},
                                   style: {width: completion() + '%'}">
                     <span class="sr-only"></span>
                   </div>
@@ -113,7 +113,7 @@
                     </span>
                     -->
                     <span data-bind="ifnot: requiresApproval">
-                     <a class="btn btn-success" data-bind="attr.href: urls.register_page,
+                     <a class="btn btn-success" data-bind="attr: {href: urls.register_page},
                                                            css: {'disabled': !isApproved}">Register</a>
                     </span>
                   </div>
@@ -142,7 +142,7 @@
         <label>
           <input type="radio" name="selectedDraftSchema"
                  data-bind="attr {value: id}, checked: $root.selectedSchemaId" />
-          {{ schema.title }}
+          <span data-bind="text: schema.title"></span>
           <!-- ko if: schema.description -->
           <i data-bind="tooltip: {title: schema.description}" class="fa fa-info-circle"> </i>
           <!-- /ko -->


### PR DESCRIPTION
Refs https://openscience.atlassian.net/browse/OSF-5889
Extension of #5216 , #5224

## Purpose
Phase out usage of knockout punches template helpers due to reported incompatibilities.

This is the second of three planned PRs. This covers addon widgets, contributor management, (lots of) nodelogs, and project dashboard items.

## Task list
- [x] `{{ expression }}` should be replaced with `<!--ko text:expression--><!--/ko-->` or some equivalent
- [x] Replace text filters (`fit`) with alternative JS expressions
- [x] Remove usages of namespaced dynamic bindings (see the docs): https://mbest.github.io/knockout.punches/
- [x] Convert pages that rely on wrapped event callbacks (by default, review `click`, `submit`, and `event` bindings)
- [x] Remove usages of `ko.punches.enableAll();`

## Testing notes
If pages do not start showing the new log templates as expected, consider deleting `_log_templates.mako` (the underscore-prefied file is automatically generated, usually when the OSF server is manually restarted). If old template cache hangs around, pages might not correctly reflect new syntax.

### List of affected pages / sections
- Project dashboard
  - [x] Node logs for ALL addons (I did not check all these exhaustively)
    - Box
    - Dataverse
    - Dropbox
    - Figshare
    - Forward
    - Github
    - Googledrive
    - Mendeley
    - OSF storage
    - S3
    - Zotero
  - [x] Dataverse dashboard widget
  - [x] Forward link dashboard widget
  - [x] Contributors list
  - Survey of miscellaneous buttons and content
- [x] File and project comments: Read, unread, and deleted comments.
- [x] Project contributors page, esp the add and remove contributors modals
- [x] Project "registrations" page (top level)


### Things to check
- Links should work
- Node log entries should not be missing fields (across all addons and osfstorage)
- Dataverse, zotero, and link widgets on project dashboard pages should render correctly
- Any text that used to be present should still be present (no fields are missing)
- Long project descriptions (>500 chars) are still truncated
- Should be able to click all buttons on the affected pages, and buttons should work as intended (no console errors)