### PR TITLE
[ember-osf] Add node ID to apiv2 comment rel links [OSF-6533]

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -132,7 +132,9 @@ class NodeSerializer(JSONAPISerializer):
     comments = RelationshipField(
         related_view='nodes:node-comments',
         related_view_kwargs={'node_id': '<pk>'},
-        related_meta={'unread': 'get_unread_comments_count'})
+        related_meta={'unread': 'get_unread_comments_count'},
+        filter={'target': '<pk>'}
+    )
 
     contributors = RelationshipField(
         related_view='nodes:node-contributors',

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -83,7 +83,9 @@ class BaseRegistrationSerializer(NodeSerializer):
     comments = HideIfWithdrawal(RelationshipField(
         related_view='registrations:registration-comments',
         related_view_kwargs={'node_id': '<pk>'},
-        related_meta={'unread': 'get_unread_comments_count'}))
+        related_meta={'unread': 'get_unread_comments_count'},
+        filter={'target': '<pk>'}
+    ))
 
     contributors = RelationshipField(
         related_view='registrations:registration-contributors',

--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -154,6 +154,7 @@ class TestNodeDetail(ApiTestCase):
         res = self.app.get(self.public_url)
         assert_equal(res.status_code, 200)
         assert_in('comments', res.json['data']['relationships'].keys())
+        assert_in('filter[target]={}'.format(self.public_project._id), res.json['data']['relationships']['comments'])
 
     def test_node_has_correct_unread_comments_count(self):
         contributor = AuthUserFactory()

--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -154,7 +154,8 @@ class TestNodeDetail(ApiTestCase):
         res = self.app.get(self.public_url)
         assert_equal(res.status_code, 200)
         assert_in('comments', res.json['data']['relationships'].keys())
-        assert_in('filter[target]={}'.format(self.public_project._id), res.json['data']['relationships']['comments'])
+        assert_in('filter[target]={}'.format(self.public_project._id),
+                  res.json['data']['relationships']['comments']['links']['related']['href'])
 
     def test_node_has_correct_unread_comments_count(self):
         contributor = AuthUserFactory()


### PR DESCRIPTION
## Purpose
Support ember-osf comment functionality, by allowing project pages to fetch only project comments by default. (and exclude comments on other items owned by the node)

This makes nodes and registrations endpoints consistent with how the same links already work for files endpoints.

## Changes

Appends `filter[target]=node_id` to the serialized relationship url for `/v2/nodes/<nid>` and `/v2/registrations/<rid>` endpoints (list and detail views).

## Side effects
None expected.

## Testing suggestions
1. Make a comment on a node, and a file owned by OSF storage on that node. Ensure that the comment appears on the web.
2. Make a registration, and do the same
3. Visit the API endpoints for the node, and the registration (eg `http://localhost:8000/v2/nodes/f263w/` and `http://localhost:8000/v2/nodes/abc12/`); ensure that `filter[target]=<node_id>` appears at the end of the `relationships/comments` field
```
            "comments": {
                "links": {
                    "related": {
                        "href": "http://localhost:8000/v2/nodes/f263w/comments/?filter[target]=f263w",
                        "meta": {}
                    }
                }
            },
```
4. Go to the API endpoint linked in that field (`.../comments/?filter...`). Confirm that you see more results without the `?filter` part of the URL; the filter should cause the endpoint to show project comments, but exclude comments made on files owned by the project.

## Ticket
https://openscience.atlassian.net/browse/OSF-6533
