### PR TITLE
[Potential migration] Feature/Fix for Veer Preregistration Schema [OSF-6510]

### DIFF
--- a/website/project/metadata/veer-1.json
+++ b/website/project/metadata/veer-1.json
@@ -156,6 +156,7 @@
             "type": "object",
             "title": "Recommended elements",
             "properties": [{
+                "id": "procedure",
                 "description": "Procedure",
                 "type": "object",
                 "properties": [{


### PR DESCRIPTION
## Purpose

ID missing from one of the nested questions in Veer Preregistration Schema which was making API requests to update registration metadata fail.  A jsonschema could not be created to validate metadata via the API due to the missing ID.   Also, the missing ID in the schema caused an undefined key in the registration metadata.  

![screen shot 2016-06-16 at 10 21 30 am](https://cloud.githubusercontent.com/assets/9755598/16120093/67060160-33ac-11e6-9bcc-66f7a48ec071.png)


## Changes

Adds missing id to schema.

## Side effects

Have any users made a registration of this type?  If so, their registration metadata might have the undefined key in the screenshot and will need a migration.

## Ticket

https://openscience.atlassian.net/browse/OSF-6510
