### PR TITLE
[fix] Remove call to .tbController

### DIFF
--- a/website/static/js/nodeSelectTreebeard.js
+++ b/website/static/js/nodeSelectTreebeard.js
@@ -78,7 +78,7 @@ function NodeSelectTreebeard(divID, data, nodesState) {
         }
     });
     var grid = new Treebeard(tbOptions);
-    projectSettingsTreebeardBase.expandOnLoad.call(grid.tbController);
+    projectSettingsTreebeardBase.expandOnLoad.call(grid);
 }
 module.exports = NodeSelectTreebeard;
 


### PR DESCRIPTION
Purpose
=======
The treebeard constructor now returns controller; calls to `.tbController` return `undefined` and cause a errors. Extension of hotfix #5413 

Changes
=======
* Remove call to .tbController

Side Effects
=========
None