### PR TITLE
hotfix/ clarify limit on storage on registrations

### DIFF
--- a/website/templates/public/pages/faq.mako
+++ b/website/templates/public/pages/faq.mako
@@ -81,7 +81,7 @@
                         </div>
                         <div class="support-item">
                             <h5 class="support-head f-w-xl"><i class="fa fa-angle-right"></i> What is the cap on data per user?</h5>
-                            <div class="support-body">There is a limit on the size of individual files uploaded to the OSF. This limit is 5 GB. If you have larger files to upload, you might consider utilizing add-ons. When archiving files during the registration process, there is a 5 GB total limit across all storage add-ons being archived.</div>
+                            <div class="support-body">There is a limit on the size of individual files uploaded to the OSF. This limit is 5 GB. If you have larger files to upload, you might consider utilizing add-ons. When archiving files during the registration process, there is a 5 GB total limit per registration across all storage being archived (OSF Storage plus Add-ons).</div>
                         </div>
                         <div class="support-item">
                             <h5 class="support-head f-w-xl"><i class="fa fa-angle-right"></i> How do I get a DOI or ARK for my project?</h5>


### PR DESCRIPTION

## Purpose

Clarify FAQ on registration size limits

## Changes

Clarification the 5GB limit includes OSF Storage and Add-on Storage.

## Side effects

Fewer help desk emails

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
