### PR TITLE
[OSF-4670] Do not show a profile page for an unconfirmed user

### DIFF
--- a/framework/auth/decorators.py
+++ b/framework/auth/decorators.py
@@ -10,8 +10,8 @@ from framework.auth import cas
 from framework.auth import signing
 from framework.flask import redirect
 from framework.exceptions import HTTPError
-
 from .core import Auth
+from .core import User
 
 
 def collect_auth(func):
@@ -20,6 +20,23 @@ def collect_auth(func):
     def wrapped(*args, **kwargs):
         kwargs['auth'] = Auth.from_kwargs(request.args.to_dict(), kwargs)
         return func(*args, **kwargs)
+
+    return wrapped
+
+
+def must_be_confirmed(func):
+
+    @functools.wraps(func)
+    def wrapped(*args, **kwargs):
+
+        user = User.load(kwargs['uid'])
+        if user.is_active:
+            return func(*args, **kwargs)
+        else:
+            raise HTTPError(httplib.BAD_REQUEST, data={
+                'message_short': 'Account not yet confirmed',
+                'message_long': 'The profile page could not be displayed as the user has not confirmed the account.'
+            })
 
     return wrapped
 

--- a/framework/auth/decorators.py
+++ b/framework/auth/decorators.py
@@ -12,7 +12,6 @@ from framework.flask import redirect
 from framework.exceptions import HTTPError
 from .core import Auth
 from .core import User
-from types import NoneType
 
 
 def collect_auth(func):

--- a/framework/auth/decorators.py
+++ b/framework/auth/decorators.py
@@ -12,6 +12,7 @@ from framework.flask import redirect
 from framework.exceptions import HTTPError
 from .core import Auth
 from .core import User
+from types import NoneType
 
 
 def collect_auth(func):
@@ -30,13 +31,16 @@ def must_be_confirmed(func):
     def wrapped(*args, **kwargs):
 
         user = User.load(kwargs['uid'])
-        if user.is_active:
-            return func(*args, **kwargs)
+        if user is not None:
+            if user.is_confirmed:
+                return func(*args, **kwargs)
+            else:
+                raise HTTPError(httplib.BAD_REQUEST, data={
+                    'message_short': 'Account not yet confirmed',
+                    'message_long': 'The profile page could not be displayed as the user has not confirmed the account.'
+                })
         else:
-            raise HTTPError(httplib.BAD_REQUEST, data={
-                'message_short': 'Account not yet confirmed',
-                'message_long': 'The profile page could not be displayed as the user has not confirmed the account.'
-            })
+            raise HTTPError(httplib.NOT_FOUND)
 
     return wrapped
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4226,7 +4226,7 @@ class TestUnconfirmedUserViews(OsfTestCase):
         user = UnconfirmedUserFactory()
         url = web_url_for('profile_view_id', uid=user._id)
         res = self.app.get(url)
-        assert_equal(res.status_code, 200)
+        assert_equal(res.status_code, 400)
 
 
 class TestProfileNodeList(OsfTestCase):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4225,8 +4225,8 @@ class TestUnconfirmedUserViews(OsfTestCase):
     def test_can_view_profile(self):
         user = UnconfirmedUserFactory()
         url = web_url_for('profile_view_id', uid=user._id)
-        res = self.app.get(url)
-        assert_equal(res.status_code, 400)
+        res = self.app.get(url, expect_errors=True)
+        assert_equal(res.status_code, http.BAD_REQUEST)
 
 
 class TestProfileNodeList(OsfTestCase):

--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -15,6 +15,7 @@ from framework import sentry
 from framework.auth import utils as auth_utils
 from framework.auth.decorators import collect_auth
 from framework.auth.decorators import must_be_logged_in
+from framework.auth.decorators import must_be_confirmed
 from framework.auth.exceptions import ChangePasswordError
 from framework.auth.views import send_confirm_email
 from framework.auth.signals import user_merged
@@ -297,6 +298,7 @@ def profile_view(auth):
 
 
 @collect_auth
+@must_be_confirmed
 def profile_view_id(uid, auth):
     user = User.load(uid)
     is_profile = auth and auth.user == user


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

- Before, when an account was made but not yet confirmed, their page was still able to be accessed.  

- Makes it so when an unconfirmed user's profile page is attempted to be accessed, it displays the text "Account not yet confirmed.  The profile page could not be displayed as the user has not confirmed the account" and throws and HTTPerror.

<!-- Describe the purpose of your changes -->

## Changes

- Added the decorator ``must_be_confirmed`` in ``decorators.py`` that checks if the user on the page being visited has activated their account.  If so, it returns normally.  If it is not activated, it raises the error and displays the message.

- Wrapped the function ``profile_view_id`` in ``profile/views.py`` that is accessed when a page is loaded up 

 
Here is a picture of the changes on a page of an unconfirmed user:
![screen shot 2016-07-22 at 12 10 29 pm](https://cloud.githubusercontent.com/assets/16651533/17063565/f763d8ca-5005-11e6-9b2f-21cf933b57b0.png)

<!-- Briefly describe or list your changes  -->

## Side effects

<!--Any possible side effects? -->


## Ticket

- https://openscience.atlassian.net/browse/OSF-4670

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->

