### PR TITLE
[Feature] Verify Admin Scope [OSF-6725]

### DIFF
--- a/api/base/permissions.py
+++ b/api/base/permissions.py
@@ -3,6 +3,8 @@ import operator
 from django.core.exceptions import ImproperlyConfigured
 from rest_framework import exceptions, permissions
 
+from api.base.utils import has_admin_scope
+
 from framework.auth import oauth_scopes
 from framework.auth.cas import CasResponse
 
@@ -74,6 +76,18 @@ class TokenHasScope(permissions.BasePermission):
                 raise ImproperlyConfigured('TokenHasScope requires the view to define the '
                                            'required_write_scopes attribute using CoreScopes rather than ComposedScopes')
             return write_scopes
+
+
+class RequestHasAdminScope(permissions.BasePermission):
+    def has_object_permission(self, request, view, obj):
+        if has_admin_scope(request):
+            return True
+        raise exceptions.NotFound()
+
+    def has_permission(self, request, view):
+        if has_admin_scope(request):
+            return True
+        raise exceptions.NotFound()
 
 
 class OwnerOnly(permissions.BasePermission):

--- a/api_tests/base/test_root.py
+++ b/api_tests/base/test_root.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import itsdangerous
+import mock
 from nose.tools import *  # flake8: noqa
 from api.base.settings.defaults import API_BASE
 
@@ -7,12 +9,21 @@ from tests.factories import (
     AuthUserFactory
 )
 
+from framework.auth.oauth_scopes import public_scopes
+from framework.auth.cas import CasResponse
+from framework.sessions.model import Session
+from website import settings
+from website.oauth.models import ApiOAuth2PersonalToken
 
 class TestWelcomeToApi(ApiTestCase):
     def setUp(self):
         super(TestWelcomeToApi, self).setUp()
         self.user = AuthUserFactory()
         self.url = '/{}'.format(API_BASE)
+
+    def tearDown(self):
+        self.app.reset()
+        super(TestWelcomeToApi, self).tearDown()
 
     def test_returns_200_for_logged_out_user(self):
         res = self.app.get(self.url)
@@ -30,3 +41,62 @@ class TestWelcomeToApi(ApiTestCase):
         res = self.app.get('/')
         assert_equal(res.status_code, 302)
         assert_equal(res.location, '/v2/')
+
+    def test_cookie_has_admin(self):
+        session = Session(data={'auth_user_id': self.user._id})
+        session.save()
+        cookie = itsdangerous.Signer(settings.SECRET_KEY).sign(session._id)
+        self.app.set_cookie(settings.COOKIE_NAME, str(cookie))
+
+        res = self.app.get(self.url)
+        assert_equal(res.status_code, 200)
+        assert_equal(res.json['meta']['admin'], True)
+
+    def test_basic_auth_does_not_have_admin(self):
+        res = self.app.get(self.url, auth=self.user.auth)
+        assert_equal(res.status_code, 200)
+        assert_not_in('admin', res.json['meta'].keys())
+
+    @mock.patch('api.base.authentication.drf.OSFCASAuthentication.authenticate')
+    def test_admin_scoped_token_has_admin(self, mock_auth):
+        token = ApiOAuth2PersonalToken(
+            owner=self.user,
+            name='Admin Token',
+            scopes='osf.admin'
+        )
+
+        mock_cas_resp = CasResponse(
+            authenticated=True,
+            user=self.user._id,
+            attributes={
+                'accessToken': token.token_id,
+                'accessTokenScope': [s for s in token.scopes.split(' ')]
+            }
+        )
+        mock_auth.return_value = self.user, mock_cas_resp
+        res = self.app.get(self.url, headers={'Authorization': 'Bearer {}'.format(token.token_id)})
+
+        assert_equal(res.status_code, 200)
+        assert_equal(res.json['meta']['admin'], True)
+
+    @mock.patch('api.base.authentication.drf.OSFCASAuthentication.authenticate')
+    def test_non_admin_scoped_token_does_not_have_admin(self, mock_auth):
+        token = ApiOAuth2PersonalToken(
+            owner=self.user,
+            name='Admin Token',
+            scopes=' '.join([key for key in public_scopes if key != 'osf.admin'])
+        )
+
+        mock_cas_resp = CasResponse(
+            authenticated=True,
+            user=self.user._id,
+            attributes={
+                'accessToken': token.token_id,
+                'accessTokenScope': [s for s in token.scopes.split(' ')]
+            }
+        )
+        mock_auth.return_value = self.user, mock_cas_resp
+        res = self.app.get(self.url, headers={'Authorization': 'Bearer {}'.format(token.token_id)})
+
+        assert_equal(res.status_code, 200)
+        assert_not_in('admin', res.json['meta'].keys())

--- a/api_tests/base/test_root.py
+++ b/api_tests/base/test_root.py
@@ -2,12 +2,14 @@
 import itsdangerous
 import mock
 from nose.tools import *  # flake8: noqa
-from api.base.settings.defaults import API_BASE
+import unittest
 
 from tests.base import ApiTestCase
 from tests.factories import (
     AuthUserFactory
 )
+
+from api.base.settings.defaults import API_BASE
 
 from framework.auth.oauth_scopes import public_scopes
 from framework.auth.cas import CasResponse
@@ -58,6 +60,7 @@ class TestWelcomeToApi(ApiTestCase):
         assert_not_in('admin', res.json['meta'].keys())
 
     @mock.patch('api.base.authentication.drf.OSFCASAuthentication.authenticate')
+    @unittest.skipIf(not settings.DEV_MODE, 'DEV_MODE disabled, osf.admin unavailable')  # TODO: Remove when available outside of DEV_MODE
     def test_admin_scoped_token_has_admin(self, mock_auth):
         token = ApiOAuth2PersonalToken(
             owner=self.user,

--- a/api_tests/tokens/views/test_token_list.py
+++ b/api_tests/tokens/views/test_token_list.py
@@ -103,6 +103,17 @@ class TestTokenList(ApiTestCase):
         res = self.app.get(self.user1_list_url, expect_errors=True)
         assert_equal(res.status_code, 401)
 
+    def test_cannot_create_admin_token(self):
+        self.sample_data['data']['attributes']['scopes'] = 'osf.admin'
+        res = self.app.post_json_api(self.user1_list_url,
+            self.sample_data,
+            auth=self.user1.auth,
+            expect_errors=True
+        )
+        assert_equal(res.status_code, 400)
+        assert_equal(res.json['errors'][0]['detail'], 'User requested invalid scope')
+
+
     def tearDown(self):
         super(TestTokenList, self).tearDown()
         ApiOAuth2PersonalToken.remove()


### PR DESCRIPTION
## Purpose
We want to use the admin scope things, and we need to verify that it's as secure as we want it to be.

Resolves (some) blockers for [OSF-6727](https://openscience.atlassian.net/browse/OSF-6727) and [OSF-6724](https://openscience.atlassian.net/browse/OSF-6724) / #5942 

## Changes

- [X] - Modify a route to have admin scope-specific behavior (`/v2/`)
- [X] - Verify that the behavior of that endpoint is correct:
- [X] ---- PATs with admin scope and cookied requests exhibit that behavior
- [X] ---- PATs without admin scope and basic auth requests do not exhibit that behavior
- [X] - Make sure that arbitrary users cannot get admin 
- [X] - Unit tests to verify the above

**TODO** (Someone with RS access after this goes in):
- [ ]  Runscope tests (Ghost inspector test of the BAPI if Runscope won't work) 

## Side effects
Until the admin scope is available outside of `DEV_MODE`, `RequestHasAdminScope` will only be useful for cookied requests.

## Ticket
[OSF-6725](https://openscience.atlassian.net/browse/OSF-6725)