### PR TITLE
[Rfr] Don't osf.htmlEscape question previews

### DIFF
--- a/website/static/js/registrationEditorExtensions.js
+++ b/website/static/js/registrationEditorExtensions.js
@@ -311,7 +311,7 @@ var AuthorImport = function(data, $root, preview) {
     }
 
     self.preview = function() {
-        return self.value();
+        return $osf.htmlEscape(self.value());
     };
     var callback = function(data) {
         self.question.value(self.serializeContributors(data.contributors));

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -182,7 +182,11 @@ var Question = function(questionSchema, data) {
     self.properties = questionSchema.properties || [];
     self.match = questionSchema.match || '';
 
-    self.extra = ko.observableArray(self.data.extra || []);
+    try {
+	self.extra =  ko.observableArray(self.data.extra || []);
+    } catch(e) {
+	self.extra = ko.observableArray([]);
+    }
 
     self.formattedFileList = ko.pureComputed(function() {
         return self.extra().map(function(elem) {
@@ -871,7 +875,8 @@ var RegistrationEditor = function(urls, editorId, preview) {
 			return unwrap(subQuestion);
 		    })
                 );
-            } else {
+            }
+	    else {
                 var value;
                 if (self.extensions[question.type] ) {
                     value = question.preview();
@@ -881,7 +886,7 @@ var RegistrationEditor = function(urls, editorId, preview) {
 		$elem.append(
 		    $('<span class="col-md-12">').append(
 			$('<p class="breaklines"><small><em>' + $osf.htmlEscape(question.description) + '</em></small></p>'),
-                            $('<span class="well col-md-12">').append($osf.htmlEscape(value))
+                            $('<span class="well col-md-12">').append(value)
 		));
             }
 	    return $elem;


### PR DESCRIPTION
# Purpose

Looks like the HTML escaping introduced in:
https://github.com/CenterForOpenScience/osf.io/pull/5531/files#diff-c7726ca88c3b2e15d44ec996c513ec73R884

might have regressed the fix introduced in https://github.com/CenterForOpenScience/osf.io/pull/5500. 

# Changes

Move the html escaping into the extensions preview method rather than trying to escape the whole return value. 

Also be more tolerant of question.extra that is now the expected type (non-array values can be ignored)