### PR TITLE
Made text improvement in merging accounts modal [OSF-6721]

### DIFF
--- a/website/static/js/accountSettings.js
+++ b/website/static/js/accountSettings.js
@@ -216,7 +216,7 @@ var UserProfileViewModel = oop.extend(ChangeMessageMixin, {
                                 title: 'Confirmation email sent',
                                 message: '<em>' + safeAddr + '</em>' + ' was added to your account.' +
                                 ' You will receive a confirmation email at ' + '<em>' + safeAddr + '</em>.' +
-                                ' Please log out of this account and check your email to confirm this action.',
+                                ' Please click the link in your email to confirm this action. You will be required to enter your password.',
                                 buttons: {
                                     ok: {
                                         label: 'Close',


### PR DESCRIPTION
## Purpose

The original confirmation message when adding an email to merge accounts was ambiguous so it should be edited to be more detailed. 

## Changes

Changed the text in accountSettings.js.

![image](https://cloud.githubusercontent.com/assets/8868219/17255473/71860fb6-5587-11e6-86cf-8185cce245f0.png)

![image](https://cloud.githubusercontent.com/assets/8868219/17255479/78cd8682-5587-11e6-89a9-1f70e50f2859.png)

## Side effects

N/A


## Ticket

https://openscience.atlassian.net/browse/OSF-6721
