### PR TITLE
Selecting embargo more than 4 years in the future gives bad error message [OSF-6106]

### DIFF
--- a/website/static/js/registrationModal.js
+++ b/website/static/js/registrationModal.js
@@ -53,10 +53,17 @@ var RegistrationViewModel = function(confirm, prompts, validator) {
     var validation = [{
         validator: function() {
             var endEmbargoDateTimestamp = self.embargoEndDate().getTime();
-            return (endEmbargoDateTimestamp < FOUR_YEARS_FROM_TODAY_TIMESTAMP && endEmbargoDateTimestamp > TWO_DAYS_FROM_TODAY_TIMESTAMP);
+            return (endEmbargoDateTimestamp > TWO_DAYS_FROM_TODAY_TIMESTAMP);
         },
-        message: 'Embargo end date must be at least two days in the future.'
+        message: 'Embargo end date must be at least three days in the future.'}, 
+        {
+        validator: function() {
+            var endEmbargoDateTimestamp = self.embargoEndDate().getTime();
+            return (endEmbargoDateTimestamp < FOUR_YEARS_FROM_TODAY_TIMESTAMP);
+        },
+        message: 'Embargo end date must be less than four years in the future.', 
     }];
+    
     if(validator) {
         validation.unshift(validator);
     }


### PR DESCRIPTION
# Purpose

Produce correct error message for selecting an embargo date more than four years in the future

Issue:
https://openscience.atlassian.net/browse/OSF-6106

# Code
 Separated the conditions of validation for selecting an embargo date, and added the approprite error message for failing to choose a date less than four years in the future:

        {
        validator: function() {
            var endEmbargoDateTimestamp = self.embargoEndDate().getTime();
            return (endEmbargoDateTimestamp < FOUR_YEARS_FROM_TODAY_TIMESTAMP);
        },
        message: 'Embargo end date must be less than four years in the future.', 
    }
