### PR TITLE
[OSF-3520] Registrations draggable

### DIFF
--- a/website/static/js/pages/files-page.js
+++ b/website/static/js/pages/files-page.js
@@ -15,19 +15,11 @@ $(document).ready(function(){
     $.ajax({
       url: nodeApiUrl + 'files/grid/'
     }).done(function(data) {
-        function register() {
-            if(node.isRegistered){
-                return false;
-            }
-            else{
-                return true;
-            }
-        }
         new Fangorn({
             placement: 'project-files',
             divID: 'treeGrid',
             filesData: data.data,
-            allowMove: register(),
+            allowMove: !node.isRegistration,
             xhrconfig: $osf.setXHRAuthorization
         });
     });

--- a/website/static/js/pages/files-page.js
+++ b/website/static/js/pages/files-page.js
@@ -3,6 +3,7 @@
 var $ = require('jquery');
 var $osf = require('js/osfHelpers');
 var Fangorn = require('js/fangorn');
+var node = window.contextVars.node;
 
 // Don't show dropped content if user drags outside grid
 window.ondragover = function(e) { e.preventDefault(); };
@@ -14,10 +15,19 @@ $(document).ready(function(){
     $.ajax({
       url: nodeApiUrl + 'files/grid/'
     }).done(function(data) {
+        function register() {
+            if(node.isRegistered){
+                return false;
+            }
+            else{
+                return true;
+            }
+        }
         new Fangorn({
             placement: 'project-files',
             divID: 'treeGrid',
             filesData: data.data,
+            allowMove: register(),
             xhrconfig: $osf.setXHRAuthorization
         });
     });

--- a/website/static/js/pages/project-dashboard-page.js
+++ b/website/static/js/pages/project-dashboard-page.js
@@ -136,9 +136,18 @@ $(document).ready(function () {
         $.ajax({
             url:  nodeApiUrl + 'files/grid/'
         }).done(function (data) {
+            function register() {
+                if(node.isRegistered){
+                    return false;
+                }
+                else{
+                    return true;
+                }
+            }
             var fangornOpts = {
                 divID: 'treeGrid',
                 filesData: data.data,
+                allowMove: register(),
                 uploads : true,
                 showFilter : true,
                 placement: 'dashboard',

--- a/website/static/js/pages/project-dashboard-page.js
+++ b/website/static/js/pages/project-dashboard-page.js
@@ -136,18 +136,10 @@ $(document).ready(function () {
         $.ajax({
             url:  nodeApiUrl + 'files/grid/'
         }).done(function (data) {
-            function register() {
-                if(node.isRegistered){
-                    return false;
-                }
-                else{
-                    return true;
-                }
-            }
             var fangornOpts = {
                 divID: 'treeGrid',
                 filesData: data.data,
-                allowMove: register(),
+                allowMove: !node.isRegistration,
                 uploads : true,
                 showFilter : true,
                 placement: 'dashboard',


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
You shouldn't be able to drag or drop any files when you are viewing a registration because everything is supposed to be frozen. This is a fix preventing moving in treebeard while viewing a registration

## Changes
I created a function that checks the boolean value `node.isRegistration` which determines if files can be moved on the project dashboard and files page by the `allowMove` option in treebeard.

## Side effects
None that I can think of.

## Ticket

[Osf-3520](https://openscience.atlassian.net/browse/OSF-3520)