### PR TITLE
Fix `inv karma` docstring

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -594,7 +594,7 @@ def test_travis_varnish(ctx):
 
 @task
 def karma(ctx, single=False, sauce=False, browsers=None):
-    """Run JS tests with Karma. Requires Chrome to be installed."""
+    """Run JS tests with Karma. Requires PhantomJS to be installed."""
     karma_bin = os.path.join(
         HERE, 'node_modules', 'karma', 'bin', 'karma'
     )


### PR DESCRIPTION
## Purpose

The default test browser in `karma.conf.js` [is PhantomJS](https://github.com/CenterForOpenScience/osf.io/blob/ef98b0bf6eb5b520fff990306bc58ea3fcaca061/karma.conf.js#L6), not Chrome.

## Changes

s/Chrome/PhantomJS

## Side effects

n/a


## Ticket

Noticed while working on [OSF-6447](https://openscience.atlassian.net/browse/OSF-6447).

