### PR TITLE
normalize user payload sent to keen

### DIFF
--- a/website/static/js/keen.js
+++ b/website/static/js/keen.js
@@ -102,7 +102,12 @@ var KeenTracker = oop.defclass({
             };
         }
         if(this.currentUser){
-            pageView.user = this.currentUser;
+            pageView.user = {
+                id: this.currentUser.id,
+                locale: this.currentUser.locale,
+                timezone: this.currentUser.timezone,
+                entryPoint: this.currentUser.entryPoint
+            };
         }
 
         this.keenClient.addEvent('pageviews', pageView, function(err){


### PR DESCRIPTION
## Purpose

Keen is rejecting some of our logging payloads because of schema mismatches (e.g. bools being represented as ints).  We have have been posting the entire `currentUser` context var into Keen, but that's fragile since a single data type property mismatch will cause Keen to reject the event.  This PR strips down the user object to just a few bare whitelisted properties.

Once merged, we should stop seeing Keen errors in the sentry logs.

## Changes

Instead of serializing the full user object, just send the `id`, `locale`, `timezone`, and `entryPoint`.

## Side effects

None expected.

@felliott will need to clean up the Staging collection after this is merged.

## Credits

Original author: @GageGaskins   This PR was cherry-picked out of https://github.com/CenterForOpenScience/osf.io/pull/5273

## Ticket

[#OSF-6074]