### PR TITLE
Do not block UI when registration fails [OSF-5967]

### DIFF
--- a/website/language.py
+++ b/website/language.py
@@ -93,8 +93,8 @@ MERGE_CONFIRMATION_REQUIRED_LONG = (
 # Node Actions
 
 AFTER_REGISTER_ARCHIVING = (
-    'Files are being copied to the newly created registration. Please check the registrations page '
-    'for more information about the status of this registration.'
+    'Files are being copied to the newly created registration, and you will receive an email '
+    'notification when the copying is finished.'
 )
 
 BEFORE_REGISTER_HAS_POINTERS = (

--- a/website/language.py
+++ b/website/language.py
@@ -93,8 +93,8 @@ MERGE_CONFIRMATION_REQUIRED_LONG = (
 # Node Actions
 
 AFTER_REGISTER_ARCHIVING = (
-    'Files are being copied to the newly created registration, and you will receive an email '
-    'notification when the copying is finished.'
+    'Files are being copied to the newly created registration. Please check the registrations page '
+    'for more information about the status of this registration.'
 )
 
 BEFORE_REGISTER_HAS_POINTERS = (

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -692,7 +692,12 @@ Draft.prototype.register = function(url, data) {
             bootbox.alert({
                 title: 'Registration failed',
                 message: language.registerFail,
-                callback: $osf.unblock
+                callback: function() {
+                    $osf.unblock();
+                    if (self.urls.registrations) {
+                        window.location.assign(self.urls.registrations)
+                    }
+                }
             });
         })
         .always(function() {

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -695,7 +695,7 @@ Draft.prototype.register = function(url, data) {
                 callback: function() {
                     $osf.unblock();
                     if (self.urls.registrations) {
-                        window.location.assign(self.urls.registrations)
+                        window.location.assign(self.urls.registrations);
                     }
                 }
             });

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -693,10 +693,11 @@ Draft.prototype.register = function(url, data) {
                 title: 'Registration failed',
                 message: language.registerFail,
                 callback: $osf.unblock
-            })
+            });
         })
         .always(function() {
-            $osf.unblock()});
+            $osf.unblock();
+        });
     return request;
 };
 Draft.prototype.submitForReview = function() {

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -677,10 +677,6 @@ Draft.prototype.registerWithoutReview = function() {
         }
     });
 };
-Draft.prototype.onRegisterFail = bootbox.alert.bind(null, {
-    title: 'Registration failed',
-    message: language.registerFail
-});
 Draft.prototype.register = function(url, data) {
     var self = this;
 
@@ -693,9 +689,14 @@ Draft.prototype.register = function(url, data) {
             }
         })
         .fail(function() {
-            self.onRegisterFail();
+            bootbox.alert({
+                title: 'Registration failed',
+                message: language.registerFail,
+                callback: $osf.unblock
+            })
         })
-        .always($osf.unblock);
+        .always(function() {
+            $osf.unblock()});
     return request;
 };
 Draft.prototype.submitForReview = function() {


### PR DESCRIPTION
Refs, but does not completely fix, https://openscience.atlassian.net/browse/OSF-5809

Fixes https://openscience.atlassian.net/browse/OSF-5967

## Purpose
When a registration of a draft fails, the UI does not unblock, and the user is left without a course of action.

Instead, the UI should be unblocked correctly, and the user should be taken back to the registration page after dismissing the modal.

## Testing notes
See the linked PR for an example test case of a failing registration. (you can fork that project if you don't directly have access). Be warned that the rare failure case in question takes ~1min of waiting before it fails.

For local machine code review purposes, you can force a failure much faster by modifying `projects.project.views.drafts.register_draft_registration` to return a 400 immediately.
