### PR TITLE
Gather more accurate data about the commits

### DIFF
--- a/scripts/meta/gatherer.py
+++ b/scripts/meta/gatherer.py
@@ -1,43 +1,64 @@
 import json
 import os
+import requests
+import re
 from website.settings import GITHUB_API_TOKEN
+from subprocess import check_output
 
 GIT_LOGS_FILE = os.path.join('website', 'static', 'built', 'git_logs.json')
+GIT_STATUS_FILE = os.path.join('website', 'static', 'built', 'git_branch.txt')
 
 
-def gather_pr_data():
-    import requests
+def gather_pr_data(current_branch='develop', master_branch='master'):
+    regex = re.compile(ur'\(#([\d]{4,})\)|Merge pull request #([\d]{4,})')
     pr_data = []
-    auth_header = {'Authorization': 'token %s' % GITHUB_API_TOKEN}
-    res = requests.get('https://api.github.com/repos/centerforopenscience/osf.io/pulls?state=closed&per_page=100',
-                       headers=auth_header)
-
-    while len(pr_data)<100:
-        if res.status_code == 200:
-            for item in res.json():
-                try:
-                    sha = item['merge_commit_sha']
-                except TypeError:
-                    sha = None
-                if sha:
-                    pr_data.append(item)
-            try:
-                next_link = res.links['next']
-            except KeyError:
-                break
-            res = requests.get(next_link['url'])
-        else:
-            break
-
+    headers = {
+        'Authorization': 'token %s' % GITHUB_API_TOKEN,
+        'media_type': 'application/vnd.github.VERSION.sha',
+    }
+    # GET /repos/:owner/:repo/compare/hubot:branchname...octocat:branchname
+    url_string = 'https://api.github.com/repos/centerforopenscience/osf.io/compare/{}...{}'
+    url = url_string.format(master_branch, current_branch)
+    res = requests.get(url, headers=headers)
+    if res.status_code == 200:
+        data = res.json()
+        commits = data['commits']
+        if commits:
+            commits.reverse()
+        index = 0
+        for item in commits:
+            index += 1
+            commit_message = item['commit']['message']
+            found_list = re.findall(regex, commit_message)
+            if found_list:
+                pr_one, pr_two = found_list[0]
+                pr = int(pr_one or pr_two)
+                pr_data.append(get_pr_data(pr))
     return pr_data
 
 
+def get_pr_data(pr):
+    headers = {
+        'Authorization': 'token %s' % GITHUB_API_TOKEN,
+        'media_type': 'application/vnd.github.VERSION.sha',
+    }
+    # GET /repos/:owner/:repo/pulls/:number
+    res = requests.get('https://api.github.com/repos/centerforopenscience/osf.io/pulls/{}'.format(pr),
+                       headers=headers)
+    if res.status_code == 200:
+        return res.json()
+    else:
+        return {}
+
+
 def main():
+    current_branch = check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD']).rstrip()
+    with open(GIT_STATUS_FILE, 'w') as f:
+        f.write(current_branch)
     if GITHUB_API_TOKEN:
-        pr_data = json.dumps(gather_pr_data())
+        pr_data = json.dumps(gather_pr_data(current_branch))
         with open(GIT_LOGS_FILE, 'w') as f:
             f.write(pr_data)
 
 if __name__ == '__main__':
     main()
-

--- a/scripts/meta/gatherer.py
+++ b/scripts/meta/gatherer.py
@@ -1,6 +1,5 @@
 import json
 import os
-import requests
 import re
 from website.settings import GITHUB_API_TOKEN
 from subprocess import check_output
@@ -10,6 +9,7 @@ GIT_STATUS_FILE = os.path.join('website', 'static', 'built', 'git_branch.txt')
 
 
 def gather_pr_data(current_branch='develop', master_branch='master'):
+    import requests
     regex = re.compile(ur'\(#([\d]{4,})\)|Merge pull request #([\d]{4,})')
     pr_data = []
     headers = {
@@ -38,6 +38,7 @@ def gather_pr_data(current_branch='develop', master_branch='master'):
 
 
 def get_pr_data(pr):
+    import requests
     headers = {
         'Authorization': 'token %s' % GITHUB_API_TOKEN,
         'media_type': 'application/vnd.github.VERSION.sha',

--- a/tests/base.py
+++ b/tests/base.py
@@ -158,7 +158,7 @@ class DbTestCase(unittest.TestCase):
         settings.BCRYPT_LOG_ROUNDS = cls._original_bcrypt_log_rounds
 
 
-class AppTestCase(unittest.TestCase):
+class   AppTestCase(unittest.TestCase):
     """Base `TestCase` for OSF tests that require the WSGI app (but no database).
     """
 

--- a/website/static/js/devModeControls.js
+++ b/website/static/js/devModeControls.js
@@ -2,9 +2,13 @@ var $ = require('jquery');
 var ko = require('knockout');
 var $osf = require('js/osfHelpers');
 
-var DevModeModel = function(source_file) {
+var DevModeModel = function(source_file, branch_file) {
     self = this;
     self.source_file = source_file;
+    self.branch = ko.observable('');
+    $.get(branch_file).done(function (data){
+        self.branch(data);
+    });
     self.pullRequests = ko.observableArray([]);
     self.showMetaInfo = ko.observable(false);
     self.showHideMetaInfo = function() {
@@ -33,8 +37,8 @@ var PullRequestItem = function(prItem) {
 
 };
 
-var DevModeControls = function(selector, source_file) {
-    this.viewModel = new DevModeModel(source_file);
+var DevModeControls = function(selector, source_file, branch_file) {
+    this.viewModel = new DevModeModel(source_file, branch_file);
     $osf.applyBindings(this.viewModel, selector);
 };
 

--- a/website/static/js/pages/base-page.js
+++ b/website/static/js/pages/base-page.js
@@ -112,7 +112,7 @@ $(function() {
         $osf.initializeResponsiveAffix();
     }
     new NavbarControl('.osf-nav-wrapper');
-    new DevModeControls('#devModeControls', '/static/built/git_logs.json');
+    new DevModeControls('#devModeControls', '/static/built/git_logs.json', '/static/built/git_branch.txt');
     if(window.contextVars.keenProjectId){
         var params = {};
         params.currentUser = window.contextVars.currentUser;

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -54,6 +54,7 @@
     % if dev_mode:
         <div class="dev-mode-helper scripted" id="devModeControls">
         <div id="metaInfo" data-bind="visible: showMetaInfo">
+            <h2>Current branch: <span data-bind="text: branch"></span></h2>
             <table>
                 <thead>
                 <tr>


### PR DESCRIPTION
## Purpose

Make the widget that shows commits to QA and other interested parties more useful

## Changes

1. Get the name of the current branch from git 
2. Check the current branch versus master and only list the commits that are different
3. Find the commits that match the two PR types (normal merge and squashed merge) and pull out the PR name from that
4. Get the PR info from github
5. Show the branch name in the widget as well

![screen shot 2016-06-08 at 4 04 46 pm](https://cloud.githubusercontent.com/assets/6599111/15909350/f2dbbd52-2d93-11e6-9e39-eedc2bc842f1.png)


## Side effects

1. It's not going to be able to show any useful information for local branches, only branches that are on centerforopenscience/osf.io
2. Will only work with git 1.7 or greater

## Ticket

No ticket