### PR TITLE
[feature] Allow Read + Write Contributors to Add Components with Inherited Contributors

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4260,7 +4260,7 @@ class TestProjectCreation(OsfTestCase):
         assert_true(node)
         assert_true(node.title, 'Im a real title')
 
-    def test_create_component_add_contributors(self):
+    def test_create_component_add_contributors_admin(self):
         url = web_url_for('project_new_node', pid=self.project._id)
         post_data = {'title': 'New Component With Contributors Title', 'category': '', 'inherit_contributors': True}
         res = self.app.post(url, post_data, auth=self.user1.auth)
@@ -4272,7 +4272,7 @@ class TestProjectCreation(OsfTestCase):
         # check redirect url
         assert_in('/contributors/', res.location)
 
-    def test_create_component_with_contributors_not_admin(self):
+    def test_create_component_with_contributors_read_write(self):
         url = web_url_for('project_new_node', pid=self.project._id)
         non_admin = AuthUserFactory()
         self.project.add_contributor(non_admin, permissions=['read', 'write'])
@@ -4282,10 +4282,21 @@ class TestProjectCreation(OsfTestCase):
         self.project.reload()
         child = self.project.nodes[0]
         assert_equal(child.title, 'New Component With Contributors Title')
-        assert_not_in(self.user1, child.contributors)
-        assert_not_in(self.user2, child.contributors)
+        assert_in(non_admin, child.contributors)
+        assert_in(self.user1, child.contributors)
+        assert_in(self.user2, child.contributors)
+        assert_equal(child.get_permissions(non_admin), ['read', 'write',  'admin'])
         # check redirect url
-        assert_not_in('/contributors/', res.location)
+        assert_in('/contributors/', res.location)
+
+    def test_create_component_with_contributors_read(self):
+        url = web_url_for('project_new_node', pid=self.project._id)
+        non_admin = AuthUserFactory()
+        self.project.add_contributor(non_admin, permissions=['read'])
+        self.project.save()
+        post_data = {'title': 'New Component With Contributors Title', 'category': '', 'inherit_contributors': True}
+        res = self.app.post(url, post_data, auth=non_admin.auth, expect_errors=True)
+        assert_equal(res.status_code, 403)
 
     def test_create_component_add_no_contributors(self):
         url = web_url_for('project_new_node', pid=self.project._id)

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -32,7 +32,7 @@ from website.project.decorators import (
     http_error_if_disk_saving_mode
 )
 from website.tokens import process_token_or_pass
-from website.util.permissions import ADMIN, READ, WRITE
+from website.util.permissions import ADMIN, READ, WRITE, CREATOR_PERMISSIONS
 from website.util.rubeus import collect_addon_js
 from website.project.model import has_anonymous_link, get_pointer_parent, NodeUpdateError, validate_title
 from website.project.forms import NewNodeForm
@@ -207,11 +207,10 @@ def project_new_node(auth, node, **kwargs):
             'Your component was created successfully. You can keep working on the project page below, '
             'or go to the new <u><a href={component_url}>component</a></u>.'
         ).format(component_url=new_component.url)
-        if form.inherit_contributors.data and (node.has_permission(user, ADMIN) or node.has_permission(user, WRITE)):
+        if form.inherit_contributors.data and node.has_permission(user, WRITE):
             for contributor in node.contributors:
-                new_component.add_contributor(contributor, permissions=node.get_permissions(contributor), auth=auth)
-                if contributor is user and not node.has_permission(contributor, 'admin'):
-                    new_component.set_permissions(contributor, ['read', 'write', 'admin'])
+                perm = CREATOR_PERMISSIONS if contributor is user else node.get_permissions(contributor)
+                new_component.add_contributor(contributor, permissions=perm, auth=auth)
 
             new_component.save()
             redirect_url = new_component.url + 'contributors/'

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -207,9 +207,12 @@ def project_new_node(auth, node, **kwargs):
             'Your component was created successfully. You can keep working on the project page below, '
             'or go to the new <u><a href={component_url}>component</a></u>.'
         ).format(component_url=new_component.url)
-        if form.inherit_contributors.data and node.has_permission(user, ADMIN):
+        if form.inherit_contributors.data and (node.has_permission(user, ADMIN) or node.has_permission(user, WRITE)):
             for contributor in node.contributors:
                 new_component.add_contributor(contributor, permissions=node.get_permissions(contributor), auth=auth)
+                if contributor is user and not node.has_permission(contributor, 'admin'):
+                    new_component.set_permissions(contributor, ['read', 'write', 'admin'])
+
             new_component.save()
             redirect_url = new_component.url + 'contributors/'
             message = (

--- a/website/templates/project/modal_add_component.mako
+++ b/website/templates/project/modal_add_component.mako
@@ -22,7 +22,7 @@
                             %endfor
                         </select>
                     </div>
-                    %if (len(node['contributors']) > 1) and user['is_admin']:
+                    %if (len(node['contributors']) > 1) and user['can_edit']:
                         <div class="form-group">
                             <label class="f-w-md"><input id="inherit_contributors"
                                           name="inherit_contributors"


### PR DESCRIPTION
##### Purpose 
- Currently, when a r+w contributor creates a new component within a project, they are not given the option to 'add contributors from the parent project'. However, a r+w contributor will become an admin on a component they create, and therefore would be able to later add contributors anyways. 

##### Changes
- Add 'add contributors' checkbox in add component modal for a r+w contributor.
- Add tests for r+w contributors to add components with inherited contributors.
- If a r+w contributor creates a new component with inherited contributors, their permission will be set to admin on the new component, instead of being inherited as r+w. 

##### JIRA 
- [OSF-5887](https://openscience.atlassian.net/browse/OSF-5887)