### PR TITLE
[Feature] Allow embargo registrations at 3 days out [OSF-4304]

### DIFF
--- a/website/static/js/_allLogTexts.js
+++ b/website/static/js/_allLogTexts.js
@@ -35,7 +35,7 @@ var logActions = {
     'file_updated' : '${user} updated file in ${node}', 
     'file_removed' : '${user} removed file ${path} from ${node}', 
     'file_restored' : '${user} restored file ${path} from ${node}', 
-    'comment_added' : '${user} added a comment to ${node}', 
+    'comment_added' : '${user} added a comment to ${node}',
     'comment_removed' : '${user} deleted a comment from ${node}', 
     'comment_updated' : '${user} updated a comment on ${node}', 
     'embargo_initiated' : '${user} initiated an embargoed registration of ${node}', 

--- a/website/static/js/logTextParser.js
+++ b/website/static/js/logTextParser.js
@@ -89,6 +89,7 @@ var LogText = {
             return false;
         };
         var logText = function() {
+            console.log(logObject);
             var text = logActions[logObject.attributes.action];
             if (text) {
                 if (text.indexOf('${user}') !== -1) {

--- a/website/static/js/logTextParser.js
+++ b/website/static/js/logTextParser.js
@@ -89,7 +89,6 @@ var LogText = {
             return false;
         };
         var logText = function() {
-            console.log(logObject);
             var text = logActions[logObject.attributes.action];
             if (text) {
                 if (text.indexOf('${user}') !== -1) {

--- a/website/static/js/registrationModal.js
+++ b/website/static/js/registrationModal.js
@@ -48,27 +48,25 @@ var RegistrationViewModel = function(confirm, prompts, validator) {
         return moment(new Date(self.pikaday())).subtract(utcOffset, 'minutes');
     });
 
-    self.minimumTimeValidation = function (embargoLocalDateTime) {
+    self.minimumTimeValidation = function (x, y, embargoLocalDateTime) {
         var minEmbargoMoment = getMinimumDate(embargoLocalDateTime),
             endEmbargoMoment = self.embargoEndDate();
         return minEmbargoMoment.isBefore(endEmbargoMoment);
     };
 
-    self.maximumTimeValidation = function (embargoLocalDateTime) {
+    self.maximumTimeValidation = function (x, y, embargoLocalDateTime) {
         var maxEmbargoMoment = getMaximumDate(embargoLocalDateTime),
             endEmbargoMoment = self.embargoEndDate();
         return maxEmbargoMoment.isAfter(endEmbargoMoment);
     };
 
     var validation = [{
-        validator: function () {
-            return self.minimumTimeValidation();
-        },
+        validator: self.minimumTimeValidation
+        ,
         message: 'Embargo end date must be at least three days in the future.'
     }, {
-        validator: function () {
-            return self.maximumTimeValidation();
-        },
+        validator: self.maximumTimeValidation
+        ,
         message: 'Embargo end date must be less than four years in the future.'
     }];
     if(validator) {

--- a/website/static/js/registrationModal.js
+++ b/website/static/js/registrationModal.js
@@ -52,14 +52,14 @@ var RegistrationViewModel = function(confirm, prompts, validator) {
 
     var validation = [{
         validator: function() {
-            var endEmbargoDateTimestamp = self.embargoEndDate().getTime();
+            var endEmbargoDateTimestamp = self.embargoEndDate().getTime() + (self.embargoEndDate().getTimezoneOffset() * 60000);
             return endEmbargoDateTimestamp > TWO_DAYS_FROM_TODAY_TIMESTAMP;
         },
         message: 'Embargo end date must be at least three days in the future.'
     }, {
 	validator: function() {
             var endEmbargoDateTimestamp = self.embargoEndDate().getTime();
-	    return endEmbargoDateTimestamp < FOUR_YEARS_FROM_TODAY_TIMESTAMP;
+	        return endEmbargoDateTimestamp < FOUR_YEARS_FROM_TODAY_TIMESTAMP;
 	},
 	message: 'Embargo end date must be less than four years in the future.'
     }];

--- a/website/static/js/registrationModal.js
+++ b/website/static/js/registrationModal.js
@@ -61,12 +61,10 @@ var RegistrationViewModel = function(confirm, prompts, validator) {
     };
 
     var validation = [{
-        validator: self.minimumTimeValidation
-        ,
+        validator: self.minimumTimeValidation,
         message: 'Embargo end date must be at least three days in the future.'
     }, {
-        validator: self.maximumTimeValidation
-        ,
+        validator: self.maximumTimeValidation,
         message: 'Embargo end date must be less than four years in the future.'
     }];
     if(validator) {

--- a/website/static/js/registrationModal.js
+++ b/website/static/js/registrationModal.js
@@ -3,6 +3,7 @@ var pikaday = require('pikaday');
 require('pikaday-css');
 var bootbox = require('bootbox');
 var $ = require('jquery');
+var moment = require('moment');
 var $osf = require('js/osfHelpers');
 var language = require('js/osfLanguage').registrations;
 
@@ -52,15 +53,14 @@ var RegistrationViewModel = function(confirm, prompts, validator) {
 
     var validation = [{
         validator: function() {
-            var timeZoneOffset = self.embargoEndDate().getTimezoneOffset() * (60 * 1000);
-            var endEmbargoDateTimestamp = self.embargoEndDate().getTime() + timeZoneOffset;
-            return endEmbargoDateTimestamp > TWO_DAYS_FROM_TODAY_TIMESTAMP;
+            var endEmbargoMoment = moment(self.embargoEndDate()).subtract(moment().utcOffset(), 'm');
+            return endEmbargoMoment.valueOf() > TWO_DAYS_FROM_TODAY_TIMESTAMP;
         },
         message: 'Embargo end date must be at least three days in the future.'
     }, {
 	validator: function() {
-            var endEmbargoDateTimestamp = self.embargoEndDate().getTime();
-	        return endEmbargoDateTimestamp < FOUR_YEARS_FROM_TODAY_TIMESTAMP;
+            var endEmbargoMoment = moment(self.embargoEndDate()).subtract(moment().utcOffset(), 'm');
+        return endEmbargoMoment < FOUR_YEARS_FROM_TODAY_TIMESTAMP;
 	},
 	message: 'Embargo end date must be less than four years in the future.'
     }];

--- a/website/static/js/registrationModal.js
+++ b/website/static/js/registrationModal.js
@@ -52,7 +52,8 @@ var RegistrationViewModel = function(confirm, prompts, validator) {
 
     var validation = [{
         validator: function() {
-            var endEmbargoDateTimestamp = self.embargoEndDate().getTime() + (self.embargoEndDate().getTimezoneOffset() * 60000);
+            var timeZoneOffset = self.embargoEndDate().getTimezoneOffset() * (60 * 1000);
+            var endEmbargoDateTimestamp = self.embargoEndDate().getTime() + timeZoneOffset;
             return endEmbargoDateTimestamp > TWO_DAYS_FROM_TODAY_TIMESTAMP;
         },
         message: 'Embargo end date must be at least three days in the future.'

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -617,7 +617,7 @@ Draft.prototype.preRegisterPrompts = function(response, confirm) {
         };
     }
     var preRegisterPrompts = response.prompts || [];
-
+    
     var registrationModal = new RegistrationModal.ViewModel(
         confirm, preRegisterPrompts, validator
     );

--- a/website/static/js/tests/registrationModal.test.js
+++ b/website/static/js/tests/registrationModal.test.js
@@ -111,22 +111,22 @@ describe('registrationModal', () => {
         it('returns true for date more than 2 days in the future', () => {
             var validDateTwoDays = new Date(2016, 0, 1);
             vm.pikaday(new Date (2016, 0, 4));
-            assert.isTrue(vm.minimumTimeValidation(validDateTwoDays));
+            assert.isTrue(vm.minimumTimeValidation(null, null, validDateTwoDays));
         });
         it('returns true for date less than 4 years in the future', () => {
             var validDateFourYears = new Date(2016, 0, 1);
             vm.pikaday(new Date (2019, 11, 30));
-            assert.isTrue(vm.maximumTimeValidation(validDateFourYears));
+            assert.isTrue(vm.maximumTimeValidation(null, null, validDateFourYears));
         });
         it('returns false for date less than 2 days in the future', () => {
             var invalidDateTwoDays = new Date(2016, 0, 1);
             vm.pikaday(new Date (2016, 0, 2));
-            assert.isFalse(vm.minimumTimeValidation(invalidDateTwoDays));
+            assert.isFalse(vm.minimumTimeValidation(null, null, invalidDateTwoDays));
         });
         it('returns false for date at least 4 years in the future', () => {
             var invalidDateFourYears = new Date(2016, 0, 1);
             vm.pikaday(new Date (2020, 0, 1));
-            assert.isFalse(vm.maximumTimeValidation(invalidDateFourYears));
+            assert.isFalse(vm.maximumTimeValidation(null, null, invalidDateFourYears));
         });
         it('returns true for date more than 2 days in the future, regardless of time zone', () => {
             var validDateTwoDaysTZ = new Date(2016, 0, 1);
@@ -134,17 +134,63 @@ describe('registrationModal', () => {
             var validDateTZFuture = new Date(validDateTwoDaysTZ);
             validDateTZFuture.setDate(validDateTwoDaysTZ.getDate() + 3);
             vm.pikaday(validDateTZFuture);
-            assert.isTrue(vm.minimumTimeValidation(validDateTwoDaysTZ));
+            assert.isTrue(vm.minimumTimeValidation(null, null, validDateTwoDaysTZ));
         });
         it('returns true for date less than 4 years in the future, regardless of time zone', () => {
             var validDateFourYearsTZ = new Date(2016, 0, 1);
             validDateFourYearsTZ.setMinutes(validDateFourYearsTZ.getMinutes() - validDateFourYearsTZ.getTimezoneOffset());
-            console.log(validDateFourYearsTZ);
             var validDateTZFutureYears = new Date(validDateFourYearsTZ);
-            validDateTZFutureYears.setDate(validDateTZFutureYears.getDate() + 1460);
-            console.log(validDateTZFutureYears);
+            validDateTZFutureYears.setDate(validDateTZFutureYears.getDate() + 1459);
             vm.pikaday(validDateTZFutureYears);
-            assert.isTrue(vm.maximumTimeValidation(validDateTZFutureYears));
+            assert.isTrue(vm.maximumTimeValidation(null, null, validDateFourYearsTZ));
+        });
+        it('returns false for date less than 2 days in the future, regardless of time zone', () => {
+            var invalidDateTwoDaysTZ = new Date(2016, 0, 1);
+            invalidDateTwoDaysTZ.setMinutes(invalidDateTwoDaysTZ.getMinutes() - invalidDateTwoDaysTZ.getTimezoneOffset());
+            var invalidDateTZFuture = new Date(invalidDateTwoDaysTZ);
+            invalidDateTZFuture.setDate(invalidDateTwoDaysTZ.getDate() + 1);
+            vm.pikaday(invalidDateTZFuture);
+            assert.isFalse(vm.minimumTimeValidation(null, null, invalidDateTwoDaysTZ));
+        });
+        it('returns false for date at least 4 years in the future, regardless of time zone', () => {
+            var invalidDateFourYearsTZ = new Date(2016, 0, 1);
+            invalidDateFourYearsTZ.setMinutes(invalidDateFourYearsTZ.getMinutes() - invalidDateFourYearsTZ.getTimezoneOffset());
+            var invalidDateTZFutureYears = new Date(invalidDateFourYearsTZ);
+            invalidDateTZFutureYears.setDate(invalidDateTZFutureYears.getDate() + 1460);
+            vm.pikaday(invalidDateTZFutureYears);
+            assert.isFalse(vm.maximumTimeValidation(null, null, invalidDateFourYearsTZ));
+        });
+        it('returns true for date more than 2 days in the future, in a western timezone', () => {
+            var validDateTwoDaysTZWest = moment().utcOffset(-4).toDate();
+            validDateTwoDaysTZWest.setMinutes(validDateTwoDaysTZWest.getMinutes() - validDateTwoDaysTZWest.getTimezoneOffset());
+            var validDateTZFutureWest = new Date(validDateTwoDaysTZWest);
+            validDateTZFutureWest.setDate(validDateTwoDaysTZWest.getDate() + 3);
+            vm.pikaday(validDateTZFutureWest);
+            assert.isTrue(vm.minimumTimeValidation(null, null, validDateTwoDaysTZWest));
+        });
+        it('returns true for date more than 2 days in the future, in an eastern timezone', () => {
+            var validDateTwoDaysTZEast = moment().utcOffset(4).toDate();
+            validDateTwoDaysTZEast.setMinutes(validDateTwoDaysTZEast.getMinutes() - validDateTwoDaysTZEast.getTimezoneOffset());
+            var validDateTZFutureEast = new Date(validDateTwoDaysTZEast);
+            validDateTZFutureEast.setDate(validDateTwoDaysTZEast.getDate() + 3);
+            vm.pikaday(validDateTZFutureEast);
+            assert.isTrue(vm.minimumTimeValidation(null, null, validDateTwoDaysTZEast));
+        });
+        it('returns true for date less than 4 years in the future, in a western timezone', () => {
+            var validDateFourYearsTZWest = moment().utcOffset(-4).toDate();
+            validDateFourYearsTZWest.setMinutes(validDateFourYearsTZWest.getMinutes() - validDateFourYearsTZWest.getTimezoneOffset());
+            var validDateTZFutureWest = new Date(validDateFourYearsTZWest);
+            validDateTZFutureWest.setDate(validDateFourYearsTZWest.getDate() + 1459);
+            vm.pikaday(validDateTZFutureWest);
+            assert.isTrue(vm.maximumTimeValidation(null, null, validDateFourYearsTZWest));
+        });
+        it('returns true for date less than 4 years in the future, in a western timezone', () => {
+            var validDateFourYearsTZEast = moment().utcOffset(4).toDate();
+            validDateFourYearsTZEast.setMinutes(validDateFourYearsTZEast.getMinutes() - validDateFourYearsTZEast.getTimezoneOffset());
+            var validDateTZFutureEastFY = new Date(validDateFourYearsTZEast);
+            validDateTZFutureEastFY.setDate(validDateFourYearsTZEast.getDate() + 1459);
+            vm.pikaday(validDateTZFutureEastFY);
+            assert.isTrue(vm.maximumTimeValidation(null, null, validDateFourYearsTZEast));
         });
     });
 });

--- a/website/static/js/tests/registrationModal.test.js
+++ b/website/static/js/tests/registrationModal.test.js
@@ -128,38 +128,6 @@ describe('registrationModal', () => {
             vm.pikaday(new Date (2020, 0, 1));
             assert.isFalse(vm.maximumTimeValidation(null, null, invalidDateFourYears));
         });
-        it('returns true for date more than 2 days in the future, regardless of time zone', () => {
-            var validDateTwoDaysTZ = new Date(2016, 0, 1);
-            validDateTwoDaysTZ.setMinutes(validDateTwoDaysTZ.getMinutes() - validDateTwoDaysTZ.getTimezoneOffset());
-            var validDateTZFuture = new Date(validDateTwoDaysTZ);
-            validDateTZFuture.setDate(validDateTwoDaysTZ.getDate() + 3);
-            vm.pikaday(validDateTZFuture);
-            assert.isTrue(vm.minimumTimeValidation(null, null, validDateTwoDaysTZ));
-        });
-        it('returns true for date less than 4 years in the future, regardless of time zone', () => {
-            var validDateFourYearsTZ = new Date(2016, 0, 1);
-            validDateFourYearsTZ.setMinutes(validDateFourYearsTZ.getMinutes() - validDateFourYearsTZ.getTimezoneOffset());
-            var validDateTZFutureYears = new Date(validDateFourYearsTZ);
-            validDateTZFutureYears.setDate(validDateTZFutureYears.getDate() + 1459);
-            vm.pikaday(validDateTZFutureYears);
-            assert.isTrue(vm.maximumTimeValidation(null, null, validDateFourYearsTZ));
-        });
-        it('returns false for date less than 2 days in the future, regardless of time zone', () => {
-            var invalidDateTwoDaysTZ = new Date(2016, 0, 1);
-            invalidDateTwoDaysTZ.setMinutes(invalidDateTwoDaysTZ.getMinutes() - invalidDateTwoDaysTZ.getTimezoneOffset());
-            var invalidDateTZFuture = new Date(invalidDateTwoDaysTZ);
-            invalidDateTZFuture.setDate(invalidDateTwoDaysTZ.getDate() + 1);
-            vm.pikaday(invalidDateTZFuture);
-            assert.isFalse(vm.minimumTimeValidation(null, null, invalidDateTwoDaysTZ));
-        });
-        it('returns false for date at least 4 years in the future, regardless of time zone', () => {
-            var invalidDateFourYearsTZ = new Date(2016, 0, 1);
-            invalidDateFourYearsTZ.setMinutes(invalidDateFourYearsTZ.getMinutes() - invalidDateFourYearsTZ.getTimezoneOffset());
-            var invalidDateTZFutureYears = new Date(invalidDateFourYearsTZ);
-            invalidDateTZFutureYears.setDate(invalidDateTZFutureYears.getDate() + 1460);
-            vm.pikaday(invalidDateTZFutureYears);
-            assert.isFalse(vm.maximumTimeValidation(null, null, invalidDateFourYearsTZ));
-        });
         it('returns true for date more than 2 days in the future, in a western timezone', () => {
             var validDateTwoDaysTZWest = moment().utcOffset(-4).toDate();
             validDateTwoDaysTZWest.setMinutes(validDateTwoDaysTZWest.getMinutes() - validDateTwoDaysTZWest.getTimezoneOffset());
@@ -184,7 +152,7 @@ describe('registrationModal', () => {
             vm.pikaday(validDateTZFutureWest);
             assert.isTrue(vm.maximumTimeValidation(null, null, validDateFourYearsTZWest));
         });
-        it('returns true for date less than 4 years in the future, in a western timezone', () => {
+        it('returns true for date less than 4 years in the future, in an eastern timezone', () => {
             var validDateFourYearsTZEast = moment().utcOffset(4).toDate();
             validDateFourYearsTZEast.setMinutes(validDateFourYearsTZEast.getMinutes() - validDateFourYearsTZEast.getTimezoneOffset());
             var validDateTZFutureEastFY = new Date(validDateFourYearsTZEast);


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

When attempting to embargo a Registration, if the user attempts to pick a date 3 days away (as is required to Embargo) after 8pm, the system informs them that they must pick a date at least 3 days away, and won't let them pick that date (ie. On August 31st 8:36pm, the calendar does not recognize September 3rd as a valid date). The problem lied in the timezone difference between local time and UTC time. There is a four hour difference (hence why it had a problem starting at 8pm). So the valid date calculation needed to account for the time zone difference.

## Changes

- Added the Timezone Offset when calculating the chosen end date in milliseconds
- Fixed some of formatting.

## Side effects

- The max length (4 years) might have a similar issue to this.

## Ticket

https://openscience.atlassian.net/browse/OSF-4304