### PR TITLE
New Folder Error Message Persists [#OSF-6778]

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -91,6 +91,7 @@ function findByTempID(parent, tmpID) {
     return item;
 }
 
+
 /**
  * Cancel a pending upload
  * @this Treebeard.controller
@@ -1830,6 +1831,9 @@ var FGToolbar = {
                     m('.fangorn-toolbar.pull-right', [dismissIcon])
                 )
             ];
+        $('.tb-row').click(function(){
+            ctrl.helpText('');
+        });
         if (ctrl.tb.options.placement !== 'fileview') {
             templates[toolbarModes.ADDFOLDER] = [
                 m('.col-xs-9', [
@@ -2396,7 +2400,7 @@ tbOptions = {
         _loadTopLevelChildren.call(tb);
         tb.uploadStates = [];
         tb.pendingFileOps = [];
-        tb.select('#tb-tbody').on('click', function(event){
+        tb.select('#tb-tbody, .tb-tbody-inner').on('click', function(event){
             if(event.target !== this) {
                 var item = tb.multiselected()[0];
                 if (item) {
@@ -2407,9 +2411,9 @@ tbOptions = {
                 }
             }
             tb.clearMultiselect();
+            m.redraw();
             dismissToolbar.call(tb);
         });
-
         $(window).on('beforeunload', function() {
             if(tb.dropzone && tb.dropzone.getUploadingFiles().length) {
                 return 'You have pending uploads, if you leave this page they may not complete.';


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Fix bug where new folder error persists if user clicks on OSF Storage immediately. Also fixed weird behavior where clicking inside the tb-tbody element but not on an actual file would deselect the currently selected file without dismissing the toolbar.
<!-- Describe the purpose of your changes -->

## Changes

made sure that whenever a new folder is selected the error text clears. 
<!-- Briefly describe or list your changes  -->

## Side effects

None
<!--Any possible side effects? -->


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->


https://openscience.atlassian.net/browse/OSF-6778