### PR TITLE
Have /help/ display the /faq/ page [#OSF-4039]

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4366,6 +4366,9 @@ class TestStaticFileViews(OsfTestCase):
         res = self.app.get('/getting-started/')
         assert_equal(res.status_code, 302)
         assert_equal(res.location, 'http://help.osf.io/')
+    def test_help_redirect(self):
+        res = self.app.get('/help/')
+        assert_equal(res.status_code,200)
 
 
 class TestUserConfirmSignal(OsfTestCase):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4368,7 +4368,7 @@ class TestStaticFileViews(OsfTestCase):
         assert_equal(res.location, 'http://help.osf.io/')
     def test_help_redirect(self):
         res = self.app.get('/help/')
-        assert_equal(res.status_code,200)
+        assert_equal(res.status_code,302)
 
 
 class TestUserConfirmSignal(OsfTestCase):

--- a/website/routes.py
+++ b/website/routes.py
@@ -238,7 +238,7 @@ def make_url_map(app):
             notemplate
         ),
         Rule('/about/', 'get', website_views.redirect_about, notemplate),
-        Rule(['/faq/', '/help/'], 'get',  {}, OsfWebRenderer('public/pages/faq.mako', trust=False)),
+        Rule(['/faq/', '/help/'], 'get', {}, OsfWebRenderer('public/pages/faq.mako', trust=False)),
         Rule(['/getting-started/', '/getting-started/email/', '/howosfworks/'], 'get', website_views.redirect_getting_started, notemplate),
         Rule('/support/', 'get', {}, OsfWebRenderer('public/pages/support.mako', trust=False)),
 

--- a/website/routes.py
+++ b/website/routes.py
@@ -238,7 +238,7 @@ def make_url_map(app):
             notemplate
         ),
         Rule('/about/', 'get', website_views.redirect_about, notemplate),
-        Rule('/faq/', 'get', {}, OsfWebRenderer('public/pages/faq.mako', trust=False)),
+        Rule(['/faq/', '/help/'], 'get',  {}, OsfWebRenderer('public/pages/faq.mako', trust=False)),
         Rule(['/getting-started/', '/getting-started/email/', '/howosfworks/'], 'get', website_views.redirect_getting_started, notemplate),
         Rule('/support/', 'get', {}, OsfWebRenderer('public/pages/support.mako', trust=False)),
 

--- a/website/routes.py
+++ b/website/routes.py
@@ -238,7 +238,8 @@ def make_url_map(app):
             notemplate
         ),
         Rule('/about/', 'get', website_views.redirect_about, notemplate),
-        Rule(['/faq/', '/help/'], 'get', {}, OsfWebRenderer('public/pages/faq.mako', trust=False)),
+        Rule('/help/', 'get', website_views.redirect_help, notemplate),
+        Rule('/faq/', 'get', {}, OsfWebRenderer('public/pages/faq.mako', trust=False)),
         Rule(['/getting-started/', '/getting-started/email/', '/howosfworks/'], 'get', website_views.redirect_getting_started, notemplate),
         Rule('/support/', 'get', {}, OsfWebRenderer('public/pages/support.mako', trust=False)),
 
@@ -251,7 +252,6 @@ def make_url_map(app):
         Rule(
             [
                 '/messages/',
-                '/help/'
             ],
             'get',
             {},

--- a/website/views.py
+++ b/website/views.py
@@ -256,6 +256,9 @@ def resolve_guid(guid, suffix=None):
 def redirect_about(**kwargs):
     return redirect('https://osf.io/4znzp/wiki/home/')
 
+def redirect_help(**kwargs):
+    return redirect('/faq/')
+
 
 # redirect osf.io/howosfworks to osf.io/getting-started/
 def redirect_howosfworks(**kwargs):


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

- As of now, the osf.io/help/ page has not been made, and is a dead end

- Displays the /faq/ page on attempting to reach the /help/ page

## Changes

- Added to a Rule in routes.py, where going to /help/ will display the /faq/ mako template.

- Added a test case that tests to make sure the page is reached in test_views.py

## Ticket
https://openscience.atlassian.net/browse/OSF-4039

