### PR TITLE
On Create Component modal, Add language to indicate Admins have read access [OSF-6826]

### DIFF
--- a/website/static/js/addProjectPlugin.js
+++ b/website/static/js/addProjectPlugin.js
@@ -230,7 +230,9 @@ var AddProject = {
                                     onchange : function() {
                                         ctrl.newProjectInheritContribs(this.checked);
                                     }
-                                }), ' Add contributors from ', m('b', options.parentTitle)
+                                }), ' Add contributors from ', m('b', options.parentTitle),
+                                m('br'),
+                                m('i', ' Admins of ', m('b', options.parentTitle), ' will have read access to this component.')
                             )
                         ]) : '',
                         m('.text-muted.pointer', { onclick : function(){


### PR DESCRIPTION
## Purpose

Based on feedback, it seems that many OSF users do not know that admins of parent projects have read access to children projects. The purpose of this fix is to clarify that by updating the language in the Create Component modal.

## Changes

Used mithril to add italicized and bold text to Create Component modal in addProjectPlugin.js file.

![image](https://cloud.githubusercontent.com/assets/8868219/17414292/dc09e7f2-5a52-11e6-87e8-e58dc95d4867.png)


## Side effects

N/A


## Ticket

https://openscience.atlassian.net/browse/OSF-6826

