### PR TITLE
Change github file widget rename icon to pencil [OSF-6465]

### DIFF
--- a/website/addons/github/static/githubFangornConfig.js
+++ b/website/addons/github/static/githubFangornConfig.js
@@ -247,7 +247,7 @@ var _githubItemButtons = {
                         tb.toolbarMode(Fangorn.Components.toolbarModes.RENAME);
                     },
                     tooltip: 'Change the name of the item',
-                    icon: 'fa fa-font',
+                    icon: 'fa fa-pencil',
                     className : 'text-info'
                 }, 'Rename')
             );

--- a/website/static/js/myProjects.js
+++ b/website/static/js/myProjects.js
@@ -1802,7 +1802,7 @@ var Information = {
                     return 'Uncategorized';
             }
         }
-        var template = '';
+        var template = ''; 
         var showRemoveFromCollection;
         var collectionFilter = args.currentView().collection;
         if (args.selected().length === 0) {

--- a/website/static/js/myProjects.js
+++ b/website/static/js/myProjects.js
@@ -1802,7 +1802,7 @@ var Information = {
                     return 'Uncategorized';
             }
         }
-        var template = ''; 
+        var template = '';
         var showRemoveFromCollection;
         var collectionFilter = args.currentView().collection;
         if (args.selected().length === 0) {


### PR DESCRIPTION
## Purpose

Make the github rename icon the consistent with other addons.

## Changes

Changes irregular "A" or fa-font icon to the fa-pencil icon, using a very simple js change.

## Side effects

Can confidently say there are none

## Ticket

https://openscience.atlassian.net/browse/OSF-6465
