### PR TITLE
Warn users they cannot search by email address [OSF-5639]

### DIFF
--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -97,7 +97,7 @@ AddContributorViewModel = oop.extend(Paginator, {
         self.childrenToChange = ko.observableArray();
 
         self.emailSearch = ko.pureComputed(function () {
-            if(String(self.query()).indexOf("@") >= 0) {
+            if(String(self.query()).indexOf('@') >= 0) {
                 return true;
             } else {
                 return false;

--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -96,11 +96,23 @@ AddContributorViewModel = oop.extend(Paginator, {
         self.totalPages = ko.observable(0);
         self.childrenToChange = ko.observableArray();
 
+        self.emailSearch = ko.pureComputed(function () {
+            if(String(self.query()).indexOf("@") >= 0) {
+                return true;
+            } else {
+                return false;
+            }
+        });
         self.foundResults = ko.pureComputed(function () {
+            if (self.emailSearch()) {
+                return false;
+            }
             return self.query() && self.results().length;
         });
-
         self.noResults = ko.pureComputed(function () {
+            if (self.emailSearch()) {
+                return false;
+            }
             return self.query() && !self.results().length && self.doneSearching();
         });
 
@@ -208,6 +220,9 @@ AddContributorViewModel = oop.extend(Paginator, {
                     });
                     self.doneSearching(true);
                     self.results(contributors);
+                    if (self.emailSearch()) {
+                        self.results([]);
+                    }
                     self.currentPage(result.page);
                     self.numberOfPages(result.pages);
                     self.addNewPaginators();

--- a/website/static/js/tests/contributors.test.js
+++ b/website/static/js/tests/contributors.test.js
@@ -163,6 +163,37 @@ describe('addContributors', () => {
                    });
                });
            });
+
+           describe('emailSearch', () => {
+               it('should return true with an email address entered', () => {
+                   vm.query(
+                       'a1234@gmail.com'
+                   );
+                   assert.isTrue(vm.emailSearch());
+               });
+               it('should return false with a name entered', () => {
+                   vm.query(
+                       faker.name.findName()
+                   );
+                   assert.isFalse(vm.emailSearch());
+               });
+           });
+
+           describe('nameSearch', () => {
+               it('should return true with a name entered', () => {
+                   var name = faker.name.findName();
+                   vm.query(
+                       name
+                   );
+                   assert.isTrue(!vm.emailSearch());
+               });
+               it('should return false with an email entered', () => {
+                   vm.query(
+                       'a1234@gmail.com'
+                   );
+                   assert.isFalse(vm.foundResults());
+               });
+           });
        });
    });
 });

--- a/website/templates/project/modal_add_contributor.mako
+++ b/website/templates/project/modal_add_contributor.mako
@@ -110,6 +110,9 @@
                             <!-- /ko -->
                             <!-- Link to add non-registered contributor -->
                             <div class='help-block'>
+                                <div data-bind="if: emailSearch">
+                                    <strong>Warning:</strong> Please search by username not email address.
+                                </div>
                                 <div data-bind='if: foundResults'>
                                     <ul class="pagination pagination-sm" data-bind="foreach: paginators">
                                         <li data-bind="css: style"><a href="#" data-bind="click: handler, text: text"></a></li>


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Currently users can search when adding contributors by email address. They can then invite a user, who may already exist in the database by the email address entered, which can cause confusion when it says they already have an account. These changes will no longer enable users to search by email address.

## Changes

If a user attempts to search an email address in the add contributors page, it will show a message that searching by email address is not allowed, and it will not give them the option to add that email address as an unregistered contributor.

BEFORE:
![screen shot 2016-05-19 at 11 53 50 am](https://cloud.githubusercontent.com/assets/12522393/15400143/74c82d78-1db8-11e6-9dfb-f536bc4cd241.png)

AFTER:
![screen shot 2016-05-19 at 11 56 43 am](https://cloud.githubusercontent.com/assets/12522393/15400237/d2a28b50-1db8-11e6-8469-ebb003f39b58.png)


## Side effects

None.


## Ticket

https://openscience.atlassian.net/browse/OSF-5639
