### PR TITLE
Feature/fixed publish hyperlink with figshare account

### DIFF
--- a/website/files/models/figshare.py
+++ b/website/files/models/figshare.py
@@ -40,7 +40,7 @@ class FigshareFile(FigshareFileNode, File):
             <div class="alert alert-info" role="alert">
             The file "{name}" is still a draft on figshare. <br>
             To view it  on the OSF
-            <a href="https://figshare.zendesk.com/hc/en-us/articles/203712033-How-do-I-publish-my-data-/">publish</a>
+            <a href="https://support.figshare.com/support/solutions ">publish</a>
             it on figshare.
             </div>
             '''.format(name=markupsafe.escape(self.name)))


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

<!-- Describe the purpose of your changes -->
Fixed a broken hyperlink to figshare.

## Changes

<!-- Briefly describe or list your changes  -->
Previously if a user connected their figshare account to view files on the OSF, there is a prompt which directs the user to publish their files publicly on figshare. However, the URL that was associated with the hyperlink is invalid, so I updated the link to link to Figshare's support and FAQ page.

## Side effects

<!--Any possible side effects? -->
If figshare changes the link to the faq, the "publish" hyperlink will be broken again.
I was unable to test the change on my local server. This is because I cannot link my figshare account on my local server. However, the only change made was the URL associated with a hyperlink.

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
https://openscience.atlassian.net/browse/OSF-6093
