### PR TITLE
Hotfix/Remove devModeControls when not in dev mode

### DIFF
--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -85,8 +85,6 @@
         </style>
         <div id='devmode' data-bind='click: showHideMetaInfo'><strong>WARNING</strong>: This site is running in development mode.</div>
     </div>
-    %else:
-        <div id="devModeControls"></div>
     % endif
 
     <%namespace name="nav_file" file="nav.mako"/>


### PR DESCRIPTION
## Purpose

Removes the devModeControls div when not in master so the previous fix will apply

## Changes

Removed the else branch on the mako template that added an empty div. Tested by manually removing all divs to ensure that nothing was loaded and removed the file to make sure file didn't 404 if the div didn't exist.

## Side effects

No, should be good.


## Ticket

https://openscience.atlassian.net/browse/OSF-6535

