### PR TITLE
Only show cancel file upload button while uploading [OSF-5972]

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -123,36 +123,41 @@ var uploadRowTemplate = function(item){
     var columns = [{
         data : '',  // Data field name
         css : '',
-        custom : function(){ return m('row.text-muted', [
-            m('.col-xs-7', {style: 'overflow: hidden;text-overflow: ellipsis;'}, [
-                m('span', { style : 'padding-left:' + padding + 'px;'}, tb.options.resolveIcon.call(tb, item)),
-                m('span',{ style : 'margin-left: 9px;'}, item.data.name)
-            ]),
-            m('.col-xs-3',
-                m('.progress', [
-                    m('.progress-bar.progress-bar-info.progress-bar-striped.active', {
-                        role : 'progressbar',
-                        'aria-valuenow' : item.data.progress,
-                        'aria-valuemin' : '0',
-                        'aria-valuemax': '100',
-                        'style':'width: ' + item.data.progress + '%' }, m('span.sr-only', item.data.progress + '% Complete'))
-                ])
-            ),
-            m('.col-xs-2', [
-                m('span', m('.fangorn-toolbar-icon.m-l-sm', {
-                        style : 'padding: 0px 6px 2px 2px;font-size: 16px;display: inline;',
-                        config : function() {
-                            reapplyTooltips();
-                        },
-                        'onclick' : function (e) {
-                            e.stopImmediatePropagation();
-                            cancelUploads.call(tb, item);
-                        }},
-                     m('span.text-muted','×')
-                )),
-            ]),
-
-        ]); }
+        custom : function(){
+            var uploadColumns = [
+                m('.col-xs-7', {style: 'overflow: hidden;text-overflow: ellipsis;'}, [
+                    m('span', { style : 'padding-left:' + padding + 'px;'}, tb.options.resolveIcon.call(tb, item)),
+                    m('span',{ style : 'margin-left: 9px;'}, item.data.name)
+                ]),
+                m('.col-xs-3',
+                    m('.progress', [
+                        m('.progress-bar.progress-bar-info.progress-bar-striped.active', {
+                            role : 'progressbar',
+                            'aria-valuenow' : item.data.progress,
+                            'aria-valuemin' : '0',
+                            'aria-valuemax': '100',
+                            'style':'width: ' + item.data.progress + '%' }, m('span.sr-only', item.data.progress + '% Complete'))
+                    ])
+                )
+            ];
+            if (item.data.progress < 100) {
+                uploadColumns.push(m('.col-xs-2', [
+                    m('span', m('.fangorn-toolbar-icon.m-l-sm', {
+                            style : 'padding: 0px 6px 2px 2px;font-size: 16px;display: inline;',
+                            config : function() {
+                                reapplyTooltips();
+                            },
+                            'onclick' : function (e) {
+                                console.log(item.data.progress);
+                                e.stopImmediatePropagation();
+                                cancelUploads.call(tb, item);
+                            }},
+                         m('span.text-muted','×')
+                    ))
+                ]));
+            }
+            return m('row.text-muted', uploadColumns);
+        }
     }];
     if(tb.options.placement === 'files'){
         columns.push({


### PR DESCRIPTION
## Purpose

If I cancel a file upload right when its upload progress reaches 100%, a growlbox pops up saying that the upload was cancelled. But when I refresh the page the file is still there.

## Changes

Only show the cancel upload button when upload progress is less than 100%

## Side effects

None.


## Ticket

https://openscience.atlassian.net/browse/OSF-5972