### PR TITLE
Remove Delete Folder button when root is selected [OSF-6139]

### DIFF
--- a/website/addons/github/README.md
+++ b/website/addons/github/README.md
@@ -2,7 +2,7 @@
 
 ## Enabling the addon for development
 
-1. On your Github user settings, go to “Applications” -> “Register new application”
+1. On your Github user settings, go to “OAuth Applications” -> "Developer applications" -> “Register new application”
 2. Enter any name for the application name, e..g “OSF Github Addon (local)”
 3. In the Homepage URL field, enter "http://localhost:5000/“
 4. In the Authorization Callback URL field, enter "http://localhost:5000/oauth/callback/github".

--- a/website/addons/github/static/githubFangornConfig.js
+++ b/website/addons/github/static/githubFangornConfig.js
@@ -181,6 +181,7 @@ var _githubItemButtons = {
                             icon: 'fa fa-trash',
                             className: 'text-danger'
                         }, 'Delete Folder'));
+                    }
                 }
                 if (item.data.addonFullname) {
                     buttons.push(

--- a/website/addons/github/static/githubFangornConfig.js
+++ b/website/addons/github/static/githubFangornConfig.js
@@ -171,15 +171,16 @@ var _githubItemButtons = {
                             },
                             icon: 'fa fa-plus',
                             className: 'text-success'
-                        }, 'Create Folder'),
-                        m.component(Fangorn.Components.button, {
-                           onclick: function (event) {
-                               _removeEvent.call(tb, event, [item]);
-                           },
-                           icon: 'fa fa-trash',
-                           className: 'text-danger'
-                       }, 'Delete Folder')
+                        }, 'Create Folder')
                     );
+                    if(!item.data.isAddonRoot){
+                        buttons.push(m.component(Fangorn.Components.button, {
+                            onclick: function (event) {
+                                _removeEvent.call(tb, event, [item]);
+                            },
+                            icon: 'fa fa-trash',
+                            className: 'text-danger'
+                        }, 'Delete Folder'));
                 }
                 if (item.data.addonFullname) {
                     buttons.push(


### PR DESCRIPTION
## Purpose

"Delete Folder" button should not be available when root node/folder of a provider is selected.

## Changes

- Hide delete folder if the root is selected.
- Update the docs for setting up GH because the settings page changed some.

## Side effects

Nothing, clicking delete on the root didn't do anything before. This just removes the button.

## Ticket

https://openscience.atlassian.net/browse/OSF-6139
[OSF-6139]