### PR TITLE
[hotfix] Access token info icon fails to display because of extra quotation mark [#OSF-6321]

### DIFF
--- a/website/templates/profile/personal_tokens_detail.mako
+++ b/website/templates/profile/personal_tokens_detail.mako
@@ -37,7 +37,7 @@
                             % for scope in scope_options:
                                 <input type="checkbox" id="${scope[0]}" value="${scope[0]}" data-bind="checked: scopes">
                                 <label for="${scope[0]}">${scope[0]} </label>
-                                <i class="fa fa-info-circle text-muted" data-bind="tooltip: {title: ${scope[1] | sjson, n }, placement: 'bottom'}"></i>
+                                <i class="fa fa-info-circle text-muted" data-bind="tooltip: {title: '${scope[1] | entity}', placement: 'bottom'}"></i>
                                 <br>
                             % endfor
                          </div>


### PR DESCRIPTION
## Purpose
Ensure that tooltips display correctly on "personal access tokens: create" page: http://localhost:5000/settings/tokens/create/

![screen shot 2016-07-29 at 4 34 58 pm](https://cloud.githubusercontent.com/assets/2957073/17262634/830e2cdc-55aa-11e6-87db-f5ed984b1a78.png)

This fixes an issue where the quotation marks added around strings by `sjson` interfered with the quotation marks used to denote an attribute in HTML.

## Changes
Replace the `sjson | n` filter (which trusted the string as given) with the `entity` filter. All possible strings for this field are plain text with no entities, apostrophes, or quotation marks.

## Side effects
None expected, but if a scope description ever adds an apostrophe, it will render oddly for reasons outlined below. No current descriptions are affected by this. Long term we plan to use a different system of tooltips in future frontend code.

### Weirdness documented
Origin: This field is strange because it *looks* like a javascript context, but behaves slightly different (at the mercy of knockout's parser). Normally correct HTML attribute escaping failed to work, and gave a "cannot parse bindings" error.

I tried removing the `sjson, n` filter entirely (so that apostrophes would be subject to regular HTML attribute escaping in mako's default filters). Even though the attribute value showed the special characters as an escaped apostrophe: `&#39;`, it did not parse correctly in knockout.

Applying the entities filter double-escapes the string. *The alternative would be to just use the `n` filter and treat the text as given (since the value is not user entered)... but this is fragile. If a scope description ever allowed apostrophes or quotation marks, the page would break in weird ways*. I'd rather the failure mode be obvious and easy to correct with a text change.


## Ticket
https://openscience.atlassian.net/browse/OSF-6321