### PR TITLE
Dashboard/dashboard fixes 7

### DIFF
--- a/api/collections/serializers.py
+++ b/api/collections/serializers.py
@@ -51,7 +51,12 @@ class CollectionSerializer(JSONAPISerializer):
         return absolute_reverse('collections:collection-detail', kwargs={'collection_id': obj._id})
 
     def get_node_links_count(self, obj):
-        return len(obj.nodes_pointer)
+        count = 0
+        auth = get_user_auth(self.context['request'])
+        for pointer in obj.nodes_pointer:
+            if not pointer.node.is_deleted and not pointer.node.is_collection and pointer.node.can_view(auth):
+                count += 1
+        return count
 
     def create(self, validated_data):
         node = Node(**validated_data)

--- a/api/collections/views.py
+++ b/api/collections/views.py
@@ -622,10 +622,11 @@ class CollectionLinkedNodesRelationship(JSONAPIBaseView, generics.RetrieveUpdate
 
     def get_object(self):
         collection = self.get_node(check_object_permissions=False)
+        auth = Auth(self.request.user)
         obj = {'data': [
             pointer for pointer in
             collection.nodes_pointer
-            if not pointer.node.is_deleted and not pointer.node.is_collection
+            if not pointer.node.is_deleted and not pointer.node.is_collection and pointer.node.can_view(auth)
         ], 'self': collection}
         self.check_object_permissions(self.request, obj)
         return obj

--- a/website/static/js/myProjects.js
+++ b/website/static/js/myProjects.js
@@ -575,7 +575,7 @@ var MyProjects = {
                   break;
                 }
 
-              for (var j = 0; i < tags.length; i++)
+              for (var j = 0; j < tags.length; j++)
                 if (node.tagSet.has(tags[j].label)) {
                   tagMatch = true;
                   break;


### PR DESCRIPTION
# Purpose

API change to related_counts for node links on a collection.  Counts only returned for nodes that are not deleted, not a collection, and user has permission to view.

Fixes botched attempt to resolve jshint errors.

