### PR TITLE
[RfR] [OSF-5654] Fix: Show 'loading contributors...' in more cases 

### DIFF
--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -191,6 +191,7 @@ AddContributorViewModel = oop.extend(Paginator, {
     },
     fetchResults: function () {
         var self = this;
+        self.doneSearching(false);
         self.notification(false);
         if (self.query()) {
             return $.getJSON(

--- a/website/templates/project/modal_add_contributor.mako
+++ b/website/templates/project/modal_add_contributor.mako
@@ -48,7 +48,7 @@
                             <!-- ko if: notification -->
                             <div data-bind="html: notification().message, css: 'alert alert-' + notification().level"></div>
                             <!-- /ko -->
-
+                            <!-- ko if: doneSearching -->
                             <table class="table-condensed">
                                 <thead data-bind="visible: foundResults">
                                 </thead>
@@ -107,6 +107,7 @@
 
                                 </tbody>
                             </table>
+                            <!-- /ko -->
                             <!-- Link to add non-registered contributor -->
                             <div class='help-block'>
                                 <div data-bind='if: foundResults'>


### PR DESCRIPTION
## Purpose
Cover the case where a user has searched for a contributor, selects that contributor, and then searches for a second contributor with a different name.

## Changes
Make sure to reset `doneSearching` when a subsequent search happens.
## Refs
https://openscience.atlassian.net/browse/OSF-5654

[OSF-5654]