### PR TITLE
[OSF-6545]Eliminate Project Ambiguity

### DIFF
--- a/website/static/js/iconmap.js
+++ b/website/static/js/iconmap.js
@@ -8,6 +8,7 @@ module.exports = {
         instrumentation: 'fa fa-flask',
         data: 'fa fa-database',
         software: 'fa fa-laptop',
+        project: 'fa fa-cube',
         analysis: 'fa fa-bar-chart',
         communication: 'fa fa-comment',
         other: 'fa fa-th-large',


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
In the files tree, subprojects created as components didn't have a project icon next to them.
![image](https://cloud.githubusercontent.com/assets/19800694/16774678/1c855a76-482b-11e6-9252-cd26998f7862.png)

## Changes
When you create a subproject, Fangorn labels it as technically a component. In Treebeard, `resolveIcon` looked for a component icon when it should have looked for the project icon. So, I added the project icon to the `componentIcons` array do let the subproject be read as a component, but still be given a project Icon. This seems to be an easier solution than changing how subprojects are read altogether.

## Side effects
I just added something to an icon array, so I don't think that would affect anything else.

<!--Any possible side effects? -->


## Ticket
[OSF-6545](https://openscience.atlassian.net/browse/OSF-6545)
