### PR TITLE
[feature] [OSF-6127] Remove OSF4M Analytics and Update Email Links

### DIFF
--- a/website/routes.py
+++ b/website/routes.py
@@ -214,7 +214,7 @@ def make_url_map(app):
 
         Rule('/faq/', 'get', {}, OsfWebRenderer('public/pages/faq.mako')),
         Rule('/getting-started/', 'get', website_views.redirect_getting_started, notemplate),
-        Rule('/getting-started/email/', 'get', website_views.redirect_meetings_analytics_link, json_renderer),
+        Rule('/getting-started/email/', 'get', website_views.redirect_getting_started, notemplate),
         Rule('/support/', 'get', {}, OsfWebRenderer('public/pages/support.mako')),
 
         Rule('/explore/', 'get', {}, OsfWebRenderer('public/explore.mako')),

--- a/website/templates/emails/conference_submitted.txt.mako
+++ b/website/templates/emails/conference_submitted.txt.mako
@@ -21,9 +21,9 @@ Get more from the OSF by enhancing your project with the following:
 * Collaborators/contributors to the submission
 * Charts, graphs, and data that didn't make it onto the submission
 * Links to related publications or reference lists
-* Connecting other accounts, like Dropbox, Google Drive, GitHub, figshare and Mendeley via add-on integration. Learn more and read the full list of available add-ons: http://osf.io/getting-started/email#addons
+* Connecting other accounts, like Dropbox, Google Drive, GitHub, figshare and Mendeley via add-on integration. Learn more and read the full list of available add-ons: http://help.osf.io/m/addons
 
-To learn more about the OSF, visit: http://osf.io/getting-started/email
+To learn more about the OSF, visit: http://help.osf.io/
 
 
 Sincerely yours,

--- a/website/views.py
+++ b/website/views.py
@@ -258,9 +258,6 @@ def redirect_howosfworks(**kwargs):
 def redirect_getting_started(**kwargs):
     return redirect('http://help.osf.io/')
 
-def redirect_meetings_analytics_link(**kwargs):
-    return redirect('/getting-started/?utm_source=osf4m&utm_medium=email&utm_campaign=success')
-
 def redirect_to_home():
     # Redirect to support page
     return redirect('/')


### PR DESCRIPTION
## Purpose

- Remove OSF4M analytics redirect.
- Also update help links in OSF4M email.

## Ticket
  - [OSF-6127](https://openscience.atlassian.net/browse/OSF-6127)