### PR TITLE
[hotfix] Sort registrations by date, most recent first

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1012,6 +1012,28 @@ class TestProjectViews(OsfTestCase):
         self.project.reload()
         assert_equal(self.project.title, 'newtitle')
 
+    # Regression test
+    def test_get_registrations_sorted_by_registered_date_descending(self):
+        # register a project several times, with various registered_dates
+        registrations = []
+        for days_ago in (21, 3, 2, 8, 13, 5, 1):
+            registration = RegistrationFactory(project=self.project)
+            reg_date = registration.registered_date - dt.timedelta(days_ago)
+            registration.registered_date = reg_date
+            registration.save()
+            registrations.append(registration)
+
+        registrations.sort(key=lambda r: r.registered_date, reverse=True)
+        expected = [ r._id for r in registrations ]
+
+        registrations_url = self.project.api_url_for('get_registrations')
+        res = self.app.get(registrations_url, auth=self.auth)
+        data = res.json
+        actual = [ n['id'] for n in data['nodes'] ]
+
+        assert_equal(actual, expected)
+
+
 
 class TestEditableChildrenViews(OsfTestCase):
 

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -1005,7 +1005,7 @@ def get_forks(auth, node, **kwargs):
 def get_registrations(auth, node, **kwargs):
     # get all undeleted registrations, including archiving
     sorted_registrations = node.registrations_all.sort('-registered_date')
-    undeleted_registrations = [n for n in sorted_registrations if not n.is_deleted] 
+    undeleted_registrations = [n for n in sorted_registrations if not n.is_deleted]
     return _render_nodes(undeleted_registrations, auth)
 
 

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -1003,8 +1003,10 @@ def get_forks(auth, node, **kwargs):
 
 @must_be_contributor_or_public
 def get_registrations(auth, node, **kwargs):
-    registrations = [n for n in reversed(node.registrations_all) if not n.is_deleted]  # get all registrations, including archiving
-    return _render_nodes(registrations, auth)
+    # get all undeleted registrations, including archiving
+    sorted_registrations = node.registrations_all.sort('-registered_date')
+    undeleted_registrations = [n for n in sorted_registrations if not n.is_deleted] 
+    return _render_nodes(undeleted_registrations, auth)
 
 
 @must_be_valid_project


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

<!-- Describe the purpose of your changes -->
Ensure that project registrations are shown in order of registration date, most recent first.

## Changes

<!-- Briefly describe or list your changes  -->
Change the get_registrations endpoint to explicitly sort registrations by registered_date, instead of assuming they were already sorted and simply reversing the order.

Add a regression test therefor. 

## Side effects

None I can see.
<!--Any possible side effects? -->


## Ticket

https://openscience.atlassian.net/browse/OSF-6008
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
