### PR TITLE
[fix] Ensure Archiver-required field returns correct value for GH

### DIFF
--- a/website/addons/github/model.py
+++ b/website/addons/github/model.py
@@ -96,17 +96,17 @@ class GitHubNodeSettings(StorageAddonBase, AddonOAuthNodeSettingsBase):
 
     @property
     def folder_id(self):
-        return self.repo
+        return self.repo or None
 
     @property
     def folder_name(self):
-        return self.repo
-
-    @property
-    def folder_path(self):
         if self.complete:
             return '{}/{}'.format(self.user, self.repo)
         return None
+
+    @property
+    def folder_path(self):
+        return self.repo or None
 
     @property
     def has_auth(self):

--- a/website/addons/github/model.py
+++ b/website/addons/github/model.py
@@ -93,9 +93,20 @@ class GitHubNodeSettings(StorageAddonBase, AddonOAuthNodeSettingsBase):
     hook_id = fields.StringField()
     hook_secret = fields.StringField()
     registration_data = fields.DictionaryField()
-    folder_id = fields.StringField(default=None)
-    folder_name = fields.StringField(default=None)
-    folder_path = fields.StringField(default=None)
+
+    @property
+    def folder_id(self):
+        return self.repo
+
+    @property
+    def folder_name(self):
+        return self.repo
+
+    @property
+    def folder_path(self):
+        if self.complete:
+            return '{}/{}'.format(self.user, self.repo)
+        return None
 
     @property
     def has_auth(self):
@@ -124,9 +135,6 @@ class GitHubNodeSettings(StorageAddonBase, AddonOAuthNodeSettingsBase):
         self.hook_id = None
         self.hook_secret = None
         self.registration_data = None
-        self.folder_id = None
-        self.folder_name = None
-        self.folder_path = None
 
     def deauthorize(self, auth=None, log=True):
         self.delete_hook(save=False)

--- a/website/addons/github/tests/factories.py
+++ b/website/addons/github/tests/factories.py
@@ -26,5 +26,3 @@ class GitHubNodeSettingsFactory(ModularOdmFactory):
 
     owner = SubFactory(ProjectFactory)
     user_settings = SubFactory(GitHubUserSettingsFactory)
-    repo = 'mock'
-    user = 'abc'

--- a/website/addons/github/tests/test_models.py
+++ b/website/addons/github/tests/test_models.py
@@ -39,6 +39,14 @@ class TestNodeSettings(models.OAuthAddonNodeSettingsTestSuiteMixin, OsfTestCase)
 
     ## Mixin Overrides ##
 
+    def _node_settings_class_kwargs(self, node, user_settings):
+        return {
+            'user_settings': self.user_settings,
+            'repo': 'mock',
+            'user': 'abc',
+            'owner': self.node
+        }
+
     def test_set_folder(self):
         # GitHub doesn't use folderpicker, and the nodesettings model
         # does not need a `set_repo` method

--- a/website/addons/github/tests/test_serializer.py
+++ b/website/addons/github/tests/test_serializer.py
@@ -19,7 +19,7 @@ class TestGitHubSerializer(StorageAddonSerializerTestSuiteMixin, OsfTestCase):
     client = GitHubClient()
 
     def set_provider_id(self, pid):
-        self.node_settings.folder_id = pid
+        self.node_settings.repo = pid
     
     ## Overrides ##
 


### PR DESCRIPTION
Original PR (against now-closed branch): #5330

Purpose
======
Fix registration failures on staging caused by the `getattr` in [archive_folder_name](https://github.com/CenterForOpenScience/osf.io/blob/release/0.66.0-develop/website/addons/base/__init__.py#L727). GH doesn't quite fit the `StorageAddon` generalization, but is close enough to me made to work, and `user/repo` is the closest approximation to `folder_name` that `GitHubNodeSettings` has.

Changes
=======
Make field used by archiver a property that returns the GitHub approximation of what that field should be: 
* `folder_name` <-- `user/repo`
* related fields (`folder_id`, `folder_path`) properties as well.

Side Effects
=========
None expected.