### PR TITLE
[RFR] Make Postcommit tasks marked as celery run as a chain

### DIFF
--- a/api/caching/listeners.py
+++ b/api/caching/listeners.py
@@ -5,4 +5,4 @@ from modularodm import signals
 @signals.save.connect
 def ban_object_from_cache(sender, instance, fields_changed, cached_data):
     if hasattr(instance, 'absolute_api_v2_url'):
-        enqueue_postcommit_task(ban_url, (instance, ), {})
+        enqueue_postcommit_task(ban_url, (instance, ), {}, celery=False, once_per_request=True)

--- a/framework/analytics/__init__.py
+++ b/framework/analytics/__init__.py
@@ -73,7 +73,7 @@ def build_page(rex, kwargs):
     except KeyError:
         return None
 
-def update_counter(page, db=None):
+def update_counter(page, db):
     """Update counters for page.
 
     :param str page: Colon-delimited page key in analytics collection
@@ -131,7 +131,7 @@ def update_counters(rex, db=None):
         def wrapped(*args, **kwargs):
             ret = func(*args, **kwargs)
             page = build_page(rex, kwargs)
-            update_counter(page, db or database)
+            update_counter(page, db)
             return ret
         return wrapped
     return wrapper

--- a/framework/analytics/__init__.py
+++ b/framework/analytics/__init__.py
@@ -75,7 +75,7 @@ def build_page(rex, kwargs):
     except KeyError:
         return None
 
-def update_counter(page, db):
+def update_counter(page, db=None):
     """Update counters for page.
 
     :param str page: Colon-delimited page key in analytics collection

--- a/framework/analytics/__init__.py
+++ b/framework/analytics/__init__.py
@@ -4,6 +4,8 @@
 import functools
 from datetime import datetime
 
+from dateutil import parser
+
 from framework.mongo import database
 from framework.postcommit_tasks.handlers import run_postcommit
 from framework.sessions import session
@@ -15,10 +17,10 @@ collection = database['pagecounters']
 
 @run_postcommit(once_per_request=False, celery=True)
 @app.task(max_retries=5, default_retry_delay=60)
-def increment_user_activity_counters(user_id, action, date, db=None):
+def increment_user_activity_counters(user_id, action, date_string, db=None):
     db = db or database  # default to local proxy
     collection = database['useractivitycounters']
-    date = date.strftime('%Y/%m/%d')
+    date = parser.parse(date_string).strftime('%Y/%m/%d')
     query = {
         '$inc': {
             'total': 1,

--- a/framework/analytics/migrate.py
+++ b/framework/analytics/migrate.py
@@ -21,4 +21,4 @@ for node in Node.find(Q('is_public', 'eq', True) & Q('is_deleted', 'eq', False))
     if node.piwik_site_id:
         continue
 
-    piwik._provision_node(node)
+    piwik._provision_node(node._id)

--- a/framework/analytics/piwik.py
+++ b/framework/analytics/piwik.py
@@ -4,7 +4,6 @@ import json
 import uuid
 from hashlib import md5
 from urllib import urlencode
-
 import requests
 
 from framework.mongo import database as db
@@ -150,8 +149,6 @@ def _change_view_access(users, node, access):
         )
 
 
-@run_postcommit(once_per_request=False, celery=True)
-@app.task(max_retries=5, default_retry_delay=60)
 def _provision_node(node_id):
     from website.project import Node
     node = Node.load(node_id)

--- a/framework/analytics/piwik.py
+++ b/framework/analytics/piwik.py
@@ -4,6 +4,8 @@ import json
 import uuid
 from hashlib import md5
 from urllib import urlencode
+from framework.postcommit_tasks.handlers import run_postcommit
+from framework.celery_tasks import app
 import requests
 
 from framework.mongo import database as db
@@ -149,6 +151,8 @@ def _change_view_access(users, node, access):
         )
 
 
+@run_postcommit(once_per_request=False, celery=True)
+@app.task(max_retries=5, default_retry_delay=60)
 def _provision_node(node_id):
     from website.project import Node
     node = Node.load(node_id)

--- a/framework/analytics/tasks.py
+++ b/framework/analytics/tasks.py
@@ -2,6 +2,7 @@
 
 from framework.celery_tasks import app
 from framework.celery_tasks.handlers import queued_task
+from framework.postcommit_tasks.handlers import run_postcommit
 from framework.transactions.context import transaction
 
 from . import piwik
@@ -19,9 +20,8 @@ def update_user(self, user_id):
         raise self.retry(exc=error)
 
 
-@queued_task
+@run_postcommit(once_per_request=False, celery=True)
 @app.task(bind=True, max_retries=5, default_retry_delay=60)
-@transaction()
 def update_node(self, node_id, updated_fields=None):
     # Avoid circular imports
     from website import models

--- a/framework/postcommit_tasks/handlers.py
+++ b/framework/postcommit_tasks/handlers.py
@@ -3,10 +3,12 @@ import functools
 import hashlib
 import logging
 import threading
+
 import binascii
 from collections import OrderedDict
 import os
 
+from celery import chain
 from celery.local import PromiseProxy
 from gevent.pool import Pool
 
@@ -20,12 +22,19 @@ def postcommit_queue():
         _local.postcommit_queue = OrderedDict()
     return _local.postcommit_queue
 
+def postcommit_celery_queue():
+    if not hasattr(_local, 'postcommit_celery_queue'):
+        _local.postcommit_celery_queue = OrderedDict()
+    return _local.postcommit_celery_queue
+
 def postcommit_before_request():
     _local.postcommit_queue = OrderedDict()
+    _local.postcommit_celery_queue = OrderedDict()
 
 def postcommit_after_request(response, base_status_error_code=500):
     if response.status_code >= base_status_error_code:
         _local.postcommit_queue = OrderedDict()
+        _local.postcommit_celery_queue = OrderedDict()
         return response
     try:
         if postcommit_queue():
@@ -34,12 +43,20 @@ def postcommit_after_request(response, base_status_error_code=500):
             for func in postcommit_queue().values():
                 pool.spawn(func)
             pool.join(timeout=5.0, raise_error=True)  # 5 second timeout and reraise exceptions
+
+        if postcommit_celery_queue():
+            if settings.USE_CELERY:
+                chain(postcommit_celery_queue().values()[0:len(postcommit_celery_queue().values())])
+            else:
+                for task in postcommit_celery_queue().values():
+                    task()
+
     except AttributeError as ex:
         if not settings.DEBUG_MODE:
             logger.error('Post commit task queue not initialized: {}'.format(ex))
     return response
 
-def enqueue_postcommit_task(fn, args, kwargs, once_per_request=True):
+def enqueue_postcommit_task(fn, args, kwargs, celery=False, once_per_request=True):
     # make a hash of the pertinent data
     raw = [fn.__name__, fn.__module__, args, kwargs]
     m = hashlib.md5()
@@ -49,7 +66,25 @@ def enqueue_postcommit_task(fn, args, kwargs, once_per_request=True):
     if not once_per_request:
         # we want to run it once for every occurrence, add a random string
         key = '{}:{}'.format(key, binascii.hexlify(os.urandom(8)))
-    postcommit_queue().update({key: functools.partial(fn, *args, **kwargs)})
+
+    if celery and isinstance(fn, PromiseProxy):
+        datetime_to_str_args = []
+        datetime_to_str_kwargs = {}
+        for arg in args:
+            try:
+                datetime_to_str_args.append(arg.isoformat())
+            except:
+                datetime_to_str_args.append(arg)
+
+        for key, value in kwargs.iteritems():
+            try:
+                datetime_to_str_kwargs[key] = value.isoformat()
+            except:
+                datetime_to_str_kwargs[key] = value
+
+        postcommit_celery_queue().update({key: fn.si(*datetime_to_str_args, **datetime_to_str_kwargs)})
+    else:
+        postcommit_queue().update({key: functools.partial(fn, *args, **kwargs)})
 
 handlers = {
     'before_request': postcommit_before_request,
@@ -69,9 +104,6 @@ def run_postcommit(once_per_request=True, celery=False):
             return func
         @functools.wraps(func)
         def wrapped(*args, **kwargs):
-            if settings.USE_CELERY and celery is True and isinstance(func, PromiseProxy):
-                func.delay(*args, **kwargs)
-            else:
-                enqueue_postcommit_task(func, args, kwargs, once_per_request=once_per_request)
+            enqueue_postcommit_task(func, args, kwargs, celery=celery, once_per_request=once_per_request)
         return wrapped
     return wrapper

--- a/tests/framework_tests/test_analytics.py
+++ b/tests/framework_tests/test_analytics.py
@@ -26,7 +26,7 @@ class TestAnalytics(OsfTestCase):
         assert_equal(analytics.get_total_activity_count(user._id), 0)
         assert_equal(analytics.get_total_activity_count(user._id), user.get_activity_points(db=self.db))
 
-        analytics.increment_user_activity_counters(user._id, 'project_created', date, db=self.db)
+        analytics.increment_user_activity_counters(user._id, 'project_created', date.isoformat(), db=self.db)
 
         assert_equal(analytics.get_total_activity_count(user._id, db=self.db), 1)
         assert_equal(analytics.get_total_activity_count(user._id, db=self.db), user.get_activity_points(db=self.db))
@@ -36,7 +36,7 @@ class TestAnalytics(OsfTestCase):
         date = datetime.utcnow()
 
         assert_equal(user.get_activity_points(db=self.db), 0)
-        analytics.increment_user_activity_counters(user._id, 'project_created', date, db=self.db)
+        analytics.increment_user_activity_counters(user._id, 'project_created', date.isoformat(), db=self.db)
         assert_equal(user.get_activity_points(db=self.db), 1)
 
 

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2455,7 +2455,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
         if save:
             self.save()
         if user:
-            increment_user_activity_counters(user._primary_key, action, log.date)
+            increment_user_activity_counters(user._primary_key, action, log.date.isoformat())
         return log
 
     @classmethod

--- a/website/project/views/comment.py
+++ b/website/project/views/comment.py
@@ -145,11 +145,11 @@ def is_reply(target):
 
 def _update_comments_timestamp(auth, node, page=Comment.OVERVIEW, root_id=None):
     if node.is_contributor(auth.user):
-        enqueue_postcommit_task(ban_url, (node, ), {})
+        enqueue_postcommit_task(ban_url, (node, ), {}, celery=False, once_per_request=True)
         if root_id is not None:
             guid_obj = Guid.load(root_id)
             if guid_obj is not None:
-                enqueue_postcommit_task(ban_url, (guid_obj.referent, ), {})
+                enqueue_postcommit_task(ban_url, (guid_obj.referent, ), {}, celery=False, once_per_request=True)
 
         # update node timestamp
         if page == Comment.OVERVIEW:


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

**REPLACES #5809**

Currently, postcommit tasks could run in any order, asynchronously. This changes them to run as a celery chain: synchronously and in order.

## Changes

There is a separate queue for celery specific postcommit tasks. This queue is run as a celery chain after the request's transaction is committed successfully.

## Side effects

Tasks decorated with run_postcommit could be delayed to the point where a user would notice.

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
