### PR TITLE
Add an .ackrc file

### DIFF
--- a/.ackrc
+++ b/.ackrc
@@ -1,0 +1,4 @@
+--ignore-directory=admin/static/public
+--ignore-directory=admin/static/vendor
+--ignore-directory=website/static/public
+--ignore-directory=website/static/vendor


### PR DESCRIPTION
## Purpose

The purpose of this PR is to make it a little easier for developers who use [`ack`](http://beyondgrep.com/) to use `ack` with the OSF, by excluding directories that are a) specific to the OSF, b) large and/or with large files (thereby slowing down searches and clogging up results), and c) uninteresting during workaday development.

## Changes

 - adds a simple `.ackrc` to ignore a few directories

## Side effects

 - a little more clutter
 - potentially a lot more clutter, if this opens the door to config files for other tools ending up in the repo

## Ticket

n/a