### PR TITLE
Hotfix/affiliation

### DIFF
--- a/framework/auth/__init__.py
+++ b/framework/auth/__init__.py
@@ -44,6 +44,7 @@ def authenticate(user, access_token, response):
         'auth_user_access_token': access_token,
     })
     user.date_last_login = datetime.utcnow()
+    user.update_affiliated_institutions_by_email_domain()
     user.save()
     response = create_session(response, data=data)
     return response

--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -932,6 +932,22 @@ class User(GuidStoredObject, AddonModelMixin):
         from website.search import search
         search.update_contributors(self.visible_contributor_to)
 
+    def update_affiliated_institutions_by_email_domain(self):
+        """
+        Append affiliated_institutions by email domain.
+        :return:
+        """
+        # Avoid circular import
+        from website.project.model import Institution
+        try:
+            email_domains = [email.split('@')[1] for email in self.emails]
+            insts = Institution.find(Q('email_domains', 'in', email_domains))
+            for inst in insts:
+                if inst not in self.affiliated_institutions:
+                    self.affiliated_institutions.append(inst)
+        except (IndexError, NoResultsFound):
+            pass
+
     @property
     def is_confirmed(self):
         return bool(self.date_confirmed)


### PR DESCRIPTION
From https://github.com/CenterForOpenScience/osf.io/pull/5784

-------------

## Purpose:
[OSF-6440](https://openscience.atlassian.net/browse/OSF-6440)
Update user's affiliated email domain institution before user gets queried to create initial project.

## Changes:
Update framework/auth/core.py add "def update_affiliated_institutions_by_email_domain" to "class User"

Update framework/auth/__init__.py update "def authenticate" to call User.update_affiliated_institutions_by_email_domain

Update  website/project/views/node.py  update def node_setting to call User.update_affiliated_institutions_by_email_domain

## Side effects
None

[#OSF-6440]