### PR TITLE
Dev/feat/math typesetting for share search results [OSF-6020]

### DIFF
--- a/website/static/js/mathrender.js
+++ b/website/static/js/mathrender.js
@@ -22,7 +22,30 @@ function mathjaxify(selector) {
     }
 }
 
+// Helper function takes an element node and typesets its math markup.
+// This can now be mapped over a nodelist or the like.
+function typeset(el) {
+
+    // If our element is not an element node, it can't have an id,
+    // and so MathJax cannot process it. Let's return from the funciton early.                  
+    if (el.nodeType !== 1) return false;
+    
+    // MathJax has issues getting loaded by webpack? Right now, it's getting 
+    // included in the file website/templates/share_search.mako, 
+    // where there is also some configuration happening.
+
+    // Make sure we're doing this in a browser...
+    // This isn't _really_ a good enough guard against this getting 
+    // run on the server, but hopefully we don't define window...
+    if (typeof window === 'undefined') return;
+        
+    // Add an element by its id to MAthJax Queue to typeset.
+    // As soon as MathJax has a queue, it'll start typesetting.
+    window.MathJax.Hub.Queue(['Typeset', MathJax.Hub, el]);
+
+}
 
 module.exports = {
+    typeset: typeset
     mathjaxify: mathjaxify
 };

--- a/website/static/js/mathrender.js
+++ b/website/static/js/mathrender.js
@@ -46,6 +46,6 @@ function typeset(el) {
 }
 
 module.exports = {
-    typeset: typeset
+    typeset: typeset,
     mathjaxify: mathjaxify
 };

--- a/website/static/js/mathrender.js
+++ b/website/static/js/mathrender.js
@@ -26,8 +26,7 @@ function mathjaxify(selector) {
 // This can now be mapped over a nodelist or the like.
 function typeset(el) {
 
-    // If our element is not an element node, it can't have an id,
-    // and so MathJax cannot process it. Let's return from the funciton early.                  
+    // Ignore nodes that aren't elements.
     if (el.nodeType !== 1) return false;
     
     // MathJax has issues getting loaded by webpack? Right now, it's getting 

--- a/website/static/js/share/results.js
+++ b/website/static/js/share/results.js
@@ -92,11 +92,7 @@ var TitleBar = {
     view: function(ctrl, params) {
         var result = params.result;
         return m('span', {}, [
-            m('a[href=' + result.uris.canonicalUri + ']', {
-                config: function(el, ini, ctx) {
-                    // mathrender.typeset(el) // Typeset each title as it's loaded into the DOM.
-                }
-            }, ((result.title || 'No title provided'))),
+            m('a[href=' + result.uris.canonicalUri + ']', ((result.title || 'No title provided'))),
             m('br'),
             m.component(Description, params)
         ]);
@@ -118,18 +114,11 @@ var Description = {
             return m('', [
                 m('p.readable.pointer', {
                     onclick: showOnClick,
-                    config: function(el, ini, ctx) {
-                        // mathrender.typeset(el) // Typeset each desctiption as it's loaded into the DOM.
-                    }
                 }, ctrl.showAll() ? result.description : $.truncate(result.description, {length: 350})),
                 m('a.sr-only', {href: '#', onclick: showOnClick}, ctrl.showAll() ? 'See less' : 'See more')
             ]);
         } else {
-            return m('p.readable', {
-                config: function(el, ini, ctx) {
-                    // mathrender.typeset(el) // Typeset each description as it's loaded into the DOM.
-                }
-            }, result.description);
+            return m('p.readable', result.description);
         }
     }
 };

--- a/website/static/js/share/results.js
+++ b/website/static/js/share/results.js
@@ -5,6 +5,7 @@ var $ = require('jquery');
 var m = require('mithril');
 var $osf = require('js/osfHelpers');
 var utils = require('./utils');
+var mathrender = require('js/mathrender');
 require('truncate');
 
 var LoadingIcon = {
@@ -17,7 +18,7 @@ var Results = {
     view: function(ctrl, params) {
         var vm = params.vm;
         var resultViews = $.map(vm.results || [], function(result, i) {
-            return m.component(Result, {result: result, vm: vm,});
+            return m.component(Result, {result: result, vm: vm});
         });
 
 
@@ -37,7 +38,11 @@ var Results = {
         };
 
         return m('', [
-            m('.row', m('.col-md-12', maybeResults(resultViews, vm.resultsLoading()))),
+            m('.row', m('.col-md-12', {
+                config: function(el, ini, ctx) {
+                    mathrender.typeset(el); // Adds all results to Mathjax queue at once.
+                }
+            }, maybeResults(resultViews, vm.resultsLoading()))),
             m('.row', m('.col-md-12', m('div', {style: {display: 'block', margin: 'auto', 'text-align': 'center'}},
                 len > 0 && len < vm.count ?
                 m('a.btn.btn-md.btn-default', {
@@ -87,7 +92,11 @@ var TitleBar = {
     view: function(ctrl, params) {
         var result = params.result;
         return m('span', {}, [
-            m('a[href=' + result.uris.canonicalUri + ']', ((result.title || 'No title provided'))),
+            m('a[href=' + result.uris.canonicalUri + ']', {
+                config: function(el, ini, ctx) {
+                    // mathrender.typeset(el) // Typeset each title as it's loaded into the DOM.
+                }
+            }, ((result.title || 'No title provided'))),
             m('br'),
             m.component(Description, params)
         ]);
@@ -107,12 +116,20 @@ var Description = {
         };
         if ((result.description || '').length > 350) {
             return m('', [
-                m('p.readable.pointer', {onclick: showOnClick},
-                    ctrl.showAll() ? result.description : $.truncate(result.description, {length: 350})
-                ),
-                m('a.sr-only', {href: '#', onclick: showOnClick}, ctrl.showAll() ? 'See less' : 'See more')]);
+                m('p.readable.pointer', {
+                    onclick: showOnClick,
+                    config: function(el, ini, ctx) {
+                        // mathrender.typeset(el) // Typeset each desctiption as it's loaded into the DOM.
+                    }
+                }, ctrl.showAll() ? result.description : $.truncate(result.description, {length: 350})),
+                m('a.sr-only', {href: '#', onclick: showOnClick}, ctrl.showAll() ? 'See less' : 'See more')
+            ]);
         } else {
-            return m('p.readable', result.description);
+            return m('p.readable', {
+                config: function(el, ini, ctx) {
+                    // mathrender.typeset(el) // Typeset each description as it's loaded into the DOM.
+                }
+            }, result.description);
         }
     }
 };

--- a/website/static/js/share/utils.js
+++ b/website/static/js/share/utils.js
@@ -60,9 +60,7 @@ utils.updateVM = function(vm, data) {
     });
     vm.results.push.apply(vm.results, data.results);
     m.redraw();
-    $.map(callbacks, function(cb) {
-        cb();
-    });
+    callbacks.map(function(cb) { cb(); });
 };
 
 /* Handles searching via the search API */

--- a/website/templates/share_search.mako
+++ b/website/templates/share_search.mako
@@ -1,15 +1,16 @@
 <%inherit file="base.mako"/>
 <%def name="title()">SHARE</%def>
 <%def name="content()">
-  <script type="text/javascript" src="/static/vendor/bower_componenets/MathJax/unpacked/MathJax.js?configi=TeX-AMS-MML_HTMLorMML"></script>
-  <script type='text/javascript'>
-    window.MathJax.Hub.Config({
-      tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}
-    });
-  </script>  
-  <div id="shareSearch"></div>
+
+    <div id="shareSearch"></div>
 </%def>
 
 <%def name="javascript_bottom()">
+    <script type="text/javascript" src="/static/vendor/bower_componenets/MathJax/unpacked/MathJax.js?configi=TeX-AMS-MML_HTMLorMML"></script>
+    <script type='text/javascript'>
+        window.MathJax.Hub.Config({
+            tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}
+        });
+    </script>  
     <script src=${"/static/public/js/share-search-page.js" | webpack_asset}></script>
 </%def>

--- a/website/templates/share_search.mako
+++ b/website/templates/share_search.mako
@@ -1,6 +1,12 @@
 <%inherit file="base.mako"/>
 <%def name="title()">SHARE</%def>
 <%def name="content()">
+  <script type="text/javascript" src="/static/vendor/bower_componenets/MathJax/unpacked/MathJax.js?configi=TeX-AMS-MML_HTMLorMML"></script>
+  <script type='text/javascript'>
+    window.MathJax.Hub.Config({
+      tex2jax: {inlineMath: [['$','$'], ['\\(','\\)']]}
+    });
+  </script>  
   <div id="shareSearch"></div>
 </%def>
 


### PR DESCRIPTION
Purpose

Allow math ml to render in a beautiful and pleasing manner in the results of share searches.

Changes

included mathjax script on the page, set up hooks to add certain elements to the mathjax queue once they're loaded into the dom.

Side effects

It'll typeset any markup in tags or contributor's names. It'll probably break in ie6.

Ticket

https://openscience.atlassian.net/browse/OSF-6020
