### PR TITLE
[feature] redirect to root [OSF-6133]

### DIFF
--- a/api/base/urls.py
+++ b/api/base/urls.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.conf.urls import include, url
 from django.conf.urls.static import static
+from django.views.generic.base import RedirectView
 from settings import API_BASE
 
 from . import views
@@ -26,7 +27,8 @@ urlpatterns = [
                 url(r'^guids/', include('api.guids.urls', namespace='guids'))
             ],
         )
-        )
+        ),
+    url(r'^$', RedirectView.as_view(pattern_name=views.root), name='redirect-to-root')
 ]
 
 

--- a/api_tests/base/test_root.py
+++ b/api_tests/base/test_root.py
@@ -26,3 +26,7 @@ class TestWelcomeToApi(ApiTestCase):
         assert_equal(res.content_type, 'application/vnd.api+json')
         assert_equal(res.json['meta']['current_user']['data']['attributes']['given_name'], self.user.given_name)
 
+    def test_returns_302_redirect_for_base_url(self):
+        res = self.app.get('/')
+        assert_equal(res.status_code, 302)
+        assert_equal(res.location, '/v2/')


### PR DESCRIPTION
## Purpose

Visiting https://api.osf.io/ return 404 File Not Found when it should redirect to https://api.osf.io/v2/.

## Changes

Add url pattern to redirect to root if `/` route is visited.

## Side effects

None


## Ticket

https://openscience.atlassian.net/browse/OSF-6133 

