### PR TITLE
[hotfix] Remove retractions from dashboard

### DIFF
--- a/website/static/js/myProjects.js
+++ b/website/static/js/myProjects.js
@@ -165,7 +165,7 @@ NodeFetcher.prototype = {
     this.nextLink = results.links.next;
     this.loaded += results.data.length;
     for(var i = 0; i < results.data.length; i++) {
-      if (this.type === 'registrations' && (results.data[i].attributes.retracted === true || results.data[i].attributes.pending_registration_approval === true))
+      if (this.type === 'registrations' && (results.data[i].attributes.withdrawn === true || results.data[i].attributes.pending_registration_approval === true))
           continue; // Exclude retracted and pending registrations
       else if (results.data[i].relationships.parent && this._handleOrphans)
           this._orphans.push(results.data[i]);


### PR DESCRIPTION
## Purpose

Issue https://openscience.atlassian.net/browse/OSF-6016

Continuation of fix https://github.com/CenterForOpenScience/osf.io/pull/5454

**This PR removes retractions from registrations list in new dashboard.**

`Uncaught TypeError: Cannot read property 'contributors' of undefined` is still happening after some JS null-checking added to MyProjects page.

Looking into it more, retractions were still showing up in the registrations list because the API seems to have changed field names to 'withdrawn' instead of 'retracted'.

(On a side node, I do not know why retractions are not embedding for retractions.  They should be embedding.  Contributors are **not** a hidden field on retractions.  If you navigate directly to `http://localhost:8000/v2/registrations/{retraction_id}/?embed=contributors`, contributors are embedded. But for now, properly restricting retractions will help.)
## Changes

Changes 'retracted' language to 'withdrawn' to properly determine if node is withdrawn.

