### PR TITLE
Fix comments field for file serializer

### DIFF
--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -3,10 +3,12 @@ from rest_framework import serializers as ser
 from rest_framework import exceptions
 
 from api.base.utils import absolute_reverse
+from api.files.serializers import FileSerializer
 from api.nodes.serializers import NodeSerializer
 from api.nodes.serializers import NodeLinksSerializer
 from api.nodes.serializers import NodeContributorsSerializer
-from api.base.serializers import IDField, RelationshipField, LinksField, HideIfRetraction, DevOnly
+from api.base.serializers import (IDField, RelationshipField, LinksField, HideIfRetraction, DevOnly,
+                                  FileCommentRelationshipField, NodeFileHyperLinkField)
 
 
 class RegistrationSerializer(NodeSerializer):
@@ -163,3 +165,17 @@ class RegistrationContributorsSerializer(NodeContributorsSerializer):
                 'user_id': obj._id
             }
         )
+
+
+class RegistrationFileSerializer(FileSerializer):
+
+    files = NodeFileHyperLinkField(
+        related_view='registrations:registration-files',
+        related_view_kwargs={'node_id': '<node_id>', 'path': '<path>', 'provider': '<provider>'},
+        kind='folder'
+    )
+
+    comments = FileCommentRelationshipField(related_view='registrations:registration-comments',
+                                            related_view_kwargs={'node_id': '<node._id>'},
+                                            related_meta={'unread': 'get_unread_comments_count'},
+                                            filter={'target': 'get_file_guid'})

--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -20,7 +20,7 @@ from api.nodes.views import (
     NodeAlternativeCitationsList, NodeAlternativeCitationDetail, NodeLogList,
     NodeInstitutionDetail, WaterButlerMixin)
 
-from api.registrations.serializers import RegistrationNodeLinksSerializer
+from api.registrations.serializers import RegistrationNodeLinksSerializer, RegistrationFileSerializer
 
 from api.nodes.permissions import (
     ContributorOrPublic,
@@ -305,11 +305,13 @@ class RegistrationRegistrationsList(NodeRegistrationsList, RegistrationMixin):
 class RegistrationFilesList(NodeFilesList, RegistrationMixin):
     view_category = 'registrations'
     view_name = 'registration-files'
+    serializer_class = RegistrationFileSerializer
 
 
 class RegistrationFileDetail(NodeFileDetail, RegistrationMixin):
     view_category = 'registrations'
     view_name = 'registration-file-detail'
+    serializer_class = RegistrationFileSerializer
 
 
 class RegistrationAlternativeCitationsList(NodeAlternativeCitationsList, RegistrationMixin):


### PR DESCRIPTION
Create registration file serializer that overrides relationship fields (e.g. comments and files) that hard-coded node views to make them registrations views.