### PR TITLE
Password verification ui and functional changes [OSF-3457]

### DIFF
--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -703,3 +703,14 @@ button.close {
 div.ball-scale-blue>div {
     background-color: #BED1E2;
 }
+
+/* Lighter danger text for dark backgrounds  */
+.pv-darkbg .text-danger {
+    color: #f97773;
+}
+.pv-darkbg .text-warning {
+    color: #f0ad4e;
+}
+.pv-darkbg .text-warning {
+    color: #5cb85c;
+}

--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -704,13 +704,17 @@ div.ball-scale-blue>div {
     background-color: #BED1E2;
 }
 
-/* Lighter danger text for dark backgrounds  */
+/* Password strength check component colors for darker backgrounds  */
 .pv-darkbg .text-danger {
     color: #f97773;
 }
 .pv-darkbg .text-warning {
     color: #f0ad4e;
 }
-.pv-darkbg .text-warning {
+.pv-darkbg .text-success {
     color: #5cb85c;
+}
+
+.pv-darkbg .osf-box-lt {
+    background-color: #a8bbc9
 }

--- a/website/static/js/passwordForms.js
+++ b/website/static/js/passwordForms.js
@@ -29,11 +29,11 @@ ko.validation.registerExtenders();
   */
 var valueProgressBar = {
     0: {'attr': {'style': 'width: 0%'}, 'text': '', 'text_attr':{}},
-    1: {'attr': {'class': 'progress-bar progress-bar-sm progress-bar-danger', 'style': 'width: 20%'}, 'text': 'Very weak', 'text_attr': {'style': 'color: grey'}},
-    2: {'attr': {'class': 'progress-bar progress-bar-sm progress-bar-danger', 'style': 'width: 40%'}, 'text': 'Weak', 'text_attr': {'style': 'color: orangered '}},
-    3: {'attr': {'class': 'progress-bar progress-bar-sm progress-bar-warning', 'style': 'width: 60%'}, 'text': 'So-so', 'text_attr': {'style': 'color: gold'}},
-    4: {'attr': {'class': 'progress-bar progress-bar-sm progress-bar-success', 'style': 'width: 80%; background-image: none; background-color: lawngreen'}, 'text': 'Good', 'text_attr': {'style': 'color: lawngreen'}},
-    5: {'attr': {'class': 'progress-bar progress-bar-sm progress-bar-success', 'style': 'width: 100%'}, 'text': 'Great!', 'text_attr': {'style': 'color: limegreen'}}
+    1: {'attr': {'class': 'progress-bar progress-bar-sm progress-bar-danger', 'style': 'width: 20%'}, 'text': 'Very weak', 'text_attr': {'style': 'color: #d9534f'}},
+    2: {'attr': {'class': 'progress-bar progress-bar-sm progress-bar-danger', 'style': 'width: 40%'}, 'text': 'Weak', 'text_attr': {'style': 'color: #d9534f '}},
+    3: {'attr': {'class': 'progress-bar progress-bar-sm progress-bar-warning', 'style': 'width: 60%'}, 'text': 'So-so', 'text_attr': {'style': 'color: #f0ad4e'}},
+    4: {'attr': {'class': 'progress-bar progress-bar-sm progress-bar-success', 'style': 'width: 80%;'}, 'text': 'Good', 'text_attr': {'style': 'color: #5cb85c'}},
+    5: {'attr': {'class': 'progress-bar progress-bar-sm progress-bar-success', 'style': 'width: 100%'}, 'text': 'Great!', 'text_attr': {'style': 'color: #5cb85c'}}
 };
 
 /**

--- a/website/static/js/passwordForms.js
+++ b/website/static/js/passwordForms.js
@@ -29,11 +29,11 @@ ko.validation.registerExtenders();
   */
 var valueProgressBar = {
     0: {'attr': {'style': 'width: 0%'}, 'text': '', 'text_attr':{}},
-    1: {'attr': {'class': 'progress-bar progress-bar-sm progress-bar-danger', 'style': 'width: 20%'}, 'text': 'Very weak', 'text_attr': {'style': 'color: #d9534f'}},
-    2: {'attr': {'class': 'progress-bar progress-bar-sm progress-bar-danger', 'style': 'width: 40%'}, 'text': 'Weak', 'text_attr': {'style': 'color: #d9534f '}},
-    3: {'attr': {'class': 'progress-bar progress-bar-sm progress-bar-warning', 'style': 'width: 60%'}, 'text': 'So-so', 'text_attr': {'style': 'color: #f0ad4e'}},
-    4: {'attr': {'class': 'progress-bar progress-bar-sm progress-bar-success', 'style': 'width: 80%;'}, 'text': 'Good', 'text_attr': {'style': 'color: #5cb85c'}},
-    5: {'attr': {'class': 'progress-bar progress-bar-sm progress-bar-success', 'style': 'width: 100%'}, 'text': 'Great!', 'text_attr': {'style': 'color: #5cb85c'}}
+    1: {'attr': {'class': 'progress-bar progress-bar-sm progress-bar-danger', 'style': 'width: 20%'}, 'text': 'Very weak', 'text_attr': {'class': 'text-danger'}},
+    2: {'attr': {'class': 'progress-bar progress-bar-sm progress-bar-danger', 'style': 'width: 40%'}, 'text': 'Weak', 'text_attr': {'class': 'text-danger'}},
+    3: {'attr': {'class': 'progress-bar progress-bar-sm progress-bar-warning', 'style': 'width: 60%'}, 'text': 'So-so', 'text_attr': {'class': 'text-warning'}},
+    4: {'attr': {'class': 'progress-bar progress-bar-sm progress-bar-success', 'style': 'width: 80%;'}, 'text': 'Good', 'text_attr': {'class': 'text-success'}},
+    5: {'attr': {'class': 'progress-bar progress-bar-sm progress-bar-success', 'style': 'width: 100%'}, 'text': 'Great!', 'text_attr': {'class': 'text-success'}}
 };
 
 /**

--- a/website/static/js/passwordForms.js
+++ b/website/static/js/passwordForms.js
@@ -10,6 +10,9 @@ var $osf = require('./osfHelpers');
 var ChangeMessageMixin = require('js/changeMessage');
 require('js/knockoutPassword');
 
+ko.validation.init({
+    insertMessages : false
+});
 
 ko.validation.rules.complexity = {
     validator: function (val, minimumComplexity) {

--- a/website/templates/claim_account.mako
+++ b/website/templates/claim_account.mako
@@ -39,19 +39,29 @@
                     >
                 </div>
             </div>
-              <div class="progress create-password">
-                  <div class="progress-bar progress-bar-sm" role="progressbar" data-bind="attr: passwordComplexityInfo().attr"></div>
-              </div>
-              <div>
-                  <!-- ko if: passwordFeedback() -->
-                  <p class="text-right" id="front-password-info" data-bind="text: passwordComplexityInfo().text, attr: passwordComplexityInfo().text_attr"></p>
-                  <p class="help-block osf-box-lt" data-bind="validationMessage: password" style="display: none;"></p>
-                  <p class="help-block osf-box-lt" data-bind="text: passwordFeedback().warning"></p>
-                  <!-- /ko -->
-                  <!-- ko if: !passwordFeedback() -->
-                  <div style="padding-top:20px"></div>
-                  <!-- /ko -->
-              </div>
+            <div class="row" data-bind="visible: typedPassword().length > 0">
+                <div class="col-xs-8">
+                    <div class="progress create-password">
+                        <div class="progress-bar progress-bar-sm" role="progressbar" data-bind="attr: passwordComplexityInfo().attr"></div>
+                    </div>
+                </div>
+                <div class="col-xs-4 f-w-xl">
+                    <!-- ko if: passwordFeedback() -->
+                    <p id="front-password-info" data-bind="text: passwordComplexityInfo().text, attr: passwordComplexityInfo().text_attr"></p>
+                    <!-- /ko -->
+                </div>
+            </div>
+
+            <div>
+                <!-- ko if: passwordFeedback() -->
+                <p class="help-block osf-box-lt p-xs" data-bind="validationMessage: password" style="display: none;"></p>
+                <p class="help-block osf-box-lt " data-bind="css : { 'p-xs': passwordFeedback().warning }, visible: typedPassword().length > 0, text: passwordFeedback().warning"></p>
+                <!-- /ko -->
+            </div>
+
+
+
+
             <div
                 class="form-group"
                 data-bind="

--- a/website/templates/claim_account.mako
+++ b/website/templates/claim_account.mako
@@ -55,7 +55,7 @@
             <div>
                 <!-- ko if: passwordFeedback() -->
                 <p class="help-block osf-box-lt p-xs" data-bind="validationMessage: password" style="display: none;"></p>
-                <p class="help-block osf-box-lt " data-bind="css : { 'p-xs': passwordFeedback().warning }, visible: typedPassword().length > 0, text: passwordFeedback().warning"></p>
+                <p class="osf-box-lt " data-bind="css : { 'p-xs': passwordFeedback().warning }, visible: typedPassword().length > 0, text: passwordFeedback().warning"></p>
                 <!-- /ko -->
             </div>
 

--- a/website/templates/landing.mako
+++ b/website/templates/landing.mako
@@ -66,16 +66,28 @@
                           <div class="form-group" data-bind="css: {'has-error': password() && !password.isValid(), 'has-success': password() && password.isValid()}">
                               <label class="placeholder-replace" style="display:none">Password</label>
                               <input type="password" class="form-control" placeholder="Password (Must be 6 to 256 characters)" data-bind=", textInput: typedPassword, value: password, disable: submitted(), event: {blur: trim.bind($data, password)}">
-                              <div class="progress create-password">
-                                  <div class="progress-bar progress-bar-sm" role="progressbar" data-bind="attr: passwordComplexityInfo().attr"></div>
+
+                              <div class="row" data-bind="visible: typedPassword().length > 0">
+                                  <div class="col-xs-8">
+                                      <div class="progress create-password">
+                                          <div class="progress-bar progress-bar-sm" role="progressbar" data-bind="attr: passwordComplexityInfo().attr"></div>
+                                      </div>
+                                  </div>
+                                  <div class="col-xs-4 f-w-xl text-left pv-darkbg">
+                                      <!-- ko if: passwordFeedback() -->
+                                      <p id="front-password-info" data-bind="text: passwordComplexityInfo().text, attr: passwordComplexityInfo().text_attr"></p>
+                                      <!-- /ko -->
+                                  </div>
                               </div>
+
                               <div>
                                   <!-- ko if: passwordFeedback() -->
-                                  <p class="text-right" id="front-password-info" data-bind="text: passwordComplexityInfo().text, attr: passwordComplexityInfo().text_attr"></p>
-                                  <p class="help-block osf-box-lt" data-bind="validationMessage: password" style="display: none;"></p>
-                                  <p class="help-block osf-box-lt" data-bind="text: passwordFeedback().warning"></p>
+                                  <p class="help-block osf-box-lt p-xs" data-bind="validationMessage: password" style="display: none;"></p>
+                                  <p class="help-block osf-box-lt" data-bind="css : { 'p-xs': passwordFeedback().warning }, visible: typedPassword().length > 0, text: passwordFeedback().warning"></p>
                                   <!-- /ko -->
                               </div>
+
+
                           </div>
 
                           <!-- Flashed Messages -->

--- a/website/templates/landing.mako
+++ b/website/templates/landing.mako
@@ -83,7 +83,7 @@
                               <div class="pv-darkbg">
                                   <!-- ko if: passwordFeedback() -->
                                   <p class="help-block osf-box-lt p-xs" data-bind="validationMessage: password" style="display: none;"></p>
-                                  <p class="help-block osf-box-lt" data-bind="css : { 'p-xs': passwordFeedback().warning }, visible: typedPassword().length > 0, text: passwordFeedback().warning"></p>
+                                  <p class="osf-box-lt" data-bind="css : { 'p-xs': passwordFeedback().warning }, visible: typedPassword().length > 0, text: passwordFeedback().warning"></p>
                                   <!-- /ko -->
                               </div>
 

--- a/website/templates/landing.mako
+++ b/website/templates/landing.mako
@@ -80,7 +80,7 @@
                                   </div>
                               </div>
 
-                              <div>
+                              <div class="pv-darkbg">
                                   <!-- ko if: passwordFeedback() -->
                                   <p class="help-block osf-box-lt p-xs" data-bind="validationMessage: password" style="display: none;"></p>
                                   <p class="help-block osf-box-lt" data-bind="css : { 'p-xs': passwordFeedback().warning }, visible: typedPassword().length > 0, text: passwordFeedback().warning"></p>

--- a/website/templates/profile/account.mako
+++ b/website/templates/profile/account.mako
@@ -124,19 +124,25 @@
                                             blur: trim.bind($data, password)
                                         }"
                                 >
-                              <div class="progress create-password">
-                                  <div class="progress-bar progress-bar-sm" role="progressbar" data-bind="attr: passwordComplexityInfo().attr"></div>
-                              </div>
-                              <div>
-                                  <!-- ko if: passwordFeedback() -->
-                                  <p class="text-right" id="front-password-info" data-bind="text: passwordComplexityInfo().text, attr: passwordComplexityInfo().text_attr"></p>
-                                  <p class="help-block osf-box-lt" data-bind="validationMessage: password" style="display: none;"></p>
-                                  <p class="help-block osf-box-lt" data-bind="text: passwordFeedback().warning"></p>
-                                  <!-- /ko -->
-                                  <!-- ko if: !passwordFeedback() -->
-                                  <div style="padding-top:10px"></div>
-                                  <!-- /ko -->
-                              </div>
+                                <div class="row" data-bind="visible: typedPassword().length > 0">
+                                    <div class="col-xs-8">
+                                        <div class="progress create-password">
+                                            <div class="progress-bar progress-bar-sm" role="progressbar" data-bind="attr: passwordComplexityInfo().attr"></div>
+                                        </div>
+                                    </div>
+                                    <div class="col-xs-4 f-w-xl">
+                                        <!-- ko if: passwordFeedback() -->
+                                        <p id="front-password-info" data-bind="text: passwordComplexityInfo().text, attr: passwordComplexityInfo().text_attr"></p>
+                                        <!-- /ko -->
+                                    </div>
+                                </div>
+
+                                <div>
+                                    <!-- ko if: passwordFeedback() -->
+                                    <p class="help-block osf-box-lt p-xs" data-bind="validationMessage: password" style="display: none;"></p>
+                                    <p class="help-block osf-box-lt " data-bind="css : { 'p-xs': passwordFeedback().warning }, visible: typedPassword().length > 0, text: passwordFeedback().warning"></p>
+                                    <!-- /ko -->
+                                </div>
                             </div>
                             <div class="form-group">
                                 <label for="confirm_password">Confirm new password</label>

--- a/website/templates/profile/account.mako
+++ b/website/templates/profile/account.mako
@@ -70,7 +70,7 @@
                                             <span class="fa fa-info-circle" data-bind="tooltip: {title: 'Merging accounts will move all projects and components associated with two emails into one account. All projects and components will be displayed under the email address listed as primary.',
                                              placement: 'bottom', container : 'body'}"></span>
                                             </p>
-                  
+
                                             <div class="form-group">
                                                 ## email input verification is not supported on safari
                                               <input placeholder="Email address" type="email" data-bind="value: emailInput" class="form-control" required maxlength="254">
@@ -140,7 +140,7 @@
                                 <div>
                                     <!-- ko if: passwordFeedback() -->
                                     <p class="help-block osf-box-lt p-xs" data-bind="validationMessage: password" style="display: none;"></p>
-                                    <p class="help-block osf-box-lt " data-bind="css : { 'p-xs': passwordFeedback().warning }, visible: typedPassword().length > 0, text: passwordFeedback().warning"></p>
+                                    <p class="osf-box-lt " data-bind="css : { 'p-xs': passwordFeedback().warning }, visible: typedPassword().length > 0, text: passwordFeedback().warning"></p>
                                     <!-- /ko -->
                                 </div>
                             </div>

--- a/website/templates/public/login.mako
+++ b/website/templates/public/login.mako
@@ -155,9 +155,9 @@
                                     <div class="progress-bar progress-bar-sm" role="progressbar" data-bind="attr: passwordComplexityInfo().attr"></div>
                                 </div>
                             </div>
-                            <div class="col-xs-4">
+                            <div class="col-xs-4 f-w-xl">
                                 <!-- ko if: passwordFeedback() -->
-                                <p class="f-w-xl" id="front-password-info" data-bind="text: passwordComplexityInfo().text, attr: passwordComplexityInfo().text_attr"></p>
+                                <p id="front-password-info" data-bind="text: passwordComplexityInfo().text, attr: passwordComplexityInfo().text_attr"></p>
                                 <!-- /ko -->
                             </div>
                         </div>
@@ -165,7 +165,7 @@
                         <div>
                             <!-- ko if: passwordFeedback() -->
                             <p class="help-block osf-box-lt p-xs" data-bind="validationMessage: password" style="display: none;"></p>
-                            <p class="help-block osf-box-lt" data-bind="css : { 'p-xs': passwordFeedback().warning }, visible: typedPassword().length > 0, text: passwordFeedback().warning"></p>
+                            <p class="help-block osf-box-lt " data-bind="css : { 'p-xs': passwordFeedback().warning }, visible: typedPassword().length > 0, text: passwordFeedback().warning"></p>
                             <!-- /ko -->
                         </div>
                     </div>

--- a/website/templates/public/login.mako
+++ b/website/templates/public/login.mako
@@ -149,7 +149,7 @@
                                 blur: trim.bind($data, password)
                             }"
                         >
-                        <div class="row">
+                        <div class="row" data-bind="visible: typedPassword().length > 0">
                             <div class="col-xs-8">
                                 <div class="progress create-password">
                                     <div class="progress-bar progress-bar-sm" role="progressbar" data-bind="attr: passwordComplexityInfo().attr"></div>
@@ -165,7 +165,7 @@
                         <div>
                             <!-- ko if: passwordFeedback() -->
                             <p class="help-block osf-box-lt p-xs" data-bind="validationMessage: password" style="display: none;"></p>
-                            <p class="help-block osf-box-lt" data-bind="css : { 'p-xs': passwordFeedback().warning }, text: passwordFeedback().warning"></p>
+                            <p class="help-block osf-box-lt" data-bind="css : { 'p-xs': passwordFeedback().warning }, visible: typedPassword().length > 0, text: passwordFeedback().warning"></p>
                             <!-- /ko -->
                         </div>
                     </div>

--- a/website/templates/public/login.mako
+++ b/website/templates/public/login.mako
@@ -164,8 +164,8 @@
 
                         <div>
                             <!-- ko if: passwordFeedback() -->
-                            <p class="help-block osf-box-lt" data-bind="validationMessage: password" style="display: none;"></p>
-                            <p class="help-block osf-box-lt" data-bind="text: passwordFeedback().warning"></p>
+                            <p class="help-block osf-box-lt p-xs" data-bind="validationMessage: password" style="display: none;"></p>
+                            <p class="help-block osf-box-lt" data-bind="css : { 'p-xs': passwordFeedback().warning }, text: passwordFeedback().warning"></p>
                             <!-- /ko -->
                         </div>
                     </div>

--- a/website/templates/public/login.mako
+++ b/website/templates/public/login.mako
@@ -149,12 +149,21 @@
                                 blur: trim.bind($data, password)
                             }"
                         >
-                        <div class="progress create-password">
-                            <div class="progress-bar progress-bar-sm" role="progressbar" data-bind="attr: passwordComplexityInfo().attr"></div>
+                        <div class="row">
+                            <div class="col-xs-8">
+                                <div class="progress create-password">
+                                    <div class="progress-bar progress-bar-sm" role="progressbar" data-bind="attr: passwordComplexityInfo().attr"></div>
+                                </div>
+                            </div>
+                            <div class="col-xs-4">
+                                <!-- ko if: passwordFeedback() -->
+                                <p class="text-center" id="front-password-info" data-bind="text: passwordComplexityInfo().text, attr: passwordComplexityInfo().text_attr"></p>
+                                <!-- /ko -->
+                            </div>
                         </div>
+
                         <div>
                             <!-- ko if: passwordFeedback() -->
-                            <p class="text-right" id="front-password-info" data-bind="text: passwordComplexityInfo().text, attr: passwordComplexityInfo().text_attr"></p>
                             <p class="help-block osf-box-lt" data-bind="validationMessage: password" style="display: none;"></p>
                             <p class="help-block osf-box-lt" data-bind="text: passwordFeedback().warning"></p>
                             <!-- /ko -->

--- a/website/templates/public/login.mako
+++ b/website/templates/public/login.mako
@@ -48,7 +48,7 @@
         </div>
     %endif
     %if campaign != "institution" or not enable_institutions:
-        <div id="signUpScope" class="col-sm-6 col-sm-offset-3 signup-form p-b-md m-b-m bg-color-light">
+        <div id="signUpScope" class="col-sm-8 col-sm-offset-2 col-md-6 col-md-offset-3 signup-form p-b-md m-b-m bg-color-light">
             <form data-bind="submit: submit" class="form-horizontal">
                 <h3 class="m-b-lg"> Create a free account </h3>
                 <div

--- a/website/templates/public/login.mako
+++ b/website/templates/public/login.mako
@@ -157,7 +157,7 @@
                             </div>
                             <div class="col-xs-4">
                                 <!-- ko if: passwordFeedback() -->
-                                <p class="text-center" id="front-password-info" data-bind="text: passwordComplexityInfo().text, attr: passwordComplexityInfo().text_attr"></p>
+                                <p class="f-w-xl" id="front-password-info" data-bind="text: passwordComplexityInfo().text, attr: passwordComplexityInfo().text_attr"></p>
                                 <!-- /ko -->
                             </div>
                         </div>

--- a/website/templates/public/resetpassword.mako
+++ b/website/templates/public/resetpassword.mako
@@ -55,7 +55,7 @@
                     <div>
                         <!-- ko if: passwordFeedback() -->
                         <p class="help-block osf-box-lt p-xs" data-bind="validationMessage: password" style="display: none;"></p>
-                        <p class="help-block osf-box-lt " data-bind="css : { 'p-xs': passwordFeedback().warning }, visible: typedPassword().length > 0, text: passwordFeedback().warning"></p>
+                        <p class="osf-box-lt " data-bind="css : { 'p-xs': passwordFeedback().warning }, visible: typedPassword().length > 0, text: passwordFeedback().warning"></p>
                         <!-- /ko -->
                     </div>
 

--- a/website/templates/public/resetpassword.mako
+++ b/website/templates/public/resetpassword.mako
@@ -39,19 +39,26 @@
                                 blur: trim.bind($data, password)
                             }"
                     >
-                  <div class="progress create-password">
-                      <div class="progress-bar progress-bar-sm" role="progressbar" data-bind="attr: passwordComplexityInfo().attr"></div>
-                  </div>
-                  <div>
-                      <!-- ko if: passwordFeedback() -->
-                      <p class="text-right" id="front-password-info" data-bind="text: passwordComplexityInfo().text, attr: passwordComplexityInfo().text_attr"></p>
-                      <p class="help-block osf-box-lt" data-bind="validationMessage: password" style="display: none;"></p>
-                      <p class="help-block osf-box-lt" data-bind="text: passwordFeedback().warning"></p>
-                      <!-- /ko -->
-                      <!-- ko if: !passwordFeedback() -->
-                      <div style="padding-top:20px"></div>
-                      <!-- /ko -->
-                  </div>
+                    <div class="row" data-bind="visible: typedPassword().length > 0">
+                        <div class="col-xs-8">
+                            <div class="progress create-password">
+                                <div class="progress-bar progress-bar-sm" role="progressbar" data-bind="attr: passwordComplexityInfo().attr"></div>
+                            </div>
+                        </div>
+                        <div class="col-xs-4 f-w-xl">
+                            <!-- ko if: passwordFeedback() -->
+                            <p id="front-password-info" data-bind="text: passwordComplexityInfo().text, attr: passwordComplexityInfo().text_attr"></p>
+                            <!-- /ko -->
+                        </div>
+                    </div>
+
+                    <div>
+                        <!-- ko if: passwordFeedback() -->
+                        <p class="help-block osf-box-lt p-xs" data-bind="validationMessage: password" style="display: none;"></p>
+                        <p class="help-block osf-box-lt " data-bind="css : { 'p-xs': passwordFeedback().warning }, visible: typedPassword().length > 0, text: passwordFeedback().warning"></p>
+                        <!-- /ko -->
+                    </div>
+
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Purpose
Make minor ui changes and fix interaction bugs

## Changes
- Password strength indicator text and progress bar colors changed to three bootstrap colors with overrides for landing page
- Layout changed so that progress bar and text is on the same row
- Fixed validation text appearing twice by removing the ko-validation automatic insertion 
- Other minor style changes


## Side effects

Most likely not. Someone should check that all possible locations where the password strength check appears are addressed. I think they are, based on global search of the code. I was able to test all instances, seems to be working fine. 


## Ticket
Partially fulfilling requirements of https://openscience.atlassian.net/browse/OSF-3457 

