### PR TITLE
[feature] Concatenate contributor ids

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -212,10 +212,13 @@ class IDField(ser.CharField):
         request = self.context.get('request')
         if request:
             if request.method in utils.UPDATE_METHODS and not utils.is_bulk_request(request):
-                id_field = getattr(self.root.instance, self.source, '_id')
+                id_field = self.get_id(self.root.instance)
                 if id_field != data:
                     raise Conflict(detail=('The id you used in the URL, "{}", does not match the id you used in the json body\'s id field, "{}". The object "{}" exists, otherwise you\'d get a 404, so most likely you need to change the id field to match.'.format(id_field, data, id_field)))
         return super(IDField, self).to_internal_value(data)
+
+    def get_id(self, obj):
+        return getattr(obj, self.source, '_id')
 
 
 class TypeField(ser.CharField):

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -506,7 +506,7 @@ class NodeContributorsSerializer(JSONAPISerializer):
     def get_id(self, obj):
         node_id = self.context['request'].parser_context['kwargs']['node_id']
         user_id = obj._id
-        return node_id + user_id
+        return '{}-{}'.format(node_id, user_id)
 
     def get_absolute_url(self, obj):
         node_id = self.context['request'].parser_context['kwargs']['node_id']

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -480,7 +480,7 @@ class NodeContributorsSerializer(JSONAPISerializer):
         'permission'
     ])
 
-    id = IDField(source='_id', required=True)
+    id = ser.SerializerMethodField()
     type = TypeField()
 
     bibliographic = ser.BooleanField(help_text='Whether the user will be included in citations for this node or not.',
@@ -502,6 +502,11 @@ class NodeContributorsSerializer(JSONAPISerializer):
 
     class Meta:
         type_ = 'contributors'
+
+    def get_id(self, obj):
+        node_id = self.context['request'].parser_context['kwargs']['node_id']
+        user_id = obj._id
+        return node_id + user_id
 
     def get_absolute_url(self, obj):
         node_id = self.context['request'].parser_context['kwargs']['node_id']

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -471,17 +471,25 @@ class NodeForksSerializer(NodeSerializer):
 
 
 class ContributorIDField(IDField):
-    """ID field to use with the contributor resources. Contributor IDs have the form "<node-id>-<user-id>"."""
+    """ID field to use with the contributor resource. Contributor IDs have the form "<node-id>-<user-id>"."""
 
     def __init__(self, *args, **kwargs):
         kwargs['source'] = kwargs.pop('source', '_id')
         kwargs['help_text'] = kwargs.get('help_text', 'Unique contributor ID. Has the form "<node-id>-<user-id>". Example: "abc12-xyz34"')
         super(ContributorIDField, self).__init__(*args, **kwargs)
 
+    def _get_node_id(self):
+        return self.context['request'].parser_context['kwargs']['node_id']
+
     # override IDField
     def get_id(self, obj):
-        node_id = self.context['request'].parser_context['kwargs']['node_id']
+        node_id = self._get_node_id()
         user_id = obj._id
+        return '{}-{}'.format(node_id, user_id)
+
+    def to_representation(self, value):
+        node_id = self._get_node_id()
+        user_id = super(ContributorIDField, self).to_representation(value)
         return '{}-{}'.format(node_id, user_id)
 
 

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -470,6 +470,21 @@ class NodeForksSerializer(NodeSerializer):
         return fork
 
 
+class ContributorIDField(IDField):
+    """ID field to use with the contributor resources. Contributor IDs have the form "<node-id>-<user-id>"."""
+
+    def __init__(self, *args, **kwargs):
+        kwargs['source'] = kwargs.pop('source', '_id')
+        kwargs['help_text'] = kwargs.get('help_text', 'Unique contributor ID. Has the form "<node-id>-<user-id>". Example: "abc12-xyz34"')
+        super(ContributorIDField, self).__init__(*args, **kwargs)
+
+    # override IDField
+    def get_id(self, obj):
+        node_id = self.context['request'].parser_context['kwargs']['node_id']
+        user_id = obj._id
+        return '{}-{}'.format(node_id, user_id)
+
+
 class NodeContributorsSerializer(JSONAPISerializer):
     """ Separate from UserSerializer due to necessity to override almost every field as read only
     """
@@ -480,7 +495,7 @@ class NodeContributorsSerializer(JSONAPISerializer):
         'permission'
     ])
 
-    id = ser.SerializerMethodField()
+    id = ContributorIDField(read_only=True)
     type = TypeField()
 
     bibliographic = ser.BooleanField(help_text='Whether the user will be included in citations for this node or not.',
@@ -503,11 +518,6 @@ class NodeContributorsSerializer(JSONAPISerializer):
     class Meta:
         type_ = 'contributors'
 
-    def get_id(self, obj):
-        node_id = self.context['request'].parser_context['kwargs']['node_id']
-        user_id = obj._id
-        return '{}-{}'.format(node_id, user_id)
-
     def get_absolute_url(self, obj):
         node_id = self.context['request'].parser_context['kwargs']['node_id']
         return absolute_reverse(
@@ -527,7 +537,7 @@ class NodeContributorsCreateSerializer(NodeContributorsSerializer):
     """
     Overrides NodeContributorsSerializer to add target_type and required id field
     """
-    id = IDField(source='_id', required=True)
+    id = ContributorIDField(required=True)
     target_type = TargetTypeField(target_type='users')
 
     def create(self, validated_data):
@@ -546,12 +556,11 @@ class NodeContributorsCreateSerializer(NodeContributorsSerializer):
         contributor.node_id = node._id
         return contributor
 
-
 class NodeContributorDetailSerializer(NodeContributorsSerializer):
     """
     Overrides node contributor serializer to add additional methods
     """
-    id = IDField(source='_id', required=True)
+    id = ContributorIDField(required=True)
 
     def update(self, instance, validated_data):
         contributor = instance

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -525,8 +525,9 @@ class NodeContributorsSerializer(JSONAPISerializer):
 
 class NodeContributorsCreateSerializer(NodeContributorsSerializer):
     """
-    Overrides NodeContributorsSerializer to add target_type field
+    Overrides NodeContributorsSerializer to add target_type and required id field
     """
+    id = IDField(source='_id', required=True)
     target_type = TargetTypeField(target_type='users')
 
     def create(self, validated_data):

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -551,6 +551,7 @@ class NodeContributorDetailSerializer(NodeContributorsSerializer):
     """
     Overrides node contributor serializer to add additional methods
     """
+    id = IDField(source='_id', required=True)
 
     def update(self, instance, validated_data):
         contributor = instance

--- a/api_tests/nodes/views/test_node_contributors_detail.py
+++ b/api_tests/nodes/views/test_node_contributors_detail.py
@@ -145,6 +145,21 @@ class TestNodeContributorUpdate(ApiTestCase):
         res = self.app.put_json_api(self.url_contributor, data, auth=self.user.auth, expect_errors=True)
         assert_equal(res.status_code, 400)
 
+    def test_change_contributor_correct_id(self):
+        contrib_id = '{}-{}'.format(self.project._id, self.user_two._id)
+        data = {
+            'data': {
+                'id': contrib_id,
+                'type': 'contributors',
+                'attributes': {
+                    'permission': permissions.ADMIN,
+                    'bibliographic': True
+                }
+            }
+        }
+        res = self.app.put_json_api(self.url_contributor, data, auth=self.user.auth, expect_errors=True)
+        assert_equal(res.status_code, 200)
+
     def test_change_contributor_incorrect_id(self):
         data = {
             'data': {
@@ -160,9 +175,10 @@ class TestNodeContributorUpdate(ApiTestCase):
         assert_equal(res.status_code, 409)
 
     def test_change_contributor_no_type(self):
+        contrib_id = '{}-{}'.format(self.project._id, self.user_two._id)
         data = {
             'data': {
-                'id': self.user_two._id,
+                'id': contrib_id,
                 'attributes': {
                     'permission': permissions.ADMIN,
                     'bibliographic': True
@@ -191,9 +207,10 @@ class TestNodeContributorUpdate(ApiTestCase):
     @assert_logs(NodeLog.PERMISSIONS_UPDATED, 'project', -2)
     @assert_logs(NodeLog.PERMISSIONS_UPDATED, 'project')
     def test_change_contributor_permissions(self):
+        contrib_id = '{}-{}'.format(self.project._id, self.user_two._id)
         data = {
             'data': {
-                'id': self.user_two._id,
+                'id': contrib_id,
                 'type': 'contributors',
                 'attributes': {
                     'permission': permissions.ADMIN,
@@ -211,7 +228,7 @@ class TestNodeContributorUpdate(ApiTestCase):
 
         data = {
             'data': {
-                'id': self.user_two._id,
+                'id': contrib_id,
                 'type': 'contributors',
                 'attributes': {
                     'permission': permissions.WRITE,
@@ -229,7 +246,7 @@ class TestNodeContributorUpdate(ApiTestCase):
 
         data = {
             'data': {
-                'id': self.user_two._id,
+                'id': contrib_id,
                 'type': 'contributors',
                 'attributes': {
                     'permission': permissions.READ,
@@ -248,9 +265,10 @@ class TestNodeContributorUpdate(ApiTestCase):
     @assert_logs(NodeLog.MADE_CONTRIBUTOR_INVISIBLE, 'project', -2)
     @assert_logs(NodeLog.MADE_CONTRIBUTOR_VISIBLE, 'project')
     def test_change_contributor_bibliographic(self):
+        contrib_id = '{}-{}'.format(self.project._id, self.user_two._id)
         data = {
             'data': {
-                'id': self.user_two._id,
+                'id': contrib_id,
                 'type': 'contributors',
                 'attributes': {
                     'bibliographic': False
@@ -267,7 +285,7 @@ class TestNodeContributorUpdate(ApiTestCase):
 
         data = {
             'data': {
-                'id': self.user_two._id,
+                'id': contrib_id,
                 'type': 'contributors',
                 'attributes': {
                     'bibliographic': True
@@ -285,9 +303,10 @@ class TestNodeContributorUpdate(ApiTestCase):
     @assert_logs(NodeLog.PERMISSIONS_UPDATED, 'project', -2)
     @assert_logs(NodeLog.MADE_CONTRIBUTOR_INVISIBLE, 'project')
     def test_change_contributor_permission_and_bibliographic(self):
+        contrib_id = '{}-{}'.format(self.project._id, self.user_two._id)
         data = {
             'data': {
-                'id': self.user_two._id,
+                'id': contrib_id,
                 'type': 'contributors',
                 'attributes': {
                     'permission': permissions.READ,
@@ -307,9 +326,10 @@ class TestNodeContributorUpdate(ApiTestCase):
 
     @assert_not_logs(NodeLog.PERMISSIONS_UPDATED, 'project')
     def test_not_change_contributor(self):
+        contrib_id = '{}-{}'.format(self.project._id, self.user_two._id)
         data = {
             'data': {
-                'id': self.user_two._id,
+                'id': contrib_id,
                 'type': 'contributors',
                 'attributes': {
                     'permission': None,
@@ -328,9 +348,10 @@ class TestNodeContributorUpdate(ApiTestCase):
         assert_true(self.project.get_visible(self.user_two))
 
     def test_invalid_change_inputs_contributor(self):
+        contrib_id = '{}-{}'.format(self.project._id, self.user_two._id)
         data = {
             'data': {
-                'id': self.user_two._id,
+                'id': contrib_id,
                 'type': 'contributors',
                 'attributes': {
                     'permission': 'invalid',
@@ -346,9 +367,10 @@ class TestNodeContributorUpdate(ApiTestCase):
     @assert_logs(NodeLog.PERMISSIONS_UPDATED, 'project')
     def test_change_admin_self_with_other_admin(self):
         self.project.add_permission(self.user_two, permissions.ADMIN, save=True)
+        contrib_id = '{}-{}'.format(self.project._id, self.user._id)
         data = {
             'data': {
-                'id': self.user._id,
+                'id': contrib_id,
                 'type': 'contributors',
                 'attributes': {
                     'permission': permissions.WRITE,
@@ -365,9 +387,10 @@ class TestNodeContributorUpdate(ApiTestCase):
         assert_equal(self.project.get_permissions(self.user), [permissions.READ, permissions.WRITE])
 
     def test_change_admin_self_without_other_admin(self):
+        contrib_id = '{}-{}'.format(self.project._id, self.user._id)
         data = {
             'data': {
-                'id': self.user._id,
+                'id': contrib_id,
                 'type': 'contributors',
                 'attributes': {
                     'permission': permissions.WRITE,
@@ -383,9 +406,10 @@ class TestNodeContributorUpdate(ApiTestCase):
 
     def test_remove_all_bibliographic_statuses_contributors(self):
         self.project.set_visible(self.user_two, False, save=True)
+        contrib_id = '{}-{}'.format(self.project._id, self.user._id)
         data = {
             'data': {
-                'id': self.user._id,
+                'id': contrib_id,
                 'type': 'contributors',
                 'attributes': {
                     'bibliographic': False

--- a/api_tests/nodes/views/test_node_contributors_detail.py
+++ b/api_tests/nodes/views/test_node_contributors_detail.py
@@ -68,12 +68,12 @@ class TestContributorDetail(NodeCRUDTestCase):
     def test_get_public_contributor_detail(self):
         res = self.app.get(self.public_url)
         assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['id'], self.user._id)
+        assert_equal(res.json['data']['id'], '{}-{}'.format(self.public_project._id, self.user._id))
 
     def test_get_private_node_contributor_detail_contributor_auth(self):
         res = self.app.get(self.private_url, auth=self.user.auth)
         assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['id'], self.user._id)
+        assert_equal(res.json['data']['id'], '{}-{}'.format(self.private_project, self.user._id))
 
     def test_get_private_node_contributor_detail_non_contributor(self):
         res = self.app.get(self.private_url, auth=self.user_two.auth, expect_errors=True)

--- a/api_tests/nodes/views/test_node_contributors_list.py
+++ b/api_tests/nodes/views/test_node_contributors_list.py
@@ -57,6 +57,8 @@ def make_node_payload(node, attributes):
         }
     }
 
+def make_contrib_id(node_id, user_id):
+    return '{}-{}'.format(node_id, user_id)
 
 class TestNodeContributorList(NodeCRUDTestCase):
 
@@ -65,6 +67,12 @@ class TestNodeContributorList(NodeCRUDTestCase):
         self.private_url = '/{}nodes/{}/contributors/'.format(API_BASE, self.private_project._id)
         self.public_url = '/{}nodes/{}/contributors/'.format(API_BASE, self.public_project._id)
 
+    def test_concatenated_id(self):
+        res = self.app.get(self.public_url)
+        assert_equal(res.status_code, 200)
+
+        assert_equal(res.json['data'][0]['id'].split('-')[0], self.public_project._id)
+        assert_equal(res.json['data'][0]['id'].split('-')[1], self.user._id)
 
     def test_return_public_contributor_list_logged_out(self):
         self.public_project.add_contributor(self.user_two, save=True)
@@ -73,15 +81,15 @@ class TestNodeContributorList(NodeCRUDTestCase):
         assert_equal(res.status_code, 200)
         assert_equal(res.content_type, 'application/vnd.api+json')
         assert_equal(len(res.json['data']), 2)
-        assert_equal(res.json['data'][0]['id'], self.user._id)
-        assert_equal(res.json['data'][1]['id'], self.user_two._id)
+        assert_equal(res.json['data'][0]['id'], make_contrib_id(self.public_project._id, self.user._id))
+        assert_equal(res.json['data'][1]['id'], make_contrib_id(self.public_project._id, self.user_two._id))
 
     def test_return_public_contributor_list_logged_in(self):
         res = self.app.get(self.public_url, auth=self.user_two.auth)
         assert_equal(res.status_code, 200)
         assert_equal(res.content_type, 'application/vnd.api+json')
         assert_equal(len(res.json['data']), 1)
-        assert_equal(res.json['data'][0]['id'], self.user._id)
+        assert_equal(res.json['data'][0]['id'], make_contrib_id(self.public_project._id, self.user._id))
 
     def test_return_private_contributor_list_logged_out(self):
         res = self.app.get(self.private_url, expect_errors=True)
@@ -96,8 +104,8 @@ class TestNodeContributorList(NodeCRUDTestCase):
         assert_equal(res.status_code, 200)
         assert_equal(res.content_type, 'application/vnd.api+json')
         assert_equal(len(res.json['data']), 2)
-        assert_equal(res.json['data'][0]['id'], self.user._id)
-        assert_equal(res.json['data'][1]['id'], self.user_two._id)
+        assert_equal(res.json['data'][0]['id'], make_contrib_id(self.private_project._id, self.user._id))
+        assert_equal(res.json['data'][1]['id'], make_contrib_id(self.private_project._id, self.user_two._id))
 
     def test_return_private_contributor_list_logged_in_non_contributor(self):
         res = self.app.get(self.private_url, auth=self.user_two.auth, expect_errors=True)
@@ -131,8 +139,8 @@ class TestNodeContributorList(NodeCRUDTestCase):
         assert_equal(res.status_code, 200)
         assert_equal(res.content_type, 'application/vnd.api+json')
         assert_equal(len(res.json['data']), 2)
-        assert_equal(res.json['data'][0]['id'], self.user._id)
-        assert_equal(res.json['data'][1]['id'], self.user_two._id)
+        assert_equal(res.json['data'][0]['id'], make_contrib_id(self.public_project._id, self.user._id))
+        assert_equal(res.json['data'][1]['id'], make_contrib_id(self.public_project._id, self.user_two._id))
         assert_equal(res.json['data'][1]['embeds']['users']['errors'][0]['meta']['full_name'], self.user_two.fullname)
         assert_equal(res.json['data'][1]['embeds']['users']['errors'][0]['detail'], 'The requested user is no longer available.')
 

--- a/api_tests/nodes/views/test_node_contributors_list.py
+++ b/api_tests/nodes/views/test_node_contributors_list.py
@@ -504,7 +504,7 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
         del self.data_user_two['data']['attributes']['bibliographic']
         res = self.app.post_json_api(self.public_url, self.data_user_two, auth=self.user.auth, expect_errors=True)
         assert_equal(res.status_code, 201)
-        assert_equal(res.json['data']['id'], self.user_two._id)
+        assert_equal(res.json['data']['id'], '{}-{}'.format(self.public_project, self.user_two._id))
 
         self.public_project.reload()
         assert_in(self.user_two, self.public_project.contributors)
@@ -514,7 +514,7 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
     def test_adds_bibliographic_contributor_public_project_admin(self):
         res = self.app.post_json_api(self.public_url, self.data_user_two, auth=self.user.auth)
         assert_equal(res.status_code, 201)
-        assert_equal(res.json['data']['id'], self.user_two._id)
+        assert_equal(res.json['data']['id'], '{}-{}'.format(self.public_project, self.user_two._id))
 
         self.public_project.reload()
         assert_in(self.user_two, self.public_project.contributors)
@@ -539,7 +539,7 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
         }
         res = self.app.post_json_api(self.private_url, data, auth=self.user.auth, expect_errors=True)
         assert_equal(res.status_code, 201)
-        assert_equal(res.json['data']['id'], self.user_two._id)
+        assert_equal(res.json['data']['id'], '{}-{}'.format(self.private_project, self.user_two._id))
         assert_equal(res.json['data']['attributes']['bibliographic'], False)
 
         self.private_project.reload()
@@ -569,7 +569,7 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
     def test_adds_contributor_private_project_admin(self):
         res = self.app.post_json_api(self.private_url, self.data_user_two, auth=self.user.auth)
         assert_equal(res.status_code, 201)
-        assert_equal(res.json['data']['id'], self.user_two._id)
+        assert_equal(res.json['data']['id'], '{}-{}'.format(self.private_project, self.user_two._id))
 
         self.private_project.reload()
         assert_in(self.user_two, self.private_project.contributors)
@@ -618,7 +618,7 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
         }
         res = self.app.post_json_api(self.private_url, data, auth=self.user.auth)
         assert_equal(res.status_code, 201)
-        assert_equal(res.json['data']['id'], self.user_two._id)
+        assert_equal(res.json['data']['id'], '{}-{}'.format(self.private_project, self.user_two._id))
 
         self.private_project.reload()
         assert_in(self.user_two, self.private_project.contributors)
@@ -645,7 +645,7 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
         }
         res = self.app.post_json_api(self.private_url, data, auth=self.user.auth)
         assert_equal(res.status_code, 201)
-        assert_equal(res.json['data']['id'], self.user_two._id)
+        assert_equal(res.json['data']['id'], '{}-{}'.format(self.private_project, self.user_two._id))
 
         self.private_project.reload()
         assert_in(self.user_two, self.private_project.contributors)
@@ -672,7 +672,7 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
         }
         res = self.app.post_json_api(self.private_url, data, auth=self.user.auth)
         assert_equal(res.status_code, 201)
-        assert_equal(res.json['data']['id'], self.user_two._id)
+        assert_equal(res.json['data']['id'], '{}-{}'.format(self.private_project, self.user_two._id))
 
         self.private_project.reload()
         assert_in(self.user_two, self.private_project.contributors)

--- a/api_tests/nodes/views/test_node_embeds.py
+++ b/api_tests/nodes/views/test_node_embeds.py
@@ -60,6 +60,7 @@ class TestNodeEmbeds(ApiTestCase):
         res = self.app.get(url, auth=self.user.auth)
         embeds = res.json['data']['embeds']
         ids = [c._id for c in self.contribs] + [self.user._id]
+        ids = ['{}-{}'.format(self.child1._id, id_) for id_ in ids]
         for contrib in embeds['contributors']['data']:
             assert_in(contrib['id'], ids)
 

--- a/api_tests/nodes/views/test_node_list.py
+++ b/api_tests/nodes/views/test_node_list.py
@@ -1837,6 +1837,8 @@ class TestNodeListPagination(ApiTestCase):
 
         uids = [e['id'] for e in res.json['data'][0]['embeds']['contributors']['data']]
         for user in self.users[:9]:
-            assert_in(user._id, uids)
-        assert_not_in(self.users[10]._id, uids)
+            contrib_id = '{}-{}'.format(res.json['data'][0]['id'], user._id)
+            assert_in(contrib_id, uids)
+
+        assert_not_in('{}-{}'.format(res.json['data'][0]['id'], self.users[10]._id), uids)
         assert_equal(res.json['data'][0]['embeds']['contributors']['links']['meta']['per_page'], 10)

--- a/api_tests/nodes/views/test_view_only_query_parameter.py
+++ b/api_tests/nodes/views/test_view_only_query_parameter.py
@@ -91,7 +91,7 @@ class TestNodeDetailViewOnlyLinks(ViewOnlyTestCase):
         assert_equal(res.status_code, 200)
         contributors = res.json['data']['embeds']['contributors']['data']
         for contributor in contributors:
-            assert_in(contributor['id'], self.valid_contributors)
+            assert_in(contributor['id'].split('-')[1], self.valid_contributors)
 
     def test_private_node_logged_in_with_anonymous_link_does_not_expose_contributor_id(self):
         res = self.app.get(self.private_node_one_url, {
@@ -101,7 +101,7 @@ class TestNodeDetailViewOnlyLinks(ViewOnlyTestCase):
         assert_equal(res.status_code, 200)
         contributors = res.json['data']['embeds']['contributors']['data']
         for contributor in contributors:
-            assert_in(contributor['id'], self.valid_contributors)
+            assert_in(contributor['id'].split('-')[1], self.valid_contributors)
 
     def test_public_node_with_link_anonymous_does_not_expose_user_id(self):
         res = self.app.get(self.public_node_one_url, {
@@ -121,7 +121,7 @@ class TestNodeDetailViewOnlyLinks(ViewOnlyTestCase):
         assert_equal(res.status_code, 200)
         contributors = res.json['data']['embeds']['contributors']['data']
         for contributor in contributors:
-            assert_in(contributor['id'], self.valid_contributors)
+            assert_in(contributor['id'].split('-')[1], self.valid_contributors)
 
     def test_public_node_with_link_unused_does_expose_contributor_id(self):
         res = self.app.get(self.public_node_one_url, {
@@ -130,7 +130,7 @@ class TestNodeDetailViewOnlyLinks(ViewOnlyTestCase):
         assert_equal(res.status_code, 200)
         contributors = res.json['data']['embeds']['contributors']['data']
         for contributor in contributors:
-            assert_in(contributor['id'], self.valid_contributors)
+            assert_in(contributor['id'].split('-')[1], self.valid_contributors)
 
     def test_view_only_link_does_not_grant_write_permission(self):
         payload = {
@@ -228,5 +228,5 @@ class TestNodeListViewOnlyLinks(ViewOnlyTestCase):
             contributors = node['embeds']['contributors']['data']
             for contributor in contributors:
                 assertions += 1
-                assert_in(contributor['id'], self.valid_contributors)
+                assert_in(contributor['id'].split('-')[1], self.valid_contributors)
         assert_not_equal(assertions, 0)

--- a/api_tests/registrations/views/test_registration_embeds.py
+++ b/api_tests/registrations/views/test_registration_embeds.py
@@ -52,6 +52,7 @@ class TestRegistrationEmbeds(ApiTestCase):
         res = self.app.get(url, auth=self.user.auth)
         embeds = res.json['data']['embeds']
         ids = [c._id for c in self.contribs] + [self.user._id]
+        ids = ['{}-{}'.format(self.registration._id, id_) for id_ in ids]
         for contrib in embeds['contributors']['data']:
             assert_in(contrib['id'], ids)
 


### PR DESCRIPTION
Replaces #5824 

--------------------

## Part of https://github.com/CenterForOpenScience/ember-osf/pull/59

## Purpose
Contributors don't have guids, so it used the id of the user, beign unique for user per node. However that becomes a problem if you look for the ocntributor data universally, as missing the node information will lead to duplicate results (problems encountered in ember-osf). New ids for contributors are unique, and are concatenations of user and node ids.

## Changes
Contributor ids are now a concatenation of node id and user id, separated by `-`


## Ticket

https://openscience.atlassian.net/browse/OSF-6490