### PR TITLE
[feature] fix typos and add node authorization and deauthorization actions [OSF-5371]

### DIFF
--- a/api/logs/views.py
+++ b/api/logs/views.py
@@ -57,8 +57,8 @@ class NodeLogDetail(JSONAPIBaseView, generics.RetrieveAPIView, LogMixin):
     ---
     * 'contributor_added': A Contributor is added to a Node
     * 'contributor_removed': A Contributor is removed from a Node
-    * 'contributors_reordered': A Contributor's position is a Node's biliography is changed
-    * 'permissions_update': A Contributor's permissions on a Node are changed
+    * 'contributors_reordered': A Contributor's position is a Node's bibliography is changed
+    * 'permissions_updated': A Contributor's permissions on a Node are changed
     * 'made_contributor_visible': A Contributor is made bibliographically visible on a Node
     * 'made_contributor_invisible': A Contributor is made bibliographically invisible on a Node
     ---
@@ -73,6 +73,8 @@ class NodeLogDetail(JSONAPIBaseView, generics.RetrieveAPIView, LogMixin):
     * 'addon_file_moved': A File in a Node's linked add-on is moved
     * 'addon_file_copied': A File in a Node's linked add-on is copied
     * 'addon_file_renamed': A File in a Node's linked add-on is renamed
+    * 'node_authorized': An addon is authorized for a project
+    * 'node_deauthorized': An addon is deauthorized for a project
     * 'folder_created': A Folder is created in a Node's linked add-on
     * 'file_added': A File is added to a Node's linked add-on
     * 'file_updated': A File is updated on a Node's linked add-on

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1652,8 +1652,8 @@ class NodeLogList(JSONAPIBaseView, generics.ListAPIView, NodeMixin, ODMFilterMix
     ===
     * 'contributor_added': A Contributor is added to a Node
     * 'contributor_removed': A Contributor is removed from a Node
-    * 'contributors_reordered': A Contributor's position is a Node's biliography is changed
-    * 'permissions_update': A Contributor's permissions on a Node are changed
+    * 'contributors_reordered': A Contributor's position is a Node's bibliography is changed
+    * 'permissions_updated': A Contributor's permissions on a Node are changed
     * 'made_contributor_visible': A Contributor is made bibliographically visible on a Node
     * 'made_contributor_invisible': A Contributor is made bibliographically invisible on a Node
     ===
@@ -1668,6 +1668,8 @@ class NodeLogList(JSONAPIBaseView, generics.ListAPIView, NodeMixin, ODMFilterMix
     * 'addon_file_moved': A File in a Node's linked add-on is moved
     * 'addon_file_copied': A File in a Node's linked add-on is copied
     * 'addon_file_renamed': A File in a Node's linked add-on is renamed
+    * 'node_authorized': An addon is authorized for a project
+    * 'node_deauthorized': An addon is deauthorized for a project
     * 'folder_created': A Folder is created in a Node's linked add-on
     * 'file_added': A File is added to a Node's linked add-on
     * 'file_updated': A File is updated on a Node's linked add-on


### PR DESCRIPTION
## Purpose

Fix typos and add node authorization and deauthorization actions to API docs. Related to the `v2/nodes/<node_id>/logs` endpoint.

## Changes

* biliography --> bibliography
* permissions_update --> permissions_updated
* added `node_authorized` and `node_deauthorized` to ticket

Note: `file_added`, `file_updated`, etc. were not changed to `addon_file_added` because the logs say the name of the addon that was added. So, if the user filters off of `addon_file_added` no results would appear because the actual logs say something like `github_file_added`.

## Side effects

None


## Ticket

https://openscience.atlassian.net/browse/OSF-5371

