### PR TITLE
Institution fixes/features 

### DIFF
--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -27,6 +27,7 @@ def sort_multiple(fields):
         reverse = False
         while fields:
             field = fields.pop(0).strip()
+
             if field[0] == '-':
                 field = field[1:]
                 reverse = True

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -24,23 +24,18 @@ from api.base.serializers import RelationshipField, TargetField
 def sort_multiple(fields):
     fields = list(fields)
     def sort_fn(a, b):
+        reverse = False
         while fields:
-            field = fields.pop(0)
+            field = fields.pop(0).strip()
             if field[0] == '-':
                 field = field[1:]
-                a_field = getattr(a, field)
-                b_field = getattr(b, field)
-                if a_field > b_field:
-                    return -1
-                elif a_field < b_field:
-                    return 1
-            else:
-                a_field = getattr(a, field)
-                b_field = getattr(b, field)
-                if a_field > b_field:
-                    return 1
-                elif a_field < b_field:
-                    return -1
+                reverse = True
+            a_field = getattr(a, field)
+            b_field = getattr(b, field)
+            if a_field > b_field:
+                return -1 if reverse else 1
+            elif a_field < b_field:
+                return 1 if reverse else -1
         return 0
     return sort_fn
 

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -26,12 +26,21 @@ def sort_multiple(fields):
     def sort_fn(a, b):
         while fields:
             field = fields.pop(0)
-            a_field = getattr(a, field)
-            b_field = getattr(b, field)
-            if a_field > b_field:
-                return 1
-            elif a_field < b_field:
-                return -1
+            if field[0] == '-':
+                field = field[1:]
+                a_field = getattr(a, field)
+                b_field = getattr(b, field)
+                if a_field > b_field:
+                    return -1
+                elif a_field < b_field:
+                    return 1
+            else:
+                a_field = getattr(a, field)
+                b_field = getattr(b, field)
+                if a_field > b_field:
+                    return 1
+                elif a_field < b_field:
+                    return -1
         return 0
     return sort_fn
 

--- a/api/institutions/views.py
+++ b/api/institutions/views.py
@@ -230,7 +230,5 @@ class InstitutionRegistrationList(InstitutionNodeList):
 
     def get_queryset(self):
         query = self.get_query_from_request()
-        nodes = Node.find(query)
-        non_retracted_list = [node._id for node in nodes if not node.is_retracted]
-        non_retracted_nodes = Node.find(Q('_id', 'in', non_retracted_list))  # querysets can be ordered
-        return non_retracted_nodes
+        nodes = list(Node.find(query))
+        return [node for node in nodes if not node.is_retracted]

--- a/api/institutions/views.py
+++ b/api/institutions/views.py
@@ -228,6 +228,8 @@ class InstitutionRegistrationList(InstitutionNodeList):
         Q('is_registration', 'eq', True)
     )
 
+    ordering = ('-date_modified', )
+
     def get_queryset(self):
         query = self.get_query_from_request()
         nodes = list(Node.find(query))

--- a/api/institutions/views.py
+++ b/api/institutions/views.py
@@ -227,3 +227,8 @@ class InstitutionRegistrationList(InstitutionNodeList):
         Q('is_folder', 'ne', True) &
         Q('is_registration', 'eq', True)
     )
+
+    def get_queryset(self):
+        query = self.get_query_from_request()
+        nodes = Node.find(query)
+        return [node for node in nodes if not node.is_retracted]

--- a/api/institutions/views.py
+++ b/api/institutions/views.py
@@ -231,4 +231,6 @@ class InstitutionRegistrationList(InstitutionNodeList):
     def get_queryset(self):
         query = self.get_query_from_request()
         nodes = Node.find(query)
-        return [node for node in nodes if not node.is_retracted]
+        non_retracted_list = [node._id for node in nodes if not node.is_retracted]
+        non_retracted_nodes = Node.find(Q('_id', 'in', non_retracted_list))  # querysets can be ordered
+        return non_retracted_nodes

--- a/api_tests/institutions/views/test_institution_registrations_list.py
+++ b/api_tests/institutions/views/test_institution_registrations_list.py
@@ -1,10 +1,11 @@
 from nose.tools import *
 
 from tests.base import ApiTestCase
-from tests.factories import InstitutionFactory, AuthUserFactory, RegistrationFactory
+from tests.factories import InstitutionFactory, AuthUserFactory, RegistrationFactory, RetractionFactory
 
 from framework.auth import Auth
 from api.base.settings.defaults import API_BASE
+from website.project.model import Sanction
 
 class TestInstitutionRegistrationList(ApiTestCase):
     def setUp(self):
@@ -54,3 +55,29 @@ class TestInstitutionRegistrationList(ApiTestCase):
         assert_in(self.registration1._id, ids)
         assert_in(self.registration2._id, ids)
         assert_in(self.registration3._id, ids)
+
+    def test_doesnt_return_retractions_without_auth(self):
+        self.registration1.retraction = RetractionFactory()
+        self.registration1.retraction.state = Sanction.APPROVED
+        self.registration1.retraction.save()
+        assert_true(self.registration1.is_retracted)
+
+        res = self.app.get(self.institution_node_url)
+
+        assert_equal(res.status_code, 200)
+        ids = [each['id'] for each in res.json['data']]
+
+        assert_not_in(self.registration1._id, ids)
+
+    def test_doesnt_return_retractions_with_auth(self):
+        self.registration1.retraction = RetractionFactory()
+        self.registration1.retraction.state = Sanction.APPROVED
+        self.registration1.retraction.save()
+        assert_true(self.registration1.is_retracted)
+
+        res = self.app.get(self.institution_node_url, auth=self.user2.auth)
+
+        assert_equal(res.status_code, 200)
+        ids = [each['id'] for each in res.json['data']]
+
+        assert_not_in(self.registration1._id, ids)

--- a/api_tests/institutions/views/test_institution_registrations_list.py
+++ b/api_tests/institutions/views/test_institution_registrations_list.py
@@ -58,6 +58,7 @@ class TestInstitutionRegistrationList(ApiTestCase):
 
     def test_doesnt_return_retractions_without_auth(self):
         self.registration1.retraction = RetractionFactory()
+        self.registration1.save()
         self.registration1.retraction.state = Sanction.APPROVED
         self.registration1.retraction.save()
         assert_true(self.registration1.is_retracted)
@@ -71,6 +72,7 @@ class TestInstitutionRegistrationList(ApiTestCase):
 
     def test_doesnt_return_retractions_with_auth(self):
         self.registration1.retraction = RetractionFactory()
+        self.registration1.save()
         self.registration1.retraction.state = Sanction.APPROVED
         self.registration1.retraction.save()
         assert_true(self.registration1.is_retracted)

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -754,6 +754,7 @@ def _view_project(node, auth, primary=False):
             'can_comment': node.can_comment(auth),
             'show_wiki_widget': _should_show_wiki_widget(node, user),
             'dashboard_id': bookmark_collection_id,
+            'institutions': get_affiliated_institutions(user),
         },
         'badges': _get_badge(user),
         # TODO: Namespace with nested dicts
@@ -766,6 +767,15 @@ def _view_project(node, auth, primary=False):
     }
     return data
 
+def get_affiliated_institutions(obj):
+    ret = []
+    for institution in obj.affiliated_institutions:
+        ret.append({
+            'name': institution.name,
+            'logo_path': institution.logo_path,
+            'id': institution._id,
+        })
+    return ret
 
 def _get_badge(user):
     if user:

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -754,7 +754,7 @@ def _view_project(node, auth, primary=False):
             'can_comment': node.can_comment(auth),
             'show_wiki_widget': _should_show_wiki_widget(node, user),
             'dashboard_id': bookmark_collection_id,
-            'institutions': get_affiliated_institutions(user),
+            'institutions': get_affiliated_institutions(user) if user else [],
         },
         'badges': _get_badge(user),
         # TODO: Namespace with nested dicts

--- a/website/templates/institution.mako
+++ b/website/templates/institution.mako
@@ -16,12 +16,14 @@
                     <div class="col-sm-3 col-sm-offset-2"><img class="img-circle" height="110px" width="110px" src=${ logo_path }></div>
                     <div class="col-sm-3">
                         <h2>${ name }</h2>
-                        % if description:
-                            <h4><small class="hidden-sm">${description}</small></h4>
-                        % endif
                     </div>
                 % endif
             </div>
+            % if description:
+                <div class="row" style="text-align: center">
+                    <h4>${description | n}</h4>
+                </div>
+            % endif
         </div>
       <div id="fileBrowser" class="dashboard clearfix" >
         <div class="ball-scale text-center m-v-xl"><div></div></div>

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -111,15 +111,16 @@
                 % endif
                 </div>
                 % if enable_institutions and not node['anonymous']:
-                    % if 'admin' in user['permissions'] and not node['is_registration']:
+                    % if ('admin' in user['permissions'] and not node['is_registration']) and (node['institution']['id'] or len(user['institutions']) != 0):
                         <a class="link-dashed" href="${node['url']}settings/#configureInstitutionAnchor" id="institution">Affiliated Institution:</a>
-                    % else:
-                        Affiliated institution:
+                        % if node['institution']['id']:
+                            <a href="/institutions/${node['institution']['id']}">${node['institution']['name']}</a>
+                        % else:
+                            <span> None </span>
+                        % endif
                     % endif
-                    % if node['institution']['id']:
-                        <a href="/institutions/${node['institution']['id']}">${node['institution']['name']}</a>
-                    % else:
-                        <span> None </span>
+                    % if not ('admin' in user['permissions'] and not node['is_registration']) and node['institution']['id']:
+                        Affiliated institution: <a href="/institutions/${node['institution']['id']}">${node['institution']['name']}</a>
                     % endif
                 % endif
                 % if node['is_fork']:

--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -341,7 +341,7 @@
                                                 <ul>
                                                     <li>institutional logos to be displayed on public projects</li>
                                                     <li>public projects to be discoverable on specific institutional landing pages</li>
-                                                    <li>single-sign on to the OSF with institutional credentials</li>
+                                                    <li>single sign-on to the OSF with institutional credentials</li>
                                                 </ul>
                                             </div>
                                         </div>
@@ -353,7 +353,7 @@
                                     <ul>
                                         <li>institutional logos to be displayed on public projects</li>
                                         <li>public projects to be discoverable on specific institutional landing pages</li>
-                                        <li>single-sign on to the OSF with institutional credentials</li>
+                                        <li>single sign-on to the OSF with institutional credentials</li>
                                     </ul>
                                 </div>
                             % endif

--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -39,7 +39,7 @@
                             <li><a href="#configureCommentingAnchor">Commenting</a></li>
                         % endif
 
-                        % if 'admin' in user['permissions'] and enable_institutions:
+                        % if enable_institutions:
                             <li><a href="#configureInstitutionAnchor">Project Affiliation / Branding</a></li>
                         % endif
 
@@ -297,6 +297,10 @@
                     </div>
 
                 </div>
+                %endif
+            % endif  ## End Configure Commenting
+
+        % if not node['is_registration']:
                 % if enable_institutions:
                     <div class="panel panel-default scripted" id="institutionSettings">
                     <span id="configureInstitutionAnchor" class="anchor"></span>
@@ -305,43 +309,54 @@
                     </div>
                     <div class="panel-body">
                         % if not node['institution']['name']:
-                            <div data-bind="visible: !loading()">
-                                <div data-bind="visible: error()">
-                                    <div class="help-block">
-                                        Could not load up available institutions. Please wait a few minutes and try again, or contact <a href="mailto:support@osf.io">support@osf.io</a> if the problem persists.
-                                    </div>
-                                </div>
-                                <div data-bind="visible: !error()">
-                                    <div data-bind="visible: availableInstitutions().length">
+                            %if 'admin' in user['permissions']:
+                                <div data-bind="visible: !loading()">
+                                    <div data-bind="visible: error()">
                                         <div class="help-block">
-                                            Projects affiliated with institutions will show some institutional branding (such as logos) and if public, will be discoverable on OSF institutional landing pages.
-
-                                            You are authorized to affiliate your projects with the following institutions:
+                                            Could not load up available institutions. Please wait a few minutes and try again, or contact <a href="mailto:support@osf.io">support@osf.io</a> if the problem persists.
                                         </div>
-                                        <div class="radio">
-                                            <div data-bind="foreach: {data: availableInstitutions, as: 'item'}">
-                                                <div>
-                                                <label>
-                                                    <input type="radio" data-bind="value: item.id, checked: $parent.selectedInstitution" name="primaryInst">
-                                                    <p data-bind="text: item.attributes.name"></p>
-                                                </label>
+                                    </div>
+                                    <div data-bind="visible: !error()">
+                                        <div data-bind="visible: availableInstitutions().length">
+                                            <div class="help-block">
+                                                Projects affiliated with institutions will show some institutional branding (such as logos) and if public, will be discoverable on OSF institutional landing pages.
+
+                                                You are authorized to affiliate your projects with the following institutions:
+                                            </div>
+                                            <div class="radio">
+                                                <div data-bind="foreach: {data: availableInstitutions, as: 'item'}">
+                                                    <div>
+                                                    <label>
+                                                        <input type="radio" data-bind="value: item.id, checked: $parent.selectedInstitution" name="primaryInst">
+                                                        <p data-bind="text: item.attributes.name"></p>
+                                                    </label>
+                                                    </div>
                                                 </div>
                                             </div>
+                                            <button data-bind="click: submitInst, css: {disabled: selectedInstitution() == null}" class="btn btn-success">Affiliate</button>
                                         </div>
-                                        <button data-bind="click: submitInst, css: {disabled: selectedInstitution() == null}" class="btn btn-success">Affiliate</button>
-                                    </div>
-                                    <div data-bind="visible: !availableInstitutions().length">
-                                        <div class="help-block">
-                                            Projects can be affiliated with institutions that have created OSF for Institution accounts. This allows:
-                                            <ul>
-                                                <li>institutional logos to be displayed on public projects</li>
-                                                <li>public projects to be discoverable on specific institutional landing pages</li>
-                                                <li>single-sign on to the OSF with institutional credentials</li>
-                                            </ul>
+                                        <div data-bind="visible: !availableInstitutions().length">
+                                            <div class="help-block">
+                                                Projects can be affiliated with institutions that have created OSF for Institution accounts. This allows:
+                                                <ul>
+                                                    <li>institutional logos to be displayed on public projects</li>
+                                                    <li>public projects to be discoverable on specific institutional landing pages</li>
+                                                    <li>single-sign on to the OSF with institutional credentials</li>
+                                                </ul>
+                                            </div>
                                         </div>
                                     </div>
                                 </div>
-                            </div>
+                            % else :
+                                <div class="help-block">
+                                    Projects can be affiliated with institutions that have created OSF for Institution accounts. This allows:
+                                    <ul>
+                                        <li>institutional logos to be displayed on public projects</li>
+                                        <li>public projects to be discoverable on specific institutional landing pages</li>
+                                        <li>single-sign on to the OSF with institutional credentials</li>
+                                    </ul>
+                                </div>
+                            % endif
                         % endif
                         % if node['institution']['name']:
                             <div class="help-block">Your project is currently affiliated with: </div>
@@ -349,17 +364,14 @@
                             <div class="help-block">
                                 Projects affiliated with institutions will show some institutional branding (such as logos), and if public, will be discoverable on OSF institutional landing pages.
                             </div>
-                            <button data-bind="click: clearInst" class="btn btn-danger">Remove affiliation</button>
+                            %if 'admin' in user['permissions']:
+                                <button data-bind="click: clearInst" class="btn btn-danger">Remove affiliation</button>
+                            %endif
                         % endif
                     </div>
                 </div>
                 % endif
-
-
-            % endif
-
-        % endif  ## End Configure Commenting
-
+        % endif
         % if user['has_read_permissions']:  ## Begin Configure Email Notifications
 
             % if not node['is_registration']:


### PR DESCRIPTION
## Purpose

More institution work clean up

## Changes

- move institution descriptions to bottom, allow html
- registration institution endpoints don't include retractions
- project settings page includes current institution info
- fix reverse sorting (ordering with a ` - `) of ` get_queryset ` returning a list
- Dont show the affiliated institutions link or the thing at all depending on situation:
    - if node is not anonymous:
         
       - if user is not admin or node is a registration:
             - node has institution: show Affiliated Institution without a link to settings
             - node doesnt have institution: show nothing

       - if user is admin and node is not a registration:
            - node has institution: show Affiliated Institution with a link to settings
            - node doesnt have an institution but user does: show Affiliated Institution with a link to settings
            - node doesnt have an institution and user doesnt also: show nothing

    - if node is anonymous: show nothing

## Ticket
https://openscience.atlassian.net/browse/OSF-6052
https://openscience.atlassian.net/browse/OSF-6065
https://trello.com/c/NpTbFN9u/24-read-user-should-see-institutional-affiliation-info
https://openscience.atlassian.net/browse/OSF-6017