### PR TITLE
[fix] [RfR] Limit five files per question on Draft upload

### DIFF
--- a/website/static/js/registrationEditorExtensions.js
+++ b/website/static/js/registrationEditorExtensions.js
@@ -177,7 +177,16 @@ var Uploader = function(question) {
         question.value(question.formattedFileList());
     });
 
+    self.UPLOAD_LANGUAGE = 'You may attach up to 5 files to this question. You may attach files that you already have' +
+        'in this OSF project, or upload a new file from your computer. Uploaded files will automatically be added to this project' +
+        'so that they can be registered.';
+
     self.addFile = function(file) {
+        if(self.selectedFiles().length === 5) {
+            bootbox.alert('Too many files. Cannot attach more than 5 files to a question.');
+            return false;
+        }
+
         if(self.fileAlreadySelected(file))
             return false;
 

--- a/website/static/js/registrationEditorExtensions.js
+++ b/website/static/js/registrationEditorExtensions.js
@@ -176,17 +176,20 @@ var Uploader = function(question) {
         });
         question.value(question.formattedFileList());
     });
+    self.fileWarn = ko.observable(true);
 
-    self.UPLOAD_LANGUAGE = 'You may attach up to 5 files to this question. You may attach files that you already have' +
-        'in this OSF project, or upload a new file from your computer. Uploaded files will automatically be added to this project' +
+    self.UPLOAD_LANGUAGE = 'You may attach up to 5 files to this question. You may attach files that you already have ' +
+        'in this OSF project, or upload a new file from your computer. Uploaded files will automatically be added to this project ' +
         'so that they can be registered.';
 
     self.addFile = function(file) {
-        if(self.selectedFiles().length === 5) {
+        if(self.selectedFiles().length >= 5 && self.fileWarn()) {
+            self.fileWarn(false);
             bootbox.alert('Too many files. Cannot attach more than 5 files to a question.');
             return false;
+        } else if(self.selectedFiles().length >= 5 && !self.fileWarn()) {
+            return false;
         }
-
         if(self.fileAlreadySelected(file))
             return false;
 

--- a/website/templates/project/registration_editor_extensions.mako
+++ b/website/templates/project/registration_editor_extensions.mako
@@ -21,6 +21,7 @@
 </script>
 
 <script type="text/html" id="osf-upload-toggle">
+    <span data-bind="text: UPLOAD_LANGUAGE"></span><br/>
     <div id="selectedFile">File(s) selected for upload:
         <div data-bind="foreach: selectedFiles">
             <span data-bind="text: data.name"></span>


### PR DESCRIPTION
## Purpose

Limit five files to be attached to a file upload question.

## Changes
- Check if user is trying to add a sixth file and give a pop up warning.
- Add description to question telling the user they can only upload 5 files.

## Side effects

None

## Ticket

https://openscience.atlassian.net/browse/OSF-5587
