### PR TITLE
Resize Wiki Edit Page Error

### DIFF
--- a/website/addons/wiki/templates/edit.mako
+++ b/website/addons/wiki/templates/edit.mako
@@ -75,9 +75,9 @@
                style="${'' if 'view' in panels_used else 'display: none'}">
               <div class="osf-panel panel panel-default no-border" data-bind="css: { 'no-border reset-height': $root.singleVis() === 'view', 'osf-panel-flex': $root.singleVis() !== 'view' }">
                 <div class="panel-heading wiki-panel-header wiki-single-heading" data-bind="css: { 'osf-panel-heading-flex': $root.singleVis() !== 'view', 'wiki-single-heading': $root.singleVis() === 'view' }">
-                    <div class="row">
-                        <div class="col-sm-4">
-                            <span class="panel-title" > <i class="fa fa-eye"> </i>  View</span>
+                    <div class="row wiki-view-icon-container">
+                        <div class="col-lg-4">
+                            <div class="panel-title" > <i class="fa fa-eye"> </i>  View</div>
                         </div>
                         <div class="col-sm-8">
 

--- a/website/static/css/pages/wiki-page.css
+++ b/website/static/css/pages/wiki-page.css
@@ -221,6 +221,15 @@
     -ms-flex: 0 0 auto;
     flex: 0 0 auto;
 }
+.wiki-view-icon-container  /* this keeps the container of the view icon and dropdown responsive */
+{
+    position: relative;
+    top: 50%;
+    transform: translateY(-50%);
+    -ms-transform: translateY(-50%);
+    -webkit-transform: translateY(-50%);
+    -moz-transform: translateY(-50%);
+}
 .wmd-button-bar {
     width: 100%;
     background-color: Silver;


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

This PR edits the bootstrap styling of the view panel on the edit wiki page so that, on collapse, the buttons and labels stay within the container and aligned properly. 

## Changes

- Changed small column to large column so that content collapses at an earlier breakpoint

## Side effects

-Adding more buttons in the panel may cause it to break yet again.


## Ticket

https://openscience.atlassian.net/browse/OSF-5966

