### PR TITLE
add Saving state to save button on profile

### DIFF
--- a/website/static/js/profile.js
+++ b/website/static/js/profile.js
@@ -729,7 +729,6 @@ SocialViewModel.prototype.submit = function() {
         );
     } else {
         this.showMessages(true);
-
     }
 };
 

--- a/website/static/js/profile.js
+++ b/website/static/js/profile.js
@@ -218,7 +218,7 @@ var BaseViewModel = function(urls, modes, preventUnsaved) {
     self.editAllowed = $.inArray('edit', self.modes) >= 0;
     self.editable = ko.observable(self.editAllowed);
     self.mode = ko.observable(self.editable() ? 'edit' : 'view');
-
+    self.saving = ko.observable(false);
     self.original = ko.observable();
     self.tracked = [];  // Define for each view model that inherits
 
@@ -268,6 +268,7 @@ BaseViewModel.prototype.changeMessage = function(text, css, timeout) {
 };
 
 BaseViewModel.prototype.handleSuccess = function() {
+    this.saving(false);
     if ($.inArray('view', this.modes) >= 0) {
         this.mode('view');
     } else {
@@ -280,6 +281,7 @@ BaseViewModel.prototype.handleSuccess = function() {
 };
 
 BaseViewModel.prototype.handleError = function(response) {
+    this.saving(false);
     var defaultMsg = 'Could not update settings';
     var msg = response.message_long || defaultMsg;
     this.changeMessage(
@@ -343,6 +345,7 @@ BaseViewModel.prototype.cancel = function(data, event) {
 };
 
 BaseViewModel.prototype.submit = function() {
+    this.saving(true);
     if (this.hasValidProperty() && this.isValid()) {
         $osf.putJSON(
             this.urls.crud,
@@ -356,6 +359,7 @@ BaseViewModel.prototype.submit = function() {
         );
     } else {
         this.showMessages(true);
+        this.saving(false);
     }
 };
 
@@ -703,6 +707,7 @@ SocialViewModel.prototype.unserialize = function(data) {
 };
 
 SocialViewModel.prototype.submit = function() {
+    this.saving(true);
     if (!this.hasValidWebsites()) {
         this.changeMessage(
             'Please update your website',
@@ -723,6 +728,8 @@ SocialViewModel.prototype.submit = function() {
         );
     } else {
         this.showMessages(true);
+        this.saving(false);
+
     }
 };
 

--- a/website/static/js/profile.js
+++ b/website/static/js/profile.js
@@ -268,7 +268,6 @@ BaseViewModel.prototype.changeMessage = function(text, css, timeout) {
 };
 
 BaseViewModel.prototype.handleSuccess = function() {
-    this.saving(false);
     if ($.inArray('view', this.modes) >= 0) {
         this.mode('view');
     } else {
@@ -281,7 +280,6 @@ BaseViewModel.prototype.handleSuccess = function() {
 };
 
 BaseViewModel.prototype.handleError = function(response) {
-    this.saving(false);
     var defaultMsg = 'Could not update settings';
     var msg = response.message_long || defaultMsg;
     this.changeMessage(
@@ -345,8 +343,8 @@ BaseViewModel.prototype.cancel = function(data, event) {
 };
 
 BaseViewModel.prototype.submit = function() {
-    this.saving(true);
     if (this.hasValidProperty() && this.isValid()) {
+        this.saving(true);
         $osf.putJSON(
             this.urls.crud,
             this.serialize()
@@ -356,10 +354,11 @@ BaseViewModel.prototype.submit = function() {
             this.setOriginal.bind(this)
         ).fail(
             this.handleError.bind(this)
+        ).always(
+            this.saving(false)
         );
     } else {
         this.showMessages(true);
-        this.saving(false);
     }
 };
 
@@ -707,7 +706,6 @@ SocialViewModel.prototype.unserialize = function(data) {
 };
 
 SocialViewModel.prototype.submit = function() {
-    this.saving(true);
     if (!this.hasValidWebsites()) {
         this.changeMessage(
             'Please update your website',
@@ -716,6 +714,7 @@ SocialViewModel.prototype.submit = function() {
         );
     }
     else if (this.hasValidProperty() && this.isValid()) {
+        this.saving(true);
         $osf.putJSON(
             this.urls.crud,
             this.serialize()
@@ -725,10 +724,11 @@ SocialViewModel.prototype.submit = function() {
             this.setOriginal.bind(this)
         ).fail(
             this.handleError.bind(this)
+        ).always(
+            this.saving(false)
         );
     } else {
         this.showMessages(true);
-        this.saving(false);
 
     }
 };

--- a/website/templates/include/profile/jobs.mako
+++ b/website/templates/include/profile/jobs.mako
@@ -109,6 +109,7 @@
                     >Discard changes</button>
 
                 <button
+                        data-bind="disable: saving(), text: saving() ? 'Saving' : 'Save'"
                         type="submit"
                         class="btn btn-success"
                     >Save</button>

--- a/website/templates/include/profile/names.mako
+++ b/website/templates/include/profile/names.mako
@@ -72,6 +72,7 @@
                 >Discard changes</button>
 
             <button
+                    data-bind="disable: saving(), text: saving() ? 'Saving' : 'Save'"
                     type="submit"
                     class="btn btn-success"
                 >Save</button>

--- a/website/templates/include/profile/schools.mako
+++ b/website/templates/include/profile/schools.mako
@@ -109,6 +109,7 @@
                     >Discard changes</button>
 
                 <button
+                        data-bind="disable: saving(), text: saving() ? 'Saving' : 'Save'"
                         type="submit"
                         class="btn btn-success"
                     >Save</button>

--- a/website/templates/include/profile/social.mako
+++ b/website/templates/include/profile/social.mako
@@ -131,16 +131,17 @@
                     >Discard changes</button>
 
                 <button
+                        data-bind="disable: saving(), text: saving() ? 'Saving' : 'Save'"
                         type="submit"
                         class="btn btn-success"
                     >Save</button>
+            </div>
 
                 <!-- Flashed Messages -->
                 <div class="help-block flashed-message">
                     <p data-bind="html: message, attr: {class: messageClass}"></p>
                 </div>
 
-            </div>
 
         </form>
 


### PR DESCRIPTION

## Purpose

The save button has no signifier while a profile save is taking place.  Users do not know that the save request is being made. 

Now, after clicking save, The save button will grey and change to "Saving" until the request is completed, then it will change back to save.


![saving](https://cloud.githubusercontent.com/assets/6232068/15471450/fbfdd6ae-20c3-11e6-9cb8-3beccf4a8bf2.png)
before request returns

![save](https://cloud.githubusercontent.com/assets/6232068/15471502/416120ac-20c4-11e6-9ece-2619b776beef.png)
after request returns


Also fixed a small bug in the social section of the profile where "Settings Updated" was on the same line as the save button.

## Ticket

https://openscience.atlassian.net/browse/OSF-3912
