### PR TITLE
Copy token with ZeroClipboard instead of clipboardjs [#OSF-6058] [Part 2]

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "bootbox": "^4.4.0",
     "bower": "^1.3.12",
     "c3": "^0.4.10",
-    "clipboard": "^1.5.10",
     "css-loader": "^0.9.1",
     "diff": "~2.2.2",
     "dropzone": "git://github.com/sloria/dropzone.git#accept-directory",

--- a/website/static/js/apiPersonalToken.js
+++ b/website/static/js/apiPersonalToken.js
@@ -19,6 +19,7 @@ var koHelpers = require('./koHelpers');  // URL validators etc
 var $osf = require('./osfHelpers');
 var oop = require('js/oop');
 var language = require('js/osfLanguage');
+var makeClient = require('js/clipboard');
 
 
 /*
@@ -314,6 +315,7 @@ var TokenDetailViewModel = oop.extend(ChangeMessageMixin, {
             this.tokenData(dataObj);
             this.originalValues(dataObj.serialize());
             this.showToken(true);
+            makeClient(document.getElementById('copy-button'));
             this.changeMessage(language.apiOauth2Token.creationSuccess, 'text-success');
             this.apiDetailUrl(dataObj.apiDetailUrl); // Toggle ViewModel --> act like a display view now.
             historyjs.replaceState({}, '', dataObj.webDetailUrl);  // Update address bar to show new detail page

--- a/website/static/js/apiPersonalToken.js
+++ b/website/static/js/apiPersonalToken.js
@@ -315,7 +315,6 @@ var TokenDetailViewModel = oop.extend(ChangeMessageMixin, {
             this.tokenData(dataObj);
             this.originalValues(dataObj.serialize());
             this.showToken(true);
-            makeClient(document.getElementById('copy-button'));
             this.changeMessage(language.apiOauth2Token.creationSuccess, 'text-success');
             this.apiDetailUrl(dataObj.apiDetailUrl); // Toggle ViewModel --> act like a display view now.
             historyjs.replaceState({}, '', dataObj.webDetailUrl);  // Update address bar to show new detail page

--- a/website/static/js/koHelpers.js
+++ b/website/static/js/koHelpers.js
@@ -262,8 +262,8 @@ ko.bindingHandlers.tooltip = {
 };
 
 var clipboard = function(el, valueAccessor) {
-    makeClient($(el));
-    $(el).attr("data-clipboard-text", valueAccessor());
+    makeClient(el);
+    $(el).attr("data-clipboard-text", ko.unwrap(valueAccessor()));
 };
 ko.bindingHandlers.clipboard = {
     init: clipboard

--- a/website/static/js/koHelpers.js
+++ b/website/static/js/koHelpers.js
@@ -4,6 +4,7 @@ var $ = require('jquery');
 var ko = require('knockout');
 var pikaday = require('pikaday');
 require('knockout.validation');
+var makeClient = require('js/clipboard');
 
 var iconmap = require('js/iconmap');
 
@@ -259,6 +260,16 @@ ko.bindingHandlers.tooltip = {
     init: tooltip,
     update: tooltip
 };
+
+var clipboard = function(el, valueAccessor) {
+    console.log(textToCopy);
+    makeClient($(el));
+    $(el).attr("data-clipboard-text", valueAccessor());
+};
+ko.bindingHandlers.clipboard = {
+    init: clipboard
+};
+
 // Attach view model logic to global keypress events
 ko.bindingHandlers.onKeyPress = {
     init: function(el, valueAccessor) {

--- a/website/static/js/koHelpers.js
+++ b/website/static/js/koHelpers.js
@@ -263,7 +263,7 @@ ko.bindingHandlers.tooltip = {
 
 var clipboard = function(el, valueAccessor) {
     makeClient(el);
-    $(el).attr("data-clipboard-text", ko.unwrap(valueAccessor()));
+    $(el).attr('data-clipboard-text', ko.unwrap(valueAccessor()));
 };
 ko.bindingHandlers.clipboard = {
     init: clipboard

--- a/website/static/js/koHelpers.js
+++ b/website/static/js/koHelpers.js
@@ -262,7 +262,6 @@ ko.bindingHandlers.tooltip = {
 };
 
 var clipboard = function(el, valueAccessor) {
-    console.log(textToCopy);
     makeClient($(el));
     $(el).attr("data-clipboard-text", valueAccessor());
 };

--- a/website/static/js/pages/profile-settings-personal-tokens-detail-page.js
+++ b/website/static/js/pages/profile-settings-personal-tokens-detail-page.js
@@ -4,7 +4,3 @@ var viewModels = require('../apiPersonalToken');
 
 var ctx = window.contextVars;
 var apiPersonalToken = new viewModels.TokenDetail('#tokenDetail', ctx.urls);
-
-var Clipboard = require('clipboard');
-
-new Clipboard('#copy-button');

--- a/website/templates/profile/personal_tokens_detail.mako
+++ b/website/templates/profile/personal_tokens_detail.mako
@@ -65,9 +65,9 @@
                         <div class="bg-danger f-w-xl token-warning">This is the only time your token will be displayed.</div>
                         <label class="f-w-xl">Token ID</label>
                         <i class="fa fa-info-circle text-muted" data-bind="tooltip: {title:'ID used to authenticate with this token. This will be shown only once.',        placement: 'bottom'}"></i>
-                        <span data-bind="text: token_id" id="token-id-text"></span>
+                        <span data-bind="text: token_id"></span>
                         <div>
-                            <button type="button" class="btn btn-primary" data-bind="attr: {'data-clipboard-text': token_id}" id="copy-button"><i class="fa fa-copy"></i> Copy to clipboard</button>
+                            <button type="button" class="btn btn-primary" data-bind="clipboard: token_id()" id="copy-button"><i class="fa fa-copy"></i> Copy to clipboard</button>
                         </div>
                     </div>
                 </form>

--- a/website/templates/profile/personal_tokens_detail.mako
+++ b/website/templates/profile/personal_tokens_detail.mako
@@ -65,7 +65,7 @@
                         <div class="bg-danger f-w-xl token-warning">This is the only time your token will be displayed.</div>
                         <label class="f-w-xl">Token ID</label>
                         <i class="fa fa-info-circle text-muted" data-bind="tooltip: {title:'ID used to authenticate with this token. This will be shown only once.',        placement: 'bottom'}"></i>
-                        <pre data-bind="text: token_id"></pre>
+                        <samp data-bind="text: token_id"></samp>
                         <div>
                             <button type="button" class="btn btn-default" data-bind="clipboard: token_id()" id="copy-button"><i class="fa fa-copy"></i> Copy to clipboard</button>
                         </div>

--- a/website/templates/profile/personal_tokens_detail.mako
+++ b/website/templates/profile/personal_tokens_detail.mako
@@ -67,7 +67,7 @@
                         <i class="fa fa-info-circle text-muted" data-bind="tooltip: {title:'ID used to authenticate with this token. This will be shown only once.',        placement: 'bottom'}"></i>
                         <span data-bind="text: token_id" id="token-id-text"></span>
                         <div>
-                            <button type="button" class="btn btn-primary" data-clipboard-target="#token-id-text" id="copy-button"><i class="fa fa-copy"></i> Copy to clipboard</button>
+                            <button type="button" class="btn btn-primary" data-bind="attr: {'data-clipboard-text': token_id}" id="copy-button"><i class="fa fa-copy"></i> Copy to clipboard</button>
                         </div>
                     </div>
                 </form>

--- a/website/templates/profile/personal_tokens_detail.mako
+++ b/website/templates/profile/personal_tokens_detail.mako
@@ -65,7 +65,7 @@
                         <div class="bg-danger f-w-xl token-warning">This is the only time your token will be displayed.</div>
                         <label class="f-w-xl">Token ID</label>
                         <i class="fa fa-info-circle text-muted" data-bind="tooltip: {title:'ID used to authenticate with this token. This will be shown only once.',        placement: 'bottom'}"></i>
-                        <span data-bind="text: token_id"></span>
+                        <pre data-bind="text: token_id"></pre>
                         <div>
                             <button type="button" class="btn btn-default" data-bind="clipboard: token_id()" id="copy-button"><i class="fa fa-copy"></i> Copy to clipboard</button>
                         </div>

--- a/website/templates/profile/personal_tokens_detail.mako
+++ b/website/templates/profile/personal_tokens_detail.mako
@@ -67,7 +67,7 @@
                         <i class="fa fa-info-circle text-muted" data-bind="tooltip: {title:'ID used to authenticate with this token. This will be shown only once.',        placement: 'bottom'}"></i>
                         <span data-bind="text: token_id"></span>
                         <div>
-                            <button type="button" class="btn btn-primary" data-bind="clipboard: token_id()" id="copy-button"><i class="fa fa-copy"></i> Copy to clipboard</button>
+                            <button type="button" class="btn btn-default" data-bind="clipboard: token_id()" id="copy-button"><i class="fa fa-copy"></i> Copy to clipboard</button>
                         </div>
                     </div>
                 </form>


### PR DESCRIPTION
## Purpose
A previous PR used clipboardjs to copy a token - this PR uses the already in place ZeroClipboard instead

## Changes
- Remove clipboardjs dependency from ```package.json```
- Add instantiation of the copy-button client in ```apiPersonalToken.js```
- send correct data to button

![screen shot 2016-04-22 at 4 46 35 pm](https://cloud.githubusercontent.com/assets/801594/14754503/d077e286-08a9-11e6-9584-c0d4476448f0.png)

## Side effects
More flash!

## Ticket
https://openscience.atlassian.net/browse/OSF-6058
