### PR TITLE
[WIP] [RfR] Migration for DraftRegistration question.extra

### DIFF
--- a/scripts/migration/migrate_registration_extra.py
+++ b/scripts/migration/migrate_registration_extra.py
@@ -1,0 +1,53 @@
+"""
+Changes existing question.extra on a draft to a list
+required for multiple files attached to a question
+"""
+import sys
+import logging
+
+from website.app import init_app
+from scripts import utils as scripts_utils
+from website.models import DraftRegistration
+from framework.transactions.context import TokuTransaction
+
+
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+def migrate_drafts(dry):
+    draft_registrations = DraftRegistration.find()
+    count = 0
+    for r in draft_registrations:
+        data = r.registration_metadata
+        for q, ans in data.iteritems():
+            try:
+                files = ans['extra']
+            except (TypeError, KeyError) as e:
+                # Non-prereg Registrations
+                logger.exception(e)
+            else:
+                if type(files) is dict:
+                    if len(files.keys()) == 0:
+                        ans['extra'] = []
+                    else:
+                        ans['extra'] = [files]
+        count += 1
+        if not dry:
+            r.save()
+    logger.info('Done with {0} drafts migrated.'.format(count))
+
+
+def main(dry=True):
+    init_app(set_backends=True, routes=False)
+    scripts_utils.add_file_logger(logger, __file__)
+    migrate_drafts(dry)
+
+
+
+if __name__ == '__main__':
+    dry_run = 'dry' in sys.argv
+    with TokuTransaction():
+        main(dry=dry_run)
+        if dry_run:
+            raise RuntimeError('Dry run, rolling back transaction.')

--- a/scripts/migration/migrate_registration_extra.py
+++ b/scripts/migration/migrate_registration_extra.py
@@ -5,34 +5,36 @@ required for multiple files attached to a question
 import sys
 import logging
 
+from modularodm import Q
 from website.app import init_app
 from scripts import utils as scripts_utils
 from website.models import DraftRegistration
+from website.prereg.utils import get_prereg_schema
 from framework.transactions.context import TokuTransaction
-
 
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 def migrate_drafts(dry):
-    draft_registrations = DraftRegistration.find()
+
+    PREREG_CHALLENGE_METASCHEMA = get_prereg_schema()
+    draft_registrations = DraftRegistration.find(
+        Q('registration_schema', 'eq', PREREG_CHALLENGE_METASCHEMA) &
+        Q('approval', 'eq', None) &
+        Q('registered_node', 'eq', None)
+    )
     count = 0
     for r in draft_registrations:
         data = r.registration_metadata
         for q, ans in data.iteritems():
-            try:
-                files = ans['extra']
-            except (TypeError, KeyError) as e:
-                # Non-prereg Registrations
-                logger.exception(e)
-            else:
-                if type(files) is dict:
-                    if len(files.keys()) == 0:
-                        ans['extra'] = []
-                    else:
-                        ans['extra'] = [files]
-        count += 1
+            files = ans['extra']
+            if type(files) is dict:
+                if len(files.keys()) == 0:
+                    ans['extra'] = []
+                else:
+                    ans['extra'] = [files]
+                    count += 1
         if not dry:
             r.save()
     logger.info('Done with {0} drafts migrated.'.format(count))

--- a/scripts/tests/test_migrate_registration_extra.py
+++ b/scripts/tests/test_migrate_registration_extra.py
@@ -1,0 +1,74 @@
+from nose.tools import *  # noqa
+
+from tests.base import OsfTestCase
+from tests.factories import UserFactory
+from tests.factories import DraftRegistrationFactory
+
+from scripts.migration.migrate_registration_extra import main
+
+
+class TestMigrateRegistrationExtra(OsfTestCase):
+    def setUp(self):
+        super(TestMigrateRegistrationExtra, self).setUp()
+        self.user = UserFactory()
+        self.file_ans = {
+            'file': {
+                'data':{
+                    'kind':'file',
+                    'extra':{
+                        'checkout': None,
+                        'hashes':{
+                            'sha256':'1fffe6116ecfa778f9938060d5caab923ba4b8db60bd2dd57f16a72e5ef06292'
+                        },
+                        'downloads':0,
+                        'version':1
+                    },
+                    'modified':'2016-04-15T18:10:48',
+                    'name':'file.txt',
+                    'provider':'osfstorage',
+                }
+            }
+        }
+        self.complex_metadata = {
+            'q1': {
+                'value': 'Answer 1',
+                'extra': []
+            },
+            'q2': {
+                'value': 'Answer 2',
+                'extra': {}
+            },
+            'q3': {
+                'value': 'Answer 3',
+                'extra': self.file_ans
+            }
+        }
+        self.simple_metadata = {
+            'Summary': 'Some airy'
+        }
+        self.draft1 = DraftRegistrationFactory(
+            registration_metadata=self.complex_metadata,
+
+        )
+        self.draft2 = DraftRegistrationFactory(
+            registration_metadata=self.simple_metadata
+        )
+
+    def test_migrate_registration_extra(self):
+        assert_equal(type(self.draft1.registration_metadata['q1']['extra']), list)
+        assert_equal(type(self.draft1.registration_metadata['q2']['extra']), dict)
+        assert_equal(type(self.draft1.registration_metadata['q2']['extra']), dict)
+
+        assert_equal(self.draft2.registration_metadata, self.simple_metadata)
+
+        main(dry=False)
+        self.draft1.reload()
+        self.draft2.reload()
+
+        assert_equal(type(self.draft1.registration_metadata['q1']['extra']), list)
+        assert_equal(type(self.draft1.registration_metadata['q2']['extra']), list)
+        assert_equal(type(self.draft1.registration_metadata['q3']['extra']), list)
+
+        assert_equal(self.draft1.registration_metadata['q3']['extra'][0], self.file_ans)
+
+        assert_equal(self.draft2.registration_metadata, self.simple_metadata)

--- a/scripts/tests/test_migrate_registration_extra.py
+++ b/scripts/tests/test_migrate_registration_extra.py
@@ -4,13 +4,21 @@ from tests.base import OsfTestCase
 from tests.factories import UserFactory
 from tests.factories import DraftRegistrationFactory
 
+from website.models import MetaSchema
+from website.project.model import ensure_schemas
+from website.prereg.utils import get_prereg_schema
 from scripts.migration.migrate_registration_extra import main
+
 
 
 class TestMigrateRegistrationExtra(OsfTestCase):
     def setUp(self):
         super(TestMigrateRegistrationExtra, self).setUp()
         self.user = UserFactory()
+        MetaSchema.remove()
+        ensure_schemas()
+
+
         self.file_ans = {
             'file': {
                 'data':{
@@ -46,8 +54,12 @@ class TestMigrateRegistrationExtra(OsfTestCase):
         self.simple_metadata = {
             'Summary': 'Some airy'
         }
+        self.schema = get_prereg_schema()
         self.draft1 = DraftRegistrationFactory(
             registration_metadata=self.complex_metadata,
+            registration_schema=self.schema,
+            approval=None,
+            registered_node=None
 
         )
         self.draft2 = DraftRegistrationFactory(
@@ -55,6 +67,7 @@ class TestMigrateRegistrationExtra(OsfTestCase):
         )
 
     def test_migrate_registration_extra(self):
+
         assert_equal(type(self.draft1.registration_metadata['q1']['extra']), list)
         assert_equal(type(self.draft1.registration_metadata['q2']['extra']), dict)
         assert_equal(type(self.draft1.registration_metadata['q2']['extra']), dict)

--- a/tests/test_registrations/test_archiver.py
+++ b/tests/test_registrations/test_archiver.py
@@ -393,12 +393,12 @@ class TestArchiverTasks(ArchiverTestCase):
         data = {
             ('q_' + selected_file['name']): {
                 'value': fake.word(),
-                'extra': {
+                'extra': [{
                     'selectedFileName': selected_file['name'],
                     'nodeId': node._id,
                     'sha256': sha256,
                     'viewUrl': '/project/{0}/files/osfstorage{1}'.format(node._id, selected_file['path'])
-                }
+                }]
             }
             for sha256, selected_file in selected_files.items()
         }
@@ -407,12 +407,12 @@ class TestArchiverTasks(ArchiverTestCase):
                 'value': {
                     name_factory(): {
                         'value': fake.word(),
-                        'extra': {
+                        'extra': [{
                             'selectedFileName': selected_file['name'],
                             'nodeId': node._id,
                             'sha256': sha256,
                             'viewUrl': '/project/{0}/files/osfstorage{1}'.format(node._id, selected_file['path'])
-                        }
+                        }]
                     },
                     name_factory(): {
                         'value': fake.word()
@@ -437,14 +437,14 @@ class TestArchiverTasks(ArchiverTestCase):
                 for key, question in registration.registered_meta[prereg_schema._id].items():
                     target = None
                     if isinstance(question['value'], dict):
-                        target = [v for v in question['value'].values() if 'extra' in v and 'sha256' in v['extra']][0]
+                        target = [v for v in question['value'].values() if 'extra' in v and 'sha256' in v['extra'][0]]
                     elif 'extra' in question and 'hashes' in question['extra']:
                         target = question
 
                     if target:
-                        assert_in(registration._id, target['extra']['viewUrl'])
-                        assert_not_in(node._id, target['extra']['viewUrl'])
-                        del selected_files[target['extra']['sha256']]
+                        assert_in(registration._id, target[0]['extra'][0]['viewUrl'])
+                        assert_not_in(node._id, target[0]['extra'][0]['viewUrl'])
+                        del selected_files[target[0]['extra'][0]['sha256']]
                     else:
                         # check non-file questions are unmodified
                         assert_equal(data[key]['value'], question['value'])
@@ -481,7 +481,7 @@ class TestArchiverTasks(ArchiverTestCase):
         data = {
             ('q_' + selected_file['name']): {
                 'value': fake.word(),
-                'extra': {
+                'extra': [{
                     'sha256': sha256,
                     'viewUrl': '/project/{0}/files/osfstorage{1}'.format(
                         selected_file_node_index[sha256],
@@ -489,7 +489,7 @@ class TestArchiverTasks(ArchiverTestCase):
                     ),
                     'selectedFileName': selected_file['name'],
                     'nodeId': selected_file_node_index[sha256]
-                }
+                }]
             }
             for sha256, selected_file in selected_files.items()
         }
@@ -498,7 +498,7 @@ class TestArchiverTasks(ArchiverTestCase):
                 'value': {
                     name_factory(): {
                         'value': fake.word(),
-                        'extra': {
+                        'extra': [{
                             'sha256': sha256,
                             'viewUrl': '/project/{0}/files/osfstorage{1}'.format(
                                 selected_file_node_index[sha256],
@@ -506,7 +506,7 @@ class TestArchiverTasks(ArchiverTestCase):
                             ),
                             'selectedFileName': selected_file['name'],
                             'nodeId': selected_file_node_index[sha256]
-                        }
+                        }]
                     },
                     name_factory(): {
                         'value': fake.word()
@@ -549,21 +549,21 @@ class TestArchiverTasks(ArchiverTestCase):
             for key, question in registration.registered_meta[prereg_schema._id].items():
                 target = None
                 if isinstance(question['value'], dict):
-                    target = [v for v in question['value'].values() if 'extra' in v and 'sha256' in v['extra']][0]
+                    target = [v for v in question['value'].values() if 'extra' in v and 'sha256' in v['extra'][0]]
                 elif 'extra' in question and 'sha256' in question['extra']:
                     target = question
 
                 if target:
                     node_id = re.search(
                         r'^/project/(?P<node_id>\w{5}).+$',
-                        target['extra']['viewUrl']
+                        target[0]['extra'][0]['viewUrl']
                     ).groupdict()['node_id']
                     assert_in(
                         node_id,
                         [r._id for r in registration.node_and_primary_descendants()]
                     )
-                    if target['extra']['sha256'] in selected_files:
-                        del selected_files[target['extra']['sha256']]
+                    if target[0]['extra'][0]['sha256'] in selected_files:
+                        del selected_files[target[0]['extra'][0]['sha256']]
                 else:
                     # check non-file questions are unmodified
                     assert_equal(data[key]['value'], question['value'])
@@ -588,7 +588,7 @@ class TestArchiverTasks(ArchiverTestCase):
         data = {
             ('q_' + fake_file['name']): {
                 'value': fake.word(),
-                'extra': {
+                'extra': [{
                     'sha256': fake_file['extra']['hashes']['sha256'],
                     'viewUrl': '/project/{0}/files/osfstorage{1}'.format(
                         node._id,
@@ -596,7 +596,7 @@ class TestArchiverTasks(ArchiverTestCase):
                     ),
                     'selectedFileName': fake_file['name'],
                     'nodeId': node._id
-                }
+                }]
             }
         }
 
@@ -605,7 +605,7 @@ class TestArchiverTasks(ArchiverTestCase):
                 job = factories.ArchiveJobFactory()
                 archive_success(registration._id, job._id)
                 for key, question in registration.registered_meta[prereg_schema._id].items():
-                    assert_equal(question['extra']['selectedFileName'], fake_file['name'])
+                    assert_equal(question['extra'][0]['selectedFileName'], fake_file['name'])
 
     def test_archive_success_same_file_in_component(self):
         ensure_schemas()
@@ -625,7 +625,7 @@ class TestArchiverTasks(ArchiverTestCase):
         data = {
             ('q_' + selected['name']): {
                 'value': fake.word(),
-                'extra': {
+                'extra': [{
                     'sha256': selected['extra']['hashes']['sha256'],
                     'viewUrl': '/project/{0}/files/osfstorage{1}'.format(
                         child._id,
@@ -633,7 +633,7 @@ class TestArchiverTasks(ArchiverTestCase):
                     ),
                     'selectedFileName': selected['name'],
                     'nodeId': child._id
-                }
+                }]
             }
         }
 
@@ -643,7 +643,7 @@ class TestArchiverTasks(ArchiverTestCase):
                 archive_success(registration._id, job._id)
                 child_reg = registration.nodes[0]
                 for key, question in registration.registered_meta[prereg_schema._id].items():
-                    assert_in(child_reg._id, question['extra']['viewUrl'])
+                    assert_in(child_reg._id, question['extra'][0]['viewUrl'])
 
 
 class TestArchiverUtils(ArchiverTestCase):

--- a/website/static/js/registrationEditorExtensions.js
+++ b/website/static/js/registrationEditorExtensions.js
@@ -231,7 +231,7 @@ var Uploader = function(question) {
             var files = question.extra();
             var elem = '';
             $.each(files, function(_, file) {
-                elem += '<a target="_blank" href="' + file.viewUrl + '">' + $osf.htmlEscape(file.selectedFileName) + ' </a>';
+                elem += '<a target="_blank" href="' + file.viewUrl + '">' + $osf.htmlEscape(file.selectedFileName) + ' </a>' + '</br>';
             });
             return $(elem);
         }


### PR DESCRIPTION
## Purpose

Having multiple files in a DraftReg requires that the extra field be a list but looking at data on staging most are still dicts. I didn't notice this problem locally which is why this migration wasn't in the original PR. 


## Changes
``` 
'q1' : {                         'q1': {
  'value': 'foo',      ->          'value': 'foo',
  'extra': {}                      'extra': []
}                                 }
'q2': {                          'q2': {
  'value': 'bar',                  'value': 'bar',
  'extra': {                       'extra': [{
    'file': 'data'       ->          'file': 'data'
  }                                 }]
}                                 }
```

## Side effects

Shouldn't be any noticeable side effects other than fixing js errors that might be currently happening on staging. 


## Ticket
No ticket other than [the parent](https://openscience.atlassian.net/browse/OSF-5586)