### PR TITLE
Improve Prerender functionalities [OSF-6735]

### DIFF
--- a/website/static/js/pages/profile-page.js
+++ b/website/static/js/pages/profile-page.js
@@ -13,3 +13,29 @@ var ctx = window.contextVars;
 new profile.Social('#social', ctx.socialUrls, ['view']);
 new profile.Jobs('#jobs', ctx.jobsUrls, ['view']);
 new profile.Schools('#schools', ctx.schoolsUrls, ['view']);
+
+window.activeAjaxCount = 0;
+
+function isAllXhrComplete(){
+    window.activeAjaxCount--;
+    if (window.activeAjaxCount === 0){
+        $("meta[name=prerender-status-code]").attr("content", "200");
+        window.prerenderReady = true;
+    }
+
+}
+
+(function(open) {
+    XMLHttpRequest.prototype.open = function(method, url, async, user, pass) {
+        this.addEventListener("load", isAllXhrComplete);
+        open.call(this, method, url, async, user, pass);
+    };
+})(XMLHttpRequest.prototype.open);
+
+
+(function(send) {
+    XMLHttpRequest.prototype.send = function (data) {
+        window.activeAjaxCount++;
+        send.call(this, data);
+    };
+})(XMLHttpRequest.prototype.send);

--- a/website/static/js/pages/profile-page.js
+++ b/website/static/js/pages/profile-page.js
@@ -19,7 +19,7 @@ window.activeAjaxCount = 0;
 function isAllXhrComplete(){
     window.activeAjaxCount--;
     if (window.activeAjaxCount === 0){
-        $("meta[name=prerender-status-code]").attr("content", "200");
+        $('meta[name=prerender-status-code]').attr('content', '200');
         window.prerenderReady = true;
     }
 
@@ -27,7 +27,7 @@ function isAllXhrComplete(){
 
 (function(open) {
     XMLHttpRequest.prototype.open = function(method, url, async, user, pass) {
-        this.addEventListener("load", isAllXhrComplete);
+        this.addEventListener('load', isAllXhrComplete);
         open.call(this, method, url, async, user, pass);
     };
 })(XMLHttpRequest.prototype.open);

--- a/website/static/js/pages/project-base-page.js
+++ b/website/static/js/pages/project-base-page.js
@@ -56,3 +56,30 @@ $(window).resize(function() {
         '-moz-transform': 'translate3d(0, ' + (-scrollTop) + 'px, 0)'
     });
 });
+
+window.activeAjaxCount = 0;
+
+function isAllXhrComplete(){
+    window.activeAjaxCount--;
+    if (window.activeAjaxCount === 0){
+        $("meta[name=prerender-status-code]").attr("content", "200");
+        console.log('prerender ready');
+        window.prerenderReady = true;
+    }
+
+}
+
+(function(open) {
+    XMLHttpRequest.prototype.open = function(method, url, async, user, pass) {
+        this.addEventListener("load", isAllXhrComplete);
+        return open.call(this, method, url, async, user, pass);
+    };
+})(XMLHttpRequest.prototype.open);
+
+
+(function(send) {
+    XMLHttpRequest.prototype.send = function (data) {
+        window.activeAjaxCount++;
+        return send.apply(this, data);
+    };
+})(XMLHttpRequest.prototype.send);

--- a/website/static/js/pages/project-base-page.js
+++ b/website/static/js/pages/project-base-page.js
@@ -62,7 +62,7 @@ window.activeAjaxCount = 0;
 function isAllXhrComplete(){
     window.activeAjaxCount--;
     if (window.activeAjaxCount === 0){
-        $("meta[name=prerender-status-code]").attr("content", "200");
+        $('meta[name=prerender-status-code]').attr('content', '200');
         window.prerenderReady = true;
     }
 
@@ -70,7 +70,7 @@ function isAllXhrComplete(){
 
 (function(open) {
     XMLHttpRequest.prototype.open = function(method, url, async, user, pass) {
-        this.addEventListener("load", isAllXhrComplete);
+        this.addEventListener('load', isAllXhrComplete);
         open.call(this, method, url, async, user, pass);
     };
 })(XMLHttpRequest.prototype.open);

--- a/website/static/js/pages/project-base-page.js
+++ b/website/static/js/pages/project-base-page.js
@@ -63,7 +63,6 @@ function isAllXhrComplete(){
     window.activeAjaxCount--;
     if (window.activeAjaxCount === 0){
         $("meta[name=prerender-status-code]").attr("content", "200");
-        console.log('prerender ready');
         window.prerenderReady = true;
     }
 
@@ -72,7 +71,7 @@ function isAllXhrComplete(){
 (function(open) {
     XMLHttpRequest.prototype.open = function(method, url, async, user, pass) {
         this.addEventListener("load", isAllXhrComplete);
-        return open.call(this, method, url, async, user, pass);
+        open.call(this, method, url, async, user, pass);
     };
 })(XMLHttpRequest.prototype.open);
 
@@ -80,6 +79,6 @@ function isAllXhrComplete(){
 (function(send) {
     XMLHttpRequest.prototype.send = function (data) {
         window.activeAjaxCount++;
-        return send.apply(this, data);
+        send.call(this, data);
     };
 })(XMLHttpRequest.prototype.send);

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -13,9 +13,11 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="fragment" content="!">
 
+    % if (node is not UNDEFINED) | (profile is not UNDEFINED):
+        <meta name="prerender-status-code" content="504">
+        <script> window.prerenderReady = false</script>
+    % endif
 
-    <meta name="prerender-status-code" content="504">
-    <script> window.prerenderReady = false</script>
 
     % if sentry_dsn_js:
     <script src="/static/vendor/bower_components/raven-js/dist/raven.min.js"></script>

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -13,6 +13,10 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="fragment" content="!">
 
+
+    <meta name="prerender-status-code" content="504">
+    <script> window.prerenderReady = false</script>
+
     % if sentry_dsn_js:
     <script src="/static/vendor/bower_components/raven-js/dist/raven.min.js"></script>
     <script>


### PR DESCRIPTION
## Purpose

Improve how Prerender takes the snapshot of the page for node related pages and profile pages.

## Changes

In profile-page.js and project-base-page.js, methods are included to tell whether all the "initial" XHRs have been returned.
In base.mako, a meta tag and a script tag is added to help prerender determine when to take a snapshot, and what status code to return under different circumstances.
The script tag added would initialize the window.prerenderReady variable to false. Prerender would only take a snapshot when window.prerenderReady is set to true. The meta tag is added in case of window.prerenderReady never gets set to true. In which case, Prerender would return a status code of 504.

## Side effects

None


## Ticket

https://openscience.atlassian.net/browse/OSF-6735
