### PR TITLE
[hotfix] don't run irrelevant JS on registrations settings

### DIFF
--- a/website/static/js/pages/project-settings-page.js
+++ b/website/static/js/pages/project-settings-page.js
@@ -229,12 +229,16 @@ $(document).ready(function() {
       if(unchecked.length > 0 || checked.length > 0) {
           return 'The changes on addon setting are not submitted!';
       }
-    /* Before closing the page, Check whether changes made to category, title or description are updated or not */
-      if (projectSettingsVM.title() !== projectSettingsVM.titlePlaceholder ||
-          projectSettingsVM.description() !== projectSettingsVM.descriptionPlaceholder ||
-          projectSettingsVM.selectedCategory() !== projectSettingsVM.categoryPlaceholder) {
-          return 'There are unsaved changes in your project settings.';
-      }
+
+        if (projectSettingsVM) {
+            /* Before closing the page, check whether changes made to category, title or
+               description are updated or not */
+            if (projectSettingsVM.title() !== projectSettingsVM.titlePlaceholder ||
+                projectSettingsVM.description() !== projectSettingsVM.descriptionPlaceholder ||
+                projectSettingsVM.selectedCategory() !== projectSettingsVM.categoryPlaceholder) {
+                return 'There are unsaved changes in your project settings.';
+            }
+        }
     });
 
     // Show capabilities modal on selecting an addon; unselect if user
@@ -299,4 +303,6 @@ WikiSettingsViewModel.enabled.subscribe(function(newValue) {
     return true;
 }, WikiSettingsViewModel);
 
-$osf.applyBindings(WikiSettingsViewModel, '#selectWikiForm');
+if ($('#selectWikiForm').length) {
+    $osf.applyBindings(WikiSettingsViewModel, '#selectWikiForm');
+}


### PR DESCRIPTION
The settings page for registrations doesn't have either a #selectWikiForm
element or a projectSettingsVM object, so check before using those.