### PR TITLE
Override get_serializer_class() in GuidRedirect view [OSF-6003]

### DIFF
--- a/api/guids/views.py
+++ b/api/guids/views.py
@@ -32,6 +32,9 @@ class GuidRedirect(JSONAPIBaseView):
     view_category = 'guids'
     view_name = 'guid-detail'
 
+    def get_serializer_class(self):
+        return None
+
     def get(self, request, **kwargs):
         url = self.get_redirect_url(**kwargs)
         if url:

--- a/api_tests/base/test_views.py
+++ b/api_tests/base/test_views.py
@@ -73,6 +73,11 @@ class TestApiBaseViews(ApiTestCase):
         for view in VIEW_CLASSES:
             assert_true(hasattr(view, '_get_embed_partial'), "{0} lacks embed support".format(view))
 
+    def test_view_classes_define_or_override_serializer_class(self):
+        for view in VIEW_CLASSES:
+            has_serializer_class = getattr(view, 'serializer_class', None) or getattr(view, 'get_serializer_class', None)
+            assert_true(has_serializer_class, "{0} should include serializer class or override get_serializer_class()".format(view))
+
     @mock.patch('framework.auth.core.User.is_confirmed', mock.PropertyMock(return_value=False))
     def test_unconfirmed_user_gets_error(self):
 


### PR DESCRIPTION
## Purpose

DRF-Swagger throws and error because `GuidRedirect` does not define a `serializer_class`.

## Changes

Override `get_serializer_class()` and have it return `None` because setting `serializer_class = None` directly is not allowed. Also add a test to ensure all views either define a `serializer_class` or override `get_serializer_class()`

## Side effects
None.

## Ticket

https://openscience.atlassian.net/browse/OSF-6003