### PR TITLE
Limit sharejs/ace editor to 64k to match MFR PR#217 [OSF-6670]

### DIFF
--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -340,8 +340,8 @@ var FileViewPage = {
                 return;
             }
             var fileType = mime.lookup(self.file.name.toLowerCase());
-            // Only allow files < 1MB to be editable
-            if (self.file.size < 1048576 && fileType) { //May return false
+            // Only allow files < 64k to be editable
+            if (self.file.size < 65536 && fileType) { //May return false
                 var editor = EDITORS[fileType.split('/')[0]];
                 if (editor) {
                     self.editor = new Panel('Edit', self.editHeader, editor, [self.file.urls.content, self.file.urls.sharejs, self.editorMeta, self.shareJSObservables], false);


### PR DESCRIPTION
## Purpose:
[OSF-6670](https://openscience.atlassian.net/browse/OSF-6670)
Large text file are failing to renderer in a disorderly manner.
Limit them.

## Changes:
Update website/static/js/filepage/index.js update file size limit to 64k to match MFR CodePygmentRenderer limit.

## Side effects
This PR is lock step with MFR PR#217 limiting the size of text file that we'll allow to use the share editor. If these limits get out of sync, users may be confused.

[#OSF-6670]