### PR TITLE
Add check for project or addonroot onclick, return to default toolbar [#OSF-6437]

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -2286,6 +2286,10 @@ tbOptions = {
         tb.pendingFileOps = [];
         tb.select('#tb-tbody').on('click', function(event){
             if(event.target !== this) {
+                var item = tb.multiselected()[0];
+                if (item.data.isAddonRoot || item.data.category === 'project') {
+                    tb.toolbarMode(toolbarModes.DEFAULT);
+                }
                 return;
             }
             tb.clearMultiselect();


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
In the file widget or on the files page, If a user clicked on a file, clicked rename, and then clicked on a Storage heading or project title, it appeared as though they could edit the name and then save the changes. Submitting the changes resulted in an "unable to rename" error. The text box should never be presented to the user in the first place.

### Before:
![before](https://cloud.githubusercontent.com/assets/801594/15903982/3a6af2d0-2d7d-11e6-903c-175dbb977e95.gif)

This PR changes the Add-on Storage titles or project titles back to the default toolbar if they're clicked after clicking the rename button.

### After:
![after](https://cloud.githubusercontent.com/assets/801594/15900782/af6fdffa-2d6e-11e6-9a66-d050bf6eb882.gif)


## Changes
- If a project title or addon name row is clicked, reset the toolbar to the default instead of staying on the Edit screen.

## Side effects
There might be a more complex project or storage heading action that this breaks, but I have not been able to find it yet. Apologies if it does!


## Ticket
https://openscience.atlassian.net/browse/OSF-6437