### PR TITLE
[feature] Fix Log Pagination

### DIFF
--- a/website/static/js/components/logFeed.js
+++ b/website/static/js/components/logFeed.js
@@ -140,12 +140,12 @@ var LogFeed = {
                 });
             }
             // one ellipse at the beginning
-            else if (ctrl.currentPage() > ctrl.totalPages() - MAX_PAGES_ON_PAGINATOR_SIDE) {
+            else if (ctrl.currentPage() > ctrl.totalPages() - MAX_PAGES_ON_PAGINATOR_SIDE + 2) {
                 ctrl.paginators().push({
                     text: '...',
                     url: function() { }
                 });
-                for (i = ctrl.totalPages() - MAX_PAGES_ON_PAGINATOR_SIDE; i < ctrl.totalPages() - 1; i++) {
+                for (i = ctrl.totalPages() - MAX_PAGES_ON_PAGINATOR_SIDE + 2; i <= ctrl.totalPages() - 1; i++) {
                     ctrl.paginators().push({
                         text: i,
                         url: function() {


### PR DESCRIPTION
#### Purpose
- Fixes the log pagination so that the second to last log page is shown.
- Preserves all other log pagination functionality (shown in screenshots).

#### Ticket
- [OSF-6682](https://openscience.atlassian.net/browse/OSF-6682)

#### Screenshots 

- Pagination with ellipsis at the end:
![screen shot 2016-07-21 at 10 41 59 am](https://cloud.githubusercontent.com/assets/7913604/17026945/e4fa10a4-4f2f-11e6-90db-a19f16cdb40f.png)

- Pagination with ellipsis at the beginning (with second to last page displayed):
![screen shot 2016-07-21 at 10 42 38 am](https://cloud.githubusercontent.com/assets/7913604/17026952/e8b687d6-4f2f-11e6-99ae-814a56c1ea63.png)

- Pagination with double ellipsis:
![screen shot 2016-07-21 at 10 42 23 am](https://cloud.githubusercontent.com/assets/7913604/17026953/eb0656f6-4f2f-11e6-899f-cf087d0707dd.png)



