### PR TITLE
[Feature] Admin Render removed user as unregistered [ADM-67]

### DIFF
--- a/admin_tests/users/test_views.py
+++ b/admin_tests/users/test_views.py
@@ -1,4 +1,5 @@
 from django.test import RequestFactory
+from django.http import Http404
 from nose import tools as nt
 import mock
 
@@ -91,6 +92,11 @@ class TestDisableUser(AdminTestCase):
         self.user.reload()
         nt.assert_false(self.user.is_disabled)
         nt.assert_equal(OSFLogEntry.objects.count(), count + 1)
+
+    def test_no_user(self):
+        view = setup_view(UserDeleteView(), self.request, guid='meh')
+        with nt.assert_raises(Http404):
+            view.delete(self.request)
 
 
 class TestRemove2Factor(AdminTestCase):

--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -439,6 +439,8 @@ class User(GuidStoredObject, AddonModelMixin):
 
     # used by django and DRF
     def get_absolute_url(self):
+        if not self.is_registered:
+            return None
         return self.absolute_api_v2_url
 
     @classmethod

--- a/website/static/js/logFeed.js
+++ b/website/static/js/logFeed.js
@@ -187,6 +187,7 @@ var createLogs = function(logData){
             nodeDescription: item.params.description_new,
             nodePath: item.node.path,
             user: item.user,
+            isActive: item.user.is_active,
             registrationCancelled: item.node.is_registration && item.node.registered_from_id == null
         });
     });

--- a/website/templates/log_list.mako
+++ b/website/templates/log_list.mako
@@ -53,6 +53,7 @@
                                     <span data-bind="ifnot: log.userURL">
                                         <span class="overflow" data-bind="text: log.userFullName"></span>
                                     </span>
+                                    <span data-bind="if: log.isActive">Whee</span>
                                 </span>
                                 <!-- Log actions are the same as their template name -->
                                     <span data-bind="template: {name: log.action, data: log}"></span>


### PR DESCRIPTION
## Purpose

Addresses the issue that a user account that has been deactivated still has live links in contributor lists. Clicking on this dead link gives a 'resource removed' message which is annoying. By removing this link it removes this possibility.

## Changes

Make a user unregistered, `is_registered = False` when user account is disabled. And `is_registered = True` when reactivated.

## Side effects

Using the `is_registered` for this purpose might seem as though the variable is being misused, however, a `User` object has several other boolean fields that do much the same things.


## Ticket

[ADM-27]