### PR TITLE
[hotfix] Properly wrap first line in wiki editor [OSF-6240]

### DIFF
--- a/website/static/js/pages/wiki-edit-page.js
+++ b/website/static/js/pages/wiki-edit-page.js
@@ -136,6 +136,9 @@ $(document).ready(function () {
                 buttonState
             ]);
             if (typeof editor !== 'undefined') { ace.edit(editor).resize(); } // jshint ignore: line
+        },
+        complete : function() {
+            if (typeof editor !== 'undefined') { ace.edit(editor).resize(); } // jshint ignore: line
         }
     });
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
The first line in the wiki editor doesn't wrap properly when the page first loads. The editor is initialized before the layout panels are fully laid out, so the editor thinks it's wider than it is until it's told otherwise.
<!-- Describe the purpose of your changes -->

## Changes
After the panels are completely rendered, poke the editor in the resize()

<!-- Briefly describe or list your changes  -->

## Side effects
None I can see.
<!--Any possible side effects? -->


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
https://openscience.atlassian.net/browse/OSF-6240
