### PR TITLE
Redirecting /help/ page to /faq/ [#OSF-4039]

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4256,6 +4256,10 @@ class TestStaticFileViews(OsfTestCase):
     def test_getting_started_page(self):
         res = self.app.get('/getting-started/')
         assert_equal(res.status_code, 200)
+        
+    def test_help_page(self):
+        res = self.app.get('/help/')
+        assert_equal(res.status_code, 302)
 
     def test_help_page(self):
         res = self.app.get('/help/')

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4256,10 +4256,6 @@ class TestStaticFileViews(OsfTestCase):
     def test_getting_started_page(self):
         res = self.app.get('/getting-started/')
         assert_equal(res.status_code, 200)
-        
-    def test_help_page(self):
-        res = self.app.get('/help/')
-        assert_equal(res.status_code, 302)
 
     def test_help_page(self):
         res = self.app.get('/help/')

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4257,6 +4257,10 @@ class TestStaticFileViews(OsfTestCase):
         res = self.app.get('/getting-started/')
         assert_equal(res.status_code, 200)
 
+    def test_help_page(self):
+        res = self.app.get('/help/')
+        assert_equal(res.status_code, 302)
+
 
 class TestUserConfirmSignal(OsfTestCase):
 

--- a/website/routes.py
+++ b/website/routes.py
@@ -262,12 +262,6 @@ def make_url_map(app):
             json_renderer
         ),
         Rule(
-            '/help/',
-            'get',
-            website_views.redirect_help_to_faq,
-            json_renderer
-        ),
-        Rule(
             '/support/',
             'get',
             {},

--- a/website/routes.py
+++ b/website/routes.py
@@ -262,6 +262,12 @@ def make_url_map(app):
             json_renderer
         ),
         Rule(
+            '/help/',
+            'get',
+            website_views.redirect_help_to_faq,
+            json_renderer
+        ),
+        Rule(
             '/support/',
             'get',
             {},

--- a/website/views.py
+++ b/website/views.py
@@ -258,9 +258,6 @@ def redirect_howosfworks(**kwargs):
 def redirect_meetings_analytics_link(**kwargs):
     return redirect('/getting-started/?utm_source=osf4m&utm_medium=email&utm_campaign=success')
 
-def redirect_help_to_faq(**kwargs):
-    return redirect('/faq/')
-
 def redirect_to_home():
     # Redirect to support page
     return redirect('/')

--- a/website/views.py
+++ b/website/views.py
@@ -258,6 +258,9 @@ def redirect_howosfworks(**kwargs):
 def redirect_meetings_analytics_link(**kwargs):
     return redirect('/getting-started/?utm_source=osf4m&utm_medium=email&utm_campaign=success')
 
+def redirect_help_to_faq(**kwargs):
+    return redirect('/faq/')
+
 def redirect_to_home():
     # Redirect to support page
     return redirect('/')


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

<!-- Describe the purpose of your changes -->

The OSF has a /help/ page, but it is only an unstyled placeholder.  This change redirects /help/ to /faq/.  



## Changes

<!-- Briefly describe or list your changes  -->

- Added a rule in website/routes.py to redirect /help/ to faq

- Added a test case in test_views.py that checks if the page was redirected

 

## Ticket
https://openscience.atlassian.net/browse/OSF-4039
