### PR TITLE
Fix search page "unresolved" error for malformed queries [OSF-4538]

### DIFF
--- a/website/language.py
+++ b/website/language.py
@@ -62,6 +62,10 @@ CLAIMED_CONTRIBUTOR = ('<strong>Welcome to the OSF!</strong> Edit your display n
 # Error Pages
 # ###########
 
+# Search-related errors
+SEARCH_QUERY_HELP = ('Please check our help (the question mark beside the search box) for more information '
+                     'on advanced search queries.')
+
 # Shown at error page if an expired/revokes email confirmation link is clicked
 EXPIRED_EMAIL_CONFIRM_TOKEN = 'This confirmation link has expired. Please <a href="/login/">log in</a> to continue.'
 

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -14,6 +14,7 @@ from elasticsearch import (
     Elasticsearch,
     NotFoundError,
     RequestError,
+    TransportError,
     helpers,
 )
 from modularodm import Q
@@ -83,6 +84,9 @@ def requires_search(func):
             except RequestError as e:
                 if 'ParseException' in e.error:
                     raise exceptions.MalformedQueryError(e.error)
+                raise exceptions.SearchException(e.error)
+            except TransportError as e:
+                # Catch and wrap generic ES 500 codes. TODO: Improve fix for https://openscience.atlassian.net/browse/OSF-4538
                 raise exceptions.SearchException(e.error)
 
         sentry.log_message('Elastic search action failed. Is elasticsearch running?')

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -2,23 +2,22 @@
 
 from __future__ import division
 
-import re
 import copy
-import math
-import logging
-import unicodedata
 import functools
+import logging
+import math
+import re
+import unicodedata
 
-import six
-
-from modularodm import Q
 from elasticsearch import (
-    Elasticsearch,
-    RequestError,
-    NotFoundError,
     ConnectionError,
+    Elasticsearch,
+    NotFoundError,
+    RequestError,
     helpers,
 )
+from modularodm import Q
+import six
 
 from framework import sentry
 from framework.celery_tasks import app as celery_app
@@ -27,11 +26,11 @@ from framework.mongo.utils import paginated
 from website import settings
 from website.filters import gravatar
 from website.models import User, Node
+from website.project.licenses import serialize_node_license_record
 from website.search import exceptions
 from website.search.util import build_query
 from website.util import sanitize
 from website.views import validate_page_num
-from website.project.licenses import serialize_node_license_record
 
 logger = logging.getLogger(__name__)
 

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -86,7 +86,7 @@ def requires_search(func):
                     raise exceptions.MalformedQueryError(e.error)
                 raise exceptions.SearchException(e.error)
             except TransportError as e:
-                # Catch and wrap generic ES 500 codes. TODO: Improve fix for https://openscience.atlassian.net/browse/OSF-4538
+                # Catch and wrap generic uncaught ES error codes. TODO: Improve fix for https://openscience.atlassian.net/browse/OSF-4538
                 raise exceptions.SearchException(e.error)
 
         sentry.log_message('Elastic search action failed. Is elasticsearch running?')

--- a/website/search/views.py
+++ b/website/search/views.py
@@ -1,33 +1,29 @@
 # -*- coding: utf-8 -*-
-import json
-import time
-import logging
 import functools
 import httplib as http
+import json
+import logging
+import time
 from urllib2 import unquote
 
 import bleach
-
 from flask import request
 
 from modularodm import Q
+
 from framework.auth.decorators import collect_auth
 from framework.auth.decorators import must_be_logged_in
-
+from framework.exceptions import HTTPError
 from website import settings
-from website.models import Node
-from website.models import User
-from website.search import util
-from website.util import api_url_for
+from website.models import Node, User
+from website.project.views.contributor import get_node_contributors_abbrev
 from website.search import exceptions
 from website.search import share_search
+from website.search import util
+from website.search.exceptions import IndexNotFoundError, MalformedQueryError
 import website.search.search as search
-from framework.exceptions import HTTPError
-from website.search.exceptions import IndexNotFoundError
-from website.search.exceptions import MalformedQueryError
 from website.search.util import build_query
-from website.project.views.contributor import get_node_contributors_abbrev
-
+from website.util import api_url_for
 
 logger = logging.getLogger(__name__)
 

--- a/website/search/views.py
+++ b/website/search/views.py
@@ -15,6 +15,7 @@ from framework.auth.decorators import collect_auth
 from framework.auth.decorators import must_be_logged_in
 from framework.exceptions import HTTPError
 from framework import sentry
+from website import language
 from website import settings
 from website.models import Node, User
 from website.project.views.contributor import get_node_contributors_abbrev
@@ -39,14 +40,13 @@ def handle_search_errors(func):
         except exceptions.MalformedQueryError:
             raise HTTPError(http.BAD_REQUEST, data={
                 'message_short': 'Bad search query',
-                'message_long': ('Please check our help (the question mark beside the search box) for more information '
-                                 'on advanced search queries.'),
+                'message_long': language.SEARCH_QUERY_HELP,
             })
         except exceptions.SearchUnavailableError:
             raise HTTPError(http.SERVICE_UNAVAILABLE, data={
                 'message_short': 'Search unavailable',
                 'message_long': ('Our search service is currently unavailable, if the issue persists, '
-                'please report it to <a href="mailto:support@osf.io">support@osf.io</a>.'),
+                                 'please report it to <a href="mailto:support@osf.io">support@osf.io</a>.'),
             })
         except exceptions.SearchException:
             # Interim fix for issue where ES fails with 500 in some settings- ensure exception is still logged until it can be better debugged. See OSF-4538
@@ -55,8 +55,7 @@ def handle_search_errors(func):
             # TODO: Add a test; may need to mock out the error response due to inability to reproduce error code locally
             raise HTTPError(http.BAD_REQUEST, data={
                 'message_short': 'Could not perform search query',
-                'message_long': ('Please check our help (the question mark beside the search box) for more information '
-                                 'on advanced search queries.'),
+                'message_long': language.SEARCH_QUERY_HELP,
             })
     return wrapped
 
@@ -201,6 +200,7 @@ def search_contributor(auth):
     user = auth.user if auth else None
     nid = request.args.get('excludeNode')
     exclude = Node.load(nid).contributors if nid else []
+    # TODO: Determine whether bleach is appropriate for ES payload. Also, inconsistent with website.sanitize.util.strip_html
     query = bleach.clean(request.args.get('query', ''), tags=[], strip=True)
     page = int(bleach.clean(request.args.get('page', '0'), tags=[], strip=True))
     size = int(bleach.clean(request.args.get('size', '5'), tags=[], strip=True))


### PR DESCRIPTION
Refs https://openscience.atlassian.net/browse/OSF-4538

## Purpose
The search page was returning "unable to resolve" errors for certain kinds of malformed queries, when it should have said "bad search query". This was traced to a problem where elasticsearch returned the wrong error code (not 400) in certain cases.

## Summary of changes
- Capture ES failures  as a generic search exception (if specific cases not already handled)
- Show a more user-friendly error message

## Testing notes
Should no longer get "unable to resolve" errors in a growl box. See sample strings in https://openscience.atlassian.net/browse/OSF-4538?focusedCommentId=30463&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-30463

## Side effects
Since the ES error code is less specific than it should be, users may get a less helpful error message than intended. We will continue to log these exceptions to Sentry until a more permanent fix can be arranged.

This is a bit tricky to unit-test, because the error does not happen locally for me. (though it does happen on staging). Suggestions welcome.