### PR TITLE
Fix bug 'Contributors listed multiple times' [OSF-6690]

### DIFF
--- a/website/static/js/myProjects.js
+++ b/website/static/js/myProjects.js
@@ -662,6 +662,7 @@ var MyProjects = {
                 if (contributors) {
                     for(var i = 0; i < contributors.length; i++) {
                         var u = contributors[i];
+                        u.id = (u.id.indexOf('-') > -1) ? u.id.split('-')[1] : u.id;
                         if ((u.id === window.contextVars.currentUser.id) && !(self.institutionId)) {
                           continue;
                         }


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

<!-- Describe the purpose of your changes -->
Fix bug where contributors are listed multiple times on the My Projects page and clicking on a contributor does not show all of the projects they contributed to, only the most recent.



## Changes

Added code that made comparison between the contributors use the contributor's user id instead of the contributor id. Up until recently, those were the same, because the contributor id was incorrectly using the user's id. Now the contributor id is unique and the user's id is used instead.


<!-- Briefly describe or list your changes  -->

## Side effects
None
<!--Any possible side effects? -->


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
https://openscience.atlassian.net/browse/OSF-6690