### PR TITLE
move clean function to cas from auth_login

### DIFF
--- a/framework/auth/__init__.py
+++ b/framework/auth/__init__.py
@@ -44,6 +44,7 @@ def authenticate(user, access_token, response):
         'auth_user_access_token': access_token,
     })
     user.date_last_login = datetime.utcnow()
+    user.clean_email_verifications()
     user.update_affiliated_institutions_by_email_domain()
     user.save()
     response = create_session(response, data=data)

--- a/framework/auth/cas.py
+++ b/framework/auth/cas.py
@@ -224,6 +224,7 @@ def make_response_from_ticket(ticket, service_url):
     cas_resp = client.service_validate(ticket, service_furl.url)
     if cas_resp.authenticated:
         user = User.load(cas_resp.user)
+        user.clean_email_verifications()
         # if we successfully authenticate and a verification key is present, invalidate it
         if user.verification_key:
             user.verification_key = None

--- a/framework/auth/cas.py
+++ b/framework/auth/cas.py
@@ -224,7 +224,6 @@ def make_response_from_ticket(ticket, service_url):
     cas_resp = client.service_validate(ticket, service_furl.url)
     if cas_resp.authenticated:
         user = User.load(cas_resp.user)
-        user.clean_email_verifications()
         # if we successfully authenticate and a verification key is present, invalidate it
         if user.verification_key:
             user.verification_key = None

--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -149,9 +149,6 @@ def auth_login(auth, **kwargs):
             raise HTTPError(http.InvalidURL)
 
     if auth.logged_in:
-        # remove expired email verifications
-        auth.user.clean_email_verifications()
-        auth.user.save()
         if not request.args.get('logout'):
             if next_url:
                 return redirect(next_url)


### PR DESCRIPTION
https://github.com/CenterForOpenScience/osf.io/pull/5000/

## Purpose

Ironically, auth_login is no longer used when logging in.  So cleaning up the old emails should happen in cas.py now.

## Ticket

https://openscience.atlassian.net/browse/OSF-5536