### PR TITLE
Enable "Register" button for non-prereg draft registrations [OSF-5924]

### DIFF
--- a/website/templates/project/registrations.mako
+++ b/website/templates/project/registrations.mako
@@ -113,8 +113,7 @@
                     </span>
                     -->
                     <span data-bind="ifnot: requiresApproval">
-                     <a class="btn btn-success" data-bind="attr: {href: urls.register_page},
-                                                           css: {'disabled': !isApproved}">Register</a>
+                     <a class="btn btn-success" data-bind="attr: {href: urls.register_page}">Register</a>
                     </span>
                   </div>
                 </div>


### PR DESCRIPTION
## Purpose

In the list of project draft registrations, non-preregistration challenge draft registrations have a disabled "Register" button. The button should be enabled because users are able to create those registrations without admin approval.

## Changes

Always enable the "Register" button if the registration draft does not require approval.

Note: Another option is to make `DraftRegistration.is_approved` return True if the registration does not require approval but that might break other aspects of draft registrations: https://github.com/CenterForOpenScience/osf.io/blob/develop/website/project/model.py#L3868

## Side effects

None.


## Ticket

https://openscience.atlassian.net/browse/OSF-5924