### PR TITLE
Allow QA to see what's in the new build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ website/static/vendor/bower_components/
 node_modules
 # Allow robots.txt to be deployment-specific
 website/static/robots.local.txt
+/website/static/git_logs.txt
 
 # OSF-specific
 ##############

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -51,8 +51,10 @@ def task(*args, **kwargs):
 
 
 @task
-def server(host=None, port=5000, debug=True, live=False):
+def server(host=None, port=5000, debug=True, live=False, gitlogs=False):
     """Run the app server."""
+    if gitlogs:
+        git_logs()
     from website.app import init_app
     app = init_app(set_backends=True, routes=True)
     settings.API_SERVER_PORT = port
@@ -64,6 +66,11 @@ def server(host=None, port=5000, debug=True, live=False):
         server.serve(port=port)
     else:
         app.run(host=host, port=port, debug=debug, threaded=debug, extra_files=[settings.ASSET_HASH_PATH])
+
+@task
+def git_logs(count=100, pretty='format:"%s - %b"', grep='"Merge pull request"'):
+    cmd = 'git log --grep={1} -n {0} --pretty={2} > website/static/git_logs.txt'.format(count, grep, pretty)
+    run(cmd, echo=True)
 
 
 @task


### PR DESCRIPTION
Purpose
-----------
Optionally generate a file that lists the most recent merge requests in an easy to read format, and place that file into the static directory. This will allow QA to go to baseurl/static/git_logs.txt and, with the default setup, see the last 100 merges. Sample output is

```
Merge pull request #5232 from caseyrollins/feature/client-side-profile-url-validation - [feature] Client Side Profile URL Validation
Merge pull request #5220 from brianjgeiger/feature/api/do_not_embed_empty_relationships - Do not embed empty relationships
Merge pull request #5287 from abought/feature/osf5674-backrefs - Remove misc unused backrefs
Merge pull request #5306 from caseyrollins/feature/add-contrib-checkbox - [feature] Allow Read + Write Contributors to Add Components with Inherited Contributors
```

Changes
-------------
- Add an invoke task to generate logs with decent defaults and ability to do some modifications
- Add an option to invoke server to kick generate the log file when starting the server for easy integration into devops pipeline
- Gitignore the log file

Side Effects
----------------
None. Everything has to be done explicitly, and it's only invoke tasks.