### PR TITLE
Dev/feat/math typesetting for share search results [OSF-6020]

### DIFF
--- a/api/templates/rest_framework_swagger/base.html
+++ b/api/templates/rest_framework_swagger/base.html
@@ -32,7 +32,7 @@
                             </div>
                             <div class="input"><input placeholder="http://example.com/api" id="input_baseUrl" name="baseUrl" type="text"/></div>
                             <div class="input"><input placeholder="api_key" id="input_apiKey" name="apiKey" type="text"/></div>
-                            <div class="input"><a id="explore" href="#">Explore</a></div>
+                            <div class="input"><a id="explore" href="#">Exploooore</a></div>
                         </form>
                     {% endblock %}
                 </div>
@@ -58,8 +58,10 @@
         <script src="{% static 'rest_framework_swagger/lib/underscore-min.js' %}" type="text/javascript"></script>
         <script src="{% static 'rest_framework_swagger/lib/backbone-min.js' %}" type="text/javascript"></script>
         <script src="{% static 'rest_framework_swagger/lib/swagger.js' %}" type="text/javascript"></script>
-        <script src="{% static 'rest_framework_swagger/swagger-ui.min.js' %}" type="text/javascript"></script>
+        {% block scripts %}{% endblock %}
+        <script src="{% static 'rest_framework_swagger/swagger-ui.js' %}" type="text/javascript"></script>
         <script src="{% static 'rest_framework_swagger/lib/highlight.8.0.pack.js' %}" type="text/javascript"></script>
+
         <script type="text/javascript">
             $(function () {
                 window.swaggerUi = new SwaggerUi({
@@ -93,6 +95,7 @@
                 window.swaggerUi.load();
             });
         </script>
+        
     </body>
 </html>
 {% endspaceless %}

--- a/api/templates/rest_framework_swagger/index.html
+++ b/api/templates/rest_framework_swagger/index.html
@@ -23,3 +23,54 @@
     </form>
 {% endblock %}
 
+{% block scripts %}
+    
+
+
+<script>
+(function() {
+
+    var opts;
+    var SwaggerRequest__unpatched = SwaggerRequest;
+
+    SwaggerRequest = function(type, url, params, opts, successCallback, errorCallback, operation, execution) {
+        console.log(operation);
+        console.log(execution);    
+     
+        var successCallback__unpatched = successCallback;
+        successCallback = function(response, opts_parent) {
+        
+            var ret = successCallback__unpatched(response, opts_parent);
+            Array.prototype.filter.call(opts_parent.el.querySelectorAll('.response_body .hljs-string'), function(el) {
+                return (
+                    el.innerHTML.slice(1, 8) == "http://" ||
+                    el.innerHTML.slice(1, 9) == "https://"
+                ); 
+            }).map(function(el) {
+                var url = el.innerHTML.slice(1, -1);
+                var anchor = document.createElement("a");
+                anchor.textContent = url;
+                anchor.href = url;
+                var pn = anchor.pathname
+                console.log(pn.split('/'))
+                console.log(anchor);
+                el.innerHTML = "\"<a href=\""+url+"?format=json\">"+url+"</a>"+"\"";
+            })
+            return ret;
+        
+        }
+        
+        SwaggerRequest__unpatched.bind(this)(type, url, params, opts, successCallback, errorCallback, operation, execution);
+    
+    }
+    
+})();
+
+
+
+
+
+</script>
+{% endblock %}
+
+

--- a/website/static/js/mathrender.js
+++ b/website/static/js/mathrender.js
@@ -22,7 +22,44 @@ function mathjaxify(selector) {
     }
 }
 
+// Helper function takes an element node and typesets its math markup.
+function typeset(el) {
+    function randomStringGen(length) {
+        if (typeof length !== "number") length = 8;
+        var text = "";
+        var possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+        for(var i = 0; i < length; i++) {
+            text += possible.charAt(Math.floor(Math.random() * possible.length));
+        }
+        return text;
+    };
+    
+    MathJax.Hub.Config({
+        tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}
+    });
+    
+    // If our element is not an element node, it can't have an id,
+    // and so MathJax cannot process it. Let's print 
+    // something helpful to the console and return from the funciton early.                  
+    if (el.nodeType != 1) {   
+        console.log("Trying to typeset non-node "+el.id+", or node does not exist in DOM.\n"
+                   +"Check the element's id is correct and that it exists.");
+        return false;
+    };
+    
+    // MathJax requires an id to target elements.
+    // We create a random string to serve as an id.
+    // 32 chars should be enouth entrop to prevent
+    // collisions.
+    el.id = randomStringGen(32); 
+    
+    // Add an element by its id to MAthJax Queue to typeset.
+    // As soon as MathJax has a queue, it'll start typesetting.
+    window.MathJax.Hub.Queue(["Typeset", MathJax.Hub, el.id]);
+}
+
 
 module.exports = {
-    mathjaxify: mathjaxify
+    mathjaxify: mathjaxify,
+    typeset: typeset
 };

--- a/website/static/js/mathrender.js
+++ b/website/static/js/mathrender.js
@@ -27,22 +27,19 @@ function mathjaxify(selector) {
 // This can now be mapped over a nodelist or the like.
 function typeset(el) {
 
-    console.log("Typesetting elements...");  
- 
     // If our element is not an element node, it can't have an id,
     // and so MathJax cannot process it. Let's return from the funciton early.                  
-    if (el.nodeType !== 1) {
-        console.log("not a node."); 
-        return false;
-    }
+    if (el.nodeType !== 1) return false;
+    
+    // MathJax has issues getting loaded by webpack? Right now, it's getting 
+    // included in the file website/templates/share_search.mako, 
+    // where there is also some configuration happening.
+
     // Make sure we're doing this in a browser...
     // This isn't _really_ a good enough guard against this getting 
     // run on the server, but hopefully we don't define window...
-    console.log(window);
-    console.log(typeof window);
     if (typeof window === "undefined") return;
         
-    console.log("queueing element to typesetter")
     // Add an element by its id to MAthJax Queue to typeset.
     // As soon as MathJax has a queue, it'll start typesetting.
     window.MathJax.Hub.Queue(["Typeset", MathJax.Hub, el]);

--- a/website/static/js/mathrender.js
+++ b/website/static/js/mathrender.js
@@ -18,21 +18,10 @@ function mathjaxify(selector) {
     }
     var preview = $elem[0];
     if (typeof(window.typeset) === 'undefined' || window.typeset === true) {
-        MathJax.Hub.Queue(['Typeset', MathJax.Hub, preview]); // This function takes an id, not a node... what are we doing here?
-        typesetStubbornMath(); // If the line above does work, we're doing the same thing again (and more, granted) here.
+        MathJax.Hub.Queue(['Typeset', MathJax.Hub, preview]);
+        typesetStubbornMath();
     }
 }
-
-// Generate a random string suitable for use as an id.
-function randomStringGen(length) {
-    if (typeof length !== "number") length = 8;
-    var text = "";
-    var possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
-    for(var i = 0; i < length; i++) {
-        text += possible.charAt(Math.floor(Math.random() * possible.length));
-    }
-    return text;
-};    
 
 // Helper function takes an element node and typesets its math markup.
 // This can now be mapped over a nodelist or the like.
@@ -41,36 +30,22 @@ function typeset(el) {
     console.log("Typesetting elements...");  
  
     // If our element is not an element node, it can't have an id,
-    // and so MathJax cannot process it. Let's print 
-    // something helpful to the console and return from the funciton early.                  
-    if (el.nodeType !== 1) {   
-        console.log("Trying to typeset non-node "+el.id+", or node does not exist in DOM.\n"
-                   +"Check the element's id is correct and that it exists.");
+    // and so MathJax cannot process it. Let's return from the funciton early.                  
+    if (el.nodeType !== 1) {
+        console.log("not a node."); 
         return false;
-    };
-    
-    // MathJax requires an id to target elements.
-    // We create a random string to serve as an id.
-    // while checking for a collision if the target
-    // node does not have an id.
-    if ( typeof el.id === "undefined" || el.id.length === 0 ) {
-        do { var id = randomStringGen(16); } while (document.getElementById(id));
-        el.id = id; 
     }
-    
     // Make sure we're doing this in a browser...
     // This isn't _really_ a good enough guard against this getting 
     // run on the server, but hopefully we don't define window...
+    console.log(window);
+    console.log(typeof window);
     if (typeof window === "undefined") return;
         
-    // Configure ajax // TODO: Put this in a config file!
-    window.MathJax.Hub.Config({
-        tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}
-    });
-    
+    console.log("queueing element to typesetter")
     // Add an element by its id to MAthJax Queue to typeset.
     // As soon as MathJax has a queue, it'll start typesetting.
-    window.MathJax.Hub.Queue(["Typeset", MathJax.Hub, el.id]);
+    window.MathJax.Hub.Queue(["Typeset", MathJax.Hub, el]);
 
 }
 

--- a/website/static/js/mathrender.js
+++ b/website/static/js/mathrender.js
@@ -38,11 +38,11 @@ function typeset(el) {
     // Make sure we're doing this in a browser...
     // This isn't _really_ a good enough guard against this getting 
     // run on the server, but hopefully we don't define window...
-    if (typeof window === "undefined") return;
+    if (typeof window === 'undefined') return;
         
     // Add an element by its id to MAthJax Queue to typeset.
     // As soon as MathJax has a queue, it'll start typesetting.
-    window.MathJax.Hub.Queue(["Typeset", MathJax.Hub, el]);
+    window.MathJax.Hub.Queue(['Typeset', MathJax.Hub, el]);
 
 }
 

--- a/website/static/js/mathrender.js
+++ b/website/static/js/mathrender.js
@@ -3,6 +3,7 @@
 var $ = require('jquery');
 var MathJax = require('MathJax');
 
+
 /**
  * Render math with MathJax within a given element.
  * */
@@ -17,31 +18,32 @@ function mathjaxify(selector) {
     }
     var preview = $elem[0];
     if (typeof(window.typeset) === 'undefined' || window.typeset === true) {
-        MathJax.Hub.Queue(['Typeset', MathJax.Hub, preview]);
-        typesetStubbornMath();
+        MathJax.Hub.Queue(['Typeset', MathJax.Hub, preview]); // This function takes an id, not a node... what are we doing here?
+        typesetStubbornMath(); // If the line above does work, we're doing the same thing again (and more, granted) here.
     }
 }
 
+// Generate a random string suitable for use as an id.
+function randomStringGen(length) {
+    if (typeof length !== "number") length = 8;
+    var text = "";
+    var possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    for(var i = 0; i < length; i++) {
+        text += possible.charAt(Math.floor(Math.random() * possible.length));
+    }
+    return text;
+};    
+
 // Helper function takes an element node and typesets its math markup.
+// This can now be mapped over a nodelist or the like.
 function typeset(el) {
-    function randomStringGen(length) {
-        if (typeof length !== "number") length = 8;
-        var text = "";
-        var possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-        for(var i = 0; i < length; i++) {
-            text += possible.charAt(Math.floor(Math.random() * possible.length));
-        }
-        return text;
-    };
-    
-    MathJax.Hub.Config({
-        tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}
-    });
-    
+
+    console.log("Typesetting elements...");  
+ 
     // If our element is not an element node, it can't have an id,
     // and so MathJax cannot process it. Let's print 
     // something helpful to the console and return from the funciton early.                  
-    if (el.nodeType != 1) {   
+    if (el.nodeType !== 1) {   
         console.log("Trying to typeset non-node "+el.id+", or node does not exist in DOM.\n"
                    +"Check the element's id is correct and that it exists.");
         return false;
@@ -49,13 +51,27 @@ function typeset(el) {
     
     // MathJax requires an id to target elements.
     // We create a random string to serve as an id.
-    // 32 chars should be enouth entrop to prevent
-    // collisions.
-    el.id = randomStringGen(32); 
+    // while checking for a collision if the target
+    // node does not have an id.
+    if ( typeof el.id === "undefined" || el.id.length === 0 ) {
+        do { var id = randomStringGen(16); } while (document.getElementById(id));
+        el.id = id; 
+    }
+    
+    // Make sure we're doing this in a browser...
+    // This isn't _really_ a good enough guard against this getting 
+    // run on the server, but hopefully we don't define window...
+    if (typeof window === "undefined") return;
+        
+    // Configure ajax // TODO: Put this in a config file!
+    window.MathJax.Hub.Config({
+        tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}
+    });
     
     // Add an element by its id to MAthJax Queue to typeset.
     // As soon as MathJax has a queue, it'll start typesetting.
     window.MathJax.Hub.Queue(["Typeset", MathJax.Hub, el.id]);
+
 }
 
 

--- a/website/static/js/share/results.js
+++ b/website/static/js/share/results.js
@@ -6,6 +6,9 @@ var m = require('mithril');
 var $osf = require('js/osfHelpers');
 var utils = require('./utils');
 require('truncate');
+var mathrender = require('js/mathrender');
+
+
 
 var LoadingIcon = {
     view: function(ctrl) {
@@ -17,7 +20,7 @@ var Results = {
     view: function(ctrl, params) {
         var vm = params.vm;
         var resultViews = $.map(vm.results || [], function(result, i) {
-            return m.component(Result, {result: result, vm: vm,});
+            return m.component(Result, {result: result, vm: vm});
         });
 
 
@@ -37,20 +40,35 @@ var Results = {
         };
 
         return m('', [
-            m('.row', m('.col-md-12', maybeResults(resultViews, vm.resultsLoading()))),
-            m('.row', m('.col-md-12', m('div', {style: {display: 'block', margin: 'auto', 'text-align': 'center'}},
+            
+            m('.row.hasMath', m('.col-md-12', [
+                maybeResults(resultViews, vm.resultsLoading()),
+                m('iframe.res_loaded_handler', {
+                    style: {display: 'none'},
+                    onload: function() {
+                        Array.prototype.map.call(
+                            document.querySelectorAll('.hasMath'), 
+                            mathrender.typeset
+                        );
+                    }
+                })
+            ])),
+
+            // This won't work for ie8 or earlier - these browser fires an onreadystatechange but no onload...
+            m('.row', m('.col-md-12', m('div', {style: {display: 'block', margin: 'auto', 'text-align': 'center'}}, 
                 len > 0 && len < vm.count ?
                 m('a.btn.btn-md.btn-default', {
                     onclick: function(){
                         utils.loadMore(vm)
                             .then(function(data) {
-                                utils.updateVM(vm, data);
+                                utils.updateVM(vm, data)
+
                             });
-                    }
+		                }
                 }, 'More') : [])
             ))
         ]);
-
+    
     }
 };
 

--- a/website/static/js/share/results.js
+++ b/website/static/js/share/results.js
@@ -35,7 +35,7 @@ var Results = {
             } else if (!loading && results.length === 0) {
                 return m('p', {class: 'text-muted'}, 'No results for this query');
             } else {
-                return m('',  [m.component(LoadingIcon), 'loading...']);
+                return m('', [m.component(LoadingIcon), 'loading...']);
             }
         };
 
@@ -43,7 +43,7 @@ var Results = {
             
             m('.row.hasMath', m('.col-md-12', {
                 config: function(el, ini, ctx) {
-                    mathrender.typeset(el) // We can start mathjax here and trigger it once to rendoer for all results...
+                    mathrender.typeset(el); // We can start mathjax here and trigger it once to rendoer for all results...
                 }
             },
                 maybeResults(resultViews, vm.resultsLoading())
@@ -55,7 +55,7 @@ var Results = {
                     onclick: function(){
                         utils.loadMore(vm)
                             .then(function(data) {
-                                utils.updateVM(vm, data)
+                                utils.updateVM(vm, data);
 
                             });
 		                }

--- a/website/static/js/share/results.js
+++ b/website/static/js/share/results.js
@@ -35,26 +35,35 @@ var Results = {
             } else if (!loading && results.length === 0) {
                 return m('p', {class: 'text-muted'}, 'No results for this query');
             } else {
-                return m('', [m.component(LoadingIcon), 'loading...']);
+                return m('',  [m.component(LoadingIcon), 'loading...']);
             }
         };
 
         return m('', [
             
-            m('.row.hasMath', m('.col-md-12', [
-                maybeResults(resultViews, vm.resultsLoading()),
-                m('iframe.res_loaded_handler', {
-                    style: {display: 'none'},
-                    onload: function() {
-                        Array.prototype.map.call(
-                            document.querySelectorAll('.hasMath'), 
-                            mathrender.typeset
-                        );
-                    }
-                })
-            ])),
+            m('.row.hasMath', m('.col-md-12', {
+                config: function(el, ini, ctx) {
+                    //console.log(el.textContent);
+                    //Array.prototype.map.call(document.querySelectorAll('.hasMath'), console.log.bind(console));
+                    //mathrender.typeset(el)
+                    //Array.prototype.map.call(document.querySelectorAll('.hasMath'), mathrender.typeset);
+                }
+            }, [
+                    maybeResults(resultViews, vm.resultsLoading())
+                    //, m('iframe.res_loaded_handler', {
+                    //    style: {
+                    //        display: 'none'
+                    //    },
+                    //    onload: function() {
+                    //        Array.prototype.map.call(
+                    //            document.querySelectorAll('.hasMath'), 
+                    //            mathrender.typeset
+                    //        );
+                    //    }
+                    //})
+                ]
+            )),
 
-            // This won't work for ie8 or earlier - these browser fires an onreadystatechange but no onload...
             m('.row', m('.col-md-12', m('div', {style: {display: 'block', margin: 'auto', 'text-align': 'center'}}, 
                 len > 0 && len < vm.count ?
                 m('a.btn.btn-md.btn-default', {
@@ -125,12 +134,25 @@ var Description = {
         };
         if ((result.description || '').length > 350) {
             return m('', [
-                m('p.readable.pointer', {onclick: showOnClick},
+                m('p.readable.pointer', {
+                    onclick: showOnClick,
+                    config: function(el, ini, ctx) {
+                    //    console.log(el);
+                        //setTimeout(function() {
+                            mathrender.typeset(el)
+                        //}, 500);
+                    }
+                },
                     ctrl.showAll() ? result.description : $.truncate(result.description, {length: 350})
                 ),
                 m('a.sr-only', {href: '#', onclick: showOnClick}, ctrl.showAll() ? 'See less' : 'See more')]);
         } else {
-            return m('p.readable', result.description);
+            return m('p.readable', {
+                config: function(el, ini, ctx) {
+                    mathrender.typeset(el)
+                }
+            },
+            result.description);
         }
     }
 };

--- a/website/static/js/share/results.js
+++ b/website/static/js/share/results.js
@@ -43,25 +43,10 @@ var Results = {
             
             m('.row.hasMath', m('.col-md-12', {
                 config: function(el, ini, ctx) {
-                    //console.log(el.textContent);
-                    //Array.prototype.map.call(document.querySelectorAll('.hasMath'), console.log.bind(console));
-                    //mathrender.typeset(el)
-                    //Array.prototype.map.call(document.querySelectorAll('.hasMath'), mathrender.typeset);
+                    mathrender.typeset(el) // We can start mathjax here and trigger it once to rendoer for all results...
                 }
-            }, [
-                    maybeResults(resultViews, vm.resultsLoading())
-                    //, m('iframe.res_loaded_handler', {
-                    //    style: {
-                    //        display: 'none'
-                    //    },
-                    //    onload: function() {
-                    //        Array.prototype.map.call(
-                    //            document.querySelectorAll('.hasMath'), 
-                    //            mathrender.typeset
-                    //        );
-                    //    }
-                    //})
-                ]
+            },
+                maybeResults(resultViews, vm.resultsLoading())
             )),
 
             m('.row', m('.col-md-12', m('div', {style: {display: 'block', margin: 'auto', 'text-align': 'center'}}, 
@@ -114,7 +99,13 @@ var TitleBar = {
     view: function(ctrl, params) {
         var result = params.result;
         return m('span', {}, [
-            m('a[href=' + result.uris.canonicalUri + ']', ((result.title || 'No title provided'))),
+            m('a[href=' + result.uris.canonicalUri + ']', {
+                    config: function(el, ini, ctx) {
+                        //mathrender.typeset(el)
+                    }
+                },
+                ((result.title || 'No title provided'))
+            ),
             m('br'),
             m.component(Description, params)
         ]);
@@ -137,10 +128,7 @@ var Description = {
                 m('p.readable.pointer', {
                     onclick: showOnClick,
                     config: function(el, ini, ctx) {
-                    //    console.log(el);
-                        //setTimeout(function() {
-                            mathrender.typeset(el)
-                        //}, 500);
+                        //mathrender.typeset(el)
                     }
                 },
                     ctrl.showAll() ? result.description : $.truncate(result.description, {length: 350})
@@ -149,7 +137,7 @@ var Description = {
         } else {
             return m('p.readable', {
                 config: function(el, ini, ctx) {
-                    mathrender.typeset(el)
+                    //mathrender.typeset(el)
                 }
             },
             result.description);

--- a/website/static/js/share/utils.js
+++ b/website/static/js/share/utils.js
@@ -15,6 +15,7 @@ utils.onSearch = function(fb) {
 var COLORBREWER_COLORS = [[166, 206, 227], [31, 120, 180], [178, 223, 138], [51, 160, 44], [251, 154, 153], [227, 26, 28], [253, 191, 111], [255, 127, 0], [202, 178, 214], [106, 61, 154], [255, 255, 153], [177, 89, 40]];
 var tags = ['div', 'i', 'b', 'sup', 'p', 'span', 'sub', 'bold', 'strong', 'italic', 'a', 'small'];
 
+
 /* Removes certain HTML tags from the source */
 utils.scrubHTML = function(text) {
     tags.forEach(function(tag) {
@@ -48,7 +49,7 @@ utils.errorState = function(vm){
  * @param {Object} vm The current state of the vm
  * @param {Object} data New search results
  */
-utils.updateVM = function(vm, data) {
+utils.updateVM = function(vm, data, callback) {
     if (data === null) {
         return;
     }
@@ -60,9 +61,7 @@ utils.updateVM = function(vm, data) {
     });
     vm.results.push.apply(vm.results, data.results);
     m.redraw();
-    $.map(callbacks, function(cb) {
-        cb();
-    });
+    callbacks.map(function(cb) { cb(); });
 };
 
 /* Handles searching via the search API */

--- a/website/static/js/share/utils.js
+++ b/website/static/js/share/utils.js
@@ -49,7 +49,7 @@ utils.errorState = function(vm){
  * @param {Object} vm The current state of the vm
  * @param {Object} data New search results
  */
-utils.updateVM = function(vm, data, callback) {
+utils.updateVM = function(vm, data) {
     if (data === null) {
         return;
     }

--- a/website/templates/share_search.mako
+++ b/website/templates/share_search.mako
@@ -1,8 +1,10 @@
 <%inherit file="base.mako"/>
 <%def name="title()">SHARE</%def>
 <%def name="content()">
-  <div id="shareSearch"></div>
+    <script type="text/javascript" src="/static/vendor/bower_components/MathJax/unpacked/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script> 
+    <div id="shareSearch"></div>
 </%def>
+
 
 <%def name="javascript_bottom()">
     <script src=${"/static/public/js/share-search-page.js" | webpack_asset}></script>

--- a/website/templates/share_search.mako
+++ b/website/templates/share_search.mako
@@ -1,7 +1,12 @@
 <%inherit file="base.mako"/>
 <%def name="title()">SHARE</%def>
 <%def name="content()">
-    <script type="text/javascript" src="/static/vendor/bower_components/MathJax/unpacked/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script> 
+    <script type="text/javascript" src="/static/vendor/bower_components/MathJax/unpacked/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+    <script type='text/javascript'>
+        window.MathJax.Hub.Config({
+            tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}
+        });
+    </script> 
     <div id="shareSearch"></div>
 </%def>
 


### PR DESCRIPTION

## Purpose
Allow math ml to render in a beautiful and pleasing manner in the results of share searches.

## Changes
included mathjax script on the page, set up hooks to add certain elements to the mathjax queue once they're loaded into the dom.

## Side effects
It'll typeset any markup in tags or contributor's names. It'll probably break in ie6.

## Ticket
https://openscience.atlassian.net/browse/OSF-6020