### PR TITLE
unconfigured add-ons display widget to non-contributors [OSF-4161]

### DIFF
--- a/website/templates/project/addon/widget.mako
+++ b/website/templates/project/addon/widget.mako
@@ -1,5 +1,5 @@
-<div class="panel panel-default" name="${short_name}">
-
+% if complete or 'write' in user['permissions']:
+    <div class="panel panel-default" name="${short_name}" id="div">
             <div class="panel-heading clearfix">
                 <h3 class="panel-title">${full_name}</h3>
                 <div class="pull-right">
@@ -9,6 +9,9 @@
 
                 </div>
             </div>
+    % else:
+        <div>
+    % endif
 
     % if complete:
 
@@ -16,7 +19,7 @@
             ${self.body()}
         </div>
 
-    % else:
+    % elif not complete and 'admin' in user['permissions']:
 
         <div mod-meta='{
                 "tpl": "project/addon/config_error.mako",

--- a/website/templates/project/addon/widget.mako
+++ b/website/templates/project/addon/widget.mako
@@ -19,7 +19,7 @@
             ${self.body()}
         </div>
 
-    % elif not complete and 'admin' in user['permissions']:
+    % elif not complete and 'write' in user['permissions']:
 
         <div mod-meta='{
                 "tpl": "project/addon/config_error.mako",

--- a/website/templates/project/addon/widget.mako
+++ b/website/templates/project/addon/widget.mako
@@ -1,24 +1,18 @@
 % if complete or 'write' in user['permissions']:
     <div class="panel panel-default" name="${short_name}">
-
-                <div class="panel-heading clearfix">
-                    <h3 class="panel-title">${full_name}</h3>
-                    <div class="pull-right">
-                        % if has_page:
-                           <a href="${node['url']}${short_name}/">  <i class="fa fa-external-link"></i> </a>
-                       % endif
-
-                    </div>
-                </div>
-
+        <div class="panel-heading clearfix">
+            <h3 class="panel-title">${full_name}</h3>
+            <div class="pull-right">
+                % if has_page:
+                   <a href="${node['url']}${short_name}/">  <i class="fa fa-external-link"></i> </a>
+               % endif
+            </div>
+        </div>
         % if complete:
-
             <div class="panel-body">
                 ${self.body()}
             </div>
-
         % else:
-
             <div mod-meta='{
                     "tpl": "project/addon/config_error.mako",
                     "kwargs": {
@@ -26,8 +20,6 @@
                         "full_name": "${full_name}"
                     }
                 }'></div>
-
         % endif
-
     </div>
 % endif

--- a/website/templates/project/addon/widget.mako
+++ b/website/templates/project/addon/widget.mako
@@ -1,34 +1,33 @@
 % if complete or 'write' in user['permissions']:
-    <div class="panel panel-default" name="${short_name}" id="div">
-            <div class="panel-heading clearfix">
-                <h3 class="panel-title">${full_name}</h3>
-                <div class="pull-right">
-                    % if has_page:
-                       <a href="${node['url']}${short_name}/">  <i class="fa fa-external-link"></i> </a>
-                   % endif
+    <div class="panel panel-default" name="${short_name}">
 
+                <div class="panel-heading clearfix">
+                    <h3 class="panel-title">${full_name}</h3>
+                    <div class="pull-right">
+                        % if has_page:
+                           <a href="${node['url']}${short_name}/">  <i class="fa fa-external-link"></i> </a>
+                       % endif
+
+                    </div>
                 </div>
+
+        % if complete:
+
+            <div class="panel-body">
+                ${self.body()}
             </div>
-    % else:
-        <div>
-    % endif
 
-    % if complete:
+        % else:
 
-        <div class="panel-body">
-            ${self.body()}
-        </div>
+            <div mod-meta='{
+                    "tpl": "project/addon/config_error.mako",
+                    "kwargs": {
+                        "short_name": "${short_name}",
+                        "full_name": "${full_name}"
+                    }
+                }'></div>
 
-    % elif not complete and 'write' in user['permissions']:
+        % endif
 
-        <div mod-meta='{
-                "tpl": "project/addon/config_error.mako",
-                "kwargs": {
-                    "short_name": "${short_name}",
-                    "full_name": "${full_name}"
-                }
-            }'></div>
-
-    % endif
-
-</div>
+    </div>
+% endif


### PR DESCRIPTION
## Purpose

Unconfigured add-ons show up in widgets to viewers that cannot edit add-ons. This provides redundant information to typical users.

## Changes
Using an unconfigured add-on:
![unconfigured addon](https://cloud.githubusercontent.com/assets/5885378/16492158/cbb3c0a4-3eae-11e6-998f-78aa1bfc8f84.png)
![hidden widget](https://cloud.githubusercontent.com/assets/5885378/16492159/cbbe32e6-3eae-11e6-808e-3fa36a5ca8bd.png)
- Render widget only if add-on is configured or if the viewer has the ability to edit it.


## Side effects

None.

## Ticket

https://openscience.atlassian.net/browse/OSF-4161