### PR TITLE
[hotfix]Allow deletion of Institutions;  don't show private nodes on OSF4I landing pages

### DIFF
--- a/api/institutions/views.py
+++ b/api/institutions/views.py
@@ -225,7 +225,8 @@ class InstitutionRegistrationList(InstitutionNodeList):
     base_node_query = (
         Q('is_deleted', 'ne', True) &
         Q('is_folder', 'ne', True) &
-        Q('is_registration', 'eq', True)
+        Q('is_registration', 'eq', True) &
+        Q('is_public', 'eq', True)
     )
 
     ordering = ('-date_modified', )

--- a/api/institutions/views.py
+++ b/api/institutions/views.py
@@ -155,19 +155,13 @@ class InstitutionNodeList(JSONAPIBaseView, ODMFilterMixin, generics.ListAPIView,
         Q('is_deleted', 'ne', True) &
         Q('is_folder', 'ne', True) &
         Q('is_registration', 'eq', False) &
-        Q('parent_node', 'eq', None)
+        Q('parent_node', 'eq', None) &
+        Q('is_public', 'eq', True)
     )
 
     # overrides ODMFilterMixin
     def get_default_odm_query(self):
-        base_query = self.base_node_query
-        user = self.request.user
-        permission_query = Q('is_public', 'eq', True)
-        if not user.is_anonymous():
-            permission_query = (permission_query | Q('contributors', 'eq', user._id))
-
-        query = base_query & permission_query
-        return query
+        return self.base_node_query
 
     # overrides RetrieveAPIView
     def get_queryset(self):

--- a/api_tests/institutions/views/test_institution_nodes_list.py
+++ b/api_tests/institutions/views/test_institution_nodes_list.py
@@ -14,12 +14,10 @@ class TestInstitutionNodeList(ApiTestCase):
         self.node1.affiliated_institutions.append(self.institution)
         self.node1.save()
         self.user1 = AuthUserFactory()
-        self.user2 = AuthUserFactory()
         self.node2 = ProjectFactory(creator=self.user1, is_public=False)
         self.node2.affiliated_institutions.append(self.institution)
-        self.node2.add_contributor(self.user2, auth=Auth(self.user1))
         self.node2.save()
-        self.node3 = ProjectFactory(creator=self.user2, is_public=False)
+        self.node3 = ProjectFactory(is_public=False)
         self.node3.affiliated_institutions.append(self.institution)
         self.node3.save()
 
@@ -35,22 +33,12 @@ class TestInstitutionNodeList(ApiTestCase):
         assert_not_in(self.node2._id, ids)
         assert_not_in(self.node3._id, ids)
 
-    def test_return_private_nodes_with_auth(self):
+    def test_does_not_return_private_nodes_with_auth(self):
         res = self.app.get(self.institution_node_url, auth=self.user1.auth)
 
         assert_equal(res.status_code, 200)
         ids = [each['id'] for each in res.json['data']]
 
         assert_in(self.node1._id, ids)
-        assert_in(self.node2._id, ids)
+        assert_not_in(self.node2._id, ids)
         assert_not_in(self.node3._id, ids)
-
-    def test_return_private_nodes_mixed_auth(self):
-        res = self.app.get(self.institution_node_url, auth=self.user2.auth)
-
-        assert_equal(res.status_code, 200)
-        ids = [each['id'] for each in res.json['data']]
-
-        assert_in(self.node1._id, ids)
-        assert_in(self.node2._id, ids)
-        assert_in(self.node3._id, ids)

--- a/api_tests/institutions/views/test_institution_registrations_list.py
+++ b/api_tests/institutions/views/test_institution_registrations_list.py
@@ -35,25 +35,15 @@ class TestInstitutionRegistrationList(ApiTestCase):
         assert_not_in(self.registration2._id, ids)
         assert_not_in(self.registration3._id, ids)
 
-    def test_return_private_nodes_with_auth(self):
+    def test_does_not_return_private_nodes_with_auth(self):
         res = self.app.get(self.institution_node_url, auth=self.user1.auth)
 
         assert_equal(res.status_code, 200)
         ids = [each['id'] for each in res.json['data']]
 
         assert_in(self.registration1._id, ids)
-        assert_in(self.registration2._id, ids)
+        assert_not_in(self.registration2._id, ids)
         assert_not_in(self.registration3._id, ids)
-
-    def test_return_private_nodes_mixed_auth(self):
-        res = self.app.get(self.institution_node_url, auth=self.user2.auth)
-
-        assert_equal(res.status_code, 200)
-        ids = [each['id'] for each in res.json['data']]
-
-        assert_in(self.registration1._id, ids)
-        assert_in(self.registration2._id, ids)
-        assert_in(self.registration3._id, ids)
 
     def test_doesnt_return_retractions_without_auth(self):
         self.registration2.is_public = True

--- a/website/institutions/model.py
+++ b/website/institutions/model.py
@@ -129,7 +129,7 @@ class Institution(object):
     def load(cls, key):
         from website.models import Node
         try:
-            node = Node.find_one(Q('institution_id', 'eq', key) & Q('is_deleted', 'ne', True), allow_institution=True)
+            node = Node.find_one(Q('institution_id', 'eq', key), allow_institution=True)
             return cls(node)
         except NoResultsFound:
             return None

--- a/website/institutions/model.py
+++ b/website/institutions/model.py
@@ -69,6 +69,7 @@ class Institution(object):
         'description': 'description',
         'email_domains': 'institution_email_domains',
         'banner_name': 'institution_banner_name',
+        'is_deleted': 'is_deleted'
     }
 
     def __init__(self, node=None):
@@ -128,7 +129,7 @@ class Institution(object):
     def load(cls, key):
         from website.models import Node
         try:
-            node = Node.find_one(Q('institution_id', 'eq', key), allow_institution=True)
+            node = Node.find_one(Q('institution_id', 'eq', key) & Q('is_deleted', 'ne', True), allow_institution=True)
             return cls(node)
         except NoResultsFound:
             return None

--- a/website/institutions/views.py
+++ b/website/institutions/views.py
@@ -3,9 +3,13 @@ import httplib as http
 from .model import Institution
 from framework.exceptions import HTTPError
 
+from modularodm import Q
+from modularodm.exceptions import NoResultsFound
+
 def view_institution(inst_id, **kwargs):
-    inst = Institution.load(inst_id)
-    if not inst:
+    try:
+        inst = Institution.find_one(Q('_id', 'eq', inst_id) & Q('is_deleted', 'ne', True))
+    except NoResultsFound:
         raise HTTPError(http.NOT_FOUND)
     return {
         'id': inst._id,

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -479,16 +479,19 @@ def update_file(file_, index=None, delete=False):
 @requires_search
 def update_institution(institution, index=None):
     index = index or INDEX
+    id_ = institution._id
+    if institution.is_deleted:
+        es.delete(index=index, doc_type='institution', id=id_, refresh=True, ignore=[404])
+    else:
+        institution_doc = {
+            'id': id_,
+            'url': '/institutions/{}/'.format(institution._id),
+            'logo_path': institution.logo_path,
+            'category': 'institution',
+            'name': institution.name,
+        }
 
-    institution_doc = {
-        'id': institution._id,
-        'url': '/institutions/{}/'.format(institution._id),
-        'logo_path': institution.logo_path,
-        'category': 'institution',
-        'name': institution.name,
-    }
-
-    es.index(index=index, doc_type='institution', body=institution_doc, id=institution._id, refresh=True)
+        es.index(index=index, doc_type='institution', body=institution_doc, id=id_, refresh=True)
 
 @requires_search
 def delete_all():


### PR DESCRIPTION
## Purpose

Allow for deletion of institutions using the `is_deleted` flag, and making sure deleted intitutions dont have a landing page and can't be found in search.

## Changes
Institution now has is_deleted attribute. Update_search looks for that to delete the elastic doc.

## Ticket
Also this https://openscience.atlassian.net/browse/OSF-6453