### PR TITLE
Hotfix: Fix unread wiki comments [OSF-6138]

### DIFF
--- a/website/project/model.py
+++ b/website/project/model.py
@@ -3200,9 +3200,9 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
         if current:
             for contrib in self.contributors:
                 if contrib.comments_viewed_timestamp.get(current._id, None):
-                    auth.user.comments_viewed_timestamp[new_page._id] = auth.user.comments_viewed_timestamp[current._id]
-                    auth.user.save()
-                    del auth.user.comments_viewed_timestamp[current._id]
+                    contrib.comments_viewed_timestamp[new_page._id] = contrib.comments_viewed_timestamp[current._id]
+                    contrib.save()
+                    del contrib.comments_viewed_timestamp[current._id]
 
         # check if the wiki page already exists in versions (existed once and is now deleted)
         if key not in self.wiki_pages_versions:


### PR DESCRIPTION
## Purpose

If Contributor A views wiki comments and Contributor B edits the page, when Contributor A tries to comment there's an "Unable to Resolve" error

## Changes

Update all contributor comments_viewed_timestamps, not just the user editing the wiki.

## Side effects
None.


## Ticket
https://openscience.atlassian.net/browse/OSF-6138
