### PR TITLE
Collections: when none show help text [OSF-6532]

### DIFF
--- a/website/static/js/myProjects.js
+++ b/website/static/js/myProjects.js
@@ -624,11 +624,11 @@ var MyProjects = {
                             'You have not made any registrations yet. Go to ',
                             m('a', {href: 'http://help.osf.io/m/registrations'}, 'Getting Started'), ' to learn how registrations work.' );
                     } else {
-                        template = 'This collection is empty.';
+                        var helpText = 'This collection is empty.';
                         if (!self.viewOnly) {
-                            template +=' To add projects or registrations, click "All my projects" or "All my registrations" in the sidebar, and then drag and drop items into the collection link.';
+                            helpText +=' To add projects or registrations, click "All my projects" or "All my registrations" in the sidebar, and then drag and drop items into the collection link.';
                         }
-                        template = m('.db-non-load-template.m-md.p-md.osf-box', template);
+                        template = m('.db-non-load-template.m-md.p-md.osf-box', helpText);
                     }
                 } else {
                     if(!self.currentView().fetcher.isEmpty()){

--- a/website/static/js/myProjects.js
+++ b/website/static/js/myProjects.js
@@ -624,8 +624,11 @@ var MyProjects = {
                             'You have not made any registrations yet. Go to ',
                             m('a', {href: 'http://help.osf.io/m/registrations'}, 'Getting Started'), ' to learn how registrations work.' );
                     } else {
-                        template = m('.db-non-load-template.m-md.p-md.osf-box',
-                            'This collection is empty.' + self.viewOnly ? '' : ' To add projects or registrations, click "All my projects" or "All my registrations" in the sidebar, and then drag and drop items into the collection link.');
+                        template = 'This collection is empty.';
+                        if (!self.viewOnly) {
+                            template +=' To add projects or registrations, click "All my projects" or "All my registrations" in the sidebar, and then drag and drop items into the collection link.';
+                        }
+                        template = m('.db-non-load-template.m-md.p-md.osf-box', template);
                     }
                 } else {
                     if(!self.currentView().fetcher.isEmpty()){

--- a/website/static/js/myProjects.js
+++ b/website/static/js/myProjects.js
@@ -623,10 +623,12 @@ var MyProjects = {
                         template = m('.db-non-load-template.m-md.p-md.osf-box',
                             'You have not made any registrations yet. Go to ',
                             m('a', {href: 'http://help.osf.io/m/registrations'}, 'Getting Started'), ' to learn how registrations work.' );
+                    } else if (lastcrumb.data.node.attributes && lastcrumb.data.node.attributes.bookmarks) {
+                        template = m('.db-non-load-template.m-md.p-md.osf-box', 'You have no bookmarks. You can add projects or registrations by dragging them into your bookmarks or by clicking the Add to Bookmark button on the project or registration.');
                     } else {
                         var helpText = 'This collection is empty.';
                         if (!self.viewOnly) {
-                            helpText +=' To add projects or registrations, click "All my projects" or "All my registrations" in the sidebar, and then drag and drop items into the collection link.';
+                            helpText +=' You can add projects or registrations by dragging them into the collection.';
                         }
                         template = m('.db-non-load-template.m-md.p-md.osf-box', helpText);
                     }


### PR DESCRIPTION
## Purpose

There was no help text for empty collections besides "All my projects" and "All my registrations," which left an empty box in the view. Turns out this text existed but did not show due to an oversight in using the ternary operator; adding the string to the boolean occurred first, which always returned true.

## Changes
![help text](https://cloud.githubusercontent.com/assets/5885378/16490658/a92db054-3ea8-11e6-83e3-7d2853a84e3a.png)

- Restored existing help text to working order
 - Altered `nonLoadTemplate` logic
- Added specific help text for bookmarks

## Side effects

None.


## Ticket

https://openscience.atlassian.net/browse/OSF-6532