### PR TITLE
[hold] [Hotfix] remove withdrawn registrations from search [OSF-6456]

### DIFF
--- a/tests/test_elastic.py
+++ b/tests/test_elastic.py
@@ -279,14 +279,14 @@ class TestRegistrationRetractions(SearchTestCase):
         ) as registration:
             self.registration = registration
 
-    def test_retraction_is_searchable(self):
+    def test_retraction_is_not_searchable(self):
         self.registration.retract_registration(self.user)
         self.registration.retraction.state = Retraction.APPROVED
         self.registration.retraction.save()
         self.registration.save()
         self.registration.retraction._on_complete(self.user)
         docs = query('category:registration AND ' + self.title)['results']
-        assert_equal(len(docs), 1)
+        assert_equal(len(docs), 0)
 
     @mock.patch('website.project.model.Node.archiving', mock.PropertyMock(return_value=False))
     def test_pending_retraction_wiki_content_is_searchable(self):
@@ -348,9 +348,9 @@ class TestRegistrationRetractions(SearchTestCase):
         docs = query('category:registration AND "{}"'.format(wiki_content['home']))['results']
         assert_equal(len(docs), 0)
 
-        # Query and ensure registration does show up
+        # Query and ensure registration does not show up
         docs = query('category:registration AND ' + self.title)['results']
-        assert_equal(len(docs), 1)
+        assert_equal(len(docs), 0)
 
 
 @requires_search

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -295,7 +295,7 @@ def update_node(node, index=None, bulk=False):
     for file_ in paginated(OsfStorageFile, Q('node', 'eq', node)):
         update_file(file_, index=index)
 
-    if node.is_deleted or not node.is_public or node.archiving:
+    if node.is_deleted or not node.is_public or node.archiving or node.is_retracted:
         delete_doc(elastic_document_id, node)
     else:
         try:
@@ -437,7 +437,7 @@ def update_file(file_, index=None, delete=False):
 
     index = index or INDEX
 
-    if not file_.node.is_public or delete or file_.node.is_deleted or file_.node.archiving:
+    if not file_.node.is_public or delete or file_.node.is_deleted or file_.node.archiving or file_.node.is_retracted:
         es.delete(
             index=index,
             doc_type='file',


### PR DESCRIPTION
## Purpose

Withdrawn registrations and their files currently appear in search results. This PR deletes the elastic search index when the registration is withdrawn. This isn't really a bug but more of a change in spec.

## Changes

If the node is retracted, the elastic document is treated as if it is deleted or private.

## Side effects

Withdrawn registrations and their files will no longer appear in search results. This will only effect nodes that go through `update_node` or `update_file`.


## Ticket

https://openscience.atlassian.net/browse/OSF-6456
