### PR TITLE
change add contributor modal height

### DIFF
--- a/website/static/css/add-contributors.css
+++ b/website/static/css/add-contributors.css
@@ -1,0 +1,4 @@
+/* Override some treebeard styles */
+#addContributors #tb-tbody {
+    max-height: 300px;
+}

--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -3,6 +3,8 @@
  */
 'use strict';
 
+require('css/add-contributors.css');
+
 var $ = require('jquery');
 var ko = require('knockout');
 var bootbox = require('bootbox');

--- a/website/templates/project/modal_add_contributor.mako
+++ b/website/templates/project/modal_add_contributor.mako
@@ -274,4 +274,3 @@
 
 <link href="/static/css/add-contributors.css" rel="stylesheet">
 
-

--- a/website/templates/project/modal_add_contributor.mako
+++ b/website/templates/project/modal_add_contributor.mako
@@ -272,5 +272,3 @@
     </div><!-- end modal-dialog -->
 </div><!-- end modal -->
 
-<link href="/static/css/add-contributors.css" rel="stylesheet">
-

--- a/website/templates/project/modal_add_contributor.mako
+++ b/website/templates/project/modal_add_contributor.mako
@@ -272,3 +272,6 @@
     </div><!-- end modal-dialog -->
 </div><!-- end modal -->
 
+<link href="/static/css/add-contributors.css" rel="stylesheet">
+
+


### PR DESCRIPTION
## Purpose

The Add Contributors Modal is too large, and goes off the page on most screens.

<img width="1440" alt="screen shot 2016-04-18 at 10 00 39 am 2" src="https://cloud.githubusercontent.com/assets/6232068/14606793/b5d0a8ba-054c-11e6-8f04-0312e684a123.png">

## Changes

Override css on the add contributors table from the default treebeard size.

<img width="1440" alt="screen shot 2016-04-18 at 9 59 33 am 2" src="https://cloud.githubusercontent.com/assets/6232068/14606821/d06fefb4-054c-11e6-8c1c-de46364919a9.png">


## Side effects

It _might_ be too awesome.

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
