### PR TITLE
Feature/add new logs to my projects page [OSF-5945]

### DIFF
--- a/website/static/js/logActionsList.json
+++ b/website/static/js/logActionsList.json
@@ -49,6 +49,7 @@
     "embargo_approved_no_user": "Embargo of registration of ${node} approved",
     "embargo_cancelled":    "${user} cancelled embargoed registration of ${node}",
     "embargo_completed_no_user": "Embargo of registration of ${node} completed",
+    "embargo_terminated": "Embargo for ${node} ended",
     "retraction_initiated":     "${user} proposed a withdrawal of registration of ${node}",
     "retraction_initiated_no_user": "A withdrawal of registration of ${node} is proposed",
     "retraction_approved":  "${user} approved withdrawal of registration of ${node}",


### PR DESCRIPTION
Part of ticket https://openscience.atlassian.net/browse/OSF-5945

## Purpose

Some new log(s) have been added since I completed my Log Audit https://github.com/CenterForOpenScience/osf.io/pull/5513.  This is trying to add additional ones missing.  Logs on the My Projects page and project overview page are diverging - we need one central source for logs asap.

## Changes

Embargo_terminated action added.  Probably will add others.


