### PR TITLE
[RFR][Feature][OSF-6467]Enable Comments PATCH to update "deleted" attribute to true

### DIFF
--- a/api/comments/serializers.py
+++ b/api/comments/serializers.py
@@ -100,6 +100,11 @@ class CommentSerializer(JSONAPISerializer):
                     comment.undelete(auth, save=True)
                 except PermissionsError:
                     raise PermissionDenied('Not authorized to undelete this comment.')
+            elif validated_data.get('is_deleted', None) is True and not comment.is_deleted:
+                try:
+                    comment.delete(auth, save=True)
+                except PermissionsError:
+                    raise PermissionDenied('Not authorized to delete this comment.')
             elif 'get_content' in validated_data:
                 content = validated_data.pop('get_content')
                 try:


### PR DESCRIPTION
## Purpose:
[OSF-6467](https://openscience.atlassian.net/browse/OSF-6467)
Allow PATCH call to "delete" comments

## Changes:
Update api/comments/serializers.py update "def update" to allow changing attribute "deleted" to true


## Side effects
None

[#OSF-6467]