### PR TITLE
Add just a few more b/c of comments made by others

### DIFF
--- a/website/static/js/comment.js
+++ b/website/static/js/comment.js
@@ -135,7 +135,7 @@ BaseComment.prototype.fetch = function() {
         if (self.id() !== undefined) {
             query += '&filter[target]=' + self.id();
         }
-        query += '&page[size]=20';
+        query += '&page[size]=30';
         var url = osfHelpers.apiV2Url(self.$root.nodeType + '/' + window.contextVars.node.id + '/comments/', {query: query});
         self.fetchNext(url, [], setUnread);
     }


### PR DESCRIPTION
## Purpose
QA noticed that comments deleted by others were just a little smaller than those deleted by the user. This ups the number of comments loaded at once to 30 -- even on the giant screen, 25 deleted comments by another user show up at once, solving this issue. 

## Changes

- Change number from 20 to 30 loaded at once

## Side effects

-nope!


## Ticket

https://openscience.atlassian.net/browse/OSF-5891

[#OSF-5891]