### PR TITLE
Hotfix/fix banning of wiki comments

### DIFF
--- a/api/caching/tasks.py
+++ b/api/caching/tasks.py
@@ -42,7 +42,6 @@ def get_bannable_urls(instance):
                                                                   path=parsed_target_url.path)
                 bannable_urls.append(url_string)
 
-
             try:
                 parsed_root_target_url = urlparse.urlparse(instance.root_target.referent.absolute_api_v2_url)
             except AttributeError:
@@ -54,9 +53,7 @@ def get_bannable_urls(instance):
                                                               path=parsed_root_target_url.path)
                 bannable_urls.append(url_string)
 
-
     return bannable_urls, parsed_absolute_url.hostname
-
 
 def ban_url(instance):
     # TODO: Refactor; Pull url generation into postcommit_task handling so we only ban urls once per request

--- a/api/caching/tasks.py
+++ b/api/caching/tasks.py
@@ -32,23 +32,28 @@ def get_bannable_urls(instance):
         if isinstance(instance, Comment):
             try:
                 parsed_target_url = urlparse.urlparse(instance.target.referent.absolute_api_v2_url)
-                url_string = '{scheme}://{netloc}{path}.*'.format(scheme=varnish_parsed_url.scheme,
-                                                                  netloc=varnish_parsed_url.netloc,
-                                                                  path=parsed_target_url.path)
-                bannable_urls.append(url_string)
             except AttributeError:
                 # some referents don't have an absolute_api_v2_url
                 # I'm looking at you NodeWikiPage
                 pass
+            else:
+                url_string = '{scheme}://{netloc}{path}.*'.format(scheme=varnish_parsed_url.scheme,
+                                                                  netloc=varnish_parsed_url.netloc,
+                                                                  path=parsed_target_url.path)
+                bannable_urls.append(url_string)
+
+
             try:
                 parsed_root_target_url = urlparse.urlparse(instance.root_target.referent.absolute_api_v2_url)
+            except AttributeError:
+                # some root_targets don't have an absolute_api_v2_url
+                pass
+            else:
                 url_string = '{scheme}://{netloc}{path}.*'.format(scheme=varnish_parsed_url.scheme,
                                                               netloc=varnish_parsed_url.netloc,
                                                               path=parsed_root_target_url.path)
                 bannable_urls.append(url_string)
-            except AttributeError:
-                # some root_targets don't have an absolute_api_v2_url
-                pass
+
 
     return bannable_urls, parsed_absolute_url.hostname
 

--- a/api/caching/tasks.py
+++ b/api/caching/tasks.py
@@ -17,6 +17,10 @@ def get_bannable_urls(instance):
     bannable_urls = []
     parsed_absolute_url = {}
 
+    if not hasattr(instance, 'absolute_api_v2_url'):
+        logger.warning('Tried to ban {}:{} but it didn\'t have a absolute_api_v2_url method'.format(instance.__class__, instance))
+        return [], ''
+
     for host in get_varnish_servers():
         # add instance url
         varnish_parsed_url = urlparse.urlparse(host)
@@ -25,18 +29,26 @@ def get_bannable_urls(instance):
                                                           netloc=varnish_parsed_url.netloc,
                                                           path=parsed_absolute_url.path)
         bannable_urls.append(url_string)
-
         if isinstance(instance, Comment):
-            parsed_target_url = urlparse.urlparse(instance.target.referent.absolute_api_v2_url)
-            url_string = '{scheme}://{netloc}{path}.*'.format(scheme=varnish_parsed_url.scheme,
-                                                              netloc=varnish_parsed_url.netloc,
-                                                              path=parsed_target_url.path)
-            bannable_urls.append(url_string)
-            parsed_root_target_url = urlparse.urlparse(instance.root_target.referent.absolute_api_v2_url)
-            url_string = '{scheme}://{netloc}{path}.*'.format(scheme=varnish_parsed_url.scheme,
+            try:
+                parsed_target_url = urlparse.urlparse(instance.target.referent.absolute_api_v2_url)
+                url_string = '{scheme}://{netloc}{path}.*'.format(scheme=varnish_parsed_url.scheme,
+                                                                  netloc=varnish_parsed_url.netloc,
+                                                                  path=parsed_target_url.path)
+                bannable_urls.append(url_string)
+            except AttributeError:
+                # some referents don't have an absolute_api_v2_url
+                # I'm looking at you NodeWikiPage
+                pass
+            try:
+                parsed_root_target_url = urlparse.urlparse(instance.root_target.referent.absolute_api_v2_url)
+                url_string = '{scheme}://{netloc}{path}.*'.format(scheme=varnish_parsed_url.scheme,
                                                               netloc=varnish_parsed_url.netloc,
                                                               path=parsed_root_target_url.path)
-            bannable_urls.append(url_string)
+                bannable_urls.append(url_string)
+            except AttributeError:
+                # some root_targets don't have an absolute_api_v2_url
+                pass
 
     return bannable_urls, parsed_absolute_url.hostname
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

This fixes wiki comment decaching.

@sloria @icereval This is a replacement for #5554 that shouldn't cause any tests to fail.

## Changes

An unhandled AttributeError was being caused during the decaching process of NodeWikiPages. This caused none of the objects modified during the request to be decached, including the comments URL. This checks the original object for an absolute_api_v2_url. If that does not exist then it returns an empty list of urls to ban. There are also try/except clauses around checking target.referents and root_target.referents. They check for an AttributeError and pass, continuing with the other potential things to ban.

## Side effects

If there are many things without absolute_api_v2_urls there could be a lot of logs in sentry. These would have been causing attribute errors in sentry previous to this PR so ... unlikely.