### PR TITLE
[fix] Use local instances of expandOnLoad

### DIFF
--- a/website/static/js/nodeSelectTreebeard.js
+++ b/website/static/js/nodeSelectTreebeard.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var $ = require('jquery');
+var $osf = require('js/osfHelpers');
 var m = require('mithril');
 var ko = require('knockout');
 var Treebeard = require('treebeard');

--- a/website/static/js/nodeSelectTreebeard.js
+++ b/website/static/js/nodeSelectTreebeard.js
@@ -6,6 +6,60 @@ var ko = require('knockout');
 var Treebeard = require('treebeard');
 var projectSettingsTreebeardBase = require('js/projectSettingsTreebeardBase');
 
+function expandOnLoad() {
+    var tb = this;  // jshint ignore: line
+    for (var i = 0; i < tb.treeData.children.length; i++) {
+        var parent = tb.treeData.children[i];
+        tb.updateFolder(null, parent);
+        expandChildren(tb, parent.children);
+    }
+}
+
+function expandChildren(tb, children) {
+    var openParent = false;
+    for (var i = 0; i < children.length; i++) {
+        var child = children[i];
+        var parent = children[i].parent();
+        if (child.data.kind === 'event' && child.data.event.notificationType !== 'adopt_parent') {
+            openParent = true;
+        }
+        if (child.children.length > 0) {
+            expandChildren(tb, child.children);
+        }
+    }
+    if (openParent) {
+        openAncestors(tb, children[0]);
+    }
+}
+
+function openAncestors (tb, item) {
+    var parent = item.parent();
+    if(parent && parent.id > 0) {
+        tb.updateFolder(null, parent);
+        openAncestors(tb, parent);
+    }
+}
+
+function subscribe(item, notification_type) {
+    var id = item.parent().data.node.id;
+    var event = item.data.event.title;
+    var payload = {
+        'id': id,
+        'event': event,
+        'notification_type': notification_type
+    };
+    $osf.postJSON(
+        '/api/v1/subscriptions/',
+        payload
+    ).done(function(){
+        //'notfiy-success' is to override default class 'success' in treebeard
+        item.notify.update('Settings updated', 'notify-success', 1, 2000);
+        item.data.event.notificationType = notification_type;
+    }).fail(function() {
+        item.notify.update('Could not update settings', 'notify-danger', 1, 2000);
+    });
+}
+
 function NodeSelectTreebeard(divID, data, nodesState) {
     /**
      *  nodesState is a knockout variable that syncs the mithril checkbox list with information on the view.  The
@@ -78,7 +132,7 @@ function NodeSelectTreebeard(divID, data, nodesState) {
         }
     });
     var grid = new Treebeard(tbOptions);
-    projectSettingsTreebeardBase.expandOnLoad.call(grid.tbController);
+    expandOnLoad.call(grid.tbController);
 }
 module.exports = NodeSelectTreebeard;
 

--- a/website/static/js/nodesPrivacySettingsTreebeard.js
+++ b/website/static/js/nodesPrivacySettingsTreebeard.js
@@ -7,6 +7,37 @@ var Treebeard = require('treebeard');
 var $osf = require('js/osfHelpers');
 var projectSettingsTreebeardBase = require('js/projectSettingsTreebeardBase');
 
+function expandOnLoad() {
+    var tb = this;  // jshint ignore: line
+    for (var i = 0; i < tb.treeData.children.length; i++) {
+        var parent = tb.treeData.children[i];
+        tb.updateFolder(null, parent);
+        expandChildren(tb, parent.children);
+    }
+}
+
+function expandChildren(tb, children) {
+    var openParent = false;
+    for (var i = 0; i < children.length; i++) {
+        var child = children[i];
+        var parent = children[i].parent();
+        if (child.children.length > 0) {
+            expandChildren(tb, child.children);
+        }
+    }
+    if (openParent) {
+        openAncestors(tb, children[0]);
+    }
+}
+
+function openAncestors (tb, item) {
+    var parent = item.parent();
+    if(parent && parent.id > 0) {
+        tb.updateFolder(null, parent);
+        openAncestors(tb, parent);
+    }
+}
+
 function NodesPrivacyTreebeard(divID, data, nodesState, nodesOriginal) {
     /**
      * nodesChanged and nodesState are knockout variables.  nodesChanged will keep track of the nodes that have
@@ -81,7 +112,7 @@ function NodesPrivacyTreebeard(divID, data, nodesState, nodesOriginal) {
         }
     });
     var grid = new Treebeard(tbOptions);
-    projectSettingsTreebeardBase.expandOnLoad.call(grid.tbController);
+    expandOnLoad.call(grid.tbController);
 }
 module.exports = NodesPrivacyTreebeard;
 

--- a/website/static/js/projectSettingsTreebeardBase.js
+++ b/website/static/js/projectSettingsTreebeardBase.js
@@ -9,6 +9,20 @@ var m = require('mithril');
 var Fangorn = require('js/fangorn');
 
 
+function resolveToggle(item) {
+    var toggleMinus = m('i.fa.fa-minus', ' '),
+        togglePlus = m('i.fa.fa-plus', ' ');
+
+    if (item.children.length > 0) {
+        if (item.open) {
+            return toggleMinus;
+        }
+        return togglePlus;
+    }
+    item.open = true;
+    return '';
+}
+
 /**
  * take treebeard tree structure of nodes and get a dictionary of parent node and all its
  * children

--- a/website/static/js/projectSettingsTreebeardBase.js
+++ b/website/static/js/projectSettingsTreebeardBase.js
@@ -5,57 +5,8 @@
 
 'use strict';
 
-var $ = require('jquery');
 var m = require('mithril');
-var Treebeard = require('treebeard');
 var Fangorn = require('js/fangorn');
-
-
-
-
-function expandOnLoad() {
-    var tb = this;  // jshint ignore: line
-    for (var i = 0; i < tb.treeData.children.length; i++) {
-        var parent = tb.treeData.children[i];
-        tb.updateFolder(null, parent);
-        expandChildren(tb, parent.children);
-    }
-}
-
-function expandChildren(tb, children) {
-    var openParent = false;
-    for (var i = 0; i < children.length; i++) {
-        var child = children[i];
-        if (child.children.length > 0) {
-            expandChildren(tb, child.children);
-        }
-    }
-    if (openParent) {
-        openAncestors(tb, children[0]);
-    }
-}
-
-function openAncestors (tb, item) {
-    var parent = item.parent();
-    if(parent && parent.id > 0) {
-        tb.updateFolder(null, parent);
-        openAncestors(tb, parent);
-    }
-}
-
-function resolveToggle(item) {
-    var toggleMinus = m('i.fa.fa-minus', ' '),
-        togglePlus = m('i.fa.fa-plus', ' ');
-
-    if (item.children.length > 0) {
-        if (item.open) {
-            return toggleMinus;
-        }
-        return togglePlus;
-    }
-    item.open = true;
-    return '';
-}
 
 
 /**
@@ -140,6 +91,5 @@ module.exports = {
           return m('i.fa.fa-refresh.fa-spin');
         }
     },
-    expandOnLoad: expandOnLoad,
     getNodesOriginal: getNodesOriginal
 };


### PR DESCRIPTION
Updated version of https://github.com/CenterForOpenScience/osf.io/pull/5233
Related to https://github.com/CenterForOpenScience/osf.io/pull/4958/files

When adding contributors, the top level is not expanding on staging.  This seems to be correlated to a move of multiple expandOnLoad functions to a global helper.  We are going to go back to using local instances for now.