### PR TITLE
[Hotfix] Update rest swagger and remove routes that we don't want documented [OSF-6171]

### DIFF
--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -180,6 +180,7 @@ SWAGGER_SETTINGS = {
         'title': 'OSF APIv2 Documentation',
     },
     'doc_expansion': 'list',
+    "exclude_namespaces": ['applications', 'tokens'],
 }
 
 DEBUG_TRANSACTIONS = DEBUG

--- a/requirements.txt
+++ b/requirements.txt
@@ -58,7 +58,7 @@ webcolors==1.4
 Django==1.9
 djangorestframework==3.3.3
 django-cors-headers==1.1.0
-django-rest-swagger==0.3.2
+django-rest-swagger==0.3.6
 djangorestframework-bulk==0.2.1
 pyjwt==1.4.0
 pyjwe==1.0.0


### PR DESCRIPTION
## Purpose

Eliminate documentation for routes we don't want documented in the V2 API (tokens and applications)

## Changes

1. Upgrade django-rest-swagger
2. Add tokens and applications namespaces to the list of ignored namespaces

### Old
![screen shot 2016-05-03 at 4 16 59 pm](https://cloud.githubusercontent.com/assets/6599111/14996989/90600526-114a-11e6-8314-e514aca04399.png)

### New
![screen shot 2016-05-03 at 4 17 13 pm](https://cloud.githubusercontent.com/assets/6599111/14996992/982d5916-114a-11e6-9458-64cf40e12d5b.png)


## Side effects

Shouldn't be. I manually tested the docs and they seem to work at least as well as they 


## Ticket

https://openscience.atlassian.net/browse/OSF-6171
