### PR TITLE
OSF-4265 Fix strange behavior of user settings page expand/collapse caret

### DIFF
--- a/website/addons/dataverse/static/dataverseUserConfig.js
+++ b/website/addons/dataverse/static/dataverseUserConfig.js
@@ -76,7 +76,7 @@ function ViewModel(url) {
                 externalAccount.dataverseUrl = account.host_url;
                 return externalAccount;
             }));
-            $('.addon-auth-table').osfToggleHeight({height: 140});
+            $('#dataverse-header').osfToggleHeight({height: 140});
         });
         request.fail(function(xhr, status, error) {
             Raven.captureMessage('Error while updating addon account', {

--- a/website/static/js/addonSettings.js
+++ b/website/static/js/addonSettings.js
@@ -145,6 +145,7 @@ var OAuthAddonSettingsViewModel = oop.defclass({
             self.accounts($.map(data.accounts, function(account) {
                 return new ExternalAccount(account);
             }));
+            $('#' + self.name + '-header').osfToggleHeight({height: 140});
         });
         request.fail(function(xhr, status, error) {
             Raven.captureMessage('Error while updating addon account', {

--- a/website/static/js/citationsNodeConfig.js
+++ b/website/static/js/citationsNodeConfig.js
@@ -71,7 +71,6 @@ var CitationsFolderPickerViewModel = oop.extend(FolderPickerViewModel, {
         var request = $.get(self.urls().accounts);
         request.then(function(data) {
             ret.resolve(data.accounts);
-            $('.addon-auth-table').osfToggleHeight({height: 140});
         });
         request.fail(function(xhr, textStatus, error) {
             self.changeMessage(self.messages.updateAccountsError(), 'text-danger');

--- a/website/static/js/pages/profile-settings-addons-page.js
+++ b/website/static/js/pages/profile-settings-addons-page.js
@@ -122,6 +122,10 @@ $(document).ready(function(){
     });
 });
 
+$(window).load(function () {
+    $(window).trigger('resize');
+});
+
 /* Before closing the page, Check whether the newly checked addon are updated or not */
 $(window).on('beforeunload',function() {
     //new checked items but not updated

--- a/website/static/js/pages/profile-settings-addons-page.js
+++ b/website/static/js/pages/profile-settings-addons-page.js
@@ -115,7 +115,11 @@ for (var i=0; i < addonEnabledSettings.length; i++) {
 }
 
 $(document).ready(function(){
-    $('.addon-auth-table').osfToggleHeight({height: 140});
+// Separately load addons whose data is loaded on the backend as opposed to async javascript.
+    var makoLoadedAddons = ['dropbox', 'github', 'box', 'figshare', 'googledrive', 's3'];
+    makoLoadedAddons.forEach(function(addon){
+        $('#'+ addon + '-header').osfToggleHeight({height: 140});
+    });
 });
 
 /* Before closing the page, Check whether the newly checked addon are updated or not */
@@ -135,6 +139,8 @@ $(window).on('beforeunload',function() {
 ****************/
 
 $('.addon-oauth').each(function(index, elem) {
+// Applies to Mendeley, Zotero.  There is a separate code for dataverse in DataverseUserConfig.js
+
     var viewModel = new addonSettings.OAuthAddonSettingsViewModel(
         $(elem).data('addon-short-name'),
         $(elem).data('addon-name')


### PR DESCRIPTION
## Purpose

User settings page's section for configuring addons have strange behaviors about the expand/collapse caret of each addon. (see https://openscience.atlassian.net/browse/OSF-4265)

## Changes

@caneruguz 's original PR(https://github.com/CenterForOpenScience/osf.io/pull/4236) on this bug was supposed to deal with the fact that different addon's are loaded differently as 

>There are two types of data load methods for addons
>1. Those that get added by backend and mako file addon_permissions.mako
>-- For these the document.ready function was used to apply
>2. Asyncronous loading with ajax after load 
>-- For these the initialization was added where nodes have been applied

and, judging from QA's feedback in the ticket, the fix did work at first. The ticket was re-opened during regression testing. I checked the current develop and the changes made in the PR are not showing. It is possible that some later PR reverted the merge.
Thus I replicate the changes made in the PR by Caner. (All such changes are included in the first commit) Somehow the expand/collapse caret's behavior for all addons are still unpredictable on each refresh of the page, and the fix does not seem to work on Safari at all (No carets will show). As QA have noticed, the caret's will show upon resizing the page. Thus, in the "profile-settings-addon-page.js", a line is added to programmatically trigger a resize event of the browser after the page is fully loaded. (The second commit)

## Side effects

Safari seems to block the resize event so that the fix still does not work on it. Works on Chrome and Firefox. Need more tests on IEs.

Don't know why the fix in the original PR worked before but not now. Maybe other components related to this bug changed between then and now. And the fix in the second commit is quite hackish I'll admit.

## Ticket

https://openscience.atlassian.net/browse/OSF-4265