### PR TITLE
Wiki help bar that adds syntax guidelines [OSF-2080]

### DIFF
--- a/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
+++ b/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
@@ -1656,6 +1656,34 @@ var Range = ace.require('ace/range').Range;
                 buttonRow.appendChild(button);
                 return button;
             };
+            var makeHelpButton = function(id,title,XShift){
+              var button = document.createElement("li");
+              //Based off the search button classes
+              //<button type=button class="btn osf-search-btn" data-toggle="modal" data-target="#search-help-modal"><i class="fa fa-question fa-lg"></i></button>
+              //$(".dropdown-toggle").attr("data-toggle", "dropdown");
+              button.className = "wmd-button";
+              // change those attributes
+              button.setAttribute('data-toggle','modal');
+              button.setAttribute('data-target','#wiki-help-modal');
+
+              togg = button.getAttribute('data-toggle');
+              targ = button.getAttribute('data-target');
+              console.log(togg);
+              console.log(targ);
+              //button.data.target = "#wiki-help-modal"
+              button.style.left = xPosition + "px";
+              xPosition += 25;
+              var buttonImage = document.createElement("span");
+              button.id = id + postfix;
+              button.appendChild(buttonImage);
+              button.title = title;
+              button.XShift = XShift;
+              //if (textOp)
+              //    button.textOp = textOp;
+              setupButton(button, true);
+              buttonRow.appendChild(button);
+              return button;
+            }
             var makeCheckBox = function (div_id, cb_id, XShift, text) {
                 var li = document.createElement("li");
                 li.id = div_id;
@@ -1716,7 +1744,7 @@ var Range = ace.require('ace/range').Range;
             makeCheckBox("wmd-autocom-toggle", "autocom", "-240px", "Autocomplete");
 
             makeSpacer(4);
-            buttons.help = makeButton("wmd-help-button", getStringAndKey("help"), "-240px", bindCommand("helpPopUp"));
+            buttons.help = makeHelpButton("wmd-help-button", getStringAndKey("help"), "-240px");
 
             //helpOptions = true;
 
@@ -2466,3 +2494,10 @@ var Range = ace.require('ace/range').Range;
 
 
 })();
+//<button type=button class="btn osf-search-btn" data-toggle="modal" data-target="#search-help-modal"><i class="fa fa-question fa-lg"></i></button>
+//$(".dropdown-toggle").attr("data-toggle", "dropdown");
+$(function(){
+  console.log($("wmd-help-button"));
+  $("wmd-help-button").attr("data-toggle","modal");
+  $("wmd-help-button").attr("data-target","#wiki-help-modal");
+});

--- a/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
+++ b/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
@@ -7,7 +7,6 @@
 
 var $ = require('jquery');
 var $osf = require('js/osfHelpers');
-var bootbox = require('bootbox');
 var Range = ace.require('ace/range').Range;
 
 (function () {
@@ -2473,17 +2472,6 @@ var Range = ace.require('ace/range').Range;
         chunk.selection = "";
         chunk.skipLines(2, 1, true);
     }
-
-    commandProto.helpPopUp = function (chunk, postProcessing){
-      bootbox.dialog({
-          title: 'Wiki Syntax Help',
-          message:
-              '<p>Wiki uses the Markdown snytax. This gives you many options, but can be very simple as well. ' +
-              'To see more information and examples go to our <a href="http://help.osf.io/m/collaborating/l/524109-using-the-wiki">guides</a>' +
-              '</p>'
-      });
-    }
-
 
 })();
 $(function(){

--- a/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
+++ b/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
@@ -3,8 +3,11 @@
 // autocompletion. This is only here for the toolbar
 
 // needs Markdown.Converter.js at the moment
+'use strict';
+
 var $ = require('jquery');
 var $osf = require('js/osfHelpers');
+var bootbox = require('bootbox');
 var Range = ace.require('ace/range').Range;
 
 (function () {
@@ -59,7 +62,7 @@ var Range = ace.require('ace/range').Range;
         undo: "Undo -",
         redo: "Redo -",
 
-        help: "Markdown Editing Help"
+        help: "Wiki Syntax Help"
     };
 
     var keyStrokes = {
@@ -110,6 +113,10 @@ var Range = ace.require('ace/range').Range;
         redo: {
             win: 'Ctrl-Y|Ctrl-Shift-Z',
             mac: 'Command-Y|Command-Shift-Z',
+        },
+        help: {
+          win: 'Ctrl-U',
+          mac: 'Command-U',
         },
     };
 
@@ -1704,8 +1711,14 @@ var Range = ace.require('ace/range').Range;
 
             buttons.redo = makeButton("wmd-redo-button", getStringAndKey("redo"), "-220px", null);
             buttons.redo.execute = function (manager) { inputBox.session.getUndoManager().redo(); };
+
             makeSpacer(4);
             makeCheckBox("wmd-autocom-toggle", "autocom", "-240px", "Autocomplete");
+
+            makeSpacer(4);
+            buttons.help = makeButton("wmd-help-button", getStringAndKey("help"), "-240px", bindCommand("helpPopUp"));
+
+            //helpOptions = true;
 
             if (helpOptions) {
                 var helpButton = document.createElement("li");
@@ -2439,6 +2452,16 @@ var Range = ace.require('ace/range').Range;
         chunk.startTag = "----------\n";
         chunk.selection = "";
         chunk.skipLines(2, 1, true);
+    }
+
+    commandProto.helpPopUp = function (chunk, postProcessing){
+      bootbox.dialog({
+          title: 'Wiki Syntax Help',
+          message:
+              '<p>Wiki uses the Markdown snytax. This gives you many options, but can be very simple as well. ' +
+              'To see more information and examples go to our <a href="http://help.osf.io/m/collaborating/l/524109-using-the-wiki">guides</a>' +
+              '</p>'
+      });
     }
 
 

--- a/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
+++ b/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
@@ -1659,8 +1659,6 @@ var Range = ace.require('ace/range').Range;
             var makeHelpButton = function(id,title,XShift){
               var button = document.createElement("li");
               //Based off the search button classes
-              //<button type=button class="btn osf-search-btn" data-toggle="modal" data-target="#search-help-modal"><i class="fa fa-question fa-lg"></i></button>
-              //$(".dropdown-toggle").attr("data-toggle", "dropdown");
               button.className = "wmd-button";
               // change those attributes
               button.setAttribute('data-toggle','modal');
@@ -1670,7 +1668,6 @@ var Range = ace.require('ace/range').Range;
               targ = button.getAttribute('data-target');
               console.log(togg);
               console.log(targ);
-              //button.data.target = "#wiki-help-modal"
               button.style.left = xPosition + "px";
               xPosition += 25;
               var buttonImage = document.createElement("span");
@@ -2494,8 +2491,6 @@ var Range = ace.require('ace/range').Range;
 
 
 })();
-//<button type=button class="btn osf-search-btn" data-toggle="modal" data-target="#search-help-modal"><i class="fa fa-question fa-lg"></i></button>
-//$(".dropdown-toggle").attr("data-toggle", "dropdown");
 $(function(){
   console.log($("wmd-help-button"));
   $("wmd-help-button").attr("data-toggle","modal");

--- a/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
+++ b/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
@@ -1663,11 +1663,6 @@ var Range = ace.require('ace/range').Range;
               // change those attributes
               button.setAttribute('data-toggle','modal');
               button.setAttribute('data-target','#wiki-help-modal');
-
-              togg = button.getAttribute('data-toggle');
-              targ = button.getAttribute('data-target');
-              console.log(togg);
-              console.log(targ);
               button.style.left = xPosition + "px";
               xPosition += 25;
               var buttonImage = document.createElement("span");

--- a/website/addons/wiki/templates/edit.mako
+++ b/website/addons/wiki/templates/edit.mako
@@ -158,8 +158,8 @@
                                                style="border: 1px solid black;" width="30px" height="30px">
                                       </a></li>
                              <!-- /ko -->
-                          <!-- /ko --> 
-                                <li><span data-bind="text: andOthersMessage"></span></li>      
+                          <!-- /ko -->
+                                <li><span data-bind="text: andOthersMessage"></span></li>
                               </ul>
                               <div id="wmd-button-bar"></div>
                               <div id="editor" class="wmd-input wiki-editor"
@@ -234,8 +234,9 @@
   </div>
 </div><!-- end wiki -->
 
-<!-- Wiki modals should also be placed here! --> 
+<!-- Wiki modals should also be placed here! -->
   <%include file="wiki/templates/add_wiki_page.mako"/>
+  <%include file="wiki/templates/wiki-bar-modal-help.mako"/>
 % if wiki_id and wiki_name != 'home':
   <%include file="wiki/templates/delete_wiki_page.mako"/>
 % endif
@@ -388,7 +389,7 @@ ${parent.javascript_bottom()}
             userGravatar: ${ urls['gravatar'] | sjson, n }.replace('&amp;', '&')
         }
     };
-    
+
 </script>
 <script src="//${sharejs_url}/text.js"></script>
 <script src="//${sharejs_url}/share.js"></script>

--- a/website/addons/wiki/templates/wiki-bar-modal-help.mako
+++ b/website/addons/wiki/templates/wiki-bar-modal-help.mako
@@ -1,0 +1,18 @@
+<div class="modal fade" id="wiki-help-modal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true"></span>&times;</button>
+                    <h3 class="modal-title">Wiki Syntax Help</h3>
+                </div>
+                <div class="modal-body">
+                  <p>
+                    Wiki uses the Markdown snytax. This gives you many options, but can be very simple as well. To see more information and examples go to our <a href="http://help.osf.io/m/collaborating/l/524109-using-the-wiki">guides</a>
+                  </p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                </div>
+            </div>
+        </div>
+</div>

--- a/website/static/js/ads.js
+++ b/website/static/js/ads.js
@@ -1,0 +1,1 @@
+var canRunAds = true;

--- a/website/static/js/ads.js
+++ b/website/static/js/ads.js
@@ -1,1 +1,6 @@
+/* http://stackoverflow.com/questions/4869154/how-to-detect-adblock-on-my-website
+ * Most adblocks will see that a file with ads in the title is attempting to be
+ * imported and block it. In this case the variable won't exist, which means we will
+ * enter the if.
+*/
 var canRunAds = true;

--- a/website/templates/project/statistics.mako
+++ b/website/templates/project/statistics.mako
@@ -5,6 +5,22 @@
   <h2 class="text-300">Analytics</h2>
 </div>
 
+<div id="hiddenFlag"></div>
+<script src="/static/js/ads.js"></script>
+<script>
+  if( window.canRunAds === undefined ){
+    var banner = document.createElement('div');
+    banner.className += 'm-b-md p-md osf-box-lt box-round';
+    var node = document.createTextNode("The use of adblocking software may prevent site analytics from loading properly. For more information go");
+    banner.appendChild(node);
+    var link = document.createElement('a');
+    link.href = "https://openscience.atlassian.net/browse/NCP-821";
+    link.innerHTML = " here";
+    banner.appendChild(link);
+    document.getElementById('hiddenFlag').appendChild(banner);
+  }
+</script>
+
 <%
     if user['is_contributor']:
         token = user.get('piwik_token', 'anonymous')

--- a/website/templates/project/statistics.mako
+++ b/website/templates/project/statistics.mako
@@ -11,12 +11,13 @@
   if( window.canRunAds === undefined ){
     var banner = document.createElement('div');
     banner.className += 'm-b-md p-md osf-box-lt box-round';
-    var node = document.createTextNode("The use of adblocking software may prevent site analytics from loading properly. For more information go");
+    var node = document.createTextNode("The use of adblocking software may prevent site analytics from loading properly.");// For more information go");
     banner.appendChild(node);
-    var link = document.createElement('a');
-    link.href = "https://openscience.atlassian.net/browse/NCP-821";
-    link.innerHTML = " here";
-    banner.appendChild(link);
+    /* Link doesn't exist yet. Commentted out until a webpage is made */
+    //var link = document.createElement('a');
+    //link.href = "https://openscience.atlassian.net/browse/NCP-821";
+    //link.innerHTML = " here";
+    //banner.appendChild(link);
     document.getElementById('hiddenFlag').appendChild(banner);
   }
 </script>

--- a/website/templates/project/statistics.mako
+++ b/website/templates/project/statistics.mako
@@ -10,7 +10,7 @@
 <script>
   if( window.canRunAds === undefined ){
     var banner = document.createElement('div');
-    banner.className += 'm-b-md p-md osf-box-lt box-round';
+    banner.className += 'm-b-md p-md osf-box-lt box-round text-center';
     var node = document.createTextNode("The use of adblocking software may prevent site analytics from loading properly.");// For more information go");
     banner.appendChild(node);
     /* Link doesn't exist yet. Commentted out until a webpage is made */

--- a/website/templates/project/statistics.mako
+++ b/website/templates/project/statistics.mako
@@ -21,6 +21,7 @@
   }
 </script>
 
+
 <%
     if user['is_contributor']:
         token = user.get('piwik_token', 'anonymous')


### PR DESCRIPTION
## Purpose

Addition of a question button to the wiki markup bar in order toi help users navigate to the page describing how markdown is done. When pressed it just pops-up with a modal box that users will see and get a link from.

## Changes

Edited the Markdown.Editor.js to add the button and give it a data-target that points to the wiki-bar-modal-help.mako page which is what will popup, Also changed the edit.mako page to include the wiki-bar-modal-help.mako page when the page is loaded.
## Side effects

If the edit bar is used anywhere else in the code then the bar will pop up with a link to the wiki pop up markdown page. Talked to QA and they said the only place that the edit bar is used is the wiki so it should be fine.

## Ticket

https://openscience.atlassian.net/browse/OSF-2080