### PR TITLE
Improve file widget "Rename" & "Create folder" buttons [OSF-6288]

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1654,7 +1654,7 @@ var FGItemButtons = {
                         onclick: function () {
                             mode(toolbarModes.RENAME);
                         },
-                        icon: 'fa fa-font',
+                        icon: 'fa fa-pencil',
                         className: 'text-info'
                     }, 'Rename')
                 );
@@ -1728,7 +1728,7 @@ var FGToolbar = {
                                 onclick: ctrl.createFolder,
                                 icon: 'fa fa-plus',
                                 className: 'text-success'
-                            }, 'Create'),
+                            }),
                             dismissIcon
                         ]
                     )
@@ -1758,7 +1758,7 @@ var FGToolbar = {
                                 },
                                 icon: 'fa fa-pencil',
                                 className: 'text-info'
-                            }, 'Rename'),
+                            }),
                             dismissIcon
                         ]
                     )


### PR DESCRIPTION
## Purpose

There was an inconsistency between the icon on the "rename" button when in the main menu vs. while entering a name. Also, low resolutions would reflow the text inside the buttons while entering a name, causing a malformed button. 

## Changes

### Before

![screen shot 2016-05-24 at 1 17 21 pm](https://cloud.githubusercontent.com/assets/6599111/15513284/f5ec9c48-21b1-11e6-96a4-bb3c2d9f26f1.png)

![screen shot 2016-05-24 at 1 17 27 pm](https://cloud.githubusercontent.com/assets/6599111/15513314/1181ea6c-21b2-11e6-9e0a-a83d6269ed6c.png)

![screen shot 2016-05-24 at 1 17 38 pm](https://cloud.githubusercontent.com/assets/6599111/15513296/fe88ad38-21b1-11e6-8526-2640e2048f67.png)


### After

![main menu](https://cloud.githubusercontent.com/assets/5885378/15506024/de64f340-2193-11e6-96b0-5edec305416e.png)
![rename view](https://cloud.githubusercontent.com/assets/5885378/15506022/de5350d6-2193-11e6-997a-08d5c2c9f4b2.png)
![create folder view](https://cloud.githubusercontent.com/assets/5885378/15506023/de5baae2-2193-11e6-8dfa-6bf04a123a45.png)

- Use pencil icon for rename in both instances
- Remove text from "rename" and "create" buttons that appear when entering text

## Side effects

None


## Ticket

https://openscience.atlassian.net/browse/OSF-6288