### PR TITLE
Hotfix/no git branch 404 [OSF-6535]

### DIFF
--- a/website/static/js/devModeControls.js
+++ b/website/static/js/devModeControls.js
@@ -38,8 +38,10 @@ var PullRequestItem = function(prItem) {
 };
 
 var DevModeControls = function(selector, source_file, branch_file) {
-    this.viewModel = new DevModeModel(source_file, branch_file);
-    $osf.applyBindings(this.viewModel, selector);
+    if ($(selector).length) {
+        this.viewModel = new DevModeModel(source_file, branch_file);
+        $osf.applyBindings(this.viewModel, selector);
+    }
 };
 
 module.exports = DevModeControls;


### PR DESCRIPTION

## Purpose

Ensure that loading a page from a release branch doesn't try to get the git_branch text file used only on staging and development

## Changes

Check for the existence of the selector that the knockout is being applied to, and don't create the viewmodel if the selector doesn't exist.

## Side effects

I am not set up to test outside of dev mode, so this would be good to check. I don't *think* it should cause any problems. Still works fine in dev mode, and it should just not do anything outside of dev mode, so should marginally increase page load speed.

## Ticket

https://openscience.atlassian.net/browse/OSF-6535