### PR TITLE
[hold] [ShareFiles/Preprints] Add query param to file detail endpoint to give file guid

### DIFF
--- a/api/files/views.py
+++ b/api/files/views.py
@@ -328,7 +328,7 @@ class FileDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView, FileMixin):
     def get_object(self):
         user = get_user_auth(self.request).user
 
-        if self.request.GET.get('giveGuid', False) and self.get_node().has_permission(user, 'admin'):
+        if self.request.GET.get('create_guid', False) and self.get_node().has_permission(user, 'admin'):
             self.get_file(check_permissions=True).get_guid(create=True)
 
         return self.get_file()

--- a/api/files/views.py
+++ b/api/files/views.py
@@ -300,12 +300,8 @@ class FileDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView, FileMixin):
 
     ##Query Params
 
-    For this endpoint,
-
-    + giveGuid={bool} if true will give the file metadata a guid, a unique identifier for internal use. You must be an
-
-    admin on the node to force the API to create a guid for your file.
-
+     For this endpoint, *none*.  Actions may permit or require certain query parameters.  See the individual action
+     documentation.
 
     #This Request/Response
 

--- a/api/files/views.py
+++ b/api/files/views.py
@@ -300,8 +300,12 @@ class FileDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView, FileMixin):
 
     ##Query Params
 
-    For this endpoint, *none*.  Actions may permit or require certain query parameters.  See the individual action
-    documentation.
+    For this endpoint,
+
+    + giveGuid={bool} if true will give the file metadata a guid, a unique identifier for internal use. You must be an
+
+    admin on the node to force the API to create a guid for your file.
+
 
     #This Request/Response
 

--- a/api/files/views.py
+++ b/api/files/views.py
@@ -13,7 +13,7 @@ from website.files.models import (
 
 from api.base.exceptions import Gone
 from api.base.permissions import PermissionWithGetter
-from api.base.utils import get_object_or_error
+from api.base.utils import get_object_or_error, get_user_auth
 from api.base.views import JSONAPIBaseView
 from api.base import permissions as base_permissions
 from api.nodes.permissions import ContributorOrPublic
@@ -326,8 +326,12 @@ class FileDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView, FileMixin):
 
     # overrides RetrieveAPIView
     def get_object(self):
-        return self.get_file()
+        user = get_user_auth(self.request).user
 
+        if self.request.GET.get('giveGuid', False) and self.get_node().has_permission(user, 'admin'):
+            self.get_file(check_permissions=True).get_guid(create=True)
+
+        return self.get_file()
 
 class FileVersionsList(JSONAPIBaseView, generics.ListAPIView, FileMixin):
     """List of versions for the requested file. *Read-only*.

--- a/api_tests/files/views/test_file_detail.py
+++ b/api_tests/files/views/test_file_detail.py
@@ -57,6 +57,13 @@ class TestFileView(ApiTestCase):
         assert_is_not_none(guid)
         assert_equal(res.json['data']['attributes']['guid'], guid._id)
 
+    def test_file_guid_created_with_query_param(self):
+        res = self.app.get(self.file_url + '?create_guid=1', auth=self.user.auth)
+        guid = self.file.get_guid(create=True)
+        assert_equal(res.status_code, 200)
+        assert_is_not_none(guid)
+        assert_equal(res.json['data']['attributes']['guid'], guid._id)
+
     def test_get_file(self):
         res = self.app.get(self.file_url, auth=self.user.auth)
         self.file.versions[-1]._clear_caches()


### PR DESCRIPTION
## Purpose

ShareFiles requires that files that are uploaded immediately have short, convenient guid links for easy sharing. Problematically files only get guids when the File View Page is visited. This feature allows us to add guids using the API v2 without visiting the file View Page.

## Changes

Modifies the get_object method of the view to accept query param 'giveGuid' and creates that id if true and user has admin permission. Also changes API docs slightly.

## Side effects

None that I know of.

## Discussions

https://openscience.atlassian.net/browse/OSF-6503
https://github.com/CenterForOpenScience/osf.io/pull/5836