### PR TITLE
[RFR] Feature/fix locking by moving tasks to celery [OSF-6294]

### DIFF
--- a/api/caching/listeners.py
+++ b/api/caching/listeners.py
@@ -5,4 +5,4 @@ from modularodm import signals
 @signals.save.connect
 def ban_object_from_cache(sender, instance, fields_changed, cached_data):
     if hasattr(instance, 'absolute_api_v2_url'):
-        enqueue_postcommit_task((ban_url, (instance,)))
+        enqueue_postcommit_task(ban_url, (instance, ), {})

--- a/framework/analytics/__init__.py
+++ b/framework/analytics/__init__.py
@@ -5,14 +5,19 @@ import functools
 from datetime import datetime
 
 from framework.mongo import database
+from framework.postcommit_tasks.handlers import run_postcommit
 from framework.sessions import session
+
+from framework.celery_tasks import app
 
 from flask import request
 
 
+
 collection = database['pagecounters']
 
-
+@run_postcommit(once_per_request=False, celery=True)
+@app.task(max_retries=5, default_retry_delay=60)
 def increment_user_activity_counters(user_id, action, date, db=None):
     db = db or database  # default to local proxy
     collection = database['useractivitycounters']
@@ -72,6 +77,8 @@ def build_page(rex, kwargs):
         return None
 
 
+@run_postcommit(once_per_request=False, celery=True)
+@app.task(max_retries=5, default_retry_delay=60)
 def update_counter(page, db=None):
     """Update counters for page.
 

--- a/framework/analytics/__init__.py
+++ b/framework/analytics/__init__.py
@@ -12,8 +12,6 @@ from framework.celery_tasks import app
 
 from flask import request
 
-
-
 collection = database['pagecounters']
 
 @run_postcommit(once_per_request=False, celery=True)

--- a/framework/postcommit_tasks/handlers.py
+++ b/framework/postcommit_tasks/handlers.py
@@ -7,9 +7,7 @@ import os
 import binascii
 from collections import OrderedDict
 
-import gevent
 from celery.local import PromiseProxy
-from celery.task import Task
 from gevent.pool import Pool
 
 from website import settings
@@ -31,11 +29,11 @@ def postcommit_after_request(response, base_status_error_code=500):
         return response
     try:
         if postcommit_queue():
-            number_of_threads = 30 # one db connection per greenlet, let's share
+            number_of_threads = 30  # one db connection per greenlet, let's share
             pool = Pool(number_of_threads)
             for func in postcommit_queue().values():
                 pool.spawn(func)
-            pool.join(timeout=5.0, raise_error=True) # 5 second timeout and reraise exceptions
+            pool.join(timeout=5.0, raise_error=True)  # 5 second timeout and reraise exceptions
     except AttributeError as ex:
         if not settings.DEBUG_MODE:
             logger.error('Post commit task queue not initialized: {}'.format(ex))

--- a/framework/postcommit_tasks/handlers.py
+++ b/framework/postcommit_tasks/handlers.py
@@ -72,7 +72,6 @@ def run_postcommit(once_per_request=True, celery=False):
             return func
         @functools.wraps(func)
         def wrapped(*args, **kwargs):
-            # print 'Celery: {} Type: {}'.format(celery, type(func))
             if celery is True and isinstance(func, PromiseProxy):
                 func.delay(*args, **kwargs)
             else:

--- a/framework/postcommit_tasks/handlers.py
+++ b/framework/postcommit_tasks/handlers.py
@@ -1,5 +1,14 @@
+import functools
+import hashlib
 import logging
 import threading
+import os
+
+import binascii
+from collections import OrderedDict
+
+import gevent
+from celery.task import Task
 
 from website import settings
 
@@ -8,31 +17,61 @@ logger = logging.getLogger(__name__)
 
 def postcommit_queue():
     if not hasattr(_local, 'postcommit_queue'):
-        _local.postcommit_queue = set()
+        _local.postcommit_queue = OrderedDict()
     return _local.postcommit_queue
 
 def postcommit_before_request():
-    _local.postcommit_queue = set()
+    _local.postcommit_queue = OrderedDict()
 
 def postcommit_after_request(response, base_status_error_code=500):
     if response.status_code >= base_status_error_code:
-        _local.postcommit_queue = set()
+        _local.postcommit_queue = OrderedDict()
         return response
     try:
-        if settings.ENABLE_VARNISH and postcommit_queue():
-            import gevent
-            threads = [gevent.spawn(func, *args) for func, args in postcommit_queue()]
+        if postcommit_queue():
+            threads = [gevent.spawn(func) for func in postcommit_queue().values()]
             gevent.joinall(threads)
+
     except AttributeError:
         if not settings.DEBUG_MODE:
             logger.error('Post commit task queue not initialized')
     return response
 
-def enqueue_postcommit_task(function_and_args):
-    postcommit_queue().add(function_and_args)
+def enqueue_postcommit_task(fn, args, kwargs, once_per_request=True):
+    # make a hash of the pertinent data
+    raw = [fn.__name__, fn.__module__, args, kwargs]
+    m = hashlib.md5()
+    m.update('-'.join([x.__repr__() for x in raw]))
+    key = m.hexdigest()
+
+    if not once_per_request:
+        # we want to run it once for every occurrence, add a random string
+        key = '{}:{}'.format(key, binascii.hexlify(os.urandom(8)))
+    postcommit_queue().update({key: functools.partial(fn, *args, **kwargs)})
 
 
 handlers = {
     'before_request': postcommit_before_request,
     'after_request': postcommit_after_request,
 }
+
+
+def run_postcommit(once_per_request=True, celery=False):
+    '''
+    Delays function execution until after the request's transaction has been committed.
+    !!!Tasks enqueued using this decorator **WILL NOT** run if the return status code is >= 500!!!
+    :return:
+    '''
+    def wrapper(func):
+        # if we're local dev or running unit tests, run without queueing
+        if settings.DEBUG_MODE:
+            return func
+        @functools.wraps(func)
+        def wrapped(*args, **kwargs):
+            import ipdb; ipdb.set_trace()
+            if celery is True and isinstance(func, Task):
+                func.delay(*args, **kwargs)
+            else:
+                enqueue_postcommit_task(func, args, kwargs, once_per_request=once_per_request)
+        return wrapped
+    return wrapper

--- a/website/notifications/utils.py
+++ b/website/notifications/utils.py
@@ -11,8 +11,6 @@ from website.notifications.model import NotificationSubscription
 from website.project import signals
 
 from framework.celery_tasks import app
-from framework.celery_tasks.handlers import queued_task
-from framework.transactions.context import transaction
 
 
 class NotificationsDict(dict):

--- a/website/notifications/utils.py
+++ b/website/notifications/utils.py
@@ -73,12 +73,12 @@ def remove_contributor_from_subscriptions(node, user):
 
 
 @signals.node_deleted.connect
-def i_am_a_bad_person(node):
-    remove_subscription(node._id)
+def remove_subscription(node):
+    remove_subscription_task(node._id)
 
 @run_postcommit(once_per_request=False, celery=True)
 @app.task(max_retries=5, default_retry_delay=60)
-def remove_subscription(node_id):
+def remove_subscription_task(node_id):
     node = Node.load(node_id)
     model.NotificationSubscription.remove(Q('owner', 'eq', node))
     parent = node.parent_node

--- a/website/project/views/comment.py
+++ b/website/project/views/comment.py
@@ -145,11 +145,11 @@ def is_reply(target):
 
 def _update_comments_timestamp(auth, node, page=Comment.OVERVIEW, root_id=None):
     if node.is_contributor(auth.user):
-        enqueue_postcommit_task((ban_url, (node, )))
+        enqueue_postcommit_task(ban_url, (node, ), {})
         if root_id is not None:
             guid_obj = Guid.load(root_id)
             if guid_obj is not None:
-                enqueue_postcommit_task((ban_url, (guid_obj.referent, )))
+                enqueue_postcommit_task(ban_url, (guid_obj.referent, ), {})
 
         # update node timestamp
         if page == Comment.OVERVIEW:


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

This should fix tasks locking user objects in mongo. 

## Changes

It adds the ability for the postcommit handler decorator to make tasks run in celery instead of running postcommit, inside or after the request. It also decorates several tasks that were causing locks.

## Side effects

If celery is down or backed up some of the tasks may be delayed to the point that users may notice the discrepancy in their activity counters.

## Ticket
This is a second pass at fixing OSF-6294 without so many side effects.
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
https://openscience.atlassian.net/browse/OSF-6294