### PR TITLE
Hotfix: Pass in named parameters to get_file_guid

### DIFF
--- a/website/files/models/osfstorage.py
+++ b/website/files/models/osfstorage.py
@@ -44,7 +44,7 @@ class OsfStorageFileNode(FileNode):
 
         if not file_obj.is_file:
             for item in file_obj.children:
-                cls.get_file_guids(item.path, provider, guids, node)
+                cls.get_file_guids(materialized_path=item.path, provider=provider, node=node, guids=guids)
         else:
             try:
                 guid = Guid.find(Q('referent', 'eq', file_obj))[0]


### PR DESCRIPTION
Fixes sentry error where the node & guid parameters were getting switched.