### PR TITLE
OSF-5199 No forbidden error when accessing settings page

### DIFF
--- a/website/project/decorators.py
+++ b/website/project/decorators.py
@@ -257,7 +257,6 @@ def must_be_contributor_even_if_public(func):
 
     @functools.wraps(func)
     def wrapped(*args, **kwargs):
-        response = None
         _inject_nodes(kwargs)
         node = kwargs['node']
 

--- a/website/project/decorators.py
+++ b/website/project/decorators.py
@@ -247,6 +247,31 @@ must_be_contributor_or_public = _must_be_contributor_factory(True)
 must_be_contributor_or_public_but_not_anonymized = _must_be_contributor_factory(include_public=True, include_view_only_anon=False)
 
 
+def must_be_contributor_even_if_public(func):
+    """Decorator that verifies whether user is a contributor even if the node is public
+
+    :returns: Decorator function
+    :raises: http.Forbidden if user is not contributor and the node is public
+
+    """
+
+    @functools.wraps(func)
+    def wrapped(*args, **kwargs):
+        response = None
+        _inject_nodes(kwargs)
+        node = kwargs['node']
+
+        kwargs['auth'] = Auth.from_kwargs(request.args.to_dict(), kwargs)
+        user = kwargs['auth'].user
+
+        if not node.is_contributor(user):
+            raise HTTPError(http.FORBIDDEN)
+
+        return func(*args, **kwargs)
+
+    return wrapped
+
+
 def must_have_addon(addon_name, model):
     """Decorator factory that ensures that a given addon has been added to
     the target node. The decorated function will throw a 404 if the required

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -25,7 +25,7 @@ from website.project import new_node, new_private_link
 from website.project.decorators import (
     must_be_contributor_or_public_but_not_anonymized,
     must_be_contributor_or_public,
-    must_be_contributor,
+    must_be_contributor_even_if_public,
     must_be_valid_project,
     must_have_permission,
     must_not_be_registration,
@@ -290,7 +290,7 @@ def node_forks(auth, node, **kwargs):
 
 @must_be_valid_project
 @must_be_logged_in
-@must_be_contributor
+@must_be_contributor_even_if_public
 def node_setting(auth, node, **kwargs):
 
     ret = _view_project(node, auth, primary=True)


### PR DESCRIPTION
<h3>
Purpose
</h3>
When trying to access a public project's settings as a non-contributor (through typing url in the browser), no Forbidden error was shown. Instead, a blank project page was rendered. This PR corrects this problem.

<h3>
Changes
</h3>
This is an interesting bug. If the code reviewers don't mind the long story of how I discovered what exactly the problem is, here's the long story:
According to the problem description and actual recreation of the bug, it is obvious that when a user tries to access the settings page of a public project, the view renders successfully. The reason it shows a blank page is that the template decides what and what not to show according to the user's permissions. In this case, the template decides to show nothing since user's permission match none of the conditionals in the template file.
But the problem is that permission control should not be handled by the template file. The fact that the server decide to return a view object to this supposedly forbidden request means the permission decorator, specifically the "@must_be_contributors" decorator, preceding the node_settings() function in the node.py file does not handle permission correctly.
So I chased to the decorators.py file to look for answers. At first, it seems that the _must_be_contributor_factory() function doesn't check whether the user is a contributor at all! However, such a huge "mistake" should be indicated by failed unit tests that checks the decorator. It seems highly unlikely that both the unit test and the decorator function is implemented incorrectly.
Closer inspection shows that the problems lies with "assumptions". 
<h5>
TL:DR? Please start reading from here.
</h5>
I believe the original implementations of the decorators are based on the assumption that being "public" and "only contributors can view this" are mutually exclusive. In other words, if a project is public, then everyone, even if it is not a contributor, can view this. This is further exemplified by the "@must_be_contributors_or_public" and "@must_be_contributors_or_public_but_not_anonymized" decorators generated by the factory function.
Thus, the "@must_be_contributor" decorator is also generated by the factory function based on the same assumptions. However, what "must be contributor" means here for the settings page is actually "must be contributor even if the project is public", which contradicts with the general assumption that "project is public" and"project can only be viewed by contributors" are mutually exclusive.
<h5>
"Enough with your story, so what exactly are the changes?" Fine, real TL:DR starts here.
</h5> 
In decorators.py, I add another decorator "@must_be_contributor_even_if_public".
In node.py, I make use of the new decorator.

<h3>
P.S.
</h3>
I am obviously really excited to find this bug and maybe I am a bit too excited. But this is truly educational for me as a newbie developer in that it shows how different assumptions may change the result. So I take some time and effort to write the long story as a reflection to remind myself. I hope I correctly diagnose the problem. If you guys have any better ideas on how to fix this please comment.