### PR TITLE
Throw API error if addon is not configured [OSF-4947]

### DIFF
--- a/api/nodes/utils.py
+++ b/api/nodes/utils.py
@@ -25,7 +25,7 @@ def get_file_object(node, path, provider, request):
             )
         return obj
 
-    if not node.has_addon(provider):
+    if not node.get_addon(provider) or not node.get_addon(provider).configured:
         raise NotFound('The {} provider is not configured for this project.'.format(provider))
 
     url = waterbutler_api_url_for(node._id, provider, path, meta=True)

--- a/api/nodes/utils.py
+++ b/api/nodes/utils.py
@@ -25,6 +25,9 @@ def get_file_object(node, path, provider, request):
             )
         return obj
 
+    if not node.has_addon(provider):
+        raise NotFound('The {} provider is not configured for this project.'.format(provider))
+
     url = waterbutler_api_url_for(node._id, provider, path, meta=True)
     waterbutler_request = requests.get(
         url,

--- a/api_tests/nodes/views/test_node_files_list.py
+++ b/api_tests/nodes/views/test_node_files_list.py
@@ -248,6 +248,14 @@ class TestNodeFilesList(ApiTestCase):
         assert_equal(res.status_code, 404)
         assert_in('detail', res.json['errors'][0])
 
+    def test_handles_request_to_provider_not_configured_on_project(self):
+        provider = 'box'
+        url = '/{}nodes/{}/files/{}/'.format(API_BASE, self.project._id, provider)
+        res = self.app.get(url, auth=self.user.auth, expect_errors=True)
+        assert_false(self.project.has_addon(provider))
+        assert_equal(res.status_code, 404)
+        assert_equal(res.json['errors'][0]['detail'], 'The {} provider is not configured for this project.'.format(provider))
+
     def test_handles_bad_waterbutler_request(self):
         wb_url = waterbutler_api_url_for(self.project._id, provider='github', path='/', meta=True)
         httpretty.register_uri(

--- a/api_tests/nodes/views/test_node_files_list.py
+++ b/api_tests/nodes/views/test_node_files_list.py
@@ -252,7 +252,7 @@ class TestNodeFilesList(ApiTestCase):
         provider = 'box'
         url = '/{}nodes/{}/files/{}/'.format(API_BASE, self.project._id, provider)
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
-        assert_false(self.project.has_addon(provider))
+        assert_false(self.project.get_addon(provider))
         assert_equal(res.status_code, 404)
         assert_equal(res.json['errors'][0]['detail'], 'The {} provider is not configured for this project.'.format(provider))
 


### PR DESCRIPTION
## Purpose

Going to the API endpoint `/v2/node_id/files/<provider>/` for an addon that is not configured on the project throws a 503 service unavailable error.

## Changes

Throw a 404 NotFound error.

## Side effects

None.


## Ticket
https://openscience.atlassian.net/browse/OSF-4947
