### PR TITLE
Fix [Object object] representation of files in registration preview

### DIFF
--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -881,7 +881,7 @@ var RegistrationEditor = function(urls, editorId, preview) {
 		$elem.append(
 		    $('<span class="col-md-12">').append(
 			$('<p class="breaklines"><small><em>' + question.description + '</em></small></p>'),
-			$('<span class="well col-md-12">' + value + '</span>')
+			$('<span class="well col-md-12">').append(value)
 		    )
 		);
             }


### PR DESCRIPTION
# Purpose

Fixes:
![image](https://cloud.githubusercontent.com/assets/2207561/14651917/f4653408-063f-11e6-9f93-bff0b395bc16.png)

like:
![screen shot 2016-04-19 at 3 04 21 pm](https://cloud.githubusercontent.com/assets/2207561/14651949/0bff5b2a-0640-11e6-97f0-274279390140.png)

