### PR TITLE
[preprints] Iterate external ember app to support preprints [#PREP-87]

### DIFF
--- a/website/routes.py
+++ b/website/routes.py
@@ -179,7 +179,7 @@ def external_ember_app(path=None):
     """
     if not path or '.' in path:
         # If this is a file, proxy the URL given directly as-is to the ember server
-        url = furl(settings.EXTERNAL_EMBER_URL).add(path=request.path)
+        url = furl.furl(settings.EXTERNAL_EMBER_URL).add(path=request.path)
     else:
         # Ember server 404s when asked for a child route- it seems to be relying on index.html to figure that stuff out.
         # So if something looks like a child route, just send the request to the base URL, and ensure a trailing slash.
@@ -264,12 +264,10 @@ def make_url_map(app):
         process_rules(app, [
             Rule(
                 [
-                    # When using baseURL in ember, the livereload file has a special name
                     '/ember-cli-live-reload.js',
-                    '/{}ember-cli-live-reload.js'.format(settings.EXTERNAL_EMBER_BASEURL.replace('/', '')),
-                    # Delegate any file or asset  requests to the ember app. May require
+                    # Delegate any file or asset  requests to the ember app.
                     settings.EXTERNAL_EMBER_BASEURL,
-                    settings.EXTERNAL_EMBER_BASEURL + '<path:_>',
+                    settings.EXTERNAL_EMBER_BASEURL + '<path:path>',
                 ],
                 'get',
                 external_ember_app,

--- a/website/routes.py
+++ b/website/routes.py
@@ -179,7 +179,7 @@ def external_ember_app(path=None):
     """
     if not path or '.' in path:
         # If this is a file, proxy the URL given directly as-is to the ember server
-        url = furl.furl(request.path.lstrip('/')).set(host=settings.EXTERNAL_EMBER_URL)
+        url = furl(settings.EXTERNAL_EMBER_URL).add(path=request.path)
     else:
         # Ember server 404s when asked for a child route- it seems to be relying on index.html to figure that stuff out.
         # So if something looks like a child route, just send the request to the base URL, and ensure a trailing slash.
@@ -269,7 +269,7 @@ def make_url_map(app):
                     '/{}ember-cli-live-reload.js'.format(settings.EXTERNAL_EMBER_BASEURL.replace('/', '')),
                     # Delegate any file or asset  requests to the ember app. May require
                     settings.EXTERNAL_EMBER_BASEURL,
-                    settings.EXTERNAL_EMBER_BASEURL + '<path:path>',
+                    settings.EXTERNAL_EMBER_BASEURL + '<path:_>',
                 ],
                 'get',
                 external_ember_app,

--- a/website/routes.py
+++ b/website/routes.py
@@ -4,10 +4,9 @@ import httplib as http
 
 from flask import request, Response
 from flask import send_from_directory
-
-import requests
+import furl
 from geoip import geolite2
-from furl import furl
+import requests
 
 from framework import status
 from framework import sentry
@@ -175,11 +174,38 @@ def robots():
 
 
 def external_ember_app(path=None):
-    """Serve the contents of the ember application"""
+    """
+    Serve the contents of an ember application running on a separate server
+    """
     if (request.path == '/ember-cli-live-reload.js'):
-        path = 'ember-cli-live-reload.js'
-    url = furl(settings.EXTERNAL_EMBER_URL).add(path=path)
+        path = 'ember-cli-live-reload.js' # FIXME: This is top-level regardless of baseURL setting
+
+        # TODO: Add additional special-case rules for how ember server works with livereload. (it name-prefixes the livereload script)
+
+    # The ember dev server will respect the `baseURL` setting it is given, and hence we need to add the base URL to the
+    #  URL we request from the standalone ember server. (all top level routes will appear to be under
+    #   http://localhost:4200/
+    #  We also need to respect all query parameters, etc etc
+    # TODO: Write tests
+    path_list = [settings.EXTERNAL_EMBER_BASEURL.replace('/', '')]
+    if path:
+        # This can be any level of hierarchy, eg /preprints/assets/vendor.js . Need to avoid encoding these middle slashes.
+        print '+++++++++ Provided path:', path
+        segments = furl.furl(path).path.segments
+        path_list.extend(segments)
+
+    if not path or '.' not in path:
+        # Base route needs a trailing slash for request to succeed. Static asset files should not have one.
+        path_list.append('')
+
+
+    # Construct URL, and make sure ember respects any provided query params.
+    url = furl.furl(settings.EXTERNAL_EMBER_URL).add(path=path_list, args=request.args)
+
+    print '-------- Requesting url: ', url
+
     resp = requests.get(url)
+
     excluded_headers = ['content-encoding', 'content-length', 'transfer-encoding', 'connection']
     headers = [(name, value) for (name, value) in resp.raw.headers.items() if name.lower() not in excluded_headers]
     return Response(resp.content, resp.status_code, headers)
@@ -251,7 +277,7 @@ def make_url_map(app):
         process_rules(app, [
             Rule(
                 [
-                    '/ember-cli-live-reload.js',
+                    '/ember-cli-live-reload.js', # TODO: In certain cases may name-prefix the file
                     settings.EXTERNAL_EMBER_BASEURL,
                     settings.EXTERNAL_EMBER_BASEURL + '<path:path>',
                 ],
@@ -364,12 +390,12 @@ def make_url_map(app):
             OsfWebRenderer('prereg_landing_page.mako', trust=False)
         ),
 
-        Rule(
-            '/preprints/',
-            'get',
-            preprint_views.preprint_landing_page,
-            OsfWebRenderer('public/pages/preprint_landing.mako', trust=False),
-        ),
+        # Rule(
+        #     '/preprints/',
+        #     'get',
+        #     preprint_views.preprint_landing_page,
+        #     OsfWebRenderer('public/pages/preprint_landing.mako', trust=False),
+        # ),
 
         Rule(
             '/preprint/',

--- a/website/routes.py
+++ b/website/routes.py
@@ -177,7 +177,7 @@ def external_ember_app(path=None):
     """
     Serve the contents of an ember application running on a separate server
     """
-    if not path or '.' in path:
+    if path and '.' in path:
         # If this is a file, proxy the URL given directly as-is to the ember server
         url = furl.furl(settings.EXTERNAL_EMBER_URL).add(path=request.path)
     else:
@@ -186,7 +186,7 @@ def external_ember_app(path=None):
         # TODO: This may break if there are other things (like mocks or non-ember endpoints)
         #   running on the ember dev server, eg routes that need to be handled separately from the parent
         url = furl.furl(settings.EXTERNAL_EMBER_URL)
-        url.path.segments.extend([settings.EXTERNAL_EMBER_BASEURL.replace('/', '')])
+        url.path.segments.extend([settings.EXTERNAL_EMBER_BASEURL.replace('/', ''), ''])  # Ensure trailing slash
 
     # Make sure URL respects any provided query params
     url.add(args=request.args)

--- a/website/routes.py
+++ b/website/routes.py
@@ -182,11 +182,11 @@ def external_ember_app(path=None):
         url = furl.furl(settings.EXTERNAL_EMBER_URL).add(path=request.path)
     else:
         # Ember server 404s when asked for a child route- it seems to be relying on index.html to figure that stuff out.
-        # So if something looks like a child route, just send the request to the base URL, and ensure a trailing slash.
+        # So if something looks like a child route, just send the request to the base URL.
         # TODO: This may break if there are other things (like mocks or non-ember endpoints)
         #   running on the ember dev server, eg routes that need to be handled separately from the parent
         url = furl.furl(settings.EXTERNAL_EMBER_URL)
-        url.path.segments.extend([settings.EXTERNAL_EMBER_BASEURL.replace('/', ''), ''])
+        url.path.segments.extend([settings.EXTERNAL_EMBER_BASEURL.replace('/', '')])
 
     # Make sure URL respects any provided query params
     url.add(args=request.args)
@@ -378,13 +378,6 @@ def make_url_map(app):
             OsfWebRenderer('prereg_landing_page.mako', trust=False)
         ),
 
-        # Rule(
-        #     '/preprints/',
-        #     'get',
-        #     preprint_views.preprint_landing_page,
-        #     OsfWebRenderer('public/pages/preprint_landing.mako', trust=False),
-        # ),
-
         Rule(
             '/preprint/',
             'get',
@@ -399,6 +392,17 @@ def make_url_map(app):
             json_renderer,
         ),
     ])
+
+    if not settings.USE_EXTERNAL_EMBER:
+        # If not delegating preprints to an external ember app, just use the OSF route.
+        process_rules(app, [
+            Rule(
+                '/preprints/',
+                'get',
+                preprint_views.preprint_landing_page,
+                OsfWebRenderer('public/pages/preprint_landing.mako', trust=False),
+            )
+        ])
 
     # Site-wide API routes
 


### PR DESCRIPTION
## Purpose
Iterate @icereval ember server proxy config to support preprints.

## Changes
Support the following behaviors:
1. Child routes should delegate to the base URL, not the full request path. This fixes an error when attempting to fetch `/preprints/browse`

2. Ensure that query params are retained when delegating to the proxied app.

3. The `USE_EXTERNAL_EMBER` flag will now automatically turn off the existing OSF preprints route in favor of the `/preprints` external ember app.

## Side effects
None expected, but delegating to an ember app may cause unexpected behaviors.

If the ember app has any http mocks/ dummy servers, these may behave oddly.

## Ticket
https://openscience.atlassian.net/browse/PREP-87
