### PR TITLE
Do not copy deleted nodes when templating project [OSF-5942]

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3260,6 +3260,7 @@ class TestParentNode(OsfTestCase):
         self.auth = Auth(user=self.user)
         self.project = ProjectFactory(creator=self.user, description='The Dudleys strike again')
         self.child = NodeFactory(parent=self.project, creator=self.user, description="Devon.")
+        self.deleted_child = NodeFactory(parent=self.project, creator=self.user, title='Deleted', is_deleted=True)
 
         self.registration = RegistrationFactory(project=self.project)
         self.template = self.project.use_as_template(auth=self.auth)
@@ -3313,6 +3314,13 @@ class TestParentNode(OsfTestCase):
         template_child = NodeFactory(parent=self.template)
         new_project_grandchild = NodeFactory(parent=template_child)
         assert_equal(new_project_grandchild.parent_node._id, template_child._id)
+
+    def test_template_project_does_not_copy_deleted_components(self):
+        """Regression test for https://openscience.atlassian.net/browse/OSF-5942. """
+        new_project = self.project.use_as_template(auth=self.auth)
+        new_nodes = [node.title for node in new_project.nodes]
+        assert_equal(len(new_project.nodes), 1)
+        assert_not_in(self.deleted_child.title, new_nodes)
 
 
 class TestRoot(OsfTestCase):

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -1638,7 +1638,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
         new.nodes = [
             x.use_as_template(auth, changes, top_level=False)
             for x in self.nodes
-            if x.can_view(auth)
+            if x.can_view(auth) and not x.is_deleted
         ]
 
         new.save()


### PR DESCRIPTION
## Purpose

Fix [OSF-5942]

If a user deletes a component in a project, and then uses that project as a template to create a new project, the deleted component shows up in the new project's logs.  E.g. "Component 2" was deleted in the original project, but shows up in the logs for the new project: 
![screen shot 2016-04-14 at 11 19 35 am](https://cloud.githubusercontent.com/assets/6414394/14533457/2c55a41c-0233-11e6-94f5-d20430daca2c.png)



## Changes
When templating a project with components, do not copy components that are deleted.

## Side effects

None.


## Ticket

https://openscience.atlassian.net/browse/OSF-5942