### PR TITLE
[CR] Keen UI updates [#OSF-6652]

### DIFF
--- a/website/static/css/pages/statistics-page.css
+++ b/website/static/css/pages/statistics-page.css
@@ -1,0 +1,1 @@
+.project-analytics .c3 svg { font: 12px sans-serif; }

--- a/website/static/js/dateRangePicker.js
+++ b/website/static/js/dateRangePicker.js
@@ -11,19 +11,19 @@ var pikaday = require('pikaday');
 
 
 var DateRangePicker = oop.defclass({
-    constructor: function(startPickerElem, startDate, endPickerElem, endDate, minDate, maxDate) {
+    constructor: function(params) {
         var self = this;
 
-        self.minDate = minDate;
-        self.maxDate = maxDate;
+        self.minDate = params.minDate;
+        self.maxDate = params.maxDate;
 
-        self.startDate = startDate;
-        self.startPickerElem = startPickerElem;
-        self._startPicker = self._makePicker(startPickerElem, 'startDate', 'updateStartDate');
+        self.startDate = params.startDate;
+        self.startPickerElem = params.startPickerElem;
+        self._startPicker = self._makePicker(params.startPickerElem, 'startDate', 'updateStartDate');
 
-        self.endDate = endDate;
-        self.endPickerElem = endPickerElem;
-        self._endPicker = self._makePicker(endPickerElem, 'endDate', 'updateEndDate');
+        self.endDate = params.endDate;
+        self.endPickerElem = params.endPickerElem;
+        self._endPicker = self._makePicker(params.endPickerElem, 'endDate', 'updateEndDate');
 
         self.updateStartDate(self.startDate);
         self.updateEndDate(self.endDate);

--- a/website/static/js/pages/statistics-page.js
+++ b/website/static/js/pages/statistics-page.js
@@ -22,6 +22,16 @@ $(function(){
 
 
 keenAnalysis.ready(function(){
+    function updateDateRangeDisplay(statsStartDate, statsEndDate) {
+        $('#startDateString').removeClass('logo-spin logo-sm').text(statsStartDate.toLocaleDateString());
+        $('#endDateString').removeClass('logo-spin logo-sm').text(statsEndDate.toLocaleDateString());
+    }
+
+    function toggleDateRangePickerView() {
+        $('#dateRange').toggleClass('hidden');
+        $('#dateRangeForm').toggleClass('hidden');
+    }
+
     function drawAllCharts(statsStartDate, statsEndDate) {
         projectUsageStats.visitsByDay('#visits', statsStartDate, statsEndDate);
         projectUsageStats.topReferrers('#topReferrers', statsStartDate, statsEndDate);
@@ -44,6 +54,8 @@ keenAnalysis.ready(function(){
     var endPickerElem = document.getElementById('endDatePicker');
     var endDate = new Date(Date.now() - oneDayInMs);
 
+    updateDateRangeDisplay(startDate, endDate);
+
     var dateRangePicker = new DateRangePicker(
         startPickerElem, startDate,
         endPickerElem, endDate,
@@ -56,8 +68,12 @@ keenAnalysis.ready(function(){
     );
     drawAllCharts(dateRangePicker.startDate, dateRangePicker.endDate);
 
-    $('#updateStatsDates').on('submit', function() {
+    $('#showDateRangeForm').on('click', function() { toggleDateRangePickerView(); });
+
+    $('#dateRangeForm').on('submit', function() {
+        updateDateRangeDisplay(dateRangePicker.startDate, dateRangePicker.endDate);
         drawAllCharts(dateRangePicker.startDate, dateRangePicker.endDate);
+        toggleDateRangePickerView();
         return false;
     });
 

--- a/website/static/js/pages/statistics-page.js
+++ b/website/static/js/pages/statistics-page.js
@@ -41,23 +41,19 @@ keenAnalysis.ready(function(){
 
     var oneDayInMs = 24 * 60 * 60 * 1000;
     var thirtyDaysAgoInMs = 30 * oneDayInMs;
-
-    var statsMinDate = new Date(2013, 5, 1);
-    var statsMaxDate = new Date();
-
-    var startPickerElem = document.getElementById('startDatePicker');
     var startDate = new Date(Date.now() - thirtyDaysAgoInMs);
-
-    var endPickerElem = document.getElementById('endDatePicker');
     var endDate = new Date(Date.now());
 
     updateDateRangeDisplay(startDate, endDate);
 
-    var dateRangePicker = new DateRangePicker(
-        startPickerElem, startDate,
-        endPickerElem, endDate,
-        statsMinDate, statsMaxDate
-    );
+    var dateRangePicker = new DateRangePicker({
+        startPickerElem: document.getElementById('startDatePicker'),
+        startDate: startDate,
+        endPickerElem: document.getElementById('endDatePicker'),
+        endDate: endDate,
+        statsMinDate: new Date(2013, 5, 1),
+        statsMaxDate: new Date(),
+    });
 
     var authParams = {
         keenProjectId: window.contextVars.keen.public.projectId,

--- a/website/static/js/statistics.js
+++ b/website/static/js/statistics.js
@@ -2,234 +2,120 @@
 
 require('keen-dataviz/dist/keen-dataviz.min.css');
 
+var oop = require('js/oop');
 var $osf = require('js/osfHelpers');
 var keenDataviz = require('keen-dataviz');
 var keenAnalysis = require('keen-analysis');
 
-var ProjectUsageStatistics = function(keenProjectId, keenReadKey, params){
-    var self = this;
 
-    params = params || {};
-    self.MAX_DISPLAY_ENTRIES = params.maxDisplayEntries || 10;
+var UserFacingChart = oop.defclass({
+    constructor: function(params) {
+        var self = this;
+        params = params || {};
+
+        var required = ['keenProjectId', 'keenReadKey', 'containingElement'];
+        required.forEach(function(paramName) {
+            if (!params[paramName]) {
+                throw 'Missing required argument "' + paramName + '"';
+            }
+        });
+
+        /**
+         * Manages the connections to Keen.  Needs a project id and valid read key for that project.
+         *
+         * @property keenClient
+         * @type {keenAnalysis}
+         */
+        self.keenClient = new keenAnalysis({
+            projectId: params.keenProjectId,
+            readKey: params.keenReadKey,
+        });
+
+        /**
+         * HTML id of containing element.
+         *
+         * @property containingElement
+         * @type {string}
+         */
+        self.containingElement = params.containingElement;
+
+        /**
+         * Max number of entries to display for category-based charts. Ignored for time-series data.
+         * Default 10.
+         *
+         * @property MAX_DISPLAY_ENTRIES
+         * @type {integer}
+         */
+        self.MAX_DISPLAY_ENTRIES = params.maxDisplayEntries || 10;
+    },
 
     /**
-    * Manages the connections to Keen.  Needs a project id and valid read key for that project.
-    *
-    * @property keenClient
-    * @type {keenAnalysis}
-    */
-    self.keenClient = new keenAnalysis({
-        projectId: keenProjectId,
-        readKey : keenReadKey,
-    });
+     * Returns an Object that defines the analysis to relay to Keen. Has two top-level keys,
+     * `type` and `params`. `type` is the type of aggregation to perform. `params` defines the
+     * parameters of the query.  The timeframe for the analysis is be filled in by the query()
+     * method, which calls baseQuery().
+     *
+     * See: https://keen.io/docs/api/?javascript#analyses
+     *
+     * @method baseQuery
+     * @return {Object}
+     */
+    baseQuery: function() {
+        throw 'Concrete class does not provide a "baseQuery" method!';
+    },
 
-    // hide non-integer labels on charts for counts
-    self._hideNonIntegers = function(d) {
-        return (parseInt(d) === d) ? d : null;
-    };
+    /**
+     * Calls the concrete class's baseQuery() and adds the timeframe for the analysis. The start
+     * and end dates of the timeframe come from the startDate and endDate parameters saved with
+     * the chart.
+     *
+     * @method query
+     * @return {Object}
+     */
+    query: function() {
+        var self = this;
 
-    // show visits to this project over the last week
-    self.visitsByDay = function(elem, startDate, endDate) {
-        var query = {
-            'type':'count_unique',
-            'params' : {
-                event_collection: 'pageviews',
-                timeframe: {
-                    start: startDate.toISOString(),
-                    end: endDate.toISOString(),
-                },
-                interval: 'daily',
-                target_property: 'anon.id'
-            }
+        var baseQuery = self.baseQuery();
+        baseQuery.params.timeframe = {
+            start: self.startDate.toISOString(),
+            end: self.endDate.toISOString(),
         };
+        return baseQuery;
+    },
+    _initDataviz: function() {
+        var self = this;
+        return new keenDataviz().el(self.containingElement);
+    },
 
-        var dataviz = new keenDataviz()
-                .el(elem)
-                .chartType('line')
-                .dateFormat('%b %d')
-                .chartOptions({
-                    tooltip: {
-                        format: {
-                            title: function(x) { return x.toDateString(); },
-                            name: function(){return 'Visits';}
-                        }
-                    },
-                    axis: {
-                        y: {
-                            tick: {
-                                format: self._hideNonIntegers,
-                            }
-                        },
-                        x: {
-                            tick: {
-                                fit: false,
-                            },
-                        },
-                    },
-                });
-
-        self.buildChart(query, dataviz);
-    };
+    /**
+     * A function that is called after the data from the query is set, but before the chart is
+     * rendered.  Can be used to modify the data before displaying.  The data is available in the
+     * `self.chart.dataset` object.  This object and the methods available on it are described here:
+     *
+     * https://github.com/keen/keen-dataviz.js/tree/master/docs/dataset
+     *
+     * Defaults to a no-op function.
+     *
+     * @method munger
+     * @return {null}
+     */
+    munger: function() { },
 
 
-    // show most common referrers to this project from the last week
-    self.topReferrers = function(elem, startDate, endDate) {
-        var query = {
-            type: 'count_unique',
-            params: {
-                event_collection: 'pageviews',
-                timeframe: {
-                    start: startDate.toISOString(),
-                    end: endDate.toISOString(),
-                },
-                target_property: 'anon.id',
-                group_by: 'referrer.info.domain'
-            }
-        };
-
-        var dataviz = new keenDataviz()
-                .el(elem)
-                .chartType('pie')
-                .chartOptions({
-                    tooltip:{
-                        format:{
-                            name: function(){return 'Visits';}
-                        }
-                    },
-                });
-
-        var munger = function() {
-            this.dataset.sortRows('desc', function(row) {
-                return row[1];
-            });
-            this.dataset.filterRows(function(row, index) {
-                return index < self.MAX_DISPLAY_ENTRIES;
-            });
-            this.dataset.updateColumn(0, function(value, index, column) {
-                return value === 'null' ? 'direct link' : value;
-            });
-        };
-
-        self.buildChart(query, dataviz, munger);
-    };
-
-    // The number of visits by hour across last week
-    self.visitsServerTime = function(elem, startDate, endDate) {
-        var query = {
-            'type': 'count_unique',
-            'params': {
-                event_collection: 'pageviews',
-                timeframe: {
-                    start: startDate.toISOString(),
-                    end: endDate.toISOString(),
-                },
-                target_property: 'anon.id',
-                group_by: 'time.local.hour_of_day',
-            }
-        };
-
-        var dataviz = new keenDataviz()
-                .el(elem)
-                .chartType('bar')
-                .chartOptions({
-                    tooltip:{
-                        format:{
-                            name: function(){return 'Visits';}
-                        }
-                    },
-                    axis: {
-                        x: {
-                            label: {
-                                text: 'Hour of Day',
-                                position: 'outer-center',
-                            },
-                            tick: {
-                                centered: true,
-                                values: ['0', '4', '8', '12', '16', '20'],
-                            },
-                        },
-                        y: {
-                            tick: {
-                                format: self._hideNonIntegers,
-                            }
-                        }
-                    },
-                });
-
-        // make sure all hours of the day 0-23 are present
-        var munger = function() {
-            var foundHours = {};
-            for (var i=this.dataset.matrix.length-1; i>0; i--) {
-                var row = this.dataset.selectRow(i);
-                foundHours[ row[0] ] = row[1];
-                this.dataset.deleteRow(i);
-            }
-
-            for (var hour=0; hour<24; hour++) {
-                var stringyNum = '' + hour;
-                this.dataset.appendRow(stringyNum, [ foundHours[stringyNum] || 0 ]);
-            }
-        };
-        self.buildChart(query, dataviz, munger);
-
-    };
-
-    // most popular sub-pages of this project
-    self.popularPages = function(elem, startDate, endDate, nodeTitle) {
-        var query = {
-            type: 'count_unique',
-            params: {
-                event_collection: 'pageviews',
-                timeframe: {
-                    start: startDate.toISOString(),
-                    end: endDate.toISOString(),
-                },
-                target_property: 'anon.id',
-                group_by: 'page.title'
-            }
-        };
-
-        var dataviz = new keenDataviz()
-                .el(elem)
-                .chartType('horizontal-bar')
-                .chartOptions({
-                    tooltip:{
-                        format:{
-                            name: function(){return 'Visits';}
-                        }
-                    },
-                    axis: {
-                        y: {
-                            tick: {
-                                format: self._hideNonIntegers,
-                            }
-                        }
-                    },
-                });
-
-        var munger = function() {
-            var dataset = this.dataset;
-            dataset.sortRows('asc', function(row) { return row[1]; });
-
-            var nbrRows = dataset.matrix.length;
-            var minimumIndex = nbrRows <= self.MAX_DISPLAY_ENTRIES ? 0 : nbrRows - self.MAX_DISPLAY_ENTRIES;
-            dataset.filterRows(function(row, index) { return index >= minimumIndex; });
-
-            dataset.updateColumn(0, function(value, index, column) {
-                var title = value.replace(/^OSF \| /, '');
-                // Strip off the project title, if present at beginning of string
-                if (title.startsWith(nodeTitle)) {
-                    // strip off first N chars where N is project title length + 1 space
-                    var pageTitleIndex = nodeTitle.length + 1;
-                    title = title.slice(pageTitleIndex);
-                }
-                return title || 'Home';
-            });
-        };
-
-        self.buildChart(query, dataviz, munger);
-    };
-
+    /**
+     * Sets the date range over which the metric should apply.  Sets the startDate and endDate
+     * properties.  These 
+     *
+     * @method setDataRange
+     * @param {Date} startDate first day (inclusive) for which to display stats
+     * @param {Date} endDate last day (exclusive) for which to display stats
+     * @return {null}
+     */
+    setDateRange: function(startDate, endDate) {
+        var self = this;
+        self.startDate = startDate;
+        self.endDate = endDate;
+    },
 
     /**
      * Build a data chart on the page. The element on the page that the chart will be inserted into
@@ -237,28 +123,257 @@ var ProjectUsageStatistics = function(keenProjectId, keenReadKey, params){
      * loaded.  If an error is returned, it will be displayed within the chart element.
      *
      * @method buildChart
-     * @param {Object} query Defines the analysis to relay to Keen. Has two top-level keys, `type`
-     *                       and `params`. `type` is the type of aggregation to perform. `params`
-     *                       defines the parameters of the query.  See:
-     *                       https://keen.io/docs/api/?javascript#analyses
      * @param {Keen.Dataviz} dataviz The Dataviz object that defines the look chart. See:
      *                               https://github.com/keen/keen-dataviz.js/tree/master/docs
-     * @param {Function} [munger] *optional* A function that can munge the Keen.Dataset returned
-     *                            from the query.  Useful for formatting data before display. See:
-     *                            https://github.com/keen/keen-dataviz.js/tree/master/docs/dataset
      */
-    self.buildChart = function(query, dataviz, munger){
-        munger = munger || function() {};
+    buildChart: function() {
+        var self = this;
+        if (!self.chart) {
+            self.chart = self._initDataviz();
+        }
 
+        self.chart.prepare();
+        var query = self.query();
         self.keenClient
             .query(query.type, query.params)
             .then(function(res) {
-                dataviz.title(' ').data(res).call(munger).render();
+                self.chart.title(' ').data(res).call(self.munger.bind(self)).render();
             })
             .catch(function(err) {
-                dataviz.message(err.message);
+                self.chart.message(err.message);
             });
-    };
-};
+    },
 
-module.exports = ProjectUsageStatistics;
+    // helpers functions to format raw data
+    _helpers: {
+        // hide non-integer labels on charts for counts
+        hideNonIntegers: function(d) {
+            return (parseInt(d) === d) ? d : null;
+        },
+    },
+
+
+});
+
+
+// show unique visits to this project
+var ChartUniqueVisits = oop.extend(UserFacingChart, {
+    constructor: function(params) {
+        this.super.constructor.call(this, params);
+    },
+    baseQuery: function() {
+        var self = this;
+        return {
+            type: 'count_unique',
+            params: {
+                event_collection: 'pageviews',
+                interval: 'daily',
+                target_property: 'anon.id'
+            }
+        };
+    },
+    _initDataviz: function() {
+        var self = this;
+        return self.super._initDataviz.call(self)
+            .chartType('line')
+            .dateFormat('%b %d')
+            .chartOptions({
+                tooltip: {
+                    format: {
+                        title: function(x) { return x.toDateString(); },
+                        name: function() { return 'Visits'; }
+                    }
+                },
+                axis: {
+                    y: {
+                        tick: {
+                            format: self._helpers.hideNonIntegers,
+                        }
+                    },
+                    x: {
+                        tick: {
+                            fit: false,
+                        },
+                    },
+                },
+            });
+    },
+
+
+
+});
+
+// show most common referrers to this project from the last week
+var ChartTopReferrers = oop.extend(UserFacingChart, {
+    constructor: function(params) {
+        this.super.constructor.call(this, params);
+    },
+    baseQuery: function() {
+        var self = this;
+        return {
+            type: 'count_unique',
+            params: {
+                event_collection: 'pageviews',
+                target_property: 'anon.id',
+                group_by: 'referrer.info.domain'
+            }
+        };
+    },
+    _initDataviz: function() {
+        var self = this;
+        return self.super._initDataviz.call(self)
+            .chartType('pie')
+            .chartOptions({
+                tooltip:{
+                    format:{
+                        name: function() { return 'Visits'; }
+                    }
+                },
+            });
+    },
+    munger: function() {
+        var self = this;
+        var dataset = self.chart.dataset;
+        dataset.sortRows('desc', function(row) {
+            return row[1];
+        });
+        dataset.filterRows(function(row, index) {
+            return index < self.MAX_DISPLAY_ENTRIES;
+        });
+        dataset.updateColumn(0, function(value, index, column) {
+            return value === 'null' ? 'direct link' : value;
+        });
+    },
+});
+
+
+// The number of visits by hour across last week
+var ChartVisitsServerTime = oop.extend(UserFacingChart, {
+    constructor: function(params) {
+        this.super.constructor.call(this, params);
+    },
+    baseQuery: function() {
+        var self = this;
+        return {
+            type: 'count_unique',
+            params: {
+                event_collection: 'pageviews',
+                target_property: 'anon.id',
+                group_by: 'time.local.hour_of_day',
+            }
+        };
+    },
+    _initDataviz: function() {
+        var self = this;
+        return self.super._initDataviz.call(self)
+            .chartType('bar')
+            .chartOptions({
+                tooltip:{
+                    format:{
+                        name: function() { return 'Visits'; }
+                    }
+                },
+                axis: {
+                    x: {
+                        label: {
+                            text: 'Hour of Day',
+                            position: 'outer-center',
+                        },
+                        tick: {
+                            centered: true,
+                            values: ['0', '4', '8', '12', '16', '20'],
+                        },
+                    },
+                    y: {
+                        tick: {
+                            format: self._helpers.hideNonIntegers,
+                        }
+                    }
+                },
+            });
+    },
+    munger: function() {
+        var self = this;
+        var dataset = self.chart.dataset;
+        // make sure all hours of the day 0-23 are present
+
+        var foundHours = {};
+        for (var i=dataset.matrix.length-1; i>0; i--) {
+            var row = dataset.selectRow(i);
+            foundHours[ row[0] ] = row[1];
+            dataset.deleteRow(i);
+        }
+
+        for (var hour=0; hour<24; hour++) {
+            var stringyNum = '' + hour;
+            dataset.appendRow(stringyNum, [ foundHours[stringyNum] || 0 ]);
+        }
+    },
+});
+
+// most popular sub-pages of this project
+var ChartPopularPages = oop.extend(UserFacingChart, {
+    constructor: function(params) {
+        var self = this;
+        self.super.constructor.call(self, params);
+        self.nodeTitle = params.nodeTitle || '';
+    },
+    baseQuery: function() {
+        var self = this;
+        return {
+            type: 'count_unique',
+            params: {
+                event_collection: 'pageviews',
+                target_property: 'anon.id',
+                group_by: 'page.title'
+            }
+        };
+    },
+    _initDataviz: function() {
+        var self = this;
+        return self.super._initDataviz.call(self)
+            .chartType('horizontal-bar')
+            .chartOptions({
+                tooltip:{
+                    format:{
+                        name: function() { return 'Visits'; }
+                    }
+                },
+                axis: {
+                    y: {
+                        tick: {
+                            format: self._helpers.hideNonIntegers,
+                        }
+                    }
+                },
+            });
+    },
+    munger: function() {
+        var self = this;
+        var dataset = self.chart.dataset;
+        dataset.sortRows('asc', function(row) { return row[1]; });
+
+        var nbrRows = dataset.matrix.length;
+        var minimumIndex = nbrRows <= self.MAX_DISPLAY_ENTRIES ? 0 : nbrRows - self.MAX_DISPLAY_ENTRIES;
+        dataset.filterRows(function(row, index) { return index >= minimumIndex; });
+
+        dataset.updateColumn(0, function(value, index, column) {
+            var title = value.replace(/^OSF \| /, '');
+            // Strip off the project title, if present at beginning of string
+            if (title.startsWith(self.nodeTitle)) {
+                // strip off first N chars where N is project title length + 1 space
+                var pageTitleIndex = self.nodeTitle.length + 1;
+                title = title.slice(pageTitleIndex);
+            }
+            return title || 'Home';
+        });
+    },
+});
+
+module.exports = {
+    UserFacingChart: UserFacingChart,
+    ChartUniqueVisits: ChartUniqueVisits,
+    ChartTopReferrers: ChartTopReferrers,
+    ChartVisitsServerTime:ChartVisitsServerTime,
+    ChartPopularPages: ChartPopularPages,
+};

--- a/website/templates/project/statistics.mako
+++ b/website/templates/project/statistics.mako
@@ -19,17 +19,25 @@
 
     <div class="row m-lg">
       <div class="col-sm-12">
-        <form class="form-inline pull-right" id="updateStatsDates">
+
+        <div id="dateRange" class="pull-right">
+          Showing analytics from <span class="m-l-xs text-bigger f-w-xl logo-spin logo-sm" id="startDateString"></span>
+          until <span class="m-l-xs text-bigger f-w-xl logo-spin logo-sm" id="endDateString"></span>
+          <button class="btn btn-default m-l-xs" id="showDateRangeForm">Update</button>
+        </div>
+
+        <form class="form-inline pull-right hidden" id="dateRangeForm">
           <div class="form-group">
             <label for="startDatePicker">From</label>
             <input type="text" class="form-control" id="startDatePicker">
           </div>
-          <div class="form-group">
+          <div class="form-group m-l-sm">
             <label for="endDatePicker">Until</label>
             <input type="text" class="form-control" id="endDatePicker">
           </div>
           <button type="submit" class="btn btn-default">Update date range</button>
         </form>
+
       </div>
     </div>
     <div class="row m-lg">

--- a/website/templates/project/statistics.mako
+++ b/website/templates/project/statistics.mako
@@ -42,7 +42,7 @@
     </div>
     <div class="row m-lg">
         <div class="col-sm-6">
-            <div class="panel panel-default">
+            <div class="panel panel-default project-analytics">
                 <div class="panel-heading clearfix">
                     <h3 class="panel-title">Unique visits</h3>
                 </div>
@@ -54,7 +54,7 @@
             </div>
         </div>
         <div class="col-sm-6">
-          <div class="panel panel-default">
+          <div class="panel panel-default project-analytics">
             <div class="panel-heading clearfix">
               <h3 class="panel-title">Time of day of visits</h3>
             </div>
@@ -66,7 +66,7 @@
           </div>
         </div>
         <div class="col-sm-6">
-            <div class="panel panel-default">
+            <div class="panel panel-default project-analytics">
                 <div class="panel-heading clearfix">
                     <h3 class="panel-title">Top referrers</h3>
                 </div>
@@ -78,7 +78,7 @@
             </div>
         </div>
         <div class="col-sm-6">
-            <div class="panel panel-default">
+            <div class="panel panel-default project-analytics">
                 <div class="panel-heading clearfix">
                     <h3 class="panel-title">Popular pages</h3>
                 </div>
@@ -92,6 +92,11 @@
     </div>
 
 %endif
+
+<%def name="stylesheets()">
+  ${parent.stylesheets()}
+  <link rel="stylesheet" href="/static/css/pages/statistics-page.css">
+</%def>
 
 <%def name="javascript_bottom()">
   ${parent.javascript_bottom()}

--- a/website/templates/project/statistics.mako
+++ b/website/templates/project/statistics.mako
@@ -44,7 +44,7 @@
         <div class="col-sm-6">
             <div class="panel panel-default">
                 <div class="panel-heading clearfix">
-                    <h3 class="panel-title">Visits over past week</h3>
+                    <h3 class="panel-title">Unique visits</h3>
                 </div>
                 <div id="visits" class="panel-body">
                     <div class="text-center">


### PR DESCRIPTION
## Purpose

This PR addresses some, but not all, of the issues mentioned in [#OSF-6652].  I'm throwing this up here because the chart library was refactored muchly and will need a code re-review.  The remaining changes will be implemented in a follow-up PR, which should be much less invasive.

## Changes

- Display spinners after clicking "Update date range"
- Make "Popular pages" bar graph horizontal to avoid wrapping issues
- Bump up font size of chart labels
- Renamed "Visits over past week" to "Unique visits"
- date range form: initial version is text, click update button to reveal form
- more spacing between "from" and "until" in date range updater
- We exclude analytics for today, should reflect that in the picker: can select today, but end date is exclusive.
- not-UI related but good: refactor DateRangePicker constructor to take params
- Limit referrers/popular pages to top N results
- Referrers: rename "null" => "direct link"

## Side effects

May cause drowsiness.

## Ticket

[#OSF-6652]

https://openscience.atlassian.net/browse/OSF-6652

