### PR TITLE
[feature] Fix Anonymous VOL Description on Public Projects

### DIFF
--- a/website/static/js/privateLinkTable.js
+++ b/website/static/js/privateLinkTable.js
@@ -31,17 +31,7 @@ function LinkViewModel(data, $root) {
     self.anonymousDisplay = ko.computed(function() {
         var openTag = '<span>';
         var closeTag = '</span>';
-        var text;
-        if (data.anonymous) {
-            text = 'Yes';
-            // Strikethrough if node is public
-            if ($root.nodeIsPublic) {
-                openTag = '<del>';
-                closeTag = '</del>';
-            }
-        } else{
-            text = 'No';
-        }
+        var text = data.anonymous ? 'Yes' : 'No' ;
         return [openTag, text, closeTag].join('');
     });
 

--- a/website/templates/project/contributors.mako
+++ b/website/templates/project/contributors.mako
@@ -216,9 +216,6 @@
             <div class="header" data-bind="visible: $root.collapsed() && expanded()"></div>
             <div class="td-content" data-bind="visible: !$root.collapsed() || expanded()">
                 <span data-bind="html: anonymousDisplay"></span>
-                <!-- ko if: $root.nodeIsPublic && anonymous -->
-                <i data-bind="tooltip: {title: 'Public projects are not anonymized.'}" class="fa fa-question-circle fa-sm"></i>
-                <!-- /ko -->
             </div>
         </td>
         <td>


### PR DESCRIPTION
##### Purpose
- The OSF now supports anonymous VOLs on public projects, but the display of anonymous VOLs on public projects has not been updated to reflect this. This PR removes the strikethrough and tooltip that were associated with anonymous VOLs on public projects.
- [OSF-5860](https://openscience.atlassian.net/browse/OSF-5860)

##### Previous 
 - ![screen shot 2016-03-25 at 10 34 25 am](https://cloud.githubusercontent.com/assets/7913604/14046107/58df6c3e-f275-11e5-9ab1-ca02f3ebba51.png)

##### Updated
 - ![screen shot 2016-03-25 at 10 34 08 am](https://cloud.githubusercontent.com/assets/7913604/14046109/5c447cac-f275-11e5-81b4-6d8a47cfef62.png)


