### PR TITLE
[RFR][Hotfix][#OSF-5939] Fix sorting for DropBox

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1284,7 +1284,7 @@ function _fangornTitleColumn(item, col) {
 function _fangornModifiedColumn(item, col) {
     var tb = this;
     // Kludge for DropBox date format
-    // TODO: remove kludge when we either move to DropBox v2 API or implememnt
+    // TODO [OSF-6461]: remove kludge when we either move to DropBox v2 API or implememnt
     // normalized dates in WaterButler
     var myFormats = ['ddd, DD MMM YYYY HH:mm:ss ZZ', 'YYYY-MM-DD hh:mm A'];
     if (item.data.isAddonRoot && item.connected === false) { // as opposed to undefined, avoids unnecessary setting of this value

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1283,15 +1283,19 @@ function _fangornTitleColumn(item, col) {
  */
 function _fangornModifiedColumn(item, col) {
     var tb = this;
+    // Kludge for DropBox date format
+    // TODO: remove kludge when we either move to DropBox v2 API or implememnt
+    // normalized dates in WaterButler
+    var myFormats = ['ddd, DD MMM YYYY HH:mm:ss ZZ', 'YYYY-MM-DD hh:mm A'];
     if (item.data.isAddonRoot && item.connected === false) { // as opposed to undefined, avoids unnecessary setting of this value
         return _connectCheckTemplate.call(this, item);
     }
     if (item.kind === 'file' && item.data.permissions.view && item.data.modified) {
         // "new Date" required for non-ISO date formats
-        var modifiedFormatted = new moment(new Date(item.data.modified)).format('YYYY-MM-DD hh:mm A');
+        item.data.modified = new moment(item.data.modified, myFormats, 'en').format('YYYY-MM-DD hh:mm A');
         return m(
             'span',
-            modifiedFormatted
+            item.data.modified
         );
     }
     return m('span', '');


### PR DESCRIPTION
## Purpose:
This PR is a hotfix for [PR#5817 OSF-5939](https://github.com/CenterForOpenScience/osf.io/pull/5817/files)
[OSF-5939](https://openscience.atlassian.net/browse/OSF-5939)
Fix incorrect sorting for DropBox v1 API formatted dates

## Changes:
Update website/static/js/fangorn.js
Update item.data.modified with OSF formatted date instead of just pushing OSF date to column. Treebeard sort funtion goes against item.data.modified not column data.

## Side effects
None

[#OSF-5939]