### PR TITLE
[hotfix] responsiveness fixes for Keen

### DIFF
--- a/website/templates/project/statistics.mako
+++ b/website/templates/project/statistics.mako
@@ -35,7 +35,7 @@
       The use of adblocking software may prevent site analytics from loading properly.
     </div>
 
-    <div class="row m-lg">
+    <div class="row m-b-sm">
       <div class="col-sm-12">
 
         <div id="dateRange" class="pull-right">
@@ -58,7 +58,8 @@
 
       </div>
     </div>
-    <div class="row m-lg">
+
+    <div class="row">
         <div class="col-sm-6">
             <div class="panel panel-default project-analytics">
                 <div class="panel-heading clearfix">
@@ -83,6 +84,9 @@
             </div>
           </div>
         </div>
+    </div>
+
+    <div class="row">
         <div class="col-sm-6">
             <div class="panel panel-default project-analytics">
                 <div class="panel-heading clearfix">

--- a/website/templates/project/statistics.mako
+++ b/website/templates/project/statistics.mako
@@ -26,7 +26,7 @@
             Analytics and begin discovering the impact of your work.
           </p>
 
-          <img src="/static/img/no_analytics.png">
+          <img class="img-responsive center-block" src="/static/img/no_analytics.png">
         </div>
     </div>
 % else:


### PR DESCRIPTION
## Purpose

On small screens, the "no analytics" image wasn't scaling, and the pie chart was scaling too small, too fast.

## Changes

* Add `.img-responsive` to the no analytics image.

* Remove inappropriate margins from chart rows, so that pie chart is sane down to 320x480.

## Side effects

Nope.
