### PR TITLE
[fix] Add serializer to InstitutionAuth to fix API Docs [OSF-5957]

### DIFF
--- a/api/institutions/views.py
+++ b/api/institutions/views.py
@@ -12,6 +12,7 @@ from website.models import Node, User, Institution
 from api.base import permissions as base_permissions
 from api.base.filters import ODMFilterMixin
 from api.base.views import JSONAPIBaseView
+from api.base.serializers import JSONAPISerializer
 from api.base.utils import get_object_or_error
 from api.nodes.serializers import NodeSerializer
 from api.users.serializers import UserSerializer
@@ -200,6 +201,8 @@ class InstitutionAuth(JSONAPIBaseView, generics.CreateAPIView):
         drf_permissions.IsAuthenticated,
         base_permissions.TokenHasScope,
     )
+
+    serializer_class = JSONAPISerializer
 
     required_read_scopes = [CoreScopes.NULL]
     required_write_scopes = [CoreScopes.NULL]


### PR DESCRIPTION
https://openscience.atlassian.net/browse/OSF-5957

# Purpose

API Swagger docs were throwing a server error:
```
AssertionError: 'InstitutionAuth' should either include a `serializer_class` attribute, or override the `get_serializer_class()` method.
```

# Changes
Add a serializer (the most basic one I could think of, the ```JSONAPISerializer```) 

# Side Effects
- None anticipated, unless the way that view was intended to be serialized is dramatically different