### PR TITLE
[Hotfix] Register External Links [OSF-6518]

### DIFF
--- a/addons.json
+++ b/addons.json
@@ -20,6 +20,7 @@
         "dataverse": "partial",
         "dropbox": "partial",
         "figshare": "partial",
+        "forward": "full",
         "googledrive": "partial",
         "github": "partial",
         "s3": "partial",

--- a/tests/test_registrations/test_archiver.py
+++ b/tests/test_registrations/test_archiver.py
@@ -383,8 +383,8 @@ class TestStorageAddonBase(ArchiverTestCase):
         self._test__get_file_tree(addon_short_name)
 
     def test_addons(self):
-        #  Test that each addon in settings.ADDONS_ARCHIVABLE other than wiki implementes the StorageAddonBase interface
-        for addon in [a for a in settings.ADDONS_ARCHIVABLE if a not in ['wiki']]:
+        #  Test that each addon in settings.ADDONS_ARCHIVABLE other than wiki/forward implements the StorageAddonBase interface
+        for addon in [a for a in settings.ADDONS_ARCHIVABLE if a not in ['wiki', 'forward']]:
             self._test_addon(addon)
 
 class TestArchiverTasks(ArchiverTestCase):

--- a/website/addons/forward/model.py
+++ b/website/addons/forward/model.py
@@ -29,6 +29,14 @@ class ForwardNodeSettings(AddonNodeSettingsBase):
         self.url = None
         self.label = None
 
+    def after_register(self, node, registration, user, save=True):
+        clone = self.clone()
+        clone.owner = registration
+        clone.on_add()
+        clone.save()
+
+        return clone, None
+
 
 @ForwardNodeSettings.subscribe('before_save')
 def validate_circular_reference(schema, instance):

--- a/website/addons/forward/tests/test_models.py
+++ b/website/addons/forward/tests/test_models.py
@@ -5,8 +5,24 @@ from nose.tools import *  # PEP8 asserts
 from modularodm.exceptions import ValidationError
 
 from tests.base import OsfTestCase
+from tests.factories import ProjectFactory, RegistrationFactory
 from website.addons.forward.tests.factories import ForwardSettingsFactory
 
+
+class TestNodeSettings(OsfTestCase):
+
+    def setUp(self):
+        super(TestNodeSettings, self).setUp()
+        self.node = ProjectFactory()
+        self.settings = ForwardSettingsFactory(owner=self.node)
+        self.node.save()
+
+    def test_forward_registered(self):
+        registration = RegistrationFactory(project=self.node)
+        assert registration.has_addon('forward')
+        
+        forward = registration.get_addon('forward')
+        assert_equal(forward.url, 'http://frozen.pizza.reviews/')
 
 class TestSettingsValidation(OsfTestCase):
 


### PR DESCRIPTION
## Purpose
From ticket:
>Registrations should include external links. 

## Changes
* Allow external links to be registered.
* Add test for registered external links.

## Side effects
None

## Ticket
[OSF-6518](https://openscience.atlassian.net/browse/OSF-6518)

<img width="396" alt="screen_shot_2016-07-05_at_09_44_47" src="https://cloud.githubusercontent.com/assets/5659262/16587869/9346cfe6-429a-11e6-8776-cf0d612c2f3b.png">
