### PR TITLE
hotfix/Password strength bugfixes [#OSF-6759]

### DIFF
--- a/website/static/js/passwordForms.js
+++ b/website/static/js/passwordForms.js
@@ -261,20 +261,11 @@ var SignUpViewModel = oop.extend(BaseViewModel, {
 
     submitError: function(xhr) {
         var self = this;
-        if (xhr.status === 400) {
-            // TODO - this is too broad and triggers when signing up with an account that exists
-            self.changeMessage(
-                'Your username cannot be the same as your password.',
-                'text-danger p-xs',
-                5000
-            );
-        } else {
-            self.changeMessage(
-                xhr.responseJSON.message_long,
-                'text-danger p-xs',
-                5000
-            );
-        }
+        self.changeMessage(
+            xhr.responseJSON.message_long,
+            'text-danger p-xs',
+            5000
+        );
     },
     submit: function() {
         var self = this;

--- a/website/static/js/passwordForms.js
+++ b/website/static/js/passwordForms.js
@@ -91,6 +91,8 @@ var ChangePasswordViewModel = oop.extend(BaseViewModel, {
     constructor: function () {
         var self = this;
 
+        self.oldPassword = ko.observable('').extend({required: true});
+
         // Call constructor at the beginning so that self.password exists
         self.super.constructor.call(this);
 
@@ -115,6 +117,21 @@ var ChangePasswordViewModel = oop.extend(BaseViewModel, {
             }
         });
 
+        self.password.extend({
+            validation: {
+                validator: function(val, other) {
+                    if (String(val).toLowerCase() === String(other).toLowerCase()) {
+                        self.typedPassword(' ');
+                        return false;
+                    } else {
+                        return true;
+                    }
+                },
+                'message': 'Your new password cannot be the same as your old password.',
+                params: self.oldPassword
+            }
+        });
+
         self.passwordConfirmation = ko.observable('').extend({
             required: true,
             validation: {
@@ -125,7 +142,9 @@ var ChangePasswordViewModel = oop.extend(BaseViewModel, {
                 params: self.password
             }
         });
-        self.oldPassword = ko.observable('').extend({required: true});
+
+        // Collect validated fields because new ones not defined in base constructor
+        self.validatedFields = ko.validatedObservable(self.getValidatedFields());
 
     },
     getValidatedFields: function() {
@@ -243,6 +262,7 @@ var SignUpViewModel = oop.extend(BaseViewModel, {
     submitError: function(xhr) {
         var self = this;
         if (xhr.status === 400) {
+            // TODO - this is too broad and triggers when signing up with an account that exists
             self.changeMessage(
                 'Your username cannot be the same as your password.',
                 'text-danger p-xs',

--- a/website/static/js/passwordForms.js
+++ b/website/static/js/passwordForms.js
@@ -91,8 +91,6 @@ var ChangePasswordViewModel = oop.extend(BaseViewModel, {
     constructor: function () {
         var self = this;
 
-        self.oldPassword = ko.observable('').extend({required: true});
-
         // Call constructor at the beginning so that self.password exists
         self.super.constructor.call(this);
 
@@ -101,6 +99,8 @@ var ChangePasswordViewModel = oop.extend(BaseViewModel, {
             required: true,
             email: true
         });
+
+        self.oldPassword = ko.observable('').extend({required: true});
 
         self.password.extend({
             validation: {
@@ -142,9 +142,6 @@ var ChangePasswordViewModel = oop.extend(BaseViewModel, {
                 params: self.password
             }
         });
-
-        // Collect validated fields because new ones not defined in base constructor
-        self.validatedFields = ko.validatedObservable(self.getValidatedFields());
 
     },
     getValidatedFields: function() {

--- a/website/templates/profile/account.mako
+++ b/website/templates/profile/account.mako
@@ -160,7 +160,7 @@
                                 >
                                 <p class="help-block" data-bind="validationMessage: passwordConfirmation" style="display: none;"></p>
                             </div>
-                            <button type="submit" class="btn btn-primary">Update password</button>
+                            <button type="submit" class="btn btn-primary" data-bind="disable: !password.isValid()">Update password</button>
                         </form>
                     </div>
                 </div>

--- a/website/templates/profile/account.mako
+++ b/website/templates/profile/account.mako
@@ -160,7 +160,7 @@
                                 >
                                 <p class="help-block" data-bind="validationMessage: passwordConfirmation" style="display: none;"></p>
                             </div>
-                            ## TODO: change so that password strength submit validation happens in knockout on the form, not with this disable
+                            ## TODO: [#OSF-6764] change so that password strength submit validation happens in knockout on the form, not with this disable
                             <button type="submit" class="btn btn-primary" data-bind="disable: !password.isValid()">Update password</button>
                         </form>
                     </div>

--- a/website/templates/profile/account.mako
+++ b/website/templates/profile/account.mako
@@ -160,6 +160,7 @@
                                 >
                                 <p class="help-block" data-bind="validationMessage: passwordConfirmation" style="display: none;"></p>
                             </div>
+                            ## TODO: change so that password strength submit validation happens in knockout on the form, not with this disable
                             <button type="submit" class="btn btn-primary" data-bind="disable: !password.isValid()">Update password</button>
                         </form>
                     </div>


### PR DESCRIPTION


## Purpose
Two bugfixes and some stumbled on improvements to the new password strength checks:
- Disable submission for low strength password on password change form in settings - needs to be handled separately because the form's submit is not data-bound in knockout
- Frontend on signup with existing account showed incorrect error message
- Backend would error on password reset to same as old password - added that to frontend validation so that feedback happens quicker

## Changes
- Add frontend validation for old password matching new password
- Move oldPassword to be used in password validation extender
- Remove catching of all 400s and changing the message - email as password checks are taking place separately and don't need a special override in submit any longer.
- Disable password reset in settings explicitly - is not data-bound to the form in knockout as the others are

## Side effects
None anticipated

## Ticket
https://openscience.atlassian.net/browse/OSF-6759