### PR TITLE
[OSF-6273] Fix last update timestamp on draft registrations to not update for al…

### DIFF
--- a/website/project/model.py
+++ b/website/project/model.py
@@ -3841,10 +3841,13 @@ class DraftRegistration(StoredObject):
         if meta_schema:
             schema = meta_schema.schema
             flags = schema.get('flags', {})
+            dirty = False
             for flag, value in flags.iteritems():
                 if flag not in self._metaschema_flags:
                     self._metaschema_flags[flag] = value
-            self.save()
+                    dirty = True
+            if dirty:
+                self.save()
         return self._metaschema_flags
 
     @flags.setter

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -70,6 +70,7 @@ function Comment(data) {
     self.created = data.created ? new Date(data.created) : new Date();
     self.lastModified = data.lastModified ? new Date(data.lastModified) : new Date();
 
+    self.isDeleted = ko.observable(data.isDeleted || false);
     self.isDeleted.subscribe(function(isDeleted) {
         if (isDeleted) {
             self.value('');

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -70,7 +70,6 @@ function Comment(data) {
     self.created = data.created ? new Date(data.created) : new Date();
     self.lastModified = data.lastModified ? new Date(data.lastModified) : new Date();
 
-    self.isDeleted = ko.observable(data.isDeleted || false);
     self.isDeleted.subscribe(function(isDeleted) {
         if (isDeleted) {
             self.value('');
@@ -772,8 +771,7 @@ Draft.prototype.reject = function() {
  * @property {Object} extensions: mapping of extenstion names to their view models
  **/
 var RegistrationEditor = function(urls, editorId, preview) {
-    var self = this;
-
+    var self = this; 
     self.urls = urls;
 
     self.readonly = ko.observable(false);
@@ -1052,8 +1050,10 @@ RegistrationEditor.prototype.updateData = function(response) {
     var self = this;
 
     var draft = self.draft();
+
     draft.pk = response.pk;
     draft.updated = new Date(response.updated);
+
     self.draft(draft);
 };
 

--- a/website/templates/project/edit_draft_registration.mako
+++ b/website/templates/project/edit_draft_registration.mako
@@ -48,7 +48,7 @@
 
                 <div class="row" style="margin-bottom: 10px;">
                   <span>
-                    Last saved: <span data-bind="text: lastSaveTime"></span>
+                    Last auto-saved: <span data-bind="text: lastSaveTime"></span>
                   </span>
                   <!-- ko if: onLastPage -->
                   <span data-bind="if: onLastPage() && hasValidationInfo()" class="pull-right">


### PR DESCRIPTION
## Purpose
Fix so that the only the draft registration being updated will have a new time stamp.

## Changes
Added a boolean check before the meta schema gets saved.

## Side effects
None.

## Ticket
https://openscience.atlassian.net/browse/OSF-6273