### PR TITLE
toggle breadcrumbs to use use component or project modal

### DIFF
--- a/website/static/js/myProjects.js
+++ b/website/static/js/myProjects.js
@@ -383,6 +383,7 @@ var MyProjects = {
                 self.data(value.data);
             }
             if(!value.data[0]){
+                debugger;
                 if(lastcrumb.type === 'collection'){
                     if(lastcrumb.data.systemCollection === 'nodes'){
                         self.nonLoadTemplate(m('.db-non-load-template.m-md.p-md.osf-box',
@@ -1287,6 +1288,7 @@ var Breadcrumbs = {
                 if(index === array.length-1){
                     var label = item.type === 'node' ? ' Create component' : ' Create project';
                     var title = item.type === 'node' ? 'Create new component' : 'Create new project';
+                    var divID = item.type === 'node' ? 'addSubComponent' : 'addProject';
                     var parentID = item.type === 'node' ? args.breadcrumbs()[args.breadcrumbs().length - 1].data.id : null;
                     var showAddProject = true;
                     var addProjectTemplate = '';
@@ -1301,11 +1303,11 @@ var Breadcrumbs = {
                     }
                     if(showAddProject && !viewOnly){
                         addProjectTemplate = m.component(AddProject, {
-                            buttonTemplate: m('.btn.btn-sm.text-muted[data-toggle="modal"][data-target="#addProject"]', {onclick: function() {
+                            buttonTemplate: m('.btn.btn-sm.text-muted[data-toggle="modal"][data-target="#' + divID + '"]', {onclick: function() {
                                 $osf.trackClick('myProjects', 'add-' + objectType, 'open-add-' + objectType + '-modal');
                             }}, [m('i.fa.fa-plus', {style: 'font-size: 10px;'}), label]),
                             parentID: parentID,
-                            modalID: 'addProject',
+                            modalID: divID,
                             title: title,
                             categoryList: args.categoryList,
                             stayCallback: function () {

--- a/website/static/js/myProjects.js
+++ b/website/static/js/myProjects.js
@@ -383,7 +383,6 @@ var MyProjects = {
                 self.data(value.data);
             }
             if(!value.data[0]){
-                debugger;
                 if(lastcrumb.type === 'collection'){
                     if(lastcrumb.data.systemCollection === 'nodes'){
                         self.nonLoadTemplate(m('.db-non-load-template.m-md.p-md.osf-box',


### PR DESCRIPTION
Currently, if you add a component via breadcrumbs, it will pop a Add project dialog.  Not the oh so needed Add component dialog.  This should make that magic happen.

:(
-

![screen shot 2016-03-22 at 5 02 30 pm](https://cloud.githubusercontent.com/assets/6232068/13967901/ed71c342-f04f-11e5-82df-8e09db7148f3.png)

:)
-

![screen shot 2016-03-22 at 5 02 39 pm](https://cloud.githubusercontent.com/assets/6232068/13967903/f1a5251c-f04f-11e5-8070-7d4cd8a0b0d1.png)
