### PR TITLE
Reverse sorting on /users/nodes/ by title gives 500 [OSF-5237]

### DIFF
--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -27,7 +27,7 @@ def sort_multiple(fields):
         rev = 1
         num = 1
         i = 0
-        for field in fields:
+        for index, field in enumerate(fields):
             i += 1
             if field[0] == '-':
                 rev = -1
@@ -39,7 +39,10 @@ def sort_multiple(fields):
             elif a_field < b_field:
                 return -1 * rev
             elif a_field == b_field:
-                continue
+                if index < len(fields) - 1:
+                    continue
+                else:
+                    return 0
         return 0
     return sort_fn
 

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -25,7 +25,10 @@ def sort_multiple(fields):
     fields = list(fields)
     def sort_fn(a, b):
         rev = 1
+        num = 1
+        i = 0
         for field in fields:
+            i += 1
             if field[0] == '-':
                 rev = -1
                 field = field[1:]
@@ -36,9 +39,10 @@ def sort_multiple(fields):
             elif a_field < b_field:
                 return -1 * rev
             elif a_field == b_field:
-                return 0
+                continue
         return 0
     return sort_fn
+
 
 
 class ODMOrderingFilter(OrderingFilter):

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -35,7 +35,6 @@ def sort_multiple(fields):
                 return 1 * sort_direction
             elif a_field < b_field:
                 return -1 * sort_direction
-            continue
         return 0
     return sort_fn
 

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -35,8 +35,7 @@ def sort_multiple(fields):
                 return 1 * sort_direction
             elif a_field < b_field:
                 return -1 * sort_direction
-            elif a_field == b_field:
-                continue
+            continue
         return 0
     return sort_fn
 

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -25,7 +25,7 @@ def sort_multiple(fields):
     fields = list(fields)
     def sort_fn(a, b):
         sort_direction = 1
-        for index, field in enumerate(fields):
+        for field in fields:
             if field[0] == '-':
                 sort_direction = -1
                 field = field[1:]

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -25,7 +25,6 @@ def sort_multiple(fields):
     fields = list(fields)
     def sort_fn(a, b):
         rev = 1
-        num = 1
         i = 0
         for index, field in enumerate(fields):
             i += 1
@@ -46,11 +45,8 @@ def sort_multiple(fields):
         return 0
     return sort_fn
 
-
-
 class ODMOrderingFilter(OrderingFilter):
     """Adaptation of rest_framework.filters.OrderingFilter to work with modular-odm."""
-
     # override
     def filter_queryset(self, request, queryset, view):
         ordering = self.get_ordering(request, queryset, view)

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -24,19 +24,17 @@ from api.base.serializers import RelationshipField, TargetField
 def sort_multiple(fields):
     fields = list(fields)
     def sort_fn(a, b):
-        rev = 1
-        i = 0
+        sort_direction = 1
         for index, field in enumerate(fields):
-            i += 1
             if field[0] == '-':
-                rev = -1
+                sort_direction = -1
                 field = field[1:]
             a_field = getattr(a, field)
             b_field = getattr(b, field)
             if a_field > b_field:
-                return 1 * rev
+                return 1 * sort_direction
             elif a_field < b_field:
-                return -1 * rev
+                return -1 * sort_direction
             elif a_field == b_field:
                 if index < len(fields) - 1:
                     continue

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -36,10 +36,7 @@ def sort_multiple(fields):
             elif a_field < b_field:
                 return -1 * sort_direction
             elif a_field == b_field:
-                if index < len(fields) - 1:
-                    continue
-                else:
-                    return 0
+                continue
         return 0
     return sort_fn
 

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -24,26 +24,19 @@ from api.base.serializers import RelationshipField, TargetField
 def sort_multiple(fields):
     fields = list(fields)
     def sort_fn(a, b):
+        rev = 1
         for field in fields:
             if field[0] == '-':
+                rev = -1
                 field = field[1:]
-                a_field = getattr(a, field)
-                b_field = getattr(b, field)
-                if a_field > b_field:
-                    return -1
-                elif a_field < b_field:
-                    return 1
-                elif a_field == b_field:
-                    return 1
-            else:
-                a_field = getattr(a, field)
-                b_field = getattr(b, field)
-                if a_field > b_field:
-                    return 1
-                elif a_field < b_field:
-                    return -1
-                elif a_field == b_field:
-                    return 1
+            a_field = getattr(a, field)
+            b_field = getattr(b, field)
+            if a_field > b_field:
+                return 1 * rev
+            elif a_field < b_field:
+                return -1 * rev
+            elif a_field == b_field:
+                return 0
         return 0
     return sort_fn
 

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -24,8 +24,7 @@ from api.base.serializers import RelationshipField, TargetField
 def sort_multiple(fields):
     fields = list(fields)
     def sort_fn(a, b):
-        while fields:
-            field = fields[0]
+        for field in fields:
             if field[0] == '-':
                 field = field[1:]
                 a_field = getattr(a, field)
@@ -34,6 +33,8 @@ def sort_multiple(fields):
                     return -1
                 elif a_field < b_field:
                     return 1
+                elif a_field == b_field:
+                    return 1
             else:
                 a_field = getattr(a, field)
                 b_field = getattr(b, field)
@@ -41,6 +42,8 @@ def sort_multiple(fields):
                     return 1
                 elif a_field < b_field:
                     return -1
+                elif a_field == b_field:
+                    return 1
         return 0
     return sort_fn
 

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -25,15 +25,25 @@ def sort_multiple(fields):
     fields = list(fields)
     def sort_fn(a, b):
         while fields:
-            field = fields.pop(0)
-            a_field = getattr(a, field)
-            b_field = getattr(b, field)
-            if a_field > b_field:
-                return 1
-            elif a_field < b_field:
-                return -1
+            field = fields[0]
+            if field[0] == '-':
+                field = field[1:]
+                a_field = getattr(a, field)
+                b_field = getattr(b, field)
+                if a_field > b_field:
+                    return -1
+                elif a_field < b_field:
+                    return 1
+            else:
+                a_field = getattr(a, field)
+                b_field = getattr(b, field)
+                if a_field > b_field:
+                    return 1
+                elif a_field < b_field:
+                    return -1
         return 0
     return sort_fn
+
 
 class ODMOrderingFilter(OrderingFilter):
     """Adaptation of rest_framework.filters.OrderingFilter to work with modular-odm."""

--- a/api_tests/base/test_filters.py
+++ b/api_tests/base/test_filters.py
@@ -254,27 +254,27 @@ class TestODMOrderingFilter(ApiTestCase):
         query_to_be_sorted = [self.query(x) for x in 'NewProj Zip Proj Activity'.split()]
         sorted_query = sorted(query_to_be_sorted, cmp=filters.sort_multiple(['title']))
         sorted_output = [str(i) for i in sorted_query]
-        assert_equal((sorted_output) , ['Activity', 'NewProj', 'Proj', 'Zip'])
+        assert_equal(sorted_output , ['Activity', 'NewProj', 'Proj', 'Zip'])
 
 
     def test_filter_queryset_forward_duplicate(self):
         query_to_be_sorted = [self.query(x) for x in 'NewProj Activity Zip Activity'.split()]
         sorted_query = sorted(query_to_be_sorted, cmp=filters.sort_multiple(['title']))
         sorted_output = [str(i) for i in sorted_query]
-        assert_equal((sorted_output) , ['Activity', 'Activity', 'NewProj', 'Zip'])
+        assert_equal(sorted_output , ['Activity', 'Activity', 'NewProj', 'Zip'])
 
 
     def test_filter_queryset_reverse(self):
         query_to_be_sorted = [self.query(x) for x in 'NewProj Zip Proj Activity'.split()]
         sorted_query = sorted(query_to_be_sorted, cmp=filters.sort_multiple(['-title']))
         sorted_output = [str(i) for i in sorted_query]
-        assert_equal((sorted_output) , ['Zip', 'Proj', 'NewProj', 'Activity'])
+        assert_equal(sorted_output , ['Zip', 'Proj', 'NewProj', 'Activity'])
     
     def test_filter_queryset_reverse_duplicate(self):
         query_to_be_sorted = [self.query(x) for x in 'NewProj Activity Zip Activity'.split()]
         sorted_query = sorted(query_to_be_sorted, cmp=filters.sort_multiple(['-title']))
         sorted_output = [str(i) for i in sorted_query]
-        assert_equal((sorted_output) , ['Zip', 'NewProj', 'Activity', 'Activity'])
+        assert_equal(sorted_output , ['Zip', 'NewProj', 'Activity', 'Activity'])
 
     def test_filter_queryset_handles_multiple_fields(self):
         objs = [self.query_with_num(title='NewProj', number=10),

--- a/api_tests/base/test_filters.py
+++ b/api_tests/base/test_filters.py
@@ -240,7 +240,7 @@ class TestODMOrderingFilter(ApiTestCase):
         def __str__(self):
             return self.title
 
-    class queryn:
+    class query_with_num:
         title = ' '
         number = 0
         def __init__(self, title, number):
@@ -249,23 +249,45 @@ class TestODMOrderingFilter(ApiTestCase):
         def __str__(self):
             return self.title
 
-    def test_filter_queryset_fails(self):
-        query_s = [self.query(x) for x in 'NewProj Zip Proj Activity'.split()]
-        sort_q = sorted(query_s, cmp=filters.sort_multiple(['-title']))
-        sortt = [str(i) for i in sort_q]
-        assert_equal((sortt) , ['Zip', 'Proj', 'NewProj', 'Activity'])
+
+    def test_filter_queryset_forward(self):
+        query_to_be_sorted = [self.query(x) for x in 'NewProj Zip Proj Activity'.split()]
+        sorted_query = sorted(query_to_be_sorted, cmp=filters.sort_multiple(['title']))
+        sorted_output = [str(i) for i in sorted_query]
+        assert_equal((sorted_output) , ['Activity', 'NewProj', 'Proj', 'Zip'])
+
+
+    def test_filter_queryset_forward_duplicate(self):
+        query_to_be_sorted = [self.query(x) for x in 'NewProj Activity Zip Activity'.split()]
+        sorted_query = sorted(query_to_be_sorted, cmp=filters.sort_multiple(['-title']))
+        sorted_output = [str(i) for i in sorted_query]
+        assert_equal((sorted_output) , ['Activity', 'Activity', 'NewProj', 'Zip'])
+
+
+    def test_filter_queryset_reverse(self):
+        query_to_be_sorted = [self.query(x) for x in 'NewProj Zip Proj Activity'.split()]
+        sorted_query = sorted(query_to_be_sorted, cmp=filters.sort_multiple(['-title']))
+        sorted_output = [str(i) for i in sorted_query]
+        assert_equal((sorted_output) , ['Zip', 'Proj', 'NewProj', 'Activity'])
     
-    def test_filter_queryset_duplicate_fails(self):
-        query_s = [self.query(x) for x in 'NewProj Activity Zip Activity'.split()]
-        sort_q = sorted(query_s, cmp=filters.sort_multiple(['-title']))
-        sortt = [str(i) for i in sort_q]
-        assert_equal((sortt) , ['Zip', 'NewProj', 'Activity', 'Activity'])
+    def test_filter_queryset_reverse_duplicate(self):
+        query_to_be_sorted = [self.query(x) for x in 'NewProj Activity Zip Activity'.split()]
+        sorted_query = sorted(query_to_be_sorted, cmp=filters.sort_multiple(['-title']))
+        sorted_output = [str(i) for i in sorted_query]
+        assert_equal((sorted_output) , ['Zip', 'NewProj', 'Activity', 'Activity'])
 
     def test_filter_queryset_handles_multiple_fields(self):
-        objs = [self.queryn(title='NewProj', number=10),
-                self.queryn(title='Zip', number=20),
-                self.queryn(title='Activity', number=30),
-                self.queryn(title='Activity', number=40)]
+        objs = [self.query_with_num(title='NewProj', number=10),
+                self.query_with_num(title='Zip', number=20),
+                self.query_with_num(title='Activity', number=30),
+                self.query_with_num(title='Activity', number=40)]
         actual = [x.number for x in sorted(objs, cmp=filters.sort_multiple(['title', '-number']))]
         assert_equal(actual, [40, 30, 10, 20])
+
+
+class TestAPIResponse(ApiTestCase):
+    def test_gives_500_error(self):
+        response = self.app.get('http://localhost:5000/v2/users/me/nodes/?sort=-title', follow=True)
+        assert_equal(response.status_code, 500)
+
 

--- a/api_tests/base/test_filters.py
+++ b/api_tests/base/test_filters.py
@@ -17,6 +17,8 @@ from api.base.filters import ODMOrderingFilter
 
 import api.base.filters as filters 
 
+from rest_framework.test import force_authenticate
+
 from api.base.exceptions import (
     InvalidFilterError,
     InvalidFilterOperator,
@@ -283,11 +285,4 @@ class TestODMOrderingFilter(ApiTestCase):
                 self.query_with_num(title='Activity', number=40)]
         actual = [x.number for x in sorted(objs, cmp=filters.sort_multiple(['title', '-number']))]
         assert_equal(actual, [40, 30, 10, 20])
-
-
-class TestAPIResponse(ApiTestCase):
-    def test_gives_500_error(self):
-        response = self.app.get('http://localhost:5000/v2/users/me/nodes/?sort=-title', follow=True)
-        assert_equal(response.status_code, 500)
-
 

--- a/api_tests/base/test_filters.py
+++ b/api_tests/base/test_filters.py
@@ -17,8 +17,6 @@ from api.base.filters import ODMOrderingFilter
 
 import api.base.filters as filters 
 
-from rest_framework.test import force_authenticate
-
 from api.base.exceptions import (
     InvalidFilterError,
     InvalidFilterOperator,
@@ -261,7 +259,7 @@ class TestODMOrderingFilter(ApiTestCase):
 
     def test_filter_queryset_forward_duplicate(self):
         query_to_be_sorted = [self.query(x) for x in 'NewProj Activity Zip Activity'.split()]
-        sorted_query = sorted(query_to_be_sorted, cmp=filters.sort_multiple(['-title']))
+        sorted_query = sorted(query_to_be_sorted, cmp=filters.sort_multiple(['title']))
         sorted_output = [str(i) for i in sorted_query]
         assert_equal((sorted_output) , ['Activity', 'Activity', 'NewProj', 'Zip'])
 

--- a/api_tests/base/test_filters.py
+++ b/api_tests/base/test_filters.py
@@ -240,6 +240,15 @@ class TestODMOrderingFilter(ApiTestCase):
         def __str__(self):
             return self.title
 
+    class queryn:
+        title = ' '
+        number = 0
+        def __init__(self, title, number):
+            self.title = title
+            self.number = number
+        def __str__(self):
+            return self.title
+
     def test_filter_queryset_fails(self):
         query_s = [self.query(x) for x in 'NewProj Zip Proj Activity'.split()]
         sort_q = sorted(query_s, cmp=filters.sort_multiple(['-title']))
@@ -251,4 +260,12 @@ class TestODMOrderingFilter(ApiTestCase):
         sort_q = sorted(query_s, cmp=filters.sort_multiple(['-title']))
         sortt = [str(i) for i in sort_q]
         assert_equal((sortt) , ['Zip', 'NewProj', 'Activity', 'Activity'])
+
+    def test_filter_queryset_handles_multiple_fields(self):
+        objs = [self.queryn(title='NewProj', number=10),
+                self.queryn(title='Zip', number=20),
+                self.queryn(title='Activity', number=30),
+                self.queryn(title='Activity', number=40)]
+        actual = [x.number for x in sorted(objs, cmp=filters.sort_multiple(['title', '-number']))]
+        assert_equal(actual, [40, 30, 10, 20])
 

--- a/api_tests/base/test_filters.py
+++ b/api_tests/base/test_filters.py
@@ -254,27 +254,27 @@ class TestODMOrderingFilter(ApiTestCase):
         query_to_be_sorted = [self.query(x) for x in 'NewProj Zip Proj Activity'.split()]
         sorted_query = sorted(query_to_be_sorted, cmp=filters.sort_multiple(['title']))
         sorted_output = [str(i) for i in sorted_query]
-        assert_equal(sorted_output , ['Activity', 'NewProj', 'Proj', 'Zip'])
+        assert_equal(sorted_output, ['Activity', 'NewProj', 'Proj', 'Zip'])
 
 
     def test_filter_queryset_forward_duplicate(self):
         query_to_be_sorted = [self.query(x) for x in 'NewProj Activity Zip Activity'.split()]
         sorted_query = sorted(query_to_be_sorted, cmp=filters.sort_multiple(['title']))
         sorted_output = [str(i) for i in sorted_query]
-        assert_equal(sorted_output , ['Activity', 'Activity', 'NewProj', 'Zip'])
+        assert_equal(sorted_output, ['Activity', 'Activity', 'NewProj', 'Zip'])
 
 
     def test_filter_queryset_reverse(self):
         query_to_be_sorted = [self.query(x) for x in 'NewProj Zip Proj Activity'.split()]
         sorted_query = sorted(query_to_be_sorted, cmp=filters.sort_multiple(['-title']))
         sorted_output = [str(i) for i in sorted_query]
-        assert_equal(sorted_output , ['Zip', 'Proj', 'NewProj', 'Activity'])
+        assert_equal(sorted_output, ['Zip', 'Proj', 'NewProj', 'Activity'])
     
     def test_filter_queryset_reverse_duplicate(self):
         query_to_be_sorted = [self.query(x) for x in 'NewProj Activity Zip Activity'.split()]
         sorted_query = sorted(query_to_be_sorted, cmp=filters.sort_multiple(['-title']))
         sorted_output = [str(i) for i in sorted_query]
-        assert_equal(sorted_output , ['Zip', 'NewProj', 'Activity', 'Activity'])
+        assert_equal(sorted_output, ['Zip', 'NewProj', 'Activity', 'Activity'])
 
     def test_filter_queryset_handles_multiple_fields(self):
         objs = [self.query_with_num(title='NewProj', number=10),

--- a/api_tests/base/test_filters.py
+++ b/api_tests/base/test_filters.py
@@ -3,6 +3,8 @@ import datetime
 import re
 from dateutil import parser
 
+import json
+
 from nose.tools import *  # flake8: noqa
 
 from rest_framework import serializers as ser
@@ -11,16 +13,16 @@ from tests.base import ApiTestCase
 
 from api.base.filters import FilterMixin
 
+from api.base.filters import ODMOrderingFilter
+
+import api.base.filters as filters 
+
 from api.base.exceptions import (
     InvalidFilterError,
     InvalidFilterOperator,
     InvalidFilterComparisonType,
     InvalidFilterMatchType,
 )
-from modularodm.query import queryset as modularodm_queryset
-from rest_framework.filters import OrderingFilter
-from modularodm import Q
-from modularodm.query import queryset as modularodm_queryset
 
 class FakeSerializer(ser.Serializer):
 
@@ -37,6 +39,7 @@ class FakeSerializer(ser.Serializer):
 class FakeView(FilterMixin):
 
     serializer_class = FakeSerializer
+
 
 class TestFilterMixin(ApiTestCase):
 
@@ -227,56 +230,50 @@ class TestFilterMixin(ApiTestCase):
         value = self.view.convert_value(value, field)
         assert_equal(value, 42.0)
 
-def sort_multiple(fields):
-    fields = list(fields)
-    def sort_fn(a, b):
-        while fields:
-            field = fields[0]
-            if field[0] == '-':
-                field = field[1:]
-                a_field = getattr(a, field)
-                b_field = getattr(b, field)
-                if a_field > b_field:
-                    return -1
-                elif a_field < b_field:
-                    return 1
-            else:
-                a_field = getattr(a, field)
-                b_field = getattr(b, field)
-                if a_field > b_field:
-                    return 1
-                elif a_field < b_field:
-                    return -1
-        return 0
-    return sort_fn
 
 
-class TestODMOrderingFilter(OrderingFilter):
-    """Adaptation of rest_framework.filters.OrderingFilter to work with modular-odm."""
-
-    def setUp(self):
-        super(TestODMOrderingFilter, self).setUp()
-        self.view = FakeView()
-
-    def test_filter_queryset(self):
-        query_s =[
-            {"title": "NewProj"},
-
-            {"title": "Zip"},
-
-            {"title": "Proj"},
-
-            {"title": "Activity"},
-        ]
-
-        sorted_list = sorted(query_s, cmp=sort_multiple('-title'))
-        assert_equal(sorted_list, [
-        {"title": "Zip"},
-
-        {"title": "Proj"},
-
-        {"title": "NewProj"},
-
-        {"title": "Activity"},
-    ])
+class TestODMOrderingFilter(ApiTestCase):
+    def test_filter_queryset_fails(self):
+        class query:
+            title = ' '
+            def __init__(self, title):
+                self.title = title
+            def __str__(self):
+                return self.title
+        query_s = []
+        q1 = query('NewProj')
+        query_s.append((q1))
+        q2 = query('Zip')
+        query_s.append((q2))
+        q3 = query('Proj')
+        query_s.append((q3))
+        q4 = query('Activity')
+        query_s.append((q4))
+        sort_q = sorted(query_s, cmp=filters.sort_multiple(['-title']))
+        sortt = []
+        for i in sort_q:
+            sortt.append(str(i))
+        assert_equal((sortt) , ['Zip', 'Proj', 'NewProj', 'Activity'])
+    
+    def test_filter_queryset_duplicate_fails(self):
+        class query:
+            title = ' '
+            def __init__(self, title):
+                self.title = title
+            def __str__(self):
+                return self.title
+        query_s = []
+        q1 = query('NewProj')
+        query_s.append((q1))
+        q2 = query('Zip')
+        query_s.append((q2))
+        q3 = query('Activity')
+        query_s.append((q3))
+        q4 = query('Activity')
+        query_s.append((q4))
+        sort_q = sorted(query_s, cmp=filters.sort_multiple(['-title']))
+        sortt = []
+        for i in sort_q:
+            sortt.append(str(i))
+        assert_equal((sortt) , ['Zip', 'NewProj', 'Activity', 'Activity'])
 

--- a/api_tests/base/test_filters.py
+++ b/api_tests/base/test_filters.py
@@ -233,47 +233,22 @@ class TestFilterMixin(ApiTestCase):
 
 
 class TestODMOrderingFilter(ApiTestCase):
+    class query:
+        title = ' '
+        def __init__(self, title):
+            self.title = title
+        def __str__(self):
+            return self.title
+
     def test_filter_queryset_fails(self):
-        class query:
-            title = ' '
-            def __init__(self, title):
-                self.title = title
-            def __str__(self):
-                return self.title
-        query_s = []
-        q1 = query('NewProj')
-        query_s.append((q1))
-        q2 = query('Zip')
-        query_s.append((q2))
-        q3 = query('Proj')
-        query_s.append((q3))
-        q4 = query('Activity')
-        query_s.append((q4))
+        query_s = [self.query(x) for x in 'NewProj Zip Proj Activity'.split()]
         sort_q = sorted(query_s, cmp=filters.sort_multiple(['-title']))
-        sortt = []
-        for i in sort_q:
-            sortt.append(str(i))
+        sortt = [str(i) for i in sort_q]
         assert_equal((sortt) , ['Zip', 'Proj', 'NewProj', 'Activity'])
     
     def test_filter_queryset_duplicate_fails(self):
-        class query:
-            title = ' '
-            def __init__(self, title):
-                self.title = title
-            def __str__(self):
-                return self.title
-        query_s = []
-        q1 = query('NewProj')
-        query_s.append((q1))
-        q2 = query('Zip')
-        query_s.append((q2))
-        q3 = query('Activity')
-        query_s.append((q3))
-        q4 = query('Activity')
-        query_s.append((q4))
+        query_s = [self.query(x) for x in 'NewProj Activity Zip Activity'.split()]
         sort_q = sorted(query_s, cmp=filters.sort_multiple(['-title']))
-        sortt = []
-        for i in sort_q:
-            sortt.append(str(i))
+        sortt = [str(i) for i in sort_q]
         assert_equal((sortt) , ['Zip', 'NewProj', 'Activity', 'Activity'])
 

--- a/api_tests/base/test_views.py
+++ b/api_tests/base/test_views.py
@@ -17,6 +17,8 @@ from rest_framework.permissions import IsAuthenticatedOrReadOnly, IsAuthenticate
 from api.base.permissions import TokenHasScope
 from website.settings import DEBUG_MODE
 
+from django.contrib.auth.models import User
+
 import importlib
 
 URLS_MODULES = []
@@ -100,6 +102,7 @@ class TestJSONAPIBaseView(ApiTestCase):
         self.user = factories.AuthUserFactory()
         self.node = factories.ProjectFactory(creator=self.user)
         self.url = '/{0}nodes/{1}/'.format(API_BASE, self.node._id)
+        self.reverse_sort_url = '/{0}users/me/nodes/{1}/'.format(API_BASE, '?sort=-title')
         for i in range(5):
             factories.ProjectFactory(parent=self.node, creator=self.user)
         for i in range(5):
@@ -109,5 +112,9 @@ class TestJSONAPIBaseView(ApiTestCase):
     def test_request_added_to_serializer_context(self, mock_to_representation):
         self.app.get(self.url, auth=self.user.auth)
         assert_in('request', mock_to_representation.call_args[0][0].context)
+
+    def test_reverse_sort_possible(self):
+        response = self.app.get('http://localhost:8000/v2/users/me/nodes/?sort=-title', auth=self.user.auth)
+        assert_equal(response.status_code, 200)
 
 

--- a/api_tests/base/test_views.py
+++ b/api_tests/base/test_views.py
@@ -102,7 +102,6 @@ class TestJSONAPIBaseView(ApiTestCase):
         self.user = factories.AuthUserFactory()
         self.node = factories.ProjectFactory(creator=self.user)
         self.url = '/{0}nodes/{1}/'.format(API_BASE, self.node._id)
-        self.reverse_sort_url = '/{0}users/me/nodes/{1}/'.format(API_BASE, '?sort=-title')
         for i in range(5):
             factories.ProjectFactory(parent=self.node, creator=self.user)
         for i in range(5):


### PR DESCRIPTION
# Purpose

Enable reverse sorting based on user node attributes such as title and date_created

Issue:
https://openscience.atlassian.net/browse/OSF-5237

# Code

Removed fields.pop(0) and simply selected the first index via fields[0].
I then included a reverse sort for the case in which the first character in the field was a '-', thus indicating a reverse sort. To implement the reverse sort, I simply switched the places of the 1 and -1 from the original sort.