### PR TITLE
[feature] Remove Addon-related backrefs

### DIFF
--- a/framework/addons/__init__.py
+++ b/framework/addons/__init__.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from modularodm import Q
+
 from framework.mongo import StoredObject
 from website import settings
 
@@ -9,6 +11,10 @@ class AddonModelMixin(StoredObject):
     _meta = {
         'abstract': True,
     }
+
+    @property
+    def addons(self):
+        return self.get_addons()
 
     def get_addons(self):
         addons = []
@@ -33,11 +39,6 @@ class AddonModelMixin(StoredObject):
             for addon in self.get_addons()
         ]
 
-    def _backref_key(self, addon_config):
-        return '{0}__addons'.format(
-            addon_config.settings_models[self._name]._name,
-        )
-
     def get_addon(self, addon_name, deleted=False):
         """Get addon for node.
 
@@ -49,11 +50,8 @@ class AddonModelMixin(StoredObject):
         if not addon_config or not addon_config.settings_models.get(self._name):
             return False
 
-        backref_key = self._backref_key(addon_config)
-        addons = [
-            addon for addon in getattr(self, backref_key)
-            if addon is not None
-        ]
+        addon_class = addon_config.settings_models[self._name]
+        addons = list(addon_class.find(Q('owner', 'eq', self)))
         if addons:
             if deleted or not addons[0].deleted:
                 assert len(addons) == 1, 'Violation of one-to-one mapping with addon model'

--- a/tests/test_addons_oauth.py
+++ b/tests/test_addons_oauth.py
@@ -96,14 +96,15 @@ class TestNodeSettings(OsfTestCase):
             external_account=self.external_account,
             user=self.user
         )
+        self.user_settings.reload()
 
         assert_equal(
             self.node_settings.external_account,
             self.external_account
         )
         assert_equal(
-            self.node_settings.user_settings,
-            self.user_settings
+            self.node_settings.user_settings._id,
+            self.user_settings._id
         )
         assert_in(
             self.project._id,
@@ -118,6 +119,12 @@ class TestNodeSettings(OsfTestCase):
             external_account=self.external_account,
             user=self.user
         )
+        self.user_settings.reload()
+        assert_equal(
+            self.user_settings.oauth_grants,
+            {self.project._id: {self.external_account._id: {}}}
+        )
+
         self.user_settings.revoke_oauth_access(self.external_account, auth=Auth(self.user))
         self.user_settings.reload()
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -383,6 +383,7 @@ class TestMustBeAddonAuthorizerDecorator(AuthAppTestCase):
         self.project.creator.add_addon('github')
         user_settings = self.project.creator.get_addon('github')
         node_settings.user_settings = user_settings
+        node_settings.save()
 
         # Test
         res = self.decorated()
@@ -397,6 +398,7 @@ class TestMustBeAddonAuthorizerDecorator(AuthAppTestCase):
         user2.add_addon('github')
         user_settings = user2.get_addon('github')
         node_settings.user_settings = user_settings
+        node_settings.save()
 
         # Test
         with assert_raises(HTTPError):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2375,12 +2375,20 @@ class TestAddonCallbacks(OsfTestCase):
     }
 
     def setUp(self):
+        def mock_get_addon(addon_name, deleted=False):
+            # Overrides AddonModelMixin.get_addon -- without backrefs,
+            # no longer guaranteed to return the same set of objects-in-memory
+            return self.patched_addons.get(addon_name, None)
+
         super(TestAddonCallbacks, self).setUp()
         # Create project with component
         self.user = UserFactory()
         self.auth = Auth(user=self.user)
         self.parent = ProjectFactory()
         self.node = NodeFactory(creator=self.user, project=self.parent)
+        self.patches = []
+        self.patched_addons = {}
+        self.original_get_addon = Node.get_addon
 
         # Mock addon callbacks
         for addon in self.node.addons:
@@ -2388,14 +2396,28 @@ class TestAddonCallbacks(OsfTestCase):
             for callback, return_value in self.callbacks.iteritems():
                 mock_callback = getattr(mock_settings, callback)
                 mock_callback.return_value = return_value
-                setattr(
+                patch = mock.patch.object(
                     addon,
                     callback,
                     getattr(mock_settings, callback)
                 )
+                patch.start()
+                self.patches.append(patch)
+            self.patched_addons[addon.config.short_name] = addon
+        n_patch = mock.patch.object(
+            self.node,
+            'get_addon',
+            mock_get_addon
+        )
+        n_patch.start()
+        self.patches.append(n_patch)
+
+    def tearDown(self):
+        super(TestAddonCallbacks, self).tearDown()
+        for patcher in self.patches:
+            patcher.stop()
 
     def test_remove_contributor_callback(self):
-
         user2 = UserFactory()
         self.node.add_contributor(contributor=user2, auth=self.auth)
         self.node.remove_contributor(contributor=user2, auth=self.auth)
@@ -2406,7 +2428,6 @@ class TestAddonCallbacks(OsfTestCase):
             )
 
     def test_set_privacy_callback(self):
-
         self.node.set_privacy('public', self.auth)
         for addon in self.node.addons:
             callback = addon.after_set_privacy
@@ -3341,6 +3362,7 @@ class TestRoot(OsfTestCase):
 
     def test_fork_has_own_root(self):
         fork = self.project.fork_node(auth=self.auth)
+        fork.save()
         assert_equal(fork.root._id, fork._id)
 
     def test_fork_children_have_correct_root(self):

--- a/tests/test_registrations/test_archiver.py
+++ b/tests/test_registrations/test_archiver.py
@@ -536,6 +536,13 @@ class TestArchiverTasks(ArchiverTestCase):
                 )
                 patch.start()
                 patches.append(patch)
+                n_patch = mock.patch.object(
+                    n,
+                    'get_addon',
+                    mock.Mock(return_value=osfstorage)
+                )
+                n_patch.start()
+                patches.append(n_patch)
             job = factories.ArchiveJobFactory()
             archive_success(registration._id, job._id)
 
@@ -776,6 +783,13 @@ class TestArchiverUtils(ArchiverTestCase):
             patch = mock.patch.object(osfstorage, '_get_file_tree', mock.Mock(return_value=file_tree))
             patch.start()
             patches.append(patch)
+            n_patch = mock.patch.object(
+                n,
+                'get_addon',
+                mock.Mock(return_value=osfstorage)
+            )
+            n_patch.start()
+            patches.append(n_patch)
 
         file_map = archiver_utils.get_file_map(node)
         stack = file_trees.values()
@@ -816,6 +830,14 @@ class TestArchiverUtils(ArchiverTestCase):
             patch.start()
             patches[n._id] = patch
             mocks[n._id] = mocked
+            n_patch = mock.patch.object(
+                n,
+                'get_addon',
+                mock.Mock(return_value=osfstorage)
+            )
+            n_patch.start()
+            patches[osfstorage._id] = n_patch
+
         # first call
         file_map = archiver_utils.get_file_map(node)
         file_map = {

--- a/website/addons/base/__init__.py
+++ b/website/addons/base/__init__.py
@@ -239,7 +239,7 @@ class AddonSettingsBase(StoredObject):
 
 class AddonUserSettingsBase(AddonSettingsBase):
 
-    owner = fields.ForeignField('user', backref='addons')
+    owner = fields.ForeignField('user')
 
     _meta = {
         'abstract': True,
@@ -260,9 +260,6 @@ class AddonUserSettingsBase(AddonSettingsBase):
         """Whether the user has added credentials for this addon."""
         return False
 
-    def get_backref_key(self, schema, backref_name):
-        return schema._name + '__' + backref_name
-
     # TODO: Test me @asmacdo
     @property
     def nodes_authorized(self):
@@ -274,10 +271,9 @@ class AddonUserSettingsBase(AddonSettingsBase):
             schema = self.config.settings_models['node']
         except KeyError:
             return []
-        nodes_backref = self.get_backref_key(schema, 'authorized')
         return [
             node_addon.owner
-            for node_addon in getattr(self, nodes_backref)
+            for node_addon in schema.find(Q('user_settings', 'eq', self))
             if node_addon.owner and not node_addon.owner.is_deleted
         ]
 
@@ -522,7 +518,7 @@ class AddonOAuthUserSettingsBase(AddonUserSettingsBase):
 
 class AddonNodeSettingsBase(AddonSettingsBase):
 
-    owner = fields.ForeignField('node', backref='addons')
+    owner = fields.ForeignField('node')
 
     _meta = {
         'abstract': True,
@@ -786,8 +782,7 @@ class AddonOAuthNodeSettingsBase(AddonNodeSettingsBase):
 
     # TODO: Validate this field to be sure it matches the provider's short_name
     # NOTE: Do not set this field directly. Use ``set_auth()``
-    external_account = fields.ForeignField('externalaccount',
-                                           backref='connected')
+    external_account = fields.ForeignField('externalaccount')
 
     # NOTE: Do not set this field directly. Use ``set_auth()``
     user_settings = fields.AbstractForeignField()

--- a/website/addons/base/testing/models.py
+++ b/website/addons/base/testing/models.py
@@ -181,6 +181,7 @@ class OAuthAddonNodeSettingsTestSuiteMixin(OAuthAddonModelTestSuiteMixinBase):
         with mock_auth(self.user):
             self.user_settings.revoke_oauth_access(self.external_account)
 
+        self.node_settings.reload()
         assert_false(self.node_settings.has_auth)
         assert_false(self.node_settings.complete)
 
@@ -290,7 +291,7 @@ class OAuthAddonNodeSettingsTestSuiteMixin(OAuthAddonModelTestSuiteMixinBase):
         node_settings.save()
 
         assert_true(node_settings.has_auth)
-        assert_equal(node_settings.user_settings, user_settings)
+        assert_equal(node_settings.user_settings._id, user_settings._id)
         # A log was saved
         last_log = node_settings.owner.logs[-1]
         assert_equal(last_log.action, '{0}_node_authorized'.format(self.short_name))
@@ -348,7 +349,7 @@ class OAuthAddonNodeSettingsTestSuiteMixin(OAuthAddonModelTestSuiteMixinBase):
         clone, message = self.node_settings.after_fork(
             node=self.node, fork=fork, user=self.user_settings.owner
         )
-        assert_equal(clone.user_settings, self.user_settings)
+        assert_equal(clone.user_settings._id, self.user_settings._id)
 
     def test_after_fork_by_unauthorized_user(self):
         fork = ProjectFactory()
@@ -548,6 +549,7 @@ class OAuthCitationsNodeSettingsTestSuiteMixin(OAuthAddonNodeSettingsTestSuiteMi
     def test_fork_by_authorizer(self, mock_push_status):
         fork = self.node.fork_node(auth=Auth(user=self.node.creator))
 
+        self.user_settings.reload()
         assert_true(fork.get_addon(self.short_name).has_auth)
         assert_true(self.user_settings.verify_oauth_access(fork, self.external_account))
 

--- a/website/addons/twofactor/tests/test_models.py
+++ b/website/addons/twofactor/tests/test_models.py
@@ -25,7 +25,8 @@ class TestCallbacks(OsfTestCase):
         self.user_settings.save()
 
         self.user.delete_addon('twofactor')
-
+        self.user_settings.reload()
+        
         assert_equal(self.user_settings.totp_drift, 0)
         assert_is_none(self.user_settings.totp_secret)
         assert_false(self.user_settings.is_confirmed)
@@ -37,7 +38,8 @@ class TestCallbacks(OsfTestCase):
         self.user_settings.save()
 
         self.user.delete_addon('twofactor')
-
+        self.user_settings.reload()
+        
         assert_equal(self.user_settings.totp_drift, 0)
         assert_is_none(self.user_settings.totp_secret)
         assert_false(self.user_settings.is_confirmed)

--- a/website/citations/models.py
+++ b/website/citations/models.py
@@ -76,6 +76,8 @@ class AddonCitationsNodeSettings(AddonOAuthNodeSettingsBase):
         addon settings.
         """
         self.list_id = None
+        self.save()
+
         return super(AddonCitationsNodeSettings, self).set_auth(*args, **kwargs)
 
     def deauthorize(self, auth=None, add_log=True):


### PR DESCRIPTION
## Purpose
Remove addon related backrefs

#### QA Notes
Things to test:

1. Previously configured addons still work and display properly
    * on the user settings page
    * on the node settings page
2. Connecting and listing new (and combinations of new/old) addons still works properly
    * on the user settings page
    * on the node settings page

Full addon regressions are probably unnecessary, though it is theoretically possible that a previously-connected model will be changed but not updated in memory. See Side Effect \# 1. 

## Changes
* backrefs removed
* tests fixed
* `test_addons` call added to `test` invoke task

## Side effects
1) `.get_addons` or similar now no longer return the same object-in-memory (i.e. the same objects are at different locations on the stack). Objects accessed by a backref are cached due to the way MODM handles these things, but querysets returned by a `modularodm.Q(uery)` are not. Anything that requires these objects to be the same (e.g. mocking) will fail, but this is unlikely to affect anything aside from tests.
2) Conflicts with `release/0.67.0` expected (S3 and GH refactors). **HOLD** until then.

## Ticket
[\[OSF-5914\]](https://openscience.atlassian.net/browse/OSF-5914)