### PR TITLE
[Feature] add withdrawn before retracted registration files in search [OSF-6456]

### DIFF
--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -466,6 +466,7 @@ def update_file(file_, index=None, delete=False):
         'node_title': file_.node.title,
         'parent_id': file_.node.parent_node._id if file_.node.parent_node else None,
         'is_registration': file_.node.is_registration,
+        'is_retracted': file_.node.is_retracted
     }
 
     es.index(

--- a/website/templates/search.mako
+++ b/website/templates/search.mako
@@ -140,7 +140,7 @@
         <!-- /ko -->
     </script>
     <script type="text/html" id="file">
-        <h4><a data-bind="attr: {href: deep_url}, text: name"></a> (<span data-bind="if: is_registration">Registration </span>File)</h4>
+        <h4><a data-bind="attr: {href: deep_url}, text: name"></a> (<span class="text-danger" data-bind="if: is_retracted">Withdrawn </span><span data-bind="if: is_registration">Registration </span>File)</h4>
         <h5>
             <!-- ko if: parent_url --> From: <a data-bind="attr: {href: parent_url}, text: parent_title || '' + ' /'"></a> <!-- /ko -->
             <!-- ko if: !parent_url --> From: <span data-bind="if: parent_title"><span data-bind="text: parent_title"></span> /</span> <!-- /ko -->


### PR DESCRIPTION
## Purpose

Currently, the user cannot tell if a file is attached to a retracted registration in search results. This PR adds "Withdrawn" before "Registration File" so that the results look similar to retracted registrations.

![screen shot 2016-06-06 at 9 53 35 am](https://cloud.githubusercontent.com/assets/7131985/15901008/8aa8a930-2d6f-11e6-9b13-80b8344a9e26.png)

## Changes

* Add `is_retracted` to elastic search file_doc
* Add "Withdrawn" text in search results if the file is attached to a retracted node

![screen shot 2016-06-08 at 11 47 46 am](https://cloud.githubusercontent.com/assets/7131985/15900999/8078fcd0-2d6f-11e6-9991-0b8322d08775.png)


## Side effects

I had to run `inv rebuild_search` on my local but I'm not sure what that means for production.


## Ticket

https://openscience.atlassian.net/browse/OSF-6456

