### PR TITLE
Fix heisenbug in test for 4 year limit on embargo dates

### DIFF
--- a/website/static/js/registrationModal.js
+++ b/website/static/js/registrationModal.js
@@ -20,7 +20,6 @@ var MAKE_EMBARGO = {
     value: 'embargo',
     message: 'Enter registration into embargo'
 };
-var utcOffset = moment().utcOffset();
 var today = new Date();
 var todayMinimum = moment().add(2, 'days');
 var todayMaximum = moment().add(4, 'years');
@@ -47,7 +46,7 @@ var RegistrationViewModel = function(confirm, prompts, validator) {
         }
     );
     self.embargoEndDate = ko.computed(function() {
-        return moment(new Date(self.pikaday())).subtract(utcOffset, 'minutes');
+        return moment(new Date(self.pikaday()));
     });
 
     self.minimumTimeValidation = function (x, y, embargoLocalDateTime) {

--- a/website/static/js/tests/registrationModal.test.js
+++ b/website/static/js/tests/registrationModal.test.js
@@ -5,8 +5,6 @@ var utils = require('tests/utils');
 var faker = require('faker');
 var moment = require('moment');
 
-console.log('UTC offset: ' + moment().utcOffset());
-
 var RegistrationModal = require('js/registrationModal').ViewModel;
 
 // Add sinon asserts to chai.assert, so we can do assert.calledWith instead of sinon.assert.calledWith

--- a/website/static/js/tests/registrationModal.test.js
+++ b/website/static/js/tests/registrationModal.test.js
@@ -94,7 +94,7 @@ describe('registrationModal', () => {
         });
         it('returns false for date more than 4 years in the future', () => {
             var invalidFutureDate = new Date();
-            invalidFutureDate.setDate(invalidFutureDate.getDate() + 1460);
+            invalidFutureDate.setDate(invalidFutureDate.getDate() + 1462);
             vm.pikaday(invalidFutureDate);
             assert.isFalse(vm.pikaday.isValid());
         });

--- a/website/static/js/tests/registrationModal.test.js
+++ b/website/static/js/tests/registrationModal.test.js
@@ -92,7 +92,7 @@ describe('registrationModal', () => {
             vm.pikaday(invalidPastDate);
             assert.isFalse(vm.pikaday.isValid());
         });
-        it.skip('returns false for date more than 4 years in the future', () => {
+        it('returns false for date more than 4 years in the future', () => {
             var invalidFutureDate = new Date();
             invalidFutureDate.setDate(invalidFutureDate.getDate() + 1460);
             vm.pikaday(invalidFutureDate);


### PR DESCRIPTION
#6025 &rarr;

## Purpose

[OSF-6477](https://openscience.atlassian.net/browse/OSF-6447) describes a bug that we're seeing intermittently during testing at Travis. This PR fixes it.

## Status

Root cause [identified](https://github.com/CenterForOpenScience/osf.io/pull/5977#issuecomment-232963579) and [analyzed](https://github.com/CenterForOpenScience/osf.io/pull/5977#issuecomment-236922483). Surrounding area [excavated](https://github.com/CenterForOpenScience/osf.io/pull/5977#issuecomment-233401612), and partially refactored (#6025, #6050). Fix [discovered](https://github.com/CenterForOpenScience/osf.io/pull/5977#issuecomment-235797811), and implemented on this PR. Ready for review! :)

## Changes

See the [commit log](https://github.com/CenterForOpenScience/osf.io/pull/5977/commits).

## Side effects

Note for QA: verify that the embargo date functionality still works as expected.

## Ticket

[OSF-6477](https://openscience.atlassian.net/browse/OSF-6447)