### PR TITLE
[Hotfix] Use HTTPS in emails [#OSF-6343]

### DIFF
--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import datetime
+import furl
 import httplib as http
 
 from flask import request
@@ -82,8 +83,8 @@ def forgot_password_post():
                 user_obj.verification_key = security.random_string(20)
                 user_obj.email_last_sent = datetime.datetime.utcnow()
                 user_obj.save()
-                reset_link = "https://{0}{1}".format(
-                    request.host,
+                reset_link = furl.urljoin(
+                    settings.DOMAIN,
                     web_url_for(
                         'reset_password',
                         verification_key=user_obj.verification_key

--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -82,7 +82,7 @@ def forgot_password_post():
                 user_obj.verification_key = security.random_string(20)
                 user_obj.email_last_sent = datetime.datetime.utcnow()
                 user_obj.save()
-                reset_link = "http://{0}{1}".format(
+                reset_link = "https://{0}{1}".format(
                     request.host,
                     web_url_for(
                         'reset_password',

--- a/website/templates/emails/contributor_added.txt.mako
+++ b/website/templates/emails/contributor_added.txt.mako
@@ -10,6 +10,6 @@ Sincerely,
 Open Science Framework Robot
 
 
-Want more information? Visit http://osf.io/ to learn about the Open Science Framework, or http://cos.io/ for information about its supporting organization, the Center for Open Science.
+Want more information? Visit https://osf.io/ to learn about the Open Science Framework, or https://cos.io/ for information about its supporting organization, the Center for Open Science.
 
 Questions? Email contact@osf.io

--- a/website/templates/emails/forward_invite.txt.mako
+++ b/website/templates/emails/forward_invite.txt.mako
@@ -21,4 +21,4 @@ Sincerely,
 The OSF Team
 
 
-Want more information? Visit http://osf.io/ or http://cos.io/ for information about the Open Science Framework and its supporting organization, the Center for Open Science. Questions? Email contact@osf.io.
+Want more information? Visit https://osf.io/ or https://cos.io/ for information about the Open Science Framework and its supporting organization, the Center for Open Science. Questions? Email contact@osf.io.

--- a/website/templates/emails/forward_invite_registered.txt.mako
+++ b/website/templates/emails/forward_invite_registered.txt.mako
@@ -21,4 +21,4 @@ Sincerely,
 The OSF Team
 
 
-Want more information? Visit http://osf.io/ or http://cos.io/ for information about the Open Science Framework and its supporting organization, the Center for Open Science. Questions? Email contact@osf.io
+Want more information? Visit https://osf.io/ or https://cos.io/ for information about the Open Science Framework and its supporting organization, the Center for Open Science. Questions? Email contact@osf.io

--- a/website/templates/emails/invite.txt.mako
+++ b/website/templates/emails/invite.txt.mako
@@ -14,5 +14,5 @@ Open Science Framework Robot
 
 
 
-Want more information? Visit http://osf.io/ to learn about the Open Science Framework, or http://cos.io/ for information about its supporting organization, the Center for Open Science. Questions? Email contact@osf.io
+Want more information? Visit https://osf.io/ to learn about the Open Science Framework, or https://cos.io/ for information about its supporting organization, the Center for Open Science. Questions? Email contact@osf.io
 

--- a/website/templates/emails/new_public_project.html.mako
+++ b/website/templates/emails/new_public_project.html.mako
@@ -26,5 +26,5 @@
 </%def>
 <%def name="footer()">
     <br>
-    The <a href="${osf_url}">Open Science Framework</a> is provided as a free, open source service from the <a href="http://cos.io/">Center for Open Science</a>.
+    The <a href="${osf_url}">Open Science Framework</a> is provided as a free, open source service from the <a href="https://cos.io/">Center for Open Science</a>.
 </%def>

--- a/website/templates/emails/no_addon.html.mako
+++ b/website/templates/emails/no_addon.html.mako
@@ -11,7 +11,7 @@
         OSF or external storage services. Files will be synced whenever you make changes.
         Get more information on OSF add-ons.
         <br><br>
-        Link your accounts today: <a href="${osf_url}settings">http://osf.io/settings</a>.
+        Link your accounts today: <a href="${osf_url}settings">https://osf.io/settings</a>.
         <br><br>
         Best wishes,<br>
         COS Support Team
@@ -19,5 +19,5 @@
 </%def>
 <%def name="footer()">
     <br>
-    The <a href="${osf_url}">Open Science Framework</a> is provided as a free, open source service from the <a href="http://cos.io/">Center for Open Science</a>.
+    The <a href="${osf_url}">Open Science Framework</a> is provided as a free, open source service from the <a href="https://cos.io/">Center for Open Science</a>.
 </%def>

--- a/website/templates/emails/no_login.html.mako
+++ b/website/templates/emails/no_login.html.mako
@@ -23,5 +23,5 @@
 </%def>
 <%def name="footer()">
     <br>
-    The <a href="${osf_url}">Open Science Framework</a> is provided as a free, open source service from the <a href="http://cos.io/">Center for Open Science</a>.
+    The <a href="${osf_url}">Open Science Framework</a> is provided as a free, open source service from the <a href="https://cos.io/">Center for Open Science</a>.
 </%def>

--- a/website/templates/emails/password_reset.txt.mako
+++ b/website/templates/emails/password_reset.txt.mako
@@ -4,7 +4,7 @@ The password for your OSF account has successfully changed.
 
 If you did not request this action or you believe an unauthorized person has accessed your account, reset your password immediately by visiting:
 
-http://osf.io/settings/account/
+https://osf.io/settings/account/
 
 If you need additional help or have questions, let us know at contact@cos.io.
 

--- a/website/templates/emails/pending_invite.txt.mako
+++ b/website/templates/emails/pending_invite.txt.mako
@@ -12,6 +12,6 @@ Sincerely,
 
 The OSF Team
 
-More information? Visit http://osf.io/ and http://cos.io/ for information about the Open Science Framework and its supporting organization, the Center for Open Science.
+More information? Visit https://osf.io/ and https://cos.io/ for information about the Open Science Framework and its supporting organization, the Center for Open Science.
 
 Questions? Email contact@osf.io

--- a/website/templates/emails/pending_registered.txt.mako
+++ b/website/templates/emails/pending_registered.txt.mako
@@ -12,6 +12,6 @@ Sincerely,
 
 The OSF Team
 
-More information? Visit http://osf.io/ and http://cos.io/ for information about the Open Science Framework and its supporting organization, the Center for Open Science.
+More information? Visit https://osf.io/ and https://cos.io/ for information about the Open Science Framework and its supporting organization, the Center for Open Science.
 
 Questions? Email contact@osf.io

--- a/website/templates/emails/welcome_osf4m.html.mako
+++ b/website/templates/emails/welcome_osf4m.html.mako
@@ -18,7 +18,7 @@
             <li>You can monitor interest in your data and materials by tracking downloads, just like you can for your ${conference} presentation.</li>
         </ul>
         To learn more about how the OSF can help you manage your research, read our <a href="http://help.osf.io">Guides</a>. Or, read about how others use the OSF from a <a href="https://osf.io/svje2/">case study</a>.
-        The best part? It’s all free! OSF is supported by the non-profit technology company, the <a href="http://cos.io/">Center for Open Science</a>.
+        The best part? It’s all free! OSF is supported by the non-profit technology company, the <a href="https://cos.io/">Center for Open Science</a>.
         <br><br>
         Best wishes,
         <br>
@@ -29,5 +29,5 @@
 </%def>
 <%def name="footer()">
     <br>
-    The <a href="${osf_url}">Open Science Framework</a> is provided as a free, open source service from the <a href="http://cos.io/">Center for Open Science</a>.
+    The <a href="${osf_url}">Open Science Framework</a> is provided as a free, open source service from the <a href="https://cos.io/">Center for Open Science</a>.
 </%def>


### PR DESCRIPTION
## Purpose
Use HTTPS in emails, especially when that email could contain keys (e.g. password resetting, user confirmation, registration approval)

## Changes
* Hard-coded links updated
* Generation of `reset_link` updated
* Verified registration links use `settings.DOMAIN`
* Verified user confirmation, merge links use `settings.DOMAIN`
* Verified queued emails use `settings.DOMAIN`


## Side effects
None expected

## QA Notes
To test, 
* request a password reset via https://osf.io/forgotpassword/
* ensure the reset link uses https and work properly.
* As footer links (to osf.io and cos.io) are not present in this email, generate a different email and verify that they both use https and work.

## Ticket
[OSF-6343](https://openscience.atlassian.net/browse/OSF-6343)