### PR TITLE
Resize wiki edit page error

### DIFF
--- a/website/addons/wiki/templates/edit.mako
+++ b/website/addons/wiki/templates/edit.mako
@@ -75,7 +75,7 @@
                style="${'' if 'view' in panels_used else 'display: none'}">
               <div class="osf-panel panel panel-default no-border" data-bind="css: { 'no-border reset-height': $root.singleVis() === 'view', 'osf-panel-flex': $root.singleVis() !== 'view' }">
                 <div class="panel-heading wiki-panel-header wiki-single-heading" data-bind="css: { 'osf-panel-heading-flex': $root.singleVis() !== 'view', 'wiki-single-heading': $root.singleVis() === 'view' }" style=" padding-top: 0; padding-bottom: 0;">
-                    <div class="row" style="position: relative; top: 50%; transform: translateY(-50%);">
+                    <div class="row wiki-view-icon-container">
                         <div class="col-lg-4" >
                             <div class="panel-title" > <i class="fa fa-eye"> </i>  View</div>
                         </div>

--- a/website/addons/wiki/templates/edit.mako
+++ b/website/addons/wiki/templates/edit.mako
@@ -74,12 +74,12 @@
                class="${'col-sm-{0}'.format(12 / num_columns)}"
                style="${'' if 'view' in panels_used else 'display: none'}">
               <div class="osf-panel panel panel-default no-border" data-bind="css: { 'no-border reset-height': $root.singleVis() === 'view', 'osf-panel-flex': $root.singleVis() !== 'view' }">
-                <div class="panel-heading wiki-panel-header wiki-single-heading" data-bind="css: { 'osf-panel-heading-flex': $root.singleVis() !== 'view', 'wiki-single-heading': $root.singleVis() === 'view' }">
-                    <div class="row">
-                        <div class="col-sm-4">
-                            <span class="panel-title" > <i class="fa fa-eye"> </i>  View</span>
+                <div class="panel-heading wiki-panel-header wiki-single-heading" data-bind="css: { 'osf-panel-heading-flex': $root.singleVis() !== 'view', 'wiki-single-heading': $root.singleVis() === 'view' }" style=" padding-top: 0; padding-bottom: 0;">
+                    <div class="row" style="position: relative; top: 50%; transform: translateY(-50%);">
+                        <div class="col-lg-4" >
+                            <div class="panel-title" > <i class="fa fa-eye"> </i>  View</div>
                         </div>
-                        <div class="col-sm-8">
+                        <div class="col-lg-8" >
 
                             <div class="pull-right">
                                 <!-- Version Picker -->

--- a/website/addons/wiki/templates/edit.mako
+++ b/website/addons/wiki/templates/edit.mako
@@ -74,12 +74,12 @@
                class="${'col-sm-{0}'.format(12 / num_columns)}"
                style="${'' if 'view' in panels_used else 'display: none'}">
               <div class="osf-panel panel panel-default no-border" data-bind="css: { 'no-border reset-height': $root.singleVis() === 'view', 'osf-panel-flex': $root.singleVis() !== 'view' }">
-                <div class="panel-heading wiki-panel-header wiki-single-heading" data-bind="css: { 'osf-panel-heading-flex': $root.singleVis() !== 'view', 'wiki-single-heading': $root.singleVis() === 'view' }" style=" padding-top: 0; padding-bottom: 0;">
+                <div class="panel-heading wiki-panel-header wiki-single-heading" data-bind="css: { 'osf-panel-heading-flex': $root.singleVis() !== 'view', 'wiki-single-heading': $root.singleVis() === 'view' }">
                     <div class="row wiki-view-icon-container">
-                        <div class="col-lg-4" >
+                        <div class="col-lg-4">
                             <div class="panel-title" > <i class="fa fa-eye"> </i>  View</div>
                         </div>
-                        <div class="col-lg-8" >
+                        <div class="col-lg-8">
 
                             <div class="pull-right">
                                 <!-- Version Picker -->

--- a/website/static/css/pages/wiki-page.css
+++ b/website/static/css/pages/wiki-page.css
@@ -319,7 +319,6 @@ select.form-control {
 .wiki-toolbar-icon:hover {
   background: rgba(51, 122, 183, 0.15);
 }
-
 .wiki-view-icon-container  /* this keeps the container of the view icon and dropdown responsive */
 {
     position: relative;
@@ -328,5 +327,9 @@ select.form-control {
     -ms-transform: translateY(-50%);
     -webkit-transform: translateY(-50%);
     -moz-transform: translateY(-50%);
-
+}
+.no-padding
+{
+    padding-top: 0;
+    padding-bottom: 0;
 }

--- a/website/static/css/pages/wiki-page.css
+++ b/website/static/css/pages/wiki-page.css
@@ -319,3 +319,14 @@ select.form-control {
 .wiki-toolbar-icon:hover {
   background: rgba(51, 122, 183, 0.15);
 }
+
+.wiki-view-icon-container  /* this keeps the container of the view icon and dropdown responsive */
+{
+    position: relative;
+    top: 50%;
+    transform: translateY(-50%);
+    -ms-transform: translateY(-50%);
+    -webkit-transform: translateY(-50%);
+    -moz-transform: translateY(-50%);
+
+}

--- a/website/static/js/project.js
+++ b/website/static/js/project.js
@@ -336,7 +336,7 @@ $(document).ready(function() {
 
         // Remove Comments link from project nav bar for pages not bound to the comment view model
         var commentsLinkElm = document.getElementById('commentsLink');
-        if (!ko.dataFor(commentsLinkElm)) {
+        if (!ko.dataFor(commentsLinkElm) && commentsLinkElm != null) {
              commentsLinkElm.remove();
         }
     });


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
To style the wiki edit widgets so that the input forms and headers do not break when resizing the page.

## Changes

- changed the bootstrap columns containing the title and selection box to large columns so that they will collapse earlier 

- added inline styles to the containing row so that it remains centered, regardless of size. 


## Ticket

https://openscience.atlassian.net/browse/OSF-5966