### PR TITLE
feature/load comments incrementally

### DIFF
--- a/website/static/js/comment.js
+++ b/website/static/js/comment.js
@@ -137,10 +137,6 @@ BaseComment.prototype.fetch = function() {
 /* Go through the paginated API response to fetch all comments for the specified target */
 BaseComment.prototype.fetchNext = function(url, comments) {
     var self = this;
-    var deferred = $.Deferred();
-    if (self._loaded) {
-        deferred.resolve(self.comments());
-    }
     var request = osfHelpers.ajaxJSON(
         'GET',
         url,
@@ -149,22 +145,21 @@ BaseComment.prototype.fetchNext = function(url, comments) {
         comments = comments.concat(response.data);
         if (self._loaded !== true) {
             self._loaded = true;
-            self.loadingComments(false);
         }
         self.comments(
             ko.utils.arrayMap(comments, function(comment) {
                 return new CommentModel(comment, self, self.$root);
             })
         );
-        deferred.resolve(self.comments());
         self.configureCommentsVisibility();
         if (response.links.next !== null) {
             self.fetchNext(response.links.next, comments);
+        } else {
+            self.loadingComments(false);
         }
     }).fail(function () {
         self.loadingComments(false);
     });
-    return deferred.promise();
 };
 
 BaseComment.prototype.setUnreadCommentCount = function() {

--- a/website/static/js/comment.js
+++ b/website/static/js/comment.js
@@ -147,18 +147,19 @@ BaseComment.prototype.fetchNext = function(url, comments) {
         {'isCors': true});
     request.done(function(response) {
         comments = comments.concat(response.data);
-        if (response.links.next !== null) {
-            self.fetchNext(response.links.next, comments);
-        } else {
-            self.comments(
-                ko.utils.arrayMap(comments, function(comment) {
-                    return new CommentModel(comment, self, self.$root);
-                })
-            );
-            deferred.resolve(self.comments());
-            self.configureCommentsVisibility();
+        if (self._loaded !== true) {
             self._loaded = true;
             self.loadingComments(false);
+        }
+        self.comments(
+            ko.utils.arrayMap(comments, function(comment) {
+                return new CommentModel(comment, self, self.$root);
+            })
+        );
+        deferred.resolve(self.comments());
+        self.configureCommentsVisibility();
+        if (response.links.next !== null) {
+            self.fetchNext(response.links.next, comments);
         }
     }).fail(function () {
         self.loadingComments(false);

--- a/website/static/js/comment.js
+++ b/website/static/js/comment.js
@@ -142,15 +142,15 @@ BaseComment.prototype.fetchNext = function(url, comments) {
         url,
         {'isCors': true});
     request.done(function(response) {
-        comments = comments.concat(response.data);
+        comments = response.data;
         if (self._loaded !== true) {
             self._loaded = true;
         }
-        self.comments(
-            ko.utils.arrayMap(comments, function(comment) {
-                return new CommentModel(comment, self, self.$root);
-            })
-        );
+        comments.forEach(function(comment) {
+            self.comments.push(
+                new CommentModel(comment, self, self.$root)
+            );
+        });
         self.configureCommentsVisibility();
         if (response.links.next !== null) {
             self.fetchNext(response.links.next, comments);

--- a/website/templates/include/comment_pane_template.mako
+++ b/website/templates/include/comment_pane_template.mako
@@ -40,13 +40,11 @@
                     <div class="text-danger">{{errorMessage}}</div>
                 </form>
             </div>
+            <div data-bind="template: {name: 'commentTemplate', foreach: comments}"></div>
             <!-- ko if: loadingComments -->
             <div style="text-align: center;">
                 <div class="logo-spin logo-lg"></div>
             </div>
-            <!-- /ko -->
-            <!-- ko ifnot: loadingComments -->
-            <div data-bind="template: {name: 'commentTemplate', foreach: comments}"></div>
             <!-- /ko -->
         </div>
     </div>


### PR DESCRIPTION
# Purpose

At the moment, comments don't load unless all of the API requests have been made. This PR makes it so that comments are revealed as they come back from the API - and the requests continue in the background

# Changes
Remove the check that there are no more links to load from the API - resolves the request and appends to the comments array, and makes it visible on the very first request that comes back. if there are more requests to make, it still runs recursively and continues to add to the array of comments already displayed.

# Side Effects
- Makes comment loading a bit jumpier than just loading them all at once when all the API requests had been made.

### Questions
- This still uses deferred promises - could this be done smoother by removing the promise components altogether?