### PR TITLE
[Feature] Create Unregistered Users via APIv2 [OSF-6753]

### DIFF
--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -118,7 +118,7 @@ class UserCreateSerializer(UserSerializer):
     username = ser.EmailField(required=True)
 
     def create(self, validated_data):
-        username = validated_data.get('username')
+        username = validated_data.get('username').lower()
         full_name = validated_data.get('fullname')
         if not username and full_name:
             raise JSONAPIException('Both a `username` and `full_name` are required to create a user.')
@@ -130,7 +130,7 @@ class UserCreateSerializer(UserSerializer):
         except ValidationValueError:
             raise Conflict('User with specified username already exists.')
 
-        if self.context['request'].GET.get('send_email', False) and has_admin_scope(self.context['request']):
+        if self.context['request'].GET.get('send_email', False):
             send_confirm_email(user, user.username)
 
         return user

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -9,7 +9,7 @@ from website.models import User
 from api.base.serializers import (
     JSONAPISerializer, LinksField, RelationshipField, DevOnly, IDField, TypeField
 )
-from api.base.utils import absolute_reverse, has_admin_scope
+from api.base.utils import absolute_reverse
 
 from framework.auth.views import send_confirm_email
 

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -23,8 +23,9 @@ from api.registrations.serializers import RegistrationSerializer
 from api.base.utils import default_node_list_query, default_node_permission_query
 from api.addons.views import AddonSettingsMixin
 
-from .serializers import UserSerializer, UserAddonSettingsSerializer, UserDetailSerializer, UserInstitutionsRelationshipSerializer
-from .permissions import ReadOnlyOrCurrentUser, ReadOnlyOrCurrentUserRelationship, CurrentUser
+from api.users.serializers import (UserSerializer, UserCreateSerializer,
+    UserAddonSettingsSerializer, UserDetailSerializer, UserInstitutionsRelationshipSerializer)
+from api.users.permissions import ReadOnlyOrCurrentUser, ReadOnlyOrCurrentUserRelationship, CurrentUser
 
 
 class UserMixin(object):
@@ -52,8 +53,8 @@ class UserMixin(object):
         return obj
 
 
-class UserList(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin):
-    """List of users registered on the OSF. *Read-only*.
+class UserList(JSONAPIBaseView, generics.ListCreateAPIView, ODMFilterMixin):
+    """List of users registered on the OSF.
 
     Paginated list of users ordered by the date they registered.  Each resource contains the full representation of the
     user, meaning additional requests to an individual user's detail view are not necessary.
@@ -106,7 +107,7 @@ class UserList(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin):
     )
 
     required_read_scopes = [CoreScopes.USERS_READ]
-    required_write_scopes = [CoreScopes.USERS_WRITE]
+    required_write_scopes = [CoreScopes.USERS_CREATE]
 
     serializer_class = UserSerializer
 
@@ -122,11 +123,18 @@ class UserList(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin):
             Q('date_disabled', 'eq', None)
         )
 
-    # overrides ListAPIView
+    # overrides ListCreateAPIView
     def get_queryset(self):
         # TODO: sort
         query = self.get_query_from_request()
         return User.find(query)
+
+    # overrides ListCreateAPIView
+    def get_serializer_class(self):
+        if self.request.method == 'POST':
+            return UserCreateSerializer
+        else:
+            return UserSerializer
 
 
 class UserDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView, UserMixin):

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -103,6 +103,7 @@ class UserList(JSONAPIBaseView, generics.ListCreateAPIView, ODMFilterMixin):
     """
     permission_classes = (
         drf_permissions.IsAuthenticatedOrReadOnly,
+        base_permissions.RequiresScopedRequestOrReadOnly,
         base_permissions.TokenHasScope,
     )
 

--- a/api_tests/tokens/views/test_token_list.py
+++ b/api_tests/tokens/views/test_token_list.py
@@ -113,6 +113,15 @@ class TestTokenList(ApiTestCase):
         assert_equal(res.status_code, 400)
         assert_equal(res.json['errors'][0]['detail'], 'User requested invalid scope')
 
+    def test_cannot_create_usercreate_token(self):
+        self.sample_data['data']['attributes']['scopes'] = 'osf.users.create'
+        res = self.app.post_json_api(self.user1_list_url,
+            self.sample_data,
+            auth=self.user1.auth,
+            expect_errors=True
+        )
+        assert_equal(res.status_code, 400)
+        assert_equal(res.json['errors'][0]['detail'], 'User requested invalid scope')
 
     def tearDown(self):
         super(TestTokenList, self).tearDown()

--- a/api_tests/users/views/test_user_list.py
+++ b/api_tests/users/views/test_user_list.py
@@ -1,11 +1,22 @@
 # -*- coding: utf-8 -*-
-import urlparse
+import itsdangerous
+import mock
 from nose.tools import *  # flake8: noqa
+import unittest
+import urlparse
+
+from modularodm import Q
 
 from tests.base import ApiTestCase
 from tests.factories import AuthUserFactory
 
 from api.base.settings.defaults import API_BASE
+
+from framework.auth.cas import CasResponse
+from framework.sessions.model import Session
+from website.models import User
+from website import settings
+from website.oauth.models import ApiOAuth2PersonalToken
 
 
 class TestUsers(ApiTestCase):
@@ -79,3 +90,180 @@ class TestUsers(ApiTestCase):
             query_dict = urlparse.parse_qs(urlparse.urlparse(profile_image_url).query)
             assert_equal(int(query_dict.get('s')[0]), size)
 
+class TestUsersCreate(ApiTestCase):
+
+    def setUp(self):
+        super(TestUsersCreate, self).setUp()
+        self.user = AuthUserFactory()
+        self.unconfirmed_email = 'tester@fake.io'
+        self.base_url = '/{}users/'.format(API_BASE)
+        self.data = {
+            'data': {
+                'type': 'users',
+                'attributes': {
+                    'username': self.unconfirmed_email,
+                    'full_name': 'Test Account'
+                }
+            }
+        }
+
+    def tearDown(self):
+        super(TestUsersCreate, self).tearDown()
+        self.app.reset()  # clears cookies
+        User.remove()
+
+    @mock.patch('framework.auth.views.mails.send_mail')
+    def test_user_can_not_create_other_user_or_send_mail(self, mock_mail):
+        assert_equal(User.find(Q('username', 'eq', self.unconfirmed_email)).count(), 0)
+        res = self.app.post_json_api(
+            '{}?send_email=true'.format(self.base_url),
+            self.data,
+            auth=self.user.auth,
+            expect_errors=True
+        )
+
+        assert_equal(res.status_code, 403)
+        assert_equal(User.find(Q('username', 'eq', self.unconfirmed_email)).count(), 0)
+        assert_equal(mock_mail.call_count, 0)
+
+    @mock.patch('framework.auth.views.mails.send_mail')
+    def test_cookied_requests_do_not_create_or_email(self, mock_mail):
+        session = Session(data={'auth_user_id': self.user._id})
+        session.save()
+        cookie = itsdangerous.Signer(settings.SECRET_KEY).sign(session._id)
+        self.app.set_cookie(settings.COOKIE_NAME, str(cookie))
+
+        assert_equal(User.find(Q('username', 'eq', self.unconfirmed_email)).count(), 0)
+        res = self.app.post_json_api(
+            self.base_url,
+            self.data,
+            expect_errors=True
+        )
+
+        assert_equal(res.status_code, 403)
+        assert_equal(User.find(Q('username', 'eq', self.unconfirmed_email)).count(), 0)
+        assert_equal(mock_mail.call_count, 0)
+
+    @mock.patch('framework.auth.views.mails.send_mail')
+    @mock.patch('api.base.authentication.drf.OSFCASAuthentication.authenticate')
+    @unittest.skipIf(not settings.DEV_MODE, 'DEV_MODE disabled, osf.users.create unavailable')  # TODO: Remove when available outside of DEV_MODE
+    def test_properly_scoped_token_can_create_and_send_email(self, mock_auth, mock_mail):
+        token = ApiOAuth2PersonalToken(
+            owner=self.user,
+            name='Authorized Token',
+            scopes='osf.users.create'
+        )
+
+        mock_cas_resp = CasResponse(
+            authenticated=True,
+            user=self.user._id,
+            attributes={
+                'accessToken': token.token_id,
+                'accessTokenScope': [s for s in token.scopes.split(' ')]
+            }
+        )
+        mock_auth.return_value = self.user, mock_cas_resp
+
+        assert_equal(User.find(Q('username', 'eq', self.unconfirmed_email)).count(), 0)
+        res = self.app.post_json_api(
+            '{}?send_email=true'.format(self.base_url),
+            self.data,
+            headers={'Authorization': 'Bearer {}'.format(token.token_id)}
+        )
+
+        assert_equal(res.status_code, 201)
+        assert_equal(User.find(Q('username', 'eq', self.unconfirmed_email)).count(), 1)
+        assert_equal(mock_mail.call_count, 1)
+
+    @mock.patch('framework.auth.views.mails.send_mail')
+    @mock.patch('api.base.authentication.drf.OSFCASAuthentication.authenticate')
+    @unittest.skipIf(not settings.DEV_MODE, 'DEV_MODE disabled, osf.users.create unavailable')  # TODO: Remove when available outside of DEV_MODE
+    def test_properly_scoped_token_does_not_send_email_without_kwarg(self, mock_auth, mock_mail):
+        token = ApiOAuth2PersonalToken(
+            owner=self.user,
+            name='Authorized Token',
+            scopes='osf.users.create'
+        )
+
+        mock_cas_resp = CasResponse(
+            authenticated=True,
+            user=self.user._id,
+            attributes={
+                'accessToken': token.token_id,
+                'accessTokenScope': [s for s in token.scopes.split(' ')]
+            }
+        )
+        mock_auth.return_value = self.user, mock_cas_resp
+
+        assert_equal(User.find(Q('username', 'eq', self.unconfirmed_email)).count(), 0)
+        res = self.app.post_json_api(
+            self.base_url,
+            self.data,
+            headers={'Authorization': 'Bearer {}'.format(token.token_id)}
+        )
+
+        assert_equal(res.status_code, 201)
+        assert_equal(User.find(Q('username', 'eq', self.unconfirmed_email)).count(), 1)
+        assert_equal(mock_mail.call_count, 0)
+
+    @mock.patch('framework.auth.views.mails.send_mail')
+    @mock.patch('api.base.authentication.drf.OSFCASAuthentication.authenticate')
+    def test_improperly_scoped_token_can_not_create_or_email(self, mock_auth, mock_mail):
+        token = ApiOAuth2PersonalToken(
+            owner=self.user,
+            name='Unauthorized Token',
+            scopes='osf.full_write'
+        )
+
+        mock_cas_resp = CasResponse(
+            authenticated=True,
+            user=self.user._id,
+            attributes={
+                'accessToken': token.token_id,
+                'accessTokenScope': [s for s in token.scopes.split(' ')]
+            }
+        )
+        mock_auth.return_value = self.user, mock_cas_resp
+
+        assert_equal(User.find(Q('username', 'eq', self.unconfirmed_email)).count(), 0)
+        res = self.app.post_json_api(
+            '{}?send_email=true'.format(self.base_url),
+            self.data,
+            headers={'Authorization': 'Bearer {}'.format(token.token_id)},
+            expect_errors=True
+        )
+
+        assert_equal(res.status_code, 403)
+        assert_equal(User.find(Q('username', 'eq', self.unconfirmed_email)).count(), 0)
+        assert_equal(mock_mail.call_count, 0)
+
+    @mock.patch('framework.auth.views.mails.send_mail')
+    @mock.patch('api.base.authentication.drf.OSFCASAuthentication.authenticate')
+    @unittest.skipIf(not settings.DEV_MODE, 'DEV_MODE disabled, osf.admin unavailable')  # TODO: Remove when available outside of DEV_MODE
+    def test_admin_scoped_token_can_create_and_send_email(self, mock_auth, mock_mail):
+        token = ApiOAuth2PersonalToken(
+            owner=self.user,
+            name='Admin Token',
+            scopes='osf.admin'
+        )
+
+        mock_cas_resp = CasResponse(
+            authenticated=True,
+            user=self.user._id,
+            attributes={
+                'accessToken': token.token_id,
+                'accessTokenScope': [s for s in token.scopes.split(' ')]
+            }
+        )
+        mock_auth.return_value = self.user, mock_cas_resp
+
+        assert_equal(User.find(Q('username', 'eq', self.unconfirmed_email)).count(), 0)
+        res = self.app.post_json_api(
+            '{}?send_email=true'.format(self.base_url),
+            self.data,
+            headers={'Authorization': 'Bearer {}'.format(token.token_id)}
+        )
+
+        assert_equal(res.status_code, 201)
+        assert_equal(User.find(Q('username', 'eq', self.unconfirmed_email)).count(), 1)
+        assert_equal(mock_mail.call_count, 1)

--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -420,6 +420,10 @@ class User(GuidStoredObject, AddonModelMixin):
     #   ...
     # }
 
+    # If this user was created through the API,
+    # keep track of who added them.
+    registered_by = fields.ForeignField('user', index=True)
+
     _meta = {'optimistic': True}
 
     def __repr__(self):

--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -422,7 +422,7 @@ class User(GuidStoredObject, AddonModelMixin):
 
     # If this user was created through the API,
     # keep track of who added them.
-    registered_by = fields.ForeignField('user', index=True)
+    registered_by = fields.ForeignField('user', default=None, index=True)
 
     _meta = {'optimistic': True}
 

--- a/framework/auth/oauth_scopes.py
+++ b/framework/auth/oauth_scopes.py
@@ -29,6 +29,7 @@ class CoreScopes(object):
 
     USERS_READ = 'users_read'
     USERS_WRITE = 'users_write'
+    USERS_CREATE = 'users_create'
 
     USER_ADDON_READ = 'users.addon_read'
 
@@ -110,6 +111,7 @@ class ComposedScopes(object):
     # Users collection
     USERS_READ = (CoreScopes.USERS_READ, CoreScopes.ALWAYS_PUBLIC, )
     USERS_WRITE = USERS_READ + (CoreScopes.USERS_WRITE,)
+    USERS_CREATE = USERS_READ + (CoreScopes.USERS_CREATE, )
 
     # Applications collection
     APPLICATIONS_READ = (CoreScopes.APPLICATIONS_READ, CoreScopes.ALWAYS_PUBLIC, )
@@ -169,7 +171,7 @@ class ComposedScopes(object):
     FULL_WRITE = FULL_READ + NODE_ALL_WRITE + USERS_WRITE + ORGANIZER_WRITE + DRAFT_WRITE
 
     # Admin permissions- includes functionality not intended for third-party use
-    ADMIN_LEVEL = FULL_WRITE + APPLICATIONS_WRITE + TOKENS_WRITE + COMMENT_REPORTS_WRITE + \
+    ADMIN_LEVEL = FULL_WRITE + APPLICATIONS_WRITE + TOKENS_WRITE + COMMENT_REPORTS_WRITE + USERS_CREATE +\
                     (CoreScopes.USER_ADDON_READ, CoreScopes.NODE_ADDON_READ, CoreScopes.NODE_ADDON_WRITE, )
 
 # List of all publicly documented scopes, mapped to composed scopes defined above.
@@ -235,6 +237,11 @@ if settings.DEV_MODE:
                                      is_public=True),
 
         # Undocumented scopes that can not be requested by third parties (per CAS restriction)
+        'osf.users.create': scope(parts_=frozenset(ComposedScopes.USERS_CREATE),
+                           description='This permission should only be granted to OSF collaborators. Allows a site to '
+                                       'programmatically create new users with this account.',
+                           is_public=False),
+
         'osf.admin': scope(parts_=frozenset(ComposedScopes.ADMIN_LEVEL),
                            description='This permission should only be granted to OSF administrators. Allows a site to '
                                        'create, read, edit, and delete all information associated with this account.',

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -373,7 +373,8 @@ class TestUserMerging(base.OsfTestCase):
             'verification_key',
             '_affiliated_institutions',
             'contributor_added_email_records',
-            'requested_deactivation'
+            'requested_deactivation',
+            'registered_by'
         ]
 
         calculated_fields = {


### PR DESCRIPTION
## Purpose
Allow (with limited availability) the creation of users through APIv2. This is required for several services currently in development.

## Changes
* Create custom scope for `USERS_CREATE`, included in the admin scope
* Add tracking mechanism to User model to see who added each user (spam mitigation)
* Create UserCreateSerializer, conditionally used on `POST` requests to `/v2/users/`
* Create permissions class to allow *only* tokened requests for unsafe methods.

### Notes
Uniqueness of users ensured by ignoring username case. This was previously a bug in one possible user-creation flow

## Side effects
`osf.users.create` scope will need to be exposed in `public_scopes` (with `public=False`) before this will work in production.

## Ticket
[OSF-6753](https://openscience.atlassian.net/browse/OSF-6753)
