### PR TITLE
[bug fix] [rfr] Make prereg form preview preserve paragraphs

### DIFF
--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -877,6 +877,10 @@ var RegistrationEditor = function(urls, editorId, preview) {
                     value = question.preview();
                 } else {
                     value = $osf.htmlEscape(question.value() || '');
+                    // preserve user's paragraph formatting
+                    while (value.indexOf('\n') > -1)
+                        value = value.replace('\n', '<br>');
+
                 }
 		$elem.append(
 		    $('<span class="col-md-12">').append(


### PR DESCRIPTION
## Purpose

Preregistration form preview should preserve paragraph formatting

## Changes

Replace newlines with `<br>` in preview

## Side effects

Better looking walls of text

## Ticket

https://openscience.atlassian.net/browse/OSF-5849