### PR TITLE
[Feature] No way to distinguish between projects in Add Links modal [OSF-4046]

### DIFF
--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -1100,6 +1100,8 @@ def _serialize_node_search(node):
         'title': title,
         'firstAuthor': first_author.family_name or first_author.given_name or first_author.full_name,
         'etal': len(node.visible_contributors) > 1,
+        'dateCreated': node.date_created.isoformat(),
+        'dateModified': node.date_modified.isoformat()
     }
 
 

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -1089,20 +1089,23 @@ def _serialize_node_search(node):
     :return: Dictionary of node data
 
     """
-    title = node.title
+    data = {
+        'id': node._id,
+        'title': node.title,
+        'etal': len(node.visible_contributors) > 1,
+        'isRegistration': node.is_registration
+    }
     if node.is_registration:
-        title += ' (registration)'
+        data['title'] += ' (registration)'
+        data['dateRegistered'] = node.registered_date.isoformat()
+    else:
+        data['dateCreated'] = node.date_created.isoformat()
+        data['dateModified'] = node.date_modified.isoformat()
 
     first_author = node.visible_contributors[0]
+    data['firstAuthor'] = first_author.family_name or first_author.given_name or first_author.full_name,
 
-    return {
-        'id': node._id,
-        'title': title,
-        'firstAuthor': first_author.family_name or first_author.given_name or first_author.full_name,
-        'etal': len(node.visible_contributors) > 1,
-        'dateCreated': node.date_created.isoformat(),
-        'dateModified': node.date_modified.isoformat()
-    }
+    return data
 
 
 @must_be_logged_in

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -1103,7 +1103,7 @@ def _serialize_node_search(node):
         data['dateModified'] = node.date_modified.isoformat()
 
     first_author = node.visible_contributors[0]
-    data['firstAuthor'] = first_author.family_name or first_author.given_name or first_author.full_name,
+    data['firstAuthor'] = first_author.family_name or first_author.given_name or first_author.full_name
 
     return data
 

--- a/website/static/js/pointers.js
+++ b/website/static/js/pointers.js
@@ -77,8 +77,12 @@ var AddPointerViewModel = oop.extend(Paginator, {
                     self.errorMsg('No results found.');
                 } else {
                     result.nodes.forEach(function(each) {
-                        each.dateCreated = new osfHelpers.FormattableDate(each.dateCreated);
-                        each.dateModified = new osfHelpers.FormattableDate(each.dateModified);
+                        if (each.isRegistration) {
+                            each.dateRegistered = new osfHelpers.FormattableDate(each.dateRegistered);
+                        } else {
+                            each.dateCreated = new osfHelpers.FormattableDate(each.dateCreated);
+                            each.dateModified = new osfHelpers.FormattableDate(each.dateModified);
+                        }
                     });
                 }
                 self.results(result.nodes);
@@ -100,16 +104,24 @@ var AddPointerViewModel = oop.extend(Paginator, {
             self.searchMyProjectsSubmitText(SEARCH_MY_PROJECTS_SUBMIT_TEXT);
         }
     },
-    addTips: function(elements) {
+    addTips: function(elements, data) {
         elements.forEach(function(element) {
-            $(element).find('.contrib-button').tooltip();
+            var titleText = '';
+            if (data.isRegistration) {
+                titleText = 'Registered: ' + data.dateRegistered.local;
+            } else {
+                titleText = 'Created: ' + data.dateCreated.local + '\nModified: ' + data.dateModified.local;
+            }
+            $(element).tooltip({
+                title: titleText
+            });
         });
     },
     add: function(data) {
         this.selection.push(data);
         // Hack: Hide and refresh tooltips
         $('.tooltip').hide();
-        $('.contrib-button').tooltip();
+        $('.pointer-row').tooltip();
     },
     remove: function(data) {
         var self = this;
@@ -118,7 +130,7 @@ var AddPointerViewModel = oop.extend(Paginator, {
         );
         // Hack: Hide and refresh tooltips
         $('.tooltip').hide();
-        $('.contrib-button').tooltip();
+        $('.pointer-row').tooltip();
     },
     addAll: function() {
         var self = this;

--- a/website/static/js/pointers.js
+++ b/website/static/js/pointers.js
@@ -75,13 +75,18 @@ var AddPointerViewModel = oop.extend(Paginator, {
             ).done(function(result) {
                 if (!result.nodes.length) {
                     self.errorMsg('No results found.');
+                } else {
+                    result.nodes.forEach(function(each) {
+                        each.dateCreated = new osfHelpers.FormattableDate(each.dateCreated);
+                        each.dateModified = new osfHelpers.FormattableDate(each.dateModified);
+                    });
                 }
                 self.results(result.nodes);
                 self.currentPage(result.page);
                 self.numberOfPages(result.pages);
                 self.addNewPaginators();
             }).fail(function(xhr) {
-                    self.searchWarningMsg(xhr.responseJSON && xhr.responseJSON.message_long);
+                self.searchWarningMsg(xhr.responseJSON && xhr.responseJSON.message_long);
             }).always( function (){
                 self.searchAllProjectsSubmitText(SEARCH_ALL_SUBMIT_TEXT);
                 self.searchMyProjectsSubmitText(SEARCH_MY_PROJECTS_SUBMIT_TEXT);

--- a/website/templates/project/modal_add_pointer.mako
+++ b/website/templates/project/modal_add_pointer.mako
@@ -47,7 +47,7 @@
                         <div class="error" data-bind="text:errorMsg"></div>
                         <table class="table table-striped">
                             <tbody data-bind="foreach:{data:results, afterRender:addTips}">
-                                <tr data-bind="if:!($root.selected($data)), tooltip: {title: 'Created: ' + $data.dateCreated.local + '\nModified: ' + $data.dateModified.local}">
+                                <tr class="pointer-row" data-bind="if:!($root.selected($data))">
                                     <td class="osf-icon-td">
                                         <a
                                                 class="btn btn-success contrib-button"
@@ -82,7 +82,7 @@
                         </div>
                         <table class="table table-striped">
                             <tbody data-bind="foreach:{data:selection, afterRender:addTips}">
-                                <tr data-bind="tooltip: {title: 'Created: ' + $data.dateCreated.local + '\nModified: ' + $data.dateModified.local}">
+                                <tr class="pointer-row">
                                     <td class="osf-icon-td">
                                         <a
                                                 class="btn btn-default contrib-button"

--- a/website/templates/project/modal_add_pointer.mako
+++ b/website/templates/project/modal_add_pointer.mako
@@ -47,11 +47,11 @@
                         <div class="error" data-bind="text:errorMsg"></div>
                         <table class="table table-striped">
                             <tbody data-bind="foreach:{data:results, afterRender:addTips}">
-                                <tr data-bind="if:!($root.selected($data))">
+                                <tr data-bind="if:!($root.selected($data)), tooltip: {title: 'Created: ' + $data.dateCreated.local + '\nModified: ' + $data.dateModified.local}">
                                     <td class="osf-icon-td">
                                         <a
                                                 class="btn btn-success contrib-button"
-                                                data-bind="click:$root.add.bind($root), tooltip: {title: 'Add link'}"
+                                                data-bind="click:$root.add.bind($root)"
                                             ><i class="fa fa-plus"></i></a>
                                     </td>
                                     <td data-bind="text:title" class="overflow"></td>
@@ -82,11 +82,11 @@
                         </div>
                         <table class="table table-striped">
                             <tbody data-bind="foreach:{data:selection, afterRender:addTips}">
-                                <tr>
+                                <tr data-bind="tooltip: {title: 'Created: ' + $data.dateCreated.local + '\nModified: ' + $data.dateModified.local}">
                                     <td class="osf-icon-td">
                                         <a
                                                 class="btn btn-default contrib-button"
-                                                data-bind="click:$root.remove.bind($root), tooltip: {title: 'Remove link'}"
+                                                data-bind="click:$root.remove.bind($root)"
                                             ><i class="fa fa-minus"></i></a>
                                     </td>
                                     <td  data-bind="text:title" class="overflow"></td>


### PR DESCRIPTION
## Purpose

The _Add Links_ modal does not distinguish between projects of the same name and author, which is particularly problematic for projects that have been registered multiple times (see screenshot).

Note that registrations have the same creation and modification date as their parent project, but have a separate registration date. This means that the "last modified" date could come before the registration date, which can be very confusing. Thus, only the registration date is shown for registrations.

## Changes
### Before
<!-- Briefly describe or list your changes  -->
![Original](https://cloud.githubusercontent.com/assets/5885378/16465038/e3c373d2-3e0a-11e6-9287-092e49db726c.png)
Revision 1:
![With tooltip](https://cloud.githubusercontent.com/assets/5885378/16465037/e3b8a664-3e0a-11e6-9dad-daa51df2734d.png)
### After (Revision 2)
<img width="442" alt="registration" src="https://cloud.githubusercontent.com/assets/5885378/16660040/c32a20c2-443a-11e6-8740-9f7979db9594.png">
<img width="443" alt="project" src="https://cloud.githubusercontent.com/assets/5885378/16660041/c32feb60-443a-11e6-8c25-8cb8ad29735f.png">
- Added tooltip conditionally displaying date created and date modified or date registered, depending on whether or not the node is a registration
- Added `dateCreated`, `dateModified`, `isRegistration`, and `dateRegistered` to `search_node` endpoint
- Removed tooltips on **+** and **-** buttons, which caused issues when two tooltips were triggered simultaneously (and are also redundant)

## Side effects

- `search_node` returns up to three additional parameters (two for registrations)
- The two removed tooltips mentioned above
- Added class `pointer-row` to node rows

## Ticket

[https://openscience.atlassian.net/browse/OSF-4046](https://openscience.atlassian.net/browse/OSF-4046)