### PR TITLE
change redirect url to cas

### DIFF
--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -199,10 +199,10 @@ def auth_logout(redirect_url=None):
     return resp
 
 
-def auth_email_logout(token, user):
+def auth_email_logout(token, user, redirect_url=None):
     """When a user is adding an email or merging an account, add the email to the user and log them out.
     """
-    redirect_url = web_url_for('auth_login')
+    redirect_url = cas.get_login_url(redirect_url)
     try:
         unconfirmed_email = user.get_unconfirmed_email_for_token(token)
     except InvalidTokenError:

--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -199,10 +199,11 @@ def auth_logout(redirect_url=None):
     return resp
 
 
-def auth_email_logout(token, user, redirect_url=None):
+def auth_email_logout(token, user):
     """When a user is adding an email or merging an account, add the email to the user and log them out.
     """
-    redirect_url = cas.get_login_url(redirect_url)
+    no_redirect = None
+    redirect_url = cas.get_login_url(no_redirect)
     try:
         unconfirmed_email = user.get_unconfirmed_email_for_token(token)
     except InvalidTokenError:

--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -202,8 +202,7 @@ def auth_logout(redirect_url=None):
 def auth_email_logout(token, user):
     """When a user is adding an email or merging an account, add the email to the user and log them out.
     """
-    no_redirect = None
-    redirect_url = cas.get_login_url(no_redirect)
+    redirect_url = cas.get_login_url(service_url='')
     try:
         unconfirmed_email = user.get_unconfirmed_email_for_token(token)
     except InvalidTokenError:

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -3452,7 +3452,7 @@ class TestAuthViews(OsfTestCase):
         self.user.reload()
         assert_equal(self.user.email_verifications[token]['confirmed'], True)
         assert_equal(res.status_code, 302)
-        login_url = '/login/?existing_user={}'.format(urllib.quote_plus(self.user.username))
+        login_url = 'login?service'
         assert_in(login_url, res.body)
 
     def test_get_email_to_add_no_email(self):


### PR DESCRIPTION
Related to PR 5000

## Purpose

Change login from login.mako to cas login.

## Ticket

https://openscience.atlassian.net/browse/OSF-4542

