### PR TITLE
[RFR][Feature][OSF-6300]File view pane, edit panel shows earlier version

### DIFF
--- a/website/addons/base/views.py
+++ b/website/addons/base/views.py
@@ -662,12 +662,12 @@ def addon_view_file(auth, node, file_node, version):
 
     ret = serialize_node(node, auth, primary=True)
 
-    if file_node._id not in node.file_guid_to_share_uuids:
-        node.file_guid_to_share_uuids[file_node._id] = uuid.uuid4()
+    if file_node._id + '-' + version._id not in node.file_guid_to_share_uuids:
+        node.file_guid_to_share_uuids[file_node._id + '-' + version._id] = uuid.uuid4()
         node.save()
 
     if ret['user']['can_edit']:
-        sharejs_uuid = str(node.file_guid_to_share_uuids[file_node._id])
+        sharejs_uuid = str(node.file_guid_to_share_uuids[file_node._id + '-' + version._id])
     else:
         sharejs_uuid = None
 

--- a/website/addons/wiki/model.py
+++ b/website/addons/wiki/model.py
@@ -271,6 +271,23 @@ class NodeWikiPage(GuidStoredObject, Commentable):
 
         return self.content
 
+    def update_active_sharejs(self, node):
+        """
+        Update all active sharejs sessions with latest wiki content.
+        """
+
+        """
+        TODO: This def is meant to be used after updating wiki content via
+        the v2 API, once updating is has been implemented. It should be removed
+        if not used for that purpose.
+        """
+
+        sharejs_uuid = wiki_utils.get_sharejs_uuid(node, self.page_name)
+        contributors = [user._id for user in node.contributors]
+        wiki_utils.broadcast_to_sharejs('reload',
+                                        sharejs_uuid,
+                                        data=contributors)
+
     def save(self, *args, **kwargs):
         rv = super(NodeWikiPage, self).save(*args, **kwargs)
         if self.node:

--- a/website/addons/wiki/shareServer.js
+++ b/website/addons/wiki/shareServer.js
@@ -197,6 +197,16 @@ wss.on('connection', function(client) {
     return share.listen(stream);
 });
 
+// Update a document from storage
+app.post('/reload/:id', jsonParser, function (req, res, next) {
+    wss.broadcast(req.params.id, JSON.stringify({
+        type: 'reload',
+        contributors: req.body // All contributors to be updated
+    }));
+    console.info('[Document reloaded from storage] docId: %s', req.params.id);
+    res.send(util.format('%s was reloaded.', req.params.id));
+});
+
 // Lock a document
 app.post('/lock/:id', function (req, res, next) {
     locked[req.params.id] = true;

--- a/website/addons/wiki/static/ShareJSDoc.js
+++ b/website/addons/wiki/static/ShareJSDoc.js
@@ -134,6 +134,10 @@ var ShareJSDoc = function(url, metadata, viewText, editor) {
                     refreshMaybe();
                 }, 3000);
                 break;
+            case 'reload':
+                refreshTriggered = true;
+                refreshMaybe();
+                break;
             case 'unlock':
                 canEdit = data.contributors.indexOf(metadata.userId) > -1;
                 refreshTriggered = true;


### PR DESCRIPTION
## Purpose:
[OSF-6300](https://openscience.atlassian.net/browse/OSF-6300)
Fix to get latest version in file editor panel
Add code to refresh active sharejs sessions. For future use in v2 API wiki updating

## Changes:
Update website/addons/base/views.py add version to key for file_guid_to_share_uuids
Update website/addons/wiki/model.py add def update_active_sharejs for use in future API updates
Update website/addons/wiki/shareServer.js add reload call
Update website/addons/wiki/static/ShareJSDoc.js add reload case

# Warning!
1. This code updates sharejs code and will require sharejs to be bounced.
2. If sharejs restart is deferred, any new shared editing sessions initiated from the file view after the code is updated will not share(js) with sessions initiated before the code is updated. This does not effect the wiki sharejs sessions

[#OSF-6300]