### PR TITLE
[hotfix] Remove forward slashes from wiki page names

### DIFF
--- a/scripts/remove_wiki_title_forward_slashes.py
+++ b/scripts/remove_wiki_title_forward_slashes.py
@@ -1,0 +1,61 @@
+"""
+Remove forward slashes from wiki page titles, since it is no longer an allowed character and
+breaks validation.
+"""
+import logging
+import sys
+
+from framework.mongo import database as db
+from framework.transactions.context import TokuTransaction
+
+from website.app import init_app
+from website.project.model import Node
+from scripts import utils as script_utils
+
+logger = logging.getLogger(__name__)
+
+
+def main():
+    wiki_pages = db.nodewikipage.find({}, {'_id': True, 'page_name': True, 'node': True})
+    wiki_pages = wiki_pages.batch_size(200)
+    fix_wiki_titles(wiki_pages)
+
+
+def fix_wiki_titles(wiki_pages):
+    for i, wiki in enumerate(wiki_pages):
+        if '/' in wiki['page_name']:
+            old_name = wiki['page_name']
+            new_name = wiki['page_name'].replace('/', '')
+
+            # update wiki page name
+            db.nodewikipage.update({'_id': wiki['_id']}, {'$set': {'page_name': new_name}})
+            logger.info('Updated wiki {} title to {}'.format(wiki['_id'], new_name))
+
+            node = Node.load(wiki['node'])
+            if not node:
+                logger.info('Invalid node {} for wiki {}'.format(node, wiki['_id']))
+                continue
+
+            # update node wiki page records
+            if old_name in node.wiki_pages_versions:
+                node.wiki_pages_versions[new_name] = node.wiki_pages_versions[old_name]
+                del node.wiki_pages_versions[old_name]
+
+            if old_name in node.wiki_pages_current:
+                node.wiki_pages_current[new_name] = node.wiki_pages_current[old_name]
+                del node.wiki_pages_current[old_name]
+
+            if old_name in node.wiki_private_uuids:
+                node.wiki_private_uuids[new_name] = node.wiki_private_uuids[old_name]
+                del node.wiki_private_uuids[old_name]
+
+
+if __name__ == '__main__':
+    dry = '--dry' in sys.argv
+    if not dry:
+        script_utils.add_file_logger(logger, __file__)
+    init_app(routes=False, set_backends=True)
+    with TokuTransaction():
+        main()
+        if dry:
+            raise Exception('Dry Run -- Aborting Transaction')

--- a/scripts/tests/test_remove_wiki_title_forward_slashes.py
+++ b/scripts/tests/test_remove_wiki_title_forward_slashes.py
@@ -1,0 +1,38 @@
+from nose.tools import *
+
+from framework.mongo import database as db
+
+from scripts.remove_wiki_title_forward_slashes import main
+
+from tests.base import OsfTestCase
+from tests.factories import NodeWikiFactory, ProjectFactory
+
+
+class TestRemoveWikiTitleForwardSlashes(OsfTestCase):
+
+    def test_forward_slash_is_removed_from_wiki_title(self):
+        project = ProjectFactory()
+        wiki = NodeWikiFactory(node=project, is_current=True)
+
+        invalid_name = 'invalid/name'
+        db.nodewikipage.update({'_id': wiki._id}, {'$set': {'page_name': invalid_name}})
+        project.wiki_pages_current['invalid/name'] = project.wiki_pages_current[wiki.page_name]
+        project.wiki_pages_versions['invalid/name'] = project.wiki_pages_versions[wiki.page_name]
+        project.save()
+
+        main()
+        wiki.reload()
+
+        assert_equal(wiki.page_name, 'invalidname')
+        assert_in('invalidname', project.wiki_pages_current)
+        assert_in('invalidname', project.wiki_pages_versions)
+
+    def test_valid_wiki_title(self):
+        project = ProjectFactory()
+        wiki = NodeWikiFactory(node=project, is_current=True)
+        page_name = wiki.page_name
+        main()
+        wiki.reload()
+        assert_equal(page_name, wiki.page_name)
+        assert_in(page_name, project.wiki_pages_current)
+        assert_in(page_name, project.wiki_pages_versions)


### PR DESCRIPTION
## Purpose

There are several wiki pages on production with a "/" in the title and because those titles are invalid the wiki pages cannot be saved.

## Changes

Remove the "/" from wiki page titles so that they can be handled by #5524 

## Side effects

## Ticket

Related to https://github.com/CenterForOpenScience/osf.io/pull/5524

