### PR TITLE
[0.69] Fix 500 error when viewing addonSettings with figshare enabled [#OSF-6173]

### DIFF
--- a/website/templates/profile/addon_permissions.mako
+++ b/website/templates/profile/addon_permissions.mako
@@ -26,6 +26,8 @@
     </div>
 
     <script>
+        ## Globals are not available to included templates
+        <% from website.util.sanitize import safe_json as sjson %>
         window.contextVars = $.extend(true, {}, window.contextVars, {
             addonsWithNodes: {
                 ${ addon_short_name | sjson, n }: {


### PR DESCRIPTION
## Purpose

Fix 500 error when viewing the user addons config page while figshare addon is enabled.

## Changes

Manually import filter not available to one-off `TemplateLookup` usage.

## Side effects

None expected.


## Ticket

https://openscience.atlassian.net/browse/OSF-6173