### PR TITLE
[Feature] show deactivated user's name in logs [OSF-6266]

### DIFF
--- a/website/templates/log_list.mako
+++ b/website/templates/log_list.mako
@@ -43,7 +43,12 @@
                         <!-- ko if: log.hasTemplate() -->
                             <!-- ko if: log.hasUser() -->
                             <span data-bind="if:log.anonymous">
-                                <span class="contributor-anonymous">A user</span>
+                                <span data-bind="if: log.user.registered" class="contributor-anonymous">
+                                    A user
+                                </span>
+                                <span data-bind="ifnot: log.user.registered">
+                                    A deactivated user
+                                </span>
                             </span>
 
                             <span data-bind="ifnot:log.anonymous">
@@ -56,7 +61,7 @@
                                 </span>
                                 </span>
                                 <span data-bind="ifnot: log.user.registered">
-                                    A deactivated user
+                                    <span data-bind="text: log.userFullName"></span>
                                 </span>
 
                             </span>


### PR DESCRIPTION
## Purpose

Currently, the deactivated user's name is not shown in logs.

## Changes

* Show the deactivated user's name in log
* Show "A deactivated user" in an anonymous view-only link log

![screen shot 2016-06-08 at 4 11 49 pm](https://cloud.githubusercontent.com/assets/7131985/15909338/d46ab2f6-2d93-11e6-9ede-41b3aefefb89.png)
![screen shot 2016-06-08 at 4 12 07 pm](https://cloud.githubusercontent.com/assets/7131985/15909339/d46bd5c8-2d93-11e6-91b5-093273c7b4f9.png)


## Side effects

None


## Ticket

https://openscience.atlassian.net/browse/OSF-6266

