### PR TITLE
[OSF-2052] Social share button should show up on Safari

### DIFF
--- a/website/static/js/components/socialshare.js
+++ b/website/static/js/components/socialshare.js
@@ -44,26 +44,31 @@ var ShareButtons = {
 
 var ShareButtonsPopover = {
     controller: function() {
-        this.justBlurred = true;
+        this.showOnClick = true;
+        this.popupShowing = false;
     },
     view: function(ctrl, options) {
         return [
             m('a#sharePopoverBtn.btn.btn-default[href=#][data-toggle=popover]', {
+                onmousedown: function() {
+                    ctrl.showOnClick = !ctrl.popupShowing;
+                },
                 onclick: function() {
-                    if (!ctrl.justBlurred) {
+                    if (ctrl.showOnClick && !ctrl.popupShowing) {
+                        $('#sharePopoverBtn').focus();
+                    } else if (!ctrl.showOnClick && ctrl.popupShowing){
                         $('#sharePopoverBtn').blur();
-                    } else {
-                        ctrl.justBlurred = false;
                     }
                 },
                 onfocus: function() {
                     $('#sharePopoverBtn').popover('show');
                     m.render(document.getElementById('shareButtonsPopoverContent'),
                              ShareButtons.view(ctrl, {title: options.title, url: options.url}));
+                    ctrl.popupShowing = true;
                 },
                 onblur: function() {
-                    ctrl.justBlurred = true;
                     $('#sharePopoverBtn').popover('hide');
+                    ctrl.popupShowing = false;
                 },
                 config: function(el, isInitialized) {
                     if (!isInitialized) {


### PR DESCRIPTION
## Purpose
Due to browser differences, clicking on the "Share" button on a project page in Safari did nothing.

## Changes
Use of onfocus and other events was changed to accommodate different browser behaviors.

## Side effects
N/A

## Ticket
https://openscience.atlassian.net/browse/OSF-2052