### PR TITLE
[hold] [hotfix] Make sure wiki content is copied to forks; make is_current a property

### DIFF
--- a/scripts/tests/test_clone_wiki_pages.py
+++ b/scripts/tests/test_clone_wiki_pages.py
@@ -21,7 +21,7 @@ class TestCloneWikiPages(OsfTestCase):
     def set_up_project_with_wiki_page(self):
         self.project_with_wikis = ProjectFactory(creator=self.user, is_public=True)
         self.wiki = NodeWikiFactory(node=self.project_with_wikis)
-        self.current_wiki = NodeWikiFactory(node=self.project_with_wikis, version=2, is_current=True)
+        self.current_wiki = NodeWikiFactory(node=self.project_with_wikis, version=2)
         return self.project_with_wikis
 
     def tearDown(self):
@@ -88,7 +88,7 @@ class TestCloneWikiPages(OsfTestCase):
         fork_creator = AuthUserFactory()
         fork = self.project.fork_node(auth=Auth(fork_creator))
         wiki = NodeWikiFactory(node=fork)
-        current_wiki = NodeWikiFactory(node=fork, version=2, is_current=True)
+        current_wiki = NodeWikiFactory(node=fork, version=2)
         main()
         assert_equal(fork.wiki_pages_versions, {wiki.page_name: [wiki._id, current_wiki._id]})
         assert_equal(fork.wiki_pages_current, {wiki.page_name: current_wiki._id})

--- a/scripts/tests/test_remove_wiki_title_forward_slashes.py
+++ b/scripts/tests/test_remove_wiki_title_forward_slashes.py
@@ -12,7 +12,7 @@ class TestRemoveWikiTitleForwardSlashes(OsfTestCase):
 
     def test_forward_slash_is_removed_from_wiki_title(self):
         project = ProjectFactory()
-        wiki = NodeWikiFactory(node=project, is_current=True)
+        wiki = NodeWikiFactory(node=project)
 
         invalid_name = 'invalid/name'
         db.nodewikipage.update({'_id': wiki._id}, {'$set': {'page_name': invalid_name}})
@@ -29,7 +29,7 @@ class TestRemoveWikiTitleForwardSlashes(OsfTestCase):
 
     def test_valid_wiki_title(self):
         project = ProjectFactory()
-        wiki = NodeWikiFactory(node=project, is_current=True)
+        wiki = NodeWikiFactory(node=project)
         page_name = wiki.page_name
         main()
         wiki.reload()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1172,7 +1172,6 @@ class TestNodeWikiPage(OsfTestCase):
         wiki = NodeWikiFactory()
         assert_equal(wiki.page_name, 'home')
         assert_equal(wiki.version, 1)
-        assert_true(hasattr(wiki, 'is_current'))
         assert_equal(wiki.content, 'Some content')
         assert_true(wiki.user)
         assert_true(wiki.node)
@@ -3933,7 +3932,7 @@ class TestForkNode(OsfTestCase):
     def test_forking_clones_project_wiki_pages(self):
         project = ProjectFactory(creator=self.user, is_public=True)
         wiki = NodeWikiFactory(node=project)
-        current_wiki = NodeWikiFactory(node=project, version=2, is_current=True)
+        current_wiki = NodeWikiFactory(node=project, version=2)
         fork = project.fork_node(self.auth)
         assert_equal(fork.wiki_private_uuids, {})
 
@@ -4164,7 +4163,7 @@ class TestRegisterNode(OsfTestCase):
     def test_registration_clones_project_wiki_pages(self):
         project = ProjectFactory(creator=self.user, is_public=True)
         wiki = NodeWikiFactory(node=project)
-        current_wiki = NodeWikiFactory(node=project, version=2, is_current=True)
+        current_wiki = NodeWikiFactory(node=project, version=2)
         registration = project.register_node(get_default_metaschema(), Auth(self.user), '', None)
         assert_equal(self.registration.wiki_private_uuids, {})
 

--- a/website/addons/wiki/model.py
+++ b/website/addons/wiki/model.py
@@ -13,6 +13,7 @@ import markdown
 from markdown.extensions import codehilite, fenced_code, wikilinks
 from modularodm import fields
 
+from framework.mongo.utils import to_mongo_key
 from framework.forms.utils import sanitize
 from framework.guid.model import GuidStoredObject
 from framework.mongo import utils as mongo_utils
@@ -169,11 +170,15 @@ class NodeWikiPage(GuidStoredObject, Commentable):
     page_name = fields.StringField(validate=validate_page_name)
     version = fields.IntegerField()
     date = fields.DateTimeField(auto_now_add=datetime.datetime.utcnow)
-    is_current = fields.BooleanField()
     content = fields.StringField(default='')
 
     user = fields.ForeignField('user')
     node = fields.ForeignField('node')
+
+    @property
+    def is_current(self):
+        key = to_mongo_key(self.page_name)
+        return self.node.wiki_pages_current[key] == self._id
 
     @property
     def deep_url(self):

--- a/website/addons/wiki/tests/test_wiki.py
+++ b/website/addons/wiki/tests/test_wiki.py
@@ -42,6 +42,26 @@ class TestNodeWikiPageModel(OsfTestCase):
         with assert_raises(ValidationValueError):
             page.save()
 
+    def test_is_current_with_single_version(self):
+        node = NodeFactory()
+        page = NodeWikiPage(page_name='foo', node=node)
+        page.save()
+        node.wiki_pages_current['foo'] = page._id
+        node.wiki_pages_versions['foo'] = [page._id]
+        node.save()
+        assert_true(page.is_current)
+
+    def test_is_current_with_multiple_versions(self):
+        node = NodeFactory()
+        ver1 = NodeWikiPage(page_name='foo', node=node)
+        ver2 = NodeWikiPage(page_name='foo', node=node)
+        ver1.save()
+        ver2.save()
+        node.wiki_pages_current['foo'] = ver2._id
+        node.wiki_pages_versions['foo'] = [ver1._id, ver2._id]
+        node.save()
+        assert_false(ver1.is_current)
+        assert_true(ver2.is_current)
 
 class TestWikiViews(OsfTestCase):
 

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -3177,7 +3177,6 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
                 version = 1
         else:
             current = NodeWikiPage.load(self.wiki_pages_current[key])
-            current.is_current = False
             version = current.version + 1
             current.save()
             if Comment.find(Q('root_target', 'eq', current._id)).count() > 0:
@@ -3187,7 +3186,6 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
             page_name=name,
             version=version,
             user=auth.user,
-            is_current=True,
             node=self,
             content=content
         )


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

There is at least one project on prod, https://osf.io/ny23d/, whose home wiki page record has `is_current` field set to `False`, even though it only has one version. The side effect of this is that forks of the project do not contain the wiki content (see https://github.com/CenterForOpenScience/osf.io/blob/585dca524b374210c615d0e28edb47366466a8d6/website/addons/wiki/model.py#L306-L307). 

## Changes

Removes the NodeWikiPage.is_current field and makes it a property so that there can be no inconsistency with `Node.wiki_pages_current`.

## Side effects

Will need to unset the `is_current` field for all `nodewikipage` records.

In mongo shell:

```
db.nodewikipage.update({}, {$unset: {is_current: ""}}, {multi: true})
```

## Ticket

https://openscience.atlassian.net/browse/OSF-6350
