### PR TITLE
Contributor lists for projects under "Most Popular" (dashboard) display incorrect order. [OSF-5948]

### DIFF
--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -646,7 +646,7 @@ class NodeContributorsList(JSONAPIBaseView, bulk_views.BulkUpdateJSONAPIView, bu
 
     # overrides ListBulkCreateJSONAPIView, BulkUpdateJSONAPIView
     def get_queryset(self):
-        queryset = self.get_queryset_from_request()
+        queryset = self.get_default_queryset()
 
         # If bulk request, queryset only contains contributors in request
         if is_bulk_request(self.request):


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

The contributors list under the "Most Popular" nodes were displaying in the incorrect order. They were ordering randomly, instead of the intended listed order. 

## Changes

Calls get_default_queryset() instead of get_queryset_from_request(). The former grabs all of the contributors from the list of contributors on a project, therefore grabbing them in the correct order.

## Side effects

n/a

## Ticket

https://openscience.atlassian.net/browse/OSF-5948
