### PR TITLE
Fix bug "new folder error persists through multiple 'create folder' attempts" [#OSF-5707]

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1791,7 +1791,7 @@ var FGToolbar = {
         self.helpText = m.prop('');
         self.dismissToolbar = dismissToolbar.bind(self.tb, self.helpText);
         self.createFolder = function(event){
-            _createFolder.call(self.tb, event, self.dismissToolbar, self.helpText );
+            _createFolder.call(self.tb, event, self.dismissToolbar, self.helpText);
         };
     },
     view : function(ctrl) {

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -919,6 +919,7 @@ function _downloadZipEvent (event, item, col) {
 
 function _createFolder(event, dismissCallback, helpText) {
     var tb = this;
+    helpText('');
     var val = $.trim(tb.select('#createFolderInput').val());
     var parent = tb.multiselected()[0];
     if (!parent.open) {
@@ -956,6 +957,7 @@ function _createFolder(event, dismissCallback, helpText) {
     }, function(data) {
         if (data && data.code === 409) {
             helpText(data.message);
+            m.redraw();
         } else {
             helpText('Folder creation failed.');
         }
@@ -1766,13 +1768,14 @@ var FGItemButtons = {
     }
 };
 
-var dismissToolbar = function(){
+var dismissToolbar = function(helpText){
     var tb = this;
     if (tb.toolbarMode() === toolbarModes.FILTER){
         tb.resetFilter();
     }
     tb.toolbarMode(toolbarModes.DEFAULT);
     tb.filterText('');
+    helpText('');
     m.redraw();
 };
 
@@ -1786,7 +1789,7 @@ var FGToolbar = {
         self.mode = self.tb.toolbarMode;
         self.isUploading = args.treebeard.isUploading;
         self.helpText = m.prop('');
-        self.dismissToolbar = dismissToolbar.bind(self.tb);
+        self.dismissToolbar = dismissToolbar.bind(self.tb, self.helpText);
         self.createFolder = function(event){
             _createFolder.call(self.tb, event, self.dismissToolbar, self.helpText );
         };


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

<!-- Describe the purpose of your changes -->
Fixes bug where any error message shown when creating a folder persists through multiple create folder attempts and certain error messages sometimes take a while to display or may even never display at all

## Changes

Fixes code to clear helpText whenever the dismiss toolbar button is hit and also whenever a create folder attempt is made
Also makes sure error messages appear using m.redraw() after helpText is filled with the error
<!-- Briefly describe or list your changes  -->

## Side effects
None

<!--Any possible side effects? -->


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->

https://openscience.atlassian.net/browse/OSF-5707