### PR TITLE
Hotfix/rename some scopes

### DIFF
--- a/api_tests/base/test_auth.py
+++ b/api_tests/base/test_auth.py
@@ -154,14 +154,14 @@ class TestOAuthScopedAccess(ApiTestCase):
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_user_read_scope_can_read_user_view(self, mock_user_info):
-        mock_user_info.return_value = self._scoped_response(['osf.users.all_read'])
+        mock_user_info.return_value = self._scoped_response(['osf.users.profile_read'])
         url = api_v2_url('users/me/', base_route='/', base_prefix='v2/')
         res = self.app.get(url, auth='some_valid_token', auth_type='jwt', expect_errors=True)
         assert_equal(res.status_code, 200)
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_user_read_scope_cant_write_user_view(self, mock_user_info):
-        mock_user_info.return_value = self._scoped_response(['osf.users.all_read'])
+        mock_user_info.return_value = self._scoped_response(['osf.users.profile_read'])
         url = api_v2_url('users/me/', base_route='/', base_prefix='v2/')
         payload = {'data': {'type': 'users', 'id': self.user._id, 'attributes': {u'suffix': u'VIII'}}}
 
@@ -171,14 +171,14 @@ class TestOAuthScopedAccess(ApiTestCase):
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_user_write_scope_implies_read_permissions_for_user_view(self, mock_user_info):
-        mock_user_info.return_value = self._scoped_response(['osf.users.all_write'])
+        mock_user_info.return_value = self._scoped_response(['osf.users.profile_write'])
         url = api_v2_url('users/me/', base_route='/', base_prefix='v2/')
         res = self.app.get(url, auth='some_valid_token', auth_type='jwt', expect_errors=True)
         assert_equal(res.status_code, 200)
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_user_write_scope_can_write_user_view(self, mock_user_info):
-        mock_user_info.return_value = self._scoped_response(['osf.users.all_write'])
+        mock_user_info.return_value = self._scoped_response(['osf.users.profile_write'])
         url = api_v2_url('users/me/', base_route='/', base_prefix='v2/')
         payload = {'data': {'type': 'users', 'id': self.user._id, 'attributes': {u'suffix': u'VIII'}}}
 
@@ -190,7 +190,7 @@ class TestOAuthScopedAccess(ApiTestCase):
 
     @mock.patch('framework.auth.cas.CasClient.profile')
     def test_node_write_scope_cant_read_user_view(self, mock_user_info):
-        mock_user_info.return_value = self._scoped_response(['osf.nodes.all_write'])
+        mock_user_info.return_value = self._scoped_response(['osf.nodes.full_write'])
         url = api_v2_url('users/me/', base_route='/', base_prefix='v2/')
         payload = {u'suffix': u'VIII'}
 

--- a/framework/auth/oauth_scopes.py
+++ b/framework/auth/oauth_scopes.py
@@ -184,14 +184,14 @@ public_scopes = {
                             description='View and edit all information associated with this account, including for '
                                         'private projects.',
                             is_public=True),
-    'osf.users.all_read': scope(parts_=frozenset(ComposedScopes.USERS_READ),
+    'osf.users.profile_read': scope(parts_=frozenset(ComposedScopes.USERS_READ),
                                 description='Read your profile data',
                                 is_public=True),
 }
 
 if settings.DEV_MODE:
     public_scopes.update({
-        'osf.users.all_write': scope(parts_=frozenset(ComposedScopes.USERS_WRITE),
+        'osf.users.profile_write': scope(parts_=frozenset(ComposedScopes.USERS_WRITE),
                                      description='Read and edit your profile data',
                                      is_public=True),
 
@@ -225,11 +225,11 @@ if settings.DEV_MODE:
                                                     'registrations.',
                                         is_public=True),  # TODO: Language: Does registrations endpoint allow creation of registrations? Is that planned?
 
-        'osf.nodes.all_read': scope(parts_=frozenset(ComposedScopes.NODE_ALL_READ),
+        'osf.nodes.full_read': scope(parts_=frozenset(ComposedScopes.NODE_ALL_READ),
                                     description='View all metadata, files, and access rights associated with all public '
                                                 'and private projects accessible to this account.',
                                     is_public=True),
-        'osf.nodes.all_write': scope(parts_=frozenset(ComposedScopes.NODE_ALL_WRITE),
+        'osf.nodes.full_write': scope(parts_=frozenset(ComposedScopes.NODE_ALL_WRITE),
                                      description='View and edit all metadata, files, and access rights associated with '
                                                  'all public and private projects accessible to this account.',
                                      is_public=True),


### PR DESCRIPTION

## Purpose

A few of the scopes are not as well named as they might be. This PR hopefully makes the scopes we have something we can live with for a while.

## Changes

* Rename osf.users.all_read to osf.users.profile_read
* Ranme osf.users.all_write to osf.users.profile_write
* Rename osf.nodes.all_read to osf.nodes.full_read
* Rename osf.nodes.all_write to osf.nodes.full_write
* Fix broken tests

## Side effects

The register oauth scopes script needs to be run. https://github.com/abought/osf.io/blob/0ca2d03465172fd2adffc87b4ae58418fbfcb559/scripts/register_oauth_scopes.py

It's not *exactly* a migration, but I've labeled the issue as a migration regardless.

## Ticket

No ticket.
