### PR TITLE
Feature/fix nodetree permissions

### DIFF
--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -986,7 +986,6 @@ def node_child_tree(user, node_ids):
                 'url': node.url if can_read else '',
                 'title': node.title if can_read else 'Private Project',
                 'is_public': node.is_public,
-                'can_write': node.has_permission(user, WRITE),
                 'contributors': contributors,
                 'visible_contributors': node.visible_contributor_ids,
                 'is_admin': node.has_permission(user, ADMIN),

--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -147,7 +147,7 @@ AddContributorViewModel = oop.extend(Paginator, {
         for (var key in nodesState) {
             var i;
             var node = nodesState[key];
-            var enabled = nodesState[key].canWrite;
+            var enabled = nodesState[key].isAdmin;
             var checked = nodesState[key].checked;
             if (enabled) {
                 var nodeContributors = [];
@@ -466,7 +466,7 @@ AddContributorViewModel = oop.extend(Paginator, {
             //parent node is changed by default
             nodesState[nodeParent].checked = true;
             //parent node cannot be changed
-            nodesState[nodeParent].canWrite = false;
+            nodesState[nodeParent].isAdmin = false;
             self.nodesState(nodesState);
         }).fail(function (xhr, status, error) {
             $osf.growl('Error', 'Unable to retrieve project settings');

--- a/website/static/js/nodeSelectTreebeard.js
+++ b/website/static/js/nodeSelectTreebeard.js
@@ -64,7 +64,7 @@ function subscribe(item, notification_type) {
 function NodeSelectTreebeard(divID, data, nodesState) {
     /**
      *  nodesState is a knockout variable that syncs the mithril checkbox list with information on the view.  The
-     *  changed boolean parameter is used to sync the checkbox with changes, the canWrite boolean parameter is used
+     *  changed boolean parameter is used to sync the checkbox with changes, the isAdmin boolean parameter is used
      *  to disable the checkbox
      * */
     var tbOptions = $.extend({}, projectSettingsTreebeardBase.defaults, {

--- a/website/static/js/nodesPrivacy.js
+++ b/website/static/js/nodesPrivacy.js
@@ -52,7 +52,7 @@ function getNodesOriginal(nodeTree, nodesOriginal) {
             public: nodeMeta.node.is_public,
             id: nodeMeta.node.id,
             title: nodeMeta.node.title,
-            canWrite: nodeMeta.node.can_write,
+            isAdmin: nodeMeta.node.is_admin,
             changed: false
         };
     });
@@ -252,7 +252,7 @@ NodesPrivacyViewModel.prototype.clear = function() {
 NodesPrivacyViewModel.prototype.selectAll = function() {
     var nodesState = ko.toJS(this.nodesState());
     for (var node in nodesState) {
-        if (nodesState[node].canWrite) {
+        if (nodesState[node].isAdmin) {
             nodesState[node].public = true;
             nodesState[node].changed = nodesState[node].public !== this.nodesOriginal[node].public;
         }
@@ -264,7 +264,7 @@ NodesPrivacyViewModel.prototype.selectAll = function() {
 NodesPrivacyViewModel.prototype.selectNone = function() {
     var nodesState = ko.toJS(this.nodesState());
     for (var node in nodesState) {
-        if (nodesState[node].canWrite) {
+        if (nodesState[node].isAdmin) {
             nodesState[node].public = false;
             nodesState[node].changed = nodesState[node].public !== this.nodesOriginal[node].public;
 

--- a/website/static/js/nodesPrivacySettingsTreebeard.js
+++ b/website/static/js/nodesPrivacySettingsTreebeard.js
@@ -83,7 +83,7 @@ function NodesPrivacyTreebeard(divID, data, nodesState, nodesOriginal) {
                     filter : false,
                     custom : function () {
                         return m('input[type=checkbox]', {
-                            disabled : !item.data.node.can_write,
+                            disabled : !item.data.node.is_admin,
                             onclick : function() {
                                 item.data.node.is_public = !item.data.node.is_public;
                                 item.open = true;

--- a/website/static/js/projectSettingsTreebeardBase.js
+++ b/website/static/js/projectSettingsTreebeardBase.js
@@ -56,7 +56,6 @@ function getNodesOriginal(nodeTree, nodesOriginal) {
         visibleContributors: nodeTree.node.visible_contributors,
         adminContributors: adminContributors,
         registeredContributors: registeredContributors,
-        canWrite: nodeTree.node.can_write,
         institutions: nodeInstitutions,
         changed: false,
         checked: false,


### PR DESCRIPTION
## Purpose

A response to code review created a permissions change that allowed users with read/write access on a project to add contributors.  It was a little unclear and redundant so I am not using the is_admin flag to determine if a user can add or remove contributors.

## Ticket
https://openscience.atlassian.net/browse/OSF-6441