### PR TITLE
Add back Veer schema

### DIFF
--- a/tests/test_registrations/test_archiver.py
+++ b/tests/test_registrations/test_archiver.py
@@ -57,7 +57,7 @@ for each in SILENT_LOGGERS:
     logging.getLogger(each).setLevel(logging.CRITICAL)
 
 sha256_factory = _unique(fake.sha256)
-name_factory = _unique(fake.word)
+name_factory = _unique(fake.ean13)
 
 def file_factory(sha256=None):
     fname = name_factory()
@@ -200,6 +200,130 @@ def use_fake_addons(func):
             active_addons = {'osfstorage', 'dropbox'}
             return ret
     return wrapper
+
+def generate_file_tree(nodes):
+    file_trees = {
+        n._id: file_tree_factory(3, 3, 3)
+        for n in nodes
+    }
+
+    selected_files = {}
+    selected_file_node_index = {}
+    for n in nodes:
+        file_tree = file_trees[n._id]
+        selected = select_files_from_tree(file_tree)
+        selected_file_node_index.update({
+            sha256: n._id
+            for sha256 in selected.keys()
+        })
+        selected_files.update(selected)  # select files from each Node
+    return file_trees, selected_files, selected_file_node_index
+
+def generate_schema_from_data(data):
+    def from_property(id, prop):
+        if isinstance(prop.get('value'), dict):
+            return {
+                'id': id,
+                'type': 'object',
+                'properties': [
+                    from_property(pid, sp)
+                    for pid, sp in prop['value'].items()
+                ]
+            }
+        else:
+            return {
+                'id': id,
+                'type': 'osf-upload' if prop.get('extra') else 'string'
+            }
+    def from_question(qid, question):
+        if q.get('extra'):
+            return {
+                'qid': qid,
+                'type': 'osf-upload'
+            }
+        elif isinstance(q.get('value'), dict):
+            return {
+                'qid': qid,
+                'type': 'object',
+                'properties': [
+                    from_property(id, value)
+                    for id, value in question.get('value').items()
+                ]
+            }
+        else:
+            return {
+                'qid': qid,
+                'type': 'string'
+            }                
+    schema = MetaSchema(
+        name='Test',
+        schema={
+            'name': "Test",
+            'version': 2,
+            'config': {
+                'hasFiles': True
+            },
+            'pages':  [{
+                'id': 'page1',
+                'questions': [
+                    from_question(qid, q)
+                    for qid, q in data.items()
+                ]
+            }]
+        },
+    )
+    schema.save()
+    return schema
+
+def generate_metadata(file_trees, selected_files, node_index):
+    data = {}
+    uploader_types = {
+        ('q_' + selected_file['name']): {
+            'value': fake.word(),
+            'extra': {
+                'sha256': sha256,
+                'viewUrl': '/project/{0}/files/osfstorage{1}'.format(
+                    node_index[sha256],
+                    selected_file['path']
+                ),
+                'selectedFileName': selected_file['name'],
+                'nodeId': node_index[sha256]
+            }
+        }
+        for sha256, selected_file in selected_files.items()
+    }
+    data.update(uploader_types)
+    object_types = {
+        ('q_' + selected_file['name'] + '_obj'): {
+            'value': {
+                name_factory(): {
+                    'value': fake.word(),
+                    'extra': {
+                        'sha256': sha256,
+                        'viewUrl': '/project/{0}/files/osfstorage{1}'.format(
+                            node_index[sha256],
+                            selected_file['path']
+                        ),
+                        'selectedFileName': selected_file['name'],
+                        'nodeId': node_index[sha256]
+                    }
+                },
+                name_factory(): {
+                    'value': fake.word()
+                }
+            }
+        }
+        for sha256, selected_file in selected_files.items()
+    }
+    data.update(object_types)
+    other_questions = {
+        'q{}'.format(i): {
+            'value': fake.word()
+        }
+        for i in range(5)
+    }
+    data.update(other_questions)
+    return data
 
 class ArchiverTestCase(OsfTestCase):
 
@@ -381,38 +505,57 @@ class TestArchiverTasks(ArchiverTestCase):
         ))
 
     def test_archive_success(self):
-        ensure_schemas()
-        file_tree = file_tree_factory(3, 3, 3)
-        selected_files = select_files_from_tree(file_tree)
-
         node = factories.NodeFactory(creator=self.user)
-        prereg_schema = MetaSchema.find_one(
-            Q('name', 'eq', 'Prereg Challenge') &
-            Q('schema_version', 'eq', 2)
+        file_trees, selected_files, node_index = generate_file_tree([node])
+        data = generate_metadata(
+            file_trees,
+            selected_files,
+            node_index
         )
+        schema = generate_schema_from_data(data)
+        with test_utils.mock_archive(node, schema=schema, data=data, autocomplete=True, autoapprove=True) as registration:
+            with mock.patch.object(StorageAddonBase, '_get_file_tree', mock.Mock(return_value=file_trees[node._id])):
+                job = factories.ArchiveJobFactory()
+                archive_success(registration._id, job._id)
+                for key, question in registration.registered_meta[schema._id].items():
+                    target = None
+                    if isinstance(question.get('value'), dict):
+                        target = [v for v in question['value'].values() if 'extra' in v and 'sha256' in v['extra']][0]
+                    elif 'extra' in question and 'hashes' in question['extra']:
+                        target = question
+                    if target:
+                        assert_in(registration._id, target['extra']['viewUrl'])
+                        assert_not_in(node._id, target['extra']['viewUrl'])
+                        del selected_files[target['extra']['sha256']]
+                    else:
+                        # check non-file questions are unmodified
+                        assert_equal(data[key]['value'], question['value'])
+                assert_false(selected_files)
+
+    def test_archive_success_with_deeply_nested_schema(self):
+        node = factories.NodeFactory(creator=self.user)
+        file_trees, selected_files, node_index = generate_file_tree([node])
         data = {
-            ('q_' + selected_file['name']): {
-                'value': fake.word(),
-                'extra': {
-                    'selectedFileName': selected_file['name'],
-                    'nodeId': node._id,
-                    'sha256': sha256,
-                    'viewUrl': '/project/{0}/files/osfstorage{1}'.format(node._id, selected_file['path'])
-                }
-            }
-            for sha256, selected_file in selected_files.items()
-        }
-        object_types = {
             ('q_' + selected_file['name'] + '_obj'): {
                 'value': {
                     name_factory(): {
-                        'value': fake.word(),
-                        'extra': {
-                            'selectedFileName': selected_file['name'],
-                            'nodeId': node._id,
-                            'sha256': sha256,
-                            'viewUrl': '/project/{0}/files/osfstorage{1}'.format(node._id, selected_file['path'])
-                        }
+                        'value': {
+                            name_factory(): {
+                                'value': fake.word(),                                
+                                'extra': {
+                                    'sha256': sha256,
+                                    'viewUrl': '/project/{0}/files/osfstorage{1}'.format(
+                                        node_index[sha256],
+                                        selected_file['path']
+                                    ),
+                                    'selectedFileName': selected_file['name'],
+                                    'nodeId': node_index[sha256]
+                                }
+                            },
+                            name_factory(): {
+                                'value': fake.word()
+                            }
+                        }                        
                     },
                     name_factory(): {
                         'value': fake.word()
@@ -421,26 +564,24 @@ class TestArchiverTasks(ArchiverTestCase):
             }
             for sha256, selected_file in selected_files.items()
         }
-        data.update(copy.deepcopy(object_types))
-        other_questions = {
-            'q{}'.format(i): {
-                'value': fake.word()
-            }
-            for i in range(5)
-        }
-        data.update(other_questions)
-
-        with test_utils.mock_archive(node, schema=prereg_schema, data=data, autocomplete=True, autoapprove=True) as registration:
-            with mock.patch.object(StorageAddonBase, '_get_file_tree', mock.Mock(return_value=file_tree)):
+        schema = generate_schema_from_data(data)
+        with test_utils.mock_archive(node, schema=schema, data=data, autocomplete=True, autoapprove=True) as registration:
+            with mock.patch.object(StorageAddonBase, '_get_file_tree', mock.Mock(return_value=file_trees[node._id])):
                 job = factories.ArchiveJobFactory()
                 archive_success(registration._id, job._id)
-                for key, question in registration.registered_meta[prereg_schema._id].items():
+                for key, question in registration.registered_meta[schema._id].items():
                     target = None
                     if isinstance(question['value'], dict):
-                        target = [v for v in question['value'].values() if 'extra' in v and 'sha256' in v['extra']][0]
+                        target = [
+                            t
+                            for t in [
+                                    v['value'].values()
+                                    for v in question['value'].values()
+                                    if 'value' in v and isinstance(v['value'], dict)
+                            ][0] if 'extra' in t
+                        ][0]
                     elif 'extra' in question and 'hashes' in question['extra']:
                         target = question
-
                     if target:
                         assert_in(registration._id, target['extra']['viewUrl'])
                         assert_not_in(node._id, target['extra']['viewUrl'])
@@ -451,80 +592,19 @@ class TestArchiverTasks(ArchiverTestCase):
                 assert_false(selected_files)
 
     def test_archive_success_with_components(self):
-        ensure_schemas()
         node = factories.NodeFactory(creator=self.user)
         comp1 = factories.NodeFactory(parent=node, creator=self.user)
         factories.NodeFactory(parent=comp1, creator=self.user)
         factories.NodeFactory(parent=node, creator=self.user)
-        nodes = [n for n in node.node_and_primary_descendants()]
-
-        file_trees = {
-            n._id: file_tree_factory(3, 3, 3)
-            for n in nodes
-        }
-
-        selected_files = {}
-        selected_file_node_index = {}
-        for n in nodes:
-            file_tree = file_trees[n._id]
-            selected = select_files_from_tree(file_tree)
-            selected_file_node_index.update({
-                sha256: n._id
-                for sha256 in selected.keys()
-            })
-            selected_files.update(selected)  # select files from each Node
-
-        prereg_schema = MetaSchema.find_one(
-            Q('name', 'eq', 'Prereg Challenge') &
-            Q('schema_version', 'eq', 2)
+        nodes = [n for n in node.node_and_primary_descendants()]        
+        file_trees, selected_files, node_index = generate_file_tree(nodes)
+        data = generate_metadata(
+            file_trees,
+            selected_files,
+            node_index
         )
-        data = {
-            ('q_' + selected_file['name']): {
-                'value': fake.word(),
-                'extra': {
-                    'sha256': sha256,
-                    'viewUrl': '/project/{0}/files/osfstorage{1}'.format(
-                        selected_file_node_index[sha256],
-                        selected_file['path']
-                    ),
-                    'selectedFileName': selected_file['name'],
-                    'nodeId': selected_file_node_index[sha256]
-                }
-            }
-            for sha256, selected_file in selected_files.items()
-        }
-        object_types = {
-            ('q_' + selected_file['name'] + '_obj'): {
-                'value': {
-                    name_factory(): {
-                        'value': fake.word(),
-                        'extra': {
-                            'sha256': sha256,
-                            'viewUrl': '/project/{0}/files/osfstorage{1}'.format(
-                                selected_file_node_index[sha256],
-                                selected_file['path']
-                            ),
-                            'selectedFileName': selected_file['name'],
-                            'nodeId': selected_file_node_index[sha256]
-                        }
-                    },
-                    name_factory(): {
-                        'value': fake.word()
-                    }
-                }
-            }
-            for sha256, selected_file in selected_files.items()
-        }
-        data.update(object_types)
-        other_questions = {
-            'q{}'.format(i): {
-                'value': fake.word()
-            }
-            for i in range(5)
-        }
-        data.update(other_questions)
-
-        with test_utils.mock_archive(node, schema=prereg_schema, data=copy.deepcopy(data), autocomplete=True, autoapprove=True) as registration:
+        schema = generate_schema_from_data(data)
+        with test_utils.mock_archive(node, schema=schema, data=copy.deepcopy(data), autocomplete=True, autoapprove=True) as registration:
             patches = []
             for n in registration.node_and_primary_descendants():
                 file_tree = file_trees[n.registered_from._id]
@@ -546,7 +626,7 @@ class TestArchiverTasks(ArchiverTestCase):
             job = factories.ArchiveJobFactory()
             archive_success(registration._id, job._id)
 
-            for key, question in registration.registered_meta[prereg_schema._id].items():
+            for key, question in registration.registered_meta[schema._id].items():
                 target = None
                 if isinstance(question['value'], dict):
                     target = [v for v in question['value'].values() if 'extra' in v and 'sha256' in v['extra']][0]
@@ -574,17 +654,12 @@ class TestArchiverTasks(ArchiverTestCase):
                 patch.stop()
 
     def test_archive_success_different_name_same_sha(self):
-        ensure_schemas()
         file_tree = file_tree_factory(0, 0, 0)
         fake_file = file_factory()
         fake_file2 = file_factory(sha256=fake_file['extra']['hashes']['sha256'])
         file_tree['children'] = [fake_file, fake_file2]
 
         node = factories.NodeFactory(creator=self.user)
-        prereg_schema = MetaSchema.find_one(
-            Q('name', 'eq', 'Prereg Challenge') &
-            Q('schema_version', 'eq', 2)
-        )
         data = {
             ('q_' + fake_file['name']): {
                 'value': fake.word(),
@@ -599,16 +674,16 @@ class TestArchiverTasks(ArchiverTestCase):
                 }
             }
         }
+        schema = generate_schema_from_data(data)
 
-        with test_utils.mock_archive(node, schema=prereg_schema, data=data, autocomplete=True, autoapprove=True) as registration:
+        with test_utils.mock_archive(node, schema=schema, data=data, autocomplete=True, autoapprove=True) as registration:
             with mock.patch.object(StorageAddonBase, '_get_file_tree', mock.Mock(return_value=file_tree)):
                 job = factories.ArchiveJobFactory()
                 archive_success(registration._id, job._id)
-                for key, question in registration.registered_meta[prereg_schema._id].items():
+                for key, question in registration.registered_meta[schema._id].items():
                     assert_equal(question['extra']['selectedFileName'], fake_file['name'])
 
     def test_archive_success_same_file_in_component(self):
-        ensure_schemas()
         file_tree = file_tree_factory(3, 3, 3)
         selected = select_files_from_tree(file_tree).values()[0]
 
@@ -618,10 +693,6 @@ class TestArchiverTasks(ArchiverTestCase):
         node = factories.NodeFactory(creator=self.user)
         child = factories.NodeFactory(creator=self.user, parent=node)
 
-        prereg_schema = MetaSchema.find_one(
-            Q('name', 'eq', 'Prereg Challenge') &
-            Q('schema_version', 'eq', 2)
-        )
         data = {
             ('q_' + selected['name']): {
                 'value': fake.word(),
@@ -636,13 +707,14 @@ class TestArchiverTasks(ArchiverTestCase):
                 }
             }
         }
+        schema = generate_schema_from_data(data)
 
-        with test_utils.mock_archive(node, schema=prereg_schema, data=data, autocomplete=True, autoapprove=True) as registration:
+        with test_utils.mock_archive(node, schema=schema, data=data, autocomplete=True, autoapprove=True) as registration:
             with mock.patch.object(StorageAddonBase, '_get_file_tree', mock.Mock(return_value=file_tree)):
                 job = factories.ArchiveJobFactory()
                 archive_success(registration._id, job._id)
                 child_reg = registration.nodes[0]
-                for key, question in registration.registered_meta[prereg_schema._id].items():
+                for key, question in registration.registered_meta[schema._id].items():
                     assert_in(child_reg._id, question['extra']['viewUrl'])
 
 

--- a/website/archiver/tasks.py
+++ b/website/archiver/tasks.py
@@ -25,7 +25,7 @@ from website.archiver.model import ArchiveJob
 from website.archiver import signals as archiver_signals
 
 from website.project import signals as project_signals
-from website.project.model import Node, MetaSchema, DraftRegistration
+from website.project.model import Node, DraftRegistration
 from website import settings
 from website.app import init_addons, do_set_backends
 
@@ -294,28 +294,6 @@ def archive(job_pk):
         ]
     )
 
-def find_registration_file(value, node):
-    orig_sha256 = value['extra']['sha256']
-    orig_name = value['extra']['selectedFileName']
-    orig_node = value['extra']['nodeId']
-    file_map = utils.get_file_map(node)
-    for sha256, value, node_id in file_map:
-        registered_from_id = Node.load(node_id).registered_from._id
-        if sha256 == orig_sha256 and registered_from_id == orig_node and orig_name == value['name']:
-            return value, node_id
-    return None, None
-
-def find_question(schema, qid):
-    for page in schema['pages']:
-        questions = {
-            q['qid']: q
-            for q in page['questions']
-        }
-        if qid in questions:
-            return questions[qid]
-
-VIEW_FILE_URL_TEMPLATE = '/project/{node_id}/files/osfstorage/{path}/'
-
 @celery_app.task(base=ArchiverTask, name="archiver.archive_success")
 @logged('archive_success')
 def archive_success(dst_pk, job_pk):
@@ -342,54 +320,9 @@ def archive_success(dst_pk, job_pk):
     # questions. These files are references to files on the unregistered Node, and
     # consequently we must migrate those file paths after archiver has run. Using
     # sha256 hashes is a convenient way to identify files post-archival.
-    prereg_schema = MetaSchema.find_one(
-        Q('name', 'eq', 'Prereg Challenge') &
-        Q('schema_version', 'eq', 2)
-    )
-    missing_files = []
-    if prereg_schema in dst.registered_schema:
-        prereg_metadata = dst.registered_meta[prereg_schema._id]
-        updated_metadata = {}
-        for key, question in prereg_metadata.items():
-            if isinstance(question['value'], dict):
-                for subkey, subvalue in question['value'].items():
-                    registration_file = None
-                    if subvalue.get('extra', {}).get('sha256'):
-                        registration_file, node_id = find_registration_file(subvalue, dst)
-                        if not registration_file:
-                            missing_files.append({
-                                'file_name': subvalue['extra']['selectedFileName'],
-                                'question_title': find_question(prereg_schema.schema, key)['title']
-                            })
-                            continue
-                        subvalue['extra'].update({
-                            'viewUrl': VIEW_FILE_URL_TEMPLATE.format(node_id=node_id, path=registration_file['path'].lstrip('/'))
-                        })
-                    question['value'][subkey] = subvalue
-            else:
-                if question.get('extra', {}).get('sha256'):
-                    registration_file, node_id = find_registration_file(question, dst)
-                    if not registration_file:
-                        missing_files.append({
-                            'file_name': question['extra']['selectedFileName'],
-                            'question_title': find_question(prereg_schema.schema, key)['title']
-                        })
-                        continue
-                    question['extra'].update({
-                        'viewUrl': VIEW_FILE_URL_TEMPLATE.format(node_id=node_id, path=registration_file['path'].lstrip('/'))
-                    })
-            updated_metadata[key] = question
-
-        if missing_files:
-            raise ArchivedFileNotFound(
-                registration=dst,
-                missing_files=missing_files
-            )
-
-        prereg_metadata.update(updated_metadata)
-        dst.registered_meta[prereg_schema._id] = prereg_metadata
-        dst.save()
-
+    for schema in dst.registered_schema:
+        if schema.has_files:
+            utils.migrate_file_metadata(dst, schema)
     job = ArchiveJob.load(job_pk)
     if not job.sent:
         job.sent = True

--- a/website/archiver/utils.py
+++ b/website/archiver/utils.py
@@ -10,8 +10,10 @@ from website.archiver import (
 )
 from website.archiver.model import ArchiveJob
 
-from website import mails
-from website import settings
+from website import (
+    mails,
+    settings
+)
 
 def send_archiver_size_exceeded_mails(src, user, stat_result):
     mails.send_mail(
@@ -199,3 +201,94 @@ def get_file_map(node, file_map):
     for child in node.nodes_primary:
         for key, value, node_id in get_file_map(child):
             yield (key, value, node_id)
+
+def find_registration_file(value, node):
+    from website.models import Node
+
+    orig_sha256 = value['extra']['sha256']
+    orig_name = value['extra']['selectedFileName']
+    orig_node = value['extra']['nodeId']
+    file_map = get_file_map(node)
+    for sha256, value, node_id in file_map:
+        registered_from_id = Node.load(node_id).registered_from._id
+        if sha256 == orig_sha256 and registered_from_id == orig_node and orig_name == value['name']:
+            return value, node_id
+    return None, None
+
+def find_question(schema, qid):
+    for page in schema['pages']:
+        questions = {
+            q['qid']: q
+            for q in page['questions']
+        }
+    if qid in questions:
+        return questions[qid]
+
+def find_selected_files(schema, metadata):
+    targets = []
+    paths = [('', p) for p in schema.schema['pages']]
+    while len(paths):
+        prefix, path = paths.pop(0)
+        if path.get('questions'):
+            paths = paths + [('', q) for q in path['questions']]
+        elif path.get('type'):
+            qid = path.get('qid', path.get('id'))
+            if path['type'] == 'object':
+                paths = paths + [('{}.{}.value'.format(prefix, qid), p) for p in path['properties']]
+            elif path['type'] == 'osf-upload':
+                targets.append('{}.{}'.format(prefix, qid).lstrip('.'))
+    selected = {}
+    for t in targets:
+        parts = t.split('.')
+        value = metadata.get(parts.pop(0))
+        while value and len(parts):
+            value = value.get(parts.pop(0))
+        if value:
+            selected[t] = value
+    return selected
+
+VIEW_FILE_URL_TEMPLATE = '/project/{node_id}/files/osfstorage/{path}/'
+
+class SettableDict(dict):
+    def set(self, path, value):
+        parts = path.split('.')
+        next_item = self
+        key = None
+        while len(parts):
+            item = next_item
+            key = parts.pop(0)
+            next_item = item.get(key, {})
+            item[key] = next_item
+        item[key] = value
+
+def migrate_file_metadata(dst, schema):
+    metadata = dst.registered_meta[schema._id]
+    missing_files = []
+    updated_metadata = SettableDict()
+    selected_files = find_selected_files(schema, metadata)
+    for path, selected in selected_files.items():
+        registration_file, node_id = find_registration_file(
+            selected,
+            dst
+        )
+        if not registration_file:
+            missing_files.append({
+                'file_name': selected['extra']['selectedFileName'],
+                'question_title': find_question(schema.schema, path[0])['title']
+            })
+            continue
+        root = path.split('.')[0]
+        updated_metadata[root] = metadata[root]
+        updated_metadata.set(
+            '{}.extra.viewUrl'.format(path),
+            VIEW_FILE_URL_TEMPLATE.format(node_id=node_id, path=registration_file['path'].lstrip('/'))
+        )
+    if missing_files:
+        from website.archiver.tasks import ArchivedFileNotFound
+        raise ArchivedFileNotFound(
+            registration=dst,
+            missing_files=missing_files
+        )
+    metadata.update(updated_metadata)
+    dst.registered_meta[schema._id] = metadata
+    dst.save()

--- a/website/project/metadata/prereg-prize.json
+++ b/website/project/metadata/prereg-prize.json
@@ -7,6 +7,7 @@
         "assignee": null
     },
     "config": {
+	"hasFiles": true,
         "requiresApproval": true,
         "requiresConsent": true,
         "messages": {

--- a/website/project/metadata/schemas.py
+++ b/website/project/metadata/schemas.py
@@ -31,6 +31,7 @@ OSF_META_SCHEMAS = [
     ensure_schema_structure(from_json('prereg-prize.json')),
     ensure_schema_structure(from_json('confirmatory-general-2.json')),
     ensure_schema_structure(from_json('egap-project-2.json')),
+    ensure_schema_structure(from_json('veer-1.json')),
 ]
 
 ACTIVE_META_SCHEMAS = (
@@ -39,4 +40,5 @@ ACTIVE_META_SCHEMAS = (
     'Replication Recipe (Brandt et al., 2013): Pre-Registration',
     'Replication Recipe (Brandt et al., 2013): Post-Completion',
     'Prereg Challenge',
+    "Pre-Registration in Social Psychology (van 't Veer & Giner-Sorolla, 2016): Pre-Registration",
 )

--- a/website/project/metadata/veer-1.json
+++ b/website/project/metadata/veer-1.json
@@ -1,0 +1,442 @@
+{
+    "name": "Pre-Registration in Social Psychology (van 't Veer & Giner-Sorolla, 2016): Pre-Registration",
+    "version": 2,
+    "description": "This template is intended for use when conducting a pre-registration. You will be asked to fill out the elements for a pre-registration as described in: van 't Veer & Giner-Sorolla (2016). This template is not a valid submission for the Pre-registration Prize.",
+    "config": {
+        "hasFiles": true
+    },
+    "pages": [{
+        "id": "page1-essential",
+        "title": "A. Hypotheses - Essential elements",
+        "description": "For any required question that does not apply to your study put 'N/A' in the space for the relevant field. See van 't Veer & Giner-Sorolla (2016) or https://osf.io/56g8e/ for additional information.",
+        "questions": [{
+            "qid": "description-hypothesis",
+            "title": "Description of essential elements",
+            "type": "object",
+            "properties": [{
+                "id": "question1a",
+                "type": "string",
+                "format": "textarea-xl",
+                "required": true,
+                "description": "Describe the (numbered) hypotheses in terms of directional relationships between your (manipulated or measured) variables."
+            }, {
+                "id": "question2a",
+                "type": "string",
+                "format": "textarea",
+                "required": true,
+                "description": "For interaction effects, describe the expected shape of the interactions."
+            }, {
+                "id": "question3a",
+                "type": "string",
+                "format": "textarea",
+                "required": true,
+                "description": "If you are manipulating a variable, make predictions for successful check variables or explain why no manipulation check is included."
+            }]
+        }]
+    }, {
+        "id": "page1-recommended",
+        "title": "Recommended elements",
+        "description": "For any required question that does not apply to your study put 'N/A' in the space for the relevant field. See van 't Veer & Giner-Sorolla (2016) or https://osf.io/56g8e/ for additional information.",
+        "questions": [{
+            "qid": "recommended-hypothesis",
+            "title": "Recommended elements",
+            "type": "object",
+            "properties": [{
+                "id": "question4a",
+                "type": "osf-upload",
+                "format": "osf-upload-open",
+                "description": "A figure or table may be helpful to describe complex interactions; this facilitates correct specification of the ordering of all group means."
+            }, {
+                "id": "question5a",
+                "type": "string",
+                "format": "textarea-lg",
+                "description": "For original research, add rationales or theoretical frameworks for why a certain hypothesis is tested."
+            }, {
+                "id": "question6a",
+                "type": "string",
+                "format": "textarea",
+                "description": "If multiple predictions can be made for the same IV-DV combination, describe what outcome would be predicted by which theory."
+            }]
+        }]
+    }, {
+        "id": "page2-essential",
+        "title": "B. Methods - Essential elements",
+        "description": "For any required question that does not apply to your study put 'N/A' in the space for the relevant field. See van 't Veer & Giner-Sorolla (2016) or https://osf.io/56g8e/ for additional information.",
+        "questions": [{
+            "qid": "description-methods",
+            "type": "object",
+            "title": "Description of essential elements",
+            "properties": [{
+                "id": "design",
+                "type": "object",
+                "description": "Design",
+                "properties": [{
+                    "id": "question2a",
+                    "format": "textarea-lg",
+                    "required": true,
+                    "description": "List, based on your hypotheses from section A:\n\nIndependent variables with all their levels\n    a. whether they are within- or between-participant\n    b. the relationship between them (e.g., orthogonal, nested)."
+                }, {
+                    "id": "question2b",
+                    "type": "string",
+                    "format": "textarea-xl",
+                    "required": true,
+                    "description": "List dependent variables, or variables in a correlational design"
+                }, {
+                    "id": "question3b",
+                    "type": "string",
+                    "format": "textarea",
+                    "required": true,
+                    "description": "Third variables acting as covariates or moderators."
+                }]
+            }, {
+                "id": "planned-sample",
+                "type": "object",
+                "description": "Planned Sample",
+                "properties": [{
+                    "id": "question4b",
+                    "type": "string",
+                    "format": "textarea",
+                    "required": true,
+                    "description": "If applicable, describe pre-selection rules."
+                }, {
+                    "id": "question5b",
+                    "type": "string",
+                    "format": "textarea",
+                    "required": true,
+                    "description": "Indicate where, from whom and how the data will be collected."
+                }, {
+                    "id": "question6b",
+                    "type": "string",
+                    "description": "Justify planned sample size",
+                    "format": "textarea",
+                    "required": true
+                }, {
+                    "id": "question6b-upload",
+                    "description": "If applicable, you can upload a file related to your power analysis here (e.g., a protocol of power analyses from G*Power, a script, a screenshot, etc.).",
+                    "type": "osf-upload",
+                    "format": "osf-upload-toggle",
+                    "required": false
+                }, {
+                    "id": "question7b",
+                    "type": "string",
+                    "format": "textarea",
+                    "required": true,
+                    "description": "Describe data collection termination rule."
+                }]
+            }, {
+                "id": "exclusion-criteria",
+                "type": "object",
+                "description": "Exclusion Criteria",
+                "properties": [{
+                    "id": "question8b",
+                    "type": "string",
+                    "format": "textarea",
+                    "required": true,
+                    "description": "Describe anticipated specific data exclusion criteria. For example:\n\n    a) missing, erroneous, or overly consistent responses;\n    b) failing check-tests or suspicion probes;\n    c) demographic exclusions;\n    d) data-based outlier criteria;\n    e) method-based outlier criteria (e.g. too short or long response times)."
+                }]
+            }, {
+                "id": "procedure",
+                "type": "object",
+                "description": "Procedure",
+                "properties": [{
+                    "id": "question10b",
+                    "type": "string",
+                    "format": "textarea-xl",
+                    "required": true,
+                    "description": "Describe all manipulations, measures, materials and procedures including the order of presentation and the method of randomization and blinding (e.g., single or double blind), as in a published Methods section."
+                }]
+            }]
+        }]
+    }, {
+        "id": "page2-recommended",
+        "title": "Recommended elements",
+        "description": "For any required question that does not apply to your study put 'N/A' in the space for the relevant field. See van 't Veer & Giner-Sorolla (2016) or https://osf.io/56g8e/ for additional information.",
+        "questions": [{
+            "qid": "recommended-methods",
+            "type": "object",
+            "title": "Recommended elements",
+            "properties": [{
+                "description": "Procedure",
+                "type": "object",
+                "properties": [{
+                    "id": "question9b",
+                    "type": "string",
+                    "format": "textarea",
+                    "description": "Set fail-safe levels of exclusion at which the whole study needs to be stopped, altered, and restarted. You may pre-determine what proportion of excluded participants will cause the study to be stopped and restarted."
+                }, {
+                    "id": "question9b-file",
+                    "type": "osf-upload",
+                    "format": "osf-upload-toggle",
+                    "description": "If applicable, you can upload any files related to your methods and procedure here (e.g., a paper describing a scale you are using, experimenter instructions, etc.)"
+                }]
+            }]
+        }]
+    }, {
+        "id": "page3-essential",
+        "title": "C. Analysis plan - Essential elements",
+        "description": "For any required question that does not apply to your study put 'N/A' in the space for the relevant field. See van 't Veer & Giner-Sorolla (2016) or https://osf.io/56g8e/ for additional information.",
+        "questions": [{
+            "qid": "confirmatory-analyses-first",
+            "type": "object",
+            "title": "Confirmatory Analyses",
+            "properties": [{
+                "id": "first",
+                "type": "object",
+                "description": "Describe the analyses that will test the first main prediction from the hypotheses section. Include:",
+                "properties": [{
+                    "id": "question1c",
+                    "description": "the relevant variables and how they are calculated;",
+                    "type": "string",
+                    "format": "textarea-lg",
+                    "required": true
+                }, {
+                    "id": "question2c",
+                    "description": "the statistical technique;",
+                    "type": "string",
+                    "format": "textarea",
+                    "required": true
+                }, {
+                    "id": "question3c",
+                    "description": "each variable’s role in the technique (e.g., IV, DV, moderator, mediator, covariate);",
+                    "type": "string",
+                    "format": "textarea",
+                    "required": true
+                }, {
+                    "id": "question4c",
+                    "description": "rationale for each covariate used, if any;",
+                    "type": "string",
+                    "format": "textarea",
+                    "required": true
+                }, {
+                    "id": "question5c",
+                    "description": "if using techniques other than null hypothesis testing (for example, Bayesian statistics), describe your criteria and inputs toward making an evidential conclusion, including prior values or distributions.",
+                    "type": "string",
+                    "format": "textarea",
+                    "required": true
+                }]
+            }]
+        }, {
+            "qid": "confirmatory-analyses-second",
+            "type": "object",
+            "title": "Second Prediction",
+            "properties": [{
+                "id": "second",
+                "type": "object",
+                "description": "Describe the analyses that will test the second main prediction from the hypotheses section. Include:",
+                "properties": [{
+                    "id": "question1c",
+                    "description": "the relevant variables and how they are calculated;",
+                    "type": "string",
+                    "format": "textarea-lg"
+                }, {
+                    "id": "question2c",
+                    "description": "the statistical technique;",
+                    "type": "string",
+                    "format": "textarea"
+                }, {
+                    "id": "question3c",
+                    "description": "each variable’s role in the technique (e.g., IV, DV, moderator, mediator, covariate);",
+                    "type": "string",
+                    "format": "textarea"
+                }, {
+                    "id": "question4c",
+                    "description": "rationale for each covariate used, if any;",
+                    "type": "string",
+                    "format": "textarea"
+                }, {
+                    "id": "question5c",
+                    "description": "if using techniques other than null hypothesis testing (for example, Bayesian statistics), describe your criteria and inputs toward making an evidential conclusion, including prior values or distributions.",
+                    "type": "string",
+                    "format": "textarea"
+                }]
+            }]
+        }, {
+            "qid": "confirmatory-analyses-third",
+            "type": "object",
+            "title": "Third Prediction",
+            "properties": [{
+                "id": "third",
+                "type": "object",
+                "description": "Describe the analyses that will test the third main prediction from the hypotheses section. Include:",
+                "properties": [{
+                    "id": "question1c",
+                    "description": "the relevant variables and how they are calculated;",
+                    "type": "string",
+                    "format": "textarea-lg"
+                }, {
+                    "id": "question2c",
+                    "description": "the statistical technique;",
+                    "type": "string",
+                    "format": "textarea"
+                }, {
+                    "id": "question3c",
+                    "description": "each variable’s role in the technique (e.g., IV, DV, moderator, mediator, covariate);",
+                    "type": "string",
+                    "format": "textarea"
+                }, {
+                    "id": "question4c",
+                    "description": "rationale for each covariate used, if any;",
+                    "type": "string",
+                    "format": "textarea"
+                }, {
+                    "id": "question5c",
+                    "description": "if using techniques other than null hypothesis testing (for example, Bayesian statistics), describe your criteria and inputs toward making an evidential conclusion, including prior values or distributions.",
+                    "type": "string",
+                    "format": "textarea"
+                }]
+            }]
+        }, {
+            "qid": "confirmatory-analyses-fourth",
+            "type": "object",
+            "title": "Fourth Prediction",
+            "properties": [{
+                "id": "fourth",
+                "type": "object",
+                "description": "Describe the analyses that will test the fourth main prediction from the hypotheses section. Include:",
+                "properties": [{
+                    "id": "question1c",
+                    "description": "the relevant variables and how they are calculated;",
+                    "type": "string",
+                    "format": "textarea-lg"
+                }, {
+                    "id": "question2c",
+                    "description": "the statistical technique;",
+                    "type": "string",
+                    "format": "textarea"
+                }, {
+                    "id": "question3c",
+                    "description": "each variable’s role in the technique (e.g., IV, DV, moderator, mediator, covariate);",
+                    "type": "string",
+                    "format": "textarea"
+                }, {
+                    "id": "question4c",
+                    "description": "rationale for each covariate used, if any;",
+                    "type": "string",
+                    "format": "textarea"
+                }, {
+                    "id": "question5c",
+                    "description": "if using techniques other than null hypothesis testing (for example, Bayesian statistics), describe your criteria and inputs toward making an evidential conclusion, including prior values or distributions.",
+                    "type": "string",
+                    "format": "textarea"
+                }]
+            }]
+        }, {
+            "qid": "confirmatory-analyses-further",
+            "type": "object",
+            "title": "Further Predictions",
+            "properties": [{
+                "id": "further",
+                "type": "object",
+                "description": "Describe the analyses that will test any further (main) predictions from the hypotheses section. Include:",
+                "properties": [{
+                    "id": "question1c",
+                    "description": "the relevant variables and how they are calculated;",
+                    "type": "string",
+                    "format": "textarea-lg"
+                }, {
+                    "id": "question2c",
+                    "description": "the statistical technique;",
+                    "type": "string",
+                    "format": "textarea"
+                }, {
+                    "id": "question3c",
+                    "description": "each variable’s role in the technique (e.g., IV, DV, moderator, mediator, covariate);",
+                    "type": "string",
+                    "format": "textarea"
+                }, {
+                    "id": "question4c",
+                    "description": "rationale for each covariate used, if any;",
+                    "type": "string",
+                    "format": "textarea"
+                }, {
+                    "id": "question5c",
+                    "description": "if using techniques other than null hypothesis testing (for example, Bayesian statistics), describe your criteria and inputs toward making an evidential conclusion, including prior values or distributions.",
+                    "type": "string",
+                    "format": "textarea"
+                }]
+            }]
+        }]
+    }, {
+        "id": "page3-recommended",
+        "title": "Recommended elements",
+        "description": "For any required question that does not apply to your study put 'N/A' in the space for the relevant field. See van 't Veer & Giner-Sorolla (2016) or https://osf.io/56g8e/ for additional information.",
+        "questions": [{
+            "qid": "recommended-analysis",
+            "type": "object",
+            "title": "Recommended Elements",
+            "required": false,
+            "properties": [{
+                "id": "specify",
+                "description": "Specify contingencies and assumptions, such as:",
+                "type": "object",
+                "required": false,
+                "properties": [{
+                    "id": "question6c",
+                    "description": "Method of correction for multiple tests.",
+                    "type": "string",
+                    "format": "textarea"
+                }, {
+                    "id": "question7c",
+                    "description": "The method of missing data handling (e.g., pairwise or listwise deletion, imputation, interpolation).",
+                    "type": "string",
+                    "format": "textarea"
+                }, {
+                    "id": "question8c",
+                    "description": "Reliability criteria for item inclusion in scale.",
+                    "type": "string",
+                    "format": "textarea"
+                }, {
+                    "id": "question9c",
+                    "description": "Anticipated data transformations.",
+                    "type": "string",
+                    "format": "textarea"
+                }, {
+                    "id": "question10c",
+                    "description": "Assumptions of analyses, and plans for alternative/corrected analyses if each assumption is violated.",
+                    "type": "string",
+                    "format": "textarea"
+                }, {
+                    "id": "question11c",
+                    "description": "Optionally, upload any files here that are related to your analyses (e.g., syntaxes, scripts, etc.).",
+                    "type": "osf-upload",
+                    "format": "osf-upload-toggle"
+                }]
+            }]
+        }]
+    }, {
+        "id": "page4",
+        "title": "Final questions",
+        "description": "For any required question that does not apply to your study put 'N/A' in the space for the relevant field. See van 't Veer & Giner-Sorolla (2016) or https://osf.io/56g8e/ for additional information.",
+        "questions": [{
+            "qid": "datacompletion",
+            "title": "Has data collection begun for this project?",
+            "nav": "Data Completion",
+            "type": "choose",
+            "format": "singleselect",
+            "options": ["No, data collection has not begun", "Yes, data collection is underway or complete"],
+            "description": "Please choose",
+            "required": true
+        }, {
+            "qid": "looked",
+            "title": "If data collection has begun, have you looked at the data?",
+            "nav": "Looked at Data",
+            "type": "choose",
+            "format": "singleselect",
+            "options": ["Yes", "No"],
+            "description": "Please choose",
+            "required": true
+        }, {
+            "qid": "dataCollectionDates",
+            "title": "The (estimated) start and end dates for this project are",
+            "nav": "Data collection period",
+            "type": "string",
+            "format": "textarea"
+        }, {
+            "qid": "additionalComments",
+            "title": "Any additional comments before I pre-register this project",
+            "nav": "Additional comments",
+            "type": "string",
+            "format": "textarea"
+        }]
+    }]
+}

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -114,6 +114,10 @@ class MetaSchema(StoredObject):
     def requires_consent(self):
         return self._config.get('requiresConsent', False)
 
+    @property
+    def has_files(self):
+        return self._config.get('hasFiles', False)
+
 def ensure_schema(schema, name, version=1):
     schema_obj = None
     try:

--- a/website/static/css/registrations.css
+++ b/website/static/css/registrations.css
@@ -13,6 +13,12 @@
     font-weight: 900;
     font-size: 120%;
 }
+.registration-editor-textarea-lg {
+    min-height: 80px;
+}
+.registration-editor-textarea-xl {
+    min-height: 160px;
+}
 #selectedFile{
     font-weight: 500;
 }
@@ -30,4 +36,7 @@
     border-radius: 2px;
     display: inline-block;
     margin-bottom: 10px;
+}
+.breaklines {
+    white-space: pre-wrap;
 }

--- a/website/static/js/registrationEditorExtensions.js
+++ b/website/static/js/registrationEditorExtensions.js
@@ -60,10 +60,8 @@ var osfUploader = function(element, valueAccessor, allBindings, viewModel, bindi
 
     var onSelectRow = function(item) {
         if (item.kind === 'file') {
-            viewModel.selectedFile(item);
+            viewModel.addFile(item);
             item.css = 'fangorn-selected';
-        } else {
-            viewModel.selectedFile(null);
         }
     };
     var fw = new FilesWidget(
@@ -136,7 +134,7 @@ var osfUploader = function(element, valueAccessor, allBindings, viewModel, bindi
                         if (item.data.path === viewModel.value()) {
                             item.css = 'fangorn-selected';
                             item.data.nodeId = tree.data.nodeId;
-                            viewModel.selectedFile(item);
+                            viewModel.addFile(item);
                         }
                     }
                     Fangorn.Utils.inheritFromParent(item, tree);
@@ -172,46 +170,85 @@ var Uploader = function(question) {
     };
     question.uid = 'uploader_' + uploaderCount;
     uploaderCount++;
-    self.selectedFile = ko.observable({});
-    self.selectedFile.subscribe(function(file) {
-        if (file) {
-            question.extra({
-                selectedFileName: file.data.name,
-                nodeId: file.data.nodeId,
-                viewUrl: '/project/' + file.data.nodeId + '/files/osfstorage' + file.data.path,
-                sha256: file.data.extra.hashes.sha256,
-                hasSelectedFile: true
-            });
-            question.value(file.data.name);
-        }
-        else {
-            question.extra({
-                selectedFileName: NO_FILE
-            });
-            question.value(NO_FILE);
-        }
+    self.selectedFiles = ko.observableArray(question.extra() || []);
+    self.selectedFiles.subscribe(function(fileList) {
+        $.each(fileList, function(idx, file) {
+            if (file && !self.fileAlreadySelected(file)) {
+                question.extra().push(file);
+            }
+        });
+        question.value(question.formattedFileList());
     });
+    self.fileWarn = ko.observable(true);
+
+    self.UPLOAD_LANGUAGE = 'You may attach up to 5 files to this question. You may attach files that you already have ' +
+        'in this OSF project, or upload a new file from your computer. Uploaded files will automatically be added to this project ' +
+        'so that they can be registered.';
+
+    self.addFile = function(file) {
+        if(self.selectedFiles().length >= 5 && self.fileWarn()) {
+            self.fileWarn(false);
+            bootbox.alert('Too many files. Cannot attach more than 5 files to a question.');
+            return false;
+        } else if(self.selectedFiles().length >= 5 && !self.fileWarn()) {
+            return false;
+        }
+        if(self.fileAlreadySelected(file))
+            return false;
+
+        self.selectedFiles.push({
+            data: file.data,
+            selectedFileName: file.data.name,
+            nodeId: file.data.nodeId,
+            viewUrl: '/project/' + file.data.nodeId + '/files/osfstorage' + file.data.path,
+            sha256: file.data.extra.hashes.sha256
+        });
+        return true;
+    };
+
+
+    self.fileAlreadySelected = function(file) {
+        var selected = false;
+        $.each(question.extra(), function(idx, alreadyFile) {
+            if(alreadyFile.sha256 === file.data.extra.hashes.sha256){
+                selected = true;
+                return;
+            }
+        });
+        return selected;
+    };
 
     self.hasSelectedFile = ko.computed(function() {
-        return !!(question.extra().viewUrl);
+        return question.extra().length !== 0;
     });
-    self.unselectFile = function() {
-        self.selectedFile(null);
-        question.extra({
-            selectedFileName: NO_FILE
-        });
+    self.unselectFile = function(fileToRemove) {
+
+        var files = question.extra();
+
+        for (var i = 0; i < files.length; i++) {
+            var file = files[i];
+            if(file.sha256 === fileToRemove.sha256) {
+                self.selectedFiles.splice(i, 1);
+                question.value(question.formattedFileList());
+                break;
+            }
+        }
     };
 
     self.filePicker = null;
 
     self.preview = function() {
         var value = question.value();
-        if (!value || value === NO_FILE) {
+        if (!value || value === NO_FILE || question.extra().length === 0) {
             return 'no file selected';
         }
         else {
-            var extra = question.extra();
-            return $('<a target="_blank" href="' + extra.viewUrl + '">' + $osf.htmlEscape(extra.selectedFileName) + '</a>');
+            var files = question.extra();
+            var elem = '';
+            $.each(files, function(_, file) {
+                elem += '<a target="_blank" href="' + file.viewUrl + '">' + $osf.htmlEscape(file.selectedFileName) + ' </a>';
+            });
+            return $(elem);
         }
     };
 

--- a/website/static/js/registrationModal.js
+++ b/website/static/js/registrationModal.js
@@ -53,9 +53,15 @@ var RegistrationViewModel = function(confirm, prompts, validator) {
     var validation = [{
         validator: function() {
             var endEmbargoDateTimestamp = self.embargoEndDate().getTime();
-            return (endEmbargoDateTimestamp < FOUR_YEARS_FROM_TODAY_TIMESTAMP && endEmbargoDateTimestamp > TWO_DAYS_FROM_TODAY_TIMESTAMP);
+            return endEmbargoDateTimestamp > TWO_DAYS_FROM_TODAY_TIMESTAMP;
         },
         message: 'Embargo end date must be at least two days in the future.'
+    }, {
+	validator: function() {
+            var endEmbargoDateTimestamp = self.embargoEndDate().getTime();
+	    return endEmbargoDateTimestamp < FOUR_YEARS_FROM_TODAY_TIMESTAMP;
+	},
+	message: 'Embargo end date must be less than four years in the future.'
     }];
     if(validator) {
         validation.unshift(validator);

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -182,7 +182,13 @@ var Question = function(questionSchema, data) {
     self.properties = questionSchema.properties || [];
     self.match = questionSchema.match || '';
 
-    self.extra = ko.observable(self.data.extra || {});
+    self.extra = ko.observableArray(self.data.extra || []);
+
+    self.formattedFileList = ko.pureComputed(function() {
+        return self.extra().map(function(elem) {
+            return elem.selectedFileName;
+        }).join(', ');
+    });
     self.showExample = ko.observable(false);
 
     self.comments = ko.observableArray(

--- a/website/static/js/tests/registrationUtils.test.js
+++ b/website/static/js/tests/registrationUtils.test.js
@@ -834,7 +834,7 @@ describe('RegistrationEditor', () => {
                 data[q.id] = {
                     value: q.value(),
                     comments: [],
-                    extra: {}
+                    extra: []
                 };
             });
 

--- a/website/templates/project/register.mako
+++ b/website/templates/project/register.mako
@@ -32,11 +32,7 @@
                 <h4 data-bind="attr: {id: question.id}, text: question.title"></h4>
                 <small><em data-bind="text: question.description"></em></small>
                 <div class="col-md-12 well">
-                  <span data-bind="if: question.value()">
-                    <p>
-                      <span data-bind="previewQuestion: $root.editor.context(question, $root.editor)"></span>
-                    </p>
-                  </span>
+                   <span data-bind="previewQuestion: $root.editor.context(question, $root.editor)"></span>
                 </div>
               </div>
             </div>

--- a/website/templates/project/registration_editor_extensions.mako
+++ b/website/templates/project/registration_editor_extensions.mako
@@ -4,12 +4,13 @@
 </script>
 
 <script type="text/html" id="osf-upload-open">
-  <div id="selectedFile">File selected for upload:
-    <span data-bind="text: extra().selectedFileName">no file selected</span>
-    <button data-bind="visible: hasSelectedFile,
-                       click: unselectFile"
-            style="margin-left: 5px;"
-            class="btn btn-xs btn-danger fa fa-times"></button>
+    <div id="selectedFile">File(s) selected for upload:
+        <div data-bind="foreach: selectedFiles">
+            <span data-bind="text: data.name"></span>
+            <button data-bind="click: $parent.unselectFile"
+                    style="margin-left: 5px;"
+                    class="btn btn-xs btn-danger fa fa-times"></button>
+        </div>
   </div>
   <div data-bind="attr: {id: $data.uid}, osfUploader"><!-- TODO: osfUploader attribute may not connect to anything? -->
     <div class="spinner-loading-wrapper">
@@ -20,12 +21,14 @@
 </script>
 
 <script type="text/html" id="osf-upload-toggle">
-  <div id="selectedFile">File selected for upload:
-    <span id="fileName" data-bind="text: extra().selectedFileName">no file selected</span>
-    <button data-bind="visible: hasSelectedFile,
-                       click: unselectFile"
-            style="margin-left: 5px;"
-            class="btn btn-xs btn-danger fa fa-times"></button>
+    <span data-bind="text: UPLOAD_LANGUAGE"></span><br/>
+    <div id="selectedFile">File(s) selected for upload:
+        <div data-bind="foreach: selectedFiles">
+            <span data-bind="text: data.name"></span>
+            <button data-bind="click: $parent.unselectFile"
+                    style="margin-left: 5px;"
+                    class="btn btn-xs btn-danger fa fa-times"></button>
+        </div>
   </div>
   <a data-bind="click: toggleUploader">Attach File</a>
   <span data-bind="visible: showUploader">

--- a/website/templates/project/registration_editor_templates.mako
+++ b/website/templates/project/registration_editor_templates.mako
@@ -18,6 +18,16 @@
                        textInput: value"
             class="form-control"> </textarea>
 </script>
+<script type="text/html" id="textarea-lg">
+  <textarea data-bind="valueUpdate: 'keyup',
+                       textInput: value"
+            class="form-control registration-editor-textarea-lg"> </textarea>
+</script>
+<script type="text/html" id="textarea-xl">
+  <textarea data-bind="valueUpdate: 'keyup',
+                       textInput: value"
+            class="form-control registration-editor-textarea-xl"> </textarea>
+</script>
 <!-- Number Types -->
 <script type="text/html" id="number">
   <input data-bind="valueUpdate: 'keyup',
@@ -61,6 +71,7 @@
 
 <script type="text/html" id="object">
   <span data-bind="foreach: $data.properties">
+    <p class="help-block breaklines f-w-xl" data-bind="text: $data.description"></p>
     <div data-bind="template: {data: $root.context($data, $root), name: $data.type}"></div>
     <hr />
   </span>
@@ -72,14 +83,14 @@
     <div class="row">
       <div class="col-md-12">
         <div class="form-group">
-          <label class="control-label" data-bind="text: title"></label>
+          <label class="control-label breaklines" data-bind="text: title"></label>
           <span class="text-muted" data-bind="if: required, tooltip: {title: 'This field is required for submission. If this field is not applicable to your study, you may state so.'}">
             (required)
           </span>
           <span class="text-muted" data-bind="ifnot: required">
             (optional)
           </span>
-          <p class="help-block" data-bind="text: description"></p>
+          <p class="help-block breaklines f-w-xl text-bigger" data-bind="text: description"></p>
           <span data-bind="if: help" class="example-block">
             <a data-bind="click: toggleExample">Show Example</a>
             <p data-bind="visible: showExample, html: help"></p>


### PR DESCRIPTION
# Purpose

We had to pull the Veer schema from 0.68 due to a migration needed for https://github.com/CenterForOpenScience/osf.io/pull/5494. This adds it back in to develop.

# Changes

Revert the commits that pulled out the Veer schema.