### PR TITLE
[hotfix][CR] read-access contributors should see analytics page [#OSF-5885]

### DIFF
--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -424,8 +424,6 @@ def project_reorder_components(node, **kwargs):
 @must_be_valid_project
 @must_be_contributor_or_public
 def project_statistics(auth, node, **kwargs):
-    if not (node.can_edit(auth) or node.is_public):
-        raise HTTPError(http.FORBIDDEN)
     ret = _view_project(node, auth, primary=True)
     ret['node']['keenio_read_key'] = node.keenio_read_key
     return ret


### PR DESCRIPTION
## Purpose

Read access contributors to a private project should see the "Make public to get analytics" message when they visit the Analytics page.  Instead, we were showing a 403 Forbidden.

## Changes

Remove some old (circa-2014) permissions code that was forbidding read-onlys.

## Side effects

None expected.

## Ticket

[#OSF-5885]
https://openscience.atlassian.net/browse/OSF-5885