### PR TITLE
Fix bug 'user cannot scroll to top ERPC terms modal' [OSF-6635]

### DIFF
--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -698,3 +698,14 @@ button.close {
 div.ball-scale-blue>div {
     background-color: #BED1E2;
 }
+
+/* Make registrations modal scrollable and background hidden
+-------------------------------------------------- */
+
+.background-unscrollable {
+    overflow: hidden;
+}
+
+.modal-scrollable {
+    overflow: scroll;
+}

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -501,15 +501,15 @@ MetaSchema.prototype.askConsent = function(pre) {
             $osf.unblock();
             bootbox.hideAll();
             ret.resolve();
-            $(document.body).css('overflow', '');
-            $('.modal').css('overflow-y', 'hidden');
+            $(document.body).removeClass('background-unscrollable');
+            $('.modal').removeClass('modal-scrollable');
         },
         cancel: function() {
             $osf.unblock();
             bootbox.hideAll();
             ret.reject();
-            $(document.body).css('overflow', '');
-            $('.modal').css('overflow-y', 'hidden');
+            $(document.body).removeClass('background-unscrollable');
+            $('.modal').removeClass('modal-scrollable');
         }
     };
 
@@ -517,15 +517,15 @@ MetaSchema.prototype.askConsent = function(pre) {
         size: 'large',
         message: function() {
             ko.renderTemplate('preRegistrationConsent', viewModel, {}, this);
-            $(document.body).css('overflow', 'hidden');
+            $(document.body).addClass('background-unscrollable');
         }
     });
 
     $('.bootbox-close-button.close').click(function() {
-        $(document.body).css('overflow', '');
-        $('.modal').css('overflow-y', 'hidden');
+        $(document.body).removeClass('background-unscrollable');
+        $('.modal').removeClass('modal-scrollable');
     });
-    $('.modal').css('overflow-y', 'scroll');
+    $('.modal').addClass('modal-scrollable');
     return ret.promise();
 };
 
@@ -1432,8 +1432,8 @@ RegistrationManager.prototype.createDraftModal = function(selected) {
                     var selectedSchema = self.selectedSchema();
                     if (selectedSchema.requiresConsent) {
                         selectedSchema.askConsent(true).then(function() {
-                            $(document.body).css('overflow', '');
-                            $('.modal').css('overflow-y', 'hidden');
+                            $(document.body).removeClass('background-unscrollable');
+                            $('.modal').removeClass('modal-scrollable');
                             $('#newDraftRegistrationForm').submit();
                         });
                     }

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -501,11 +501,15 @@ MetaSchema.prototype.askConsent = function(pre) {
             $osf.unblock();
             bootbox.hideAll();
             ret.resolve();
+            $(document.body).css('overflow', '');
+            $('.modal').css('overflow-y', 'hidden');
         },
         cancel: function() {
             $osf.unblock();
             bootbox.hideAll();
             ret.reject();
+            $(document.body).css('overflow', '');
+            $('.modal').css('overflow-y', 'hidden');
         }
     };
 
@@ -513,9 +517,15 @@ MetaSchema.prototype.askConsent = function(pre) {
         size: 'large',
         message: function() {
             ko.renderTemplate('preRegistrationConsent', viewModel, {}, this);
+            $(document.body).css('overflow', 'hidden');
         }
     });
 
+    $('.bootbox-close-button.close').click(function() {
+        $(document.body).css('overflow', '');
+        $('.modal').css('overflow-y', 'hidden');
+    });
+    $('.modal').css('overflow-y', 'scroll');
     return ret.promise();
 };
 
@@ -1422,6 +1432,8 @@ RegistrationManager.prototype.createDraftModal = function(selected) {
                     var selectedSchema = self.selectedSchema();
                     if (selectedSchema.requiresConsent) {
                         selectedSchema.askConsent(true).then(function() {
+                            $(document.body).css('overflow', '');
+                            $('.modal').css('overflow-y', 'hidden');
                             $('#newDraftRegistrationForm').submit();
                         });
                     }


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

<!-- Describe the purpose of your changes -->
Enable users to scroll to top of ERPC terms model when modal is long enough that there is overflow

## Changes
Since the default CSS for modals is found in a 3rd party library, added jquery code that overrode default CSS and made the overflow for the modal scrollable. Also made overflow of the background (body) hidden so there is only one scroll bar
<!-- Briefly describe or list your changes  -->
Before:
![screen shot 2016-07-14 at 10 29 48 am](https://cloud.githubusercontent.com/assets/14872944/16843149/08aee22c-49ae-11e6-9e59-9552b4eac833.png)
After: (Notice scrollbar)
![screen shot 2016-07-14 at 10 30 14 am](https://cloud.githubusercontent.com/assets/14872944/16843161/19befad4-49ae-11e6-8ceb-e569cbae26d8.png)

## Side effects

<!--Any possible side effects? -->
None

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->

https://openscience.atlassian.net/browse/OSF-6635