### PR TITLE
[rfr] reset modifyChildren after request

### DIFF
--- a/website/static/js/institutionProjectSettings.js
+++ b/website/static/js/institutionProjectSettings.js
@@ -210,11 +210,6 @@ var ViewModel = function(data) {
                     self.availableInstitutions.push(removed);
                 }
             }
-            self.loading(false);
-            self.modifyChildren(false);
-            //fetchNodeTree is called to refresh self.nodesOriginal after a state change.  This is the simplest way to
-            //update state check if the modal is necessary.
-            self.fetchNodeTree(self.treebeardUrl);
         }).fail(function (xhr, status, error) {
             $osf.growl('Unable to modify the institution on this node. Please try again. If the problem persists, email <a href="mailto:support@osf.io.">support@osf.io</a>');
             Raven.captureMessage('Unable to modify this institution!', {
@@ -224,7 +219,12 @@ var ViewModel = function(data) {
                     error: error
                 }
             });
-        });
+        }).always(function() {
+            self.modifyChildren(false);
+            self.loading(false);
+            //fetchNodeTree is called to refresh self.nodesOriginal after a state change.  This is the simplest way to
+            //update state to check if the modal is necessary.
+            self.fetchNodeTree(self.treebeardUrl);        });
     };
 };
 

--- a/website/static/js/institutionProjectSettings.js
+++ b/website/static/js/institutionProjectSettings.js
@@ -211,6 +211,7 @@ var ViewModel = function(data) {
                 }
             }
             self.loading(false);
+            self.modifyChildren(false);
             //fetchNodeTree is called to refresh self.nodesOriginal after a state change.  This is the simplest way to
             //update state check if the modal is necessary.
             self.fetchNodeTree(self.treebeardUrl);


### PR DESCRIPTION
Related to #5726

## Purpose

QA found a bug where if you set and unset an institution, the single institution does not work.  I needed to reset modifyChildren after a request is made.

## Ticket

https://openscience.atlassian.net/browse/OSF-6165
