### PR TITLE
License cannot be applied to the RPP project[#OSF-5389]

### DIFF
--- a/website/project/model.py
+++ b/website/project/model.py
@@ -1692,7 +1692,11 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
             ) if c.is_public and not c.is_deleted]
             # this returns generator, that would get unspooled anyways
             if children:
-                Node.bulk_update_search(children)
+                if len(children) > 100:
+                    Node.bulk_update_search(children[:99])
+                    Node.bulk_update_search(children[99:])
+                else:
+                    Node.bulk_update_search(children)
 
         # This method checks what has changed.
         if settings.PIWIK_HOST and update_piwik:

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -1689,7 +1689,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
         if 'node_license' in saved_fields:
             children = [c for c in self.get_descendants_recursive(
                 include=lambda n: n.node_license is None
-            )]
+            ) if c.is_public and not c.is_deleted]
             # this returns generator, that would get unspooled anyways
             if children:
                 Node.bulk_update_search(children)

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -1692,17 +1692,10 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
             ) if c.is_public and not c.is_deleted]
             # this returns generator, that would get unspooled anyways
             if children:
-                count = len(children) / 100
-                if count == 0:
-                    Node.bulk_update_search(children)
-                else:
-                    start = 0
-                    end = 100
-                    for i in range(1, count + 1):
-                        Node.bulk_update_search(children[start:end])
-                        start = end
-                        end = 100 * (i + 1)
-                    Node.bulk_update_search(children[(100 * count):])
+                while len(children):
+                    batch = children[:99]
+                    Node.bulk_update_search(batch)
+                    children = children[99:]
 
         # This method checks what has changed.
         if settings.PIWIK_HOST and update_piwik:

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -1692,11 +1692,17 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
             ) if c.is_public and not c.is_deleted]
             # this returns generator, that would get unspooled anyways
             if children:
-                if len(children) > 100:
-                    Node.bulk_update_search(children[:99])
-                    Node.bulk_update_search(children[99:])
-                else:
+                count = len(children) / 100
+                if count == 0:
                     Node.bulk_update_search(children)
+                else:
+                    start = 0
+                    end = 100
+                    for i in range(1, count + 1):
+                        Node.bulk_update_search(children[start:end])
+                        start = end
+                        end = 100 * (i + 1)
+                    Node.bulk_update_search(children[(100 * count):])
 
         # This method checks what has changed.
         if settings.PIWIK_HOST and update_piwik:

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -1691,11 +1691,10 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
                 include=lambda n: n.node_license is None
             ) if c.is_public and not c.is_deleted]
             # this returns generator, that would get unspooled anyways
-            if children:
-                while len(children):
-                    batch = children[:99]
-                    Node.bulk_update_search(batch)
-                    children = children[99:]
+            while len(children):
+                batch = children[:99]
+                Node.bulk_update_search(batch)
+                children = children[99:]
 
         # This method checks what has changed.
         if settings.PIWIK_HOST and update_piwik:


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

<!-- Describe the purpose of your changes -->
Excluded deleted and private node from update search when try to save nodes for node_license update. Can be a solution to the problem of https://openscience.atlassian.net/browse/OSF-5389. Even if it does not solve this ticket, deleted nodes and private nodes shouldn't be included in updates for node_license search update. And we can still use https://github.com/CenterForOpenScience/osf.io/pull/6054 to add license to rpp as a ultimate solution.

## Changes

<!-- Briefly describe or list your changes  -->

## Side effects

<!--Any possible side effects? -->


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->

… nodes for node_license update[#OSF-5389]
https://openscience.atlassian.net/browse/OSF-5389.