### PR TITLE
[feature fix] Uploads do not continue after Dataverse upload cancel [OSF-5459]

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -150,7 +150,7 @@ function cancelUploads(row) {
     }
     if (!handled) {
         // File is currently being uploaded/managed by dropzone
-        filesArr.some(function(file) {
+        handled = filesArr.some(function(file) {
             if (file.tmpID === row.data.tmpID) {
                 tb.deleteNode(row.parentID, row.id);
                 tb.dropzone.removeFile(file);
@@ -158,7 +158,7 @@ function cancelUploads(row) {
             }
         });
     }
-    tb.isUploading(filesArr.length > 1);
+    tb.isUploading(handled && filesArr.length > 1);
 }
 
 var uploadRowTemplate = function(item) {
@@ -748,7 +748,9 @@ function _fangornComplete(treebeard, file) {
 
     if (file.isSync) {
         if (this.syncFileCache[item.data.provider].length > 0) {
-            this.processFile(this.syncFileCache[item.data.provider].pop());
+            var nextFile = this.syncFileCache[item.data.provider].pop();
+            this.files.push(nextFile);
+            this.processFile(nextFile);
         }
     }
 }


### PR DESCRIPTION
## Purpose
Cancelling pending uploads to Dataverse and Github (those that require synchronous uploads) failed to cancel uploads. Instead, **fangorn** would attempt to upload a cancelled file, which would either succeed (undesired) or raise an error, stopping all uploads (also undesired). However, it would appear cancelled to the user because **fangorn** removes all uploads the user cancels, cancelled or not, from the UI. This was because uploads were removed from the UI regardless of whether they were found in `dropzone`.

In addition, when cancelling an upload in progress by a synchronous provider, the next upload that gets processed is not cancellable (even though the old code searched `dropzone.files`) due to `dropzone` not adding it to the `files` list.

## Changes

- Add robust searching through `syncFileCache` in addition to `dropzone.files` in `cancelUploads`
 - Remove all pending uploads from `syncFileCache` when `row` is not specified
 - Search through `syncFileCache` for `row` if provider is part of `SYNC_UPLOAD_ADDONS`
- Prevent removing from UI (`tb.deleteNode`) unless file to cancel is found
- Optimize filtering `dropzone.files` for cancellable files
- Add comments to `cancelUploads`
- Manually append next file in `syncFileCache` to `dropzone.files` when queued upload starts

_Note that files with synchronous providers may not actually appear in `syncFileCache` if they are currently being uploaded by `dropzone`._

## Side effects

Could affect uploading to asynchronous providers, but unlikely—it should be _more_ reliable, since the file is not removed from the UI unless it is actually cancelled. Tested working with Box.

## Ticket

https://openscience.atlassian.net/browse/OSF-5459
