### PR TITLE
Hotfix/email help desk stuck registrations [#OSF-5848]

### DIFF
--- a/scripts/cleanup_failed_registrations.py
+++ b/scripts/cleanup_failed_registrations.py
@@ -6,8 +6,6 @@ import logging
 from modularodm import Q
 
 from website.archiver import (
-    ARCHIVER_UNCAUGHT_ERROR,
-    ARCHIVER_FAILURE,
     ARCHIVER_INITIATED
 )
 
@@ -17,7 +15,6 @@ from website import (
 )
 
 from website.settings import ARCHIVE_TIMEOUT_TIMEDELTA
-from website.archiver.utils import handle_archive_fail
 from website.archiver.model import ArchiveJob
 
 from website.app import init_app
@@ -54,10 +51,10 @@ def notify_desk_about_failed_registrations(dry_run=True):
             # Send an email to the OSF Help Desk
             mails.send_mail(
                 to_addr=settings.SUPPORT_EMAIL,
-                mail=mails.ARCHIVE_UNCAUGHT_ERROR_DESK,
+                mail=mails.ARCHIVE_REGISTRATION_STUCK_DESK,
                 user=f.creator,
                 src=f.registered_from,
-                results=f.archive_job.target_info(),
+                archive_job=f.archve_job,
             )
 
             count += 1

--- a/scripts/cleanup_failed_registrations.py
+++ b/scripts/cleanup_failed_registrations.py
@@ -10,6 +10,12 @@ from website.archiver import (
     ARCHIVER_FAILURE,
     ARCHIVER_INITIATED
 )
+
+from website import (
+    mails,
+    settings
+)
+
 from website.settings import ARCHIVE_TIMEOUT_TIMEDELTA
 from website.archiver.utils import handle_archive_fail
 from website.archiver.model import ArchiveJob
@@ -21,6 +27,7 @@ from scripts import utils as script_utils
 
 logger = logging.getLogger(__name__)
 
+
 def find_failed_registrations():
     expired_if_before = datetime.utcnow() - ARCHIVE_TIMEOUT_TIMEDELTA
     jobs = ArchiveJob.find(
@@ -30,7 +37,8 @@ def find_failed_registrations():
     )
     return {node.root for node in [job.dst_node for job in jobs] if node}
 
-def remove_failed_registrations(dry_run=True):
+
+def notify_desk_about_failed_registrations(dry_run=True):
     init_app(set_backends=True, routes=False)
     count = 0
     failed = find_failed_registrations()
@@ -40,26 +48,27 @@ def remove_failed_registrations(dry_run=True):
             if not f.registered_from:
                 logging.info('Node {0} had registered_from == None'.format(f._id))
                 continue
-            if not f.archive_job:  # Be extra sure not to delete legacy registrations
+            if not f.archive_job:  # Be extra sure not to deal with legacy registrations
                 continue
-            f.archive_job.status = ARCHIVER_FAILURE
-            f.archive_job.sent = True
-            f.archive_job.save()
-            handle_archive_fail(
-                ARCHIVER_UNCAUGHT_ERROR,
-                f.registered_from,
-                f,
-                f.creator,
-                f.archive_job.target_info()
+
+            # Send an email to the OSF Help Desk
+            mails.send_mail(
+                to_addr=settings.SUPPORT_EMAIL,
+                mail=mails.ARCHIVE_UNCAUGHT_ERROR_DESK,
+                user=f.creator,
+                src=f.registered_from,
+                results=f.archive_job.target_info(),
             )
+
             count += 1
-    logging.info('Cleaned {} registrations'.format(count))
+    logging.info('Found {} registrations, notified the OSF Help Desk'.format(count))
+
 
 def main():
     dry = 'dry' in sys.argv
     if not dry:
         script_utils.add_file_logger(logger, __file__)
-    remove_failed_registrations(dry_run=dry)
+    notify_desk_about_failed_registrations(dry_run=dry)
 
 if __name__ == '__main__':
     main()

--- a/website/mails/mails.py
+++ b/website/mails/mails.py
@@ -219,6 +219,7 @@ FILE_OPERATION_FAILED = Mail(
 
 UNESCAPE = "<% from website.util.sanitize import unescape_entities %> ${unescape_entities(src.title)}"
 PROBLEM_REGISTERING = "Problem registering " + UNESCAPE
+PROBLEM_REGISTERING_STUCK = PROBLEM_REGISTERING + '- Stuck Registration'
 
 ARCHIVE_SIZE_EXCEEDED_DESK = Mail(
     'archive_size_exceeded_desk',
@@ -251,6 +252,12 @@ ARCHIVE_UNCAUGHT_ERROR_DESK = Mail(
     'archive_uncaught_error_desk',
     subject=PROBLEM_REGISTERING
 )
+
+ARCHIVE_REGISTRATION_STUCK_DESK = Mail(
+    'archive_registration_stuck_desk',
+    subject=PROBLEM_REGISTERING_STUCK
+)
+
 ARCHIVE_UNCAUGHT_ERROR_USER = Mail(
     'archive_uncaught_error_user',
     subject=PROBLEM_REGISTERING

--- a/website/templates/emails/archive_registration_stuck_desk.txt.mako
+++ b/website/templates/emails/archive_registration_stuck_desk.txt.mako
@@ -1,0 +1,12 @@
+
+User: ${user.fullname} (${user.username}) [${user._id}]
+
+Registration ${src.title} [${src._id}] is stuck in archiving.
+
+Archive Job: [${archive_job._id}]
+
+<% import json %>
+
+${archive_job.to_storage()}
+
+Automatically sent from scripts/cleanup_failed_registrations.py


### PR DESCRIPTION
## Purpose
There is an existing script that is not being run currently to find stuck registrations, delete them, and send an email to both Desk.com and the user telling them there is a problem. 

This PR changes this script to only email the help desk so we can deal with stuck registrations on a case by case basis, and NOT email the user.

## Changes
- Add ```email_users``` flag to ```handle_archive_fail``` function
- Set that flag to ```False``` to only email the Help desk with stuck registrations

## Side effects
- None anticipated

## Ticket
https://openscience.atlassian.net/browse/OSF-5848