### PR TITLE
[OSF-2052] LinkedIn share button should warn about adblockers. Share button file url should be the OSF file page url.

### DIFF
--- a/website/static/js/components/socialshare.js
+++ b/website/static/js/components/socialshare.js
@@ -22,12 +22,19 @@ var ShareButtons = {
         var facebookHref = 'https://www.facebook.com/sharer/sharer.php?u=' + url;
         var linkedinHref = 'https://www.linkedin.com/cws/share?url=' + url + '&title=' + title;
         var emailHref = 'mailto:?subject=' + title + '&body=' + url;
-        return m('div.share-buttons', {}, [
+        return m('div.share-buttons ', {
+                config: function(el, isInitialized) {
+                    $('div.share-buttons [data-toggle="tooltip"]').tooltip();
+                }
+            }, [
             m('a', {href: twitterHref, target: '_blank', onclick: this.openLinkInPopup.bind(this, twitterHref)},
                 m('i.fa.fa-twitter[aria-hidden=true]')),
             m('a', {href: facebookHref, target: '_blank', onclick: this.openLinkInPopup.bind(this, facebookHref)},
                 m('i.fa.fa-facebook[aria-hidden=true]')),
-            m('a', {href: linkedinHref, target: '_blank', onclick: this.openLinkInPopup.bind(this, linkedinHref)},
+            m('a', {href: linkedinHref, target: '_blank',
+                    'data-toggle': 'tooltip', 'data-placement': 'bottom',
+                    'data-original-title': 'Disable adblock for full sharing functionality',
+                    onclick: this.openLinkInPopup.bind(this, linkedinHref)},
                 m('i.fa.fa-linkedin[aria-hidden=true]')),
             m('a', {href: emailHref, target: '_blank', onclick: this.openLinkInPopup.bind(this, emailHref)},
                 m('i.fa.fa-envelope[aria-hidden=true]')),

--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -41,9 +41,10 @@ var SharePopover =  {
     view: function(ctrl, params) {
         var copyButtonHeight = '34px';
         var popoverWidth = '450px';
-        var link = params.link;
+        var renderLink = params.link;
+        var fileLink = window.location.href;
 
-        var url = link.substring(0, link.indexOf('render'));
+        var mfrHost = renderLink.substring(0, renderLink.indexOf('render'));
         return m('button#sharebutton.disabled.btn.btn-sm.btn-primary.file-share', {onclick: function popOverShow() {
                 var pop = document.getElementById('popOver');
                 //This is bad, should only happen for Firefox, thanks @chrisseto
@@ -58,25 +59,25 @@ var SharePopover =  {
                     m('.tab-content', [
                         m('.tab-pane.active#share', [
                             m('.input-group', [
-                                CopyButton.view(ctrl, {link: link, height: copyButtonHeight}), //workaround to allow button to show up on first click
-                                m('input.form-control[readonly][type="text"][value="'+ link +'"]')
+                                CopyButton.view(ctrl, {link: renderLink, height: copyButtonHeight}), //workaround to allow button to show up on first click
+                                m('input.form-control[readonly][type="text"][value="'+ renderLink +'"]')
                             ]),
-                            SocialShare.ShareButtons.view(ctrl, {title: window.contextVars.file.name, url: link})
+                            SocialShare.ShareButtons.view(ctrl, {title: window.contextVars.file.name, url: fileLink})
                         ]),
                         m('.tab-pane#embed', [
                             m('p', 'Dynamically render iframe with JavaScript'),
                             m('textarea.form-control[readonly][type="text"][value="' +
                                 '<script>window.jQuery || document.write(\'<script src="//code.jquery.com/jquery-1.11.2.min.js">\\x3C/script>\') </script>'+
-                                '<link href="' + url + 'static/css/mfr.css" media="all" rel="stylesheet">' +
+                                '<link href="' + mfrHost + 'static/css/mfr.css" media="all" rel="stylesheet">' +
                                 '<div id="mfrIframe" class="mfr mfr-file"></div>' +
-                                '<script src="' + url + 'static/js/mfr.js">' +
+                                '<script src="' + mfrHost + 'static/js/mfr.js">' +
                                 '</script> <script>' +
-                                    'var mfrRender = new mfr.Render("mfrIframe", "' + link + '");' +
+                                    'var mfrRender = new mfr.Render("mfrIframe", "' + renderLink + '");' +
                                 '</script>' + '"]'
                             ), m('br'),
                             m('p', 'Direct iframe with fixed height and width'),
                             m('textarea.form-control[readonly][value="' +
-                                '<iframe src="' + link + '" width="100%" scrolling="yes" height="' + params.height + '" marginheight="0" frameborder="0" allowfullscreen webkitallowfullscreen>"]'
+                                '<iframe src="' + renderLink + '" width="100%" scrolling="yes" height="' + params.height + '" marginheight="0" frameborder="0" allowfullscreen webkitallowfullscreen>"]'
                             )
                         ])
                     ])
@@ -90,7 +91,11 @@ var SharePopover =  {
                         button.data()['bs.popover'].$tip.css('text-align', 'center').css('max-width', popoverWidth).css('width', popoverWidth);
                     });
                 }
-            }, 'data-toggle': 'popover', 'data-placement': 'bottom', 'data-content': '<div id="popOver"></div>', 'title': 'Share', 'data-container': 'body', 'data-html': 'true'}, 'Share');
+            },
+            'data-toggle': 'popover', 'data-placement': 'bottom',
+            'data-content': '<div id="popOver"></div>', 'title': 'Share',
+            'data-container': 'body', 'data-html': 'true'
+        }, 'Share');
     }
 };
 


### PR DESCRIPTION
## Purpose
(1) If a user has ad block turned on and tries to share a project via linked in, the user is not able to share the project and get no information as to why. I think we should improve this with a tooltip that informs the user that having ad blocked enabled may prevent successful sharing of their project.
(2) The link on the file detail page used in the share/embed popover is to the rendered file, which is fine, however with the social media sharing links the link should be to the file.

## Changes
Added tooltip, changed share button file link.

![screen shot 2016-07-28 at 9 57 40 am](https://cloud.githubusercontent.com/assets/1449974/17215160/ee9fc926-54a9-11e6-9f2c-66c5fbc3603b.png)

![screen shot 2016-07-27 at 2 04 00 pm](https://cloud.githubusercontent.com/assets/1449974/17186396/0b2fb364-5403-11e6-8946-a16ca1139dac.png)

## Side effects
NO

## Ticket
https://openscience.atlassian.net/browse/OSF-2052