### PR TITLE
[RFR][Feature][OSF-6300]File view pane, edit panel shows earlier version

### DIFF
--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -344,6 +344,9 @@ var FileViewPage = {
             if (self.file.size < 1048576 && fileType) { //May return false
                 var editor = EDITORS[fileType.split('/')[0]];
                 if (editor) {
+                    // next line is a temporary fix. "docId" should not be
+                    // getting passed to this point.
+                    self.editorMeta.docId = null;
                     self.editor = new Panel('Edit', self.editHeader, editor, [self.file.urls.content, self.file.urls.sharejs, self.editorMeta, self.shareJSObservables], false);
                 }
             }


### PR DESCRIPTION
## Purpose:
[OSF-6300](https://openscience.atlassian.net/browse/OSF-6300)
Fix to get latest version in file editor panel

## Changes:
Update website/static/js/filepage/index.js set docId to null just before creating file editor panel, ensuring latest version of file is loaded

## Side effects:
None

## Additional notes
I believe that docId is being erroneously set/passed upstream. This might merit additional investigation.

[#OSF-6300]