### PR TITLE
[Hotfix] Fix guid view scopes [OSF-6148]

### DIFF
--- a/api/base/permissions.py
+++ b/api/base/permissions.py
@@ -53,6 +53,11 @@ class TokenHasScope(permissions.BasePermission):
             except AttributeError:
                 raise ImproperlyConfigured('TokenHasScope requires the view to define the '
                                            'required_read_scopes attribute')
+            assert isinstance(view.required_read_scopes, list), 'The required_read_scopes must be a list of CoreScopes'
+            if view.required_read_scopes and type(view.required_read_scopes[0]) == tuple:
+                raise ImproperlyConfigured('TokenHasScope requires the view to define the '
+                                           'required_read_scopes attribute using CoreScopes')
+
             return read_scopes
         else:
             # A write operation implicitly also requires access to read scopes
@@ -61,7 +66,10 @@ class TokenHasScope(permissions.BasePermission):
             except AttributeError:
                 raise ImproperlyConfigured('TokenHasScope requires the view to define the '
                                            'required_write_scopes attribute')
-
+            assert isinstance(view.required_write_scopes, list), 'The required_write_scopes must be a list of CoreScopes'
+            if view.required_write_scopes and type(view.required_write_scopes[0]) == tuple:
+                raise ImproperlyConfigured('TokenHasScope requires the view to define the '
+                                           'required_write_scopes attribute using CoreScopes')
             return write_scopes
 
 

--- a/api/base/permissions.py
+++ b/api/base/permissions.py
@@ -7,6 +7,7 @@ from framework.auth import oauth_scopes
 from framework.auth.cas import CasResponse
 
 from website.models import ApiOAuth2Application, ApiOAuth2PersonalToken
+from website.util.sanitize import is_iterable_but_not_string
 
 
 # Implementation built on django-oauth-toolkit, but  with more granular control over read+write permissions
@@ -53,8 +54,9 @@ class TokenHasScope(permissions.BasePermission):
             except AttributeError:
                 raise ImproperlyConfigured('TokenHasScope requires the view to define the '
                                            'required_read_scopes attribute')
-            assert isinstance(view.required_read_scopes, list), 'The required_read_scopes must be a list of CoreScopes'
-            if view.required_read_scopes and type(view.required_read_scopes[0]) == tuple:
+            assert is_iterable_but_not_string(view.required_read_scopes), \
+                'The required_read_scopes must be an iterable of CoreScopes'
+            if view.required_read_scopes and isinstance(view.required_read_scopes[0], tuple):
                 raise ImproperlyConfigured('TokenHasScope requires the view to define the '
                                            'required_read_scopes attribute using CoreScopes rather than ComposedScopes')
 
@@ -66,8 +68,9 @@ class TokenHasScope(permissions.BasePermission):
             except AttributeError:
                 raise ImproperlyConfigured('TokenHasScope requires the view to define the '
                                            'required_write_scopes attribute')
-            assert isinstance(view.required_write_scopes, list), 'The required_write_scopes must be a list of CoreScopes'
-            if view.required_write_scopes and type(view.required_write_scopes[0]) == tuple:
+            assert is_iterable_but_not_string(view.required_read_scopes), \
+                'The required_write_scopes must be an iterable of CoreScopes'
+            if view.required_write_scopes and isinstance(view.required_write_scopes[0], tuple):
                 raise ImproperlyConfigured('TokenHasScope requires the view to define the '
                                            'required_write_scopes attribute using CoreScopes rather than ComposedScopes')
             return write_scopes

--- a/api/base/permissions.py
+++ b/api/base/permissions.py
@@ -56,7 +56,7 @@ class TokenHasScope(permissions.BasePermission):
             assert isinstance(view.required_read_scopes, list), 'The required_read_scopes must be a list of CoreScopes'
             if view.required_read_scopes and type(view.required_read_scopes[0]) == tuple:
                 raise ImproperlyConfigured('TokenHasScope requires the view to define the '
-                                           'required_read_scopes attribute using CoreScopes')
+                                           'required_read_scopes attribute using CoreScopes rather than ComposedScopes')
 
             return read_scopes
         else:
@@ -69,7 +69,7 @@ class TokenHasScope(permissions.BasePermission):
             assert isinstance(view.required_write_scopes, list), 'The required_write_scopes must be a list of CoreScopes'
             if view.required_write_scopes and type(view.required_write_scopes[0]) == tuple:
                 raise ImproperlyConfigured('TokenHasScope requires the view to define the '
-                                           'required_write_scopes attribute using CoreScopes')
+                                           'required_write_scopes attribute using CoreScopes rather than ComposedScopes')
             return write_scopes
 
 

--- a/api/guids/views.py
+++ b/api/guids/views.py
@@ -3,7 +3,7 @@ from rest_framework.exceptions import NotFound
 from rest_framework import permissions as drf_permissions
 
 from framework.guid.model import Guid
-from framework.auth.oauth_scopes import CoreScopes, ComposedScopes
+from framework.auth.oauth_scopes import CoreScopes
 from api.base.exceptions import EndpointNotImplementedError
 from api.base import permissions as base_permissions
 from api.base.views import JSONAPIBaseView
@@ -26,7 +26,7 @@ class GuidRedirect(JSONAPIBaseView):
         base_permissions.TokenHasScope,
     )
 
-    required_read_scopes = [ComposedScopes.FULL_READ]
+    required_read_scopes = [CoreScopes.GUIDS_READ]
     required_write_scopes = [CoreScopes.NULL]
 
     view_category = 'guids'

--- a/api_tests/base/test_auth.py
+++ b/api_tests/base/test_auth.py
@@ -195,3 +195,19 @@ class TestOAuthScopedAccess(ApiTestCase):
 
         res = self.app.get(url, params=payload, auth='some_valid_token', auth_type='jwt', expect_errors=True)
         assert_equal(res.status_code, 403)
+
+    @mock.patch('framework.auth.cas.CasClient.profile')
+    def test_full_read_scope_can_read_guid_view(self, mock_user_info):
+        project = ProjectFactory()
+        mock_user_info.return_value = self._scoped_response(['osf.full_read'])
+        url = api_v2_url('guids/{}/'.format(project._id), base_route='/', base_prefix='v2/')
+        res = self.app.get(url, auth='some_valid_token', auth_type='jwt', expect_errors=True)
+        assert_equal(res.status_code, 302)
+
+    @mock.patch('framework.auth.cas.CasClient.profile')
+    def test_full_write_scope_can_read_guid_view(self, mock_user_info):
+        project = ProjectFactory()
+        mock_user_info.return_value = self._scoped_response(['osf.full_write'])
+        url = api_v2_url('guids/{}/'.format(project._id), base_route='/', base_prefix='v2/')
+        res = self.app.get(url, auth='some_valid_token', auth_type='jwt', expect_errors=True)
+        assert_equal(res.status_code, 302)

--- a/api_tests/base/test_auth.py
+++ b/api_tests/base/test_auth.py
@@ -9,6 +9,7 @@ from nose.tools import *  # flake8: noqa
 from framework.auth import cas
 from website.util import api_v2_url
 from website.addons.twofactor.tests import _valid_code
+from website.settings import API_DOMAIN
 
 from tests.base import ApiTestCase
 from tests.factories import AuthUserFactory, ProjectFactory, UserFactory
@@ -201,13 +202,17 @@ class TestOAuthScopedAccess(ApiTestCase):
         project = ProjectFactory()
         mock_user_info.return_value = self._scoped_response(['osf.full_read'])
         url = api_v2_url('guids/{}/'.format(project._id), base_route='/', base_prefix='v2/')
-        res = self.app.get(url, auth='some_valid_token', auth_type='jwt', expect_errors=True)
+        res = self.app.get(url, auth='some_valid_token', auth_type='jwt')
+        redirect_url = '{}{}nodes/{}/'.format(API_DOMAIN, API_BASE, project._id)
         assert_equal(res.status_code, 302)
+        assert_equal(res.location, redirect_url)
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_full_write_scope_can_read_guid_view(self, mock_user_info):
         project = ProjectFactory()
         mock_user_info.return_value = self._scoped_response(['osf.full_write'])
         url = api_v2_url('guids/{}/'.format(project._id), base_route='/', base_prefix='v2/')
-        res = self.app.get(url, auth='some_valid_token', auth_type='jwt', expect_errors=True)
+        res = self.app.get(url, auth='some_valid_token', auth_type='jwt')
+        redirect_url = '{}{}nodes/{}/'.format(API_DOMAIN, API_BASE, project._id)
         assert_equal(res.status_code, 302)
+        assert_equal(res.location, redirect_url)

--- a/api_tests/base/test_auth.py
+++ b/api_tests/base/test_auth.py
@@ -6,7 +6,7 @@ import mock
 
 from nose.tools import *  # flake8: noqa
 
-from framework.auth import cas
+from framework.auth import cas, core
 from website.util import api_v2_url
 from website.addons.twofactor.tests import _valid_code
 from website.settings import API_DOMAIN
@@ -198,7 +198,31 @@ class TestOAuthScopedAccess(ApiTestCase):
         assert_equal(res.status_code, 403)
 
     @mock.patch('framework.auth.cas.CasClient.profile')
-    def test_full_read_scope_can_read_guid_view(self, mock_user_info):
+    def test_full_read_scope_can_read_guid_view_and_user_can_view_project(self, mock_user_info):
+        project = ProjectFactory(creator=self.user)
+        mock_user_info.return_value = self._scoped_response(['osf.full_read'])
+        url = api_v2_url('guids/{}/'.format(project._id), base_route='/', base_prefix='v2/')
+        res = self.app.get(url, auth='some_valid_token', auth_type='jwt')
+        redirect_url = '{}{}nodes/{}/'.format(API_DOMAIN, API_BASE, project._id)
+        assert_equal(res.status_code, 302)
+        assert_equal(res.location, redirect_url)
+        redirect_res = res.follow(auth='some_valid_token', auth_type='jwt')
+        assert_equal(redirect_res.json['data']['attributes']['title'], project.title)
+
+    @mock.patch('framework.auth.cas.CasClient.profile')
+    def test_full_write_scope_can_read_guid_view_and_user_can_view_project(self, mock_user_info):
+        project = ProjectFactory(creator=self.user)
+        mock_user_info.return_value = self._scoped_response(['osf.full_write'])
+        url = api_v2_url('guids/{}/'.format(project._id), base_route='/', base_prefix='v2/')
+        res = self.app.get(url, auth='some_valid_token', auth_type='jwt')
+        redirect_url = '{}{}nodes/{}/'.format(API_DOMAIN, API_BASE, project._id)
+        assert_equal(res.status_code, 302)
+        assert_equal(res.location, redirect_url)
+        redirect_res = res.follow(auth='some_valid_token', auth_type='jwt')
+        assert_equal(redirect_res.json['data']['attributes']['title'], project.title)
+
+    @mock.patch('framework.auth.cas.CasClient.profile')
+    def test_full_read_scope_can_read_guid_view_and_user_cannot_view_project(self, mock_user_info):
         project = ProjectFactory()
         mock_user_info.return_value = self._scoped_response(['osf.full_read'])
         url = api_v2_url('guids/{}/'.format(project._id), base_route='/', base_prefix='v2/')
@@ -206,9 +230,11 @@ class TestOAuthScopedAccess(ApiTestCase):
         redirect_url = '{}{}nodes/{}/'.format(API_DOMAIN, API_BASE, project._id)
         assert_equal(res.status_code, 302)
         assert_equal(res.location, redirect_url)
+        redirect_res = res.follow(auth='some_valid_token', auth_type='jwt', expect_errors=True)
+        assert_equal(redirect_res.status_code, 403)
 
     @mock.patch('framework.auth.cas.CasClient.profile')
-    def test_full_write_scope_can_read_guid_view(self, mock_user_info):
+    def test_full_write_scope_can_read_guid_view_and_user_cannot_view_project(self, mock_user_info):
         project = ProjectFactory()
         mock_user_info.return_value = self._scoped_response(['osf.full_write'])
         url = api_v2_url('guids/{}/'.format(project._id), base_route='/', base_prefix='v2/')
@@ -216,3 +242,5 @@ class TestOAuthScopedAccess(ApiTestCase):
         redirect_url = '{}{}nodes/{}/'.format(API_DOMAIN, API_BASE, project._id)
         assert_equal(res.status_code, 302)
         assert_equal(res.location, redirect_url)
+        redirect_res = res.follow(auth='some_valid_token', auth_type='jwt', expect_errors=True)
+        assert_equal(redirect_res.status_code, 403)

--- a/framework/auth/oauth_scopes.py
+++ b/framework/auth/oauth_scopes.py
@@ -61,6 +61,8 @@ class CoreScopes(object):
     ORGANIZER_COLLECTIONS_BASE_READ = 'collections.base_read'
     ORGANIZER_COLLECTIONS_BASE_WRITE = 'collections.base_write'
 
+    GUIDS_READ = 'guids.base_read'
+
 
 class ComposedScopes(object):
     """
@@ -111,7 +113,7 @@ class ComposedScopes(object):
     NODE_ALL_WRITE = NODE_ALL_READ + NODE_METADATA_WRITE + NODE_DATA_WRITE + NODE_ACCESS_WRITE
 
     # Full permissions: all routes intended to be exposed to third party API users
-    FULL_READ = NODE_ALL_READ + USERS_READ + ORGANIZER_READ
+    FULL_READ = NODE_ALL_READ + USERS_READ + ORGANIZER_READ + (CoreScopes.GUIDS_READ, )
     FULL_WRITE = NODE_ALL_WRITE + USERS_WRITE + ORGANIZER_WRITE
 
     # Admin permissions- includes functionality not intended for third-party use

--- a/framework/auth/oauth_scopes.py
+++ b/framework/auth/oauth_scopes.py
@@ -17,6 +17,9 @@ class CoreScopes(object):
     """
     The smallest units of permission that can be granted- all other scopes are built out of these.
     Each named constant is a single string."""
+    # IMPORTANT: All views should be based on the smallest number of Core scopes required to describe
+    # the data in that view
+
     USERS_READ = 'users_read'
     USERS_WRITE = 'users_write'
 
@@ -68,6 +71,8 @@ class ComposedScopes(object):
     """
     Composed scopes, listed in increasing order of access (most restrictive first). Each named constant is a tuple.
     """
+    # IMPORTANT: Composed scopes exist only as an internal implementation detail.
+    # All views should be based on selections from CoreScopes, above
 
     # Users collection
     USERS_READ = (CoreScopes.USERS_READ,)

--- a/framework/auth/oauth_scopes.py
+++ b/framework/auth/oauth_scopes.py
@@ -120,7 +120,7 @@ class ComposedScopes(object):
     FULL_WRITE = NODE_ALL_WRITE + USERS_WRITE + ORGANIZER_WRITE + GUIDS_READ
 
     # Admin permissions- includes functionality not intended for third-party use
-    ADMIN_LEVEL = FULL_WRITE + APPLICATIONS_WRITE + TOKENS_WRITE + COMMENT_REPORTS_WRITE + GUIDS_READ
+    ADMIN_LEVEL = FULL_WRITE + APPLICATIONS_WRITE + TOKENS_WRITE + COMMENT_REPORTS_WRITE
 
 
 # List of all publicly documented scopes, mapped to composed scopes defined above.

--- a/framework/auth/oauth_scopes.py
+++ b/framework/auth/oauth_scopes.py
@@ -81,6 +81,9 @@ class ComposedScopes(object):
     TOKENS_READ = (CoreScopes.TOKENS_READ,)
     TOKENS_WRITE = TOKENS_READ + (CoreScopes.TOKENS_WRITE,)
 
+    # Guid redirect view
+    GUIDS_READ = (CoreScopes.GUIDS_READ, )
+
     # Comment reports collection
     COMMENT_REPORTS_READ = (CoreScopes.COMMENT_REPORTS_READ,)
     COMMENT_REPORTS_WRITE = COMMENT_REPORTS_READ + (CoreScopes.COMMENT_REPORTS_WRITE,)
@@ -113,11 +116,11 @@ class ComposedScopes(object):
     NODE_ALL_WRITE = NODE_ALL_READ + NODE_METADATA_WRITE + NODE_DATA_WRITE + NODE_ACCESS_WRITE
 
     # Full permissions: all routes intended to be exposed to third party API users
-    FULL_READ = NODE_ALL_READ + USERS_READ + ORGANIZER_READ + (CoreScopes.GUIDS_READ, )
-    FULL_WRITE = NODE_ALL_WRITE + USERS_WRITE + ORGANIZER_WRITE
+    FULL_READ = NODE_ALL_READ + USERS_READ + ORGANIZER_READ + GUIDS_READ
+    FULL_WRITE = NODE_ALL_WRITE + USERS_WRITE + ORGANIZER_WRITE + GUIDS_READ
 
     # Admin permissions- includes functionality not intended for third-party use
-    ADMIN_LEVEL = FULL_WRITE + APPLICATIONS_WRITE + TOKENS_WRITE + COMMENT_REPORTS_WRITE
+    ADMIN_LEVEL = FULL_WRITE + APPLICATIONS_WRITE + TOKENS_WRITE + COMMENT_REPORTS_WRITE + GUIDS_READ
 
 
 # List of all publicly documented scopes, mapped to composed scopes defined above.


### PR DESCRIPTION
## Purpose

Users get the error "The user has not authorized access to this view" when viewing the `/v2/guids/<guid>` API route if they are authenticated with a personal access token.

## Changes

Create a `CoreScope` for the guids view and add it to `ComposedScopes.FULL_READ` instead of directly requiring `ComposedScope.FULL_READ`.

Also check to ensure that the required scopes are lists of `CoreScopes`, not `ComposedScopes`

## Side effects

None.

## Ticket

https://openscience.atlassian.net/browse/OSF-6148