### PR TITLE
Stop side navbar on account settings scrolls behind main text of page [OSF-5125]

### DIFF
--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -265,7 +265,7 @@ a {
 
 }
 
-@media (max-width: 768px) {
+@media (max-width: 991px) {
     .affix {
         position: relative; /*For project setting side-bar*/
     }
@@ -278,7 +278,7 @@ a {
 .osf-affix {
     display: none;
 }
-@media (min-width: 769px) {
+@media (min-width: 990px) {
     .osf-affix.profile-affix {
         top: 80px;
     }


### PR DESCRIPTION
## Purpose

Currently on account setting the side navbar won't be properly responsive and will slide under the panels on that page.

## Changes

Simple change to media query.

## Side effects

None that I know of

## Ticket

https://openscience.atlassian.net/browse/OSF-5125