### PR TITLE
[RFR][Fix][#OSF-6548]Fix sorting for non-iso date formats

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1287,10 +1287,11 @@ function _fangornModifiedColumn(item, col) {
         return _connectCheckTemplate.call(this, item);
     }
     if (item.kind === 'file' && item.data.permissions.view && item.data.modified) {
+        // "new Date" required for non-ISO date formats
+        item.data.modified = new moment(new Date(item.data.modified)).format('YYYY-MM-DD hh:mm A');
         return m(
             'span',
-            // "new Date" required for non-ISO date formats
-            new moment(new Date(item.data.modified)).format('YYYY-MM-DD hh:mm A')
+            item.data.modified
         );
     }
     return m('span', '');


### PR DESCRIPTION
## Purpose:
This PR is a fix for [PR#5817 OSF-5939](https://github.com/CenterForOpenScience/osf.io/pull/5817/files)
[OSF-6548](https://openscience.atlassian.net/browse/OSF-6548)
Fix incorrect sorting for non-iso formatted dates

## Changes:
Update website/static/js/fangorn.js
Update item.data.modified with iso formatted date instead of just pushing iso date to column. Treebeard sort funtion goes against item.data.modified not column data.

## Side effects
None

[#OSF-6548]