### PR TITLE
Bold warning on access token creation [#OSF-6058]

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "bootbox": "^4.4.0",
     "bower": "^1.3.12",
     "c3": "^0.4.10",
+    "clipboard": "^1.5.10",
     "css-loader": "^0.9.1",
     "diff": "~2.2.2",
     "dropzone": "git://github.com/sloria/dropzone.git#accept-directory",
@@ -57,8 +58,8 @@
     "style-loader": "^0.8.3",
     "treebeard": "git://github.com/caneruguz/treebeard.git#89895536486e3535d9980b8f20a73f72bbb64222",
     "typeahead.js": "^0.10.5",
-    "uuid": "^2.0.1",
     "url-loader": "^0.5.5",
+    "uuid": "^2.0.1",
     "webpack": "^1.7.2",
     "ws": "~0.4.32"
   },

--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
     "style-loader": "^0.8.3",
     "treebeard": "git://github.com/caneruguz/treebeard.git#89895536486e3535d9980b8f20a73f72bbb64222",
     "typeahead.js": "^0.10.5",
-    "url-loader": "^0.5.5",
     "uuid": "^2.0.1",
+    "url-loader": "^0.5.5",
     "webpack": "^1.7.2",
     "ws": "~0.4.32"
   },

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -655,4 +655,11 @@ button.close {
 .token-warning {
     margin-bottom: 5px;
     margin-top: 15px;
+    padding-left: 10px;
+    padding-top: 5px;
+    padding-bottom: 5px;
+}
+
+#copy-button {
+    margin-top: 10px;
 }

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -646,3 +646,13 @@ button.close {
 .comma-separated:last-of-type:after {
     content: "";
 }
+
+.action-buttons {
+    margin-top: 10px;
+    margin-bottom: 10px;
+}
+
+.token-warning {
+    margin-bottom: 5px;
+    margin-top: 15px;
+}

--- a/website/static/js/pages/profile-settings-personal-tokens-detail-page.js
+++ b/website/static/js/pages/profile-settings-personal-tokens-detail-page.js
@@ -4,3 +4,7 @@ var viewModels = require('../apiPersonalToken');
 
 var ctx = window.contextVars;
 var apiPersonalToken = new viewModels.TokenDetail('#tokenDetail', ctx.urls);
+
+var Clipboard = require('clipboard');
+
+new Clipboard('#copy-button');

--- a/website/templates/profile/personal_tokens_detail.mako
+++ b/website/templates/profile/personal_tokens_detail.mako
@@ -62,8 +62,8 @@
 
                     <div id="token-keys" class="border-box text-left"
                          data-bind="visible: $root.showToken()">
-                        <div class="bg-warning lead token-warning">This is the only time your token will be displayed.</div>
-                        <label>Token ID</label>
+                        <div class="bg-danger lead token-warning">This is the only time your token will be displayed.</div>
+                        <label class="f-w-xl">Token ID</label>
                         <i class="fa fa-info-circle text-muted" data-bind="tooltip: {title:'ID used to authenticate with this token. This will be shown only once.',        placement: 'bottom'}"></i>
                         <span data-bind="text: token_id" id="token-id-text"></span>
                         <div>

--- a/website/templates/profile/personal_tokens_detail.mako
+++ b/website/templates/profile/personal_tokens_detail.mako
@@ -62,12 +62,12 @@
 
                     <div id="token-keys" class="border-box text-left"
                          data-bind="visible: $root.showToken()">
-                        <div class="bg-danger lead token-warning">This is the only time your token will be displayed.</div>
+                        <div class="bg-danger f-w-xl token-warning">This is the only time your token will be displayed.</div>
                         <label class="f-w-xl">Token ID</label>
                         <i class="fa fa-info-circle text-muted" data-bind="tooltip: {title:'ID used to authenticate with this token. This will be shown only once.',        placement: 'bottom'}"></i>
                         <span data-bind="text: token_id" id="token-id-text"></span>
                         <div>
-                            <button type="button" class="btn btn-primary" data-clipboard-target="#token-id-text" id="copy-button">Copy Token to Clipboard</button>
+                            <button type="button" class="btn btn-primary" data-clipboard-target="#token-id-text" id="copy-button"><i class="fa fa-copy"></i> Copy to clipboard</button>
                         </div>
                     </div>
                 </form>

--- a/website/templates/profile/personal_tokens_detail.mako
+++ b/website/templates/profile/personal_tokens_detail.mako
@@ -44,20 +44,7 @@
                         <p data-bind="validationMessage: scopes, visible: $root.showMessages()" class="text-danger"></p>
                     </div>
 
-                    <br/>
-                    <div id="token-keys" class="border-box text-left"
-                         data-bind="visible: $root.showToken()">
-                        <label>Token ID</label>
-                        <i class="fa fa-info-circle text-muted" data-bind="tooltip: {title:'ID used to authenticate with this token. This will be shown only once.',        placement: 'bottom'}"></i>
-                        <span data-bind="text: token_id"></span>
-                    </div>
-
-                    <!-- Flashed Messages -->
-                    <div class="help-block">
-                        <p data-bind="html: $root.message, attr: {class: $root.messageClass}"></p>
-                    </div>
-
-                    <div class="padded">
+                    <div class="padded action-buttons">
                         <button type="reset" class="btn btn-default"
                                 data-bind="click: $root.cancelChange.bind($root)">Cancel</button>
                         <button type="submit" class="btn btn-success"
@@ -66,6 +53,22 @@
                                 data-bind="visible: !$root.isCreateView(), click: $root.deleteToken.bind($root)">Delete</button>
                         <button type="submit" class="btn btn-success"
                                 data-bind="visible: !$root.isCreateView()">Save</button>
+                    </div>
+
+                    <!-- Flashed Messages -->
+                    <div class="help-block">
+                        <p data-bind="html: $root.message, attr: {class: $root.messageClass}"></p>
+                    </div>
+
+                    <div id="token-keys" class="border-box text-left"
+                         data-bind="visible: $root.showToken()">
+                        <div class="bg-warning lead token-warning">This is the only time your token will be displayed.</div>
+                        <label>Token ID</label>
+                        <i class="fa fa-info-circle text-muted" data-bind="tooltip: {title:'ID used to authenticate with this token. This will be shown only once.',        placement: 'bottom'}"></i>
+                        <span data-bind="text: token_id" id="token-id-text"></span>
+                        <div>
+                            <button type="button" class="btn btn-primary" data-clipboard-target="#token-id-text" id="copy-button">Copy Token to Clipboard</button>
+                        </div>
                     </div>
                 </form>
 


### PR DESCRIPTION
## Purpose
When creating an access token on the OSF on your settings page, it's not clear that the first time the token is created is the last time you'll be able to view it. This PR adds a bolder warning to the first time the token is displayed, as well as a "copy to clipboard" button to help facilitate using the code later on in an actual application.

## Changes
- Add clipboardjs to npm installable packages
    - copies text to the clipboard without flash!
- Add warning text to first time token is displayed
- Move Cancel, Save, and Delete Buttons to above token display
    - These buttons deal directly with any potential token changes, not with the new token that was just created. 
- Small CSS style changes

## Side effects
- Not sure about how well the copy to clipboard button will work on IE - tested locally as much as possible

## Ticket
https://openscience.atlassian.net/browse/OSF-6058
