### PR TITLE
[RFR][Hotfix][OSF-6471]wiki not live updating before the first save

### DIFF
--- a/website/addons/wiki/views.py
+++ b/website/addons/wiki/views.py
@@ -259,12 +259,6 @@ def project_wiki_view(auth, wname, path=None, **kwargs):
     except InvalidVersionError:
         raise WIKI_INVALID_VERSION_ERROR
 
-    # Default versions for view and compare
-    version_settings = {
-        'view': view or ('preview' if 'edit' in panels_used else 'current'),
-        'compare': compare or 'previous',
-    }
-
     # ensure home is always lower case since it cannot be renamed
     if wiki_name.lower() == 'home':
         wiki_name = 'home'
@@ -296,6 +290,12 @@ def project_wiki_view(auth, wname, path=None, **kwargs):
     # Opens 'edit' panel when home wiki is empty
     if not content and can_edit and wiki_name == 'home':
         panels_used.append('edit')
+
+    # Default versions for view and compare
+    version_settings = {
+        'view': view or ('preview' if 'edit' in panels_used else 'current'),
+        'compare': compare or 'previous',
+    }
 
     ret = {
         'wiki_id': wiki_page._primary_key if wiki_page else None,


### PR DESCRIPTION
## Purpose:
[OSF-6471](https://openscience.atlassian.net/browse/OSF-6471)
Fix "wiki not live updating before the first save"

## Changes:
Update website/addons/wiki/views.py move "version_settings = below "empty home page logic.


## Side effects
None

[#OSF-6471]