### PR TITLE
Feature/at mentions contributor sorting [OSF-5948] [OSF-6734]

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -529,7 +529,6 @@ class NodeContributorsSerializer(JSONAPISerializer):
 
     id = ContributorIDField(read_only=True)
     type = TypeField()
-    index = ser.IntegerField(read_only=True)
 
     bibliographic = ser.BooleanField(help_text='Whether the user will be included in citations for this node or not.',
                                      default=True)

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -20,7 +20,7 @@ from api.base.utils import get_user_auth, get_object_or_error, absolute_reverse,
 from api.base.serializers import (JSONAPISerializer, WaterbutlerLink, NodeFileHyperLinkField, IDField, TypeField,
                                   TargetTypeField, JSONAPIListField, LinksField, RelationshipField,
                                   HideIfRegistration, RestrictedDictSerializer,
-                                  JSONAPIRelationshipSerializer, relationship_diff)
+                                  JSONAPIRelationshipSerializer, relationship_diff, )
 from api.base.exceptions import (InvalidModelValueError, RelationshipPostMakesNoChanges, Conflict,
                                  EndpointNotImplementedError)
 from api.base.settings import ADDONS_FOLDER_CONFIGURABLE
@@ -523,11 +523,13 @@ class NodeContributorsSerializer(JSONAPISerializer):
     filterable_fields = frozenset([
         'id',
         'bibliographic',
-        'permission'
+        'permission',
+        'index'
     ])
 
     id = ContributorIDField(read_only=True)
     type = TypeField()
+    index = ser.IntegerField(read_only=True)
 
     bibliographic = ser.BooleanField(help_text='Whether the user will be included in citations for this node or not.',
                                      default=True)

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -545,6 +545,7 @@ class NodeContributorsList(JSONAPIBaseView, bulk_views.BulkUpdateJSONAPIView, bu
         bibliographic               boolean  Whether the user will be included in citations for this node. Default is true.
         permission                  string   User permission level. Must be "read", "write", or "admin". Default is "write".
         unregistered_contributor    string   Contributor's assigned name if contributor hasn't yet claimed account
+        index                       integer  The index of the contributor for sorting. Currently read-only
 
     ##Links
 
@@ -621,16 +622,20 @@ class NodeContributorsList(JSONAPIBaseView, bulk_views.BulkUpdateJSONAPIView, bu
     serializer_class = NodeContributorsSerializer
     view_category = 'nodes'
     view_name = 'node-contributors'
+    ordering = ('index',)  # default ordering
 
     def get_default_queryset(self):
         node = self.get_node()
         visible_contributors = set(node.visible_contributor_ids)
         contributors = []
+        index = 0
         for contributor in node.contributors:
+            contributor.index = index
             contributor.bibliographic = contributor._id in visible_contributors
             contributor.permission = node.get_permissions(contributor)[-1]
             contributor.node_id = node._id
             contributors.append(contributor)
+            index += 1
         return contributors
 
     # overrides ListBulkCreateJSONAPIView, BulkUpdateJSONAPIView, BulkDeleteJSONAPIView

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -545,7 +545,6 @@ class NodeContributorsList(JSONAPIBaseView, bulk_views.BulkUpdateJSONAPIView, bu
         bibliographic               boolean  Whether the user will be included in citations for this node. Default is true.
         permission                  string   User permission level. Must be "read", "write", or "admin". Default is "write".
         unregistered_contributor    string   Contributor's assigned name if contributor hasn't yet claimed account
-        index                       integer  The index of the contributor for sorting. Currently read-only
 
     ##Links
 


### PR DESCRIPTION
## Purpose

Make default contributor sort order a) a thing; and b) match what we use on the front-end.

## Changes

1. Test
2. Add an index to allow us to know the order from the list structure
3. Sort by that list by default

## Side effects

Shouldn't be, although the index is currently read-only, so we'll need to do more work. Added to at-mentions because it's related to a problem they're having, but they may fix it another way so we could save this for an IR.

## Ticket

https://openscience.atlassian.net/browse/OSF-5948
https://openscience.atlassian.net/browse/OSF-6734
