### PR TITLE
[RFR] Eliminate record lock on log creation activity count

### DIFF
--- a/api/caching/listeners.py
+++ b/api/caching/listeners.py
@@ -5,4 +5,4 @@ from modularodm import signals
 @signals.save.connect
 def ban_object_from_cache(sender, instance, fields_changed, cached_data):
     if hasattr(instance, 'absolute_api_v2_url'):
-        enqueue_postcommit_task((ban_url, (instance,)))
+        enqueue_postcommit_task(ban_url, [instance, ], {})

--- a/api/caching/listeners.py
+++ b/api/caching/listeners.py
@@ -5,4 +5,4 @@ from modularodm import signals
 @signals.save.connect
 def ban_object_from_cache(sender, instance, fields_changed, cached_data):
     if hasattr(instance, 'absolute_api_v2_url'):
-        enqueue_postcommit_task(ban_url, [instance, ], {})
+        enqueue_postcommit_task(ban_url, (instance, ), {})

--- a/framework/analytics/__init__.py
+++ b/framework/analytics/__init__.py
@@ -5,6 +5,7 @@ import functools
 from datetime import datetime
 
 from framework.mongo import database
+from framework.postcommit_tasks.handlers import run_postcommit
 from framework.sessions import session
 
 from flask import request
@@ -12,7 +13,7 @@ from flask import request
 
 collection = database['pagecounters']
 
-
+@run_postcommit(once_per_request=False)
 def increment_user_activity_counters(user_id, action, date, db=None):
     db = db or database  # default to local proxy
     collection = database['useractivitycounters']
@@ -71,7 +72,7 @@ def build_page(rex, kwargs):
     except KeyError:
         return None
 
-
+@run_postcommit(once_per_request=False)
 def update_counter(page, db=None):
     """Update counters for page.
 

--- a/framework/postcommit_tasks/handlers.py
+++ b/framework/postcommit_tasks/handlers.py
@@ -1,5 +1,13 @@
+import functools
+import hashlib
 import logging
 import threading
+import os
+
+import binascii
+from collections import OrderedDict
+
+import gevent
 
 from website import settings
 
@@ -8,31 +16,57 @@ logger = logging.getLogger(__name__)
 
 def postcommit_queue():
     if not hasattr(_local, 'postcommit_queue'):
-        _local.postcommit_queue = set()
+        _local.postcommit_queue = OrderedDict()
     return _local.postcommit_queue
 
 def postcommit_before_request():
-    _local.postcommit_queue = set()
+    _local.postcommit_queue = OrderedDict()
 
 def postcommit_after_request(response, base_status_error_code=500):
     if response.status_code >= base_status_error_code:
-        _local.postcommit_queue = set()
+        _local.postcommit_queue = OrderedDict()
         return response
     try:
-        if settings.ENABLE_VARNISH and postcommit_queue():
-            import gevent
-            threads = [gevent.spawn(func, *args) for func, args in postcommit_queue()]
+        if postcommit_queue():
+            threads = [gevent.spawn(func) for func in postcommit_queue().values()]
             gevent.joinall(threads)
+
     except AttributeError:
         if not settings.DEBUG_MODE:
             logger.error('Post commit task queue not initialized')
     return response
 
-def enqueue_postcommit_task(function_and_args):
-    postcommit_queue().add(function_and_args)
+def enqueue_postcommit_task(fn, args, kwargs, once_per_request=True):
+    # make a hash of the pertinent data
+    raw = [fn.__name__, fn.__module__, args, kwargs]
+    m = hashlib.md5()
+    m.update('-'.join([x.__repr__() for x in raw]))
+    key = m.hexdigest()
+
+    if not once_per_request:
+        # we want to run it once for every occurrence, add a random string
+        key = '{}:{}'.format(key, binascii.hexlify(os.urandom(8)))
+    postcommit_queue().update({key: functools.partial(fn, *args, **kwargs)})
 
 
 handlers = {
     'before_request': postcommit_before_request,
     'after_request': postcommit_after_request,
 }
+
+
+def run_postcommit(once_per_request=True):
+    '''
+    Delays function execution until after the request's transaction has been committed.
+    !!!Tasks enqueued using this decorator **WILL NOT** run if the return status code is >= 500!!!
+    :return:
+    '''
+    def wrapper(func):
+        # if we're local dev or running unit tests, run without queueing
+        if settings.DEBUG_MODE:
+            return func
+        @functools.wraps(func)
+        def wrapped(*args, **kwargs):
+            enqueue_postcommit_task(func, args, kwargs, once_per_request=once_per_request)
+        return wrapped
+    return wrapper

--- a/website/project/views/comment.py
+++ b/website/project/views/comment.py
@@ -145,11 +145,11 @@ def is_reply(target):
 
 def _update_comments_timestamp(auth, node, page=Comment.OVERVIEW, root_id=None):
     if node.is_contributor(auth.user):
-        enqueue_postcommit_task((ban_url, (node, )))
+        enqueue_postcommit_task(ban_url, [node, ], {})
         if root_id is not None:
             guid_obj = Guid.load(root_id)
             if guid_obj is not None:
-                enqueue_postcommit_task((ban_url, (guid_obj.referent, )))
+                enqueue_postcommit_task(ban_url, [guid_obj.referent, ], {})
 
         # update node timestamp
         if page == Comment.OVERVIEW:

--- a/website/project/views/comment.py
+++ b/website/project/views/comment.py
@@ -145,11 +145,11 @@ def is_reply(target):
 
 def _update_comments_timestamp(auth, node, page=Comment.OVERVIEW, root_id=None):
     if node.is_contributor(auth.user):
-        enqueue_postcommit_task(ban_url, [node, ], {})
+        enqueue_postcommit_task(ban_url, (node, ), {})
         if root_id is not None:
             guid_obj = Guid.load(root_id)
             if guid_obj is not None:
-                enqueue_postcommit_task(ban_url, [guid_obj.referent, ], {})
+                enqueue_postcommit_task(ban_url, (guid_obj.referent, ), {})
 
         # update node timestamp
         if page == Comment.OVERVIEW:


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Fix locking of mongo records in user_activity_counters caused by incrementing the same user's counter concurrently in different requests.

## Changes

I refactored the postcommit handler to accept func, args, and kwargs. I created a decorator which allows limiting the number of times the enqueued function can be run per request. If DEBUG=True then the functions are NOT enqueued. Changing the task storage object to an OrderedDict should enable tasks to be run in the order that they were added to the queue.

## Side effects

It's possible that the hash created could not be unique enough. This would cause tasks to be lost. Suggestions are welcome. My initial effort tried pickling the `raw` list but I encountered things that were unable to be pickled (mongo collection passed in from the analytics tests).

`OrderedDict.update(existing_key, value)` will update the value and move the element to the end of the dictionary. This could be unexpected behavior. The previous behavior was that of a set, adding existing elements had no effect.

## Ticket
https://openscience.atlassian.net/browse/OSF-6294
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->