### PR TITLE
Feature/resend confirm email throttle [OSF-6000]

### DIFF
--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -291,7 +291,7 @@ class User(GuidStoredObject, AddonModelMixin):
     # verification key used for resetting password
     verification_key = fields.StringField()
 
-    forgot_password_last_post = fields.DateTimeField()
+    email_last_sent = fields.DateTimeField()
 
     # confirmed emails
     #   emails should be stripped of whitespace and lower-cased before appending

--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -29,7 +29,6 @@ from website import security
 from website.models import User
 from website.util import web_url_for
 from website.util.sanitize import strip_html
-from website.settings import FORGOT_PASSWORD_MINIMUM_TIME
 
 
 @collect_auth
@@ -78,13 +77,10 @@ def forgot_password_post():
                           'should have, please contact OSF Support. ').format(email)
         user_obj = get_user(email=email)
         if user_obj:
-            #TODO: Remove this rate limiting and replace it with something that doesn't write to the User model
             now = datetime.datetime.utcnow()
-            last_attempt = user_obj.forgot_password_last_post or now - datetime.timedelta(seconds=FORGOT_PASSWORD_MINIMUM_TIME)
-            user_obj.forgot_password_last_post = now
-            time_since_last_attempt = now - last_attempt
-            if time_since_last_attempt.seconds >= FORGOT_PASSWORD_MINIMUM_TIME:
+            if not user_obj.email_last_sent or (now - user_obj.email_last_sent).total_seconds() > settings.SEND_EMAIL_THROTTLE:
                 user_obj.verification_key = security.random_string(20)
+                user_obj.email_last_sent = now
                 user_obj.save()
                 reset_link = "http://{0}{1}".format(
                     request.host,
@@ -100,7 +96,6 @@ def forgot_password_post():
                 )
                 status.push_status_message(status_message, 'success')
             else:
-                user_obj.save()
                 status.push_status_message('You have recently requested to change your password. Please wait a little '
                                            'while before trying again.', 'error')
         else:

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -341,8 +341,8 @@ class TestUserMerging(base.OsfTestCase):
             'date_disabled',
             'date_last_login',
             'date_registered',
+            'email_last_sent'
             'family_name',
-            'forgot_password_last_post',
             'fullname',
             'given_name',
             'is_claimed',

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -35,7 +35,7 @@ EMAIL_TOKEN_EXPIRATION = 24
 CITATION_STYLES_PATH = os.path.join(BASE_PATH, 'static', 'vendor', 'bower_components', 'styles')
 
 # Minimum seconds between forgot password email attempts
-FORGOT_PASSWORD_MINIMUM_TIME = 30
+SEND_EMAIL_THROTTLE = 30
 
 # Hours before pending embargo/retraction/registration automatically becomes active
 RETRACTION_PENDING_TIME = datetime.timedelta(days=2)


### PR DESCRIPTION
Note: This PR relies on changes made in #5484, which must get merged first! 

## Purpose
When a user adds an additional email to their account (which can be any email address), a confirmation email gets sent to that email address. Users can resend that confirmation email any number of times, which can potentially be used for spamming. 

## Changes

Only allow users to click "Resend confirmation email" once every 30 seconds.

## Side effects

None.

## Ticket
https://openscience.atlassian.net/browse/OSF-6000
