### PR TITLE
[WIP] Use main file view function for deleted files

### DIFF
--- a/website/routes.py
+++ b/website/routes.py
@@ -952,7 +952,7 @@ def make_url_map(app):
                 '/project/<pid>/node/<nid>/files/deleted/<trashed_id>/',
             ],
             'get',
-            addon_views.addon_deleted_file,
+            addon_views.addon_view_or_download_file,
             OsfWebRenderer('project/view_file.mako', trust=False)
         ),
         Rule(


### PR DESCRIPTION
https://openscience.atlassian.net/browse/OSF-5962

# Purpose

On staging, navagating to a deleted file throws a 500 error, as incorrect information gets passed to the mako template. This PR changes the view function that's called to the main ```addon_view_or_download_file``` view, which properly handles when a file has been deleted, calling the  ```addon_deleted_file``` method where appropriate and returning a 404 page to the user.

# Changes
-``` '/project/<pid>/files/deleted/<trashed_id>/' ``` now routes to ```addon_view_or_download_file``` instead of ```addon_deleted_file```

# Side Effects
None anticipated