### PR TITLE
Remove misc unused backrefs

### DIFF
--- a/tests/test_registrations/test_embargoes.py
+++ b/tests/test_registrations/test_embargoes.py
@@ -104,17 +104,6 @@ class RegistrationEmbargoModelsTestCase(OsfTestCase):
         )
         assert_equal(Embargo.find().count(), initial_count + 1)
 
-    # Backref tests
-    def test_embargo_initiator_has_backref(self):
-        self.registration.embargo_registration(
-            self.user,
-            self.valid_embargo_end_date
-        )
-        self.registration.save()
-        self.registration.reload()
-        assert_equal(len(self.user.embargo__embargoed),
-            Embargo.find(Q('initiated_by', 'eq', self.user)).count())
-
     # Node#embargo_registration tests
     def test_embargo_from_non_admin_raises_PermissionsError(self):
         self.registration.remove_permission(self.user, 'admin')

--- a/tests/test_registrations/test_retractions.py
+++ b/tests/test_registrations/test_retractions.py
@@ -5,17 +5,18 @@ import httplib as http
 
 import mock
 from nose.tools import *  # noqa
+
+from modularodm.exceptions import ValidationValueError
+from modularodm import Q
+
+from framework.auth import Auth
+from framework.exceptions import PermissionsError
 from tests.base import fake, OsfTestCase
 from tests.factories import (
     AuthUserFactory, NodeFactory, ProjectFactory,
     RegistrationFactory, UserFactory, UnconfirmedUserFactory,
     UnregUserFactory
 )
-
-from modularodm.exceptions import ValidationValueError
-from framework.auth import Auth
-from framework.exceptions import HTTPError, PermissionsError
-
 from website import tokens
 from website.exceptions import (
     InvalidSanctionApprovalToken, InvalidSanctionRejectionToken,

--- a/tests/test_registrations/test_retractions.py
+++ b/tests/test_registrations/test_retractions.py
@@ -86,7 +86,7 @@ class RegistrationRetractionModelsTestCase(OsfTestCase):
         self.registration.retract_registration(self.user, self.valid_justification)
         self.registration.save()
         self.registration.reload()
-        assert_equal(len(self.user.retraction__initiated), 1)
+        assert_equal(Retraction.find(Q('initiated_by', 'eq', self.user)).count(), 1)
 
     # Node#retract_registration tests
     def test_pending_retract(self):

--- a/website/addons/badges/model/badges.py
+++ b/website/addons/badges/model/badges.py
@@ -161,7 +161,7 @@ class BadgeAssertion(StoredObject):
     @property
     def recipient(self):
         return {
-            'idenity': self.node._id,
+            'idenity': self.node._id,  # TODO: An unknown amount of code may depend on this typo
             'type': 'osfnode',  # TODO Could be an email?
             'hashed': False
         }

--- a/website/addons/box/model.py
+++ b/website/addons/box/model.py
@@ -81,9 +81,7 @@ class BoxNodeSettings(StorageAddonBase, AddonOAuthNodeSettingsBase):
     oauth_provider = Box
     serializer = BoxSerializer
 
-    foreign_user_settings = fields.ForeignField(
-        'boxusersettings', backref='authorized'
-    )
+    foreign_user_settings = fields.ForeignField('boxusersettings')
     folder_id = fields.StringField(default=None)
     folder_name = fields.StringField()
     folder_path = fields.StringField()

--- a/website/addons/box/model.py
+++ b/website/addons/box/model.py
@@ -81,7 +81,6 @@ class BoxNodeSettings(StorageAddonBase, AddonOAuthNodeSettingsBase):
     oauth_provider = Box
     serializer = BoxSerializer
 
-    foreign_user_settings = fields.ForeignField('boxusersettings')
     folder_id = fields.StringField(default=None)
     folder_name = fields.StringField()
     folder_path = fields.StringField()

--- a/website/addons/dataverse/model.py
+++ b/website/addons/dataverse/model.py
@@ -45,10 +45,6 @@ class AddonDataverseNodeSettings(StorageAddonBase, AddonOAuthNodeSettingsBase):
     study_hdl = fields.StringField()    # Now dataset_doi
     study = fields.StringField()        # Now dataset
 
-    foreign_user_settings = fields.ForeignField(
-        'addondataverseusersettings', backref='authorized'
-    )
-
     # Legacy settings objects won't have IDs
     @property
     def folder_name(self):

--- a/website/conferences/model.py
+++ b/website/conferences/model.py
@@ -58,4 +58,4 @@ class Conference(StoredObject):
 class MailRecord(StoredObject):
     _id = fields.StringField(primary=True, default=lambda: str(bson.ObjectId()))
     data = fields.DictionaryField()
-    records = fields.AbstractForeignField(list=True, backref='created')
+    records = fields.AbstractForeignField(list=True)

--- a/website/notifications/model.py
+++ b/website/notifications/model.py
@@ -19,9 +19,9 @@ class NotificationSubscription(StoredObject):
     owner = fields.AbstractForeignField()
 
     # Notification types
-    none = fields.ForeignField('user', list=True, backref='none')
-    email_digest = fields.ForeignField('user', list=True, backref='email_digest')
-    email_transactional = fields.ForeignField('user', list=True, backref='email_transactional')
+    none = fields.ForeignField('user', list=True)
+    email_digest = fields.ForeignField('user', list=True)
+    email_transactional = fields.ForeignField('user', list=True)
 
     def add_user_to_subscription(self, user, notification_type, save=True):
         for nt in NOTIFICATION_TYPES:

--- a/website/notifications/model.py
+++ b/website/notifications/model.py
@@ -19,9 +19,9 @@ class NotificationSubscription(StoredObject):
     owner = fields.AbstractForeignField()
 
     # Notification types
-    none = fields.ForeignField('user', list=True)
-    email_digest = fields.ForeignField('user', list=True)
-    email_transactional = fields.ForeignField('user', list=True)
+    none = fields.ForeignField('user', list=True, backref='none')
+    email_digest = fields.ForeignField('user', list=True, backref='email_digest')
+    email_transactional = fields.ForeignField('user', list=True, backref='email_transactional')
 
     def add_user_to_subscription(self, user, notification_type, save=True):
         for nt in NOTIFICATION_TYPES:

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -4194,7 +4194,7 @@ class RegistrationApproval(PreregCallbackMixin, EmailApprovableSanction):
     APPROVE_URL_TEMPLATE = settings.DOMAIN + 'project/{node_id}/?token={token}'
     REJECT_URL_TEMPLATE = settings.DOMAIN + 'project/{node_id}/?token={token}'
 
-    initiated_by = fields.ForeignField('user', backref='registration_approved')
+    initiated_by = fields.ForeignField('user')
 
     def _get_registration(self):
         return Node.find_one(Q('registration_approval', 'eq', self))

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -137,10 +137,10 @@ def ensure_schemas():
 
 
 class MetaData(GuidStoredObject):
-
+    # TODO: This model may be unused; potential candidate for deprecation depending on contents of production database
     _id = fields.StringField(primary=True)
 
-    target = fields.AbstractForeignField(backref='metadata')
+    target = fields.AbstractForeignField()
     data = fields.DictionaryField()
 
     date_created = fields.DateTimeField(auto_now_add=datetime.datetime.utcnow)

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -3909,7 +3909,7 @@ class Embargo(PreregCallbackMixin, EmailApprovableSanction):
     APPROVE_URL_TEMPLATE = settings.DOMAIN + 'project/{node_id}/?token={token}'
     REJECT_URL_TEMPLATE = settings.DOMAIN + 'project/{node_id}/?token={token}'
 
-    initiated_by = fields.ForeignField('user', backref='embargoed')
+    initiated_by = fields.ForeignField('user')
     for_existing_registration = fields.BooleanField(default=False)
 
     @property

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -4063,7 +4063,7 @@ class Retraction(EmailApprovableSanction):
     APPROVE_URL_TEMPLATE = settings.DOMAIN + 'project/{node_id}/?token={token}'
     REJECT_URL_TEMPLATE = settings.DOMAIN + 'project/{node_id}/?token={token}'
 
-    initiated_by = fields.ForeignField('user', backref='initiated')
+    initiated_by = fields.ForeignField('user')
     justification = fields.StringField(default=None, validate=MaxLengthValidator(2048))
 
     def __repr__(self):


### PR DESCRIPTION
Refs various, general parent is https://openscience.atlassian.net/browse/OSF-5674 

## Purpose
We are attempting to reduce the number of unused backrefs on our models, as backrefs create side effects (record locking) that are not ideal.

This PR is intended to encompass the low-hanging fruit: backrefs that aren't used at all, in various places.

## Summary of changes
- Remove various unused backrefs (see diff)

## Side effects/ testing notes
Should be no side effects because these backrefs were unused. Migration probably unnecessary. Where relevant, below are notes on how to hit endpoints where these models are used.

- The `MailRecord` model is used to track email submissions to conferences (OSF For Meetings); I wasn't able to test this locally.

- Also try creating embargoed and retratcted registrations, as well as approving a registration when asked to do so via email

- Very quickly confirm the box addon works as expected (usersettings recognized)

## Subtasks

https://openscience.atlassian.net/browse/OSF-5897
https://openscience.atlassian.net/browse/OSF-5902
https://openscience.atlassian.net/browse/OSF-5903
https://openscience.atlassian.net/browse/OSF-5905
~~https://openscience.atlassian.net/browse/OSF-5909~~ (moved to a different PR)
https://openscience.atlassian.net/browse/OSF-5910
https://openscience.atlassian.net/browse/OSF-5918