### PR TITLE
Correctly catch errors when filter type does not match field type

### DIFF
--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -374,10 +374,17 @@ class ListFilterMixin(FilterMixin):
                 if params['value'].lower() in getattr(item, field_name, {}).lower()
             ]
         else:
-            return_val = [
-                item for item in default_queryset
-                if self.FILTERS[params['op']](getattr(item, field_name, None), params['value'])
-            ]
+            return_val = []
+            for item in default_queryset:
+                item_val = getattr(item, field_name, None)
+                filter_val = params['value']
+                try:
+                    accept = self.FILTERS[params['op']](item_val, filter_val)
+                except TypeError:
+                    raise InvalidFilterValue(detail='Cannot compare filter of type {} to item of type {}'.format(
+                        type(item_val).__name__, type(filter_val).__name__))
+                else:
+                    if accept: return_val.append(item)
 
         return return_val
 

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -374,17 +374,13 @@ class ListFilterMixin(FilterMixin):
                 if params['value'].lower() in getattr(item, field_name, {}).lower()
             ]
         else:
-            return_val = []
-            filter_val = params['value']
-            for item in default_queryset:
-                item_val = getattr(item, field_name, None)
-                try:
-                    accept = self.FILTERS[params['op']](item_val, filter_val)
-                except TypeError:
-                    raise InvalidFilterValue(detail='Cannot compare filter of type {} to item of type {}'.format(
-                        type(item_val).__name__, type(filter_val).__name__))
-                else:
-                    if accept: return_val.append(item)
+            try:
+                return_val = [
+                    item for item in default_queryset
+                    if self.FILTERS[params['op']](getattr(item, field_name, None), params['value'])
+                ]
+            except TypeError:
+                raise InvalidFilterValue(detail='Could not apply filter to specified field')
 
         return return_val
 

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -375,9 +375,9 @@ class ListFilterMixin(FilterMixin):
             ]
         else:
             return_val = []
+            filter_val = params['value']
             for item in default_queryset:
                 item_val = getattr(item, field_name, None)
-                filter_val = params['value']
                 try:
                     accept = self.FILTERS[params['op']](item_val, filter_val)
                 except TypeError:

--- a/api_tests/nodes/views/test_node_files_list.py
+++ b/api_tests/nodes/views/test_node_files_list.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 
 import httpretty
@@ -317,22 +318,21 @@ class TestNodeFilesListFiltering(ApiTestCase):
         assert_equal(res.json['data'][0]['attributes']['name'], 'abc')
 
     def test_node_files_external_provider_can_filter_by_last_touched(self):
-        # TODO: should we use full utc stamp ('yesterday')?
-        url = '/{}nodes/{}/files/github/?filter[last_touched]>{}'.format(API_BASE,
-                                                                         self.project._id,
-                                                                         '2013')
+        yesterday_stamp = datetime.datetime.utcnow() - datetime.timedelta(days=1)
+        url = '/{}nodes/{}/files/github/?filter[last_touched][gt]={}'.format(API_BASE,
+                                                                             self.project._id,
+                                                                             yesterday_stamp.isoformat())
         res = self.app.get(url, auth=self.user.auth)
         assert_equal(res.status_code, 200)
         assert_equal(len(res.json['data']), 2)
 
     def test_node_files_osfstorage_cannot_filter_by_last_touched(self):
-        #yesterday_stamp = datetime.datetime.utcnow() - datetime.timedelta(days=1)
+        yesterday_stamp = datetime.datetime.utcnow() - datetime.timedelta(days=1)
         self.file = api_utils.create_test_file(self.project, self.user)
 
-        # TODO Filtering fails for a year-only datestamp, but succeeds for a full UTC stamp...?!
-        url = '/{}nodes/{}/files/osfstorage/?filter[last_touched]={}'.format(API_BASE,
-                                                                             self.project._id,
-                                                                             '2013')
+        url = '/{}nodes/{}/files/osfstorage/?filter[last_touched][gt]={}'.format(API_BASE,
+                                                                                 self.project._id,
+                                                                                 yesterday_stamp.isoformat())
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
         assert_equal(res.status_code, 400)
         assert_equal(len(res.json['errors']), 1)


### PR DESCRIPTION
## Purpose

Certain APIv2 views exit with a 500 error when the filter has a different datatype than the field.

This was evident in the `/v2/nodes/<nid>/files/<provider>` endpoint, when filtering by `last_touched`: this fails for osfstorage, because that provider does not store a value for the field. (by design)


## Changes
- When filtering fails due to a `TypeError`, Provide a JSONAPI-formatted error message and a 400 error, instead of returning an unhelpful 500.

```
{
    "errors": [
        {
            "source": {
                "parameter": "filter"
            }, 
            "meta": {}, 
            "detail": "Could not apply filter to specified field"
        }
    ]
}

```

## Side effects
Should be none, as this is merely handling a previously uncaught exception.

I can create a custom exception class if preferred.

## Ticket
https://openscience.atlassian.net/browse/OSF-4967