### PR TITLE
Upgrade MathJax

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
     "select2": "3.5.1",
     "ace-builds": "1.1.8",
     "bootstrap.growl": "2.0.0",
-    "MathJax": "2.5",
+    "MathJax": "2.6",
     "jquery.tagsinput": "1.3.2",
     "jquery-autosize": "1.18.15",
     "jquery-qrcode": "https://github.com/samanehsan/jquery-qrcode.git#5edbf81811b128a6df62bee4cff37892de3ac894",


### PR DESCRIPTION
## Purpose

Upgrade MathJax and resolve https://openscience.atlassian.net/browse/OSF-5876

## Changes

MathJax#2.5 -> MathJax2.6

Before (notice trailing |)
![screen shot 2016-04-13 at 11 56 38 am](https://cloud.githubusercontent.com/assets/2207561/14500182/22701320-016f-11e6-870d-0a108efc238d.png)
After
![screen shot 2016-04-13 at 11 58 57 am](https://cloud.githubusercontent.com/assets/2207561/14500183/227ba0a0-016f-11e6-9fda-b5fc151ede38.png)
