### PR TITLE
0.67.0/fix qa info logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ node_modules
 # Allow robots.txt to be deployment-specific
 website/static/robots.local.txt
 /website/static/git_logs.txt
+/website/static/gitlogs.json
 
 # OSF-specific
 ##############

--- a/.gitignore
+++ b/.gitignore
@@ -55,7 +55,7 @@ node_modules
 # Allow robots.txt to be deployment-specific
 website/static/robots.local.txt
 /website/static/git_logs.txt
-/website/static/gitlogs.json
+/website/static/git_logs.json
 
 # OSF-specific
 ##############

--- a/.gitignore
+++ b/.gitignore
@@ -54,8 +54,6 @@ website/static/vendor/bower_components/
 node_modules
 # Allow robots.txt to be deployment-specific
 website/static/robots.local.txt
-/website/static/git_logs.txt
-/website/static/git_logs.json
 
 # OSF-specific
 ##############

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -20,6 +20,3 @@ livereload==2.3.2
 
 # Avoid eating cpu with live reloading
 watchdog==0.8.3
-
-# QA Helper
-requests==2.5.3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -20,3 +20,6 @@ livereload==2.3.2
 
 # Avoid eating cpu with live reloading
 watchdog==0.8.3
+
+# QA Helper
+requests==2.5.3

--- a/scripts/meta/gatherer.py
+++ b/scripts/meta/gatherer.py
@@ -1,0 +1,42 @@
+import requests
+import json
+from website.settings import GITHUB_API_TOKEN
+
+the_filename = 'website/static/git_logs.json'
+
+
+def gather_pr_data():
+    pr_data = []
+    auth_header = {'Authorization': 'token %s' % GITHUB_API_TOKEN}
+    res = requests.get('https://api.github.com/repos/centerforopenscience/osf.io/pulls?state=closed&per_page=100',
+                       headers=auth_header)
+
+    while len(pr_data)<100:
+        if res.status_code == 200:
+            for item in res.json():
+                try:
+                    sha = item['merge_commit_sha']
+                except TypeError:
+                    sha = None
+                if sha:
+                    pr_data.append(item)
+            try:
+                next_link = res.links['next']
+            except KeyError:
+                break
+            res = requests.get(next_link['url'])
+        else:
+            break
+
+    return pr_data
+
+
+def main():
+    if GITHUB_API_TOKEN:
+        pr_data = json.dumps(gather_pr_data())
+        with open(the_filename, 'w') as f:
+            f.write(pr_data)
+
+if __name__ == '__main__':
+    main()
+

--- a/scripts/meta/gatherer.py
+++ b/scripts/meta/gatherer.py
@@ -1,7 +1,8 @@
 import json
+import os
 from website.settings import GITHUB_API_TOKEN
 
-the_filename = 'website/static/git_logs.json'
+GIT_LOGS_FILE = os.path.join('website', 'static', 'built', 'git_logs.json')
 
 
 def gather_pr_data():
@@ -34,7 +35,7 @@ def gather_pr_data():
 def main():
     if GITHUB_API_TOKEN:
         pr_data = json.dumps(gather_pr_data())
-        with open(the_filename, 'w') as f:
+        with open(GIT_LOGS_FILE, 'w') as f:
             f.write(pr_data)
 
 if __name__ == '__main__':

--- a/scripts/meta/gatherer.py
+++ b/scripts/meta/gatherer.py
@@ -1,4 +1,3 @@
-import requests
 import json
 from website.settings import GITHUB_API_TOKEN
 
@@ -6,6 +5,7 @@ the_filename = 'website/static/git_logs.json'
 
 
 def gather_pr_data():
+    import requests
     pr_data = []
     auth_header = {'Authorization': 'token %s' % GITHUB_API_TOKEN}
     res = requests.get('https://api.github.com/repos/centerforopenscience/osf.io/pulls?state=closed&per_page=100',

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -17,6 +17,7 @@ from invoke import run, Collection
 from website import settings
 from admin import tasks as admin_tasks
 from utils import pip_install, bin_prefix
+from scripts.meta import gatherer
 
 logging.getLogger('invoke').setLevel(logging.CRITICAL)
 
@@ -69,9 +70,8 @@ def server(host=None, port=5000, debug=True, live=False, gitlogs=False):
         app.run(host=host, port=port, debug=debug, threaded=debug, extra_files=[settings.ASSET_HASH_PATH])
 
 @task
-def git_logs(count=100, pretty='format:"%s - %b"', grep='"Merge pull request"'):
-    cmd = 'git log --grep={1} -n {0} --pretty={2} > website/static/git_logs.txt'.format(count, grep, pretty)
-    run(cmd, echo=True)
+def git_logs():
+    gatherer.main()
 
 
 @task

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -447,3 +447,6 @@ ENABLE_VARNISH = False
 ENABLE_ESI = False
 VARNISH_SERVERS = []  # This should be set in local.py or cache invalidation won't work
 ESI_MEDIA_TYPES = {'application/vnd.api+json', 'application/json'}
+
+# Used for gathering meta information about the current build
+GITHUB_API_TOKEN = None

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -14,6 +14,27 @@ a {
     cursor: pointer;
 }
 
+/*Meta Info
+----------------------------------------------------*/
+
+#metaInfo {
+    text-shadow: 0 1px 0 #fff;
+    border-top: 1px solid #e5e5e5;
+    border-bottom: 1px solid #e5e5e5;
+    width: 100%;
+    color: #555;
+    position: absolute;
+    padding-top:20px;
+    padding-bottom:20px;
+    z-index:10;
+    background-color:white;
+    border-top:2px solid black;
+}
+
+#metaInfo th, #metaInfo td{
+    padding-left: 15px;
+    text-align: left;
+}
 
 /* Footer
 -------------------------------------------------- */

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -23,7 +23,7 @@ a {
     border-bottom: 1px solid #e5e5e5;
     width: 100%;
     color: #555;
-    position: absolute;
+    position: relative;
     padding-top:20px;
     padding-bottom:20px;
     z-index:10;

--- a/website/static/js/devmodeHelper.js
+++ b/website/static/js/devmodeHelper.js
@@ -8,15 +8,19 @@ var DevModeModel = function() {
     self.showMetaInfo = ko.observable(false);
     self.showHideMetaInfo = function() {
         if(self.pullRequests().length === 0) {
-            $.getJSON('/static/git_logs.json')
-                .done(function(data){
-                    dataLength = data.length;
-                    for(i=0; i<dataLength; i++) {
-                        self.pullRequests.push(new PullRequestItem(data[i]));
-                    }
-            });
+            if(!self.showMetaInfo()) {
+                $.getJSON('/static/git_logs.json')
+                    .done(function (data) {
+                        dataLength = data.length;
+                        for (i = 0; i < dataLength; i++) {
+                            self.pullRequests.push(new PullRequestItem(data[i]));
+                        }
+                        self.showMetaInfo(true);
+                    });
+            }
+        } else {
+            self.showMetaInfo(!self.showMetaInfo());
         }
-        self.showMetaInfo(!self.showMetaInfo());
     };
 };
 

--- a/website/static/js/devmodeHelper.js
+++ b/website/static/js/devmodeHelper.js
@@ -1,0 +1,36 @@
+var $ = require('jquery');
+var ko = require('knockout');
+var $osf = require('js/osfHelpers');
+
+var DevModeModel = function() {
+    self = this;
+    self.pullRequests = ko.observableArray([]);
+    self.showMetaInfo = ko.observable(false);
+    self.showHideMetaInfo = function() {
+        if(self.pullRequests().length === 0) {
+            $.getJSON('/static/git_logs.json')
+                .done(function(data){
+                    dataLength = data.length;
+                    for(i=0; i<dataLength; i++) {
+                        self.pullRequests.push(new PullRequestItem(data[i]));
+                    }
+            });
+        }
+        self.showMetaInfo(!self.showMetaInfo());
+    };
+};
+
+var PullRequestItem = function(prItem) {
+    this.url = prItem.html_url || '';
+    this.number = prItem.number || '';
+    this.title = prItem.title || '';
+    this.mergedAt = prItem.merged_at || '';
+
+};
+
+var DevModeControls = function(selector) {
+    this.viewModel = new DevModeModel();
+    $osf.applyBindings(this.viewModel, selector);
+};
+
+module.exports = DevModeControls;

--- a/website/static/js/devmodeHelper.js
+++ b/website/static/js/devmodeHelper.js
@@ -2,14 +2,15 @@ var $ = require('jquery');
 var ko = require('knockout');
 var $osf = require('js/osfHelpers');
 
-var DevModeModel = function() {
+var DevModeModel = function(source_file) {
     self = this;
+    self.source_file = source_file;
     self.pullRequests = ko.observableArray([]);
     self.showMetaInfo = ko.observable(false);
     self.showHideMetaInfo = function() {
         if(self.pullRequests().length === 0) {
             if(!self.showMetaInfo()) {
-                $.getJSON('/static/git_logs.json')
+                $.getJSON(self.source_file)
                     .done(function (data) {
                         dataLength = data.length;
                         for (i = 0; i < dataLength; i++) {
@@ -32,8 +33,8 @@ var PullRequestItem = function(prItem) {
 
 };
 
-var DevModeControls = function(selector) {
-    this.viewModel = new DevModeModel();
+var DevModeControls = function(selector, source_file) {
+    this.viewModel = new DevModeModel(source_file);
     $osf.applyBindings(this.viewModel, selector);
 };
 

--- a/website/static/js/pages/base-page.js
+++ b/website/static/js/pages/base-page.js
@@ -20,6 +20,7 @@ var NavbarControl = require('js/navbarControl');
 var Raven = require('raven-js');
 var moment = require('moment');
 var KeenTracker = require('js/keen');
+var DevModeHelper = require('js/devModeHelper');
 
 // Prevent IE from caching responses
 $.ajaxSetup({cache: false});
@@ -111,6 +112,7 @@ $(function() {
         $osf.initializeResponsiveAffix();
     }
     new NavbarControl('.osf-nav-wrapper');
+    new DevModeHelper('.dev-mode-helper');
     if(window.contextVars.keenProjectId){
         var params = {};
         params.currentUser = window.contextVars.currentUser;

--- a/website/static/js/pages/base-page.js
+++ b/website/static/js/pages/base-page.js
@@ -112,7 +112,7 @@ $(function() {
         $osf.initializeResponsiveAffix();
     }
     new NavbarControl('.osf-nav-wrapper');
-    new DevModeHelper('.dev-mode-helper');
+    new DevModeHelper('#devModeHelper', '/static/built/git_logs.json');
     if(window.contextVars.keenProjectId){
         var params = {};
         params.currentUser = window.contextVars.currentUser;

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -52,18 +52,40 @@
 <body data-spy="scroll" data-target=".scrollspy">
 
     % if dev_mode:
-    <style>
-        #devmode {
-            position:fixed;
-            bottom:0;
-            left:0;
-            border-top-right-radius:8px;
-            background-color:red;
-            color:white;
-            padding:.5em;
-        }
-    </style>
-    <div id='devmode'><strong>WARNING</strong>: This site is running in development mode.</div>
+    <div class="dev-mode-helper scripted" id="devModeHelper">
+        <div id="metaInfo" data-bind="visible: showMetaInfo">
+            <table>
+                <thead>
+                <tr>
+                    <th>PR</th>
+                    <th>Title</th>
+                    <th>Date Merged</th>
+                </tr>
+                </thead>
+                <tbody data-bind="foreach: pullRequests">
+                    <tr>
+                        <td>#<a data-bind="attr: {href: url}, text: number"></a></td>
+                        <td data-bind="text: title"></td>
+                        <td data-bind="text: mergedAt"></td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+        <style>
+            #devmode {
+                position:fixed;
+                bottom:0;
+                left:0;
+                border-top-right-radius:8px;
+                background-color:red;
+                color:white;
+                padding:.5em;
+            }
+        </style>
+        <div id='devmode' data-bind='click: showHideMetaInfo'><strong>WARNING</strong>: This site is running in development mode.</div>
+    </div>
+    %else:
+        <div id="devModeHelper"></div>
     % endif
 
     <%namespace name="nav_file" file="nav.mako"/>
@@ -303,5 +325,4 @@
     ## the webpack runtime and a number of necessary stylesheets which should be loaded before the user sees
     ## content.
     <script src="${'/static/public/js/vendor.js' | webpack_asset}"></script>
-
 </%def>


### PR DESCRIPTION
Purpose
-----------
The github 'Merge and Squash' command broke the git_logs task because. This fixes the problem and makes it a bit nicer for QA because they have clickable links to go to the github pr.


Changes
------------
1. Added a meta script module for gathering info such as this
2. Added a gatherer script to get the last 1000 commits from git and compare those to the last 100 PRs from github. Whatever overlaps there gets its json dumped into a json file. 
3. Added a GITHUB_API_TOKEN setting
4. Added a knockout script to get the json data that was created by the script and show it when you click on the 'Warning: dev mode' banner (and hide it again if you click again)

![qa helper](https://cloud.githubusercontent.com/assets/6599111/14428269/61fcb732-ffc6-11e5-9d97-56c0a86fbf1f.gif)

![screen shot 2016-04-11 at 9 10 04 am](https://cloud.githubusercontent.com/assets/6599111/14428109/a05b98aa-ffc5-11e5-90b2-17013d349cb2.png)
![screen shot 2016-04-11 at 9 10 07 am](https://cloud.githubusercontent.com/assets/6599111/14428125/acdee8d4-ffc5-11e5-86fa-3f59d5120ddb.png)



Side effects
--------------
- It seems to work fine out of dev mode. Well, it should. I tested the else branch of the mako by removing everything from the if branch that didn't match, and it doesn't error or anything. So it should be good.
- If you don't have a github api token in your local.py, then you won't get any cool stats, and the script will 404 in the console, but otherwise will not show any problems.