### PR TITLE
Update regex to handle domain and update tests [OSF-5658]

### DIFF
--- a/framework/mongo/validators.py
+++ b/framework/mongo/validators.py
@@ -16,7 +16,7 @@ def comment_maxlength(max_length):
     def link_repl(matchobj):
         return matchobj.group(1)
 
-    mention_re = re.compile(r'\[([@|\+].*?)\]\(\/[a-z\d]{5}\/\)')
+    mention_re = re.compile(r'\[([@|\+].*?)\]\(htt[ps]{1,2}:\/\/[a-z\d:.]+?\/[a-z\d]{5}\/\)')
 
     def validator(value):
         reduced_comment = mention_re.sub(link_repl, value)

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -137,7 +137,7 @@ class TestCommentModel(OsfTestCase):
                 node=self.comment.node,
                 target=self.comment.target,
                 is_public=True,
-                content=''.join(['c' for c in range(settings.COMMENT_MAXLENGTH - 8)]) + '[@George Ant](/' + self.comment.user._id + '/)'
+                content=''.join(['c' for c in range(settings.COMMENT_MAXLENGTH - 8)]) + '[@George Ant](http://localhost:5000/' + self.comment.user._id + '/)'
             )
 
     def test_create_comment_content_does_not_exceed_max_length_complex(self):
@@ -147,7 +147,7 @@ class TestCommentModel(OsfTestCase):
             node=self.comment.node,
             target=self.comment.target,
             is_public=True,
-            content=''.join(['c' for c in range(settings.COMMENT_MAXLENGTH - 12)]) + '[@George Ant](/' + self.comment.user._id + '/)'
+            content=''.join(['c' for c in range(settings.COMMENT_MAXLENGTH - 12)]) + '[@George Ant](http://localhost:5000/' + self.comment.user._id + '/)'
         )
 
     def test_create_comment_content_cannot_be_none(self):
@@ -207,7 +207,7 @@ class TestCommentModel(OsfTestCase):
                 node=self.comment.node,
                 target=self.comment.target,
                 is_public=True,
-                content='This is a comment with a bad mention [@Unconfirmed User](/' + self.comment.user._id + '/).'
+                content='This is a comment with a bad mention [@Unconfirmed User](http://localhost:5000/' + self.comment.user._id + '/).'
             )
         assert_equal(mock_signals.signals_sent(), set([comment_added, mention_added]))
 
@@ -227,7 +227,7 @@ class TestCommentModel(OsfTestCase):
                     node=self.comment.node,
                     target=self.comment.target,
                     is_public=True,
-                    content='This is a comment with a bad mention [@Unconfirmed User](/' + user._id + '/).'
+                    content='This is a comment with a bad mention [@Unconfirmed User](http://localhost:5000/' + user._id + '/).'
                 )
         assert_equal(mock_signals.signals_sent(), set([contributor_added]))
         assert_equal(error.exception.message, 'User does not exist or is not active.')
@@ -242,7 +242,7 @@ class TestCommentModel(OsfTestCase):
                     node=self.comment.node,
                     target=self.comment.target,
                     is_public=True,
-                    content='This is a comment with a bad mention [@Non-contributor User](/' + user._id + '/).'
+                    content='This is a comment with a bad mention [@Non-contributor User](http://localhost:5000/' + user._id + '/).'
                 )
         assert_equal(mock_signals.signals_sent(), set([]))
         assert_equal(error.exception.message, 'Mentioned user is not a contributor.')
@@ -256,7 +256,7 @@ class TestCommentModel(OsfTestCase):
                     node=self.comment.node,
                     target=self.comment.target,
                     is_public=True,
-                    content='This is a comment with a bad mention [@Not a User](/qwert/).'
+                    content='This is a comment with a bad mention [@Not a User](http://localhost:5000/qwert/).'
                 )
         assert_equal(mock_signals.signals_sent(), set([]))
         assert_equal(error.exception.message, 'User does not exist or is not active.')
@@ -276,7 +276,7 @@ class TestCommentModel(OsfTestCase):
         with capture_signals() as mock_signals:
             self.comment.edit(
                 auth=self.auth,
-                content='This is a comment with a bad mention [@Mentioned User](/' + self.comment.user._id + '/).',
+                content='This is a comment with a bad mention [@Mentioned User](http://localhost:5000/' + self.comment.user._id + '/).',
                 save=True
             )
         assert_equal(mock_signals.signals_sent(), set([mention_added]))
@@ -286,7 +286,7 @@ class TestCommentModel(OsfTestCase):
             with capture_signals() as mock_signals:
                 self.comment.edit(
                     auth=self.auth,
-                    content='This is a comment with a bad mention [@Not a User](/qwert/).',
+                    content='This is a comment with a bad mention [@Not a User](http://localhost:5000/qwert/).',
                     save=True
                 )
         assert_equal(mock_signals.signals_sent(), set([]))
@@ -298,7 +298,7 @@ class TestCommentModel(OsfTestCase):
                 user = UserFactory()
                 self.comment.edit(
                     auth=self.auth,
-                    content='This is a comment with a bad mention [@Non-contributor User](/' + user._id + '/).',
+                    content='This is a comment with a bad mention [@Non-contributor User](http://localhost:5000/' + user._id + '/).',
                     save=True
                 )
         assert_equal(mock_signals.signals_sent(), set([]))
@@ -316,7 +316,7 @@ class TestCommentModel(OsfTestCase):
 
                 self.comment.edit(
                     auth=self.auth,
-                    content='This is a comment with a bad mention [@Unconfirmed User](/' + user._id + '/).',
+                    content='This is a comment with a bad mention [@Unconfirmed User](http://localhost:5000/' + user._id + '/).',
                     save=True
                 )
         assert_equal(mock_signals.signals_sent(), set([contributor_added]))
@@ -327,7 +327,7 @@ class TestCommentModel(OsfTestCase):
             self.comment.ever_mentioned=[self.comment.user._id]
             self.comment.edit(
                 auth=self.auth,
-                content='This is a comment with a bad mention [@Already Mentioned User](/' + self.comment.user._id + '/).',
+                content='This is a comment with a bad mention [@Already Mentioned User](http://localhost:5000/' + self.comment.user._id + '/).',
                 save=True
             )
         assert_equal(mock_signals.signals_sent(), set([]))

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -197,7 +197,7 @@ def get_valid_mentioned_users_guids(comment, contributors):
     :param list contributors: List of contributors on the node
     :return list new_mentions: List of valid users mentioned in the comment content
     """
-    new_mentions = set(re.findall(r"\[[@|\+].*?\]\(\/([a-z\d]{5})\/\)", comment.content))
+    new_mentions = set(re.findall(r"\[[@|\+].*?\]\(htt[ps]{1,2}:\/\/[a-z\d:.]+?\/([a-z\d]{5})\/\)", comment.content))
     new_mentions = [
         m for m in new_mentions if
         m not in comment.ever_mentioned and

--- a/website/static/js/comment.js
+++ b/website/static/js/comment.js
@@ -107,7 +107,7 @@ var exclusifyGroup = function() {
 
 var convertMentionHtmlToMarkdown = function(commentContent) {
     var content = commentContent || '';
-    var pattern = '<span[^>]*?data-atwho-guid="([a-z\\d]{5})"[^>]*?>((@|\\+).+)<\/span>';
+    var pattern = '<span[^>]*?data-atwho-guid="([a-z\\d]{5})"[^>]*?>((@|\\+)[^<]+)<\/span>';
     var regex = new RegExp(pattern);
     var regexG = new RegExp(pattern, 'g');
     var matches = content.match(regexG);
@@ -131,7 +131,7 @@ var convertMentionHtmlToMarkdown = function(commentContent) {
 
 var convertMentionMarkdownToHtml = function(commentContent) {
     var content = commentContent ||'';
-    var pattern = '\\[(@|\\+)(.*?)\\]\\(\\/([a-z\\d]{5})\\/\\)';
+    var pattern = '\\[(@|\\+)(.*?)\\]\\(htt[ps]{1,2}:\\/\\/[a-z\\d:.]+?\\/([a-z\\d]{5})\\/\\)';
     var regex = new RegExp(pattern);
     var regexG = new RegExp(pattern, 'g');
     var matches = content.match(regexG);

--- a/website/static/js/tests/comment.test.js
+++ b/website/static/js/tests/comment.test.js
@@ -2,15 +2,16 @@
 'use strict';
 var assert = require('chai').assert;
 
+var osfHelpers = require('js/osfHelpers');
 var comment = require('js/comment');
 var convertMentionHtmlToMarkdown = comment.convertMentionHtmlToMarkdown;
 var convertMentionMarkdownToHtml = comment.convertMentionMarkdownToHtml;
 
 describe('@Mentions', () => {
     var atMentionHTML = 'Hello, <span class="atwho-inserted" contenteditable="false" data-atwho-guid="12345" data-atwho-at-query="@">@Test User</span>';
-    var atMentionMarkdown = 'Hello, [@Test User](http://localhost:5000/12345/)';
+    var atMentionMarkdown = 'Hello, [@Test User](' + osfHelpers.getDomain() + '/12345/)';
     var plusMentionHTML = 'Hello, <span class="atwho-inserted" contenteditable="false" data-atwho-guid="12345" data-atwho-at-query="+">+Test User</span>';
-    var plusMentionMarkdown = 'Hello, [+Test User](http://localhost:5000/12345/)';
+    var plusMentionMarkdown = 'Hello, [+Test User](' + osfHelpers.getDomain() + '/12345/)';
     var returnHTML = 'Test.<br>';
     var returnMarkdown = 'Test.&#13;&#10;';
     var returnMarkdown2 = 'Test.\r\n';

--- a/website/static/js/tests/comment.test.js
+++ b/website/static/js/tests/comment.test.js
@@ -8,9 +8,9 @@ var convertMentionMarkdownToHtml = comment.convertMentionMarkdownToHtml;
 
 describe('@Mentions', () => {
     var atMentionHTML = 'Hello, <span class="atwho-inserted" contenteditable="false" data-atwho-guid="12345" data-atwho-at-query="@">@Test User</span>';
-    var atMentionMarkdown = 'Hello, [@Test User](/12345/)';
+    var atMentionMarkdown = 'Hello, [@Test User](http://localhost:5000/12345/)';
     var plusMentionHTML = 'Hello, <span class="atwho-inserted" contenteditable="false" data-atwho-guid="12345" data-atwho-at-query="+">+Test User</span>';
-    var plusMentionMarkdown = 'Hello, [+Test User](/12345/)';
+    var plusMentionMarkdown = 'Hello, [+Test User](http://localhost:5000/12345/)';
     var returnHTML = 'Test.<br>';
     var returnMarkdown = 'Test.&#13;&#10;';
     var returnMarkdown2 = 'Test.\r\n';


### PR DESCRIPTION
## Purpose

Update regex to handle the domain in the embedded link.

Note: the grouping is different in the python regexes

## Changes

* Updated tests
* Updated regex

## Side effects

None


## Ticket

https://openscience.atlassian.net/browse/OSF-5658

