### PR TITLE
[rfr][fix] Fixing esi embeds for drf 3.3.3

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -513,8 +513,8 @@ class RelationshipField(ser.HyperlinkedIdentityField):
 
     def to_esi_representation(self, value, envelope='data'):
         relationships = self.to_representation(value)
-        if relationships is not None and 'related' in relationships.keys():
-            href = relationships['related']
+        if relationships is not None and 'links' in relationships.keys() and 'related' in relationships['links'].keys():
+            href = relationships['links']['related']['href']
             if href and not href == '{}':
                 if self.always_embed:
                     envelope = 'data'
@@ -1007,7 +1007,6 @@ class JSONAPISerializer(ser.Serializer):
                         else:
                             try:
                                 # If a field has an empty representation, it should not be embedded.
-                                field.to_representation(attribute)
                                 result = self.context['embed'][field.field_name](obj)
                             except SkipField:
                                 result = None

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -513,8 +513,11 @@ class RelationshipField(ser.HyperlinkedIdentityField):
 
     def to_esi_representation(self, value, envelope='data'):
         relationships = self.to_representation(value)
-        if relationships is not None and 'links' in relationships.keys() and 'related' in relationships['links'].keys():
+        try:
             href = relationships['links']['related']['href']
+        except KeyError:
+            raise SkipField
+        else:
             if href and not href == '{}':
                 if self.always_embed:
                     envelope = 'data'
@@ -523,8 +526,6 @@ class RelationshipField(ser.HyperlinkedIdentityField):
                     query_dict.update(view_only=[self.parent.context['request'].query_params['view_only']])
                 esi_url = extend_querystring_params(href, query_dict)
                 return '<esi:include src="{}"/>'.format(esi_url)
-        else:
-            raise SkipField
 
     def format_filter(self, obj):
         qd = QueryDict(mutable=True)

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -129,7 +129,7 @@ class JSONAPIBaseView(generics.GenericAPIView):
         context.update({
             'enable_esi': (
                 is_truthy(self.request.query_params.get('esi', django_settings.ENABLE_ESI)) and
-                self.request.accepted_media_type in django_settings.ESI_MEDIA_TYPES
+                self.request.accepted_renderer.media_type in django_settings.ESI_MEDIA_TYPES
             ),
             'embed': embeds_partials,
             'envelope': self.request.query_params.get('envelope', 'data'),


### PR DESCRIPTION
As far as I can tell, I'll look more in the morning, this fixes ESI embeds for DRF 3.3.3. It looks like the structure of related links changed in the way they were being passed to `to_esi_representation`. After a few key checks and digging deeper into the object I got the correct href and passed it to thing that generates the ESI url. The key checks don't seem very pythonic and I'll try to clean them up in the morning but I think this will fix it. The output on local matches the output on staging and the error I was getting on `/myprojects/` locally is gone.

The bit in `api/base/views.py` just solidifies that the API really is trying to serve JSON on this particular request instead of just checking the global allowed content types. h/t @chrisseto 

@icereval, @brianjgeiger, @Ghalko 