### PR TITLE
Hotfix/ Fix API referent error on get_paginated_response [#OSF-6427

### DIFF
--- a/api/base/pagination.py
+++ b/api/base/pagination.py
@@ -144,13 +144,14 @@ class CommentPagination(JSONAPIPagination):
             user = self.request.user
             if target_id and not user.is_anonymous() and node.is_contributor(user):
                 root_target = Guid.load(target_id)
-                page = getattr(root_target.referent, 'root_target_page', None)
-                if page:
-                    if not len(data):
-                        unread = 0
-                    else:
-                        unread = Comment.find_n_unread(user=user, node=node, page=page, root_id=target_id)
-                    response_dict['links']['meta']['unread'] = unread
+                if root_target:
+                    page = getattr(root_target.referent, 'root_target_page', None)
+                    if page:
+                        if not len(data):
+                            unread = 0
+                        else:
+                            unread = Comment.find_n_unread(user=user, node=node, page=page, root_id=target_id)
+                        response_dict['links']['meta']['unread'] = unread
         return Response(response_dict)
 
 

--- a/api_tests/nodes/views/test_node_comments_list.py
+++ b/api_tests/nodes/views/test_node_comments_list.py
@@ -981,6 +981,11 @@ class TestCommentFiltering(ApiTestCase):
         res = self.app.get(url, auth=self.user.auth)
         assert_equal(len(res.json['data']), 0)
 
+    def test_filtering_by_target_no_results_with_related_counts(self):
+        url = '{}?filter[target]=fakeid&related_counts=True'.format(self.base_url)
+        res = self.app.get(url, auth=self.user.auth)
+        assert_equal(len(res.json['data']), 0)
+
     def test_filtering_for_comment_replies(self):
         reply = CommentFactory(node=self.project, user=self.user, target=Guid.load(self.comment._id))
         url = self.base_url + '?filter[target]=' + str(self.comment._id)


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
When filtering by  node id, and using related counts, a non found node would throw a 500 error. This PR changes the filter function to check if a node being filtered on exists before trying to paginate.

## Changes
- Add check for root_target to filter for pagination
- Add test to make sure that no results are found when filtering on a fake node id with related counts

## Side effects
- none anticipated


## Ticket
https://openscience.atlassian.net/browse/OSF-6427
