### PR TITLE
Fix comment relationship link serialization for registrations [OSF-6551]

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -508,7 +508,7 @@ class RelationshipField(ser.HyperlinkedIdentityField):
                     urls[view_name] = {}
                 else:
                     if callable(view):
-                        view = view(getattr(obj, self.field_name))
+                        view = view(getattr(obj, self.field_name, self.field_name))
                     url = self.reverse(view, kwargs=kwargs, request=request, format=format)
                     if self.filter:
                         formatted_filter = self.format_filter(obj)

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -134,7 +134,7 @@ class NodeSerializer(JSONAPISerializer):
     )
 
     comments = RelationshipField(
-        related_view='nodes:node-comments',
+        related_view=lambda n: 'registrations:registration-comments' if getattr(n, 'is_registration', False) else 'nodes:node-comments',
         related_view_kwargs={'node_id': '<pk>'},
         related_meta={'unread': 'get_unread_comments_count'},
         filter={'target': '<pk>'}


### PR DESCRIPTION
## Purpose

Ensure comment links for registrations go to the registration view not the node view.

## Changes

1. Fixed the relationship field to allow lambdas on virtual fields
2. Added a lambda to the comments field to detect if it's a node or a registration

## Side effects

Shouldn't be, but I might have broken relationship links in some way that is not being tested.


## Ticket

https://openscience.atlassian.net/browse/OSF-6551
