### PR TITLE
Make flag for non-meetings Meetings in Admin app [#OSF-5645]

### DIFF
--- a/admin/meetings/forms.py
+++ b/admin/meetings/forms.py
@@ -61,6 +61,11 @@ class MeetingForm(forms.Form):
         required=False,
         widget=forms.TextInput(attrs={'size': '60'}),
     )
+    is_meeting = forms.BooleanField(
+        label='This is a meeting',
+        initial=True,
+        required=False,
+    )
     active = forms.BooleanField(
         label='Conference is active',
         required=False,

--- a/admin/meetings/forms.py
+++ b/admin/meetings/forms.py
@@ -138,7 +138,7 @@ class MeetingForm(forms.Form):
         endpoint = self.cleaned_data['endpoint']
         edit = self.cleaned_data['edit']
         try:
-            Conference.get_by_endpoint(endpoint)
+            Conference.get_by_endpoint(endpoint, False)
             if not edit:
                 raise forms.ValidationError(
                     'A meeting with this endpoint exists already.'

--- a/admin/meetings/serializers.py
+++ b/admin/meetings/serializers.py
@@ -1,6 +1,9 @@
 
 
 def serialize_meeting(meeting):
+    is_meeting = True
+    if hasattr(meeting, 'is_meeting'):
+        is_meeting = meeting.is_meeting
     return {
         'endpoint': meeting.endpoint,
         'name': meeting.name,
@@ -24,4 +27,5 @@ def serialize_meeting(meeting):
         'mail_subject': meeting.field_names['mail_subject'],
         'mail_message_body': meeting.field_names['mail_message_body'],
         'mail_attachment': meeting.field_names['mail_attachment'],
+        'is_meeting': is_meeting,
     }

--- a/admin/meetings/views.py
+++ b/admin/meetings/views.py
@@ -65,6 +65,7 @@ class MeetingFormView(OSFAdmin, FormView):
         self.conf.name = data.get('name')
         self.conf.info_url = data.get('info_url')
         self.conf.logo_url = data.get('logo_url')
+        self.conf.is_meeting = data.get('is_meeting')
         self.conf.active = data.get('active')
         self.conf.public_projects = data.get('public_projects')
         self.conf.poster = data.get('poster')

--- a/tests/test_conferences.py
+++ b/tests/test_conferences.py
@@ -48,6 +48,7 @@ class ConferenceFactory(ModularOdmFactory):
     endpoint = Sequence(lambda n: 'conference{0}'.format(n))
     name = FakerAttribute('catch_phrase')
     active = True
+    is_meeting = True
 
     @post_generation
     def admins(self, create, extracted, **kwargs):

--- a/website/conferences/model.py
+++ b/website/conferences/model.py
@@ -34,6 +34,7 @@ class Conference(StoredObject):
     location = fields.StringField(required=False, default=None)
     start_date = fields.DateTimeField(default=None)
     end_date = fields.DateTimeField(default=None)
+    is_meeting = fields.BooleanField(required=True)
     active = fields.BooleanField(required=True)
     admins = fields.ForeignField('user', list=True, required=False, default=None)
     #: Whether to make submitted projects public

--- a/website/conferences/views.py
+++ b/website/conferences/views.py
@@ -231,7 +231,7 @@ def conference_submissions(**kwargs):
     submissions = []
     #  TODO: Revisit this loop, there has to be a way to optimize it
     for conf in Conference.find():
-        if (hasattr(conf, 'is_meeting') and (conf.is_meeting == False)) or (conf.name == 'Psi Chi') or (conf.name == 'Time-sharing Experiments for the Social Sciences'):
+        if (hasattr(conf, 'is_meeting') and (conf.is_meeting is False)) or (conf.name == 'Psi Chi') or (conf.name == 'Time-sharing Experiments for the Social Sciences'):
             break
         # For efficiency, we filter by tag first, then node
         # instead of doing a single Node query
@@ -261,7 +261,7 @@ def conference_view(**kwargs):
     for conf in Conference.find():
         if conf.num_submissions < settings.CONFERENCE_MIN_COUNT:
             continue
-        if (hasattr(conf, 'is_meeting') and (conf.is_meeting == False)) or (conf.name == 'Psi Chi') or (conf.name == 'Time-sharing Experiments for the Social Sciences'):
+        if (hasattr(conf, 'is_meeting') and (conf.is_meeting is False)) or (conf.name == 'Psi Chi') or (conf.name == 'Time-sharing Experiments for the Social Sciences'):
             continue
         meetings.append({
             'name': conf.name,

--- a/website/conferences/views.py
+++ b/website/conferences/views.py
@@ -231,7 +231,7 @@ def conference_submissions(**kwargs):
     submissions = []
     #  TODO: Revisit this loop, there has to be a way to optimize it
     for conf in Conference.find():
-        if (hasattr(conf, 'is_meeting') and (not conf.is_meeting)) or (conf.name == 'Psi Chi') or (conf.name == 'Time-sharing Experiments for the Social Sciences'):
+        if (hasattr(conf, 'is_meeting') and (conf.is_meeting == False)) or (conf.name == 'Psi Chi') or (conf.name == 'Time-sharing Experiments for the Social Sciences'):
             break
         # For efficiency, we filter by tag first, then node
         # instead of doing a single Node query
@@ -260,6 +260,8 @@ def conference_view(**kwargs):
     meetings = []
     for conf in Conference.find():
         if conf.num_submissions < settings.CONFERENCE_MIN_COUNT:
+            continue
+        if (hasattr(conf, 'is_meeting') and (conf.is_meeting == False)) or (conf.name == 'Psi Chi') or (conf.name == 'Time-sharing Experiments for the Social Sciences'):
             continue
         meetings.append({
             'name': conf.name,

--- a/website/conferences/views.py
+++ b/website/conferences/views.py
@@ -231,7 +231,7 @@ def conference_submissions(**kwargs):
     submissions = []
     #  TODO: Revisit this loop, there has to be a way to optimize it
     for conf in Conference.find():
-        if (hasattr(conf, 'is_meeting') and (conf.is_meeting is False)) or (conf.name == 'Psi Chi') or (conf.name == 'Time-sharing Experiments for the Social Sciences'):
+        if (hasattr(conf, 'is_meeting') and (conf.is_meeting is False)):
             break
         # For efficiency, we filter by tag first, then node
         # instead of doing a single Node query
@@ -261,7 +261,7 @@ def conference_view(**kwargs):
     for conf in Conference.find():
         if conf.num_submissions < settings.CONFERENCE_MIN_COUNT:
             continue
-        if (hasattr(conf, 'is_meeting') and (conf.is_meeting is False)) or (conf.name == 'Psi Chi') or (conf.name == 'Time-sharing Experiments for the Social Sciences'):
+        if (hasattr(conf, 'is_meeting') and (conf.is_meeting is False)):
             continue
         meetings.append({
             'name': conf.name,

--- a/website/conferences/views.py
+++ b/website/conferences/views.py
@@ -231,6 +231,8 @@ def conference_submissions(**kwargs):
     submissions = []
     #  TODO: Revisit this loop, there has to be a way to optimize it
     for conf in Conference.find():
+        if (hasattr(conf, 'is_meeting') and (not conf.is_meeting)) or (conf.name == 'Psi Chi') or (conf.name == 'Time-sharing Experiments for the Social Sciences'):
+            break
         # For efficiency, we filter by tag first, then node
         # instead of doing a single Node query
         projects = set()

--- a/website/static/js/pages/meetings-page.js
+++ b/website/static/js/pages/meetings-page.js
@@ -2,6 +2,12 @@ var $ = require('jquery');
 var Meetings = require('../meetings.js');
 var Submissions = require('../submissions.js');
 
+for (var i = 0; i < window.contextVars.meetings.length; i++) {
+    if window.contextVars.meetings[i].name === 'Psi Chi' || window.contextVars.meetings[i].name === 'Time-sharing Experiments for the Social Sciences' || ( (typeOf(window.contextVars.meetings[i].is_meeting) === 'boolean') && (window.contextVars.meetings[i].is_meeting === false) ) {
+        window.contextVars.meetings.splice(i, 1);
+        i = i - 1;
+    }
+}
 new Meetings(window.contextVars.meetings);
 
 var request = $.getJSON('/api/v1/meetings/submissions/');

--- a/website/static/js/pages/meetings-page.js
+++ b/website/static/js/pages/meetings-page.js
@@ -2,12 +2,6 @@ var $ = require('jquery');
 var Meetings = require('../meetings.js');
 var Submissions = require('../submissions.js');
 
-for (var i = 0; i < window.contextVars.meetings.length; i++) {
-    if window.contextVars.meetings[i].name === 'Psi Chi' || window.contextVars.meetings[i].name === 'Time-sharing Experiments for the Social Sciences' || ( (typeOf(window.contextVars.meetings[i].is_meeting) === 'boolean') && (window.contextVars.meetings[i].is_meeting === false) ) {
-        window.contextVars.meetings.splice(i, 1);
-        i = i - 1;
-    }
-}
 new Meetings(window.contextVars.meetings);
 
 var request = $.getJSON('/api/v1/meetings/submissions/');


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Adds functionality where it is possible to specify in the admin app when creating a meeting that the meeting should not show up on the meetings page. 
Also removes 2 already existing non-meetings meetings from the view on the meetings page

<!-- Describe the purpose of your changes -->

## Changes

Added input in the create meeting form in the admin app that you deselect if the meeting is actually not a meeting
<!-- Briefly describe or list your changes  -->

## Side effects

When editing and older meeting that does not have the attribute is_meeting because if has been added in this change) the check-box for 'Is A Meeting' defaults to unchecked and if not checked before submitting, the meeting will not display on the meetings page. 
<!--Any possible side effects? -->


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
https://openscience.atlassian.net/browse/OSF-5645
