### PR TITLE
Fix attempting to put logos on non-existing div breaking mithril

### DIFF
--- a/website/static/js/pages/project-dashboard-page.js
+++ b/website/static/js/pages/project-dashboard-page.js
@@ -95,7 +95,9 @@ var institutionLogos = {
 
 $(document).ready(function () {
 
-    m.mount(document.getElementById('instLogo'), m.component(institutionLogos, {institutions: window.contextVars.node.institutions}));
+    if (ctx.node.institutions.length){
+        m.mount(document.getElementById('instLogo'), m.component(institutionLogos, {institutions: window.contextVars.node.institutions}));
+    }
     $('#contributorsList').osfToggleHeight();
     if (!ctx.node.isRetracted) {
         // Treebeard Files view


### PR DESCRIPTION

## Purpose

To prevent mithril from breaking when looking for the instLogo div which is not existent if the node has no affiliated institutions.

## Changes

Check if the node has institutions before looking for id `instLogo`
