### PR TITLE
Check for selected item before trying to reset toolbar [#OSF-6437]

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -2287,10 +2287,12 @@ tbOptions = {
         tb.select('#tb-tbody').on('click', function(event){
             if(event.target !== this) {
                 var item = tb.multiselected()[0];
-                if (item.data.isAddonRoot || item.data.nodeType === 'project' || item.data.nodeType === 'component') {
-                    tb.toolbarMode(toolbarModes.DEFAULT);
+                if (item) {
+                    if (item.data.isAddonRoot || item.data.nodeType === 'project' || item.data.nodeType === 'component') {
+                        tb.toolbarMode(toolbarModes.DEFAULT);
+                    }
+                    return;
                 }
-                return;
             }
             tb.clearMultiselect();
             dismissToolbar.call(tb);


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
:bug: found by @felliott , related to renaming text box appearing where it shouldn't, was console errors that appeared when an item wasn't selected, but instead the expand contract button.

This PR checks for a selected item before trying to mess with its toolbar reset properties, thus getting rid of the console errors and keeping the rename bugfix intact.

## Changes
- Check for selected item before assessing things about it

## Side effects
Hopefully none


## Ticket
https://openscience.atlassian.net/browse/OSF-6437

