### PR TITLE
[hold] Add UVA DV to list of possible hosts

### DIFF
--- a/website/addons/dataverse/settings/defaults.py
+++ b/website/addons/dataverse/settings/defaults.py
@@ -1,5 +1,6 @@
 DEFAULT_HOSTS = [
     'dataverse.harvard.edu',            # Harvard PRODUCTION server
+    'dataverse.lib.virginia.edu',       # UVA PRODUCTION server
     'dataverse-demo.iq.harvard.edu',    # Harvard DEMO server
     'apitest.dataverse.org',            # Dataverse TEST server
 ]


### PR DESCRIPTION
Hold
====
~~Completely~~ Almost entirely untested

* Confirmed that it redirects to the proper page for a API token retrieval (indicating UVA's DV has standard DV endpoints). 

Update: Standard endpoints, nonstandard permissions. 

Two possible solutions:
* UVA changes their permissions structure to the default, allowing users to create their own dataverses
* IQSS resolves https://github.com/IQSS/dataverse/issues/1070, allowing users with non-admin write access to dataverses to create/manage datasets via the API

TODO
---------

- [ ] Improvement: allow creation of datasets via OSF