### PR TITLE
Do not log comment actions on a registered node [OSF-5961]

### DIFF
--- a/website/project/model.py
+++ b/website/project/model.py
@@ -291,15 +291,16 @@ class Comment(GuidStoredObject, SpamMixin, Commentable):
 
         comment.save()
 
-        comment.node.add_log(
-            NodeLog.COMMENT_ADDED,
-            log_dict,
-            auth=auth,
-            save=False,
-        )
+        if not comment.node.is_registration:
+            comment.node.add_log(
+                NodeLog.COMMENT_ADDED,
+                log_dict,
+                auth=auth,
+                save=False,
+            )
 
-        comment.node.save()
-        project_signals.comment_added.send(comment, auth=auth)
+            comment.node.save()
+            project_signals.comment_added.send(comment, auth=auth)
 
         return comment
 
@@ -318,13 +319,14 @@ class Comment(GuidStoredObject, SpamMixin, Commentable):
         self.date_modified = datetime.datetime.utcnow()
         if save:
             self.save()
-            self.node.add_log(
-                NodeLog.COMMENT_UPDATED,
-                log_dict,
-                auth=auth,
-                save=False,
-            )
-            self.node.save()
+            if not self.node.is_registration:
+                self.node.add_log(
+                    NodeLog.COMMENT_UPDATED,
+                    log_dict,
+                    auth=auth,
+                    save=False,
+                )
+                self.node.save()
 
     def delete(self, auth, save=False):
         if not self.node.can_comment(auth) or self.user._id != auth.user._id:
@@ -340,13 +342,14 @@ class Comment(GuidStoredObject, SpamMixin, Commentable):
         self.date_modified = datetime.datetime.utcnow()
         if save:
             self.save()
-            self.node.add_log(
-                NodeLog.COMMENT_REMOVED,
-                log_dict,
-                auth=auth,
-                save=False,
-            )
-            self.node.save()
+            if not self.node.is_registration:
+                self.node.add_log(
+                    NodeLog.COMMENT_REMOVED,
+                    log_dict,
+                    auth=auth,
+                    save=False,
+                )
+                self.node.save()
 
     def undelete(self, auth, save=False):
         if not self.node.can_comment(auth) or self.user._id != auth.user._id:
@@ -362,12 +365,13 @@ class Comment(GuidStoredObject, SpamMixin, Commentable):
         self.date_modified = datetime.datetime.utcnow()
         if save:
             self.save()
-            self.node.add_log(
-                NodeLog.COMMENT_RESTORED,
-                log_dict,
-                auth=auth,
-                save=False,
-            )
+            if not self.node.is_registration:
+                self.node.add_log(
+                    NodeLog.COMMENT_RESTORED,
+                    log_dict,
+                    auth=auth,
+                    save=False,
+                )
             self.node.save()
 
 


### PR DESCRIPTION
## Purpose

In order to keep registration logs frozen, comment actions shouldn't be logged but comments should be possible. 

## Changes

Do not log comment actions if the node is a registration.

After adding, editing and deleting one comment, then adding a second:

![screen shot 2016-05-09 at 10 05 03 am](https://cloud.githubusercontent.com/assets/8905795/15116394/225a2210-15d1-11e6-9364-0a3da3297662.png)


## Side effects

No logs for comment actions. I tried to make sure every log that would try to reference a comment log won't error trying to reference it.

## Ticket

https://openscience.atlassian.net/browse/OSF-5961

[OSF-5961]