### PR TITLE
make institution.find not get deleted_insts

### DIFF
--- a/api_tests/institutions/views/test_institution_list.py
+++ b/api_tests/institutions/views/test_institution_list.py
@@ -3,6 +3,7 @@ from nose.tools import *  # flake8: noqa
 from tests.base import ApiTestCase
 from tests.factories import InstitutionFactory
 
+from website.models import Node
 from api.base.settings.defaults import API_BASE
 
 class TestInstitutionList(ApiTestCase):
@@ -11,6 +12,10 @@ class TestInstitutionList(ApiTestCase):
         self.institution = InstitutionFactory()
         self.institution2 = InstitutionFactory()
         self.institution_url = '/{}institutions/'.format(API_BASE)
+
+    def tearDown(self):
+        super(TestInstitutionList, self).tearDown()
+        Node.remove()
 
     def test_return_all_institutions(self):
         res = self.app.get(self.institution_url)
@@ -23,7 +28,7 @@ class TestInstitutionList(ApiTestCase):
         assert_in(self.institution2._id, ids)
 
     def test_does_not_return_deleted_institution(self):
-        self.institution.is_deleted = True
+        self.institution.node.is_deleted = True
         self.institution.node.save()
 
         res = self.app.get(self.institution_url)

--- a/api_tests/institutions/views/test_institution_list.py
+++ b/api_tests/institutions/views/test_institution_list.py
@@ -21,3 +21,16 @@ class TestInstitutionList(ApiTestCase):
         assert_equal(len(res.json['data']), 2)
         assert_in(self.institution._id, ids)
         assert_in(self.institution2._id, ids)
+
+    def test_does_not_return_deleted_institution(self):
+        self.institution.is_deleted = True
+        self.institution.node.save()
+
+        res = self.app.get(self.institution_url)
+
+        assert_equal(res.status_code, 200)
+
+        ids = [each['id'] for each in res.json['data']]
+        assert_equal(len(res.json['data']), 1)
+        assert_not_in(self.institution._id, ids)
+        assert_in(self.institution2._id, ids)

--- a/website/institutions/model.py
+++ b/website/institutions/model.py
@@ -102,7 +102,7 @@ class Institution(object):
         elif isinstance(query, RawQuery):
             replacement_attr = cls.attribute_map.get(query.attribute, False)
             query.attribute = replacement_attr or query.attribute
-        query = query & Q('institution_id', 'ne', None) if query else Q('institution_id', 'ne', None)
+        query = query & Q('institution_id', 'ne', None) & Q('is_deleted', 'ne', True) if query else Q('institution_id', 'ne', None) & Q('is_deleted', 'ne', True)
         nodes = Node.find(query, allow_institution=True, **kwargs)
         return InstitutionQuerySet(nodes)
 
@@ -116,7 +116,7 @@ class Institution(object):
         elif isinstance(query, RawQuery):
             replacement_attr = cls.attribute_map.get(query.attribute, False)
             query.attribute = replacement_attr if replacement_attr else query.attribute
-        query = query & Q('institution_id', 'ne', None) if query else Q('institution_id', 'ne', None)
+        query = query & Q('institution_id', 'ne', None) & Q('is_deleted', 'ne', True) if query else Q('institution_id', 'ne', None) & Q('is_deleted', 'ne', True)
         node = Node.find_one(query, allow_institution=True, **kwargs)
         return cls(node)
 

--- a/website/institutions/model.py
+++ b/website/institutions/model.py
@@ -93,7 +93,7 @@ class Institution(object):
         self.node.save()
 
     @classmethod
-    def find(cls, query=None, **kwargs):
+    def find(cls, query=None, deleted=False, **kwargs):
         from website.models import Node  # done to prevent import error
         if query and getattr(query, 'nodes', False):
             for node in query.nodes:
@@ -102,12 +102,13 @@ class Institution(object):
         elif isinstance(query, RawQuery):
             replacement_attr = cls.attribute_map.get(query.attribute, False)
             query.attribute = replacement_attr or query.attribute
-        query = query & Q('institution_id', 'ne', None) & Q('is_deleted', 'ne', True) if query else Q('institution_id', 'ne', None) & Q('is_deleted', 'ne', True)
+        query = query & Q('institution_id', 'ne', None) if query else Q('institution_id', 'ne', None)
+        query = query & Q('is_deleted', 'ne', True) if not deleted else query
         nodes = Node.find(query, allow_institution=True, **kwargs)
         return InstitutionQuerySet(nodes)
 
     @classmethod
-    def find_one(cls, query=None, **kwargs):
+    def find_one(cls, query=None, deleted=False, **kwargs):
         from website.models import Node
         if query and getattr(query, 'nodes', False):
             for node in query.nodes:
@@ -116,7 +117,8 @@ class Institution(object):
         elif isinstance(query, RawQuery):
             replacement_attr = cls.attribute_map.get(query.attribute, False)
             query.attribute = replacement_attr if replacement_attr else query.attribute
-        query = query & Q('institution_id', 'ne', None) & Q('is_deleted', 'ne', True) if query else Q('institution_id', 'ne', None) & Q('is_deleted', 'ne', True)
+        query = query & Q('institution_id', 'ne', None) if query else Q('institution_id', 'ne', None)
+        query = query & Q('is_deleted', 'ne', True) if not deleted else query
         node = Node.find_one(query, allow_institution=True, **kwargs)
         return cls(node)
 


### PR DESCRIPTION

## Purpose

prevent deleted institutions from being accidently found.

## Changes

added argument to .find on institution that by default adds ` Q('is_deleted', 'ne', True) `

## Side effects

To find a deleted inst, one would have to call `.find` with a deleted=True argument.

