### PR TITLE
[Feature] reduce number of institutions so arrows can be seen [OSF-6478]

### DIFF
--- a/website/static/js/components/carousel.js
+++ b/website/static/js/components/carousel.js
@@ -8,13 +8,19 @@ var m = require('mithril');
 // We need to use a CSS ID in order for the controls to work
 var CAROUSEL_ID = '__carousel';
 
+var controlStyle = {
+    'padding-top': '20px',
+    'font-size': '50px',
+    'width': '5%',
+    'background-image': 'none'
+};
 
 // TODO: Make these controls look better
 var CarouselControls = {
     view: function() {
         return m('div', [
-            m('a.left.carousel-control', {href: '#' + CAROUSEL_ID, 'data-slide': 'prev', style: {'padding-top': '5%', width: '5%', 'background-image': 'none'}}, '‹'),
-            m('a.right.carousel-control', {href: '#' + CAROUSEL_ID, 'data-slide': 'next', style: {'padding-top': '5%', width: '5%', 'background-image': 'none'}}, '›')
+            m('a.left.carousel-control', {href: '#' + CAROUSEL_ID, 'data-slide': 'prev', style: controlStyle}, '‹'),
+            m('a.right.carousel-control', {href: '#' + CAROUSEL_ID, 'data-slide': 'next', style: controlStyle}, '›')
         ]);
     }
 };

--- a/website/static/js/components/carousel.js
+++ b/website/static/js/components/carousel.js
@@ -39,7 +39,7 @@ var Carousel = {
 var CarouselRow = {
     view: function(ctrl, opts, children) {
         return m('div', {className: 'item' + (opts.active ? ' active' : '')}, [
-            m('.row', {}, children)
+            m('.row', {style: {'text-align': 'center'}}, children)
         ]);
     }
 };

--- a/website/static/js/home-page/institutionsPanelPlugin.js
+++ b/website/static/js/home-page/institutionsPanelPlugin.js
@@ -16,16 +16,17 @@ var Institution = institutionComps.InstitutionImg;
 var Carousel = carouselComps.Carousel;
 var CarouselRow = carouselComps.CarouselRow;
 
-var CAROUSEL_WIDTH = 5;  // Must be a multiple of 10 (leave 2 for arrows)
+var CAROUSEL_WIDTH = 5;
+var REDUCED_CAROUSEL_WIDTH = CAROUSEL_WIDTH - 1;
+var COLUMN_WIDTH = Math.floor(12 / CAROUSEL_WIDTH);
 var LOGO_WIDTH = '120px';
-
 
 var InstitutionsPanel = {
     controller: function() {
         // Helper method to render logo link
         this.renderLogo = function(inst, opts) {
             var href = '/institutions/' + inst.id + '/';
-            var columnWidth = (10 / CAROUSEL_WIDTH).toString();
+            var columnWidth = COLUMN_WIDTH.toString();
             return m('.col-sm-' + columnWidth, {style: {'display':'inline-block', 'float':'none'}}, [
                 m('a', {href: href, className: 'thumbnail', style: {'background': 'inherit', 'border': 'none'}},
                     [m.component(Institution,
@@ -50,6 +51,9 @@ var InstitutionsPanel = {
 
         var institutions = affiliated.concat(unaffiliated);
         var controls = institutions.length > CAROUSEL_WIDTH;
+        if (controls && (12 % CAROUSEL_WIDTH) === 0 && CAROUSEL_WIDTH > REDUCED_CAROUSEL_WIDTH) {
+            CAROUSEL_WIDTH = REDUCED_CAROUSEL_WIDTH;
+        }
 
         var groupedInstitutions = lodashChunk(institutions, CAROUSEL_WIDTH);
         return m.component(Carousel, {controls: controls},

--- a/website/static/js/home-page/institutionsPanelPlugin.js
+++ b/website/static/js/home-page/institutionsPanelPlugin.js
@@ -16,7 +16,7 @@ var Institution = institutionComps.InstitutionImg;
 var Carousel = carouselComps.Carousel;
 var CarouselRow = carouselComps.CarouselRow;
 
-var CAROUSEL_WIDTH = 6;  // Must be a multiple of 12
+var CAROUSEL_WIDTH = 5;  // Must be a multiple of 10 (leave 2 for arrows)
 var LOGO_WIDTH = '120px';
 
 
@@ -25,8 +25,8 @@ var InstitutionsPanel = {
         // Helper method to render logo link
         this.renderLogo = function(inst, opts) {
             var href = '/institutions/' + inst.id + '/';
-            var columnWidth = (12 / CAROUSEL_WIDTH).toString();
-            return m('.col-sm-' + columnWidth, [
+            var columnWidth = (10 / CAROUSEL_WIDTH).toString();
+            return m('.col-sm-' + columnWidth, {style: {'display':'inline-block', 'float':'none'}}, [
                 m('a', {href: href, className: 'thumbnail', style: {'background': 'inherit', 'border': 'none'}},
                     [m.component(Institution,
                                 {

--- a/website/static/js/home-page/institutionsPanelPlugin.js
+++ b/website/static/js/home-page/institutionsPanelPlugin.js
@@ -16,10 +16,9 @@ var Institution = institutionComps.InstitutionImg;
 var Carousel = carouselComps.Carousel;
 var CarouselRow = carouselComps.CarouselRow;
 
-var CAROUSEL_WIDTH = 5;
+var CAROUSEL_WIDTH = 6;
 var REDUCED_CAROUSEL_WIDTH = CAROUSEL_WIDTH - 1;
 var COLUMN_WIDTH = Math.floor(12 / CAROUSEL_WIDTH);
-var LOGO_WIDTH = '120px';
 
 var InstitutionsPanel = {
     controller: function() {


### PR DESCRIPTION
## Purpose

Currently the arrows on the carousel are not highly visible if there are more than six institutions displayed.

![screen shot 2016-06-09 at 11 13 56 am](https://cloud.githubusercontent.com/assets/7131985/15934940/73a871f6-2e33-11e6-8c72-c08a48cb0462.png)

## Changes

* reduce the amount of institutions displayed at a time to 5 if there are more than 6 institutions
* center institutions

More than six:
![screen shot 2016-06-10 at 3 02 15 pm](https://cloud.githubusercontent.com/assets/7131985/15975713/e35a7910-2f1c-11e6-9a62-d6dc1592f6dd.png)
![screen shot 2016-06-10 at 3 05 43 pm](https://cloud.githubusercontent.com/assets/7131985/15975712/e3539690-2f1c-11e6-9bb0-6c5801451404.png)

Six or less:
![screen shot 2016-06-09 at 11 07 33 am](https://cloud.githubusercontent.com/assets/7131985/15935014/c9d05d64-2e33-11e6-959e-5b888e4307db.png)


## Side effects

Depending on the `CAROUSEL_WIDTH`, the padding on the control arrows in `carousel.js` may have to be adjusted. The alignment of the arrows is correct for column widths of 2/carousel widths of 5 or 6.

## Ticket

https://openscience.atlassian.net/browse/OSF-6478

