### PR TITLE
Improve Prerender functionalities [OSF-6735]

### DIFF
--- a/website/static/js/prerender.js
+++ b/website/static/js/prerender.js
@@ -1,0 +1,25 @@
+window.activeAjaxCount = 0;
+
+function isAllXhrComplete(){
+    window.activeAjaxCount--;
+    if (window.activeAjaxCount === 0){
+        $('meta[name=prerender-status-code]').attr('content', '200');
+        window.prerenderReady = true;
+    }
+
+}
+
+(function(open) {
+    XMLHttpRequest.prototype.open = function(method, url, async, user, pass) {
+        this.addEventListener('load', isAllXhrComplete);
+        open.call(this, method, url, async, user, pass);
+    };
+})(XMLHttpRequest.prototype.open);
+
+
+(function(send) {
+    XMLHttpRequest.prototype.send = function (data) {
+        window.activeAjaxCount++;
+        send.call(this, data);
+    };
+})(XMLHttpRequest.prototype.send);

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -1,4 +1,5 @@
 <% from website import settings %>
+<% from flask import request %>
 
 <!DOCTYPE html>
 <html lang="en">
@@ -12,9 +13,13 @@
     <meta name="description" content="${self.description()}">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="fragment" content="!">
-    <!-- replaceme1 -->
-    <!-- replaceme2 -->
-    <!-- replaceme3 -->
+    
+    % if "Prerender" in request.headers.get("User-Agent"):
+        <meta name="prerender-status-code" content="504">
+        <script> window.prerenderReady = false </script>
+        <script src="/static/js/prerender.js"> </script>
+    % endif
+
     % if sentry_dsn_js:
     <script src="/static/vendor/bower_components/raven-js/dist/raven.min.js"></script>
     <script>

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -12,7 +12,9 @@
     <meta name="description" content="${self.description()}">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="fragment" content="!">
-
+    <!-- replaceme1 -->
+    <!-- replaceme2 -->
+    <!-- replaceme3 -->
     % if sentry_dsn_js:
     <script src="/static/vendor/bower_components/raven-js/dist/raven.min.js"></script>
     <script>

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -14,7 +14,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="fragment" content="!">
     
-    % if "Prerender" in request.headers.get("User-Agent"):
+    % if request.headers.get("User-Agent") is not None and "Prerender" in request.headers.get("User-Agent"):
         <meta name="prerender-status-code" content="504">
         <script> window.prerenderReady = false </script>
         <script src="/static/js/prerender.js"> </script>


### PR DESCRIPTION
## Purpose

To improve functionality of Prerender without affecting the experience of normal users. Prerender should wait for a page to render completely, or return a 504 status code if a page fails to render before timeout.

## Changes

Three lines are added to base.mako within a conditional so that they are only viewable to prerender. In other words, the change to base.mako can make sure there are two different set of templates, one for normal browsers and another one for robots (as identified by user agent string of the request).
A new javascript file (prerender.js) is added to be included in the template for robots. The purpose of the js file is to determine whether there are currently active XHR requests. If not, then the meta tag of "prerender-status-code" would be set to 200 (so that Prerender knows to return a 200 to the request) and the prerenderReady variable of the window will be set to true.

## Side effects

The beauty of this approach is that there is no side effects, or any effects at all on normal users. (Big thanks to @JeffSpies who came up with the idea) 
## Ticket

https://openscience.atlassian.net/browse/OSF-6735
