### PR TITLE
[Hotfix] Rate limit when refreshing OAuth token [OSF-5853]

### DIFF
--- a/scripts/refresh_addon_tokens.py
+++ b/scripts/refresh_addon_tokens.py
@@ -3,8 +3,10 @@
 
 import logging
 import datetime
+import time
 
 from modularodm import Q
+from oauthlib.oauth2 import InvalidGrantError
 from dateutil.relativedelta import relativedelta
 
 from framework.celery_tasks import app as celery_app
@@ -16,7 +18,6 @@ from website.addons.box.model import Box
 from website.addons.googledrive.model import GoogleDriveProvider
 from website.addons.mendeley.model import Mendeley
 from website.oauth.models import ExternalAccount
-from website.addons.base.exceptions import AddonError
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -38,7 +39,9 @@ def get_targets(delta, addon_short_name):
         Q('provider', 'eq', addon_short_name)
     )
 
-def main(delta, Provider, dry_run):
+def main(delta, Provider, rate_limit, dry_run):
+    allowance = rate_limit[0]
+    last_call = time.time()
     for record in get_targets(delta, Provider.short_name):
         logger.info(
             'Refreshing tokens on record {0}; expires at {1}'.format(
@@ -47,11 +50,20 @@ def main(delta, Provider, dry_run):
             )
         )
         if not dry_run:
+            if allowance < 1:
+                try: 
+                    time.sleep(rate_limit[1] - (time.time() - last_call))
+                except ValueError:
+                    pass  # ValueError indicates a negative sleep time
+                allowance = rate_limit[0]
+
+            allowance -= 1
+            last_call = time.time()
             success = False
             try:
                 success = Provider(record).refresh_oauth_key(force=True)
-            except AddonError as ex:
-                logger.error(ex.message)
+            except InvalidGrantError as e:
+                logger.error(e)
             else:
                 logger.info(
                     'Status of record {}: {}'.format(
@@ -59,10 +71,12 @@ def main(delta, Provider, dry_run):
                         'SUCCESS' if success else 'FAILURE')
                 )
 
+
 @celery_app.task(name='scripts.refresh_addon_tokens')
-def run_main(addons=None, dry_run=True):
+def run_main(addons=None, rate_limit=(5, 1), dry_run=True):
     """
     :param dict addons: of form {'<addon_short_name>': int(<refresh_token validity duration in days>)}
+    :param tuple rate_limit: of form (<requests>, <seconds>). Default is five per second
     """
     init_app(set_backends=True, routes=False)
     if not dry_run:
@@ -77,4 +91,4 @@ def run_main(addons=None, dry_run=True):
         if not Provider:
             logger.error('Unable to find Provider class for addon {}'.format(addon_short_name))
         else:
-            main(delta, Provider, dry_run=dry_run)
+            main(delta, Provider, rate_limit, dry_run=dry_run)

--- a/website/addons/base/exceptions.py
+++ b/website/addons/base/exceptions.py
@@ -2,13 +2,9 @@
 Custom exceptions for add-ons.
 """
 
-
 class AddonError(Exception):
     pass
 
 
 class HookError(AddonError):
-    pass
-
-class InvalidAuthError(AddonError):
     pass

--- a/website/addons/googledrive/serializer.py
+++ b/website/addons/googledrive/serializer.py
@@ -1,4 +1,4 @@
-from website.addons.base.exceptions import InvalidAuthError
+from oauthlib.oauth2 import InvalidGrantError
 from website.addons.base.serializer import StorageAddonSerializer
 from website.util import api_url_for
 
@@ -9,7 +9,7 @@ class GoogleDriveSerializer(StorageAddonSerializer):
     def credentials_are_valid(self, user_settings, client):
         try:
             self.node_settings.fetch_access_token()
-        except (InvalidAuthError, AttributeError):
+        except (InvalidGrantError, AttributeError):
             return False
         return True
 
@@ -40,7 +40,7 @@ class GoogleDriveSerializer(StorageAddonSerializer):
         if self.node_settings.external_account is not None:
             try:
                 self.node_settings.fetch_access_token()
-            except InvalidAuthError:
+            except InvalidGrantError:
                 valid_credentials = False
         result['validCredentials'] = valid_credentials
         return {'result': result}

--- a/website/addons/googledrive/views.py
+++ b/website/addons/googledrive/views.py
@@ -2,11 +2,10 @@
 from flask import request
 
 from framework.exceptions import HTTPError
+from oauthlib.oauth2 import InvalidGrantError
 from website.project.decorators import must_have_addon, must_be_addon_authorizer
 
 from website.addons.base import generic_views
-from website.addons.base.exceptions import InvalidAuthError
-
 from website.addons.googledrive.utils import to_hgrid
 from website.addons.googledrive.client import GoogleDriveClient
 from website.addons.googledrive.serializer import GoogleDriveSerializer
@@ -61,7 +60,7 @@ def googledrive_folder_list(node_addon, **kwargs):
 
     try:
         access_token = node_addon.fetch_access_token()
-    except InvalidAuthError:
+    except InvalidGrantError:
         raise HTTPError(403)
 
     client = GoogleDriveClient(access_token)

--- a/website/addons/mendeley/model.py
+++ b/website/addons/mendeley/model.py
@@ -5,9 +5,9 @@ import time
 import mendeley
 from mendeley.exception import MendeleyApiException
 from modularodm import fields
+from oauthlib.oauth2 import InvalidGrantError
 
 from website.addons.base import AddonOAuthUserSettingsBase
-from website.addons.base.exceptions import InvalidAuthError
 from website.addons.mendeley.serializer import MendeleySerializer
 from website.addons.mendeley import settings
 from website.addons.mendeley.api import APISession
@@ -74,7 +74,7 @@ class Mendeley(CitationsOauthProvider):
             if error.status == 401 and 'Token has expired' in error.message:
                 try:
                     refreshed_key = self.refresh_oauth_key()
-                except InvalidAuthError:
+                except InvalidGrantError:
                     self._client = None
                     raise HTTPError(401)
                 if not refreshed_key:


### PR DESCRIPTION
## Purpose
The cron script to refresh tokens for addons that have expiring tokens seems to have failed, and the logs are unhelpful.

## Changes
* Improve error logging
* Limit the number of outgoing requests to 5/second
* `InvalidAuthError(AddonError)` removed, it was an unnecessary wrapper

## Side effects
None
<!--Any possible side effects? -->


## Ticket
[OSF-5853](https://openscience.atlassian.net/browse/OSF-5853)