### PR TITLE
secure DOIs

### DIFF
--- a/website/addons/dataverse/serializer.py
+++ b/website/addons/dataverse/serializer.py
@@ -54,7 +54,7 @@ class DataverseSerializer(OAuthAddonSerializer):
             'importAuth': node.api_url_for('dataverse_import_auth'),
             'deauthorize': node.api_url_for('dataverse_deauthorize_node'),
             'getDatasets': node.api_url_for('dataverse_get_datasets'),
-            'datasetPrefix': 'http://dx.doi.org/',
+            'datasetPrefix': 'https://doi.org/',
             'dataversePrefix': 'http://{0}/dataverse/'.format(host),
             'accounts': api_url_for('dataverse_account_list'),
         }

--- a/website/addons/dataverse/views.py
+++ b/website/addons/dataverse/views.py
@@ -311,7 +311,7 @@ def dataverse_get_widget_contents(node_addon, **kwargs):
 
     dataverse_host = node_addon.external_account.oauth_key
     dataverse_url = 'http://{0}/dataverse/{1}'.format(dataverse_host, alias)
-    dataset_url = 'http://dx.doi.org/' + doi
+    dataset_url = 'https://doi.org/' + doi
 
     data.update({
         'connected': True,

--- a/website/static/js/citationGrid.js
+++ b/website/static/js/citationGrid.js
@@ -142,7 +142,7 @@ var buildExternalUrl = function(csl) {
     if (csl.URL) {
         return csl.URL;
     } else if (csl.DOI) {
-        return 'http://dx.doi.org/' + csl.DOI;
+        return 'https://doi.org/' + csl.DOI;
     } else if (csl.PMID) {
         return 'http://www.ncbi.nlm.nih.gov/pubmed/' + csl.PMID;
     }


### PR DESCRIPTION
The DOI foundation has [stopped listing the `dx` resolver as "preferred", and started to support HTTPS](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). I hope I correctly understood your code to generate/display DOI links, not parse them.

I omitted the same change in `citeproc.js`, because [an upstream PR](https://bitbucket.org/fbennett/citeproc-js/pull-requests/8/generate-secure-doi-links/diff) is pending.