### PR TITLE
Add wikis to Node non_anonymized_fields [OSF-6168]

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -73,6 +73,7 @@ class NodeSerializer(JSONAPISerializer):
         'parent',
         'root',
         'logs',
+        'wikis'
     ]
 
     id = IDField(source='_id', read_only=True)


### PR DESCRIPTION
# Purpose

Fixes issue where the `wikis` node serializer field did not appear when viewing a project through the API using a view-only link.

## Changes

Add `wikis` to `non_anonymized_fields` in the `NodeSerializer`

## Side effects

None.


## Ticket

https://openscience.atlassian.net/browse/OSF-6168
