### PR TITLE
Change required fields [OSF-6059]

### DIFF
--- a/website/static/js/profile.js
+++ b/website/static/js/profile.js
@@ -914,7 +914,7 @@ var JobViewModel = function() {
         trimmed: true,
         required: {
             onlyIf: function() {
-               return !!self.department() || !!self.title();
+               return !!self.department() || !!self.title() || !!self.startYear() || !!self.endYear();
             },
             message: 'Institution/Employer required'
         }
@@ -968,7 +968,7 @@ var SchoolViewModel = function() {
         trimmed: true,
         required: {
             onlyIf: function() {
-                return !!self.department() || !!self.degree();
+                return !!self.department() || !!self.degree() || !!self.startYear() || !!self.endYear();
             },
             message: 'Institution required'
         }


### PR DESCRIPTION
## Purpose

Currently, in Profile Settings, a user is able to fill out a start and end date for either an institution or employment and click 'Save' without also filling out the required institution/employer fields. A green 'Settings updated' message appears, even though upon refresh, none of the fields were actually saved.

## Changes

A user is now unable to click 'Save' when editing institutions or employment unless the required fields ('Institution' or 'Employer' respectively) are filled out. When a user tries to fill out just the start and end dates without entering the required fields and then click 'Save', a red error message appears like "Institution/employer required". This matches the current correct behavior for when a user tries to fill out a field like 'Job title' and click 'Save' without also entering the institution/employer field.

## Side effects

None that I can think of!


## Ticket

https://openscience.atlassian.net/browse/OSF-6059