### PR TITLE
[Feature fix] add comment about sending signal after save [OSF-5748]

### DIFF
--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2190,6 +2190,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
         # Need this save in order to access _primary_key
         forked.save()
 
+        # Need to call this after save for the notifications to be created with the _primary_key
         project_signals.contributor_added.send(forked, contributor=user, auth=auth)
 
         forked.add_log(


### PR DESCRIPTION
## Purpose

Add comment to explain why, when adding a fork, the contributor_added signal is deferred until after save.

## Changes

* add comment

## Side effects

None


## Ticket

https://openscience.atlassian.net/browse/OSF-5748

