### PR TITLE
CORSMiddleware cleanup/fixes

### DIFF
--- a/api/base/middleware.py
+++ b/api/base/middleware.py
@@ -120,7 +120,10 @@ class CorsMiddleware(corsheaders.middleware.CorsMiddleware):
                     elif (
                         request.method == 'OPTIONS' and
                         'HTTP_ACCESS_CONTROL_REQUEST_METHOD' in request.META and
-                        'authorization' in request.META.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS', '').split(', ')
+                        'authorization' in map(
+                            lambda h: h.strip(),
+                            request.META.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS', '').split(',')
+                        )
                     ):
                         return
             return not_found

--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -98,6 +98,8 @@ CORS_ORIGIN_ALLOW_ALL = False
 CORS_ORIGIN_WHITELIST = (urlparse(osf_settings.DOMAIN).netloc,
                          osf_settings.DOMAIN,
                          )
+# This needs to remain True to allow cross origin requests that are in CORS_ORIGIN_WHITELIST to
+# use cookies.
 CORS_ALLOW_CREDENTIALS = True
 # Set dynamically on app init
 INSTITUTION_ORIGINS_WHITELIST = ()


### PR DESCRIPTION
## Purpose

- The APIv2's CORSMiddleware had a little extra code accidentally brought in during a merge. This removes the dead code.
- FF sends its `ACCESS_CONTROL_REQUEST_HEADERS` as a comma separated list with no spaces which broke the CORSMiddleware's check for whether or not to send CORS headers on options requests. This fixes that.

### Resolves: https://openscience.atlassian.net/browse/OSF-6287