### PR TITLE
Hotfix/search migrate

### DIFF
--- a/framework/celery_tasks/handlers.py
+++ b/framework/celery_tasks/handlers.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
-
 import logging
 import threading
 import functools
 
 from celery import group
+from flask import _app_ctx_stack as context_stack
 
 from website import settings
 
@@ -50,11 +50,11 @@ def enqueue_task(signature):
     after request is complete; else run signature immediately.
     :param signature: Celery task signature
     """
-    try:
+    if context_stack.top is None:  # Not in a request context
+        signature()
+    else:
         if signature not in queue():
             queue().append(signature)
-    except (RuntimeError):
-        signature()
 
 
 def queued_task(task):

--- a/framework/mongo/utils.py
+++ b/framework/mongo/utils.py
@@ -147,7 +147,15 @@ def autoload(Model, extract_key, inject_key, func):
         return func(*args, **kwargs)
     return wrapper
 
-def paginated(model, query=None, increment=200):
+def paginated(model, query=None, increment=200, each=True):
+    """Paginate a MODM query.
+
+    :param StoredObject model: Model to query.
+    :param Q query: Optional query object.
+    :param int increment: Page size
+    :param bool each: If True, each record is yielded. If False, pages
+        are yielded.
+    """
     last_id = ''
     pages = (model.find(query).count() / increment) + 1
     for i in xrange(pages):
@@ -155,7 +163,12 @@ def paginated(model, query=None, increment=200):
         if query:
             q &= query
         page = list(model.find(q).limit(increment))
-        for item in page:
-            yield item
-        if page:
-            last_id = item._id
+        if each:
+            for item in page:
+                yield item
+            if page:
+                last_id = item._id
+        else:
+            if page:
+                yield page
+                last_id = page[-1]._id

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -66,19 +66,8 @@ The code snippet below will paginate result and load them into memory so timeout
 
 ```python
 from framework.mongo.utils import paginated
-```
 
-```python
-def paginated(model, query=None, increment=200):
-    last_id = ''
-    pages = (model.find(query).count() / increment) + 1
-    for i in xrange(pages):
-        q = Q('_id', 'gt', last_id)
-        if query:
-            q &= query
-        page = list(model.find(q).limit(increment))
-        for item in page:
-            yield item
-        if page:
-            last_id = item._id
+nodes = paginated(Node, Q('is_public', 'eq', True))
+for node in nodes:
+    #...
 ```

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -358,7 +358,6 @@ def bulk_update_nodes(serialize, nodes, index=None):
     index = index or INDEX
     actions = []
     for node in nodes:
-        logger.info('Updating node {}'.format(node._id))
         serialized = serialize(node)
         if serialized:
             actions.append({


### PR DESCRIPTION
## Purpose

- Manual search migrations (`inv migrate_search`) are getting cursor timeout errors in production
- Running `node.update_search()` outside of request context (e.g. in a shell) is currently not working

## Changes

<!-- Briefly describe or list your changes  -->

- Paginate queries when doing `inv migrate_search`
- Fix check for request context in `enqueue_task`

## Side effects

<!--Any possible side effects? -->

## Ticket

Related to https://openscience.atlassian.net/browse/OSF-6436
