### PR TITLE
Bumping libpcre version for travis/varnish build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
     - TOKUMX_ARCHIVE="tokumx-2.0.0-linux-x86_64-main.tar.gz"
     - ELASTICSEARCH_ARCHIVE="elasticsearch-1.5.0.tar.gz"
     - LIBJEMALLOC_DEB="libjemalloc1_3.5.1-2_amd64.deb"
-    - LIBPCRE_DEB="libpcre3_8.31-2ubuntu2.1_amd64.deb"
+    - LIBPCRE_DEB="libpcre3_8.31-2ubuntu2.3_amd64.deb"
     - VARNISH_DEB="varnish_4.1.0-1~trusty_amd64.deb"
   matrix:
     - TEST_BUILD="osf"


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

@sloria @abought @icereval This should fix the tests for #5543. 

Ubuntu removed the version of libpcre we were manually installing from their server. This bumps it a couple of minor versions.

## Changes

I changed the file name of the libpcre deb package.

## Side effects

I suppose varnish might not work with this version of libpcre but it's doubtful since it's a minor version change. It's also going to break again down the line. I assume our only choice is to install it manually and that apt-get isn't included in the travis image but it might be worth thinking about a long-term solution.


## Ticket

This was discovered because tests for #5543 were failing.