### PR TITLE
Feature/APIv2 Fork Functionality [OSF-3897]

### DIFF
--- a/api/base/parsers.py
+++ b/api/base/parsers.py
@@ -52,6 +52,7 @@ class JSONAPIParser(JSONParser):
 
         relationships = resource_object.get('relationships')
         is_relationship = parser_context.get('is_relationship')
+        attributes_required = parser_context.get('attributes_required', True)
         request_method = parser_context['request'].method
 
         # Request must include "relationships" or "attributes"
@@ -59,7 +60,7 @@ class JSONAPIParser(JSONParser):
             if not relationships:
                 raise JSONAPIException(source={'pointer': '/data/relationships'}, detail=NO_RELATIONSHIPS_ERROR)
         else:
-            if "attributes" not in resource_object and request_method != 'DELETE':
+            if "attributes" not in resource_object and attributes_required and request_method != 'DELETE':
                 raise JSONAPIException(source={'pointer': '/data/attributes'}, detail=NO_ATTRIBUTES_ERROR)
 
         object_id = resource_object.get('id')

--- a/api/nodes/permissions.py
+++ b/api/nodes/permissions.py
@@ -19,6 +19,14 @@ class ContributorOrPublic(permissions.BasePermission):
             return obj.can_edit(auth)
 
 
+class IsPublic(permissions.BasePermission):
+
+    def has_object_permission(self, request, view, obj):
+        assert isinstance(obj, (Node)), 'obj must be a Node got {}'.format(obj)
+        auth = get_user_auth(request)
+        return obj.is_public or obj.can_view(auth)
+
+
 class AdminOrPublic(permissions.BasePermission):
 
     def has_object_permission(self, request, view, obj):

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -131,6 +131,11 @@ class NodeSerializer(JSONAPISerializer):
         related_view_kwargs={'node_id': '<forked_from_id>'}
     )
 
+    forks = RelationshipField(
+        related_view='nodes:node-forks',
+        related_view_kwargs={'node_id': '<pk>'}
+    )
+
     node_links = RelationshipField(
         related_view='nodes:node-pointers',
         related_view_kwargs={'node_id': '<pk>'},

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -273,6 +273,30 @@ class NodeDetailSerializer(NodeSerializer):
     id = IDField(source='_id', required=True)
 
 
+class NodeForksSerializer(NodeSerializer):
+
+    category_choices = Node.CATEGORY_MAP.items()
+    category_choices_string = ', '.join(["'{}'".format(choice[0]) for choice in category_choices])
+
+    title = ser.CharField(required=False)
+    category = ser.ChoiceField(read_only=True, choices=category_choices, help_text="Choices: " + category_choices_string)
+    forked_date = ser.DateTimeField(read_only=True)
+
+    def create(self, validated_data):
+        node = validated_data.pop('node')
+        fork_title = validated_data.pop('title', 'Fork of ')
+        request = self.context['request']
+        auth = get_user_auth(request)
+        fork = node.fork_node(auth, title=fork_title)
+
+        try:
+            fork.save()
+        except ValidationValueError as e:
+            raise InvalidModelValueError(detail=e.message)
+
+        return fork
+
+
 class NodeContributorsSerializer(JSONAPISerializer):
     """ Separate from UserSerializer due to necessity to override almost every field as read only
     """

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -127,7 +127,7 @@ class NodeSerializer(JSONAPISerializer):
     )
 
     forked_from = RelationshipField(
-        related_view='nodes:node-detail',
+        related_view=lambda n: 'registrations:registration-detail' if getattr(n, 'is_registration', False) else 'nodes:node-detail',
         related_view_kwargs={'node_id': '<forked_from_id>'}
     )
 

--- a/api/nodes/urls.py
+++ b/api/nodes/urls.py
@@ -12,6 +12,7 @@ urlpatterns = [
     url(r'^(?P<node_id>\w+)/contributors/$', views.NodeContributorsList.as_view(), name=views.NodeContributorsList.view_name),
     url(r'^(?P<node_id>\w+)/contributors/(?P<user_id>\w+)/$', views.NodeContributorDetail.as_view(), name=views.NodeContributorDetail.view_name),
     url(r'^(?P<node_id>\w+)/children/$', views.NodeChildrenList.as_view(), name=views.NodeChildrenList.view_name),
+    url(r'^(?P<node_id>\w+)/forks/$', views.NodeForksList.as_view(), name=views.NodeForksList.view_name),
     url(r'^(?P<node_id>\w+)/files/$', views.NodeProvidersList.as_view(), name=views.NodeProvidersList.view_name),
     url(r'^(?P<node_id>\w+)/files/providers/(?P<provider>\w+)/?$', views.NodeProviderDetail.as_view(), name=views.NodeProviderDetail.view_name),
     url(r'^(?P<node_id>\w+)/files/(?P<provider>\w+)(?P<path>/(?:.*/)?)$', views.NodeFilesList.as_view(), name=views.NodeFilesList.view_name),

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -21,6 +21,7 @@ from api.users.views import UserMixin
 from api.nodes.serializers import (
     NodeSerializer,
     NodeLinksSerializer,
+    NodeForksSerializer,
     NodeDetailSerializer,
     NodeProviderSerializer,
     NodeContributorsSerializer,
@@ -1068,6 +1069,109 @@ class NodeLinksDetail(JSONAPIBaseView, generics.RetrieveDestroyAPIView, NodeMixi
         except ValueError as err:  # pointer doesn't belong to node
             raise NotFound(err.message)
         node.save()
+
+
+class NodeForksList(JSONAPIBaseView, generics.ListCreateAPIView, NodeMixin, ODMFilterMixin):
+    """Forks of the current node. *Writeable*.
+
+    Paginated list of the current node's forks ordered by their `forked_date`. Forks are copies of projects that you can
+    change without affecting the original project.  When creating a fork, your fork will will only contain public components or those
+    for which you are a contributor.  Private components that you do not have access to will not be forked.
+
+    ##Node Fork Attributes
+
+    <!--- Copied Attributes from NodeDetail with exception of forked_date-->
+
+    OSF Node Fork entities have the "nodes" `type`.
+
+        name                        type               description
+        =================================================================================
+        title                       string             title of project or component
+        description                 string             description of the node
+        category                    string             node category, must be one of the allowed values
+        date_created                iso8601 timestamp  timestamp that the node was created
+        date_modified               iso8601 timestamp  timestamp when the node was last updated
+        tags                        array of strings   list of tags that describe the node
+        registration                boolean            has this project been registered? (always False)
+        collection                  boolean            is this node a collection (always False)
+        fork                        boolean            is this node a fork of another node? (always True)
+        public                      boolean            has this node been made publicly-visible?
+        forked_date                 iso8601 timestamp  timestamp when the node was forked
+        current_user_permissions    array of strings   List of strings representing the permissions for the current user on this node
+
+    ##Links
+
+    See the [JSON-API spec regarding pagination](http://jsonapi.org/format/1.0/#fetching-pagination).
+
+    ##Actions
+
+    ###Create Node Fork
+
+        Method:        POST
+        URL:           /links/self
+        Query Params:  <none>
+        Body (JSON): {
+                         "data": {
+                           "type": "nodes", # required
+                           "attributes": {
+                             "title": {title} # optional
+                           }
+                         }
+                    }
+        Success: 201 CREATED + node representation
+
+    To create a fork of the current node, issue a POST request to this endpoint.  The `title` field is optional, with the
+    default title being 'Fork of ' + the current node's title. If the fork's creation is successful the API will return a
+    201 response with the representation of the forked node in the body. For the new fork's canonical URL, see the `/links/self`
+    field of the response.
+
+    ##Query Params
+
+    + `page=<Int>` -- page number of results to view, default 1
+
+    + `filter[<fieldname>]=<Str>` -- fields and values to filter the search results on.
+
+    <!--- Copied Query Params from NodeList -->
+
+    Nodes may be filtered by their `title`, `category`, `description`, `public`, `registration`, `tags`, `date_created`,
+    `date_modified`, `root`, `parent`, and `contributors`. Most are string fields and will be filtered using simple
+    substring matching.  Others are booleans, and can be filtered using truthy values, such as `true`, `false`, `0`, or `1`.
+    Note that quoting `true` or `false` in the query will cause the match to fail regardless. `tags` is an array of simple strings.
+
+    #This Request/Response
+    """
+    permission_classes = (
+        IsPublic,
+        drf_permissions.IsAuthenticatedOrReadOnly,
+        base_permissions.TokenHasScope,
+        ExcludeRetractions
+    )
+
+    required_read_scopes = [CoreScopes.NODE_FORKS_READ]
+    required_write_scopes = [CoreScopes.NODE_FORKS_WRITE]
+
+    serializer_class = NodeForksSerializer
+    view_category = 'nodes'
+    view_name = 'node-forks'
+
+     # overrides ListCreateAPIView
+    def get_queryset(self):
+        all_forks = self.get_node().forks
+        auth = get_user_auth(self.request)
+        return sorted([node for node in all_forks if node.can_view(auth)], key=lambda n: n.forked_date, reverse=True)
+
+    # overrides ListCreateAPIView
+    def perform_create(self, serializer):
+        serializer.save(node=self.get_node())
+
+    # overrides ListCreateAPIView
+    def get_parser_context(self, http_request):
+        """
+        Tells parser that attributes are not required in request
+        """
+        res = super(NodeForksList, self).get_parser_context(http_request)
+        res['attributes_required'] = False
+        return res
 
 
 class NodeFilesList(JSONAPIBaseView, generics.ListAPIView, WaterButlerMixin, ListFilterMixin, NodeMixin):

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1154,7 +1154,7 @@ class NodeForksList(JSONAPIBaseView, generics.ListCreateAPIView, NodeMixin, ODMF
     view_category = 'nodes'
     view_name = 'node-forks'
 
-     # overrides ListCreateAPIView
+    # overrides ListCreateAPIView
     def get_queryset(self):
         all_forks = self.get_node().forks
         auth = get_user_auth(self.request)

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -34,6 +34,7 @@ from api.nodes.utils import get_file_object
 from api.registrations.serializers import RegistrationSerializer
 from api.institutions.serializers import InstitutionSerializer
 from api.nodes.permissions import (
+    IsPublic,
     AdminOrPublic,
     ContributorOrPublic,
     ContributorOrPublicForPointers,

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -67,6 +67,11 @@ class RegistrationSerializer(NodeSerializer):
         related_view_kwargs={'node_id': '<forked_from_id>'}
     ))
 
+    forks = HideIfRetraction(RelationshipField(
+        related_view='registrations:registration-forks',
+        related_view_kwargs={'node_id': '<pk>'}
+    ))
+
     node_links = HideIfRetraction(RelationshipField(
         related_view='registrations:registration-pointers',
         related_view_kwargs={'node_id': '<pk>'},

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -63,7 +63,7 @@ class RegistrationSerializer(NodeSerializer):
     ))
 
     forked_from = HideIfRetraction(RelationshipField(
-        related_view='nodes:node-detail',
+        related_view=lambda n: 'registrations:registration-detail' if getattr(n, 'is_registration', False) else 'nodes:node-detail',
         related_view_kwargs={'node_id': '<forked_from_id>'}
     ))
 

--- a/api/registrations/urls.py
+++ b/api/registrations/urls.py
@@ -13,6 +13,7 @@ urlpatterns = [
     url(r'^(?P<node_id>\w+)/contributors/$', views.RegistrationContributorsList.as_view(), name=views.RegistrationContributorsList.view_name),
     url(r'^(?P<node_id>\w+)/contributors/(?P<user_id>\w+)/$', views.RegistrationContributorDetail.as_view(), name=views.RegistrationContributorDetail.view_name),
     url(r'^(?P<node_id>\w+)/children/$', views.RegistrationChildrenList.as_view(), name=views.RegistrationChildrenList.view_name),
+    url(r'^(?P<node_id>\w+)/forks/$', views.RegistrationForksList.as_view(), name=views.RegistrationForksList.view_name),
     url(r'^(?P<node_id>\w+)/files/$', views.RegistrationProvidersList.as_view(), name=views.RegistrationProvidersList.view_name),
     url(r'^(?P<node_id>\w+)/files/(?P<provider>\w+)(?P<path>/(?:.*/)?)$', views.RegistrationFilesList.as_view(), name=views.RegistrationFilesList.view_name),
     url(r'^(?P<node_id>\w+)/files/(?P<provider>\w+)(?P<path>/.+[^/])$', views.RegistrationFileDetail.as_view(), name=views.RegistrationFileDetail.view_name),

--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -18,7 +18,7 @@ from api.nodes.views import (
     NodeChildrenList, NodeCommentsList, NodeProvidersList, NodeLinksList,
     NodeContributorDetail, NodeFilesList, NodeLinksDetail, NodeFileDetail,
     NodeAlternativeCitationsList, NodeAlternativeCitationDetail, NodeLogList,
-    NodeInstitutionDetail, WaterButlerMixin)
+    NodeInstitutionDetail, WaterButlerMixin, NodeForksList)
 
 from api.registrations.serializers import RegistrationNodeLinksSerializer, RegistrationFileSerializer
 
@@ -275,6 +275,9 @@ class RegistrationChildrenList(NodeChildrenList, RegistrationMixin):
         query = base_query & permission_query
         return query
 
+class RegistrationForksList(NodeForksList, RegistrationMixin):
+    view_category = 'registrations'
+    view_name = 'registration-forks'
 
 class RegistrationCommentsList(NodeCommentsList, RegistrationMixin):
     view_category = 'registrations'

--- a/api_tests/nodes/views/test_node_forks_list.py
+++ b/api_tests/nodes/views/test_node_forks_list.py
@@ -202,7 +202,7 @@ class TestNodeForkCreate(ApiTestCase):
         assert_equal(res.json['errors'][0]['detail'], 'You do not have permission to perform this action.')
 
     def test_can_fork_private_node_logged_in_contributor(self):
-        res = self.app.post_json_api(self.private_project_url + '?embed=children&embed=node_links&embed=logs&embed=contributors&embed=forked_from', self.fork_data, auth=self.user.auth, expect_errors=True)
+        res = self.app.post_json_api(self.private_project_url + '?embed=children&embed=node_links&embed=logs&embed=contributors&embed=forked_from', self.fork_data, auth=self.user.auth)
         assert_equal(res.status_code, 201)
 
         data = res.json['data']

--- a/api_tests/nodes/views/test_node_forks_list.py
+++ b/api_tests/nodes/views/test_node_forks_list.py
@@ -1,0 +1,278 @@
+from nose.tools import *  # flake8: noqa
+
+from framework.auth.core import Auth
+
+from website.models import Node
+from website.util import permissions
+
+from api.base.settings.defaults import API_BASE
+
+from tests.base import ApiTestCase
+from tests.factories import (
+    NodeFactory,
+    ProjectFactory,
+    RegistrationFactory,
+    AuthUserFactory,
+    ForkFactory
+)
+
+
+class TestNodeForksList(ApiTestCase):
+    def setUp(self):
+        super(TestNodeForksList, self).setUp()
+        self.user = AuthUserFactory()
+        self.private_project = ProjectFactory()
+        self.private_project.add_contributor(self.user, permissions=[permissions.READ, permissions.WRITE])
+        self.private_project.save()
+        self.component = NodeFactory(parent=self.private_project, creator=self.user)
+        self.pointer = ProjectFactory(creator=self.user)
+        self.private_project.add_pointer(self.pointer, auth=Auth(self.user), save=True)
+        self.private_fork = ForkFactory(project=self.private_project, user=self.user)
+        self.private_project_url = '/{}nodes/{}/forks/'.format(API_BASE, self.private_project._id)
+
+        self.public_project = ProjectFactory(is_public=True, creator=self.user)
+        self.public_project.save()
+        self.public_component = NodeFactory(parent=self.public_project, creator=self.user, is_public=True)
+        self.public_project_url = '/{}nodes/{}/forks/'.format(API_BASE, self.public_project._id)
+        self.public_fork = ForkFactory(project=self.public_project, user=self.user)
+        self.user_two = AuthUserFactory()
+
+    def test_can_access_public_node_forks_list_when_unauthenticated(self):
+        res = self.app.get(self.public_project_url)
+        assert_equal(res.status_code, 200)
+        assert_equal(len(res.json['data']), 0)
+        # Fork defaults to private
+        assert_equal(self.public_fork.is_public, False)
+
+        self.public_fork.is_public = True
+        self.public_fork.save()
+
+        res = self.app.get(self.public_project_url)
+        assert_equal(len(res.json['data']), 1)
+        assert_equal(self.public_fork.is_public, True)
+        data = res.json['data'][0]
+        assert_equal(data['attributes']['title'], 'Fork of ' + self.public_project.title)
+        assert_equal(data['id'], self.public_fork._id)
+        assert_equal(data['attributes']['registration'], False)
+        assert_equal(data['attributes']['fork'], True)
+
+    def test_can_access_public_node_forks_list_authenticated_contributor(self):
+        res = self.app.get(self.public_project_url, auth=self.user.auth)
+        assert_equal(res.status_code, 200)
+        assert_equal(self.public_fork.is_public, False)
+        assert_equal(len(res.json['data']), 1)
+        data = res.json['data'][0]
+        assert_equal(data['attributes']['title'], 'Fork of ' + self.public_project.title)
+        assert_equal(data['id'], self.public_fork._id)
+        assert_equal(data['attributes']['registration'], False)
+        assert_equal(data['attributes']['fork'], True)
+
+    def test_can_access_public_node_forks_list_authenticated_non_contributor(self):
+        res = self.app.get(self.public_project_url, auth=self.user_two.auth)
+        assert_equal(res.status_code, 200)
+        assert_equal(len(res.json['data']), 0)
+        # Fork defaults to private
+        assert_equal(self.public_fork.is_public, False)
+
+        self.public_fork.is_public = True
+        self.public_fork.save()
+
+        res = self.app.get(self.public_project_url)
+        assert_equal(len(res.json['data']), 1)
+        assert_equal(self.public_fork.is_public, True)
+        data = res.json['data'][0]
+        assert_equal(data['attributes']['title'], 'Fork of ' + self.public_project.title)
+        assert_equal(data['id'], self.public_fork._id)
+        assert_equal(data['attributes']['registration'], False)
+        assert_equal(data['attributes']['fork'], True)
+
+    def test_cannot_access_private_node_forks_list_unauthenticated(self):
+        res = self.app.get(self.private_project_url, expect_errors=True)
+
+        assert_equal(res.status_code, 401)
+        assert_equal(res.json['errors'][0]['detail'], 'Authentication credentials were not provided.')
+
+    def test_authenticated_contributor_can_access_private_node_forks_list(self):
+        res = self.app.get(self.private_project_url + '?embed=children&embed=node_links&embed=logs&embed=contributors&embed=forked_from', auth=self.user.auth)
+        assert_equal(res.status_code, 200)
+        assert_equal(len(res.json['data']), 1)
+        data = res.json['data'][0]
+        assert_equal(data['attributes']['title'], 'Fork of ' + self.private_project.title)
+        assert_equal(data['id'], self.private_fork._id)
+
+        fork_contributors = data['embeds']['contributors']['data'][0]['embeds']['users']['data']
+        assert_equal(fork_contributors['attributes']['family_name'], self.user.family_name)
+        assert_equal(fork_contributors['id'], self.user._id)
+
+        forked_children = data['embeds']['children']['data'][0]
+        assert_equal(forked_children['id'], self.component.forks[0]._id)
+        assert_equal(forked_children['attributes']['title'], self.component.title)
+
+        forked_node_links = data['embeds']['node_links']['data'][0]['embeds']['target_node']['data']
+        assert_equal(forked_node_links['id'], self.pointer._id)
+        assert_equal(forked_node_links['attributes']['title'], self.pointer.title)
+
+        expected_logs = [log.action for log in self.private_project.logs]
+        expected_logs.append(self.component.logs[0].action)
+        expected_logs.append('node_forked')
+        expected_logs.append('node_forked')
+
+        forked_logs = data['embeds']['logs']['data']
+        assert_equal(set(expected_logs), set(log['attributes']['action'] for log in forked_logs))
+        assert_equal(len(forked_logs), 6)
+
+        forked_from = data['embeds']['forked_from']['data']
+        assert_equal(forked_from['id'], self.private_project._id)
+
+    def test_authenticated_non_contributor_cannot_access_private_node_forks_list(self):
+        res = self.app.get(self.private_project_url, auth=self.user_two.auth, expect_errors=True)
+        assert_equal(res.status_code, 403)
+        assert_equal(res.json['errors'][0]['detail'], 'You do not have permission to perform this action.')
+
+
+class TestNodeForkCreate(ApiTestCase):
+
+    def setUp(self):
+        super(TestNodeForkCreate, self).setUp()
+        self.user = AuthUserFactory()
+        self.user_two = AuthUserFactory()
+        self.user_three = AuthUserFactory()
+        self.private_project = ProjectFactory(creator=self.user)
+
+        self.fork_data = {
+            'data': {
+                'type': 'nodes'
+            }
+        }
+
+        self.fork_data_with_title = {
+            'data': {
+                'type': 'nodes',
+                'attributes':
+                    {'title': 'My Forked Project'}
+            }
+        }
+
+        self.private_project_url = '/{}nodes/{}/forks/'.format(API_BASE, self.private_project._id)
+
+        self.public_project = ProjectFactory(is_public=True, creator=self.user)
+        self.public_project_url = '/{}nodes/{}/forks/'.format(API_BASE, self.public_project._id)
+
+    def tearDown(self):
+        super(TestNodeForkCreate, self).tearDown()
+        Node.remove()
+
+    def test_create_fork_from_public_project_with_new_title(self):
+        res = self.app.post_json_api(self.public_project_url, self.fork_data_with_title, auth=self.user.auth)
+        assert_equal(res.status_code, 201)
+        assert_equal(res.json['data']['id'], self.public_project.forks[0]._id)
+        assert_equal(res.json['data']['attributes']['title'], self.fork_data_with_title['data']['attributes']['title'])
+
+    def test_create_fork_from_private_project_with_new_title(self):
+        res = self.app.post_json_api(self.private_project_url, self.fork_data_with_title, auth=self.user.auth)
+        assert_equal(res.status_code, 201)
+        assert_equal(res.json['data']['id'], self.private_project.forks[0]._id)
+        assert_equal(res.json['data']['attributes']['title'], self.fork_data_with_title['data']['attributes']['title'])
+
+    def test_can_fork_public_node_logged_in(self):
+        res = self.app.post_json_api(self.public_project_url, self.fork_data, auth=self.user_two.auth)
+        assert_equal(res.status_code, 201)
+        assert_equal(res.json['data']['id'], self.public_project.forks[0]._id)
+        assert_equal(res.json['data']['attributes']['title'], 'Fork of ' + self.public_project.title)
+
+    def test_cannot_fork_public_node_logged_out(self):
+        res = self.app.post_json_api(self.public_project_url, self.fork_data, expect_errors=True)
+        assert_equal(res.status_code, 401)
+        assert_equal(res.json['errors'][0]['detail'], 'Authentication credentials were not provided.')
+
+    def test_can_fork_public_node_logged_in_contributor(self):
+        res = self.app.post_json_api(self.public_project_url, self.fork_data, auth=self.user.auth)
+        assert_equal(res.status_code, 201)
+        assert_equal(res.json['data']['id'], self.public_project.forks[0]._id)
+        assert_equal(res.json['data']['attributes']['title'], 'Fork of ' + self.public_project.title)
+
+    def test_cannot_fork_private_node_logged_out(self):
+        res = self.app.post_json_api(self.private_project_url, self.fork_data, expect_errors=True)
+        assert_equal(res.status_code, 401)
+        assert_equal(res.json['errors'][0]['detail'], 'Authentication credentials were not provided.')
+
+    def test_cannot_fork_private_node_logged_in_non_contributor(self):
+        res = self.app.post_json_api(self.private_project_url, self.fork_data, auth=self.user_two.auth, expect_errors=True)
+        assert_equal(res.status_code, 403)
+        assert_equal(res.json['errors'][0]['detail'], 'You do not have permission to perform this action.')
+
+    def test_can_fork_private_node_logged_in_contributor(self):
+        res = self.app.post_json_api(self.private_project_url + '?embed=children&embed=node_links&embed=logs&embed=contributors&embed=forked_from', self.fork_data, auth=self.user.auth, expect_errors=True)
+        assert_equal(res.status_code, 201)
+
+        data = res.json['data']
+        assert_equal(data['attributes']['title'], 'Fork of ' + self.private_project.title)
+
+        fork_contributors = data['embeds']['contributors']['data'][0]['embeds']['users']['data']
+        assert_equal(fork_contributors['attributes']['family_name'], self.user.family_name)
+        assert_equal(fork_contributors['id'], self.user._id)
+
+        forked_from = data['embeds']['forked_from']['data']
+        assert_equal(forked_from['id'], self.private_project._id)
+
+    def test_fork_private_components_no_access(self):
+        url = self.public_project_url + '?embed=children'
+        private_component = NodeFactory(parent=self.public_project, creator=self.user_two, is_public=False)
+        res = self.app.post_json_api(url, self.fork_data, auth=self.user_three.auth)
+        assert_equal(res.status_code, 201)
+        # Private components that you do not have access to are not forked
+        assert_equal(res.json['data']['embeds']['children']['links']['meta']['total'], 0)
+
+    def test_fork_components_you_can_access(self):
+        url = self.private_project_url + '?embed=children'
+        new_component = NodeFactory(parent=self.private_project, creator=self.user)
+        res = self.app.post_json_api(url, self.fork_data, auth=self.user.auth)
+        assert_equal(res.status_code, 201)
+        assert_equal(res.json['data']['embeds']['children']['links']['meta']['total'], 1)
+        assert_equal(res.json['data']['embeds']['children']['data'][0]['id'], new_component.forks[0]._id)
+
+    def test_fork_private_node_links(self):
+        private_pointer = ProjectFactory(creator=self.user_two)
+        actual_pointer = self.private_project.add_pointer(private_pointer, auth=Auth(self.user_two), save=True)
+
+        url = self.private_project_url + '?embed=node_links'
+
+        # Node link is forked, but shows up as a private node link
+        res = self.app.post_json_api(url, self.fork_data, auth=self.user.auth)
+        assert_equal(res.status_code, 201)
+
+        assert_equal(res.json['data']['embeds']['node_links']['data'][0]['embeds']['target_node']['errors'][0]['detail'],
+                     'You do not have permission to perform this action.')
+        assert_equal(res.json['data']['embeds']['node_links']['links']['meta']['total'], 1)
+
+        self.private_project.rm_pointer(actual_pointer, auth=Auth(self.user_two))
+
+    def test_fork_node_links_you_can_access(self):
+        pointer = ProjectFactory(creator=self.user)
+        self.private_project.add_pointer(pointer, auth=Auth(self.user_two), save=True)
+
+        url = self.private_project_url + '?embed=node_links'
+
+        res = self.app.post_json_api(url, self.fork_data, auth=self.user.auth)
+        assert_equal(res.status_code, 201)
+
+        assert_equal(res.json['data']['embeds']['node_links']['data'][0]['embeds']['target_node']['data']['id'], pointer._id)
+        assert_equal(res.json['data']['embeds']['node_links']['links']['meta']['total'], 1)
+
+    def test_can_fork_registration(self):
+        registration = RegistrationFactory(project=self.private_project, user=self.user)
+
+        url = '/{}registrations/{}/forks/'.format(API_BASE, registration._id)
+        res = self.app.post_json_api(url, self.fork_data, auth=self.user.auth)
+        assert_equal(res.status_code, 201)
+        assert_equal(res.json['data']['id'], registration.forks[0]._id)
+        assert_equal(res.json['data']['attributes']['title'], 'Fork of ' + registration.title)
+
+    def test_read_only_contributor_can_fork_private_registration(self):
+        read_only_user = AuthUserFactory()
+
+        self.private_project.add_contributor(read_only_user, permissions=[permissions.READ], save=True)
+        res = self.app.post_json_api(self.private_project_url, self.fork_data, auth=read_only_user.auth)
+        assert_equal(res.status_code, 201)
+        assert_equal(res.json['data']['id'], self.private_project.forks[0]._id)
+        assert_equal(res.json['data']['attributes']['title'], 'Fork of ' + self.private_project.title)

--- a/api_tests/registrations/views/test_registration_forks.py
+++ b/api_tests/registrations/views/test_registration_forks.py
@@ -287,9 +287,3 @@ class TestRegistrationForkCreate(ApiTestCase):
 
         res = self.app.post_json_api(url, self.fork_data, auth=self.user.auth, expect_errors=True)
         assert_equal(res.status_code, 403)
-
-
-
-
-
-

--- a/api_tests/registrations/views/test_registration_forks.py
+++ b/api_tests/registrations/views/test_registration_forks.py
@@ -228,7 +228,7 @@ class TestRegistrationForkCreate(ApiTestCase):
         assert_equal(res.json['errors'][0]['detail'], 'You do not have permission to perform this action.')
 
     def test_can_fork_private_registration_logged_in_contributor(self):
-        res = self.app.post_json_api(self.private_registration_url + '?embed=children&embed=node_links&embed=logs&embed=contributors&embed=forked_from', self.fork_data, auth=self.user.auth, expect_errors=True)
+        res = self.app.post_json_api(self.private_registration_url + '?embed=children&embed=node_links&embed=logs&embed=contributors&embed=forked_from', self.fork_data, auth=self.user.auth)
         assert_equal(res.status_code, 201)
 
         data = res.json['data']

--- a/api_tests/registrations/views/test_registration_forks.py
+++ b/api_tests/registrations/views/test_registration_forks.py
@@ -1,0 +1,295 @@
+from nose.tools import *  # flake8: noqa
+
+from framework.auth.core import Auth
+
+from website.models import Node
+from website.util import permissions
+
+from api.base.settings.defaults import API_BASE
+
+from tests.base import ApiTestCase
+from tests.factories import (
+    NodeFactory,
+    ProjectFactory,
+    RegistrationFactory,
+    AuthUserFactory,
+    RetractedRegistrationFactory,
+    ForkFactory
+)
+
+
+class TestRegistrationForksList(ApiTestCase):
+    def setUp(self):
+        super(TestRegistrationForksList, self).setUp()
+        self.user = AuthUserFactory()
+        self.private_project = ProjectFactory()
+        self.private_project.add_contributor(self.user, permissions=[permissions.READ, permissions.WRITE])
+        self.private_project.save()
+        self.component = NodeFactory(parent=self.private_project, creator=self.user)
+        self.pointer = ProjectFactory(creator=self.user)
+        self.private_project.add_pointer(self.pointer, auth=Auth(self.user), save=True)
+        self.private_registration = RegistrationFactory(project = self.private_project, creator=self.user)
+        self.private_fork = ForkFactory(project=self.private_registration, user=self.user)
+        self.private_registration_url = '/{}registrations/{}/forks/'.format(API_BASE, self.private_registration._id)
+
+        self.public_project = ProjectFactory(is_public=True, creator=self.user)
+        self.public_project.save()
+        self.public_component = NodeFactory(parent=self.public_project, creator=self.user, is_public=True)
+        self.public_registration = RegistrationFactory(project = self.public_project, creator=self.user, is_public=True)
+
+        self.public_registration_url = '/{}registrations/{}/forks/'.format(API_BASE, self.public_registration._id)
+        self.public_fork = ForkFactory(project=self.public_registration, user=self.user)
+        self.user_two = AuthUserFactory()
+
+    def test_can_access_public_registration_forks_list_when_unauthenticated(self):
+        res = self.app.get(self.public_registration_url)
+        assert_equal(len(res.json['data']), 0)
+        # Fork defaults to private
+        assert_equal(self.public_fork.is_public, False)
+
+        self.public_fork.is_public = True
+        self.public_fork.save()
+
+        res = self.app.get(self.public_registration_url)
+        assert_equal(res.status_code, 200)
+        assert_equal(len(res.json['data']), 1)
+        assert_equal(self.public_fork.is_public, True)
+        data = res.json['data'][0]
+        assert_equal(data['attributes']['title'], 'Fork of ' + self.public_registration.title)
+        assert_equal(data['id'], self.public_fork._id)
+        assert_equal(data['attributes']['registration'], False)
+        assert_equal(data['attributes']['fork'], True)
+
+    def test_can_access_public_registration_forks_list_authenticated_contributor(self):
+        res = self.app.get(self.public_registration_url, auth=self.user.auth)
+        assert_equal(res.status_code, 200)
+
+        assert_equal(self.public_fork.is_public, False)
+        assert_equal(len(res.json['data']), 1)
+        data = res.json['data'][0]
+        assert_equal(data['attributes']['title'], 'Fork of ' + self.public_project.title)
+        assert_equal(data['id'], self.public_fork._id)
+        assert_equal(data['attributes']['registration'], False)
+        assert_equal(data['attributes']['fork'], True)
+
+    def test_can_access_public_registration_forks_list_authenticated_non_contributor(self):
+        res = self.app.get(self.public_registration_url, auth=self.user_two.auth)
+        assert_equal(res.status_code, 200)
+
+        assert_equal(len(res.json['data']), 0)
+        # Fork defaults to private
+        assert_equal(self.public_fork.is_public, False)
+
+        self.public_fork.is_public = True
+        self.public_fork.save()
+
+        res = self.app.get(self.public_registration_url)
+        assert_equal(len(res.json['data']), 1)
+        assert_equal(self.public_fork.is_public, True)
+        data = res.json['data'][0]
+        assert_equal(data['attributes']['title'], 'Fork of ' + self.public_project.title)
+        assert_equal(data['id'], self.public_fork._id)
+        assert_equal(data['attributes']['registration'], False)
+        assert_equal(data['attributes']['fork'], True)
+
+    def test_cannot_access_private_registration_forks_list_unauthenticated(self):
+        res = self.app.get(self.private_registration_url, expect_errors=True)
+        assert_equal(res.status_code, 401)
+        assert_equal(res.json['errors'][0]['detail'], 'Authentication credentials were not provided.')
+
+    def test_authenticated_contributor_can_access_private_registration_forks_list(self):
+        res = self.app.get(self.private_registration_url + '?embed=children&embed=node_links&embed=logs&embed=contributors&embed=forked_from', auth=self.user.auth)
+        assert_equal(res.status_code, 200)
+        assert_equal(len(res.json['data']), 1)
+        data = res.json['data'][0]
+        assert_equal(data['attributes']['title'], 'Fork of ' + self.private_project.title)
+        assert_equal(data['id'], self.private_fork._id)
+
+        fork_contributors = data['embeds']['contributors']['data'][0]['embeds']['users']['data']
+        assert_equal(fork_contributors['attributes']['family_name'], self.user.family_name)
+        assert_equal(fork_contributors['id'], self.user._id)
+
+        forked_children = data['embeds']['children']['data'][0]
+        assert_equal(forked_children['id'], self.private_registration.nodes[0].forks[0]._id)
+        assert_equal(forked_children['attributes']['title'], self.component.title)
+
+        forked_node_links = data['embeds']['node_links']['data'][0]['embeds']['target_node']['data']
+        assert_equal(forked_node_links['id'], self.pointer._id)
+        assert_equal(forked_node_links['attributes']['title'], self.pointer.title)
+        assert_equal(data['attributes']['registration'], False)
+        assert_equal(data['attributes']['fork'], True)
+
+        expected_logs = [log.action for log in self.private_registration.logs]
+        expected_logs.append(self.private_registration.nodes[0].logs[0].action)
+        expected_logs.append('node_forked')
+        expected_logs.append('node_forked')
+
+        forked_logs = data['embeds']['logs']['data']
+        assert_equal(set(expected_logs), set(log['attributes']['action'] for log in forked_logs))
+        assert_equal(len(forked_logs), 6)
+
+        forked_from = data['embeds']['forked_from']['data']
+        assert_equal(forked_from['id'], self.private_registration._id)
+
+    def test_authenticated_non_contributor_cannot_access_private_registration_forks_list(self):
+        res = self.app.get(self.private_registration_url, auth=self.user_two.auth, expect_errors=True)
+        assert_equal(res.status_code, 403)
+        assert_equal(res.json['errors'][0]['detail'], 'You do not have permission to perform this action.')
+
+
+class TestRegistrationForkCreate(ApiTestCase):
+
+    def setUp(self):
+        super(TestRegistrationForkCreate, self).setUp()
+        self.user = AuthUserFactory()
+        self.user_two = AuthUserFactory()
+        self.user_three = AuthUserFactory()
+        self.private_project = ProjectFactory(creator=self.user)
+
+        private_pointer = ProjectFactory(creator=self.user_two)
+        actual_pointer = self.private_project.add_pointer(private_pointer, auth=Auth(self.user_two), save=True)
+
+        self.private_registration = RegistrationFactory(creator=self.user, project=self.private_project)
+
+        self.fork_data = {
+            'data': {
+                'type': 'nodes'
+            }
+        }
+
+        self.fork_data_with_title = {
+            'data': {
+                'type': 'nodes',
+                'attributes':
+                    {'title': 'My Forked Project'}
+            }
+        }
+
+        self.private_registration_url = '/{}registrations/{}/forks/'.format(API_BASE, self.private_registration._id)
+
+
+        self.public_project = ProjectFactory(is_public=True, creator=self.user)
+        self.public_registration = RegistrationFactory(creator=self.user, project=self.public_project, is_public=True)
+        self.public_registration_url = '/{}registrations/{}/forks/'.format(API_BASE, self.public_registration._id)
+
+    def tearDown(self):
+        super(TestRegistrationForkCreate, self).tearDown()
+        Node.remove()
+
+    def test_create_fork_from_public_registration_with_new_title(self):
+        res = self.app.post_json_api(self.public_registration_url, self.fork_data_with_title, auth=self.user.auth)
+        assert_equal(res.status_code, 201)
+        data = res.json['data']
+        assert_equal(data['id'], self.public_registration.forks[0]._id)
+        assert_equal(data['attributes']['title'], self.fork_data_with_title['data']['attributes']['title'])
+        assert_equal(data['attributes']['registration'], False)
+        assert_equal(data['attributes']['fork'], True)
+
+    def test_create_fork_from_private_registration_with_new_title(self):
+        res = self.app.post_json_api(self.private_registration_url, self.fork_data_with_title, auth=self.user.auth)
+        assert_equal(res.status_code, 201)
+        data = res.json['data']
+        assert_equal(data['id'], self.private_registration.forks[0]._id)
+        assert_equal(data['attributes']['title'], self.fork_data_with_title['data']['attributes']['title'])
+        assert_equal(data['attributes']['registration'], False)
+        assert_equal(data['attributes']['fork'], True)
+
+    def test_can_fork_public_registration_logged_in(self):
+        res = self.app.post_json_api(self.public_registration_url, self.fork_data, auth=self.user_two.auth)
+        assert_equal(res.status_code, 201)
+        data = res.json['data']
+        assert_equal(data['id'], self.public_registration.forks[0]._id)
+        assert_equal(data['attributes']['title'], 'Fork of ' + self.public_registration.title)
+        assert_equal(data['attributes']['registration'], False)
+        assert_equal(data['attributes']['fork'], True)
+
+    def test_cannot_fork_public_registration_logged_out(self):
+        res = self.app.post_json_api(self.public_registration_url, self.fork_data, expect_errors=True)
+        assert_equal(res.status_code, 401)
+        assert_equal(res.json['errors'][0]['detail'], 'Authentication credentials were not provided.')
+
+    def test_can_fork_public_registration_logged_in_contributor(self):
+        res = self.app.post_json_api(self.public_registration_url, self.fork_data, auth=self.user.auth)
+        assert_equal(res.status_code, 201)
+        data = res.json['data']
+        assert_equal(data['id'], self.public_registration.forks[0]._id)
+        assert_equal(data['attributes']['title'], 'Fork of ' + self.public_registration.title)
+        assert_equal(data['attributes']['registration'], False)
+        assert_equal(data['attributes']['fork'], True)
+
+    def test_cannot_fork_private_registration_logged_out(self):
+        res = self.app.post_json_api(self.private_registration_url, self.fork_data, expect_errors=True)
+        assert_equal(res.status_code, 401)
+        assert_equal(res.json['errors'][0]['detail'], 'Authentication credentials were not provided.')
+
+    def test_cannot_fork_private_registration_logged_in_non_contributor(self):
+        res = self.app.post_json_api(self.private_registration_url, self.fork_data, auth=self.user_two.auth, expect_errors=True)
+        assert_equal(res.status_code, 403)
+        assert_equal(res.json['errors'][0]['detail'], 'You do not have permission to perform this action.')
+
+    def test_can_fork_private_registration_logged_in_contributor(self):
+        res = self.app.post_json_api(self.private_registration_url + '?embed=children&embed=node_links&embed=logs&embed=contributors&embed=forked_from', self.fork_data, auth=self.user.auth, expect_errors=True)
+        assert_equal(res.status_code, 201)
+
+        data = res.json['data']
+        assert_equal(data['attributes']['title'], 'Fork of ' + self.private_registration.title)
+        assert_equal(data['attributes']['registration'], False)
+        assert_equal(data['attributes']['fork'], True)
+
+        fork_contributors = data['embeds']['contributors']['data'][0]['embeds']['users']['data']
+        assert_equal(fork_contributors['attributes']['family_name'], self.user.family_name)
+        assert_equal(fork_contributors['id'], self.user._id)
+
+        forked_from = data['embeds']['forked_from']['data']
+        assert_equal(forked_from['id'], self.private_registration._id)
+
+    def test_fork_private_components_no_access(self):
+        url = self.public_registration_url + '?embed=children'
+        private_component = NodeFactory(parent=self.public_registration, creator=self.user_two, is_public=False)
+        res = self.app.post_json_api(url, self.fork_data, auth=self.user_three.auth)
+        assert_equal(res.status_code, 201)
+        # Private components that you do not have access to are not forked
+        assert_equal(res.json['data']['embeds']['children']['links']['meta']['total'], 0)
+
+    def test_fork_components_you_can_access(self):
+        url = self.private_registration_url + '?embed=children'
+        new_component = NodeFactory(parent=self.private_registration, creator=self.user)
+        res = self.app.post_json_api(url, self.fork_data, auth=self.user.auth)
+        assert_equal(res.status_code, 201)
+        assert_equal(res.json['data']['embeds']['children']['links']['meta']['total'], 1)
+        assert_equal(res.json['data']['embeds']['children']['data'][0]['id'], new_component.forks[0]._id)
+
+    def test_fork_private_node_links(self):
+
+        url = self.private_registration_url + '?embed=node_links'
+
+        # Node link is forked, but shows up as a private node link
+        res = self.app.post_json_api(url, self.fork_data, auth=self.user.auth)
+        assert_equal(res.json['data']['embeds']['node_links']['data'][0]['embeds']['target_node']['errors'][0]['detail'],
+                     'You do not have permission to perform this action.')
+        assert_equal(res.json['data']['embeds']['node_links']['links']['meta']['total'], 1)
+
+    def test_fork_node_links_you_can_access(self):
+        pointer = ProjectFactory(creator=self.user)
+        self.private_project.add_pointer(pointer, auth=Auth(self.user), save=True)
+
+        new_registration = RegistrationFactory(project = self.private_project, creator=self.user)
+
+        url = '/{}registrations/{}/forks/'.format(API_BASE, new_registration._id) + '?embed=node_links'
+
+        res = self.app.post_json_api(url, self.fork_data, auth=self.user.auth)
+        assert_equal(res.json['data']['embeds']['node_links']['data'][1]['embeds']['target_node']['data']['id'], pointer._id)
+        assert_equal(res.json['data']['embeds']['node_links']['links']['meta']['total'], 2)
+
+    def test_cannot_fork_retractions(self):
+        retraction = RetractedRegistrationFactory(registration=self.private_registration, user=self.user)
+        url = '/{}registrations/{}/forks/'.format(API_BASE, self.private_registration._id) + '?embed=forked_from'
+
+        res = self.app.post_json_api(url, self.fork_data, auth=self.user.auth, expect_errors=True)
+        assert_equal(res.status_code, 403)
+
+
+
+
+
+

--- a/framework/auth/oauth_scopes.py
+++ b/framework/auth/oauth_scopes.py
@@ -26,6 +26,9 @@ class CoreScopes(object):
     NODE_CHILDREN_READ = 'nodes.children_read'
     NODE_CHILDREN_WRITE = 'nodes.children_write'
 
+    NODE_FORKS_READ = 'nodes.forks_read'
+    NODE_FORKS_WRITE = 'nodes.forks_write'
+
     NODE_CONTRIBUTORS_READ = 'nodes.contributors_read'
     NODE_CONTRIBUTORS_WRITE = 'nodes.contributors_write'
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -300,6 +300,23 @@ class RetractedRegistrationFactory(AbstractNodeFactory):
 
         return retraction
 
+
+class ForkFactory(ModularOdmFactory):
+    class Meta:
+        model = Node
+
+    @classmethod
+    def _create(cls, *args, **kwargs):
+
+        project = kwargs.pop('project', None)
+        user = kwargs.pop('user', project.creator)
+        title = kwargs.pop('title', 'Fork of ')
+
+        fork = project.fork_node(auth=Auth(user), title=title)
+        fork.save()
+        return fork
+
+
 class PointerFactory(ModularOdmFactory):
     class Meta:
         model = Pointer

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2119,7 +2119,11 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
                 if forked_node is not None:
                     forked.nodes.append(forked_node)
 
-        forked.title = title + forked.title
+        if title == 'Fork of ' or title == '':
+            forked.title = title + forked.title
+        else:
+            forked.title = title
+
         forked.is_fork = True
         forked.is_registration = False
         forked.forked_date = when


### PR DESCRIPTION
JIRA https://openscience.atlassian.net/browse/OSF-3897

## Purpose

Adds ability for fork projects and get list of forks via the API v2.  

## Changes

Functionality added: 

- GET /v2/nodes/{node_id}/forks/
- POST /v2/nodes/{node_id}/forks/
- GET /v2/registrations/{registration_id}/forks/
- POST /v2/registrations/{registration_id}/forks/

To create a fork, issue a POST request to the node forks or the registration forks list endpoint.  Request body should look like this:
```
{
    "data": {
        "type": "nodes", # MANDATORY
        "attributes": {
            "title": "{insert_title}" # OPTIONAL
        }
    }
}

```
`forks` relationship link added to Node and Registration serializers.  Also, the title for the fork can be specified up-front, rather than having to edit the title.  If no title supplied, default is still 'Fork of ' + current node title.

