### PR TITLE
Also return to default toolbar for Component clicks [#OSF-6437]

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -2287,7 +2287,7 @@ tbOptions = {
         tb.select('#tb-tbody').on('click', function(event){
             if(event.target !== this) {
                 var item = tb.multiselected()[0];
-                if (item.data.isAddonRoot || item.data.category === 'project') {
+                if (item.data.isAddonRoot || item.data.nodeType === 'project' || item.data.nodeType === 'component') {
                     tb.toolbarMode(toolbarModes.DEFAULT);
                 }
                 return;


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

To fix a bug found in #5808 by the wonderful and thorough QA. Previously, storage providers and project titles would reset to default toolbar when clicked if in edit mode, but components would NOT switch back to default, causing a repeat of the "text box that should not be there" error. 

### New and improved functionality:
![comp_renmae](https://cloud.githubusercontent.com/assets/801594/16018693/930da83e-3173-11e6-82ec-28bb7c65d5ef.gif)


## Changes
- Now also check for the "component" node type. And use NodeType to check for both projects and components onclick for better consistency.

## Side effects

None I can think of


## Ticket
https://openscience.atlassian.net/browse/OSF-6437

