### PR TITLE
[hotfix] fix Raven.captureMessage context var reporting in js

### DIFF
--- a/website/static/js/accountSettings.js
+++ b/website/static/js/accountSettings.js
@@ -81,9 +81,11 @@ var UserProfileClient = oop.defclass({
         request.fail(function(xhr, status, error) {
             $osf.growl('Error', 'Could not fetch user profile.', 'danger');
             Raven.captureMessage('Error fetching user profile', {
-                url: this.urls.fetch,
-                status: status,
-                error: error
+                extra: {
+                    url: this.urls.fetch,
+                    status: status,
+                    error: error
+                }
             });
             ret.reject(xhr, status, error);
         }.bind(this));
@@ -112,9 +114,11 @@ var UserProfileClient = oop.defclass({
             }
 
             Raven.captureMessage('Error fetching user profile', {
-                url: this.urls.update,
-                status: status,
-                error: error
+                extra: {
+                    url: this.urls.update,
+                    status: status,
+                    error: error
+                }
             });
             ret.reject(xhr, status, error);
         }.bind(this));
@@ -321,9 +325,11 @@ var DeactivateAccountViewModel = oop.defclass({
                 'danger'
             );
             Raven.captureMessage('Error requesting account deactivation', {
-                url: this.urls.update,
-                status: status,
-                error: error
+                extra: {
+                    url: this.urls.update,
+                    status: status,
+                    error: error
+                }
             });
         }.bind(this));
         return request;
@@ -369,9 +375,11 @@ var ExportAccountViewModel = oop.defclass({
                 'danger'
             );
             Raven.captureMessage('Error requesting account export', {
-                url: this.urls.update,
-                status: status,
-                error: error
+                extra: {
+                    url: this.urls.update,
+                    status: status,
+                    error: error
+                }
             });
         }.bind(this));
         return request;

--- a/website/static/js/addonSettings.js
+++ b/website/static/js/addonSettings.js
@@ -39,9 +39,11 @@ var ExternalAccount = oop.defclass({
             })
             .fail(function(xhr, status, error) {
                 Raven.captureMessage('Error deauthorizing node: ' + node.id, {
-                    url: url,
-                    status: status,
-                    error: error
+                    extra: {
+                        url: url,
+                        status: status,
+                        error: error
+                    }
                 });
             });
     },
@@ -126,9 +128,11 @@ var OAuthAddonSettingsViewModel = oop.defclass({
         });
         request.fail(function(xhr, status, error) {
             Raven.captureMessage('Error while removing addon authorization for ' + account.id, {
-                url: url,
-                status: status,
-                error: error
+                extra: {
+                    url: url,
+                    status: status,
+                    error: error
+                }
             });
         });
         return request;
@@ -144,9 +148,11 @@ var OAuthAddonSettingsViewModel = oop.defclass({
         });
         request.fail(function(xhr, status, error) {
             Raven.captureMessage('Error while updating addon account', {
-                url: url,
-                status: status,
-                error: error
+                extra: {
+                    url: url,
+                    status: status,
+                    error: error
+                }
             });
         });
         return request;

--- a/website/static/js/apiApplication.js
+++ b/website/static/js/apiApplication.js
@@ -191,9 +191,11 @@ var ApplicationsListViewModel = oop.defclass({
                 'danger');
 
             Raven.captureMessage('Error fetching list of registered applications', {
-                url: this.apiListUrl,
-                status: status,
-                error: error
+                extra: {
+                    url: this.apiListUrl,
+                    status: status,
+                    error: error
+                }
             });
         }.bind(this));
     },
@@ -280,9 +282,11 @@ var ApplicationDetailViewModel = oop.extend(ChangeMessageMixin, {
                             'danger');
 
                 Raven.captureMessage('Error fetching application data', {
-                    url: this.apiDetailUrl(),
-                    status: status,
-                    error: error
+                    extra: {
+                        url: this.apiDetailUrl(),
+                        status: status,
+                        error: error
+                    }
                 });
             }.bind(this));
         }
@@ -313,9 +317,11 @@ var ApplicationDetailViewModel = oop.extend(ChangeMessageMixin, {
                        'danger');
 
             Raven.captureMessage('Error updating instance', {
-                url: this.apiDetailUrl,
-                status: status,
-                error: error
+                extra: {
+                    url: this.apiDetailUrl,
+                    status: status,
+                    error: error
+                }
             });
         }.bind(this));
         return request;
@@ -337,9 +343,11 @@ var ApplicationDetailViewModel = oop.extend(ChangeMessageMixin, {
                        'danger');
 
             Raven.captureMessage('Error registering new OAuth2 application', {
-                url: this.apiDetailUrl,
-                status: status,
-                error: error
+                extra: {
+                    url: this.apiDetailUrl,
+                    status: status,
+                    error: error
+                }
             });
         }.bind(this));
     },
@@ -409,9 +417,11 @@ var ApplicationDetailViewModel = oop.extend(ChangeMessageMixin, {
                             'danger');
 
                         Raven.captureMessage('Error resetting instance secret', {
-                            url: appData.apiResetUrl,
-                            status: status,
-                            error: error
+                            extra: {
+                                url: appData.apiResetUrl,
+                                status: status,
+                                error: error
+                            }
                         });
                     }.bind(self));
                 }

--- a/website/static/js/apiPersonalToken.js
+++ b/website/static/js/apiPersonalToken.js
@@ -173,9 +173,11 @@ var TokensListViewModel = oop.defclass({
                 'danger');
 
             Raven.captureMessage('Error fetching list of registered personal access tokens', {
-                url: this.apiListUrl,
-                status: status,
-                error: error
+                extra: {
+                    url: this.apiListUrl,
+                    status: status,
+                    error: error
+                }
             });
         }.bind(this));
     },
@@ -262,9 +264,11 @@ var TokenDetailViewModel = oop.extend(ChangeMessageMixin, {
                             'danger');
 
                 Raven.captureMessage('Error fetching token data', {
-                    url: this.apiDetailUrl(),
-                    status: status,
-                    error: error
+                    extra: {
+                        url: this.apiDetailUrl(),
+                        status: status,
+                        error: error
+                    }
                 });
             }.bind(this));
         }
@@ -295,9 +299,11 @@ var TokenDetailViewModel = oop.extend(ChangeMessageMixin, {
                        'danger');
 
             Raven.captureMessage('Error updating instance', {
-                url: this.apiDetailUrl,
-                status: status,
-                error: error
+                extra: {
+                    url: this.apiDetailUrl,
+                    status: status,
+                    error: error
+                }
             });
         }.bind(this));
         return request;
@@ -319,9 +325,11 @@ var TokenDetailViewModel = oop.extend(ChangeMessageMixin, {
                        'danger');
 
             Raven.captureMessage('Error registering new OAuth2 personal access token', {
-                url: this.apiDetailUrl,
-                status: status,
-                error: error
+                extra: {
+                    url: this.apiDetailUrl,
+                    status: status,
+                    error: error
+                }
             });
         }.bind(this));
     },

--- a/website/static/js/citationGrid.js
+++ b/website/static/js/citationGrid.js
@@ -339,9 +339,11 @@ CitationGrid.prototype.initStyleSelect = function() {
             self.updateStyle(event.val, xml);
         }).fail(function(jqxhr, status, error) {
             Raven.captureMessage('Error while selecting citation style: ' + event.val, {
-                url: styleUrl,
-                status: status,
-                error: error
+                extra: {
+                    url: styleUrl,
+                    status: status,
+                    error: error
+                }
             });
         });
     });

--- a/website/static/js/citationWidget.js
+++ b/website/static/js/citationWidget.js
@@ -71,10 +71,12 @@ CitationWidget.prototype.init = function() {
                 'danger'
             );
             Raven.captureMessage('Unexpected error when fetching citation', {
-                url: styleUrl,
-                citationStyle: event.val,
-                status: status,
-                error: error
+                extra: {
+                    url: styleUrl,
+                    citationStyle: event.val,
+                    status: status,
+                    error: error
+                }
             });
         });
     }).on('select2-removed', function(e) {

--- a/website/static/js/citationsNodeConfig.js
+++ b/website/static/js/citationsNodeConfig.js
@@ -76,9 +76,11 @@ var CitationsFolderPickerViewModel = oop.extend(FolderPickerViewModel, {
         request.fail(function(xhr, textStatus, error) {
             self.changeMessage(self.messages.updateAccountsError(), 'text-danger');
             Raven.captureMessage('Could not GET ' + self.addonName + ' accounts for user', {
-                url: self.url,
-                textStatus: textStatus,
-                error: error
+                extra: {
+                    url: self.url,
+                    textStatus: textStatus,
+                    error: error
+                }
             });
             ret.reject(xhr, textStatus, error);
         });

--- a/website/static/js/comment.js
+++ b/website/static/js/comment.js
@@ -254,9 +254,11 @@ BaseComment.prototype.submitReply = function() {
         self.cancelReply();
         self.errorMessage('Could not submit comment');
         Raven.captureMessage('Error creating comment', {
-            url: url,
-            status: status,
-            error: error
+            extra: {
+                url: url,
+                status: status,
+                error: error
+            }
         });
     });
 };
@@ -415,9 +417,11 @@ CommentModel.prototype.submitEdit = function(data, event) {
         self.cancelEdit();
         self.errorMessage('Could not submit comment');
         Raven.captureMessage('Error editing comment', {
-            url: url,
-            status: status,
-            error: error
+            extra: {
+                url: url,
+                status: status,
+                error: error
+            }
         });
     });
     return request;
@@ -458,9 +462,11 @@ CommentModel.prototype.submitAbuse = function() {
     request.fail(function(xhr, status, error) {
         self.errorMessage('Could not report abuse.');
         Raven.captureMessage('Error reporting abuse', {
-            url: url,
-            status: status,
-            error: error
+            extra: {
+                url: url,
+                status: status,
+                error: error
+            }
         });
     });
     return request;
@@ -485,9 +491,11 @@ CommentModel.prototype.submitDelete = function() {
     request.fail(function(xhr, status, error) {
         self.deleting(false);
         Raven.captureMessage('Error deleting comment', {
-            url: url,
-            status: status,
-            error: error
+            extra: {
+                url: url,
+                status: status,
+                error: error
+            }
         });
     });
     return request;
@@ -521,9 +529,11 @@ CommentModel.prototype.submitUndelete = function() {
     });
     request.fail(function(xhr, status, error) {
         Raven.captureMessage('Error undeleting comment', {
-            url: url,
-            status: status,
-            error: error
+            extra: {
+                url: url,
+                status: status,
+                error: error
+            }
         });
 
     });
@@ -544,9 +554,11 @@ CommentModel.prototype.submitUnreportAbuse = function() {
     });
     request.fail(function(xhr, status, error) {
         Raven.captureMessage('Error unreporting comment', {
-            url: url,
-            status: status,
-            error: error
+            extra: {
+                url: url,
+                status: status,
+                error: error
+            }
         });
 
     });
@@ -643,9 +655,11 @@ var onOpen = function(page, rootId, nodeApiUrl) {
     );    
     request.fail(function(xhr, textStatus, errorThrown) {
         Raven.captureMessage('Could not update comment timestamp', {
-            url: timestampUrl,
-            textStatus: textStatus,
-            errorThrown: errorThrown
+            extra: {
+                url: timestampUrl,
+                textStatus: textStatus,
+                errorThrown: errorThrown
+            }
         });
     });
     return request;

--- a/website/static/js/components/autocomplete.js
+++ b/website/static/js/components/autocomplete.js
@@ -80,9 +80,11 @@ $.extend(BaseSearchViewModel.prototype, {
         return $.get(self.dataUrl).fail(
             function(xhr, status, error) {
                 Raven.captureMessage('Could not GET autocomplete data', {
-                    url: self.dataUrl,
-                    textStatus: status,
-                    error: error
+                    extra: {
+                        url: self.dataUrl,
+                        textStatus: status,
+                        error: error
+                    }
                 });
             });
     },

--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -345,9 +345,11 @@ var AddContributorViewModel = oop.extend(Paginator, {
             $osf.unblock();
             $osf.growl('Could not add contributors', 'There was a problem trying to add contributors. ' + osfLanguage.REFRESH_OR_SUPPORT);
             Raven.captureMessage('Error adding contributors', {
-                url: url,
-                status: status,
-                error: error
+                extra: {
+                    url: url,
+                    status: status,
+                    error: error
+                }
             });
         });
     },

--- a/website/static/js/contribRemover.js
+++ b/website/static/js/contribRemover.js
@@ -206,7 +206,9 @@ var RemoveContributorViewModel = oop.extend(Paginator, {
         }).fail(function(xhr, status, error) {
             $osf.growl('Error', 'Unable to retrieve projects and components');
             Raven.captureMessage('Unable to retrieve projects and components', {
-                url: self.nodeApiUrl, status: status, error: error
+                extra: {
+                    url: self.nodeApiUrl, status: status, error: error
+                }
             });
         });
     },
@@ -228,7 +230,9 @@ var RemoveContributorViewModel = oop.extend(Paginator, {
             }        }).fail(function(xhr, status, error) {
             $osf.growl('Error', 'Unable to delete Contributor');
             Raven.captureMessage('Could not DELETE Contributor.' + error, {
-                url: window.contextVars.node.urls.api + 'contributor/remove/', status: status, error: error
+                extra: {
+                    url: window.contextVars.node.urls.api + 'contributor/remove/', status: status, error: error
+                }
             });
             self.clear();
             window.location.reload();

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -508,12 +508,14 @@ function doItemOp(operation, to, from, rename, conflict) {
         $osf.growl(operation.verb + ' failed.', message);
 
         Raven.captureMessage('Failed to move or copy file', {
-            xhr: xhr,
-            requestData: {
-                rename: rename,
-                conflict: conflict,
-                source: waterbutler.toJsonBlob(from),
-                destination: waterbutler.toJsonBlob(to),
+            extra: {
+                xhr: xhr,
+                requestData: {
+                    rename: rename,
+                    conflict: conflict,
+                    source: waterbutler.toJsonBlob(from),
+                    destination: waterbutler.toJsonBlob(to),
+                }
             }
         });
 

--- a/website/static/js/filepage/editor.js
+++ b/website/static/js/filepage/editor.js
@@ -56,9 +56,11 @@ var FileEditor = {
             }).fail(function (xhr, textStatus, error) {
                 $osf.growl('Error','The file content could not be loaded.');
                 Raven.captureMessage('Could not GET file contents.', {
-                    url: self.url,
-                    textStatus: textStatus,
-                    error: error
+                    extra: {
+                        url: self.url,
+                        textStatus: textStatus,
+                        error: error
+                    }
                 });
             });
         };
@@ -92,8 +94,10 @@ var FileEditor = {
                 model.editor.setValue(self.initialText);
                 $osf.growl('Error', message);
                 Raven.captureMessage('Could not PUT file content.', {
-                    textStatus: textStatus,
-                    url: self.url
+                    extra: {
+                        textStatus: textStatus,
+                        url: self.url
+                    }
                 });
                 m.redraw();
             });

--- a/website/static/js/filesWidget.js
+++ b/website/static/js/filesWidget.js
@@ -76,9 +76,11 @@ FilesWidget.prototype.init = function() {
         self.filebrowser = new Fangorn(self.fangornOpts);
     }).fail(function(xhr, status, error) {
         Raven.captureMessage('Could not GET files', {
-            url: self.filesUrl,
-            textStatus: status,
-            error: error
+            extra: {
+                url: self.filesUrl,
+                textStatus: status,
+                error: error
+            }
         });
         $('#' + self.fangornOpts.divID).replaceWith(
             $('<div>', {

--- a/website/static/js/folderPickerNodeConfig.js
+++ b/website/static/js/folderPickerNodeConfig.js
@@ -285,9 +285,11 @@ var FolderPickerViewModel = oop.defclass({
         request.fail(function(xhr, textStatus, error) {
             self.changeMessage(self.messages.cantRetrieveSettings(), 'text-danger');
             Raven.captureMessage('Could not GET ' + self.addonName + 'settings', {
-                url: self.url,
-                textStatus: textStatus,
-                error: error
+                extra: {
+                    url: self.url,
+                    textStatus: textStatus,
+                    error: error
+                }
             });
             ret.reject(xhr, textStatus, error);
         });
@@ -311,9 +313,11 @@ var FolderPickerViewModel = oop.defclass({
         function onSubmitError(xhr, status, error) {
             self.changeMessage(self.messages.submitSettingsError(), 'text-danger');
             Raven.captureMessage('Failed to update ' + self.addonName + ' settings.', {
-                xhr: xhr,
-                status: status,
-                error: error
+                extra: {
+                    xhr: xhr,
+                    status: status,
+                    error: error
+                }
             });
         }
         return $osf.putJSON(self.urls().config, self._serializeSettings())
@@ -333,9 +337,11 @@ var FolderPickerViewModel = oop.defclass({
         var self = this;
         self.changeMessage(self.messages.tokenImportError(), 'text-danger');
         Raven.captureMessage('Failed to import ' + self.addonName + ' access token.', {
-            xhr: xhr,
-            status: status,
-            error: error
+            extra: {
+                xhr: xhr,
+                status: status,
+                error: error
+            }
         });
     },
     _importAuthPayload: function() {
@@ -389,9 +395,11 @@ var FolderPickerViewModel = oop.defclass({
         request.fail(function(xhr, textStatus, error) {
             self.changeMessage(self.messages.deauthorizeFail(), 'text-danger');
             Raven.captureMessage('Could not deauthorize ' + self.addonName + ' account from node', {
-                url: self.urls().deauthorize,
-                textStatus: textStatus,
-                error: error
+                extra: {
+                    url: self.urls().deauthorize,
+                    textStatus: textStatus,
+                    error: error
+                }
             });
         });
         return request;
@@ -471,8 +479,10 @@ var FolderPickerViewModel = oop.defclass({
                     self.loading(false);
                     self.changeMessage(self.messages.connectError(), 'text-danger');
                     Raven.captureMessage('Could not GET get ' + self.addonName + ' contents.', {
-                        textStatus: textStatus,
-                        error: error
+                        extra: {
+                            textStatus: textStatus,
+                            error: error
+                        }
                     });
                 }
             },

--- a/website/static/js/home-page/newAndNoteworthyPlugin.js
+++ b/website/static/js/home-page/newAndNoteworthyPlugin.js
@@ -32,7 +32,9 @@ var NewAndNoteworthy = {
         // Switches errorLoading to true
         self.requestError = function(result){
             self.errorLoading = m.prop(true);
-            Raven.captureMessage('Error loading new and noteworthy projects on home page.', {requestReturn: result});
+            Raven.captureMessage('Error loading new and noteworthy projects on home page.', {
+                extra: { requestReturn: result }
+            });
         };
 
         // Load new and noteworthy nodes

--- a/website/static/js/home-page/quickProjectSearchPlugin.js
+++ b/website/static/js/home-page/quickProjectSearchPlugin.js
@@ -37,7 +37,9 @@ var QuickSearchProject = {
         // Switches errorLoading to true
         self.requestError = function(result) {
             self.errorLoading(true);
-            Raven.captureMessage('Error loading user projects on home page.', {requestReturn: result});
+            Raven.captureMessage('Error loading user projects on home page.', {
+                extra: {requestReturn: result}
+            });
         };
 
         self.templateNodes = new NodeFetcher('nodes');

--- a/website/static/js/institutionNodes.js
+++ b/website/static/js/institutionNodes.js
@@ -23,9 +23,11 @@ var ViewModel = function(context) {
             self.allNodes(response.data.embeds.nodes.data);
         }).fail(function(xhr, status, error){
             Raven.captureMessage('Failed to load Institution\'s nodes', {
-                url: url,
-                textStatus: status,
-                err: error
+                extra: {
+                    url: url,
+                    textStatus: status,
+                    err: error
+                }
             });
         });
     };

--- a/website/static/js/institutionProjectSettings.js
+++ b/website/static/js/institutionProjectSettings.js
@@ -27,9 +27,11 @@ var ViewModel = function(data) {
             self.error(true);
             self.loading(false);
             Raven.captureMessage('Unable to fetch user with embedded institutions', {
-                url: url,
-                status: status,
-                error: error
+                extra: {
+                    url: url,
+                    status: status,
+                    error: error
+                }
             });
         });
     };
@@ -46,9 +48,11 @@ var ViewModel = function(data) {
             }
         }).fail(function (xhr, status, error) {
             Raven.captureMessage('Unable to fetch node with embedded institutions', {
-                url: url,
-                status: status,
-                error: error
+                extra: {
+                    url: url,
+                    status: status,
+                    error: error
+                }
             });
         });
     };
@@ -70,9 +74,11 @@ var ViewModel = function(data) {
         }).fail(function (xhr, status, error) {
             $osf.growl('Unable to add institution to this node. Please try again. If the problem persists, email <a href="mailto:support@osf.io.">support@osf.io</a>');
             Raven.captureMessage('Unable to add institution to this node', {
-                url: url,
-                status: status,
-                error: error
+                extra: {
+                    url: url,
+                    status: status,
+                    error: error
+                }
             });
         });
     };
@@ -93,9 +99,11 @@ var ViewModel = function(data) {
         }).fail(function (xhr, status, error) {
             $osf.growl('Unable to remove institution from this node. Please try again. If the problem persists, email <a href="mailto:support@osf.io.">support@osf.io</a>');
             Raven.captureMessage('Unable to remove institution from this node!', {
-                url: url,
-                status: status,
-                error: error
+                extra: {
+                    url: url,
+                    status: status,
+                    error: error
+                }
             });
         });
     };

--- a/website/static/js/institutionSignIn.js
+++ b/website/static/js/institutionSignIn.js
@@ -43,9 +43,11 @@ var ViewModel = function() {
             self.loading(false);
         }).fail(function (xhr, status, error) {
             Raven.captureMessage('Unable to fetch institutions', {
-                url: url,
-                status: status,
-                error: error
+                extra: {
+                    url: url,
+                    status: status,
+                    error: error
+                }
             });
         });
     };

--- a/website/static/js/licensePicker.js
+++ b/website/static/js/licensePicker.js
@@ -189,9 +189,11 @@ var LicensePicker = oop.extend(ChangeMessageMixin, {
         self.changeMessage('There was a problem updating your license. Please try again.', 'text-danger', 2500);
 
         Raven.captureMessage('Error fetching user profile', {
-            url: self.saveUrl,
-            status: status,
-            error: error
+            extra: {
+                url: self.saveUrl,
+                status: status,
+                error: error
+            }
         });
     },
     /**

--- a/website/static/js/logTextParser.js
+++ b/website/static/js/logTextParser.js
@@ -7,6 +7,7 @@ var m = require('mithril'); // exposes mithril methods, useful for redraw etc.
 var logActions = require('json!js/_allLogTexts.json');
 var $ = require('jquery');  // jQuery
 var $osf = require('js/osfHelpers');
+var Raven = require('raven-js');
 
 var ravenMessagesCache = []; // Cache messages to avoid sending multiple times in one page view
 /**
@@ -16,7 +17,7 @@ var ravenMessagesCache = []; // Cache messages to avoid sending multiple times i
  */
 function ravenMessage (message, logObject) {
     if(ravenMessagesCache.indexOf(message) === -1){
-        Raven.captureMessage(message, {logObject: logObject});
+        Raven.captureMessage(message, {extra: {logObject: logObject}});
         ravenMessagesCache.push(message);
     }
 }

--- a/website/static/js/myProjects.js
+++ b/website/static/js/myProjects.js
@@ -219,7 +219,9 @@ NodeFetcher.prototype = {
       return this.resume();
     this._continue = false;
     this._promise = null;
-    Raven.captureMessage('Error loading nodes with nodeType ' + this.type + ' at url ' + this.nextLink, {requestReturn: result});
+    Raven.captureMessage('Error loading nodes with nodeType ' + this.type + ' at url ' + this.nextLink, {
+        extra: {requestReturn: result}
+    });
     $osf.growl('We\'re having some trouble contacting our servers. Try reloading the page.', 'Something went wrong!', 'danger', 5000);
   },
   _onFinish: function() {
@@ -386,7 +388,7 @@ var MyProjects = {
                 }
             }, function _error(results){
                 var message = 'Error loading project category names.';
-                Raven.captureMessage(message, {requestReturn: results});
+                Raven.captureMessage(message, {extra: {requestReturn: results}});
             });
             return promise;
         };
@@ -780,7 +782,7 @@ var MyProjects = {
             }, function(){
                 var message = 'Collections could not be loaded.';
                 $osf.growl(message, 'Please reload the page.');
-                Raven.captureMessage(message, { url: url });
+                Raven.captureMessage(message, {extra: { url: url }});
             });
             return promise;
         };
@@ -1070,7 +1072,7 @@ var Collections = {
                 var name = self.newCollectionName();
                 var message = '"' + name + '" collection could not be created.';
                 $osf.growl(message, 'Please try again', 'danger', 5000);
-                Raven.captureMessage(message, { url: url, data : data });
+                Raven.captureMessage(message, {extra: { url: url, data : data }});
                 self.newCollectionName('');
             });
             self.resetAddCollection();
@@ -1103,7 +1105,7 @@ var Collections = {
                 var name = self.collectionMenuObject().item.label;
                 var message = '"' + name + '" could not be deleted.';
                 $osf.growl(message, 'Please try again', 'danger', 5000);
-                Raven.captureMessage(message, {collectionObject: self.collectionMenuObject() });
+                Raven.captureMessage(message, {extra: {collectionObject: self.collectionMenuObject() }});
             });
             self.dismissModal();
             return promise;
@@ -1128,7 +1130,7 @@ var Collections = {
                 var name = self.collectionMenuObject().item.label;
                 var message = '"' + name + '" could not be renamed.';
                 $osf.growl(message, 'Please try again', 'danger', 5000);
-                Raven.captureMessage(message, {collectionObject: self.collectionMenuObject() });
+                Raven.captureMessage(message, {extra: {collectionObject: self.collectionMenuObject() }});
             });
             self.dismissModal();
             self.isValid(false);

--- a/website/static/js/nodeControl.js
+++ b/website/static/js/nodeControl.js
@@ -236,7 +236,7 @@ var ProjectViewModel = function(data) {
                 'Please try again soon and/or contact ' +
                 '<a href="mailto: support@osf.io">support@osf.io</a>';
             osfHelpers.growl('Error', message, 'danger');
-            Raven.captureMessage('Could not create identifiers', {url: url, status: xhr.status});
+            Raven.captureMessage('Could not create identifiers', {extra: {url: url, status: xhr.status}});
         }).always(function() {
             clearTimeout(timeout);
             self.idCreationInProgress(false); // hide loading indicator

--- a/website/static/js/nodesPrivacy.js
+++ b/website/static/js/nodesPrivacy.js
@@ -149,7 +149,7 @@ var NodesPrivacyViewModel = function(parentIsPublic) {
         }).fail(function(xhr, status, error) {
             $osf.growl('Error', 'Unable to retrieve project settings');
             Raven.captureMessage('Could not GET project settings.', {
-                url: treebeardUrl, status: status, error: error
+                extra: { url: treebeardUrl, status: status, error: error }
             });
         });
     };

--- a/website/static/js/oauthAddonNodeConfig.js
+++ b/website/static/js/oauthAddonNodeConfig.js
@@ -194,9 +194,11 @@ var OauthAddonFolderPickerViewModel = oop.extend(FolderPickerViewModel, {
         }).fail(function(xhr, textStatus, error) {
             self.changeMessage(self.messages.UPDATE_ACCOUNTS_ERROR(), 'text-warning');
             Raven.captureMessage('Could not GET ' + self.addonName + ' accounts for user', {
-                url: self.url,
-                textStatus: textStatus,
-                error: error
+                extra: {
+                    url: self.url,
+                    textStatus: textStatus,
+                    error: error
+                }
             });
         });
     },

--- a/website/static/js/pages/dashboard-page.js
+++ b/website/static/js/pages/dashboard-page.js
@@ -30,9 +30,11 @@ var ensureUserTimezone = function(savedTimezone, savedLocale, id) {
         );
         request.fail(function(xhr, textStatus, error) {
             Raven.captureMessage('Could not set user timezone or locale', {
-                url: url,
-                textStatus: textStatus,
-                error: error
+                extra: {
+                    url: url,
+                    textStatus: textStatus,
+                    error: error
+                }
             });
         });
     }

--- a/website/static/js/pages/file-page.js
+++ b/website/static/js/pages/file-page.js
@@ -3,6 +3,7 @@ var m = require('mithril');
 var $osf = require('js/osfHelpers');
 var FileViewPage = require('js/filepage');
 var waterbutler = require('js/waterbutler');
+var Raven = require('raven-js');
 
 require('jquery-tagsinput');
 
@@ -22,7 +23,7 @@ $(function() {
             request.fail(function (xhr, textStatus, error) {
                 $osf.growl('Error', 'Could not add tag.');
                 Raven.captureMessage('Failed to add tag', {
-                    tag: tag, url: url, textStatus: textStatus, error: error
+                    extra: { tag: tag, url: url, textStatus: textStatus, error: error }
                 });
             });
         },
@@ -31,7 +32,7 @@ $(function() {
             request.fail(function (xhr, textStatus, error) {
                 $osf.growl('Error', 'Could not remove tag.');
                 Raven.captureMessage('Failed to remove tag', {
-                    tag: tag, url: url, textStatus: textStatus, error: error
+                    extra: { tag: tag, url: tagUrl, textStatus: textStatus, error: error }
                 });
             });
         }

--- a/website/static/js/pages/prereg-landing-page.js
+++ b/website/static/js/pages/prereg-landing-page.js
@@ -64,7 +64,7 @@ $(function(){
         });
         promise.fail(function(xhr, textStatus, error) {
             Raven.captureMessage('Next page load failed for user nodes.', {
-                url: url, textStatus: textStatus, error: error
+                extra: { url: url, textStatus: textStatus, error: error }
             });
         });
     }

--- a/website/static/js/pages/project-dashboard-page.js
+++ b/website/static/js/pages/project-dashboard-page.js
@@ -144,7 +144,9 @@ $(document).ready(function () {
             var request = $osf.postJSON(url, data);
             request.fail(function(xhr, textStatus, error) {
                 Raven.captureMessage('Failed to add tag', {
-                    tag: tag, url: url, textStatus: textStatus, error: error
+                    extra: {
+                        tag: tag, url: url, textStatus: textStatus, error: error
+                    }
                 });
             });
         },
@@ -160,7 +162,9 @@ $(document).ready(function () {
             });
             request.fail(function(xhr, textStatus, error) {
                 Raven.captureMessage('Failed to remove tag', {
-                    tag: tag, url: url, textStatus: textStatus, error: error
+                    extra: {
+                        tag: tag, url: url, textStatus: textStatus, error: error
+                    }
                 });
             });
         }

--- a/website/static/js/pages/project-settings-page.js
+++ b/website/static/js/pages/project-settings-page.js
@@ -30,7 +30,7 @@ if ($('#grid').length) {
         $notificationsMsg.addClass('text-danger');
         $notificationsMsg.text('Could not retrieve notification settings.');
         Raven.captureMessage('Could not GET notification settings.', {
-            url: notificationsURL, status: status, error: error
+            extra: { url: notificationsURL, status: status, error: error }
         });
     });
 }
@@ -51,7 +51,7 @@ if ($('#wgrid').length) {
         $wikiMsg.addClass('text-danger');
         $wikiMsg.text('Could not retrieve wiki settings.');
         Raven.captureMessage('Could not GET wiki settings.', {
-            url: wikiSettingsURL, status: status, error: error
+            extra: { url: wikiSettingsURL, status: status, error: error }
         });
     });
 }
@@ -290,7 +290,9 @@ WikiSettingsViewModel.enabled.subscribe(function(newValue) {
     }).fail(function(xhr, status, error) {
         $osf.growl('Error', 'Unable to update wiki');
         Raven.captureMessage('Could not update wiki.', {
-            url: ctx.node.urls.api + 'settings/addons/', status: status, error: error
+            extra: {
+                url: ctx.node.urls.api + 'settings/addons/', status: status, error: error
+            }
         });
         setTimeout(function(){window.location.reload();}, 1500);
     });

--- a/website/static/js/pages/wiki-edit-page.js
+++ b/website/static/js/pages/wiki-edit-page.js
@@ -75,9 +75,11 @@ if (ctx.canEditPageName) {
             } else {
                 // Log unexpected error with Raven
                 Raven.captureMessage('Error in renaming wiki', {
-                    url: ctx.urls.rename,
-                    responseText: response.responseText,
-                    statusText: response.statusText
+                    extra: {
+                        url: ctx.urls.rename,
+                        responseText: response.responseText,
+                        statusText: response.statusText
+                    }
                 });
                 return 'An unexpected error occurred. Please try again.';
             }
@@ -102,7 +104,7 @@ $(document).ready(function () {
         errorMsg.append('<p>Could not retrieve wiki pages. If this issue persists, ' +
             'please report it to <a href="mailto:support@osf.io">support@osf.io</a>.</p>');
         Raven.captureMessage('Could not GET wiki menu pages', {
-            url: ctx.urls.grid, status: status, error: error
+            extra: { url: ctx.urls.grid, status: status, error: error }
         });
     });
 

--- a/website/static/js/projectSettings.js
+++ b/website/static/js/projectSettings.js
@@ -56,9 +56,11 @@ var ProjectSettings = oop.extend(
                 errorMessage = language.updateErrorMessage;
             }
             Raven.captureMessage(errorMessage, {
-                url: self.updateUrl,
-                textStatus: status,
-                err: error
+                extra: {
+                    url: self.updateUrl,
+                    textStatus: status,
+                    err: error
+                }
             });
         },
         /*update handler*/
@@ -133,9 +135,11 @@ request.done(function(response) {
 });
 request.fail(function(xhr, textStatus, err) {
     Raven.captureMessage('Error requesting contributors', {
-        url: contribURL,
-        textStatus: textStatus,
-        err: err,
+        extra: {
+            url: contribURL,
+            textStatus: textStatus,
+            err: err,
+        }
     });
 });
 

--- a/website/static/js/registrationEditorExtensions.js
+++ b/website/static/js/registrationEditorExtensions.js
@@ -232,9 +232,11 @@ var AuthorImport = function(data, $root, preview) {
         return self.makeContributorsRequest()
             .fail(function(xhr, status, error) {
                 Raven.captureMessage('Could not GET contributors', {
-                    url: window.contextVars.node.urls.api + 'get_contributors/',
-                    textStatus: status,
-                    error: error
+                    extra: {
+                        url: window.contextVars.node.urls.api + 'get_contributors/',
+                        textStatus: status,
+                        error: error
+                    }
                 });
                 $osf.growl('Could not retrieve contributors.', osfLanguage.REFRESH_OR_SUPPORT);
             });

--- a/website/static/js/registrationRetraction.js
+++ b/website/static/js/registrationRetraction.js
@@ -60,9 +60,11 @@ var RegistrationRetractionViewModel = oop.extend(
             self.disableSave(false);
             self.changeMessage(self.SUBMIT_ERROR_MESSAGE, self.MESSAGE_ERROR_CLASS);
             Raven.captureMessage('Could not submit registration retraction.', {
-                xhr: xhr,
-                status: status,
-                error: errorThrown
+                extra: {
+                    xhr: xhr,
+                    status: status,
+                    error: errorThrown
+                }
             });
         },
         submit: function() {

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -1058,9 +1058,11 @@ RegistrationEditor.prototype.submit = function() {
             });
             request.fail(function(xhr, status, error) {
                 Raven.captureMessage('Could not submit draft registration', {
-                    url: url,
-                    textStatus: status,
-                    error: error
+                    extra: {
+                        url: url,
+                        textStatus: status,
+                        error: error
+                    }
                 });
                 $osf.growl('Error submitting for review', language.submitForReviewFail);
             });
@@ -1141,9 +1143,11 @@ RegistrationEditor.prototype.save = function() {
     }
     request.fail(function(xhr, status, error) {
         Raven.captureMessage('Could not save draft registration', {
-            url: self.urls.update.replace('{draft_pk}', self.draft().pk),
-            textStatus: status,
-            error: error
+            extra: {
+                url: self.urls.update.replace('{draft_pk}', self.draft().pk),
+                textStatus: status,
+                error: error
+            }
         });
         $osf.growl('Problem saving draft', 'There was a problem saving this draft. Please try again, and if the problem persists please contact ' + SUPPORT_LINK + '.');
     });
@@ -1270,9 +1274,11 @@ RegistrationManager.prototype.init = function() {
     });
     getSchemas.fail(function(xhr, status, error) {
         Raven.captureMessage('Could not load registration templates', {
-            url: self.urls.schemas,
-            textStatus: status,
-            error: error
+            extra: {
+                url: self.urls.schemas,
+                textStatus: status,
+                error: error
+            }
         });
         $osf.growl('Error loading registration templates', language.loadMetaSchemaFail);
     });
@@ -1291,9 +1297,11 @@ RegistrationManager.prototype.init = function() {
         });
         getDraftRegistrations.fail(function(xhr, status, error) {
             Raven.captureMessage('Could not load draft registrations', {
-                url: self.urls.list,
-                textStatus: status,
-                error: error
+                extra: {
+                    url: self.urls.list,
+                    textStatus: status,
+                    error: error
+                }
             });
             $osf.growl('Error loading draft registrations', language.loadDraftsFail);
         });
@@ -1344,9 +1352,11 @@ RegistrationManager.prototype.deleteDraft = function(draft) {
                         });
                     }).fail(function(xhr, status, err) {
                         Raven.captureMessage('Could not submit draft registration', {
-                            url: url,
-                            textStatus: status,
-                            error: err
+                            extra: {
+                                url: url,
+                                textStatus: status,
+                                error: err
+                            }
                         });
                         $osf.growl('Error deleting draft', language.deleteDraftFail);
                     });

--- a/website/static/js/resources/base.js
+++ b/website/static/js/resources/base.js
@@ -52,7 +52,7 @@ var DEFAULT_ERROR_MESSAGE = 'Request failed.';
 function captureError(message, callback) {
     return function(xhr, status, error) {
         Raven.captureMessage(message || DEFAULT_ERROR_MESSAGE, {
-            xhr: xhr, status: status, error: error
+            extra: { xhr: xhr, status: status, error: error }
         });
         // Additional error-handling
         callback && callback(xhr, status, error);

--- a/website/static/js/share/utils.js
+++ b/website/static/js/share/utils.js
@@ -279,7 +279,7 @@ utils.loadRawNormalized = function(result){
             error.raw = '"Raw data not found."';
             if (xhr.status >= 500) {
                 Raven.captureMessage('SHARE Raw and Normalized API Internal Server Error.', {
-                    textStatus: status
+                    extra: {textStatus: xhr.status}
                 });
             }
 

--- a/website/static/js/tests/projectSettings.test.js
+++ b/website/static/js/tests/projectSettings.test.js
@@ -77,9 +77,11 @@ describe('ProjectSettings', () => {
             vm.updateError({}, error, {});
             assert.calledWith(changeMessageSpy, language.updateErrorMessage);
             assert.calledWith(ravenStub, language.updateErrorMessage, {
-                url: updateUrl,
-                textStatus: error,
-                err: {},
+                extra: {
+                    url: updateUrl,
+                    textStatus: error,
+                    err: {},
+                }
             });
         });
     });


### PR DESCRIPTION
Additional context vars can be logged in the second argument to
Raven.captureMessage(), but must be stashed under the 'extra'
key. Only 'level', 'logger', 'tags', and 'extra' are valid top-level
keys in the context-vars object.

See: https://docs.getsentry.com/hosted/clients/javascript/usage/#passing-additional-data