### PR TITLE
Use constraints file to resolve dependency conflicts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Base requirements for running the OSF.
 # NOTE: This does not include addon, development, metrics or release requirements.
+# NOTE: When updating pinned version, you may also need to update constraints.txt
 # To install addon requirements: inv requirements --addons
 # To install dev requirements: inv requirements --dev
 # To install metrics requirements: inv requirements --metrics

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -1,0 +1,14 @@
+## Constraints file for resolving conflicts across addons. In general, the version specified by OSF base requirements "wins"
+## "Constraints files are requirements files that only control which version of a requirement is installed, not whether it is installed or not."
+##     See https://pip-python3.readthedocs.org/en/latest/user_guide.html#constraints-files
+
+lxml==3.4.1
+pytz==2014.9
+python-dateutil==2.5.0
+html5lib==0.999
+bleach==1.4.1
+requests==2.5.3
+urllib3==1.10.4
+requests-oauthlib==0.5.0
+oauthlib>=1.0  # Mendeley pins to a much lower version but OSF overrides
+git+https://github.com/jmcarp/HTTPretty@matcher-priority

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -24,6 +24,7 @@ logging.getLogger('invoke').setLevel(logging.CRITICAL)
 # gets the root path for all the scripts that rely on it
 HERE = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..'))
 WHEELHOUSE_PATH = os.environ.get('WHEELHOUSE')
+CONSTRAINTS_PATH = os.path.join(HERE, 'requirements', 'constraints.txt')
 
 try:
     __import__('rednose')
@@ -451,17 +452,29 @@ def requirements(base=False, addons=False, release=False, dev=False, metrics=Fal
     # "release" takes precedence
     if release:
         req_file = os.path.join(HERE, 'requirements', 'release.txt')
-        run(pip_install(req_file), echo=True)
+        run(
+            pip_install(req_file, constraints_file=CONSTRAINTS_PATH),
+            echo=True
+        )
     else:
         if dev:  # then dev requirements
             req_file = os.path.join(HERE, 'requirements', 'dev.txt')
-            run(pip_install(req_file), echo=True)
+            run(
+                pip_install(req_file, constraints_file=CONSTRAINTS_PATH),
+                echo=True
+            )
         if metrics:  # then dev requirements
             req_file = os.path.join(HERE, 'requirements', 'metrics.txt')
-            run(pip_install(req_file), echo=True)
+            run(
+                pip_install(req_file, constraints_file=CONSTRAINTS_PATH),
+                echo=True
+            )
         if base:  # then base requirements
             req_file = os.path.join(HERE, 'requirements.txt')
-            run(pip_install(req_file), echo=True)
+            run(
+                pip_install(req_file, constraints_file=CONSTRAINTS_PATH),
+                echo=True
+            )
 
 
 @task
@@ -573,7 +586,7 @@ def karma(single=False, sauce=False, browsers=None):
 
 @task
 def wheelhouse(addons=False, release=False, dev=False, metrics=False):
-    """Install python dependencies.
+    """Build wheels for python dependencies.
 
     Examples:
 
@@ -607,18 +620,16 @@ def addon_requirements():
     """Install all addon requirements."""
     for directory in os.listdir(settings.ADDON_PATH):
         path = os.path.join(settings.ADDON_PATH, directory)
-        if os.path.isdir(path):
-            try:
-                requirements_file = os.path.join(path, 'requirements.txt')
-                open(requirements_file)
-                print('Installing requirements for {0}'.format(directory))
-                cmd = 'pip install --exists-action w --upgrade -r {0}'.format(requirements_file)
-                if WHEELHOUSE_PATH:
-                    cmd += ' --no-index --find-links={}'.format(WHEELHOUSE_PATH)
-                run(bin_prefix(cmd))
-            except IOError:
-                pass
-    print('Finished')
+
+        requirements_file = os.path.join(path, 'requirements.txt')
+        if os.path.isdir(path) and os.path.isfile(requirements_file):
+            print('Installing requirements for {0}'.format(directory))
+            run(
+                pip_install(requirements_file, constraints_file=CONSTRAINTS_PATH),
+                echo=True
+            )
+
+    print('Finished installing addon requirements')
 
 
 @task

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -15,11 +15,15 @@ def bin_prefix(cmd):
     return os.path.join(get_bin_path(), cmd)
 
 
-def pip_install(req_file):
-    """Return the proper 'pip install' command for installing the dependencies
-    defined in ``req_file``.
+def pip_install(req_file, constraints_file=None):
+    """
+    Return the proper 'pip install' command for installing the dependencies
+    defined in ``req_file``. Optionally obey a file of constraints in case of version conflicts
     """
     cmd = bin_prefix('pip install --exists-action w --upgrade -r {} '.format(req_file))
+    if constraints_file:  # Support added in pip 7.1
+        cmd += ' -c {}'.format(constraints_file)
+
     if WHEELHOUSE_PATH:
         cmd += ' --no-index --find-links={}'.format(WHEELHOUSE_PATH)
     return cmd


### PR DESCRIPTION
## Purpose
Speed up installation of python requirements, by implementing some basic dependency resolution.

### Options for future scope creep
- Pin dependencies for certain addons that are currently allowed to auto-upgrade to newest
- Remove dependency on personal repositories (Lyndsy, Josh, etc)
- Modernize very old dependencies (after thorough review)

## Changes
- Add a constraints file. Dependency choices were based on analysis of logs without constraints. In general, we chose versions to match the version that was present after final installation- since each run of pip happens separately, the version in OSF base requirements "wins".
- Update all invoke tasks that use pip so that they recognize the constraints file
- Add a reminder into the base requirements file


## Side effects
In general, the final result WITH the constraints file should be the same set of packages/versions as if we ran with no constraints file- but it should happen faster (because we don't need to wait for lxml etc to install twice). See artifacts on linked ticket for audit.

There are some disadvantages:

- Developer virtual environments must be upgraded to pip >= 7.1 (released June 30, 2015)
- When upgrading packages to a newer pinned version, we will need to check if it is defined in `constraints.txt`. 

It's a slight maintenance headache, but provides a simple mechanism for resolving conflicts caused by external dependencies whose requirements we don't control.

## Ticket
https://openscience.atlassian.net/browse/OSF-5959