### PR TITLE
[OSF-6499]Add validator for NotificationSubscription.event_name and NotificationDigest.event

### DIFF
--- a/website/notifications/model.py
+++ b/website/notifications/model.py
@@ -4,7 +4,7 @@ from framework.mongo import StoredObject, ObjectId
 from modularodm.exceptions import ValidationValueError
 
 from website.project.model import Node
-from website.notifications.constants import NOTIFICATION_TYPES
+from website.notifications.constants import NOTIFICATION_TYPES, NODE_SUBSCRIPTIONS_AVAILABLE, USER_SUBSCRIPTIONS_AVAILABLE
 
 
 def validate_subscription_type(value):
@@ -12,10 +12,15 @@ def validate_subscription_type(value):
         raise ValidationValueError
 
 
+def validate_event_type(value):
+    if value not in NODE_SUBSCRIPTIONS_AVAILABLE or USER_SUBSCRIPTIONS_AVAILABLE:
+        raise ValidationValueError
+
+
 class NotificationSubscription(StoredObject):
     _id = fields.StringField(primary=True)  # pxyz_wiki_updated, uabc_comment_replies
 
-    event_name = fields.StringField()      # wiki_updated, comment_replies
+    event_name = fields.StringField(index=True, validate=validate_event_type)      # wiki_updated, comment_replies
     owner = fields.AbstractForeignField()
 
     # Notification types
@@ -64,6 +69,6 @@ class NotificationDigest(StoredObject):
     user_id = fields.StringField(index=True)
     timestamp = fields.DateTimeField()
     send_type = fields.StringField(index=True, validate=validate_subscription_type)
-    event = fields.StringField()
+    event = fields.StringField(index=True, validate=validate_event_type)
     message = fields.StringField()
     node_lineage = fields.StringField(list=True)

--- a/website/notifications/model.py
+++ b/website/notifications/model.py
@@ -13,7 +13,7 @@ def validate_subscription_type(value):
 
 
 def validate_event_type(value):
-    if value not in NODE_SUBSCRIPTIONS_AVAILABLE or USER_SUBSCRIPTIONS_AVAILABLE:
+    if value not in (NODE_SUBSCRIPTIONS_AVAILABLE or USER_SUBSCRIPTIONS_AVAILABLE):
         raise ValidationValueError
 
 

--- a/website/notifications/model.py
+++ b/website/notifications/model.py
@@ -14,6 +14,14 @@ def validate_subscription_type(value):
 
 
 def validate_event_type(value):
+    """
+
+    :param value:
+
+    Checks if the value passed in is in the NODE_SUBSCRIPTIONS_AVAILABLE or USER_SUBSCRIPTIONS_AVAILABLE
+    if it is an event name.  Since the only things from NODE_SUBSCRIPTIONS_AVAILABLE that contains "file_updated"
+    is preceded by a user ID, a regex checker was added for that.
+    """
     prefix = re.compile('[[a-zA-Z0-9]*_]?')
     if prefix.search(value):
         value = 'file_updated'

--- a/website/notifications/model.py
+++ b/website/notifications/model.py
@@ -5,6 +5,7 @@ from modularodm.exceptions import ValidationValueError
 
 from website.project.model import Node
 from website.notifications.constants import NOTIFICATION_TYPES, NODE_SUBSCRIPTIONS_AVAILABLE, USER_SUBSCRIPTIONS_AVAILABLE
+import re
 
 
 def validate_subscription_type(value):
@@ -13,7 +14,10 @@ def validate_subscription_type(value):
 
 
 def validate_event_type(value):
-    if value not in (NODE_SUBSCRIPTIONS_AVAILABLE or USER_SUBSCRIPTIONS_AVAILABLE):
+    prefix = re.compile('[[a-zA-Z0-9]*_]?')
+    if prefix.search(value):
+        value = 'file_updated'
+    if value not in NODE_SUBSCRIPTIONS_AVAILABLE and value not in USER_SUBSCRIPTIONS_AVAILABLE:
         raise ValidationValueError
 
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

- To add validators for NotificationSubscription.event_name and NotificationDigest.event

<!-- Describe the purpose of your changes -->

## Changes

- Imported two more lists from ``website/notifications/constants.py``.  

- Created a function ``validate_event_type(value)`` that checked if the value passed in was not in the two lists imported.  If it was not, it would raise a validation error.

- Changed the event_name of NotificationSubscription and the event of NotificationDigest to allow for validations (using the above function)

<!-- Briefly describe or list your changes  -->

## Side effects

<!--Any possible side effects? -->


## Ticket

https://openscience.atlassian.net/browse/OSF-6499