### PR TITLE
Set the X-Frame-Options header to disallow embedding into frames

### DIFF
--- a/framework/sessions/__init__.py
+++ b/framework/sessions/__init__.py
@@ -174,4 +174,7 @@ def after_request(response):
     if session.data.get('auth_user_id'):
         session.save()
 
+    # Disallow embeding in frames
+    response.headers['X-Frame-Options'] = 'SAMEORIGIN'
+
     return response


### PR DESCRIPTION
## Purpose

Set the `X-Frame-Options` header for all requests.

## Changes

Set the `X-Frame-Options` header for all requests.

## Side effects

None

## Ticket

https://openscience.atlassian.net/browse/OSF-6113
https://openscience.atlassian.net/browse/SEC-15

### Before:
![screen shot 2016-04-26 at 12 06 06](https://cloud.githubusercontent.com/assets/5532905/14825586/83cccb48-0ba8-11e6-8075-7fe865484303.png)

### After:
![screen shot 2016-04-26 at 12 04 37](https://cloud.githubusercontent.com/assets/5532905/14825585/82b3722a-0ba8-11e6-9d26-87acba564ac0.png)