### PR TITLE
[feature] Rate limit password reset view [OSF-5960]

### DIFF
--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -291,6 +291,8 @@ class User(GuidStoredObject, AddonModelMixin):
     # verification key used for resetting password
     verification_key = fields.StringField()
 
+    forgot_password_last_post = fields.DateTimeField()
+
     # confirmed emails
     #   emails should be stripped of whitespace and lower-cased before appending
     # TODO: Add validator to ensure an email address only exists once across

--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -78,6 +78,7 @@ def forgot_password_post():
                           'should have, please contact OSF Support. ').format(email)
         user_obj = get_user(email=email)
         if user_obj:
+            #TODO: Remove this rate limiting and replace it with something that doesn't write to the User model
             now = datetime.datetime.utcnow()
             last_attempt = user_obj.forgot_password_last_post or now - datetime.timedelta(seconds=FORGOT_PASSWORD_MINIMUM_TIME)
             user_obj.forgot_password_last_post = now

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -305,6 +305,7 @@ class TestUserMerging(base.OsfTestCase):
             'date_last_login',
             'date_registered',
             'family_name',
+            'forgot_password_last_post',
             'fullname',
             'given_name',
             'is_claimed',

--- a/tests/webtest_tests.py
+++ b/tests/webtest_tests.py
@@ -884,15 +884,14 @@ class TestForgotAndResetPasswordViews(OsfTestCase):
         self.user.verification_key = self.key
         self.user.save()
 
-        self.reset_url = web_url_for('reset_password', verification_key=self.key)
-        self.forgot_url = web_url_for('forgot_password_post')
+        self.url = web_url_for('reset_password', verification_key=self.key)
 
     def test_reset_password_view_returns_200(self):
-        res = self.app.get(self.reset_url)
+        res = self.app.get(self.url)
         assert_equal(res.status_code, 200)
 
     def test_can_reset_password_if_form_success(self):
-        res = self.app.get(self.reset_url)
+        res = self.app.get(self.url)
         form = res.forms['resetPasswordForm']
         form['password'] = 'newpassword'
         form['password2'] = 'newpassword'
@@ -906,7 +905,7 @@ class TestForgotAndResetPasswordViews(OsfTestCase):
     def test_reset_password_logs_out_user(self):
         another_user = AuthUserFactory()
         # visits reset password link while another user is logged in
-        res = self.app.get(self.reset_url, auth=another_user.auth)
+        res = self.app.get(self.url, auth=another_user.auth)
         assert_equal(res.status_code, 200)
         # We check if another_user is logged in by checking if
         # their full name appears on the page (it should be in the navbar).
@@ -914,18 +913,6 @@ class TestForgotAndResetPasswordViews(OsfTestCase):
         assert_not_in(another_user.fullname, res)
         # make sure the form is on the page
         assert_true(res.forms['resetPasswordForm'])
-
-    def test_submit_forgot_password(self):
-        header = {'email': self.user.username}
-        res = self.app.post_json(self.forgot_url, header)
-        assert_equal(res.status_code, 200)
-
-    def test_cannot_submit_forgot_password_twice(self):
-        header = {'email': self.user.username}
-        res = self.app.post_json(self.forgot_url, header)
-        assert_equal(res.status_code, 200)
-        res = self.app.post_json(self.forgot_url, header)
-        assert_equal(res.status_code, 400)
 
 class TestAUserProfile(OsfTestCase):
 

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -34,6 +34,9 @@ with open(os.path.join(APP_PATH, 'package.json'), 'r') as fobj:
 EMAIL_TOKEN_EXPIRATION = 24
 CITATION_STYLES_PATH = os.path.join(BASE_PATH, 'static', 'vendor', 'bower_components', 'styles')
 
+# Minimum seconds between forgot password email attempts
+FORGOT_PASSWORD_MINIMUM_TIME = 30
+
 # Hours before pending embargo/retraction/registration automatically becomes active
 RETRACTION_PENDING_TIME = datetime.timedelta(days=2)
 EMBARGO_PENDING_TIME = datetime.timedelta(days=2)


### PR DESCRIPTION
Purpose
-----------
Fix https://openscience.atlassian.net/browse/OSF-5960 which also fixes [SEC-5]

Currently, we have broad rate limiting over everything in the OSF, but someone reported a vulnerability with the forgot password field that would let malicious users email someone with a "reset password" link thousands of times in a minute. This adds a rate limit to that field to prevent it from happening nearly as frequently

Changes
------------
1. Add a test for the condition
2. Add a field to the user model to track when the last time a request was made
3. Add a setting for how frequently we'll allow people to request a new password (currently set to 30 seconds, which seems decent to me)
4. Add a new webtest function to ensure that html wasn't in a view, not just that it was in the view

Side effects
---------------
The malicious user will be able to lock the user object and write to the DB with each forgotten password request. This is less than ideal, but was discussed with Michael. In the long term, we'll add some better rate limiting at other, more appropriate places, but we want to make sure users are not harmed and we don't get marked as spam in the meantime.