### PR TITLE
[hotfix] [OSF-6393] move folders from osfstorage

### DIFF
--- a/website/addons/osfstorage/tests/test_models.py
+++ b/website/addons/osfstorage/tests/test_models.py
@@ -430,6 +430,88 @@ class TestOsfstorageFileNode(StorageTestCase):
             '/'+folder._id, provider='osfstorage', node=node)
         assert [] == all_guids
 
+    def test_get_file_guids_for_live_folder_recursive(self):
+        node = self.node_settings.owner
+        folder = models.OsfStorageFolder(name='foofolder', node=node)
+        folder.save()
+
+        files = []
+        for i in range(1,4):
+            files.append(folder.append_file('foo.{}'.format(i)))
+            files[-1].get_guid(create=True)
+
+        subfolder = folder.append_folder('subfoo')
+        for i in range(1,4):
+            files.append(subfolder.append_file('subfoo.{}'.format(i)))
+            files[-1].get_guid(create=True)
+
+        guids = [ file.get_guid()._id for file in files ]
+        assert len(guids) == len(files)
+
+        all_guids = models.OsfStorageFileNode.get_file_guids(
+            '/'+folder._id, provider='osfstorage', node=node)
+        assert guids == all_guids
+
+    def test_get_file_guids_for_trashed_folder_recursive(self):
+        node = self.node_settings.owner
+        folder = models.OsfStorageFolder(name='foofolder', node=node)
+        folder.save()
+
+        files = []
+        for i in range(1,4):
+            files.append(folder.append_file('foo.{}'.format(i)))
+            files[-1].get_guid(create=True)
+
+        subfolder = folder.append_folder('subfoo')
+        for i in range(1,4):
+            files.append(subfolder.append_file('subfoo.{}'.format(i)))
+            files[-1].get_guid(create=True)
+
+        guids = [ file.get_guid()._id for file in files ]
+        assert len(guids) == len(files)
+
+        folder.delete()
+
+        all_guids = models.OsfStorageFileNode.get_file_guids(
+            '/'+folder._id, provider='osfstorage', node=node)
+        assert guids == all_guids
+
+    def test_get_file_guids_for_live_folder_recursive_wo_guids(self):
+        node = self.node_settings.owner
+        folder = models.OsfStorageFolder(name='foofolder', node=node)
+        folder.save()
+
+        files = []
+        for i in range(1,4):
+            files.append(folder.append_file('foo.{}'.format(i)))
+
+        subfolder = folder.append_folder('subfoo')
+        for i in range(1,4):
+            files.append(subfolder.append_file('subfoo.{}'.format(i)))
+
+        all_guids = models.OsfStorageFileNode.get_file_guids(
+            '/'+folder._id, provider='osfstorage', node=node)
+        assert [] == all_guids
+
+    def test_get_file_guids_for_trashed_folder_recursive_wo_guids(self):
+        node = self.node_settings.owner
+        folder = models.OsfStorageFolder(name='foofolder', node=node)
+        folder.save()
+
+        files = []
+        for i in range(1,4):
+            files.append(folder.append_file('foo.{}'.format(i)))
+
+        subfolder = folder.append_folder('subfoo')
+        for i in range(1,4):
+            files.append(subfolder.append_file('subfoo.{}'.format(i)))
+
+        folder.delete()
+
+        all_guids = models.OsfStorageFileNode.get_file_guids(
+            '/'+folder._id, provider='osfstorage', node=node)
+        assert [] == all_guids
+
 
 class TestNodeSettingsModel(StorageTestCase):
 

--- a/website/addons/osfstorage/tests/test_models.py
+++ b/website/addons/osfstorage/tests/test_models.py
@@ -368,6 +368,25 @@ class TestOsfstorageFileNode(StorageTestCase):
         assert guid in models.OsfStorageFileNode.get_file_guids(
             '/'+file._id, provider='osfstorage', node=node)
 
+    def test_get_file_guids_for_trashed_folder(self):
+        node = self.node_settings.owner
+        folder = models.OsfStorageFolder(name='foofolder', node=node)
+        folder.save()
+
+        files = []
+        for i in range(1,4):
+            files.append(folder.append_file('foo.{}'.format(i)))
+            files[-1].get_guid(create=True)
+
+        guids = [ file.get_guid()._id for file in files ]
+        assert len(guids) == len(files)
+
+        folder.delete()
+
+        all_guids = models.OsfStorageFileNode.get_file_guids(
+            '/'+folder._id, provider='osfstorage', node=node)
+        assert guids == all_guids
+
     def test_get_file_guids_live_file_wo_guid(self):
         node = self.node_settings.owner
         file = models.OsfStorageFile(name='foo', node=node)
@@ -395,6 +414,21 @@ class TestOsfstorageFileNode(StorageTestCase):
         file.delete()
         assert [] == models.OsfStorageFileNode.get_file_guids(
             '/'+file._id, provider='osfstorage', node=node)
+
+    def test_get_file_guids_for_trashed_folder_wo_guids(self):
+        node = self.node_settings.owner
+        folder = models.OsfStorageFolder(name='foofolder', node=node)
+        folder.save()
+
+        files = []
+        for i in range(1,4):
+            files.append(folder.append_file('foo.{}'.format(i)))
+
+        folder.delete()
+
+        all_guids = models.OsfStorageFileNode.get_file_guids(
+            '/'+folder._id, provider='osfstorage', node=node)
+        assert [] == all_guids
 
 
 class TestNodeSettingsModel(StorageTestCase):

--- a/website/files/models/base.py
+++ b/website/files/models/base.py
@@ -327,8 +327,8 @@ class FileNode(object):
             return cls.create(node=node, path=path)
 
     @classmethod
-    def get_file_guids(cls, materialized_path, provider, node, guids=None):
-        guids = guids or []
+    def get_file_guids(cls, materialized_path, provider, node):
+        guids = []
         materialized_path = '/' + materialized_path.lstrip('/')
         if materialized_path.endswith('/'):
             folder_children = cls.find(Q('provider', 'eq', provider) &

--- a/website/files/models/osfstorage.py
+++ b/website/files/models/osfstorage.py
@@ -38,8 +38,8 @@ class OsfStorageFileNode(FileNode):
         return cls.create(node=node, path=path)
 
     @classmethod
-    def get_file_guids(cls, materialized_path, provider, node=None, guids=None):
-        guids = guids or []
+    def get_file_guids(cls, materialized_path, provider, node=None):
+        guids = []
         path = materialized_path.strip('/')
         file_obj = cls.load(path)
         if not file_obj:
@@ -47,7 +47,7 @@ class OsfStorageFileNode(FileNode):
 
         if not file_obj.is_file:
             for item in file_obj.children:
-                cls.get_file_guids(item.path, provider, node=node, guids=guids)
+                guids.extend(cls.get_file_guids(item.path, provider, node=node))
         else:
             try:
                 guid = Guid.find(Q('referent', 'eq', file_obj))[0]
@@ -55,6 +55,7 @@ class OsfStorageFileNode(FileNode):
                 guid = None
             if guid:
                 guids.append(guid._id)
+
         return guids
 
     @property

--- a/website/files/models/osfstorage.py
+++ b/website/files/models/osfstorage.py
@@ -45,8 +45,19 @@ class OsfStorageFileNode(FileNode):
         if not file_obj:
             file_obj = TrashedFileNode.load(path)
 
+        # At this point, file_obj may be an OsfStorageFile, an OsfStorageFolder, or a
+        # TrashedFileNode. TrashedFileNodes do not have *File and *Folder subclasses, since
+        # only osfstorage trashes folders. To search for children of TrashFileNodes
+        # representing ex-OsfStorageFolders, we will reimplement the `children` method of the
+        # Folder class here.
         if not file_obj.is_file:
-            for item in file_obj.children:
+            children = []
+            if isinstance(file_obj, TrashedFileNode):
+                children = TrashedFileNode.find(Q('parent', 'eq', file_obj._id))
+            else:
+                children = file_obj.children
+
+            for item in children:
                 guids.extend(cls.get_file_guids(item.path, provider, node=node))
         else:
             try:


### PR DESCRIPTION
## Purpose

Moving a folder from osfstorage to an external provider reports an error, even though the move actually succeeds.  This is caused by the guid-preservation code not knowing how to look up the children of trashed osfstorage folders.  While fixing this, I also discovered that we weren't properly returning guids we did find, meaning they would still point to the old TrashedFileNode.

## Changes

* Taught `website.files.models.osfstorage.get_file_guids` to handle trashed osfstorage folders.
* Removed pass-by-reference code from `get_file_guids`.  It was buggy, unnecessary, and unused.  Both `get_file_guids` implementations now just return lists of guids found.
* Added tests for `osfstorage.get_file_guids`

## Side effects

None expected.

## Ticket

[#OSF-6393] https://openscience.atlassian.net/browse/OSF-6393