### PR TITLE
Create file_guid if one doesn't exist

### DIFF
--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -128,6 +128,7 @@ class FileSerializer(JSONAPISerializer):
     date_created = ser.SerializerMethodField(read_only=True, help_text='Timestamp when the file was created')
     extra = ser.SerializerMethodField(read_only=True, help_text='Additional metadata about this file')
     tags = JSONAPIListField(child=FileTagField(), required=False)
+    file_guid = ser.SerializerMethodField(read_only=True, help_text='The unique id of this file')
 
     files = NodeFileHyperLinkField(
         related_view='nodes:node-files',
@@ -241,9 +242,7 @@ class FileSerializer(JSONAPISerializer):
 
     def get_file_guid(self, obj):
         if obj:
-            guid = obj.get_guid()
-            if guid:
-                return guid._id
+            return obj.get_guid(create=True)._id
         return None
 
     def get_absolute_url(self, obj):


### PR DESCRIPTION
# Purpose

In order to build API-consuming applications that include commenting we need to expose the file guid to the API consumer. Additionally, this guid is needed to generate commenting links. Before we were lazily generating this guid when the file is viewed on the OSF. In the API context, we'll need to treat fetching file metadata as a "view".

# Changes

Add file_guid to the serialized file representation. Generate a guid of one doesn't exist.