### PR TITLE
Remove unused backref from ApiOAuth2Application

### DIFF
--- a/website/oauth/models/__init__.py
+++ b/website/oauth/models/__init__.py
@@ -474,7 +474,6 @@ class ApiOAuth2Application(StoredObject):
                                     index=True)
 
     owner = fields.ForeignField('User',
-                                backref='created',
                                 index=True,
                                 required=True)
 


### PR DESCRIPTION
Refs https://openscience.atlassian.net/browse/OSF-5911

## Purpose
Clean up unused and unnecessary backref from `ApiOauth2Application` model.

## Summary of changes
- Remove the line that creates the backref with the ForeignField. Confirmed that after the change, mongo records still create a foreign field, but don't save the backref.

## Side effects
There should be no side effects. This backref was never used. It was only referenced once, and at that, in a unit test that was [removed](https://github.com/CenterForOpenScience/osf.io/pull/4813/files#diff-327b130c82fa4e83e97f6c1a50a0da1cL1073) several months ago.


Although some data will persist in the `_backrefs` section of the mongo user document, this should not affect other code and can reasonably be ignored.

[#OSF-5911]