### PR TITLE
[ember-osf] Add "GUID" field to apiv2 files serializer [OSF-6534]

### DIFF
--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -115,6 +115,9 @@ class FileSerializer(JSONAPISerializer):
     ])
     id = IDField(source='_id', read_only=True)
     type = TypeField()
+    guid = ser.SerializerMethodField(read_only=True,
+                                     method_name='get_file_guid',
+                                     help_text='OSF GUID for this file (if one has been assigned)')
     checkout = CheckoutField()
     name = ser.CharField(read_only=True, help_text='Display name used in the general user interface')
     kind = ser.CharField(read_only=True, help_text='Either folder or file')

--- a/api_tests/utils.py
+++ b/api_tests/utils.py
@@ -1,11 +1,14 @@
 from website.addons.osfstorage import settings as osfstorage_settings
 
 
-def create_test_file(node, user, filename='test_file'):
+def create_test_file(node, user, filename='test_file', create_guid=True):
     osfstorage = node.get_addon('osfstorage')
     root_node = osfstorage.get_root()
     test_file = root_node.append_file(filename)
-    test_file.get_guid(create=True)
+
+    if create_guid:
+        test_file.get_guid(create=True)
+
     test_file.create_version(user, {
         'object': '06d80e',
         'service': 'cloud',


### PR DESCRIPTION
## Purpose
Add a "guid" field to APIv2 file serializer.

This will support commenting in ember-osf. (which requires specifying file GUID as a target)

The field name is deliberately generic.

## Changes
- Add serializer field
- Add unit tests
- Update files tests to support "file without a guid" scenario

## Side effects
None expected. This is a new field with a well-defined default fallback value.

## Ticket
https://openscience.atlassian.net/browse/OSF-6534
