### PR TITLE
[Feature] Hides account deactivation button upon refresh if user has requested to deactivate. [OSF-2735]

### DIFF
--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -407,6 +407,9 @@ class User(GuidStoredObject, AddonModelMixin):
     # user language and locale data (e.g. 'en_US')
     locale = fields.StringField(default='en_US')
 
+    # whether the user has requested to deactivate their account
+    requestedDeactivation = fields.BooleanField(default=False)
+
     _meta = {'optimistic': True}
 
     def __repr__(self):

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -363,7 +363,8 @@ class TestUserMerging(base.OsfTestCase):
             'mailing_lists',
             'verification_key',
             '_affiliated_institutions',
-            'contributor_added_email_records'
+            'contributor_added_email_records',
+            'requestedDeactivation'
         ]
 
         calculated_fields = {
@@ -410,14 +411,18 @@ class TestUserMerging(base.OsfTestCase):
         # from the explicit rules above, compile expected field/value pairs
         expected = {}
         expected.update(calculated_fields)
+        print(expected)
         for key in default_to_master_user_fields:
             expected[key] = getattr(self.user, key)
-
+        print(set(expected.keys()))
+        print("/n")
+        print(set(self.user._fields))
         # ensure all fields of the user object have an explicit expectation
         assert_equal(
             set(expected.keys()),
             set(self.user._fields),
         )
+
 
         # mock mailchimp
         mock_client = mock.MagicMock()

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -411,18 +411,14 @@ class TestUserMerging(base.OsfTestCase):
         # from the explicit rules above, compile expected field/value pairs
         expected = {}
         expected.update(calculated_fields)
-        print(expected)
         for key in default_to_master_user_fields:
             expected[key] = getattr(self.user, key)
-        print(set(expected.keys()))
-        print("/n")
-        print(set(self.user._fields))
+
         # ensure all fields of the user object have an explicit expectation
         assert_equal(
             set(expected.keys()),
             set(self.user._fields),
         )
-
 
         # mock mailchimp
         mock_client = mock.MagicMock()

--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -344,7 +344,7 @@ def user_account(auth, **kwargs):
         'addons': user_addons,
         'addons_js': collect_user_config_js([addon for addon in settings.ADDONS_AVAILABLE if 'user' in addon.configs]),
         'addons_css': [],
-        'requestedDeactivationgit ': user.requestedDeactivation
+        'requestedDeactivation': user.requestedDeactivation
     }
 
 

--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -343,7 +343,8 @@ def user_account(auth, **kwargs):
         'user_id': user._id,
         'addons': user_addons,
         'addons_js': collect_user_config_js([addon for addon in settings.ADDONS_AVAILABLE if 'user' in addon.configs]),
-        'addons_css': []
+        'addons_css': [],
+        'requestedDeactivationgit ': user.requestedDeactivation
     }
 
 
@@ -815,6 +816,7 @@ def request_deactivation(auth):
         user=auth.user,
     )
     user.email_last_sent = datetime.datetime.utcnow()
+    user.requestedDeactivation = True
     user.save()
     return {'message': 'Sent account deactivation request'}
 

--- a/website/templates/profile/account.mako
+++ b/website/templates/profile/account.mako
@@ -129,9 +129,15 @@
                 <div id="deactivateAccount" class="panel panel-default">
                     <div class="panel-heading clearfix"><h3 class="panel-title">Deactivate Account</h3></div>
                     <div class="panel-body">
-                        <p class="alert alert-warning"><strong>Warning:</strong> This action is irreversible.</p>
+                        %if not requestedDeactivation:
+                            <p class="alert alert-warning"><strong>Warning:</strong> This action is irreversible.</p>
+                        %endif
                         <p>Deactivating your account will remove you from all public projects to which you are a contributor. Your account will no longer be associated with OSF projects, and your work on the OSF will be inaccessible.</p>
-                        <a class="btn btn-danger" data-bind="click: submit, css: success() === true ? 'disabled' : ''">Request deactivation</a>
+                        %if not requestedDeactivation:
+                             <a class="btn btn-danger" data-bind="click: submit, css: success() === true ? 'disabled' : ''">Request deactivation</a>
+                        %else:
+                             <p><b>Your account is currently pending deactivation.</b></p>
+                        %endif
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Purpose
This prevents confusion when a user requests to deactivate their account then refreshes the page and sees that the deactivate button is still available.

## Changes
By adding a requestedDeactivation to the User class, the page checks if the account is pending deactivation on load, and in the case that the user has requested deactivation, it displays a message informing the user rather than the button.

Before:
<img src="http://i.imgur.com/ovqzmmH.png">
After:
<img src="http://i.imgur.com/VUSIOGV.png">

## Side effects
N/A

## Ticket
https://openscience.atlassian.net/browse/OSF-2735