### PR TITLE
[fix] Change blank assert to assert_equal

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3304,7 +3304,7 @@ class TestRoot(OsfTestCase):
         self.registration = RegistrationFactory(project=self.project)
 
     def test_top_level_project_has_own_root(self):
-        assert(self.project.root._id, self.project._id)
+        assert_equal(self.project.root._id, self.project._id)
 
     def test_child_project_has_root_of_parent(self):
         child = NodeFactory(parent=self.project)


### PR DESCRIPTION
# Purpose

@felliott pointed out that a test for roots had a blank assert statement - so was always returning true! This fixes it to make it actually check if the top level project has its own ID as its root

# Changes
in ```test_models.py``` change ```test_top_level_project_has_own_root``` to ```assert_equals``` instead of ```assert```

# Side effects
None anticipated