### PR TITLE
Fix token serializer absolute url method

### DIFF
--- a/api/tokens/serializers.py
+++ b/api/tokens/serializers.py
@@ -36,7 +36,7 @@ class ApiOAuth2PersonalTokenSerializer(JSONAPISerializer):
         return obj.absolute_url
 
     def get_absolute_url(self, obj):
-        return self.absolute_url(obj)
+        return obj.absolute_api_v2_url
 
     def to_representation(self, obj, envelope='data'):
         data = super(ApiOAuth2PersonalTokenSerializer, self).to_representation(obj, envelope=envelope)


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Fix ESI included token list. This resolves a bug that should have been fixed in #5544.

## Changes

The absolute_url method returns the html version of the token, not the json version. I changed the get_absolute_url method on the token serializer to return the absolute_api_v2_url instead.

## Side effects

Anything using this method and expecting the html link would break but since I am the last committer in the file and my last commit was adding this method I don't believe anyway is expecting this behavior.
