### PR TITLE
[Ready to Review] Add logs and forks scope [OSF-6309]

### DIFF
--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1189,7 +1189,7 @@ class NodeForksList(JSONAPIBaseView, generics.ListCreateAPIView, NodeMixin, ODMF
         ExcludeWithdrawals
     )
 
-    required_read_scopes = [CoreScopes.NODE_FORKS_READ]
+    required_read_scopes = [CoreScopes.NODE_FORKS_READ, CoreScopes.NODE_BASE_READ]
     required_write_scopes = [CoreScopes.NODE_FORKS_WRITE]
 
     serializer_class = NodeForksSerializer

--- a/framework/auth/oauth_scopes.py
+++ b/framework/auth/oauth_scopes.py
@@ -99,10 +99,10 @@ class ComposedScopes(object):
     # Nodes collection.
     # Base node data includes node metadata, links, and children.
     NODE_METADATA_READ = (CoreScopes.NODE_BASE_READ, CoreScopes.NODE_CHILDREN_READ, CoreScopes.NODE_LINKS_READ,
-                          CoreScopes.NODE_CITATIONS_READ, CoreScopes.NODE_COMMENTS_READ)
+                          CoreScopes.NODE_CITATIONS_READ, CoreScopes.NODE_COMMENTS_READ, CoreScopes.NODE_LOG_READ, CoreScopes.NODE_FORKS_READ)
     NODE_METADATA_WRITE = NODE_METADATA_READ + \
                     (CoreScopes.NODE_BASE_WRITE, CoreScopes.NODE_CHILDREN_WRITE, CoreScopes.NODE_LINKS_WRITE,
-                     CoreScopes.NODE_CITATIONS_WRITE, CoreScopes.NODE_COMMENTS_WRITE)
+                     CoreScopes.NODE_CITATIONS_WRITE, CoreScopes.NODE_COMMENTS_WRITE, CoreScopes.NODE_FORKS_WRITE)
 
     # Organizer Collections collection
     # Using Organizer Collections and the node links they collect. Reads Node Metadata.


### PR DESCRIPTION
JIRA https://openscience.atlassian.net/browse/OSF-6309
## Purpose

Logs and forks are not included in osf.full_write or osf.full_read scopes which means we can't access logs or fork endpoints in Ember OSF.

## Changes

Adds log read/fork read to osf.full_read and fork write to osf.full_write.