### PR TITLE
[hotfix] Add missing '/' to start of materialized path

### DIFF
--- a/scripts/fix_materialized_paths.py
+++ b/scripts/fix_materialized_paths.py
@@ -1,0 +1,40 @@
+"""
+Fix any file materialized paths that are missing a beginning "/".
+Addresses https://openscience.atlassian.net/browse/OSF-5954 for existing files.
+"""
+import logging
+import sys
+
+from modularodm import Q
+
+from framework.transactions.context import TokuTransaction
+
+from website.app import init_app
+from website.files.models import StoredFileNode
+from scripts import utils as script_utils
+
+logger = logging.getLogger(__name__)
+
+
+def main():
+    files = StoredFileNode.find(Q('provider', 'ne', 'osfstorage'))
+    update_file_materialized_paths(files)
+
+
+def update_file_materialized_paths(files):
+    for file_obj in files:
+        if not file_obj.materialized_path.startswith('/'):
+            file_obj.materialized_path = '/' + file_obj.materialized_path
+            file_obj.save()
+            logger.info('Updated materialized path for file {0} to {1}'.format(file_obj._id, file_obj.materialized_path))
+
+
+if __name__ == '__main__':
+    dry = '--dry' in sys.argv
+    if not dry:
+        script_utils.add_file_logger(logger, __file__)
+    init_app(routes=False, set_backends=True)
+    with TokuTransaction():
+        main()
+        if dry:
+            raise Exception('Dry Run -- Aborting Transaction')

--- a/scripts/tests/test_fix_materialized_paths.py
+++ b/scripts/tests/test_fix_materialized_paths.py
@@ -1,0 +1,81 @@
+from modularodm import Q
+
+from website.files.models import StoredFileNode
+from website.files.models.dropbox import DropboxFile
+from website.files.models.github import GithubFile
+from website.files.models.googledrive import GoogleDriveFile
+from website.files.models.s3 import S3File
+from scripts.fix_materialized_paths import update_file_materialized_paths
+
+from tests.base import OsfTestCase
+from tests.factories import ProjectFactory, AuthUserFactory
+from nose.tools import *  # noqa PEP8 asserts
+
+
+class FixMaterializedPathTestMixin(object):
+    @property
+    def provider(self):
+        raise NotImplementedError
+
+    @property
+    def ProviderFile(self):
+        raise NotImplementedError
+
+    def setUp(self):
+        super(FixMaterializedPathTestMixin, self).setUp()
+        self.user = AuthUserFactory()
+        self.project = ProjectFactory(creator=self.user)
+
+    def test_exclude_correct_file_materialized_path(self):
+        test_file = self.ProviderFile.create(
+            is_file=True,
+            node=self.project,
+            path='/test',
+            name='test',
+            materialized_path='/test',
+        )
+        test_file.save()
+        targets = StoredFileNode.find(Q('provider', 'ne', 'osfstorage'))
+        assert_not_in(test_file, targets)
+
+    def test_fix_incorrect_file_materialized_path(self):
+        test_file = self.ProviderFile.create(
+            is_file=True,
+            node=self.project,
+            path='/path',
+            name='path',
+            materialized_path='path',
+        )
+        test_file.save()
+        targets = StoredFileNode.find(Q('provider', 'ne', 'osfstorage'))
+        update_file_materialized_paths(targets)
+        test_file.reload()
+        assert_equal(test_file.materialized_path, '/path')
+
+    def tearDown(self):
+        super(FixMaterializedPathTestMixin, self).tearDown()
+        StoredFileNode.remove()
+
+
+class TestFixDropboxMaterializedPaths(FixMaterializedPathTestMixin, OsfTestCase):
+
+    provider = 'dropbox'
+    ProviderFile = DropboxFile
+
+
+class TestFixGoogleDriveMaterializedPaths(FixMaterializedPathTestMixin, OsfTestCase):
+
+    provider = 'googledrive'
+    ProviderFile = GoogleDriveFile
+
+
+class TestFixGithubMaterializedPaths(FixMaterializedPathTestMixin, OsfTestCase):
+
+    provider = 'github'
+    ProviderFile = GithubFile
+
+
+class TestFixS3MaterializedPaths(FixMaterializedPathTestMixin, OsfTestCase):
+
+    provider = 's3'
+    ProviderFile = S3File

--- a/website/project/views/comment.py
+++ b/website/project/views/comment.py
@@ -59,6 +59,10 @@ def create_new_file(obj, source, destination, destination_node):
         new_file = FileNode.resolve_class(destination['provider'], FileNode.FILE).get_or_create(destination_node, destination['path'])
         if destination['provider'] != 'osfstorage':
             new_file.update(revision=None, data=data)
+            # TODO: Remove when materialized paths are fixed in the payload returned from waterbutler
+            if not new_file.materialized_path.startswith('/'):
+                new_file.materialized_path = '/' + new_file.materialized_path
+                new_file.save()
     else:
         new_file = find_and_create_file_from_metadata(destination.get('children', []), source, destination, destination_node, obj)
         if not new_file:
@@ -68,7 +72,7 @@ def create_new_file(obj, source, destination, destination_node):
                 new_path = obj.referent.materialized_path.replace(source['materialized'], destination['materialized'])
             new_file = FileNode.resolve_class(destination['provider'], FileNode.FILE).get_or_create(destination_node, new_path)
             new_file.name = new_path.split('/')[-1]
-            new_file.materialized_path = new_path
+            new_file.materialized_path = '/' + new_path
             new_file.save()
     return new_file
 

--- a/website/project/views/comment.py
+++ b/website/project/views/comment.py
@@ -70,9 +70,12 @@ def create_new_file(obj, source, destination, destination_node):
                 new_path = obj.referent.path
             else:
                 new_path = obj.referent.materialized_path.replace(source['materialized'], destination['materialized'])
+            # TODO: Remove when materialized paths are fixed in the payload returned from waterbutler
+            if not new_path.startswith('/'):
+                new_path = '/' + new_path
             new_file = FileNode.resolve_class(destination['provider'], FileNode.FILE).get_or_create(destination_node, new_path)
             new_file.name = new_path.split('/')[-1]
-            new_file.materialized_path = '/' + new_path
+            new_file.materialized_path = new_path
             new_file.save()
     return new_file
 


### PR DESCRIPTION
Fixes issue where the materialized paths returned from waterbutler when renaming a file in dropbox,
github, googledrive and s3 did not start with '`/'` and caused errors when renaming the file again.
Because the materialized path did not match the one used to look up the file, the files received new guids.