### PR TITLE
Remove sort param [OSF-5658]

### DIFF
--- a/website/static/js/comment.js
+++ b/website/static/js/comment.js
@@ -818,7 +818,6 @@ var onOpen = function(page, rootId, nodeApiUrl, currentUserId) {
 function initAtMention(nodeId, selectorOrElem) {
     var url = osfHelpers.apiV2Url('nodes/' + nodeId + '/contributors/', {
         query: {
-            'sort': '_id',
             'page[size]': 50
         }
     });


### PR DESCRIPTION
## Purpose

Remove sort param since contributor endpoint was updated.

## Changes

* remove sort param

## Side effects

Contributors are originally displayed in the order they are cited. This results in the current user being first in the list.


## Ticket

https://openscience.atlassian.net/browse/OSF-5658

