### PR TITLE
[RFR] Limit Varnish banning to once per url

### DIFF
--- a/api/caching/listeners.py
+++ b/api/caching/listeners.py
@@ -1,5 +1,3 @@
-from functools import partial
-
 from api.caching.tasks import ban_url
 from framework.postcommit_tasks.handlers import enqueue_postcommit_task
 from modularodm import signals

--- a/api/caching/listeners.py
+++ b/api/caching/listeners.py
@@ -6,9 +6,5 @@ from modularodm import signals
 
 @signals.save.connect
 def ban_object_from_cache(sender, instance, fields_changed, cached_data):
-    abs_url = None
     if hasattr(instance, 'absolute_api_v2_url'):
-        abs_url = instance.absolute_api_v2_url
-
-    if abs_url is not None:
-        enqueue_postcommit_task(partial(ban_url, instance, fields_changed))
+        enqueue_postcommit_task((ban_url, (instance,)))

--- a/api/caching/tasks.py
+++ b/api/caching/tasks.py
@@ -13,8 +13,7 @@ def get_varnish_servers():
     #  TODO: this should get the varnish servers from HAProxy or a setting
     return settings.VARNISH_SERVERS
 
-    #  fields_changed will eventually let us ban even more accurately
-def get_bannable_urls(instance, fields_changed):
+def get_bannable_urls(instance):
     bannable_urls = []
     parsed_absolute_url = {}
 
@@ -42,11 +41,11 @@ def get_bannable_urls(instance, fields_changed):
     return bannable_urls, parsed_absolute_url.hostname
 
 
-def ban_url(instance, fields_changed):
+def ban_url(instance):
     # TODO: Refactor; Pull url generation into postcommit_task handling so we only ban urls once per request
     timeout = 0.3  # 300ms timeout for bans
     if settings.ENABLE_VARNISH:
-        bannable_urls, hostname = get_bannable_urls(instance, fields_changed)
+        bannable_urls, hostname = get_bannable_urls(instance)
 
         for url_to_ban in set(bannable_urls):
             try:

--- a/framework/postcommit_tasks/handlers.py
+++ b/framework/postcommit_tasks/handlers.py
@@ -30,12 +30,7 @@ def postcommit_after_request(response, base_status_error_code=500):
     return response
 
 def enqueue_postcommit_task(function_and_args):
-    try:
-        postcommit_queue().add(function_and_args)
-    except RuntimeError:
-        # if we can't add to the queue just log and run it
-        logger.error('Couldn\'t add {} to the postcommit queue, running syncronously'.format(function_and_args))
-        function_and_args[0](*function_and_args[1])
+    postcommit_queue().add(function_and_args)
 
 
 handlers = {

--- a/framework/postcommit_tasks/handlers.py
+++ b/framework/postcommit_tasks/handlers.py
@@ -22,7 +22,6 @@ def postcommit_after_request(response, base_status_error_code=500):
         return response
     try:
         if postcommit_queue():
-            pcq = postcommit_queue()
             threads = [gevent.spawn(func, *args) for func, args in postcommit_queue()]
             gevent.joinall(threads)
     except AttributeError:

--- a/framework/postcommit_tasks/handlers.py
+++ b/framework/postcommit_tasks/handlers.py
@@ -18,7 +18,7 @@ def postcommit_before_request():
 
 def postcommit_after_request(response, base_status_error_code=500):
     if response.status_code >= base_status_error_code:
-        _local.postcommmit_queue = set()
+        _local.postcommit_queue = set()
         return response
     try:
         if postcommit_queue():

--- a/framework/postcommit_tasks/handlers.py
+++ b/framework/postcommit_tasks/handlers.py
@@ -1,6 +1,8 @@
 import logging
 import threading
 
+import gevent
+
 from website import settings
 
 _local = threading.local()
@@ -8,31 +10,33 @@ logger = logging.getLogger(__name__)
 
 def postcommit_queue():
     if not hasattr(_local, 'postcommit_queue'):
-        _local.postcommit_queue = []
+        _local.postcommit_queue = set()
     return _local.postcommit_queue
 
 def postcommit_before_request():
-    _local.postcommit_queue = []
+    _local.postcommit_queue = set()
 
 def postcommit_after_request(response, base_status_error_code=500):
     if response.status_code >= base_status_error_code:
-        _local.postcommmit_queue = []
+        _local.postcommmit_queue = set()
         return response
     try:
         if postcommit_queue():
-            for task in postcommit_queue():
-                task()
+            pcq = postcommit_queue()
+            threads = [gevent.spawn(func, *args) for func, args in postcommit_queue()]
+            gevent.joinall(threads)
     except AttributeError:
         if not settings.DEBUG_MODE:
             logger.error('Post commit task queue not initialized')
     return response
 
-def enqueue_postcommit_task(f):
+def enqueue_postcommit_task(function_and_args):
     try:
-        if f not in postcommit_queue():
-            postcommit_queue().append(f)
+        postcommit_queue().add(function_and_args)
     except RuntimeError:
-        f()
+        # if we can't add to the queue just log and run it
+        logger.error('Couldn\'t add {} to the postcommit queue, running syncronously'.format(function_and_args))
+        function_and_args[0](*function_and_args[1])
 
 
 handlers = {

--- a/website/project/views/comment.py
+++ b/website/project/views/comment.py
@@ -1,26 +1,24 @@
 # -*- coding: utf-8 -*-
-from functools import partial
 
-import pytz
-import markdown
 from datetime import datetime
+
+import markdown
+import pytz
 from flask import request
 
 from api.caching.tasks import ban_url
+from framework.guid.model import Guid
 from framework.postcommit_tasks.handlers import enqueue_postcommit_task
 from modularodm import Q
-
-from framework.guid.model import Guid
-
+from website import settings
 from website.addons.base.signals import file_updated
 from website.files.models import FileNode, TrashedFileNode
+from website.models import Comment
 from website.notifications.constants import PROVIDERS
 from website.notifications.emails import notify
-from website.models import Comment
 from website.project.decorators import must_be_contributor_or_public
 from website.project.model import Node
 from website.project.signals import comment_added
-from website import settings
 
 
 @file_updated.connect
@@ -137,11 +135,11 @@ def is_reply(target):
 
 def _update_comments_timestamp(auth, node, page=Comment.OVERVIEW, root_id=None):
     if node.is_contributor(auth.user):
-        enqueue_postcommit_task(partial(ban_url, node, []))
+        enqueue_postcommit_task((ban_url, (node, )))
         if root_id is not None:
             guid_obj = Guid.load(root_id)
             if guid_obj is not None:
-                enqueue_postcommit_task(partial(ban_url, guid_obj.referent, []))
+                enqueue_postcommit_task((ban_url, (guid_obj.referent, )))
 
         # update node timestamp
         if page == Comment.OVERVIEW:


### PR DESCRIPTION
## Purpose
Limit the banning of each api v2 url to once per request. So if the Node xyz12 is saved 7,123 times during one request it will be banned from Varnish once.

## Changes
- Remove passing fields_changed because as a list it's unhashable and it wasn't being used anyway
- Changed enqueue_postcommit_task to take a tuple comprised of a function and a tuple of arguments
- Changed the save listener to call enqueue_postcommit_task with a function and the instance of the object saved

## Side effects
- Could completely break decaching in varnish.
    - I've functionally tested with a debugger attached in both the API and the OSF
