### PR TITLE
[Hotfix] change make private modal text [OSF-6480]

### DIFF
--- a/website/static/js/nodesPrivacy.js
+++ b/website/static/js/nodesPrivacy.js
@@ -108,7 +108,7 @@ var NodesPrivacyViewModel = function(node, onSetPrivacy) {
 
     self.parentIsEmbargoed = node.is_embargoed;
     self.parentIsPublic = node.is_public;
-    self.isComponent = node.node_type === 'component';
+    self.parentNodeType = node.node_type;
     self.treebeardUrl = window.contextVars.node.urls.api  + 'tree/';
     self.nodesOriginal = {};
     self.nodesChanged = ko.observable();
@@ -145,7 +145,7 @@ var NodesPrivacyViewModel = function(node, onSetPrivacy) {
 
         return {
             warning: self.parentIsPublic ?
-                self.isComponent ? 'Make component private' : 'Make project private' :
+                'Make ' + self.parentNodeType + ' private' :
                 'Warning',
             select: 'Change privacy settings',
             confirm: 'Projects and components affected'

--- a/website/static/js/nodesPrivacy.js
+++ b/website/static/js/nodesPrivacy.js
@@ -18,6 +18,9 @@ var MESSAGES = {
     'Please review your projects, components, and add-ons for sensitive or restricted information before making them public.' +
     '<br><br>Once they are made public, you should assume they will always be public. You can ' +
         'return them to private later, but search engines (including Google’s cache) or others may access files before you do.',
+    makeProjectPrivateWarning:
+    '<ul><li>Public forks and registrations of this project will remain public.</li>' +
+    '<li>Search engines (including Google\'s cache) or others may have accessed files while this project was public.</li></ul>',
     makeEmbargoPublicWarning: 'By clicking confirm, an email will be sent to project administrator(s) to approve ending the embargo. If approved, this registration, including any components, will be made public immediately. This action is irreversible.',
     makeEmbargoPublicTitle: 'End embargo early',
     selectNodes: 'Adjust your privacy settings by checking the boxes below. ' +
@@ -105,6 +108,7 @@ var NodesPrivacyViewModel = function(node, onSetPrivacy) {
 
     self.parentIsEmbargoed = node.is_embargoed;
     self.parentIsPublic = node.is_public;
+    self.isComponent = node.node_type === 'component';
     self.treebeardUrl = window.contextVars.node.urls.api  + 'tree/';
     self.nodesOriginal = {};
     self.nodesChanged = ko.observable();
@@ -139,9 +143,10 @@ var NodesPrivacyViewModel = function(node, onSetPrivacy) {
             return MESSAGES.makeEmbargoPublicTitle;
         }
 
-
         return {
-            warning: 'Warning',
+            warning: self.parentIsPublic ?
+                self.isComponent ? 'Make component private' : 'Make project private' :
+                'Warning',
             select: 'Change privacy settings',
             confirm: 'Projects and components affected'
         }[self.page()];
@@ -153,7 +158,9 @@ var NodesPrivacyViewModel = function(node, onSetPrivacy) {
         }
 
         return {
-            warning: MESSAGES.makeProjectPublicWarning,
+            warning: self.parentIsPublic ?
+                MESSAGES.makeProjectPrivateWarning :
+                MESSAGES.makeProjectPublicWarning,
             select: MESSAGES.selectNodes,
             confirm: MESSAGES.confirmWarning
         }[self.page()];


### PR DESCRIPTION
## Purpose

Currently, the confirmation modal when making a project/component private is the same as the confirmation modal when making a project/component public.

![screen shot 2016-06-09 at 3 44 25 pm](https://cloud.githubusercontent.com/assets/7131985/15965927/b5f5ad56-2eee-11e6-858e-59a7c53fde0d.png)

## Changes

* add check for whether the project is public or private
* add check for whether the node is a project or component
* add message for changing project/component to private

![screen shot 2016-06-10 at 9 29 38 am](https://cloud.githubusercontent.com/assets/7131985/15965921/aed22afe-2eee-11e6-8197-f2d91f4d6355.png)
![screen shot 2016-06-10 at 9 30 16 am](https://cloud.githubusercontent.com/assets/7131985/15965922/aed29ff2-2eee-11e6-9614-a0a05c0bc378.png)

## Side effects

None


## Ticket

https://openscience.atlassian.net/browse/OSF-6480
