### PR TITLE
Wiki help bar that adds syntax guidelines [OSF-2080]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,7 +5,7 @@ Changelog
 0.72.0 (2016-05-17)
 ===================
 
-- Make all pages sanitize on display rather than on storage.
+- Make all pages escape user values on the frontend.
 - Remove usage of knockout-punches and remove strip_ko Mako filter.
 
 0.71.0 (2016-05-11)

--- a/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
+++ b/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
@@ -2463,7 +2463,3 @@ var Range = ace.require('ace/range').Range;
     }
 
 })();
-$(function(){
-  $("wmd-help-button").attr("data-toggle","modal");
-  $("wmd-help-button").attr("data-target","#wiki-help-modal");
-});

--- a/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
+++ b/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
@@ -3,7 +3,6 @@
 // autocompletion. This is only here for the toolbar
 
 // needs Markdown.Converter.js at the moment
-'use strict';
 
 var $ = require('jquery');
 var $osf = require('js/osfHelpers');

--- a/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
+++ b/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
@@ -1726,7 +1726,7 @@ var Range = ace.require('ace/range').Range;
             makeCheckBox("wmd-autocom-toggle", "autocom", "-240px", "Autocomplete");
 
             makeSpacer(5);
-            buttons.help = makeHelpButton("wmd-help-button", getStringAndKey("help"), "-240px");
+            buttons.help = makeHelpButton("wmd-help-button", getString("help"), "-240px");
 
             if (helpOptions) {
                 var helpButton = document.createElement("li");

--- a/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
+++ b/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
@@ -111,11 +111,7 @@ var Range = ace.require('ace/range').Range;
         redo: {
             win: 'Ctrl-Y|Ctrl-Shift-Z',
             mac: 'Command-Y|Command-Shift-Z',
-        },
-        help: {
-          win: 'Ctrl-U',
-          mac: 'Command-U',
-        },
+        }
     };
 
 

--- a/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
+++ b/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
@@ -1657,9 +1657,7 @@ var Range = ace.require('ace/range').Range;
             };
             var makeHelpButton = function(id,title,XShift){
               var button = document.createElement("li");
-              //Based off the search button classes
               button.className = "wmd-button";
-              // change those attributes
               button.setAttribute('data-toggle','modal');
               button.setAttribute('data-target','#wiki-help-modal');
               button.style.left = xPosition + "px";
@@ -1669,8 +1667,6 @@ var Range = ace.require('ace/range').Range;
               button.appendChild(buttonImage);
               button.title = title;
               button.XShift = XShift;
-              //if (textOp)
-              //    button.textOp = textOp;
               setupButton(button, true);
               buttonRow.appendChild(button);
               return button;
@@ -1736,8 +1732,6 @@ var Range = ace.require('ace/range').Range;
 
             makeSpacer(4);
             buttons.help = makeHelpButton("wmd-help-button", getStringAndKey("help"), "-240px");
-
-            //helpOptions = true;
 
             if (helpOptions) {
                 var helpButton = document.createElement("li");

--- a/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
+++ b/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
@@ -1,8 +1,10 @@
-﻿// OSF Note: This file has been changed for UI reasons, to prevent
+// OSF Note: This file has been changed for UI reasons, to prevent
 // automatic rendering, and to add a checkbox for toggling snippet
 // autocompletion. This is only here for the toolbar
 
 // needs Markdown.Converter.js at the moment
+'use strict';
+
 var $ = require('jquery');
 var $osf = require('js/osfHelpers');
 var Range = ace.require('ace/range').Range;
@@ -59,7 +61,7 @@ var Range = ace.require('ace/range').Range;
         undo: "Undo -",
         redo: "Redo -",
 
-        help: "Markdown Editing Help"
+        help: "Wiki Syntax Help"
     };
 
     var keyStrokes = {
@@ -110,6 +112,10 @@ var Range = ace.require('ace/range').Range;
         redo: {
             win: 'Ctrl-Y|Ctrl-Shift-Z',
             mac: 'Command-Y|Command-Shift-Z',
+        },
+        help: {
+          win: 'Ctrl-U',
+          mac: 'Command-U',
         },
     };
 
@@ -1649,6 +1655,26 @@ var Range = ace.require('ace/range').Range;
                 buttonRow.appendChild(button);
                 return button;
             };
+            var makeHelpButton = function(id,title,XShift){
+              var button = document.createElement("li");
+              //Based off the search button classes
+              button.className = "wmd-button";
+              // change those attributes
+              button.setAttribute('data-toggle','modal');
+              button.setAttribute('data-target','#wiki-help-modal');
+              button.style.left = xPosition + "px";
+              xPosition += 25;
+              var buttonImage = document.createElement("span");
+              button.id = id + postfix;
+              button.appendChild(buttonImage);
+              button.title = title;
+              button.XShift = XShift;
+              //if (textOp)
+              //    button.textOp = textOp;
+              setupButton(button, true);
+              buttonRow.appendChild(button);
+              return button;
+            }
             var makeCheckBox = function (div_id, cb_id, XShift, text) {
                 var li = document.createElement("li");
                 li.id = div_id;
@@ -1704,8 +1730,14 @@ var Range = ace.require('ace/range').Range;
 
             buttons.redo = makeButton("wmd-redo-button", getStringAndKey("redo"), "-220px", null);
             buttons.redo.execute = function (manager) { inputBox.session.getUndoManager().redo(); };
+
             makeSpacer(4);
             makeCheckBox("wmd-autocom-toggle", "autocom", "-240px", "Autocomplete");
+
+            makeSpacer(4);
+            buttons.help = makeHelpButton("wmd-help-button", getStringAndKey("help"), "-240px");
+
+            //helpOptions = true;
 
             if (helpOptions) {
                 var helpButton = document.createElement("li");
@@ -2441,5 +2473,8 @@ var Range = ace.require('ace/range').Range;
         chunk.skipLines(2, 1, true);
     }
 
-
 })();
+$(function(){
+  $("wmd-help-button").attr("data-toggle","modal");
+  $("wmd-help-button").attr("data-target","#wiki-help-modal");
+});

--- a/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
+++ b/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
@@ -1726,7 +1726,7 @@ var Range = ace.require('ace/range').Range;
             makeCheckBox("wmd-autocom-toggle", "autocom", "-240px", "Autocomplete");
 
             makeSpacer(5);
-            buttons.help = makeHelpButton("wmd-help-button", getString("help"), "-240px");
+            buttons.help = makeHelpButton("wmd-help-button",getString("help"),"-240px");
 
             if (helpOptions) {
                 var helpButton = document.createElement("li");

--- a/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
+++ b/website/addons/wiki/static/pagedown-ace/Markdown.Editor.js
@@ -1725,7 +1725,7 @@ var Range = ace.require('ace/range').Range;
             makeSpacer(4);
             makeCheckBox("wmd-autocom-toggle", "autocom", "-240px", "Autocomplete");
 
-            makeSpacer(4);
+            makeSpacer(5);
             buttons.help = makeHelpButton("wmd-help-button", getStringAndKey("help"), "-240px");
 
             if (helpOptions) {

--- a/website/addons/wiki/templates/edit.mako
+++ b/website/addons/wiki/templates/edit.mako
@@ -158,8 +158,8 @@
                                                style="border: 1px solid black;" width="30px" height="30px">
                                       </a></li>
                              <!-- /ko -->
-                          <!-- /ko --> 
-                                <li><span data-bind="text: andOthersMessage"></span></li>      
+                          <!-- /ko -->
+                                <li><span data-bind="text: andOthersMessage"></span></li>
                               </ul>
                               <div id="wmd-button-bar"></div>
                               <div id="editor" class="wmd-input wiki-editor"
@@ -234,8 +234,9 @@
   </div>
 </div><!-- end wiki -->
 
-<!-- Wiki modals should also be placed here! --> 
+<!-- Wiki modals should also be placed here! -->
   <%include file="wiki/templates/add_wiki_page.mako"/>
+  <%include file="wiki/templates/wiki-bar-modal-help.mako"/>
 % if wiki_id and wiki_name != 'home':
   <%include file="wiki/templates/delete_wiki_page.mako"/>
 % endif
@@ -388,7 +389,7 @@ ${parent.javascript_bottom()}
             userGravatar: ${ urls['gravatar'] | sjson, n }.replace('&amp;', '&')
         }
     };
-    
+
 </script>
 <script src="//${sharejs_url}/text.js"></script>
 <script src="//${sharejs_url}/share.js"></script>

--- a/website/addons/wiki/templates/wiki-bar-modal-help.mako
+++ b/website/addons/wiki/templates/wiki-bar-modal-help.mako
@@ -7,7 +7,7 @@
                 </div>
                 <div class="modal-body">
                   <p>
-                    Wiki uses the Markdown snytax. This gives you many options, but can be very simple as well. To see more information and examples go to our <a href="http://help.osf.io/m/collaborating/l/524109-using-the-wiki">guides</a>
+                    Wiki uses the Markdown syntax. This gives you many options, but can be very simple as well. To see more information and examples go to our <a href="http://help.osf.io/m/collaborating/l/524109-using-the-wiki">guides</a>
                   </p>
                 </div>
                 <div class="modal-footer">

--- a/website/addons/wiki/templates/wiki-bar-modal-help.mako
+++ b/website/addons/wiki/templates/wiki-bar-modal-help.mako
@@ -7,7 +7,7 @@
                 </div>
                 <div class="modal-body">
                   <p>
-                    Wiki uses the Markdown syntax. This gives you many options but can be very simple as well. To see more information and examples go to markdown <a href="https://daringfireball.net/projects/markdown/">guides.</a>
+                    Wiki uses the <a href="https://daringfireball.net/projects/markdown/ ">Markdown</a> syntax. This gives you many options but can be very simple as well. To see more information and examples go to our <a href="http://help.osf.io/m/collaborating/l/524109-using-the-wiki">guides.</a>
                   </p>
                 </div>
                 <div class="modal-footer">

--- a/website/addons/wiki/templates/wiki-bar-modal-help.mako
+++ b/website/addons/wiki/templates/wiki-bar-modal-help.mako
@@ -11,7 +11,7 @@
                   </p>
                 </div>
                 <div class="modal-footer">
-                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                    <button type="button" class="btn btn-primary" data-dismiss="modal">Close</button>
                 </div>
             </div>
         </div>

--- a/website/addons/wiki/templates/wiki-bar-modal-help.mako
+++ b/website/addons/wiki/templates/wiki-bar-modal-help.mako
@@ -1,0 +1,18 @@
+<div class="modal fade" id="wiki-help-modal" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true"></span>&times;</button>
+                    <h3 class="modal-title">Wiki Syntax Help</h3>
+                </div>
+                <div class="modal-body">
+                  <p>
+                    Wiki uses the Markdown snytax. This gives you many options, but can be very simple as well. To see more information and examples go to our <a href="http://help.osf.io/m/collaborating/l/524109-using-the-wiki">guides</a>
+                  </p>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                </div>
+            </div>
+        </div>
+</div>

--- a/website/addons/wiki/templates/wiki-bar-modal-help.mako
+++ b/website/addons/wiki/templates/wiki-bar-modal-help.mako
@@ -7,7 +7,7 @@
                 </div>
                 <div class="modal-body">
                   <p>
-                    Wiki uses the <a href="https://daringfireball.net/projects/markdown/ ">Markdown</a> syntax. This gives you many options but can be very simple as well. To see more information and examples go to our <a href="http://help.osf.io/m/collaborating/l/524109-using-the-wiki">guides.</a>
+                    Wiki uses the <a href="https://daringfireball.net/projects/markdown/ ">Markdown</a> syntax. To see more information and examples go to our <a href="http://help.osf.io/m/collaborating/l/524109-using-the-wiki">guides.</a>
                   </p>
                 </div>
                 <div class="modal-footer">

--- a/website/addons/wiki/templates/wiki-bar-modal-help.mako
+++ b/website/addons/wiki/templates/wiki-bar-modal-help.mako
@@ -3,11 +3,11 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true"></span>&times;</button>
-                    <h3 class="modal-title">Wiki Syntax Help</h3>
+                    <h3 class="modal-title">Wiki syntax help</h3>
                 </div>
                 <div class="modal-body">
                   <p>
-                    Wiki uses the Markdown syntax. This gives you many options, but can be very simple as well. To see more information and examples go to our <a href="http://help.osf.io/m/collaborating/l/524109-using-the-wiki">guides</a>
+                    Wiki uses the Markdown syntax. This gives you many options but can be very simple as well. To see more information and examples go to markdown <a href="https://daringfireball.net/projects/markdown/">guides.</a>
                   </p>
                 </div>
                 <div class="modal-footer">

--- a/website/addons/wiki/templates/wiki-bar-modal-help.mako
+++ b/website/addons/wiki/templates/wiki-bar-modal-help.mako
@@ -7,7 +7,7 @@
                 </div>
                 <div class="modal-body">
                   <p>
-                    Wiki uses the <a href="https://daringfireball.net/projects/markdown/ ">Markdown</a> syntax. To see more information and examples go to our <a href="http://help.osf.io/m/collaborating/l/524109-using-the-wiki">guides.</a>
+                    Wiki uses the <a href="https://daringfireball.net/projects/markdown/">Markdown</a> syntax. To see more information and examples go to our <a href="http://help.osf.io/m/collaborating/l/524109-using-the-wiki">guides.</a>
                   </p>
                 </div>
                 <div class="modal-footer">


### PR DESCRIPTION
## Purpose

Addition of a question button to the wiki markup bar in order toi help users navigate to the page describing how markdown is done. When pressed it just pops-up with a modal box that users will see and get a link from.

## Changes

Edited the Markdown.Editor.js to add the button and give it a data-target that points to the wiki-bar-modal-help.mako page which is what will popup, Also changed the edit.mako page to include the wiki-bar-modal-help.mako page when the page is loaded.
## Side effects

If the edit bar is used anywhere else in the code then the bar will pop up with a link to the wiki pop up markdown page. Talked to QA and they said the only place that the edit bar is used is the wiki so it should be fine.

## Ticket

https://openscience.atlassian.net/browse/OSF-2080