### PR TITLE
subscribe users to global notifications when confirmed [OSF-5658]

### DIFF
--- a/website/notifications/emails.py
+++ b/website/notifications/emails.py
@@ -49,7 +49,8 @@ def notify_mentions(event, user, node, timestamp, **context):
     sent_users = []
     new_mentions = context.get('new_mentions', [])
     for m in new_mentions:
-        subscriptions = get_user_subscriptions(user, event_type)
+        mentioned_user = website_models.User.load(m)
+        subscriptions = get_user_subscriptions(mentioned_user, event_type)
         for notification_type in subscriptions:
             if notification_type != 'none' and subscriptions[notification_type] and m in subscriptions[notification_type]:
                 store_emails([m], notification_type, 'mentions', user, node,

--- a/website/notifications/listeners.py
+++ b/website/notifications/listeners.py
@@ -1,7 +1,8 @@
 import logging
 from website.notifications.exceptions import InvalidSubscriptionError
-from website.notifications.utils import subscribe_user_to_notifications
+from website.notifications.utils import subscribe_user_to_notifications, subscribe_user_to_global_notifications
 from website.project.signals import contributor_added, project_created
+from framework.auth.signals import user_confirmed
 
 logger = logging.getLogger(__name__)
 
@@ -20,4 +21,12 @@ def subscribe_contributor(node, contributor, auth=None, *args, **kwargs):
         subscribe_user_to_notifications(node, contributor)
     except InvalidSubscriptionError as err:
         logger.warn('Skipping subscription of user {} to node {}'.format(contributor, node._id))
+        logger.warn('Reason: {}'.format(str(err)))
+
+@user_confirmed.connect
+def subscribe_confirmed_user(user):
+    try:
+        subscribe_user_to_global_notifications(user)
+    except InvalidSubscriptionError as err:
+        logger.warn('Skipping subscription of user {} to global subscriptions'.format(user))
         logger.warn('Reason: {}'.format(str(err)))

--- a/website/notifications/utils.py
+++ b/website/notifications/utils.py
@@ -405,6 +405,17 @@ def check_if_all_global_subscriptions_are_none(user):
     return all_global_subscriptions_none
 
 
+def subscribe_user_to_global_notifications(user):
+    notification_type = 'email_transactional'
+    user_events = constants.USER_SUBSCRIPTIONS_AVAILABLE
+    for user_event in user_events:
+        user_event_id = to_subscription_key(user._id, user_event)
+
+        subscription = NotificationSubscription(_id=user_event_id, owner=user, event_name=user_event)
+        subscription.add_user_to_subscription(user, notification_type)
+        subscription.save()
+
+
 def subscribe_user_to_notifications(node, user):
     """ Update the notification settings for the creator or contributors
 


### PR DESCRIPTION
## Purpose

Subscribe users to global notifications upon confirmation.

## Changes

* check the proper users subscriptions
* add listener for `user_confirmed`

## Side effects

Users are subscribed to user subscriptions on confirmation.


## Ticket

https://openscience.atlassian.net/browse/OSF-5658

