### PR TITLE
[ShareFiles/Preprints] Add query param to file detail endpoint to give file guid

### DIFF
--- a/api/files/views.py
+++ b/api/files/views.py
@@ -281,8 +281,11 @@ class FileDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView, FileMixin):
 
     ##Query Params
 
-    For this endpoint, *none*.  Actions may permit or require certain query parameters.  See the individual action
-    documentation.
+    For this endpoint,
+
+    + giveGuid={bool} if true will give the file metadata a guid, a unique identifier for internal use.
+
+    Other actions may permit or require certain query parameters.  See the individual action documentation.
 
     #This Request/Response
 
@@ -307,6 +310,10 @@ class FileDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView, FileMixin):
 
     # overrides RetrieveAPIView
     def get_object(self):
+
+        if self.request.GET.get('giveGuid', False):
+            self.get_file().get_guid(create=True)
+
         return self.get_file()
 
 

--- a/api/files/views.py
+++ b/api/files/views.py
@@ -283,7 +283,8 @@ class FileDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView, FileMixin):
 
     For this endpoint,
 
-    + giveGuid={bool} if true will give the file metadata a guid, a unique identifier for internal use.
+    + giveGuid={bool} if true will give the file metadata a guid, a unique identifier for internal use. You must be an
+    admin on the node to add a guid to a file.
 
     Other actions may permit or require certain query parameters.  See the individual action documentation.
 
@@ -311,7 +312,7 @@ class FileDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView, FileMixin):
     # overrides RetrieveAPIView
     def get_object(self):
 
-        if self.request.GET.get('giveGuid', False):
+        if CoreScopes.NODE_CONTRIBUTORS_WRITE and self.request.GET.get('giveGuid', False):
             self.get_file().get_guid(create=True)
 
         return self.get_file()


### PR DESCRIPTION
## Purpose

ShareFiles requires that files that are uploaded immediately have short, convenient guid links for easy sharing. Problematically files only get guids when the File View Page is visited. This feature allows us to add guids using the API v2 without visiting the file View Page.

## Changes

Modifies the get_object method of the view to accept query param 'giveGuid' and creates that id if true. Also changes API docs slightly.

## Side effects

None that I know of.

## Discussions

https://openscience.atlassian.net/browse/OSF-6503
https://github.com/CenterForOpenScience/osf.io/pull/5836