### PR TITLE
Make flag for non-meetings meetings [#OSF-5645]

### DIFF
--- a/website/static/js/pages/meetings-page.js
+++ b/website/static/js/pages/meetings-page.js
@@ -1,34 +1,33 @@
 var $ = require('jquery');
- var Meetings = require('../meetings.js');
- var Submissions = require('../submissions.js');
+var Meetings = require('../meetings.js');
+var Submissions = require('../submissions.js');
 
-  var tracker = 0; 
-for (var i = 0; i < window.contextVars.meetings.length; i++) { 
-    if (window.contextVars.meetings[i].name === 'Psi Chi' || window.contextVars.meetings[i].name === 'Time-sharing Experiments for the Social Sciences') { 
+var tracker = 0; 
+for (var i = 0; i < window.contextVars.meetings.length; i++) {
+    if (window.contextVars.meetings[i].name === 'Psi Chi' || window.contextVars.meetings[i].name === 'Time-sharing Experiments for the Social Sciences') {
         window.contextVars.meetings.splice(i, 1);
-        i = i - 1; 
+        i = i - 1;
         tracker = tracker + 1;
-        if (tracker === 2) { // Once we have removed both of the non meetings meetings, the for loop can break 
+        if (tracker === 2) { // Once we have removed both of the non meetings meetings, the for loop can break
             break;
-         } 
-    } 
+         }
+    }
 }
 new Meetings(window.contextVars.meetings);
-      
-var request = $.getJSON('/api/v1/meetings/submissions/');  
 
-request.always(function() { 
+var request = $.getJSON('/api/v1/meetings/submissions/');
+
+request.always(function() {
     $('#allMeetingsLoader').hide();
 });
 
 request.done(function(data) {
-     console.log(data.submissions); 
+     console.log(data.submissions);
     for (var i = 0; i < data.submissions.length; i++) {
-        if (data.submissions[i].confName === 'Psi Chi' || data.submissions[i].confName === 'Time-sharing Experiments for the Social Sciences'){ 
-            data.submissions.splice(i, 1); 
-            i = i - 1; 
-        } 
+        if (data.submissions[i].confName === 'Psi Chi' || data.submissions[i].confName === 'Time-sharing Experiments for the Social Sciences') {
+            data.submissions.splice(i, 1);
+            i = i - 1;
+        }
     }
     new Submissions(data.submissions);
- }); 
-
+ });

--- a/website/static/js/pages/meetings-page.js
+++ b/website/static/js/pages/meetings-page.js
@@ -1,14 +1,34 @@
 var $ = require('jquery');
-var Meetings = require('../meetings.js');
-var Submissions = require('../submissions.js');
+ var Meetings = require('../meetings.js');
+ var Submissions = require('../submissions.js');
 
+  var tracker = 0; 
+for (var i = 0; i < window.contextVars.meetings.length; i++) { 
+    if (window.contextVars.meetings[i].name === 'Psi Chi' || window.contextVars.meetings[i].name === 'Time-sharing Experiments for the Social Sciences') { 
+        window.contextVars.meetings.splice(i, 1);
+        i = i - 1; 
+        tracker = tracker + 1;
+        if (tracker === 2) { // Once we have removed both of the non meetings meetings, the for loop can break 
+            break;
+         } 
+    } 
+}
 new Meetings(window.contextVars.meetings);
+      
+var request = $.getJSON('/api/v1/meetings/submissions/');  
 
-var request = $.getJSON('/api/v1/meetings/submissions/');
-
-request.always(function() {
+request.always(function() { 
     $('#allMeetingsLoader').hide();
 });
+
 request.done(function(data) {
+     console.log(data.submissions); 
+    for (var i = 0; i < data.submissions.length; i++) {
+        if (data.submissions[i].confName === 'Psi Chi' || data.submissions[i].confName === 'Time-sharing Experiments for the Social Sciences'){ 
+            data.submissions.splice(i, 1); 
+            i = i - 1; 
+        } 
+    }
     new Submissions(data.submissions);
-});
+ }); 
+


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Make non-meetings meetings and non-meetings meeting's submissions not get shown on the meetings page
<!-- Describe the purpose of your changes -->

## Changes

Checks through meetings and submissions data and removes all meetings and submissions with specific names before passing the data to the treebeard wrapper and then treebeard.
<!-- Briefly describe or list your changes  -->

## Side effects

None
<!--Any possible side effects? -->


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->

https://openscience.atlassian.net/browse/OSF-5645