### PR TITLE
Only change privacy for root node of embargo [#OSF-5641]

### DIFF
--- a/website/static/js/nodesPrivacy.js
+++ b/website/static/js/nodesPrivacy.js
@@ -56,6 +56,7 @@ function getNodesOriginal(nodeTree, nodesOriginal) {
             changed: false
         };
     });
+    nodesOriginal[nodeTree.node.id].isRoot = true;
     return nodesOriginal;
 }
 
@@ -282,11 +283,14 @@ NodesPrivacyViewModel.prototype.back = function() {
 NodesPrivacyViewModel.prototype.makeEmbargoPublic = function() {
     var self = this;
 
-    $.each(self.nodesOriginal, function(key, node) {
-        node.public = true;
-    });
+    var nodesChanged = $.map(self.nodesOriginal, function(node) {
+	if (node.isRoot) {
+            node.public = true;
+	    return node;
+	}
+	return null;
+    }).filter(Boolean);
     $osf.block('Submitting request to end embargo early ...');
-    var nodesChanged = $.map(self.nodesOriginal, function(node) {return node;});
     patchNodesPrivacy(nodesChanged).then(function (res) {
         $osf.unblock();
         $('.modal').modal('hide');


### PR DESCRIPTION
# Purpose

The PATCH to update the privacy of an embargo was including all the nodes in the tree; which was causing (appropriately) permissions errors for nodes with components. 

# Changes
- only try to patch the privacy of the root of an embargoed tree