### PR TITLE
fix bugs in FormattableDate JS tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "markdown-it-video": "~0.2.1",
     "mime-types": "~2.0.12",
     "mithril": "0.2.0",
-    "moment": "^2.9.0",
+    "moment": "^2.10.6",
     "morgan": "^1.5.1",
     "object-assign": "^2.0.0",
     "pikaday": "^1.3.2",

--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -473,7 +473,12 @@ var hasTimeComponent = function(dateString) {
   * A date object with two formats: local time or UTC time.
   * @param {String} date The original date as a string. Should be an standard
   *                      format such as RFC or ISO. If the date is a datetime string
-  *                      with no offset, an offset of UTC +00:00 will be assumed
+  *                      with no offset, an offset of UTC +00:00 will be assumed. However,
+  *                      if the date is just a date (no time component), the time
+  *                      component will be set to midnight local time.  Ergo, if date
+  *                      is '2016-04-08' the imputed time will be '2016-04-08 04:00 UTC'
+  *                      if run in EDT. But if date is '2016-04-08:00:00:00.000' it will
+  *                      always be '2016-04-08 00:00 UTC', regardless of the local timezone.
   */
 var LOCAL_DATEFORMAT = 'YYYY-MM-DD hh:mm A';
 var UTC_DATEFORMAT = 'YYYY-MM-DD HH:mm UTC';

--- a/website/static/js/tests/osfHelpers.test.js
+++ b/website/static/js/tests/osfHelpers.test.js
@@ -348,7 +348,13 @@ describe('osfHelpers', () => {
             var dateString = [year, month, day].join('-');
             var dateTimeString = dateString + 'T' + [hour, minute, second].join(':') + '.' + millisecond.toString();
 
-            var assertDateEqual = function(date, year, month, day, hour, minute, second, millisecond) {
+            var assertDateEqual = function(date, year, month, day) {
+                assert.equal(date.getUTCFullYear(), year);
+                assert.equal(date.getUTCMonth(), month - 1); // Javascript months count from 0
+                assert.equal(date.getUTCDate(), day);
+            };
+
+            var assertDateTimeEqual = function(date, year, month, day, hour, minute, second, millisecond) {
                 assert.equal(date.getUTCFullYear(), year);
                 assert.equal(date.getUTCMonth(), month - 1); // Javascript months count from 0
                 assert.equal(date.getUTCDate(), day);
@@ -369,20 +375,19 @@ describe('osfHelpers', () => {
         });
         it('should parse date strings', () => {
             var parsedDate = new $osf.FormattableDate(dateString).date;
-            var parsedDateTime = new $osf.FormattableDate(dateTimeString).date;
-            assertDateEqual(parsedDate, year, month, day, 0, 0, 0, 0);
+            assertDateEqual(parsedDate, year, month, day);
         });
         it('should parse datetime strings', () => {
             var parsedDateTime = new $osf.FormattableDate(dateTimeString).date;
-            assertDateEqual(parsedDateTime, year, month, day, hour, minute, second, millisecond);
+            assertDateTimeEqual(parsedDateTime, year, month, day, hour, minute, second, millisecond);
         });
         it('should allow datetimes with UTC offsets', () => {
             var parsedDateTime = null;
-            var UTCOffsets = ['+00', '+00:00', '+0000', 'Z'];
+            var UTCOffsets = ['+00', '-00', '+00:00', '-00:00', '+0000', '-0000', 'Z'];
 
             UTCOffsets.forEach(function(offset) {
                 parsedDateTime = new $osf.FormattableDate(dateTimeString + offset).date;
-                assertDateEqual(parsedDateTime, year, month, day, hour, minute, second, millisecond);
+                assertDateTimeEqual(parsedDateTime, year, month, day, hour, minute, second, millisecond);
             });
         });
         it('should allow datetimes with positive offsets', () => {
@@ -390,7 +395,7 @@ describe('osfHelpers', () => {
             var positiveOffset = '+02:00';
 
             parsedDateTime = new $osf.FormattableDate(dateTimeString + positiveOffset).date;
-            assertDateEqual(parsedDateTime, year, month, day, hour - 2, minute, second, millisecond);
+            assertDateTimeEqual(parsedDateTime, year, month, day, hour - 2, minute, second, millisecond);
 
         });
         it('should allow datetimes with negative offsets', () => {
@@ -398,7 +403,7 @@ describe('osfHelpers', () => {
             var negativeOffset = '-02:00';
 
             parsedDateTime = new $osf.FormattableDate(dateTimeString + negativeOffset).date;
-            assertDateEqual(parsedDateTime, year, month, day, hour + 2, minute, second, millisecond);
+            assertDateTimeEqual(parsedDateTime, year, month, day, hour + 2, minute, second, millisecond);
         });
     });
 


### PR DESCRIPTION
## Purpose

Our karma tests for FormattableDates had two consistent failures.  One was a bad test, the other was a bug in the underlying library.  Both tests happen to pass on Travis because the local timezone on their server is GMT.  These tests will fail in any other timezone.

## Changes

The first error was caused by FormattableDate assuming that date-only input
represents midnight in local-time.  Our test was comparing the return
value to midnight in UTC, which means the test would fail anywhere but
in +0.  We should probably fix up FormattableDate to consistently return
midnight UTC, but that will require a lot more verification of our
consuming code.  For now, add a new test function that only verifies
the date component of the returned datetime.

The second bug was caused by moment.js not recognizing the '+00' method
of indicating timezone offset.  moment.js has now been pinned to
v2.10.6, and the tests updated to test both positive and negative
offsets.

## Side effects

Upgrading moment.js from `2.9.0` to `2.10.6` has the potential to cause errors elsewhere.  I've looked through the code and didn't see any obvious problems, I didn't encounter any JS errors or misformatted dates while running the code locally.  QA should check share events, activity logs, and wiki timestamps.

## Ticket

[#OSF-5950|https://openscience.atlassian.net/browse/OSF-5950]

I couldn't reproduce the S3 issues locally, so that is not part of this PR.