### PR TITLE
[hotfix] Move loadingComments ko observabale to BaseComment

### DIFF
--- a/website/static/js/comment.js
+++ b/website/static/js/comment.js
@@ -282,6 +282,7 @@ var CommentModel = function(data, $parent, $root) {
     self.isAbuse = ko.observable(data.attributes.is_abuse);
     self.canEdit = ko.observable(data.attributes.can_edit);
     self.hasChildren = ko.observable(data.attributes.has_children);
+    self.loadingComments = ko.observable(true);
 
     if (window.contextVars.node.anonymous) {
         self.author = {

--- a/website/static/js/comment.js
+++ b/website/static/js/comment.js
@@ -83,6 +83,8 @@ var BaseComment = function() {
 
     self.comments = ko.observableArray();
 
+    self.loadingComments = ko.observable(true);
+
     self.replyNotEmpty = ko.pureComputed(function() {
         return notEmpty(self.replyContent());
     });
@@ -282,7 +284,6 @@ var CommentModel = function(data, $parent, $root) {
     self.isAbuse = ko.observable(data.attributes.is_abuse);
     self.canEdit = ko.observable(data.attributes.can_edit);
     self.hasChildren = ko.observable(data.attributes.has_children);
-    self.loadingComments = ko.observable(true);
 
     if (window.contextVars.node.anonymous) {
         self.author = {
@@ -602,7 +603,6 @@ var CommentListModel = function(options) {
     self.canComment = ko.observable(options.canComment);
     self.hasChildren = ko.observable(options.hasChildren);
     self.author = options.currentUser;
-    self.loadingComments = ko.observable(true);
 
     self.togglePane = options.togglePane;
 


### PR DESCRIPTION
# Purpose
@felliott  noticed that production was throwing an error because the loadingComments ko observable was defined only on the ListCommentModel and not also on the CommentModel: https://sentry.cos.io/share/issue/31312e32393036/

 This PR also adds it to the BaseModel to make sure it's good everywhere

# Changes 
- Add ```self.loadingComments = ko.observable(true);``` to the ```BasetModel``` in ```website/static/js/comment.js```

# Side Effects
None I can think of!