### PR TITLE
[0.69-ish] Fix text in project addon removal modal

### DIFF
--- a/website/static/js/pages/project-settings-page.js
+++ b/website/static/js/pages/project-settings-page.js
@@ -183,7 +183,7 @@ $(document).ready(function() {
             var uncheckedText = $.map(unchecked, function(el){
                 return ['<li>', $(el).closest('label').text().trim(), '</li>'].join('');
             }).join('');
-            uncheckedText = ['<ul>', $osf.htmlEscape(uncheckedText), '</ul>'].join('');
+            uncheckedText = ['<ul>', uncheckedText, '</ul>'].join('');
             bootbox.confirm({
                 title: 'Are you sure you want to remove the add-ons you have deselected? ',
                 message: uncheckedText,


### PR DESCRIPTION
## Purpose

Fix double escaped text in addon removal modals; name should not be rendered as `<li>figshare</li>`

## Changes
Remove redundant use of `htmlEscape`.

## Side effects
None expected. Profile addon removal modals code is different. (there may be some dead code in the latter file, but outside scope of this PR). Shouldn't have any addon names that will introdsuce display artifacts.

## Ticket
https://openscience.atlassian.net/browse/OSF-6298
