### PR TITLE
[Hotfix] List more than 10 Folders through API [OSF-6830]

### DIFF
--- a/api/base/pagination.py
+++ b/api/base/pagination.py
@@ -128,6 +128,11 @@ class JSONAPIPagination(pagination.PageNumberPagination):
             return super(JSONAPIPagination, self).paginate_queryset(queryset, request, view=None)
 
 
+class MaxSizePagination(JSONAPIPagination):
+    page_size = 1000
+    max_page_size = None
+    page_size_query_param = None
+
 class CommentPagination(JSONAPIPagination):
 
     def get_paginated_response(self, data):

--- a/api/institutions/views.py
+++ b/api/institutions/views.py
@@ -16,6 +16,7 @@ from api.base.filters import ODMFilterMixin
 from api.base.views import JSONAPIBaseView
 from api.base.serializers import JSONAPISerializer
 from api.base.utils import get_object_or_error, get_user_auth
+from api.base.pagination import MaxSizePagination
 from api.base.parsers import (
     JSONAPIRelationshipParser,
     JSONAPIRelationshipParserForRegularJSON,
@@ -69,6 +70,7 @@ class InstitutionList(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin):
     required_write_scopes = [CoreScopes.NULL]
     model_class = Institution
 
+    pagination_class = MaxSizePagination
     serializer_class = InstitutionSerializer
     view_category = 'institutions'
     view_name = 'institution-list'

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -16,7 +16,7 @@ from api.base.parsers import (
     JSONAPIRelationshipParserForRegularJSON,
 )
 from api.base.exceptions import RelationshipPostMakesNoChanges, EndpointNotImplementedError
-from api.base.pagination import CommentPagination, NodeContributorPagination
+from api.base.pagination import CommentPagination, NodeContributorPagination, MaxSizePagination
 from api.base.utils import get_object_or_error, is_bulk_request, get_user_auth, is_truthy
 from api.base.settings import ADDONS_OAUTH, API_BASE
 from api.addons.views import AddonSettingsMixin
@@ -2022,6 +2022,7 @@ class NodeAddonFolderList(JSONAPIBaseView, generics.ListAPIView, NodeMixin, Addo
     required_read_scopes = [CoreScopes.NODE_ADDON_READ, CoreScopes.NODE_FILE_READ]
     required_write_scopes = [CoreScopes.NULL]
 
+    pagination_class = MaxSizePagination
     serializer_class = NodeAddonFolderSerializer
     view_category = 'nodes'
     view_name = 'node-addon-folders'

--- a/api_tests/base/test_pagination.py
+++ b/api_tests/base/test_pagination.py
@@ -7,4 +7,5 @@ from api.base.pagination import MaxSizePagination
 
 class TestMaxPagination(ApiTestCase):
     def test_no_query_param_alters_page_size(self):
-        assert_is_none(MaxSizePagination.page_size_query_param)
+        assert MaxSizePagination.page_size_query_param is None, 'Adding variable page sizes to the paginator ' +\
+            'requires tests to ensure that you can\'t request more than the class\'s maximum number of values.'

--- a/api_tests/base/test_pagination.py
+++ b/api_tests/base/test_pagination.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+from nose.tools import *  # flake8: noqa
+
+from tests.base import ApiTestCase
+
+from api.base.pagination import MaxSizePagination
+
+class TestMaxPagination(ApiTestCase):
+    def test_no_query_param_alters_page_size(self):
+        assert_is_none(MaxSizePagination.page_size_query_param)

--- a/api_tests/institutions/views/test_institution_list.py
+++ b/api_tests/institutions/views/test_institution_list.py
@@ -24,6 +24,7 @@ class TestInstitutionList(ApiTestCase):
 
         ids = [each['id'] for each in res.json['data']]
         assert_equal(len(res.json['data']), 2)
+        assert_equal(res.json['links']['meta']['per_page'], 1000)
         assert_in(self.institution._id, ids)
         assert_in(self.institution2._id, ids)
 

--- a/api_tests/nodes/views/test_node_addons.py
+++ b/api_tests/nodes/views/test_node_addons.py
@@ -468,6 +468,7 @@ class NodeAddonFolderMixin(object):
         if not wrong_type:
             addon_data = res.json['data'][0]['attributes']
             assert_equal(addon_data['kind'], 'folder')
+            assert_equal(res.json['links']['meta']['per_page'], 1000)
             assert '/ (Full ' in addon_data['name']
             assert_equal(addon_data['path'], '/')
             assert addon_data['folder_id'] in VALID_ROOT_FOLDER_IDS

--- a/website/static/js/folderPickerNodeConfig.js
+++ b/website/static/js/folderPickerNodeConfig.js
@@ -515,11 +515,7 @@ var FolderPickerViewModel = oop.defclass({
                 // Also handle data from API -- squash `attributes` to what TB expects
                 // TODO: [OSF-6384] DRY this up when PR #5240 goes in
                 if (data.data) {
-                    $.each(data.data, function(i, obj) {
-                        var savedAttributes = obj.attributes;
-                        delete obj.attributes;
-                        $.extend(true, obj, savedAttributes);
-                    });
+                    return $osf.squashAPIAttributes(data);
                 }
                 return data;
             },

--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -94,6 +94,20 @@ var ajaxJSON = function(method, url, options) {
     return $.ajax(ajaxFields);
 };
 
+ /**
+  * Squashes APIv2 data.attributes to top level JSON for treebeard
+  *
+  * @param {Object} data JSON data
+  * @return {Object data}
+  */
+  var squashAPIAttributes = function(data) {
+    $.each(data.data, function(i, obj) {
+        var savedAttributes = obj.attributes;
+        delete obj.attributes;
+        $.extend(true, obj, savedAttributes);
+    });
+    return data;
+};
 
 /**
 * Posts JSON data.
@@ -907,6 +921,7 @@ module.exports = window.$.osf = {
     postJSON: postJSON,
     putJSON: putJSON,
     ajaxJSON: ajaxJSON,
+    squashAPIAttributes: squashAPIAttributes,
     setXHRAuthorization: setXHRAuthorization,
     handleAddonApiHTTPError: handleAddonApiHTTPError,
     handleJSONError: handleJSONError,


### PR DESCRIPTION
## Purpose
List more than 10 folders for addons when using APIv2

## Changes
* Page size set to 1k
* Opportunistic Fix: `InstitutionsList` page size set to 1k:

>I do see us going over 100 institutions but we will likely remain under 1k
\- @icereval 

## Side effects
This isn't pagination. Because [where this is being called in TreeBeard](https://github.com/CenterForOpenScience/treebeard/blob/develop/dist/treebeard.js#L1064) doesn't resolve promises, this flow is difficult to hook into.

Consider adding a JSONAPI-compliant pagination feature to TreeBeard.

## Ticket
[OSF-6830](https://openscience.atlassian.net/browse/OSF-6830)