### PR TITLE
Fix registration comment related links [OSF-6551]

### DIFF
--- a/api/comments/serializers.py
+++ b/api/comments/serializers.py
@@ -43,8 +43,8 @@ class CommentSerializer(JSONAPISerializer):
 
     target = TargetField(link_type='related', meta={'type': 'get_target_type'})
     user = RelationshipField(related_view='users:user-detail', related_view_kwargs={'user_id': '<user._id>'})
-    node = RelationshipField(related_view='nodes:node-detail', related_view_kwargs={'node_id': '<node._id>'})
-    replies = RelationshipField(self_view='nodes:node-comments', self_view_kwargs={'node_id': '<node._id>'}, filter={'target': '<pk>'})
+    node = RelationshipField(related_view='registrations:registration-detail', related_view_kwargs={'node_id': '<node._id>'})
+    replies = RelationshipField(related_view='registrations:registration-comments', related_view_kwargs={'node_id': '<node._id>'}, filter={'target': '<pk>'})
     reports = RelationshipField(related_view='comments:comment-reports', related_view_kwargs={'comment_id': '<pk>'})
 
     date_created = ser.DateTimeField(read_only=True)

--- a/api/comments/serializers.py
+++ b/api/comments/serializers.py
@@ -43,8 +43,6 @@ class CommentSerializer(JSONAPISerializer):
 
     target = TargetField(link_type='related', meta={'type': 'get_target_type'})
     user = RelationshipField(related_view='users:user-detail', related_view_kwargs={'user_id': '<user._id>'})
-    node = RelationshipField(related_view='registrations:registration-detail', related_view_kwargs={'node_id': '<node._id>'})
-    replies = RelationshipField(related_view='registrations:registration-comments', related_view_kwargs={'node_id': '<node._id>'}, filter={'target': '<pk>'})
     reports = RelationshipField(related_view='comments:comment-reports', related_view_kwargs={'comment_id': '<pk>'})
 
     date_created = ser.DateTimeField(read_only=True)
@@ -133,6 +131,16 @@ class CommentSerializer(JSONAPISerializer):
         return ret
 
 
+class RegistrationCommentSerializer(CommentSerializer):
+    replies = RelationshipField(related_view='registrations:registration-comments', related_view_kwargs={'node_id': '<node._id>'}, filter={'target': '<pk>'})
+    node = RelationshipField(related_view='registrations:registration-detail', related_view_kwargs={'node_id': '<node._id>'})
+
+
+class NodeCommentSerializer(CommentSerializer):
+    replies = RelationshipField(related_view='nodes:node-comments', related_view_kwargs={'node_id': '<node._id>'}, filter={'target': '<pk>'})
+    node = RelationshipField(related_view='nodes:node-detail', related_view_kwargs={'node_id': '<node._id>'})
+
+
 class CommentCreateSerializer(CommentSerializer):
 
     target_type = ser.SerializerMethodField(method_name='get_validated_target_type')
@@ -183,6 +191,16 @@ class CommentDetailSerializer(CommentSerializer):
     """
     Overrides CommentSerializer to make id required.
     """
+    id = IDField(source='_id', required=True)
+    deleted = ser.BooleanField(source='is_deleted', required=True)
+
+
+class RegistrationCommentDetailSerializer(RegistrationCommentSerializer):
+    id = IDField(source='_id', required=True)
+    deleted = ser.BooleanField(source='is_deleted', required=True)
+
+
+class NodeCommentDetailSerializer(NodeCommentSerializer):
     id = IDField(source='_id', required=True)
     deleted = ser.BooleanField(source='is_deleted', required=True)
 

--- a/api/comments/views.py
+++ b/api/comments/views.py
@@ -13,15 +13,19 @@ from api.comments.permissions import (
 )
 from api.comments.serializers import (
     CommentSerializer,
-    CommentDetailSerializer,
+    NodeCommentDetailSerializer,
+    RegistrationCommentDetailSerializer,
     CommentReportSerializer,
     CommentReportDetailSerializer,
     CommentReport
 )
 from framework.auth.core import Auth
+from framework.guid.model import Guid
 from framework.auth.oauth_scopes import CoreScopes
 from framework.exceptions import PermissionsError
-from website.project.model import Comment
+from website.project.model import Comment, Node
+from website.addons.wiki.model import NodeWikiPage
+from website.files.models.base import StoredFileNode
 
 
 class CommentMixin(object):
@@ -159,13 +163,24 @@ class CommentDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, Comm
     required_read_scopes = [CoreScopes.NODE_COMMENTS_READ]
     required_write_scopes = [CoreScopes.NODE_COMMENTS_WRITE]
 
-    serializer_class = CommentDetailSerializer
+    serializer_class = NodeCommentDetailSerializer
     view_category = 'comments'
     view_name = 'comment-detail'
 
     # overrides RetrieveAPIView
     def get_object(self):
-        return self.get_comment()
+        comment = self.get_comment()
+
+        if isinstance(comment.target.referent, Node):
+            comment_node = comment.target.referent
+        elif isinstance(comment.target.referent, (NodeWikiPage,
+                                                  StoredFileNode)):
+            comment_node = Guid.load(comment.target.referent.node).referent
+
+        if comment_node.is_registration:
+            self.serializer_class = RegistrationCommentDetailSerializer
+
+        return comment
 
     def perform_destroy(self, instance):
         auth = Auth(self.request.user)

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -21,7 +21,7 @@ from api.base.utils import get_object_or_error, is_bulk_request, get_user_auth, 
 from api.base.settings import ADDONS_OAUTH, API_BASE
 from api.addons.views import AddonSettingsMixin
 from api.files.serializers import FileSerializer
-from api.comments.serializers import CommentSerializer, CommentCreateSerializer
+from api.comments.serializers import NodeCommentSerializer, CommentCreateSerializer
 from api.comments.permissions import CanCommentOrPublic
 from api.users.views import UserMixin
 from api.wikis.serializers import WikiSerializer
@@ -2560,7 +2560,7 @@ class NodeCommentsList(JSONAPIBaseView, generics.ListCreateAPIView, ODMFilterMix
     required_write_scopes = [CoreScopes.NODE_COMMENTS_WRITE]
 
     pagination_class = CommentPagination
-    serializer_class = CommentSerializer
+    serializer_class = NodeCommentSerializer
     view_category = 'nodes'
     view_name = 'node-comments'
 
@@ -2585,7 +2585,7 @@ class NodeCommentsList(JSONAPIBaseView, generics.ListCreateAPIView, ODMFilterMix
         if self.request.method == 'POST':
             return CommentCreateSerializer
         else:
-            return CommentSerializer
+            return NodeCommentSerializer
 
     # overrides ListCreateAPIView
     def get_parser_context(self, http_request):

--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -13,6 +13,7 @@ from api.base.serializers import LinkedNodesRelationshipSerializer
 from api.base.parsers import JSONAPIRelationshipParser
 from api.base.parsers import JSONAPIRelationshipParserForRegularJSON
 from api.base.utils import get_user_auth
+from api.comments.serializers import RegistrationCommentSerializer, CommentCreateSerializer
 
 from api.registrations.serializers import (
     RegistrationSerializer,
@@ -318,8 +319,15 @@ class RegistrationForksList(NodeForksList, RegistrationMixin):
     view_name = 'registration-forks'
 
 class RegistrationCommentsList(NodeCommentsList, RegistrationMixin):
+    serializer_class = RegistrationCommentSerializer
     view_category = 'registrations'
     view_name = 'registration-comments'
+
+    def get_serializer_class(self):
+        if self.request.method == 'POST':
+            return CommentCreateSerializer
+        else:
+            return RegistrationCommentSerializer
 
 
 class RegistrationLogList(NodeLogList, RegistrationMixin):

--- a/api_tests/comments/views/test_comment_detail.py
+++ b/api_tests/comments/views/test_comment_detail.py
@@ -478,6 +478,28 @@ class TestCommentDetailView(CommentDetailMixin, ApiTestCase):
         res = self.app.delete_json_api(url, auth=self.non_contributor.auth)
         assert_equal(res.status_code, 204)
 
+    def test_registration_comment_has_usable_replies_relationship_link(self):
+        self._set_up_registration_with_comment()
+        res = self.app.get(self.registration_url, auth=self.user.auth)
+        assert_equal(res.status_code, 200)
+        relationships = res.json['data']['relationships']
+        comments_url = relationships['replies']['links']['related']['href']
+        comments_res = self.app.get(comments_url, auth=self.user.auth)
+        assert_equal(comments_res.status_code, 200)
+        ids = [item['id'] for item in comments_res.json['data']]
+        assert_in(self.registration_comment._id, ids)
+
+    def test_registration_comment_has_usable_node_relationship_link(self):
+        self._set_up_registration_with_comment()
+        res = self.app.get(self.registration_url, auth=self.user.auth)
+        assert_equal(res.status_code, 200)
+        relationships = res.json['data']['relationships']
+        comments_url = relationships['node']['links']['related']['href']
+        comments_res = self.app.get(comments_url, auth=self.user.auth)
+        assert_equal(comments_res.status_code, 200)
+        ids = [item['id'] for item in comments_res.json['data']]
+        assert_in(self.registration_comment._id, ids)
+
 
 class TestFileCommentDetailView(CommentDetailMixin, ApiTestCase):
 

--- a/api_tests/utils.py
+++ b/api_tests/utils.py
@@ -1,3 +1,4 @@
+from urlparse import urlparse
 from website.addons.osfstorage import settings as osfstorage_settings
 
 
@@ -18,3 +19,9 @@ def create_test_file(node, user, filename='test_file', create_guid=True):
         'contentType': 'img/png'
     }).save()
     return test_file
+
+def urlparse_drop_netloc(url):
+    url = urlparse(url)
+    if url[4]:
+        return url[2] + '?' + url[4]
+    return url[2]


### PR DESCRIPTION
## Purpose:
[OSF-6551](https://openscience.atlassian.net/browse/OSF-6551)
Fix "node" and "replies" links for registration comments. Covers comments for nodes, wikis, and files.

## Changes:
Update api/comments/serializers.py make registration and node super classes of *CommentSerializer
Update api/comments/views.py add logic to differentiate between Node and Registration
Update api/nodes/views.py switch to NodeCommentSerializer
Update api/registrations/views.py switch to RegistrationCommentSerializer
Update api_tests/comments/views/test_comment_detail.py fix several tests and add three tests
Update api_tests/utils.py add "def urlparse_drop_netloc" for converting links to URIs for app.get


## Side effects
None

https://openscience.atlassian.net/browse/OSF-6551