### PR TITLE
Warn users they cannot search by email address [OSF-5639] 

### DIFF
--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -97,7 +97,7 @@ AddContributorViewModel = oop.extend(Paginator, {
         self.childrenToChange = ko.observableArray();
 
         self.emailSearch = ko.pureComputed(function () {
-            if(String(self.query()).indexOf("@") >= 0) {
+            if(String(self.query()).indexOf('@') >= 0) {
                 return true;
             } else {
                 return false;

--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -96,11 +96,23 @@ AddContributorViewModel = oop.extend(Paginator, {
         self.totalPages = ko.observable(0);
         self.childrenToChange = ko.observableArray();
 
+        self.emailSearch = ko.pureComputed(function () {
+            if(String(self.query()).indexOf("@") >= 0) {
+                return true;
+            } else {
+                return false;
+            }
+        });
         self.foundResults = ko.pureComputed(function () {
+            if (self.emailSearch()) {
+                return false;
+            }
             return self.query() && self.results().length;
         });
-
         self.noResults = ko.pureComputed(function () {
+            if (self.emailSearch()) {
+                return false;
+            }
             return self.query() && !self.results().length && self.doneSearching();
         });
 
@@ -208,6 +220,9 @@ AddContributorViewModel = oop.extend(Paginator, {
                     });
                     self.doneSearching(true);
                     self.results(contributors);
+                    if (self.emailSearch()) {
+                        self.results([]);
+                    }
                     self.currentPage(result.page);
                     self.numberOfPages(result.pages);
                     self.addNewPaginators();

--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -97,22 +97,17 @@ AddContributorViewModel = oop.extend(Paginator, {
         self.childrenToChange = ko.observableArray();
 
         self.emailSearch = ko.pureComputed(function () {
-            if(String(self.query()).indexOf('@') >= 0) {
+            var emailRegex = new RegExp('[a-zA-Z0-9]+@[a-zA-Z0-9]+\.[a-z]+');
+            if (emailRegex.test(String(self.query()))) {
                 return true;
             } else {
                 return false;
             }
         });
         self.foundResults = ko.pureComputed(function () {
-            if (self.emailSearch()) {
-                return false;
-            }
             return self.query() && self.results().length;
         });
         self.noResults = ko.pureComputed(function () {
-            if (self.emailSearch()) {
-                return false;
-            }
             return self.query() && !self.results().length && self.doneSearching();
         });
 
@@ -220,9 +215,6 @@ AddContributorViewModel = oop.extend(Paginator, {
                     });
                     self.doneSearching(true);
                     self.results(contributors);
-                    if (self.emailSearch()) {
-                        self.results([]);
-                    }
                     self.currentPage(result.page);
                     self.numberOfPages(result.pages);
                     self.addNewPaginators();

--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -97,7 +97,7 @@ AddContributorViewModel = oop.extend(Paginator, {
         self.childrenToChange = ko.observableArray();
 
         self.emailSearch = ko.pureComputed(function () {
-            var emailRegex = new RegExp('[a-zA-Z0-9]+@[a-zA-Z0-9]+\.[a-z]+');
+            var emailRegex = new RegExp('[a-z0-9!#$%&\'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&\'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?');
             if (emailRegex.test(String(self.query()))) {
                 return true;
             } else {

--- a/website/static/js/tests/contributors.test.js
+++ b/website/static/js/tests/contributors.test.js
@@ -178,22 +178,6 @@ describe('addContributors', () => {
                    assert.isFalse(vm.emailSearch());
                });
            });
-
-           describe('nameSearch', () => {
-               it('should return true with a name entered', () => {
-                   var name = faker.name.findName();
-                   vm.query(
-                       name
-                   );
-                   assert.isTrue(!vm.emailSearch());
-               });
-               it('should return false with an email entered', () => {
-                   vm.query(
-                       'a1234@gmail.com'
-                   );
-                   assert.isFalse(vm.foundResults());
-               });
-           });
        });
    });
 });

--- a/website/static/js/tests/contributors.test.js
+++ b/website/static/js/tests/contributors.test.js
@@ -163,6 +163,37 @@ describe('addContributors', () => {
                    });
                });
            });
+
+           describe('emailSearch', () => {
+               it('should return true with an email address entered', () => {
+                   vm.query(
+                       'a1234@gmail.com'
+                   );
+                   assert.isTrue(vm.emailSearch());
+               });
+               it('should return false with a name entered', () => {
+                   vm.query(
+                       faker.name.findName()
+                   );
+                   assert.isFalse(vm.emailSearch());
+               });
+           });
+
+           describe('nameSearch', () => {
+               it('should return true with a name entered', () => {
+                   var name = faker.name.findName();
+                   vm.query(
+                       name
+                   );
+                   assert.isTrue(!vm.emailSearch());
+               });
+               it('should return false with an email entered', () => {
+                   vm.query(
+                       'a1234@gmail.com'
+                   );
+                   assert.isFalse(vm.foundResults());
+               });
+           });
        });
    });
 });

--- a/website/templates/project/modal_add_contributor.mako
+++ b/website/templates/project/modal_add_contributor.mako
@@ -110,24 +110,28 @@
                             <!-- /ko -->
                             <!-- Link to add non-registered contributor -->
                             <div class='help-block'>
-                                <div data-bind="if: emailSearch">
-                                    <strong>Warning:</strong> Please search by name, not email address.
-                                </div>
                                 <div data-bind='if: foundResults'>
                                     <ul class="pagination pagination-sm" data-bind="foreach: paginators">
                                         <li data-bind="css: style"><a href="#" data-bind="click: handler, text: text"></a></li>
                                     </ul>
                                     <p>
-                                        <a href="#" data-bind="click:gotoInvite">Add <strong><em data-bind="text: query"></em></strong> as an unregistered contributor</a>.
+                                        <div data-bind='ifnot: emailSearch'>
+                                            <a href="#" data-bind="click:gotoInvite">Add <strong><em data-bind="text: query"></em></strong> as an unregistered contributor</a>.
+                                        </div>
                                     </p>
                                 </div>
                                 <div data-bind="if: showLoading">
                                     <p class="text-muted">Searching contributors...</p>
                                 </div>
-                                    <div data-bind="if: noResults">
-                                        No results found. Try a more specific search or
+                                <div data-bind="if: noResults">
+                                    No results found. Try a more specific search
+                                    <div data-bind="ifnot: emailSearch"> or
                                         <a href="#" data-bind="click:gotoInvite">add <strong><em data-bind="text: query"></em></strong> as an unregistered contributor</a>.
                                     </div>
+                                </div>
+                                <div data-bind="if: emailSearch">
+                                    <p>It looks like you are trying to search by email address. If you search by name, you can add an unregistered contributor.</p>
+                                </div>
                             </div>
                         </div><!-- ./col-md -->
 
@@ -273,4 +277,3 @@
         </div><!-- end modal-content -->
     </div><!-- end modal-dialog -->
 </div><!-- end modal -->
-

--- a/website/templates/project/modal_add_contributor.mako
+++ b/website/templates/project/modal_add_contributor.mako
@@ -111,7 +111,7 @@
                             <!-- Link to add non-registered contributor -->
                             <div class='help-block'>
                                 <div data-bind="if: emailSearch">
-                                    <strong>Warning:</strong> Please search by username not email address.
+                                    <strong>Warning:</strong> Please search by name, not email address.
                                 </div>
                                 <div data-bind='if: foundResults'>
                                     <ul class="pagination pagination-sm" data-bind="foreach: paginators">

--- a/website/templates/project/modal_add_contributor.mako
+++ b/website/templates/project/modal_add_contributor.mako
@@ -110,6 +110,9 @@
                             <!-- /ko -->
                             <!-- Link to add non-registered contributor -->
                             <div class='help-block'>
+                                <div data-bind="if: emailSearch">
+                                    <strong>Warning:</strong> Please search by username not email address.
+                                </div>
                                 <div data-bind='if: foundResults'>
                                     <ul class="pagination pagination-sm" data-bind="foreach: paginators">
                                         <li data-bind="css: style"><a href="#" data-bind="click: handler, text: text"></a></li>


### PR DESCRIPTION
## Purpose

Currently users can search when adding contributors by email address. They can then invite a user, who may already exist in the database by the email address entered, which can cause confusion when it says they already have an account. These changes will no longer enable users to search by email address.

## Changes

If a user attempts to search an email address in the add contributors page, it will show a message that searching by email address is not allowed, and it will not give them the option to add that email address as an unregistered contributor.

### BEFORE:

![image](https://cloud.githubusercontent.com/assets/12522393/15709116/e3096456-27d0-11e6-9ef3-e61ac4053faf.png)

### AFTER:
![image](https://cloud.githubusercontent.com/assets/12522393/15715157/64f8e6b6-27eb-11e6-99be-dca19a0bcfee.png)


## Side effects

None.

## Ticket

https://openscience.atlassian.net/browse/OSF-5639