### PR TITLE
Feature/APIv2 500 Error Update Contributors [OSF-6376]

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -386,6 +386,8 @@ class NodeContributorDetailSerializer(NodeContributorsSerializer):
             node.update_contributor(contributor, permission, visible, auth, save=True)
         except NodeStateError as e:
             raise exceptions.ValidationError(detail=e.message)
+        except ValueError as e:
+            raise exceptions.ValidationError(detail=e.message)
         contributor.permission = osf_permissions.reduce_permissions(node.get_permissions(contributor))
         contributor.bibliographic = node.get_visible(contributor)
         contributor.node_id = node._id

--- a/api_tests/nodes/views/test_node_contributors_list.py
+++ b/api_tests/nodes/views/test_node_contributors_list.py
@@ -1139,6 +1139,25 @@ class TestNodeContributorBulkUpdate(NodeCRUDTestCase):
         assert_items_equal([data[0]['attributes']['permission'], data[1]['attributes']['permission'], data[2]['attributes']['permission']],
                            ['admin', 'read', 'read'])
 
+    def test_bulk_update_contributors_must_be_one_bibliographic_contributor(self):
+        res = self.app.put_json_api(self.public_url, {'data': [self.payload_two,
+                                                               {'id': self.user._id, 'type': 'contributors',
+                                                                'attributes': {'permission': 'admin', 'bibliographic': False}},
+                                                               {'id': self.user_two._id, 'type': 'contributors',
+                                                                'attributes': {'bibliographic': False}}
+                                                               ]},
+                                    auth=self.user.auth, expect_errors=True, bulk=True)
+
+        assert_equal(res.status_code, 400)
+        assert_equal(res.json['errors'][0]['detail'], 'Must have at least one visible contributor')
+
+    def test_bulk_update_contributors_must_be_at_least_one_admin(self):
+        res = self.app.put_json_api(self.public_url, {'data': [self.payload_two,
+                                                               {'id': self.user._id, 'type': 'contributors',
+                                                                'attributes': {'permission': 'read'}}]},
+                                    auth=self.user.auth, expect_errors=True, bulk=True)
+        assert_equal(res.status_code, 400)
+        assert_equal(res.json['errors'][0]['detail'], '{} is the only admin.'.format(self.user.fullname))
 
 class TestNodeContributorBulkPartialUpdate(NodeCRUDTestCase):
 

--- a/api_tests/nodes/views/test_node_contributors_list.py
+++ b/api_tests/nodes/views/test_node_contributors_list.py
@@ -1139,7 +1139,7 @@ class TestNodeContributorBulkUpdate(NodeCRUDTestCase):
         assert_items_equal([data[0]['attributes']['permission'], data[1]['attributes']['permission'], data[2]['attributes']['permission']],
                            ['admin', 'read', 'read'])
 
-    def test_bulk_update_contributors_must_be_one_bibliographic_contributor(self):
+    def test_bulk_update_contributors_must_have_at_least_one_bibliographic_contributor(self):
         res = self.app.put_json_api(self.public_url, {'data': [self.payload_two,
                                                                {'id': self.user._id, 'type': 'contributors',
                                                                 'attributes': {'permission': 'admin', 'bibliographic': False}},
@@ -1151,7 +1151,7 @@ class TestNodeContributorBulkUpdate(NodeCRUDTestCase):
         assert_equal(res.status_code, 400)
         assert_equal(res.json['errors'][0]['detail'], 'Must have at least one visible contributor')
 
-    def test_bulk_update_contributors_must_be_at_least_one_admin(self):
+    def test_bulk_update_contributors_must_have_at_least_one_admin(self):
         res = self.app.put_json_api(self.public_url, {'data': [self.payload_two,
                                                                {'id': self.user._id, 'type': 'contributors',
                                                                 'attributes': {'permission': 'read'}}]},


### PR DESCRIPTION
Ticket https://openscience.atlassian.net/browse/OSF-6376
## Purpose

ValueError not being handled properly.  Getting a 500 error when user attempts an update or bulk update request on contributors that causes there to be no bibliographic contributors. 

In example below, there are two contributors and I am attempting to make them both non-bibliographic, which isn't allowed.  Instead of handling the error properly, a server error is returned.
```
BULK PATCH /v2/nodes/<node_id>/contributors/
{
    "data": [{
        "id": "12345",
        "type": "contributors",
        "attributes": {
            "bibliographic": "False"
        }
    },
      {
        "id": "abcde",
        "type": "contributors", 
        "attributes": {
            "bibliographic": "False"
        }
        
    }]
}

```
## Changes

Properly handles 500 error by throwing a validation error.
