### PR TITLE
Profile: long Personal Website URLs run over in cause problems in display #5270 [OSF-6722]

### DIFF
--- a/website/templates/include/profile/social.mako
+++ b/website/templates/include/profile/social.mako
@@ -154,7 +154,7 @@
                 <tr data-bind="if: hasProfileWebsites()">
                     <td data-bind="visible: profileWebsites().length > 1">Personal websites</td>
                     <td data-bind="visible: profileWebsites().length === 1">Personal website</td>
-                    <td data-bind="foreach: profileWebsites"><a data-bind="attr: {href: $data}, text: $data"></a><br></td>
+                    <td data-bind="foreach: profileWebsites" width="400px"><a data-bind="attr: {href: $data}, text: $data"></a><br></td>
                 </tr>
             </tbody>
 


### PR DESCRIPTION
## Purpose

Having a long URL for personal websites causes the rest of the items under "Social" to be misaligned. 

## Changes

Changed the width of each column in the table so that the first column with the labels can all fit on one line. 

## Side effects

N/A


## Ticket
https://openscience.atlassian.net/browse/OSF-6722
