### PR TITLE
[Hotfix] Dashboard Create Button Fixes [#OSF-6500]

### DIFF
--- a/website/static/js/addProjectPlugin.js
+++ b/website/static/js/addProjectPlugin.js
@@ -55,6 +55,8 @@ var AddProject = {
         // Validation
         self.isValid = m.prop(false);
 
+        self.isAdding = m.prop(false);
+
         self.mapTemplates = function() {
             self.userProjects([]);
             options.templatesFetcher._flat.map(function(node){
@@ -72,6 +74,10 @@ var AddProject = {
 
 
         self.add = function _add () {
+            if (self.isAdding()) {
+                return;
+            }
+            self.isAdding(true);
             var url;
             var data;
             self.viewState('processing');
@@ -99,9 +105,11 @@ var AddProject = {
                 self.viewState('success');
                 self.goToProjectLink(result.data.links.html);
                 self.saveResult(result);
+                self.isAdding(false);
             };
             var error = function _error (result) {
                 self.viewState('error');
+                self.isAdding(false);
             };
             var request = m.request({method : 'POST', url : url, data : data, config : xhrconfig});
             if (self.institutions.length > 0) {

--- a/website/static/js/home-page/newAndNoteworthyPlugin.js
+++ b/website/static/js/home-page/newAndNoteworthyPlugin.js
@@ -92,13 +92,13 @@ var NewAndNoteworthy = {
             promise.then(function(result){
                 var contribNames = [];
                 result.data.forEach(function (contrib){
-                    if (contrib.attributes.unregistered_contributor && contrib.attributes.bibliographic) {
+                    if (lodashGet(contrib, 'attributes.unregistered_contributor', false) && lodashGet(contrib, 'attributes.bibliographic', false)) {
                         contribNames.push(contrib.attributes.unregistered_contributor);
                     }
-                    else if (contrib.embeds.users.data && contrib.attributes.bibliographic){
+                    else if (lodashGet(contrib, 'embeds.users.data', false) && lodashGet(contrib, 'attributes.bibliographic', false)){
                         contribNames.push($osf.findContribName(contrib.embeds.users.data.attributes));
                     }
-                    else if (contrib.embeds.users.errors) {
+                    else if (lodashGet(contrib, 'embeds.users.errors', false)) {
                         contribNames.push($osf.findContribName(contrib.embeds.users.errors[0].meta));
                     }
 


### PR DESCRIPTION
## Purpose
Fixes two existing bugs associated with the `Create Project` button on the dashboard:
* Sometimes disabled in edge case associated with `Most Popular` nodes
* Hitting return multiple times creates multiple projects

## Changes
* Avoid throwing `TypeErrors` when attempting to access possibly-undefined vars
* Add simple locking mechanism to only allow the creation of only one project at a time

## Side effects
None known

## Ticket
[OSF-6500](https://openscience.atlassian.net/browse/OSF-6500)
