### PR TITLE
Make User API Endpoint use Underscores/lowercase keys [OSF-6537]

### DIFF
--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -32,7 +32,7 @@ class UserSerializer(JSONAPISerializer):
     active = HideIfDisabled(ser.BooleanField(read_only=True, source='is_active'))
 
     # Social Fields are broken out to get around DRF complex object bug and to make API updating more user friendly.
-    gitHub = DevOnly(HideIfDisabled(AllowMissing(ser.CharField(required=False, source='social.github',
+    github = DevOnly(HideIfDisabled(AllowMissing(ser.CharField(required=False, source='social.github',
                                                           allow_blank=True, help_text='GitHub Handle'), required=False, source='social.github')))
     scholar = DevOnly(HideIfDisabled(AllowMissing(ser.CharField(required=False, source='social.scholar',
                                                            allow_blank=True, help_text='Google Scholar Account'), required=False, source='social.scholar')))
@@ -40,21 +40,21 @@ class UserSerializer(JSONAPISerializer):
                                                                    allow_blank=True, help_text='Personal Website'), required=False, source='social.personal')))
     twitter = DevOnly(HideIfDisabled(AllowMissing(ser.CharField(required=False, source='social.twitter',
                                                            allow_blank=True, help_text='Twitter Handle'), required=False, source='social.twitter')))
-    linkedIn = DevOnly(HideIfDisabled(AllowMissing(ser.CharField(required=False, source='social.linkedIn',
+    linkedin = DevOnly(HideIfDisabled(AllowMissing(ser.CharField(required=False, source='social.linkedIn',
                                                             allow_blank=True, help_text='LinkedIn Account'), required=False, source='social.linkedIn')))
-    impactStory = DevOnly(HideIfDisabled(AllowMissing(ser.CharField(required=False, source='social.impactStory',
+    impactstory = DevOnly(HideIfDisabled(AllowMissing(ser.CharField(required=False, source='social.impactStory',
                                                                allow_blank=True, help_text='ImpactStory Account'), required=False, source='social.impactStory')))
     orcid = DevOnly(HideIfDisabled(AllowMissing(ser.CharField(required=False, source='social.orcid',
                                                          allow_blank=True, help_text='ORCID'), required=False, source='social.orcid')))
-    researcherId = DevOnly(HideIfDisabled(AllowMissing(ser.CharField(required=False, source='social.researcherId',
+    researcherid = DevOnly(HideIfDisabled(AllowMissing(ser.CharField(required=False, source='social.researcherId',
                                                       allow_blank=True, help_text='ResearcherId Account'), required=False, source='social.researcherId')))
-    researchGate = DevOnly(HideIfDisabled(AllowMissing(ser.CharField(required=False, source='social.researchGate',
+    researchgate = DevOnly(HideIfDisabled(AllowMissing(ser.CharField(required=False, source='social.researchGate',
                                                       allow_blank=True, help_text='ResearchGate Account'), required=False, source='social.researchGate')))
-    academiaInstitution = DevOnly(HideIfDisabled(AllowMissing(ser.CharField(required=False, source='social.academiaInstitution',
+    academia_institution = DevOnly(HideIfDisabled(AllowMissing(ser.CharField(required=False, source='social.academiaInstitution',
                                                       allow_blank=True, help_text='AcademiaInstitution Field'), required=False, source='social.academiaInstitution')))
-    academiaProfileID = DevOnly(HideIfDisabled(AllowMissing(ser.CharField(required=False, source='social.academiaProfileID',
+    academia_profile_id = DevOnly(HideIfDisabled(AllowMissing(ser.CharField(required=False, source='social.academiaProfileID',
                                                       allow_blank=True, help_text='AcademiaProfileID Field'), required=False, source='social.academiaProfileID')))
-    baiduScholar = DevOnly(HideIfDisabled(AllowMissing(ser.CharField(required=False, source='social.baiduScholar',
+    baidu_scholar = DevOnly(HideIfDisabled(AllowMissing(ser.CharField(required=False, source='social.baiduScholar',
                                                            allow_blank=True, help_text='Baidu Scholar Account'), required=False, source='social.baiduScholar')))
     timezone = HideIfDisabled(ser.CharField(required=False, help_text="User's timezone, e.g. 'Etc/UTC"))
     locale = HideIfDisabled(ser.CharField(required=False, help_text="User's locale, e.g.  'en_US'"))

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -54,7 +54,7 @@ class UserSerializer(JSONAPISerializer):
                                                       allow_blank=True, help_text='AcademiaInstitution Field'), required=False, source='social.academiaInstitution')))
     academia_profile_id = DevOnly(HideIfDisabled(AllowMissing(ser.CharField(required=False, source='social.academiaProfileID',
                                                       allow_blank=True, help_text='AcademiaProfileID Field'), required=False, source='social.academiaProfileID')))
-    baidu_scholar = DevOnly(HideIfDisabled(AllowMissing(ser.CharField(required=False, source='social.baiduScholar',
+    baiduscholar = DevOnly(HideIfDisabled(AllowMissing(ser.CharField(required=False, source='social.baiduScholar',
                                                            allow_blank=True, help_text='Baidu Scholar Account'), required=False, source='social.baiduScholar')))
     timezone = HideIfDisabled(ser.CharField(required=False, help_text="User's timezone, e.g. 'Etc/UTC"))
     locale = HideIfDisabled(ser.CharField(required=False, help_text="User's locale, e.g.  'en_US'"))

--- a/api_tests/users/views/test_user_detail.py
+++ b/api_tests/users/views/test_user_detail.py
@@ -277,10 +277,10 @@ class TestUserUpdate(ApiTestCase):
                 scholar='userOneScholar',
                 personal='http://www.useronepersonalwebsite.com',
                 twitter='userOneTwitter',
-                linkedin='userOneLinkedIn',
-                impactstory='userOneImpactStory',
+                linkedIn='userOneLinkedIn',
+                impactStory='userOneImpactStory',
                 orcid='userOneOrcid',
-                researcherid='userOneResearcherId'
+                researcherId='userOneResearcherId'
             )
         )
         self.user_one.save()
@@ -485,10 +485,10 @@ class TestUserUpdate(ApiTestCase):
         assert_equal(res.json['data']['attributes']['family_name'], self.user_one.family_name)
         assert_equal(res.json['data']['attributes']['personal_website'], self.user_one.social['personal'])
         assert_equal(res.json['data']['attributes']['twitter'], self.user_one.social['twitter'])
-        assert_equal(res.json['data']['attributes']['linkedin'], self.user_one.social['linkedin'])
-        assert_equal(res.json['data']['attributes']['impactstory'], self.user_one.social['impactstory'])
+        assert_equal(res.json['data']['attributes']['linkedin'], self.user_one.social['linkedIn'])
+        assert_equal(res.json['data']['attributes']['impactstory'], self.user_one.social['impactStory'])
         assert_equal(res.json['data']['attributes']['orcid'], self.user_one.social['orcid'])
-        assert_equal(res.json['data']['attributes']['researcherid'], self.user_one.social['researcherid'])
+        assert_equal(res.json['data']['attributes']['researcherid'], self.user_one.social['researcherId'])
         assert_equal(self.user_one.fullname, 'new_fullname')
         assert_equal(self.user_one.suffix, 'The Millionth')
         assert_equal(self.user_one.social['github'], 'even_newer_github')
@@ -515,10 +515,10 @@ class TestUserUpdate(ApiTestCase):
         assert_equal(res.json['data']['attributes']['family_name'], self.user_one.family_name)
         assert_equal(res.json['data']['attributes']['personal_website'], self.user_one.social['personal'])
         assert_equal(res.json['data']['attributes']['twitter'], self.user_one.social['twitter'])
-        assert_equal(res.json['data']['attributes']['linkedin'], self.user_one.social['linkedin'])
-        assert_equal(res.json['data']['attributes']['impactstory'], self.user_one.social['impactstory'])
+        assert_equal(res.json['data']['attributes']['linkedin'], self.user_one.social['linkedIn'])
+        assert_equal(res.json['data']['attributes']['impactstory'], self.user_one.social['impactStory'])
         assert_equal(res.json['data']['attributes']['orcid'], self.user_one.social['orcid'])
-        assert_equal(res.json['data']['attributes']['researcherid'], self.user_one.social['researcherid'])
+        assert_equal(res.json['data']['attributes']['researcherid'], self.user_one.social['researcherId'])
         assert_equal(self.user_one.fullname, 'new_fullname')
         assert_equal(self.user_one.suffix, 'The Millionth')
         assert_equal(self.user_one.social['github'], self.user_one.social['github'])
@@ -573,10 +573,10 @@ class TestUserUpdate(ApiTestCase):
         assert_equal(self.user_one.social['github'], self.new_user_one_data['data']['attributes']['github'])
         assert_equal(self.user_one.social['personal'], self.new_user_one_data['data']['attributes']['personal_website'])
         assert_equal(self.user_one.social['twitter'], self.new_user_one_data['data']['attributes']['twitter'])
-        assert_equal(self.user_one.social['linkedin'], self.new_user_one_data['data']['attributes']['linkedin'])
-        assert_equal(self.user_one.social['impactstory'], self.new_user_one_data['data']['attributes']['impactstory'])
+        assert_equal(self.user_one.social['linkedIn'], self.new_user_one_data['data']['attributes']['linkedin'])
+        assert_equal(self.user_one.social['impactStory'], self.new_user_one_data['data']['attributes']['impactstory'])
         assert_equal(self.user_one.social['orcid'], self.new_user_one_data['data']['attributes']['orcid'])
-        assert_equal(self.user_one.social['researcherid'], self.new_user_one_data['data']['attributes']['researcherid'])
+        assert_equal(self.user_one.social['researcherId'], self.new_user_one_data['data']['attributes']['researcherid'])
 
     def test_put_user_logged_out(self):
         res = self.app.put_json_api(self.user_one_url, self.new_user_one_data, expect_errors=True)

--- a/api_tests/users/views/test_user_detail.py
+++ b/api_tests/users/views/test_user_detail.py
@@ -56,14 +56,14 @@ class TestUserDetail(ApiTestCase):
         assert_equal(res.status_code, 200)
         user_json = res.json['data']['attributes']
         assert_equal(user_json['full_name'], self.user_two.fullname)
-        assert_equal(user_json['gitHub'], '')
+        assert_equal(user_json['github'], '')
         assert_equal(user_json['scholar'], '')
         assert_equal(user_json['personal_website'], '')
         assert_equal(user_json['twitter'], '')
-        assert_equal(user_json['linkedIn'], '')
-        assert_equal(user_json['impactStory'], '')
+        assert_equal(user_json['linkedin'], '')
+        assert_equal(user_json['impactstory'], '')
         assert_equal(user_json['orcid'], '')
-        assert_equal(user_json['researcherId'], '')
+        assert_equal(user_json['researcherid'], '')
 
     def test_get_incorrect_pk_user_not_logged_in(self):
         url = "/{}users/{}/".format(API_BASE, self.user_two._id)
@@ -277,10 +277,10 @@ class TestUserUpdate(ApiTestCase):
                 scholar='userOneScholar',
                 personal='http://www.useronepersonalwebsite.com',
                 twitter='userOneTwitter',
-                linkedIn='userOneLinkedIn',
-                impactStory='userOneImpactStory',
+                linkedin='userOneLinkedIn',
+                impactstory='userOneImpactStory',
                 orcid='userOneOrcid',
-                researcherId='userOneResearcherId'
+                researcherid='userOneResearcherId'
             )
         )
         self.user_one.save()
@@ -300,14 +300,14 @@ class TestUserUpdate(ApiTestCase):
                     'middle_names': 'Malik el-Shabazz',
                     'family_name': 'X',
                     'suffix': 'Sr.',
-                    'gitHub': 'newGitHub',
+                    'github': 'newGithub',
                     'scholar': 'newScholar',
                     'personal_website': 'http://www.newpersonalwebsite.com',
                     'twitter': 'http://www.newpersonalwebsite.com',
-                    'linkedIn': 'newLinkedIn',
-                    'impactStory': 'newImpactStory',
+                    'linkedin': 'newLinkedIn',
+                    'impactstory': 'newImpactStory',
                     'orcid': 'newOrcid',
-                    'researcherId': 'newResearcherId',
+                    'researcherid': 'newResearcherId',
                 }
             }
         }
@@ -470,7 +470,7 @@ class TestUserUpdate(ApiTestCase):
                 'type': 'users',
                 'attributes': {
                     'full_name': 'new_fullname',
-                    'gitHub': 'even_newer_github',
+                    'github': 'even_newer_github',
                     'suffix': 'The Millionth'
                 }
             }
@@ -479,16 +479,16 @@ class TestUserUpdate(ApiTestCase):
         assert_equal(res.status_code, 200)
         assert_equal(res.json['data']['attributes']['full_name'], 'new_fullname')
         assert_equal(res.json['data']['attributes']['suffix'], 'The Millionth')
-        assert_equal(res.json['data']['attributes']['gitHub'], 'even_newer_github')
+        assert_equal(res.json['data']['attributes']['github'], 'even_newer_github')
         assert_equal(res.json['data']['attributes']['given_name'], self.user_one.given_name)
         assert_equal(res.json['data']['attributes']['middle_names'], self.user_one.middle_names)
         assert_equal(res.json['data']['attributes']['family_name'], self.user_one.family_name)
         assert_equal(res.json['data']['attributes']['personal_website'], self.user_one.social['personal'])
         assert_equal(res.json['data']['attributes']['twitter'], self.user_one.social['twitter'])
-        assert_equal(res.json['data']['attributes']['linkedIn'], self.user_one.social['linkedIn'])
-        assert_equal(res.json['data']['attributes']['impactStory'], self.user_one.social['impactStory'])
+        assert_equal(res.json['data']['attributes']['linkedin'], self.user_one.social['linkedin'])
+        assert_equal(res.json['data']['attributes']['impactstory'], self.user_one.social['impactstory'])
         assert_equal(res.json['data']['attributes']['orcid'], self.user_one.social['orcid'])
-        assert_equal(res.json['data']['attributes']['researcherId'], self.user_one.social['researcherId'])
+        assert_equal(res.json['data']['attributes']['researcherid'], self.user_one.social['researcherid'])
         assert_equal(self.user_one.fullname, 'new_fullname')
         assert_equal(self.user_one.suffix, 'The Millionth')
         assert_equal(self.user_one.social['github'], 'even_newer_github')
@@ -509,16 +509,16 @@ class TestUserUpdate(ApiTestCase):
         assert_equal(res.status_code, 200)
         assert_equal(res.json['data']['attributes']['full_name'], 'new_fullname')
         assert_equal(res.json['data']['attributes']['suffix'], 'The Millionth')
-        assert_equal(res.json['data']['attributes']['gitHub'], self.user_one.social['github'])
+        assert_equal(res.json['data']['attributes']['github'], self.user_one.social['github'])
         assert_equal(res.json['data']['attributes']['given_name'], self.user_one.given_name)
         assert_equal(res.json['data']['attributes']['middle_names'], self.user_one.middle_names)
         assert_equal(res.json['data']['attributes']['family_name'], self.user_one.family_name)
         assert_equal(res.json['data']['attributes']['personal_website'], self.user_one.social['personal'])
         assert_equal(res.json['data']['attributes']['twitter'], self.user_one.social['twitter'])
-        assert_equal(res.json['data']['attributes']['linkedIn'], self.user_one.social['linkedIn'])
-        assert_equal(res.json['data']['attributes']['impactStory'], self.user_one.social['impactStory'])
+        assert_equal(res.json['data']['attributes']['linkedin'], self.user_one.social['linkedin'])
+        assert_equal(res.json['data']['attributes']['impactstory'], self.user_one.social['impactstory'])
         assert_equal(res.json['data']['attributes']['orcid'], self.user_one.social['orcid'])
-        assert_equal(res.json['data']['attributes']['researcherId'], self.user_one.social['researcherId'])
+        assert_equal(res.json['data']['attributes']['researcherid'], self.user_one.social['researcherid'])
         assert_equal(self.user_one.fullname, 'new_fullname')
         assert_equal(self.user_one.suffix, 'The Millionth')
         assert_equal(self.user_one.social['github'], self.user_one.social['github'])
@@ -531,7 +531,7 @@ class TestUserUpdate(ApiTestCase):
                 'type': 'users',
                 'attributes': {
                     'full_name': 'new_fullname',
-                    'gitHub': 'even_newer_github',
+                    'github': 'even_newer_github',
                     'suffix': 'The Millionth'
                 }
             }
@@ -540,7 +540,7 @@ class TestUserUpdate(ApiTestCase):
         assert_equal(res.status_code, 200)
         assert_equal(res.json['data']['attributes']['full_name'], 'new_fullname')
         assert_equal(res.json['data']['attributes']['suffix'], 'The Millionth')
-        assert_equal(res.json['data']['attributes']['gitHub'], 'even_newer_github')
+        assert_equal(res.json['data']['attributes']['github'], 'even_newer_github')
         assert_equal(res.json['data']['attributes']['given_name'], self.user_one.given_name)
         assert_equal(res.json['data']['attributes']['middle_names'], self.user_one.middle_names)
         assert_equal(res.json['data']['attributes']['family_name'], self.user_one.family_name)
@@ -557,26 +557,26 @@ class TestUserUpdate(ApiTestCase):
         assert_equal(res.json['data']['attributes']['middle_names'], self.new_user_one_data['data']['attributes']['middle_names'])
         assert_equal(res.json['data']['attributes']['family_name'], self.new_user_one_data['data']['attributes']['family_name'])
         assert_equal(res.json['data']['attributes']['suffix'], self.new_user_one_data['data']['attributes']['suffix'])
-        assert_equal(res.json['data']['attributes']['gitHub'], self.new_user_one_data['data']['attributes']['gitHub'])
+        assert_equal(res.json['data']['attributes']['github'], self.new_user_one_data['data']['attributes']['github'])
         assert_equal(res.json['data']['attributes']['personal_website'], self.new_user_one_data['data']['attributes']['personal_website'])
         assert_equal(res.json['data']['attributes']['twitter'], self.new_user_one_data['data']['attributes']['twitter'])
-        assert_equal(res.json['data']['attributes']['linkedIn'], self.new_user_one_data['data']['attributes']['linkedIn'])
-        assert_equal(res.json['data']['attributes']['impactStory'], self.new_user_one_data['data']['attributes']['impactStory'])
+        assert_equal(res.json['data']['attributes']['linkedin'], self.new_user_one_data['data']['attributes']['linkedin'])
+        assert_equal(res.json['data']['attributes']['impactstory'], self.new_user_one_data['data']['attributes']['impactstory'])
         assert_equal(res.json['data']['attributes']['orcid'], self.new_user_one_data['data']['attributes']['orcid'])
-        assert_equal(res.json['data']['attributes']['researcherId'], self.new_user_one_data['data']['attributes']['researcherId'])
+        assert_equal(res.json['data']['attributes']['researcherid'], self.new_user_one_data['data']['attributes']['researcherid'])
         self.user_one.reload()
         assert_equal(self.user_one.fullname, self.new_user_one_data['data']['attributes']['full_name'])
         assert_equal(self.user_one.given_name, self.new_user_one_data['data']['attributes']['given_name'])
         assert_equal(self.user_one.middle_names, self.new_user_one_data['data']['attributes']['middle_names'])
         assert_equal(self.user_one.family_name, self.new_user_one_data['data']['attributes']['family_name'])
         assert_equal(self.user_one.suffix, self.new_user_one_data['data']['attributes']['suffix'])
-        assert_equal(self.user_one.social['github'], self.new_user_one_data['data']['attributes']['gitHub'])
+        assert_equal(self.user_one.social['github'], self.new_user_one_data['data']['attributes']['github'])
         assert_equal(self.user_one.social['personal'], self.new_user_one_data['data']['attributes']['personal_website'])
         assert_equal(self.user_one.social['twitter'], self.new_user_one_data['data']['attributes']['twitter'])
-        assert_equal(self.user_one.social['linkedIn'], self.new_user_one_data['data']['attributes']['linkedIn'])
-        assert_equal(self.user_one.social['impactStory'], self.new_user_one_data['data']['attributes']['impactStory'])
+        assert_equal(self.user_one.social['linkedin'], self.new_user_one_data['data']['attributes']['linkedin'])
+        assert_equal(self.user_one.social['impactstory'], self.new_user_one_data['data']['attributes']['impactstory'])
         assert_equal(self.user_one.social['orcid'], self.new_user_one_data['data']['attributes']['orcid'])
-        assert_equal(self.user_one.social['researcherId'], self.new_user_one_data['data']['attributes']['researcherId'])
+        assert_equal(self.user_one.social['researcherid'], self.new_user_one_data['data']['attributes']['researcherid'])
 
     def test_put_user_logged_out(self):
         res = self.app.put_json_api(self.user_one_url, self.new_user_one_data, expect_errors=True)


### PR DESCRIPTION
## Purpose

API V2 keys were not correctly cased to be processed by ember-osf.

## Changes

All "Social" keys changed to underscores or all lowercase, instead of camelCasing.

## Side effects

Should be no side effects.

## Ticket

https://openscience.atlassian.net/browse/OSF-6537