### PR TITLE
feature/Load more comments at once to accomodate larger screens

### DIFF
--- a/website/static/js/comment.js
+++ b/website/static/js/comment.js
@@ -135,6 +135,7 @@ BaseComment.prototype.fetch = function() {
         if (self.id() !== undefined) {
             query += '&filter[target]=' + self.id();
         }
+        query += '&page[size]=20';
         var url = osfHelpers.apiV2Url(self.$root.nodeType + '/' + window.contextVars.node.id + '/comments/', {query: query});
         self.fetchNext(url, [], setUnread);
     }


### PR DESCRIPTION
## Purpose

During QA, @jinluyuan found a problem with infinite scroll for comments, where project comments displayed on a large screen with some deleted ones, making them smaller than ususal, never displayed a scroll bar and so never triggered the loading more behavior.

This PR changes things so that 20 comments are loaded at once, therefore filling up even big screens so that the scroll for more even is able to be triggered.

## Changes

- Add page size query parameter to ```fetch``` to query 20 comments at once instead of the default 10

## Side effects
- None anticipated!


## Ticket
https://openscience.atlassian.net/browse/OSF-5891

[#OSF-5891]