### PR TITLE
Feature/password verification

### DIFF
--- a/website/static/js/passwordForms.js
+++ b/website/static/js/passwordForms.js
@@ -119,7 +119,7 @@ var ChangePasswordViewModel = oop.extend(BaseViewModel, {
 var SetPasswordViewModel = oop.extend(BaseViewModel, {
     constructor: function () {
         var self = this;
-        // Call constructor at the begining so that self.password exists
+        // Call constructor at the beginning so that self.password exists
         self.super.constructor.call(this);
 
         // pick up the email from contextVars if we can't get it from first typing it in

--- a/website/static/js/passwordForms.js
+++ b/website/static/js/passwordForms.js
@@ -244,7 +244,19 @@ var SignUpViewModel = oop.extend(BaseViewModel, {
 
 /** Wrapper classes */
 var ChangePassword = function(selector) {
-    $osf.applyBindings(new ChangePasswordViewModel(), selector);
+    this.ChangePasswordViewModel = new ChangePasswordViewModel();
+    $osf.applyBindings(this.ChangePasswordViewModel, selector);
+        // Necessary to prevent enter submitting forms with invalid frontend zxcvbn validation
+        $(selector).keypress(
+            event => {
+            // If the enter key is pressed to submit a form, check if the password is valid
+            if (event.which === 13) {
+                    if (!this.ChangePasswordViewModel.password.isValid()) {
+                        return false;
+                    }
+                }
+            }
+        )
 };
 
 var SetPassword = function(selector) {

--- a/website/static/js/passwordForms.js
+++ b/website/static/js/passwordForms.js
@@ -58,7 +58,6 @@ var BaseViewModel = oop.extend(ChangeMessageMixin, {
             complexity: 2,
         });
 
-
         // Preserve object of validated fields for use in `submit`
         var validatedObservables = {
             password: self.password
@@ -133,6 +132,7 @@ var ChangePasswordViewModel = oop.extend(BaseViewModel, {
     getValidatedFields: function() {
         var self = this;
         return {
+            password: self.password,
             oldPassword: self.oldPassword
         };
     }
@@ -289,12 +289,12 @@ var SignUpViewModel = oop.extend(BaseViewModel, {
 
 /** Wrapper classes */
 var ChangePassword = function(selector) {
-    ChangePasswordViewModel = new ChangePasswordViewModel();
-    $osf.applyBindings(ChangePasswordViewModel, selector);
+    var viewModel = new ChangePasswordViewModel();
+    $osf.applyBindings(viewModel, selector);
     // Necessary to prevent enter submitting forms with invalid frontend zxcvbn validation
     $(selector).keypress(function(event) {
         if (event.which === 13) {
-            if (!ChangePasswordViewModel.password.isValid()) {
+            if (!viewModel.password.isValid()) {
                 return false;
             }
         }
@@ -302,12 +302,12 @@ var ChangePassword = function(selector) {
 };
 
 var SetPassword = function(selector) {
-    SetPasswordViewModel = new SetPasswordViewModel();
-    $osf.applyBindings(SetPasswordViewModel, selector);
+    var viewModel = new SetPasswordViewModel();
+    $osf.applyBindings(viewModel, selector);
     // Necessary to prevent enter submitting forms with invalid frontend zxcvbn validation
     $(selector).keypress(function(event) {
         if (event.which === 13) {
-            if (!SetPasswordViewModel.password.isValid()) {
+            if (!viewModel.password.isValid()) {
                 return false;
             }
         }
@@ -315,12 +315,12 @@ var SetPassword = function(selector) {
 };
 
 var SignUp = function(selector) {
-    SignUpViewModel = new SignUpViewModel();
-    $osf.applyBindings(SignUpViewModel, selector);
+    var viewModel = new SignUpViewModel();
+    $osf.applyBindings(viewModel, selector);
     // Necessary to prevent enter submitting forms with invalid frontend zxcvbn validation
     $(selector).keypress(function(event) {
         if (event.which === 13) {
-            if (!SignUpViewModel.password.isValid()) {
+            if (!viewModel.password.isValid()) {
                 return false;
             }
         }

--- a/website/static/js/passwordForms.js
+++ b/website/static/js/passwordForms.js
@@ -121,6 +121,28 @@ var SetPasswordViewModel = oop.extend(BaseViewModel, {
         var self = this;
         // Call constructor at the begining so that self.password exists
         self.super.constructor.call(this);
+
+        // pick up the email from contextVars if we can't get it from first typing it in
+        self.email1 = ko.observable(window.contextVars.username || '').extend({
+            required: true,
+            email: true
+        });
+
+        self.password.extend({
+            validation: {
+                validator: function(val, other) {
+                    if (String(val).toLowerCase() === String(other).toLowerCase()) {
+                        self.typedPassword(' ');
+                        return false;
+                    } else {
+                        return true;
+                    }
+                },
+                'message': 'Your password cannot be the same as your email address.',
+                params: self.email1
+            }
+        });
+
         self.passwordConfirmation = ko.observable('').extend({
             required: true,
             validation: {
@@ -276,7 +298,6 @@ var SetPassword = function(selector) {
 };
 
 var SignUp = function(selector) {
-    $osf.applyBindings(new SignUpViewModel(), selector);
     this.SignUpViewModel = new SignUpViewModel();
     $osf.applyBindings(this.SignUpViewModel, selector);
         // Necessary to prevent enter submitting forms with invalid frontend zxcvbn validation

--- a/website/static/js/passwordForms.js
+++ b/website/static/js/passwordForms.js
@@ -248,7 +248,19 @@ var ChangePassword = function(selector) {
 };
 
 var SetPassword = function(selector) {
-    $osf.applyBindings(new SetPasswordViewModel(), selector);
+    this.setPasswprdViewModel = new SetPasswordViewModel();
+    $osf.applyBindings(this.setPasswprdViewModel, selector);
+        // Necessary to prevent enter submitting forms with invalid frontend zxcvbn validation
+        $(selector).keypress(
+            event => {
+            // If the enter key is pressed to submit a form, check if the password is valid
+            if (event.which === 13) {
+                    if (!this.setPasswprdViewModel.password.isValid()) {
+                        return false;
+                    }
+                }
+            }
+        )
 };
 
 var SignUp = function(selector) {

--- a/website/static/js/passwordForms.js
+++ b/website/static/js/passwordForms.js
@@ -266,51 +266,42 @@ var SignUpViewModel = oop.extend(BaseViewModel, {
 
 /** Wrapper classes */
 var ChangePassword = function(selector) {
-    this.ChangePasswordViewModel = new ChangePasswordViewModel();
-    $osf.applyBindings(this.ChangePasswordViewModel, selector);
-        // Necessary to prevent enter submitting forms with invalid frontend zxcvbn validation
-        $(selector).keypress(
-            event => {
-            // If the enter key is pressed to submit a form, check if the password is valid
-            if (event.which === 13) {
-                    if (!this.ChangePasswordViewModel.password.isValid()) {
-                        return false;
-                    }
-                }
+    var ChangePasswordViewModel = new ChangePasswordViewModel();
+    $osf.applyBindings(ChangePasswordViewModel, selector);
+    // Necessary to prevent enter submitting forms with invalid frontend zxcvbn validation
+    $(selector).keypress(function(event) {
+        if (event.which == 13) {
+            if (!SignUpViewModel.password.isValid()) {
+                return false;
             }
-        );
+        }
+    });
 };
 
 var SetPassword = function(selector) {
-    this.SetPasswprdViewModel = new SetPasswordViewModel();
-    $osf.applyBindings(this.SetPasswprdViewModel, selector);
-        // Necessary to prevent enter submitting forms with invalid frontend zxcvbn validation
-        $(selector).keypress(
-            event => {
-            // If the enter key is pressed to submit a form, check if the password is valid
-            if (event.which === 13) {
-                    if (!this.SetPasswprdViewModel.password.isValid()) {
-                        return false;
-                    }
-                }
+    var SetPasswordViewModel = new SetPasswordViewModel();
+    $osf.applyBindings(SetPasswordViewModel, selector);
+    // Necessary to prevent enter submitting forms with invalid frontend zxcvbn validation
+    $(selector).keypress(function(event) {
+        if (event.which == 13) {
+            if (!SignUpViewModel.password.isValid()) {
+                return false;
             }
-        );
+        }
+    });
 };
 
 var SignUp = function(selector) {
-    this.SignUpViewModel = new SignUpViewModel();
-    $osf.applyBindings(this.SignUpViewModel, selector);
-        // Necessary to prevent enter submitting forms with invalid frontend zxcvbn validation
-        $(selector).keypress(
-            event => {
-            // If the enter key is pressed to submit a form, check if the password is valid
-            if (event.which === 13) {
-                    if (!this.SignUpViewModel.password.isValid()) {
-                        return false;
-                    }
-                }
+    SignUpViewModel = new SignUpViewModel();
+    $osf.applyBindings(SignUpViewModel, selector);
+    // Necessary to prevent enter submitting forms with invalid frontend zxcvbn validation
+    $(selector).keypress(function(event) {
+        if (event.which == 13) {
+            if (!SignUpViewModel.password.isValid()) {
+                return false;
             }
-        );
+        }
+    });
 };
 
 module.exports = {

--- a/website/static/js/passwordForms.js
+++ b/website/static/js/passwordForms.js
@@ -260,14 +260,14 @@ var ChangePassword = function(selector) {
 };
 
 var SetPassword = function(selector) {
-    this.setPasswprdViewModel = new SetPasswordViewModel();
-    $osf.applyBindings(this.setPasswprdViewModel, selector);
+    this.SetPasswprdViewModel = new SetPasswordViewModel();
+    $osf.applyBindings(this.SetPasswprdViewModel, selector);
         // Necessary to prevent enter submitting forms with invalid frontend zxcvbn validation
         $(selector).keypress(
             event => {
             // If the enter key is pressed to submit a form, check if the password is valid
             if (event.which === 13) {
-                    if (!this.setPasswprdViewModel.password.isValid()) {
+                    if (!this.SetPasswprdViewModel.password.isValid()) {
                         return false;
                     }
                 }
@@ -277,6 +277,19 @@ var SetPassword = function(selector) {
 
 var SignUp = function(selector) {
     $osf.applyBindings(new SignUpViewModel(), selector);
+    this.SignUpViewModel = new SignUpViewModel();
+    $osf.applyBindings(this.SignUpViewModel, selector);
+        // Necessary to prevent enter submitting forms with invalid frontend zxcvbn validation
+        $(selector).keypress(
+            event => {
+            // If the enter key is pressed to submit a form, check if the password is valid
+            if (event.which === 13) {
+                    if (!this.SignUpViewModel.password.isValid()) {
+                        return false;
+                    }
+                }
+            }
+        )
 };
 
 module.exports = {

--- a/website/static/js/passwordForms.js
+++ b/website/static/js/passwordForms.js
@@ -92,6 +92,31 @@ var BaseViewModel = oop.extend(ChangeMessageMixin, {
 var ChangePasswordViewModel = oop.extend(BaseViewModel, {
     constructor: function () {
         var self = this;
+
+        // Call constructor at the beginning so that self.password exists
+        self.super.constructor.call(this);
+
+        // pick up the email from contextVars
+        self.email1 = ko.observable(window.contextVars.username || '').extend({
+            required: true,
+            email: true
+        });
+
+        self.password.extend({
+            validation: {
+                validator: function(val, other) {
+                    if (String(val).toLowerCase() === String(other).toLowerCase()) {
+                        self.typedPassword(' ');
+                        return false;
+                    } else {
+                        return true;
+                    }
+                },
+                'message': 'Your password cannot be the same as your email address.',
+                params: self.email1
+            }
+        });
+
         self.passwordConfirmation = ko.observable('').extend({
             required: true,
             validation: {
@@ -104,8 +129,6 @@ var ChangePasswordViewModel = oop.extend(BaseViewModel, {
         });
         self.oldPassword = ko.observable('').extend({required: true});
 
-        // Call constructor after declaring observables so that validatedFields is populated correctly
-        self.super.constructor.call(this);
     },
     getValidatedFields: function() {
         var self = this;
@@ -266,12 +289,12 @@ var SignUpViewModel = oop.extend(BaseViewModel, {
 
 /** Wrapper classes */
 var ChangePassword = function(selector) {
-    var ChangePasswordViewModel = new ChangePasswordViewModel();
+    ChangePasswordViewModel = new ChangePasswordViewModel();
     $osf.applyBindings(ChangePasswordViewModel, selector);
     // Necessary to prevent enter submitting forms with invalid frontend zxcvbn validation
     $(selector).keypress(function(event) {
-        if (event.which == 13) {
-            if (!SignUpViewModel.password.isValid()) {
+        if (event.which === 13) {
+            if (!ChangePasswordViewModel.password.isValid()) {
                 return false;
             }
         }
@@ -279,12 +302,12 @@ var ChangePassword = function(selector) {
 };
 
 var SetPassword = function(selector) {
-    var SetPasswordViewModel = new SetPasswordViewModel();
+    SetPasswordViewModel = new SetPasswordViewModel();
     $osf.applyBindings(SetPasswordViewModel, selector);
     // Necessary to prevent enter submitting forms with invalid frontend zxcvbn validation
     $(selector).keypress(function(event) {
-        if (event.which == 13) {
-            if (!SignUpViewModel.password.isValid()) {
+        if (event.which === 13) {
+            if (!SetPasswordViewModel.password.isValid()) {
                 return false;
             }
         }
@@ -296,7 +319,7 @@ var SignUp = function(selector) {
     $osf.applyBindings(SignUpViewModel, selector);
     // Necessary to prevent enter submitting forms with invalid frontend zxcvbn validation
     $(selector).keypress(function(event) {
-        if (event.which == 13) {
+        if (event.which === 13) {
             if (!SignUpViewModel.password.isValid()) {
                 return false;
             }

--- a/website/static/js/passwordForms.js
+++ b/website/static/js/passwordForms.js
@@ -119,6 +119,8 @@ var ChangePasswordViewModel = oop.extend(BaseViewModel, {
 var SetPasswordViewModel = oop.extend(BaseViewModel, {
     constructor: function () {
         var self = this;
+        // Call constructor at the begining so that self.password exists
+        self.super.constructor.call(this);
         self.passwordConfirmation = ko.observable('').extend({
             required: true,
             validation: {
@@ -129,7 +131,6 @@ var SetPasswordViewModel = oop.extend(BaseViewModel, {
                 params: self.password
             }
         });
-        self.super.constructor.call(this);
     }
 });
 

--- a/website/static/js/passwordForms.js
+++ b/website/static/js/passwordForms.js
@@ -58,11 +58,9 @@ var BaseViewModel = oop.extend(ChangeMessageMixin, {
             complexity: 2,
         });
 
-        // Preserve object of validated fields for use in `submit`
-        var validatedObservables = {
-            password: self.password
-        };
-        self.validatedObservables = $.extend({}, validatedObservables, self.getValidatedFields());
+        // To ensure that validated fields are populated correctly
+        self.validatedObservables = self.getValidatedFields();
+        self.validatedFields = ko.validatedObservable(self.validatedObservables);
 
         // Collect validated fields
         self.validatedFields = ko.validatedObservable(self.validatedObservables);
@@ -83,7 +81,8 @@ var BaseViewModel = oop.extend(ChangeMessageMixin, {
      * Hook to add validated observables to the validation group.
      */
     getValidatedFields: function() {
-        return {};
+        var self = this;
+        return {password: self.password};
     }
 });
 
@@ -133,6 +132,7 @@ var ChangePasswordViewModel = oop.extend(BaseViewModel, {
         var self = this;
         return {
             password: self.password,
+            passwordConfirmation: self.passwordConfirmation,
             oldPassword: self.oldPassword
         };
     }
@@ -225,6 +225,7 @@ var SignUpViewModel = oop.extend(BaseViewModel, {
     getValidatedFields: function() {
         var self = this;
         return {
+            password: self.password,
             fullName: self.fullName,
             email1: self.email1,
             email2: self.email2
@@ -294,7 +295,7 @@ var ChangePassword = function(selector) {
     // Necessary to prevent enter submitting forms with invalid frontend zxcvbn validation
     $(selector).keypress(function(event) {
         if (event.which === 13) {
-            if (!viewModel.password.isValid()) {
+            if (!viewModel.password.isValid() || !viewModel.passwordConfirmation.isValid()) {
                 return false;
             }
         }
@@ -307,7 +308,7 @@ var SetPassword = function(selector) {
     // Necessary to prevent enter submitting forms with invalid frontend zxcvbn validation
     $(selector).keypress(function(event) {
         if (event.which === 13) {
-            if (!viewModel.password.isValid()) {
+            if (!viewModel.password.isValid() || !viewModel.passwordConfirmation.isValid()) {
                 return false;
             }
         }

--- a/website/static/js/passwordForms.js
+++ b/website/static/js/passwordForms.js
@@ -278,7 +278,7 @@ var ChangePassword = function(selector) {
                     }
                 }
             }
-        )
+        );
 };
 
 var SetPassword = function(selector) {
@@ -294,7 +294,7 @@ var SetPassword = function(selector) {
                     }
                 }
             }
-        )
+        );
 };
 
 var SignUp = function(selector) {
@@ -310,7 +310,7 @@ var SignUp = function(selector) {
                     }
                 }
             }
-        )
+        );
 };
 
 module.exports = {

--- a/website/templates/public/login.mako
+++ b/website/templates/public/login.mako
@@ -169,8 +169,10 @@
                             <!-- /ko -->
                         </div>
                     </div>
-
-                </div>
+                    <!-- Flashed Messages -->
+                    <div class="help-block osf-box-lt" >
+                        <p data-bind="html: message, attr: {class: messageClass}" class=""></p>
+                    </div>
                 </br>
                 <div class="form-group">
                     <div class="col-md-8 col-sm-12" style="padding-left: 25px">


### PR DESCRIPTION
Fixing messed up #6001 

## Purpose
Fix up some things that were broken with the refactor of the password verifications

Tested on the following pages:
- Front splash page
- Create an account page
- Account Settings page
- Forgot password page
- Claim account page

For the following actions:
- Password strength bar fills and empties
- Cannot use your email address as your password
- Cannot click submit when the password is invalid
- Cannot hit enter to submit when the password is invalid
- Password is successfully reset on completion

## Changes
- Change order of constructor call so that ```self.password``` is defined before it's checked
- Add back checking for frontend validation of using email as password on the claim account page
- Add back disabling ENTER key also when validation does not pass on the front end
- Add back success message back for signing up on the ```login``` page

## Side effects
None anticipated


## Ticket
https://openscience.atlassian.net/browse/OSF-6689