### PR TITLE
Small fixes to landing page

### DIFF
--- a/api/institutions/views.py
+++ b/api/institutions/views.py
@@ -67,6 +67,8 @@ class InstitutionList(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin):
     view_category = 'institutions'
     view_name = 'institution-list'
 
+    ordering = ('name', )
+
     def get_default_odm_query(self):
         return Q('_id', 'ne', None)
 

--- a/api/institutions/views.py
+++ b/api/institutions/views.py
@@ -67,8 +67,6 @@ class InstitutionList(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin):
     view_category = 'institutions'
     view_name = 'institution-list'
 
-    ordering = ('-date_modified', )
-
     def get_default_odm_query(self):
         return Q('_id', 'ne', None)
 
@@ -142,6 +140,8 @@ class InstitutionNodeList(JSONAPIBaseView, ODMFilterMixin, generics.ListAPIView,
     serializer_class = NodeSerializer
     view_category = 'institutions'
     view_name = 'institution-nodes'
+
+    ordering = ('-date_modified', )
 
     base_node_query = (
         Q('is_deleted', 'ne', True) &

--- a/website/static/js/myProjects.js
+++ b/website/static/js/myProjects.js
@@ -662,7 +662,7 @@ var MyProjects = {
               var contributors = item.embeds.contributors.data || [];
               for(var i = 0; i < contributors.length; i++) {
                 var u = contributors[i];
-                if (u.id === window.contextVars.currentUser.id) {
+                if ((u.id === window.contextVars.currentUser.id) && !(self.institutionId)) {
                   continue;
                 }
                 if(self.users[u.id] === undefined) {

--- a/website/static/js/myProjects.js
+++ b/website/static/js/myProjects.js
@@ -632,7 +632,7 @@ var MyProjects = {
                             'You have not made any registrations yet.');
                     } else {
                         template = m('.db-non-load-template.m-md.p-md.osf-box',
-                            'This collection is empty. To add projects or registrations, click "All my projects" or "All my registrations" in the sidebar, and then drag and drop items into the collection link.');
+                            'This collection is empty.' + self.viewOnly ? '' : ' To add projects or registrations, click "All my projects" or "All my registrations" in the sidebar, and then drag and drop items into the collection link.');
                     }
                 } else {
                     if(!self.currentView().fetcher.isEmpty()){
@@ -1263,7 +1263,7 @@ var Collections = {
         var collectionListTemplate = [
             m('h5.clearfix', [
                 'Collections ',
-                m('i.fa.fa-question-circle.text-muted', {
+                 viewOnly ? '' : m('i.fa.fa-question-circle.text-muted', {
                     'data-toggle':  'tooltip',
                     'title':  'Collections are groups of projects. You can create custom collections. Drag and drop your projects or bookmarked projects to add them.',
                     'data-placement' : 'bottom'
@@ -1715,7 +1715,7 @@ var Filters = {
             [
                 m('h5.m-t-sm', [
                     'Contributors ',
-                    m('i.fa.fa-question-circle.text-muted', {
+                    args.viewOnly ? '' : m('i.fa.fa-question-circle.text-muted', {
                         'data-toggle':  'tooltip',
                         'title': 'Click a contributor\'s name to see projects that you have in common.',
                         'data-placement' : 'bottom'


### PR DESCRIPTION
## Purpose
small clean ups and fixes to landing page
## Changes
* Ordering happens at the node list view, to allow for proper fetching of additional nodes without adding duplicates
* Prevent showing help text that implies that the user is looking at the my projects page (including the tooltips for collections and contributors)
* Current user should be a filter in institution's contributors if they are a contibutor to one of those institutions nodes