### PR TITLE
Fix: remove dupe description text [OSF-6278]

### DIFF
--- a/website/templates/project/register.mako
+++ b/website/templates/project/register.mako
@@ -30,7 +30,6 @@
             <div data-bind="foreach: {data: page.questions, as: 'question'}">
               <div class="row">
                 <h4 data-bind="attr: {id: question.id}, text: question.title"></h4>
-                <small><em data-bind="text: question.description"></em></small>
                 <div class="col-md-12 well">
                    <span data-bind="previewQuestion: $root.editor.context(question, $root.editor)"></span>
                 </div>


### PR DESCRIPTION
## Purpose

Fix registration supplements showing double helper text.
## Changes

`RegistrationEditor#unwrap` now appends the question description so we don't need it in the template. 
## Side effects

N/A 

## Ticket

https://openscience.atlassian.net/browse/OSF-6278

[OSF-6278]