### PR TITLE
Institutions Search

### DIFF
--- a/scripts/populate_institutions.py
+++ b/scripts/populate_institutions.py
@@ -10,6 +10,7 @@ from modularodm import Q
 from website import settings
 from website.app import init_app
 from website.models import Institution, Node
+from website.search.search import update_institution
 from framework.transactions.context import TokuTransaction
 
 logger = logging.getLogger(__name__)
@@ -31,13 +32,16 @@ def update_or_create(inst_data):
         changed_fields = inst.node.save()
         if changed_fields:
             print('Updated {}: {}'.format(inst.name, changed_fields))
+        update_institution(inst)
         return inst, False
     else:
         inst = Institution(None)
         inst_data = {inst.attribute_map[k]: v for k, v in inst_data.iteritems()}
         new_inst = Node(**inst_data)
         new_inst.save()
+        inst = Institution.load(new_inst.institution_id)
         print('Added new institution: {}'.format(new_inst.institution_id))
+        update_institution(inst)
         return new_inst, True
 
 

--- a/website/institutions/model.py
+++ b/website/institutions/model.py
@@ -87,6 +87,8 @@ class Institution(object):
         return self._id == other._id
 
     def save(self):
+        from website.search.search import update_institution
+        update_institution(self)
         for key, value in self.attribute_map.iteritems():
             if getattr(self, key) != getattr(self.node, value):
                 setattr(self.node, value, getattr(self, key))

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -3519,7 +3519,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
     @classmethod
     def find_by_institution(cls, inst, query=None):
         inst_node = inst.node
-        query = query & Q('_primary_institution', 'eq', inst_node)
+        query = query & Q('_primary_institution', 'eq', inst_node) if query else Q('_primary_institution', 'eq', inst_node)
         return cls.find(query, allow_institution=True)
 
     # Primary institution node is attached to

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -44,6 +44,7 @@ ALIASES = {
     'user': 'Users',
     'total': 'Total',
     'file': 'Files',
+    'institution': 'Institutions',
 }
 
 # Prevent tokenizing and stop word removal.
@@ -483,6 +484,20 @@ def update_file(file_, index=None, delete=False):
     )
 
 @requires_search
+def update_institution(institution, index=None):
+    index = index or INDEX
+
+    institution_doc = {
+        'id': institution._id,
+        'url': '/institutions/{}/'.format(institution._id),
+        'logo_path': institution.logo_path,
+        'category': 'institution',
+        'name': institution.name,
+    }
+
+    es.index(index=index, doc_type='institution', body=institution_doc, id=institution._id, refresh=True)
+
+@requires_search
 def delete_all():
     delete_index(INDEX)
 
@@ -498,7 +513,7 @@ def create_index(index=None):
     all of which are applied to all projects, components, and registrations.
     '''
     index = index or INDEX
-    document_types = ['project', 'component', 'registration', 'user', 'file']
+    document_types = ['project', 'component', 'registration', 'user', 'file', 'institution']
     project_like_types = ['project', 'component', 'registration']
     analyzed_fields = ['title', 'description']
 

--- a/website/search/search.py
+++ b/website/search/search.py
@@ -69,6 +69,11 @@ def update_file(file_, index=None, delete=False):
     search_engine.update_file(file_, index=index, delete=delete)
 
 @requires_search
+def update_institution(institution, index=None):
+    index = index or settings.ELASTIC_INDEX
+    search_engine.update_institution(institution, index=index)
+
+@requires_search
 def delete_all():
     search_engine.delete_all()
 

--- a/website/templates/search.mako
+++ b/website/templates/search.mako
@@ -226,6 +226,16 @@
         </div>
 
     </script>
+    <script type="text/html" id="institution">
+        <div class="row">
+            <div class="col-md-2">
+                <img class="img-circle" height="75px" width="75px" data-bind="attr: {src: logo_path}">
+            </div>
+            <div class="col-md-10">
+                <h4><a data-bind="attr: {href: url}, text: name"></a></h4>
+            </div>
+        </div>
+    </script>
     <script type="text/html" id="node">
       <!-- ko if: parent_url -->
       <h4><a data-bind="attr: {href: parent_url}, text: parent_title"></a> / <a data-bind="attr: {href: url}, text: title"></a></h4>


### PR DESCRIPTION
## Purpose

Allow institutions to be findable by search.

## Changes

### Search Specs:
 - A user can type the name of the institution ('University of Notre dame') or pieces of the name ('notre'), and that will find the institution itself, and all public nodes with that institution as its primary institution (later affiliated institution). 
 - A user can type the university id, which is often its initials, to find the institution itself. ('nd' will return Notre Dame). 
 - Searching the word 'institution' will also find all institutions.
 - There is also a filter on the left bar for Institutions.

Add an institution category and serialize them.
![screen shot 2016-04-22 at 4 33 29 pm](https://cloud.githubusercontent.com/assets/6268982/14754217/fbb1f0f6-08a7-11e6-8a2c-c2839593cd2d.png)
![screen shot 2016-04-22 at 4 33 21 pm](https://cloud.githubusercontent.com/assets/6268982/14754218/000a9108-08a8-11e6-9883-1845ca24a89a.png)


## Ticket

https://openscience.atlassian.net/browse/OSF-6085
