### PR TITLE
Uploads do not continue after Dataverse upload cancel [OSF-5459]

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -143,14 +143,16 @@ function cancelAllUploads() {
         tb.deleteNode(parent.id, item.id);
     };
     // Clear all synchronous uploads
-    SYNC_UPLOAD_ADDONS.forEach(function(provider) {
-        if (tb.dropzone.syncFileCache[provider] !== undefined) {
-            // Remove cached provider files from UI
-            tb.dropzone.syncFileCache[provider].forEach(removeFromUI);
-            // Clear provider cache
-            tb.dropzone.syncFileCache[provider].length = 0;
-        }
-    });
+    if (tb.dropzone.syncFileCache !== undefined) {
+        SYNC_UPLOAD_ADDONS.forEach(function(provider) {
+            if (tb.dropzone.syncFileCache[provider] !== undefined) {
+                // Remove cached provider files from UI
+                tb.dropzone.syncFileCache[provider].forEach(removeFromUI);
+                // Clear provider cache
+                tb.dropzone.syncFileCache[provider].length = 0;
+            }
+        });
+    }
     // Clear all ongoing uploads
     filesArr.forEach(function(file, index) {
         // Ignore completed files


### PR DESCRIPTION
## Purpose
Cancelling all uploads for an asynchronous provider (without any synchronous uploads) would not work, due to `syncFileCache` not being defined for async-only uploads.

## Changes
- Check if `syncFileCache !== undefined` before checking synchronous providers

## Side effects
N/A

## Ticket
https://openscience.atlassian.net/browse/OSF-5459

