### PR TITLE
Fix zero microsecond testing bug [OSF-6414]

### DIFF
--- a/api_tests/nodes/views/test_node_logs.py
+++ b/api_tests/nodes/views/test_node_logs.py
@@ -82,7 +82,7 @@ class TestNodeLogList(ApiTestCase):
         res = self.app.get(self.private_url, auth=self.user.auth)
         assert_equal(res.status_code, 200)
         assert_equal(len(res.json['data']), len(self.public_project.logs))
-        assert_datetime_equal(datetime.datetime.strptime(res.json['data'][API_FIRST]['attributes']['date'], "%Y-%m-%dT%H:%M:%S.%f"),
+        assert_datetime_equal(parse_date(res.json['data'][API_FIRST]['attributes']['date']),
                               self.private_project.logs[OSF_FIRST].date)
         assert_equal(res.json['data'][API_FIRST]['attributes']['action'], self.private_project.logs[OSF_FIRST].action)
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -430,11 +430,10 @@ def assert_before(lst, item1, item2):
     assert_less(lst.index(item1), lst.index(item2),
         '{0!r} appears before {1!r}'.format(item1, item2))
 
-
 def assert_datetime_equal(dt1, dt2, allowance=500):
     """Assert that two datetimes are about equal."""
-    assert_less(dt1 - dt2, dt.timedelta(milliseconds=allowance))
 
+    assert abs(dt1 - dt2) < dt.timedelta(milliseconds=allowance)
 
 def init_mock_addon(short_name, user_settings=None, node_settings=None):
     """Add an addon to the settings, so that it is ready for app init

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -405,7 +405,7 @@ class NodeLog(StoredObject):
         ],
     }, {
         'key_or_list': [
-            ('node', 1),
+            ('node', 1), 
             ('should_hide', 1),
             ('date', -1)
         ]

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -405,7 +405,7 @@ class NodeLog(StoredObject):
         ],
     }, {
         'key_or_list': [
-            ('node', 1), 
+            ('node', 1),
             ('should_hide', 1),
             ('date', -1)
         ]

--- a/website/static/js/myProjects.js
+++ b/website/static/js/myProjects.js
@@ -1802,7 +1802,7 @@ var Information = {
                     return 'Uncategorized';
             }
         }
-        var template = '';
+        var template = ''; 
         var showRemoveFromCollection;
         var collectionFilter = args.currentView().collection;
         if (args.selected().length === 0) {


### PR DESCRIPTION
## Purpose

Prevent test from fail when time of exactly one second is parsed to the microsecond

## Changes

Dates now parsed using the dateutils, which does not throw error.

## Side effects

I noticed small bug in assert_date_equals method which I fixed.

## Ticket

https://openscience.atlassian.net/browse/OSF-6414