### PR TITLE
Fix KO click events broken by KO punches removal

### DIFF
--- a/website/templates/include/profile/jobs.mako
+++ b/website/templates/include/profile/jobs.mako
@@ -22,7 +22,7 @@
                         </span>
                         <a
                                 class="text-danger pull-right"
-                                data-bind="click: $parent.removeContent"
+                                data-bind="click: $parent.removeContent.bind($parent)"
                                 >Remove</a>
                     </div>
 

--- a/website/templates/include/profile/schools.mako
+++ b/website/templates/include/profile/schools.mako
@@ -22,7 +22,7 @@
                         </span>
                         <a
                                 class="text-danger pull-right"
-                                data-bind="click: $parent.removeContent"
+                                data-bind="click: $parent.removeContent.bind($parent)"
                                 >Remove</a>
                     </div>
 

--- a/website/templates/profile/account.mako
+++ b/website/templates/profile/account.mako
@@ -43,8 +43,8 @@
                             <tbody data-bind="foreach: profile().alternateEmails()">
                                 <tr>
                                     <td style="word-break: break-all;"><span data-bind="text: $data.address"></span></td>
-                                    <td style="width:150px;"><a data-bind="click: $parent.makeEmailPrimary">make&nbsp;primary</a></td>
-                                    <td style="width:50px;"><a data-bind="click: $parent.removeEmail"><i class="fa fa-times text-danger"></i></a></td>
+                                    <td style="width:150px;"><a data-bind="click: $parent.makeEmailPrimary.bind($parent)">make&nbsp;primary</a></td>
+                                    <td style="width:50px;"><a data-bind="click: $parent.removeEmail.bind($parent)"><i class="fa fa-times text-danger"></i></a></td>
                                 </tr>
                             </tbody>
                         </table>
@@ -58,8 +58,8 @@
                                 <!-- ko foreach: profile().unconfirmedEmails() -->
                                 <tr>
                                     <td style="word-break: break-all;"><span data-bind="text: $data.address"></span></td>
-                                    <td style="width:150px;"><a data-bind="click: $parent.resendConfirmation">resend&nbsp;confirmation</a></td>
-                                    <td style="width:50px;" ><a data-bind="click: $parent.removeEmail"><i class="fa fa-times text-danger"></i></a></td>
+                                    <td style="width:150px;"><a data-bind="click: $parent.resendConfirmation.bind($parent)">resend&nbsp;confirmation</a></td>
+                                    <td style="width:50px;" ><a data-bind="click: $parent.removeEmail.bind($parent)"><i class="fa fa-times text-danger"></i></a></td>
                                 </tr>
                                 <!-- /ko -->
                                 <tr>

--- a/website/templates/project/modal_add_contributor.mako
+++ b/website/templates/project/modal_add_contributor.mako
@@ -155,7 +155,7 @@
                                         <td class="p-r-sm" class="osf-icon-td">
                                             <a
                                                     class="btn btn-default contrib-button btn-mini"
-                                                    data-bind="click:$root.remove, tooltip: {title: 'Remove contributor'}"
+                                                    data-bind="click:$root.remove.bind($root), tooltip: {title: 'Remove contributor'}"
                                                 ><i class="fa fa-minus"></i></a>
                                         </td>
                                         <td>

--- a/website/templates/project/modal_add_pointer.mako
+++ b/website/templates/project/modal_add_pointer.mako
@@ -51,7 +51,7 @@
                                     <td class="osf-icon-td">
                                         <a
                                                 class="btn btn-success contrib-button"
-                                                data-bind="click:$root.add, tooltip: {title: 'Add link'}"
+                                                data-bind="click:$root.add.bind($root), tooltip: {title: 'Add link'}"
                                             ><i class="fa fa-plus"></i></a>
                                     </td>
                                     <td data-bind="text:title" class="overflow"></td>
@@ -86,7 +86,7 @@
                                     <td class="osf-icon-td">
                                         <a
                                                 class="btn btn-default contrib-button"
-                                                data-bind="click:$root.remove, tooltip: {title: 'Remove link'}"
+                                                data-bind="click:$root.remove.bind($root), tooltip: {title: 'Remove link'}"
                                             ><i class="fa fa-minus"></i></a>
                                     </td>
                                     <td  data-bind="text:title" class="overflow"></td>

--- a/website/templates/project/register_draft.mako
+++ b/website/templates/project/register_draft.mako
@@ -29,7 +29,7 @@
           <button id="register-submit" type="button" class="btn btn-success pull-right"
                   style="margin-left: 5px;"
                   data-bind="visible: draft.requiresApproval,
-                             click: draft.submitForReview,
+                             click: draft.submitForReview.bind(draft),
                              enable: editor.canSubmit">
             Submit for review
           </button>
@@ -39,7 +39,7 @@
         </span>
 
         <span data-bind="if: draft.metaSchema.name === 'Prereg Challenge'">
-          <button id="register-submit" type="button" class="btn btn-primary pull-right" data-toggle="tooltip" data-placement="top" title="Not eligible for the Pre-Registration Challenge" data-bind="click: draft.registerWithoutReview">Register without review</button>
+          <button id="register-submit" type="button" class="btn btn-primary pull-right" data-toggle="tooltip" data-placement="top" title="Not eligible for the Pre-Registration Challenge" data-bind="click: draft.registerWithoutReview.bind(draft)">Register without review</button>
         </span>
 
         <button id="register-submit" type="button" class="btn btn-success pull-right"


### PR DESCRIPTION
## Purpose
Fix various buttons that stopped working when KO punches was removed.

## Changes
Bind the correct context to various buttons. For list of buttons affected and problem details, see [#OSF-6132]. Incorporates previous reg fixes by Eric.

This fixes several broken buttons so that they no longer give JS console errors. The results of clicking should now be consistent with the intended behavior.

## Side effects
This was a limited audit for one common failure case; there may be other broken buttons.

## Ticket
https://openscience.atlassian.net/browse/OSF-6132
