### PR TITLE
[RFR] Fix ESI content negotiation for Applications and Tokens API segments

### DIFF
--- a/api/applications/views.py
+++ b/api/applications/views.py
@@ -6,6 +6,7 @@ from rest_framework import generics
 from rest_framework import renderers
 from rest_framework import permissions as drf_permissions
 
+from api.base.renderers import JSONAPIRenderer, JSONRendererWithESISupport
 from modularodm import Q
 
 from framework.auth import cas
@@ -50,7 +51,7 @@ class ApplicationList(JSONAPIBaseView, generics.ListCreateAPIView, ODMFilterMixi
     view_category = 'applications'
     view_name = 'application-list'
 
-    renderer_classes = [renderers.JSONRenderer]  # Hide from web-browsable API tool
+    renderer_classes = [JSONRendererWithESISupport, JSONAPIRenderer,]  # Hide from web-browsable API tool
 
     def get_default_odm_query(self):
 
@@ -90,7 +91,7 @@ class ApplicationDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, 
     view_category = 'applications'
     view_name = 'application-detail'
 
-    renderer_classes = [renderers.JSONRenderer]  # Hide from web-browsable API tool
+    renderer_classes = [JSONRendererWithESISupport, JSONAPIRenderer,]  # Hide from web-browsable API tool
 
     def get_object(self):
         return self.get_app()
@@ -128,7 +129,7 @@ class ApplicationReset(JSONAPIBaseView, generics.CreateAPIView, ApplicationMixin
 
     serializer_class = ApiOAuth2ApplicationResetSerializer
 
-    renderer_classes = [renderers.JSONRenderer]  # Hide from web-browsable API tool
+    renderer_classes = [JSONRendererWithESISupport, JSONAPIRenderer, ]  # Hide from web-browsable API tool
 
     view_category = 'applications'
     view_name = 'application-reset'

--- a/api/applications/views.py
+++ b/api/applications/views.py
@@ -50,6 +50,8 @@ class ApplicationList(JSONAPIBaseView, generics.ListCreateAPIView, ODMFilterMixi
     view_category = 'applications'
     view_name = 'application-list'
 
+    # TODO: When we switch to Swagger this should be removed in lieu of a better
+    # solution for hiding this api endpoint
     renderer_classes = [JSONRendererWithESISupport, JSONAPIRenderer, ]  # Hide from web-browsable API tool
 
     def get_default_odm_query(self):
@@ -90,6 +92,8 @@ class ApplicationDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, 
     view_category = 'applications'
     view_name = 'application-detail'
 
+    # TODO: When we switch to Swagger this should be removed in lieu of a better
+    # solution for hiding this api endpoint
     renderer_classes = [JSONRendererWithESISupport, JSONAPIRenderer, ]  # Hide from web-browsable API tool
 
     def get_object(self):
@@ -128,6 +132,8 @@ class ApplicationReset(JSONAPIBaseView, generics.CreateAPIView, ApplicationMixin
 
     serializer_class = ApiOAuth2ApplicationResetSerializer
 
+    # TODO: When we switch to Swagger this should be removed in lieu of a better
+    # solution for hiding this api endpoint
     renderer_classes = [JSONRendererWithESISupport, JSONAPIRenderer, ]  # Hide from web-browsable API tool
 
     view_category = 'applications'

--- a/api/applications/views.py
+++ b/api/applications/views.py
@@ -3,7 +3,6 @@ Views related to OAuth2 platform applications. Intended for OSF internal use onl
 """
 from rest_framework.exceptions import APIException
 from rest_framework import generics
-from rest_framework import renderers
 from rest_framework import permissions as drf_permissions
 
 from api.base.renderers import JSONAPIRenderer, JSONRendererWithESISupport
@@ -51,7 +50,7 @@ class ApplicationList(JSONAPIBaseView, generics.ListCreateAPIView, ODMFilterMixi
     view_category = 'applications'
     view_name = 'application-list'
 
-    renderer_classes = [JSONRendererWithESISupport, JSONAPIRenderer,]  # Hide from web-browsable API tool
+    renderer_classes = [JSONRendererWithESISupport, JSONAPIRenderer, ]  # Hide from web-browsable API tool
 
     def get_default_odm_query(self):
 
@@ -91,7 +90,7 @@ class ApplicationDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, 
     view_category = 'applications'
     view_name = 'application-detail'
 
-    renderer_classes = [JSONRendererWithESISupport, JSONAPIRenderer,]  # Hide from web-browsable API tool
+    renderer_classes = [JSONRendererWithESISupport, JSONAPIRenderer, ]  # Hide from web-browsable API tool
 
     def get_object(self):
         return self.get_app()

--- a/api/applications/views.py
+++ b/api/applications/views.py
@@ -1,47 +1,47 @@
 """
 Views related to OAuth2 platform applications. Intended for OSF internal use only
 """
-from rest_framework.exceptions import APIException
-from rest_framework import generics
-from rest_framework import permissions as drf_permissions
-
-from api.base.renderers import JSONAPIRenderer, JSONRendererWithESISupport
 from modularodm import Q
+from rest_framework import permissions as drf_permissions
+from rest_framework import generics
+from rest_framework.exceptions import APIException
 
-from framework.auth import cas
-from framework.auth.oauth_scopes import CoreScopes
-
-from website.models import ApiOAuth2Application
-
+from api.applications.serializers import (ApiOAuth2ApplicationDetailSerializer,
+                                          ApiOAuth2ApplicationResetSerializer,
+                                          ApiOAuth2ApplicationSerializer)
+from api.base import permissions as base_permissions
 from api.base.filters import ODMFilterMixin
+from api.base.renderers import JSONAPIRenderer, JSONRendererWithESISupport
 from api.base.utils import get_object_or_error
 from api.base.views import JSONAPIBaseView
-from api.base import permissions as base_permissions
-from api.applications.serializers import ApiOAuth2ApplicationSerializer, ApiOAuth2ApplicationDetailSerializer, ApiOAuth2ApplicationResetSerializer
+from framework.auth import cas
+from framework.auth.oauth_scopes import CoreScopes
+from website.models import ApiOAuth2Application
 
 
 class ApplicationMixin(object):
     """Mixin with convenience methods for retrieving the current application based on the
     current URL. By default, fetches the current application based on the client_id kwarg.
     """
+
     def get_app(self):
-        app = get_object_or_error(ApiOAuth2Application,
-                                  Q('client_id', 'eq', self.kwargs['client_id']) &
-                                  Q('is_active', 'eq', True))
+        app = get_object_or_error(
+            ApiOAuth2Application,
+            Q('client_id', 'eq', self.kwargs['client_id'])
+            & Q('is_active', 'eq', True))
 
         self.check_object_permissions(self.request, app)
         return app
 
 
-class ApplicationList(JSONAPIBaseView, generics.ListCreateAPIView, ODMFilterMixin):
+class ApplicationList(JSONAPIBaseView, generics.ListCreateAPIView,
+                      ODMFilterMixin):
     """
     Get a list of API applications (eg OAuth2) that the user has registered
     """
-    permission_classes = (
-        drf_permissions.IsAuthenticated,
-        base_permissions.OwnerOnly,
-        base_permissions.TokenHasScope,
-    )
+    permission_classes = (drf_permissions.IsAuthenticated,
+                          base_permissions.OwnerOnly,
+                          base_permissions.TokenHasScope, )
 
     required_read_scopes = [CoreScopes.APPLICATIONS_READ]
     required_write_scopes = [CoreScopes.APPLICATIONS_WRITE]
@@ -50,15 +50,15 @@ class ApplicationList(JSONAPIBaseView, generics.ListCreateAPIView, ODMFilterMixi
     view_category = 'applications'
     view_name = 'application-list'
 
-    renderer_classes = [JSONRendererWithESISupport, JSONAPIRenderer, ]  # Hide from web-browsable API tool
+    # TODO: When we switch to Swagger this should be removed in lieu of a better
+    # solution for hiding this api endpoint
+    renderer_classes = [JSONRendererWithESISupport,
+                        JSONAPIRenderer, ]  # Hide from web-browsable API tool
 
     def get_default_odm_query(self):
 
         user_id = self.request.user._id
-        return (
-            Q('owner', 'eq', user_id) &
-            Q('is_active', 'eq', True)
-        )
+        return (Q('owner', 'eq', user_id) & Q('is_active', 'eq', True))
 
     # overrides ListAPIView
     def get_queryset(self):
@@ -71,17 +71,16 @@ class ApplicationList(JSONAPIBaseView, generics.ListCreateAPIView, ODMFilterMixi
         serializer.save()
 
 
-class ApplicationDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, ApplicationMixin):
+class ApplicationDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView,
+                        ApplicationMixin):
     """
     Get information about a specific API application (eg OAuth2) that the user has registered
 
     Should not return information if the application belongs to a different user
     """
-    permission_classes = (
-        drf_permissions.IsAuthenticated,
-        base_permissions.OwnerOnly,
-        base_permissions.TokenHasScope,
-    )
+    permission_classes = (drf_permissions.IsAuthenticated,
+                          base_permissions.OwnerOnly,
+                          base_permissions.TokenHasScope, )
 
     required_read_scopes = [CoreScopes.APPLICATIONS_READ]
     required_write_scopes = [CoreScopes.APPLICATIONS_WRITE]
@@ -90,7 +89,10 @@ class ApplicationDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, 
     view_category = 'applications'
     view_name = 'application-detail'
 
-    renderer_classes = [JSONRendererWithESISupport, JSONAPIRenderer, ]  # Hide from web-browsable API tool
+    # TODO: When we switch to Swagger this should be removed in lieu of a better
+    # solution for hiding this api endpoint
+    renderer_classes = [JSONRendererWithESISupport,
+                        JSONAPIRenderer, ]  # Hide from web-browsable API tool
 
     def get_object(self):
         return self.get_app()
@@ -102,7 +104,8 @@ class ApplicationDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, 
         try:
             obj.deactivate(save=True)
         except cas.CasHTTPError:
-            raise APIException("Could not revoke application auth tokens; please try again later")
+            raise APIException(
+                "Could not revoke application auth tokens; please try again later")
 
     def perform_update(self, serializer):
         """Necessary to prevent owner field from being blanked on updates"""
@@ -111,24 +114,26 @@ class ApplicationDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, 
         serializer.save(owner=self.request.user)
 
 
-class ApplicationReset(JSONAPIBaseView, generics.CreateAPIView, ApplicationMixin):
+class ApplicationReset(JSONAPIBaseView, generics.CreateAPIView,
+                       ApplicationMixin):
     """
     Resets client secret of a specific API application (eg OAuth2) that the user has registered
 
     Should not perform update or return information if the application belongs to a different user
     """
-    permission_classes = (
-        drf_permissions.IsAuthenticated,
-        base_permissions.OwnerOnly,
-        base_permissions.TokenHasScope,
-    )
+    permission_classes = (drf_permissions.IsAuthenticated,
+                          base_permissions.OwnerOnly,
+                          base_permissions.TokenHasScope, )
 
     required_read_scopes = [CoreScopes.APPLICATIONS_READ]
     required_write_scopes = [CoreScopes.APPLICATIONS_WRITE]
 
     serializer_class = ApiOAuth2ApplicationResetSerializer
 
-    renderer_classes = [JSONRendererWithESISupport, JSONAPIRenderer, ]  # Hide from web-browsable API tool
+    # TODO: When we switch to Swagger this should be removed in lieu of a better
+    # solution for hiding this api endpoint
+    renderer_classes = [JSONRendererWithESISupport,
+                        JSONAPIRenderer, ]  # Hide from web-browsable API tool
 
     view_category = 'applications'
     view_name = 'application-reset'

--- a/api/tokens/views.py
+++ b/api/tokens/views.py
@@ -3,7 +3,6 @@ Views related to personal access tokens. Intended for OSF internal use only
 """
 from rest_framework.exceptions import APIException
 from rest_framework import generics
-from rest_framework import renderers
 from rest_framework import permissions as drf_permissions
 
 from api.base.renderers import JSONAPIRenderer, JSONRendererWithESISupport

--- a/api/tokens/views.py
+++ b/api/tokens/views.py
@@ -6,6 +6,7 @@ from rest_framework import generics
 from rest_framework import renderers
 from rest_framework import permissions as drf_permissions
 
+from api.base.renderers import JSONAPIRenderer, JSONRendererWithESISupport
 from modularodm import Q
 
 from framework.auth import cas
@@ -37,7 +38,7 @@ class TokenList(JSONAPIBaseView, generics.ListCreateAPIView, ODMFilterMixin):
     view_category = 'tokens'
     view_name = 'token-list'
 
-    renderer_classes = [renderers.JSONRenderer]  # Hide from web-browsable API tool
+    renderer_classes = [JSONRendererWithESISupport, JSONAPIRenderer, ]  # Hide from web-browsable API tool
 
     def get_default_odm_query(self):
 
@@ -77,7 +78,7 @@ class TokenDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView):
     view_category = 'tokens'
     view_name = 'token-detail'
 
-    renderer_classes = [renderers.JSONRenderer]  # Hide from web-browsable API tool
+    renderer_classes = [JSONRendererWithESISupport, JSONAPIRenderer, ]  # Hide from web-browsable API tool
 
     # overrides RetrieveAPIView
     def get_object(self):

--- a/api/tokens/views.py
+++ b/api/tokens/views.py
@@ -1,19 +1,22 @@
 """
 Views related to personal access tokens. Intended for OSF internal use only
 """
-from modularodm import Q
-from rest_framework import permissions as drf_permissions
-from rest_framework import generics
 from rest_framework.exceptions import APIException
+from rest_framework import generics
+from rest_framework import permissions as drf_permissions
 
-from api.base import permissions as base_permissions
-from api.base.filters import ODMFilterMixin
 from api.base.renderers import JSONAPIRenderer, JSONRendererWithESISupport
-from api.base.utils import get_object_or_error
-from api.base.views import JSONAPIBaseView
-from api.tokens.serializers import ApiOAuth2PersonalTokenSerializer
+from modularodm import Q
+
 from framework.auth import cas
 from framework.auth.oauth_scopes import CoreScopes
+
+from api.base.filters import ODMFilterMixin
+from api.base.utils import get_object_or_error
+from api.base.views import JSONAPIBaseView
+from api.base import permissions as base_permissions
+from api.tokens.serializers import ApiOAuth2PersonalTokenSerializer
+
 from website.models import ApiOAuth2PersonalToken
 
 
@@ -21,9 +24,11 @@ class TokenList(JSONAPIBaseView, generics.ListCreateAPIView, ODMFilterMixin):
     """
     Get a list of personal access tokens that the user has registered
     """
-    permission_classes = (drf_permissions.IsAuthenticated,
-                          base_permissions.OwnerOnly,
-                          base_permissions.TokenHasScope, )
+    permission_classes = (
+        drf_permissions.IsAuthenticated,
+        base_permissions.OwnerOnly,
+        base_permissions.TokenHasScope,
+    )
 
     required_read_scopes = [CoreScopes.TOKENS_READ]
     required_write_scopes = [CoreScopes.TOKENS_WRITE]
@@ -32,15 +37,15 @@ class TokenList(JSONAPIBaseView, generics.ListCreateAPIView, ODMFilterMixin):
     view_category = 'tokens'
     view_name = 'token-list'
 
-    # TODO: When we switch to Swagger this should be removed in lieu of a better
-    # solution for hiding this api endpoint
-    renderer_classes = [JSONRendererWithESISupport,
-                        JSONAPIRenderer, ]  # Hide from web-browsable API tool
+    renderer_classes = [JSONRendererWithESISupport, JSONAPIRenderer, ]  # Hide from web-browsable API tool
 
     def get_default_odm_query(self):
 
         owner = self.request.user._id
-        return (Q('owner', 'eq', owner) & Q('is_active', 'eq', True))
+        return (
+            Q('owner', 'eq', owner) &
+            Q('is_active', 'eq', True)
+        )
 
     # overrides ListAPIView
     def get_queryset(self):
@@ -59,9 +64,11 @@ class TokenDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView):
 
     Should not return information if the token belongs to a different user
     """
-    permission_classes = (drf_permissions.IsAuthenticated,
-                          base_permissions.OwnerOnly,
-                          base_permissions.TokenHasScope, )
+    permission_classes = (
+        drf_permissions.IsAuthenticated,
+        base_permissions.OwnerOnly,
+        base_permissions.TokenHasScope,
+    )
 
     required_read_scopes = [CoreScopes.TOKENS_READ]
     required_write_scopes = [CoreScopes.TOKENS_WRITE]
@@ -70,16 +77,13 @@ class TokenDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView):
     view_category = 'tokens'
     view_name = 'token-detail'
 
-    # TODO: When we switch to Swagger this should be removed in lieu of a better
-    # solution for hiding this api endpoint
-    renderer_classes = [JSONRendererWithESISupport,
-                        JSONAPIRenderer, ]  # Hide from web-browsable API tool
+    renderer_classes = [JSONRendererWithESISupport, JSONAPIRenderer, ]  # Hide from web-browsable API tool
 
     # overrides RetrieveAPIView
     def get_object(self):
         obj = get_object_or_error(ApiOAuth2PersonalToken,
-                                  Q('_id', 'eq', self.kwargs['_id'])
-                                  & Q('is_active', 'eq', True))
+                                  Q('_id', 'eq', self.kwargs['_id']) &
+                                  Q('is_active', 'eq', True))
 
         self.check_object_permissions(self.request, obj)
         return obj
@@ -91,8 +95,7 @@ class TokenDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView):
         try:
             obj.deactivate(save=True)
         except cas.CasHTTPError:
-            raise APIException(
-                "Could not revoke tokens; please try again later")
+            raise APIException("Could not revoke tokens; please try again later")
 
     def perform_update(self, serializer):
         """Necessary to prevent owner field from being blanked on updates"""

--- a/api/tokens/views.py
+++ b/api/tokens/views.py
@@ -1,22 +1,19 @@
 """
 Views related to personal access tokens. Intended for OSF internal use only
 """
-from rest_framework.exceptions import APIException
-from rest_framework import generics
-from rest_framework import permissions as drf_permissions
-
-from api.base.renderers import JSONAPIRenderer, JSONRendererWithESISupport
 from modularodm import Q
+from rest_framework import permissions as drf_permissions
+from rest_framework import generics
+from rest_framework.exceptions import APIException
 
-from framework.auth import cas
-from framework.auth.oauth_scopes import CoreScopes
-
+from api.base import permissions as base_permissions
 from api.base.filters import ODMFilterMixin
+from api.base.renderers import JSONAPIRenderer, JSONRendererWithESISupport
 from api.base.utils import get_object_or_error
 from api.base.views import JSONAPIBaseView
-from api.base import permissions as base_permissions
 from api.tokens.serializers import ApiOAuth2PersonalTokenSerializer
-
+from framework.auth import cas
+from framework.auth.oauth_scopes import CoreScopes
 from website.models import ApiOAuth2PersonalToken
 
 
@@ -24,11 +21,9 @@ class TokenList(JSONAPIBaseView, generics.ListCreateAPIView, ODMFilterMixin):
     """
     Get a list of personal access tokens that the user has registered
     """
-    permission_classes = (
-        drf_permissions.IsAuthenticated,
-        base_permissions.OwnerOnly,
-        base_permissions.TokenHasScope,
-    )
+    permission_classes = (drf_permissions.IsAuthenticated,
+                          base_permissions.OwnerOnly,
+                          base_permissions.TokenHasScope, )
 
     required_read_scopes = [CoreScopes.TOKENS_READ]
     required_write_scopes = [CoreScopes.TOKENS_WRITE]
@@ -37,15 +32,15 @@ class TokenList(JSONAPIBaseView, generics.ListCreateAPIView, ODMFilterMixin):
     view_category = 'tokens'
     view_name = 'token-list'
 
-    renderer_classes = [JSONRendererWithESISupport, JSONAPIRenderer, ]  # Hide from web-browsable API tool
+    # TODO: When we switch to Swagger this should be removed in lieu of a better
+    # solution for hiding this api endpoint
+    renderer_classes = [JSONRendererWithESISupport,
+                        JSONAPIRenderer, ]  # Hide from web-browsable API tool
 
     def get_default_odm_query(self):
 
         owner = self.request.user._id
-        return (
-            Q('owner', 'eq', owner) &
-            Q('is_active', 'eq', True)
-        )
+        return (Q('owner', 'eq', owner) & Q('is_active', 'eq', True))
 
     # overrides ListAPIView
     def get_queryset(self):
@@ -64,11 +59,9 @@ class TokenDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView):
 
     Should not return information if the token belongs to a different user
     """
-    permission_classes = (
-        drf_permissions.IsAuthenticated,
-        base_permissions.OwnerOnly,
-        base_permissions.TokenHasScope,
-    )
+    permission_classes = (drf_permissions.IsAuthenticated,
+                          base_permissions.OwnerOnly,
+                          base_permissions.TokenHasScope, )
 
     required_read_scopes = [CoreScopes.TOKENS_READ]
     required_write_scopes = [CoreScopes.TOKENS_WRITE]
@@ -77,13 +70,16 @@ class TokenDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView):
     view_category = 'tokens'
     view_name = 'token-detail'
 
-    renderer_classes = [JSONRendererWithESISupport, JSONAPIRenderer, ]  # Hide from web-browsable API tool
+    # TODO: When we switch to Swagger this should be removed in lieu of a better
+    # solution for hiding this api endpoint
+    renderer_classes = [JSONRendererWithESISupport,
+                        JSONAPIRenderer, ]  # Hide from web-browsable API tool
 
     # overrides RetrieveAPIView
     def get_object(self):
         obj = get_object_or_error(ApiOAuth2PersonalToken,
-                                  Q('_id', 'eq', self.kwargs['_id']) &
-                                  Q('is_active', 'eq', True))
+                                  Q('_id', 'eq', self.kwargs['_id'])
+                                  & Q('is_active', 'eq', True))
 
         self.check_object_permissions(self.request, obj)
         return obj
@@ -95,7 +91,8 @@ class TokenDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView):
         try:
             obj.deactivate(save=True)
         except cas.CasHTTPError:
-            raise APIException("Could not revoke tokens; please try again later")
+            raise APIException(
+                "Could not revoke tokens; please try again later")
 
     def perform_update(self, serializer):
         """Necessary to prevent owner field from being blanked on updates"""

--- a/api/tokens/views.py
+++ b/api/tokens/views.py
@@ -37,6 +37,8 @@ class TokenList(JSONAPIBaseView, generics.ListCreateAPIView, ODMFilterMixin):
     view_category = 'tokens'
     view_name = 'token-list'
 
+    # TODO: When we switch to Swagger this should be removed in lieu of a better
+    # solution for hiding this api endpoint
     renderer_classes = [JSONRendererWithESISupport, JSONAPIRenderer, ]  # Hide from web-browsable API tool
 
     def get_default_odm_query(self):
@@ -77,6 +79,8 @@ class TokenDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView):
     view_category = 'tokens'
     view_name = 'token-detail'
 
+    # TODO: When we switch to Swagger this should be removed in lieu of a better
+    # solution for hiding this api endpoint
     renderer_classes = [JSONRendererWithESISupport, JSONAPIRenderer, ]  # Hide from web-browsable API tool
 
     # overrides RetrieveAPIView


### PR DESCRIPTION
## Purpose

[With ESI enabled Application and Token API segments would return `""` for each application or token.](https://www.flowdock.com/app/cos/osf-dev/threads/fRTR6af6NTCnxThJApnh0CAm87i) This fixes that problem.

## Changes

In order to disable the browseable API for these endpoints the list of renderers was specified on the view. The renderer specified didn't process the response, removing quotes from around ESI tags. I changed the renderers list to the two renderers that will remove those quotes.

## Side effects

I functionally tested the endpoints for applications and tokens using both the `?format=json` and the content-type request header. They both returned correct responses and the endpoints did not appear in the browseable API locally. My local setup runs through varnish. It's possible that something is amiss @abought and @samchrisinger should probably take a look at it once it gets on staging to make sure it's secure.

## Ticket

Flowdock link of the [conversation](https://www.flowdock.com/app/cos/osf-dev/threads/fRTR6af6NTCnxThJApnh0CAm87i) regarding this.
