### PR TITLE
Release/fix fork and registration wikis [OSF-6095]

### DIFF
--- a/scripts/clone_wiki_pages.py
+++ b/scripts/clone_wiki_pages.py
@@ -17,10 +17,10 @@ logger = logging.getLogger(__name__)
 
 def main():
     nodes = Node.find()
-    clone_wiki_pages(nodes)
+    update_wiki_pages(nodes)
 
 
-def clone_wiki_pages(nodes):
+def update_wiki_pages(nodes):
     for i, node in enumerate(nodes):
         if node.wiki_pages_versions:
             cloned_wiki_pages = {}
@@ -29,10 +29,7 @@ def clone_wiki_pages(nodes):
                 for wiki_id in node.wiki_pages_versions[key]:
                     node_wiki = NodeWikiPage.load(wiki_id)
                     if node_wiki.node._id != node._id:
-                        clone = node_wiki.clone()
-                        clone.node = node
-                        clone.user = node_wiki.user
-                        clone.save()
+                        clone = node_wiki.clone_wiki(node)
                         logger.info('Cloned wiki page {} from node {} to {}'.format(wiki_id, node_wiki.node._id, node._id))
                         cloned_wiki_pages[key].append(clone._id)
 

--- a/scripts/clone_wiki_pages.py
+++ b/scripts/clone_wiki_pages.py
@@ -5,6 +5,7 @@ using the same NodeWikiPage objects as the original node.
 import logging
 import sys
 
+from framework.mongo import database as db
 from framework.transactions.context import TokuTransaction
 
 from website.addons.wiki.model import NodeWikiPage
@@ -14,9 +15,12 @@ from scripts import utils as script_utils
 
 logger = logging.getLogger(__name__)
 
+BACKUP_COLLECTION = 'unmigratedwikipages'
+
 
 def main():
-    nodes = Node.find()
+    nodes = db.node.find({}, {'_id': True})
+    nodes = nodes.batch_size(200)
     update_wiki_pages(nodes)
 
 
@@ -24,18 +28,23 @@ def update_wiki_pages(nodes):
     for i, node in enumerate(nodes):
         if node.wiki_pages_versions:
             cloned_wiki_pages = {}
-            for key in node.wiki_pages_versions:
+            for key, wiki_versions in node.wiki_pages_versions.items():
                 cloned_wiki_pages[key] = []
-                for wiki_id in node.wiki_pages_versions[key]:
+                for wiki_id in wiki_versions:
                     node_wiki = NodeWikiPage.load(wiki_id)
-                    if node_wiki.node._id != node._id:
+                    if not node_wiki:
+                        continue
+                    if node_wiki.to_storage()['node'] != node._id:
                         clone = node_wiki.clone_wiki(node)
-                        logger.info('Cloned wiki page {} from node {} to {}'.format(wiki_id, node_wiki.node._id, node._id))
+                        logger.info('Cloned wiki page {} from node {} to {}'.format(wiki_id, node_wiki.node, node))
                         cloned_wiki_pages[key].append(clone._id)
 
                         # update current wiki page
                         if node_wiki.is_current:
                             node.wiki_pages_current[key] = clone._id
+
+                        if not node_wiki.node:
+                            move_to_backup_collection(node_wiki._id)
                     else:
                         cloned_wiki_pages[key].append(wiki_id)
             node.wiki_pages_versions = cloned_wiki_pages
@@ -46,6 +55,15 @@ def update_wiki_pages(nodes):
             for key in ('node', 'user','fileversion', 'storedfilenode'):
                 Node._cache.data.get(key, {}).clear()
                 Node._object_cache.data.get(key, {}).clear()
+
+
+# Wiki pages with nodes that no longer exist are removed from NodeWikiPage
+# and put into a separate collection
+def move_to_backup_collection(wiki_id):
+    wiki = db.nodewikipage.find_one({'_id': wiki_id})
+    assert wiki
+    db[BACKUP_COLLECTION].insert(wiki)
+    db.nodewikipage.remove({'_id': wiki_id}, just_one=True)
 
 
 if __name__ == '__main__':

--- a/scripts/clone_wiki_pages.py
+++ b/scripts/clone_wiki_pages.py
@@ -31,6 +31,7 @@ def clone_wiki_pages(nodes):
                     if node_wiki.node._id != node._id:
                         clone = node_wiki.clone()
                         clone.node = node
+                        clone.user = node_wiki.user
                         clone.save()
                         logger.info('Cloned wiki page {} from node {} to {}'.format(wiki_id, node_wiki.node._id, node._id))
                         cloned_wiki_pages[key].append(clone._id)

--- a/scripts/clone_wiki_pages.py
+++ b/scripts/clone_wiki_pages.py
@@ -1,0 +1,61 @@
+"""
+Create copies of wiki pages for existing forks and registrations instead of
+using the same NodeWikiPage objects as the original node.
+"""
+import logging
+import sys
+
+from framework.transactions.context import TokuTransaction
+
+from website.addons.wiki.model import NodeWikiPage
+from website.models import Node
+from website.app import init_app
+from scripts import utils as script_utils
+
+logger = logging.getLogger(__name__)
+
+
+def main():
+    nodes = Node.find()
+    clone_wiki_pages(nodes)
+
+
+def clone_wiki_pages(nodes):
+    for i, node in enumerate(nodes):
+        if node.wiki_pages_versions:
+            cloned_wiki_pages = {}
+            for key in node.wiki_pages_versions:
+                cloned_wiki_pages[key] = []
+                for wiki_id in node.wiki_pages_versions[key]:
+                    node_wiki = NodeWikiPage.load(wiki_id)
+                    if node_wiki.node._id != node._id:
+                        clone = node_wiki.clone()
+                        clone.node = node
+                        clone.save()
+                        logger.info('Cloned wiki page {} from node {} to {}'.format(wiki_id, node_wiki.node._id, node._id))
+                        cloned_wiki_pages[key].append(clone._id)
+
+                        # update current wiki page
+                        if node_wiki.is_current:
+                            node.wiki_pages_current[key] = clone._id
+                    else:
+                        cloned_wiki_pages[key].append(wiki_id)
+            node.wiki_pages_versions = cloned_wiki_pages
+            node.save()
+
+        # clear ODM cache
+        if i % 1000 == 0:
+            for key in ('node', 'user','fileversion', 'storedfilenode'):
+                Node._cache.data.get(key, {}).clear()
+                Node._object_cache.data.get(key, {}).clear()
+
+
+if __name__ == '__main__':
+    dry = '--dry' in sys.argv
+    if not dry:
+        script_utils.add_file_logger(logger, __file__)
+    init_app(routes=False, set_backends=True)
+    with TokuTransaction():
+        main()
+        if dry:
+            raise Exception('Dry Run -- Aborting Transaction')

--- a/scripts/tests/test_clone_wiki_pages.py
+++ b/scripts/tests/test_clone_wiki_pages.py
@@ -1,6 +1,6 @@
 from framework.auth.core import Auth
 
-from scripts.clone_wiki_pages import clone_wiki_pages
+from scripts.clone_wiki_pages import update_wiki_pages
 
 from website.addons.wiki.model import NodeWikiPage
 
@@ -23,25 +23,25 @@ class TestCloneWikiPages(OsfTestCase):
         return self.project_with_wikis
 
     def test_project_no_wiki_pages(self):
-        clone_wiki_pages([self.project])
+        update_wiki_pages([self.project])
         assert_equal(self.project.wiki_pages_versions, {})
         assert_equal(self.project.wiki_pages_current, {})
 
     def test_forked_project_no_wiki_pages(self):
         fork = self.project.fork_node(auth=Auth(self.user))
-        clone_wiki_pages([fork])
+        update_wiki_pages([fork])
         assert_equal(fork.wiki_pages_versions, {})
         assert_equal(fork.wiki_pages_current, {})
 
     def test_registration_no_wiki_pages(self):
         registration = RegistrationFactory()
-        clone_wiki_pages([registration])
+        update_wiki_pages([registration])
         assert_equal(registration.wiki_pages_versions, {})
         assert_equal(registration.wiki_pages_current, {})
 
     def test_project_wiki_pages_do_not_get_cloned(self):
         project = self.set_up_project_with_wiki_page()
-        clone_wiki_pages([project])
+        update_wiki_pages([project])
         assert_equal(project.wiki_pages_versions, {self.wiki.page_name: [self.wiki._id, self.current_wiki._id]})
         assert_equal(project.wiki_pages_current, {self.current_wiki.page_name: self.current_wiki._id})
 
@@ -50,7 +50,7 @@ class TestCloneWikiPages(OsfTestCase):
         fork = self.project.fork_node(auth=Auth(fork_creator))
         wiki = NodeWikiFactory(node=fork)
         current_wiki = NodeWikiFactory(node=fork, version=2, is_current=True)
-        clone_wiki_pages([fork])
+        update_wiki_pages([fork])
         assert_equal(fork.wiki_pages_versions, {wiki.page_name: [wiki._id, current_wiki._id]})
         assert_equal(fork.wiki_pages_current, {wiki.page_name: current_wiki._id})
 
@@ -62,7 +62,7 @@ class TestCloneWikiPages(OsfTestCase):
         fork.wiki_pages_current = project.wiki_pages_current
         fork.save()
 
-        clone_wiki_pages([fork])
+        update_wiki_pages([fork])
         wiki_versions = fork.wiki_pages_versions[self.wiki.page_name]
 
         current_wiki = NodeWikiPage.load(fork.wiki_pages_current[self.current_wiki.page_name])
@@ -81,7 +81,7 @@ class TestCloneWikiPages(OsfTestCase):
         registration.wiki_pages_current = project.wiki_pages_current
         registration.save()
 
-        clone_wiki_pages([registration])
+        update_wiki_pages([registration])
         wiki_versions = registration.wiki_pages_versions[self.wiki.page_name]
 
         current_wiki = NodeWikiPage.load(registration.wiki_pages_current[self.current_wiki.page_name])

--- a/scripts/tests/test_clone_wiki_pages.py
+++ b/scripts/tests/test_clone_wiki_pages.py
@@ -1,0 +1,93 @@
+from framework.auth.core import Auth
+
+from scripts.clone_wiki_pages import clone_wiki_pages
+
+from website.addons.wiki.model import NodeWikiPage
+
+from tests.base import OsfTestCase, get_default_metaschema
+from tests.factories import NodeWikiFactory, ProjectFactory, RegistrationFactory, AuthUserFactory
+from nose.tools import *
+
+
+class TestCloneWikiPages(OsfTestCase):
+
+    def setUp(self):
+        super(TestCloneWikiPages, self).setUp()
+        self.user = AuthUserFactory()
+        self.project = ProjectFactory(creator=self.user, is_public=True)
+
+    def set_up_project_with_wiki_page(self):
+        self.project_with_wikis = ProjectFactory(creator=self.user, is_public=True)
+        self.wiki = NodeWikiFactory(node=self.project_with_wikis)
+        self.current_wiki = NodeWikiFactory(node=self.project_with_wikis, version=2, is_current=True)
+        return self.project_with_wikis
+
+    def test_project_no_wiki_pages(self):
+        clone_wiki_pages([self.project])
+        assert_equal(self.project.wiki_pages_versions, {})
+        assert_equal(self.project.wiki_pages_current, {})
+
+    def test_forked_project_no_wiki_pages(self):
+        fork = self.project.fork_node(auth=Auth(self.user))
+        clone_wiki_pages([fork])
+        assert_equal(fork.wiki_pages_versions, {})
+        assert_equal(fork.wiki_pages_current, {})
+
+    def test_registration_no_wiki_pages(self):
+        registration = RegistrationFactory()
+        clone_wiki_pages([registration])
+        assert_equal(registration.wiki_pages_versions, {})
+        assert_equal(registration.wiki_pages_current, {})
+
+    def test_project_wiki_pages_do_not_get_cloned(self):
+        project = self.set_up_project_with_wiki_page()
+        clone_wiki_pages([project])
+        assert_equal(project.wiki_pages_versions, {self.wiki.page_name: [self.wiki._id, self.current_wiki._id]})
+        assert_equal(project.wiki_pages_current, {self.current_wiki.page_name: self.current_wiki._id})
+
+    def test_forked_project_wiki_pages_created_post_fork_do_not_get_cloned(self):
+        fork_creator = AuthUserFactory()
+        fork = self.project.fork_node(auth=Auth(fork_creator))
+        wiki = NodeWikiFactory(node=fork)
+        current_wiki = NodeWikiFactory(node=fork, version=2, is_current=True)
+        clone_wiki_pages([fork])
+        assert_equal(fork.wiki_pages_versions, {wiki.page_name: [wiki._id, current_wiki._id]})
+        assert_equal(fork.wiki_pages_current, {wiki.page_name: current_wiki._id})
+
+    def test_forked_project_wiki_pages_created_pre_fork_get_cloned(self):
+        project = self.set_up_project_with_wiki_page()
+        fork = project.fork_node(auth=Auth(self.user))
+        # reset wiki pages for test
+        fork.wiki_pages_versions = project.wiki_pages_versions
+        fork.wiki_pages_current = project.wiki_pages_current
+        fork.save()
+
+        clone_wiki_pages([fork])
+        wiki_versions = fork.wiki_pages_versions[self.wiki.page_name]
+
+        current_wiki = NodeWikiPage.load(fork.wiki_pages_current[self.current_wiki.page_name])
+        assert_equal(current_wiki.node, fork)
+        assert_not_equal(current_wiki._id, self.current_wiki._id)
+
+        wiki_version = NodeWikiPage.load(wiki_versions[0])
+        assert_equal(wiki_version.node, fork)
+        assert_not_equal(wiki_version._id, self.current_wiki._id)
+
+    def test_registration_wiki_pages_created_pre_registration_get_cloned(self):
+        project = self.set_up_project_with_wiki_page()
+        registration = project.register_node(get_default_metaschema(), Auth(self.user), '', None)
+        # reset wiki pages for test
+        registration.wiki_pages_versions = project.wiki_pages_versions
+        registration.wiki_pages_current = project.wiki_pages_current
+        registration.save()
+
+        clone_wiki_pages([registration])
+        wiki_versions = registration.wiki_pages_versions[self.wiki.page_name]
+
+        current_wiki = NodeWikiPage.load(registration.wiki_pages_current[self.current_wiki.page_name])
+        assert_equal(current_wiki.node, registration)
+        assert_not_equal(current_wiki._id, self.current_wiki._id)
+
+        wiki_version = NodeWikiPage.load(wiki_versions[0])
+        assert_equal(wiki_version.node, registration)
+        assert_not_equal(wiki_version._id, self.current_wiki._id)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -367,7 +367,10 @@ class NodeWikiFactory(ModularOdmFactory):
     @post_generation
     def set_node_keys(self, create, extracted):
         self.node.wiki_pages_current[self.page_name] = self._id
-        self.node.wiki_pages_versions[self.page_name] = [self._id]
+        if self.node.wiki_pages_versions.get(self.page_name, None):
+            self.node.wiki_pages_versions[self.page_name].append(self._id)
+        else:
+            self.node.wiki_pages_versions[self.page_name] = [self._id]
         self.node.save()
 
 

--- a/website/addons/wiki/model.py
+++ b/website/addons/wiki/model.py
@@ -21,6 +21,7 @@ from website.addons.base import AddonNodeSettingsBase
 from website.addons.wiki import utils as wiki_utils
 from website.addons.wiki.settings import WIKI_CHANGE_DATE
 from website.project.commentable import Commentable
+from website.project.model import Node
 from website.project.signals import write_permissions_revoked
 
 from website.exceptions import NodeStateError
@@ -264,11 +265,14 @@ class NodeWikiPage(GuidStoredObject, Commentable):
     def to_json(self):
         return {}
 
-    def clone_wiki(self, node):
+    def clone_wiki(self, node_id):
         """Clone a node wiki page.
         :param node: The Node of the cloned wiki page
         :return: The cloned wiki page
         """
+        node = Node.load(node_id)
+        if not node:
+            raise ValueError('Invalid node')
         clone = self.clone()
         clone.node = node
         clone.user = self.user
@@ -291,7 +295,7 @@ class NodeWikiPage(GuidStoredObject, Commentable):
             copy.wiki_pages_versions[key] = []
             for wiki_id in node.wiki_pages_versions[key]:
                 node_wiki = NodeWikiPage.load(wiki_id)
-                cloned_wiki = node_wiki.clone_wiki(copy)
+                cloned_wiki = node_wiki.clone_wiki(copy._id)
                 copy.wiki_pages_versions[key].append(cloned_wiki._id)
                 if node_wiki.is_current:
                     copy.wiki_pages_current[key] = cloned_wiki._id

--- a/website/addons/wiki/model.py
+++ b/website/addons/wiki/model.py
@@ -264,6 +264,17 @@ class NodeWikiPage(GuidStoredObject, Commentable):
     def to_json(self):
         return {}
 
+    def clone_wiki(self, node):
+        """Clone a node wiki page.
+        :param node: The Node of the cloned wiki page
+        :return: The cloned wiki page
+        """
+        clone = self.clone()
+        clone.node = node
+        clone.user = self.user
+        clone.save()
+        return clone
+
     @classmethod
     def clone_wiki_versions(cls, node, copy, user, save=True):
         """Clone wiki pages for a forked or registered project.
@@ -280,13 +291,10 @@ class NodeWikiPage(GuidStoredObject, Commentable):
             copy.wiki_pages_versions[key] = []
             for wiki_id in node.wiki_pages_versions[key]:
                 node_wiki = NodeWikiPage.load(wiki_id)
-                cloned_version = node_wiki.clone()
-                cloned_version.node = copy
-                cloned_version.user = node_wiki.user
-                cloned_version.save()
-                copy.wiki_pages_versions[key].append(cloned_version._id)
+                cloned_wiki = node_wiki.clone_wiki(copy)
+                copy.wiki_pages_versions[key].append(cloned_wiki._id)
                 if node_wiki.is_current:
-                    copy.wiki_pages_current[key] = cloned_version._id
+                    copy.wiki_pages_current[key] = cloned_wiki._id
         if save:
             copy.save()
         return copy

--- a/website/addons/wiki/model.py
+++ b/website/addons/wiki/model.py
@@ -282,6 +282,7 @@ class NodeWikiPage(GuidStoredObject, Commentable):
                 node_wiki = NodeWikiPage.load(wiki_id)
                 cloned_version = node_wiki.clone()
                 cloned_version.node = copy
+                cloned_version.user = node_wiki.user
                 cloned_version.save()
                 copy.wiki_pages_versions[key].append(cloned_version._id)
                 if node_wiki.is_current:

--- a/website/addons/wiki/tests/test_wiki.py
+++ b/website/addons/wiki/tests/test_wiki.py
@@ -811,8 +811,8 @@ class TestWikiUuid(OsfTestCase):
         assert_equal(fork_res.status_code, 200)
         fork.reload()
 
-        # uuids are stored the same internally
-        assert_equal(
+        # uuids are not copied over to forks
+        assert_not_equal(
             self.project.wiki_private_uuids.get(self.wkey),
             fork.wiki_private_uuids.get(self.wkey)
         )
@@ -831,12 +831,12 @@ class TestWikiUuid(OsfTestCase):
         original_uuid = generate_private_uuid(self.project, self.wname)
         self.project.update_node_wiki(self.wname, 'Hello world', Auth(self.user))
         fork = self.project.fork_node(Auth(self.user))
-        assert_equal(original_uuid, fork.wiki_private_uuids.get(self.wkey))
+        assert_equal(fork.wiki_private_uuids.get(self.wkey), None)
 
         migrate_uuid(self.project, self.wname)
 
         assert_not_equal(original_uuid, self.project.wiki_private_uuids.get(self.wkey))
-        assert_equal(original_uuid, fork.wiki_private_uuids.get(self.wkey))
+        assert_equal(fork.wiki_private_uuids.get(self.wkey), None)
 
     @mock.patch('website.addons.wiki.utils.broadcast_to_sharejs')
     def test_uuid_persists_after_delete(self, mock_sharejs):

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2099,11 +2099,8 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
         if original.is_deleted:
             raise NodeStateError('Cannot fork deleted node.')
 
-        # Note: Cloning a node copies its `wiki_pages_current` and
-        # `wiki_pages_versions` fields, but does not clone the underlying
-        # database objects to which these dictionaries refer. This means that
-        # the cloned node must pass itself to its wiki objects to build the
-        # correct URLs to that content.
+        # Note: Cloning a node will clone each node wiki page version and add it to
+        # `registered.wiki_pages_current` and `registered.wiki_pages_versions`.
         forked = original.clone()
 
         forked.tags = self.tags
@@ -2127,6 +2124,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
         forked.creator = user
         forked.piwik_site_id = None
         forked.node_license = original.license.copy() if original.license else None
+        forked.wiki_private_uuids = {}
 
         # Forks default to private status
         forked.is_public = False
@@ -2204,11 +2202,8 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
 
         original = self.load(self._primary_key)
 
-        # Note: Cloning a node copies its `wiki_pages_current` and
-        # `wiki_pages_versions` fields, but does not clone the underlying
-        # database objects to which these dictionaries refer. This means that
-        # the cloned node must pass itself to its wiki objects to build the
-        # correct URLs to that content.
+        # Note: Cloning a node will clone each node wiki page version and add it to
+        # `registered.wiki_pages_current` and `registered.wiki_pages_versions`.
         if original.is_deleted:
             raise NodeStateError('Cannot register deleted node.')
 
@@ -2232,6 +2227,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
         registered._affiliated_institutions = self._affiliated_institutions
         registered.alternative_citations = self.alternative_citations
         registered.node_license = original.license.copy() if original.license else None
+        registered.wiki_private_uuids = {}
 
         registered.save()
 


### PR DESCRIPTION
## Purpose
When a node is forked or registered, the `wiki_pages_current` and `wiki_pages_versions` lists are copied over, but not the `NodeWikiPage` objects themselves. As a result, a fork or registration can include a wiki version where its `node` field is the original project. Because the wiki node id does not match the fork/registration id, the API throws an error when a user tries to comment on one of those wiki pages.

## Changes
When a project is forked or registered, create a copy of each wiki page in `wiki_pages_versions` and change the node to the fork or registration instead.

## Side effects
More NodeWikiPages!

Requires migration:

```
python -m scripts.clone_wiki_pages
```

## Ticket
https://openscience.atlassian.net/browse/OSF-6095
