### PR TITLE
Include api relationships even if embedding [OSF-6488]

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -1010,7 +1010,7 @@ class JSONAPISerializer(ser.Serializer):
                     continue
                 if getattr(field, 'json_api_link', False) or getattr(nested_field, 'json_api_link', False):
                     # If embed=field_name is appended to the query string or 'always_embed' flag is True, directly embed the
-                    # results rather than adding a relationship link
+                    # results in addition to adding a relationship link
                     if embeds and (field.field_name in embeds or getattr(field, 'always_embed', None)):
                         if enable_esi:
                             try:

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -1028,14 +1028,13 @@ class JSONAPISerializer(ser.Serializer):
                             data['embeds'][field.field_name] = result
                         else:
                             data['embeds'][field.field_name] = {'error': 'This field is not embeddable.'}
-                    else:
-                        try:
-                            if not (is_anonymous and
-                                        hasattr(field, 'view_name') and
-                                            field.view_name in self.views_to_hide_if_anonymous):
-                                data['relationships'][field.field_name] = representation
-                        except SkipField:
-                            continue
+                    try:
+                        if not (is_anonymous and
+                                    hasattr(field, 'view_name') and
+                                        field.view_name in self.views_to_hide_if_anonymous):
+                            data['relationships'][field.field_name] = representation
+                    except SkipField:
+                        continue
                 elif field.field_name == 'id':
                     data['id'] = representation
                 elif field.field_name == 'links':

--- a/api/caching/tests/test_caching.py
+++ b/api/caching/tests/test_caching.py
@@ -158,11 +158,6 @@ class TestVarnish(DbTestCase):
                 embed_keys.sort()
                 assert item__embed_keys == embed_keys, 'Embed key mismatch: \n{}\n{}'.format(item__embed_keys,
                                                                                              embed_keys)
-            if 'relationships' in item.keys():
-                for rel_key in item['relationships'].keys():
-                    assert unicode(
-                        rel_key) not in embed_keys, 'Relationship mismatch: {}'.format(
-                        rel_key)
 
     @unittest.skipIf(not django_settings.ENABLE_VARNISH, 'Varnish is disabled')
     def test_cache_invalidation(self):

--- a/api_tests/base/test_serializers.py
+++ b/api_tests/base/test_serializers.py
@@ -178,6 +178,11 @@ class TestApiBaseSerializers(ApiTestCase):
         assert_equal(res.status_code, http.BAD_REQUEST)
         assert_equal(res.json['errors'][0]['detail'], "The following fields are not embeddable: foo")
 
+    def test_embed_does_not_remove_relationship(self):
+        res = self.app.get(self.url, params={'embed': 'root'})
+        assert_equal(res.status_code, 200)
+        assert_in(self.url, res.json['data']['relationships']['root']['links']['related']['href'])
+
     def test_counts_included_in_children_field_with_children_related_counts_query_param(self):
 
         res = self.app.get(self.url, params={'related_counts': 'children'})


### PR DESCRIPTION
## Purpose

Keep the relationship link when embedding the relationship

## Changes

1. Pull the relationship link creation out of the else block in the serializer
2. Add a test

## Side effects

No

## Ticket

https://openscience.atlassian.net/browse/OSF-6488