### PR TITLE
Fix list filter issue when field name did not match source field name [#OSF-6702]

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -526,7 +526,7 @@ class NodeContributorsSerializer(JSONAPISerializer):
         'permission'
     ])
 
-    id = ContributorIDField(read_only=True)
+    id = ContributorIDField(read_only=True, source='_id')
     type = TypeField()
 
     bibliographic = ser.BooleanField(help_text='Whether the user will be included in citations for this node or not.',
@@ -591,7 +591,7 @@ class NodeContributorDetailSerializer(NodeContributorsSerializer):
     """
     Overrides node contributor serializer to add additional methods
     """
-    id = ContributorIDField(required=True)
+    id = ContributorIDField(required=True, source='_id')
 
     def update(self, instance, validated_data):
         contributor = instance


### PR DESCRIPTION
## Purpose

Fix an APIv2 issue with 500 errors: could not filter on fields whose field name was different than the DB source field. (eg `filter[id]=<item_id>`. Affected multiple endpoints using ListFilterMixin; see JIRA ticket for list.

## Changes
Changed `parse_query_params` to avoid losing information about the modified field name.

## Side effects

None expected. Filtering should work the same as before on all ODMFilter endpoints, but now should also work for ListFilterMixin endpoints.

## Ticket
https://openscience.atlassian.net/browse/OSF-6702