### PR TITLE
Hotfix - Fix 500 error when embedding identifiers on registration API view [#OSF-6628]

### DIFF
--- a/api/identifiers/urls.py
+++ b/api/identifiers/urls.py
@@ -4,4 +4,5 @@ from api.identifiers import views
 
 urlpatterns = [
     url(r'^(?P<identifier_id>\w+)/$', views.IdentifierDetail.as_view(), name=views.IdentifierDetail.view_name),
+    url(r'^(?P<node_id>\w+)/identifiers/$', views.IdentifierList.as_view(), name=views.IdentifierList.view_name),
 ]

--- a/api_tests/registrations/views/test_registration_embeds.py
+++ b/api_tests/registrations/views/test_registration_embeds.py
@@ -55,6 +55,12 @@ class TestRegistrationEmbeds(ApiTestCase):
         for contrib in embeds['contributors']['data']:
             assert_in(contrib['id'], ids)
 
+    def test_embed_identifiers(self):
+        url = '/{0}registrations/{1}/?embed=identifiers'.format(API_BASE, self.registration._id)
+
+        res = self.app.get(url, auth=self.user.auth)
+        assert_equal(res.status_code, 200)
+
     def test_embed_attributes_not_relationships(self):
         url = '/{}registrations/{}/?embed=title'.format(API_BASE, self.registration._id)
 


### PR DESCRIPTION
## Purpose

Embedding identifiers on the api registrations endpoint leads to a 500 error. 
https://api.osf.io/v2/registrations/?embed=identifiers

## Changes
- Add identifier list to the identifiers urls.py so that embeds can get the correct URL for self links in the reverse URL search
- Add a test to make sure the embed returns a desired status code

## Side effects
None anticipated


## Ticket
https://openscience.atlassian.net/browse/OSF-6628