### PR TITLE
[Feature] File view pane, edit panel shows earlier version [OSF-6300]

### DIFF
--- a/website/addons/base/views.py
+++ b/website/addons/base/views.py
@@ -662,12 +662,12 @@ def addon_view_file(auth, node, file_node, version):
 
     ret = serialize_node(node, auth, primary=True)
 
-    if file_node._id not in node.file_guid_to_share_uuids:
-        node.file_guid_to_share_uuids[file_node._id] = uuid.uuid4()
+    if file_node._id + '-' + version._id not in node.file_guid_to_share_uuids:
+        node.file_guid_to_share_uuids[file_node._id + '-' + version._id] = uuid.uuid4()
         node.save()
 
     if ret['user']['can_edit']:
-        sharejs_uuid = str(node.file_guid_to_share_uuids[file_node._id])
+        sharejs_uuid = str(node.file_guid_to_share_uuids[file_node._id + '-' + version._id])
     else:
         sharejs_uuid = None
 


### PR DESCRIPTION
## Purpose:
[OSF-6300](https://openscience.atlassian.net/browse/OSF-6300)
Fix to get latest version in file editor panel

## Changes:
Update website/addons/base/views.py add version to key for file_guid_to_share_uuids

## Credits
Just like Brian said all along.

# Warning!
It may be best to stop the sharejs server during the merging of this code. If there is an existing editing session before merging and a new user starts editing afterwards, then the new session will not share(js) with the old session. Unexpected results may occur.

[#OSF-6300]