### PR TITLE
[hotfix] remove unused hgrid css from meetings page

### DIFF
--- a/website/templates/public/pages/meeting.mako
+++ b/website/templates/public/pages/meeting.mako
@@ -7,7 +7,6 @@
 
 <%def name="stylesheets()">
     ${parent.stylesheets()}
-    <link rel="stylesheet" href="/static/vendor/bower_components/hgrid/dist/hgrid.min.css" />
 </%def>
 
 <%def name="javascript_bottom()">


### PR DESCRIPTION
hgrid was removed from bower.json by c07269d0f2 on Feb. 24.  We no
longer use or serve it and it 404s.