### PR TITLE
[Fix] Remove static dir that isn't used

### DIFF
--- a/admin/base/settings/defaults.py
+++ b/admin/base/settings/defaults.py
@@ -134,10 +134,6 @@ LOGIN_REDIRECT_URL = '/admin/'
 
 STATIC_ROOT = os.path.join(os.path.dirname(BASE_DIR), 'static_root')
 
-STATICFILES_DIRS = (
-    os.path.join(BASE_DIR, 'static'),
-)
-
 LANGUAGE_CODE = 'en-us'
 
 WEBPACK_LOADER = {


### PR DESCRIPTION
## Purpose

Allows the css for the django_admin interface to be used.

## Changes

Remove essentially duplicate settings
## Side effects

Makes things better. Possibly if a server is cleaned this could lead to other issues that are currently hidden.


## Ticket

None

