### PR TITLE
Updates the 'webpack' task, removing the use of the --colors arg when…

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -897,10 +897,7 @@ def webpack(clean=False, watch=False, dev=False):
         clean_assets()
     webpack_bin = os.path.join(HERE, 'node_modules', 'webpack', 'bin', 'webpack.js')
     args = [webpack_bin]
-    if settings.DEBUG_MODE and dev:
-        args += ['--colors']
-    else:
-        args += ['--progress']
+    args += ['--progress']
     if watch:
         args += ['--watch']
     config_file = 'webpack.dev.config.js' if dev else 'webpack.prod.config.js'


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Removes the `--colors` argument from the webpack task, avoiding an interaction with the terminal environment that causes a development build to fail with:

> UnicodeEncodeError: 'ascii' codec can't encode characters in position 18-20: ordinal not in range(128)

Color output will not be emitted by the `webpack` task in a development environment.  Builds are a bit more dreary, but won't fail when executed from a Docker container.

## Changes

Updates the `webpack` to be invoked with `--progress` no matter the environment (development or production).

## Side effects

The webpack task will be invoked with `--progress`, even in a development build.

## Ticket

Proposed fix for issue #5739.