### PR TITLE
Unregistered contributor email should have link to project that they are invited to [OSF-3211][redo]

### DIFF
--- a/website/templates/emails/invite.txt.mako
+++ b/website/templates/emails/invite.txt.mako
@@ -12,6 +12,11 @@ Once you have set a password, you will be able to make contributions to ${node.t
 
 If you are not ${fullname} or you are erroneously being associated with ${node.title} then email contact@osf.io with the subject line "Claiming Error" to report the problem.
 
+To preview ${node.title} click the following link: ${node.absolute_url}
+
+(NOTE: if this project is private, you will not be able to view it until you have confirmed your account)
+
+
 Sincerely,
 
 Open Science Framework Robot


### PR DESCRIPTION
## Purpose

To allow a user visit a project they were just invited to, before registering.

## Changes

modified email templates and send parameters, add comments to template explain template function

## Side effects

none that I know of.

## Ticket

https://openscience.atlassian.net/browse/OSF-3211
