### PR TITLE
hotfix/Make prereg the first option in registration template

### DIFF
--- a/website/project/metadata/schemas.py
+++ b/website/project/metadata/schemas.py
@@ -34,9 +34,9 @@ OSF_META_SCHEMAS = [
 ]
 
 ACTIVE_META_SCHEMAS = (
+    'Prereg Challenge',
     'Open-Ended Registration',
     'OSF-Standard Pre-Data Collection Registration',
     'Replication Recipe (Brandt et al., 2013): Pre-Registration',
     'Replication Recipe (Brandt et al., 2013): Post-Completion',
-    'Prereg Challenge',
 )


### PR DESCRIPTION
## Purpose

Community reported that prereg challenge participants were often mistakenly selecting the default "open ended registration" on the registration page, and requested that the prereg challenge become the top and default option.

## Changes
- Move prereg challenge to the top of the list of schemas that renders on the registration options

## Side effects
- None on the dev side, but new registrations may now accidentally be prereg


## Ticket

https://openscience.atlassian.net/browse/OSF-6122

[#OSF-6122]