### PR TITLE
[RFR][Feature][OSF-6504]Add exception handling for invalid subscription targets 

### DIFF
--- a/scripts/populate_institutions.py
+++ b/scripts/populate_institutions.py
@@ -10,10 +10,7 @@ from modularodm import Q
 from website import settings
 from website.app import init_app
 from website.models import Institution, Node
-from website.notifications.listeners import subscribe_creator
-from website.project.signals import project_created
 from website.search.search import update_institution, update_node
-from website.util import disconnected_from
 from framework.transactions.context import TokuTransaction
 
 logger = logging.getLogger(__name__)
@@ -42,7 +39,6 @@ def update_or_create(inst_data):
         inst_data = {inst.attribute_map[k]: v for k, v in inst_data.iteritems()}
         new_inst = Node(**inst_data)
         new_inst.save()
-
         inst = Institution.load(new_inst.institution_id)
         print('Added new institution: {}'.format(new_inst.institution_id))
         update_institution(inst)
@@ -278,10 +274,7 @@ def main(env):
     init_app(routes=False)
     with TokuTransaction():
         for inst_data in INSTITUTIONS:
-            with disconnected_from(signal=project_created,
-                                   listener=subscribe_creator):
-                new_inst, inst_created = update_or_create(inst_data)
-
+            new_inst, inst_created = update_or_create(inst_data)
             # update the nodes elastic docs, to have current names of institutions. This will
             # only work properly if this file is the only thing changing institution attributes
             if not inst_created:

--- a/website/notifications/exceptions.py
+++ b/website/notifications/exceptions.py
@@ -1,0 +1,8 @@
+from website.exceptions import NodeError
+
+class InvalidSubscriptionError(NodeError):
+    """Raised if an invalid subscription is attempted. e.g. attempt to
+    subscribe to an invalid target: institution, bookmark, deleted project etc.
+    """
+    message_short = 'Invalid Subscription'
+    message_long = 'This Subscription is not valid.'

--- a/website/notifications/exceptions.py
+++ b/website/notifications/exceptions.py
@@ -1,8 +1,7 @@
-from website.exceptions import NodeError
+from website.exceptions import OSFError
 
-class InvalidSubscriptionError(NodeError):
+class InvalidSubscriptionError(OSFError):
     """Raised if an invalid subscription is attempted. e.g. attempt to
     subscribe to an invalid target: institution, bookmark, deleted project etc.
     """
-    message_short = 'Invalid Subscription'
-    message_long = 'This Subscription is not valid.'
+    pass

--- a/website/notifications/listeners.py
+++ b/website/notifications/listeners.py
@@ -1,12 +1,27 @@
+import logging
+from website.notifications.exceptions import InvalidSubscriptionError
 from website.notifications.utils import subscribe_user_to_notifications
 from website.project.signals import contributor_added, project_created
 from website.project.views.contributor import notify_added_contributor
 
+logger = logging.getLogger(__name__)
+
 @project_created.connect
 def subscribe_creator(node):
-    subscribe_user_to_notifications(node, node.creator)
+    try:
+        subscribe_user_to_notifications(node, node.creator)
+    except InvalidSubscriptionError as err:
+        user = node.creator._id if node.creator else 'None'
+        logger.warn('Skipping subscription of user {} to node {}'.format(user, node._id))
+        logger.warn('Reason: {}'.format(str(err)))
 
 @contributor_added.connect
 def subscribe_contributor(node, contributor, auth=None, *args, **kwargs):
-    subscribe_user_to_notifications(node, contributor)
-    notify_added_contributor(node, contributor, auth)
+    try:
+        subscribe_user_to_notifications(node, contributor)
+    except InvalidSubscriptionError as err:
+        user = contributor or 'None'
+        logger.warn('Skipping subscription of user {} to node {}'.format(user, node._id))
+        logger.warn('Reason: {}'.format(str(err)))
+    else:
+        notify_added_contributor(node, contributor, auth)

--- a/website/notifications/listeners.py
+++ b/website/notifications/listeners.py
@@ -20,8 +20,7 @@ def subscribe_contributor(node, contributor, auth=None, *args, **kwargs):
     try:
         subscribe_user_to_notifications(node, contributor)
     except InvalidSubscriptionError as err:
-        user = contributor or 'None'
-        logger.warn('Skipping subscription of user {} to node {}'.format(user, node._id))
+        logger.warn('Skipping subscription of user {} to node {}'.format(contributor, node._id))
         logger.warn('Reason: {}'.format(str(err)))
     else:
         notify_added_contributor(node, contributor, auth)

--- a/website/notifications/utils.py
+++ b/website/notifications/utils.py
@@ -7,6 +7,7 @@ from modularodm.exceptions import NoResultsFound
 from website.models import Node, User
 from website.notifications import constants
 from website.notifications import model
+from website.notifications.exceptions import InvalidSubscriptionError
 from website.notifications.model import NotificationSubscription
 from website.project import signals
 
@@ -404,6 +405,16 @@ def subscribe_user_to_notifications(node, user):
 
     :param user: User to subscribe to notifications
     """
+
+    if node.institution_id:
+        raise InvalidSubscriptionError('Institutions are invalid targets for subscriptions')
+
+    if node.is_bookmark_collection:
+        raise InvalidSubscriptionError('Bookmark Collections are invalid targets for subscriptions')
+
+    if node.is_deleted:
+        raise InvalidSubscriptionError('Deleted Nodes are invalid targets for subscriptions')
+
     events = constants.NODE_SUBSCRIPTIONS_AVAILABLE
     notification_type = 'email_transactional'
     target_id = node._id

--- a/website/notifications/utils.py
+++ b/website/notifications/utils.py
@@ -409,8 +409,8 @@ def subscribe_user_to_notifications(node, user):
     if node.institution_id:
         raise InvalidSubscriptionError('Institutions are invalid targets for subscriptions')
 
-    if node.is_bookmark_collection:
-        raise InvalidSubscriptionError('Bookmark Collections are invalid targets for subscriptions')
+    if node.is_collection:
+        raise InvalidSubscriptionError('Collections are invalid targets for subscriptions')
 
     if node.is_deleted:
         raise InvalidSubscriptionError('Deleted Nodes are invalid targets for subscriptions')


### PR DESCRIPTION
## Purpose:
[OSF-6504](https://openscience.atlassian.net/browse/OSF-6504)
Fix "populate_institutions.py no longer works"

## Changes:
Add  website/notifications/exceptions.py containing class InvalidSubscriptionError(NodeError)
Update website/notifications/listeners.py to try/except and catch InvalidSubscriptionError
Update website/notifications/utils.py "def subscribe_user_to_notifications" raise InvalidSubscriptionError for institutions/deleted nodes/collections targets

## Side effects
None

[#OSF-6504]