### PR TITLE
Speed up User PUT and PATCH Methods by modifying User properties [OSF-5338]

### DIFF
--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -1074,12 +1074,11 @@ class User(GuidStoredObject, AddonModelMixin):
 
     @property
     def contributor_to(self):
-        return (
-            node for node in self.contributed
-            if not (
-                node.is_deleted
-                or node.is_bookmark_collection
-            )
+        from website.project.model import Node
+        return Node.find(
+            Q('contributors', 'eq', self._id) &
+            Q('is_deleted', 'eq', False) &
+            Q('is_bookmark_collection', 'eq', False)
         )
 
     @property

--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -1083,9 +1083,12 @@ class User(GuidStoredObject, AddonModelMixin):
 
     @property
     def visible_contributor_to(self):
-        return (
-            node for node in self.contributor_to
-            if self._id in node.visible_contributor_ids
+        from website.project.model import Node
+        return Node.find(
+            Q('contributors', 'eq', self._id) &
+            Q('is_deleted', 'eq', False) &
+            Q('is_bookmark_collection', 'eq', False) &
+            Q(self._id, 'eq', 'visible_contributor_ids')
         )
 
     def get_summary(self, formatter='long'):

--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -421,11 +421,6 @@ class User(GuidStoredObject, AddonModelMixin):
         return self._id
 
     @property
-    def contributed(self):
-        from website.project.model import Node
-        return Node.find(Q('contributors', 'eq', self._id))
-
-    @property
     def email(self):
         return self.username
 
@@ -1071,6 +1066,11 @@ class User(GuidStoredObject, AddonModelMixin):
     @property
     def profile_url(self):
         return '/{}/'.format(self._id)
+
+    @property
+    def contributed(self):
+        from website.project.model import Node
+        return Node.find(Q('contributors', 'eq', self._id))
 
     @property
     def contributor_to(self):

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -136,6 +136,15 @@ class TestUser(base.OsfTestCase):
         )
         assert_equal(list(contributor_to), list(self.user.contributor_to))
 
+    def test_visible_contributor_to_property(self):
+        visible_contributor_to = project.model.Node.find(
+            Q('contributors', 'eq', self.user._id) &
+            Q('is_deleted', 'eq', False) &
+            Q('is_bookmark_collection', 'eq', False) &
+            Q(self.user._id, 'eq', 'visible_contributor_ids')
+        )
+        assert_equal(list(visible_contributor_to), list(self.user.visible_contributor_to))
+
     def test_created_property(self):
         # make sure there's at least one project
         factories.ProjectFactory(creator=self.user)

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -124,6 +124,18 @@ class TestUser(base.OsfTestCase):
         projects_contributed_to = project.model.Node.find(Q('contributors', 'eq', self.user._id))
         assert_equal(list(self.user.contributed), list(projects_contributed_to))
 
+    def test_contributor_to_property(self):
+        # Make sure there's at least one deleted project and bookmark collection
+        factories.ProjectFactory(creator=self.user, is_deleted=True)
+        factories.BookmarkCollectionFactory(creator=self.user)
+
+        contributor_to = project.model.Node.find(
+            Q('contributors', 'eq', self.user._id) &
+            Q('is_deleted', 'eq', False) &
+            Q('is_bookmark_collection', 'eq', False)
+        )
+        assert_equal(list(contributor_to), list(self.user.contributor_to))
+
     def test_created_property(self):
         # make sure there's at least one project
         factories.ProjectFactory(creator=self.user)


### PR DESCRIPTION
https://openscience.atlassian.net/browse/OSF-5338

# Purpose
```PUT``` and ```PATCH``` methods are very slow on the OSF API at the moment. @brianjgeiger noticed that was because the ```contributor_to``` method was a list comprehension relying on a previous property and not a faster ModularODM Query. This PR changes the ```contributor_to``` property to return a ModularODM query with the appropriate nodes.

# Changes 
- Move the  ```contributed``` property to be closer to the others
- Update the ```contributor_to``` property to return a ModularODM queryset instead of relying on the ```contributed``` property

# Side Effects
- The places that use those properties right now don't seem to be affected by this change, but these properties are now returning query sets instead of acting as generators so I might have missed something....