### PR TITLE
Populate New and Noteworthy Round Two [OSF-6049] 

### DIFF
--- a/scripts/populate_new_and_noteworthy_projects.py
+++ b/scripts/populate_new_and_noteworthy_projects.py
@@ -18,9 +18,9 @@ from website.settings import POPULAR_LINKS_NODE, NEW_AND_NOTEWORTHY_LINKS_NODE, 
 
 logger = logging.getLogger(__name__)
 
-
 def popular_activity_json():
     """ Return popular_public_projects node_ids """
+
     activity_json = activity()
     popular = activity_json['popular_public_projects']
     popular_ids = {'popular_node_ids': []}
@@ -28,13 +28,49 @@ def popular_activity_json():
         popular_ids['popular_node_ids'].append(project._id)
     return popular_ids
 
+def unique_contributors(nodes, node):
+    """ Projects in New and Noteworthy should not have common contributors """
+
+    for added_node in nodes:
+        if set(added_node['contributors']).intersection(node['contributors']) != set():
+            return False
+    return True
+
+def acceptable_title(node):
+    """ Omit projects that have certain words in the title """
+
+    omit_titles = ['test', 'photo', 'workshop', 'data']
+    if any(word in str(node['title']).lower() for word in omit_titles):
+        return False
+    return True
+
+def filter_nodes(node_list):
+    final_node_list = []
+    for node in node_list:
+        if unique_contributors(final_node_list, node) and acceptable_title(node):
+            final_node_list.append(node)
+    return final_node_list
+
 def get_new_and_noteworthy_nodes():
-    """ Fetches nodes created in the last month and returns 25 sorted by highest log activity """
+    """ Fetches new and noteworthy nodes
+
+    Mainly: public top-level projects with the greatest number of unique log actions
+
+    """
     today = datetime.datetime.now()
     last_month = (today - dateutil.relativedelta.relativedelta(months=1))
-    data = db.node.find({'date_created': {'$gt': last_month}, 'is_public': True, 'is_registration': False})
-    noteworthy_nodes = sorted(data, key=lambda node: len(node['logs']), reverse=True)[:25]
-    return [each['_id'] for each in noteworthy_nodes]
+    data = db.node.find({'date_created': {'$gt': last_month}, 'is_public': True, 'is_registration': False, 'parent_node': None,
+                         'is_deleted': False, 'is_collection': False})
+    nodes = []
+    for node in data:
+        unique_actions = len(db.nodelog.find({'node': node['_id']}).distinct('action'))
+        node['unique_actions'] = unique_actions
+        nodes.append(node)
+
+    noteworthy_nodes = sorted(nodes, key=lambda node: node.get('unique_actions'), reverse=True)[:25]
+    filtered_new_and_noteworthy = filter_nodes(noteworthy_nodes)
+
+    return [each['_id'] for each in filtered_new_and_noteworthy]
 
 def is_eligible_node(node):
     """

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -379,7 +379,7 @@ else:
         'new-and-noteworthy': {
             'task': 'scripts.populate_new_and_noteworthy_projects',
             'schedule': crontab(minute=0, hour=2, day_of_week=6),  # Saturday 2:00 a.m.
-            'kwargs': {'dry_run': True}
+            'kwargs': {'dry_run': False}
         },
         # 'usage_audit': {
         #     'task': 'scripts.osfstorage.usage_audit',


### PR DESCRIPTION
Jira https://openscience.atlassian.net/browse/OSF-6049

## Purpose

Script to populate new and noteworthy needed some work.  It ran one time and then we turned it off until we could come up with a better way to populate the list.  I've been manually populating it for the last few weeks and came up with a list of items that I thought would help better pick the projects we should highlight.

The original script just pulled recently created nodes and ordered by highest # log actions.

## Changes

This is what script is pulling:
- Highest number of unique log actions - people that are using a lot of features in the OSF
- Projects from the last month
- Top level projects (not components! not registrations!)
- Projects selected should not have common contributors
- Projects selected should not have "test", "photo", "workshop", or "data" in the title.
