### PR TITLE
[Feature] fix registration preview style on narrow window [OSF-6464]

### DIFF
--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -772,7 +772,7 @@ Draft.prototype.reject = function() {
  * @property {Object} extensions: mapping of extenstion names to their view models
  **/
 var RegistrationEditor = function(urls, editorId, preview) {
-    var self = this; 
+    var self = this;
     self.urls = urls;
 
     self.readonly = ko.observable(false);
@@ -885,7 +885,7 @@ var RegistrationEditor = function(urls, editorId, preview) {
 		$elem.append(
 		    $('<span class="col-md-12">').append(
 			$('<p class="breaklines"><small><em>' + $osf.htmlEscape(question.description) + '</em></small></p>'),
-                            $('<span class="well col-md-12">').append(value)
+                            $('<span class="well col-xs-12">').append(value)
 		));
             }
 	    return $elem;


### PR DESCRIPTION
## Purpose

If the window is narrow when looking at a preview of a registration, the formatting is strange.
![screen shot 2016-06-09 at 3 00 57 pm](https://cloud.githubusercontent.com/assets/7131985/15942826/2b52c28c-2e54-11e6-9e14-8b336cec3232.png)

## Changes

* switch from col-md to col-xs

![screen shot 2016-06-09 at 3 04 24 pm](https://cloud.githubusercontent.com/assets/7131985/15942844/431ecae6-2e54-11e6-82e7-6f2646ee3908.png)

## Side effects

None

## Ticket

https://openscience.atlassian.net/browse/OSF-6464
