### PR TITLE
Fix API V2 filter by size [OSF-4948]

### DIFF
--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -20,6 +20,7 @@ from api.base.exceptions import (
 )
 from api.base import utils
 from api.base.serializers import RelationshipField, TargetField
+from api.files.serializers import SerializerMethodIntegerField
 
 def lowercase(lower):
     if hasattr(lower, '__call__'):
@@ -373,11 +374,16 @@ class ListFilterMixin(FilterMixin):
         field = self.serializer_class._declared_fields[field_name]
         field_name = self.convert_key(field_name, field)
 
-        if isinstance(field, ser.SerializerMethodField):
+        if isinstance(field, ser.SerializerMethodField) and not isinstance(field. SerializerMethodIntegerField):
             return_val = [
                 item for item in default_queryset
                 if self.FILTERS[params['op']](self.get_serializer_method(field_name)(item), params['value'])
             ]
+        elif isinstance(field, SerializerMethodIntegerField):
+            return_val = [
+                item for item in default_queryset
+                if self.FILTERS[params['op']](self.get_serializer_method(field_name)(item), int(params['value']))
+                ]
         elif isinstance(field, ser.CharField):
             return_val = [
                 item for item in default_queryset

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -383,7 +383,7 @@ class ListFilterMixin(FilterMixin):
             return_val = [
                 item for item in default_queryset
                 if self.FILTERS[params['op']](self.get_serializer_method(field_name)(item), int(params['value']))
-                ]
+            ]
         elif isinstance(field, ser.CharField):
             return_val = [
                 item for item in default_queryset

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -72,7 +72,7 @@ class FilterMixin(object):
         ser.ListField: 'contains',
     }
 
-    NUMERIC_FIELDS = (ser.IntegerField, ser.DecimalField, ser.FloatField)
+    NUMERIC_FIELDS = (ser.IntegerField, ser.DecimalField, ser.FloatField, SerializerMethodIntegerField)
 
     DATE_FIELDS = (ser.DateTimeField, ser.DateField)
     DATETIME_PATTERN = re.compile(r'^\d{4}\-\d{2}\-\d{2}(?P<time>T\d{2}:\d{2}(:\d{2}(\.\d{1,6})?)?)$')

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -374,7 +374,7 @@ class ListFilterMixin(FilterMixin):
         field = self.serializer_class._declared_fields[field_name]
         field_name = self.convert_key(field_name, field)
 
-        if isinstance(field, ser.SerializerMethodField) and not isinstance(field. SerializerMethodIntegerField):
+        if isinstance(field, ser.SerializerMethodField) and not isinstance(field, SerializerMethodIntegerField):
             return_val = [
                 item for item in default_queryset
                 if self.FILTERS[params['op']](self.get_serializer_method(field_name)(item), params['value'])

--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -27,6 +27,11 @@ from api.base.utils import get_user_auth
 from website.util import api_v2_url
 
 
+class SerializerMethodIntegerField(ser.SerializerMethodField):
+    def __init__(self, **kwargs):
+        super(SerializerMethodIntegerField, self).__init__(**kwargs)
+
+
 class CheckoutField(ser.HyperlinkedRelatedField):
 
     default_error_messages = {'invalid_data': 'Checkout must be either the current user or null'}
@@ -122,7 +127,7 @@ class FileSerializer(JSONAPISerializer):
     name = ser.CharField(read_only=True, help_text='Display name used in the general user interface')
     kind = ser.CharField(read_only=True, help_text='Either folder or file')
     path = ser.CharField(read_only=True, help_text='The unique path used to reference this object')
-    size = ser.SerializerMethodField(read_only=True, help_text='The size of this file at this version')
+    size = ser.SerializerMethodIntegerField(read_only=True, help_text='The size of this file at this version')
     provider = ser.CharField(read_only=True, help_text='The Add-on service this file originates from')
     materialized_path = ser.CharField(
         read_only=True, help_text='The Unix-style path of this object relative to the provider root')

--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -127,7 +127,7 @@ class FileSerializer(JSONAPISerializer):
     name = ser.CharField(read_only=True, help_text='Display name used in the general user interface')
     kind = ser.CharField(read_only=True, help_text='Either folder or file')
     path = ser.CharField(read_only=True, help_text='The unique path used to reference this object')
-    size = ser.SerializerMethodIntegerField(read_only=True, help_text='The size of this file at this version')
+    size = SerializerMethodIntegerField(read_only=True, help_text='The size of this file at this version')
     provider = ser.CharField(read_only=True, help_text='The Add-on service this file originates from')
     materialized_path = ser.CharField(
         read_only=True, help_text='The Unix-style path of this object relative to the provider root')

--- a/api_tests/nodes/views/test_node_files_list.py
+++ b/api_tests/nodes/views/test_node_files_list.py
@@ -321,9 +321,9 @@ class TestNodeFilesListFiltering(ApiTestCase):
             'service': 'cloud',
             osfstorage_settings.WATERBUTLER_RESOURCE: 'osf',
         }, {
-                                     'size': 1337,
-                                     'contentType': 'img/png'
-                                 }).save()
+            'size': 1337,
+            'contentType': 'img/png'
+        }).save()
         return test_file
 
     def _create_test_file_for_size_filter(self, node, user):
@@ -336,9 +336,9 @@ class TestNodeFilesListFiltering(ApiTestCase):
             'service': 'cloud',
             osfstorage_settings.WATERBUTLER_RESOURCE: 'osf',
         }, {
-                                     'size': 123,
-                                     'contentType': 'img/png'
-                                 }).save()
+            'size': 123,
+            'contentType': 'img/png'
+        }).save()
 
         test_file_2 = root_node.append_file('test_file_2')
         test_file_2.get_guid(create=True)
@@ -347,9 +347,9 @@ class TestNodeFilesListFiltering(ApiTestCase):
             'service': 'cloud',
             osfstorage_settings.WATERBUTLER_RESOURCE: 'osf',
         }, {
-                                       'size': 456,
-                                       'contentType': 'img/png'
-                                   }).save()
+            'size': 456,
+            'contentType': 'img/png'
+        }).save()
 
         return test_file, test_file_2
 

--- a/api_tests/nodes/views/test_node_files_list.py
+++ b/api_tests/nodes/views/test_node_files_list.py
@@ -10,12 +10,12 @@ from website.addons.github.tests.factories import GitHubAccountFactory
 from website.models import Node
 from website.util import waterbutler_api_url_for
 from api.base.settings.defaults import API_BASE
-from api_tests import utils as api_utils
 from tests.base import ApiTestCase
 from tests.factories import (
     ProjectFactory,
     AuthUserFactory
 )
+from website.addons.osfstorage import settings as osfstorage_settings
 
 def prepare_mock_wb_response(
         node=None,
@@ -311,6 +311,48 @@ class TestNodeFilesListFiltering(ApiTestCase):
         httpretty.disable()
         httpretty.reset()
 
+    def _create_test_file(self, node, user):
+        osfstorage = node.get_addon('osfstorage')
+        root_node = osfstorage.get_root()
+        test_file = root_node.append_file('test_file')
+        test_file.get_guid(create=True)
+        test_file.create_version(user, {
+            'object': '06d80e',
+            'service': 'cloud',
+            osfstorage_settings.WATERBUTLER_RESOURCE: 'osf',
+        }, {
+                                     'size': 1337,
+                                     'contentType': 'img/png'
+                                 }).save()
+        return test_file
+
+    def _create_test_file_for_size_filter(self, node, user):
+        osfstorage = node.get_addon('osfstorage')
+        root_node = osfstorage.get_root()
+        test_file = root_node.append_file('test_file')
+        test_file.get_guid(create=True)
+        test_file.create_version(user, {
+            'object': '06d80e',
+            'service': 'cloud',
+            osfstorage_settings.WATERBUTLER_RESOURCE: 'osf',
+        }, {
+                                     'size': 123,
+                                     'contentType': 'img/png'
+                                 }).save()
+
+        test_file_2 = root_node.append_file('test_file_2')
+        test_file_2.get_guid(create=True)
+        test_file_2.create_version(user, {
+            'object': '06d80e',
+            'service': 'cloud',
+            osfstorage_settings.WATERBUTLER_RESOURCE: 'osf',
+        }, {
+                                       'size': 456,
+                                       'contentType': 'img/png'
+                                   }).save()
+
+        return test_file, test_file_2
+
     def add_github(self):
         user_auth = Auth(self.user)
         self.project.add_addon('github', auth=user_auth)
@@ -358,6 +400,14 @@ class TestNodeFilesListFiltering(ApiTestCase):
         assert_equal(len(res.json['data']), 1)  # filters out 'xyz'
         assert_equal(res.json['data'][0]['attributes']['name'], 'abc')
 
+    def test_node_files_are_filterable_by_size(self):
+        files = self._create_test_file_for_size_filter(self.project, self.user)
+        url = '/{}nodes/{}/files/osfstorage/?filter[size]=123'.format(API_BASE, self.project._id,)
+        res = self.app.get(url, auth=self.user.auth)
+        assert_equal(res.status_code, 200)
+        assert_equal(res.json['data'][0]['attributes']['name'], files[0].name)
+        assert_equal(res.json['data'][0]['attributes']['size'], files[0].get_version().size)
+
     def test_node_files_external_provider_can_filter_by_last_touched(self):
         yesterday_stamp = datetime.datetime.utcnow() - datetime.timedelta(days=1)
         self.add_github()
@@ -370,7 +420,7 @@ class TestNodeFilesListFiltering(ApiTestCase):
 
     def test_node_files_osfstorage_cannot_filter_by_last_touched(self):
         yesterday_stamp = datetime.datetime.utcnow() - datetime.timedelta(days=1)
-        self.file = api_utils.create_test_file(self.project, self.user)
+        self.file = self._create_test_file(self.project, self.user)
 
         url = '/{}nodes/{}/files/osfstorage/?filter[last_touched][gt]={}'.format(API_BASE,
                                                                                  self.project._id,

--- a/api_tests/nodes/views/test_node_files_list.py
+++ b/api_tests/nodes/views/test_node_files_list.py
@@ -402,11 +402,27 @@ class TestNodeFilesListFiltering(ApiTestCase):
 
     def test_node_files_are_filterable_by_size(self):
         files = self._create_test_file_for_size_filter(self.project, self.user)
-        url = '/{}nodes/{}/files/osfstorage/?filter[size]=123'.format(API_BASE, self.project._id,)
+        url = '/{}nodes/{}/files/osfstorage/?filter[size]=123'.format(API_BASE, self.project._id)
         res = self.app.get(url, auth=self.user.auth)
         assert_equal(res.status_code, 200)
+        assert_equal(len(res.json['data']), 1)  # filters out test_file_2
         assert_equal(res.json['data'][0]['attributes']['name'], files[0].name)
         assert_equal(res.json['data'][0]['attributes']['size'], files[0].get_version().size)
+
+    def test_node_files_are_filterable_by_size_operator(self):
+        files = self._create_test_file_for_size_filter(self.project, self.user)
+        url = '/{}nodes/{}/files/osfstorage/?filter[size][lt]=200'.format(API_BASE, self.project._id)
+        url2 = '/{}nodes/{}/files/osfstorage/?filter[size][gt]=200'.format(API_BASE, self.project._id)
+        res = self.app.get(url, auth=self.user.auth)
+        res2 = self.app.get(url2, auth=self.user.auth)
+        assert_equal(res.status_code, 200)
+        assert_equal(res2.status_code, 200)
+        assert_equal(len(res.json['data']), 1)  # filters out test_file
+        assert_equal(len(res2.json['data']), 1)  # filters out test_file_2
+        assert_equal(res.json['data'][0]['attributes']['name'], files[0].name)
+        assert_equal(res.json['data'][0]['attributes']['size'], files[0].get_version().size)
+        assert_equal(res2.json['data'][0]['attributes']['name'], files[1].name)
+        assert_equal(res2.json['data'][0]['attributes']['size'], files[1].get_version().size)
 
     def test_node_files_external_provider_can_filter_by_last_touched(self):
         yesterday_stamp = datetime.datetime.utcnow() - datetime.timedelta(days=1)


### PR DESCRIPTION
## Purpose

Fix the problem that API v2 is not able to filter by file size

## Changes

Add SerializerMethodIntegerField, a subclass of SerializerMethodField.
Change "size" of FileSerializer to be a SerializerMethodIntegerField

## Side effects

None


## Ticket

https://openscience.atlassian.net/browse/OSF-4948

## Note

This PR is a new version of https://github.com/CenterForOpenScience/osf.io/pull/5715, which I had to close due to some improper use of git.
