### PR TITLE
fix Uncaught TypeError: Cannot read property 'nodeType' of null

### DIFF
--- a/website/static/js/project.js
+++ b/website/static/js/project.js
@@ -250,7 +250,7 @@ $(document).ready(function() {
     });
 
     $('body').on('click', '.tagsinput .tag > span', function(e) {
-      if(typeof e !== 'undefined' && e){
+      if(e){
         window.location = '/search/?q=(tags:"' + $(e.target).text().toString().trim()+ '")';
       }
     });
@@ -278,7 +278,7 @@ $(document).ready(function() {
 
         // Remove Comments link from project nav bar for pages not bound to the comment view model
         var commentsLinkElm = document.getElementById('commentsLink');
-        if (typeof commentsLinkElm !== 'undefined' && commentsLinkElm) {
+        if (commentsLinkElm) {
           if(!ko.dataFor(commentsLinkElm))
              commentsLinkElm.remove();
         }

--- a/website/static/js/project.js
+++ b/website/static/js/project.js
@@ -250,7 +250,9 @@ $(document).ready(function() {
     });
 
     $('body').on('click', '.tagsinput .tag > span', function(e) {
+      if(typeof e != 'undefined' && e){
         window.location = '/search/?q=(tags:"' + $(e.target).text().toString().trim()+ '")';
+      }
     });
 
 
@@ -276,7 +278,8 @@ $(document).ready(function() {
 
         // Remove Comments link from project nav bar for pages not bound to the comment view model
         var commentsLinkElm = document.getElementById('commentsLink');
-        if (!ko.dataFor(commentsLinkElm)) {
+        if (typeof commentsLinkElm != 'undefined' && commentsLinkElm) {
+          if(!ko.dataFor(commentsLinkElm))
              commentsLinkElm.remove();
         }
     });

--- a/website/static/js/project.js
+++ b/website/static/js/project.js
@@ -250,7 +250,7 @@ $(document).ready(function() {
     });
 
     $('body').on('click', '.tagsinput .tag > span', function(e) {
-      if(typeof e != 'undefined' && e){
+      if(typeof e !== 'undefined' && e){
         window.location = '/search/?q=(tags:"' + $(e.target).text().toString().trim()+ '")';
       }
     });
@@ -278,7 +278,7 @@ $(document).ready(function() {
 
         // Remove Comments link from project nav bar for pages not bound to the comment view model
         var commentsLinkElm = document.getElementById('commentsLink');
-        if (typeof commentsLinkElm != 'undefined' && commentsLinkElm) {
+        if (typeof commentsLinkElm !== 'undefined' && commentsLinkElm) {
           if(!ko.dataFor(commentsLinkElm))
              commentsLinkElm.remove();
         }


### PR DESCRIPTION
## Purpose

Fixes the console error: _Uncaught TypeError: Cannot read property 'nodeType' of null_
when looking at a profile page

## Changes

Added type checking conditions, so as to ensure variables 'e' and 'commentsLinkElm' are not undefined and/or null.

## Side effects

None.

## Ticket

https://openscience.atlassian.net/browse/OSF-6303