### PR TITLE
[feature] MathJax rendering in SHARE

### DIFF
--- a/website/static/js/share/results.js
+++ b/website/static/js/share/results.js
@@ -112,7 +112,7 @@ var Description = {
                 ),
                 m('a.sr-only', {href: '#', onclick: showOnClick}, ctrl.showAll() ? 'See less' : 'See more')]);
         } else {
-            return m('p.readable', MathJax.Hub.Queue(['Typeset', MathJax.Hub]), result.description);
+            return m('p.readable', MathJax.Hub.Queue(['Typeset', MathJax.Hub]), result.description); // jshint ignore:line
         }
     }
 };

--- a/website/static/js/share/results.js
+++ b/website/static/js/share/results.js
@@ -47,7 +47,7 @@ var Results = {
                                 utils.updateVM(vm, data);
                             });
                     }
-                }, 'More') : [])
+                }, 'More'): [])
             ))
         ]);
 
@@ -105,14 +105,16 @@ var Description = {
         var showOnClick = function() {
             ctrl.showAll(!ctrl.showAll());
         };
-        if ((result.description || '').length > 350) {
+        //if its long and does not contain any math then you can truncate it
+        if ((result.description || '').length > 350 && result.description.indexOf('$') === -1) {
             return m('', [
                 m('p.readable.pointer', {onclick: showOnClick},
                     ctrl.showAll() ? result.description : $.truncate(result.description, {length: 350})
                 ),
                 m('a.sr-only', {href: '#', onclick: showOnClick}, ctrl.showAll() ? 'See less' : 'See more')]);
+        //otherwise run MathJax and display the entire description
         } else {
-            return m('p.readable', result.description);
+            return m('p.readable', MathJax.Hub.Queue(['Typeset', MathJax.Hub]), result.description);
         }
     }
 };

--- a/website/static/js/share/results.js
+++ b/website/static/js/share/results.js
@@ -7,6 +7,7 @@ var $osf = require('js/osfHelpers');
 var utils = require('./utils');
 require('truncate');
 
+
 var LoadingIcon = {
     view: function(ctrl) {
         return m('img', {src: '/static/img/loading.gif', alt: 'loading spinner'});

--- a/website/static/js/share/results.js
+++ b/website/static/js/share/results.js
@@ -94,7 +94,6 @@ var TitleBar = {
     }
 };
 
-/* Render the description of a single result. Will highlight the matched text */
 var Description = {
     controller: function(vm) {
         var self = this;
@@ -105,14 +104,12 @@ var Description = {
         var showOnClick = function() {
             ctrl.showAll(!ctrl.showAll());
         };
-        //if its long and does not contain any math then you can truncate it
         if ((result.description || '').length > 350 && result.description.indexOf('$') === -1) {
             return m('', [
                 m('p.readable.pointer', {onclick: showOnClick},
                     ctrl.showAll() ? result.description : $.truncate(result.description, {length: 350})
                 ),
                 m('a.sr-only', {href: '#', onclick: showOnClick}, ctrl.showAll() ? 'See less' : 'See more')]);
-        //otherwise run MathJax and display the entire description
         } else {
             return m('p.readable', MathJax.Hub.Queue(['Typeset', MathJax.Hub]), result.description);
         }

--- a/website/templates/share_search.mako
+++ b/website/templates/share_search.mako
@@ -6,4 +6,16 @@
 
 <%def name="javascript_bottom()">
     <script src=${"/static/public/js/share-search-page.js" | webpack_asset}></script>
+
+<script type="text/x-mathjax-config">
+   MathJax.Hub.Config({
+       tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']], processEscapes: true}
+    });
+</script>
+
+<script type="text/javascript"
+    src="/static/vendor/bower_components/MathJax/unpacked/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+</script>
+
 </%def>
+


### PR DESCRIPTION
## Purpose
Currently, any descriptions in SHARE that contain LaTeX do not render correctly. For example, there is no math rendering in many of the descriptions for ArXiv (https://osf.io/share/?q=*&optional=match%3AshareProperties.source%3Aarxiv_oai&sort=Relevance# ).
Now, whenever there is math present in a description, the equations and symbols will render correctly.

## Changes 
This PR uses MathJax to render LaTeX in the description section of any SHARE results. As a result some descriptions cannot be truncated to a shorter length. This is because when the descriptions automatically truncate to 350 characters, sometimes a math phrase or symbol becomes incomplete and MathJax cannot recognize it. Also, math phrases and symbols not recognized by MathJax are printed in red ink, but this isn’t super prevalent. 

**_BEFORE_**:
![screen shot 2016-03-22 at 1 20 58 pm](https://cloud.githubusercontent.com/assets/10505527/13961012/1b883a28-f031-11e5-979d-23d3d178a86f.png)
_**AFTER**_:
![screen shot 2016-03-22 at 1 29 16 pm](https://cloud.githubusercontent.com/assets/10505527/13961243/24159b6c-f032-11e5-9484-d202689a8404.png)



## Side Effects
The change in length of descriptions containing math and the red highlighting of math that could not be rendered by MathJax.