### PR TITLE
[0.69] Fix S3 addon selector and and deauth modals [#OSF-6156]

### DIFF
--- a/website/addons/dataverse/static/dataverseUserConfig.js
+++ b/website/addons/dataverse/static/dataverseUserConfig.js
@@ -135,7 +135,7 @@ function ViewModel(url) {
             title: 'Disconnect Dataverse Account?',
             message: '<p class="overflow">' +
                 'Are you sure you want to disconnect the Dataverse account on <strong>' +
-                $osf.htmlEscape(account.name) + '</strong>? This will revoke access to Dataverse for all projects associated with this account.' +
+                osfHelpers.htmlEscape(account.name) + '</strong>? This will revoke access to Dataverse for all projects associated with this account.' +
                 '</p>',
             callback: function (confirm) {
                 if (confirm) {

--- a/website/addons/dataverse/templates/dataverse_user_settings.mako
+++ b/website/addons/dataverse/templates/dataverse_user_settings.mako
@@ -15,7 +15,7 @@
 
     <div class="addon-auth-table" id="${addon_short_name}-header">
         <!-- ko foreach: accounts -->
-        <a data-bind="click: $root.askDisconnect" class="text-danger pull-right default-authorized-by">Disconnect Account</a>
+        <a data-bind="click: $root.askDisconnect.bind($root)" class="text-danger pull-right default-authorized-by">Disconnect Account</a>
         <div class="m-h-lg addon-auth-table" id="${addon_short_name}-header">
             <table class="table table-hover">
                 <thead>

--- a/website/addons/dataverse/templates/dataverse_user_settings.mako
+++ b/website/addons/dataverse/templates/dataverse_user_settings.mako
@@ -31,7 +31,7 @@
                             <!-- ko if: !title --><em>Private project</em><!-- /ko -->
                         </td>
                         <td>
-                            <a data-bind="click: $parent.deauthorizeNode">
+                            <a data-bind="click: $parent.deauthorizeNode.bind($parent)">
                                 <i class="fa fa-times text-danger pull-right" title="Deauthorize Project"></i>
                             </a>
                         </td>

--- a/website/addons/s3/static/s3UserConfig.js
+++ b/website/addons/s3/static/s3UserConfig.js
@@ -107,7 +107,7 @@ function ViewModel(url) {
             title: 'Disconnect Amazon S3 Account?',
             message: '<p class="overflow">' +
                 'Are you sure you want to disconnect the S3 account <strong>' +
-                $osf.htmlEscape(account.name) + '</strong>? This will revoke access to S3 for all projects associated with this account.' +
+                osfHelpers.htmlEscape(account.name) + '</strong>? This will revoke access to S3 for all projects associated with this account.' +
                 '</p>',
             callback: function (confirm) {
                 if (confirm) {

--- a/website/addons/s3/templates/s3_node_settings.mako
+++ b/website/addons/s3/templates/s3_node_settings.mako
@@ -35,7 +35,9 @@
           <span data-bind="ifnot: currentBucket">
             None
           </span>
-          <a data-bind="if: currentBucket, attr: {href: urls().files}, text: currentBucket"></a>
+          <a data-bind="if: currentBucket, attr: {href: urls().files}">
+              <span data-bind="text: currentBucket"></span>
+          </a>
         </p>
         <div data-bind="attr: {disabled: creating}">
           <button data-bind="visible: canChange, click: toggleSelect,

--- a/website/addons/s3/templates/s3_user_settings.mako
+++ b/website/addons/s3/templates/s3_user_settings.mako
@@ -32,7 +32,7 @@
                             <!-- ko if: !title --><em>Private project</em><!-- /ko -->
                         </td>
                         <td>
-                            <a data-bind="click: $parent.deauthorizeNode">
+                            <a data-bind="click: $parent.deauthorizeNode.bind($parent)">
                                 <i class="fa fa-times text-danger pull-right" title="disconnect Project"></i>
                             </a>
                         </td>

--- a/website/addons/s3/templates/s3_user_settings.mako
+++ b/website/addons/s3/templates/s3_user_settings.mako
@@ -15,7 +15,7 @@
 
     <div class="addon-auth-table" id="${addon_short_name}-header">
         <!-- ko foreach: accounts -->
-        <a data-bind="click: $root.askDisconnect" class="text-danger pull-right default-authorized-by">Disconnect Account</a>
+        <a data-bind="click: $root.askDisconnect.bind($root)" class="text-danger pull-right default-authorized-by">Disconnect Account</a>
 
         <div class="m-h-lg">
             <table class="table table-hover">

--- a/website/templates/log_templates.mako
+++ b/website/templates/log_templates.mako
@@ -284,7 +284,7 @@ on
 <a data-bind="attr: {href: params.file.url}, text: params.file.name"></a>
 in
 <!-- /ko -->
-<!-- ko: params.wiki -->
+<!-- ko if: params.wiki -->
 wiki page
 <a data-bind="attr: {href: params.wiki.url}, text: params.wiki.name"></a>
 in

--- a/website/templates/profile/user_settings_default.mako
+++ b/website/templates/profile/user_settings_default.mako
@@ -11,7 +11,7 @@
     </h4>
     <div class="addon-auth-table" id="${addon_short_name}-header">
         <!-- ko foreach: accounts -->
-        <a data-bind="click: $root.askDisconnect" class="text-danger pull-right default-authorized-by">Disconnect Account</a>
+        <a data-bind="click: $root.askDisconnect.bind($root)" class="text-danger pull-right default-authorized-by">Disconnect Account</a>
 
         <div class="m-h-lg">
             <table class="table table-hover">

--- a/website/templates/profile/user_settings_default.mako
+++ b/website/templates/profile/user_settings_default.mako
@@ -28,7 +28,7 @@
                             <!-- ko if: !title --><em>Private project</em><!-- /ko -->
                         </td>
                         <td>
-                            <a data-bind="click: $parent.deauthorizeNode">
+                            <a data-bind="click: $parent.deauthorizeNode.bind($parent)">
                                 <i class="fa fa-times text-danger pull-right" title="disconnect Project"></i>
                             </a>
                         </td>


### PR DESCRIPTION
## Purpose
Fix JS console errors that occurred after authorizing S3 addon on a project settings page. These errors prevented selection of a bucket to be associated with that project.

Also identified and fixed some related errors on user settings page when deauthorizing an addon for a specific node, as well as disconnecting an addon account for the user.

Thanks to Nici for the help getting S3 working locally.

## Changes
- Fix s3 addon for node settings page
- Fix "Remove addon" modal dialogs on the user settings page; should now be able to remove an addon by clicking the red "x" next to a project name, without the "remove" button generating JS errors. Special cases addressed in this PR are noted as separate items:
  - Dataverse
  - S3
  - Settings for other addons
- Fix "Disconnect account" links on the user settings page. Clicking the remove button in the modal that comes up should no longer give a JS error. (h/t @tombaxter for reporting)
- Fix error rendering a "comment updated" log entry when commenting on wikis. The log entry would appear on the project dashboard.

## Side effects
None expected. Let me know if any addon-related buttons are broken on either the project or user settings "configure addons" pages.

## Ticket
https://openscience.atlassian.net/browse/OSF-6156
