### PR TITLE
[Hotfix] ADM Prereg commenting [OSF-6674]

### DIFF
--- a/admin/templates/pre_reg/draft_detail.html
+++ b/admin/templates/pre_reg/draft_detail.html
@@ -7,7 +7,6 @@
 <title>OSF Admin | {{ draft.title }}</title>
 {% endblock %}
 
-
 {% block content %}
 {% render_bundle 'vendor' %}
 <link href="{% static 'css/registrations.css' %}" rel="stylesheet" type="text/css" />
@@ -37,7 +36,7 @@
         }
         return cookieValue;
     }
-    var csrftoken = getCookie('csrftoken');
+    var csrftoken = getCookie('admin-csrf');
     function csrfSafeMethod(method) {
     // these HTTP methods do not require CSRF protection
     return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));


### PR DESCRIPTION
## Purpose
Allow ADM prereg users to comment on prereg drafts 

## Changes
* Use correct cookie name.

## Side effects
None

## Ticket
[OSF-6674](https://openscience.atlassian.net/browse/OSF-6674)