### PR TITLE
Fix malformed list of scope permissions

### DIFF
--- a/framework/auth/oauth_scopes.py
+++ b/framework/auth/oauth_scopes.py
@@ -106,7 +106,7 @@ class ComposedScopes(object):
 
     # Organizer Collections collection
     # Using Organizer Collections and the node links they collect. Reads Node Metadata.
-    ORGANIZER_READ = (CoreScopes.ORGANIZER_COLLECTIONS_BASE_READ, NODE_METADATA_READ)
+    ORGANIZER_READ = (CoreScopes.ORGANIZER_COLLECTIONS_BASE_READ,) + NODE_METADATA_READ
     ORGANIZER_WRITE = ORGANIZER_READ + (CoreScopes.ORGANIZER_COLLECTIONS_BASE_WRITE, CoreScopes.NODE_LINKS_WRITE)
 
     # Privileges relating to editing content uploaded under that node # TODO: Add wiki etc when implemented


### PR DESCRIPTION
## Purpose
Fix malformed list of scope permissions. Because the thing appended at the bottom was redundant with the rest of the list, this should not alter the list of views accessible for a token with any of the existing publicly available scopes. This PR resolves a badly formed list revealed during auditing.

Since the only affected scopes (osf.full_read/osf.full_write) are already covered by runscope tests, there is a good chance that QA will already have this covered: just check that runscope oauth tests involving nodes still pass after this is merged.

Run `python -m framework.auth.oauth_scopes` to verify.

Before, there was a tuple embedded at the end of a flat list.

```
 'osf.full_read': ['collections.base_read',
                   'comments.data_read',
                   'guids.base_read',
                   'institutions_read',
                   'nodes.base_read',
                   'nodes.children_read',
                   'nodes.citations_read',
                   'nodes.contributors_read',
                   'nodes.files_read',
                   'nodes.links_read',
                   'nodes.registrations_read',
                   'users_read',
                   ('nodes.base_read',
                    'nodes.children_read',
                    'nodes.links_read',
                    'nodes.citations_read',
                    'comments.data_read')],
```

After, it's just a flat list.
```
 'osf.full_read': ['collections.base_read',
                   'comments.data_read',
                   'guids.base_read',
                   'institutions_read',
                   'nodes.base_read',
                   'nodes.children_read',
                   'nodes.citations_read',
                   'nodes.contributors_read',
                   'nodes.files_read',
                   'nodes.links_read',
                   'nodes.registrations_read',
                   'users_read'],
```

## Changes
Concatenate tuples, instead of nesting.

## Side effects
None expected.

## Ticket
https://openscience.atlassian.net/browse/OSF-6310