### PR TITLE
[Hotfix] Catch correct error when refreshing tokens [OSF-5853]

### DIFF
--- a/scripts/refresh_addon_tokens.py
+++ b/scripts/refresh_addon_tokens.py
@@ -59,8 +59,8 @@ def main(delta, Provider, rate_limit, dry_run):
             if allowance < 1:
                 try: 
                     time.sleep(rate_limit[1] - (time.time() - last_call))
-                except ValueError:
-                    pass  # ValueError indicates a negative sleep time
+                except (ValueError, IOError):
+                    pass  # Value/IOError indicates negative sleep time in Py 3.5/2.7, respectively
                 allowance = rate_limit[0]
 
             allowance -= 1


### PR DESCRIPTION
## Purpose
Negative sleep time will currently crash the script, preventing any further token updates. Too many requests can make third-party APIs impose a rate limit. Prevent either of these.

## Changes
* Catch the correct error for `time.sleep( x < 0 )` for python 2.7

## Side effects
None

## Ticket
[OSF-5853](https://openscience.atlassian.net/browse/OSF-5853)