### PR TITLE
[CR] Final UI updates for user-facing analytics [#OSF-6652]

### DIFF
--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -159,6 +159,7 @@ var resolve = {
         // GASP Items not defined as main in its package.json
         'TweenLite' : nodePath('gsap/src/minified/TweenLite.min.js'),
         'EasePack' : nodePath('gsap/src/minified/easing/EasePack.min.js'),
+        'keen-dataset' : nodePath('keen-dataviz/lib/dataset/'),
     }
 };
 

--- a/website/addons/wiki/templates/edit.mako
+++ b/website/addons/wiki/templates/edit.mako
@@ -389,6 +389,12 @@ ${parent.javascript_bottom()}
             userGravatar: ${ urls['gravatar'] | sjson, n }.replace('&amp;', '&')
         }
     };
+    window.contextVars.analyticsMeta = $.extend(true, {}, window.contextVars.analyticsMeta, {
+        pageMeta: {
+            title: 'Wiki: ' + ${wiki_name | sjson, n },
+            public: true,
+        },
+    });
 
 </script>
 <script src="//${sharejs_url}/text.js"></script>

--- a/website/static/js/dateRangePicker.js
+++ b/website/static/js/dateRangePicker.js
@@ -14,6 +14,8 @@ var DateRangePicker = oop.defclass({
     constructor: function(params) {
         var self = this;
 
+        self._oneDayInMs = 24 * 60 * 60 * 1000;
+
         self.minDate = params.minDate;
         self.maxDate = params.maxDate;
 
@@ -46,14 +48,20 @@ var DateRangePicker = oop.defclass({
     },
     updateStartDate: function(start) {
         var self = this;
+
+        var startPlusOne = new Date(start.getTime() + self._oneDayInMs);
+        self._endPicker.setMinDate(startPlusOne);
+
         self._startPicker.setStartRange(start);
         self._endPicker.setStartRange(start);
-        self._endPicker.setMinDate(start);
     },
     updateEndDate: function(end) {
         var self = this;
+
+        var endMinusOne = new Date(end.getTime() - self._oneDayInMs);
+        self._startPicker.setMaxDate(endMinusOne);
+
         self._startPicker.setEndRange(end);
-        self._startPicker.setMaxDate(end);
         self._endPicker.setEndRange(end);
     },
 });

--- a/website/static/js/keen.js
+++ b/website/static/js/keen.js
@@ -39,10 +39,12 @@ var KeenTracker = (function() {
 
         var user = window.contextVars.currentUser;
         var node = window.contextVars.node;
+        var pageMeta = lodashGet(window.contextVars, 'analyticsMeta.pageMeta');
         return {
             page: {
                 title: document.title,
                 url: document.URL,
+                meta: pageMeta,
                 info: {},
             },
             referrer: {
@@ -206,7 +208,8 @@ var KeenTracker = (function() {
 
             self.trackPageView = function () {
                 var self = this;
-                if (window.contextVars.node && window.contextVars.node.isPublic) {
+                if (lodashGet(window.contextVars, 'node').isPublic &&
+                    lodashGet(window.contextVars, 'analyticsMeta.pageMeta').public) {
                     self.trackPublicEvent('pageviews', {});
                 }
                 self.trackPrivateEvent('pageviews', {});

--- a/website/static/js/pages/statistics-page.js
+++ b/website/static/js/pages/statistics-page.js
@@ -73,7 +73,7 @@ keenAnalysis.ready(function(){
         new ProjectUsageStatistics.ChartPopularPages(
             $.extend({}, authParams, {
                 containingElement: '#popularPages',
-                nodeTitle: window.contextVars.node.title,
+                nodeId: window.contextVars.node.id,
             })
         ),
     ];

--- a/website/static/js/pages/statistics-page.js
+++ b/website/static/js/pages/statistics-page.js
@@ -51,8 +51,8 @@ keenAnalysis.ready(function(){
         startDate: startDate,
         endPickerElem: document.getElementById('endDatePicker'),
         endDate: endDate,
-        statsMinDate: new Date(2013, 5, 1),
-        statsMaxDate: new Date(),
+        minDate: new Date(2013, 5, 1),
+        maxDate: new Date(),
     });
 
     var authParams = {

--- a/website/static/js/statistics.js
+++ b/website/static/js/statistics.js
@@ -47,6 +47,12 @@ var UserFacingChart = oop.defclass({
          * @type {integer}
          */
         self.MAX_DISPLAY_ENTRIES = params.maxDisplayEntries || 10;
+
+        var spinnerHtml = '';
+        spinnerHtml += '<div class="text-center">';
+        spinnerHtml += '    <div class="logo-spin logo-lg"></div>';
+        spinnerHtml += '</div>';
+        self._spinnerHtml = spinnerHtml;
     },
 
     /**
@@ -117,6 +123,10 @@ var UserFacingChart = oop.defclass({
         self.endDate = endDate;
     },
 
+    getElement: function() { return document.getElementById(this.containingElement.replace(/^#/, '')); },
+    startSpinner: function() { this.getElement().innerHTML = this._spinnerHtml; },
+    endSpinner: function() { this.getElement().innerHTML = ''; },
+
     /**
      * Build a data chart on the page. The element on the page that the chart will be inserted into
      * is defined in the `dataviz` parameter. A spinner will be displayed while the data is being
@@ -132,14 +142,17 @@ var UserFacingChart = oop.defclass({
             self.chart = self._initDataviz();
         }
 
-        self.chart.prepare();
+        self.startSpinner();
         var query = self.query();
         self.keenClient
             .query(query.type, query.params)
             .then(function(res) {
-                self.chart.title(' ').data(res).call(self.munger.bind(self)).render();
+                self.chart.title(' ').data(res).call(self.munger.bind(self));
+                self.endSpinner();
+                self.chart.render();
             })
             .catch(function(err) {
+                self.endSpinner();
                 self.chart.message(err.message);
             });
     },

--- a/website/static/js/statistics.js
+++ b/website/static/js/statistics.js
@@ -48,6 +48,7 @@ var UserFacingChart = oop.defclass({
          */
         self.MAX_DISPLAY_ENTRIES = params.maxDisplayEntries || 10;
 
+        // prebuild html for showing spinner
         var spinnerHtml = '';
         spinnerHtml += '<div class="text-center">';
         spinnerHtml += '    <div class="logo-spin logo-lg"></div>';
@@ -88,6 +89,16 @@ var UserFacingChart = oop.defclass({
         };
         return baseQuery;
     },
+
+    /**
+     * Builds underlying dataviz object, binds it to the containingElement.  Inheriting classes
+     * should extend this method to set chart properties. Make sure to call the parent method!
+     *
+     * See: https://github.com/keen/keen-dataviz.js/tree/master/docs
+     *
+     * @method _initDataviz
+     * @return {KeenDataviz}
+     */
     _initDataviz: function() {
         var self = this;
         return new keenDataviz().el(self.containingElement);
@@ -109,8 +120,8 @@ var UserFacingChart = oop.defclass({
 
 
     /**
-     * Sets the date range over which the metric should apply.  Sets the startDate and endDate
-     * properties.  These 
+     * Sets the date range over which the metric should apply, specifically the startDate and
+     * endDate properties.
      *
      * @method setDataRange
      * @param {Date} startDate first day (inclusive) for which to display stats
@@ -123,18 +134,21 @@ var UserFacingChart = oop.defclass({
         self.endDate = endDate;
     },
 
+    // Fetch the DOM element the chart is rendered to.
     getElement: function() { return document.getElementById(this.containingElement.replace(/^#/, '')); },
+
+    // Put up a COS spinner in the chart container.
     startSpinner: function() { this.getElement().innerHTML = this._spinnerHtml; },
+
+    // Remove the COS spinner from the chart container.
     endSpinner: function() { this.getElement().innerHTML = ''; },
 
     /**
-     * Build a data chart on the page. The element on the page that the chart will be inserted into
-     * is defined in the `dataviz` parameter. A spinner will be displayed while the data is being
-     * loaded.  If an error is returned, it will be displayed within the chart element.
+     * Show a spinner, issue the query to keen, then render the chart  If an error is returned, it
+     * will be displayed within the chart element.
      *
      * @method buildChart
-     * @param {Keen.Dataviz} dataviz The Dataviz object that defines the look chart. See:
-     *                               https://github.com/keen/keen-dataviz.js/tree/master/docs
+     * @return {null}
      */
     buildChart: function() {
         var self = this;
@@ -338,7 +352,7 @@ var ChartPopularPages = oop.extend(UserFacingChart, {
             params: {
                 event_collection: 'pageviews',
                 target_property: 'anon.id',
-                group_by: 'page.title'
+                group_by: 'page.title',
             }
         };
     },

--- a/website/static/js/statistics.js
+++ b/website/static/js/statistics.js
@@ -16,7 +16,7 @@ var UserFacingChart = oop.defclass({
         var required = ['keenProjectId', 'keenReadKey', 'containingElement'];
         required.forEach(function(paramName) {
             if (!params[paramName]) {
-                throw 'Missing required argument "' + paramName + '"';
+                throw new Error('Missing required argument "' + paramName + '"');
             }
         });
 
@@ -61,7 +61,7 @@ var UserFacingChart = oop.defclass({
      * @return {Object}
      */
     baseQuery: function() {
-        throw 'Concrete class does not provide a "baseQuery" method!';
+        throw new Error('Concrete class does not provide a "baseQuery" method!');
     },
 
     /**

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -191,7 +191,8 @@
                 allInstitutions: ${ all_institutions | sjson, n},
                 popular: ${ popular_links_node | sjson, n },
                 newAndNoteworthy: ${ noteworthy_links_node | sjson, n },
-                maintenance: ${ maintenance | sjson, n}
+                maintenance: ${ maintenance | sjson, n},
+                analyticsMeta: {},
             });
         </script>
 

--- a/website/templates/project/contributors.mako
+++ b/website/templates/project/contributors.mako
@@ -370,6 +370,12 @@
       window.contextVars.isRegistration = ${ node['is_registration'] | sjson, n };
       window.contextVars.contributors = ${ contributors | sjson, n };
       window.contextVars.adminContributors = ${ adminContributors | sjson, n };
+      window.contextVars.analyticsMeta = $.extend(true, {}, window.contextVars.analyticsMeta, {
+          pageMeta: {
+              title: 'Contributors',
+              public: false,
+          },
+      });
     </script>
 
     <script src=${"/static/public/js/sharing-page.js" | webpack_asset}></script>

--- a/website/templates/project/files.mako
+++ b/website/templates/project/files.mako
@@ -34,5 +34,11 @@
         % if 'write' in user['permissions'] and not node['is_registration']:
             window.contextVars.diskSavingMode = !${ disk_saving_mode | sjson, n };
         % endif
+        window.contextVars.analyticsMeta = $.extend(true, {}, window.contextVars.analyticsMeta, {
+            pageMeta: {
+                title: 'Files',
+                public: true,
+            },
+        });
     </script>
 </%def>

--- a/website/templates/project/forks.mako
+++ b/website/templates/project/forks.mako
@@ -28,3 +28,16 @@
                 </div>
         </div>
 </div>
+
+<%def name="javascript_bottom()">
+  ${parent.javascript_bottom()}
+  <script type="text/javascript">
+   window.contextVars = window.contextVars || {};
+   window.contextVars.analyticsMeta = $.extend(true, {}, window.contextVars.analyticsMeta, {
+       pageMeta: {
+           title: 'Forks',
+           public: true,
+       },
+   });
+  </script>
+</%def>

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -466,7 +466,13 @@ ${parent.javascript_bottom()}
             tags: ${ node['tags'] | sjson, n },
             institutions: ${node['institutions'] | sjson, n},
         },
-        nodeCategories: ${ node_categories | sjson, n }
+        nodeCategories: ${ node_categories | sjson, n },
+        analyticsMeta: {
+            pageMeta: {
+                title: 'Home',
+                public: true,
+            },
+        },
     });
 </script>
 

--- a/website/templates/project/registrations.mako
+++ b/website/templates/project/registrations.mako
@@ -151,6 +151,14 @@
 </script>
 <%def name="javascript_bottom()">
     ${parent.javascript_bottom()}
+    <script>
+        window.contextVars.analyticsMeta = $.extend(true, {}, window.contextVars.analyticsMeta, {
+            pageMeta: {
+                title: 'Registrations',
+                public: true,
+            },
+        });
+    </script>
 
     <script src=${"/static/public/js/project-registrations-page.js" | webpack_asset}> </script>
 </%def>

--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -477,6 +477,12 @@
       window.contextVars.wiki.isEnabled = ${wiki.short_name in addons_enabled | sjson, n };
       window.contextVars.currentUser = window.contextVars.currentUser || {};
       window.contextVars.currentUser.institutions = ${ user['institutions'] | sjson, n };
+      window.contextVars.analyticsMeta = $.extend(true, {}, window.contextVars.analyticsMeta, {
+          pageMeta: {
+              title: 'Settings',
+              pubic: false,
+          },
+      });
     </script>
 
     <script type="text/javascript" src=${"/static/public/js/project-settings-page.js" | webpack_asset}></script>

--- a/website/templates/project/statistics.mako
+++ b/website/templates/project/statistics.mako
@@ -100,6 +100,14 @@
 
 <%def name="javascript_bottom()">
   ${parent.javascript_bottom()}
+  <script>
+      window.contextVars.analyticsMeta = $.extend(true, {}, window.contextVars.analyticsMeta, {
+          pageMeta: {
+              title: 'Analytics',
+              public: true,
+          },
+      });
+  </script>
   % if keen['public']['project_id'] and node['is_public']:
     <script>
      window.contextVars = $.extend(true, {}, window.contextVars, {

--- a/website/templates/project/view_file.mako
+++ b/website/templates/project/view_file.mako
@@ -209,7 +209,13 @@
         panelsUsed: ['edit', 'view'],
         currentUser: {
           canEdit: ${ int(user['can_edit']) | sjson, n }
-        }
+        },
+        analyticsMeta: {
+            pageMeta: {
+                title: 'File: ' + ${file_name | sjson, n},
+                public: true,
+            },
+        },
       });
       window.contextVars.file.urls.external = window.contextVars.file.extra.webView;
     </script>


### PR DESCRIPTION
## Purpose

Finish up UI updates for user-facing analytics.

## Changes

* disallow startDate == endDate to avoid ugly error message
* show cos-spinner instead of keen-dataviz spinner
* reimplement popular pages to avoid entry duplication after project rename
* pages that can be logged into public pageviews must now set a contextVar to indicate it.
* nit: throw errors, not strings

## Side effects

None expected.

## Ticket

[#OSF-6652]
https://openscience.atlassian.net/browse/OSF-6652