### PR TITLE
Add setting to make celery ignore everything but errors

### DIFF
--- a/framework/celery_tasks/handlers.py
+++ b/framework/celery_tasks/handlers.py
@@ -34,16 +34,12 @@ def celery_teardown_request(error=None):
     if error is not None:
         _local.queue = []
         return
-    try:
-        if queue():
-            if settings.USE_CELERY:
-                group(queue()).apply_async()
-            else:
-                for task in queue():
-                    task.apply()
-    except AttributeError:
-        if not settings.DEBUG_MODE:
-            logger.error('Task queue not initialized')
+    if queue():
+        if settings.USE_CELERY:
+            group(queue()).apply_async()
+        else:
+            for task in queue():
+                task.apply()
 
 
 def enqueue_task(signature):

--- a/framework/postcommit_tasks/handlers.py
+++ b/framework/postcommit_tasks/handlers.py
@@ -70,7 +70,7 @@ def run_postcommit(once_per_request=True, celery=False):
             return func
         @functools.wraps(func)
         def wrapped(*args, **kwargs):
-            if celery is True and isinstance(func, PromiseProxy):
+            if settings.USE_CELERY and celery is True and isinstance(func, PromiseProxy):
                 func.delay(*args, **kwargs)
             else:
                 enqueue_postcommit_task(func, args, kwargs, once_per_request=once_per_request)

--- a/website/archiver/tasks.py
+++ b/website/archiver/tasks.py
@@ -90,7 +90,7 @@ class ArchiverTask(celery.Task):
                 each for each in
                 dst.archive_job.target_info()
                 if each is not None
-                ]
+            ]
         elif isinstance(exc, ArchivedFileNotFound):
             dst.archive_status = ARCHIVER_FILE_NOT_FOUND
             errors = {

--- a/website/archiver/tasks.py
+++ b/website/archiver/tasks.py
@@ -29,7 +29,6 @@ from website.project.model import Node, DraftRegistration
 from website import settings
 from website.app import init_addons, do_set_backends
 
-
 def create_app_context():
     try:
         init_addons(settings)
@@ -42,21 +41,18 @@ logger = get_task_logger(__name__)
 
 
 class ArchiverSizeExceeded(Exception):
-
     def __init__(self, result, *args, **kwargs):
         super(ArchiverSizeExceeded, self).__init__(*args, **kwargs)
         self.result = result
 
 
 class ArchiverStateError(Exception):
-
     def __init__(self, info, *args, **kwargs):
         super(ArchiverStateError, self).__init__(*args, **kwargs)
         self.info = info
 
 
 class ArchivedFileNotFound(Exception):
-
     def __init__(self, registration, missing_files, *args, **kwargs):
         super(ArchivedFileNotFound, self).__init__(*args, **kwargs)
 
@@ -69,7 +65,7 @@ class ArchivedFileNotFound(Exception):
 class ArchiverTask(celery.Task):
     abstract = True
     max_retries = 0
-    ignore_result = False
+    ignore_result = (not settings.USE_CELERY)
 
     def on_failure(self, exc, task_id, args, kwargs, einfo):
         job = ArchiveJob.load(kwargs.get('job_pk'))
@@ -94,7 +90,7 @@ class ArchiverTask(celery.Task):
                 each for each in
                 dst.archive_job.target_info()
                 if each is not None
-            ]
+                ]
         elif isinstance(exc, ArchivedFileNotFound):
             dst.archive_status = ARCHIVER_FILE_NOT_FOUND
             errors = {
@@ -108,7 +104,7 @@ class ArchiverTask(celery.Task):
         archiver_signals.archive_fail.send(dst, errors=errors)
 
 
-@celery_app.task(base=ArchiverTask, ignore_result=False)
+@celery_app.task(base=ArchiverTask, ignore_result=(not settings.USE_CELERY))
 @logged('stat_addon')
 def stat_addon(addon_short_name, job_pk):
     """Collect metadata about the file tree of a given addon
@@ -145,7 +141,7 @@ def stat_addon(addon_short_name, job_pk):
     return result
 
 
-@celery_app.task(base=ArchiverTask, ignore_result=False)
+@celery_app.task(base=ArchiverTask, ignore_result=(not settings.USE_CELERY))
 @logged('make_copy_request')
 def make_copy_request(job_pk, url, data):
     """Make the copy request to the WaterBulter API and handle
@@ -187,7 +183,7 @@ def make_waterbutler_payload(src, dst, addon_short_name, rename, cookie, revisio
     return ret
 
 
-@celery_app.task(base=ArchiverTask, ignore_result=False)
+@celery_app.task(base=ArchiverTask, ignore_result=(not settings.USE_CELERY))
 @logged('archive_addon')
 def archive_addon(addon_short_name, job_pk, stat_result):
     """Archive the contents of an addon by making a copy request to the
@@ -219,14 +215,15 @@ def archive_addon(addon_short_name, job_pk, stat_result):
         #
         # Additionally trying to run the archive without this distinction creates a race
         # condition that non-deterministically caused archive jobs to fail.
-        data = make_waterbutler_payload(src, dst, addon_name, '{0} ({1})'.format(folder_name, folder_name_suffix), cookie, revision=revision)
+        data = make_waterbutler_payload(src, dst, addon_name, '{0} ({1})'.format(folder_name, folder_name_suffix),
+                                        cookie, revision=revision)
         make_copy_request.delay(job_pk=job_pk, url=copy_url, data=data)
     else:
         data = make_waterbutler_payload(src, dst, addon_name, folder_name, cookie)
         make_copy_request.delay(job_pk=job_pk, url=copy_url, data=data)
 
 
-@celery_app.task(base=ArchiverTask, ignore_result=False)
+@celery_app.task(base=ArchiverTask, ignore_result=(not settings.USE_CELERY))
 @logged('archive_node')
 def archive_node(stat_results, job_pk):
     """First use the results of #stat_node to check disk usage of the
@@ -295,7 +292,8 @@ def archive(job_pk):
         ]
     )
 
-@celery_app.task(base=ArchiverTask, ignore_result=False)
+
+@celery_app.task(base=ArchiverTask, ignore_result=(not settings.USE_CELERY))
 @logged('archive_success')
 def archive_success(dst_pk, job_pk):
     """Archiver's final callback. For the time being the use case for this task

--- a/website/archiver/tasks.py
+++ b/website/archiver/tasks.py
@@ -69,6 +69,7 @@ class ArchivedFileNotFound(Exception):
 class ArchiverTask(celery.Task):
     abstract = True
     max_retries = 0
+    ignore_result = False
 
     def on_failure(self, exc, task_id, args, kwargs, einfo):
         job = ArchiveJob.load(kwargs.get('job_pk'))
@@ -107,7 +108,7 @@ class ArchiverTask(celery.Task):
         archiver_signals.archive_fail.send(dst, errors=errors)
 
 
-@celery_app.task(base=ArchiverTask)
+@celery_app.task(base=ArchiverTask, ignore_result=False)
 @logged('stat_addon')
 def stat_addon(addon_short_name, job_pk):
     """Collect metadata about the file tree of a given addon
@@ -144,7 +145,7 @@ def stat_addon(addon_short_name, job_pk):
     return result
 
 
-@celery_app.task(base=ArchiverTask)
+@celery_app.task(base=ArchiverTask, ignore_result=False)
 @logged('make_copy_request')
 def make_copy_request(job_pk, url, data):
     """Make the copy request to the WaterBulter API and handle
@@ -186,7 +187,7 @@ def make_waterbutler_payload(src, dst, addon_short_name, rename, cookie, revisio
     return ret
 
 
-@celery_app.task(base=ArchiverTask)
+@celery_app.task(base=ArchiverTask, ignore_result=False)
 @logged('archive_addon')
 def archive_addon(addon_short_name, job_pk, stat_result):
     """Archive the contents of an addon by making a copy request to the
@@ -225,7 +226,7 @@ def archive_addon(addon_short_name, job_pk, stat_result):
         make_copy_request.delay(job_pk=job_pk, url=copy_url, data=data)
 
 
-@celery_app.task(base=ArchiverTask)
+@celery_app.task(base=ArchiverTask, ignore_result=False)
 @logged('archive_node')
 def archive_node(stat_results, job_pk):
     """First use the results of #stat_node to check disk usage of the
@@ -294,7 +295,7 @@ def archive(job_pk):
         ]
     )
 
-@celery_app.task(base=ArchiverTask)
+@celery_app.task(base=ArchiverTask, ignore_result=False)
 @logged('archive_success')
 def archive_success(dst_pk, job_pk):
     """Archiver's final callback. For the time being the use case for this task

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -352,6 +352,8 @@ else:
 
     CELERY_DEFAULT_EXCHANGE_TYPE = 'direct'
     CELERY_ROUTES = ('framework.celery_tasks.routers.CeleryRouter', )
+    CELERY_IGNORE_RESULT = True
+    CELERY_STORE_ERRORS_EVEN_IF_IGNORED = True
 
 # Default RabbitMQ broker
 BROKER_URL = 'amqp://'

--- a/website/settings/local-travis.py
+++ b/website/settings/local-travis.py
@@ -33,8 +33,9 @@ SECRET_KEY = "CHANGEME"
 ## Default RabbitMQ broker
 BROKER_URL = 'amqp://'
 
-# Default RabbitMQ backend
-CELERY_RESULT_BACKEND = 'amqp://'
+# In-memory result backend
+CELERY_RESULT_BACKEND = 'cache'
+CELERY_CACHE_BACKEND = 'memory'
 
 USE_CDN_FOR_CLIENT_LIBS = False
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Celery is breaking RabbitMQ because it's storing all completed tasks in it to the point it runs out of memory. [This makes it only store errors.](http://docs.celeryproject.org/en/latest/configuration.html#celery-ignore-result)

This one's for you @icereval!

## Changes

Added two settings to defaults.py

## Side effects

It's possible that it will make Flower very confused about what's going on or potentially completely useless. I don't remember if it does or not. We can deploy it to staging and check, maybe? I would say visibility at the cost of rabbit dying every few days might not be worth it. An alternative solution would be to write a custom kombu task that runs in beat and empties out everything older than X or to switch the result backend to postgres or redis and setup the existing celery task to empty out old results.

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->

## Things that need to be fixed for tests to pass:

There was a AttributeError exception clause around running the celery_tasks synchronously, like in the case of travis or local development. This caused a number of tests to fail silently. These tests need their attribute errors fixed. Travis will be red in the face until then. The entire stack traces are attached.
[failing_tests.txt](https://github.com/CenterForOpenScience/osf.io/files/309964/failing_tests.txt)


```
ERROR: test_register_node_makes_private_child_registrations (tests.test_models.TestNode)
AttributeError: 'NoneType' object has no attribute 'forcibly_reject'

ERROR: test_register_node_makes_private_registration (tests.test_models.TestNode)
AttributeError: 'NoneType' object has no attribute 'forcibly_reject'

ERROR: test_registration_clones_project_wiki_pages (tests.test_models.TestRegisterNode)
AttributeError: 'NoneType' object has no attribute 'forcibly_reject'

ERROR: test_view_project_pending_registration_for_admin_contributor_does_contain_cancel_link (tests.test_serializers.TestViewProject)
AttributeError: 'NoneType' object has no attribute 'archive_status'

ERROR: test_view_project_pending_registration_for_write_contributor_does_not_contain_cancel_link (tests.test_serializers.TestViewProject)
AttributeError: 'NoneType' object has no attribute 'archive_status'
```
