### PR TITLE
Don't allow users to view Collections as Projects [OSF-5843]

### DIFF
--- a/tests/test_project_decorators.py
+++ b/tests/test_project_decorators.py
@@ -73,9 +73,9 @@ class TestValidProject(OsfTestCase):
         res = as_factory_allow_retractions(pid=self.project._id)
         assert_equal(res['node'], self.project)
 
-    def test_collection_guid_bad_request(self):
+    def test_collection_guid_not_found(self):
         collection = CollectionFactory()
         collection.add_pointer(self.project, self.auth)
         with assert_raises(HTTPError) as exc_info:
             valid_project_helper(pid=collection._id, nid=collection._id)
-        assert_equal(exc_info.exception.code, 400)
+        assert_equal(exc_info.exception.code, 404)

--- a/tests/test_project_decorators.py
+++ b/tests/test_project_decorators.py
@@ -7,9 +7,10 @@ from website.project.decorators import must_be_valid_project
 from website.project.model import Sanction
 
 from tests.base import OsfTestCase
-from tests.factories import ProjectFactory, NodeFactory, RetractionFactory
+from tests.factories import ProjectFactory, NodeFactory, RetractionFactory, CollectionFactory
 
 from framework.exceptions import HTTPError
+from framework.auth import Auth
 
 
 @must_be_valid_project
@@ -28,6 +29,7 @@ class TestValidProject(OsfTestCase):
         self.project = ProjectFactory()
         self.node = NodeFactory(project=self.project)
         self.retraction = RetractionFactory()
+        self.auth = Auth(user=self.project.creator)
 
     def test_populates_kwargs_node(self):
         res = valid_project_helper(pid=self.project._id)
@@ -70,3 +72,10 @@ class TestValidProject(OsfTestCase):
         self.retraction.save()
         res = as_factory_allow_retractions(pid=self.project._id)
         assert_equal(res['node'], self.project)
+
+    def test_collection_guid_bad_request(self):
+        collection = CollectionFactory()
+        collection.add_pointer(self.project, self.auth)
+        with assert_raises(HTTPError) as exc_info:
+            valid_project_helper(pid=collection._id, nid=collection._id)
+        assert_equal(exc_info.exception.code, 400)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -3823,7 +3823,7 @@ class TestODMTitleSearch(OsfTestCase):
                                'includeContributed': 'yes',
                                'isFolder': 'yes'
                            }, auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, 400)
+        assert_equal(res.status_code, 404)
         res = self.app.get(self.url,
                            {
                                'term': self.folder.title,
@@ -3849,7 +3849,7 @@ class TestODMTitleSearch(OsfTestCase):
                                'includeContributed': 'yes',
                                'isFolder': 'yes'
                            }, auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, 400)
+        assert_equal(res.status_code, 404)
 
 
 class TestReorderComponents(OsfTestCase):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -3822,9 +3822,8 @@ class TestODMTitleSearch(OsfTestCase):
                                'includePublic': 'yes',
                                'includeContributed': 'yes',
                                'isFolder': 'yes'
-                           }, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(len(res.json), 1)
+                           }, auth=self.user.auth, expect_errors=True)
+        assert_equal(res.status_code, 400)
         res = self.app.get(self.url,
                            {
                                'term': self.folder.title,
@@ -3849,9 +3848,8 @@ class TestODMTitleSearch(OsfTestCase):
                                'includePublic': 'yes',
                                'includeContributed': 'yes',
                                'isFolder': 'yes'
-                           }, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(len(res.json), 1)
+                           }, auth=self.user.auth, expect_errors=True)
+        assert_equal(res.status_code, 400)
 
 
 class TestReorderComponents(OsfTestCase):

--- a/website/project/decorators.py
+++ b/website/project/decorators.py
@@ -88,7 +88,7 @@ def must_be_valid_project(func=None, retractions_valid=False):
 
             if getattr(kwargs['node'], 'is_collection', True):
                 raise HTTPError(
-                    http.BAD_REQUEST,
+                    http.NOT_FOUND,
                     data=dict(message_long='Viewing collections is not permitted')
                 )
 

--- a/website/project/decorators.py
+++ b/website/project/decorators.py
@@ -86,6 +86,12 @@ def must_be_valid_project(func=None, retractions_valid=False):
 
             _inject_nodes(kwargs)
 
+            if getattr(kwargs['node'], 'is_collection', True):
+                raise HTTPError(
+                    http.BAD_REQUEST,
+                    data=dict(message_long='Viewing collections is not permitted')
+                )
+
             if not retractions_valid and getattr(kwargs['node'].retraction, 'is_retracted', False):
                 raise HTTPError(
                     http.BAD_REQUEST,

--- a/website/project/decorators.py
+++ b/website/project/decorators.py
@@ -88,8 +88,7 @@ def must_be_valid_project(func=None, retractions_valid=False):
 
             if getattr(kwargs['node'], 'is_collection', True):
                 raise HTTPError(
-                    http.NOT_FOUND,
-                    data=dict(message_long='Viewing collections is not permitted')
+                    http.NOT_FOUND
                 )
 
             if not retractions_valid and getattr(kwargs['node'].retraction, 'is_retracted', False):


### PR DESCRIPTION
https://openscience.atlassian.net/browse/OSF-5843

# Purpose
Right now, users can access a collection by visiting it's guid as if it were a normal project. This PR adds a check to the ```@must_be_valid_project``` decorator that checks to see if it's a collection, and throws a 404 error with relevant message if it is.

# Changes
- Add check to ```@must_be_valid_project``` to see if guid being accessed is a collection

# Side Effects
None I can think of 