### PR TITLE
Fix how osfToggleHeight is loaded [OSF-4265]

### DIFF
--- a/website/addons/dataverse/static/dataverseUserConfig.js
+++ b/website/addons/dataverse/static/dataverseUserConfig.js
@@ -74,7 +74,7 @@ function ViewModel(url) {
                 externalAccount.dataverseUrl = account.host_url;
                 return externalAccount;
             }));
-            $('.addon-auth-table').osfToggleHeight({height: 140});
+            $('#dataverse-header').osfToggleHeight({height: 140});
         });
         request.fail(function(xhr, status, error) {
             Raven.captureMessage('Error while updating addon account', {

--- a/website/addons/s3/static/s3UserConfig.js
+++ b/website/addons/s3/static/s3UserConfig.js
@@ -51,7 +51,7 @@ function ViewModel(url) {
                 externalAccount.secretKey = account.oauth_secret;
                 return externalAccount;
             }));
-            $('.addon-auth-table').osfToggleHeight({height: 140});
+            $('#s3-header').osfToggleHeight({height: 140});
         }).fail(function(xhr, status, error) {
             self.changeMessage(language.userSettingsError, 'text-danger');
             Raven.captureMessage('Error while updating addon account', {

--- a/website/static/js/addonSettings.js
+++ b/website/static/js/addonSettings.js
@@ -148,6 +148,8 @@ var OAuthAddonSettingsViewModel = oop.defclass({
             self.accounts($.map(data.accounts, function(account) {
                 return new ExternalAccount(account);
             }));
+            $('#' + self.name + '-header').osfToggleHeight({height: 140});
+          });
         });
         request.fail(function(xhr, status, error) {
             Raven.captureMessage('Error while updating addon account', {

--- a/website/static/js/addonSettings.js
+++ b/website/static/js/addonSettings.js
@@ -149,7 +149,6 @@ var OAuthAddonSettingsViewModel = oop.defclass({
                 return new ExternalAccount(account);
             }));
             $('#' + self.name + '-header').osfToggleHeight({height: 140});
-          });
         });
         request.fail(function(xhr, status, error) {
             Raven.captureMessage('Error while updating addon account', {

--- a/website/static/js/pages/profile-settings-addons-page.js
+++ b/website/static/js/pages/profile-settings-addons-page.js
@@ -112,10 +112,6 @@ for (var i=0; i < addonEnabledSettings.length; i++) {
    }
 }
 
-$(document).ready(function(){
-    $('.addon-auth-table').osfToggleHeight({height: 140});
-});
-
 /* Before closing the page, Check whether the newly checked addon are updated or not */
 $(window).on('beforeunload',function() {
     //new checked items but not updated


### PR DESCRIPTION
## Purpose

Change how the collapse/expand caret (osfToggleHeight) is loaded.

## Changes

Changed how the caret is loaded in dataverseUserConfig.js and s3UserConfig.js since Dataverse and S3 are the only two addons that are not loaded through OAuthAddonSettingsViewModel.
For the addons that are loaded through OAuthAddonSettingsViewModel, the caret is loaded for each addon. 

## Side effects

None that I can think of.


## Ticket

https://openscience.atlassian.net/browse/OSF-4265
