### PR TITLE
Make category icon show again by fixing quotes [OSF-6308]

### DIFF
--- a/website/templates/util/render_node.mako
+++ b/website/templates/util/render_node.mako
@@ -34,7 +34,7 @@
                     <span class="label label-primary"><strong>Archiving</strong></span> |
                   % endif
                 </span>
-            <span data-bind="getIcon: ${ summary['category'] | sjson, n }"></span>
+            <span data-bind='getIcon: ${ summary["category"] | sjson, n }'></span>
             % if not summary['archiving']:
                 <a href="${summary['url']}">${summary['title']}</a>
             % else:


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Make the category icons show in the components widget of the project summary page. It looks like this was broken by the markup safe feature because whatever handled the wrapping of the item in quotes use the wrong style of quotes for the surrounding part of the tag.

![screen shot 2016-05-12 at 11 54 42 am](https://cloud.githubusercontent.com/assets/6599111/15221343/0cb42d1a-1839-11e6-9ddf-b30639cad5ed.png)


## Changes

Change single quotes to double quotes and vice versa. 

## Side effects

Not expected; it's pretty well localized.


## Ticket

https://openscience.atlassian.net/browse/OSF-6308