### PR TITLE
[Ready for review] Display original exception even if transaction rollback fails.

### DIFF
--- a/framework/transactions/handlers.py
+++ b/framework/transactions/handlers.py
@@ -52,7 +52,13 @@ def transaction_after_request(response, base_status_code_error=500):
     if view_has_annotation(NO_AUTO_TRANSACTION_ATTR):
         return response
     if response.status_code >= base_status_code_error:
-        commands.rollback()
+        try:
+            commands.rollback()
+        except OperationFailure as ex:
+            logger.exception('Operation Failure during rollback: {}'.format(ex.message), exc_info=ex)
+            return response
+        else:
+            return response
     else:
         try:
             commands.commit()

--- a/framework/transactions/handlers.py
+++ b/framework/transactions/handlers.py
@@ -55,7 +55,7 @@ def transaction_after_request(response, base_status_code_error=500):
         try:
             commands.rollback()
         except OperationFailure as ex:
-            logger.exception('Operation Failure during rollback: {}'.format(ex.message), exc_info=ex)
+            logger.exception('Operation Failure during rollback')
             return response
         else:
             return response

--- a/framework/transactions/handlers.py
+++ b/framework/transactions/handlers.py
@@ -3,6 +3,7 @@
 import httplib
 import logging
 
+import sys
 from flask import request, current_app
 from pymongo.errors import OperationFailure
 
@@ -52,10 +53,11 @@ def transaction_after_request(response, base_status_code_error=500):
     if view_has_annotation(NO_AUTO_TRANSACTION_ATTR):
         return response
     if response.status_code >= base_status_code_error:
+        original_exception = sys.exc_info()
         try:
             commands.rollback()
-        except OperationFailure as ex:
-            logger.exception('Operation Failure during rollback')
+        except OperationFailure:
+            logger.error(original_exception, exc_info=1)
             return response
         else:
             return response


### PR DESCRIPTION
@sloria, @icereval, @chrisseto This tries to rollback, catches the exception and logs it and then returns the original response with the original exception error message. 