### PR TITLE
Remove DevOnly from necessary collections fields

### DIFF
--- a/api/collections/serializers.py
+++ b/api/collections/serializers.py
@@ -5,7 +5,7 @@ from framework.exceptions import PermissionsError
 from website.exceptions import NodeStateError
 
 from website.models import Node
-from api.base.serializers import LinksField, RelationshipField, DevOnly, JSONAPIRelationshipSerializer
+from api.base.serializers import LinksField, RelationshipField, JSONAPIRelationshipSerializer
 from api.base.serializers import JSONAPISerializer, IDField, TypeField, relationship_diff
 from api.base.exceptions import InvalidModelValueError, RelationshipPostMakesNoChanges
 from api.base.utils import absolute_reverse, get_user_auth
@@ -29,20 +29,20 @@ class CollectionSerializer(JSONAPISerializer):
 
     links = LinksField({})
 
-    node_links = DevOnly(RelationshipField(
+    node_links = RelationshipField(
         related_view='collections:node-pointers',
         related_view_kwargs={'collection_id': '<pk>'},
         related_meta={'count': 'get_node_links_count'}
-    ))
+    )
 
     # TODO: Add a self link to this when it's available
-    linked_nodes = DevOnly(RelationshipField(
+    linked_nodes = RelationshipField(
         related_view='collections:linked-nodes',
         related_view_kwargs={'collection_id': '<pk>'},
         related_meta={'count': 'get_node_links_count'},
         self_view='collections:collection-node-pointer-relationship',
         self_view_kwargs={'collection_id': '<pk>'}
-    ))
+    )
 
     class Meta:
         type_ = 'collections'


### PR DESCRIPTION
Purpose
-----------
Make collections work properly when it goes to production.

Changes
-------------
Remove DevOnly from two fields

Side Effects
----------------
None. Shouldn't even notice it on staging or local development.