### PR TITLE
Remove "delete" button from detail page of published Dataverse file [OSF-4551]

### DIFF
--- a/website/addons/dataverse/static/dataverseFangornConfig.js
+++ b/website/addons/dataverse/static/dataverseFangornConfig.js
@@ -76,6 +76,9 @@ var _dataverseItemButtons = {
                     item.data.dataverseIsPublished = true;
                     item.data.hasPublishedFiles = item.children.length > 0;
                     item.data.version = item.data.hasPublishedFiles ? 'latest-published' : 'latest';
+                    for (var i = 0; i < item.children.length; i++) { // Brute force the child files to be set as "latest-published" without page reload
+                        item.children[i].data.extra.datasetVersion = item.data.version;
+                    }
                 }).fail(function (xhr, status, error) {
                     var statusCode = xhr.responseJSON.code;
                     var message;


### PR DESCRIPTION
OSF-4551 [](https://openscience.atlassian.net/browse/OSF-4551)

Issue:

- Delete button was erroneously showing up on the file page for a published Dataverse file if a user visited that file immediately after publishing
- The "latest-published" property on the dataverse file (versus the folder) seemed to only be updating after a route change

Fix:

- Add a line in dataverseFangornConfig to set datasetVersion to "latest-published" for the child files of a Dataverse folder
- This line is executed when a Dataverse folder is successfully published from the filetree