### PR TITLE
Change message under 'Recent Activity' when no logs to show

### DIFF
--- a/website/templates/log_list.mako
+++ b/website/templates/log_list.mako
@@ -34,7 +34,7 @@
 	                </div>
                 </span>
                 <p data-bind="if: !logs().length && !loading()" class="help-block">
-                    No logs to show.g
+                    No logs to show.
                 </p>
                 <span data-bind="if: !loading()">
                     <dl class="dl-horizontal activity-log" data-bind="foreach: {data: logs, as: 'log'}"  >

--- a/website/templates/log_list.mako
+++ b/website/templates/log_list.mako
@@ -34,8 +34,7 @@
 	                </div>
                 </span>
                 <p data-bind="if: !logs().length && !loading()" class="help-block">
-                    No logs to show. Click the watch icon (<i class="fa fa-eye"></i>) on a
-                    project's page to get activity updates here.
+                    No logs to show.g
                 </p>
                 <span data-bind="if: !loading()">
                     <dl class="dl-horizontal activity-log" data-bind="foreach: {data: logs, as: 'log'}"  >


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Change the description of an empty 'Recent Activity' widget to be consistent with the fact that there is no longer a watch button/feature.

## Changes

Change description of empty 'Recent Activity' widget from "No logs to show. Click the watch icon on a project's page to get activity updates here." to "No logs to show."

## Ticket

[OSF-6022]