### PR TITLE
Embargo Termination Followup [#OSF-5641], [#OSF-6126]

### DIFF
--- a/tests/test_registrations/test_embargoes.py
+++ b/tests/test_registrations/test_embargoes.py
@@ -980,16 +980,11 @@ class RegistrationEmbargoViewsTestCase(OsfTestCase):
             registration.embargo.approve_embargo(User.load(user_id), approval_token)
         self.registration.save()
 
-        sub_reg = registration.nodes[0].nodes[0]
         res = self.app.post(
-            sub_reg.api_url_for('project_set_privacy', permissions='public'),
-            auth=c2.auth,
-            expect_errors=True
+            registration.api_url_for('project_set_privacy', permissions='public'),
+            auth=self.user.auth
         )
         assert_equal(res.status_code, 200)
-        sub_reg.reload()
-        assert_true(sub_reg.embargo_termination_approval)
-        assert_true(sub_reg.embargo_termination_approval.is_pending_approval)
         asked_admins = [(admin._id, n._id) for admin, n in mock_ask.call_args[0][0]]
         for admin, node in registration.get_admin_contributors_recursive():
             assert_in((admin._id, node._id), asked_admins)

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -3437,6 +3437,8 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
         embargo early."""
         if not self.is_embargoed:
             raise NodeStateError("This node is not under active embargo")
+        if not self.root == self:
+            raise NodeStateError("Only the root of an embargoed registration can request termination")
 
         approval = EmbargoTerminationApproval(
             initiated_by=auth.user,

--- a/website/static/js/nodesPrivacy.js
+++ b/website/static/js/nodesPrivacy.js
@@ -292,7 +292,7 @@ NodesPrivacyViewModel.prototype.makeEmbargoPublic = function() {
         $('.modal').modal('hide');
         self.onSetPrivacy(nodesChanged, true);
         $osf.growl(
-            'Request Initiated',
+            'Request initiated',
             'You have initiated a request to end this registration\'s embargo early, and to make it and all of its components public immediately. All adminstrators on this registration have 48 hours to approve or disapprove of this action.',
             'success'
         );

--- a/website/static/js/nodesPrivacy.js
+++ b/website/static/js/nodesPrivacy.js
@@ -47,13 +47,12 @@ function _flattenNodeTree(nodeTree) {
  */
 function getNodesOriginal(nodeTree, nodesOriginal) {
     var flatNodes = _flattenNodeTree(nodeTree);
-    $.each(flatNodes, function(_, node) {
-        var nodeId = nodeTree.node.id;
-        nodesOriginal[nodeId] = {
-            public: nodeTree.node.is_public,
-            id: nodeTree.node.id,
-            title: nodeTree.node.title,
-            canWrite: nodeTree.node.can_write,
+    $.each(flatNodes, function(_, nodeMeta) {
+        nodesOriginal[nodeMeta.node.id] = {
+            public: nodeMeta.node.is_public,
+            id: nodeMeta.node.id,
+            title: nodeMeta.node.title,
+            canWrite: nodeMeta.node.can_write,
             changed: false
         };
     });

--- a/website/templates/emails/pending_embargo_termination_admin.txt.mako
+++ b/website/templates/emails/pending_embargo_termination_admin.txt.mako
@@ -7,6 +7,7 @@ ${initiated_by} initiated a request to end the embargo for a registration of ${p
 % endif
 
 To approve this change and to make this registration public immediately, click the following link: ${approval_link}.
+
 To cancel this change, click the following link: ${disapproval_link}.
 
 Sincerely yours,

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -36,7 +36,7 @@
                     <div class="btn-group">
                     % if not node["is_public"]:
                         <button class="btn btn-default disabled">Private</button>
-                        % if 'admin' in user['permissions'] and not node['is_pending_registration'] and not node['is_pending_embargo']:
+                        % if 'admin' in user['permissions'] and not node['is_pending_registration'] and not node['is_pending_embargo'] and (not node['is_registration'] or (node['is_embargoed'] and not parent_node['exists'])):
                         <a disabled data-bind="attr: {'disabled': false}, css: {'disabled': nodeIsPendingEmbargoTermination}" class="btn btn-default"  href="#nodesPrivacy" data-toggle="modal">
                           Make Public
 			  <!-- ko if: nodeIsPendingEmbargoTermination -->


### PR DESCRIPTION
# Purpose

Fixes for: https://openscience.atlassian.net/browse/OSF-5641

# Changes

- Misc language changes 
- Disallow making components of embargoes public (frontend/backend)
- fix getNodesOriginal implementation: https://openscience.atlassian.net/browse/OSF-6126