### PR TITLE
[RFR][Feature][OSF-2718]Can't see all components when permission to one is denied

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1138,24 +1138,24 @@ class TestChildrenViews(OsfTestCase):
         OsfTestCase.setUp(self)
         self.user = AuthUserFactory()
 
-    def test_get_children(self):
+    def test_get_readable_descendants(self):
         project = ProjectFactory(creator=self.user)
         child = NodeFactory(parent=project, creator=self.user)
 
-        url = project.api_url_for('get_children')
+        url = project.api_url_for('get_readable_descendants')
         res = self.app.get(url, auth=self.user.auth)
 
         nodes = res.json['nodes']
         assert_equal(len(nodes), 1)
         assert_equal(nodes[0]['id'], child._primary_key)
 
-    def test_get_children_includes_pointers(self):
+    def test_get_readable_descendants_includes_pointers(self):
         project = ProjectFactory(creator=self.user)
         pointed = ProjectFactory()
         project.add_pointer(pointed, Auth(self.user))
         project.save()
 
-        url = project.api_url_for('get_children')
+        url = project.api_url_for('get_readable_descendants')
         res = self.app.get(url, auth=self.user.auth)
 
         nodes = res.json['nodes']
@@ -1164,7 +1164,7 @@ class TestChildrenViews(OsfTestCase):
         pointer = Pointer.find_one(Q('node', 'eq', pointed))
         assert_equal(nodes[0]['id'], pointer._primary_key)
 
-    def test_get_children_filter_for_permissions(self):
+    def test_get_readable_descendants_filter_for_permissions(self):
         # self.user has admin access to this project
         project = ProjectFactory(creator=self.user)
 
@@ -1185,19 +1185,19 @@ class TestChildrenViews(OsfTestCase):
         project.add_pointer(read_only_pointed, Auth(self.user))
         project.save()
 
-        url = project.api_url_for('get_children')
+        url = project.api_url_for('get_readable_descendants')
         res = self.app.get(url, auth=self.user.auth)
         assert_equal(len(res.json['nodes']), 2)
 
-        url = project.api_url_for('get_children', permissions='write')
+        url = project.api_url_for('get_readable_descendants', permissions='write')
         res = self.app.get(url, auth=self.user.auth)
         assert_equal(len(res.json['nodes']), 0)
 
-    def test_get_children_render_nodes_receives_auth(self):
+    def test_get_readable_descendants_render_nodes_receives_auth(self):
         project = ProjectFactory(creator=self.user)
         NodeFactory(parent=project, creator=self.user)
 
-        url = project.api_url_for('get_children')
+        url = project.api_url_for('get_readable_descendants')
         res = self.app.get(url, auth=self.user.auth)
 
         perm = res.json['nodes'][0]['permissions']

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2848,6 +2848,24 @@ class TestPointerViews(OsfTestCase):
         node = ProjectFactory(creator=user)
         project.add_pointer(node, auth=Auth(user=user), save=save)
 
+    def test_pointer_list_write_contributor_can_remove_private_component_entry(self):
+         """Ensure that write contributors see the button to delete a pointer,
+             even if they cannot see what it is pointing at"""
+         url = web_url_for('view_project', pid=self.project._id)
+         user2 = AuthUserFactory()
+         self.project.add_contributor(user2,
+                                      auth=Auth(self.project.creator),
+                                      permissions=permissions.DEFAULT_CONTRIBUTOR_PERMISSIONS)
+
+         self._make_pointer_only_user_can_see(user2, self.project)
+         self.project.save()
+
+         res = self.app.get(url, auth=self.user.auth).maybe_follow()
+         assert_equal(res.status_code, 200)
+
+         has_controls = res.lxml.xpath('//li[@node_reference]/p[starts-with(normalize-space(text()), "Private Link")]//i[contains(@class, "remove-pointer")]')
+         assert_true(has_controls)
+
     def test_pointer_list_write_contributor_can_remove_public_component_entry(self):
         url = web_url_for('view_project', pid=self.project._id)
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2884,9 +2884,9 @@ class TestPointerViews(OsfTestCase):
     def test_pointer_list_read_contributor_cannot_remove_public_component_entry(self):
         url = web_url_for('view_project', pid=self.project._id)
 
-        linked_to = ProjectFactory(creator=self.user)
-        linked_to.update(fields={'is_public':1})
-        self.project.add_pointer(linked_to, auth=Auth(user=self.user))
+        self.project.add_pointer(ProjectFactory(creator=self.user,
+                                                is_public=True),
+                                 auth=Auth(user=self.user))
 
         user2 = AuthUserFactory()
         self.project.add_contributor(user2,

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -1282,8 +1282,8 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
         each descendant branch.
         """
         ret = []
+        new_branches = []
         for node in self.nodes:
-            new_branches = []
             if not node.primary or node.is_deleted:
                 continue
 

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -1278,24 +1278,22 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
             next_parent = next_parent.parent_node
 
     def find_readable_descendants(self, auth):
-        """ Returns list of first descendant node readable by <user> in
-        each descendant branch.
+        """ Returns a generator of first descendant node(s) readable by <user>
+        in each descendant branch.
         """
-        ret = []
         new_branches = []
         for node in self.nodes:
             if not node.primary or node.is_deleted:
                 continue
 
             if node.can_view(auth):
-                ret.append(node)
+                yield node
             else:
                 new_branches.append(node)
 
-        for node in new_branches:
-            ret.extend(node.find_readable_descendants(auth))
-
-        return ret
+        for bnode in new_branches:
+            for node in bnode.find_readable_descendants(auth):
+                yield node
 
     def has_addon_on_children(self, addon):
         """Checks if a given node has a specific addon on child nodes

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -1267,6 +1267,36 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
 
         return False
 
+    def find_readable_antecedent(self, user):
+        """ Returns first antecendant node readable by <user>.
+        """
+
+        next_parent = self.parent_node
+        while next_parent:
+            if next_parent.has_permission(user, 'read'):
+                return next_parent
+            next_parent = next_parent.parent_node
+
+    def find_readable_descendants(self, user):
+        """ Returns list of first descendant node readable by <user> in
+        each descendant branch.
+        """
+        ret = []
+        for node in self.nodes:
+            new_branches = []
+            if not node.primary or node.is_deleted:
+                continue
+
+            if node.has_permission(user, 'read'):
+                ret.append(node)
+            else:
+                new_branches.append(node)
+
+        for node in new_branches:
+            ret.extend(node.find_readable_descendants(user))
+
+        return ret
+
     def has_addon_on_children(self, addon):
         """Checks if a given node has a specific addon on child nodes
             that are not registrations or deleted

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -1267,17 +1267,17 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
 
         return False
 
-    def find_readable_antecedent(self, user):
+    def find_readable_antecedent(self, auth):
         """ Returns first antecendant node readable by <user>.
         """
 
         next_parent = self.parent_node
         while next_parent:
-            if next_parent.has_permission(user, 'read'):
+            if next_parent.can_view(auth):
                 return next_parent
             next_parent = next_parent.parent_node
 
-    def find_readable_descendants(self, user):
+    def find_readable_descendants(self, auth):
         """ Returns list of first descendant node readable by <user> in
         each descendant branch.
         """
@@ -1287,13 +1287,13 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
             if not node.primary or node.is_deleted:
                 continue
 
-            if node.has_permission(user, 'read'):
+            if node.can_view(auth):
                 ret.append(node)
             else:
                 new_branches.append(node)
 
         for node in new_branches:
-            ret.extend(node.find_readable_descendants(user))
+            ret.extend(node.find_readable_descendants(auth))
 
         return ret
 

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -927,12 +927,12 @@ def get_readable_descendants(auth, node, **kwargs):
             continue
         elif child.can_view(auth):
             descendants.append(child)
-        else:
-            if not child.primary:
+        elif not child.primary:
                 if node.has_permission(auth.user, 'write'):
                     descendants.append(child)
                 continue
-        descendants.extend(child.find_readable_descendants(auth))
+        else:
+            descendants.extend(child.find_readable_descendants(auth))
     return _render_nodes(descendants, auth)
 
 def node_child_tree(user, node_ids):

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -925,30 +925,11 @@ def get_readable_descendants(auth, node, **kwargs):
             descendants.append(child)
         else:
             if not child.primary:
-                if node.has_permission(auth.user, 'read'):
+                if node.has_permission(auth.user, 'write'):
                     descendants.append(child)
                 continue
         descendants.extend(child.find_readable_descendants(auth))
     return _render_nodes(descendants, auth)
-
-@must_be_contributor_or_public
-def get_children(auth, node, **kwargs):
-    user = auth.user
-    if request.args.get('permissions'):
-        perm = request.args['permissions'].lower().strip()
-        nodes = [
-            each
-            for each in node.nodes
-            if perm in each.get_permissions(user) and not each.is_deleted
-        ]
-    else:
-        nodes = [
-            each
-            for each in node.nodes
-            if not each.is_deleted
-        ]
-    return _render_nodes(nodes, auth)
-
 
 def node_child_tree(user, node_ids):
     """ Format data to test for node privacy settings for use in treebeard.

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -928,9 +928,9 @@ def get_readable_descendants(auth, node, **kwargs):
         elif child.can_view(auth):
             descendants.append(child)
         elif not child.primary:
-                if node.has_permission(auth.user, 'write'):
-                    descendants.append(child)
-                continue
+            if node.has_permission(auth.user, 'write'):
+                descendants.append(child)
+            continue
         else:
             descendants.extend(child.find_readable_descendants(auth))
     return _render_nodes(descendants, auth)

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -646,7 +646,7 @@ def _view_project(node, auth, primary=False):
     """
     user = auth.user
 
-    parent = node.find_readable_antecedent(auth.user)
+    parent = node.find_readable_antecedent(auth)
     if user:
         bookmark_collection = find_bookmark_collection(user)
         bookmark_collection_id = bookmark_collection._id
@@ -917,7 +917,6 @@ def get_summary(auth, node, **kwargs):
 
 @must_be_contributor_or_public
 def get_readable_descendants(auth, node, **kwargs):
-    user = auth.user
     descendants = []
     for child in node.nodes:
         if child.is_deleted:
@@ -925,7 +924,7 @@ def get_readable_descendants(auth, node, **kwargs):
         elif child.can_view(auth):
             descendants.append(child)
         else:
-            descendants.extend(child.find_readable_descendants(user))
+            descendants.extend(child.find_readable_descendants(auth))
     return _render_nodes(descendants, auth)
 
 @must_be_contributor_or_public

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -646,7 +646,7 @@ def _view_project(node, auth, primary=False):
     """
     user = auth.user
 
-    parent = node.parent_node
+    parent = node.find_readable_antecedent(auth.user)
     if user:
         bookmark_collection = find_bookmark_collection(user)
         bookmark_collection_id = bookmark_collection._id
@@ -915,6 +915,18 @@ def get_summary(auth, node, **kwargs):
         node, auth, primary=primary, link_id=link_id, show_path=show_path
     )
 
+@must_be_contributor_or_public
+def get_readable_descendants(auth, node, **kwargs):
+    user = auth.user
+    descendants = []
+    for child in node.nodes:
+        if child.is_deleted:
+            continue
+        elif child.can_view(auth):
+            descendants.append(child)
+        else:
+            descendants.extend(child.find_readable_descendants(user))
+    return _render_nodes(descendants, auth)
 
 @must_be_contributor_or_public
 def get_children(auth, node, **kwargs):

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -924,6 +924,8 @@ def get_readable_descendants(auth, node, **kwargs):
         elif child.can_view(auth):
             descendants.append(child)
         else:
+            if not child.primary:
+                continue
             descendants.extend(child.find_readable_descendants(auth))
     return _render_nodes(descendants, auth)
 

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -925,8 +925,10 @@ def get_readable_descendants(auth, node, **kwargs):
             descendants.append(child)
         else:
             if not child.primary:
+                if node.has_permission(auth.user, 'read'):
+                    descendants.append(child)
                 continue
-            descendants.extend(child.find_readable_descendants(auth))
+        descendants.extend(child.find_readable_descendants(auth))
     return _render_nodes(descendants, auth)
 
 @must_be_contributor_or_public

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -932,7 +932,8 @@ def get_readable_descendants(auth, node, **kwargs):
                 descendants.append(child)
             continue
         else:
-            descendants.extend(child.find_readable_descendants(auth))
+            for descendant in child.find_readable_descendants(auth):
+                descendants.append(descendant)
     return _render_nodes(descendants, auth)
 
 def node_child_tree(user, node_ids):

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -919,6 +919,10 @@ def get_summary(auth, node, **kwargs):
 def get_readable_descendants(auth, node, **kwargs):
     descendants = []
     for child in node.nodes:
+        if request.args.get('permissions'):
+            perm = request.args['permissions'].lower().strip()
+            if perm not in child.get_permissions(auth.user):
+                continue
         if child.is_deleted:
             continue
         elif child.can_view(auth):

--- a/website/routes.py
+++ b/website/routes.py
@@ -1247,8 +1247,6 @@ def make_url_map(app):
         Rule([
             '/project/<pid>/get_children/',
             '/project/<pid>/node/<nid>/get_children/',
-        ], 'get', project_views.node.get_readable_descendants, json_renderer),
-        Rule([
             '/project/<pid>/get_readable_descendants/',
             '/project/<pid>/node/<nid>/get_readable_descendants/',
         ], 'get', project_views.node.get_readable_descendants, json_renderer),

--- a/website/routes.py
+++ b/website/routes.py
@@ -1243,6 +1243,11 @@ def make_url_map(app):
             '/project/<pid>/get_summary/',
             '/project/<pid>/node/<nid>/get_summary/',
         ], 'get', project_views.node.get_summary, json_renderer),
+        # Route "get_children" is deprecated. Use get_readable_descendants.
+        Rule([
+            '/project/<pid>/get_children/',
+            '/project/<pid>/node/<nid>/get_children/',
+        ], 'get', project_views.node.get_readable_descendants, json_renderer),
         Rule([
             '/project/<pid>/get_readable_descendants/',
             '/project/<pid>/node/<nid>/get_readable_descendants/',

--- a/website/routes.py
+++ b/website/routes.py
@@ -1243,7 +1243,7 @@ def make_url_map(app):
             '/project/<pid>/get_summary/',
             '/project/<pid>/node/<nid>/get_summary/',
         ], 'get', project_views.node.get_summary, json_renderer),
-        # Route "get_children" is deprecated. Use get_readable_descendants.
+        # TODO: [#OSF-6557] Route "get_children" is deprecated. Use get_readable_descendants.
         Rule([
             '/project/<pid>/get_children/',
             '/project/<pid>/node/<nid>/get_children/',

--- a/website/routes.py
+++ b/website/routes.py
@@ -1243,11 +1243,6 @@ def make_url_map(app):
             '/project/<pid>/get_summary/',
             '/project/<pid>/node/<nid>/get_summary/',
         ], 'get', project_views.node.get_summary, json_renderer),
-
-        Rule([
-            '/project/<pid>/get_children/',
-            '/project/<pid>/node/<nid>/get_children/',
-        ], 'get', project_views.node.get_children, json_renderer),
         Rule([
             '/project/<pid>/get_readable_descendants/',
             '/project/<pid>/node/<nid>/get_readable_descendants/',

--- a/website/routes.py
+++ b/website/routes.py
@@ -1249,6 +1249,10 @@ def make_url_map(app):
             '/project/<pid>/node/<nid>/get_children/',
         ], 'get', project_views.node.get_children, json_renderer),
         Rule([
+            '/project/<pid>/get_readable_descendants/',
+            '/project/<pid>/node/<nid>/get_readable_descendants/',
+        ], 'get', project_views.node.get_readable_descendants, json_renderer),
+        Rule([
             '/project/<pid>/get_forks/',
             '/project/<pid>/node/<nid>/get_forks/',
         ], 'get', project_views.node.get_forks, json_renderer),

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -403,7 +403,7 @@
                 <div id="containment">
                     <div mod-meta='{
                         "tpl": "util/render_nodes.mako",
-                        "uri": "${node["api_url"]}get_children/",
+                        "uri": "${node["api_url"]}get_readable_descendants/",
                         "replace": true,
                         "kwargs": {
                           "sortable" : ${'true' if not node['is_registration'] else 'false'},

--- a/website/util/rubeus.py
+++ b/website/util/rubeus.py
@@ -165,13 +165,20 @@ class NodeFileCollector(object):
 
     def _collect_components(self, node, visited):
         rv = []
+        if not node.can_view(self.auth):
+            return rv
         for child in node.nodes:
-            if not child.can_view(self.auth):
-                readable_descendants = child.find_readable_descendants(self.auth)
-                for desc in readable_descendants:
-                    visited.append(desc.resolve()._id)
-                    rv.append(self._serialize_node(desc, visited=visited))
-            elif child.resolve()._id not in visited and not child.is_deleted and node.can_view(self.auth):
+            if child.is_deleted:
+                continue
+            elif not child.can_view(self.auth):
+                if child.primary:
+                    readable_descendants = child.find_readable_descendants(self.auth)
+                    for desc in readable_descendants:
+                        visited.append(desc.resolve()._id)
+                        rv.append(self._serialize_node(desc, visited=visited))
+                else:
+                    continue
+            elif child.resolve()._id not in visited:
                 visited.append(child.resolve()._id)
                 rv.append(self._serialize_node(child, visited=visited))
         return rv

--- a/website/util/rubeus.py
+++ b/website/util/rubeus.py
@@ -176,8 +176,6 @@ class NodeFileCollector(object):
                     for desc in readable_descendants:
                         visited.append(desc.resolve()._id)
                         rv.append(self._serialize_node(desc, visited=visited))
-                else:
-                    continue
             elif child.resolve()._id not in visited:
                 visited.append(child.resolve()._id)
                 rv.append(self._serialize_node(child, visited=visited))

--- a/website/util/rubeus.py
+++ b/website/util/rubeus.py
@@ -167,7 +167,7 @@ class NodeFileCollector(object):
         rv = []
         for child in node.nodes:
             if not child.can_view(self.auth):
-                readable_descendants = child.find_readable_descendants(self.auth.user)
+                readable_descendants = child.find_readable_descendants(self.auth)
                 for desc in readable_descendants:
                     visited.append(desc.resolve()._id)
                     rv.append(self._serialize_node(desc, visited=visited))

--- a/website/util/rubeus.py
+++ b/website/util/rubeus.py
@@ -172,8 +172,7 @@ class NodeFileCollector(object):
                 continue
             elif not child.can_view(self.auth):
                 if child.primary:
-                    readable_descendants = child.find_readable_descendants(self.auth)
-                    for desc in readable_descendants:
+                    for desc in child.find_readable_descendants(self.auth):
                         visited.append(desc.resolve()._id)
                         rv.append(self._serialize_node(desc, visited=visited))
             elif child.resolve()._id not in visited:

--- a/website/util/rubeus.py
+++ b/website/util/rubeus.py
@@ -166,7 +166,12 @@ class NodeFileCollector(object):
     def _collect_components(self, node, visited):
         rv = []
         for child in node.nodes:
-            if child.resolve()._id not in visited and not child.is_deleted and node.can_view(self.auth):
+            if not child.can_view(self.auth):
+                readable_descendants = child.find_readable_descendants(self.auth.user)
+                for desc in readable_descendants:
+                    visited.append(desc.resolve()._id)
+                    rv.append(self._serialize_node(desc, visited=visited))
+            elif child.resolve()._id not in visited and not child.is_deleted and node.can_view(self.auth):
                 visited.append(child.resolve()._id)
                 rv.append(self._serialize_node(child, visited=visited))
         return rv


### PR DESCRIPTION
## Purpose:
[OSF-2718](https://openscience.atlassian.net/browse/OSF-2718)
In project overview page and project file view page...
- Enable viewing components masked by unauthorized parent.
- Allow for breadcrumbs to to get back from masked components.
In project overview page
- Update components widget to match info in file tree widget.

## Bonus
Remove visibility of unauthorized components. "Private Component"

## Changes:
Updated tests/test_views.py
* Updated various for get_children now get_readable_descendants
* Fixed test_pointer_list_read_contributor_cannot_remove_public_component_entry now actually public
* Added def test_readable_descendants_masked_by_permissions

Updated website/project/model.py
* Added def find_readable_antecedent to find logical parent
* Added def find_readable_descendants to find logical children

Updated website/project/views/node.py "def _view_project" to find logical parent and children

Updated website/routes.py added get_readable_descendants route for use by component widget

Updated website/templates/project/project.mako to utilize new get_readable_descendants route

Updated website/util/rubeus.py "def _collect_components" to find logical children and not return unauthorized nodes


## Side effects
None


[#OSF-2718]