### PR TITLE
Add documentation for new GUID field on file endpoints [#OSF-6536]

### DIFF
--- a/api/files/views.py
+++ b/api/files/views.py
@@ -65,6 +65,7 @@ class FileDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView, FileMixin):
 
         name          type       description
         =========================================================================
+        guid          string            OSF GUID for this file (if one has been assigned)
         name          string            name of the file
         path          string            unique identifier for this file entity for this
                                         project and storage provider. may not end with '/'

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1570,6 +1570,7 @@ class NodeFilesList(JSONAPIBaseView, generics.ListAPIView, WaterButlerMixin, Lis
 
         name          type               description
         ===================================================================================================
+        guid              string             OSF GUID for this file (if one has been assigned)
         name              string             name of the file or folder; used for display
         kind              string             "file" or "folder"
         path              string             same as for corresponding WaterButler entity


### PR DESCRIPTION
## Purpose
This adds documentation (explaining the new "guid" field for files api endpoints) to the long-form prose in the browseable API and swagger for endpoints, where applicable. This adds text, but not functionality.

Swagger docs will also continue to show the field-level help text that was already present.

## Changes
Adds documentation for the API to swagger docs, and browseable docs, for these endpoints:
-  `v2/nodes/<nid>/files/osfstorage/`
- `/v2/files/{file_id}`
- `v2/docs`

## Side effects
This edits docstrings only. No side effects expected.

## Ticket
https://openscience.atlassian.net/browse/OSF-6536