### PR TITLE
Allow bulk DELETE with query parameters [OSF-6732]

### DIFF
--- a/api/base/generic_bulk_views.py
+++ b/api/base/generic_bulk_views.py
@@ -71,19 +71,19 @@ class BulkDestroyJSONAPIView(bulk_generics.BulkDestroyAPIView):
     Custom BulkDestroyAPIView that handles validation and permissions for
     bulk delete
     """
-    def get_requested_resources(self, request):
+    def get_requested_resources(self, request, request_data):
         """
         Retrieves resources in request body
         """
         model_cls = request.parser_context['view'].model_class
-        requested_ids = [data['id'] for data in request.data]
+        requested_ids = [data['id'] for data in request_data]
         resource_object_list = model_cls.find(Q('_id', 'in', requested_ids))
 
         for resource in resource_object_list:
             if getattr(resource, 'is_deleted', None):
                 raise Gone
 
-        if len(resource_object_list) != len(request.data):
+        if len(resource_object_list) != len(request_data):
             raise ValidationError({'non_field_errors': 'Could not find all objects to delete.'})
 
         return resource_object_list
@@ -109,7 +109,25 @@ class BulkDestroyJSONAPIView(bulk_generics.BulkDestroyAPIView):
 
         Handles some validation and enforces bulk limit.
         """
-        num_items = len(request.data)
+        if hasattr(request,'query_params') and 'id' in request.query_params:
+            if hasattr(request, 'data') and len(request.data) > 0:
+                raise Conflict('A bulk DELETE can only have a body or query parameters, not both.')
+
+            ids = request.query_params['id'].split(',')
+
+            if 'type' in request.query_params:
+                request_type = request.query_params['type']
+                data = []
+                for id in ids:
+                    data.append({'type':request_type, 'id': id})
+            else:
+                raise ValidationError('Type query parameter is also required for a bulk DELETE using query parameters.')
+        elif not request.data:
+            raise ValidationError('Request must contain array of resource identifier objects.')
+        else:
+            data = request.data
+
+        num_items = len(data)
         bulk_limit = BULK_SETTINGS['DEFAULT_BULK_LIMIT']
 
         if num_items > bulk_limit:
@@ -119,12 +137,9 @@ class BulkDestroyJSONAPIView(bulk_generics.BulkDestroyAPIView):
         user = self.request.user
         object_type = self.serializer_class.Meta.type_
 
-        if not request.data:
-            raise ValidationError('Request must contain array of resource identifier objects.')
+        resource_object_list = self.get_requested_resources(request=request, request_data=data)
 
-        resource_object_list = self.get_requested_resources(request)
-
-        for item in request.data:
+        for item in data:
             item_type = item[u'type']
             if item_type != object_type:
                 raise Conflict()

--- a/api/base/generic_bulk_views.py
+++ b/api/base/generic_bulk_views.py
@@ -142,7 +142,7 @@ class BulkDestroyJSONAPIView(bulk_generics.BulkDestroyAPIView):
         for item in data:
             item_type = item[u'type']
             if item_type != object_type:
-                raise Conflict("Type needs to match type expected at this endpoint.")
+                raise Conflict('Type needs to match type expected at this endpoint.')
 
         if not self.allow_bulk_destroy_resources(user, resource_object_list):
             raise PermissionDenied

--- a/api/base/generic_bulk_views.py
+++ b/api/base/generic_bulk_views.py
@@ -109,7 +109,7 @@ class BulkDestroyJSONAPIView(bulk_generics.BulkDestroyAPIView):
 
         Handles some validation and enforces bulk limit.
         """
-        if hasattr(request,'query_params') and 'id' in request.query_params:
+        if hasattr(request, 'query_params') and 'id' in request.query_params:
             if hasattr(request, 'data') and len(request.data) > 0:
                 raise Conflict('A bulk DELETE can only have a body or query parameters, not both.')
 
@@ -119,7 +119,7 @@ class BulkDestroyJSONAPIView(bulk_generics.BulkDestroyAPIView):
                 request_type = request.query_params['type']
                 data = []
                 for id in ids:
-                    data.append({'type':request_type, 'id': id})
+                    data.append({'type': request_type, 'id': id})
             else:
                 raise ValidationError('Type query parameter is also required for a bulk DELETE using query parameters.')
         elif not request.data:

--- a/api/base/generic_bulk_views.py
+++ b/api/base/generic_bulk_views.py
@@ -142,7 +142,7 @@ class BulkDestroyJSONAPIView(bulk_generics.BulkDestroyAPIView):
         for item in data:
             item_type = item[u'type']
             if item_type != object_type:
-                raise Conflict()
+                raise Conflict("Type needs to match type expected at this endpoint.")
 
         if not self.allow_bulk_destroy_resources(user, resource_object_list):
             raise PermissionDenied

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -684,9 +684,9 @@ class NodeContributorsList(JSONAPIBaseView, bulk_views.BulkUpdateJSONAPIView, bu
             raise ValidationError('Must have at least one registered admin contributor')
 
     # Overrides BulkDestroyJSONAPIView
-    def get_requested_resources(self, request):
+    def get_requested_resources(self, request, request_data):
         requested_ids = []
-        for data in request.data:
+        for data in request_data:
             try:
                 requested_ids.append(data['id'].split('-')[1])
             except IndexError:
@@ -697,7 +697,7 @@ class NodeContributorsList(JSONAPIBaseView, bulk_views.BulkUpdateJSONAPIView, bu
             if getattr(resource, 'is_deleted', None):
                 raise Gone
 
-        if len(resource_object_list) != len(request.data):
+        if len(resource_object_list) != len(request_data):
             raise ValidationError({'non_field_errors': 'Could not find all objects to delete.'})
 
         return resource_object_list

--- a/api_tests/nodes/views/test_node_list.py
+++ b/api_tests/nodes/views/test_node_list.py
@@ -1569,7 +1569,42 @@ class TestNodeBulkDelete(ApiTestCase):
         self.private_project_url = "/{}nodes/{}/".format(API_BASE, self.private_project_user_one._id)
 
         self.public_payload = {'data': [{'id': self.project_one._id, 'type': 'nodes'}, {'id': self.project_two._id, 'type': 'nodes'}]}
+        self.public_query_params = 'id={},{}'.format(self.project_one._id, self.project_two._id)
+        self.type_query_param = 'type=nodes'
         self.private_payload = {'data': [{'id': self.private_project_user_one._id, 'type': 'nodes'}]}
+        self.private_query_params = 'id={}'.format(self.private_project_user_one._id)
+
+    def test_bulk_delete_with_query_params(self):
+        url = '{}?{}&{}'.format(self.url, self.type_query_param, self.public_query_params)
+        res = self.app.delete_json_api(url, auth=self.user_one.auth, bulk=True)
+        assert_equal(res.status_code, 204)
+
+    def test_bulk_delete_with_query_params_and_payload(self):
+        url = '{}?{}&{}'.format(self.url, self.type_query_param, self.public_query_params)
+        res = self.app.delete_json_api(url, self.public_payload, auth=self.user_one.auth, expect_errors=True, bulk=True)
+        assert_equal(res.status_code, 409)
+        assert_equal(
+            res.json['errors'][0]['detail'],
+            u'A bulk DELETE can only have a body or query parameters, not both.'
+        )
+
+    def test_bulk_delete_with_query_params_no_type(self):
+        url = '{}?{}'.format(self.url, self.public_query_params)
+        res = self.app.delete_json_api(url, auth=self.user_one.auth, expect_errors=True, bulk=True)
+        assert_equal(res.status_code, 400)
+        assert_equal(
+            res.json['errors'][0]['detail'],
+            u'Type query parameter is also required for a bulk DELETE using query parameters.'
+        )
+
+    def test_bulk_delete_with_query_params_wrong_type(self):
+        url = '{}?{}&{}'.format(self.url, self.public_query_params, "type=node_not_nodes")
+        res = self.app.delete_json_api(url, auth=self.user_one.auth, expect_errors=True, bulk=True)
+        assert_equal(res.status_code, 409)
+        assert_equal(
+            res.json['errors'][0]['detail'],
+            u'Type needs to match type expected at this endpoint.'
+        )
 
     def test_bulk_delete_nodes_blank_request(self):
         res = self.app.delete_json_api(self.url, auth=self.user_one.auth, expect_errors=True, bulk=True)


### PR DESCRIPTION
## Purpose

The Google Cloud / Kubernetes load balancer does not allow DELETE requests with JSON bodies, and the initial spec for JSON API Bulk DELETEs has just this combination. So we have a new implementation of Bulk DELETEs that will use query parameters to perform the delete rather than JSON body. The JSON body is still acceptable for now, because it's used in places, but that will probably be phased out before we move all the servers over to the new load balancer.

A request would look like:
DELETE `https://api.osf.io/v2/nodes/?type=nodes&id=abcde,fgh4j,k8mn2`

You cannot use both the JSON body and the query parameters. if the id field is in the query parameters and there is a JSON body, the request will fail with a good error. If only the type field is in the query parameters, it will ignore the type field and will work with the JSON body.

There is a set of runscope test on the OSF Status Board that should be updated for this new method of deleting. When this makes it onto staging2, then the test that has been failing is updated and runs, it should all work again.

## Changes

1. Update bulk delete code to allow use of query parameters
2. Update node contributors bulk delete code to work with refactored code
3. Update one error message to be more useful
4. Tests

## Side effects

If any bulk requests were overridden but not tested, those requests will probably fail. 


## Ticket

https://openscience.atlassian.net/browse/OSF-6732
