### PR TITLE
[RfR] Fix JS scoping error after ko punches removal

### DIFF
--- a/website/static/js/registrationEditorExtensions.js
+++ b/website/static/js/registrationEditorExtensions.js
@@ -165,6 +165,9 @@ var Uploader = function(question) {
     var self = this;
 
     question.showUploader = ko.observable(false);
+    self.toggleUploader = function() {
+        question.showUploader(!question.showUploader());
+    };
     question.uid = 'uploader_' + uploaderCount;
     uploaderCount++;
     self.selectedFiles = ko.observableArray(question.extra() || []);

--- a/website/templates/project/edit_draft_registration.mako
+++ b/website/templates/project/edit_draft_registration.mako
@@ -17,7 +17,7 @@
                 <ul class="nav nav-stacked list-group" data-bind="foreach: {data: pages, as: 'page'}, visible: pages().length > 1">
                   <li class="re-navbar">
                     <a class="registration-editor-page" id="top-nav" style="text-align: left;"
-                       data-bind="text: title, click: $root.selectPage,
+                       data-bind="text: title, click: $root.selectPage.bind($root),
                                   style:{'font-weight': active() ? 'bold' : 'normal'},
                                   css: {'bg-danger': ($root.showValidation() && page.hasValidationInfo())}">
                     </a>

--- a/website/templates/project/registrations.mako
+++ b/website/templates/project/registrations.mako
@@ -102,7 +102,7 @@
                       <i style="margin-right: 5px;" class="fa fa-pencil"></i>Preview
                     </a>
                     <button class="btn btn-danger"
-                            data-bind="click: $root.deleteDraft">
+                            data-bind="click: $root.deleteDraft.bind($root)">
                       <i style="margin-right: 5px;" class="fa fa-times"></i>Delete
                     </button>
                   </div>


### PR DESCRIPTION
## Purpose

There were some errors with the prereg form on staging2 probably caused by some scoping changes with the removal of ko punches. This PR fixes them.
## Changes

- Re-implement `toggleUploader`
- Use `.bind` to prevent losing $parent/$root to the current `this` value

## Side effects

Shouldn't be any.
