### PR TITLE
[hotfix] Remove calls to .tbController

### DIFF
--- a/website/static/js/citationGrid.js
+++ b/website/static/js/citationGrid.js
@@ -353,7 +353,7 @@ CitationGrid.prototype.updateStyle = function(name, xml) {
     this.styleName = name;
     this.styleXml = xml;
     this.bibliographies = {};
-    this.treebeard.tbController.redraw();
+    this.treebeard.redraw();
 };
 
 CitationGrid.prototype.makeBibliography = function(folder, format) {

--- a/website/static/js/filesWidget.js
+++ b/website/static/js/filesWidget.js
@@ -98,9 +98,8 @@ FilesWidget.prototype.init = function() {
 };
 FilesWidget.prototype.destroy = function() {
     if (this.filebrowser) {
-        if (this.filebrowser.grid.tbController) {
-            this.filebrowser.grid.tbController.destroy();
-            delete this.filebrowser.tbController;
+        if (this.filebrowser.grid) {
+            this.filebrowser.grid.destroy();
         }
         delete this.filebrowser;
     }

--- a/website/static/js/folderpicker.js
+++ b/website/static/js/folderpicker.js
@@ -198,7 +198,7 @@ function FolderPicker(selector, opts) {
     self.options.rootName = opts.rootName;
 
     // Start up the grid
-    self.grid = new Treebeard(self.options).tbController;
+    self.grid = new Treebeard(self.options);
 }
 
 FolderPicker.prototype.destroy = function() {


### PR DESCRIPTION
Purpose
=======
The treebeard constructor now returns controller; calls to `.tbController` return `undefined` and cause a errors

Changes
=======
* Remove calls to .tbController

Side Effects
=========
None