### PR TITLE
[Ready for review] Fix file comment banning

### DIFF
--- a/website/project/views/comment.py
+++ b/website/project/views/comment.py
@@ -143,6 +143,10 @@ def _update_comments_timestamp(auth, node, page=Comment.OVERVIEW, root_id=None):
             user_timestamp[node._id] = dict()
         timestamps = auth.user.comments_viewed_timestamp[node._id]
         enqueue_postcommit_task(partial(ban_url, node, []))
+        if root_id is not None:
+            guid_obj = Guid.load(root_id)
+            if guid_obj is not None:
+                enqueue_postcommit_task(partial(ban_url, guid_obj.referent, []))
 
         # update node timestamp
         if page == Comment.OVERVIEW:


### PR DESCRIPTION
This should fix the bug with dataverse and figshare (among others) comment unread counts not updating. 

It would be nice if when we replaced the v1 route for updating the timestamps for unread comment counts it was related more directly to the object being commented upon instead of the user. The current setup causes many logic branches to handle the fact that the URL/object being modified is the user but the object we're expected to see change is the File, Node, etc.

@sloria @nicipfeiffer @samanehsan 