### PR TITLE
Importing contributors from parent does not paginate [OSF-4762]

### DIFF
--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -199,32 +199,37 @@ AddContributorViewModel = oop.extend(Paginator, {
         this.fetchResults();
     },
     fetchResults: function () {
-        var self = this;
-        self.doneSearching(false);
-        self.notification(false);
-        if (self.query()) {
-            return $.getJSON(
-                '/api/v1/user/search/', {
-                    query: self.query(),
-                    page: self.pageToGet
-                },
-                function (result) {
-                    var contributors = result.users.map(function (userData) {
-                        userData.added = (self.contributors().indexOf(userData.id) !== -1);
-                        return new Contributor(userData);
-                    });
-                    self.doneSearching(true);
-                    self.results(contributors);
-                    self.currentPage(result.page);
-                    self.numberOfPages(result.pages);
-                    self.addNewPaginators(false);
-                }
-            );
+        if (this.parentImport()){
+            this.importFromParent();
         } else {
-            self.results([]);
-            self.currentPage(0);
-            self.totalPages(0);
-            self.doneSearching(true);
+            console.log("fetchResults Running");
+            var self = this;
+            self.doneSearching(false);
+            self.notification(false);
+            if (self.query()) {
+                return $.getJSON(
+                    '/api/v1/user/search/', {
+                        query: self.query(),
+                        page: self.pageToGet
+                    },
+                    function (result) {
+                        var contributors = result.users.map(function (userData) {
+                            userData.added = (self.contributors().indexOf(userData.id) !== -1);
+                            return new Contributor(userData);
+                        });
+                        self.doneSearching(true);
+                        self.results(contributors);
+                        self.currentPage(result.page);
+                        self.numberOfPages(result.pages);
+                        self.addNewPaginators(false);
+                    }
+                );
+            } else {
+                self.results([]);
+                self.currentPage(0);
+                self.totalPages(0);
+                self.doneSearching(true);
+            }
         }
     },
     getContributors: function () {
@@ -250,7 +255,6 @@ AddContributorViewModel = oop.extend(Paginator, {
     },
     startSearchParent: function () {
         this.parentImport(true);
-        this.pageToGet(0);
         this.importFromParent();
     },
     importFromParent: function () {

--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -202,7 +202,6 @@ AddContributorViewModel = oop.extend(Paginator, {
         if (this.parentImport()){
             this.importFromParent();
         } else {
-            console.log("fetchResults Running");
             var self = this;
             self.doneSearching(false);
             self.notification(false);

--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -268,12 +268,12 @@ AddContributorViewModel = oop.extend(Paginator, {
                 var pageToShow = [];
                 var startingSpot = (self.pageToGet() * 5);
                 if (contributors.length > startingSpot + 5){
-                    for (var i = startingSpot; i < startingSpot + 5; i++) {
-                        pageToShow.push(contributors[i]);
+                    for (var iterate = startingSpot; i < startingSpot + 5; i++) {
+                        pageToShow.push(contributors[iterate]);
                     }
                 } else {
-                    for (var i = startingSpot; i < contributors.length; i++) {
-                        pageToShow.push(contributors[i]);
+                    for (var iterateTwo = startingSpot; i < contributors.length; i++) {
+                        pageToShow.push(contributors[iterateTwo]);
                     }
                 }
                 self.doneSearching(true);

--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -268,11 +268,11 @@ AddContributorViewModel = oop.extend(Paginator, {
                 var pageToShow = [];
                 var startingSpot = (self.pageToGet() * 5);
                 if (contributors.length > startingSpot + 5){
-                    for (var iterate = startingSpot; i < startingSpot + 5; i++) {
+                    for (var iterate = startingSpot; iterate < startingSpot + 5; iterate++) {
                         pageToShow.push(contributors[iterate]);
                     }
                 } else {
-                    for (var iterateTwo = startingSpot; i < contributors.length; i++) {
+                    for (var iterateTwo = startingSpot; iterateTwo < contributors.length; iterateTwo++) {
                         pageToShow.push(contributors[iterateTwo]);
                     }
                 }

--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -444,6 +444,7 @@ AddContributorViewModel = oop.extend(Paginator, {
     clear: function () {
         var self = this;
         self.page('whom');
+        self.parentImport(false);
         self.query('');
         self.results([]);
         self.selection([]);

--- a/website/static/js/paginator.js
+++ b/website/static/js/paginator.js
@@ -17,14 +17,14 @@ var Paginator = oop.defclass({
         this.currentPage = ko.observable(0);
         this.paginators = ko.observableArray([]);
     },
-    addNewPaginators: function() {
+    addNewPaginators: function(isFromParent=false) {
         var self = this;
         var i;
         self.paginators.removeAll();
         if (self.numberOfPages() > 1) {
             self.paginators.push({
                 style: (self.currentPage() === 0) ? 'disabled' : '',
-                handler: self.previousPage.bind(self),
+                handler: self.previousPage.bind(self, isFromParent),
                 text: '<'
             }); /* jshint ignore:line */
                 /* functions defined inside loop */
@@ -35,7 +35,11 @@ var Paginator = oop.defclass({
                 handler: function() {
                     self.pageToGet(0);
                     if (self.pageToGet() !== self.currentPage()) {
-                        self.fetchResults();
+                        if (isFromParent == true){
+                            self.importFromParent();
+                        } else {
+                            self.fetchResults();
+                        }
                     }
                 }
             });
@@ -47,7 +51,11 @@ var Paginator = oop.defclass({
                         handler: function() {
                             self.pageToGet(parseInt(this.text) - 1);
                             if (self.pageToGet() !== self.currentPage()) {
-                                self.fetchResults();
+                                if (isFromParent == true){
+                                    self.importFromParent();
+                                } else {
+                                    self.fetchResults();
+                                }
                             }
                         }
                     });/* jshint ignore:line */
@@ -61,7 +69,11 @@ var Paginator = oop.defclass({
                         handler: function() {
                             self.pageToGet(parseInt(this.text) - 1);
                             if (self.pageToGet() !== self.currentPage()) {
-                                self.fetchResults();
+                                if (isFromParent == true){
+                                    self.importFromParent();
+                                } else {
+                                    self.fetchResults();
+                                }
                             }
                         }
                     });/* jshint ignore:line */
@@ -86,7 +98,11 @@ var Paginator = oop.defclass({
                         handler: function() {
                             self.pageToGet(parseInt(this.text) - 1);
                             if (self.pageToGet() !== self.currentPage()) {
-                                self.fetchResults();
+                                if (isFromParent == true){
+                                    self.importFromParent();
+                                } else {
+                                    self.fetchResults();
+                                }
                             }
                         }
                     });/* jshint ignore:line */
@@ -106,7 +122,11 @@ var Paginator = oop.defclass({
                         handler: function() {
                             self.pageToGet(parseInt(this.text) - 1);
                             if (self.pageToGet() !== self.currentPage()) {
-                                self.fetchResults();
+                                if (isFromParent == true){
+                                    self.importFromParent();
+                                } else {
+                                    self.fetchResults();
+                                }
                             }
                         }
                     });/* jshint ignore:line */
@@ -125,31 +145,46 @@ var Paginator = oop.defclass({
                 handler: function() {
                     self.pageToGet(self.numberOfPages() - 1);
                     if (self.pageToGet() !== self.currentPage()) {
-                        self.fetchResults();
+                        if (isFromParent == true){
+                            self.importFromParent();
+                        } else {
+                            self.fetchResults();
+                        }
                     }
                 }
             });
             self.paginators.push({
                 style: (self.currentPage() === self.numberOfPages() - 1) ? 'disabled' : '',
-                handler: self.nextPage.bind(self),
+                handler: self.nextPage.bind(self, isFromParent),
                 text: '>'
             });
         }
     },
-    nextPage: function() {
+    nextPage: function(isFromParent) {
         this.pageToGet(this.currentPage() + 1);
         if (this.pageToGet() < this.numberOfPages()){
-            this.fetchResults();
+            if (isFromParent){
+                this.importFromParent();
+            } else {
+                this.fetchResults();
+            }
         }
     },
-    previousPage: function() {
+    previousPage: function(isFromParent) {
         this.pageToGet(this.currentPage() - 1);
         if (this.pageToGet() >= 0) {
-            this.fetchResults();
+            if (isFromParent){
+                this.importFromParent();
+            } else {
+                this.fetchResults();
+            }
         }
     },
     fetchResults: function() {
         throw new Error('Paginator subclass must define a "fetchResults" method.');
+    },
+    importFromParent: function() {
+        throw new Error('Paginator subclass must define a "importFromParent" method.');
     }
 });
 

--- a/website/static/js/paginator.js
+++ b/website/static/js/paginator.js
@@ -17,14 +17,14 @@ var Paginator = oop.defclass({
         this.currentPage = ko.observable(0);
         this.paginators = ko.observableArray([]);
     },
-    addNewPaginators: function(isFromParent=false) {
+    addNewPaginators: function() {
         var self = this;
         var i;
         self.paginators.removeAll();
         if (self.numberOfPages() > 1) {
             self.paginators.push({
                 style: (self.currentPage() === 0) ? 'disabled' : '',
-                handler: self.previousPage.bind(self, isFromParent),
+                handler: self.previousPage.bind(self),
                 text: '<'
             }); /* jshint ignore:line */
                 /* functions defined inside loop */
@@ -35,11 +35,7 @@ var Paginator = oop.defclass({
                 handler: function() {
                     self.pageToGet(0);
                     if (self.pageToGet() !== self.currentPage()) {
-                        if (isFromParent === true){
-                            self.importFromParent();
-                        } else {
-                            self.fetchResults();
-                        }
+                        self.fetchResults();
                     }
                 }
             });
@@ -51,11 +47,7 @@ var Paginator = oop.defclass({
                         handler: function() {
                             self.pageToGet(parseInt(this.text) - 1);
                             if (self.pageToGet() !== self.currentPage()) {
-                                if (isFromParent === true){
-                                    self.importFromParent();
-                                } else {
-                                    self.fetchResults();
-                                }
+                                self.fetchResults();
                             }
                         }
                     });/* jshint ignore:line */
@@ -69,11 +61,7 @@ var Paginator = oop.defclass({
                         handler: function() {
                             self.pageToGet(parseInt(this.text) - 1);
                             if (self.pageToGet() !== self.currentPage()) {
-                                if (isFromParent === true){
-                                    self.importFromParent();
-                                } else {
-                                    self.fetchResults();
-                                }
+                                self.fetchResults();
                             }
                         }
                     });/* jshint ignore:line */
@@ -98,11 +86,7 @@ var Paginator = oop.defclass({
                         handler: function() {
                             self.pageToGet(parseInt(this.text) - 1);
                             if (self.pageToGet() !== self.currentPage()) {
-                                if (isFromParent === true){
-                                    self.importFromParent();
-                                } else {
-                                    self.fetchResults();
-                                }
+                                self.fetchResults();
                             }
                         }
                     });/* jshint ignore:line */
@@ -122,11 +106,7 @@ var Paginator = oop.defclass({
                         handler: function() {
                             self.pageToGet(parseInt(this.text) - 1);
                             if (self.pageToGet() !== self.currentPage()) {
-                                if (isFromParent === true){
-                                    self.importFromParent();
-                                } else {
-                                    self.fetchResults();
-                                }
+                                self.fetchResults();
                             }
                         }
                     });/* jshint ignore:line */
@@ -145,46 +125,31 @@ var Paginator = oop.defclass({
                 handler: function() {
                     self.pageToGet(self.numberOfPages() - 1);
                     if (self.pageToGet() !== self.currentPage()) {
-                        if (isFromParent === true){
-                            self.importFromParent();
-                        } else {
-                            self.fetchResults();
-                        }
+                        self.fetchResults();
                     }
                 }
             });
             self.paginators.push({
                 style: (self.currentPage() === self.numberOfPages() - 1) ? 'disabled' : '',
-                handler: self.nextPage.bind(self, isFromParent),
+                handler: self.nextPage.bind(self),
                 text: '>'
             });
         }
     },
-    nextPage: function(isFromParent) {
+    nextPage: function() {
         this.pageToGet(this.currentPage() + 1);
         if (this.pageToGet() < this.numberOfPages()){
-            if (isFromParent){
-                this.importFromParent();
-            } else {
-                this.fetchResults();
-            }
+            this.fetchResults();
         }
     },
-    previousPage: function(isFromParent) {
+    previousPage: function() {
         this.pageToGet(this.currentPage() - 1);
         if (this.pageToGet() >= 0) {
-            if (isFromParent){
-                this.importFromParent();
-            } else {
-                this.fetchResults();
-            }
+            this.fetchResults();
         }
     },
     fetchResults: function() {
         throw new Error('Paginator subclass must define a "fetchResults" method.');
-    },
-    importFromParent: function() {
-        throw new Error('Paginator subclass must define a "importFromParent" method.');
     }
 });
 

--- a/website/static/js/paginator.js
+++ b/website/static/js/paginator.js
@@ -35,7 +35,7 @@ var Paginator = oop.defclass({
                 handler: function() {
                     self.pageToGet(0);
                     if (self.pageToGet() !== self.currentPage()) {
-                        if (isFromParent == true){
+                        if (isFromParent === true){
                             self.importFromParent();
                         } else {
                             self.fetchResults();
@@ -51,7 +51,7 @@ var Paginator = oop.defclass({
                         handler: function() {
                             self.pageToGet(parseInt(this.text) - 1);
                             if (self.pageToGet() !== self.currentPage()) {
-                                if (isFromParent == true){
+                                if (isFromParent === true){
                                     self.importFromParent();
                                 } else {
                                     self.fetchResults();
@@ -69,7 +69,7 @@ var Paginator = oop.defclass({
                         handler: function() {
                             self.pageToGet(parseInt(this.text) - 1);
                             if (self.pageToGet() !== self.currentPage()) {
-                                if (isFromParent == true){
+                                if (isFromParent === true){
                                     self.importFromParent();
                                 } else {
                                     self.fetchResults();
@@ -98,7 +98,7 @@ var Paginator = oop.defclass({
                         handler: function() {
                             self.pageToGet(parseInt(this.text) - 1);
                             if (self.pageToGet() !== self.currentPage()) {
-                                if (isFromParent == true){
+                                if (isFromParent === true){
                                     self.importFromParent();
                                 } else {
                                     self.fetchResults();
@@ -122,7 +122,7 @@ var Paginator = oop.defclass({
                         handler: function() {
                             self.pageToGet(parseInt(this.text) - 1);
                             if (self.pageToGet() !== self.currentPage()) {
-                                if (isFromParent == true){
+                                if (isFromParent === true){
                                     self.importFromParent();
                                 } else {
                                     self.fetchResults();
@@ -145,7 +145,7 @@ var Paginator = oop.defclass({
                 handler: function() {
                     self.pageToGet(self.numberOfPages() - 1);
                     if (self.pageToGet() !== self.currentPage()) {
-                        if (isFromParent == true){
+                        if (isFromParent === true){
                             self.importFromParent();
                         } else {
                             self.fetchResults();

--- a/website/templates/project/modal_add_contributor.mako
+++ b/website/templates/project/modal_add_contributor.mako
@@ -22,18 +22,18 @@
                                         <input type="submit" value="Search" class="btn btn-default">
                                     </span>
                                 </div>
-                            </div>
-                        </div>
-                    <hr />
-                        <div class="row search-contributor-links">
-                            <div class="col-md-12">
-                                <div>
-                                    <!-- ko if:parentId -->
-                                        <a class="f-w-lg" data-bind="click:importFromParent, text:'Import contributors from ' + parentTitle"></a>
-                                    <!-- /ko -->
+                                <div class="row search-contributor-links">
+                                    <div class="col-md-12">
+                                        <div style='margin-left: 5px'>
+                                            <!-- ko if:parentId -->
+                                                <a class="f-w-lg" data-bind="click: startSearchParent, text:'Import contributors from ' + parentTitle"></a>
+                                            <!-- /ko -->
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
                         </div>
+                    <hr />
                     </form>
 
 
@@ -118,13 +118,18 @@
                                         <a href="#" data-bind="click:gotoInvite">Add <strong><em data-bind="text: query"></em></strong> as an unregistered contributor</a>.
                                     </p>
                                 </div>
+                                <div data-bind="if: parentPagination">
+                                    <ul class="pagination pagination-sm" data-bind="foreach: paginators">
+                                        <li data-bind="css: style"><a href="#" data-bind="click: handler, text: text"></a></li>
+                                    </ul>
+                                </div>
                                 <div data-bind="if: showLoading">
                                     <p class="text-muted">Searching contributors...</p>
                                 </div>
-                                    <div data-bind="if: noResults">
-                                        No results found. Try a more specific search or
-                                        <a href="#" data-bind="click:gotoInvite">add <strong><em data-bind="text: query"></em></strong> as an unregistered contributor</a>.
-                                    </div>
+                                <div data-bind="if: noResults">
+                                    No results found. Try a more specific search or
+                                    <a href="#" data-bind="click:gotoInvite">add <strong><em data-bind="text: query"></em></strong> as an unregistered contributor</a>.
+                                </div>
                             </div>
                         </div><!-- ./col-md -->
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

<!-- Describe the purpose of your changes -->
Fix bug where when importing contributors in a component from a parent node, the results do not paginate like a normal search, and there is some weird behavior where the results of an import from parent will appear on whatever page of the pagination from a normal search, and if you move to another page and then back to the page the import from parent appeared on, it is gone.

## Changes

Since, unlike the normal search results, the import from parent does not have API support for pagination (normal search request to API includes the page number that is wanted), had to add frontend code that splits the results of an import from parent into the page requested, and added paginator for the import from parent results.
Also moved the import from parent button from above the results header to below the search box because it makes more sense for it to be up there and also makes for an easier solution to this bug
Before:
![screen shot 2016-07-19 at 10 00 38 am](https://cloud.githubusercontent.com/assets/14872944/16952580/c80c5554-4d97-11e6-9067-6a6657dbc85f.png)
After:
![screen shot 2016-07-19 at 9 59 55 am](https://cloud.githubusercontent.com/assets/14872944/16952585/cc7e2022-4d97-11e6-9c2a-cfda398985aa.png)


<!-- Briefly describe or list your changes  -->

## Side effects

<!--Any possible side effects? -->
None

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
https://openscience.atlassian.net/browse/OSF-4762