### PR TITLE
[hotfix] Fix citation listing for Zotero

### DIFF
--- a/website/citations/providers.py
+++ b/website/citations/providers.py
@@ -200,7 +200,7 @@ class CitationsProvider(object):
 
         # Folders with 'parent_list_id'==None are children of 'All Documents'
         for folder in account_folders:
-            if folder.get('parent_list_id') is None:
+            if not folder.get('parent_list_id'):
                 folder['parent_list_id'] = 'ROOT'
 
         node_account = node_addon.external_account


### PR DESCRIPTION
## Purpose
Fix ability to traverse Zotero's directory structure. The Zotero API *may* have had a "non-breaking" change over the past ~2 months, causing `'parent_list_id'` to be returned as `False` rather than `None`.

<img width="279" alt="screen shot 2016-04-13 at 22 09 26" src="https://cloud.githubusercontent.com/assets/5659262/14515083/734af1de-01c4-11e6-981e-31b9e814847f.png">


## Changes
* Check for `not <attr>` instead of `<attr> is None`

## Side effects
None. Verified that Mendeley still works as expected.

### Ticket
Side effect of [\[OSF-5359\]](https://openscience.atlassian.net/browse/OSF-5369)

#### Side Note
`'__'` is given for `<root_folder>['parent_list_id']` for both citation addons, it's only first-level children that have `<folder>['parent_list_id']` not provided.