### PR TITLE
Force all serializers to have a get_absolute_url method

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -549,3 +549,7 @@ class NodeAlternativeCitationSerializer(JSONAPISerializer):
                 names = "', '".join([str(citation.name) for citation in matching_citations])
                 errors.append("Citation matches '{}'".format(names))
         return errors
+
+    def get_absolute_url(self, obj):
+        #  Citations don't have urls
+        raise NotImplementedError


### PR DESCRIPTION
This test checks that all serializers not based in `api_test` or `test` modules have a get_absolute_url method. 

I also had to add a get_absolute_url method to `NodeAlternativeCitationSerializer` that doesn't do anything, other than throw an exception, because AFAIK Node Alternative Citations don't have a url.