### PR TITLE
Add "delete" button to file view for GitHub folders [OSF-5732]

### DIFF
--- a/website/addons/github/static/githubFangornConfig.js
+++ b/website/addons/github/static/githubFangornConfig.js
@@ -171,7 +171,14 @@ var _githubItemButtons = {
                             },
                             icon: 'fa fa-plus',
                             className: 'text-success'
-                        }, 'Create Folder')
+                        }, 'Create Folder'),
+                        m.component(Fangorn.Components.button, {
+                           onclick: function (event) {
+                               _removeEvent.call(tb, event, [item]);
+                           },
+                           icon: 'fa fa-trash',
+                           className: 'text-danger'
+                       }, 'Delete')
                     );
                 }
                 if (item.data.addonFullname) {

--- a/website/addons/github/static/githubFangornConfig.js
+++ b/website/addons/github/static/githubFangornConfig.js
@@ -178,7 +178,7 @@ var _githubItemButtons = {
                            },
                            icon: 'fa fa-trash',
                            className: 'text-danger'
-                       }, 'Delete')
+                       }, 'Delete Folder')
                     );
                 }
                 if (item.data.addonFullname) {


### PR DESCRIPTION
OSF-5732 [](https://openscience.atlassian.net/browse/OSF-5732)

Issue:

- No delete button was appearing for folders created in the root folder of a GitHub repo linked to an OSF account.

Fix:

- Add a line in githubFangornConfig that displays the Delete button in the UI if the user has the appropriate permissions