### PR TITLE
"End embargo early" log has incorrect outdated language [OSF-6341]

### DIFF
--- a/website/project/model.py
+++ b/website/project/model.py
@@ -3081,7 +3081,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
         :param permissions: A string, either 'public' or 'private'
         :param auth: All the auth information including user, API key.
         :param bool log: Whether to add a NodeLog for the privacy change.
-        :param bool meeting_creation: Whther this was creayed due to a meetings email.
+        :param bool meeting_creation: Whether this was created due to a meetings email.
         """
         if auth and not self.has_permission(auth.user, ADMIN):
             raise PermissionsError('Must be an admin to change privacy settings.')

--- a/website/templates/log_templates.mako
+++ b/website/templates/log_templates.mako
@@ -39,7 +39,7 @@ initiated an embargoed registration of
 <script type="text/html" id="embargo_terminated_no_user">
 Embargo for
 <a class="log-node-title-link overflow" data-bind="text: nodeTitle, attr: {href: nodeUrl}"></a>
-ended.
+ended
 </script>
 
 ## Retraction related logs


### PR DESCRIPTION
## Purpose

The formatting of embargo end logs is inconsistent with other logs. This fixes the trailing period.
<img alt="screen shot 2016-05-18 at 2 38 32 pm" src="https://cloud.githubusercontent.com/assets/5885378/15370750/4824cc70-1d06-11e6-9115-7d7068b2ab66.png">

## Changes

- ~~Added words to the log template to match other logs~~
- Removed the trailing period
- ~~Change node to `registered_from_id` (previously registration id)~~

## Side effects

None

## Ticket

[OSF-6341 "End embargo early" log has incorrect outdated language](https://openscience.atlassian.net/browse/OSF-6341)