### PR TITLE
Feature: Change structure of User.comments_viewed_timestamps

### DIFF
--- a/scripts/tests/test_update_comments.py
+++ b/scripts/tests/test_update_comments.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from framework.auth.core import User
 from scripts.update_comments import update_comments_viewed_timestamp
 from tests.base import OsfTestCase
 from tests.factories import UserFactory
@@ -7,14 +8,9 @@ from nose.tools import *  # PEP8 asserts
 
 class TestUpdateCommentFields(OsfTestCase):
 
-    def test_update_comments_viewed_timestamp(self):
-        user = UserFactory()
-        timestamp = datetime.utcnow().replace(microsecond=0)
-        user.comments_viewed_timestamp = {'abc123': timestamp}
-        user.save()
-        update_comments_viewed_timestamp()
-        user.reload()
-        assert_equal(user.comments_viewed_timestamp, {'abc123': {'node': timestamp}})
+    def tearDown(self):
+        super(TestUpdateCommentFields, self).tearDown()
+        User.remove()
 
     def test_update_comments_viewed_timestamp_none(self):
         user = UserFactory()
@@ -23,3 +19,20 @@ class TestUpdateCommentFields(OsfTestCase):
         update_comments_viewed_timestamp()
         user.reload()
         assert_equal(user.comments_viewed_timestamp, {})
+
+    def test_update_comments_viewed_timestamp(self):
+        user = UserFactory()
+        timestamp = datetime.utcnow().replace(microsecond=0)
+        user.comments_viewed_timestamp = {
+            'node_id': {
+                'node': timestamp,
+                'files': {
+                    'file_id_1': timestamp,
+                    'file_id_2': timestamp,
+                }
+            }
+        }
+        user.save()
+        update_comments_viewed_timestamp()
+        user.reload()
+        assert_equal(user.comments_viewed_timestamp, {'node_id': timestamp, 'file_id_1': timestamp, 'file_id_2': timestamp})

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -53,7 +53,7 @@ class TestCommentViews(OsfTestCase):
         }, auth=self.user.auth)
         self.user.reload()
 
-        user_timestamp = self.user.comments_viewed_timestamp[self.project._id]['node']
+        user_timestamp = self.user.comments_viewed_timestamp[self.project._id]
         view_timestamp = dt.datetime.utcnow()
         assert_datetime_equal(user_timestamp, view_timestamp)
 
@@ -88,7 +88,7 @@ class TestCommentViews(OsfTestCase):
         }, auth=self.user.auth)
         self.user.reload()
 
-        user_timestamp = self.user.comments_viewed_timestamp[self.project._id]['files'][test_file._id]
+        user_timestamp = self.user.comments_viewed_timestamp[test_file._id]
         view_timestamp = dt.datetime.utcnow()
         assert_datetime_equal(user_timestamp, view_timestamp)
 

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -215,10 +215,10 @@ class Comment(GuidStoredObject, SpamMixin):
     def find_n_unread(cls, user, node, page, root_id=None):
         if node.is_contributor(user):
             if page == Comment.OVERVIEW:
-                view_timestamp = user.get_node_comment_timestamps(node, 'node')
+                view_timestamp = user.get_node_comment_timestamps(target_id=node._id)
                 root_target = Guid.load(node._id)
             elif page == Comment.FILES:
-                view_timestamp = user.get_node_comment_timestamps(node, page, file_id=root_id)
+                view_timestamp = user.get_node_comment_timestamps(target_id=root_id)
                 root_target = Guid.load(root_id)
             else:
                 raise ValueError('Invalid page')

--- a/website/project/views/comment.py
+++ b/website/project/views/comment.py
@@ -136,27 +136,12 @@ def is_reply(target):
 
 def _update_comments_timestamp(auth, node, page=Comment.OVERVIEW, root_id=None):
     if node.is_contributor(auth.user):
-        user_timestamp = auth.user.comments_viewed_timestamp
-        node_timestamp = user_timestamp.get(node._id, None)
-        if not node_timestamp:
-            user_timestamp[node._id] = dict()
-        timestamps = auth.user.comments_viewed_timestamp[node._id]
         enqueue_postcommit_task(partial(ban_url, node, []))
-
-        # update node timestamp
         if page == Comment.OVERVIEW:
-            timestamps[Comment.OVERVIEW] = datetime.utcnow()
-            auth.user.save()
-            return {node._id: auth.user.comments_viewed_timestamp[node._id][Comment.OVERVIEW].isoformat()}
-
-        # set up timestamp dictionary for files page
-        if not timestamps.get(page, None):
-            timestamps[page] = dict()
-
-        # if updating timestamp on a specific file page
-        timestamps[page][root_id] = datetime.utcnow()
+            root_id = node._id
+        auth.user.comments_viewed_timestamp[root_id] = datetime.utcnow()
         auth.user.save()
-        return {node._id: auth.user.comments_viewed_timestamp[node._id][page][root_id].isoformat()}
+        return {root_id: auth.user.comments_viewed_timestamp[root_id].isoformat()}
     else:
         return {}
 


### PR DESCRIPTION
Purpose
-----------
Since `user.comments_viewed_timestamps` organizes timestamps under a `node_id` top-level key, when a file moves nodes the field needs to be updated and that locks the user. Instead, make the timestamps a dictionary of `{target_id: timestamp}`

Changes
------------
- Change structure of user.comments_viewed_timestamps from {'node_id': {'node': timestamp, 'files': {'file_id': timestamp}}} to {'node_id: timestamp, file_id: timestamp, ...}.
- Need to run `scripts.update_comments_viewed_timestamp`