### PR TITLE
[rfr] Change misleading language in registrationModal [OSF-6116]

### DIFF
--- a/website/static/js/registrationModal.js
+++ b/website/static/js/registrationModal.js
@@ -55,7 +55,7 @@ var RegistrationViewModel = function(confirm, prompts, validator) {
             var endEmbargoDateTimestamp = self.embargoEndDate().getTime();
             return endEmbargoDateTimestamp > TWO_DAYS_FROM_TODAY_TIMESTAMP;
         },
-        message: 'Embargo end date must be at least two days in the future.'
+        message: 'Embargo end date must be at least three days in the future.'
     }, {
 	validator: function() {
             var endEmbargoDateTimestamp = self.embargoEndDate().getTime();


### PR DESCRIPTION
## Purpose

Clear up confusing language in `registrationModal`.

## Changes

At least two days -> at least three days

## Side effects
None

## Ticket

https://openscience.atlassian.net/browse/OSF-6116

[OSF-6116]