### PR TITLE
[RFR] Remove .always call and unsave button in function

### DIFF
--- a/website/static/js/profile.js
+++ b/website/static/js/profile.js
@@ -268,6 +268,7 @@ BaseViewModel.prototype.changeMessage = function(text, css, timeout) {
 };
 
 BaseViewModel.prototype.handleSuccess = function() {
+    this.saving(false);
     if ($.inArray('view', this.modes) >= 0) {
         this.mode('view');
     } else {
@@ -280,6 +281,7 @@ BaseViewModel.prototype.handleSuccess = function() {
 };
 
 BaseViewModel.prototype.handleError = function(response) {
+    this.saving(false);
     var defaultMsg = 'Could not update settings';
     var msg = response.message_long || defaultMsg;
     this.changeMessage(
@@ -354,8 +356,6 @@ BaseViewModel.prototype.submit = function() {
             this.setOriginal.bind(this)
         ).fail(
             this.handleError.bind(this)
-        ).always(
-            function() { this.saving(false); }
         );
     } else {
         this.showMessages(true);


### PR DESCRIPTION
related to https://github.com/CenterForOpenScience/osf.io/pull/5714

QA caught a problem where the .always call is not "allllllwayyyys" (get it) working on Safari or Firefox to enable the save button after an AJAX request.  And by not always, I mean ever.  So I am calling the request in the handle success and handle error functions.

https://openscience.atlassian.net/browse/OSF-3912