### PR TITLE
[RFR][Feature][OSF-5939]Sort files by Dates in project(overview) page and project files page

### DIFF
--- a/website/addons/dataverse/static/dataverseFangornConfig.js
+++ b/website/addons/dataverse/static/dataverseFangornConfig.js
@@ -262,7 +262,7 @@ function _fangornColumns(item) {
         filter : true,
         custom: _fangornDataverseTitle
     });
-    if(tb.options.placement === 'project-files') {
+    if (tb.options.placement === 'project-files') {
         columns.push(
         {
             data  : 'size',
@@ -271,7 +271,7 @@ function _fangornColumns(item) {
             custom : function() {return m('');}
         });
     }
-    if(tb.options.placement === 'project-files') {
+    if (tb.options.placement === 'project-files') {
         columns.push(
         {
             data  : 'downloads',

--- a/website/addons/dataverse/static/dataverseFangornConfig.js
+++ b/website/addons/dataverse/static/dataverseFangornConfig.js
@@ -3,6 +3,7 @@
 var m = require('mithril');
 var URI = require('URIjs');
 var $ = require('jquery');
+var Raven = require('raven-js');
 
 var Fangorn = require('js/fangorn');
 var waterbutler = require('js/waterbutler');
@@ -254,25 +255,36 @@ function _fangornDataverseTitle(item, col) {
 
 function _fangornColumns(item) {
     var tb = this;
-    var selectClass = '';
     var columns = [];
     columns.push({
         data : 'name',
         folderIcons : true,
         filter : true,
-        css: selectClass,
         custom: _fangornDataverseTitle
     });
-
-    if (tb.options.placement === 'project-files') {
+    if(tb.options.placement === 'project-files') {
         columns.push(
-            {
-                data: 'downloads',
-                filter: false,
-                css: ''
-            }
-        );
+        {
+            data  : 'size',
+            sortInclude : false,
+            filter : false,
+            custom : function() {return m('');}
+        });
     }
+    if(tb.options.placement === 'project-files') {
+        columns.push(
+        {
+            data  : 'downloads',
+            sortInclude : false,
+            filter : false,
+            custom : function() {return m('');}
+        });
+    }
+    columns.push({
+        data : 'modified',
+        filter: false,
+        custom : function() {return m('');}
+    });
     return columns;
 }
 

--- a/website/addons/dataverse/static/dataverseFangornConfig.js
+++ b/website/addons/dataverse/static/dataverseFangornConfig.js
@@ -270,8 +270,6 @@ function _fangornColumns(item) {
             filter : false,
             custom : function() {return m('');}
         });
-    }
-    if (tb.options.placement === 'project-files') {
         columns.push(
         {
             data  : 'downloads',

--- a/website/addons/github/static/githubFangornConfig.js
+++ b/website/addons/github/static/githubFangornConfig.js
@@ -301,10 +301,8 @@ function _fangornGithubTitle(item, col)  {
     if (item.data.addonFullname) {
         var urlParams = $osf.urlParams();
         
-        if (!item.data.branch) {
-            if (urlParams.branch && urlParams.branch != item.data.branch) {
-                item.data.branch = urlParams.branch;
-            }
+        if (!item.data.branch && urlParams.branch) {
+            item.data.branch = urlParams.branch;
         }
         var branch = item.data.branch || item.data.defaultBranch;
         
@@ -327,7 +325,6 @@ function _fangornGithubTitle(item, col)  {
 
 function _fangornColumns (item) {
     var tb = this;
-    var selectClass = '';
     var node = item.parent().parent();
     var columns = [];
     columns.push({
@@ -340,11 +337,27 @@ function _fangornColumns (item) {
     if(tb.options.placement === 'project-files') {
         columns.push(
         {
-            data  : 'downloads',
+            data  : 'size',
+            sortInclude : false,
             filter : false,
-            css : ''
+            custom : function() {return item.data.size ? $osf.humanFileSize(item.data.size, true) : '';}
         });
     }
+
+    if(tb.options.placement === 'project-files') {
+        columns.push(
+        {
+            data  : 'downloads',
+            sortInclude : false,
+            filter : false,
+            custom : function() {return m('');}
+        });
+    }
+    columns.push({
+        data : 'modified',
+        filter: false,
+        custom : function() {return m('');}
+    });
     return columns;
 }
 

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1239,7 +1239,7 @@ function _fangornModifiedColumn(item, col) {
         return m(
             'span',
             // "new Date" required for non-ISO date formats
-            Moment(new Date(item.data.modified)).format('YYYY-MM-DD hh:mm A')
+            new Moment(new Date(item.data.modified)).format('YYYY-MM-DD hh:mm A')
         );
     }
     return m('span', '');

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -10,8 +10,9 @@ var m = require('mithril');
 var URI = require('URIjs');
 var Raven = require('raven-js');
 var Treebeard = require('treebeard');
-var Moment = require('moment');
+var moment = require('moment');
 var Dropzone = require('dropzone');
+var lodashGet = require('lodash.get');
 
 var $osf = require('js/osfHelpers');
 var waterbutler = require('js/waterbutler');
@@ -1283,12 +1284,11 @@ function _fangornModifiedColumn(item, col) {
     if (item.data.isAddonRoot && item.connected === false) { // as opposed to undefined, avoids unnecessary setting of this value
         return _connectCheckTemplate.call(this, item);
     }
-    var assert = require('assert');
     if (item.kind === 'file' && item.data.permissions.view && item.data.modified) {
         return m(
             'span',
             // "new Date" required for non-ISO date formats
-            new Moment(new Date(item.data.modified)).format('YYYY-MM-DD hh:mm A')
+            new moment(new Date(item.data.modified)).format('YYYY-MM-DD hh:mm A')
         );
     }
     return m('span', '');
@@ -1376,7 +1376,7 @@ function _fangornResolveRows(item) {
             data : 'downloads',
             sortInclude : false,
             filter : false,
-            custom: function() { return item.data.extra && item.data.extra.downloads ? item.data.extra.downloads.toString() : ''; }
+            custom: function() { return lodashGet(item, 'data.extra.downloads', '').toString(); }
         });
     } else {
         default_columns.push({

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1232,8 +1232,6 @@ function _fangornModifiedColumn(item, col) {
     if (item.data.isAddonRoot && item.connected === false) { // as opposed to undefined, avoids unnecessary setting of this value
         return _connectCheckTemplate.call(this, item);
     }
-    console.log(item.data.provider);
-    console.log(item.data.name);
     var assert = require('assert');
     if (item.kind === 'file' && item.data.permissions.view && item.data.modified) {
         return m(
@@ -1327,7 +1325,7 @@ function _fangornResolveRows(item) {
             data : 'downloads',
             sortInclude : false,
             filter : false,
-            custom: function() { return item.data.extra ? item.data.extra.downloads.toString() : ''; }
+            custom: function() { return item.data.extra && item.data.extra.downloads ? item.data.extra.downloads.toString() : ''; }
         });
     } else {
         default_columns.push({

--- a/website/static/js/pages/project-dashboard-page.js
+++ b/website/static/js/pages/project-dashboard-page.js
@@ -117,7 +117,13 @@ $(document).ready(function () {
                     return [
                         {
                             title: 'Name',
-                            width : '100%',
+                            width : '70%',
+                            sort : true,
+                            sortType : 'text'
+                        },
+                        {
+                            title: 'Modified',
+                            width : '30%',
                             sort : true,
                             sortType : 'text'
                         }
@@ -137,7 +143,12 @@ $(document).ready(function () {
                                 data: 'name',
                                 folderIcons: true,
                                 filter: true,
-                                custom: Fangorn.DefaultColumns._fangornTitleColumn
+                                custom: Fangorn.DefaultColumns._fangornTitleColumn},
+                                {
+                                data: 'modified',
+                                folderIcons: false,
+                                filter: false,
+                                custom: Fangorn.DefaultColumns._fangornModifiedColumn
                             }];
                     if (item.parentID) {
                         item.data.permissions = item.data.permissions || item.parent().data.permissions;


### PR DESCRIPTION
## Purpose:
[OSF-5939](https://openscience.atlassian.net/browse/OSF-5939)
In project overview page and project file view page...
- Add last modified date to file info.
- Allow sorting by modified date

## Bonus
GitHub files now show their file size in project files view
Dataverse Raven logging should now work

## Changes:
Update website/addons/dataverse/static/dataverseFangornConfig.js
- Require raven-js to resolve unknown name
- Add columns size, downloads, and modified to allow for sorting by last modified date

Update website/addons/github/static/githubFangornConfig.js
- Minor clean up
- Add columns size, downloads, and modified to allow for sorting by last modified date

Update  website/static/js/fangorn.js 
- Require moment-js for handling date/time
- Add  function _fangornModifiedColumn to normalize modified date using moment-js
- Update function _fangornResolveRows to fill in size, download, and modified for all files
- Allow for sorting by last modified date

Update website/static/js/pages/project-dashboard-page.js
- Update $(document).ready(function () to show sortable modified column

## Side effects
None

## Caveats
WB does not provide file last modified dates for the following providers...
Dataverse
FigShare
GitHub

WB does not provide file sizes for the Dataverse provider

WB only provides download counts for the OSFStorage provider


[#OSF-5939]