### PR TITLE
Feature/Google Analytics Audit [OSF-6479]

### DIFF
--- a/website/static/js/myProjects.js
+++ b/website/static/js/myProjects.js
@@ -1114,7 +1114,6 @@ var Collections = {
             self.newCollectionName('');
             self.isValid(false);
             $('#addCollInput').val('');
-            $osf.trackClick('myProjects', 'add-collection', 'click-cancel-button');
         },
         self.deleteCollection = function _deleteCollection(){
             var url = self.collectionMenuObject().item.data.node.links.self;
@@ -1381,6 +1380,7 @@ var Collections = {
                             {
                                 onclick : function(){
                                     ctrl.resetAddCollection();
+                                    $osf.trackClick('myProjects', 'add-collection', 'click-cancel-button');
                                 }
                             }, 'Cancel'),
                         ctrl.isValid() ? m('button[type="button"].btn.btn-success', { onclick : function() {

--- a/website/static/js/pages/statistics-page.js
+++ b/website/static/js/pages/statistics-page.js
@@ -1,4 +1,6 @@
 'use strict';
+var $ = require('jquery');
+
 $(function(){
     // Ad script alert
     var adBlockPersistKey = 'adBlockDismiss';

--- a/website/static/js/project-organizer.js
+++ b/website/static/js/project-organizer.js
@@ -242,7 +242,7 @@ function _poMultiselect(event, tree) {
     tb.options.updateSelected(tb.multiselected());
     if (tb.multiselected().length === 1) {
         tb.select('#tb-tbody').removeClass('unselectable');
-        if (event.currentTarget != null) {
+        if (event.currentTarget != null && event.target.className.indexOf('po-draggable') !== -1) {
             $osf.trackClick('myProjects', 'projectOrganizer', 'single-project-selected');
         }
     } else if (tb.multiselected().length > 1) {


### PR DESCRIPTION
## Purpose

I did an audit of the google analytics events in the Dashboard and My Projects pages.  There are a couple items that are triggering firing of two events.

1) There is an 'x' (close) button as well as a 'Cancel' button on the Add Collection modal on the My Projects page.   When the close button is clicked, the 'cancel' button event tracking was also fired.

2) There are a few items we track in the mobile view only.  If you click on the button with a horizontal ellipsis beside a project in the mobile view to open up the information panel, the event tracking for a single project being selected is also fired. 

## Changes

Corrected firing of two events for these two actions.

## Side effects

Before the date that this gets merged in, event tracking will be incorrect. After this date, event tracking for these two items should be fixed.  If analyzing data before and after this change, corrections will need to be made.

These are minor items and easy to fix when analyzing data - when I did my GA presentation in April, I manually corrected this data for these items.

## Ticket

https://openscience.atlassian.net/browse/OSF-6479
