### PR TITLE
File widget textboxes have incorrect highlight [OSF-4481]

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1619,7 +1619,7 @@ var FGInput = {
         return m('span', [
             m('input' + value, {
                 'id' : id,
-                className: 'tb-header-input' + extraCSS,
+                className: 'pull-right form-control' + extraCSS,
                 onkeypress: onkeypress,
                 'data-toggle':  tooltipText ? 'tooltip' : '',
                 'title':  tooltipText,


### PR DESCRIPTION
## Purpose

Text inputs for renaming and folder adding didn't focus properly, this fixes that and makes them consistent.

## Changes

one line fix makes all input fields focus properly

## Side effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/OSF-4481