### PR TITLE
[Feature fix] have forks default proper settings [OSF-5748]

### DIFF
--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -411,6 +411,13 @@ class User(GuidStoredObject, AddonModelMixin):
     # whether the user has requested to deactivate their account
     requested_deactivation = fields.BooleanField(default=False)
 
+    # dictionary of projects a user has changed the setting on
+    dirty_dict = fields.DictionaryField()
+    # Format: {
+    #   <node.id>: True
+    #   ...
+    # }
+
     _meta = {'optimistic': True}
 
     def __repr__(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2056,10 +2056,6 @@ class TestNode(OsfTestCase):
             assert_equal(r.registered_meta[meta_schema._id], data)
             assert_equal(r.registered_schema[0], meta_schema)
 
-    def test_notification_settings_not_dirty_on_new_project(self):
-        project = ProjectFactory()
-        assert_false(project.notification_settings_dirty)
-
 class TestNodeUpdate(OsfTestCase):
 
     def setUp(self):

--- a/website/notifications/utils.py
+++ b/website/notifications/utils.py
@@ -179,7 +179,7 @@ def get_configured_projects(user):
         if (
             not isinstance(node, Node) or
             (user in subscription.none and not node.parent_id) or
-            not node.notification_settings_dirty or
+            node._id not in user.dirty_dict or
             node.is_collection
         ):
             continue

--- a/website/notifications/views.py
+++ b/website/notifications/views.py
@@ -101,9 +101,9 @@ def configure_subscription(auth):
     if not subscription:
         subscription = NotificationSubscription(_id=event_id, owner=owner, event_name=event)
 
-    if node and not node.notification_settings_dirty:
-        node.notification_settings_dirty = True
-        node.save()
+    if node and node._id not in user.dirty_dict:
+        user.dirty_dict[node._id] = True
+        user.save()
 
     subscription.add_user_to_subscription(user, notification_type)
 

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2182,15 +2182,17 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
                 save=False
             )
 
-        # Need this save in order to access _primary_key
-        forked.save()
-
         forked.add_contributor(
             contributor=user,
             permissions=CREATOR_PERMISSIONS,
             log=False,
             save=False
         )
+
+        # Need this save in order to access _primary_key
+        forked.save()
+
+        project_signals.contributor_added.send(forked, contributor=user, auth=auth)
 
         forked.add_log(
             action=NodeLog.NODE_FORKED,
@@ -3009,7 +3011,8 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
             if save:
                 self.save()
 
-            project_signals.contributor_added.send(self, contributor=contributor, auth=auth)
+            if self._id:
+                project_signals.contributor_added.send(self, contributor=contributor, auth=auth)
 
             return True
 

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2182,15 +2182,15 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
                 save=False
             )
 
+        # Need this save in order to access _primary_key
+        forked.save()
+
         forked.add_contributor(
             contributor=user,
             permissions=CREATOR_PERMISSIONS,
             log=False,
             save=False
         )
-
-        # Need this save in order to access _primary_key
-        forked.save()
 
         forked.add_log(
             action=NodeLog.NODE_FORKED,

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -892,8 +892,6 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
 
     alternative_citations = fields.ForeignField('alternativecitation', list=True)
 
-    notification_settings_dirty = fields.BooleanField(default=False)
-
     _meta = {
         'optimistic': True,
     }


### PR DESCRIPTION
## Purpose

* Forks should be created with default settings
* Configured projects should be based on the user not the node

## Changes

* Check if `_id` exists before sending contributor added 
* Use `dirty_dict` instead of `notification_settings_dirty`

## Side effects

None


## Ticket

https://openscience.atlassian.net/browse/OSF-5748

