### PR TITLE
Make Github delete confirmation modal match standard delete confirmation modal [OSF-6346]

### DIFF
--- a/website/addons/github/static/githubFangornConfig.js
+++ b/website/addons/github/static/githubFangornConfig.js
@@ -17,7 +17,6 @@ function _uploadUrl(item, file) {
     return waterbutler.buildTreeBeardUpload(item, file, {branch: item.data.branch});
 }
 
-// TODO: Refactor, repeating from core function too much
 function _removeEvent (event, items) {
     var tb = this;
     function cancelDelete() {
@@ -25,8 +24,9 @@ function _removeEvent (event, items) {
     }
 
     function runDelete (item) {
-        tb.select('.tb-modal-footer .text-danger').html('<i> Deleting...</i>').css('color', 'grey');;
         // delete from server, if successful delete from view
+        tb.select('.modal-footer .btn-danger').html('<i> Deleting...</i>').removeClass('btn-danger').addClass('btn-default disabled');
+
         $.ajax({
             url: waterbutler.buildTreeBeardDelete(item, {branch: item.data.branch, sha: item.data.extra.fileSha}),
             type : 'DELETE',

--- a/website/addons/github/static/githubFangornConfig.js
+++ b/website/addons/github/static/githubFangornConfig.js
@@ -56,17 +56,16 @@ function _removeEvent (event, items) {
     if(items.length === 1) {
         var parent = items[0].parent();
         var mithrilContentSingle = m('div', [
-            m('h3.break-word', 'Delete "' + items[0].data.name + '"'),
             m('p', 'This action is irreversible.'),
             parent.children.length < 2 ? m('p', 'If a folder in Github has no children it will automatically be removed.') : ''
         ]);
         var mithrilButtonsSingle = m('div', [
-            m('span.tb-modal-btn', { 'class' : 'text-default', onclick : function() { cancelDelete(); } }, 'Cancel'),
-            m('span.tb-modal-btn', { 'class' : 'text-danger', onclick : function() { runDelete(items[0]); }  }, 'Delete')
+            m('span.btn.btn-default', { onclick : function() { cancelDelete(); } }, 'Cancel'),
+            m('span.btn.btn-danger', { onclick : function() { runDelete(items[0]); }  }, 'Delete')
         ]);
         // This is already being checked before this step but will keep this edit permission check
         if(items[0].data.permissions.edit){
-            tb.modal.update(mithrilContentSingle, mithrilButtonsSingle);
+            tb.modal.update(mithrilContentSingle, mithrilButtonsSingle, m('h3.break-word.modal-title', 'Delete "' + items[0].data.name + '"?'));
         }
     } else {
         // Check if all items can be deleted
@@ -86,19 +85,17 @@ function _removeEvent (event, items) {
         // If all items can be deleted
         if(canDelete){
             mithrilContentMultiple = m('div', [
-                    m('h3.break-word', 'Delete multiple files?'),
                     m('p', 'This action is irreversible.'),
                     deleteList.map(function(item){
                         return m('.fangorn-canDelete.text-success', item.data.name);
                     })
                 ]);
             mithrilButtonsMultiple =  m('div', [
-                    m('span.tb-modal-btn', { 'class' : 'text-default', onclick : function() { cancelDelete(); } }, 'Cancel'),
-                    m('span.tb-modal-btn', { 'class' : 'text-danger', onclick : function() { runDeleteMultiple.call(tb, deleteList); }  }, 'Delete All')
+                    m('span.btn.btn-default', { 'class' : 'text-default', onclick : function() { cancelDelete(); } }, 'Cancel'),
+                    m('span.btn.btn-danger', {  'class' : 'text-danger', onclick : function() { runDeleteMultiple.call(tb, deleteList); }  }, 'Delete All')
                 ]);
         } else {
             mithrilContentMultiple = m('div', [
-                    m('h3.break-word', 'Delete multiple files?'),
                     m('p', 'Some of these files can\'t be deleted but you can delete the ones highlighted with green. This action is irreversible.'),
                     deleteList.map(function(n){
                         return m('.fangorn-canDelete.text-success', n.data.name);
@@ -108,11 +105,11 @@ function _removeEvent (event, items) {
                     })
                 ]);
             mithrilButtonsMultiple =  m('div', [
-                    m('span.tb-modal-btn', { 'class' : 'text-default', onclick : function() { cancelDelete(); } }, 'Cancel'),
-                    m('span.tb-modal-btn', { 'class' : 'text-danger', onclick : function() { runDeleteMultiple.call(tb, deleteList); }  }, 'Delete Some')
+                    m('span.btn.btn-default', { 'class' : 'text-default', onclick : function() { cancelDelete(); } }, 'Cancel'),
+                    m('span.btn.btn-danger', { 'class' : 'text-danger', onclick : function() { runDeleteMultiple.call(tb, deleteList); }  }, 'Delete Some')
                 ]);
         }
-        tb.modal.update(mithrilContentMultiple, mithrilButtonsMultiple);
+        tb.modal.update(mithrilContentMultiple, mithrilButtonsMultiple, m('h3.break-word.modal-title', 'Delete multiple files?'));
     }
 
     return true; // Let fangorn know this config option was used.


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

The purpose of this PR is to resolve [[OSF-6346]](https://openscience.atlassian.net/browse/OSF-6346): a style inconsistency stemming from the fact that the GitHub add-on uses a different fangorn helper than the other add-ons. The specific problem was had three parts:
1. A discrepancy in modal button style
2. Incorrect placement of the modal header content (placed in body instead of in header)
3. If a non-GitHub file foo.bar was deleted earlier in the same session, "Delete foo.bar?" would be in the modal header. Otherwise, the header would be empty.

## Changes

<!-- Briefly describe or list your changes  -->
1. To fix button style, I changed the classes of the buttons to align with what's in `fangorn.js`.
2. To fix the placement of the header content, I moved the header text to the modal .update() function, consistent with `fangorn.js`.
3. This part was resolved via change 2 - By updating the header before each display of the modal, no old modal headers are now shown.

## Side effects

* None that I can foresee.

<!--Any possible side effects? -->

## Images

### Before

![image](https://cloud.githubusercontent.com/assets/7365276/15400583/060f57f6-1dba-11e6-9bb6-03b4f4402e46.png)

### After

![image](https://cloud.githubusercontent.com/assets/7365276/15400622/28aa0310-1dba-11e6-97e2-0693c43e782b.png)
![image](https://cloud.githubusercontent.com/assets/7365276/15400648/44998c6c-1dba-11e6-8a9f-7115e2c4c770.png)


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->

[[OSF-6346]](https://openscience.atlassian.net/browse/OSF-6346)