### PR TITLE
Feature/Error Message on Model upon Incorrect Embargo End Date [OSF-3087]

### DIFF
--- a/api_tests/registrations/views/test_registration_list.py
+++ b/api_tests/registrations/views/test_registration_list.py
@@ -708,7 +708,7 @@ class TestRegistrationCreate(DraftRegistrationTestCase):
 
         res = self.app.post_json_api(self.url, payload, auth=self.user.auth, expect_errors=True)
         assert_equal(res.status_code, 400)
-        assert_equal(res.json['errors'][0]['detail'], 'Embargo end date must be more than one day in the future')
+        assert_equal(res.json['errors'][0]['detail'], 'Embargo end date must be at least three days in the future.')
 
     def test_invalid_embargo_end_date_format(self):
         today = datetime.datetime.utcnow().isoformat()

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -3455,7 +3455,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
         if not self._is_embargo_date_valid(end_date):
             if (end_date - datetime.datetime.utcnow()) >= settings.EMBARGO_END_DATE_MIN:
                 raise ValidationValueError('Registrations can only be embargoed for up to four years.')
-            raise ValidationValueError('Embargo end date must be more than one day in the future')
+            raise ValidationValueError('Embargo end date must be at least three days in the future.')
 
         embargo = self._initiate_embargo(user, end_date, for_existing_registration=for_existing_registration, notify_initiator_on_complete=notify_initiator_on_complete)
 


### PR DESCRIPTION
## Purpose

ValidationValueError on model when Embargo End Date is not far enough in the future should read "Embargo end date must be at least three days in the future." rather than "Embargo end date must be more than one day in the future'.

## Changes

Error message changed. 

## Side effects

Now APIv2 error (which throws error model) when embargo end date is incorrect will match front end.

## Ticket

https://openscience.atlassian.net/browse/OSF-3087