### PR TITLE
Improve application of text filters

### DIFF
--- a/framework/routing/__init__.py
+++ b/framework/routing/__init__.py
@@ -25,6 +25,11 @@ logger = logging.getLogger(__name__)
 TEMPLATE_DIR = settings.TEMPLATES_PATH
 
 _TPL_LOOKUP = TemplateLookup(
+    default_filters=[
+        'unicode',  # default filter; must set explicitly when overriding
+        'strip_ko',  # Filter that strips out Knockout punches syntax. Can be removed if Knockout-punches is removed.
+    ],
+    imports=['from website.util.sanitize import strip_ko'],
     directories=[
         TEMPLATE_DIR,
         os.path.join(settings.BASE_PATH, 'addons/'),


### PR DESCRIPTION
Related to, and possible alternative to, #5292 
This fix is to master. Replaces #5295 

## Purpose

Improve application of the `strip_ko` filter. We can reasonably apply this to all templates, because it is separate from the markupsafe flag.

## Developer / Deployment notes

When testing the fix, try these steps to ensure that your mako cache is cleared and templates reflect the newest filters. Because this is a global  without help.

1. Pull code
2. Stop any running OSF server
3. Clear contents of `/tmp/mako_modules` directory
4. Restart server

## QA testing notes

I can walk you through in person.