### PR TITLE
#OSF-6011 Fixed bug 'Extra logs when deauthorizing addons'

### DIFF
--- a/api_tests/nodes/views/test_node_logs.py
+++ b/api_tests/nodes/views/test_node_logs.py
@@ -108,8 +108,10 @@ class TestNodeLogList(ApiTestCase):
     def test_remove_addon(self):
         self.public_project.add_addon('github', auth=self.user_auth)
         assert_equal('addon_added', self.public_project.logs[OSF_LATEST].action)
+        old_log_length = len(list(self.public_project.logs))
         self.public_project.delete_addon('github', auth=self.user_auth)
         assert_equal('addon_removed', self.public_project.logs[OSF_LATEST].action)
+        assert_equal((len(list(self.public_project.logs)) - 1), old_log_length)
         res = self.app.get(self.public_url, auth=self.user.auth)
         assert_equal(res.status_code, 200)
         assert_equal(len(res.json['data']), len(self.public_project.logs))

--- a/framework/addons/__init__.py
+++ b/framework/addons/__init__.py
@@ -123,7 +123,7 @@ class AddonModelMixin(StoredObject):
         if addon:
             if self._name in addon.config.added_mandatory and not _force:
                 raise ValueError('Cannot delete mandatory add-on.')
-            if hasattr(addon, 'external_account'):
+            if hasattr(addon, 'external_accounts'):
                 addon.deauthorize(auth=auth)
             addon.delete(save=True)
             return True

--- a/framework/addons/__init__.py
+++ b/framework/addons/__init__.py
@@ -123,9 +123,8 @@ class AddonModelMixin(StoredObject):
         if addon:
             if self._name in addon.config.added_mandatory and not _force:
                 raise ValueError('Cannot delete mandatory add-on.')
-            if hasattr(addon, 'external_account'):
-                if getattr(addon, 'external_account'):
-                    addon.deauthorize(auth=auth)
+            if getattr(addon, 'external_account', None):
+                addon.deauthorize(auth=auth)
             addon.delete(save=True)
             return True
         return False

--- a/framework/addons/__init__.py
+++ b/framework/addons/__init__.py
@@ -123,9 +123,11 @@ class AddonModelMixin(StoredObject):
         if addon:
             if self._name in addon.config.added_mandatory and not _force:
                 raise ValueError('Cannot delete mandatory add-on.')
-            if hasattr(addon, 'external_accounts'):
-                addon.deauthorize(auth=auth)
+            if hasattr(addon, 'external_account'):
+                if getattr(addon, 'external_account'):
+                    addon.deauthorize(auth=auth)
             addon.delete(save=True)
+            print("Did a thing")
             return True
         return False
 

--- a/framework/addons/__init__.py
+++ b/framework/addons/__init__.py
@@ -135,7 +135,6 @@ class AddonModelMixin(StoredObject):
 
         :param dict config: Mapping between add-on names and enabled / disabled
             statuses
-
         """
 
         for addon_name, enabled in config.iteritems():

--- a/framework/addons/__init__.py
+++ b/framework/addons/__init__.py
@@ -127,7 +127,6 @@ class AddonModelMixin(StoredObject):
                 if getattr(addon, 'external_account'):
                     addon.deauthorize(auth=auth)
             addon.delete(save=True)
-            print("Did a thing")
             return True
         return False
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

<!-- Describe the purpose of your changes -->
Fix bug where deleting an addon would create unnecessary log messages. 

## Changes

<!-- Briefly describe or list your changes  -->
Fixed code that checked if addon that was being deleted had attribute 'external_accounts' 
Wrote unit test that checks that deleting an addon does not make any unnecessary messages in the log. Test fails without change, passes with it. 

## Side effects

<!--Any possible side effects? -->
None

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->

https://openscience.atlassian.net/browse/OSF-6011