### PR TITLE
Remove overflow scrollbar on Wiki Edit pane [OSF-5970]

### DIFF
--- a/website/addons/wiki/templates/edit.mako
+++ b/website/addons/wiki/templates/edit.mako
@@ -123,7 +123,7 @@
                  class="${'col-sm-{0}'.format(12 / num_columns)}"
                  style="${'' if 'edit' in panels_used else 'display: none' | n}">
               <form id="wiki-form" action="${urls['web']['edit']}" method="POST">
-                <div class="osf-panel panel panel-default" data-bind="css: { 'no-border': $root.singleVis() === 'edit' }">
+                <div class="osf-panel panel panel-default osf-panel-edit" data-bind="css: { 'no-border': $root.singleVis() === 'edit' }">
                   <div class="panel-heading wiki-panel-header clearfix" data-bind="css : { 'wiki-single-heading': $root.singleVis() === 'edit' }">
                     <div class="row">
                       <div class="col-md-6">

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -373,13 +373,18 @@ a {
 
 /* OSF-panel */
 
-/* 
-formatting for the osf-panel in the Wiki.
-*/
 .osf-panel {
     border: 1px solid #ddd;
     display: block;
     position: relative;
+	overflow-x: hidden;
+	overflow: auto;
+	height: 764px;
+}
+
+/* removes the automatic height and overflow properties from the Edit Wiki pane */
+.osf-panel-edit {
+	height: auto;
 }
 
 @media (max-width: 991px) {

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -375,16 +375,16 @@ a {
 
 .osf-panel {
     border: 1px solid #ddd;
+    height: 764px;
+    overflow: auto;
     display: block;
     position: relative;
-	overflow-x: hidden;
-	overflow: auto;
-	height: 764px;
+    overflow-x: hidden;
 }
 
 /* removes the automatic height and overflow properties from the Edit Wiki pane */
 .osf-panel-edit {
-	height: auto;
+    height: auto;
 }
 
 @media (max-width: 991px) {

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -372,13 +372,14 @@ a {
 }
 
 /* OSF-panel */
+
+/* 
+formatting for the osf-panel in the Wiki.
+*/
 .osf-panel {
     border: 1px solid #ddd;
-    height: 764px;
-    overflow: auto;
     display: block;
     position: relative;
-    overflow-x: hidden;
 }
 
 @media (max-width: 991px) {


### PR DESCRIPTION
## Purpose

On the Wiki Edit pane, the setup of the Revert/Save buttons made the box have an overflow.  This was unnecessary for the interface, and didn't make it very user-friendly.  
![scroll_bar](https://cloud.githubusercontent.com/assets/19379783/15430370/176439ea-1e73-11e6-80b3-6502ae8a67d5.png)

The purpose of this PR is to remove the scrollbar on the Edit pane.  The scrollbar appeared by default on the pane when the page loaded.  


## Changes

Currently when a user goes to the Edit pane on their Wiki page, the scrollbar will appear by default on the Edit pane.  All of the changes made for this PR involve fixing the styling on the Edit pane in order to remove the scrollbar.  

The main changes included getting rid of the fixed height and overflow properties for the Edit pane. 
![screen shot 2016-05-19 at 4 39 57 pm](https://cloud.githubusercontent.com/assets/19379783/15438052/628be420-1e98-11e6-9824-74636cf67202.png)
 


## Side effects

Shouldn't be any


## Ticket

<a href="https://openscience.atlassian.net/browse/OSF-5970">https://openscience.atlassian.net/browse/OSF-5970</a>