### PR TITLE
[OSF-5639] Warn users they cannot search by email address

### DIFF
--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -98,6 +98,15 @@ AddContributorViewModel = oop.extend(Paginator, {
         self.totalPages = ko.observable(0);
         self.childrenToChange = ko.observableArray();
 
+        self.emailSearch = ko.pureComputed(function () {
+            var emailRegex = new RegExp('[^\\s]+@[^\\s]+\\.[^\\s]');
+            if (emailRegex.test(String(self.query()))) {
+                return true;
+            } else {
+                return false;
+            }
+        });
+
         self.foundResults = ko.pureComputed(function () {
             return self.query() && self.results().length && !self.parentImport();
         });

--- a/website/static/js/tests/contributors.test.js
+++ b/website/static/js/tests/contributors.test.js
@@ -163,6 +163,33 @@ describe('addContributors', () => {
                    });
                });
            });
+
+            describe('emailSearch', () => {
+                it('should return true with an email address entered', () => {
+                    vm.query(
+                        'a1234@gmail.com'
+                    );
+                    assert.isTrue(vm.emailSearch());
+                });
+                it('should return false with a name entered', () => {
+                    vm.query(
+                    faker.name.findName()
+                );
+                assert.isFalse(vm.emailSearch());
+                });
+                it('should return false with a name with an @, but not an email', () => {
+                    vm.query(
+                        'mys@mplename'
+                );
+                assert.isFalse(vm.emailSearch());
+                });
+                it('should return false with an email not containing .com', () => {
+                    vm.query(
+                    'a1234@gmail'
+                );
+                assert.isFalse(vm.emailSearch());
+                });
+            });
        });
    });
 });

--- a/website/templates/project/modal_add_contributor.mako
+++ b/website/templates/project/modal_add_contributor.mako
@@ -115,7 +115,9 @@
                                         <li data-bind="css: style"><a href="#" data-bind="click: handler, text: text"></a></li>
                                     </ul>
                                     <p>
-                                        <a href="#" data-bind="click:gotoInvite">Add <strong><em data-bind="text: query"></em></strong> as an unregistered contributor</a>.
+                                        <div data-bind='ifnot: emailSearch'>
+                                            <a href="#" data-bind="click:gotoInvite">Add <strong><em data-bind="text: query"></em></strong> as an unregistered contributor</a>.
+                                        </div>
                                     </p>
                                 </div>
                                 <div data-bind="if: parentPagination">
@@ -127,8 +129,18 @@
                                     <p class="text-muted">Searching contributors...</p>
                                 </div>
                                 <div data-bind="if: noResults">
-                                    No results found. Try a more specific search or
-                                    <a href="#" data-bind="click:gotoInvite">add <strong><em data-bind="text: query"></em></strong> as an unregistered contributor</a>.
+                                    <div data-bind='if: emailSearch'>
+                                      No results found. Try a more specific search.
+                                    </div>
+                                    <div data-bind='ifnot: emailSearch'>
+                                      No results found. Try a more specific search
+                                    </div>
+                                    <div data-bind="ifnot: emailSearch"> or
+                                        <a href="#" data-bind="click:gotoInvite">add <strong><em data-bind="text: query"></em></strong> as an unregistered contributor</a>.
+                                    </div>
+                                </div>
+                                <div data-bind="if: emailSearch">
+                                    <p>It looks like you are trying to search by email address. If you search by name, you can add an unregistered contributor.</p>
                                 </div>
                             </div>
                         </div><!-- ./col-md -->
@@ -275,4 +287,3 @@
         </div><!-- end modal-content -->
     </div><!-- end modal-dialog -->
 </div><!-- end modal -->
-

--- a/website/templates/project/modal_add_contributor.mako
+++ b/website/templates/project/modal_add_contributor.mako
@@ -140,7 +140,7 @@
                                     </div>
                                 </div>
                                 <div data-bind="if: emailSearch">
-                                    <p>It looks like you are trying to search by email address. If you search by name, you can add an unregistered contributor.</p>
+                                    <p>It looks like you are trying to search by email address. Please try your search again using your collaborator's name. You will be able to add users without OSF accounts as unregistered contributors.</p>
                                 </div>
                             </div>
                         </div><!-- ./col-md -->


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Inform users that they cannot add an email address as an unregistered user. Gives the user an error message if the regular expression matches the syntax of an email address.

## Changes

Checks the regular expression of the query. If the input has the format of [text]@[text].[text], it registers it as an email address, informs the user with an error, and does NOT allow for that user to be added as an unregistered contributor.

## Side effects

n/a

## Ticket

https://openscience.atlassian.net/browse/OSF-5639