### PR TITLE
Feature/linked nodes for nodes and registrations

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -11,12 +11,17 @@ from rest_framework.fields import SkipField
 from rest_framework.fields import get_attribute as get_nested_attributes
 
 from api.base import utils
-from api.base.exceptions import InvalidQueryStringError, Conflict, JSONAPIException, TargetNotSupportedError
+from api.base.exceptions import InvalidQueryStringError
+from api.base.exceptions import Conflict
+from api.base.exceptions import JSONAPIException
+from api.base.exceptions import TargetNotSupportedError
+from api.base.exceptions import RelationshipPostMakesNoChanges
 from api.base.settings import BULK_SETTINGS
 from api.base.utils import absolute_reverse, extend_querystring_params
 from framework.auth import core as auth_core
 from website import settings
 from website import util as website_utils
+from website.models import Node
 from website.util.sanitize import strip_html
 
 
@@ -1162,3 +1167,77 @@ class AddonAccountSerializer(JSONAPISerializer):
             kwargs=kwargs
         )
         return obj.get_absolute_url()
+
+
+class LinkedNode(JSONAPIRelationshipSerializer):
+    id = ser.CharField(source='node._id', required=False, allow_null=True)
+
+    class Meta:
+        type_ = 'linked_nodes'
+
+
+class LinkedNodesRelationshipSerializer(ser.Serializer):
+
+    data = ser.ListField(child=LinkedNode())
+    links = LinksField({'self': 'get_self_url',
+                        'html': 'get_related_url'})
+
+    def get_self_url(self, obj):
+        return obj['self'].linked_nodes_self_url
+
+    def get_related_url(self, obj):
+        return obj['self'].linked_nodes_related_url
+
+    class Meta:
+        type_ = 'linked_nodes'
+
+    def get_pointers_to_add_remove(self, pointers, new_pointers):
+        diff = relationship_diff(
+            current_items={pointer.node._id: pointer for pointer in pointers},
+            new_items={val['node']['_id']: val for val in new_pointers}
+        )
+
+        nodes_to_add = []
+        for node_id in diff['add']:
+            node = Node.load(node_id)
+            if not node:
+                raise exceptions.NotFound(detail='Node with id "{}" was not found'.format(node_id))
+            nodes_to_add.append(node)
+
+        return nodes_to_add, diff['remove'].values()
+
+    def make_instance_obj(self, obj):
+        # Convenience method to format instance based on view's get_object
+        return {'data': [
+            pointer for pointer in
+            obj.nodes_pointer
+            if not pointer.node.is_deleted and not pointer.node.is_collection
+        ], 'self': obj}
+
+    def update(self, instance, validated_data):
+        collection = instance['self']
+        auth = utils.get_user_auth(self.context['request'])
+
+        add, remove = self.get_pointers_to_add_remove(pointers=instance['data'], new_pointers=validated_data['data'])
+
+        for pointer in remove:
+            collection.rm_pointer(pointer, auth)
+        for node in add:
+            collection.add_pointer(node, auth)
+
+        return self.make_instance_obj(collection)
+
+    def create(self, validated_data):
+        instance = self.context['view'].get_object()
+        auth = utils.get_user_auth(self.context['request'])
+        collection = instance['self']
+
+        add, remove = self.get_pointers_to_add_remove(pointers=instance['data'], new_pointers=validated_data['data'])
+
+        if not len(add):
+            raise RelationshipPostMakesNoChanges
+
+        for node in add:
+            collection.add_pointer(node, auth)
+
+        return self.make_instance_obj(collection)

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -172,7 +172,7 @@ class LinkedNodesRelationship(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPI
         Success:       201
 
     This requires both edit permission on the collection, and for the user that is
-    making the request to be able to read the nodes requested. Data can be contain any number of
+    making the request to be able to read the nodes requested. Data can contain any number of
     node identifiers. This will create a node_link for all node_ids in the request that
     do not currently have a corresponding node_link in this collection.
 
@@ -189,8 +189,8 @@ class LinkedNodesRelationship(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPI
                        }
         Success:       200
 
-    This requires both edit permission on the collection, and for the user that is
-    making the request to be able to read the nodes requested. Data can be contain any number of
+    This requires both edit permission on the collection and for the user that is
+    making the request to be able to read the nodes requested. Data can contain any number of
     node identifiers. This will replace the contents of the node_links for this collection with
     the contents of the request. It will delete all node links that don't have a node_id in the data
     array, create node links for the node_ids that don't currently have a node id, and do nothing

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -3,13 +3,26 @@ from django.http import JsonResponse
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 from rest_framework import generics
-# from rest_framework.serializers
+from rest_framework import status
+from rest_framework import permissions as drf_permissions
+
+from framework.auth.oauth_scopes import CoreScopes
+
 from rest_framework.mixins import ListModelMixin
+from api.base import permissions as base_permissions
+from api.base.exceptions import RelationshipPostMakesNoChanges
 
 from api.users.serializers import UserSerializer
+from api.base.parsers import JSONAPIRelationshipParser
+from api.base.parsers import JSONAPIRelationshipParserForRegularJSON
+from api.base.serializers import LinkedNodesRelationshipSerializer
+from api.nodes.permissions import ReadOnlyIfRegistration
+from api.nodes.permissions import ContributorOrPublicForRelationshipPointers
 
 from django.conf import settings as django_settings
-from .utils import absolute_reverse, is_truthy
+from .utils import absolute_reverse
+from .utils import is_truthy
+from .utils import get_user_auth
 
 from .requests import EmbeddedRequest
 
@@ -135,6 +148,112 @@ class JSONAPIBaseView(generics.GenericAPIView):
             'envelope': self.request.query_params.get('envelope', 'data'),
         })
         return context
+
+
+class LinkedNodesRelationship(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, generics.CreateAPIView):
+    """ Relationship Endpoint for Linked Node relationships
+
+    Used to set, remove, update and retrieve the ids of the linked nodes attached to this collection. For each id, there
+    exists a node link that contains that node.
+
+    ##Actions
+
+    ###Create
+
+        Method:        POST
+        URL:           /links/self
+        Query Params:  <none>
+        Body (JSON):   {
+                         "data": [{
+                           "type": "linked_nodes",   # required
+                           "id": <node_id>   # required
+                         }]
+                       }
+        Success:       201
+
+    This requires both edit permission on the collection, and for the user that is
+    making the request to be able to read the nodes requested. Data can be contain any number of
+    node identifiers. This will create a node_link for all node_ids in the request that
+    do not currently have a corresponding node_link in this collection.
+
+    ###Update
+
+        Method:        PUT || PATCH
+        URL:           /links/self
+        Query Params:  <none>
+        Body (JSON):   {
+                         "data": [{
+                           "type": "linked_nodes",   # required
+                           "id": <node_id>   # required
+                         }]
+                       }
+        Success:       200
+
+    This requires both edit permission on the collection, and for the user that is
+    making the request to be able to read the nodes requested. Data can be contain any number of
+    node identifiers. This will replace the contents of the node_links for this collection with
+    the contents of the request. It will delete all node links that don't have a node_id in the data
+    array, create node links for the node_ids that don't currently have a node id, and do nothing
+    for node_ids that already have a corresponding node_link. This means a update request with
+    {"data": []} will remove all node_links in this collection
+
+    ###Destroy
+
+        Method:        DELETE
+        URL:           /links/self
+        Query Params:  <none>
+        Body (JSON):   {
+                         "data": [{
+                           "type": "linked_nodes",   # required
+                           "id": <node_id>   # required
+                         }]
+                       }
+        Success:       204
+
+    This requires edit permission on the node. This will delete any node_links that have a
+    corresponding node_id in the request.
+    """
+    permission_classes = (
+        ContributorOrPublicForRelationshipPointers,
+        drf_permissions.IsAuthenticatedOrReadOnly,
+        base_permissions.TokenHasScope,
+        ReadOnlyIfRegistration,
+    )
+
+    required_read_scopes = [CoreScopes.NODE_LINKS_READ]
+    required_write_scopes = [CoreScopes.NODE_LINKS_WRITE]
+
+    serializer_class = LinkedNodesRelationshipSerializer
+    parser_classes = (JSONAPIRelationshipParser, JSONAPIRelationshipParserForRegularJSON, )
+
+    def get_object(self):
+        object = self.get_node(check_object_permissions=False)
+        auth = get_user_auth(self.request)
+        obj = {'data': [
+            pointer for pointer in
+            object.nodes_pointer
+            if not pointer.node.is_deleted and not pointer.node.is_collection and
+            pointer.node.can_view(auth)
+        ], 'self': object}
+        self.check_object_permissions(self.request, obj)
+        return obj
+
+    def perform_destroy(self, instance):
+        data = self.request.data['data']
+        auth = get_user_auth(self.request)
+        current_pointers = {pointer.node._id: pointer for pointer in instance['data']}
+        collection = instance['self']
+        for val in data:
+            if val['id'] in current_pointers:
+                collection.rm_pointer(current_pointers[val['id']], auth)
+
+    def create(self, *args, **kwargs):
+        try:
+            ret = super(LinkedNodesRelationship, self).create(*args, **kwargs)
+        except RelationshipPostMakesNoChanges:
+            return Response(status=status.HTTP_204_NO_CONTENT)
+        return ret
+
 
 @api_view(('GET',))
 def root(request, format=None):

--- a/api/collections/serializers.py
+++ b/api/collections/serializers.py
@@ -5,9 +5,9 @@ from framework.exceptions import PermissionsError
 from website.exceptions import NodeStateError
 
 from website.models import Node
-from api.base.serializers import LinksField, RelationshipField, JSONAPIRelationshipSerializer
-from api.base.serializers import JSONAPISerializer, IDField, TypeField, relationship_diff
-from api.base.exceptions import InvalidModelValueError, RelationshipPostMakesNoChanges
+from api.base.serializers import LinksField, RelationshipField
+from api.base.serializers import JSONAPISerializer, IDField, TypeField
+from api.base.exceptions import InvalidModelValueError
 from api.base.utils import absolute_reverse, get_user_auth
 from api.nodes.serializers import NodeLinksSerializer
 
@@ -107,74 +107,3 @@ class CollectionNodeLinkSerializer(NodeLinksSerializer):
         )
 
 
-class LinkedNode(JSONAPIRelationshipSerializer):
-    id = ser.CharField(source='node._id', required=False, allow_null=True)
-    class Meta:
-        type_ = 'linked_nodes'
-
-
-class CollectionLinkedNodesRelationshipSerializer(ser.Serializer):
-
-    data = ser.ListField(child=LinkedNode())
-    links = LinksField({'self': 'get_self_url',
-                        'html': 'get_related_url'})
-
-    def get_self_url(self, obj):
-        return obj['self'].linked_nodes_self_url
-
-    def get_related_url(self, obj):
-        return obj['self'].linked_nodes_related_url
-
-    class Meta:
-        type_ = 'linked_nodes'
-
-    def get_pointers_to_add_remove(self, pointers, new_pointers):
-        diff = relationship_diff(
-            current_items={pointer.node._id: pointer for pointer in pointers},
-            new_items={val['node']['_id']: val for val in new_pointers}
-        )
-
-        nodes_to_add = []
-        for node_id in diff['add']:
-            node = Node.load(node_id)
-            if not node:
-                raise exceptions.NotFound(detail='Node with id "{}" was not found'.format(node_id))
-            nodes_to_add.append(node)
-
-        return nodes_to_add, diff['remove'].values()
-
-    def make_instance_obj(self, obj):
-        # Convenience method to format instance based on view's get_object
-        return {'data': [
-            pointer for pointer in
-            obj.nodes_pointer
-            if not pointer.node.is_deleted and not pointer.node.is_collection
-        ], 'self': obj}
-
-    def update(self, instance, validated_data):
-        collection = instance['self']
-        auth = get_user_auth(self.context['request'])
-
-        add, remove = self.get_pointers_to_add_remove(pointers=instance['data'], new_pointers=validated_data['data'])
-
-        for pointer in remove:
-            collection.rm_pointer(pointer, auth)
-        for node in add:
-            collection.add_pointer(node, auth)
-
-        return self.make_instance_obj(collection)
-
-    def create(self, validated_data):
-        instance = self.context['view'].get_object()
-        auth = get_user_auth(self.context['request'])
-        collection = instance['self']
-
-        add, remove = self.get_pointers_to_add_remove(pointers=instance['data'], new_pointers=validated_data['data'])
-
-        if not len(add):
-            raise RelationshipPostMakesNoChanges
-
-        for node in add:
-            collection.add_pointer(node, auth)
-
-        return self.make_instance_obj(collection)

--- a/api/collections/serializers.py
+++ b/api/collections/serializers.py
@@ -105,5 +105,3 @@ class CollectionNodeLinkSerializer(NodeLinksSerializer):
                 'node_link_id': obj._id
             }
         )
-
-

--- a/api/collections/views.py
+++ b/api/collections/views.py
@@ -13,11 +13,11 @@ from api.base.views import JSONAPIBaseView
 from api.base.parsers import JSONAPIRelationshipParser, JSONAPIRelationshipParserForRegularJSON
 from api.base.utils import get_object_or_error, is_bulk_request, get_user_auth
 from api.base.exceptions import RelationshipPostMakesNoChanges
+from api.base.serializers import LinkedNodesRelationshipSerializer
 from api.collections.serializers import (
     CollectionSerializer,
     CollectionDetailSerializer,
     CollectionNodeLinkSerializer,
-    CollectionLinkedNodesRelationshipSerializer
 )
 from api.nodes.serializers import NodeSerializer
 
@@ -611,7 +611,7 @@ class CollectionLinkedNodesRelationship(JSONAPIBaseView, generics.RetrieveUpdate
     required_read_scopes = [CoreScopes.NODE_LINKS_READ]
     required_write_scopes = [CoreScopes.NODE_LINKS_WRITE]
 
-    serializer_class = CollectionLinkedNodesRelationshipSerializer
+    serializer_class = LinkedNodesRelationshipSerializer
     parser_classes = (JSONAPIRelationshipParser, JSONAPIRelationshipParserForRegularJSON, )
 
     view_category = 'collections'

--- a/api/collections/views.py
+++ b/api/collections/views.py
@@ -1,8 +1,6 @@
 from modularodm import Q
 from rest_framework import generics, permissions as drf_permissions
-from rest_framework import status
 from rest_framework.exceptions import ValidationError, NotFound, PermissionDenied
-from rest_framework.response import Response
 
 from framework.auth.oauth_scopes import CoreScopes
 
@@ -13,7 +11,6 @@ from api.base.views import JSONAPIBaseView
 from api.base.views import LinkedNodesRelationship
 
 from api.base.utils import get_object_or_error, is_bulk_request, get_user_auth
-from api.base.exceptions import RelationshipPostMakesNoChanges
 from api.collections.serializers import (
     CollectionSerializer,
     CollectionDetailSerializer,
@@ -604,4 +601,3 @@ class CollectionLinkedNodesRelationship(LinkedNodesRelationship, CollectionMixin
 
     view_category = 'collections'
     view_name = 'collection-node-pointer-relationship'
-

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -207,6 +207,14 @@ class NodeSerializer(JSONAPISerializer):
         related_meta={'count': 'get_logs_count'}
     )
 
+    linked_nodes = RelationshipField(
+        related_view='nodes:linked-nodes',
+        related_view_kwargs={'node_id': '<pk>'},
+        related_meta={'count': 'get_node_links_count'},
+        self_view='nodes:node-pointer-relationship',
+        self_view_kwargs={'node_id': '<pk>'}
+    )
+
     def get_current_user_permissions(self, obj):
         user = self.context['request'].user
         if user.is_anonymous():
@@ -242,6 +250,14 @@ class NodeSerializer(JSONAPISerializer):
 
     def get_pointers_count(self, obj):
         return len(obj.nodes_pointer)
+
+    def get_node_links_count(self, obj):
+        count = 0
+        auth = get_user_auth(self.context['request'])
+        for pointer in obj.nodes_pointer:
+            if not pointer.node.is_deleted and not pointer.node.is_collection and pointer.node.can_view(auth):
+                count += 1
+        return count
 
     def get_unread_comments_count(self, obj):
         user = get_user_auth(self.context['request']).user

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -212,7 +212,8 @@ class NodeSerializer(JSONAPISerializer):
         related_view_kwargs={'node_id': '<pk>'},
         related_meta={'count': 'get_node_links_count'},
         self_view='nodes:node-pointer-relationship',
-        self_view_kwargs={'node_id': '<pk>'}
+        self_view_kwargs={'node_id': '<pk>'},
+        self_meta={'count': 'get_node_links_count'}
     )
 
     def get_current_user_permissions(self, obj):

--- a/api/nodes/urls.py
+++ b/api/nodes/urls.py
@@ -30,6 +30,8 @@ urlpatterns = [
     url(r'^(?P<node_id>\w+)/registrations/$', views.NodeRegistrationsList.as_view(), name=views.NodeRegistrationsList.view_name),
     url(r'^(?P<node_id>\w+)/draft_registrations/$', views.NodeDraftRegistrationsList.as_view(), name=views.NodeDraftRegistrationsList.view_name),
     url(r'^(?P<node_id>\w+)/draft_registrations/(?P<draft_id>\w+)/$', views.NodeDraftRegistrationDetail.as_view(), name=views.NodeDraftRegistrationDetail.view_name),
+    url(r'^(?P<node_id>\w+)/relationships/linked_nodes/$', views.NodeLinkedNodesRelationship.as_view(), name=views.NodeLinkedNodesRelationship.view_name),
+    url(r'^(?P<node_id>\w+)/linked_nodes/$', views.LinkedNodesList.as_view(), name=views.LinkedNodesList.view_name),
 ]
 
 # Routes only active in local/staging environments

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -25,6 +25,7 @@ from api.comments.serializers import CommentSerializer, CommentCreateSerializer
 from api.comments.permissions import CanCommentOrPublic
 from api.users.views import UserMixin
 from api.wikis.serializers import WikiSerializer
+from api.base.views import LinkedNodesRelationship
 
 from api.nodes.serializers import (
     NodeSerializer,
@@ -2567,6 +2568,7 @@ class NodeCommentsList(JSONAPIBaseView, generics.ListCreateAPIView, ODMFilterMix
         serializer.validated_data['node'] = node
         serializer.save()
 
+
 class NodeInstitutionsList(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin, NodeMixin):
     """ Detail of the affiliated institutions a node has, if any. Returns [] if the node has no
     affiliated institution.
@@ -2771,3 +2773,154 @@ class NodeWikiList(JSONAPIBaseView, generics.ListAPIView, NodeMixin, ODMFilterMi
 
     def get_queryset(self):
         return NodeWikiPage.find(self.get_query_from_request())
+
+
+class NodeLinkedNodesRelationship(LinkedNodesRelationship, NodeMixin):
+    """ Relationship Endpoint for Nodes -> Linked Node relationships
+
+    Used to set, remove, update and retrieve the ids of the linked nodes attached to this collection. For each id, there
+    exists a node link that contains that node.
+
+    ##Actions
+
+    ###Create
+
+        Method:        POST
+        URL:           /links/self
+        Query Params:  <none>
+        Body (JSON):   {
+                         "data": [{
+                           "type": "linked_nodes",   # required
+                           "id": <node_id>   # required
+                         }]
+                       }
+        Success:       201
+
+    This requires both edit permission on the collection, and for the user that is
+    making the request to be able to read the nodes requested. Data can be contain any number of
+    node identifiers. This will create a node_link for all node_ids in the request that
+    do not currently have a corresponding node_link in this collection.
+
+    ###Update
+
+        Method:        PUT || PATCH
+        URL:           /links/self
+        Query Params:  <none>
+        Body (JSON):   {
+                         "data": [{
+                           "type": "linked_nodes",   # required
+                           "id": <node_id>   # required
+                         }]
+                       }
+        Success:       200
+
+    This requires both edit permission on the collection, and for the user that is
+    making the request to be able to read the nodes requested. Data can be contain any number of
+    node identifiers. This will replace the contents of the node_links for this collection with
+    the contents of the request. It will delete all node links that don't have a node_id in the data
+    array, create node links for the node_ids that don't currently have a node id, and do nothing
+    for node_ids that already have a corresponding node_link. This means a update request with
+    {"data": []} will remove all node_links in this collection
+
+    ###Destroy
+
+        Method:        DELETE
+        URL:           /links/self
+        Query Params:  <none>
+        Body (JSON):   {
+                         "data": [{
+                           "type": "linked_nodes",   # required
+                           "id": <node_id>   # required
+                         }]
+                       }
+        Success:       204
+
+    This requires edit permission on the node. This will delete any node_links that have a
+    corresponding node_id in the request.
+    """
+
+    view_category = 'nodes'
+    view_name = 'node-pointer-relationship'
+
+
+class LinkedNodesList(JSONAPIBaseView, generics.ListAPIView, NodeMixin):
+    """List of nodes linked to this node. *Read-only*.
+
+    Linked nodes are the nodes pointed to by node links. This view will probably replace node_links in the near future.
+
+    <!--- Copied Spiel from NodeDetail -->
+
+    On the front end, nodes are considered 'projects' or 'components'. The difference between a project and a component
+    is that a project is the top-level node, and components are children of the project. There is also a [category
+    field](/v2/#osf-node-categories) that includes 'project' as an option. The categorization essentially determines
+    which icon is displayed by the node in the front-end UI and helps with search organization. Top-level nodes may have
+    a category other than project, and children nodes may have a category of project.
+
+    ##Linked Node Attributes
+
+    <!--- Copied Attributes from NodeDetail -->
+
+    OSF Node entities have the "nodes" `type`.
+
+        name           type               description
+        =================================================================================
+        title          string             title of project or component
+        description    string             description of the node
+        category       string             node category, must be one of the allowed values
+        date_created   iso8601 timestamp  timestamp that the node was created
+        date_modified  iso8601 timestamp  timestamp when the node was last updated
+        tags           array of strings   list of tags that describe the node
+        registration   boolean            is this is a registration?
+        collection     boolean            is this node a collection of other nodes?
+        public         boolean            has this node been made publicly-visible?
+
+    ##Links
+
+    See the [JSON-API spec regarding pagination](http://jsonapi.org/format/1.0/#fetching-pagination).
+
+    ##Query Params
+
+    + `page=<Int>` -- page number of results to view, default 1
+
+    + `filter[<fieldname>]=<Str>` -- fields and values to filter the search results on.
+
+    Nodes may be filtered by their `title`, `category`, `description`, `public`, `registration`, or `tags`.  `title`,
+    `description`, and `category` are string fields and will be filtered using simple substring matching.  `public` and
+    `registration` are booleans, and can be filtered using truthy values, such as `true`, `false`, `0`, or `1`.  Note
+    that quoting `true` or `false` in the query will cause the match to fail regardless.  `tags` is an array of simple strings.
+
+    #This Request/Response
+    """
+    permission_classes = (
+        drf_permissions.IsAuthenticatedOrReadOnly,
+        ContributorOrPublic,
+        ReadOnlyIfRegistration,
+        base_permissions.TokenHasScope,
+    )
+
+    required_read_scopes = [CoreScopes.NODE_LINKS_READ]
+    required_write_scopes = [CoreScopes.NODE_LINKS_WRITE]
+
+    serializer_class = NodeSerializer
+    view_category = 'nodes'
+    view_name = 'linked-nodes'
+
+    model_class = Pointer
+
+    def get_queryset(self):
+        auth = get_user_auth(self.request)
+        return sorted([
+            pointer.node for pointer in
+            self.get_node().nodes_pointer
+            if not pointer.node.is_deleted and not pointer.node.is_collection and
+            pointer.node.can_view(auth)
+        ], key=lambda n: n.date_modified, reverse=True)
+
+    # overrides APIView
+    def get_parser_context(self, http_request):
+        """
+        Tells parser that we are creating a relationship
+        """
+        res = super(LinkedNodesList, self).get_parser_context(http_request)
+        res['is_relationship'] = True
+        return res

--- a/api/registrations/urls.py
+++ b/api/registrations/urls.py
@@ -27,6 +27,8 @@ urlpatterns = [
     url(r'^(?P<node_id>\w+)/node_links/(?P<node_link_id>\w+)/', views.RegistrationNodeLinksDetail.as_view(), name=views.RegistrationNodeLinksDetail.view_name),
     url(r'^(?P<node_id>\w+)/wikis/$', views.RegistrationWikiList.as_view(), name=views.RegistrationWikiList.view_name),
     url(r'^(?P<node_id>\w+)/identifiers/$', identifier_views.IdentifierList.as_view(), name=identifier_views.IdentifierList.view_name),
+    url(r'^(?P<node_id>\w+)/relationships/linked_nodes/$', views.RegistrationLinkedNodesRelationship.as_view(), name=views.RegistrationLinkedNodesRelationship.view_name),
+    url(r'^(?P<node_id>\w+)/linked_nodes/$', views.RegistrationLinkedNodesList.as_view(), name=views.RegistrationLinkedNodesList.view_name),
 ]
 
 # Routes only active in local/staging environments

--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -412,13 +412,13 @@ class RegistrationLinkedNodesRelationship(JSONAPIBaseView, generics.RetrieveAPIV
     parser_classes = (JSONAPIRelationshipParser, JSONAPIRelationshipParserForRegularJSON, )
 
     def get_object(self):
-        object = self.get_node(check_object_permissions=False)
+        node = self.get_node(check_object_permissions=False)
         auth = get_user_auth(self.request)
         obj = {'data': [
             pointer for pointer in
-            object.nodes_pointer
+            node.nodes_pointer
             if not pointer.node.is_deleted and not pointer.node.is_collection and
             pointer.node.can_view(auth)
-        ], 'self': object}
+        ], 'self': node}
         self.check_object_permissions(self.request, obj)
         return obj

--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -7,6 +7,13 @@ from api.base import permissions as base_permissions
 from api.base.views import JSONAPIBaseView
 
 from api.base.serializers import HideIfWithdrawal
+from api.nodes.permissions import ReadOnlyIfRegistration
+from api.nodes.permissions import ContributorOrPublicForRelationshipPointers
+from api.base.serializers import LinkedNodesRelationshipSerializer
+from api.base.parsers import JSONAPIRelationshipParser
+from api.base.parsers import JSONAPIRelationshipParserForRegularJSON
+from api.base.utils import get_user_auth
+
 from api.registrations.serializers import (
     RegistrationSerializer,
     RegistrationDetailSerializer,
@@ -19,7 +26,9 @@ from api.nodes.views import (
     NodeChildrenList, NodeCommentsList, NodeProvidersList, NodeLinksList,
     NodeContributorDetail, NodeFilesList, NodeLinksDetail, NodeFileDetail,
     NodeAlternativeCitationsList, NodeAlternativeCitationDetail, NodeLogList,
-    NodeInstitutionsList, WaterButlerMixin, NodeForksList, NodeWikiList)
+    NodeInstitutionsList, WaterButlerMixin, NodeForksList, NodeWikiList,
+    LinkedNodesList
+)
 
 from api.registrations.serializers import RegistrationNodeLinksSerializer, RegistrationFileSerializer
 
@@ -370,3 +379,46 @@ class RegistrationInstitutionsList(NodeInstitutionsList, RegistrationMixin):
 class RegistrationWikiList(NodeWikiList, RegistrationMixin):
     view_category = 'registrations'
     view_name = 'registration-wikis'
+
+
+class RegistrationLinkedNodesList(LinkedNodesList, RegistrationMixin):
+    view_category = 'registrations'
+    view_name = 'linked-nodes'
+
+
+class RegistrationLinkedNodesRelationship(JSONAPIBaseView, generics.RetrieveAPIView, RegistrationMixin):
+    """ Relationship Endpoint for Nodes -> Linked Node relationships
+
+    Used to retrieve the ids of the linked nodes attached to this collection. For each id, there
+    exists a node link that contains that node.
+
+    ##Actions
+
+    """
+    view_category = 'registrations'
+    view_name = 'node-pointer-relationship'
+
+    permission_classes = (
+        ContributorOrPublicForRelationshipPointers,
+        drf_permissions.IsAuthenticatedOrReadOnly,
+        base_permissions.TokenHasScope,
+        ReadOnlyIfRegistration,
+    )
+
+    required_read_scopes = [CoreScopes.NODE_LINKS_READ]
+    required_write_scopes = [CoreScopes.NULL]
+
+    serializer_class = LinkedNodesRelationshipSerializer
+    parser_classes = (JSONAPIRelationshipParser, JSONAPIRelationshipParserForRegularJSON, )
+
+    def get_object(self):
+        object = self.get_node(check_object_permissions=False)
+        auth = get_user_auth(self.request)
+        obj = {'data': [
+            pointer for pointer in
+            object.nodes_pointer
+            if not pointer.node.is_deleted and not pointer.node.is_collection and
+            pointer.node.can_view(auth)
+        ], 'self': object}
+        self.check_object_permissions(self.request, obj)
+        return obj

--- a/api_tests/base/test_serializers.py
+++ b/api_tests/base/test_serializers.py
@@ -117,11 +117,14 @@ class TestApiBaseSerializers(ApiTestCase):
 
     def setUp(self):
         super(TestApiBaseSerializers, self).setUp()
-
+        self.user = factories.AuthUserFactory()
+        self.auth = factories.Auth(self.user)
         self.node = factories.ProjectFactory(is_public=True)
 
         for i in range(5):
             factories.ProjectFactory(is_public=True, parent=self.node)
+        self.linked_node = factories.NodeFactory(creator=self.user, is_public=True)
+        self.node.add_pointer(self.linked_node, auth=self.auth)
 
         self.url = '/{}nodes/{}/'.format(API_BASE, self.node._id)
 
@@ -156,7 +159,7 @@ class TestApiBaseSerializers(ApiTestCase):
                 field = field.field
             if (field.related_meta or {}).get('count'):
                 link = relation['links'].values()[0]
-                assert_in('count', link['meta'])
+                assert_in('count', link['meta'], field)
 
     def test_related_counts_excluded_query_param_false(self):
 

--- a/api_tests/collections/test_views.py
+++ b/api_tests/collections/test_views.py
@@ -1772,6 +1772,7 @@ class TestBulkDeleteCollectionNodeLinks(ApiTestCase):
         assert_equal(len(errors), 1)
         assert_equal(errors[0]['detail'], 'Node link does not belong to the requested node.')
 
+
 class TestCollectionRelationshipNodeLinks(ApiTestCase):
 
     def setUp(self):

--- a/api_tests/nodes/views/test_node_linked_nodes.py
+++ b/api_tests/nodes/views/test_node_linked_nodes.py
@@ -33,7 +33,7 @@ class TestNodeRelationshipNodeLinks(ApiTestCase):
 
     def payload(self, node_ids=None):
         node_ids = node_ids or [self.admin_node._id]
-        env_linked_nodes = [{"type": "linked_nodes", "id": node_id} for node_id in node_ids]
+        env_linked_nodes = [{'type': 'linked_nodes', 'id': node_id} for node_id in node_ids]
         return {"data": env_linked_nodes}
 
     def test_get_relationship_linked_nodes(self):
@@ -228,6 +228,23 @@ class TestNodeRelationshipNodeLinks(ApiTestCase):
         )
         assert_equal(len(res.json['data']), number_of_links)
 
+    def test_delete_invalid_payload(self):
+        number_of_links = len(self.linking_node.nodes)
+        # No id in datum
+        payload = {'data': [{'type': 'linked_nodes'}]}
+        res = self.app.delete_json_api(
+            self.url, payload,
+            auth=self.user.auth,
+            expect_errors=True
+        )
+        assert_equal(res.status_code, 400)
+        error = res.json['errors'][0]
+        assert_equal(error['detail'], 'Request must include /data/id.')
+
+        res = self.app.get(
+            self.url, auth=self.user.auth
+        )
+        assert_equal(len(res.json['data']), number_of_links)
 
     def test_node_doesnt_exist(self):
         res = self.app.post_json_api(

--- a/api_tests/nodes/views/test_node_linked_nodes.py
+++ b/api_tests/nodes/views/test_node_linked_nodes.py
@@ -1,0 +1,407 @@
+from nose.tools import *  # flake8: noqa
+
+from api.base.settings.defaults import API_BASE
+from tests.base import ApiTestCase
+from tests.factories import (
+    NodeFactory,
+    AuthUserFactory
+)
+from framework.auth.core import Auth
+
+
+class TestNodeRelationshipNodeLinks(ApiTestCase):
+
+    def setUp(self):
+        super(TestNodeRelationshipNodeLinks, self).setUp()
+        self.user = AuthUserFactory()
+        self.user2 = AuthUserFactory()
+        self.auth = Auth(self.user)
+        self.linking_node = NodeFactory(creator=self.user)
+        self.admin_node = NodeFactory(creator=self.user)
+        self.contributor_node = NodeFactory(creator=self.user2)
+        self.contributor_node.add_contributor(self.user, auth=Auth(self.user2))
+        self.contributor_node.save()
+        self.other_node = NodeFactory()
+        self.private_node = NodeFactory(creator=self.user)
+        self.public_node = NodeFactory(is_public=True)
+        self.linking_node.add_pointer(self.private_node, auth=self.auth)
+        self.public_linking_node = NodeFactory(is_public=True, creator=self.user2)
+        self.public_linking_node.add_pointer(self.private_node, auth=Auth(self.user2))
+        self.public_linking_node.add_pointer(self.public_node, auth=Auth(self.user2))
+        self.url = '/{}nodes/{}/relationships/linked_nodes/'.format(API_BASE, self.linking_node._id)
+        self.public_url = '/{}nodes/{}/relationships/linked_nodes/'.format(API_BASE, self.public_linking_node._id)
+
+    def payload(self, node_ids=None):
+        node_ids = node_ids or [self.admin_node._id]
+        env_linked_nodes = [{"type": "linked_nodes", "id": node_id} for node_id in node_ids]
+        return {"data": env_linked_nodes}
+
+    def test_get_relationship_linked_nodes(self):
+        res = self.app.get(
+            self.url, auth=self.user.auth
+        )
+
+        assert_equal(res.status_code, 200)
+
+        assert_in(self.linking_node.linked_nodes_self_url, res.json['links']['self'])
+        assert_in(self.linking_node.linked_nodes_related_url, res.json['links']['html'])
+        assert_equal(res.json['data'][0]['id'], self.private_node._id)
+
+    def test_get_public_relationship_linked_nodes_logged_out(self):
+        res = self.app.get(self.public_url)
+
+        assert_equal(res.status_code, 200)
+        assert_equal(len(res.json['data']), 1)
+        assert_equal(res.json['data'][0]['id'], self.public_node._id)
+
+    def test_get_public_relationship_linked_nodes_logged_in(self):
+        res = self.app.get(self.public_url, auth=self.user.auth)
+
+        assert_equal(res.status_code, 200)
+        assert_equal(len(res.json['data']), 2)
+
+    def test_get_private_relationship_linked_nodes_logged_out(self):
+        res = self.app.get(self.url, expect_errors=True)
+
+        assert_equal(res.status_code, 401)
+
+    def test_post_contributing_node(self):
+        res = self.app.post_json_api(
+            self.url, self.payload([self.contributor_node._id]),
+            auth=self.user.auth
+        )
+
+        assert_equal(res.status_code, 201)
+
+        ids = [data['id'] for data in res.json['data']]
+        assert_in(self.contributor_node._id, ids)
+        assert_in(self.private_node._id, ids)
+
+    def test_post_public_node(self):
+        res = self.app.post_json_api(
+            self.url, self.payload([self.public_node._id]),
+            auth=self.user.auth
+        )
+
+        assert_equal(res.status_code, 201)
+
+        ids = [data['id'] for data in res.json['data']]
+        assert_in(self.public_node._id, ids)
+        assert_in(self.private_node._id, ids)
+
+    def test_post_private_node(self):
+        res = self.app.post_json_api(
+            self.url, self.payload([self.other_node._id]),
+            auth=self.user.auth,
+            expect_errors=True
+        )
+
+        assert_equal(res.status_code, 403)
+
+        res = self.app.get(
+            self.url, auth=self.user.auth
+        )
+
+        ids = [data['id'] for data in res.json['data']]
+        assert_not_in(self.other_node._id, ids)
+        assert_in(self.private_node._id, ids)
+
+    def test_post_mixed_nodes(self):
+        res = self.app.post_json_api(
+            self.url, self.payload([self.other_node._id, self.contributor_node._id]),
+            auth=self.user.auth,
+            expect_errors=True
+        )
+
+        assert_equal(res.status_code, 403)
+
+        res = self.app.get(
+            self.url, auth=self.user.auth
+        )
+
+        ids = [data['id'] for data in res.json['data']]
+        assert_not_in(self.other_node._id, ids)
+        assert_not_in(self.contributor_node._id, ids)
+        assert_in(self.private_node._id, ids)
+
+    def test_post_node_already_linked(self):
+        res = self.app.post_json_api(
+            self.url, self.payload([self.private_node._id]),
+            auth=self.user.auth
+        )
+
+        assert_equal(res.status_code, 204)
+
+    def test_put_contributing_node(self):
+        res = self.app.put_json_api(
+            self.url, self.payload([self.contributor_node._id]),
+            auth=self.user.auth
+        )
+
+        assert_equal(res.status_code, 200)
+
+        ids = [data['id'] for data in res.json['data']]
+        assert_in(self.contributor_node._id, ids)
+        assert_not_in(self.private_node._id, ids)
+
+    def test_put_private_node(self):
+        res = self.app.put_json_api(
+            self.url, self.payload([self.other_node._id]),
+            auth=self.user.auth,
+            expect_errors=True
+        )
+
+        assert_equal(res.status_code, 403)
+
+        res = self.app.get(
+            self.url, auth=self.user.auth
+        )
+
+        ids = [data['id'] for data in res.json['data']]
+        assert_not_in(self.other_node._id, ids)
+        assert_in(self.private_node._id, ids)
+
+    def test_put_mixed_nodes(self):
+        res = self.app.put_json_api(
+            self.url, self.payload([self.other_node._id, self.contributor_node._id]),
+            auth=self.user.auth,
+            expect_errors=True
+        )
+
+        assert_equal(res.status_code, 403)
+
+        res = self.app.get(
+            self.url, auth=self.user.auth
+        )
+
+        ids = [data['id'] for data in res.json['data']]
+        assert_not_in(self.other_node._id, ids)
+        assert_not_in(self.contributor_node._id, ids)
+        assert_in(self.private_node._id, ids)
+
+    def test_delete_with_put_empty_array(self):
+        self.linking_node.add_pointer(self.admin_node, auth=self.auth)
+        payload = self.payload()
+        payload['data'].pop()
+        res = self.app.put_json_api(
+            self.url, payload,
+            auth=self.user.auth
+        )
+        assert_equal(res.status_code, 200)
+        assert_equal(res.json['data'], payload['data'])
+
+    def test_delete_one(self):
+        self.linking_node.add_pointer(self.admin_node, auth=self.auth)
+        res = self.app.delete_json_api(
+            self.url, self.payload([self.private_node._id]),
+            auth=self.user.auth,
+        )
+        assert_equal(res.status_code, 204)
+
+        res = self.app.get(self.url, auth=self.user.auth)
+
+        ids = [data['id'] for data in res.json['data']]
+        assert_in(self.admin_node._id, ids)
+        assert_not_in(self.private_node._id, ids)
+
+    def test_delete_multiple(self):
+        self.linking_node.add_pointer(self.admin_node, auth=self.auth)
+        res = self.app.delete_json_api(
+            self.url, self.payload([self.private_node._id, self.admin_node._id]),
+            auth=self.user.auth,
+        )
+        assert_equal(res.status_code, 204)
+
+        res = self.app.get(self.url, auth=self.user.auth)
+        assert_equal(res.json['data'], [])
+
+    def test_delete_not_present(self):
+        number_of_links = len(self.linking_node.nodes)
+        res = self.app.delete_json_api(
+            self.url, self.payload([self.other_node._id]),
+            auth=self.user.auth
+        )
+        assert_equal(res.status_code, 204)
+
+        res = self.app.get(
+            self.url, auth=self.user.auth
+        )
+        assert_equal(len(res.json['data']), number_of_links)
+
+
+    def test_node_doesnt_exist(self):
+        res = self.app.post_json_api(
+            self.url, self.payload(['aquarela']),
+            auth=self.user.auth,
+            expect_errors=True
+        )
+
+        assert_equal(res.status_code, 404)
+
+    def test_type_mistyped(self):
+        res = self.app.post_json_api(
+            self.url,
+            {
+                'data': [{'type': 'not_linked_nodes', 'id': self.contributor_node._id}]
+            },
+            auth=self.user.auth,
+            expect_errors=True
+        )
+
+        assert_equal(res.status_code, 409)
+
+    def test_creates_public_linked_node_relationship_logged_out(self):
+        res = self.app.post_json_api(
+                self.public_url, self.payload([self.public_node._id]),
+                expect_errors=True
+        )
+
+        assert_equal(res.status_code, 401)
+
+    def test_creates_public_linked_node_relationship_logged_in(self):
+        res = self.app.post_json_api(
+                self.public_url, self.payload([self.public_node._id]),
+                auth=self.user.auth, expect_errors=True
+        )
+
+        assert_equal(res.status_code, 403)
+
+    def test_creates_private_linked_node_relationship_logged_out(self):
+        res = self.app.post_json_api(
+                self.url, self.payload([self.other_node._id]),
+                expect_errors=True
+        )
+
+        assert_equal(res.status_code, 401)
+
+    def test_put_public_nodes_relationships_logged_out(self):
+        res = self.app.put_json_api(
+                self.public_url, self.payload([self.public_node._id]),
+                expect_errors=True
+        )
+
+        assert_equal(res.status_code, 401)
+
+    def test_put_public_nodes_relationships_logged_in(self):
+        res = self.app.put_json_api(
+                self.public_url, self.payload([self.private_node._id]),
+                auth=self.user.auth, expect_errors=True
+        )
+
+        assert_equal(res.status_code, 403)
+
+    def test_delete_public_nodes_relationships_logged_out(self):
+        res = self.app.delete_json_api(
+            self.public_url, self.payload([self.public_node._id]),
+            expect_errors=True
+        )
+
+        assert_equal(res.status_code, 401)
+
+    def test_delete_public_nodes_relationships_logged_in(self):
+        res = self.app.delete_json_api(
+                self.public_url, self.payload([self.private_node._id]),
+                auth=self.user.auth, expect_errors=True
+        )
+
+        assert_equal(res.status_code, 403)
+
+    def test_node_links_and_relationship_represent_same_nodes(self):
+        self.linking_node.add_pointer(self.admin_node, auth=self.auth)
+        self.linking_node.add_pointer(self.contributor_node, auth=self.auth)
+        res_relationship = self.app.get(
+            self.url, auth=self.user.auth
+        )
+        res_node_links = self.app.get(
+            '/{}nodes/{}/node_links/'.format(API_BASE, self.linking_node._id),
+            auth=self.user.auth
+        )
+        node_links_id = [data['embeds']['target_node']['data']['id'] for data in res_node_links.json['data']]
+        relationship_id = [data['id'] for data in res_relationship.json['data']]
+
+        assert_equal(set(node_links_id), set(relationship_id))
+
+
+class TestNodeLinkedNodes(ApiTestCase):
+    def setUp(self):
+        super(TestNodeLinkedNodes, self).setUp()
+        self.user = AuthUserFactory()
+        self.auth = Auth(self.user)
+        self.linking_node = NodeFactory(creator=self.user)
+        self.linked_node = NodeFactory(creator=self.user)
+        self.linked_node2 = NodeFactory(creator=self.user)
+        self.public_node = NodeFactory(is_public=True, creator=self.user)
+        self.linking_node.add_pointer(self.linked_node, auth=self.auth)
+        self.linking_node.add_pointer(self.linked_node2, auth=self.auth)
+        self.linking_node.add_pointer(self.public_node, auth=self.auth)
+        self.linking_node.save()
+        self.url = '/{}nodes/{}/linked_nodes/'.format(API_BASE, self.linking_node._id)
+        self.node_ids = [pointer.node._id for pointer in self.linking_node.nodes_pointer]
+
+    def test_linked_nodes_returns_everything(self):
+        res = self.app.get(self.url, auth=self.user.auth)
+
+        assert_equal(res.status_code, 200)
+        nodes_returned = [linked_node['id'] for linked_node in res.json['data']]
+        assert_equal(len(nodes_returned), len(self.node_ids))
+
+        for node_id in self.node_ids:
+            assert_in(node_id, nodes_returned)
+
+    def test_linked_nodes_only_return_viewable_nodes(self):
+        user = AuthUserFactory()
+        new_linking_node = NodeFactory(creator=user)
+        self.linked_node.add_contributor(user, auth=self.auth, save=True)
+        self.linked_node2.add_contributor(user, auth=self.auth, save=True)
+        self.public_node.add_contributor(user, auth=self.auth, save=True)
+        new_linking_node.add_pointer(self.linked_node, auth=Auth(user))
+        new_linking_node.add_pointer(self.linked_node2, auth=Auth(user))
+        new_linking_node.add_pointer(self.public_node, auth=Auth(user))
+        new_linking_node.save()
+
+        res = self.app.get(
+            '/{}nodes/{}/linked_nodes/'.format(API_BASE, new_linking_node._id),
+            auth=user.auth
+        )
+
+        assert_equal(res.status_code, 200)
+        nodes_returned = [linked_node['id'] for linked_node in res.json['data']]
+        assert_equal(len(nodes_returned), len(self.node_ids))
+
+        for node_id in self.node_ids:
+            assert_in(node_id, nodes_returned)
+
+        self.linked_node2.remove_contributor(user, auth=self.auth)
+        self.public_node.remove_contributor(user, auth=self.auth)
+
+        res = self.app.get(
+            '/{}nodes/{}/linked_nodes/'.format(API_BASE, new_linking_node._id),
+            auth=user.auth
+        )
+        nodes_returned = [linked_node['id'] for linked_node in res.json['data']]
+        assert_equal(len(nodes_returned), len(self.node_ids) - 1)
+
+        assert_in(self.linked_node._id, nodes_returned)
+        assert_in(self.public_node._id, nodes_returned)
+        assert_not_in(self.linked_node2._id, nodes_returned)
+
+    def test_linked_nodes_doesnt_return_deleted_nodes(self):
+        self.linked_node.is_deleted = True
+        self.linked_node.save()
+        res = self.app.get(self.url, auth=self.user.auth)
+
+        assert_equal(res.status_code, 200)
+        nodes_returned = [linked_node['id'] for linked_node in res.json['data']]
+        assert_equal(len(nodes_returned), len(self.node_ids) - 1)
+
+        assert_not_in(self.linked_node._id, nodes_returned)
+        assert_in(self.linked_node2._id, nodes_returned)
+        assert_in(self.public_node._id, nodes_returned)
+
+    def test_attempt_to_return_linked_nodes_logged_out(self):
+        res = self.app.get(
+            self.url, auth=None,
+            expect_errors=True
+        )
+
+        assert_equal(res.status_code, 401)

--- a/api_tests/registrations/views/test_registration_linked_nodes.py
+++ b/api_tests/registrations/views/test_registration_linked_nodes.py
@@ -1,0 +1,380 @@
+from nose.tools import *  # flake8: noqa
+
+from api.base.settings.defaults import API_BASE
+from tests.base import ApiTestCase
+from tests.factories import NodeFactory
+from tests.factories import AuthUserFactory
+from tests.factories import RegistrationFactory
+from framework.auth.core import Auth
+
+
+class TestNodeRelationshipNodeLinks(ApiTestCase):
+
+    def setUp(self):
+        super(TestNodeRelationshipNodeLinks, self).setUp()
+        self.user = AuthUserFactory()
+        self.user2 = AuthUserFactory()
+        self.auth = Auth(self.user)
+        self.linking_node_source = NodeFactory(creator=self.user)
+        self.admin_node = NodeFactory(creator=self.user)
+        self.contributor_node = NodeFactory(creator=self.user2)
+        self.contributor_node.add_contributor(self.user, auth=Auth(self.user2))
+        self.contributor_node.save()
+        self.other_node = NodeFactory()
+        self.private_node = NodeFactory(creator=self.user)
+        self.public_node = NodeFactory(is_public=True)
+        self.linking_node_source.add_pointer(self.private_node, auth=self.auth)
+        self.linking_node_source.add_pointer(self.admin_node, auth=self.auth)
+        self.public_linking_node_source = NodeFactory(is_public=True, creator=self.user2)
+        self.public_linking_node_source.add_pointer(self.private_node, auth=Auth(self.user2))
+        self.public_linking_node_source.add_pointer(self.public_node, auth=Auth(self.user2))
+        self.public_linking_node = RegistrationFactory(project=self.public_linking_node_source, is_public=True, creator=self.user2)
+        self.linking_node = RegistrationFactory(project=self.linking_node_source, creator=self.user)
+        self.url = '/{}registrations/{}/relationships/linked_nodes/'.format(API_BASE, self.linking_node._id)
+        self.public_url = '/{}registrations/{}/relationships/linked_nodes/'.format(API_BASE, self.public_linking_node._id)
+
+    def payload(self, node_ids=None):
+        node_ids = node_ids or [self.admin_node._id]
+        env_linked_nodes = [{"type": "linked_nodes", "id": node_id} for node_id in node_ids]
+        return {"data": env_linked_nodes}
+
+    def test_get_relationship_linked_nodes(self):
+        res = self.app.get(
+            self.url, auth=self.user.auth
+        )
+
+        assert_equal(res.status_code, 200)
+
+        assert_in(self.linking_node.linked_nodes_self_url, res.json['links']['self'])
+        assert_in(self.linking_node.linked_nodes_related_url, res.json['links']['html'])
+        assert_equal(res.json['data'][0]['id'], self.private_node._id)
+
+    def test_get_public_relationship_linked_nodes_logged_out(self):
+        res = self.app.get(self.public_url)
+
+        assert_equal(res.status_code, 200)
+        assert_equal(len(res.json['data']), 1)
+        assert_equal(res.json['data'][0]['id'], self.public_node._id)
+
+    def test_get_public_relationship_linked_nodes_logged_in(self):
+        res = self.app.get(self.public_url, auth=self.user.auth)
+
+        assert_equal(res.status_code, 200)
+        assert_equal(len(res.json['data']), 2)
+
+    def test_get_private_relationship_linked_nodes_logged_out(self):
+        res = self.app.get(self.url, expect_errors=True)
+
+        assert_equal(res.status_code, 401)
+
+    def test_post_contributing_node(self):
+        res = self.app.post_json_api(
+            self.url, self.payload([self.contributor_node._id]),
+            auth=self.user.auth, expect_errors=True
+        )
+
+        assert_equal(res.status_code, 405)
+
+    def test_post_public_node(self):
+        res = self.app.post_json_api(
+            self.url, self.payload([self.public_node._id]),
+            auth=self.user.auth, expect_errors=True
+        )
+
+        assert_equal(res.status_code, 405)
+
+    def test_post_private_node(self):
+        res = self.app.post_json_api(
+            self.url, self.payload([self.other_node._id]),
+            auth=self.user.auth,
+            expect_errors=True
+        )
+
+        assert_equal(res.status_code, 405)
+
+        res = self.app.get(
+            self.url, auth=self.user.auth
+        )
+
+        ids = [data['id'] for data in res.json['data']]
+        assert_not_in(self.other_node._id, ids)
+        assert_in(self.private_node._id, ids)
+
+    def test_post_mixed_nodes(self):
+        res = self.app.post_json_api(
+            self.url, self.payload([self.other_node._id, self.contributor_node._id]),
+            auth=self.user.auth,
+            expect_errors=True
+        )
+
+        assert_equal(res.status_code, 405)
+
+        res = self.app.get(
+            self.url, auth=self.user.auth
+        )
+
+        ids = [data['id'] for data in res.json['data']]
+        assert_not_in(self.other_node._id, ids)
+        assert_not_in(self.contributor_node._id, ids)
+        assert_in(self.private_node._id, ids)
+
+    def test_post_node_already_linked(self):
+        res = self.app.post_json_api(
+            self.url, self.payload([self.private_node._id]),
+            auth=self.user.auth, expect_errors=True
+        )
+
+        assert_equal(res.status_code, 405)
+
+    def test_put_contributing_node(self):
+        res = self.app.put_json_api(
+            self.url, self.payload([self.contributor_node._id]),
+            auth=self.user.auth, expect_errors=True
+        )
+
+        assert_equal(res.status_code, 405)
+
+    def test_put_private_node(self):
+        res = self.app.put_json_api(
+            self.url, self.payload([self.other_node._id]),
+            auth=self.user.auth,
+            expect_errors=True
+        )
+
+        assert_equal(res.status_code, 405)
+
+        res = self.app.get(
+            self.url, auth=self.user.auth
+        )
+
+        ids = [data['id'] for data in res.json['data']]
+        assert_not_in(self.other_node._id, ids)
+        assert_in(self.private_node._id, ids)
+
+    def test_put_mixed_nodes(self):
+        res = self.app.put_json_api(
+            self.url, self.payload([self.other_node._id, self.contributor_node._id]),
+            auth=self.user.auth, expect_errors=True
+        )
+
+        assert_equal(res.status_code, 405)
+
+        res = self.app.get(
+            self.url, auth=self.user.auth
+        )
+
+        ids = [data['id'] for data in res.json['data']]
+        assert_not_in(self.other_node._id, ids)
+        assert_not_in(self.contributor_node._id, ids)
+        assert_in(self.private_node._id, ids)
+
+    def test_delete_with_put_empty_array(self):
+        payload = self.payload()
+        payload['data'].pop()
+        res = self.app.put_json_api(
+            self.url, payload, auth=self.user.auth, expect_errors=True
+        )
+        assert_equal(res.status_code, 405)
+
+    def test_delete_one(self):
+        res = self.app.delete_json_api(
+            self.url, self.payload([self.private_node._id]),
+            auth=self.user.auth, expect_errors=True
+        )
+        assert_equal(res.status_code, 405)
+
+        res = self.app.get(self.url, auth=self.user.auth)
+
+        ids = [data['id'] for data in res.json['data']]
+        assert_in(self.admin_node._id, ids)
+        assert_in(self.private_node._id, ids)
+
+    def test_delete_multiple(self):
+
+        res = self.app.delete_json_api(
+            self.url, self.payload([self.private_node._id, self.admin_node._id]),
+            auth=self.user.auth, expect_errors=True
+        )
+        assert_equal(res.status_code, 405)
+
+        res = self.app.get(self.url, auth=self.user.auth)
+        assert_equal(len(res.json['data']), 2)
+
+    def test_delete_not_present(self):
+        number_of_links = len(self.linking_node.nodes)
+        res = self.app.delete_json_api(
+            self.url, self.payload([self.other_node._id]),
+            auth=self.user.auth, expect_errors=True
+        )
+        assert_equal(res.status_code, 405)
+
+        res = self.app.get(
+            self.url, auth=self.user.auth
+        )
+        assert_equal(len(res.json['data']), number_of_links)
+
+
+    def test_node_doesnt_exist(self):
+        res = self.app.post_json_api(
+            self.url, self.payload(['aquarela']),
+            auth=self.user.auth,
+            expect_errors=True
+        )
+
+        assert_equal(res.status_code, 405)
+
+    def test_type_mistyped(self):
+        res = self.app.post_json_api(
+            self.url,
+            {
+                'data': [{'type': 'not_linked_nodes', 'id': self.contributor_node._id}]
+            },
+            auth=self.user.auth,
+            expect_errors=True
+        )
+
+        assert_equal(res.status_code, 405)
+
+    def test_creates_public_linked_node_relationship_logged_out(self):
+        res = self.app.post_json_api(
+                self.public_url, self.payload([self.public_node._id]),
+                expect_errors=True
+        )
+
+        assert_equal(res.status_code, 401)
+
+    def test_creates_public_linked_node_relationship_logged_in(self):
+        res = self.app.post_json_api(
+                self.public_url, self.payload([self.public_node._id]),
+                auth=self.user.auth, expect_errors=True
+        )
+
+        assert_equal(res.status_code, 405)
+
+    def test_creates_private_linked_node_relationship_logged_out(self):
+        res = self.app.post_json_api(
+                self.url, self.payload([self.other_node._id]),
+                expect_errors=True
+        )
+
+        assert_equal(res.status_code, 401)
+
+    def test_put_public_nodes_relationships_logged_out(self):
+        res = self.app.put_json_api(
+                self.public_url, self.payload([self.public_node._id]),
+                expect_errors=True
+        )
+
+        assert_equal(res.status_code, 401)
+
+    def test_put_public_nodes_relationships_logged_in(self):
+        res = self.app.put_json_api(
+                self.public_url, self.payload([self.private_node._id]),
+                auth=self.user.auth, expect_errors=True
+        )
+
+        assert_equal(res.status_code, 405)
+
+    def test_delete_public_nodes_relationships_logged_out(self):
+        res = self.app.delete_json_api(
+            self.public_url, self.payload([self.public_node._id]),
+            expect_errors=True
+        )
+
+        assert_equal(res.status_code, 401)
+
+    def test_delete_public_nodes_relationships_logged_in(self):
+        res = self.app.delete_json_api(
+                self.public_url, self.payload([self.private_node._id]),
+                auth=self.user.auth, expect_errors=True
+        )
+
+        assert_equal(res.status_code, 405)
+
+
+class TestNodeLinkedNodes(ApiTestCase):
+    def setUp(self):
+        super(TestNodeLinkedNodes, self).setUp()
+        self.user = AuthUserFactory()
+        self.auth = Auth(self.user)
+        self.linking_node_source = NodeFactory(creator=self.user)
+        self.linked_node = NodeFactory(creator=self.user)
+        self.linked_node2 = NodeFactory(creator=self.user)
+        self.public_node = NodeFactory(is_public=True, creator=self.user)
+        self.linking_node_source.add_pointer(self.linked_node, auth=self.auth)
+        self.linking_node_source.add_pointer(self.linked_node2, auth=self.auth)
+        self.linking_node_source.add_pointer(self.public_node, auth=self.auth)
+        self.linking_node_source.save()
+        self.linking_node = RegistrationFactory(project=self.linking_node_source, creator=self.user)
+
+        self.url = '/{}registrations/{}/linked_nodes/'.format(API_BASE, self.linking_node._id)
+        self.node_ids = [pointer.node._id for pointer in self.linking_node.nodes_pointer]
+
+    def test_linked_nodes_returns_everything(self):
+        res = self.app.get(self.url, auth=self.user.auth)
+
+        assert_equal(res.status_code, 200)
+        nodes_returned = [linked_node['id'] for linked_node in res.json['data']]
+        assert_equal(len(nodes_returned), len(self.node_ids))
+
+        for node_id in self.node_ids:
+            assert_in(node_id, nodes_returned)
+
+    def test_linked_nodes_only_return_viewable_nodes(self):
+        user = AuthUserFactory()
+        new_linking_node = NodeFactory(creator=user)
+        self.linked_node.add_contributor(user, auth=self.auth, save=True)
+        self.linked_node2.add_contributor(user, auth=self.auth, save=True)
+        self.public_node.add_contributor(user, auth=self.auth, save=True)
+        new_linking_node.add_pointer(self.linked_node, auth=Auth(user))
+        new_linking_node.add_pointer(self.linked_node2, auth=Auth(user))
+        new_linking_node.add_pointer(self.public_node, auth=Auth(user))
+        new_linking_node.save()
+        new_linking_registration = RegistrationFactory(project=new_linking_node, creator=self.user)
+
+        res = self.app.get(
+            '/{}registrations/{}/linked_nodes/'.format(API_BASE, new_linking_registration._id),
+            auth=user.auth
+        )
+
+        assert_equal(res.status_code, 200)
+        nodes_returned = [linked_node['id'] for linked_node in res.json['data']]
+        assert_equal(len(nodes_returned), len(self.node_ids))
+
+        for node_id in self.node_ids:
+            assert_in(node_id, nodes_returned)
+
+        self.linked_node2.remove_contributor(user, auth=self.auth)
+        self.public_node.remove_contributor(user, auth=self.auth)
+
+        res = self.app.get(
+            '/{}registrations/{}/linked_nodes/'.format(API_BASE, new_linking_registration._id),
+            auth=user.auth
+        )
+        nodes_returned = [linked_node['id'] for linked_node in res.json['data']]
+        assert_equal(len(nodes_returned), len(self.node_ids) - 1)
+
+        assert_in(self.linked_node._id, nodes_returned)
+        assert_in(self.public_node._id, nodes_returned)
+        assert_not_in(self.linked_node2._id, nodes_returned)
+
+    def test_linked_nodes_doesnt_return_deleted_nodes(self):
+        self.linked_node.is_deleted = True
+        self.linked_node.save()
+        res = self.app.get(self.url, auth=self.user.auth)
+
+        assert_equal(res.status_code, 200)
+        nodes_returned = [linked_node['id'] for linked_node in res.json['data']]
+        assert_equal(len(nodes_returned), len(self.node_ids) - 1)
+
+        assert_not_in(self.linked_node._id, nodes_returned)
+        assert_in(self.linked_node2._id, nodes_returned)
+        assert_in(self.public_node._id, nodes_returned)
+
+    def test_attempt_to_return_linked_nodes_logged_out(self):
+        res = self.app.get(
+            self.url, auth=None,
+            expect_errors=True
+        )
+
+        assert_equal(res.status_code, 401)


### PR DESCRIPTION
Replaces #5921  

---------------

## Purpose

Add linked_node relationship and relationship self link to nodes and registrations

## Changes

1. Refactor linked_nodes so that it's not collection specific
2. Add to nodes (with tests)
3. Add to registrations (with tests)

## Side effects

## Ticket

https://openscience.atlassian.net/browse/OSF-6541