### PR TITLE
Create component, selecting "import contributors" takes u… [#OSF-6517]

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4115,7 +4115,7 @@ class TestProjectCreation(OsfTestCase):
         assert_in(self.user1, child.contributors)
         assert_in(self.user2, child.contributors)
         # check redirect url
-        assert_in('/contributors/', res.location)
+        assert_not_in('/contributors/', res.location)
 
     def test_create_component_with_contributors_read_write(self):
         url = web_url_for('project_new_node', pid=self.project._id)
@@ -4132,7 +4132,7 @@ class TestProjectCreation(OsfTestCase):
         assert_in(self.user2, child.contributors)
         assert_equal(child.get_permissions(non_admin), ['read', 'write', 'admin'])
         # check redirect url
-        assert_in('/contributors/', res.location)
+        assert_not_in('/contributors/', res.location)
 
     def test_create_component_with_contributors_read(self):
         url = web_url_for('project_new_node', pid=self.project._id)

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -182,12 +182,6 @@ def project_new_node(auth, node, **kwargs):
                 new_component.add_contributor(contributor, permissions=perm, auth=auth)
 
             new_component.save()
-            redirect_url = new_component.url + 'contributors/'
-            message = (
-                'Your component was created successfully. You can edit the contributor permissions below, '
-                'work on your <u><a href={component_url}>component</a></u> or return to the <u> '
-                '<a href="{project_url}">project page</a></u>.'
-            ).format(component_url=new_component.url, project_url=node.url)
         status.push_status_message(message, kind='info', trust=True)
 
         return {


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

When the user goes to create a new component, they have the option to add contributors from the parent project:
  
- If they don't add contributors, they stay on the main project page
- If they choose to add contributors, they're automatically redirected to the new component's collaborators page

The user experience should be the same no matter what they select.  The purpose of this PR is to make sure that the user isn't redirected to a new page if they choose to add collaborators.

## Changes

The changes include removing code that redirects the user if they choose to add collaborators from the main project.  Now the user stays on the same page no matter what they choose when making a new component.

## Side effects

There shouldn't be any side effects.

## Ticket

https://openscience.atlassian.net/browse/OSF-6517
