### PR TITLE
[Hotfix] Apply Alt Citation Styles [OSF-5893]

### DIFF
--- a/website/static/css/citations_widget.css
+++ b/website/static/css/citations_widget.css
@@ -27,3 +27,11 @@ Override treebeard styles
 .citation-widget > ul > li:last-child {
     margin-bottom:0px;
 }
+
+.csl-left-margin {
+    display: inline;
+}
+
+.csl-right-inline {
+    display: inline;
+}


### PR DESCRIPTION
## Purpose
Display citations with selected style.

## Changes
Add `display: inline;` to make selected style visible.

![cites](https://cloud.githubusercontent.com/assets/5659262/15291796/b8e501d8-1b4d-11e6-82fa-97b994bca415.gif)


## Side effects
Consider investigating whether or not upgrading `citeproc.js` would fix this.


## Ticket

[#OSF-5893](https://openscience.atlassian.net/browse/OSF-5893)