### PR TITLE
[Feature] Recognizes URLs in project comments [OSF-598]

### DIFF
--- a/website/static/js/comment.js
+++ b/website/static/js/comment.js
@@ -656,7 +656,7 @@ var onOpen = function(page, rootId, nodeApiUrl, currentUserId) {
 
 function replaceURLWithHTMLLinks (text) {
     var exp = /(\b(http|ftp|https):\/\/([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:/~+#-]*[\w@?^=%&/~+#-])?)/ig;
-    return text.replace(exp,"<a href='$1'>$1</a>");
+    return text.replace(exp,'<a href=\'$1\'>$1</a>');
 }
 
 /* options example: {

--- a/website/static/js/comment.js
+++ b/website/static/js/comment.js
@@ -271,6 +271,7 @@ var CommentModel = function(data, $parent, $root) {
     self.$root = $root;
 
     self.id = ko.observable(data.id);
+    data.attributes.content = replaceURLWithHTMLLinks(data.attributes.content);
     self.content = ko.observable(data.attributes.content || '');
     self.page = ko.observable(data.attributes.page);
     self.dateCreated = ko.observable(data.attributes.date_created);
@@ -299,9 +300,7 @@ var CommentModel = function(data, $parent, $root) {
     } else {
         self.author = self.$root.author;
     }
-
     self.contentDisplay = ko.observable(markdown.full.render(self.content()));
-
     // Update contentDisplay with rendered markdown whenever content changes
     self.content.subscribe(function(newContent) {
         self.contentDisplay(markdown.full.render(newContent));
@@ -655,6 +654,11 @@ var onOpen = function(page, rootId, nodeApiUrl, currentUserId) {
     });
     return request;
 };
+
+function replaceURLWithHTMLLinks (text) {
+    var exp = /(\b(http|ftp|https):\/\/([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:/~+#-]*[\w@?^=%&/~+#-])?)/ig;
+    return text.replace(exp,"<a href=\"$1\">$1</a>")
+}
 
 /* options example: {
  *      nodeId: Node._id,

--- a/website/static/js/comment.js
+++ b/website/static/js/comment.js
@@ -271,7 +271,6 @@ var CommentModel = function(data, $parent, $root) {
     self.$root = $root;
 
     self.id = ko.observable(data.id);
-    data.attributes.content = replaceURLWithHTMLLinks(data.attributes.content);
     self.content = ko.observable(data.attributes.content || '');
     self.page = ko.observable(data.attributes.page);
     self.dateCreated = ko.observable(data.attributes.date_created);
@@ -300,7 +299,7 @@ var CommentModel = function(data, $parent, $root) {
     } else {
         self.author = self.$root.author;
     }
-    self.contentDisplay = ko.observable(markdown.full.render(self.content()));
+    self.contentDisplay = ko.observable(replaceURLWithHTMLLinks(markdown.full.render(self.content())));
     // Update contentDisplay with rendered markdown whenever content changes
     self.content.subscribe(function(newContent) {
         self.contentDisplay(markdown.full.render(newContent));
@@ -657,7 +656,7 @@ var onOpen = function(page, rootId, nodeApiUrl, currentUserId) {
 
 function replaceURLWithHTMLLinks (text) {
     var exp = /(\b(http|ftp|https):\/\/([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:/~+#-]*[\w@?^=%&/~+#-])?)/ig;
-    return text.replace(exp,"<a href=\"$1\">$1</a>")
+    return text.replace(exp,"<a href='$1'>$1</a>");
 }
 
 /* options example: {


### PR DESCRIPTION
## Purpose

Allow users to comment usable links by URL.

## Changes

Before comments are displayed, a function is run which searches the comment for URLs and replaces them with a link to that URL.

Before:
<img src='http://i.imgur.com/mHOI1U7.png'/>

After:
<img src='http://i.imgur.com/NiTGn9Z.png'/>

## Side effects

It's possible that the regex expression could pick up things that are not URLs and try to create links. This is pretty unlikely and would be very rare if there is an error.

## Ticket

https://openscience.atlassian.net/browse/OSF-598