### PR TITLE
[fix] Speed up User PUT and PATCH Methods by modifying User properties [OSF-5338]

### DIFF
--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -1086,7 +1086,7 @@ class User(GuidStoredObject, AddonModelMixin):
         from website.project.model import Node
         return Node.find(
             Q('contributors', 'eq', self._id) &
-            Q('is_deleted', 'eq', False) &
+            Q('is_deleted', 'ne', True) &
             Q('is_bookmark_collection', 'ne', True) &
             Q('visible_contributor_ids', 'eq', self.user._id)
         )

--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -1074,12 +1074,11 @@ class User(GuidStoredObject, AddonModelMixin):
 
     @property
     def contributor_to(self):
-        return (
-            node for node in self.contributed
-            if not (
-                node.is_deleted
-                or node.is_bookmark_collection
-            )
+        from website.project.model import Node
+        return Node.find(
+            Q('contributors', 'eq', self._id) &
+            Q('is_deleted', 'eq', False) &
+            Q('is_bookmark_collection', 'eq', False)
         )
 
     @property

--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -1088,7 +1088,7 @@ class User(GuidStoredObject, AddonModelMixin):
             Q('contributors', 'eq', self._id) &
             Q('is_deleted', 'ne', True) &
             Q('is_collection', 'ne', True) &
-            Q('visible_contributor_ids', 'eq', self.user._id)
+            Q('visible_contributor_ids', 'eq', self._id)
         )
 
     def get_summary(self, formatter='long'):

--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -1083,9 +1083,12 @@ class User(GuidStoredObject, AddonModelMixin):
 
     @property
     def visible_contributor_to(self):
-        return (
-            node for node in self.contributor_to
-            if self._id in node.visible_contributor_ids
+        from website.project.model import Node
+        return Node.find(
+            Q('contributors', 'eq', self._id) &
+            Q('is_deleted', 'eq', False) &
+            Q('is_bookmark_collection', 'eq', False) &
+            Q(self._id, 'eq', 'visible_contributor_ids')
         )
 
     def get_summary(self, formatter='long'):

--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -1078,7 +1078,7 @@ class User(GuidStoredObject, AddonModelMixin):
         return Node.find(
             Q('contributors', 'eq', self._id) &
             Q('is_deleted', 'ne', True) &
-            Q('is_bookmark_collection', 'ne', True)
+            Q('is_collection', 'ne', True)
         )
 
     @property
@@ -1087,7 +1087,7 @@ class User(GuidStoredObject, AddonModelMixin):
         return Node.find(
             Q('contributors', 'eq', self._id) &
             Q('is_deleted', 'ne', True) &
-            Q('is_bookmark_collection', 'ne', True) &
+            Q('is_collection', 'ne', True) &
             Q('visible_contributor_ids', 'eq', self.user._id)
         )
 

--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -1077,7 +1077,7 @@ class User(GuidStoredObject, AddonModelMixin):
         from website.project.model import Node
         return Node.find(
             Q('contributors', 'eq', self._id) &
-            Q('is_deleted', 'eq', False) &
+            Q('is_deleted', 'ne', True) &
             Q('is_bookmark_collection', 'eq', False)
         )
 

--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -1078,7 +1078,7 @@ class User(GuidStoredObject, AddonModelMixin):
         return Node.find(
             Q('contributors', 'eq', self._id) &
             Q('is_deleted', 'ne', True) &
-            Q('is_bookmark_collection', 'eq', False)
+            Q('is_bookmark_collection', 'ne', True)
         )
 
     @property
@@ -1087,8 +1087,8 @@ class User(GuidStoredObject, AddonModelMixin):
         return Node.find(
             Q('contributors', 'eq', self._id) &
             Q('is_deleted', 'eq', False) &
-            Q('is_bookmark_collection', 'eq', False) &
-            Q(self._id, 'eq', 'visible_contributor_ids')
+            Q('is_bookmark_collection', 'ne', True) &
+            Q('visible_contributor_ids', 'eq', self.user._id)
         )
 
     def get_summary(self, formatter='long'):

--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -421,11 +421,6 @@ class User(GuidStoredObject, AddonModelMixin):
         return self._id
 
     @property
-    def contributed(self):
-        from website.project.model import Node
-        return Node.find(Q('contributors', 'eq', self._id))
-
-    @property
     def email(self):
         return self.username
 
@@ -1071,6 +1066,11 @@ class User(GuidStoredObject, AddonModelMixin):
     @property
     def profile_url(self):
         return '/{}/'.format(self._id)
+
+    @property
+    def contributed(self):
+        from website.project.model import Node
+        return Node.find(Q('contributors', 'eq', self._id))
 
     @property
     def contributor_to(self):

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -132,7 +132,7 @@ class TestUser(base.OsfTestCase):
         contributor_to = project.model.Node.find(
             Q('contributors', 'eq', self.user._id) &
             Q('is_deleted', 'ne', True) &
-            Q('is_bookmark_collection', 'ne', True)
+            Q('is_collection', 'ne', True)
         )
         assert_equal(list(contributor_to), list(self.user.contributor_to))
 
@@ -140,7 +140,7 @@ class TestUser(base.OsfTestCase):
         visible_contributor_to = project.model.Node.find(
             Q('contributors', 'eq', self.user._id) &
             Q('is_deleted', 'ne', True) &
-            Q('is_bookmark_collection', 'ne', True) &
+            Q('is_collection', 'ne', True) &
             Q('visible_contributor_ids', 'eq', self.user._id)
         )
         assert_equal(list(visible_contributor_to), list(self.user.visible_contributor_to))

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -131,7 +131,7 @@ class TestUser(base.OsfTestCase):
 
         contributor_to = project.model.Node.find(
             Q('contributors', 'eq', self.user._id) &
-            Q('is_deleted', 'eq', False) &
+            Q('is_deleted', 'ne', True) &
             Q('is_bookmark_collection', 'eq', False)
         )
         assert_equal(list(contributor_to), list(self.user.contributor_to))
@@ -139,7 +139,7 @@ class TestUser(base.OsfTestCase):
     def test_visible_contributor_to_property(self):
         visible_contributor_to = project.model.Node.find(
             Q('contributors', 'eq', self.user._id) &
-            Q('is_deleted', 'eq', False) &
+            Q('is_deleted', 'ne', True) &
             Q('is_bookmark_collection', 'eq', False) &
             Q(self.user._id, 'eq', 'visible_contributor_ids')
         )

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -136,6 +136,15 @@ class TestUser(base.OsfTestCase):
         )
         assert_equal(list(contributor_to), list(self.user.contributor_to))
 
+    def test_visible_contributor_to_property(self):
+        visible_contributor_to = project.model.Node.find(
+            Q('contributors', 'eq', self.user._id) &
+            Q('is_deleted', 'eq', False) &
+            Q('is_bookmark_collection', 'eq', False) &
+            Q(self.user._id, 'eq', 'visible_contributor_ids')
+        )
+        assert_equal(list(visible_contributor_to), list(self.user.visible_contributor_to))
+
     def test_created_property(self):
         # make sure there's at least one project
         factories.ProjectFactory(creator=self.user)

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -132,7 +132,7 @@ class TestUser(base.OsfTestCase):
         contributor_to = project.model.Node.find(
             Q('contributors', 'eq', self.user._id) &
             Q('is_deleted', 'ne', True) &
-            Q('is_bookmark_collection', 'eq', False)
+            Q('is_bookmark_collection', 'ne', True)
         )
         assert_equal(list(contributor_to), list(self.user.contributor_to))
 
@@ -140,8 +140,8 @@ class TestUser(base.OsfTestCase):
         visible_contributor_to = project.model.Node.find(
             Q('contributors', 'eq', self.user._id) &
             Q('is_deleted', 'ne', True) &
-            Q('is_bookmark_collection', 'eq', False) &
-            Q(self.user._id, 'eq', 'visible_contributor_ids')
+            Q('is_bookmark_collection', 'ne', True) &
+            Q('visible_contributor_ids', 'eq', self.user._id)
         )
         assert_equal(list(visible_contributor_to), list(self.user.visible_contributor_to))
 

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -144,7 +144,6 @@ class TestUser(base.OsfTestCase):
         collection_node = factories.CollectionFactory(creator=invisible_contributor)
         project_to_be_invisible_on = factories.ProjectFactory()
         project_to_be_invisible_on.add_contributor(invisible_contributor, visible=False)
-
         visible_contributor_to_nodes = [node._id for node in invisible_contributor.visible_contributor_to]
 
         assert_in(normal_node._id, visible_contributor_to_nodes)

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -126,12 +126,20 @@ class TestUser(base.OsfTestCase):
 
     def test_contributor_to_property(self):
         normal_node = factories.ProjectFactory(creator=self.user)
+        normal_contributed_node = factories.ProjectFactory()
+        normal_contributed_node.add_contributor(self.user)
+        normal_contributed_node.save()
         deleted_node = factories.ProjectFactory(creator=self.user, is_deleted=True)
         bookmark_collection_node = factories.BookmarkCollectionFactory(creator=self.user)
         collection_node = factories.CollectionFactory(creator=self.user)
+        project_to_be_invisible_on = factories.ProjectFactory()
+        project_to_be_invisible_on.add_contributor(self.user, visible=False)
+        project_to_be_invisible_on.save()
         contributor_to_nodes = [node._id for node in self.user.contributor_to]
 
         assert_in(normal_node._id, contributor_to_nodes)
+        assert_in(normal_contributed_node._id, contributor_to_nodes)
+        assert_in(project_to_be_invisible_on._id, contributor_to_nodes)
         assert_not_in(deleted_node._id, contributor_to_nodes)
         assert_not_in(bookmark_collection_node._id, contributor_to_nodes)
         assert_not_in(collection_node._id, contributor_to_nodes)
@@ -144,6 +152,7 @@ class TestUser(base.OsfTestCase):
         collection_node = factories.CollectionFactory(creator=invisible_contributor)
         project_to_be_invisible_on = factories.ProjectFactory()
         project_to_be_invisible_on.add_contributor(invisible_contributor, visible=False)
+        project_to_be_invisible_on.save()
         visible_contributor_to_nodes = [node._id for node in invisible_contributor.visible_contributor_to]
 
         assert_in(normal_node._id, visible_contributor_to_nodes)

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -124,6 +124,18 @@ class TestUser(base.OsfTestCase):
         projects_contributed_to = project.model.Node.find(Q('contributors', 'eq', self.user._id))
         assert_equal(list(self.user.contributed), list(projects_contributed_to))
 
+    def test_contributor_to_property(self):
+        # Make sure there's at least one deleted project and bookmark collection
+        factories.ProjectFactory(creator=self.user, is_deleted=True)
+        factories.BookmarkCollectionFactory(creator=self.user)
+
+        contributor_to = project.model.Node.find(
+            Q('contributors', 'eq', self.user._id) &
+            Q('is_deleted', 'eq', False) &
+            Q('is_bookmark_collection', 'eq', False)
+        )
+        assert_equal(list(contributor_to), list(self.user.contributor_to))
+
     def test_created_property(self):
         # make sure there's at least one project
         factories.ProjectFactory(creator=self.user)


### PR DESCRIPTION
https://openscience.atlassian.net/browse/OSF-5338

# Purpose
```PUT``` and ```PATCH``` methods are very slow on the OSF API at the moment. @chrisseto noticed that was because the ```contributor_to``` and ```visible_contributor_to``` methods were list comprehensions relying on a previous property and not a faster ModularODM Query. This PR changes the ```contributor_to``` and and ```visible_contributor_to``` properties to return a ModularODM query with the appropriate nodes.

# Changes 
- Move the  ```contributed``` property to be closer to the others
- Update the ```contributor_to``` property to return a ModularODM queryset instead of relying on the ```contributed``` property
- Update the ```visible_contributor_to``` property to return a ModularODM queryset instead of relying on the ```contributed``` property
- Add tests for the ```contributed_to``` and ```visible_contributor_to``` properties

# Side Effects
- The places that use those properties right now don't seem to be affected by this change, but these properties are now returning query sets instead of acting as generators so I might have missed something....

Moved from #5415!