### PR TITLE
Pass VOL query param to redirect_url [OSF-6161]

### DIFF
--- a/api/guids/views.py
+++ b/api/guids/views.py
@@ -37,7 +37,10 @@ class GuidRedirect(JSONAPIBaseView):
 
     def get(self, request, **kwargs):
         url = self.get_redirect_url(**kwargs)
+        view_only_token = self.request.query_params.get('view_only')
         if url:
+            if view_only_token:
+                url += '?view_only={}'.format(view_only_token)
             return http.HttpResponseRedirect(url)
         raise NotFound
 

--- a/api_tests/guids/views/test_guid_redirect.py
+++ b/api_tests/guids/views/test_guid_redirect.py
@@ -5,7 +5,8 @@ from website.files.models.osfstorage import OsfStorageFile
 from website.settings import API_DOMAIN
 
 from tests.base import ApiTestCase
-from tests.factories import AuthUserFactory, ProjectFactory, RegistrationFactory, CommentFactory, NodeWikiFactory, CollectionFactory
+from tests.factories import (AuthUserFactory, ProjectFactory, RegistrationFactory,
+                             CommentFactory, NodeWikiFactory, CollectionFactory, PrivateLinkFactory)
 
 
 class TestGuidRedirect(ApiTestCase):
@@ -13,6 +14,12 @@ class TestGuidRedirect(ApiTestCase):
     def setUp(self):
         super(TestGuidRedirect, self).setUp()
         self.user = AuthUserFactory()
+
+    def _add_private_link(self, project, anonymous=False):
+        view_only_link = PrivateLinkFactory(anonymous=anonymous)
+        view_only_link.nodes.append(project)
+        view_only_link.save()
+        return view_only_link
 
     def test_redirect_to_node_view(self):
         project = ProjectFactory()
@@ -72,3 +79,41 @@ class TestGuidRedirect(ApiTestCase):
         url = '/{}guids/{}/'.format(API_BASE, wiki._id)
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
         assert_equal(res.status_code, 501)
+
+    def test_redirect_when_viewing_private_project_through_view_only_link(self):
+        project = ProjectFactory()
+        view_only_link = self._add_private_link(project)
+        url = '/{}guids/{}/?view_only={}'.format(API_BASE, project._id, view_only_link.key)
+        res = self.app.get(url, auth=AuthUserFactory().auth)
+        redirect_url = '{}{}nodes/{}/?view_only={}'.format(API_DOMAIN, API_BASE, project._id, view_only_link.key)
+        assert_equal(res.status_code, 302)
+        assert_equal(res.location, redirect_url)
+
+    def test_redirect_when_viewing_private_project_file_through_view_only_link(self):
+        project = ProjectFactory()
+        test_file = OsfStorageFile.create(
+            is_file=True,
+            node=project,
+            path='/test',
+            name='test',
+            materialized_path='/test',
+        )
+        test_file.save()
+        guid = test_file.get_guid(create=True)
+        view_only_link = self._add_private_link(project)
+
+        url = '/{}guids/{}/?view_only={}'.format(API_BASE, guid._id, view_only_link.key)
+        res = self.app.get(url, auth=AuthUserFactory().auth)
+        redirect_url = '{}{}files/{}/?view_only={}'.format(API_DOMAIN, API_BASE, test_file._id, view_only_link.key)
+        assert_equal(res.status_code, 302)
+        assert_equal(res.location, redirect_url)
+
+    def test_redirect_when_viewing_private_project_comment_through_view_only_link(self):
+        project = ProjectFactory()
+        view_only_link = self._add_private_link(project)
+        comment = CommentFactory(node=project)
+        url = '/{}guids/{}/?view_only={}'.format(API_BASE, comment._id, view_only_link.key)
+        res = self.app.get(url, auth=AuthUserFactory().auth)
+        redirect_url = '{}{}comments/{}/?view_only={}'.format(API_DOMAIN, API_BASE, comment._id, view_only_link.key)
+        assert_equal(res.status_code, 302)
+        assert_equal(res.location, redirect_url)


### PR DESCRIPTION
## Purpose

The API guid redirect route throws an error when viewing a private project/file/etc. even if there is a view_only parameter included in the url.

## Changes

Add the `view_only parameter` to the redirect url.

## Side effects

None.


## Ticket

https://openscience.atlassian.net/browse/OSF-6161