### PR TITLE
github usernames appearing in View Only links [#OSF-6449]

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -15,11 +15,8 @@ from api.base.exceptions import InvalidQueryStringError, Conflict, JSONAPIExcept
 from api.base.settings import BULK_SETTINGS
 from api.base.utils import extend_querystring_params
 from framework.auth import core as auth_core
-from modularodm import Q
-from modularodm.exceptions import NoResultsFound
 from website import settings
 from website import util as website_utils
-from website.models import PrivateLink
 from website.util.sanitize import strip_html
 
 
@@ -52,16 +49,8 @@ def format_relationship_links(related_link=None, self_link=None, rel_meta=None, 
 
 
 def is_anonymized(request):
-    is_anonymous = False
     private_key = request.query_params.get('view_only', None)
-    if private_key is not None:
-        try:
-            link = PrivateLink.find_one(Q('key', 'eq', private_key))
-        except NoResultsFound:
-            link = None
-        if link is not None:
-            is_anonymous = link.anonymous
-    return is_anonymous
+    return website_utils.check_private_key_for_anonymized_link(private_key)
 
 
 class HideIfRegistration(ser.Field):

--- a/website/addons/base/generic_views.py
+++ b/website/addons/base/generic_views.py
@@ -79,6 +79,7 @@ def root_folder(addon_short_name):
             permissions=auth,
             nodeUrl=node.url,
             nodeApiUrl=node.api_url,
+            private_key=kwargs.get('view_only', None),
         )
         return [root]
     _root_folder.__name__ = '{0}_root_folder'.format(addon_short_name)

--- a/website/addons/dataverse/views.py
+++ b/website/addons/dataverse/views.py
@@ -232,7 +232,8 @@ def _dataverse_root_folder(node_addon, auth, **kwargs):
         return [rubeus.build_addon_root(
             node_addon,
             node_addon.dataset,
-            permissions=permissions
+            permissions=permissions,
+            private_key=kwargs.get('view_only', None),
         )]
 
     # Quit if doi does not produce a dataset
@@ -280,6 +281,7 @@ def _dataverse_root_folder(node_addon, auth, **kwargs):
         datasetDraftModified=dataset_draft_modified,
         version=version,
         host=dataverse_host,
+        private_key=kwargs.get('view_only', None),
     )]
 
 

--- a/website/addons/github/views.py
+++ b/website/addons/github/views.py
@@ -260,6 +260,7 @@ def github_hgrid_data(node_settings, auth, **kwargs):
         permissions=permissions,
         branches=branch_names,
         defaultBranch=branch,
+        private_key=kwargs.get('view_only', None),
     )]
 
 #########

--- a/website/util/__init__.py
+++ b/website/util/__init__.py
@@ -13,6 +13,8 @@ from flask import request, url_for
 
 from website import settings as website_settings
 from api.base import settings as api_settings
+from modularodm import Q
+from modularodm.exceptions import NoResultsFound
 
 # Keep me: Makes rubeus importable from website.util
 from . import rubeus  # noqa
@@ -193,3 +195,17 @@ def disconnected_from(signal, listener):
     signal.disconnect(listener)
     yield
     signal.connect(listener)
+
+
+def check_private_key_for_anonymized_link(private_key):
+    from website.project.model import PrivateLink
+
+    is_anonymous = False
+    if private_key is not None:
+        try:
+            link = PrivateLink.find_one(Q('key', 'eq', private_key))
+        except NoResultsFound:
+            link = None
+        if link is not None:
+            is_anonymous = link.anonymous
+    return is_anonymous

--- a/website/util/rubeus.py
+++ b/website/util/rubeus.py
@@ -74,12 +74,10 @@ def build_addon_root(node_settings, name, permissions=None,
     from website.util import check_private_key_for_anonymized_link
 
     permissions = permissions or DEFAULT_PERMISSIONS
-    if name:
+    if name and not check_private_key_for_anonymized_link(private_key):
         name = u'{0}: {1}'.format(node_settings.config.full_name, name)
     else:
         name = node_settings.config.full_name
-    if check_private_key_for_anonymized_link(private_key):
-        name = name.replace(node_settings.user, '')
     if hasattr(node_settings.config, 'urls') and node_settings.config.urls:
         urls = node_settings.config.urls
     if urls is None:

--- a/website/util/rubeus.py
+++ b/website/util/rubeus.py
@@ -53,7 +53,7 @@ def to_hgrid(node, auth, **data):
 
 def build_addon_root(node_settings, name, permissions=None,
                      urls=None, extra=None, buttons=None, user=None,
-                     **kwargs):
+                     private_key=None, **kwargs):
     """Builds the root or "dummy" folder for an addon.
 
     :param addonNodeSettingsBase node_settings: Addon settings
@@ -66,15 +66,20 @@ def build_addon_root(node_settings, name, permissions=None,
     :param list of dicts buttons: List of buttons to appear in HGrid row. Each
         dict must have 'text', a string that will appear on the button, and
         'action', the name of a function in
+    :param bool private_key: Used to check if information should be stripped from anonymous links
     :param dict kwargs: Any additional information to add to the root folder
     :return dict: Hgrid formatted dictionary for the addon root folder
 
     """
+    from website.util import check_private_key_for_anonymized_link
+
     permissions = permissions or DEFAULT_PERMISSIONS
     if name:
         name = u'{0}: {1}'.format(node_settings.config.full_name, name)
     else:
         name = node_settings.config.full_name
+    if check_private_key_for_anonymized_link(private_key):
+        name = name.replace(node_settings.user, '')
     if hasattr(node_settings.config, 'urls') and node_settings.config.urls:
         urls = node_settings.config.urls
     if urls is None:


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Anonymous view only links that were connected to a github repo still showed their github username as a part of the connected repo storage heading - since usernames can lead to identification, they should be hidden if the files are being shown as part of a view only link. 

In fact, to anonymize a little more, no part of the file path should be shown at all on anonymous links - only the addon heading. 

## Changes
- Add private_key kwarg that can be passed when building the addon root name for the hgrid file tree
- if that private_key kwarg is passed, and checks out as anonymous, remove the file path or folder or bucket name from the name of the heading for all addons
- refactor ```is_anonymized``` in ```api.base.serializers``` to facilitate reuse elsewhere
- use new ```check_private_key_for_anonymized_link``` to check if passed view_only private key is anonymous or not
- Add rubeus tests to make sure path/bucket is removed for anon but not all private links

In short - anonymized view_only links should no longer show the exact path as part of the storage heading. Normal view_only links should stay the same and still show the path and username as appropriate.

### before -- anonymous view_only link
![screen shot 2016-06-10 at 1 32 34 pm](https://cloud.githubusercontent.com/assets/801594/15973166/e9133a48-2f0f-11e6-9b77-e2f94a21c225.png)

### after -- anonymous view_only link
![screen shot 2016-06-13 at 1 42 56 pm](https://cloud.githubusercontent.com/assets/801594/16017219/c8eb0d0e-316c-11e6-9d02-b9de038f1909.png)


Non-anonymous view only links, and projects should **still** show the full filepath and usernames where passed.

## Side effects
None anticipated


## Ticket
https://openscience.atlassian.net/browse/OSF-6449