### PR TITLE
Fixes for deleted/missing file error messages

### DIFF
--- a/website/addons/base/views.py
+++ b/website/addons/base/views.py
@@ -44,25 +44,19 @@ from website.notifications.events.files import FileEvent  # noqa
 
 ERROR_MESSAGES = {'FILE_GONE': u'''
 <style>
-.file-download{{display: none;}}
-.file-share{{display: none;}}
-.file-delete{{display: none;}}
+#toggleBar{{display: none;}}
 </style>
 <div class="alert alert-info" role="alert">
 <p>
 The file "{file_name}" stored on {provider} was deleted via the OSF.
 </p>
 <p>
-
 It was deleted by <a href="/{deleted_by_guid}">{deleted_by}</a> on {deleted_on}.
-
 </p>
 </div>''',
                   'DONT_KNOW': u'''
 <style>
-.file-download{{display: none;}}
-.file-share{{display: none;}}
-.file-delete{{display: none;}}
+#toggleBar{{display: none;}}
 </style>
 <div class="alert alert-info" role="alert">
 <p>
@@ -71,9 +65,7 @@ File not found at {provider}.
 </div>''',
                   'BLAME_PROVIDER': u'''
 <style>
-.file-download{{display: none;}}
-.file-share{{display: none;}}
-.file-delete{{display: none;}}
+#toggleBar{{display: none;}}
 </style>
 <div class="alert alert-info" role="alert">
 <p>
@@ -84,11 +76,9 @@ The provider ({provider}) may currently be unavailable or "{file_name}" may have
 You may wish to verify this through {provider}'s website.
 </p>
 </div>''',
-'FILE_SUSPENDED': u'''
+                  'FILE_SUSPENDED': u'''
 <style>
-.file-download{{display: none;}}
-.file-share{{display: none;}}
-.file-delete{{display: none;}}
+#toggleBar{{display: none;}}
 </style>
 <div class="alert alert-info" role="alert">
 This content has been removed.

--- a/website/addons/base/views.py
+++ b/website/addons/base/views.py
@@ -54,6 +54,18 @@ The file "{file_name}" stored on {provider} was deleted via the OSF.
 It was deleted by <a href="/{deleted_by_guid}">{deleted_by}</a> on {deleted_on}.
 </p>
 </div>''',
+                  'FILE_GONE_ACTOR_UNKNOWN': u'''
+<style>
+#toggleBar{{display: none;}}
+</style>
+<div class="alert alert-info" role="alert">
+<p>
+The file "{file_name}" stored on {provider} was deleted via the OSF.
+</p>
+<p>
+It was deleted on {deleted_on}.
+</p>
+</div>''',
                   'DONT_KNOW': u'''
 <style>
 #toggleBar{{display: none;}}
@@ -514,7 +526,10 @@ def addon_deleted_file(auth, node, error_type='BLAME_PROVIDER', **kwargs):
         if file_node.suspended:
             error_type = 'FILE_SUSPENDED'
         elif file_node.deleted_by is None:
-            error_type = 'BLAME_PROVIDER'
+            if file_node.provider == 'osfstorage':
+                error_type = 'FILE_GONE_ACTOR_UNKNOWN'
+            else:
+                error_type = 'BLAME_PROVIDER'
         else:
             error_type = 'FILE_GONE'
     else:

--- a/website/addons/osfstorage/views.py
+++ b/website/addons/osfstorage/views.py
@@ -201,7 +201,8 @@ def osfstorage_create_child(file_node, payload, node_addon, **kwargs):
 @must_not_be_registration
 @decorators.autoload_filenode()
 def osfstorage_delete(file_node, payload, node_addon, **kwargs):
-    auth = Auth(User.load(payload['user']))
+    user = User.load(payload['user'])
+    auth = Auth(user)
 
     #TODO Auth check?
     if not auth:
@@ -211,7 +212,7 @@ def osfstorage_delete(file_node, payload, node_addon, **kwargs):
         raise HTTPError(httplib.BAD_REQUEST)
 
     try:
-        file_node.delete()
+        file_node.delete(user=user)
 
     except exceptions.FileNodeCheckedOutError:
         raise HTTPError(httplib.FORBIDDEN)


### PR DESCRIPTION
## Purpose

Improve display of "this file has been deleted" error messages.

## Changes

1. Start saving the deleting user for osfstorage.
2. Hide the 'view' and 'revision' action buttons when the file is deleted/missing.
3. If an osfstorage file doesn't have a `deleted_by` field, just show the date of deletion.

## Side effects

<None expected>

## Ticket

[#OSF-5883]