### PR TITLE
[Hotfix] Encode wiki page_name when creating absolute url [OSF-6141]

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,6 +7,7 @@ from nose.tools import *  # noqa (PEP8 asserts)
 import pytz
 import datetime
 import urlparse
+import urllib
 import itsdangerous
 import random
 import string
@@ -1179,6 +1180,18 @@ class TestNodeWikiPage(OsfTestCase):
     def test_url(self):
         assert_equal(self.wiki.url, '{project_url}wiki/home/'
                                     .format(project_url=self.project.url))
+
+    def test_absolute_url_for_wiki_page_name_with_spaces(self):
+        wiki = NodeWikiFactory(user=self.user, node=self.project, page_name='Test Wiki')
+        url = '{}wiki/{}/'.format(self.project.absolute_url, urllib.quote(wiki.page_name))
+        assert_equal(wiki.get_absolute_url(), url)
+
+    def test_absolute_url_for_wiki_page_name_with_special_characters(self):
+        wiki = NodeWikiFactory(user=self.user, node=self.project)
+        wiki.page_name = 'Wiki!@#$%^&*()+'
+        wiki.save()
+        url = '{}wiki/{}/'.format(self.project.absolute_url, urllib.quote(wiki.page_name))
+        assert_equal(wiki.get_absolute_url(), url)
 
 
 class TestUpdateNodeWiki(OsfTestCase):

--- a/website/addons/wiki/model.py
+++ b/website/addons/wiki/model.py
@@ -3,6 +3,7 @@
 import datetime
 import functools
 import logging
+import urllib
 
 from bleach import linkify
 from bleach.callbacks import nofollow
@@ -211,7 +212,7 @@ class NodeWikiPage(GuidStoredObject, Commentable):
 
     # used by django and DRF - use v1 url since there are no v2 wiki routes
     def get_absolute_url(self):
-        return '{}wiki/{}/'.format(self.node.absolute_url, self.page_name)
+        return '{}wiki/{}/'.format(self.node.absolute_url, urllib.quote(self.page_name))
 
     def html(self, node):
         """The cleaned HTML of the page"""


### PR DESCRIPTION
## Purpose

If a wiki has a page name with spaces in it (e.g. "Test Wiki"), it's absolute url is `http://osf.io/<project_id/wiki/Test Wiki`, which redirects to ``http://osf.io/<project_id/wiki/Test` because of the space.

## Changes

%encode the wiki page name so that spaces or special characters do not break the url.

## Side effects

None.


## Ticket

https://openscience.atlassian.net/browse/OSF-6141