### PR TITLE
Unregistered contributor email should have link to project that they are invited to [OSF-3211]

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2366,7 +2366,7 @@ class TestUserInviteViews(OsfTestCase):
             auth=Auth(project.creator),
         )
         project.save()
-        send_claim_email(email=given_email, user=unreg_user, node=project)
+        send_claim_email(email=given_email, invitedUser=unreg_user, node=project)
 
         assert_true(send_mail.called)
         assert_true(send_mail.called_with(
@@ -2383,21 +2383,22 @@ class TestUserInviteViews(OsfTestCase):
                                                           email=given_email, auth=Auth(
                                                               referrer)
                                                           )
+        claim_url=unreg_user.get_claim_url(project._id, external=True)
+
         project.save()
-        send_claim_email(email=real_email, user=unreg_user, node=project)
+        send_claim_email(email=real_email, invitedUser=unreg_user, node=project)
 
         assert_true(send_mail.called)
         # email was sent to referrer
         send_mail.assert_called_with(
-            referrer.username,
-            mails.FORWARD_INVITE,
-            user=unreg_user,
+            mail=mails.FORWARD_INVITE,
+            invitedUser=unreg_user,
             referrer=referrer,
-            claim_url=unreg_user.get_claim_url(project._id, external=True),
-            email=real_email.lower().strip(),
-            fullname=unreg_user.get_unclaimed_record(project._id)['name'],
-            node=project
+            claim_url=claim_url,
+            node=project,
+            to_addr=referrer.email
         )
+
 
     @mock.patch('website.project.views.contributor.mails.send_mail')
     def test_send_claim_email_before_throttle_expires(self, send_mail):
@@ -2409,11 +2410,11 @@ class TestUserInviteViews(OsfTestCase):
             auth=Auth(project.creator),
         )
         project.save()
-        send_claim_email(email=fake.email(), user=unreg_user, node=project)
+        send_claim_email(email=fake.email(), invitedUser=unreg_user, node=project)
         send_mail.reset_mock()
         # 2nd call raises error because throttle hasn't expired
         with assert_raises(HTTPError):
-            send_claim_email(email=fake.email(), user=unreg_user, node=project)
+            send_claim_email(email=fake.email(), invitedUser=unreg_user, node=project)
         assert_false(send_mail.called)
 
 

--- a/website/mails/mails.py
+++ b/website/mails/mails.py
@@ -144,7 +144,7 @@ FORWARD_INVITE_REGISTERED = Mail('forward_invite_registered', subject='Please fo
 
 FORGOT_PASSWORD = Mail('forgot_password', subject='Reset Password')
 PASSWORD_RESET = Mail('password_reset', subject='Your OSF password has been reset')
-PENDING_VERIFICATION = Mail('pending_invite', subject='Your account is almost ready!')
+PENDING_INVITE_VERIFICATION = Mail('pending_invite', subject='Your account is almost ready!')
 PENDING_VERIFICATION_REGISTERED = Mail('pending_registered', subject='Received request to be a contributor')
 
 REQUEST_EXPORT = Mail('support_request', subject='[via OSF] Export Request')

--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -400,12 +400,12 @@ def send_claim_registered_email(claimer, unreg_user, node, throttle=24 * 3600):
     )
 
 
-def send_claim_email(email, user, node, notify=True, throttle=24 * 3600):
+def send_claim_email(email, invitedUser, node, notify=True, throttle=24 * 3600):
     """Send an email for claiming a user account. Either sends to the given email
     or the referrer's email, depending on the email address provided.
 
     :param str email: The address given in the claim user form
-    :param User user: The User record to claim.
+    :param User invitedUser: The User record to claim.
     :param Node node: The node where the user claimed their account.
     :param bool notify: If True and an email is sent to the referrer, an email
         will also be sent to the invited user about their pending verification.
@@ -413,19 +413,28 @@ def send_claim_email(email, user, node, notify=True, throttle=24 * 3600):
         emailed during which the referrer will not be emailed again.
 
     """
-    claimer_email = email.lower().strip()
+    invited_email = email.lower().strip()
 
-    unclaimed_record = user.get_unclaimed_record(node._primary_key)
+    unclaimed_record = invitedUser.get_unclaimed_record(node._primary_key)
     referrer = User.load(unclaimed_record['referrer_id'])
-    claim_url = user.get_claim_url(node._primary_key, external=True)
+    claim_url = invitedUser.get_claim_url(node._primary_key, external=True)
+
     # If given email is the same provided by user, just send to that email
-    if unclaimed_record.get('email') == claimer_email:
-        mail_tpl = mails.INVITE
-        to_addr = claimer_email
-        unclaimed_record['claimer_email'] = claimer_email
-        user.save()
-    else:  # Otherwise have the referrer forward the email to the user
+    if unclaimed_record.get('email') == invited_email:
+        mails.send_mail(
+            mail=mails.INVITE,
+            to_addr=invited_email,
+            referrer=referrer,
+            invitedUser=invitedUser,
+            node=node,
+            claim_url=claim_url
+        )
+        invitedUser.save()
+
+    else:
+        # Otherwise have the referrer forward the email to the user
         # roll the valid token for each email, thus user cannot change email and approve a different email address
+
         timestamp = unclaimed_record.get('last_sent')
         if not throttle_period_expired(timestamp, throttle):
             raise HTTPError(400, data=dict(
@@ -433,32 +442,27 @@ def send_claim_email(email, user, node, notify=True, throttle=24 * 3600):
             ))
         unclaimed_record['last_sent'] = get_timestamp()
         unclaimed_record['token'] = generate_confirm_token()
-        unclaimed_record['claimer_email'] = claimer_email
-        user.save()
-        claim_url = user.get_claim_url(node._primary_key, external=True)
+        invitedUser.save()
+
         if notify:
-            pending_mail = mails.PENDING_VERIFICATION
             mails.send_mail(
-                claimer_email,
-                pending_mail,
-                user=user,
+                mail=mails.PENDING_INVITE_VERIFICATION,
+                to_addr=invited_email,
                 referrer=referrer,
-                fullname=unclaimed_record['name'],
+                invitedUser=invitedUser,
                 node=node
             )
-        mail_tpl = mails.FORWARD_INVITE
-        to_addr = referrer.username
-    mails.send_mail(
-        to_addr,
-        mail_tpl,
-        user=user,
-        referrer=referrer,
-        node=node,
-        claim_url=claim_url,
-        email=claimer_email,
-        fullname=unclaimed_record['name']
-    )
-    return to_addr
+
+        mails.send_mail(
+            mail=mails.FORWARD_INVITE,
+            to_addr=referrer.email,
+            referrer=referrer,
+            invitedUser=invitedUser,
+            node=node,
+            claim_url=claim_url
+        )
+
+    return invited_email
 
 
 @contributor_added.connect

--- a/website/templates/emails/invite.txt.mako
+++ b/website/templates/emails/invite.txt.mako
@@ -1,12 +1,23 @@
-Hello ${fullname},
+<%doc>
+    Purpose:
+        This message is sent when an admin invites an unregistered User to a project or component
+
+        invitedUser: User, invited to project and must claim token.
+        referrer: User, invited invitedUser user to join thier project/component.
+        node: Node, the node refferer invited invitedUser to.
+</%doc>
+
+Hello ${invitedUser.fullname},
 
 You have been added by ${referrer.fullname} as a contributor to the project "${node.title}" on the Open Science Framework. To set a password for your account, visit:
 
 ${claim_url}
 
-Once you have set a password, you will be able to make contributions to ${node.title} and create your own projects.
+To preview ${node.title} click the following link: ${node.absolute_url}
 
-If you are not ${fullname} or you are erroneously being associated with ${node.title} then email contact@osf.io with the subject line "Claiming Error" to report the problem.
+(NOTE: if this project is private, you will not be able to view it until you have confirmed your account)
+
+If you are not ${invitedUser.fullname} or you are erroneously being associated with ${node.title} then email contact@osf.io with the subject line "Claiming Error" to report the problem.
 
 Sincerely,
 


### PR DESCRIPTION
## Purpose

To allow a user visit a project they were just invited to, before registering.

## Changes

modified email templates and send parameters, add comments to template explain template function

## Side effects

none that I know of.

## Ticket

https://openscience.atlassian.net/browse/OSF-3211
