### PR TITLE
Multiple File Check Out/In via APIv2 and Files Page [#OSF-5108]

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -889,7 +889,8 @@ class JSONAPIListSerializer(ser.ListSerializer):
 
         if num_items > bulk_limit:
             raise JSONAPIException(source={'pointer': '/data'},
-                                   detail='Bulk operation limit is {}, got {}.'.format(bulk_limit, num_items))
+                                   detail='Bulk operation limit is {}, got {}.'.format(bulk_limit, num_items),
+                                   meta={'type': 'api_limit', 'bulk_limit': bulk_limit, 'num_items': num_items})
 
         return super(JSONAPIListSerializer, self).run_validation(data)
 

--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -246,6 +246,8 @@ class FileSerializer(JSONAPISerializer):
 
         for attr, value in validated_data.items():
             if attr == 'checkout':
+                if value == '':
+                    value = None
                 user = self.context['request'].user
                 instance.check_in_or_out(user, value)
             else:

--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -246,8 +246,6 @@ class FileSerializer(JSONAPISerializer):
 
         for attr, value in validated_data.items():
             if attr == 'checkout':
-                if value == '':
-                    value = None
                 user = self.context['request'].user
                 instance.check_in_or_out(user, value)
             else:

--- a/api/files/urls.py
+++ b/api/files/urls.py
@@ -6,4 +6,5 @@ urlpatterns = [
     url(r'^(?P<file_id>\w+)/$', views.FileDetail.as_view(), name=views.FileDetail.view_name),
     url(r'^(?P<file_id>\w+)/versions/$', views.FileVersionsList.as_view(), name=views.FileVersionsList.view_name),
     url(r'^(?P<file_id>\w+)/versions/(?P<version_id>\w+)/$', views.FileVersionDetail.as_view(), name=views.FileVersionDetail.view_name),
+    url(r'^(?P<node_id>\w+)/list/(?P<provider>\w+)(?P<path>/(?:.*/)?)', views.FileList.as_view(), name=views.FileList.view_name),
 ]

--- a/api/files/views.py
+++ b/api/files/views.py
@@ -333,7 +333,6 @@ class FileDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView, FileMixin):
 
 
 class FileList(JSONAPIBaseView, generics.ListAPIView, NodeMixin, ListFilterMixin, WaterButlerMixin, bulk_views.BulkUpdateJSONAPIView):
-# class FileList(JSONAPIBaseView, NodeMixin, ListFilterMixin, WaterButlerMixin, bulk_views.BulkUpdateJSONAPIView):
     """Special case for getting lists from files on a node stored with OSFStorage.
     Used for bulk file checkout, and other simple metadata updates.
     """

--- a/api/files/views.py
+++ b/api/files/views.py
@@ -15,9 +15,12 @@ from api.base.exceptions import Gone
 from api.base.permissions import PermissionWithGetter
 from api.base.utils import get_object_or_error
 from api.base.views import JSONAPIBaseView
+from api.base.filters import ListFilterMixin
+from api.base import generic_bulk_views as bulk_views
 from api.base import permissions as base_permissions
 from api.nodes.permissions import ContributorOrPublic
 from api.nodes.permissions import ReadOnlyIfRegistration
+from api.nodes.views import WaterButlerMixin, NodeMixin
 from api.files.permissions import CheckedOutOrAdmin
 from api.files.serializers import FileSerializer
 from api.files.serializers import FileDetailSerializer
@@ -327,6 +330,54 @@ class FileDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView, FileMixin):
     # overrides RetrieveAPIView
     def get_object(self):
         return self.get_file()
+
+
+class FileList(JSONAPIBaseView, generics.ListAPIView, NodeMixin, ListFilterMixin, WaterButlerMixin, bulk_views.BulkUpdateJSONAPIView):
+# class FileList(JSONAPIBaseView, NodeMixin, ListFilterMixin, WaterButlerMixin, bulk_views.BulkUpdateJSONAPIView):
+    """Special case for getting lists from files on a node stored with OSFStorage.
+    Used for bulk file checkout, and other simple metadata updates.
+    """
+
+    permission_classes = (
+        drf_permissions.IsAuthenticatedOrReadOnly,
+        CheckedOutOrAdmin,
+        base_permissions.TokenHasScope,
+        PermissionWithGetter(ContributorOrPublic, 'node'),
+        PermissionWithGetter(ReadOnlyIfRegistration, 'node'),
+    )
+
+    file_lookup_url_kwarg = 'file_id'
+
+    required_read_scopes = [CoreScopes.NODE_FILE_READ]
+    required_write_scopes = [CoreScopes.NODE_FILE_WRITE]
+
+    serializer_class = FileDetailSerializer
+    view_category = 'files'
+    view_name = 'file-list'
+
+    def get_file(self, check_permissions=True):
+        obj = get_object_or_error(FileNode, self.kwargs[self.file_lookup_url_kwarg])
+
+        if check_permissions:
+            # May raise a permission denied
+            self.check_object_permissions(self.request, obj)
+        return obj.wrapped()
+
+    def get_default_queryset(self):
+        # Don't bother going to waterbutler for osfstorage
+        files_list = self.fetch_from_waterbutler()
+
+        if isinstance(files_list, list):
+            return [self.get_file_item(file) for file in files_list]
+
+        if isinstance(files_list, dict) or getattr(files_list, 'is_file', False):
+            # We should not have gotten a file here
+            raise NotFound
+
+        return list(files_list.children)
+
+    def get_queryset(self):
+        return self.get_queryset_from_request()
 
 
 class FileVersionsList(JSONAPIBaseView, generics.ListAPIView, FileMixin):

--- a/api/files/views.py
+++ b/api/files/views.py
@@ -333,10 +333,6 @@ class FileDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView, FileMixin):
 
 
 class FileList(JSONAPIBaseView, generics.ListAPIView, NodeMixin, ListFilterMixin, WaterButlerMixin, bulk_views.BulkUpdateJSONAPIView):
-    """Special case for getting lists from files on a node stored with OSFStorage.
-    Used for bulk file checkout, and other simple metadata updates.
-    """
-
     permission_classes = (
         drf_permissions.IsAuthenticatedOrReadOnly,
         CheckedOutOrAdmin,

--- a/api/files/views.py
+++ b/api/files/views.py
@@ -381,7 +381,7 @@ class FileList(JSONAPIBaseView, generics.ListAPIView, NodeMixin, ListFilterMixin
         # If bulk request, queryset only contains contributors in request
         if is_bulk_request(self.request):
             file_ids = [item['id'] for item in self.request.data]
-            queryset[:] = [file for file in queryset if file._id in file_ids]
+            queryset = [file for file in queryset if file._id in file_ids]
 
         return queryset
 

--- a/api_tests/files/views/test_file_list.py
+++ b/api_tests/files/views/test_file_list.py
@@ -189,7 +189,6 @@ class TestFileLists(ApiTestCase):
         admin = AuthUserFactory()
         self.node.add_contributor(admin, auth=self.auth, permissions=['read', 'write', 'admin'])
         self.node.save()
-        self.node.reload()
 
         nt.assert_equal(self.checked_in_one.checkout, self.user)
         nt.assert_equal(self.checked_in_two.checkout, self.user)

--- a/api_tests/files/views/test_file_list.py
+++ b/api_tests/files/views/test_file_list.py
@@ -92,6 +92,7 @@ class TestFileLists(ApiTestCase):
 
         self.file_one = api_utils.create_test_file(self.node, self.user, filename="Man I'm the Macho")
         self.file_two = api_utils.create_test_file(self.node, self.user, filename="Like Randy")
+        self.file_three = api_utils.create_test_file(self.node, self.user, filename="The choppa go Oscar for Grammy")
 
     def test_bulk_checkout(self):
         nt.assert_equal(self.file_one.checkout, None)

--- a/website/files/models/osfstorage.py
+++ b/website/files/models/osfstorage.py
@@ -137,7 +137,7 @@ class OsfStorageFileNode(FileNode):
         action = NodeLog.CHECKED_OUT if checkout else NodeLog.CHECKED_IN
 
         if self.is_checked_out and action == NodeLog.CHECKED_IN or not self.is_checked_out and action == NodeLog.CHECKED_OUT:
-            self.checkout = checkout
+            self.checkout = checkout if checkout else None
 
             self.node.add_log(
                 action=action,

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1159,8 +1159,16 @@ function doMultipleCheckout(items, checkout, showError) {
         }
     }).fail(function(xhr) {
         if (showError) {
-            $osf.growl('Error', 'Unable to check out file. This is most likely due to the file being already checked-out' +
-                ' by another user.');
+            if (xhr.responseJSON.errors[0].meta) {
+                var error_object = xhr.responseJSON.errors[0].meta;
+                if (error_object.type === "api_limit") {
+                    $osf.growl('Error', 'You have reached the check out selection limit of ' + error_object.bulk_limit +
+                    '. Please select fewer items to check out at once.');
+                }
+            } else {
+                $osf.growl('Error', 'Unable to check out one of the selected files. This is most likely due to one of the files being already checked-out' +
+                    ' by another user.');
+            }
         }
     });
 }
@@ -2000,8 +2008,7 @@ var FGToolbar = {
                 generalButtons.push(
                     m.component(FGButton, {
                         onclick: function () {
-                            doMultipleCheckout(items, window.contextVars.currentUser.id, false);
-                            window.location.reload();
+                            doMultipleCheckout(items, window.contextVars.currentUser.id, true);
                         },
                         icon: 'fa fa-sign-out',
                         className: 'text-warning'
@@ -2012,8 +2019,7 @@ var FGToolbar = {
                 generalButtons.push(
                     m.component(FGButton, {
                         onclick: function () {
-                            doMultipleCheckout(items, null, false);
-                            window.location.reload();
+                            doMultipleCheckout(items, null, true);
                         },
                         icon: 'fa fa-sign-in',
                         className: 'text-warning'

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1161,7 +1161,7 @@ function doMultipleCheckout(items, checkout, showError) {
         if (showError) {
             if (xhr.responseJSON.errors[0].meta) {
                 var error_object = xhr.responseJSON.errors[0].meta;
-                if (error_object.type === "api_limit") {
+                if (error_object.type === 'api_limit') {
                     $osf.growl('Error', 'You have reached the check out selection limit of ' + error_object.bulk_limit +
                     '. Please select fewer items to check out at once.');
                 }

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1147,7 +1147,7 @@ function doMultipleCheckout(items, checkout, showError) {
 
     return $osf.ajaxJSON(
         'PUT',
-        window.contextVars.apiV2Prefix + 'files' + items[0].data.nodeUrl + 'list/osfstorage/',
+        $osf.apiV2Url('files/' + items[0].data.nodeUrl + 'list/osfstorage/', {}),
         {
             isCors: true,
             data: {data: checkoutData},

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1851,17 +1851,17 @@ var FGToolbar = {
         var items = ctrl.items();
         var item = items[0];
         var dismissIcon = m.component(FGButton, {
-            onclick: ctrl.dismissToolbar,
-            icon: 'fa fa-times'
-        }, '');
-        templates[toolbarModes.FILTER] = [
+                onclick: ctrl.dismissToolbar,
+                icon : 'fa fa-times'
+            }, '');
+        templates[toolbarModes.FILTER] =  [
             m('.col-xs-9', [
                 ctrl.tb.options.filterTemplate.call(ctrl.tb)
-            ]),
-            m('.col-xs-3.tb-buttons-col',
-                m('.fangorn-toolbar.pull-right', [dismissIcon])
-            )
-        ];
+                ]),
+                m('.col-xs-3.tb-buttons-col',
+                    m('.fangorn-toolbar.pull-right', [dismissIcon])
+                )
+            ];
         if (ctrl.tb.options.placement !== 'fileview') {
             templates[toolbarModes.ADDFOLDER] = [
                 m('.col-xs-9', [
@@ -1922,27 +1922,27 @@ var FGToolbar = {
         }
         // Bar mode
         // Which buttons should show?
-        if (items.length === 1) {
+        if(items.length === 1){
             var addonButtons = resolveconfigOption.call(ctrl.tb, item, 'itemButtons', [item]);
             if (addonButtons) {
-                finalRowButtons = m.component(addonButtons, {treebeard: ctrl.tb, item: item}); // jshint ignore:line
+                finalRowButtons = m.component(addonButtons, { treebeard : ctrl.tb, item : item }); // jshint ignore:line
             } else if (ctrl.tb.options.placement !== 'fileview') {
-                finalRowButtons = m.component(FGItemButtons, {treebeard: ctrl.tb, mode: ctrl.mode, item: item}); // jshint ignore:line
+                finalRowButtons = m.component(FGItemButtons, {treebeard : ctrl.tb, mode : ctrl.mode, item : item }); // jshint ignore:line
             }
         }
-        if (ctrl.isUploading() && ctrl.tb.options.placement !== 'fileview') {
+        if(ctrl.isUploading() && ctrl.tb.options.placement !== 'fileview') {
             generalButtons.push(
                 m.component(FGButton, {
-                    onclick: function () {
+                    onclick: function() {
                         cancelAllUploads.call(ctrl.tb);
                     },
                     icon: 'fa fa-time-circle',
-                    className: 'text-danger'
+                    className : 'text-danger'
                 }, 'Cancel Pending Uploads')
             );
         }
         //multiple selection icons
-        if (items.length > 1 && ctrl.tb.multiselected()[0].data.provider !== 'github' && ctrl.tb.options.placement !== 'fileview' && !(ctrl.tb.multiselected()[0].data.provider === 'dataverse' && ctrl.tb.multiselected()[0].parent().data.version === 'latest-published')) {
+        if(items.length > 1 && ctrl.tb.multiselected()[0].data.provider !== 'github' && ctrl.tb.options.placement !== 'fileview' && !(ctrl.tb.multiselected()[0].data.provider === 'dataverse' && ctrl.tb.multiselected()[0].parent().data.version === 'latest-published') ) {
             // Special cased to not show 'delete multiple' for github or published dataverses
             var showDelete = false;
             var showCheckout = true;
@@ -1984,17 +1984,15 @@ var FGToolbar = {
                     break;
                 }
             }
-            if (showDelete) {
+            if(showDelete){
                 generalButtons.push(
                     m.component(FGButton, {
-                        onclick: function (event) {
+                        onclick: function(event) {
                             var configOption = resolveconfigOption.call(ctrl.tb, item, 'removeEvent', [event, items]); // jshint ignore:line
-                            if (!configOption) {
-                                _removeEvent.call(ctrl.tb, null, items);
-                            }
+                            if(!configOption){ _removeEvent.call(ctrl.tb, null, items); }
                         },
                         icon: 'fa fa-trash',
-                        className: 'text-danger'
+                        className : 'text-danger'
                     }, 'Delete multiple')
                 );
             }

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -2003,6 +2003,7 @@ var FGToolbar = {
                     m.component(FGButton, {
                         onclick: function () {
                             doMultipleCheckout(items, window.contextVars.currentUser.id, false);
+                            window.location.reload();
                         },
                         icon: 'fa fa-sign-out',
                         className: 'text-warning'
@@ -2014,6 +2015,7 @@ var FGToolbar = {
                     m.component(FGButton, {
                         onclick: function () {
                             doMultipleCheckout(items, null, false);
+                            window.location.reload();
                         },
                         icon: 'fa fa-sign-in',
                         className: 'text-warning'

--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -67,7 +67,8 @@ var ajaxJSON = function(method, url, options) {
     var defaults = {
         data: {},  // Request body (required for PUT, PATCH, POST, etc)
         isCors: false,  // Is this sending a cross-domain request? (if true, will also send any login credentials)
-        fields: {}  // Additional fields (settings) for the JQuery AJAX call; overrides any defaults set by function
+        fields: {},  // Additional fields (settings) for the JQuery AJAX call; overrides any defaults set by function
+        bulk: false  // Is this sending a bulk request? If so, update the content type later on
     };
     var opts = $.extend({}, defaults, options);
 
@@ -78,7 +79,7 @@ var ajaxJSON = function(method, url, options) {
         dataType: 'json'
     };
 
-    if (options.bulk) {
+    if (opts.bulk) {
         ajaxFields.contentType = 'application/vnd.api+json; ext=bulk';
     }
     // Add JSON payload if not a GET request

--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -77,6 +77,10 @@ var ajaxJSON = function(method, url, options) {
         contentType: 'application/json',
         dataType: 'json'
     };
+
+    if (options.bulk) {
+        ajaxFields.contentType = 'application/vnd.api+json; ext=bulk';
+    }
     // Add JSON payload if not a GET request
     if (method.toLowerCase() !== 'get') {
         ajaxFields.data = JSON.stringify(opts.data);

--- a/website/static/js/tests/osfHelpers.test.js
+++ b/website/static/js/tests/osfHelpers.test.js
@@ -275,6 +275,21 @@ describe('osfHelpers', () => {
                         {withCredentials: false}
                 });
             });
+            it('calls $.ajax as PUT bulk request, and the content type is correct', () => {
+                var url = '/foo';
+                var payload = {'data':[{'bar': 42}, {'foo': 42}]};
+
+                $osf.ajaxJSON('PUT', url,
+                    {data: payload, bulk: true});
+                assert.calledOnce(stub);
+                assert.calledWith(stub, {
+                    url: url,
+                    type: 'PUT',
+                    data: JSON.stringify(payload),
+                    contentType: 'application/vnd.api+json; ext=bulk',
+                    dataType: 'json'
+                });
+            });
         });
 
         describe('postJSON', () => {


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Previously, efficient multiple file check in and check out was blocked by the lack of bulk API requests. Now that bulk API requests are possible, this PR adds bulk file operations functionality so that files can be multi-selected and checked in or out.

## Changes
- Update the files serializer to handle bulk updates through the API
- Add a new route to access files lists from the API independent of nodes
- Add a new files list view to apiv2 that can only access metadata for files stored in OSF storage
    - this was to get around update complications for waterbutler, and to simplify updating a file's metadata only via the API
- Add tests for bulk updating checkout metadata via this files route
- Add multiple checkout buttons and functions to fangorn using the new bulk-enabled files list route

## Side effects
- a files list can now be accessed through the nodes route and files route.


## Questions for CR:
- The route allows entering any provider to get the file lists, but updating metadata this way should really only be for files in osfstorage (esp since you can only check out files from osfstorage). Should I make this route more restrictive, or leave it open to future changes that would allow for metadata changes via the API directly instead of thru waterbutler?


## Ticket
https://openscience.atlassian.net/browse/OSF-5108