### PR TITLE
Make sure landing page links go to osf.io

### DIFF
--- a/website/templates/footer.mako
+++ b/website/templates/footer.mako
@@ -4,19 +4,19 @@
             <div class="col-sm-2 col-md-3 col-md-offset-1">
                 <h4>OSF</h4>
                 <ul>
-                    <li><a href="/explore/activity/">Explore</a></li>
+                    <li><a href="${domain}explore/activity/">Explore</a></li>
                     <li><script type="text/javascript">document.write("<n uers=\"znvygb:pbagnpg@bfs.vb\" ery=\"absbyybj\">Pbagnpg</n>".replace(/[a-zA-Z]/g,function(e){return String.fromCharCode((e<="Z"?90:122)>=(e=e.charCodeAt(0)+13)?e:e-26)}));</script><noscript>Contact OSF: <span class="obfuscated-email-noscript"><strong><u>cont<span style="display:none;">null</span>act@<span style="display:none;">null</span>osf.<span style="display:none;">null</span>io</u></strong></span></noscript></li>
-                    <li><a href="/support">Help/Support</a></li>
-                    <li><a href="/getting-started">Getting Started</a></li>
-                    <li><a href="/faq">FAQ</a></li>
+                    <li><a href="${domain}support">Help/Support</a></li>
+                    <li><a href="${domain}getting-started">Getting Started</a></li>
+                    <li><a href="${domain}faq">FAQ</a></li>
                 </ul>
             </div>
             <div class="col-sm-5 col-md-4">
                 <h4>Center for Open Science</h4>
                 <ul>
                     <li><a href="http://cos.io">Home</a></li>
-                    <li><a href="/ezcuj/wiki/home/">Reproducibility Project: Psychology</a></li>
-                    <li><a href="/e81xl/wiki/home/">Reproducibility Project: Cancer Biology</a></li>
+                    <li><a href="${domain}ezcuj/wiki/home/">Reproducibility Project: Psychology</a></li>
+                    <li><a href="${domain}e81xl/wiki/home/">Reproducibility Project: Cancer Biology</a></li>
                     <li><a href="http://cos.io/top/">TOP Guidelines</a></li>
                      <li><a href="https://www.givinglibrary.org/organizations/center-for-open-science">Donate</a></li>
                </ul>


### PR DESCRIPTION
## Purpose
landing pages footer links were not properly linking to osf.io, instead remaining on the domain of the institution. This fixes that.

## Ticket
https://openscience.atlassian.net/browse/OSF-6164


