### PR TITLE
Type error on user profile

### DIFF
--- a/website/static/js/project.js
+++ b/website/static/js/project.js
@@ -336,7 +336,7 @@ $(document).ready(function() {
 
         // Remove Comments link from project nav bar for pages not bound to the comment view model
         var commentsLinkElm = document.getElementById('commentsLink');
-        if (!ko.dataFor(commentsLinkElm)) {
+        if (!ko.dataFor(commentsLinkElm) && commentsLinkElm != null) {
              commentsLinkElm.remove();
         }
     });


### PR DESCRIPTION

Remove the TypeError that is thrown when viewing user profiles.

Adding if statements to catch null objects that functions attempt to access. 

https://openscience.atlassian.net/browse/OSF-6303
