### PR TITLE
[Feature] Multiple celery queues [#DEV-100]

### DIFF
--- a/framework/celery_tasks/routers.py
+++ b/framework/celery_tasks/routers.py
@@ -1,34 +1,8 @@
 # -*- coding: utf-8 -*-
-from website.settings import DEFAULT_QUEUE, LOW_QUEUE, MED_QUEUE, HIGH_QUEUE
-
-LOW_PRI_MODULES = {
-    'framework.analytics.tasks',
-    'framework.celery_tasks',
-    'scripts.osfstorage.usage_audit',
-    'scripts.osfstorage.glacier_inventory',
-    'scripts.analytics.tasks',
-    'scripts.osfstorage.files_audit',
-    'scripts.osfstorage.glacier_audit',
-    'scripts.populate_new_and_noteworthy_projects',
-    'website.search.elastic_search',
-}
-
-MED_PRI_MODULES = {
-    'framework.email.tasks',
-    'scripts.send_queued_mails',
-    'scripts.triggered_mails',
-    'website.mailchimp_utils',
-    'website.notifications.tasks',
-}
-
-HIGH_PRI_MODULES = {
-    'scripts.approve_embargo_terminations',
-    'scripts.approve_registrations',
-    'scripts.embargo_registrations',
-    'scripts.refresh_box_tokens',
-    'scripts.retract_registrations',
-    'website.archiver.tasks',
-}
+from website.settings import (
+    DEFAULT_QUEUE, LOW_QUEUE, MED_QUEUE, HIGH_QUEUE,
+    LOW_PRI_MODULES, MED_PRI_MODULES, HIGH_PRI_MODULES
+)
 
 def match_by_module(task_path):
     task_parts = task_path.split('.')

--- a/framework/celery_tasks/routers.py
+++ b/framework/celery_tasks/routers.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+from website.settings import DEFAULT_QUEUE, LOW_QUEUE, MED_QUEUE, HIGH_QUEUE
+
+LOW_PRI_MODULES = {
+    'framework.analytics.tasks',
+    'framework.celery_tasks',
+    'scripts.osfstorage.usage_audit',
+    'scripts.osfstorage.glacier_inventory',
+    'scripts.analytics.tasks',
+    'scripts.osfstorage.files_audit',
+    'scripts.osfstorage.glacier_audit',
+    'scripts.populate_new_and_noteworthy_projects',
+    'website.search.elastic_search',
+}
+
+MED_PRI_MODULES = {
+    'framework.email.tasks',
+    'scripts.send_queued_mails',
+    'scripts.triggered_mails',
+    'website.mailchimp_utils',
+    'website.notifications.tasks',
+}
+
+HIGH_PRI_MODULES = {
+    'scripts.approve_embargo_terminations',
+    'scripts.approve_registrations',
+    'scripts.embargo_registrations',
+    'scripts.refresh_box_tokens',
+    'scripts.retract_registrations',
+    'website.archiver.tasks',
+}
+
+def match_by_module(task_path):
+    task_parts = task_path.split('.')
+    for i in range(2, len(task_parts) + 1):
+        task_subpath = '.'.join(task_parts[:i])
+        if task_subpath in LOW_PRI_MODULES:
+            return LOW_QUEUE
+        if task_subpath in MED_PRI_MODULES:
+            return MED_QUEUE
+        if task_subpath in HIGH_PRI_MODULES:
+            return HIGH_QUEUE
+    return DEFAULT_QUEUE
+
+
+class CeleryRouter(object):
+    def route_for_task(self, task, args=None, kwargs=None):
+        """ Handles routing of celery tasks.
+        See http://docs.celeryproject.org/en/latest/userguide/routing.html#routers
+
+        :param str task:    Of the form 'full.module.path.to.class.function'
+        :returns dict:      Tells celery into which queue to route this task.
+        """
+        return {
+            'queue': match_by_module(task)
+        }

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,6 +44,10 @@ git+https://github.com/CenterForOpenScience/modular-odm.git@develop
 # Python markdown extensions for comment emails
 git+git://github.com/aleray/mdx_del_ins.git
 
+# Kombu with the ability to specify queue priority
+# TODO: Remove this when Kombu has a stable release including commit c20f854
+git+git://github.com/mfraezz/kombu.git@v3.0.36
+
 # Issue: certifi-2015.9.6.1 and 2015.9.6.2 fail verification (https://github.com/certifi/python-certifi/issues/26)
 # MailChimp Ticket: LTK1218902287135X, Domain: https://us9.api.mailchimp.com
 certifi==2015.4.28

--- a/scripts/osfstorage/files_audit.py
+++ b/scripts/osfstorage/files_audit.py
@@ -168,22 +168,22 @@ def main(nworkers, worker_id, dry_run):
     audit(parity_targets(), nworkers, worker_id, dry_run)
     logger.info('parity audit complete')
 
-@celery_app.task(name='scripts.osfstorage.files_audit_0')
+@celery_app.task(name='scripts.osfstorage.files_audit.0')
 def file_audit_1(num_of_workers=4, dry_run=True):
     run_main(num_of_workers, 0, dry_run)
 
 
-@celery_app.task(name='scripts.osfstorage.files_audit_1')
+@celery_app.task(name='scripts.osfstorage.files_audit.1')
 def file_audit_2(num_of_workers=4, dry_run=True):
     run_main(num_of_workers, 1, dry_run)
 
 
-@celery_app.task(name='scripts.osfstorage.files_audit_2')
+@celery_app.task(name='scripts.osfstorage.files_audit.2')
 def file_audit_3(num_of_workers=4, dry_run=True):
     run_main(num_of_workers, 2, dry_run)
 
 
-@celery_app.task(name='scripts.osfstorage.files_audit_3')
+@celery_app.task(name='scripts.osfstorage.files_audit.3')
 def file_audit_4(num_of_workers=4, dry_run=True):
     run_main(num_of_workers, 3, dry_run)
 

--- a/website/notifications/tasks.py
+++ b/website/notifications/tasks.py
@@ -16,7 +16,7 @@ from website.notifications.model import NotificationDigest
 from website import mails
 
 
-@celery_app.task(name='notify.send_users_email', max_retries=0)
+@celery_app.task(name='website.notifications.tasks.send_users_email', max_retries=0)
 def send_users_email(send_type):
     """Find pending Emails and amalgamates them into a single Email.
 

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -298,6 +298,26 @@ JWT_ALGORITHM = 'HS256'
 
 ##### CELERY #####
 
+DEFAULT_QUEUE = 'celery'
+LOW_QUEUE = 'low'
+MED_QUEUE = 'med'
+HIGH_QUEUE = 'high'
+
+from kombu import Queue, Exchange
+CELERY_QUEUES = (
+    Queue(LOW_QUEUE, Exchange(LOW_QUEUE), routing_key=LOW_QUEUE,
+          consumer_arguments={'x-priority': -1}),
+    Queue(DEFAULT_QUEUE, Exchange(DEFAULT_QUEUE), routing_key=DEFAULT_QUEUE,
+          consumer_arguments={'x-priority': 0}),
+    Queue(MED_QUEUE, Exchange(MED_QUEUE), routing_key=MED_QUEUE,
+          consumer_arguments={'x-priority': 1}),
+    Queue(HIGH_QUEUE, Exchange(HIGH_QUEUE), routing_key=HIGH_QUEUE,
+          consumer_arguments={'x-priority': 10}),
+)
+
+CELERY_DEFAULT_EXCHANGE_TYPE = 'direct'
+CELERY_ROUTES = ('framework.celery_tasks.routers.CeleryRouter', )
+
 # Default RabbitMQ broker
 BROKER_URL = 'amqp://'
 

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -303,20 +303,24 @@ LOW_QUEUE = 'low'
 MED_QUEUE = 'med'
 HIGH_QUEUE = 'high'
 
-from kombu import Queue, Exchange
-CELERY_QUEUES = (
-    Queue(LOW_QUEUE, Exchange(LOW_QUEUE), routing_key=LOW_QUEUE,
-          consumer_arguments={'x-priority': -1}),
-    Queue(DEFAULT_QUEUE, Exchange(DEFAULT_QUEUE), routing_key=DEFAULT_QUEUE,
-          consumer_arguments={'x-priority': 0}),
-    Queue(MED_QUEUE, Exchange(MED_QUEUE), routing_key=MED_QUEUE,
-          consumer_arguments={'x-priority': 1}),
-    Queue(HIGH_QUEUE, Exchange(HIGH_QUEUE), routing_key=HIGH_QUEUE,
-          consumer_arguments={'x-priority': 10}),
-)
+try:
+    from kombu import Queue, Exchange
+except ImportError:
+    pass
+else:
+    CELERY_QUEUES = (
+        Queue(LOW_QUEUE, Exchange(LOW_QUEUE), routing_key=LOW_QUEUE,
+              consumer_arguments={'x-priority': -1}),
+        Queue(DEFAULT_QUEUE, Exchange(DEFAULT_QUEUE), routing_key=DEFAULT_QUEUE,
+              consumer_arguments={'x-priority': 0}),
+        Queue(MED_QUEUE, Exchange(MED_QUEUE), routing_key=MED_QUEUE,
+              consumer_arguments={'x-priority': 1}),
+        Queue(HIGH_QUEUE, Exchange(HIGH_QUEUE), routing_key=HIGH_QUEUE,
+              consumer_arguments={'x-priority': 10}),
+    )
 
-CELERY_DEFAULT_EXCHANGE_TYPE = 'direct'
-CELERY_ROUTES = ('framework.celery_tasks.routers.CeleryRouter', )
+    CELERY_DEFAULT_EXCHANGE_TYPE = 'direct'
+    CELERY_ROUTES = ('framework.celery_tasks.routers.CeleryRouter', )
 
 # Default RabbitMQ broker
 BROKER_URL = 'amqp://'

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -303,6 +303,35 @@ LOW_QUEUE = 'low'
 MED_QUEUE = 'med'
 HIGH_QUEUE = 'high'
 
+LOW_PRI_MODULES = {
+    'framework.analytics.tasks',
+    'framework.celery_tasks',
+    'scripts.osfstorage.usage_audit',
+    'scripts.osfstorage.glacier_inventory',
+    'scripts.analytics.tasks',
+    'scripts.osfstorage.files_audit',
+    'scripts.osfstorage.glacier_audit',
+    'scripts.populate_new_and_noteworthy_projects',
+    'website.search.elastic_search',
+}
+
+MED_PRI_MODULES = {
+    'framework.email.tasks',
+    'scripts.send_queued_mails',
+    'scripts.triggered_mails',
+    'website.mailchimp_utils',
+    'website.notifications.tasks',
+}
+
+HIGH_PRI_MODULES = {
+    'scripts.approve_embargo_terminations',
+    'scripts.approve_registrations',
+    'scripts.embargo_registrations',
+    'scripts.refresh_box_tokens',
+    'scripts.retract_registrations',
+    'website.archiver.tasks',
+}
+
 try:
     from kombu import Queue, Exchange
 except ImportError:

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -363,12 +363,12 @@ else:
     #  Setting up a scheduler, essentially replaces an independent cron job
     CELERYBEAT_SCHEDULE = {
         '5-minute-emails': {
-            'task': 'notify.send_users_email',
+            'task': 'website.notifications.tasks.send_users_email',
             'schedule': crontab(minute='*/5'),
             'args': ('email_transactional',),
         },
         'daily-emails': {
-            'task': 'notify.send_users_email',
+            'task': 'website.notifications.tasks.send_users_email',
             'schedule': crontab(minute=0, hour=0),
             'args': ('email_digest',),
         },
@@ -432,22 +432,22 @@ else:
     #         'kwargs': {'dry_run': False},
     #     },
     #     'files_audit_0': {
-    #         'task': 'scripts.osfstorage.files_audit_0',
+    #         'task': 'scripts.osfstorage.files_audit.0',
     #         'schedule': crontab(minute=0, hour=2, day_of_week=0),  # Sunday 2:00 a.m.
     #         'kwargs': {'num_of_workers': 4, 'dry_run': False},
     #     },
     #     'files_audit_1': {
-    #         'task': 'scripts.osfstorage.files_audit_1',
+    #         'task': 'scripts.osfstorage.files_audit.1',
     #         'schedule': crontab(minute=0, hour=2, day_of_week=0),  # Sunday 2:00 a.m.
     #         'kwargs': {'num_of_workers': 4, 'dry_run': False},
     #     },
     #     'files_audit_2': {
-    #         'task': 'scripts.osfstorage.files_audit_2',
+    #         'task': 'scripts.osfstorage.files_audit.2',
     #         'schedule': crontab(minute=0, hour=2, day_of_week=0),  # Sunday 2:00 a.m.
     #         'kwargs': {'num_of_workers': 4, 'dry_run': False},
     #     },
     #     'files_audit_3': {
-    #         'task': 'scripts.osfstorage.files_audit_3',
+    #         'task': 'scripts.osfstorage.files_audit.3',
     #         'schedule': crontab(minute=0, hour=2, day_of_week=0),  # Sunday 2:00 a.m.
     #         'kwargs': {'num_of_workers': 4, 'dry_run': False},
     #     },


### PR DESCRIPTION
## Purpose
Allow celery tasks to be queued by priority.

## Changes
* Pin to a fork of Kombu with a fix that is not yet in a stable release
* Default queue now defined explicitly
* Three queues added (`low`, `med`, `high`)
* Automatic task router added. Note: future tasks will need their modules added to a priority level, or will be put in the default queue between `low` and `med`
* Tasks with names that didn't follow the `module.path.to.function` convention fixed.

## Side effects
Names of commented-out celerybeat tasks (for easier local dev) will need to be updated manually on staging/prod to queue those tasks properly (`LOW` rather than `DEFAULT`). 

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
[#DEV-100](https://openscience.atlassian.net/browse/DEV-100)