### PR TITLE
Fix registrations files provider relationship [#OSF-6413]

### DIFF
--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -4,7 +4,7 @@ from rest_framework import exceptions
 
 from api.base.utils import absolute_reverse
 from api.files.serializers import FileSerializer
-from api.nodes.serializers import NodeSerializer
+from api.nodes.serializers import NodeSerializer, NodeProviderSerializer
 from api.nodes.serializers import NodeLinksSerializer, NodeLicenseSerializer
 from api.nodes.serializers import NodeContributorsSerializer, NodeTagField
 from api.base.serializers import (IDField, RelationshipField, LinksField, HideIfWithdrawal,
@@ -86,6 +86,13 @@ class RegistrationSerializer(NodeSerializer):
         related_view='registrations:registration-providers',
         related_view_kwargs={'node_id': '<pk>'}
     ))
+    #
+    # files = NodeFileHyperLinkField(
+    #     related_view='registrations:registration-files',
+    #     related_view_kwargs={'node_id': '<node_id>', 'path': '<path>', 'provider': '<provider>'},
+    #     kind='folder',
+    #     never_embed=True
+    # )
 
     wikis = HideIfWithdrawal(RelationshipField(
         related_view='registrations:registration-wikis',
@@ -231,3 +238,15 @@ class RegistrationFileSerializer(FileSerializer):
                                             related_view_kwargs={'node_id': '<node._id>'},
                                             related_meta={'unread': 'get_unread_comments_count'},
                                             filter={'target': 'get_file_guid'})
+
+
+class RegistrationProviderSerializer(NodeProviderSerializer):
+    """
+    Overrides NodeProviderSerializer to lead to correct registration file links
+    """
+    files = NodeFileHyperLinkField(
+        related_view='registrations:registration-files',
+        related_view_kwargs={'node_id': '<node_id>', 'path': '<path>', 'provider': '<provider>'},
+        kind='folder',
+        never_embed=True
+    )

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -86,13 +86,6 @@ class RegistrationSerializer(NodeSerializer):
         related_view='registrations:registration-providers',
         related_view_kwargs={'node_id': '<pk>'}
     ))
-    #
-    # files = NodeFileHyperLinkField(
-    #     related_view='registrations:registration-files',
-    #     related_view_kwargs={'node_id': '<node_id>', 'path': '<path>', 'provider': '<provider>'},
-    #     kind='folder',
-    #     never_embed=True
-    # )
 
     wikis = HideIfWithdrawal(RelationshipField(
         related_view='registrations:registration-wikis',

--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -20,7 +20,9 @@ from api.nodes.views import (
     NodeAlternativeCitationsList, NodeAlternativeCitationDetail, NodeLogList,
     NodeInstitutionDetail, WaterButlerMixin, NodeForksList, NodeWikiList)
 
-from api.registrations.serializers import RegistrationNodeLinksSerializer, RegistrationFileSerializer
+from api.registrations.serializers import (
+    RegistrationNodeLinksSerializer, RegistrationFileSerializer, RegistrationProviderSerializer
+)
 
 from api.nodes.permissions import (
     ContributorOrPublic,
@@ -296,6 +298,8 @@ class RegistrationLogList(NodeLogList, RegistrationMixin):
 
 
 class RegistrationProvidersList(NodeProvidersList, RegistrationMixin):
+    serializer_class = RegistrationProviderSerializer
+
     view_category = 'registrations'
     view_name = 'registration-providers'
 


### PR DESCRIPTION

## Purpose
In the API, registration files were being redirected to ```/node/```  instead of ```/registrations/``` and were so causing an error. This adds a registration file provider serializer to send the correct information

## Changes
- Add RegistrationProviderSerializer
- Use that serializer

## Side effects
- nope

## Ticket
https://openscience.atlassian.net/browse/OSF-6413