### PR TITLE
Make sure legacy private registrations can be made public [OSF-6276]

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4176,6 +4176,11 @@ class TestRegisterNode(OsfTestCase):
         assert_equal(registration_wiki_version.node, registration)
         assert_not_equal(registration_wiki_version._id, wiki._id)
 
+    def test_legacy_private_registrations_can_be_made_public(self):
+        self.registration.is_public = False
+        self.registration.set_privacy(Node.PUBLIC, auth=Auth(self.registration.creator))
+        assert_true(self.registration.is_public)
+
 
 class TestNodeLog(OsfTestCase):
 

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -36,7 +36,7 @@
                     <div class="btn-group">
                     % if not node["is_public"]:
                         <button class="btn btn-default disabled">Private</button>
-                        % if 'admin' in user['permissions'] and not node['is_pending_registration'] and not node['is_pending_embargo'] and (not node['is_registration'] or (node['is_embargoed'] and not parent_node['exists'])):
+                        % if 'admin' in user['permissions'] and not (node['is_pending_registration'] or node['is_pending_embargo']) and not (node['is_embargoed'] and parent_node['exists']):
                         <a disabled data-bind="attr: {'disabled': false}, css: {'disabled': nodeIsPendingEmbargoTermination}" class="btn btn-default"  href="#nodesPrivacy" data-toggle="modal">
                           Make Public
 			  <!-- ko if: nodeIsPendingEmbargoTermination -->


### PR DESCRIPTION
# Purpose

Changes introduced in Early Embargo Terminations hid the Make Public button on legacy private registrations.

# Changes

- Change the conditional to make the button visible again
- Add a unit test 