### PR TITLE
Sam's Original API-CORS PR

### DIFF
--- a/api/base/middleware.py
+++ b/api/base/middleware.py
@@ -122,6 +122,7 @@ class CorsMiddleware(corsheaders.middleware.CorsMiddleware):
                         return False
                     elif (
                         request.method == 'OPTIONS' and
+                        'HTTP_ACCESS_CONTROL_REQUEST_METHOD' in request.META and
                         'authorization' in request.META.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS', '').split(', ')
                     ):
                         return False

--- a/api/base/middleware.py
+++ b/api/base/middleware.py
@@ -31,7 +31,7 @@ from framework.transactions.handlers import (
     transaction_teardown_request
 )
 from .api_globals import api_globals
-from api.base import setttings as api_settings
+from api.base import settings as api_settings
 
 
 class MongoConnectionMiddleware(object):

--- a/api/base/middleware.py
+++ b/api/base/middleware.py
@@ -8,7 +8,6 @@ import StringIO
 import types
 import functools
 
-from modularodm import Q
 import corsheaders.middleware
 from django.conf import settings
 from raven.contrib.django.raven_compat.models import sentry_exception_handler
@@ -26,13 +25,13 @@ from framework.celery_tasks.handlers import (
     celery_after_request,
     celery_teardown_request
 )
-from website.models import Institution
 from framework.transactions.handlers import (
     transaction_before_request,
     transaction_after_request,
     transaction_teardown_request
 )
 from .api_globals import api_globals
+from api.base import setttings as api_settings
 
 
 class MongoConnectionMiddleware(object):
@@ -114,7 +113,7 @@ class CorsMiddleware(corsheaders.middleware.CorsMiddleware):
             not_found = super(CorsMiddleware, self).origin_not_found_in_white_lists(origin, url)
             if not_found:
                 # Check if origin is in the dynamic Institutions whitelist
-                if Institution.find(Q('domains', 'eq', url.netloc.lower())).count() != 0:
+                if url.netloc.lower() in api_settings.INSTITUTION_ORIGINS_WHITELIST:
                     return False
                 # Check if a cross-origin request using the Authorization header
                 elif not request.COOKIES:

--- a/api/base/settings/__init__.py
+++ b/api/base/settings/__init__.py
@@ -27,7 +27,7 @@ if not DEBUG and os.environ.get('DJANGO_SETTINGS_MODULE') == 'api.base.settings'
 def load_institutions():
     global INSTITUTION_ORIGINS_WHITELIST
     from website import models
-    INSTITUTION_ORIGINS_WHITELIST = tuple(itertools.chain(*[
+    INSTITUTION_ORIGINS_WHITELIST = tuple(domain.lower() for domain in itertools.chain(*[
         institution.domains
         for institution in models.Institution.find()
     ]))

--- a/api/base/settings/__init__.py
+++ b/api/base/settings/__init__.py
@@ -8,6 +8,7 @@
 '''
 import os
 import warnings
+import itertools
 
 from .defaults import *  # noqa
 
@@ -22,3 +23,11 @@ if not DEBUG and os.environ.get('DJANGO_SETTINGS_MODULE') == 'api.base.settings'
     from . import defaults
     for setting in ('JWE_SECRET', 'JWT_SECRET'):
         assert getattr(local, setting, None) and getattr(local, setting, None) != getattr(defaults, setting, None), '{} must be specified in local.py when DEV_MODE is False'.format(setting)
+
+def load_institutions():
+    global INSTITUTION_ORIGINS_WHITELIST
+    from website import models
+    INSTITUTION_ORIGINS_WHITELIST = tuple(itertools.chain(*[
+        institution.domains
+        for institution in models.Institution.find()
+    ]))

--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -99,6 +99,8 @@ CORS_ORIGIN_WHITELIST = (urlparse(osf_settings.DOMAIN).netloc,
                          osf_settings.DOMAIN,
                          )
 CORS_ALLOW_CREDENTIALS = True
+# Set dynamically on app init
+INSTITUTION_ORIGINS_WHITELIST = ()
 
 MIDDLEWARE_CLASSES = (
     # TokuMX transaction support

--- a/api/base/wsgi.py
+++ b/api/base/wsgi.py
@@ -6,7 +6,10 @@ It exposes the WSGI callable as a module-level variable named ``application``.
 For more information on this file, see
 https://docs.djangoproject.com/en/1.8/howto/deployment/wsgi/
 """
-from website import settings
+import itertools
+
+from website import settings, models
+from api.base import settings as api_settings
 
 if not settings.DEBUG_MODE:
     from gevent import monkey
@@ -38,5 +41,10 @@ def __getattr__(self, attr):
 Request.__getattr__ = __getattr__
 
 init_app(set_backends=True, routes=False, attach_request_handlers=False)
+
+api_settings.INSTITUTION_ORIGINS_WHITELIST = tuple(itertools.chain(*[
+    institution.domains
+    for institution in models.Institution.find()
+]))
 
 application = get_wsgi_application()

--- a/api/base/wsgi.py
+++ b/api/base/wsgi.py
@@ -6,9 +6,7 @@ It exposes the WSGI callable as a module-level variable named ``application``.
 For more information on this file, see
 https://docs.djangoproject.com/en/1.8/howto/deployment/wsgi/
 """
-import itertools
-
-from website import settings, models
+from website import settings
 from api.base import settings as api_settings
 
 if not settings.DEBUG_MODE:
@@ -41,10 +39,6 @@ def __getattr__(self, attr):
 Request.__getattr__ = __getattr__
 
 init_app(set_backends=True, routes=False, attach_request_handlers=False)
-
-api_settings.INSTITUTION_ORIGINS_WHITELIST = tuple(itertools.chain(*[
-    institution.domains
-    for institution in models.Institution.find()
-]))
+api_settings.load_institutions()
 
 application = get_wsgi_application()

--- a/api_tests/base/test_middleware.py
+++ b/api_tests/base/test_middleware.py
@@ -8,6 +8,7 @@ from nose.tools import *  # flake8: noqa
 from rest_framework.test import APIRequestFactory
 
 from website.util import api_v2_url
+from api.base import settings
 from api.base.middleware import TokuTransactionMiddleware, CorsMiddleware
 from tests.base import ApiTestCase
 from tests import factories
@@ -50,6 +51,7 @@ class TestCorsMiddleware(MiddlewareTestCase):
             institution_domains=[domain.netloc.lower()],
             title="Institute for Sexy Lizards"
         )
+        settings.load_institutions()
         request = self.request_factory.get(url, HTTP_ORIGIN=domain.geturl())
         response = {}
         self.middleware.process_request(request)

--- a/api_tests/base/test_middleware.py
+++ b/api_tests/base/test_middleware.py
@@ -2,18 +2,28 @@
 
 from tests.base import ApiTestCase, fake
 
+from urlparse import urlparse
 import mock
 from nose.tools import *  # flake8: noqa
+from rest_framework.test import APIRequestFactory
 
-from api.base.middleware import TokuTransactionMiddleware
+from website.util import api_v2_url
+from api.base.middleware import TokuTransactionMiddleware, CorsMiddleware
 from tests.base import ApiTestCase
+from tests import factories
 
-class TestMiddlewareRollback(ApiTestCase):
+class MiddlewareTestCase(ApiTestCase):
+    MIDDLEWARE = None
+
     def setUp(self):
-        super(TestMiddlewareRollback, self).setUp()
-        self.middleware = TokuTransactionMiddleware()
+        super(MiddlewareTestCase, self).setUp()
+        self.middleware = self.MIDDLEWARE()
         self.mock_response = mock.Mock()
-    
+        self.request_factory = APIRequestFactory()
+
+class TestMiddlewareRollback(MiddlewareTestCase):
+    MIDDLEWARE = TokuTransactionMiddleware
+
     @mock.patch('framework.transactions.handlers.commands')
     def test_400_error_causes_rollback(self, mock_commands):
 
@@ -29,3 +39,56 @@ class TestMiddlewareRollback(ApiTestCase):
         self.middleware.process_response(mock.Mock(), self.mock_response)
 
         assert_true(mock_commands.commit.called)
+
+class TestCorsMiddleware(MiddlewareTestCase):
+    MIDDLEWARE = CorsMiddleware
+
+    def test_institutions_added_to_cors_whitelist(self):
+        url = api_v2_url('users/me/')
+        domain = urlparse("https://dinosaurs.sexy")
+        institution = factories.InstitutionFactory(
+            institution_domains=[domain.netloc.lower()],
+            title="Institute for Sexy Lizards"
+        )
+        request = self.request_factory.get(url, HTTP_ORIGIN=domain.geturl())
+        response = {}
+        self.middleware.process_request(request)
+        processed = self.middleware.process_response(request, response)
+        assert_equal(response['Access-Control-Allow-Origin'], domain.geturl())
+
+    def test_cross_origin_request_with_cookies_does_not_get_cors_headers(self):
+        url = api_v2_url('users/me/')
+        domain = urlparse("https://dinosaurs.sexy")
+        request = self.request_factory.get(url, HTTP_ORIGIN=domain.geturl())
+        response = {}
+        with mock.patch.object(request, 'COOKIES', True):
+            self.middleware.process_request(request)
+            processed = self.middleware.process_response(request, response)
+        assert_not_in('Access-Control-Allow-Origin', response)
+
+    def test_cross_origin_request_with_Authorization_gets_cors_headers(self):
+        url = api_v2_url('users/me/')
+        domain = urlparse("https://dinosaurs.sexy")
+        request = self.request_factory.get(
+            url,
+            HTTP_ORIGIN=domain.geturl(),
+            HTTP_AUTHORIZATION="Bearer aqweqweohuweglbiuwefq"
+        )
+        response = {}
+        self.middleware.process_request(request)
+        processed = self.middleware.process_response(request, response)
+        assert_equal(response['Access-Control-Allow-Origin'], domain.geturl())
+
+    def test_cross_origin_request_with_Authorization_and_cookie_does_not_get_cors_headers(self):
+        url = api_v2_url('users/me/')
+        domain = urlparse("https://dinosaurs.sexy")
+        request = self.request_factory.get(
+            url,
+            HTTP_ORIGIN=domain.geturl(),
+            HTTP_AUTHORIZATION="Bearer aqweqweohuweglbiuwefq"
+        )
+        response = {}
+        with mock.patch.object(request, 'COOKIES', True):
+            self.middleware.process_request(request)
+            processed = self.middleware.process_response(request, response)
+        assert_not_in('Access-Control-Allow-Origin', response)


### PR DESCRIPTION
> ##Purpose
> 
> Third party sites using OAuth or personal access tokens will want to make authenticated requests to our APIv2. The current CORS policy makes this impossible, so this PR aims to allow cross-origin requests when:
> 
> - the client includes the Authorization header (auth still must be checked later in the middleware pipe) AND
> - the client is not sending cookies with the request
> 
> ##Changes
> 
> Slight refactor of the code for dynamically whitelisting Institutions. Given the nature of the CorsMiddleware source, I think origin_not_found_in_white_lists is an elegant place to add custom logic, but checking for cross-origin requests requires having the request in context. So there's a little hackery here to bind the request into that method of the class instance, but it seems to work pretty nicely.

I brought it back to the original version with the setting, thinking that might help things.