### PR TITLE
My Projects page displays icons properly [OSF-6047]

### DIFF
--- a/website/static/js/project-organizer.js
+++ b/website/static/js/project-organizer.js
@@ -16,6 +16,7 @@ var moment = require('moment');
 var $osf = require('js/osfHelpers');
 var lodashGet = require('lodash.get');
 var lodashFind = require('lodash.find');
+var iconmap = require('js/iconmap');
 
 var LinkObject;
 var NodeFetcher;
@@ -335,7 +336,7 @@ var tbOptions = {
         if (item.data.attributes.registration){
             return m('i.fa.fa-cube.text-muted-more');
         }
-        return m('i.fa.fa-cube');
+        return m('i.' + iconmap.projectComponentIcons[item.data.attributes.category]);
     },
     resolveToggle : _poResolveToggle,
     resolveLazyloadUrl : function(item) {

--- a/website/static/js/project-organizer.js
+++ b/website/static/js/project-organizer.js
@@ -332,10 +332,7 @@ var tbOptions = {
         $('[data-toggle="tooltip"]').tooltip();
     },
     onmultiselect : _poMultiselect,
-    resolveIcon : function _poIconView(item) {
-        if (item.data.attributes.fork){
-            return m('i.fa.fa-code-fork');
-        }
+    resolveIcon : function _poIconView(item) { // Project Organizer doesn't use icons
         return m('i.' + iconmap.projectComponentIcons[item.data.attributes.category]);
     },
     resolveToggle : _poResolveToggle,

--- a/website/static/js/project-organizer.js
+++ b/website/static/js/project-organizer.js
@@ -332,9 +332,9 @@ var tbOptions = {
         $('[data-toggle="tooltip"]').tooltip();
     },
     onmultiselect : _poMultiselect,
-    resolveIcon : function _poIconView(item) { // Project Organizer doesn't use icons
-        if (item.data.attributes.registration){
-            return m('i.fa.fa-cube.text-muted-more');
+    resolveIcon : function _poIconView(item) {
+        if (item.data.attributes.fork){
+            return m('i.fa.fa-code-fork');
         }
         return m('i.' + iconmap.projectComponentIcons[item.data.attributes.category]);
     },


### PR DESCRIPTION
## Purpose

Currently every project icon is a cube on the My Projects page, this properly makes them based on catagory

## Changes

Before:
<img width="1025" alt="screen shot 2016-08-02 at 9 05 22 am" src="https://cloud.githubusercontent.com/assets/9688518/17329417/92210b02-5890-11e6-81f2-20d5f85e4f06.png">

After:
<img width="1028" alt="screen shot 2016-08-02 at 9 06 46 am" src="https://cloud.githubusercontent.com/assets/9688518/17329423/99ddac42-5890-11e6-94c1-e5f7ac1241e1.png">


Simple two line fix, uses iconmap.js to ensure proper icon is used.

## Side effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/OSF-6047