### PR TITLE
[#OSF-6420]Fix modal message inconsistent for folder deletion

### DIFF
--- a/website/addons/github/static/githubFangornConfig.js
+++ b/website/addons/github/static/githubFangornConfig.js
@@ -85,7 +85,7 @@ function _removeEvent (event, items) {
         // If all items can be deleted
         if(canDelete){
             mithrilContentMultiple = m('div', [
-                    m('p', 'This action is irreversible.'),
+                    m('p.text-danger',, 'This folder and ALL its contents will be deleted. This action is irreversible.'),
                     deleteList.map(function(item){
                         return m('.fangorn-canDelete.text-success', item.data.name);
                     })


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

<!-- Describe the purpose of your changes -->
Fix the delete folder pop test for github is different from other addons.

## Changes

<!-- Briefly describe or list your changes  -->
When you try to delete a folder with content on github,
Before the change:

![image](https://cloud.githubusercontent.com/assets/4974056/17027853/a4292fd4-4f33-11e6-976c-a440ca61509a.png)

After the change:

![image](https://cloud.githubusercontent.com/assets/4974056/17027864/b0eff8c4-4f33-11e6-840f-e55befbf6da1.png)
## Side effects

<!--Any possible side effects? -->


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
https://openscience.atlassian.net/browse/OSF-6420
