### PR TITLE
hotfix: prevent osf4m queued mail from crashing by checking for files

### DIFF
--- a/website/mails/listeners.py
+++ b/website/mails/listeners.py
@@ -47,7 +47,7 @@ def queue_first_public_project_email(user, node, meeting_creation):
 def queue_osf4m_welcome_email(user, conference, node):
     """Queue an email once a new user is created for OSF for Meetings"""
     root = (node.get_addon('osfstorage')).get_root()
-    fid = root.children[0]._id if root.children else None
+    root_children = [child for child in root.children if child.is_file]
     mails.queue_mail(
         to_addr=user.username,
         mail=mails.WELCOME_OSF4M,
@@ -55,5 +55,5 @@ def queue_osf4m_welcome_email(user, conference, node):
         user=user,
         conference=conference.name,
         fullname=user.fullname,
-        fid=fid
+        fid=root_children[0]._id if len(root_children) else None
     )


### PR DESCRIPTION
## Purpose

Prevent ` folder has no download count ` error to be triggered in sending osf4m queued mails.

## Changes

Makes the presend find the first file, rather than the first whatever under osfstorage root.

## Test
Create a new osf4m project by sending an email. Then, delete all the files in it, leaving only a folder. If the email is received anyways, this worked!