### PR TITLE
Fix external sites opening in new tabs [#OSF-6426]

### DIFF
--- a/website/addons/forward/templates/forward_widget.mako
+++ b/website/addons/forward/templates/forward_widget.mako
@@ -22,7 +22,7 @@
 
         <div>
             This project contains a forward to
-            <a data-bind="attr: {href: url}, text: linkDisplay" target="_blank"></a>.
+            <a data-bind="attr: {href: url}, text: linkDisplay"></a>.
         </div>
 
         <div class="spaced-buttons m-t-sm">

--- a/website/addons/forward/templates/log_templates.mako
+++ b/website/addons/forward/templates/log_templates.mako
@@ -1,6 +1,6 @@
 <script type="text/html" id="forward_url_changed">
 changed forward URL to
-<a target="_blank" class="overflow log-file-link" data-bind="attr: {href: params.forward_url}, text: params.forward_url"></a>
+<a class="overflow log-file-link" data-bind="attr: {href: params.forward_url}, text: params.forward_url"></a>
 in
 <a class="log-node-title-link overflow" data-bind="attr: {href: nodeUrl}, text: nodeTitle"></a>
 </script>

--- a/website/templates/include/profile/social.mako
+++ b/website/templates/include/profile/social.mako
@@ -154,7 +154,7 @@
                 <tr data-bind="if: hasProfileWebsites()">
                     <td data-bind="visible: profileWebsites().length > 1">Personal websites</td>
                     <td data-bind="visible: profileWebsites().length === 1">Personal website</td>
-                    <td data-bind="foreach: profileWebsites"><a target="_blank" data-bind="attr: {href: $data}, text: $data"></a><br></td>
+                    <td data-bind="foreach: profileWebsites"><a data-bind="attr: {href: $data}, text: $data"></a><br></td>
                 </tr>
             </tbody>
 

--- a/website/templates/public/pages/meeting_body.mako
+++ b/website/templates/public/pages/meeting_body.mako
@@ -12,7 +12,7 @@
         <a id="addLink" onclick="" href="#">${('Add your ' + meeting['field_names']['add_submission']) if meeting['poster'] and meeting['talk'] else ('Add your ' + meeting['field_names']['submission1_plural']) if meeting['poster'] else ('Add your ' + meeting['field_names']['submission2_plural'])}</a>
 
         % if meeting['info_url']:
-          | <a href="${ meeting['info_url'] }" target="_blank">Conference homepage <i class="fa fa-sm fa fa-external-link"></i></a>
+          | <a href="${ meeting['info_url'] }">Conference homepage <i class="fa fa-sm fa fa-external-link"></i></a>
         % endif
     </div>
 


### PR DESCRIPTION
## Purpose
- External links from the profile page, OSF for meetings pages, or forward widgets open tabs in a new window, which could lead to some undesirable effects (see tickets for more detail)

## Changes

- Remove "_blank" target from link in forward widget on configured projects
- Remove "_blank" target from log link for changed forward URL
- Remove "_blank" target from link in external websites in the user profile
- Remove "_blank" target from external conference website URL

## Side effects
- None anticipated

## Ticket
https://openscience.atlassian.net/browse/OSF-6426
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
