### PR TITLE
[Feature] Add cookie expiration after 30 days for osf and admin [SEC-10][OSF-6099]

### DIFF
--- a/admin/base/settings/defaults.py
+++ b/admin/base/settings/defaults.py
@@ -14,6 +14,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__fil
 # from the OSF settings
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = osf_settings.SECRET_KEY
+SESSION_COOKIE_AGE = osf_settings.OSF_COOKIE_MAX_AGE
 
 
 # SECURITY WARNING: don't run with debug turned on in production!

--- a/framework/sessions/__init__.py
+++ b/framework/sessions/__init__.py
@@ -5,7 +5,7 @@ import urllib
 import urlparse
 import bson.objectid
 import httplib as http
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import itsdangerous
 
@@ -107,7 +107,9 @@ def create_session(response, data=None):
         cookie_value = itsdangerous.Signer(settings.SECRET_KEY).sign(session_id)
         set_session(session)
     if response is not None:
-        response.set_cookie(settings.COOKIE_NAME, value=cookie_value, max_age=settings.OSF_COOKIE_MAX_AGE, domain=settings.OSF_COOKIE_DOMAIN)
+        now = datetime.utcnow() + timedelta(days=settings.OSF_COOKIE_EXPIRES)
+        exp_date = now.strftime("%a %b %d %H:%M:%S UTC %Y")
+        response.set_cookie(settings.COOKIE_NAME, value=cookie_value, max_age=settings.OSF_COOKIE_MAX_AGE, expires=exp_date, domain=settings.OSF_COOKIE_DOMAIN)
         return response
 
 

--- a/framework/sessions/__init__.py
+++ b/framework/sessions/__init__.py
@@ -107,7 +107,7 @@ def create_session(response, data=None):
         cookie_value = itsdangerous.Signer(settings.SECRET_KEY).sign(session_id)
         set_session(session)
     if response is not None:
-        response.set_cookie(settings.COOKIE_NAME, value=cookie_value, domain=settings.OSF_COOKIE_DOMAIN)
+        response.set_cookie(settings.COOKIE_NAME, value=cookie_value, max_age=settings.OSF_COOKIE_MAX_AGE, domain=settings.OSF_COOKIE_DOMAIN)
         return response
 
 

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -82,7 +82,8 @@ SHARE_ELASTIC_INDEX_TEMPLATE = 'share_v{}'
 # Sessions
 # TODO: Override OSF_COOKIE_DOMAIN in local.py in production
 OSF_COOKIE_DOMAIN = None
-OSF_COOKIE_MAX_AGE = 30 * 24 * 60 * 60  # 31 days
+OSF_COOKIE_MAX_AGE = 30 * 24 * 60 * 60  # 30 days in seconds
+OSF_COOKIE_EXPIRES = 30  # 30 days
 COOKIE_NAME = 'osf'
 # TODO: Override SECRET_KEY in local.py in production
 SECRET_KEY = 'CHANGEME'

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -82,6 +82,7 @@ SHARE_ELASTIC_INDEX_TEMPLATE = 'share_v{}'
 # Sessions
 # TODO: Override OSF_COOKIE_DOMAIN in local.py in production
 OSF_COOKIE_DOMAIN = None
+OSF_COOKIE_MAX_AGE = 30 * 24 * 60 * 60  # 31 days
 COOKIE_NAME = 'osf'
 # TODO: Override SECRET_KEY in local.py in production
 SECRET_KEY = 'CHANGEME'


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Add cookie expiration after 30 days for osf and admin.

## Changes

Before, user session is entirely determined by browser lifetime. This fix forces the user to re-log-in after 30 days. In addition, there is no need to log in again each time browser restarts.

## Side effects

No side effects.

## Ticket

[SEC-10](https://openscience.atlassian.net/browse/SEC-10), [OSF-6099](https://openscience.atlassian.net/browse/OSF-6099)
