### PR TITLE
Add institution logo links to Dashboard page

### DIFF
--- a/website/routes.py
+++ b/website/routes.py
@@ -49,6 +49,8 @@ def get_globals():
     OSFWebRenderer.
     """
     user = _get_current_user()
+    user_institutions = [{'id': inst._id, 'name': inst.name, 'logo_path': inst.logo_path} for inst in user.affiliated_institutions] if user else []
+    all_institutions = [{'id': inst._id, 'name': inst.name, 'logo_path': inst.logo_path} for inst in Institution.find().sort('name')]
     if request.host_url != settings.DOMAIN:
         try:
             inst_id = (Institution.find_one(Q('domains', 'eq', request.host.lower())))._id
@@ -68,6 +70,8 @@ def get_globals():
         'user_gravatar': profile_views.current_user_gravatar(size=25)['gravatar_url'] if user else '',
         'user_api_url': user.api_url if user else '',
         'user_entry_point': metrics.get_entry_point(user) if user else '',
+        'user_institutions': user_institutions if user else None,
+        'all_institutions': all_institutions,
         'display_name': get_display_name(user.fullname) if user else '',
         'use_cdn': settings.USE_CDN_FOR_CLIENT_LIBS,
         'piwik_host': settings.PIWIK_HOST,

--- a/website/static/css/pages/home-page.css
+++ b/website/static/css/pages/home-page.css
@@ -14,6 +14,13 @@ h3, h4 {
     color: #FFF;
 }
 
+.institutions-panel {
+    min-height: 200px;
+    background: #45818E;
+    padding-top: 25px;
+    padding-bottom: 25px;
+}
+
 .meetings {
     background: #166595 url("/static/img/front-page/bg-web.png") no-repeat center top;
     background-size: cover;

--- a/website/static/js/components/institution.js
+++ b/website/static/js/components/institution.js
@@ -1,0 +1,46 @@
+/**
+* Mithril components for OSF4I.
+*/
+'use strict';
+var $ = require('jquery');
+var m = require('mithril');
+
+var utils = require('js/components/utils');
+var required = utils.required;
+
+/**
+ * Display an OSF4I logo.
+ */
+var MUTED_OPACITY = '0.5';
+var InstitutionImg = {
+    view: function(ctrl, opts) {
+        var defaults = {
+            muted: false
+        };
+        if (!opts.width && !opts.height) {
+            throw new Error('InstitionImg requires width and/or height option.');
+        }
+        if (opts.width && !opts.height) { opts.height = opts.width; }
+        if (opts.height && !opts.width) { opts.width = opts.height; }
+        var logoPath = required(opts, 'logoPath');
+        var institutionName = required(opts, 'name');
+        var style = {};
+        if (opts.muted) {
+            style.opacity = MUTED_OPACITY;
+        }
+        // allow user to pass additional styles
+        style = $.extend({}, style, opts.style);
+        var imgOpts = $.extend({}, opts, {
+            className: 'img-circle text-muted ' + (opts.className || ''),
+            style: style,
+            src: logoPath,
+            width: opts.width, height: opts.height,
+            alt: opts.alt || institutionName
+        });
+        return m('img', imgOpts);
+    }
+};
+
+module.exports = {
+    InstitutionImg: InstitutionImg
+};

--- a/website/static/js/components/utils.js
+++ b/website/static/js/components/utils.js
@@ -1,0 +1,20 @@
+'use strict';
+var lodashGet  = require('lodash.get');
+
+/**
+ * Helper for required options passed to components.
+ * Usage:
+ *    var title = required(opts, 'title')
+ *    var lastName = required(opts, 'name.last')
+ */
+function required(opts, attribute) {
+    var opt = lodashGet(opts, attribute);
+    if (opt == null || opt === undefined) {
+        throw new Error('Missing required option: ' + attribute);
+    }
+    return opt;
+}
+
+module.exports = {
+    required: required
+};

--- a/website/static/js/home-page/institutionsPanelPlugin.js
+++ b/website/static/js/home-page/institutionsPanelPlugin.js
@@ -1,0 +1,55 @@
+/**
+ * Display a horizontal listing of clickable OSF4I logos (links to institution landing pages).
+ */
+'use strict';
+
+var $ = require('jquery');
+var m = require('mithril');
+var utils = require('js/components/utils');
+var required = utils.required;
+
+var components = require('js/components/institution');
+var Institution = components.InstitutionImg;
+
+var LOGO_WIDTH = '120px';
+
+var InstitutionsPanel = {
+    controller: function() {
+        // Helper method to render logo link
+        this.renderLogo = function(inst, opts) {
+            var href = '/institutions/' + inst.id + '/';
+            return m('a', {href: href},
+                        [m.component(Institution,
+                                    {
+                                        name: inst.name,
+                                        logoPath: inst.logoPath,
+                                        muted: opts.muted,
+                                        width: LOGO_WIDTH,
+                                        style: {'margin-right': '15px'}
+                                    })]);
+        };
+    },
+    view: function(ctrl, opts) {
+        var affiliated = required(opts, 'affiliatedInstitutions');
+        var allInstitutions = required(opts, 'allInstitutions');
+
+        var affiliatedIds = affiliated.map(function(inst) { return inst.id; });
+        var unaffiliated = allInstitutions.filter(function(inst) {
+            return $.inArray(inst.id, affiliatedIds) === -1;
+        });
+
+        return m('.p-v-sm',
+            m('.row',
+                [
+                    m('.col-md-12',
+                        // Display affiliated institutions before unaffiliated institutions
+                        affiliated.map(function(inst) { return ctrl.renderLogo(inst, {muted: false}); })
+                            .concat(unaffiliated.map(function(inst) { return ctrl.renderLogo(inst, {muted: true}); }))
+                    )
+                ]
+            )
+        );
+    }
+};
+
+module.exports = InstitutionsPanel;

--- a/website/static/js/pages/home-page.js
+++ b/website/static/js/pages/home-page.js
@@ -6,16 +6,27 @@
 
 var $ = require('jquery');
 var m = require('mithril');
+var lodashGet = require('lodash.get');
 
 var QuickSearchProject = require('js/home-page/quickProjectSearchPlugin');
 var NewAndNoteworthy = require('js/home-page/newAndNoteworthyPlugin');
 var MeetingsAndConferences = require('js/home-page/meetingsAndConferencesPlugin');
+var InstitutionsPanel = require('js/home-page/institutionsPanelPlugin');
 
 var columnSizeClass = '.col-md-10 col-md-offset-1 col-lg-8 col-lg-offset-2';
 
 $(document).ready(function(){
     var osfHome = {
         view : function(ctrl, args) {
+            // Camel-case institutions keys
+            var _affiliatedInstitutions = lodashGet(window, 'contextVars.currentUser.institutions') || [];
+            var affiliatedInstitutions = _affiliatedInstitutions.map(function(inst) {
+                return {logoPath: inst.logo_path, id: inst.id, name: inst.name};
+            });
+            var _allInstitutions = lodashGet(window, 'contextVars.allInstitutions') || [];
+            var allInstitutions = _allInstitutions.map(function(inst) {
+                return {logoPath: inst.logo_path, id: inst.id, name: inst.name};
+            });
             return [
                 m('.quickSearch', m('.container.p-t-lg',
                     [
@@ -24,6 +35,16 @@ $(document).ready(function(){
                         ])
                     ]
                 )),
+                allInstitutions.length ? m('.institutions-panel', m('.container',
+                    [
+                        m('.row', [
+                            m(columnSizeClass,  m.component(InstitutionsPanel, {
+                                affiliatedInstitutions: affiliatedInstitutions,
+                                allInstitutions: allInstitutions
+                            }))
+                        ])
+                    ]
+                )) : '',
                 m('.newAndNoteworthy', m('.container',
                     [
                         m('.row', [

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -188,10 +188,12 @@
                     id: ${ user_id | sjson, n },
                     locale: ${ user_locale | sjson, n },
                     timezone: ${ user_timezone | sjson, n },
-                    entryPoint: ${ user_entry_point | sjson, n }
+                    entryPoint: ${ user_entry_point | sjson, n },
+                    institutions: ${ user_institutions | sjson, n},
                 },
+                allInstitutions: ${ all_institutions | sjson, n},
                 popular: ${ popular_links_node | sjson, n },
-                newAndNoteworthy: ${ noteworthy_links_node | sjson, n }
+                newAndNoteworthy: ${ noteworthy_links_node | sjson, n },
             });
         </script>
 


### PR DESCRIPTION

## Purpose

To aid affiliated users in discovering their affiliated institutions landing page.

## Changes

Add institution logo links to Dashboard. Links go to OSF4I landing pages.

Unaffiliated institutions are muted.

![osf___home](https://cloud.githubusercontent.com/assets/2379650/15615883/b68e40ba-240e-11e6-8864-fce3cace2bd7.png)

## Side effects

The `InstitutionImg` mithril component added in this PR should be used to render logo images for other features, e.g. https://github.com/CenterForOpenScience/osf.io/pull/5754 . Ping @hmoco 

## Ticket

https://openscience.atlassian.net/browse/OSF-6311 . 
