### PR TITLE
OSF-5239 Two Factor Auth bug

### DIFF
--- a/website/addons/twofactor/static/twoFactorUserConfig.js
+++ b/website/addons/twofactor/static/twoFactorUserConfig.js
@@ -107,6 +107,7 @@ ViewModel.prototype.disableTwofactorConfirm = function() {
             self.isEnabled(false);
             self.isConfirmed(false);
             $(self.qrCodeSelector).html('');
+            self.tfaCode('');
         })
         .fail(function(xhr, status, error) {
             Raven.captureMessage('Failed to disable two-factor.', {


### PR DESCRIPTION
## Purpose

Two factor authentication code still exists after disabling and enabling. Fixed

## Changes

In "twoFactorUserConfig.js", added a line so that it resets the field after disabling.

## Side effects

None. At least not that I may think of.

## Ticket

OSF-5239
https://openscience.atlassian.net/browse/OSF-5239
