### PR TITLE
Updates to Dataverse Publishing flow and UI [OSF-6397]  [OSF-4553] 

### DIFF
--- a/website/addons/dataverse/static/dataverseFangornConfig.js
+++ b/website/addons/dataverse/static/dataverseFangornConfig.js
@@ -74,6 +74,7 @@ var _dataverseItemButtons = {
                     ];
                     tb.modal.update(modalContent, modalActions, m('h3.break-word.modal-title', 'Successfully published'));
                     item.data.dataverseIsPublished = true;
+                    item.data.datasetDraftModified = false;
                     item.data.hasPublishedFiles = item.children.length > 0;
                     item.data.version = item.data.hasPublishedFiles ? 'latest-published' : 'latest';
                     for (var i = 0; i < item.children.length; i++) { // Brute force the child files to be set as "latest-published" without page reload

--- a/website/addons/dataverse/static/dataverseFangornConfig.js
+++ b/website/addons/dataverse/static/dataverseFangornConfig.js
@@ -74,6 +74,7 @@ var _dataverseItemButtons = {
                     ];
                     tb.modal.update(modalContent, modalActions, m('h3.break-word.modal-title', 'Successfully published'));
                     item.data.dataverseIsPublished = true;
+                    item.data.datasetIsPublished = true;
                     item.data.datasetDraftModified = false;
                     item.data.hasPublishedFiles = item.children.length > 0;
                     item.data.version = item.data.hasPublishedFiles ? 'latest-published' : 'latest';
@@ -117,7 +118,7 @@ var _dataverseItemButtons = {
             var options = [
                 m('option', {selected: item.data.version === 'latest', value: 'latest'}, 'Draft')
             ];
-            if (item.data.dataverseIsPublished) {
+            if (item.data.datasetIsPublished) {
                 options.push(m('option', {selected: item.data.version === 'latest-published', value: 'latest-published'}, 'Published'));
             }
             buttons.push(

--- a/website/addons/dataverse/static/dataverseFangornConfig.js
+++ b/website/addons/dataverse/static/dataverseFangornConfig.js
@@ -141,8 +141,8 @@ var _dataverseItemButtons = {
                         className: 'text-success'
                     }, 'Upload')
                 );
-                // Only allow the Publish button to appear if this is truly an unpublished dataset, vs. a draft version of a published dataset.
-                if(!item.data.dataverseIsPublished) {
+                // Only allow the Publish button to appear if the draft dataset is modified
+                if(item.data.datasetDraftModified) {
                     buttons.push(
                         m.component(Fangorn.Components.button, {
                             onclick: function (event) {

--- a/website/addons/dataverse/views.py
+++ b/website/addons/dataverse/views.py
@@ -256,8 +256,10 @@ def _dataverse_root_folder(node_addon, auth, **kwargs):
     # versions of the dataset
     try:
         dataset.get_metadata('latest-published')
+        dataset_is_published = True
         dataset_draft_modified = dataset.get_state() == 'DRAFT'
     except VersionJsonNotFoundError:
+        dataset_is_published = False
         dataset_draft_modified = True
 
     return [rubeus.build_addon_root(
@@ -270,6 +272,7 @@ def _dataverse_root_folder(node_addon, auth, **kwargs):
         dataverse=dataverse.title,
         hasPublishedFiles=bool(published_files),
         dataverseIsPublished=dataverse.is_published,
+        datasetIsPublished=dataset_is_published,
         datasetDraftModified=dataset_draft_modified,
         version=version,
     )]

--- a/website/addons/dataverse/views.py
+++ b/website/addons/dataverse/views.py
@@ -16,6 +16,7 @@ from website.addons.dataverse import client
 from website.addons.dataverse.model import DataverseProvider
 from website.addons.dataverse.settings import DEFAULT_HOSTS
 from website.addons.dataverse.serializer import DataverseSerializer
+from dataverse.exceptions import VersionJsonNotFoundError
 from website.oauth.models import ExternalAccount
 from website.project.decorators import (
     must_have_addon, must_be_addon_authorizer,
@@ -255,10 +256,8 @@ def _dataverse_root_folder(node_addon, auth, **kwargs):
     # versions of the dataset
     try:
         dataset.get_metadata('latest-published')
-        dataset_is_published = True
         dataset_draft_modified = dataset.get_state() == 'DRAFT'
-    except dataverse.exceptions.VersionJsonNotFoundError:
-        dataset_is_published = False
+    except VersionJsonNotFoundError:
         dataset_draft_modified = True
 
     return [rubeus.build_addon_root(

--- a/website/addons/dataverse/views.py
+++ b/website/addons/dataverse/views.py
@@ -256,7 +256,7 @@ def _dataverse_root_folder(node_addon, auth, **kwargs):
     try:
         dataset.get_metadata('latest-published')
         dataset_is_published = True
-        dataset_draft_modified = dataset.get_status() == 'DRAFT'
+        dataset_draft_modified = dataset.get_state() == 'DRAFT'
     except dataverse.exceptions.VersionJsonNotFoundError:
         dataset_is_published = False
         dataset_draft_modified = True

--- a/website/addons/dataverse/views.py
+++ b/website/addons/dataverse/views.py
@@ -251,6 +251,16 @@ def _dataverse_root_folder(node_addon, auth, **kwargs):
         'publish': node.api_url_for('dataverse_publish_dataset'),
     }
 
+    # determine if there are any changes between the published and draft
+    # versions of the dataset
+    try:
+        dataset.get_metadata('latest-published')
+        dataset_is_published = True
+        dataset_draft_modified = dataset.get_status() == 'DRAFT'
+    except dataverse.exceptions.VersionJsonNotFoundError:
+        dataset_is_published = False
+        dataset_draft_modified = True
+
     return [rubeus.build_addon_root(
         node_addon,
         node_addon.dataset,
@@ -261,6 +271,7 @@ def _dataverse_root_folder(node_addon, auth, **kwargs):
         dataverse=dataverse.title,
         hasPublishedFiles=bool(published_files),
         dataverseIsPublished=dataverse.is_published,
+        datasetDraftModified=dataset_draft_modified,
         version=version,
     )]
 

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -757,7 +757,6 @@ function _fangornDropzoneSuccess(treebeard, file, response) {
 
     if (item.data.provider === "dataverse") {
         item.parent().data.datasetDraftModified = true;
-        
     }
 
     treebeard.redraw();

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -754,6 +754,11 @@ function _fangornDropzoneSuccess(treebeard, file, response) {
     }
     var url = item.data.nodeUrl + 'files/' + item.data.provider + item.data.path;
     addFileStatus(treebeard, file, true, '', url);
+
+    if (item.data.provider === "dataverse") {
+        item.parent().data.datasetDraftModified = true;
+    }
+    
     treebeard.redraw();
 }
 
@@ -929,6 +934,10 @@ function _removeEvent (event, items, col) {
             tb.deleteNode(item.parentID, item.id);
             tb.modal.dismiss();
             tb.clearMultiselect();
+
+            if (item.data.provider === "dataverse") {
+                item.parent().data.datasetDraftModified = true;
+            }
         })
         .fail(function(data){
             tb.modal.dismiss();

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -935,7 +935,7 @@ function _removeEvent (event, items, col) {
             tb.modal.dismiss();
             tb.clearMultiselect();
 
-            if (item.data.provider === "dataverse") {
+            if (item.data.provider === 'dataverse') {
                 item.parent().data.datasetDraftModified = true;
             }
         })

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -757,8 +757,9 @@ function _fangornDropzoneSuccess(treebeard, file, response) {
 
     if (item.data.provider === "dataverse") {
         item.parent().data.datasetDraftModified = true;
+        
     }
-    
+
     treebeard.redraw();
 }
 

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -755,7 +755,7 @@ function _fangornDropzoneSuccess(treebeard, file, response) {
     var url = item.data.nodeUrl + 'files/' + item.data.provider + item.data.path;
     addFileStatus(treebeard, file, true, '', url);
 
-    if (item.data.provider === "dataverse") {
+    if (item.data.provider === 'dataverse') {
         item.parent().data.datasetDraftModified = true;
     }
 
@@ -1176,7 +1176,7 @@ function gotoFileEvent (item) {
     } else {
         window.open(fileurl, '_self');
     }
-}
+
 /**
  * Defines the contents of the title column (does not include the toggle and folder sections
  * @param {Object} item A Treebeard _item object for the row involved. Node information is inside item.data

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1176,6 +1176,7 @@ function gotoFileEvent (item) {
     } else {
         window.open(fileurl, '_self');
     }
+}
 
 /**
  * Defines the contents of the title column (does not include the toggle and folder sections


### PR DESCRIPTION
(These two tickets were so similar that the code changes were essentially the same... and thus the pull requests were also merged)
## For OSF-4553
## Purpose
Previous to this change, the publish option for a dataset would only be available if the entire dataverse had not yet been published. If the user publishes their dataverse/dataset once, then the publish option would be removed. Further changes to the draft dataverse would not be able to be published through the Fangorn interface, and a user would have to go to the dataverse website to do this.

## Changes
The behavior is implemented as follows:
Initially, with an unpublished dataverse/dataset, the publish option is available.
Once the dataset is published, the publish option is removed.
If the user uploads or deletes a file from the draft dataset, the publish option is again enabled to publish these new changes.
Further publishing and further changing continue this cycle.

## Side effects
This fix enables full testing of both modals in ticket https://openscience.atlassian.net/browse/OSF-4556 by making the publish button appear in the circumstances to make both modal versions appear.

## Ticket
https://openscience.atlassian.net/browse/OSF-4553
Old PR merged with this one: https://github.com/CenterForOpenScience/osf.io/pull/5719

## For OSF-6397
## Purpose
To allow the publish button to appear at the correct times, and to prevent the "view"published" option from appearing unless the published version actually exists.

## Changes
This additional change just makes sure that the "view published" option is only available for published datasets.

## Side effects
No side effects.

## Ticket
https://openscience.atlassian.net/browse/OSF-6397