### PR TITLE
Feature/File Checkin Checkout Fix [OSF-6487]

### DIFF
--- a/api_tests/files/views/test_file_detail.py
+++ b/api_tests/files/views/test_file_detail.py
@@ -417,14 +417,14 @@ class TestFileTagging(ApiTestCase):
     def test_add_tag_adds_log(self):
         count = len(self.node.logs)
         self.app.put_json_api(self.url, self.payload, auth=self.user.auth)
-        assert_equal(len(self.node.logs), count + 2)
-        assert_equal(NodeLog.FILE_TAG_ADDED, self.node.logs[-2].action)
+        assert_equal(len(self.node.logs), count + 1)
+        assert_equal(NodeLog.FILE_TAG_ADDED, self.node.logs[-1].action)
 
     def test_remove_tag_adds_log(self):
         self.app.put_json_api(self.url, self.payload, auth=self.user.auth)
         self.payload['data']['attributes']['tags'] = []
         count = len(self.node.logs)
         self.app.put_json_api(self.url, self.payload, auth=self.user.auth)
-        assert_equal(len(self.node.logs), count + 2)
-        assert_equal(NodeLog.FILE_TAG_REMOVED, self.node.logs[-2].action)
+        assert_equal(len(self.node.logs), count + 1)
+        assert_equal(NodeLog.FILE_TAG_REMOVED, self.node.logs[-1].action)
 

--- a/website/files/models/osfstorage.py
+++ b/website/files/models/osfstorage.py
@@ -123,25 +123,27 @@ class OsfStorageFileNode(FileNode):
             raise exceptions.FileNodeCheckedOutError()
 
         action = NodeLog.CHECKED_OUT if checkout else NodeLog.CHECKED_IN
-        self.checkout = checkout
 
-        self.node.add_log(
-            action=action,
-            params={
-                'kind': self.kind,
-                'project': self.node.parent_id,
-                'node': self.node._id,
-                'urls': {
-                    # web_url_for unavailable -- called from within the API, so no flask app
-                    'download': "/project/{}/files/{}/{}/?action=download".format(self.node._id, self.provider, self._id),
-                    'view': "/project/{}/files/{}/{}".format(self.node._id, self.provider, self._id)},
-                'path': self.materialized_path
-            },
-            auth=Auth(user),
-        )
+        if self.is_checked_out and action == NodeLog.CHECKED_IN or not self.is_checked_out and action == NodeLog.CHECKED_OUT:
+            self.checkout = checkout
 
-        if save:
-            self.save()
+            self.node.add_log(
+                action=action,
+                params={
+                    'kind': self.kind,
+                    'project': self.node.parent_id,
+                    'node': self.node._id,
+                    'urls': {
+                        # web_url_for unavailable -- called from within the API, so no flask app
+                        'download': "/project/{}/files/{}/{}/?action=download".format(self.node._id, self.provider, self._id),
+                        'view': "/project/{}/files/{}/{}".format(self.node._id, self.provider, self._id)},
+                    'path': self.materialized_path
+                },
+                auth=Auth(user),
+            )
+
+            if save:
+                self.save()
 
     def save(self):
         self.path = ''


### PR DESCRIPTION
## Purpose

Fix for file checkin/checkout.  Via the API, if a file was checked in, you could send a request to check it in.  If a file was already checked out, you could send a request to check it out.  This also created a bunch of unnecessary logs.

So this request to `PATCH /v2/files/{file_id}/` for an already checked-in file, would check it in again.  So there would be two logs created, one for `file_tag_added`(correct) and one for `checked_in` (incorrect).
```
If already checked in, this request would result in another checkin.
{
    "data": {
        "id": "<file_id>",
        "type": "files", 
        "attributes": {
            "tags": ["hey"],
            "checkout": null
            }
    }
}
```

```
If file checked out, this request would result in another checkout.
{
    "data": {
        "id": "<file_id>",
        "type": "files", 
        "attributes": {
            "tags": ["hey"],
            "checkout": {user_id}
            }
    }
}
```

## Changes

Corrects above behavior, fixes broken tests that were testing the wrong thing, and adds new tests to ensure you can't checkin when file is checked in and can't checkout when file is checked out.

## Ticket

https://openscience.atlassian.net/browse/OSF-6487
