### PR TITLE
Update API URL syntax to avoid deprecation warnings

### DIFF
--- a/api/base/urls.py
+++ b/api/base/urls.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.conf.urls import include, url, patterns
+from django.conf.urls import include, url
 from django.conf.urls.static import static
 from settings import API_BASE
 
@@ -9,20 +9,22 @@ base_pattern = '^{}'.format(API_BASE)
 
 urlpatterns = [
     url(base_pattern,
-        include(patterns('',
-                         url(r'^$', views.root, name='root'),
-                         url(r'^applications/', include('api.applications.urls', namespace='applications')),
-                         url(r'^comments/', include('api.comments.urls', namespace='comments')),
-                         url(r'^nodes/', include('api.nodes.urls', namespace='nodes')),
-                         url(r'^registrations/', include('api.registrations.urls', namespace='registrations')),
-                         url(r'^users/', include('api.users.urls', namespace='users')),
-                         url(r'^tokens/', include('api.tokens.urls', namespace='tokens')),
-                         url(r'^logs/', include('api.logs.urls', namespace='logs')),
-                         url(r'^files/', include('api.files.urls', namespace='files')),
-                         url(r'^docs/', include('rest_framework_swagger.urls')),
-                         url(r'^institutions/', include('api.institutions.urls', namespace='institutions')),
-                         url(r'^collections/', include('api.collections.urls', namespace='collections')),
-                         ))
+        include(
+            [
+                url(r'^$', views.root, name='root'),
+                url(r'^applications/', include('api.applications.urls', namespace='applications')),
+                url(r'^comments/', include('api.comments.urls', namespace='comments')),
+                url(r'^nodes/', include('api.nodes.urls', namespace='nodes')),
+                url(r'^registrations/', include('api.registrations.urls', namespace='registrations')),
+                url(r'^users/', include('api.users.urls', namespace='users')),
+                url(r'^tokens/', include('api.tokens.urls', namespace='tokens')),
+                url(r'^logs/', include('api.logs.urls', namespace='logs')),
+                url(r'^files/', include('api.files.urls', namespace='files')),
+                url(r'^docs/', include('rest_framework_swagger.urls')),
+                url(r'^institutions/', include('api.institutions.urls', namespace='institutions')),
+                url(r'^collections/', include('api.collections.urls', namespace='collections'))
+            ],
+        )
         )
 ]
 


### PR DESCRIPTION
## Purpose
Update API to use the recommended syntax for defining URLs; avoids django deprecation warnings.

Syntax should be compatible with 1.8+.

## Changes
Update URL patterns to new recommended documentation. (see ticket for notes on version compatibility)

## Side effects
Should be none; all routes should load as expected.

## Ticket
https://openscience.atlassian.net/browse/OSF-6012

[#OSF-6012]