### PR TITLE
Add absolute_api_v2_url property to NodeWikiPage

### DIFF
--- a/website/addons/wiki/model.py
+++ b/website/addons/wiki/model.py
@@ -213,6 +213,11 @@ class NodeWikiPage(GuidStoredObject, Commentable):
     def get_absolute_url(self):
         return '{}wiki/{}/'.format(self.node.absolute_url, self.page_name)
 
+    @property
+    def absolute_api_v2_url(self):
+        # using v1 since there are no v2 routes
+        return self.get_absolute_url()
+
     def html(self, node):
         """The cleaned HTML of the page"""
         sanitized_content = render_content(self.content, node=node)


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

This fixes wiki comment decaching.

## Changes

I added absolute_api_v2_url property to NodeWikiPage model. An unhandled AttributeError was being caused during the decaching process. This caused none of the objects modified during the request to be decached, including the comments URL.

## Side effects

In the future, if people use absolute_api_v2_url property for other things they may get back html instead of JSON since NodeWikiPage does not have a v2 url I just used it's absolute_url which returns HTML. Since varnish is only keeping track of v2 pages now it will be adding NodeWikiPage to it's banlist which will do nothing. If we eventually start caching non-v2 urls this cache invalidation will already be in place.