### PR TITLE
[#OSF-6587]Page numbers for logs

### DIFF
--- a/website/static/js/components/logFeed.js
+++ b/website/static/js/components/logFeed.js
@@ -166,7 +166,7 @@ var LogFeed = {
                 });
                 for (i = parseInt(ctrl.currentPage()) - 1; i <= parseInt(ctrl.currentPage()) + 1; i++) {
                     ctrl.paginators().push({
-                        text: i + 1,
+                        text: i,
                         url: function() {
                             ctrl.pageToGet(parseInt(this.text));
                             if (ctrl.pageToGet() !== ctrl.currentPage()) {


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

<!-- Describe the purpose of your changes -->
Fix the paginator's current page is not in the middle when there are two clips on both sides.
Before changes:
![screen shot 2016-07-10 at 4 04 06 pm](https://cloud.githubusercontent.com/assets/4974056/16715789/f5e46a7a-46b7-11e6-940a-a704ad61273a.png)

After changes:
![screen shot 2016-07-10 at 4 04 28 pm](https://cloud.githubusercontent.com/assets/4974056/16715791/04ae3482-46b8-11e6-977e-f306a5f5673d.png)


## Changes

<!-- Briefly describe or list your changes  -->

## Side effects

<!--Any possible side effects? -->


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
https://openscience.atlassian.net/browse/OSF-6587
