### PR TITLE
Add ability to invoke automatic maintenance notice [#OSF-6482]

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -10,6 +10,7 @@ import json
 import platform
 import subprocess
 import logging
+from time import sleep
 
 import invoke
 from invoke import run, Collection

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -967,7 +967,16 @@ def usage():
 def set_maintenance_state(start=None, end=None):
     """Set the time period for the maintenance notice to be displayed.
     If no start or end values are displayed, default to starting now
-    and ending 24 hours from now
+    and ending 24 hours from now. If no timezone info is passed along,
+    everything will be converted to UTC.
+
+    If a given end time results in a start that is after the end, start
+    will be changed to be 24 hours before the end time.
+
+    Examples:
+        invoke set_maintenance_state
+        invoke set_maintenance_state --start 2016-03-16T15:41:00-04:00
+        invoke set_maintenance_state --end 2016-03-16T15:41:00-04:00
     """
     set_maintenance(start, end)
 

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -972,11 +972,11 @@ def set_maintenance(start=None, end=None):
     If no start or end values are displayed, default to starting now
     and ending 24 hours from now
     """
-    # TODO - should we set default time period in settings?
     start = parse(start) if start else datetime.now()
     end = parse(end) if end else start + timedelta(1)
 
-    database.maintenance.insert({'maintenance': True, 'start': start, 'end': end})
+    database.drop_collection('maintenance')
+    database.maintenance.insert({'maintenance': True, 'start': start.isoformat(), 'end': end.isoformat()})
 
 
 @task

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -17,7 +17,6 @@ from invoke import run, Collection
 
 from website import settings
 from utils import pip_install, bin_prefix
-from website.maintenance import set_maintenance, get_maintenance, unset_maintenance
 
 logging.getLogger('invoke').setLevel(logging.CRITICAL)
 
@@ -965,6 +964,8 @@ def usage():
 
 @task
 def set_maintenance_state(start=None, end=None):
+    from website.maintenance import set_maintenance
+
     """Set the time period for the maintenance notice to be displayed.
     If no start or end values are displayed, default to starting now
     and ending 24 hours from now. If no timezone info is passed along,
@@ -983,6 +984,7 @@ def set_maintenance_state(start=None, end=None):
 
 @task
 def get_maintenance_state():
+    from website.maintenance import get_maintenance
     """Get the current start and end times for the maintenance state.
     Return None for start and end if there is no maintenacne state
     """
@@ -991,4 +993,5 @@ def get_maintenance_state():
 
 @task
 def unset_maintenance_state():
+    from website.maintenance import unset_maintenance
     unset_maintenance()

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -10,17 +10,13 @@ import json
 import platform
 import subprocess
 import logging
-import pymongo
-from datetime import datetime, timedelta
-
-from dateutil.parser import parse
 
 import invoke
 from invoke import run, Collection
 
 from website import settings
-from framework.mongo import database
 from utils import pip_install, bin_prefix
+from website.maintenance import set_maintenance, get_maintenance, unset_maintenance
 
 logging.getLogger('invoke').setLevel(logging.CRITICAL)
 
@@ -967,16 +963,12 @@ def usage():
 ### Maintenance Tasks ###
 
 @task
-def set_maintenance(start=None, end=None):
+def set_maintenance_state(start=None, end=None):
     """Set the time period for the maintenance notice to be displayed.
     If no start or end values are displayed, default to starting now
     and ending 24 hours from now
     """
-    start = parse(start) if start else datetime.now()
-    end = parse(end) if end else start + timedelta(1)
-
-    database.drop_collection('maintenance')
-    database.maintenance.insert({'maintenance': True, 'start': start.isoformat(), 'end': end.isoformat()})
+    set_maintenance(start, end)
 
 
 @task
@@ -984,15 +976,9 @@ def get_maintenance_state():
     """Get the current start and end times for the maintenance state.
     Return None for start and end if there is no maintenacne state
     """
-    maintenance_state = database.maintenance.find_one({'maintenance': True})
-    state = {}
-    if maintenance_state:
-        state['start'] = maintenance_state.get('start')
-        state['end'] = maintenance_state.get('end')
-
-    return state if state else None
+    get_maintenance()
 
 
 @task
-def unset_maintenance():
-    database.drop_collection('maintenance')
+def unset_maintenance_state():
+    unset_maintenance()

--- a/website/maintenance.py
+++ b/website/maintenance.py
@@ -1,0 +1,33 @@
+from datetime import datetime, timedelta
+from dateutil.parser import parse
+
+from framework.mongo import database
+
+
+def set_maintenance(start=None, end=None):
+    """Set the time period for the maintenance notice to be displayed.
+    If no start or end values are displayed, default to starting now
+    and ending 24 hours from now
+    """
+    start = parse(start) if start else datetime.now()
+    end = parse(end) if end else start + timedelta(1)
+
+    database.drop_collection('maintenance')
+    database.maintenance.insert({'maintenance': True, 'start': start.isoformat(), 'end': end.isoformat()})
+
+
+def get_maintenance():
+    """Get the current start and end times for the maintenance state.
+    Return None for start and end if there is no maintenacne state
+    """
+    maintenance_state = database.maintenance.find_one({'maintenance': True})
+    state = {}
+    if maintenance_state:
+        state['start'] = maintenance_state.get('start')
+        state['end'] = maintenance_state.get('end')
+
+    return state if state else None
+
+
+def unset_maintenance():
+    database.drop_collection('maintenance')

--- a/website/routes.py
+++ b/website/routes.py
@@ -53,6 +53,8 @@ def get_globals():
     user = _get_current_user()
     user_institutions = [{'id': inst._id, 'name': inst.name, 'logo_path': inst.logo_path} for inst in user.affiliated_institutions] if user else []
     all_institutions = [{'id': inst._id, 'name': inst.name, 'logo_path': inst.logo_path} for inst in Institution.find().sort('name')]
+    maintenance = database.maintenance.find_one({'maintenance': True})
+    del maintenance['_id']
     if request.host_url != settings.DOMAIN:
         try:
             inst_id = (Institution.find_one(Q('domains', 'eq', request.host.lower())))._id
@@ -104,7 +106,7 @@ def get_globals():
         'enable_institutions': settings.ENABLE_INSTITUTIONS,
         'keen_project_id': settings.KEEN_PROJECT_ID,
         'keen_write_key': settings.KEEN_WRITE_KEY,
-        'maintenance': database.maintenance.find_one({'maintenance': True}),
+        'maintenance': maintenance,
     }
 
 def is_private_link_anonymous_view():

--- a/website/routes.py
+++ b/website/routes.py
@@ -9,6 +9,7 @@ from framework import status
 from framework import sentry
 from framework.auth import cas
 from framework.routing import Rule
+from framework.mongo import database
 from framework.flask import redirect
 from framework.routing import WebRenderer
 from framework.exceptions import HTTPError
@@ -103,6 +104,7 @@ def get_globals():
         'enable_institutions': settings.ENABLE_INSTITUTIONS,
         'keen_project_id': settings.KEEN_PROJECT_ID,
         'keen_write_key': settings.KEEN_WRITE_KEY,
+        'maintenance': True if database.maintenance.find_one({'maintenance': True}) else False,
     }
 
 def is_private_link_anonymous_view():

--- a/website/routes.py
+++ b/website/routes.py
@@ -54,7 +54,8 @@ def get_globals():
     user_institutions = [{'id': inst._id, 'name': inst.name, 'logo_path': inst.logo_path} for inst in user.affiliated_institutions] if user else []
     all_institutions = [{'id': inst._id, 'name': inst.name, 'logo_path': inst.logo_path} for inst in Institution.find().sort('name')]
     maintenance = database.maintenance.find_one({'maintenance': True})
-    del maintenance['_id']
+    if maintenance:
+        del maintenance['_id']
     if request.host_url != settings.DOMAIN:
         try:
             inst_id = (Institution.find_one(Q('domains', 'eq', request.host.lower())))._id

--- a/website/routes.py
+++ b/website/routes.py
@@ -104,7 +104,7 @@ def get_globals():
         'enable_institutions': settings.ENABLE_INSTITUTIONS,
         'keen_project_id': settings.KEEN_PROJECT_ID,
         'keen_write_key': settings.KEEN_WRITE_KEY,
-        'maintenance': True if database.maintenance.find_one({'maintenance': True}) else False,
+        'maintenance': database.maintenance.find_one({'maintenance': True}),
     }
 
 def is_private_link_anonymous_view():

--- a/website/static/js/pages/base-page.js
+++ b/website/static/js/pages/base-page.js
@@ -231,14 +231,12 @@ $(function() {
         $maintenance.show();
     }
     // Localize maintenance period datetimes
-    var startMaintenanceUTC = moment.utc({year: 2016, month: 3, day: 15, hour: 1});
-    var endMaintenanceUTC = moment.utc({year: 2016, month: 3, day: 15, hour: 3, minute: 59});
-    var startMaintenance = moment(startMaintenanceUTC.toDate());
-    var endMaintenance = moment(endMaintenanceUTC.toDate());
+    var startMaintenance = moment(window.contextVars.maintenance.start);
+    var endMaintenance = moment(window.contextVars.maintenance.end);
     $('#maintenanceTime').html(
         '<strong>' +
         startMaintenance.format('lll') +
-            '-' +
+            ' and ' +
                 endMaintenance.format('lll') + '</strong>' +
                     ' (' + startMaintenance.format('ZZ') + ' UTC)');
     // END Maintenance alert

--- a/website/static/js/pages/base-page.js
+++ b/website/static/js/pages/base-page.js
@@ -222,23 +222,26 @@ $(function() {
     confirmEmails(window.contextVars.currentUser.emailsToAdd);
 
     // Maintenance alert
-    var maintenancePersistKey = 'maintenance';
-    var $maintenance = $('#maintenance').on('closed.bs.alert', function() {
-        $.cookie(maintenancePersistKey, '0', { expires: 1, path: '/'});
-    });
-    var dismissed = $.cookie(maintenancePersistKey) === '0';
-    if (!dismissed) {
-        $maintenance.show();
+    if (window.contextVars.maintenance) {
+        var maintenancePersistKey = 'maintenance';
+        var $maintenance = $('#maintenance').on('closed.bs.alert', function() {
+            $.cookie(maintenancePersistKey, '0', { expires: 1, path: '/'});
+        });
+        var dismissed = $.cookie(maintenancePersistKey) === '0';
+        if (!dismissed) {
+            $maintenance.show();
+        }
+        // Localize maintenance period datetimes
+        var startMaintenance = moment(window.contextVars.maintenance.start);
+        var endMaintenance = moment(window.contextVars.maintenance.end);
+        $('#maintenanceTime').html(
+            '<strong>' +
+            startMaintenance.format('lll') +
+                ' and ' +
+                    endMaintenance.format('lll') + '</strong>' +
+                        ' (' + startMaintenance.format('ZZ') + ' UTC)'
+        );
     }
-    // Localize maintenance period datetimes
-    var startMaintenance = moment(window.contextVars.maintenance.start);
-    var endMaintenance = moment(window.contextVars.maintenance.end);
-    $('#maintenanceTime').html(
-        '<strong>' +
-        startMaintenance.format('lll') +
-            ' and ' +
-                endMaintenance.format('lll') + '</strong>' +
-                    ' (' + startMaintenance.format('ZZ') + ' UTC)');
     // END Maintenance alert
 
 });

--- a/website/static/js/pages/base-page.js
+++ b/website/static/js/pages/base-page.js
@@ -221,4 +221,26 @@ $(function() {
 
     confirmEmails(window.contextVars.currentUser.emailsToAdd);
 
+    // Maintenance alert
+    var maintenancePersistKey = 'maintenance';
+    var $maintenance = $('#maintenance').on('closed.bs.alert', function() {
+        $.cookie(maintenancePersistKey, '0', { expires: 1, path: '/'});
+    });
+    var dismissed = $.cookie(maintenancePersistKey) === '0';
+    if (!dismissed) {
+        $maintenance.show();
+    }
+    // Localize maintenance period datetimes
+    var startMaintenanceUTC = moment.utc({year: 2016, month: 3, day: 15, hour: 1});
+    var endMaintenanceUTC = moment.utc({year: 2016, month: 3, day: 15, hour: 3, minute: 59});
+    var startMaintenance = moment(startMaintenanceUTC.toDate());
+    var endMaintenance = moment(endMaintenanceUTC.toDate());
+    $('#maintenanceTime').html(
+        '<strong>' +
+        startMaintenance.format('lll') +
+            '-' +
+                endMaintenance.format('lll') + '</strong>' +
+                    ' (' + startMaintenance.format('ZZ') + ' UTC)');
+    // END Maintenance alert
+
 });

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -195,7 +195,8 @@
                 },
                 allInstitutions: ${ all_institutions | sjson, n},
                 popular: ${ popular_links_node | sjson, n },
-                newAndNoteworthy: ${ noteworthy_links_node | sjson, n }
+                newAndNoteworthy: ${ noteworthy_links_node | sjson, n },
+                maintenance: ${ maintenance | sjson, n}
             });
         </script>
 
@@ -289,8 +290,7 @@
                 <button type="button" class="close" data-dismiss="alert" aria-label="Close">
                     <span aria-hidden="true">&times;</span></button>
                 <strong>Notice:</strong> The site will undergo maintenance between
-                <strong>${ maintenance['start'] | sjson, n } and ${ maintenance['end'] | sjson, n }</strong>
-##                 <span id="maintenanceTime"></span>.
+                <span id="maintenanceTime"></span>.
                 Thank you for your patience.
             </div>
             ## End Maintenance alert

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -283,7 +283,7 @@
 <%def name="content_wrap()">
     <div class="watermarked">
         <div class="container ${self.container_class()}">
-
+            % if maintenance:
             ## Maintenance alert
             <div id="maintenance" class="scripted alert alert-info alert-dismissible" role="alert">
                 <button type="button" class="close" data-dismiss="alert" aria-label="Close">
@@ -293,6 +293,7 @@
                 Thank you for your patience.
             </div>
             ## End Maintenance alert
+            % endif
 
             % if status:
                 ${self.alert()}

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -289,7 +289,8 @@
                 <button type="button" class="close" data-dismiss="alert" aria-label="Close">
                     <span aria-hidden="true">&times;</span></button>
                 <strong>Notice:</strong> The site will undergo maintenance between
-                <span id="maintenanceTime"></span>.
+                <strong>${ maintenance['start'] | sjson, n } and ${ maintenance['end'] | sjson, n }</strong>
+##                 <span id="maintenanceTime"></span>.
                 Thank you for your patience.
             </div>
             ## End Maintenance alert

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -283,6 +283,17 @@
 <%def name="content_wrap()">
     <div class="watermarked">
         <div class="container ${self.container_class()}">
+
+            ## Maintenance alert
+            <div id="maintenance" class="scripted alert alert-info alert-dismissible" role="alert">
+                <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                    <span aria-hidden="true">&times;</span></button>
+                <strong>Notice:</strong> The site will undergo maintenance between
+                <span id="maintenanceTime"></span>.
+                Thank you for your patience.
+            </div>
+            ## End Maintenance alert
+
             % if status:
                 ${self.alert()}
             % endif


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
To put up a maintenance notice right now, we manually commit and uncommit code that adds a specified banner to the top of the page.  This adds instead a way to do this programmatically, either through an invoke task or by calling the maintenance module directly (future uses in the admin module!)

Examples:
```
        invoke set_maintenance_state
        invoke set_maintenance_state --start 2016-03-16T15:41:00-04:00
        invoke set_maintenance_state --end 2016-03-16T15:41:00-04:00
```
## Changes
- Add a maintenance module with a few options:
    - **set_maintenance**:  make a new collection called 'maintenance' in the database that will have some info about what period to set the maintenance from. Either pass in a start and end date or have them be calculated for you. Dates default to UTC if no timezone info is specified.
    - **get_maintenance**: return the current state of the maintenance notice, if there is one
    - **unset_maintenance**: get rid of the maintenance collection altogether, removing the notice
- Update ```base-page.js``` to have display info if there is maintenance info to display, in local time converted from UTC

## Side effects
- None anticipated

<!--Any possible side effects? -->


## Ticket
https://openscience.atlassian.net/browse/OSF-6482