### PR TITLE
Fix ko-related JS errors that prevent loading various pages

### DIFF
--- a/website/addons/wiki/templates/edit.mako
+++ b/website/addons/wiki/templates/edit.mako
@@ -132,7 +132,7 @@
                       </div>
                         <div class="col-md-6">
                           <div class="pull-right">
-                            <div class="progress no-margin pointer " data-toggle="modal" data-bind="attr: {data-target: modalTarget}" >
+                            <div class="progress no-margin pointer " data-toggle="modal" data-bind="attr: {'data-target': modalTarget}" >
                                 <div role="progressbar"data-bind="attr: progressBar">
                                     <span class="progress-bar-content p-h-sm">
                                         <span data-bind="text: statusDisplay"></span>

--- a/website/addons/wiki/templates/edit.mako
+++ b/website/addons/wiki/templates/edit.mako
@@ -133,7 +133,7 @@
                         <div class="col-md-6">
                           <div class="pull-right">
                             <div class="progress no-margin pointer " data-toggle="modal" data-bind="attr: {'data-target': modalTarget}" >
-                                <div role="progressbar"data-bind="attr: progressBar">
+                                <div role="progressbar" data-bind="attr: progressBar">
                                     <span class="progress-bar-content p-h-sm">
                                         <span data-bind="text: statusDisplay"></span>
                                         <span class="sharejs-info-btn">

--- a/website/templates/include/profile/jobs.mako
+++ b/website/templates/include/profile/jobs.mako
@@ -145,7 +145,7 @@
                                 </div>
                                 <span data-bind="attr: {class: expanded() ? 'fa toggle-icon fa-angle-down' : 'fa toggle-icon fa-angle-up'}"></span>
                             </div>
-                            <div data-bind="attr: {id: 'jobCard' + $index(), aria-labelledby: 'jobHeading' + $index()}" class="panel-collapse collapse">
+                            <div data-bind="attr: {id: 'jobCard' + $index(), 'aria-labelledby': 'jobHeading' + $index()}" class="panel-collapse collapse">
                                 <div class="panel-body">
                                     <span data-bind="if: department().length"><h5>Department:</h5> <span data-bind="text: department"></span></span>
                                     <span data-bind="if: title().length"><h5>Title:</h5> <span data-bind="text: title"></span></span>

--- a/website/templates/include/profile/schools.mako
+++ b/website/templates/include/profile/schools.mako
@@ -144,7 +144,7 @@
                                 </div>
                                 <span data-bind="attr: {class: expanded() ? 'fa toggle-icon fa-angle-down' : 'fa toggle-icon fa-angle-up'}"></span>
                             </div>
-                            <div data-bind="attr: {id: 'schoolCard' + $index(), aria-labelledby: 'schoolHeading' + $index()}" class="panel-collapse collapse">
+                            <div data-bind="attr: {id: 'schoolCard' + $index(), 'aria-labelledby': 'schoolHeading' + $index()}" class="panel-collapse collapse">
                                 <div class="panel-body">
                                     <span data-bind="if: department().length"><h5>Department:</h5> <span data-bind="text: department"></span></span>
                                     <span data-bind="if: degree().length"><h5>Degree:</h5> <span data-bind="text: degree"></span></span>


### PR DESCRIPTION
## Purpose

Fix several issues on staging2 that prevent viewing or editing of pages.

## Changes

KO punches was more tolerant of syntax errors; when it was removed, hyphenated JS object keys stopped working. The solution is to quote them properly.

I have also attempted to audit for any similar problems. The most effective regex we collectively came up with is below, and did not find any other usages along these lines.
 
`data\-bind="[^"]*?attr:\s*\{(?:[^:}]+|[^}]+,[^:}\-]+)\-`
`data\-bind="[^"]*?attr:\s*\{(?:[^:}]+|[^}]+,[^:}\-]*?)\-[^}]+\}[^"]*"` (h/t @felliott )

## Testing notes
Affected pages include:
- Profile page (jobs and schools tabs
- Wiki edit links

## Side effects
None expected.

## Ticket
https://openscience.atlassian.net/browse/OSF-6075