### PR TITLE
[hotfix] fix Dataverse api token url for DV v4.4 [OSF-6665]

### DIFF
--- a/website/addons/dataverse/static/dataverseNodeConfig.js
+++ b/website/addons/dataverse/static/dataverseNodeConfig.js
@@ -61,7 +61,9 @@ function ViewModel(url) {
         return Boolean(self.selectedHost());
     });
     self.tokenUrl = ko.pureComputed(function() {
-       return self.host() ? 'https://' + self.host() + '/account/apitoken' : null;
+        var token_path = self.host() === 'dataverse.lib.virginia.edu'
+                ? '/account/apitoken' : '/dataverseuser.xhtml?selectTab=apiTokenTab';
+        return self.host() ? 'https://' + self.host() + token_path : null;
     });
     self.savedHostUrl = ko.pureComputed(function() {
         return 'https://' + self.savedHost();

--- a/website/addons/dataverse/static/dataverseUserConfig.js
+++ b/website/addons/dataverse/static/dataverseUserConfig.js
@@ -48,7 +48,9 @@ function ViewModel(url) {
         return Boolean(self.selectedHost());
     });
     self.tokenUrl = ko.pureComputed(function() {
-       return self.host() ? 'https://' + self.host() + '/account/apitoken' : null;
+        var token_path = self.host() === 'dataverse.lib.virginia.edu'
+                ? '/account/apitoken' : '/dataverseuser.xhtml?selectTab=apiTokenTab';
+        return self.host() ? 'https://' + self.host() + token_path : null;
     });
 
     // Flashed messages


### PR DESCRIPTION
## Purpose

Dataverse v4.4 was just released, changing the path the user must visit to fetch their api token.  The new v4.4 path is  `/dataverseuser.xhtml?selectTab=apiTokenTab`.  UVa's DV instance is v4.3 which uses the old path of `/account/apitoken`.  

## Changes

This patch will use the old token path if the host is UVa, otherwise it will default to the new path. 

## Side effects

This will break the link for `apitest`, but `apitest` is due to be upgraded to v4.4 shortly and is currently broken for unrelated reasons.

The v4.4 url change also causes a minor user incovenience.  If a user clicks on the api token link while not yet logged in, they are taken to the DV login page.  The DV login page does not preserve the query parameter in the redirect target, so the user is then sent to their account page, where 'API Token' is one of the tabs they can select. Closing the DV window then clicking on the link will take the user directly to the token page if they are logged in.

This should only be a temporary fix.  We've asked DV to [restore the old url as a redirect](https://github.com/IQSS/dataverse/issues/3204).  If they are unable to, we will need to add version-specific configs to this addon.

## Ticket

[#OSF-6665]
