### PR TITLE
[OSF-6026] feature/versions fixes for specific versioning

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1281,7 +1281,7 @@ function _fangornTitleColumn(item, col) {
 
 function _fangornVersionColumn(item,col) {
     var tb = this;
-    if (item.kind !== 'folder'){
+    if (item.kind !== 'folder' && item.data.provider === 'osfstorage'){
         return _fangornTitleColumnHelper(tb,item,col,String(item.data.extra.version),'/?show=revision','fg-version-links');
     }
     return;
@@ -1385,16 +1385,16 @@ function _fangornResolveRows(item) {
         custom : _fangornTitleColumn
     });
     defaultColumns.push({
-        data: 'version',
-        filter: true,
-        sortInclude : false,
-        custom: _fangornVersionColumn
-    });
-    defaultColumns.push({
         data : 'size',  // Data field name
         sortInclude : false,
         filter : false,
         custom : function() {return item.data.size ? $osf.humanFileSize(item.data.size, true) : '';}
+    });
+    defaultColumns.push({
+        data: 'version',
+        filter: true,
+        sortInclude : false,
+        custom: _fangornVersionColumn
     });
     if (item.data.provider === 'osfstorage') {
         defaultColumns.push({
@@ -1435,14 +1435,14 @@ function _fangornColumnTitles () {
         sort : true,
         sortType : 'text'
     }, {
-        title: 'Version',
-        width : '10%',
-        sort : false
-    },{
         title : 'Size',
         width : '8%',
         sort : false
     }, {
+        title: 'Version',
+        width : '10%',
+        sort : false
+    },{
         title : 'Downloads',
         width : '8%',
         sort : false

--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -391,6 +391,7 @@ var FileViewPage = {
         }
 
         function changeVersionHeader(){
+            document.getElementById('versionLink').style.display = 'inline';
             m.render(document.getElementById('versionLink'), m('a', {onclick: toggleRevisions}, document.getElementById('versionLink').innerHTML));
         }
 
@@ -405,7 +406,9 @@ var FileViewPage = {
            }
         }
 
-        changeVersionHeader();
+        if(self.file.provider === 'osfstorage'){
+            changeVersionHeader();
+        }
 
     },
     view: function(ctrl) {

--- a/website/templates/project/view_file.mako
+++ b/website/templates/project/view_file.mako
@@ -16,7 +16,7 @@
     <h2 class="break-word">
       ## Split file name into two parts: with and without extension
       ${file_name_title | h}<span id="file-ext">${file_name_ext | h}</span>
-      <a id='versionLink'>(Version: ${ version_id | h})</a>
+      <a id='versionLink' class='scripted'>(Version: ${ version_id | h})</a>
       % if file_revision:
         <small>&nbsp;${file_revision | h}</small>
       % endif


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Fixes for develop and the versioning. Since we are the only ones that keep track of versions and it seems that I can't get the hases of the versions for anything but the osfstorage without rewriting the underlying architecture, I decided to only show versions for the column that is from the osfstorage and leave the rest blank. This should also fix the display problem on the file revision page.

## Changes

Special cased osfstorage to show versions

## Side effects

There should not be any.

## Ticket

https://openscience.atlassian.net/browse/OSF-6026
