### PR TITLE
Clean up Knockout-Validation usage

### DIFF
--- a/website/static/js/registrationModal.js
+++ b/website/static/js/registrationModal.js
@@ -65,15 +65,13 @@ var RegistrationViewModel = function(confirm, prompts, validator) {
 
     self._now = function() { return new Date(); };  // this is a hook for testing
 
-    self.embargoIsLongEnough = function(value, otherValue) {
-        var min = moment(self._now()).add(2, 'days'),
-            end = self.embargoEndDate();
+    self.embargoIsLongEnough = function(end) {
+        var min = moment(self._now()).add(2, 'days');
         return end.isAfter(min) && end.isSameOrAfter(todayMinimum);
     };
 
-    self.embargoIsShortEnough = function(value, otherValue) {
-        var max = moment(self._now()).add(4, 'years').subtract(1, 'days'),
-            end = self.embargoEndDate();
+    self.embargoIsShortEnough = function(end) {
+        var max = moment(self._now()).add(4, 'years').subtract(1, 'days');
         return end.isBefore(max) && end.isSameOrBefore(todayMaximum);
     };
 
@@ -87,7 +85,7 @@ var RegistrationViewModel = function(confirm, prompts, validator) {
     if(validator) {
         validation.unshift(validator);
     }
-    self.pikaday.extend({
+    self.embargoEndDate.extend({
         validation: validation
     });
 
@@ -96,7 +94,7 @@ var RegistrationViewModel = function(confirm, prompts, validator) {
 
     self.canRegister = ko.pureComputed(function() {
         if (self.requestingEmbargo()) {
-            return self.pikaday.isValid();
+            return self.embargoEndDate.isValid();
         }
         return true;
     });
@@ -116,11 +114,12 @@ RegistrationViewModel.prototype.show = function() {
     });
 };
 RegistrationViewModel.prototype.register = function() {
+    var end = this.embargoEndDate();
     this.confirm({
         registrationChoice: this.registrationChoice(),
-        embargoEndDate: this.embargoEndDate(),
-        embargoIsLongEnough: this.embargoIsLongEnough(),
-        embargoIsShortEnough: this.embargoIsShortEnough()
+        embargoEndDate: end,
+        embargoIsLongEnough: this.embargoIsLongEnough(end),
+        embargoIsShortEnough: this.embargoIsShortEnough(end)
     });
 };
 

--- a/website/static/js/registrationModal.js
+++ b/website/static/js/registrationModal.js
@@ -63,14 +63,16 @@ var RegistrationViewModel = function(confirm, prompts, validator) {
         return moment(new Date(self.pikaday()));
     });
 
-    self.embargoIsLongEnough = function (x, y, embargoLocalDateTime) {
-        var min = getMinimumDate(embargoLocalDateTime),
+    self._now = function() { return new Date(); };  // this is a hook for testing
+
+    self.embargoIsLongEnough = function(value, otherValue) {
+        var min = moment(self._now()).add(2, 'days'),
             end = self.embargoEndDate();
         return end.isAfter(min) && end.isSameOrAfter(todayMinimum);
     };
 
-    self.embargoIsShortEnough = function (x, y, embargoLocalDateTime) {
-        var max = getMaximumDate(embargoLocalDateTime),
+    self.embargoIsShortEnough = function(value, otherValue) {
+        var max = moment(self._now()).add(4, 'years').subtract(1, 'days'),
             end = self.embargoEndDate();
         return end.isBefore(max) && end.isSameOrBefore(todayMaximum);
     };
@@ -125,11 +127,3 @@ RegistrationViewModel.prototype.register = function() {
 module.exports = {
     ViewModel: RegistrationViewModel
 };
-
-function getMinimumDate(embargoLocalDateTime) {
-    return moment(embargoLocalDateTime).add(2, 'days');
-}
-
-function getMaximumDate(embargoLocalDateTime) {
-    return moment(embargoLocalDateTime).add(4, 'years').subtract(1, 'days');
-}

--- a/website/static/js/registrationModal.js
+++ b/website/static/js/registrationModal.js
@@ -63,15 +63,15 @@ var RegistrationViewModel = function(confirm, prompts, validator) {
         return moment(new Date(self.pikaday()));
     });
 
-    self._now = function() { return new Date(); };  // this is a hook for testing
+    self._now = function() { return moment(); };  // this is a hook for testing
 
     self.embargoIsLongEnough = function(end) {
-        var min = moment(self._now()).add(2, 'days');
+        var min = self._now().add(2, 'days');
         return end.isAfter(min) && end.isSameOrAfter(todayMinimum);
     };
 
     self.embargoIsShortEnough = function(end) {
-        var max = moment(self._now()).add(4, 'years').subtract(1, 'days');
+        var max = self._now().add(4, 'years').subtract(1, 'days');
         return end.isBefore(max) && end.isSameOrBefore(todayMaximum);
     };
 

--- a/website/static/js/registrationModal.js
+++ b/website/static/js/registrationModal.js
@@ -66,13 +66,13 @@ var RegistrationViewModel = function(confirm, prompts, validator) {
     self.embargoIsLongEnough = function (x, y, embargoLocalDateTime) {
         var min = getMinimumDate(embargoLocalDateTime),
             end = self.embargoEndDate();
-        return end.isSameOrAfter(min) && end.isSameOrAfter(todayMinimum);
+        return end.isAfter(min) && end.isSameOrAfter(todayMinimum);
     };
 
     self.embargoIsShortEnough = function (x, y, embargoLocalDateTime) {
         var max = getMaximumDate(embargoLocalDateTime),
             end = self.embargoEndDate();
-        return end.isSameOrBefore(max) && end.isSameOrBefore(todayMaximum);
+        return end.isBefore(max) && end.isSameOrBefore(todayMaximum);
     };
 
     var validation = [{

--- a/website/static/js/registrationModal.js
+++ b/website/static/js/registrationModal.js
@@ -20,9 +20,6 @@ var MAKE_EMBARGO = {
     value: 'embargo',
     message: 'Enter registration into embargo'
 };
-var today = new Date();
-var todayMinimum = moment().add(2, 'days');
-var todayMaximum = moment().add(4, 'years');
 
 var RegistrationViewModel = function(confirm, prompts, validator) {
 
@@ -48,7 +45,7 @@ var RegistrationViewModel = function(confirm, prompts, validator) {
         self.showEmbargoDatePicker(requestingEmbargo);
     });
     self.showEmbargoDatePicker = ko.observable(false);
-    self.pikaday = ko.observable(today);  // interacts with a datePicker from koHelpers.js
+    self.pikaday = ko.observable(new Date());  // interacts with a datePicker from koHelpers.js
 
 
     // Wire up embargo validation.
@@ -67,12 +64,12 @@ var RegistrationViewModel = function(confirm, prompts, validator) {
 
     self.embargoIsLongEnough = function(end) {
         var min = self._now().add(2, 'days');
-        return end.isAfter(min) && end.isSameOrAfter(todayMinimum);
+        return end.isAfter(min);
     };
 
     self.embargoIsShortEnough = function(end) {
         var max = self._now().add(4, 'years').subtract(1, 'days');
-        return end.isBefore(max) && end.isSameOrBefore(todayMaximum);
+        return end.isBefore(max);
     };
 
     var validation = [{

--- a/website/static/js/registrationModal.js
+++ b/website/static/js/registrationModal.js
@@ -1,6 +1,6 @@
 var ko = require('knockout');
 var moment = require('moment');
-var pikaday = require('pikaday');
+require('pikaday');
 require('pikaday-css');
 var bootbox = require('bootbox');
 var $ = require('jquery');
@@ -35,16 +35,7 @@ var RegistrationViewModel = function(confirm, prompts, validator) {
     self.registrationChoice = ko.observable(MAKE_PUBLIC.value);
 
     self.pikaday = ko.observable(today);
-    var picker = new pikaday(
-        {
-            bound: true,
-            field: document.getElementById('endDatePicker'),
-            onSelect: function() {
-                self.pikaday(picker.toString());
-                self.isEmbargoEndDateValid();
-            }
-        }
-    );
+
     self.embargoEndDate = ko.computed(function() {
         return moment(new Date(self.pikaday()));
     });

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -627,7 +627,7 @@ Draft.prototype.preRegisterPrompts = function(response, confirm) {
         };
     }
     var preRegisterPrompts = response.prompts || [];
-    
+
     var registrationModal = new RegistrationModal.ViewModel(
         confirm, preRegisterPrompts, validator
     );

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -24,9 +24,6 @@ var RegistrationModal = require('js/registrationModal');
 
 // This value should match website.settings.DRAFT_REGISTRATION_APPROVAL_PERIOD
 var DRAFT_REGISTRATION_MIN_EMBARGO_DAYS = 10;
-var DRAFT_REGISTRATION_MIN_EMBARGO_TIMESTAMP = new Date().getTime() + (
-        DRAFT_REGISTRATION_MIN_EMBARGO_DAYS * 24 * 60 * 60 * 1000
-);
 
 var VALIDATORS = {
     required: {
@@ -620,8 +617,9 @@ Draft.prototype.preRegisterPrompts = function(response, confirm) {
     var validator = null;
     if (self.metaSchema.requiresApproval) {
         validator = {
-            validator: function(value) {
-                return (new Date(value)).getTime() > DRAFT_REGISTRATION_MIN_EMBARGO_TIMESTAMP;
+            validator: function(end) {
+                var min = moment().add(DRAFT_REGISTRATION_MIN_EMBARGO_DAYS, 'days');
+                return end.isAfter(min);
             },
             message: 'Embargo end date must be at least ' + DRAFT_REGISTRATION_MIN_EMBARGO_DAYS + ' days in the future.'
         };

--- a/website/static/js/tests/registrationModal.test.js
+++ b/website/static/js/tests/registrationModal.test.js
@@ -36,11 +36,12 @@ describe('registrationModal', () => {
 
     describe('#constructor', () => {
         it('takes a confirm method as a callback for bootbox success', () => {
+            var end = vm.embargoEndDate();
             var args = {
                 registrationChoice: vm.registrationChoice(),
-                embargoEndDate: vm.embargoEndDate(),
-                embargoIsLongEnough: vm.embargoIsLongEnough(),
-                embargoIsShortEnough: vm.embargoIsShortEnough()
+                embargoEndDate: end,
+                embargoIsLongEnough: vm.embargoIsLongEnough(end),
+                embargoIsShortEnough: vm.embargoIsShortEnough(end)
             };
             vm.register();
             assert.isTrue(confirm.calledWith(args));
@@ -58,7 +59,7 @@ describe('registrationModal', () => {
             var d = new Date();
             d.setDate(d.getDate() + 3);
             instance.pikaday(d);
-            instance.pikaday.isValid();
+            instance.embargoEndDate.isValid();
             assert.isTrue(validate.called);
         });
     });
@@ -77,24 +78,24 @@ describe('registrationModal', () => {
             assert.isFalse(vm.requestingEmbargo());
         });
     });
-    describe('#pikaday.isValid', () => {
+    describe('#embargoEndDate.isValid', () => {
         it('returns true for date more than 2 days but less than 4 years in the future', () => {
             var validDate = new Date();
             validDate.setDate(validDate.getDate() + 3);
             vm.pikaday(validDate);
-            assert.isTrue(vm.pikaday.isValid());
+            assert.isTrue(vm.embargoEndDate.isValid());
         });
         it('returns false for date less than 2 days in the future', () => {
             var invalidPastDate = new Date();
             invalidPastDate.setDate(invalidPastDate.getDate() - 2);
             vm.pikaday(invalidPastDate);
-            assert.isFalse(vm.pikaday.isValid());
+            assert.isFalse(vm.embargoEndDate.isValid());
         });
         it('returns false for date more than 4 years in the future', () => {
             var invalidFutureDate = new Date();
             invalidFutureDate.setDate(invalidFutureDate.getDate() + 1462);
             vm.pikaday(invalidFutureDate);
-            assert.isFalse(vm.pikaday.isValid());
+            assert.isFalse(vm.embargoEndDate.isValid());
         });
     });
     describe('#requestingEmbargo', () => {
@@ -112,25 +113,25 @@ describe('registrationModal', () => {
             var validDateTwoDays = new Date();
             vm.pikaday(new Date (validDateTwoDays.getTime() + 259200000)); //+3 Days
             vm._now = function() { return validDateTwoDays; };
-            assert.isTrue(vm.embargoIsLongEnough());
+            assert.isTrue(vm.embargoIsLongEnough(vm.embargoEndDate()));
         });
         it('returns true for date less than 4 years in the future', () => {
             var validDateFourYears = new Date();
             vm.pikaday(new Date (validDateFourYears.getTime() + 126057600000)); //+1459 Days
             vm._now = function() { return validDateFourYears; };
-            assert.isTrue(vm.embargoIsShortEnough());
+            assert.isTrue(vm.embargoIsShortEnough(vm.embargoEndDate()));
         });
         it('returns false for date less than 2 days in the future', () => {
             var invalidDateTwoDays = new Date();
             vm.pikaday(new Date (invalidDateTwoDays.getTime() + 86400000)); //+1 Day
             vm._now = function() { return invalidDateTwoDays; };
-            assert.isFalse(vm.embargoIsLongEnough());
+            assert.isFalse(vm.embargoIsLongEnough(vm.embargoEndDate()));
         });
         it('returns false for date at least 4 years in the future', () => {
             var invalidDateFourYears = new Date();
             vm.pikaday(new Date (invalidDateFourYears.getTime() + 126144000000)); //+1460 Days
             vm._now = function() { return invalidDateFourYears; };
-            assert.isFalse(vm.embargoIsShortEnough());
+            assert.isFalse(vm.embargoIsShortEnough(vm.embargoEndDate()));
         });
         it('returns true for date more than 2 days in the future, in a western timezone', () => {
             var validDateTwoDaysTZWest = moment().utcOffset(-4).toDate();
@@ -139,7 +140,7 @@ describe('registrationModal', () => {
             validDateTZFutureWest.setDate(validDateTwoDaysTZWest.getDate() + 3);
             vm.pikaday(validDateTZFutureWest);
             vm._now = function() { return validDateTwoDaysTZWest; };
-            assert.isTrue(vm.embargoIsLongEnough());
+            assert.isTrue(vm.embargoIsLongEnough(vm.embargoEndDate()));
         });
         it('returns true for date more than 2 days in the future, in an eastern timezone', () => {
             var validDateTwoDaysTZEast = moment().utcOffset(4).toDate();
@@ -148,7 +149,7 @@ describe('registrationModal', () => {
             validDateTZFutureEast.setDate(validDateTwoDaysTZEast.getDate() + 3);
             vm.pikaday(validDateTZFutureEast);
             vm._now = function() { return validDateTwoDaysTZEast; };
-            assert.isTrue(vm.embargoIsLongEnough());
+            assert.isTrue(vm.embargoIsLongEnough(vm.embargoEndDate()));
         });
         it('returns true for date less than 4 years in the future, in a western timezone', () => {
             var validDateFourYearsTZWest = moment().utcOffset(-4).toDate();
@@ -157,7 +158,7 @@ describe('registrationModal', () => {
             validDateTZFutureWest.setDate(validDateFourYearsTZWest.getDate() + 1459);
             vm.pikaday(validDateTZFutureWest);
             vm._now = function() { return validDateFourYearsTZWest; };
-            assert.isTrue(vm.embargoIsShortEnough());
+            assert.isTrue(vm.embargoIsShortEnough(vm.embargoEndDate()));
         });
         it('returns true for date less than 4 years in the future, in an eastern timezone', () => {
             var validDateFourYearsTZEast = moment().utcOffset(4).toDate();
@@ -166,7 +167,7 @@ describe('registrationModal', () => {
             validDateTZFutureEastFY.setDate(validDateFourYearsTZEast.getDate() + 1459);
             vm.pikaday(validDateTZFutureEastFY);
             vm._now = function() { return validDateFourYearsTZEast; };
-            assert.isTrue(vm.embargoIsShortEnough());
+            assert.isTrue(vm.embargoIsShortEnough(vm.embargoEndDate()));
         });
     });
 });

--- a/website/static/js/tests/registrationModal.test.js
+++ b/website/static/js/tests/registrationModal.test.js
@@ -19,13 +19,13 @@ describe('registrationModal', () => {
 
     var confirm = sinon.stub();
     var vm = new RegistrationModal(
-        confirm, 
+        confirm,
         [],
         null
-    ); 
+    );
     beforeEach(() => {
         vm = new RegistrationModal(
-            confirm, 
+            confirm,
             [],
             null
         );
@@ -39,8 +39,8 @@ describe('registrationModal', () => {
             var args = {
                 registrationChoice: vm.registrationChoice(),
                 embargoEndDate: vm.embargoEndDate(),
-                minimumTimeValidation: vm.minimumTimeValidation(),
-                maximumTimeValidation: vm.maximumTimeValidation()
+                embargoIsLongEnough: vm.embargoIsLongEnough(),
+                embargoIsShortEnough: vm.embargoIsShortEnough()
             };
             vm.register();
             assert.isTrue(confirm.calledWith(args));
@@ -77,7 +77,7 @@ describe('registrationModal', () => {
             assert.isFalse(vm.requestingEmbargo());
         });
     });
-    describe('#pikaday.isValid', () => {             
+    describe('#pikaday.isValid', () => {
         it('returns true for date more than 2 days but less than 4 years in the future', () => {
             var validDate = new Date();
             validDate.setDate(validDate.getDate() + 3);
@@ -111,22 +111,22 @@ describe('registrationModal', () => {
         it('returns true for date more than 2 days in the future', () => {
             var validDateTwoDays = new Date();
             vm.pikaday(new Date (validDateTwoDays.getTime() + 259200000)); //+3 Days
-            assert.isTrue(vm.minimumTimeValidation(null, null, validDateTwoDays));
+            assert.isTrue(vm.embargoIsLongEnough(null, null, validDateTwoDays));
         });
         it('returns true for date less than 4 years in the future', () => {
             var validDateFourYears = new Date();
             vm.pikaday(new Date (validDateFourYears.getTime() + 126057600000)); //+1459 Days
-            assert.isTrue(vm.maximumTimeValidation(null, null, validDateFourYears));
+            assert.isTrue(vm.embargoIsShortEnough(null, null, validDateFourYears));
         });
         it('returns false for date less than 2 days in the future', () => {
             var invalidDateTwoDays = new Date();
             vm.pikaday(new Date (invalidDateTwoDays.getTime() + 86400000)); //+1 Day
-            assert.isFalse(vm.minimumTimeValidation(null, null, invalidDateTwoDays));
+            assert.isFalse(vm.embargoIsLongEnough(null, null, invalidDateTwoDays));
         });
         it('returns false for date at least 4 years in the future', () => {
             var invalidDateFourYears = new Date();
             vm.pikaday(new Date (invalidDateFourYears.getTime() + 126144000000)); //+1460 Days
-            assert.isFalse(vm.maximumTimeValidation(null, null, invalidDateFourYears));
+            assert.isFalse(vm.embargoIsShortEnough(null, null, invalidDateFourYears));
         });
         it('returns true for date more than 2 days in the future, in a western timezone', () => {
             var validDateTwoDaysTZWest = moment().utcOffset(-4).toDate();
@@ -134,7 +134,7 @@ describe('registrationModal', () => {
             var validDateTZFutureWest = new Date(validDateTwoDaysTZWest);
             validDateTZFutureWest.setDate(validDateTwoDaysTZWest.getDate() + 3);
             vm.pikaday(validDateTZFutureWest);
-            assert.isTrue(vm.minimumTimeValidation(null, null, validDateTwoDaysTZWest));
+            assert.isTrue(vm.embargoIsLongEnough(null, null, validDateTwoDaysTZWest));
         });
         it('returns true for date more than 2 days in the future, in an eastern timezone', () => {
             var validDateTwoDaysTZEast = moment().utcOffset(4).toDate();
@@ -142,7 +142,7 @@ describe('registrationModal', () => {
             var validDateTZFutureEast = new Date(validDateTwoDaysTZEast);
             validDateTZFutureEast.setDate(validDateTwoDaysTZEast.getDate() + 3);
             vm.pikaday(validDateTZFutureEast);
-            assert.isTrue(vm.minimumTimeValidation(null, null, validDateTwoDaysTZEast));
+            assert.isTrue(vm.embargoIsLongEnough(null, null, validDateTwoDaysTZEast));
         });
         it('returns true for date less than 4 years in the future, in a western timezone', () => {
             var validDateFourYearsTZWest = moment().utcOffset(-4).toDate();
@@ -150,7 +150,7 @@ describe('registrationModal', () => {
             var validDateTZFutureWest = new Date(validDateFourYearsTZWest);
             validDateTZFutureWest.setDate(validDateFourYearsTZWest.getDate() + 1459);
             vm.pikaday(validDateTZFutureWest);
-            assert.isTrue(vm.maximumTimeValidation(null, null, validDateFourYearsTZWest));
+            assert.isTrue(vm.embargoIsShortEnough(null, null, validDateFourYearsTZWest));
         });
         it('returns true for date less than 4 years in the future, in an eastern timezone', () => {
             var validDateFourYearsTZEast = moment().utcOffset(4).toDate();
@@ -158,7 +158,7 @@ describe('registrationModal', () => {
             var validDateTZFutureEastFY = new Date(validDateFourYearsTZEast);
             validDateTZFutureEastFY.setDate(validDateFourYearsTZEast.getDate() + 1459);
             vm.pikaday(validDateTZFutureEastFY);
-            assert.isTrue(vm.maximumTimeValidation(null, null, validDateFourYearsTZEast));
+            assert.isTrue(vm.embargoIsShortEnough(null, null, validDateFourYearsTZEast));
         });
     });
 });

--- a/website/static/js/tests/registrationModal.test.js
+++ b/website/static/js/tests/registrationModal.test.js
@@ -111,22 +111,26 @@ describe('registrationModal', () => {
         it('returns true for date more than 2 days in the future', () => {
             var validDateTwoDays = new Date();
             vm.pikaday(new Date (validDateTwoDays.getTime() + 259200000)); //+3 Days
-            assert.isTrue(vm.embargoIsLongEnough(null, null, validDateTwoDays));
+            vm._now = function() { return validDateTwoDays; };
+            assert.isTrue(vm.embargoIsLongEnough());
         });
         it('returns true for date less than 4 years in the future', () => {
             var validDateFourYears = new Date();
             vm.pikaday(new Date (validDateFourYears.getTime() + 126057600000)); //+1459 Days
-            assert.isTrue(vm.embargoIsShortEnough(null, null, validDateFourYears));
+            vm._now = function() { return validDateFourYears; };
+            assert.isTrue(vm.embargoIsShortEnough());
         });
         it('returns false for date less than 2 days in the future', () => {
             var invalidDateTwoDays = new Date();
             vm.pikaday(new Date (invalidDateTwoDays.getTime() + 86400000)); //+1 Day
-            assert.isFalse(vm.embargoIsLongEnough(null, null, invalidDateTwoDays));
+            vm._now = function() { return invalidDateTwoDays; };
+            assert.isFalse(vm.embargoIsLongEnough());
         });
         it('returns false for date at least 4 years in the future', () => {
             var invalidDateFourYears = new Date();
             vm.pikaday(new Date (invalidDateFourYears.getTime() + 126144000000)); //+1460 Days
-            assert.isFalse(vm.embargoIsShortEnough(null, null, invalidDateFourYears));
+            vm._now = function() { return invalidDateFourYears; };
+            assert.isFalse(vm.embargoIsShortEnough());
         });
         it('returns true for date more than 2 days in the future, in a western timezone', () => {
             var validDateTwoDaysTZWest = moment().utcOffset(-4).toDate();
@@ -134,7 +138,8 @@ describe('registrationModal', () => {
             var validDateTZFutureWest = new Date(validDateTwoDaysTZWest);
             validDateTZFutureWest.setDate(validDateTwoDaysTZWest.getDate() + 3);
             vm.pikaday(validDateTZFutureWest);
-            assert.isTrue(vm.embargoIsLongEnough(null, null, validDateTwoDaysTZWest));
+            vm._now = function() { return validDateTwoDaysTZWest; };
+            assert.isTrue(vm.embargoIsLongEnough());
         });
         it('returns true for date more than 2 days in the future, in an eastern timezone', () => {
             var validDateTwoDaysTZEast = moment().utcOffset(4).toDate();
@@ -142,7 +147,8 @@ describe('registrationModal', () => {
             var validDateTZFutureEast = new Date(validDateTwoDaysTZEast);
             validDateTZFutureEast.setDate(validDateTwoDaysTZEast.getDate() + 3);
             vm.pikaday(validDateTZFutureEast);
-            assert.isTrue(vm.embargoIsLongEnough(null, null, validDateTwoDaysTZEast));
+            vm._now = function() { return validDateTwoDaysTZEast; };
+            assert.isTrue(vm.embargoIsLongEnough());
         });
         it('returns true for date less than 4 years in the future, in a western timezone', () => {
             var validDateFourYearsTZWest = moment().utcOffset(-4).toDate();
@@ -150,7 +156,8 @@ describe('registrationModal', () => {
             var validDateTZFutureWest = new Date(validDateFourYearsTZWest);
             validDateTZFutureWest.setDate(validDateFourYearsTZWest.getDate() + 1459);
             vm.pikaday(validDateTZFutureWest);
-            assert.isTrue(vm.embargoIsShortEnough(null, null, validDateFourYearsTZWest));
+            vm._now = function() { return validDateFourYearsTZWest; };
+            assert.isTrue(vm.embargoIsShortEnough());
         });
         it('returns true for date less than 4 years in the future, in an eastern timezone', () => {
             var validDateFourYearsTZEast = moment().utcOffset(4).toDate();
@@ -158,7 +165,8 @@ describe('registrationModal', () => {
             var validDateTZFutureEastFY = new Date(validDateFourYearsTZEast);
             validDateTZFutureEastFY.setDate(validDateFourYearsTZEast.getDate() + 1459);
             vm.pikaday(validDateTZFutureEastFY);
-            assert.isTrue(vm.embargoIsShortEnough(null, null, validDateFourYearsTZEast));
+            vm._now = function() { return validDateFourYearsTZEast; };
+            assert.isTrue(vm.embargoIsShortEnough());
         });
     });
 });

--- a/website/static/js/tests/registrationModal.test.js
+++ b/website/static/js/tests/registrationModal.test.js
@@ -110,63 +110,55 @@ describe('registrationModal', () => {
     });
     describe('#timeValidation', () => {
         it('returns true for date more than 2 days in the future', () => {
-            var validDateTwoDays = new Date();
-            vm.pikaday(new Date (validDateTwoDays.getTime() + 259200000)); //+3 Days
-            vm._now = function() { return validDateTwoDays; };
+            var d = new Date();
+            vm.pikaday(new Date(d.getTime() + 259200000)); //+3 Days
+            vm._now = function() { return moment(d); };
             assert.isTrue(vm.embargoIsLongEnough(vm.embargoEndDate()));
         });
         it('returns true for date less than 4 years in the future', () => {
-            var validDateFourYears = new Date();
-            vm.pikaday(new Date (validDateFourYears.getTime() + 126057600000)); //+1459 Days
-            vm._now = function() { return validDateFourYears; };
+            var d = new Date();
+            vm.pikaday(new Date(d.getTime() + 126057600000)); //+1459 Days
+            vm._now = function() { return moment(d); };
             assert.isTrue(vm.embargoIsShortEnough(vm.embargoEndDate()));
         });
         it('returns false for date less than 2 days in the future', () => {
-            var invalidDateTwoDays = new Date();
-            vm.pikaday(new Date (invalidDateTwoDays.getTime() + 86400000)); //+1 Day
-            vm._now = function() { return invalidDateTwoDays; };
+            var d = new Date();
+            vm.pikaday(new Date(d.getTime() + 86400000)); //+1 Day
+            vm._now = function() { return moment(d); };
             assert.isFalse(vm.embargoIsLongEnough(vm.embargoEndDate()));
         });
         it('returns false for date at least 4 years in the future', () => {
-            var invalidDateFourYears = new Date();
-            vm.pikaday(new Date (invalidDateFourYears.getTime() + 126144000000)); //+1460 Days
-            vm._now = function() { return invalidDateFourYears; };
+            var d = new Date();
+            vm.pikaday(new Date (d.getTime() + 126144000000)); //+1460 Days
+            vm._now = function() { return moment(d); };
             assert.isFalse(vm.embargoIsShortEnough(vm.embargoEndDate()));
         });
         it('returns true for date more than 2 days in the future, in a western timezone', () => {
-            var validDateTwoDaysTZWest = moment().utcOffset(-4).toDate();
-            validDateTwoDaysTZWest.setMinutes(validDateTwoDaysTZWest.getMinutes() - validDateTwoDaysTZWest.getTimezoneOffset());
-            var validDateTZFutureWest = new Date(validDateTwoDaysTZWest);
-            validDateTZFutureWest.setDate(validDateTwoDaysTZWest.getDate() + 3);
-            vm.pikaday(validDateTZFutureWest);
-            vm._now = function() { return validDateTwoDaysTZWest; };
+            var d = moment().utcOffset(-4).toDate();
+            d.setMinutes(d.getMinutes() - d.getTimezoneOffset());
+            var d2 = new Date(d); d2.setDate(d.getDate() + 3); vm.pikaday(d2);
+            vm._now = function() { return moment(d); };
             assert.isTrue(vm.embargoIsLongEnough(vm.embargoEndDate()));
         });
         it('returns true for date more than 2 days in the future, in an eastern timezone', () => {
-            var validDateTwoDaysTZEast = moment().utcOffset(4).toDate();
-            validDateTwoDaysTZEast.setMinutes(validDateTwoDaysTZEast.getMinutes() - validDateTwoDaysTZEast.getTimezoneOffset());
-            var validDateTZFutureEast = new Date(validDateTwoDaysTZEast);
-            validDateTZFutureEast.setDate(validDateTwoDaysTZEast.getDate() + 3);
-            vm.pikaday(validDateTZFutureEast);
-            vm._now = function() { return validDateTwoDaysTZEast; };
+            var d = moment().utcOffset(4).toDate();
+            d.setMinutes(d.getMinutes() - d.getTimezoneOffset());
+            var d2 = new Date(d); d2.setDate(d.getDate() + 3); vm.pikaday(d2);
+            vm._now = function() { return moment(d); };
             assert.isTrue(vm.embargoIsLongEnough(vm.embargoEndDate()));
         });
         it('returns true for date less than 4 years in the future, in a western timezone', () => {
-            var validDateFourYearsTZWest = moment().utcOffset(-4).toDate();
-            validDateFourYearsTZWest.setMinutes(validDateFourYearsTZWest.getMinutes() - validDateFourYearsTZWest.getTimezoneOffset());
-            var validDateTZFutureWest = new Date(validDateFourYearsTZWest);
-            validDateTZFutureWest.setDate(validDateFourYearsTZWest.getDate() + 1459);
-            vm.pikaday(validDateTZFutureWest);
-            vm._now = function() { return validDateFourYearsTZWest; };
+            var d = moment().utcOffset(-4).toDate();
+            d.setMinutes(d.getMinutes() - d.getTimezoneOffset());
+            var d2 = new Date(d); d2.setDate(d.getDate() + 1459); vm.pikaday(d2);
+            vm._now = function() { return moment(d); };
             assert.isTrue(vm.embargoIsShortEnough(vm.embargoEndDate()));
         });
         it('returns true for date less than 4 years in the future, in an eastern timezone', () => {
-            var validDateFourYearsTZEast = moment().utcOffset(4).toDate();
-            validDateFourYearsTZEast.setMinutes(validDateFourYearsTZEast.getMinutes() - validDateFourYearsTZEast.getTimezoneOffset());
-            var validDateTZFutureEastFY = new Date(validDateFourYearsTZEast);
-            validDateTZFutureEastFY.setDate(validDateFourYearsTZEast.getDate() + 1459);
-            vm.pikaday(validDateTZFutureEastFY);
-            vm._now = function() { return validDateFourYearsTZEast; };
+            var d = moment().utcOffset(4).toDate();
+            d.setMinutes(d.getMinutes() - d.getTimezoneOffset());
+            var d2 = new Date(d); d2.setDate(d.getDate() + 1459); vm.pikaday(d2);
+            vm._now = function() { return moment(d); };
             assert.isTrue(vm.embargoIsShortEnough(vm.embargoEndDate()));
         });
     });

--- a/website/static/templates/registration-modal.html
+++ b/website/static/templates/registration-modal.html
@@ -8,14 +8,14 @@
                                           value: registrationChoice,
                                           optionsText: 'message',
                                           optionsValue: 'value'"></select>
-  
 </div>
 <span data-bind="visible: showEmbargoDatePicker">
   <div class="form-group">
     <label class="control-label">
       Embargo End Date
     </label>
-    <input type="text" class="form-control" data-bind="datePicker: {value: $root.pikaday, valid: $root.pikaday.isValid}">
+    <input type="text" class="form-control"
+           data-bind="datePicker: {value: $root.pikaday, valid: $root.pikaday.isValid}">
   </div>
 </span>
 <em class="text-danger" data-bind="validationMessage: $root.pikaday"></em>

--- a/website/static/templates/registration-modal.html
+++ b/website/static/templates/registration-modal.html
@@ -15,10 +15,10 @@
       Embargo End Date
     </label>
     <input type="text" class="form-control"
-           data-bind="datePicker: {value: $root.pikaday, valid: $root.pikaday.isValid}">
+           data-bind="datePicker: {value: $root.pikaday, valid: $root.embargoEndDate.isValid}">
   </div>
 </span>
-<em class="text-danger" data-bind="validationMessage: $root.pikaday"></em>
+<em class="text-danger" data-bind="validationMessage: $root.embargoEndDate"></em>
 <div class="modal-footer">
   <button class="btn btn-default" data-bind="click: close">Cancel</button>
   <button class="btn btn-success" data-bind="click: register, enable: canRegister">

--- a/website/templates/project/registration_utils.mako
+++ b/website/templates/project/registration_utils.mako
@@ -22,32 +22,3 @@
     </div>
   </div>
 </script>
-
-<script type="text/html" id="preRegistrationTemplate">
-  <ul data-bind="foreach: preRegisterPrompts">
-    <li data-bind="html: $data"></li>
-  </ul>
-  <div class="form-group">
-    <label class="control-label">Registration Choice</label>
-    <select class="form-control" data-bind="options: registrationOptions,
-                                            value: registrationChoice,
-                                            optionsText: 'message',
-                                            optionsValue: 'value',
-                                            event: {change: checkShowEmbargoDatePicker}" ></select>
-  </div>
-  <span data-bind="visible: showEmbargoDatePicker">
-    <div class="form-group">
-      <label class="control-label">
-        Embargo End Date
-      </label>
-      <input type="text" class="form-control" data-bind="datePicker: {value: $root.pikaday, valid: isEmbargoEndDateValid}">
-    </div>
-  </span>
-  <em class="text-danger" data-bind="validationMessage: $root.pikaday"></em>
-  <div class="modal-footer">
-    <button class="btn btn-default" data-bind="click: close">Cancel</button>
-    <button class="btn btn-success" data-bind="click: register, enable: canRegister">
-      Continue
-    </button>
-  </div>
-</script>


### PR DESCRIPTION
&larr; #6025 ([diff](https://github.com/whit537/osf.io/compare/refactor-registration-modal...clean-up-knockout-validation-usage))

## Purpose

This PR cleans up our usage of Knockout-Validation in the registration modal. Non-idiomatic usage makes the logic harder to follow.

## Changes

n/a

## Side effects

n/a

## Ticket

https://openscience.atlassian.net/browse/OSF-6837

### TODO

- [x] Were there tests for the 10 day validation? Did we break them?
- [x] Make sure we didn't screw up the 10-day validation in 4b5f9b168831da26eb85cecb673f7301119fe56b (compare the logic with the `todayMinimum` in the 3-day validation).
- [x] Clean up tests.
- [ ] Rebase once #6025 lands.