### PR TITLE
Warn users they cannot search by email address [OSF-5639]

### DIFF
--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -98,22 +98,17 @@ AddContributorViewModel = oop.extend(Paginator, {
         self.childrenToChange = ko.observableArray();
 
         self.emailSearch = ko.pureComputed(function () {
-            if(String(self.query()).indexOf('@') >= 0) {
+            var emailRegex = new RegExp('[a-zA-Z0-9]+@[a-zA-Z0-9]+\.[a-z]+');
+            if (emailRegex.test(String(self.query()))) {
                 return true;
             } else {
                 return false;
             }
         });
         self.foundResults = ko.pureComputed(function () {
-            if (self.emailSearch()) {
-                return false;
-            }
             return self.query() && self.results().length;
         });
         self.noResults = ko.pureComputed(function () {
-            if (self.emailSearch()) {
-                return false;
-            }
             return self.query() && !self.results().length && self.doneSearching();
         });
 
@@ -221,9 +216,6 @@ AddContributorViewModel = oop.extend(Paginator, {
                     });
                     self.doneSearching(true);
                     self.results(contributors);
-                    if (self.emailSearch()) {
-                        self.results([]);
-                    }
                     self.currentPage(result.page);
                     self.numberOfPages(result.pages);
                     self.addNewPaginators();

--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -98,16 +98,18 @@ AddContributorViewModel = oop.extend(Paginator, {
         self.childrenToChange = ko.observableArray();
 
         self.emailSearch = ko.pureComputed(function () {
-            var emailRegex = new RegExp('[a-z0-9!#$%&\'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&\'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?');
+            var emailRegex = new RegExp('[^\\s]+@[^\\s]+\\.[^\\s]');
             if (emailRegex.test(String(self.query()))) {
                 return true;
             } else {
                 return false;
             }
         });
+
         self.foundResults = ko.pureComputed(function () {
             return self.query() && self.results().length;
         });
+
         self.noResults = ko.pureComputed(function () {
             return self.query() && !self.results().length && self.doneSearching();
         });

--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -98,7 +98,7 @@ AddContributorViewModel = oop.extend(Paginator, {
         self.childrenToChange = ko.observableArray();
 
         self.emailSearch = ko.pureComputed(function () {
-            if(String(self.query()).indexOf("@") >= 0) {
+            if(String(self.query()).indexOf('@') >= 0) {
                 return true;
             } else {
                 return false;

--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -98,7 +98,7 @@ AddContributorViewModel = oop.extend(Paginator, {
         self.childrenToChange = ko.observableArray();
 
         self.emailSearch = ko.pureComputed(function () {
-            var emailRegex = new RegExp('[a-zA-Z0-9]+@[a-zA-Z0-9]+\.[a-z]+');
+            var emailRegex = new RegExp('[a-z0-9!#$%&\'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&\'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?');
             if (emailRegex.test(String(self.query()))) {
                 return true;
             } else {

--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -97,11 +97,23 @@ AddContributorViewModel = oop.extend(Paginator, {
         self.totalPages = ko.observable(0);
         self.childrenToChange = ko.observableArray();
 
+        self.emailSearch = ko.pureComputed(function () {
+            if(String(self.query()).indexOf("@") >= 0) {
+                return true;
+            } else {
+                return false;
+            }
+        });
         self.foundResults = ko.pureComputed(function () {
+            if (self.emailSearch()) {
+                return false;
+            }
             return self.query() && self.results().length;
         });
-
         self.noResults = ko.pureComputed(function () {
+            if (self.emailSearch()) {
+                return false;
+            }
             return self.query() && !self.results().length && self.doneSearching();
         });
 
@@ -209,6 +221,9 @@ AddContributorViewModel = oop.extend(Paginator, {
                     });
                     self.doneSearching(true);
                     self.results(contributors);
+                    if (self.emailSearch()) {
+                        self.results([]);
+                    }
                     self.currentPage(result.page);
                     self.numberOfPages(result.pages);
                     self.addNewPaginators();

--- a/website/static/js/tests/contributors.test.js
+++ b/website/static/js/tests/contributors.test.js
@@ -178,22 +178,6 @@ describe('addContributors', () => {
                    assert.isFalse(vm.emailSearch());
                });
            });
-
-           describe('nameSearch', () => {
-               it('should return true with a name entered', () => {
-                   var name = faker.name.findName();
-                   vm.query(
-                       name
-                   );
-                   assert.isTrue(!vm.emailSearch());
-               });
-               it('should return false with an email entered', () => {
-                   vm.query(
-                       'a1234@gmail.com'
-                   );
-                   assert.isFalse(vm.foundResults());
-               });
-           });
        });
    });
 });

--- a/website/static/js/tests/contributors.test.js
+++ b/website/static/js/tests/contributors.test.js
@@ -163,6 +163,37 @@ describe('addContributors', () => {
                    });
                });
            });
+
+           describe('emailSearch', () => {
+               it('should return true with an email address entered', () => {
+                   vm.query(
+                       'a1234@gmail.com'
+                   );
+                   assert.isTrue(vm.emailSearch());
+               });
+               it('should return false with a name entered', () => {
+                   vm.query(
+                       faker.name.findName()
+                   );
+                   assert.isFalse(vm.emailSearch());
+               });
+           });
+
+           describe('nameSearch', () => {
+               it('should return true with a name entered', () => {
+                   var name = faker.name.findName();
+                   vm.query(
+                       name
+                   );
+                   assert.isTrue(!vm.emailSearch());
+               });
+               it('should return false with an email entered', () => {
+                   vm.query(
+                       'a1234@gmail.com'
+                   );
+                   assert.isFalse(vm.foundResults());
+               });
+           });
        });
    });
 });

--- a/website/static/js/tests/contributors.test.js
+++ b/website/static/js/tests/contributors.test.js
@@ -164,20 +164,32 @@ describe('addContributors', () => {
                });
            });
 
-           describe('emailSearch', () => {
-               it('should return true with an email address entered', () => {
-                   vm.query(
-                       'a1234@gmail.com'
-                   );
-                   assert.isTrue(vm.emailSearch());
-               });
-               it('should return false with a name entered', () => {
-                   vm.query(
-                       faker.name.findName()
-                   );
-                   assert.isFalse(vm.emailSearch());
-               });
-           });
+            describe('emailSearch', () => {
+                it('should return true with an email address entered', () => {
+                    vm.query(
+                        'a1234@gmail.com'
+                    );
+                    assert.isTrue(vm.emailSearch());
+                });
+                it('should return false with a name entered', () => {
+                    vm.query(
+                    faker.name.findName()
+                );
+                assert.isFalse(vm.emailSearch());
+                });
+                it('should return false with a name with an @, but not an email', () => {
+                    vm.query(
+                        'mys@mplename'
+                );
+                assert.isFalse(vm.emailSearch());
+                });
+                it('should return false with an email not containing .com', () => {
+                    vm.query(
+                    'a1234@gmail'
+                );
+                assert.isFalse(vm.emailSearch());
+                });
+            });
        });
    });
 });

--- a/website/templates/prereg_landing_page.mako
+++ b/website/templates/prereg_landing_page.mako
@@ -61,7 +61,7 @@
       </div>
       %if has_draft_registrations:
       <div class="row">
-        <div class="prereg-button m-b-md p-md osf-box-lt p-md box-round" data-qtoggle-group="prereg" data-qtoggle-target="#existingPreregXS">Continue working on an existing preregistration</div>
+        <div class="prereg-button m-b-md p-md osf-box-lt p-md box-round" data-qtoggle-group="prereg" data-qtoggle-target="#existingPreregXS">Continue working on an existing draft preregistration</div>
         <div class="col-md-12 prereg-button-content-xs">
           ${existingPrereg('XS')}
         </div>
@@ -98,7 +98,7 @@
             </td>
             %if has_draft_registrations:
             <td class="col-sm-${ num_cols } prereg-button-col">
-              <div class="prereg-button m-b-md p-md osf-box-lt p-md box-round" data-qtoggle-group="prereg" data-qtoggle-target="#existingPrereg">Continue working on an existing preregistration</div>
+              <div class="prereg-button m-b-md p-md osf-box-lt p-md box-round" data-qtoggle-group="prereg" data-qtoggle-target="#existingPrereg">Continue working on an existing draft preregistration</div>
             </td>
             %endif
             %if has_projects:

--- a/website/templates/project/modal_add_contributor.mako
+++ b/website/templates/project/modal_add_contributor.mako
@@ -110,24 +110,28 @@
                             <!-- /ko -->
                             <!-- Link to add non-registered contributor -->
                             <div class='help-block'>
-                                <div data-bind="if: emailSearch">
-                                    <strong>Warning:</strong> Please search by name, not email address.
-                                </div>
                                 <div data-bind='if: foundResults'>
                                     <ul class="pagination pagination-sm" data-bind="foreach: paginators">
                                         <li data-bind="css: style"><a href="#" data-bind="click: handler, text: text"></a></li>
                                     </ul>
                                     <p>
-                                        <a href="#" data-bind="click:gotoInvite">Add <strong><em data-bind="text: query"></em></strong> as an unregistered contributor</a>.
+                                        <div data-bind='ifnot: emailSearch'>
+                                            <a href="#" data-bind="click:gotoInvite">Add <strong><em data-bind="text: query"></em></strong> as an unregistered contributor</a>.
+                                        </div>
                                     </p>
                                 </div>
                                 <div data-bind="if: showLoading">
                                     <p class="text-muted">Searching contributors...</p>
                                 </div>
-                                    <div data-bind="if: noResults">
-                                        No results found. Try a more specific search or
+                                <div data-bind="if: noResults">
+                                    No results found. Try a more specific search
+                                    <div data-bind="ifnot: emailSearch"> or
                                         <a href="#" data-bind="click:gotoInvite">add <strong><em data-bind="text: query"></em></strong> as an unregistered contributor</a>.
                                     </div>
+                                </div>
+                                <div data-bind="if: emailSearch">
+                                    <p>It looks like you are trying to search by email address. If you search by name, you can add an unregistered contributor.</p>
+                                </div>
                             </div>
                         </div><!-- ./col-md -->
 
@@ -273,4 +277,3 @@
         </div><!-- end modal-content -->
     </div><!-- end modal-dialog -->
 </div><!-- end modal -->
-

--- a/website/templates/project/modal_add_contributor.mako
+++ b/website/templates/project/modal_add_contributor.mako
@@ -111,7 +111,7 @@
                             <!-- Link to add non-registered contributor -->
                             <div class='help-block'>
                                 <div data-bind="if: emailSearch">
-                                    <strong>Warning:</strong> Please search by username not email address.
+                                    <strong>Warning:</strong> Please search by name, not email address.
                                 </div>
                                 <div data-bind='if: foundResults'>
                                     <ul class="pagination pagination-sm" data-bind="foreach: paginators">

--- a/website/templates/project/modal_add_contributor.mako
+++ b/website/templates/project/modal_add_contributor.mako
@@ -110,6 +110,9 @@
                             <!-- /ko -->
                             <!-- Link to add non-registered contributor -->
                             <div class='help-block'>
+                                <div data-bind="if: emailSearch">
+                                    <strong>Warning:</strong> Please search by username not email address.
+                                </div>
                                 <div data-bind='if: foundResults'>
                                     <ul class="pagination pagination-sm" data-bind="foreach: paginators">
                                         <li data-bind="css: style"><a href="#" data-bind="click: handler, text: text"></a></li>

--- a/website/templates/project/modal_add_contributor.mako
+++ b/website/templates/project/modal_add_contributor.mako
@@ -135,7 +135,7 @@
                                     </div>
                                 </div>
                                 <div data-bind="if: emailSearch">
-                                    <p>It looks like you are trying to search by email address. If you search by name, you can add an unregistered contributor.</p>
+                                    <p>It looks like you are trying to search by email address. Please try your search again using your collaborator's name. You will be able to add users without OSF accounts as unregistered contributors.</p>
                                 </div>
                             </div>
                         </div><!-- ./col-md -->

--- a/website/templates/project/modal_add_contributor.mako
+++ b/website/templates/project/modal_add_contributor.mako
@@ -124,7 +124,12 @@
                                     <p class="text-muted">Searching contributors...</p>
                                 </div>
                                 <div data-bind="if: noResults">
-                                    No results found. Try a more specific search
+                                    <div data-bind='if: emailSearch'>
+                                      No results found. Try a more specific search.
+                                    </div>
+                                    <div data-bind='ifnot: emailSearch'>
+                                      No results found. Try a more specific search
+                                    </div>
                                     <div data-bind="ifnot: emailSearch"> or
                                         <a href="#" data-bind="click:gotoInvite">add <strong><em data-bind="text: query"></em></strong> as an unregistered contributor</a>.
                                     </div>
@@ -277,3 +282,4 @@
         </div><!-- end modal-content -->
     </div><!-- end modal-dialog -->
 </div><!-- end modal -->
+


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

When a user attempt to add contributors to a project, if the name entered is an email, we don't want to allow them to add it as an unregistered user (we want them to add "John Doe" not "jdoe89@gmail.com"). So we want to alert them to search by name, not email, when they search for an email address.

## Changes

The entered name is now checked against a Regular Expression to see if it fits the format of an email address (ie. [text]@[text].[text]). It then outputs the correct responses based on whether or not the name is an email or not.

## Side effects

None

## Ticket

https://openscience.atlassian.net/browse/OSF-5639