### PR TITLE
Allow read-write users to remove linked  [OSF-440]

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -821,7 +821,7 @@ class TestProjectViews(OsfTestCase):
         url = self.project.api_url_for('get_logs')
         res = self.app.get(url, {"page": 1}, auth=self.auth)
         assert_equal(len(res.json['logs']), 4)
-        #1 project create log, 1 add contributor log, then 12 generated logs
+        # 1 project create log, 1 add contributor log, then 12 generated logs
         assert_equal(res.json['total'], 12 + 2)
         assert_equal(res.json['page'], 1)
         assert_equal(res.json['pages'], 2)
@@ -1015,7 +1015,6 @@ class TestProjectViews(OsfTestCase):
         res = self.app.get(url, auth=self.auth)
         assert_equal(res.status_code, 302)
         assert_in(self.project.web_url_for('node_registration_retraction_get', _guid=True), res.location)
-
 
     def test_update_node(self):
         url = self.project.api_url_for('update_node')
@@ -1470,7 +1469,6 @@ class TestUserProfile(OsfTestCase):
         assert_equal(self.user.schools, schools)
 
     def test_unserialize_jobs_valid(self):
-        jobs_cached = self.user.jobs
         jobs = [
             {
                 'institution': fake.company(),
@@ -1577,7 +1575,7 @@ class TestUserProfile(OsfTestCase):
         email = 'test@cos.io'
         header = {'id': user1._id,
                   'emails': [{'address': user1.username, 'primary': True, 'confirmed': True},
-                            {'address': email, 'primary': False, 'confirmed': False}
+                             {'address': email, 'primary': False, 'confirmed': False}
                   ]}
         res = self.app.put_json(url, header, auth=user1.auth)
         assert_equal(res.status_code, 200)
@@ -2064,7 +2062,6 @@ class TestAddingContributorViews(OsfTestCase):
 
         # send_mail is called for both the project and the sub-component
         assert_equal(mock_send_mail.call_count, 2)
-
 
     @mock.patch('website.project.views.contributor.send_claim_email')
     def test_email_sent_when_unreg_user_is_added(self, send_mail):
@@ -2696,20 +2693,6 @@ class TestWatchViews(OsfTestCase):
         watch_cfg = WatchConfigFactory(node=project)
         self.user.watch(watch_cfg)
         self.user.save()
-        url = "/api/v1/watched/logs/"
-        res = self.app.get(url, auth=self.auth)
-        assert_equal(len(res.json['logs']), 10)
-        assert_equal(res.json['logs'][0]['action'], 'file_added')
-
-    def test_get_watched_logs(self):
-        project = ProjectFactory()
-        # Add some logs
-        for _ in range(12):
-            project.logs.append(NodeLogFactory(user=self.user, action="file_added"))
-        project.save()
-        watch_cfg = WatchConfigFactory(node=project)
-        self.user.watch(watch_cfg)
-        self.user.save()
         url = api_url_for("watched_logs_get")
         res = self.app.get(url, auth=self.auth)
         assert_equal(len(res.json['logs']), 10)
@@ -2976,7 +2959,7 @@ class TestPointerViews(OsfTestCase):
     def test_fork_pointer_not_provided(self):
         url = self.project.api_url + 'pointer/fork/'
         res = self.app.post_json(url, {}, auth=self.user.auth,
-                expect_errors=True)
+                                 expect_errors=True)
         assert_equal(res.status_code, 400)
 
     def test_fork_pointer_not_found(self):
@@ -3015,7 +2998,7 @@ class TestPointerViews(OsfTestCase):
         assert_equal(len(prompts), 1)
 
     def test_before_fork_with_pointer(self):
-        "Assert that link warning appears in before fork callback."
+        """Assert that link warning appears in before fork callback."""
         node = NodeFactory()
         self.project.add_pointer(node, auth=self.consolidate_auth)
         url = self.project.api_url + 'beforeregister/'
@@ -3028,7 +3011,7 @@ class TestPointerViews(OsfTestCase):
         assert_equal(len(prompts), 1)
 
     def test_before_register_no_pointer(self):
-        "Assert that link warning does not appear in before register callback."
+        """Assert that link warning does not appear in before register callback."""
         url = self.project.api_url + 'fork/before/'
         res = self.app.get(url, auth=self.user.auth).maybe_follow()
         prompts = [
@@ -3039,9 +3022,7 @@ class TestPointerViews(OsfTestCase):
         assert_equal(len(prompts), 0)
 
     def test_before_fork_no_pointer(self):
-        """Assert that link warning does not appear in before fork callback.
-
-        """
+        """Assert that link warning does not appear in before fork callback."""
         url = self.project.api_url + 'beforeregister/'
         res = self.app.get(url, auth=self.user.auth).maybe_follow()
         prompts = [
@@ -3210,8 +3191,7 @@ class TestAuthViews(OsfTestCase):
 
         name, email = fake.name(), fake.email()
 
-        project.add_unregistered_contributor(fullname=name, email=email,
-                auth=Auth(project.creator))
+        project.add_unregistered_contributor(fullname=name, email=email, auth=Auth(project.creator))
         project.save()
 
         # The new, unregistered user
@@ -3471,8 +3451,9 @@ class TestConfigureMailingListViews(OsfTestCase):
         # check that user is subscribed
         mock_client.lists.subscribe.assert_called_with(id=list_id,
                                                        email={'email': user.username},
-                                                       merge_vars= {'fname': user.given_name,
-                                                                    'lname': user.family_name,
+                                                       merge_vars={
+                                                           'fname': user.given_name,
+                                                           'lname': user.family_name,
                                                        },
                                                        double_optin=False,
                                                        update_existing=True)
@@ -3499,9 +3480,10 @@ class TestConfigureMailingListViews(OsfTestCase):
         user.save()
 
         # user subscribes and webhook sends request to OSF
-        data = {'type': 'subscribe',
-                'data[list_id]': list_id,
-                'data[email]': user.username
+        data = {
+            'type': 'subscribe',
+            'data[list_id]': list_id,
+            'data[email]': user.username
         }
         url = api_url_for('sync_data_from_mailchimp') + '?key=' + settings.MAILCHIMP_WEBHOOK_SECRET_KEY
         res = self.app.post(url,
@@ -3531,9 +3513,10 @@ class TestConfigureMailingListViews(OsfTestCase):
 
         # user hits subscribe again, which will update the user's existing info on mailchimp
         # webhook sends request (when configured to update on changes made through the API)
-        data = {'type': 'profile',
-                'data[list_id]': list_id,
-                'data[email]': user.username
+        data = {
+            'type': 'profile',
+            'data[list_id]': list_id,
+            'data[email]': user.username
         }
         url = api_url_for('sync_data_from_mailchimp') + '?key=' + settings.MAILCHIMP_WEBHOOK_SECRET_KEY
         res = self.app.post(url,
@@ -3559,9 +3542,10 @@ class TestConfigureMailingListViews(OsfTestCase):
         user.save()
 
         # user unsubscribes through mailchimp and webhook sends request
-        data = {'type': 'unsubscribe',
-                'data[list_id]': list_id,
-                'data[email]': user.username
+        data = {
+            'type': 'unsubscribe',
+            'data[list_id]': list_id,
+            'data[email]': user.username
         }
         url = api_url_for('sync_data_from_mailchimp') + '?key=' + settings.MAILCHIMP_WEBHOOK_SECRET_KEY
         res = self.app.post(url,
@@ -3879,7 +3863,6 @@ class TestReorderComponents(OsfTestCase):
         assert_equal(res.status_code, 200)
 
 
-
 class TestWikiWidgetViews(OsfTestCase):
 
     def setUp(self):
@@ -3980,7 +3963,7 @@ class TestProjectCreation(OsfTestCase):
         user = AuthUserFactory()
         project = ProjectFactory(creator=user)
         url = web_url_for('project_new_node', pid=project._id)
-        post_data = {'title': '<b>New <blink>Component</blink> Title</b>',  'category': ''}
+        post_data = {'title': '<b>New <blink>Component</blink> Title</b>', 'category': ''}
         request = self.app.post(url, post_data, auth=user.auth).follow()
         project.reload()
         child = project.nodes[0]
@@ -4062,7 +4045,7 @@ class TestProjectCreation(OsfTestCase):
         assert_in(non_admin, child.contributors)
         assert_in(self.user1, child.contributors)
         assert_in(self.user2, child.contributors)
-        assert_equal(child.get_permissions(non_admin), ['read', 'write',  'admin'])
+        assert_equal(child.get_permissions(non_admin), ['read', 'write', 'admin'])
         # check redirect url
         assert_in('/contributors/', res.location)
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2812,17 +2812,16 @@ class TestPointerViews(OsfTestCase):
         res = self.app.get(url, auth=user2.auth).maybe_follow()
         assert_equal(res.status_code, 200)
 
-        # TODO: Check length nodes total
+        pointer_nodes = res.lxml.xpath('//li[@node_reference]')
         has_controls = res.lxml.xpath('//li[@node_reference]/p[starts-with(normalize-space(text()), "Private Link")]//i[contains(@class, "remove-pointer")]')
+        assert_equal(len(pointer_nodes), 1)
         assert_false(has_controls)
 
     def test_pointer_list_read_contributor_cannot_remove_public_component_entry(self):
         url = web_url_for('view_project', pid=self.project._id)
 
-        for i in xrange(3):
-            self.project.add_pointer(ProjectFactory(creator=self.user),
-                                     auth=Auth(user=self.user))
-
+        self.project.add_pointer(ProjectFactory(creator=self.user),
+                                 auth=Auth(user=self.user))
 
         user2 = AuthUserFactory()
         self.project.add_contributor(user2,
@@ -2833,9 +2832,10 @@ class TestPointerViews(OsfTestCase):
         res = self.app.get(url, auth=user2.auth).maybe_follow()
         assert_equal(res.status_code, 200)
 
-        # TODO: Check length nodes total
+        pointer_nodes = res.lxml.xpath('//li[@node_reference]')
         has_controls = res.lxml.xpath(
             '//li[@node_reference]//i[contains(@class, "remove-pointer")]')
+        assert_equal(len(pointer_nodes), 1)
         assert_equal(len(has_controls), 0)
 
     # https://github.com/CenterForOpenScience/openscienceframework.org/issues/1109

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,69 +1,61 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-'''Views tests for the OSF.'''
+"""Views tests for the OSF."""
 
 from __future__ import absolute_import
-import unittest
-import json
+
 import datetime as dt
-import mock
 import httplib as http
+import json
 import math
 import time
+import unittest
 
+import mock
 from nose.tools import *  # noqa PEP8 asserts
 
-from tests.test_features import requires_search
 from modularodm import Q
 from modularodm.exceptions import ValidationError
 
 from framework import auth
-from framework.exceptions import HTTPError
 from framework.auth import User, Auth
-from framework.auth.utils import impute_names_model
 from framework.auth.exceptions import InvalidTokenError
+from framework.auth.utils import impute_names_model
 from framework.celery_tasks import handlers
-from framework.mongo import database
-
-from website import mailchimp_utils
-from website.util import permissions
-from website.models import Node, Pointer, NodeLog, MetaSchema, DraftRegistration
-from website.project.model import ensure_schemas, has_anonymous_link
-from website.project.views.contributor import (
-    send_claim_email,
-    deserialize_contributors,
-    send_claim_registered_email,
-    notify_added_contributor
-)
-from website.profile.utils import add_contributor_json, serialize_unregistered
-from website.profile.views import fmt_date_or_none, update_osf_help_mails_subscription
-from website.util import api_url_for, web_url_for
-from website import mails, settings
-from website.util import rubeus
-from website.project.views.node import _view_project, abbrev_authors, _should_show_wiki_widget
-from website.project.decorators import check_can_access
-from website.project.signals import contributor_added
-from website.addons.github.tests.factories import GitHubAccountFactory
-from website.project.metadata.schemas import ACTIVE_META_SCHEMAS, _name_to_id
-
+from framework.exceptions import HTTPError
 from tests.base import (
-    OsfTestCase,
-    fake,
-    capture_signals,
     assert_is_redirect,
-    assert_datetime_equal,
-    get_default_metaschema
+    capture_signals,
+    fake,
+    get_default_metaschema,
+    OsfTestCase,
 )
 from tests.factories import (
-    UserFactory, ApiOAuth2ApplicationFactory, ApiOAuth2PersonalTokenFactory, ProjectFactory, WatchConfigFactory,
-    NodeFactory, NodeLogFactory, AuthUserFactory, UnregUserFactory,
-    RegistrationFactory,
-    PrivateLinkFactory,
-    UnconfirmedUserFactory,
-    BookmarkCollectionFactory,
-    CollectionFactory,
-    ProjectWithAddonFactory, MockAddonNodeSettings
+    ApiOAuth2ApplicationFactory, ApiOAuth2PersonalTokenFactory, AuthUserFactory,
+    BookmarkCollectionFactory, CollectionFactory, MockAddonNodeSettings, NodeFactory,
+    NodeLogFactory, PrivateLinkFactory, ProjectWithAddonFactory, ProjectFactory,
+    RegistrationFactory, UnconfirmedUserFactory, UnregUserFactory, UserFactory, WatchConfigFactory,
 )
+from tests.test_features import requires_search
+from website import mailchimp_utils
+from website import mails, settings
+from website.addons.github.tests.factories import GitHubAccountFactory
+from website.models import Node, NodeLog, Pointer
+from website.profile.utils import add_contributor_json, serialize_unregistered
+from website.profile.views import fmt_date_or_none, update_osf_help_mails_subscription
+from website.project.decorators import check_can_access
+from website.project.model import has_anonymous_link
+from website.project.signals import contributor_added
+from website.project.views.contributor import (
+    deserialize_contributors,
+    notify_added_contributor,
+    send_claim_email,
+    send_claim_registered_email,
+)
+from website.project.views.node import _should_show_wiki_widget, _view_project, abbrev_authors
+from website.util import api_url_for, web_url_for
+from website.util import rubeus
+
 
 class Addon(MockAddonNodeSettings):
     @property

--- a/website/templates/util/render_node.mako
+++ b/website/templates/util/render_node.mako
@@ -51,7 +51,7 @@
             <!-- Show/Hide recent activity log -->
             % if not summary['archiving']:
             <div class="pull-right">
-                % if not summary['primary'] and 'admin' in user['permissions'] and not node['is_registration']:
+                % if not summary['primary'] and 'write' in user['permissions'] and not node['is_registration']:
                     <i class="fa fa-times remove-pointer" data-id="${summary['id']}" data-toggle="tooltip" title="Remove link"></i>
                     <i class="fa fa-code-fork" onclick="NodeActions.forkPointer('${summary['id']}', '${summary['primary_id']}');" data-toggle="tooltip" title="Fork this ${summary['node_type']} into ${node['node_type']} ${node['title']}"></i>
                 % endif

--- a/website/templates/util/render_node.mako
+++ b/website/templates/util/render_node.mako
@@ -145,6 +145,12 @@
             %else:
                 Private Component
             %endif
+            % if not summary['primary'] and 'write' in user['permissions'] and not node['is_registration']:
+                ## Allow deletion of pointers, even if user doesn't know what they are deleting
+                <span class="pull-right">
+                    <i class="fa fa-times remove-pointer pointer" data-id="${summary['id']}" data-toggle="tooltip" title="Remove link"></i>
+                </span>
+            % endif
         </p>
     </li>
 


### PR DESCRIPTION
Refs: https://openscience.atlassian.net/browse/OSF-440

## Purpose
Allow read-write users to remove links to other projects. Should address an issue where no one, including the destination project owner, could delete a link to a private project.

Additionally, allow users with write access to delete links, *even if they don't know what the link is pointing at*. (see screenshot) This was deemed slightly preferable to an unremovable link owned by someone who is no longer a contributor.
![screen shot 2016-04-05 at 1 05 31 pm](https://cloud.githubusercontent.com/assets/2957073/14291196/64f3e6b2-fb30-11e5-8331-0bcdfb610f01.png)

Tested "private item deletion" with a private fork, and a private node, using two users (one admin, one with write access).


## Summary of changes
In the screenshots below: an admin user created 1 link to a public project, and a RW user created 1 link to a private project (that the admin wasn't a contributor on)

For the admin, BEFORE / AFTER (same!)
<img width="580" alt="screen shot 2016-04-04 at 3 40 07 pm" src="https://cloud.githubusercontent.com/assets/2957073/14260856/9394f502-fa7b-11e5-86fc-e7bf58c1fe2c.png">

For the RW user, BEFORE/AFTER
<img width="651" alt="screen shot 2016-04-04 at 3 40 13 pm" src="https://cloud.githubusercontent.com/assets/2957073/14260860/9843567a-fa7b-11e5-8c4a-6e05195cc810.png">
<img width="654" alt="screen shot 2016-04-04 at 3 41 09 pm" src="https://cloud.githubusercontent.com/assets/2957073/14260889/d75ab5ce-fa7b-11e5-8977-50aacd76f24d.png">