### PR TITLE
Mobile: Password warning cut off on front page [OSF-4072]

### DIFF
--- a/website/static/css/front-page.css
+++ b/website/static/css/front-page.css
@@ -130,6 +130,20 @@ h6 {
 #hero-signup a:hover {
     text-decoration: none;
 }
+
+@media(max-width: 767px){
+
+    #home-hero {
+        height: 1000px;
+    }
+
+    .sign-up-div {
+        position: relative;
+        margin-top: -100px;
+    }
+
+}
+
 #signUpScope button, #signUpScope input, #signUpScope .help-block {
     z-index: 9;
     position: relative;

--- a/website/templates/landing.mako
+++ b/website/templates/landing.mako
@@ -42,7 +42,7 @@
               <a class="youtube" href="//www.youtube.com/watch?v=2TV21gOzfhw" aria-label="OSF YouTube Video"><i class="icon icon-play"></i></a>
               <img src="/static/img/front-page/screenshot.png" class="img-responsive" id="screenshot" alt="Screenshot of OSF" />
             </div>
-            <div class="col-sm-6">
+            <div class="col-sm-6 sign-up-div">
               <h2>Free and open source. Start now.</h2>
 
              <div id="signUp" class="anchor"></div>


### PR DESCRIPTION
## Purpose

On mobile view, the Sign Up Free button overlaps with the section underneath it when the user submits the form without filling out any of the boxes. 

## Changes

Adjusted the spacing in CSS by changing the height of the entire div and moving the sign up form up by 100px. 

![image](https://cloud.githubusercontent.com/assets/8868219/17186649/140d16f6-5404-11e6-8b8d-cc13aac554dd.png)

![image](https://cloud.githubusercontent.com/assets/8868219/17186660/1ad2f67c-5404-11e6-9547-e2f51b760208.png)

## Side effects

N/A


## Ticket

https://openscience.atlassian.net/browse/OSF-4072

