### PR TITLE
[feature] Add .configured to <Addon>NodeSettings

### DIFF
--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1519,7 +1519,7 @@ class NodeProvidersList(JSONAPIBaseView, generics.ListAPIView, NodeMixin):
             for addon
             in self.get_node().get_addons()
             if addon.config.has_hgrid_files
-            and addon.complete
+            and addon.configured
         ]
 
 class NodeProviderDetail(JSONAPIBaseView, generics.RetrieveAPIView, NodeMixin):

--- a/website/addons/base/__init__.py
+++ b/website/addons/base/__init__.py
@@ -536,6 +536,13 @@ class AddonNodeSettingsBase(AddonSettingsBase):
         raise NotImplementedError()
 
     @property
+    def configured(self):
+        """Whether or not this addon has had a folder connected.
+        :rtype bool:
+        """
+        return self.complete
+
+    @property
     def has_auth(self):
         """Whether the node has added credentials for this addon."""
         return False
@@ -843,6 +850,13 @@ class AddonOAuthNodeSettingsBase(AddonNodeSettingsBase):
                 node=self.owner,
                 external_account=self.external_account,
             )
+        )
+
+    @property
+    def configured(self):
+        return bool(
+            self.complete and
+            (self.folder_id or self.folder_name or self.folder_path)
         )
 
     @property

--- a/website/addons/base/testing/models.py
+++ b/website/addons/base/testing/models.py
@@ -173,6 +173,16 @@ class OAuthAddonNodeSettingsTestSuiteMixin(OAuthAddonModelTestSuiteMixinBase):
         self.node.remove()
         self.user.remove()
 
+    def test_configured_true(self):
+        assert_true(self.node_settings.has_auth)
+        assert_true(self.node_settings.complete)
+        assert_true(self.node_settings.configured)
+
+    def test_configured_false(self):
+        self.node_settings.clear_settings()
+        self.node_settings.save()
+        assert_false(self.node_settings.configured)
+
     def test_complete_true(self):
         assert_true(self.node_settings.has_auth)
         assert_true(self.node_settings.complete)


### PR DESCRIPTION
## Purpose
Fixes API bug where authorized storage addons without a selected folder were throwing `503`'s when links were followed

## Changes
* Add `.configured` property to base classes
* Use `.configured` instead of `.complete` in API call
* Tests

## Side effects
None, although there may be other places where similar bugs exist. This only fixes a very specific case.


## Ticket
[\[OSF-6019\]](https://openscience.atlassian.net/browse/OSF-6019)