### PR TITLE
[Hotfix] Skip expired credentials in token refresh script [OSF-5853]

### DIFF
--- a/scripts/refresh_addon_tokens.py
+++ b/scripts/refresh_addon_tokens.py
@@ -43,9 +43,15 @@ def main(delta, Provider, rate_limit, dry_run):
     allowance = rate_limit[0]
     last_call = time.time()
     for record in get_targets(delta, Provider.short_name):
+        if Provider(record).has_expired_credentials:
+            logger.info(
+                'Found expired record {}, skipping'.format(record.__repr__())
+            )
+            continue
+
         logger.info(
             'Refreshing tokens on record {0}; expires at {1}'.format(
-                record._id,
+                record.__repr__(),
                 record.expires_at.strftime('%c')
             )
         )
@@ -67,7 +73,7 @@ def main(delta, Provider, rate_limit, dry_run):
             else:
                 logger.info(
                     'Status of record {}: {}'.format(
-                        record._id,
+                        record.__repr__(),
                         'SUCCESS' if success else 'FAILURE')
                 )
 

--- a/scripts/refresh_addon_tokens.py
+++ b/scripts/refresh_addon_tokens.py
@@ -6,7 +6,7 @@ import datetime
 import time
 
 from modularodm import Q
-from oauthlib.oauth2 import InvalidGrantError
+from oauthlib.oauth2 import OAuth2Error
 from dateutil.relativedelta import relativedelta
 
 from framework.celery_tasks import app as celery_app
@@ -68,7 +68,7 @@ def main(delta, Provider, rate_limit, dry_run):
             success = False
             try:
                 success = Provider(record).refresh_oauth_key(force=True)
-            except InvalidGrantError as e:
+            except OAuth2Error as e:
                 logger.error(e)
             else:
                 logger.info(

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -674,6 +674,7 @@ class MockOAuth2Provider(ExternalProvider):
     callback_url = "https://mock2.com/callback"
     auto_refresh_url = "https://mock2.com/callback"
     refresh_time = 300
+    expiry_time = 9001
 
     def handle_callback(self, response):
         return {

--- a/website/addons/box/model.py
+++ b/website/addons/box/model.py
@@ -31,6 +31,7 @@ class Box(ExternalProvider):
     callback_url = settings.BOX_OAUTH_TOKEN_ENDPOINT
     auto_refresh_url = callback_url
     refresh_time = settings.REFRESH_TIME
+    expiry_time = settings.EXPIRY_TIME
     default_scopes = ['root_readwrite']
 
     def handle_callback(self, response):

--- a/website/addons/box/settings/defaults.py
+++ b/website/addons/box/settings/defaults.py
@@ -3,6 +3,7 @@ BOX_KEY = None
 BOX_SECRET = None
 
 REFRESH_TIME = 5 * 60  # 5 minutes
+EXPIRY_TIME = 60 * 60 * 24 * 60  # 60 days
 
 BOX_OAUTH_TOKEN_ENDPOINT = 'https://www.box.com/api/oauth2/token'
 BOX_OAUTH_AUTH_ENDPOINT = 'https://www.box.com/api/oauth2/authorize'

--- a/website/addons/googledrive/model.py
+++ b/website/addons/googledrive/model.py
@@ -29,6 +29,7 @@ class GoogleDriveProvider(ExternalProvider):
     callback_url = '{}{}'.format(drive_settings.API_BASE_URL, 'oauth2/v3/token')
     auto_refresh_url = callback_url
     refresh_time = drive_settings.REFRESH_TIME
+    expiry_time = drive_settings.EXPIRY_TIME
 
     default_scopes = drive_settings.OAUTH_SCOPE
     _auth_client = GoogleAuthClient()

--- a/website/addons/googledrive/settings/defaults.py
+++ b/website/addons/googledrive/settings/defaults.py
@@ -4,6 +4,7 @@ CLIENT_ID = 'chaneme'
 CLIENT_SECRET = 'changeme'
 
 REFRESH_TIME = 5 * 60  # 5 minutes
+EXPIRY_TIME = 60 * 60 * 24 * 14  # 14 days
 
 # Check https://developers.google.com/drive/scopes for all available scopes
 OAUTH_SCOPE = [

--- a/website/addons/mendeley/model.py
+++ b/website/addons/mendeley/model.py
@@ -30,6 +30,8 @@ class Mendeley(CitationsOauthProvider):
     auto_refresh_url = callback_url
     default_scopes = ['all']
 
+    expiry_time = settings.EXPIRY_TIME
+
     serializer = MendeleySerializer
 
     def handle_callback(self, response):

--- a/website/addons/mendeley/settings/defaults.py
+++ b/website/addons/mendeley/settings/defaults.py
@@ -1,3 +1,5 @@
 # OAuth app keys
 MENDELEY_CLIENT_ID = None
 MENDELEY_CLIENT_SECRET = None
+
+EXPIRY_TIME = 60 * 60 * 24 * 14  # 14 days, in seconds


### PR DESCRIPTION
## Purpose
It's pointless to make 500+ failing requests each morning for tokens that have expired. This adds a mechanism to see, on a per-provider basis, whether or not tokens are passed the window of time that they can even be refreshed.

## Changes
* Add `has_expired_credentials` property on authenticaed `ExternalProvider` instances for providers that support it (defaults to `False`)
* Update addons that this affects with `expiry_time`
* Update script to skip expired accounts
* Update text fixtures to support this
* Add tests for this behavior
* Improve error handling in script

## Side effects
None

## Ticket

[OSF-5853](https://openscience.atlassian.net/browse/OSF-5853)