### PR TITLE
[feature] [OSF-6679] Project/Component Icons 

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -228,18 +228,15 @@ var uploadRowTemplate = function(item) {
  * @returns {Object}  Returns a mithril template with the m() function.
  */
 function resolveIconView(item) {
-    var componentIcons = iconmap.componentIcons;
-    var projectIcons = iconmap.projectIcons;
+    var icons = iconmap.projectComponentIcons;
     function returnView(type, category) {
-        var iconType = projectIcons[type];
-        if (type === 'component' || type === 'registeredComponent') {
-            if (!item.data.permissions.view) {
-                return null;
+        var iconType = icons[type];
+        if(type === 'project' || type === 'component' || type === 'registeredProject' || type === 'registeredComponent') {
+            if (item.data.permissions.view) {
+                iconType = icons[category];
             } else {
-                iconType = componentIcons[category];
+                return null;
             }
-        } else if (type === 'project' || type === 'registeredProject') {
-            iconType = projectIcons[category];
         }
         if (type === 'registeredComponent' || type === 'registeredProject') {
             iconType += ' po-icon-registered';

--- a/website/static/js/iconmap.js
+++ b/website/static/js/iconmap.js
@@ -1,7 +1,7 @@
 require('css/iconmap.css');
 
 module.exports = {
-    componentIcons: {
+    projectComponentIcons: {
         hypothesis: 'fa fa-lightbulb-o',
         'methods and measures': 'fa fa-pencil',
         procedure: 'fa fa-cogs',
@@ -12,12 +12,9 @@ module.exports = {
         analysis: 'fa fa-bar-chart',
         communication: 'fa fa-comment',
         other: 'fa fa-th-large',
-        '': 'fa fa-circle-o-notch'
-    },
-    projectIcons: {
+        '': 'fa fa-circle-o-notch',
         collection: 'fa fa-cubes',
         smartCollection: 'fa fa-certificate',
-        project: 'fa fa-cube',
         registration:  'fa fa-th-list text-muted',
         component:  'fa fa-th-large',
         registeredComponent:  'fa fa-th-large text-muted',

--- a/website/static/js/koHelpers.js
+++ b/website/static/js/koHelpers.js
@@ -466,14 +466,8 @@ ko.bindingHandlers.datePicker = {
  */
 ko.bindingHandlers.getIcon = {
     init: function(elem, valueAccessor) {
-        var icon;
         var category = valueAccessor();
-        if (Object.keys(iconmap.componentIcons).indexOf(category) >=0 ){
-            icon = iconmap.componentIcons[category];
-        }
-        else {
-            icon = iconmap.projectIcons[category];
-        }
+        var icon =  iconmap.projectComponentIcons[category];
         $(elem).addClass(icon);
     }
 };

--- a/website/static/js/nodeControl.js
+++ b/website/static/js/nodeControl.js
@@ -74,11 +74,7 @@ var ProjectViewModel = function(data, options) {
     // Add icon to title
     self.icon = ko.pureComputed(function() {
         var category = self.categoryValue();
-        if (Object.keys(iconmap.componentIcons).indexOf(category) >=0 ){
-            return iconmap.componentIcons[category];
-        } else {
-            return iconmap.projectIcons[category];
-        }
+        return iconmap.projectComponentIcons[category];
     });
 
     // Editable Title and Description

--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -6,7 +6,6 @@ var Raven = require('raven-js');
 var moment = require('moment');
 var URI = require('URIjs');
 var bootbox = require('bootbox');
-var iconmap = require('js/iconmap');
 var lodashGet = require('lodash.get');
 
 

--- a/website/static/js/wikiMenu.js
+++ b/website/static/js/wikiMenu.js
@@ -19,10 +19,8 @@ function resolveToggle(item) {
 }
 
 function resolveIcon(item) {
-    var componentIcons = iconmap.componentIcons;
-    var projectIcons = iconmap.projectIcons;
+    var icons = iconmap.projectComponentIcons;
     function returnView(category) {
-        var icons = componentIcons[category] ? componentIcons : projectIcons;
         return m('span', { 'class' : icons[category]});
     }
     if (item.data.kind === 'component' && item.parent().data.title === 'Component Wiki Pages') {


### PR DESCRIPTION
#### Purpose
- Fixes icon display for categorized projects in the files widget. 

#### Changes
- Combines project and component icons in ```iconmap.js```, as both projects and components can have categories. 

#### QA
- I checked the pages/files that use ```iconmap.js``` but in addition to the files widget, the icons in the component list and wiki pages should be double checked.

#### Ticket
- [OSF-6679](https://openscience.atlassian.net/browse/OSF-6679)

#### Screenshots
- Broken:
![image](https://cloud.githubusercontent.com/assets/7913604/16998291/c8901ba6-4e86-11e6-8022-036f718a2a62.png)

- Fixed:
![screen shot 2016-07-20 at 2 33 23 pm](https://cloud.githubusercontent.com/assets/7913604/16998331/f263b5fa-4e86-11e6-9ff7-b2339dd06615.png)
