### PR TITLE
Page number for logs with ellipsis on the left not showing [#OSF-6660]

### DIFF
--- a/website/static/js/components/logFeed.js
+++ b/website/static/js/components/logFeed.js
@@ -147,7 +147,7 @@ var LogFeed = {
                 });
                 for (i = ctrl.totalPages() - MAX_PAGES_ON_PAGINATOR_SIDE; i < ctrl.totalPages() - 1; i++) {
                     ctrl.paginators().push({
-                        text: i + 1,
+                        text: i,
                         url: function() {
                             ctrl.pageToGet(parseInt(this.text));
                             if (ctrl.pageToGet() !== ctrl.currentPage()) {


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

<!-- Describe the purpose of your changes -->
Fix the paginator when there are one eclipse at the beginning.


## Changes

<!-- Briefly describe or list your changes  -->
Before change:
![screen shot 2016-07-11 at 12 12 47 pm](https://cloud.githubusercontent.com/assets/4974056/16737759/d2e6c262-4760-11e6-94fa-1e2c316d1650.png)
After change:
![screen shot 2016-07-11 at 12 12 14 pm](https://cloud.githubusercontent.com/assets/4974056/16737787/f60a574a-4760-11e6-9001-c512f6f26464.png)
## Side effects

<!--Any possible side effects? -->


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
https://openscience.atlassian.net/browse/OSF-6660