### PR TITLE
Change privacy on project with publicly editable wiki [OSF-5482]

### DIFF
--- a/api_tests/base/test_utils.py
+++ b/api_tests/base/test_utils.py
@@ -2,10 +2,11 @@
 from nose.tools import *  # flake8: noqa
 
 from rest_framework import fields
-
+from rest_framework.exceptions import ValidationError
 from api.base import utils as api_utils
 
 from tests.base import ApiTestCase
+from framework.status import push_status_message
 
 
 class TruthyFalsyTestCase(ApiTestCase):
@@ -18,3 +19,27 @@ class TruthyFalsyTestCase(ApiTestCase):
 
     def test_falsy(self):
         assert_equal(api_utils.FALSY, fields.BooleanField.FALSE_VALUES)
+
+
+class FlaskDjangoIntegrationTestCase(ApiTestCase):
+    def test_push_status_message_no_response(self):
+        status_message = 'This is a message'
+        statuses = ['info', 'warning', 'warn', 'success', 'danger', 'default']
+        for status in statuses:
+            try:
+                push_status_message(status_message, kind=status)
+            except:
+                assert_true(False, 'Exception from push_status_message via API v2 with type "{}".'.format(status))
+
+    def test_push_status_message_error(self):
+        status_message = 'This is a message'
+        try:
+            push_status_message(status_message, kind='error')
+            assert_true(False, 'push_status_message() should have generated a ValidationError exception.')
+        except ValidationError as e:
+            assert_equal(e.detail[0], status_message,
+                         'push_status_message() should have passed along the message with the Exception.')
+        except RuntimeError:
+            assert_true(False, 'push_status_message() should have caught the runtime error and replaced it.')
+        except:
+            assert_true(False, 'Exception from push_status_message when called from the v2 API with type "error"')

--- a/api_tests/base/test_utils.py
+++ b/api_tests/base/test_utils.py
@@ -45,12 +45,16 @@ class FlaskDjangoIntegrationTestCase(ApiTestCase):
         except:
             assert_true(False, 'Exception from push_status_message when called from the v2 API with type "error"')
 
-    def test_push_status_message_unexpected_error(self):
+    @mock.patch('framework.status.session')
+    def test_push_status_message_unexpected_error(self, mock_sesh):
         status_message = 'This is a message'
         exception_message = 'this is some very unexpected problem'
+        mock_get = mock.Mock(side_effect=RuntimeError(exception_message))
+        mock_data = mock.Mock()
+        mock_data.attach_mock(mock_get, 'get')
+        mock_sesh.attach_mock(mock_data, 'data')
         try:
-            with mock.patch('framework.status.get_session_data', mock.Mock(side_effect=RuntimeError(exception_message))):
-                push_status_message(status_message, kind='error')
+            push_status_message(status_message, kind='error')
             assert_true(False, 'push_status_message() should have generated a RuntimeError exception.')
         except ValidationError as e:
             assert_true(False, 'push_status_message() should have re-raised the RuntimeError not gotten ValidationError.')

--- a/api_tests/base/test_utils.py
+++ b/api_tests/base/test_utils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from nose.tools import *  # flake8: noqa
+import mock # noqa
 
 from rest_framework import fields
 from rest_framework.exceptions import ValidationError
@@ -31,7 +32,7 @@ class FlaskDjangoIntegrationTestCase(ApiTestCase):
             except:
                 assert_true(False, 'Exception from push_status_message via API v2 with type "{}".'.format(status))
 
-    def test_push_status_message_error(self):
+    def test_push_status_message_expected_error(self):
         status_message = 'This is a message'
         try:
             push_status_message(status_message, kind='error')
@@ -43,3 +44,21 @@ class FlaskDjangoIntegrationTestCase(ApiTestCase):
             assert_true(False, 'push_status_message() should have caught the runtime error and replaced it.')
         except:
             assert_true(False, 'Exception from push_status_message when called from the v2 API with type "error"')
+
+    def test_push_status_message_unexpected_error(self):
+        status_message = 'This is a message'
+        exception_message = 'this is some very unexpected problem'
+        try:
+            with mock.patch('framework.status.get_session_data', mock.Mock(side_effect=RuntimeError(exception_message))):
+                push_status_message(status_message, kind='error')
+            assert_true(False, 'push_status_message() should have generated a RuntimeError exception.')
+        except ValidationError as e:
+            assert_true(False, 'push_status_message() should have re-raised the RuntimeError not gotten ValidationError.')
+        except RuntimeError as e:
+            assert_equal(getattr(e, 'message', None),
+                         exception_message,
+                         'push_status_message() should have re-raised the '
+                         'original RuntimeError with the original message.')
+        except:
+            assert_true(False, 'Unexpected Exception from push_status_message when called '
+                               'from the v2 API with type "error"')

--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -747,6 +747,16 @@ class TestNodeUpdate(NodeCRUDTestCase):
         assert_equal(res.status_code, 400)
         assert_equal(res.json['errors'][0]['detail'], 'Title cannot exceed 200 characters.')
 
+    def test_public_project_with_publicly_editable_wiki_turns_private(self):
+        wiki = self.public_project.get_addon('wiki')
+        wiki.set_editing(permissions=True, auth=Auth(user=self.user), log=True)
+        res = self.app.patch_json_api(
+            self.public_url,
+            make_node_payload(self.public_project, {'public': False}),
+            auth=self.user.auth  # self.user is creator/admin
+        )
+        assert_equal(res.status_code, 200)
+
 
 class TestNodeDelete(NodeCRUDTestCase):
 

--- a/framework/status/__init__.py
+++ b/framework/status/__init__.py
@@ -17,11 +17,6 @@ TYPE_MAP = {
     'default': 'default',
 }
 
-
-def get_session_data(item):
-    return session.data.get(item)
-
-
 def push_status_message(message, kind='warning', dismissible=True, trust=True, jumbotron=False):
     """
     Push a status message that will be displayed as a banner on the next page loaded by the user.
@@ -35,7 +30,7 @@ def push_status_message(message, kind='warning', dismissible=True, trust=True, j
     """
     # TODO: Change the default to trust=False once conversion to markupsafe rendering is complete
     try:
-        statuses = get_session_data('status')
+        statuses = session.data.get('status')
     except RuntimeError as e:
         exception_message = getattr(e, 'message', None)
         if exception_message == 'working outside of request context':

--- a/framework/status/__init__.py
+++ b/framework/status/__init__.py
@@ -3,6 +3,7 @@
 from collections import namedtuple
 
 from framework.sessions import session
+# from api.base.api_globals import api_globals
 
 Status = namedtuple('Status', ['message', 'jumbotron', 'css_class', 'dismissible', 'trust'])  # trust=True displays msg as raw HTML
 
@@ -29,7 +30,14 @@ def push_status_message(message, kind='warning', dismissible=True, trust=True, j
     :param jumbotron: Should this be in a jumbstron element rather than an alert
     """
     # TODO: Change the default to trust=False once conversion to markupsafe rendering is complete
-    statuses = session.data.get('status')
+    try:
+        statuses = session.data.get('status')
+    except RuntimeError:
+        # Working outside of request context, so should be a DRF issue. Status messages are not appropriate there.
+        # Currently the only time this happens is when there's an info message that should be swallowed, but when
+        # we have a test case that requires an error response:
+        # TODO: we should probably have DRF raise a 400 and pass the error message along if it's an error
+        return
     if not statuses:
         statuses = []
     css_class = TYPE_MAP.get(kind, 'warning')


### PR DESCRIPTION
Purpose
-----------
Allow public projects with publicly editable wikis to be made private via the API.

Closes [OSF-5482]

Changes
------------
Check within push_status_message() to see if we're running inside a Flask context. If so, under most circumstances let the message go, unless it's an error, in which case raise a 400 and pass along the error message.

Also, test all that, including the case directly related to the purpose. h/t to @mfraezz for the mock code in the unit test.

Side effects
----------------
push_status_message() isn't actually supposed to be called from anything that the API can get to, but it's littered throughout the model. If it failed, it would 500 for sure, so this is almost certainly better, but we only have the one case right now. The worst would be if someone were using 'warning' when it's really an error or something, because then it should error but might fail silently. *Probably* not, because if it fails it should fail anyways. So it should be fine, but.