### PR TITLE
Improved error message for multiple Dropbox add-ons [#OSF-5744]

### DIFF
--- a/website/static/js/addonSettings.js
+++ b/website/static/js/addonSettings.js
@@ -92,7 +92,9 @@ var OAuthAddonSettingsViewModel = oop.defclass({
             self.updateAccounts().done( function() {
                 (self.accounts().length > accountCount) ?
                     self.setMessage('Add-on successfully authorized. To link this add-on to an OSF project, go to the settings page of the project, enable ' + self.properName + ', and choose content to connect.', 'text-success') :
-                    self.setMessage('Error while authorizing addon. Please log in to your ' + self.properName + ' account and grant access to the OSF to enable this addon.', 'text-danger');
+                    (self.name == 'dropbox') ?
+                        self.setMessage('Error while authorizing add-on. Log out of dropbox.com before attempting to connect to a second Dropbox account on the OSF. This will clear the credentials stored in your browser.', 'text-danger') :
+                        self.setMessage('Error while authorizing add-on. Please log in to your ' + self.properName + ' account and grant access to the OSF to enable this addon.', 'text-danger');
                 });
         };
         window.open('/oauth/connect/' + self.name + '/');

--- a/website/static/js/addonSettings.js
+++ b/website/static/js/addonSettings.js
@@ -90,12 +90,16 @@ var OAuthAddonSettingsViewModel = oop.defclass({
             self.setMessage('');
             var accountCount = self.accounts().length;
             self.updateAccounts().done( function() {
-                (self.accounts().length > accountCount) ?
-                    self.setMessage('Add-on successfully authorized. To link this add-on to an OSF project, go to the settings page of the project, enable ' + self.properName + ', and choose content to connect.', 'text-success') :
-                    (self.name == 'dropbox') ?
-                        self.setMessage('Error while authorizing add-on. Log out of dropbox.com before attempting to connect to a second Dropbox account on the OSF. This will clear the credentials stored in your browser.', 'text-danger') :
-                        self.setMessage('Error while authorizing add-on. Please log in to your ' + self.properName + ' account and grant access to the OSF to enable this addon.', 'text-danger');
-                });
+                if (self.accounts().length > accountCount) {
+                    self.setMessage('Add-on successfully authorized. To link this add-on to an OSF project, go to the settings page of the project, enable ' + self.properName + ', and choose content to connect.', 'text-success');
+                } else {
+                    if (self.name == 'dropbox') {
+                        self.setMessage('Error while authorizing add-on. Log out of dropbox.com before attempting to connect to a second Dropbox account on the OSF. This will clear the credentials stored in your browser.', 'text-danger');
+                    } else {
+                        self.setMessage('Error while authorizing add-on. Please log in to your ' + self.properName + ' account and grant access to the OSF to enable this add-on.', 'text-danger');
+                    }
+                }
+            });
         };
         window.open('/oauth/connect/' + self.name + '/');
     },


### PR DESCRIPTION

## Purpose

When a user adds multiple Dropbox add-ons, the error message that displayed was unhelpful.  The original message  was: 

> Error while authorizing add-on. Please log in to your Dropbox account and grant access to the OSF to enable this addon.


This didn't give a lot of help to the user to set up a second Dropbox account.  The purpose of this PR was to fix the message so that it would be of more help to the user.  

## Changes

The error only shows when the user tries to add an additional account without logging out of their current Dropbox account.  Therefore the message that was displayed was changed to be more accurate to the steps needed to fix the issue.  The issue that displays now shows:

![screen shot 2016-06-29 at 1 44 33 pm](https://cloud.githubusercontent.com/assets/19379783/16462527/b01c6954-3dff-11e6-94eb-c25aa0616bdf.png)


## Side effects

There shouldn't be any side effects from the fixes applied.  

## Ticket

https://openscience.atlassian.net/browse/OSF-5744