### PR TITLE
feature/Add spinner when comments are loading

### DIFF
--- a/website/static/js/comment.js
+++ b/website/static/js/comment.js
@@ -158,6 +158,7 @@ BaseComment.prototype.fetchNext = function(url, comments) {
             deferred.resolve(self.comments());
             self.configureCommentsVisibility();
             self._loaded = true;
+            self.loadingComments(false);
         }
     });
     return deferred.promise();
@@ -590,6 +591,7 @@ var CommentListModel = function(options) {
     self.canComment = ko.observable(options.canComment);
     self.hasChildren = ko.observable(options.hasChildren);
     self.author = options.currentUser;
+    self.loadingComments = ko.observable(true);
 
     self.togglePane = options.togglePane;
 

--- a/website/static/js/comment.js
+++ b/website/static/js/comment.js
@@ -160,6 +160,8 @@ BaseComment.prototype.fetchNext = function(url, comments) {
             self._loaded = true;
             self.loadingComments(false);
         }
+    }).fail(function () {
+        self.loadingComments(false);
     });
     return deferred.promise();
 };

--- a/website/templates/include/comment_pane_template.mako
+++ b/website/templates/include/comment_pane_template.mako
@@ -40,8 +40,14 @@
                     <div class="text-danger">{{errorMessage}}</div>
                 </form>
             </div>
-
+            <!-- ko if: loadingComments -->
+            <div style="text-align: center;">
+                <div class="logo-spin logo-lg"></div>
+            </div>
+            <!-- /ko -->
+            <!-- ko ifnot: loadingComments -->
             <div data-bind="template: {name: 'commentTemplate', foreach: comments}"></div>
+            <!-- /ko -->
         </div>
     </div>
 


### PR DESCRIPTION
# Purpose
Comments can take awhile to load - add a variable that gets set when they're done being requested and a spinner that shows until that variable is set to false

# Changes
Add ko observable variable for when all comments are done loading
use that variable in mako template to show if the comments are done loading or not

# Side effects
shouldn't be any