### PR TITLE
[Fix] Add rate-limit to resending confirmation email [#OSF-6561]

### DIFF
--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -587,12 +587,19 @@ def resend_confirmation_post(auth):
                           'you should have, please contact OSF Support.').format(clean_email)
         kind = 'success'
         if user:
-            try:
-                send_confirm_email(user, clean_email)
-            except KeyError:
-                # already confirmed, redirect to dashboard
-                status_message = 'This email {0} has already been confirmed.'.format(clean_email)
-                kind = 'warning'
+            if throttle_period_expired(user.email_last_sent, settings.SEND_EMAIL_THROTTLE):
+                try:
+                    send_confirm_email(user, clean_email)
+                except KeyError:
+                    # already confirmed, redirect to dashboard
+                    status_message = 'This email {0} has already been confirmed.'.format(clean_email)
+                    kind = 'warning'
+                user.email_last_sent = datetime.datetime.utcnow()
+                user.save()
+            else:
+                status_message = 'You have recently requested to resend confirmation email.' \
+                                 'Please wait a little while before trying again.'
+                kind = 'error'
         status.push_status_message(status_message, kind=kind, trust=False)
     else:
         forms.push_errors_to_status(form.errors)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -3199,10 +3199,6 @@ class TestAuthViews(OsfTestCase):
                                                        auth.signals.unconfirmed_user_created]))
         assert_true(mock_send_confirm_email.called)
 
-    def test_resend_confirmation_get(self):
-        res = self.app.get('/resend/')
-        assert_equal(res.status_code, 200)
-
     @mock.patch('framework.auth.views.mails.send_mail')
     def test_resend_confirmation(self, send_mail):
         email = 'test@example.com'


### PR DESCRIPTION
## Purpose

Limit the rate of uses' attempt to resending confirmation email. This prevents unconfirmed user from being spammed.

## Changes

- Add `throttle_period_expired()` check before `send_confirm_email()`
- Users will be notified if they make a second request too fast.
![throttle-notification](https://cloud.githubusercontent.com/assets/3750414/16694660/6f6b2cb8-4509-11e6-87f8-5551b6e9eed8.png)
- Add related unit tests

## Side effects

No

## Ticket

https://openscience.atlassian.net/browse/OSF-6561