### PR TITLE
[Feature] Allow DOI Creation on Public Projects [OSF-6754]

### DIFF
--- a/framework/exceptions/__init__.py
+++ b/framework/exceptions/__init__.py
@@ -22,7 +22,7 @@ class HTTPError(FrameworkError):
         },
         http.FORBIDDEN: {
             'message_short': 'Forbidden',
-            'message_long': ('User has restricted access to this page. '
+            'message_long': ('You do not have permission to perform this action. '
                 'If this should not have occurred and the issue persists, '
                 'please report it to <a href="mailto:support@osf.io">support@osf.io</a>.'),
         },

--- a/framework/exceptions/__init__.py
+++ b/framework/exceptions/__init__.py
@@ -22,7 +22,7 @@ class HTTPError(FrameworkError):
         },
         http.FORBIDDEN: {
             'message_short': 'Forbidden',
-            'message_long': ('You do not have permission to perform this action. '
+            'message_long': ('User has restricted access to this page. '
                 'If this should not have occurred and the issue persists, '
                 'please report it to <a href="mailto:support@osf.io">support@osf.io</a>.'),
         },
@@ -34,7 +34,7 @@ class HTTPError(FrameworkError):
         },
         http.GONE: {
             'message_short': 'Resource deleted',
-            'message_long': ('The requested resource has been deleted. If this should '
+            'message_long': ('User has deleted this content. If this should '
                 'not have occurred and the issue persists, please report it to '
                 '<a href="mailto:support@osf.io">support@osf.io</a>.'),
         },

--- a/framework/mongo/utils.py
+++ b/framework/mongo/utils.py
@@ -107,9 +107,7 @@ def get_or_http_error(Model, pk_or_query, allow_deleted=False, display_name=None
             message_long='This content has been removed'
         ))
     if not allow_deleted and getattr(instance, 'is_deleted', False):
-        raise HTTPError(http.GONE, data=dict(
-            message_long='This {name} record has been deleted'.format(name=safe_name)
-        ))
+        raise HTTPError(http.GONE)
     return instance
 
 

--- a/website/project/decorators.py
+++ b/website/project/decorators.py
@@ -179,7 +179,9 @@ def check_can_access(node, user, key=None, api_node=None):
     if not node.can_view(Auth(user=user)) and api_node != node:
         if key in node.private_link_keys_deleted:
             status.push_status_message('The view-only links you used are expired.', trust=False)
-        raise HTTPError(http.FORBIDDEN)
+        raise HTTPError(http.FORBIDDEN, data={'message_long': ('User has restricted access to this page. '
+            'If this should not have occurred and the issue persists, please report it to '
+            '<a href="mailto:support@osf.io">support@osf.io</a>.')})
     return True
 
 

--- a/website/project/views/register.py
+++ b/website/project/views/register.py
@@ -250,7 +250,7 @@ def _get_or_create_identifiers(node):
 def node_identifiers_get(node, **kwargs):
     """Retrieve identifiers for a node. Node must be a public registration.
     """
-    if not node.is_registration or not node.is_public:
+    if not node.is_public:
         raise HTTPError(http.BAD_REQUEST)
     return {
         'doi': node.get_identifier_value('doi'),
@@ -263,8 +263,7 @@ def node_identifiers_get(node, **kwargs):
 def node_identifiers_post(auth, node, **kwargs):
     """Create identifier pair for a node. Node must be a public registration.
     """
-    # TODO: Fail if `node` is retracted
-    if not node.is_registration or not node.is_public:  # or node.is_retracted:
+    if not node.is_public or node.is_retracted:
         raise HTTPError(http.BAD_REQUEST)
     if node.get_identifier('doi') or node.get_identifier('ark'):
         raise HTTPError(http.BAD_REQUEST)

--- a/website/static/js/nodeControl.js
+++ b/website/static/js/nodeControl.js
@@ -221,7 +221,6 @@ var ProjectViewModel = function(data, options) {
 
     self.canCreateIdentifiers = ko.pureComputed(function() {
         return !self.hasIdentifiers() &&
-            self.isRegistration &&
             self.nodeIsPublic &&
             self.userPermissions.indexOf('admin') !== -1;
     });

--- a/website/static/js/nodeControl.js
+++ b/website/static/js/nodeControl.js
@@ -239,7 +239,8 @@ var ProjectViewModel = function(data, options) {
             title: 'Create identifiers',
             message: '<p class="overflow">' +
                 'Are you sure you want to create a DOI and ARK for this ' +
-                $osf.htmlEscape(self.nodeType) + '?',
+                $osf.htmlEscape(self.nodeType) + '? DOI and ARK identifiers' +
+                ' are persistent and will always resolve to this page.',
             callback: function(confirmed) {
                 if (confirmed) {
                     self.createIdentifiers();

--- a/website/static/js/tests/nodeControl.test.js
+++ b/website/static/js/tests/nodeControl.test.js
@@ -43,23 +43,29 @@ describe('nodeControl', () => {
                 vm.ark('24601');
                 assert.isTrue(vm.hasIdentifiers());
             });
-            it('can have identifiers when public, registered, and admin', () => {
+            it('can have identifiers when admin and public', () => {
                 var data = $.extend({}, nodeData);
                 data.node = $.extend(data.node, {is_registration: true, is_public: true});
                 var vm = new nodeControl._ProjectViewModel(data);
                 assert.isTrue(vm.canCreateIdentifiers());
+                data.node = $.extend(data.node, {is_registration: false, is_public: true});
+                vm = new nodeControl._ProjectViewModel(data);
+                assert.isTrue(vm.canCreateIdentifiers());
             });
-            it('cannot have identifiers when private, not registered, or not admin', () => {
+            it('cannot have identifiers when private or not admin', () => {
                 var vm;
                 var data = $.extend({}, nodeData);
                 data.node = $.extend(data.node, {is_registration: true, is_public: false});
                 vm = new nodeControl._ProjectViewModel(data);
                 assert.isFalse(vm.canCreateIdentifiers());
-                data.node = $.extend(data.node, {is_registration: false, is_public: true});
+                data.node = $.extend(data.node, {is_registration: false, is_public: false});
                 vm = new nodeControl._ProjectViewModel(data);
                 assert.isFalse(vm.canCreateIdentifiers());
                 data = $.extend(data, {user: {permissions: ['read', 'write']}});
                 data.node = $.extend(data.node, {is_registration: true, is_public: true});
+                vm = new nodeControl._ProjectViewModel(data);
+                assert.isFalse(vm.canCreateIdentifiers());
+                data.node = $.extend(data.node, {is_registration: false, is_public: true});
                 vm = new nodeControl._ProjectViewModel(data);
                 assert.isFalse(vm.canCreateIdentifiers());
             });


### PR DESCRIPTION
## Purpose
From ticket:
>Users should be able to create a DOI for Public Projects and Components. Much like for public registrations, DOIs should only be issued upon request (link click) from the Project/Component Overview page.
>
>If a public project has a DOI and then it is registered (or forked), the project DOI should not be copied over to the registration (or fork).

## Changes
* Allow admin contributors to create DOI/ARKs on public projects

## Side effects
If a public project with a DOI becomes private again, anyone who follows that DOI but cannot view the project will be confused.

## Ticket
[OSF-6754](https://openscience.atlassian.net/browse/OSF-6754)