### PR TITLE
[hotfix] Allow non-editors to see project category and description

### DIFF
--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -180,13 +180,14 @@
                   <!-- /ko -->
                 </span>
                 <p>
-                    Category: <span id="nodeCategoryEditable"></span>
+                    Category: <span id="nodeCategoryEditable">${node['category']}</span>
                     <span data-bind="css: icon"></span>
                 </p>
 
                 % if (node['description']) or (not node['description'] and 'write' in user['permissions'] and not node['is_registration']):
                     <p>
-                    <span id="description">Description:</span> <span id="nodeDescriptionEditable" class="node-description overflow" data-type="textarea"></span>
+                    <span id="description">Description:</span> <span id="nodeDescriptionEditable" class="node-description overflow" data-type="textarea">
+                        ${node['description']}</span>
                     </p>
                 % endif
                 % if ('admin' in user['permissions'] or node['license'].get('name', 'No license') != 'No license'):


### PR DESCRIPTION
## Purpose
Fix regression introduced in #5617: ensure that non-editors can see project category and descriptions for public projects across the OSF. Hotfix to master: let me know what testing is needed.


This can be tested by looking at category and description of a public project when a user is logged out. Reported for: 
https://osf.io/e4rvz/

In my defense, the AJAX editor widgets were a nice improvement for the three people on earth who could see them. Smidge of a regression for the other 7 billion, though.

## Changes
Add a default value (from mako) for people who can't see the editor controls.
- People who are not editors on a project should see the CATEGORY and DESCRIPTION fields displayed correctly, as static text
<img width="619" alt="screen shot 2016-05-22 at 11 45 08 pm" src="https://cloud.githubusercontent.com/assets/2957073/15459836/6f0d2930-2077-11e6-880f-2c76f5158353.png">

- People who are editors on a project should have interactive editor widgets to change the title and description on the page
<img width="681" alt="screen shot 2016-05-22 at 11 46 23 pm" src="https://cloud.githubusercontent.com/assets/2957073/15459838/76fee2c8-2077-11e6-9fee-9d3de5380ec6.png">

## Side effects
Hopefully none, this time.

Since the editor widget will now be getting the text from two places (mako and JS), let me know if the editor widget acts strange.




## Ticket
https://openscience.atlassian.net/browse/OSF-6396