### PR TITLE
Fixed icon popover in "New Token" [#OSF-6321]

### DIFF
--- a/website/templates/profile/personal_tokens_detail.mako
+++ b/website/templates/profile/personal_tokens_detail.mako
@@ -37,7 +37,7 @@
                             % for scope in scope_options:
                                 <input type="checkbox" id="${scope[0]}" value="${scope[0]}" data-bind="checked: scopes">
                                 <label for="${scope[0]}">${scope[0]} </label>
-                                <i class="fa fa-info-circle text-muted" data-bind="tooltip: {title: ${scope[1] | sjson, n }, placement: 'bottom'}"></i>
+                                <i class="fa fa-info-circle text-muted" data-bind="tooltip: {title: '${scope[1]}', placement: 'right'}"></i>
                                 <br>
                             % endfor
                          </div>


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

  The fa-icons in the New Token Detail page in settings/tokens/create/ didn't all show information when hovering over them. 

## Changes

I changed the title in the i tag so it now shows the popover, and it goes out to the right instead of bottom so it doesn't cover the other options.

## Side effects

None that I can think of, I only changed the icon, not anything else on the page.

## Ticket

https://openscience.atlassian.net/browse/OSF-6321
