### PR TITLE
Draft registrations should be in reverse chronological order [#OSF-6243]

### DIFF
--- a/website/project/views/drafts.py
+++ b/website/project/views/drafts.py
@@ -3,6 +3,8 @@ import httplib as http
 import datetime
 import itertools
 
+from operator import itemgetter
+
 from dateutil.parser import parse as parse_date
 from flask import request, redirect
 
@@ -224,10 +226,13 @@ def get_draft_registrations(auth, node, *args, **kwargs):
     :return: serialized draft registrations
     :rtype: dict
     """
+    #'updated': '2016-08-03T14:24:12Z'
     count = request.args.get('count', 100)
     drafts = itertools.islice(node.draft_registrations_active, 0, count)
+    serialized_drafts = [serialize_draft_registration(d, auth) for d in drafts]
+    sorted_serialized_drafts = sorted(serialized_drafts, key=itemgetter('updated'), reverse=True)
     return {
-        'drafts': [serialize_draft_registration(d, auth) for d in drafts]
+        'drafts': sorted_serialized_drafts
     }, http.OK
 
 @must_have_permission(ADMIN)

--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -1331,9 +1331,6 @@ RegistrationManager.prototype.init = function() {
             var drafts = $.map(response.drafts, function(draft) {
                 return new Draft(draft);
             });
-            drafts.sort(function(a, b) {
-                return a.initiated.getTime() < b.initiated.getTime();
-            });
             self.drafts(drafts);
             self.loadingDrafts(false);
         });


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Sorted draft registrations in reverse chronological order by last updated date.
<!-- Describe the purpose of your changes -->

## Changes

Added code to sort draft registrations by last updated date in API and removed code that was sorting draft registrations by created date on frontend
<!-- Briefly describe or list your changes  -->

## Side effects

None
<!--Any possible side effects? -->


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
https://openscience.atlassian.net/browse/OSF-6243
