### PR TITLE
Update Language about Categories of Components/Projects [OSF-6627]

### DIFF
--- a/website/static/js/addProjectPlugin.js
+++ b/website/static/js/addProjectPlugin.js
@@ -256,7 +256,7 @@ var AddProject = {
                             ]),
                             ctrl.options.parentID !== null ? [
                                 m('label.f-w-lg.text-bigger','Category'),
-                                m("i", ' (for descriptive purposes)'),
+                                m('i', ' (for descriptive purposes)'),
                                 m('select.form-control', {
                                     onchange : function(event) {
                                         ctrl.newProjectCategory(this.value);

--- a/website/static/js/addProjectPlugin.js
+++ b/website/static/js/addProjectPlugin.js
@@ -256,6 +256,7 @@ var AddProject = {
                             ]),
                             ctrl.options.parentID !== null ? [
                                 m('label.f-w-lg.text-bigger','Category'),
+                                m("i", ' (for descriptive purposes)'),
                                 m('select.form-control', {
                                     onchange : function(event) {
                                         ctrl.newProjectCategory(this.value);

--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -78,6 +78,7 @@
                         <div class="form-group">
                             <label>Category:</label>
                             <select data-bind="options: categoryOptions, optionsValue: 'value', optionsText: 'label', value: selectedCategory"></select>
+                            <i>(For descriptive purposes)</i>
                         </div>
                         <div class="form-group">
                             <label for="title">Title:</label>


### PR DESCRIPTION
Purpose
======

Add more descriptive language when changing Category in components to clarify what Category means to the user.

Changes
======

Added "(for descriptive purposes)" when adding new component and under component settings.

**Before**
![image](https://cloud.githubusercontent.com/assets/8868219/16805416/1a114d14-48de-11e6-9a88-3cfab4fa1bcb.png)

![image](https://cloud.githubusercontent.com/assets/8868219/16805430/2ab21f04-48de-11e6-8340-59c3b74e1cbc.png)

**After**
![image](https://cloud.githubusercontent.com/assets/8868219/16805486/76212d86-48de-11e6-9ab1-3e7dd9e6dcd4.png)

![image](https://cloud.githubusercontent.com/assets/8868219/16805494/7cbf2bfc-48de-11e6-8cef-a9954f6ffd34.png)




Side effects
=========

None

Ticket
=====

https://openscience.atlassian.net/browse/OSF-6627
