### PR TITLE
hotfix/repair registrations files provider relationship [#OSF-6413]

### DIFF
--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -87,13 +87,6 @@ class RegistrationSerializer(NodeSerializer):
         related_view='registrations:registration-providers',
         related_view_kwargs={'node_id': '<pk>'}
     ))
-    #
-    # files = NodeFileHyperLinkField(
-    #     related_view='registrations:registration-files',
-    #     related_view_kwargs={'node_id': '<node_id>', 'path': '<path>', 'provider': '<provider>'},
-    #     kind='folder',
-    #     never_embed=True
-    # )
 
     forked_from = HideIfWithdrawal(RelationshipField(
         related_view=lambda n: 'registrations:registration-detail' if getattr(n, 'is_registration', False) else 'nodes:node-detail',

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -4,6 +4,8 @@ from rest_framework import exceptions
 
 from api.base.utils import absolute_reverse
 from api.files.serializers import FileSerializer
+from api.nodes.serializers import NodeSerializer, NodeProviderSerializer
+from api.nodes.serializers import NodeLinksSerializer, NodeLicenseSerializer
 from api.nodes.serializers import NodeSerializer
 from api.nodes.serializers import NodeLinksSerializer
 from api.nodes.serializers import NodeContributorsSerializer, NodeTagField
@@ -85,6 +87,13 @@ class RegistrationSerializer(NodeSerializer):
         related_view='registrations:registration-providers',
         related_view_kwargs={'node_id': '<pk>'}
     ))
+    #
+    # files = NodeFileHyperLinkField(
+    #     related_view='registrations:registration-files',
+    #     related_view_kwargs={'node_id': '<node_id>', 'path': '<path>', 'provider': '<provider>'},
+    #     kind='folder',
+    #     never_embed=True
+    # )
 
     forked_from = HideIfWithdrawal(RelationshipField(
         related_view=lambda n: 'registrations:registration-detail' if getattr(n, 'is_registration', False) else 'nodes:node-detail',
@@ -216,3 +225,15 @@ class RegistrationFileSerializer(FileSerializer):
                                             related_view_kwargs={'node_id': '<node._id>'},
                                             related_meta={'unread': 'get_unread_comments_count'},
                                             filter={'target': 'get_file_guid'})
+
+
+class RegistrationProviderSerializer(NodeProviderSerializer):
+    """
+    Overrides NodeProviderSerializer to lead to correct registration file links
+    """
+    files = NodeFileHyperLinkField(
+        related_view='registrations:registration-files',
+        related_view_kwargs={'node_id': '<node_id>', 'path': '<path>', 'provider': '<provider>'},
+        kind='folder',
+        never_embed=True
+    )

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -5,8 +5,6 @@ from rest_framework import exceptions
 from api.base.utils import absolute_reverse
 from api.files.serializers import FileSerializer
 from api.nodes.serializers import NodeSerializer, NodeProviderSerializer
-from api.nodes.serializers import NodeLinksSerializer, NodeLicenseSerializer
-from api.nodes.serializers import NodeSerializer
 from api.nodes.serializers import NodeLinksSerializer
 from api.nodes.serializers import NodeContributorsSerializer, NodeTagField
 from api.base.serializers import (IDField, RelationshipField, LinksField, HideIfWithdrawal,

--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -11,6 +11,7 @@ from api.registrations.serializers import (
     RegistrationSerializer,
     RegistrationDetailSerializer,
     RegistrationContributorsSerializer,
+    RegistrationProviderSerializer
 )
 
 from api.nodes.views import (
@@ -290,6 +291,8 @@ class RegistrationLogList(NodeLogList, RegistrationMixin):
 
 
 class RegistrationProvidersList(NodeProvidersList, RegistrationMixin):
+    serializer_class = RegistrationProviderSerializer
+
     view_category = 'registrations'
     view_name = 'registration-providers'
 


### PR DESCRIPTION
Reopening #5761 as a hotfix instead

## Purpose

In the API, registration files were being redirected to ```/node/```  instead of ```/registrations/``` and were so causing an error. This adds a registration file provider serializer to send the correct information.

```/v2/registrations/3nb7j/files/``` should now have ```relationships>files>links>related``` be referring to ```registrations``` instead of ```nodes```

![screen shot 2016-05-27 at 2 49 12 pm](https://cloud.githubusercontent.com/assets/801594/15618098/49518028-241a-11e6-9eb4-897713bde177.png)


```
{
    "data": [
        {
            "relationships": {
                "files": {
                    "links": {
                        "related": {
                            "href": "http://localhost:8000/v2/registrations/3nb7j/files/osfstorage/",
                            "meta": {}
                        }
                    }
                }
            }
    ]
}
```

## Changes
- Add RegistrationProviderSerializer
- Use that serializer

## Side effects
- nope

## Ticket
https://openscience.atlassian.net/browse/OSF-6413