### PR TITLE
[featurefix] Fix missing file names in log templates

### DIFF
--- a/website/addons/dataverse/templates/log_templates.mako
+++ b/website/addons/dataverse/templates/log_templates.mako
@@ -22,7 +22,7 @@ linked Dataverse dataset
 <!-- Legacy version -->
 <script type="text/html" id="dataverse_study_linked">
 linked Dataverse dataset
-<span class="overflow" data-bind="params.study"></span> to
+<span class="overflow" data-bind="text: params.study"></span> to
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>
 

--- a/website/addons/osfstorage/templates/log_templates.mako
+++ b/website/addons/osfstorage/templates/log_templates.mako
@@ -17,7 +17,7 @@ updated file
 </script>
 
 <script type="text/html" id="osf_storage_file_removed">
-  removed <span data-bind="text: pathType(params.path)"></span> <span class="overflow" data-bind="stripSlash(params.path)"></span>
+  removed <span data-bind="text: pathType(params.path)"></span> <span class="overflow" data-bind="text: stripSlash(params.path)"></span>
   from OSF Storage in
   <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>


### PR DESCRIPTION
## Purpose

File/folder names are not being displayed for osfstorage file delete actions:

![screen shot 2016-05-11 at 1 32 30 pm](https://cloud.githubusercontent.com/assets/86835/15197874/ddcf6a4c-17a1-11e6-91e8-1003dfc2b616.png)

because the expected display string isn't being assigned to the `data-bind`'s `text` attribute.

## Changes

Add `text: ` to `data-bind` in the osfstorage delete template and the dataverse study_linked template.

## Side effects

Nope.

## Ticket

No ticket.