### PR TITLE
Fix checking for wikis with no ids

### DIFF
--- a/website/static/js/pages/wiki-edit-page.js
+++ b/website/static/js/pages/wiki-edit-page.js
@@ -173,7 +173,7 @@ $(document).ready(function () {
 });
 
 var $comments = $('.comments');
-if ($comments.length && window.contextVars.wiki.wikiID !== 'None') {
+if ($comments.length && window.contextVars.wiki.wikiID !== null) {
     var options = {
         nodeId: window.contextVars.node.id,
         nodeApiUrl: window.contextVars.node.urls.api,


### PR DESCRIPTION
## Purpose

Fixes regression where wiki comment view model was getting instantiated even if there was no wiki.

## Changes
Only instantiate the wiki comment view model if `window.contextVars.wiki.wikiID !== null`.

## Side effects

None


## Ticket

https://openscience.atlassian.net/browse/OSF-6349


Fix [#OSF-6349]