### PR TITLE
Allow git_logs to accept branch parameter

### DIFF
--- a/scripts/meta/gatherer.py
+++ b/scripts/meta/gatherer.py
@@ -52,8 +52,8 @@ def get_pr_data(pr):
         return {}
 
 
-def main():
-    current_branch = check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD']).rstrip()
+def main(branch=None):
+    current_branch = branch or check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD']).rstrip()
     with open(GIT_STATUS_FILE, 'w') as f:
         f.write(current_branch)
     if GITHUB_API_TOKEN:

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -80,9 +80,9 @@ def server(ctx, host=None, port=5000, debug=True, live=False, gitlogs=False):
 
 
 @task
-def git_logs(ctx):
+def git_logs(ctx, branch=None):
     from scripts.meta import gatherer
-    gatherer.main()
+    gatherer.main(branch=branch)
 
 
 @task


### PR DESCRIPTION
## Purpose

Allow `invoke git_logs` to accept branch parameter and use that rather than requesting from git

## Changes

1. Add branch parameter to invoke task
2. Have gatherer use the branch passed in if it exists, otherwise use existing implementation.

## Side effects

None

