### PR TITLE
Make sure import contributors shows results [OSF-6096]

### DIFF
--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -250,6 +250,7 @@ AddContributorViewModel = oop.extend(Paginator, {
                     return updatedUser;
                 });
                 self.results(contributors);
+                self.doneSearching(true);
             }
         );
     },


### PR DESCRIPTION
## Purpose

The Add Contributors modal isn't showing results from `importFromParent`. They're there just not visible.

## Changes
Make sure that the modal knows it's allowed to show the results table after importing.

![screen shot 2016-05-09 at 11 09 51 am](https://cloud.githubusercontent.com/assets/8905795/15117756/feb7674a-15d6-11e6-87d5-b26fb0c16101.png)


## Side effects

N/A

## Ticket

https://openscience.atlassian.net/browse/OSF-6096
