### PR TITLE
[Hotfix] Raise error on bad GDrive folder select [OSF-6593]

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -365,13 +365,18 @@ class NodeAddonSettingsSerializer(JSONAPISerializer):
             folder_info = None
             set_folder = False
 
-        if folder_info and addon_name == 'googledrive':
+        if addon_name == 'googledrive':
+            folder_id = folder_info
             try:
                 folder_path = data['folder_path']
             except KeyError:
                 folder_path = None
+
+            if (folder_id or folder_path) and not (folder_id and folder_path):
+                raise exceptions.ValidationError(detail='Must specify both folder_id and folder_path for {}'.format(addon_name))
+
             folder_info = {
-                'id': folder_info,
+                'id': folder_id,
                 'path': folder_path
             }
         return set_folder, folder_info
@@ -417,6 +422,7 @@ class NodeAddonSettingsSerializer(JSONAPISerializer):
         if instance and instance.has_auth and set_account and not external_account_id:
             # Settings authorized, User requesting deauthorization
             instance.deauthorize(auth=auth)  # clear_auth performs save
+            return instance
         elif external_account_id:
             # Settings may or may not be authorized, user requesting to set instance.external_account
             account = self.get_account_or_error(addon_name, external_account_id, auth)

--- a/api_tests/nodes/views/test_node_addons.py
+++ b/api_tests/nodes/views/test_node_addons.py
@@ -714,7 +714,7 @@ class TestNodeGoogleDriveAddon(NodeConfigurableAddonTestSuiteMixin, ApiAddonTest
         with mock.patch.object(self.node_settings.__class__, 'fetch_access_token', return_value='asdfghjkl') as mock_fetch:
             super(TestNodeGoogleDriveAddon, self).test_folder_list_GET_expected_behavior()
 
-    def test_settings_detail_PATCH_only_folder_id_raises_error(self):
+    def test_settings_detail_PUT_PATCH_only_folder_id_raises_error(self):
         self.node_settings.clear_settings()
         self.node_settings.save()
         data = {'data': { 
@@ -725,15 +725,16 @@ class TestNodeGoogleDriveAddon(NodeConfigurableAddonTestSuiteMixin, ApiAddonTest
                     }
                 }
             }
-        res = self.app.put_json_api(self.setting_detail_url, 
-            data, auth=self.user.auth,
-            expect_errors=True)
+        res_put = self.app.put_json_api(self.setting_detail_url, 
+            data, auth=self.user.auth, expect_errors=True)
+        res_patch = self.app.patch_json_api(self.setting_detail_url,
+            data, auth=self.user.auth, expect_errors=True)
 
-        assert_equal(res.status_code, 400)
-        assert_equal('Must specify both folder_id and folder_path for {}'.format(self.short_name),
-             res.json['errors'][0]['detail'])
+        assert res_put.status_code == res_patch.status_code == 400
+        assert ('Must specify both folder_id and folder_path for {}'.format(self.short_name) ==
+             res_put.json['errors'][0]['detail'] == res_patch.json['errors'][0]['detail'])
 
-    def test_settings_detail_PATCH_only_folder_path_raises_error(self):
+    def test_settings_detail_PUT_PATCH_only_folder_path_raises_error(self):
         self.node_settings.clear_settings()
         self.node_settings.save()
         data = {'data': { 
@@ -744,13 +745,14 @@ class TestNodeGoogleDriveAddon(NodeConfigurableAddonTestSuiteMixin, ApiAddonTest
                     }
                 }
             }
-        res = self.app.put_json_api(self.setting_detail_url, 
-            data, auth=self.user.auth,
-            expect_errors=True)
+        res_put = self.app.put_json_api(self.setting_detail_url, 
+            data, auth=self.user.auth, expect_errors=True)
+        res_patch = self.app.patch_json_api(self.setting_detail_url,
+            data, auth=self.user.auth, expect_errors=True)
 
-        assert_equal(res.status_code, 400)
-        assert_equal('Must specify both folder_id and folder_path for {}'.format(self.short_name),
-             res.json['errors'][0]['detail'])
+        assert res_put.status_code == res_patch.status_code == 400
+        assert ('Must specify both folder_id and folder_path for {}'.format(self.short_name) ==
+             res_put.json['errors'][0]['detail'] == res_patch.json['errors'][0]['detail'])
 
     def test_settings_detail_incomplete_PUT_raises_error(self):
         self.node_settings.deauthorize(auth=self.auth)


### PR DESCRIPTION

## Purpose
Raise an exception with a useful error if a user specifies either `folder_id` or `folder_path` but not both for a `PUT`/`PATCH` to google drive, which requires both.

## Changes
* Raise error
* Add tests

## Side effects
None

## Ticket
[OSF-6593](https://openscience.atlassian.net/browse/OSF-6593)


`PATCH` on authorized node: <img width="845" alt="screen shot 2016-07-05 at 10 40 41" src="https://cloud.githubusercontent.com/assets/5659262/16590590/39c839f8-42a6-11e6-8686-9ed8a360d922.png">
`PATCH` on authorized node: <img width="856" alt="screen shot 2016-07-05 at 10 44 43" src="https://cloud.githubusercontent.com/assets/5659262/16590589/39c62d52-42a6-11e6-82b8-88f64918d51f.png">
`PUT` on unauthorized node: <img width="845" alt="screen shot 2016-07-05 at 11 46 56" src="https://cloud.githubusercontent.com/assets/5659262/16590591/39cbdeb4-42a6-11e6-89f6-40752daa2c0f.png">