### PR TITLE
Fix Keen session logic and error logging.

### DIFF
--- a/website/static/js/keen.js
+++ b/website/static/js/keen.js
@@ -17,15 +17,11 @@ var KeenTracker = oop.defclass({
     },
 
     createOrUpdateKeenSession: function() {
-        var date = new Date();
+        var expDate = new Date();
         var expiresInMinutes = 25;
-        var expDate = date.setTime(date.getTime() + (expiresInMinutes*60*1000));
-        if(!$.cookie('keenSessionId')){
-            $.cookie('keenSessionId', uuid.v1(), {expires: expDate, path: '/'});
-        } else {
-            var sessionId = $.cookie('keenSessionId');
-            $.cookie('keenSessionId', sessionId, {expires: expDate, path: '/'});
-        }
+        expDate.setTime(expDate.getTime() + (expiresInMinutes*60*1000));
+        var currentSessionId = $.cookie('keenSessionId') || uuid.v1();
+        $.cookie('keenSessionId', currentSessionId, {expires: expDate, path: '/'});
     },
 
     getOrCreateKeenId: function() {

--- a/website/static/js/keen.js
+++ b/website/static/js/keen.js
@@ -4,6 +4,7 @@ var keen = require('keen-js');
 var oop = require('js/oop');
 var $ = require('jquery');
 var uuid = require('uuid');
+var Raven = require('raven-js');
 
 var KeenTracker = oop.defclass({
     constructor: function(keenProjectId, keenWriteKey, params) {
@@ -106,7 +107,9 @@ var KeenTracker = oop.defclass({
 
         this.keenClient.addEvent('pageviews', pageView, function(err){
             if(err){
-                throw new Error('Error sending Keen data: ' + err, pageView);
+                Raven.captureMessage('Error sending Keen data: <' + err + '>', {
+                    payload: pageView
+                });
             }
         });
     },


### PR DESCRIPTION
The keen session cookie expiration date was being incorrectly set and silently ignored, leading to session inconsistencies in the logged data.  This patch correctly sets the session time to 25min.  It also explicitly logs to Sentry pageview events that Keen rejects, so that we can inspect them later.