### PR TITLE
Feature/fix regressed registration logs[OSF-6409]

### DIFF
--- a/scripts/migrate_regressed_registration_logs.py
+++ b/scripts/migrate_regressed_registration_logs.py
@@ -1,0 +1,105 @@
+"""
+Some registration-related logs have regressed where there is 1) no params['registration'] field, 2) params['node'] field points to registration,
+and original node field is incorrect(since original_node = params['node'].
+
+This is causing some logs to link to registrations instead of nodes.
+"""
+
+import logging
+import sys
+from modularodm import Q
+
+from framework.transactions.context import TokuTransaction
+
+from website.models import Node, NodeLog, RegistrationApproval
+from website.app import init_app
+from scripts import utils as script_utils
+
+logger = logging.getLogger(__name__)
+
+
+def main():
+    targets = get_targets()
+    fix_log_params(targets)
+    reg_approved_logs = get_registration_approved_logs()
+    fix_reg_approved_log_params(reg_approved_logs)
+
+
+def get_targets():
+    """
+    These logs are potentially missing params['registration'] fields.  Params['node'] and original_node fields may incorrectly
+    be pointing to the registration instead of the node.
+    """
+    logs = NodeLog.find(
+        Q('action', 'eq', 'registration_cancelled') |
+        Q('action', 'eq', 'retraction_approved') |
+        Q('action', 'eq', 'retraction_cancelled') |
+        Q('action', 'eq', 'embargo_approved') |
+        Q('action', 'eq', 'embargo_cancelled') |
+        Q('action', 'eq', 'embargo_terminated')
+    )
+    return logs
+
+
+def get_registration_approved_logs():
+    # These logs do not have params['registration'] field
+    logs = NodeLog.find(Q('action', 'eq', 'registration_approved') & Q('params.registration', 'eq', None))
+    return logs
+
+
+def fix_log_params(targets):
+    """
+    Restores params['registration'] field and points params['node'] and original_node fields to the node instead of registration
+    """
+    logger.info('Migrating registration_cancelled, registration_approved, retraction_cancelled, embargo_approved, embargo_cancelled, and embargo_terminated logs.')
+    count = 0
+    for log in targets:
+        node_id = log.params['node']
+        node = Node.load(node_id)
+        if node.is_registration:
+            log.params['node'] = get_registered_from(node)
+            log.params['registration'] = node._id
+            log.original_node = log.params['node']
+            logger.info('Updating params of log {}. params[node]={}, params[registration]={}, and original_node = {}'.format(log._id, log.params['node'], log.params['registration'], log.original_node))
+            log.save()
+            count += 1
+    logger.info('{} logs migrated'.format(count))
+
+
+def fix_reg_approved_log_params(targets):
+    """
+    Restores params['registration'] field
+    """
+    logger.info('Migrating registration_approved logs.')
+    count = 0
+    for log in targets:
+        log.params['registration'] = RegistrationApproval.load(log.params['registration_approval_id'])._get_registration()._id
+        logger.info(
+            'Updating params[registration] of log {}. params[node]={}, params[registration]={}'.format(
+                log._id, log.params['node'], log.params['registration'], log.original_node))
+        log.save()
+        count += 1
+    logger.info('{} logs migrated'.format(count))
+
+
+def get_registered_from(registration):
+    """
+    Gets node registration was registered from.  Handles deleted registrations where registered_from is null.
+
+    """
+    if registration.registered_from:
+        return registration.registered_from_id
+    else:
+        log = registration.logs[0] # We assume this is the project created log.
+        return log.params.get('node') or log.params.get('project')
+
+
+if __name__ == '__main__':
+    dry = '--dry' in sys.argv
+    if not dry:
+        script_utils.add_file_logger(logger, __file__)
+    init_app(routes=False, set_backends=True)
+    with TokuTransaction():
+        main()
+        if dry:
+            raise Exception('Dry Run -- Aborting Transaction')

--- a/scripts/retract_registrations.py
+++ b/scripts/retract_registrations.py
@@ -44,7 +44,8 @@ def main(dry_run=True):
                         parent_registration.registered_from.add_log(
                             action=NodeLog.RETRACTION_APPROVED,
                             params={
-                                'node': parent_registration._id,
+                                'node': parent_registration.registered_from._id,
+                                'registration': parent_registration._id,
                                 'retraction_id': parent_registration.retraction._id,
                             },
                             auth=Auth(parent_registration.retraction.initiated_by),

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -3482,7 +3482,8 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
             action=NodeLog.EMBARGO_TERMINATED,
             params={
                 'project': self._id,
-                'node': self._id,
+                'node': self.registered_from_id,
+                'registration': self._id,
             },
             auth=None,
             save=True

--- a/website/project/sanctions.py
+++ b/website/project/sanctions.py
@@ -502,7 +502,7 @@ class Embargo(PreregCallbackMixin, EmailApprovableSanction):
             action=NodeLog.EMBARGO_CANCELLED,
             params={
                 'node': parent_registration.registered_from_id,
-                'registration':  parent_registration._id,
+                'registration': parent_registration._id,
                 'embargo_id': self._id,
             },
             auth=Auth(user),
@@ -832,9 +832,9 @@ class RegistrationApproval(PreregCallbackMixin, EmailApprovableSanction):
         registered_from.add_log(
             action=NodeLog.REGISTRATION_APPROVAL_CANCELLED,
             params={
-                  'node': registered_from._id,
-                  'registration': register._id,
-                  'registration_approval_id': self._id,
+                'node': registered_from._id,
+                'registration': register._id,
+                'registration_approval_id': self._id,
             },
             auth=Auth(user),
         )

--- a/website/project/sanctions.py
+++ b/website/project/sanctions.py
@@ -501,7 +501,8 @@ class Embargo(PreregCallbackMixin, EmailApprovableSanction):
         parent_registration.registered_from.add_log(
             action=NodeLog.EMBARGO_CANCELLED,
             params={
-                'node': parent_registration._id,
+                'node': parent_registration.registered_from_id,
+                'registration':  parent_registration._id,
                 'embargo_id': self._id,
             },
             auth=Auth(user),
@@ -527,7 +528,8 @@ class Embargo(PreregCallbackMixin, EmailApprovableSanction):
         parent_registration.registered_from.add_log(
             action=NodeLog.EMBARGO_APPROVED,
             params={
-                'node': parent_registration._id,
+                'node': parent_registration.registered_from_id,
+                'registration': parent_registration._id,
                 'embargo_id': self._id,
             },
             auth=Auth(self.initiated_by),
@@ -647,7 +649,8 @@ class Retraction(EmailApprovableSanction):
         parent_registration.registered_from.add_log(
             action=NodeLog.RETRACTION_CANCELLED,
             params={
-                'node': parent_registration._id,
+                'node': parent_registration.registered_from_id,
+                'registration': parent_registration._id,
                 'retraction_id': self._id,
             },
             auth=Auth(user),
@@ -661,8 +664,9 @@ class Retraction(EmailApprovableSanction):
         parent_registration.registered_from.add_log(
             action=NodeLog.RETRACTION_APPROVED,
             params={
-                'node': parent_registration._id,
+                'node': parent_registration.registered_from_id,
                 'retraction_id': self._id,
+                'registration': parent_registration._id
             },
             auth=Auth(self.initiated_by),
         )
@@ -672,7 +676,8 @@ class Retraction(EmailApprovableSanction):
             parent_registration.registered_from.add_log(
                 action=NodeLog.EMBARGO_CANCELLED,
                 params={
-                    'node': parent_registration._id,
+                    'node': parent_registration.registered_from_id,
+                    'registration': parent_registration._id,
                     'embargo_id': parent_registration.embargo._id,
                 },
                 auth=Auth(self.initiated_by),
@@ -807,6 +812,7 @@ class RegistrationApproval(PreregCallbackMixin, EmailApprovableSanction):
             action=NodeLog.REGISTRATION_APPROVAL_APPROVED,
             params={
                 'node': registered_from._id,
+                'registration': register._id,
                 'registration_approval_id': self._id,
             },
             auth=auth,
@@ -826,8 +832,9 @@ class RegistrationApproval(PreregCallbackMixin, EmailApprovableSanction):
         registered_from.add_log(
             action=NodeLog.REGISTRATION_APPROVAL_CANCELLED,
             params={
-                'node': register._id,
-                'registration_approval_id': self._id,
+                  'node': registered_from._id,
+                  'registration': register._id,
+                  'registration_approval_id': self._id,
             },
             auth=Auth(user),
         )


### PR DESCRIPTION
Ticket https://openscience.atlassian.net/browse/OSF-6409

## Purpose

Some registration logs have regressed.  Registration-related logs were supposed to have a params['node'] field and a params['registration'] field.  Now some logs do not have params['registration'] field and params['node'] field points to the registration. This means original_node is incorrect since it is supposed to be the same as params['node'].

## Changes

Restores params['registration'] fields where missing.  Points params['node'] fields to node instead of registration where incorrect.  Original_node should be set to params['node'].

**params['registration'] may be missing and params['node'] and original_node incorrectly pointing to the registration for the following log actions:**
- embargo_approved
- embargo_cancelled
- embargo_terminated
- retraction_approved
- retraction_cancelled
- registration_cancelled

**params['registration'] may be missing**

- registration_approved 



## Side effects
Requires migration.