### PR TITLE
[Hotfix] Logical signal placement, related check-in/out fix

### DIFF
--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -1315,7 +1315,8 @@ class User(GuidStoredObject, AddonModelMixin):
 
         # Disconnect signal to prevent emails being sent about being a new contributor when merging users
         # be sure to reconnect it at the end of this code block. Import done here to prevent circular import error.
-        from website.project.signals import contributor_added
+        from website.addons.osfstorage.listeners import checkin_files_by_user
+        from website.project.signals import contributor_added, contributor_removed
         from website.project.views.contributor import notify_added_contributor
         from website.util import disconnected_from
 
@@ -1346,16 +1347,18 @@ class User(GuidStoredObject, AddonModelMixin):
                         log=False,
                     )
 
-                try:
-                    node.remove_contributor(
-                        contributor=user,
-                        auth=Auth(user=self),
-                        log=False,
-                    )
-                except ValueError:
-                    logger.error('Contributor {0} not in list on node {1}'.format(
-                        user._id, node._id
-                    ))
+                with disconnected_from(signal=contributor_removed, listener=checkin_files_by_user):
+                    try:
+                        node.remove_contributor(
+                            contributor=user,
+                            auth=Auth(user=self),
+                            log=False,
+                        )
+                    except ValueError:
+                        logger.error('Contributor {0} not in list on node {1}'.format(
+                            user._id, node._id
+                        ))
+
                 node.save()
 
         # - projects where the user was the creator

--- a/framework/auth/signals.py
+++ b/framework/auth/signals.py
@@ -8,7 +8,4 @@ user_confirmed = signals.signal('user-confirmed')
 user_email_removed = signals.signal('user-email-removed')
 user_merged = signals.signal('user-merged')
 
-contributor_removed = signals.signal('contributor-removed')
-node_deleted = signals.signal('node-deleted')
-
 unconfirmed_user_created = signals.signal('unconfirmed-user-created')

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -11,8 +11,6 @@ from nose.tools import *  # noqa PEP8 asserts
 
 from framework.auth import Auth
 from framework.auth.core import User
-from framework.auth.signals import contributor_removed
-from framework.auth.signals import node_deleted
 from framework.guid.model import Guid
 
 from website.notifications.tasks import get_users_emails, send_users_email, group_by_node, remove_notifications
@@ -22,6 +20,7 @@ from website.notifications.model import NotificationSubscription
 from website.notifications import emails
 from website.notifications import utils
 from website.project.model import Node, Comment
+from website.project.signals import contributor_removed, node_deleted
 from website import mails
 from website.util import api_url_for
 from website.util import web_url_for

--- a/website/addons/osfstorage/listeners.py
+++ b/website/addons/osfstorage/listeners.py
@@ -3,11 +3,11 @@ Listens for actions to be done to OSFstorage file nodes specifically.
 '''
 from modularodm import Q
 
-from website.project import signals as project_signals
+from website.project.signals import contributor_removed
 from website.files.models.osfstorage import OsfStorageFileNode
 
-@project_signals.contributor_removed.connect
-def checkin_files_by_user(node, user):
+@contributor_removed.connect
+def checkin_files_by_user(user, node):
     ''' Listens to a contributor being removed to check in all of their files
     '''
     files = OsfStorageFileNode.find(Q('node', 'eq', node) & Q('checkout', 'eq', user))

--- a/website/addons/osfstorage/listeners.py
+++ b/website/addons/osfstorage/listeners.py
@@ -7,7 +7,7 @@ from website.project.signals import contributor_removed
 from website.files.models.osfstorage import OsfStorageFileNode
 
 @contributor_removed.connect
-def checkin_files_by_user(user, node):
+def checkin_files_by_user(node, user):
     ''' Listens to a contributor being removed to check in all of their files
     '''
     files = OsfStorageFileNode.find(Q('node', 'eq', node) & Q('checkout', 'eq', user))

--- a/website/notifications/utils.py
+++ b/website/notifications/utils.py
@@ -3,11 +3,11 @@ import collections
 from modularodm import Q
 from modularodm.exceptions import NoResultsFound
 
-from framework.auth import signals
 from website.models import Node, User
 from website.notifications import constants
 from website.notifications import model
 from website.notifications.model import NotificationSubscription
+from website.project import signals
 
 
 class NotificationsDict(dict):

--- a/website/notifications/utils.py
+++ b/website/notifications/utils.py
@@ -57,14 +57,14 @@ def from_subscription_key(key):
 
 
 @signals.contributor_removed.connect
-def remove_contributor_from_subscriptions(contributor, node):
+def remove_contributor_from_subscriptions(node, user):
     """ Remove contributor from node subscriptions unless the user is an
         admin on any of node's parent projects.
     """
-    if contributor._id not in node.admin_contributor_ids:
-        node_subscriptions = get_all_node_subscriptions(contributor, node)
+    if user._id not in node.admin_contributor_ids:
+        node_subscriptions = get_all_node_subscriptions(user, node)
         for subscription in node_subscriptions:
-            subscription.remove_user_from_subscription(contributor)
+            subscription.remove_user_from_subscription(user)
 
 
 @signals.node_deleted.connect

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2755,7 +2755,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
         self.save()
 
         #send signal to remove this user from project subscriptions
-        project_signals.contributor_removed.send(contributor, node=self)
+        project_signals.contributor_removed.send(self, user=contributor)
 
         return True
 

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -26,7 +26,6 @@ from framework.mongo import StoredObject
 from framework.mongo import validators
 from framework.addons import AddonModelMixin
 from framework.auth import get_user, User, Auth
-from framework.auth import signals as auth_signals
 from framework.exceptions import PermissionsError
 from framework.guid.model import GuidStoredObject, Guid
 from framework.auth.utils import privacy_info_handle
@@ -2098,7 +2097,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
         self.deleted_date = date
         self.save()
 
-        auth_signals.node_deleted.send(self)
+        project_signals.node_deleted.send(self)
 
         return True
 
@@ -2756,7 +2755,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
         self.save()
 
         #send signal to remove this user from project subscriptions
-        auth_signals.contributor_removed.send(contributor, node=self)
+        project_signals.contributor_removed.send(contributor, node=self)
 
         return True
 
@@ -2770,8 +2769,6 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
                 contributor=contrib, auth=auth, log=False,
             )
             results.append(outcome)
-            if outcome:
-                project_signals.contributor_removed.send(self, user=contrib)
             removed.append(contrib._id)
         if log:
             self.add_log(
@@ -2788,10 +2785,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
         if save:
             self.save()
 
-        if False in results:
-            return False
-
-        return True
+        return all(results)
 
     def update_contributor(self, user, permission, visible, auth, save=False):
         """ TODO: this method should be updated as a replacement for the main loop of

--- a/website/project/signals.py
+++ b/website/project/signals.py
@@ -6,6 +6,7 @@ contributor_added = signals.signal('contributor-added')
 contributor_removed = signals.signal('contributor-removed')
 unreg_contributor_added = signals.signal('unreg-contributor-added')
 write_permissions_revoked = signals.signal('write-permissions-revoked')
+node_deleted = signals.signal('node-deleted')
 
 after_create_registration = signals.signal('post-create-registration')
 

--- a/website/signals.py
+++ b/website/signals.py
@@ -6,12 +6,12 @@ from website.addons.base import signals as event
 from website.conferences import signals as conference
 
 ALL_SIGNALS = [
-    auth.contributor_removed,
-    auth.node_deleted,
     project.comment_added,
     project.unreg_contributor_added,
     project.contributor_added,
+    project.contributor_removed,
     project.privacy_set_public,
+    project.node_deleted,
     auth.user_confirmed,
     auth.user_email_removed,
     auth.user_registered,


### PR DESCRIPTION
## Purpose
De-duplicate the `contributor_removed` signal, put project-related signals in `website.project.signals`. 
Contributors that are removed individually (`remove_contributor()` instead of just `remove_contributors()`) will now have any checked-out files checked-in when removed.

## Changes
* Remove duplicate `contributor_removed` from `framework.auth.signals`
* Put `node_deleted` signal in `website.project.signals` rather than `framework.auth.signals`
* Update senders, listeners, tests to use correct signals.
* Minor: `return all(<bool_list>)` when trying to determine if any items in `<bool_list>` are `False`

## Side effects
None

## Ticket
None that I know of ¯\\\_(ツ)_/¯ 

## QA Notes

### To test that this fix works, 

1) Have a write contributor check out a file
2) Remove the write contributor via Contributors page
3) Ensure file was checked back in.

### To test that this doesn't break anything,

A1) Make node, configure some notification settings for it. 
A2) Ensure node is present on user settings page -> Notifications -> Configure Notification Preferences
A3) Delete node.
A4) Ensure node is not present on user settings page -> Notifications -> Configure Notification Preferences

B1) Make node with multiple contributors, configure notifications for contribs (e.g. commenting)
B2) Ensure emails are sent out according to notification settings.
B3) Delete one of the contributors who would receive a notification email for an event
B4) Perform event that would trigger email
B5) Ensure: removed contributor does not receive email, any subscribed contribs still do.

C1) Check out a file as one user
C2) Merge that user into another user
C3) Ensure checkout is now owned by the merged-into user.

==========================================================================
#### Review Note
May require migration to fix any files checked-out by a now-noncontributor, though project admins can still check those in.