### PR TITLE
configure github addon in tests

### DIFF
--- a/api_tests/nodes/views/test_node_files_list.py
+++ b/api_tests/nodes/views/test_node_files_list.py
@@ -78,6 +78,8 @@ def prepare_mock_wb_response(
         content_type='application/json'
     )
 
+
+
 class TestNodeFilesList(ApiTestCase):
 
     def setUp(self):
@@ -96,6 +98,21 @@ class TestNodeFilesList(ApiTestCase):
         super(TestNodeFilesList, self).tearDown()
         httpretty.disable()
         httpretty.reset()
+
+    def add_github(self):
+        user_auth = Auth(self.user)
+        self.project.add_addon('github', auth=user_auth)
+        addon = self.project.get_addon('github')
+        addon.repo = 'something'
+        addon.user = 'someone'
+        oauth_settings = GitHubAccountFactory()
+        oauth_settings.save()
+        self.user.add_addon('github')
+        self.user.external_accounts.append(oauth_settings)
+        self.user.save()
+        addon.user_settings = self.user.get_addon('github')
+        addon.save()
+        self.project.save()
 
     def _prepare_mock_wb_response(self, node=None, **kwargs):
         prepare_mock_wb_response(node=node or self.project, **kwargs)
@@ -181,6 +198,7 @@ class TestNodeFilesList(ApiTestCase):
 
     def test_returns_node_files_list(self):
         self._prepare_mock_wb_response(provider='github', files=[{'name': 'NewFile'}])
+        self.add_github()
         url = '/{}nodes/{}/files/github/'.format(API_BASE, self.project._id)
         res = self.app.get(url, auth=self.user.auth)
         assert_equal(res.json['data'][0]['attributes']['name'], 'NewFile')
@@ -188,6 +206,7 @@ class TestNodeFilesList(ApiTestCase):
 
     def test_returns_node_file(self):
         self._prepare_mock_wb_response(provider='github', files=[{'name': 'NewFile'}], folder=False, path='/file')
+        self.add_github()
         url = '/{}nodes/{}/files/github/file'.format(API_BASE, self.project._id)
         res = self.app.get(url, auth=self.user.auth, headers={
             'COOKIE': 'foo=bar;'  # Webtests doesnt support cookies?
@@ -215,6 +234,7 @@ class TestNodeFilesList(ApiTestCase):
 
     def test_waterbutler_server_error_returns_503(self):
         self._prepare_mock_wb_response(status_code=500)
+        self.add_github()
         url = '/{}nodes/{}/files/github/'.format(API_BASE, self.project._id)
         res = self.app.get(url, auth=self.user.auth, expect_errors=True, headers={
             'COOKIE': 'foo=bar;'  # Webtests doesnt support cookies?
@@ -223,6 +243,7 @@ class TestNodeFilesList(ApiTestCase):
 
     def test_waterbutler_invalid_data_returns_503(self):
         wb_url = waterbutler_api_url_for(self.project._id, provider='github', path='/', meta=True)
+        self.add_github()
         httpretty.register_uri(
             httpretty.GET,
             wb_url,
@@ -235,6 +256,7 @@ class TestNodeFilesList(ApiTestCase):
 
     def test_handles_unauthenticated_waterbutler_request(self):
         self._prepare_mock_wb_response(status_code=401)
+        self.add_github()
         url = '/{}nodes/{}/files/github/'.format(API_BASE, self.project._id)
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
         assert_equal(res.status_code, 403)
@@ -264,6 +286,7 @@ class TestNodeFilesList(ApiTestCase):
             body=json.dumps({}),
             status=418
         )
+        self.add_github()
         url = '/{}nodes/{}/files/github/'.format(API_BASE, self.project._id)
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
         assert_equal(res.status_code, 503)
@@ -297,8 +320,24 @@ class TestNodeFilesListFiltering(ApiTestCase):
         httpretty.disable()
         httpretty.reset()
 
+    def add_github(self):
+        user_auth = Auth(self.user)
+        self.project.add_addon('github', auth=user_auth)
+        addon = self.project.get_addon('github')
+        addon.repo = 'something'
+        addon.user = 'someone'
+        oauth_settings = GitHubAccountFactory()
+        oauth_settings.save()
+        self.user.add_addon('github')
+        self.user.external_accounts.append(oauth_settings)
+        self.user.save()
+        addon.user_settings = self.user.get_addon('github')
+        addon.save()
+        self.project.save()
+
     def test_node_files_are_filterable_by_name(self):
         url = '/{}nodes/{}/files/github/?filter[name]=xyz'.format(API_BASE, self.project._id)
+        self.add_github()
         res = self.app.get(url, auth=self.user.auth)
         assert_equal(res.status_code, 200)
         assert_equal(len(res.json['data']), 1)  # filters out 'abc'
@@ -306,6 +345,7 @@ class TestNodeFilesListFiltering(ApiTestCase):
 
     def test_node_files_filter_by_name_case_insensitive(self):
         url = '/{}nodes/{}/files/github/?filter[name]=XYZ'.format(API_BASE, self.project._id)
+        self.add_github()
         res = self.app.get(url, auth=self.user.auth)
         assert_equal(res.status_code, 200)
         assert_equal(len(res.json['data']), 1)  # filters out 'abc', but finds 'xyz'
@@ -313,6 +353,7 @@ class TestNodeFilesListFiltering(ApiTestCase):
 
     def test_node_files_are_filterable_by_path(self):
         url = '/{}nodes/{}/files/github/?filter[path]=abc'.format(API_BASE, self.project._id)
+        self.add_github()
         res = self.app.get(url, auth=self.user.auth)
         assert_equal(res.status_code, 200)
         assert_equal(len(res.json['data']), 1)  # filters out 'xyz'
@@ -320,6 +361,7 @@ class TestNodeFilesListFiltering(ApiTestCase):
 
     def test_node_files_are_filterable_by_kind(self):
         url = '/{}nodes/{}/files/github/?filter[kind]=folder'.format(API_BASE, self.project._id)
+        self.add_github()
         res = self.app.get(url, auth=self.user.auth)
         assert_equal(res.status_code, 200)
         assert_equal(len(res.json['data']), 1)  # filters out 'xyz'
@@ -327,6 +369,7 @@ class TestNodeFilesListFiltering(ApiTestCase):
 
     def test_node_files_external_provider_can_filter_by_last_touched(self):
         yesterday_stamp = datetime.datetime.utcnow() - datetime.timedelta(days=1)
+        self.add_github()
         url = '/{}nodes/{}/files/github/?filter[last_touched][gt]={}'.format(API_BASE,
                                                                              self.project._id,
                                                                              yesterday_stamp.isoformat())
@@ -357,6 +400,21 @@ class TestNodeFilesListPagination(ApiTestCase):
         super(TestNodeFilesListPagination, self).tearDown()
         httpretty.disable()
         httpretty.reset()
+
+    def add_github(self):
+        user_auth = Auth(self.user)
+        self.project.add_addon('github', auth=user_auth)
+        addon = self.project.get_addon('github')
+        addon.repo = 'something'
+        addon.user = 'someone'
+        oauth_settings = GitHubAccountFactory()
+        oauth_settings.save()
+        self.user.add_addon('github')
+        self.user.external_accounts.append(oauth_settings)
+        self.user.save()
+        addon.user_settings = self.user.get_addon('github')
+        addon.save()
+        self.project.save()
 
     def check_file_order(self, resp):
         previous_file_name = 0
@@ -396,6 +454,7 @@ class TestNodeFilesListPagination(ApiTestCase):
                 {'name': '24', 'path': '/24', 'materialized': '/24', 'kind': 'file'},
             ]
         )
+        self.add_github()
         url = '/{}nodes/{}/files/github/?page[size]=100'.format(API_BASE, self.project._id)
         res = self.app.get(url, auth=self.user.auth)
         self.check_file_order(res)


### PR DESCRIPTION
Related to https://github.com/CenterForOpenScience/osf.io/pull/5581/files

## Purpose

Addons need to be:

enabled on the node.
authorized on the node.
configured on the node.
## Changes

Changed tests by adding a method to authenticate github for testing.

## Ticket

[*OSF-6280]
