### PR TITLE
Remove totally unused backref from ApiOAuth2PersonalToken

### DIFF
--- a/website/oauth/models/__init__.py
+++ b/website/oauth/models/__init__.py
@@ -548,10 +548,9 @@ class ApiOAuth2PersonalToken(StoredObject):
     # Name of the field being `token_id` is a CAS requirement.
     # This is the actual value of the token that's used to authenticate
     token_id = fields.StringField(default=functools.partial(random_string, length=70),
-                               unique=True)
+                                  unique=True)
 
     owner = fields.ForeignField('User',
-                                backref='created',
                                 index=True,
                                 required=True)
 


### PR DESCRIPTION
Refs https://openscience.atlassian.net/browse/OSF-5912


## Purpose
(same as #5282. If you give a mouse a cookie...) 
Clean up unused and unnecessary backref from `ApiOAuth2PersonalToken` model.

## Summary of changes
- Remove the line that creates the backref with the ForeignField. Confirmed that after the change, mongo records still create a foreign field, but don't save the backref.

## Testing notes
Tested `<api>/v2/tokens` endpoint : create and edit personal access tokens from profile settings page on the OSF, and see list of tokens.

## Side effects
There should be no side effects. This backref was never used.

Although some data will persist in the `_backrefs` section of the mongo user record, this should be ignored by other code and can reasonably be ignored.

[#OSF-5912]