### PR TITLE
hotfix/osf.users.all_read scope on production

### DIFF
--- a/framework/auth/oauth_scopes.py
+++ b/framework/auth/oauth_scopes.py
@@ -184,13 +184,13 @@ public_scopes = {
                             description='View and edit all information associated with this account, including for '
                                         'private projects.',
                             is_public=True),
+    'osf.users.all_read': scope(parts_=frozenset(ComposedScopes.USERS_READ),
+                                description='Read your profile data',
+                                is_public=True),
 }
 
 if settings.DEV_MODE:
     public_scopes.update({
-        'osf.users.all_read': scope(parts_=frozenset(ComposedScopes.USERS_READ),
-                                    description='Read your profile data',
-                                    is_public=True),
         'osf.users.all_write': scope(parts_=frozenset(ComposedScopes.USERS_WRITE),
                                      description='Read and edit your profile data',
                                      is_public=True),


### PR DESCRIPTION
## Purpose

Allow users on Production, especially Experimenter users, to us `osf.users.all_read` scope rather than the `osf.full_read` scope. 

## Changes

Moved the scope out of dev mode into the normal block

## Side effects

Shouldn't be. Other people can use the users.all_read scope.


## Ticket

https://openscience.atlassian.net/browse/OSF-6658