### PR TITLE
Fix error messages when adding institution

### DIFF
--- a/website/static/js/profile.js
+++ b/website/static/js/profile.js
@@ -824,13 +824,10 @@ ListViewModel.prototype = Object.create(BaseViewModel.prototype);
 ListViewModel.prototype.addContent = function() {
     if (!this.institutionObjectsEmpty() && this.isValid()) {
         this.contents.push(new this.ContentModel(this));
+        this.showMessages(false);
     }
     else {
-        this.changeMessage(
-            'Institution field is required.',
-            'text-danger',
-            5000
-        );
+        this.showMessages(true);
     }
 };
 


### PR DESCRIPTION
## Purpose
Fix display of error messages on the education tab of profile page: show field-specific error messages when clicking "add another" while fields are invalid.

Previously, it showed the same message ("*Institution field is required.*") regardless of the actual errors.

## Changes
Clicking the "add another button" should show/hide user messages in a consistent fashion, rather than hard-coding a different message.

## Side effects
Should be none.

This changes the behavior of a shared class (`ListViewModel`)- look for anomalies on the Jobs profile page, which uses shared code.

## Ticket
https://openscience.atlassian.net/browse/OSF-5175

[#OSF-5175]