### PR TITLE
[hotfix] Institution Logo w Anonymous VOL

### DIFF
--- a/website/static/js/pages/project-dashboard-page.js
+++ b/website/static/js/pages/project-dashboard-page.js
@@ -95,7 +95,7 @@ var institutionLogos = {
 
 $(document).ready(function () {
 
-    if (ctx.node.institutions.length){
+    if (ctx.node.institutions.length && !ctx.node.anonymous){
         m.mount(document.getElementById('instLogo'), m.component(institutionLogos, {institutions: window.contextVars.node.institutions}));
     }
     $('#contributorsList').osfToggleHeight();


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

##### Purpose
- Currently, if you view a project that has an affiliated institution with an anonymous VOL, parts of the project dashboard will break due to a mithril error (attempting to render the ```institutionLogo``` mithril component into the [```#instLogo```](https://github.com/CenterForOpenScience/osf.io/blob/5441d3bffa89b99658d8dbd09e9e610963d6383d/website/templates/project/project.mako#L25) div, which doesn't exist). This PR fixes this by not rendering the ```institutionLogo``` mithril component when viewing a project through an anonymous VOL.

##### Ticket
[OSF-6486](https://openscience.atlassian.net/browse/OSF-6486)