### PR TITLE
[hotfix] fix keen js error that causes dashboard to not load

### DIFF
--- a/website/static/js/keen.js
+++ b/website/static/js/keen.js
@@ -39,7 +39,7 @@ var KeenTracker = (function() {
 
         var user = window.contextVars.currentUser;
         var node = window.contextVars.node;
-        var pageMeta = lodashGet(window.contextVars, 'analyticsMeta.pageMeta');
+        var pageMeta = lodashGet(window, 'contextVars.analyticsMeta.pageMeta', {});
         return {
             page: {
                 title: document.title,
@@ -208,8 +208,8 @@ var KeenTracker = (function() {
 
             self.trackPageView = function () {
                 var self = this;
-                if (lodashGet(window.contextVars, 'node').isPublic &&
-                    lodashGet(window.contextVars, 'analyticsMeta.pageMeta').public) {
+                if (lodashGet(window, 'contextVars.node.isPublic', false) &&
+                    lodashGet(window, 'contextVars.analyticsMeta.pageMeta.public', false)) {
                     self.trackPublicEvent('pageviews', {});
                 }
                 self.trackPrivateEvent('pageviews', {});


### PR DESCRIPTION
## Purpose

Fix dashboard not loading because of bad code in keen.js.

## Changes

Bad usage of lodash.get was causing JS errors on certain pages.

## Side effects

None expected.

## Ticket

No ticket. Issue reported directly by QA.