### PR TITLE
Upgrade markdown-it-video [OSF-6130]

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "markdown-it-ins-del": "^0.1.1",
     "markdown-it-sanitizer": "~0.3.0",
     "markdown-it-toc": "~1.1.0",
-    "markdown-it-video": "~0.2.1",
+    "markdown-it-video": "~0.4.0",
     "mime-types": "~2.0.12",
     "mithril": "0.2.0",
     "moment": "^2.14.1",

--- a/website/addons/wiki/static/ace-markdown-snippets.js
+++ b/website/addons/wiki/static/ace-markdown-snippets.js
@@ -72,6 +72,14 @@ snippet vimeo-video\n\
 	\n\
 	@[vimeo](${1:url})\n\
 \n\
+snippet vine-video\n\
+	\n\
+	@[vine](${1:url})\n\
+\n\
+snippet prezi-video\n\
+	\n\
+	@[prezi](${1:url})\n\
+\n\
 snippet table-of-contents\n\
 	\n\
 	@[toc](${1:optional_label})\n\


### PR DESCRIPTION
**Purpose**

Markdown-it-video has upgraded to a new version that has Vine support and bug fixes. The version used by the OSF did not have these changes, so an upgrade was necessary. After the upgrade was implemented, testing was done to ensure everything still works. Autocomplete for Vine and Prezi has also been added. 

**Changes**

Vine and Prezi can be embedded into the Wiki editor by using the same Markdown syntax used for Youtube and Vimeo. This was possible after updating the version number in package.json.

@[youtube](url)
@[vimeo](url)
@[vine](url)
@[prezi](url)

Adding snippets to ace-markdown-snippets.js for Vine and Prezi allowed for both websites to be autocompleted as well as Youtube and Vimeo. 

![image](https://cloud.githubusercontent.com/assets/8868219/16966747/f8c2b1d4-4dd3-11e6-8b64-da09ecd64152.png)

![image](https://cloud.githubusercontent.com/assets/8868219/16966755/04183928-4dd4-11e6-8429-902c010d5a86.png)

**Side effects**

N/A

**Ticket**

https://openscience.atlassian.net/browse/OSF-6130