### PR TITLE
Make flag for non-meetings meetings [#OSF-5645]

### DIFF
--- a/website/static/js/meetings.js
+++ b/website/static/js/meetings.js
@@ -46,8 +46,8 @@ function Meetings(data) {
                     data : 'name',  // Data field name
                     sortInclude : true,
                     filter : true,
-                    custom : function() { return m('a', { href : item.data.url, target : '_blank' }, item.data.name ); }
-
+                    custom : function() { return m('a', { href : item.data.url, target : '_blank' }, item.data.name ); },
+                    show : function() { return (item.data.name !== 'Time-sharing Experiments for the Social Sciences' && item.data.name !== 'Psi Chi'); }
                 },
                 {
                     data: 'count',

--- a/website/static/js/submissions.js
+++ b/website/static/js/submissions.js
@@ -53,9 +53,8 @@ function Submissions(data) {
                     data : 'title',  // Data field name
                     sortInclude : true,
                     filter : true,
-                    custom : function() {
-                        return m('a', { href : item.data.nodeUrl, target : '_blank' }, item.data.title ); }
-
+                    custom : function() { return m('a', { href : item.data.nodeUrl, target : '_blank' }, item.data.title ); },
+                    show : function() { return (item.data.confName !== 'Time-sharing Experiments for the Social Sciences' && item.data.confName !== 'Psi Chi'); }
                 },
                 {
                     data: 'author',  // Data field name


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Make non-meetings meetings and non-meetings meeting's submissions not get shown on the meetings page
<!-- Describe the purpose of your changes -->

## Changes

Added show function that returns false if meeting should not be shown and true if it should 
Change reliant on this PR to treebeard (https://github.com/CenterForOpenScience/treebeard/pull/103)
<!-- Briefly describe or list your changes  -->

## Side effects

None
<!--Any possible side effects? -->


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->

https://openscience.atlassian.net/browse/OSF-5645