### PR TITLE
Add "project preview" link to unregistered user invite email [OSF-3211] 

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2341,7 +2341,7 @@ class TestUserInviteViews(OsfTestCase):
             auth=Auth(project.creator),
         )
         project.save()
-        send_claim_email(email=given_email, user=unreg_user, node=project)
+        send_claim_email(email=given_email, invitedUser=unreg_user, node=project)
 
         assert_true(send_mail.called)
         assert_true(send_mail.called_with(
@@ -2358,20 +2358,20 @@ class TestUserInviteViews(OsfTestCase):
                                                           email=given_email, auth=Auth(
                                                               referrer)
                                                           )
+        claim_url=unreg_user.get_claim_url(project._id, external=True)
+
         project.save()
-        send_claim_email(email=real_email, user=unreg_user, node=project)
+        send_claim_email(email=real_email, invitedUser=unreg_user, node=project)
 
         assert_true(send_mail.called)
         # email was sent to referrer
         send_mail.assert_called_with(
-            referrer.username,
-            mails.FORWARD_INVITE,
-            user=unreg_user,
+            mail=mails.FORWARD_INVITE,
+            invitedUser=unreg_user,
             referrer=referrer,
-            claim_url=unreg_user.get_claim_url(project._id, external=True),
-            email=real_email.lower().strip(),
-            fullname=unreg_user.get_unclaimed_record(project._id)['name'],
-            node=project
+            claim_url=claim_url,
+            node=project,
+            to_addr=referrer.email
         )
 
     @mock.patch('website.project.views.contributor.mails.send_mail')
@@ -2384,11 +2384,11 @@ class TestUserInviteViews(OsfTestCase):
             auth=Auth(project.creator),
         )
         project.save()
-        send_claim_email(email=fake.email(), user=unreg_user, node=project)
+        send_claim_email(email=fake.email(), invitedUser=unreg_user, node=project)
         send_mail.reset_mock()
         # 2nd call raises error because throttle hasn't expired
         with assert_raises(HTTPError):
-            send_claim_email(email=fake.email(), user=unreg_user, node=project)
+            send_claim_email(email=fake.email(), invitedUser=unreg_user, node=project)
         assert_false(send_mail.called)
 
 

--- a/website/mails/mails.py
+++ b/website/mails/mails.py
@@ -144,7 +144,7 @@ FORWARD_INVITE_REGISTERED = Mail('forward_invite_registered', subject='Please fo
 
 FORGOT_PASSWORD = Mail('forgot_password', subject='Reset Password')
 PASSWORD_RESET = Mail('password_reset', subject='Your OSF password has been reset')
-PENDING_VERIFICATION = Mail('pending_invite', subject='Your account is almost ready!')
+PENDING_INVITE_VERIFICATION = Mail('pending_invite', subject='Your account is almost ready!')
 PENDING_VERIFICATION_REGISTERED = Mail('pending_registered', subject='Received request to be a contributor')
 
 REQUEST_EXPORT = Mail('support_request', subject='[via OSF] Export Request')

--- a/website/mails/mails.py
+++ b/website/mails/mails.py
@@ -80,7 +80,7 @@ def send_mail(to_addr, mail, mimetype='plain', from_addr=None, mailer=None,
 
         from website import mails
 
-        mails.send_email('foo@bar.com', mails.TEST, name="Foo")
+        mails.send_mail('foo@bar.com', mails.TEST, name="Foo")
 
     :param str to_addr: The recipient's email address
     :param Mail mail: The mail object

--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -424,7 +424,7 @@ def send_claim_email(email, invitedUser, node, notify=True, throttle=24 * 3600):
     referrer = User.load(unclaimed_record['referrer_id'])
     claim_url = invitedUser.get_claim_url(node._primary_key, external=True)
 
-    inviteArgs = "reffererName={0}&projectName={1}&claimUrl={2}".format(referrer.fullname,node.title,claim_url)
+    inviteArgs = "referrerName={0}&projectName={1}&claimUrl={2}".format(referrer.fullname,node.title,claim_url)
 
     if hasattr(invitedUser,"inviteLink"): # in for tests
         if '/?' not in invitedUser.inviteLink:

--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -188,7 +188,7 @@ def deserialize_contributors(node, user_dicts, auth, validate=False):
         if (not contributor.is_registered
                 and node._primary_key not in contributor.unclaimed_records):
 
-            contributor.inviteLink = contrib_dict.get('inviteLink', "http://osf.io") # Here to avoid failing tests.
+            contributor.inviteLink = contrib_dict.get('inviteLink', "http://osf.io")  # Here to avoid failing tests.
 
             contributor.add_unclaimed_record(node=node, referrer=auth.user,
                 given_name=fullname,
@@ -424,13 +424,13 @@ def send_claim_email(email, invitedUser, node, notify=True, throttle=24 * 3600):
     referrer = User.load(unclaimed_record['referrer_id'])
     claim_url = invitedUser.get_claim_url(node._primary_key, external=True)
 
-    inviteArgs = "referrerName={0}&projectName={1}&claimUrl={2}".format(referrer.fullname,node.title,claim_url)
+    inviteArgs = "referrerName={0}&projectName={1}&claimUrl={2}".format(referrer.fullname, node.title, claim_url)
 
-    if hasattr(invitedUser,"inviteLink"): # in for tests
+    if hasattr(invitedUser, "inviteLink"):  # in for tests
         if '/?' not in invitedUser.inviteLink:
-            invitedUser.inviteLink +="?"
+            invitedUser.inviteLink += "?"
         else:
-            invitedUser.inviteLink +="&"
+            invitedUser.inviteLink += "&"
         invitedUser.inviteLink += inviteArgs
     else:
         invitedUser.inviteLink = "http://osf.io"

--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -191,8 +191,11 @@ def deserialize_contributors(node, user_dicts, auth, validate=False):
                 given_name=fullname,
                 email=email)
             contributor.save()
+
+            contributor.inviteLink = contrib_dict['inviteLink']
             unreg_contributor_added.send(node, contributor=contributor,
                 auth=auth)
+            del contributor.inviteLink
 
         contribs.append({
             'user': contributor,

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -668,8 +668,8 @@ def _view_project(node, auth, primary=False):
     redirect_url = node.url + '?view_only=None'
 
     invitation = {}
-    if request.args.get('reffererName', False):
-        invitation["reffererName"] = request.args.get('reffererName', False)
+    if request.args.get('referrerName', False):
+        invitation["referrerName"] = request.args.get('referrerName', False)
         invitation["projectName"] = request.args.get('projectName', False)
         invitation["claimUrl"] = request.args.get('claimUrl', False)
 

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -667,6 +667,12 @@ def _view_project(node, auth, primary=False):
     widgets, configs, js, css = _render_addon(node)
     redirect_url = node.url + '?view_only=None'
 
+    invitation = {}
+    if request.args.get('reffererName', False):
+        invitation["reffererName"] = request.args.get('reffererName', False)
+        invitation["projectName"] = request.args.get('projectName', False)
+        invitation["claimUrl"] = request.args.get('claimUrl', False)
+
     disapproval_link = ''
     if (node.is_pending_registration and node.has_permission(user, ADMIN)):
         disapproval_link = node.root.registration_approval.stashed_urls.get(user._id, {}).get('reject', '')
@@ -776,6 +782,7 @@ def _view_project(node, auth, primary=False):
             'show_wiki_widget': _should_show_wiki_widget(node, user),
             'dashboard_id': bookmark_collection_id,
             'institutions': get_affiliated_institutions(user) if user else [],
+            'invitation': invitation
         },
         'badges': _get_badge(user),
         # TODO: Namespace with nested dicts

--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -231,15 +231,15 @@ AddContributorViewModel = oop.extend(Paginator, {
             dataType: 'json'
         }).done(function (response) {
 
-            response.node.private_links = response.node.private_links.map(function (pirvateLink) {
-                pirvateLink.date_created = new $osf.FormattableDate(pirvateLink.date_created);
-                pirvateLink.url = response.node.absolute_url + "?view_only=" +  pirvateLink.key;
+            response.node.private_links = response.node.private_links.map(function (privateLink) {
+                privateLink.date_created = new $osf.FormattableDate(privateLink.date_created);
+                privateLink.url = response.node.absolute_url + "?view_only=" +  privateLink.key;
 
-                pirvateLink.components = pirvateLink.nodes.map(function(component){
+                privateLink.components = privateLink.nodes.map(function(component){
                     return component.title;
                 }).join(", ");
 
-                return pirvateLink;
+                return privateLink;
             });
 
             self.inviteLinks(response.node);

--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -82,6 +82,7 @@ AddContributorViewModel = oop.extend(Paginator, {
         self.query = ko.observable();
         self.results = ko.observableArray([]);
         self.contributors = ko.observableArray([]);
+        self.inviteLinks = ko.observableArray([]);
         self.selection = ko.observableArray();
 
         self.contributorIDsToAdd = ko.pureComputed(function () {
@@ -220,6 +221,33 @@ AddContributorViewModel = oop.extend(Paginator, {
             self.doneSearching(true);
         }
     },
+    getInviteLinks: function () {
+        var self = this;
+        var url = self.nodeApiUrl + 'private_link/';
+
+        $.ajax({
+            url: url,
+            type: 'GET',
+            dataType: 'json'
+        }).done(function (response) {
+
+            response.node.private_links = response.node.private_links.map(function (pirvateLink) {
+                pirvateLink.date_created = new $osf.FormattableDate(pirvateLink.date_created);
+                pirvateLink.url = response.node.absolute_url + "?view_only=" +  pirvateLink.key;
+
+                pirvateLink.components = pirvateLink.nodes.map(function(component){
+                    return component.title;
+                }).join(", ");
+
+                return pirvateLink;
+            });
+
+            self.inviteLinks(response.node);
+
+            }).fail(
+        );
+
+    },
     getContributors: function () {
         var self = this;
         self.notification(false);
@@ -302,7 +330,7 @@ AddContributorViewModel = oop.extend(Paginator, {
             self.inviteError(validated);
             return false;
         }
-        return self.postInviteRequest(self.inviteName(), self.inviteEmail());
+        return self.postValidateInvite(self.inviteName(), self.inviteEmail());
     },
     add: function (data) {
         var self = this;
@@ -421,7 +449,7 @@ AddContributorViewModel = oop.extend(Paginator, {
         self.childrenToChange([]);
         self.notification(false);
     },
-    postInviteRequest: function (fullname, email) {
+    postValidateInvite: function (fullname, email) {
         var self = this;
         return $osf.postJSON(
             self.nodeApiUrl + 'invite_contributor/', {
@@ -436,6 +464,7 @@ AddContributorViewModel = oop.extend(Paginator, {
     },
     onInviteSuccess: function (result) {
         var self = this;
+        result.contributor.inviteLink = $("input:radio[name ='inviteLinkRadioGroup']:checked").val();
         self.query('');
         self.results([]);
         self.page('whom');
@@ -505,6 +534,7 @@ ContribAdder.prototype.init = function() {
     var self = this;
     var treebeardUrl = window.contextVars.node.urls.api + 'tree/';
     self.viewModel.getContributors();
+    self.viewModel.getInviteLinks();
     self.viewModel.fetchNodeTree(treebeardUrl).done(function(response) {
         new NodeSelectTreebeard('addContributorsTreebeard', response, self.viewModel.nodesState);
     });

--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -233,11 +233,11 @@ AddContributorViewModel = oop.extend(Paginator, {
 
             response.node.private_links = response.node.private_links.map(function (privateLink) {
                 privateLink.date_created = new $osf.FormattableDate(privateLink.date_created);
-                privateLink.url = response.node.absolute_url + "?view_only=" +  privateLink.key;
+                privateLink.url = response.node.absolute_url + '?view_only=' +  privateLink.key;
 
                 privateLink.components = privateLink.nodes.map(function(component){
                     return component.title;
-                }).join(", ");
+                }).join(', ');
 
                 return privateLink;
             });
@@ -464,7 +464,7 @@ AddContributorViewModel = oop.extend(Paginator, {
     },
     onInviteSuccess: function (result) {
         var self = this;
-        result.contributor.inviteLink = $("input:radio[name ='inviteLinkRadioGroup']:checked").val();
+        result.contributor.inviteLink = $('input:radio[name ="inviteLinkRadioGroup"]:checked').val();
         self.query('');
         self.results([]);
         self.page('whom');

--- a/website/templates/emails/forward_invite.txt.mako
+++ b/website/templates/emails/forward_invite.txt.mako
@@ -1,4 +1,4 @@
-Hello ${refferer.fullname},
+Hello ${referrer.fullname},
 
 You recently added ${invitedUser.fullname} to "${node.title}". ${invitedUser.fullname} wants to claim their account, but the email address they provided is different from the one you provided.  To maintain security of your project, we are sending the account confirmation to you first.
 
@@ -10,7 +10,7 @@ After ${invitedUser.fullname} confirms their account, they will be able to contr
 
 Hello ${invitedUser.fullname},
 
-You have been added by ${refferer.fullname} as a contributor to the project "${node.title}" on the Open Science Framework. To set a password for your account, visit:
+You have been added by ${referrer.fullname} as a contributor to the project "${node.title}" on the Open Science Framework. To set a password for your account, visit:
 
 ${claim_url}
 

--- a/website/templates/emails/forward_invite.txt.mako
+++ b/website/templates/emails/forward_invite.txt.mako
@@ -1,20 +1,22 @@
-Hello ${referrer.fullname},
+Hello ${refferer.fullname},
 
-You recently added ${fullname} to "${node.title}". ${fullname} wants to claim their account, but the email address they provided is different from the one you provided.  To maintain security of your project, we are sending the account confirmation to you first.
+You recently added ${invitedUser.fullname} to "${node.title}". ${invitedUser.fullname} wants to claim their account, but the email address they provided is different from the one you provided.  To maintain security of your project, we are sending the account confirmation to you first.
 
-IMPORTANT: To ensure that the correct person is added to your project please forward the message below to ${fullname}.
+IMPORTANT: To ensure that the correct person is added to your project please forward the message below to ${invitedUser.fullname}.
 
-After ${fullname} confirms their account, they will be able to contribute to the project.
+After ${invitedUser.fullname} confirms their account, they will be able to contribute to the project.
 
 ----------------------
 
-Hello ${fullname},
+Hello ${invitedUser.fullname},
 
-You have been added by ${referrer.fullname} as a contributor to the project "${node.title}" on the Open Science Framework. To set a password for your account, visit:
+You have been added by ${refferer.fullname} as a contributor to the project "${node.title}" on the Open Science Framework. To set a password for your account, visit:
 
 ${claim_url}
 
 Once you have set a password, you will be able to make contributions to ${node.title}.
+
+To preview "${node.title}", click the following link: ${invitedUser.inviteLink}
 
 Sincerely,
 

--- a/website/templates/emails/invite.txt.mako
+++ b/website/templates/emails/invite.txt.mako
@@ -4,7 +4,9 @@ You have been added by ${referrer.fullname} as a contributor to the project "${n
 
 ${claim_url}
 
-Once you have set a password, you will be able to make contributions to ${node.title} and create your own projects.
+Once you have set a password, you will be able to make contributions to "${node.title}" and create your own projects.
+
+To visit "${node.title}" click the following link: https://osf.io${node.url}
 
 If you are not ${fullname} or you are erroneously being associated with ${node.title} then email contact@osf.io with the subject line "Claiming Error" to report the problem.
 

--- a/website/templates/emails/invite.txt.mako
+++ b/website/templates/emails/invite.txt.mako
@@ -1,4 +1,4 @@
-Hello ${fullname},
+Hello ${invitedUser.fullname},
 
 You have been added by ${referrer.fullname} as a contributor to the project "${node.title}" on the Open Science Framework. To set a password for your account, visit:
 
@@ -6,9 +6,9 @@ ${claim_url}
 
 Once you have set a password, you will be able to make contributions to "${node.title}" and create your own projects.
 
-To visit "${node.title}" click the following link: https://osf.io${node.url}
+To preview "${node.title}" click the following link: ${invitedUser.inviteLink}
 
-If you are not ${fullname} or you are erroneously being associated with ${node.title} then email contact@osf.io with the subject line "Claiming Error" to report the problem.
+If you are not ${invitedUser.fullname} or you are erroneously being associated with ${node.title} then email contact@osf.io with the subject line "Claiming Error" to report the problem.
 
 Sincerely,
 

--- a/website/templates/emails/pending_invite.txt.mako
+++ b/website/templates/emails/pending_invite.txt.mako
@@ -2,7 +2,7 @@ Hello ${invitedUser.fullname},
 
 We received your request to claim an OSF account and become a contributor for "${node.title}".
 
-To confirm your identity, ${refferer.fullname} has been sent an email to forward to you with your confirmation link.
+To confirm your identity, ${referrer.fullname} has been sent an email to forward to you with your confirmation link.
 
 This link will allow you to complete your registration.
 

--- a/website/templates/emails/pending_invite.txt.mako
+++ b/website/templates/emails/pending_invite.txt.mako
@@ -1,8 +1,8 @@
-Hello ${fullname},
+Hello ${invitedUser.fullname},
 
-We received your request to claim an OSF account and become a contributor for "${node.title}". 
+We received your request to claim an OSF account and become a contributor for "${node.title}".
 
-To confirm your identity, ${referrer.fullname} has been sent an email to forward to you with your confirmation link.
+To confirm your identity, ${refferer.fullname} has been sent an email to forward to you with your confirmation link.
 
 This link will allow you to complete your registration.
 

--- a/website/templates/project/modal_add_contributor.mako
+++ b/website/templates/project/modal_add_contributor.mako
@@ -16,20 +16,20 @@
                             <div class="col-md-6">
                                 <div class="input-group m-b-sm">
                                     <input class='form-control'
-                                            data-bind="value:query"
-                                            placeholder='Search by name' autofocus/>
+                                           data-bind="value:query"
+                                           placeholder='Search by name' autofocus/>
                                     <span class="input-group-btn">
                                         <input type="submit" value="Search" class="btn btn-default">
                                     </span>
                                 </div>
                             </div>
                         </div>
-                    <hr />
+                        <hr />
                         <div class="row search-contributor-links">
                             <div class="col-md-12">
                                 <div>
                                     <!-- ko if:parentId -->
-                                        <a class="f-w-lg" data-bind="click:importFromParent, text:'Import contributors from ' + parentTitle"></a>
+                                    <a class="f-w-lg" data-bind="click:importFromParent, text:'Import contributors from ' + parentTitle"></a>
                                     <!-- /ko -->
                                 </div>
                             </div>
@@ -53,42 +53,42 @@
                                 <thead data-bind="visible: foundResults">
                                 </thead>
                                 <tbody data-bind="foreach:{data:results, as: 'contributor', afterRender:addTips}">
-                                    <tr data-bind="if:!($root.selected($data))">
-                                        <td class="p-r-sm osf-icon-td" >
-                                            <a
-                                                    class="btn btn-success contrib-button btn-mini"
-                                                    data-bind="visible: !contributor.added,
+                                <tr data-bind="if:!($root.selected($data))">
+                                    <td class="p-r-sm osf-icon-td" >
+                                        <a
+                                                class="btn btn-success contrib-button btn-mini"
+                                                data-bind="visible: !contributor.added,
                                                                click:$root.add.bind($root),
                                                                tooltip: {title: 'Add contributor'}"
                                                 ><i class="fa fa-plus"></i></a>
-                                            <div data-bind="visible: contributor.added,
+                                        <div data-bind="visible: contributor.added,
                                                             tooltip: {title: 'Already added'}"
                                                 ><div
-                                                    class="btn btn-default contrib-button btn-mini disabled"
-                                                    ><i class="fa fa-check"></i></div></div>
-                                        </td>
-                                        <td>
-                                            <!-- height and width are explicitly specified for faster rendering -->
-                                            <img data-bind="attr: {src: contributor.gravatar_url}" height=35 width=35 />
-                                        </td>
-                                        <td width="75%">
-                                            <a data-bind = "attr: {href: contributor.profile_url}" target="_blank">
-                                                <span data-bind= "text:contributor.fullname"></span>
-                                            </a><br>
+                                                class="btn btn-default contrib-button btn-mini disabled"
+                                                ><i class="fa fa-check"></i></div></div>
+                                    </td>
+                                    <td>
+                                        <!-- height and width are explicitly specified for faster rendering -->
+                                        <img data-bind="attr: {src: contributor.gravatar_url}" height=35 width=35 />
+                                    </td>
+                                    <td width="75%">
+                                        <a data-bind = "attr: {href: contributor.profile_url}" target="_blank">
+                                            <span data-bind= "text:contributor.fullname"></span>
+                                        </a><br>
 
 
                                                 <span data-bind="if: contributor.employment">
                                                     <span
-                                                        class = 'small'
-                                                        data-bind="text: contributor.employment">
+                                                            class = 'small'
+                                                            data-bind="text: contributor.employment">
                                                     </span><br>
                                                 </span>
 
 
                                                 <span data-bind="if: contributor.education">
                                                     <span
-                                                        class = 'small'
-                                                        data-bind= "text: contributor.education">
+                                                            class = 'small'
+                                                            data-bind= "text: contributor.education">
                                                     </span><br>
                                                 </span>
 
@@ -100,9 +100,9 @@
                                                     class='text-muted'
                                                     data-bind="visible: !contributor.registered">(unregistered)</span>
 
-                                        </td>
+                                    </td>
 
-                                    </tr>
+                                </tr>
 
 
                                 </tbody>
@@ -121,10 +121,10 @@
                                 <div data-bind="if: showLoading">
                                     <p class="text-muted">Searching contributors...</p>
                                 </div>
-                                    <div data-bind="if: noResults">
-                                        No results found. Try a more specific search or
-                                        <a href="#" data-bind="click:gotoInvite">add <strong><em data-bind="text: query"></em></strong> as an unregistered contributor</a>.
-                                    </div>
+                                <div data-bind="if: noResults">
+                                    No results found. Try a more specific search or
+                                    <a href="#" data-bind="click:gotoInvite">add <strong><em data-bind="text: query"></em></strong> as an unregistered contributor</a>.
+                                </div>
                             </div>
                         </div><!-- ./col-md -->
 
@@ -137,48 +137,48 @@
                             <!-- TODO: Duplication here: Put this in a KO template -->
                             <table class="table-condensed">
                                 <thead data-bind="visible: selection().length">
-                                    <th width="10%"></th>
-                                    <th width="15%"></th>
-                                    <th>Name</th>
-                                    <th>
-                                        Permissions
-                                        <i class="fa fa-question-circle permission-info"
-                                                data-toggle="popover"
-                                                data-title="Permission Information"
-                                                data-container="#addContributors"
-                                                data-html="true"
+                                <th width="10%"></th>
+                                <th width="15%"></th>
+                                <th>Name</th>
+                                <th>
+                                    Permissions
+                                    <i class="fa fa-question-circle permission-info"
+                                       data-toggle="popover"
+                                       data-title="Permission Information"
+                                       data-container="#addContributors"
+                                       data-html="true"
                                             ></i>
-                                    </th>
+                                </th>
                                 </thead>
                                 <tbody data-bind="foreach:{data:selection, as: 'contributor', afterRender:makeAfterRender()}">
-                                    <tr>
-                                        <td class="p-r-sm" class="osf-icon-td">
-                                            <a
-                                                    class="btn btn-default contrib-button btn-mini"
-                                                    data-bind="click:$root.remove.bind($root), tooltip: {title: 'Remove contributor'}"
+                                <tr>
+                                    <td class="p-r-sm" class="osf-icon-td">
+                                        <a
+                                                class="btn btn-default contrib-button btn-mini"
+                                                data-bind="click:$root.remove.bind($root), tooltip: {title: 'Remove contributor'}"
                                                 ><i class="fa fa-minus"></i></a>
-                                        </td>
-                                        <td>
-                                            <!-- height and width are explicitly specified for faster rendering -->
-                                            <img data-bind="attr: {src: contributor.gravatar_url || '/static/img/unreg_gravatar.png'}" height=35 width=35 />
-                                        </td>
+                                    </td>
+                                    <td>
+                                        <!-- height and width are explicitly specified for faster rendering -->
+                                        <img data-bind="attr: {src: contributor.gravatar_url || '/static/img/unreg_gravatar.png'}" height=35 width=35 />
+                                    </td>
 
-                                        <td>
-                                            <span   data-bind="text: contributor.fullname"></span>
+                                    <td>
+                                        <span   data-bind="text: contributor.fullname"></span>
 
                                             <span
                                                     class='text-muted'
                                                     data-bind="visible: !contributor.registered">(unregistered)</span>
-                                        </td>
+                                    </td>
 
-                                        <td>
-                                            <select class="form-control input-sm" data-bind="
+                                    <td>
+                                        <select class="form-control input-sm" data-bind="
                                                 options: $root.permissionList,
                                                 value: permission,
                                                 optionsText: 'text'">
-                                            </select>
-                                        </td>
-                                    </tr>
+                                        </select>
+                                    </td>
+                                </tr>
                                 </tbody>
                             </table>
                         </div>
@@ -229,16 +229,69 @@
                         <div class="form-group">
                             <label for="inviteUserName">Full Name</label>
                             <input type="text" class='form-control' id="inviteName"
-                                placeholder="Full name" data-bind='value: inviteName, valueUpdate: "input"'/>
+                                   placeholder="Full name" data-bind='value: inviteName, valueUpdate: "input"'/>
                         </div>
                         <div class="form-group">
                             <label for="inviteUserEmail">Email</label>
                             <input type="email" class='form-control' id="inviteUserEmail"
-                                    placeholder="Email" data-bind='value: inviteEmail' autofocus/>
+                                   placeholder="Email" data-bind='value: inviteEmail' autofocus/>
                         </div>
-                         <div class="help-block">
-                            <p>We will notify the user that they have been added to your project.</p>
-                            <p class='text-danger' data-bind='text: inviteError'></p>
+                        <div class="form-group">
+                            <label data-bind="tooltip: {title: 'A view-only link can give unregistered users a preview of private components on the site'}" for="inviteUserLink">Send a view-only or public link</label>
+                            <table class="table">
+                                <th width="3%;">
+
+                                </th>
+                                <th>
+                                    Name
+                                </th>
+                                <th>
+                                    Visible Components
+                                </th>
+                                <tbody>
+                                <tr>
+                                    <td>
+                                        <input checked class="radio" type="radio" name="inviteLinkRadioGroup" data-bind="value: inviteLinks().absolute_url" />
+                                    </td>
+                                    <td>
+                                        <span><i>Public Link</i></span>
+                                    </td>
+                                    <td>
+                                        <span><i>Only Public Components</i></span>
+                                    </td>
+                                </tr>
+                                </tbody>
+                                <tbody data-bind="foreach: inviteLinks().private_links">
+                                <tr>
+                                    <td>
+                                        <input class="radio" type="radio" name="inviteLinkRadioGroup" data-bind="value: url" />
+                                    </td>
+                                    <td>
+                                        <span data-bind="text: name"></span>
+                                    </td>
+                                    <td>
+                                        <span data-bind="text: components"></span>
+                                    </td>
+                                </tr>
+                                </tbody>
+                                <tbody>
+                                    <tr>
+                                        <td>
+                                            
+                                        </td>
+                                        <td>
+                                            <a href="#addPrivateLink" data-toggle="modal" class="btn btn-success btn-sm m-l-md">
+                                                <i class="fa fa-plus"></i> Add View-Only Link
+                                            </a>
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+
+                            <div class="help-block">
+                                <p>We will notify the user that they have been added to your project.</p>
+                                <p class='text-danger' data-bind='text: inviteError'></p>
+                            </div>
                         </div>
                     </form>
                 </div><!-- end invite user page -->
@@ -252,8 +305,8 @@
                 <span data-bind="if: page() === 'invite'">
                     <button class="btn btn-primary" data-bind='click:selectWhom'>Back</button>
                     <button class='btn btn-success'
-                         data-bind='click: postInvite'
-                                    type="submit">Add</button>
+                            data-bind='click: postInvite'
+                            type="submit">Add</button>
                 </span>
 
                 <span data-bind="if:selection().length && page() == 'whom'">

--- a/website/templates/project/modal_add_contributor.mako
+++ b/website/templates/project/modal_add_contributor.mako
@@ -237,7 +237,7 @@
                                    placeholder="Email" data-bind='value: inviteEmail' autofocus/>
                         </div>
                         <div class="form-group">
-                            <label data-bind="tooltip: {title: 'A view-only link can give unregistered users a preview of private components on the site'}" for="inviteUserLink">Send a view-only or public link</label>
+                            <label for="inviteUserLink">Send a view-only or public link <span data-bind=" tooltip: {title: 'This will allow you to send the invited contributor a view-only link to preview the project.'}" class="glyphicon glyphicon-question-sign"></span></label>
                             <table class="table">
                                 <th width="3%;">
 

--- a/website/templates/project/modal_generate_private_link.mako
+++ b/website/templates/project/modal_generate_private_link.mako
@@ -1,4 +1,4 @@
-<div class="modal fade" id="addPrivateLink">
+<div style="z-index:99999999;" class="modal fade" id="addPrivateLink">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">

--- a/website/templates/project/project_header.mako
+++ b/website/templates/project/project_header.mako
@@ -156,6 +156,10 @@
         <div class="alert alert-info">This ${node['node_type']} is being viewed through a private, view-only link. Anyone with the link can view this project. Keep the link safe.</div>
     % endif
 
+    % if user['invitation'] and not user['is_contributor']:
+        <div class="alert alert-info">You have been added by ${user['invitation']["reffererName"]} as a contributor to ${user['invitation']["projectName"]}. Click <a class="link-solid" href="${user['invitation']['claimUrl']}">here</a>  to claim your account.</div>
+    % endif
+
     % if disk_saving_mode:
         <div class="alert alert-info"><strong>NOTICE: </strong>Forks, registrations, and uploads will be temporarily disabled while the OSF undergoes a hardware upgrade. These features will return shortly. Thank you for your patience.</div>
     % endif

--- a/website/templates/project/project_header.mako
+++ b/website/templates/project/project_header.mako
@@ -157,7 +157,7 @@
     % endif
 
     % if user['invitation'] and not user['is_contributor']:
-        <div class="alert alert-info">You have been added by ${user['invitation']["reffererName"]} as a contributor to ${user['invitation']["projectName"]}. Click <a class="link-solid" href="${user['invitation']['claimUrl']}">here</a>  to claim your account.</div>
+        <div class="alert alert-info">You have been added by ${user['invitation']["referrerName"]} as a contributor to ${user['invitation']["projectName"]}. Click <a class="link-solid" href="${user['invitation']['claimUrl']}">here</a>  to claim your account.</div>
     % endif
 
     % if disk_saving_mode:


### PR DESCRIPTION
## Purpose

To allow an invited unregistered user to view the project or component they were invited to via a public or view-only link. After clicking this link they are sent to a to the linked project/component page where a non-dismissible alert appearing urging them to join the project with the set password token embedded in a link. 


## Changes

- Modifies HTML/JS in add_contributor_modal/contribAdder.js to display, pick and send an invite link to the server side.

- Modifes contributor.py's send_claim_email to send INVITE, INVITE_FORWARD, PENDING_INVITE_VERIFICATION with different arguments, including the invite link passed by the referrer. It also adds arguments to the url which allow the non-dismissible alert to be displayed.

- Modifies INVITE, INVITE_FORWARD, PENDING_INVITE_VERIFICATION email templates to include invite link, also refactors to make variable names a little more intuitive.

- Modifies node.py's _view_project to read url arguments passed in invitation link and add them to the user object where they can be read in project_header.mako and displayed.

- Modifes tests to accommodate new email parameters. 


## Side effects

- Changed z-index on add view-only modal so it pops over add contributor modal, so you add a view-only during the invite process.

- Not really a side effect, but in my rambling I noticed, add_unregistered_contributor isn't used anywhere in the code base except for tests, this is counterintuitive and should be changed, but I didn't want to creep on it.

## Ticket

https://openscience.atlassian.net/browse/OSF-3211

##Note
 I closed the original PR #5723 because the branch was failing to push so I had to rename and repush. 