### PR TITLE
Improve Invite email link language [OSF-3211]

### DIFF
--- a/website/templates/emails/invite.txt.mako
+++ b/website/templates/emails/invite.txt.mako
@@ -10,11 +10,11 @@ ${claim_url}
 
 Once you have set a password, you will be able to make contributions to ${node.title} and create your own projects. You will automatically be subscribed to notification emails for this project. To change your email notification preferences, visit your project or your user settings: ${settings.DOMAIN + "settings/notifications/"}
 
-If you are not ${fullname} or you are erroneously being associated with ${node.title} then email contact@osf.io with the subject line "Claiming Error" to report the problem.
-
 To preview ${node.title} click the following link: ${node.absolute_url}
 
 (NOTE: if this project is private, you will not be able to view it until you have confirmed your account)
+
+If you are not ${fullname} or you are erroneously being associated with ${node.title} then email contact@osf.io with the subject line "Claiming Error" to report the problem.
 
 
 Sincerely,


### PR DESCRIPTION
## Purpose

Made the language for invite email even clearer. 

## Changes

Simple modification to the invite.txt.mako template.

## Side effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/OSF-3211