### PR TITLE
unconfigured add-ons display widget to non-contributors [OSF-4161]

### DIFF
--- a/website/templates/project/addon/widget.mako
+++ b/website/templates/project/addon/widget.mako
@@ -1,5 +1,5 @@
-<div class="panel panel-default" name="${short_name}">
-
+% if complete or 'write' in user['permissions']:
+    <div class="panel panel-default" name="${short_name}" id="div">
             <div class="panel-heading clearfix">
                 <h3 class="panel-title">${full_name}</h3>
                 <div class="pull-right">
@@ -9,6 +9,9 @@
 
                 </div>
             </div>
+    % else:
+        <div>
+    % endif
 
     % if complete:
 
@@ -16,7 +19,7 @@
             ${self.body()}
         </div>
 
-    % else:
+    % elif not complete and 'admin' in user['permissions']:
 
         <div mod-meta='{
                 "tpl": "project/addon/config_error.mako",

--- a/website/templates/project/addon/widget.mako
+++ b/website/templates/project/addon/widget.mako
@@ -19,7 +19,7 @@
             ${self.body()}
         </div>
 
-    % elif not complete and 'admin' in user['permissions']:
+    % elif not complete and 'write' in user['permissions']:
 
         <div mod-meta='{
                 "tpl": "project/addon/config_error.mako",


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Currently users who do not have the ability to contribute to a project can see when that project has unconfigured add-ons. After this change, they will not be able to see what is not configured. 

## Changes

non-contributors can no longer see add-ons that are not configured

BEFORE:
![screen shot 2016-05-20 at 2 39 54 pm](https://cloud.githubusercontent.com/assets/12522393/15438400/fe7f6234-1e99-11e6-8f9c-e6cd589ad312.png)

AFTER: (with one add-on set to configured)
![screen shot 2016-05-20 at 2 40 14 pm](https://cloud.githubusercontent.com/assets/12522393/15438427/135a566e-1e9a-11e6-85e6-5a7a69ec33fa.png)



## Side effects

None.


## Ticket

https://openscience.atlassian.net/browse/OSF-4161