### PR TITLE
Anon-view only links show names in prereg registration schemas [OSF-6526]

### DIFF
--- a/website/project/views/register.py
+++ b/website/project/views/register.py
@@ -31,6 +31,7 @@ from website.project import signals as project_signals
 from website.project.metadata.schemas import _id_to_name
 from website import util
 from website.project.metadata.utils import serialize_meta_schema
+from website.project.model import has_anonymous_link
 from website.archiver.decorators import fail_archive_on_error
 
 from website.identifiers.client import EzidClient
@@ -141,6 +142,12 @@ def node_register_template_page(auth, node, metaschema_id, **kwargs):
             })
 
         ret = _view_project(node, auth, primary=True)
+        my_meta = serialize_meta_schema(meta_schema)
+        if has_anonymous_link(node, auth):
+            for i, v in enumerate(my_meta['schema']['pages']):
+                for j, w in enumerate(v['questions']):
+                    if w['title'] in settings.ANONYMIZED_TITLES:
+                        del my_meta['schema']['pages'][i]['questions'][j]
         ret['node']['registered_schema'] = serialize_meta_schema(meta_schema)
         return ret
     else:

--- a/website/project/views/register.py
+++ b/website/project/views/register.py
@@ -144,10 +144,10 @@ def node_register_template_page(auth, node, metaschema_id, **kwargs):
         ret = _view_project(node, auth, primary=True)
         my_meta = serialize_meta_schema(meta_schema)
         if has_anonymous_link(node, auth):
-            for i, v in enumerate(my_meta['schema']['pages']):
-                for j, w in enumerate(v['questions']):
-                    if w['title'] in settings.ANONYMIZED_TITLES:
-                        del my_meta['schema']['pages'][i]['questions'][j]
+            for indx, schema_page in enumerate(my_meta['schema']['pages']):
+                for idx, schema_question in enumerate(schema_page['questions']):
+                    if schema_question['title'] in settings.ANONYMIZED_TITLES:
+                        del my_meta['schema']['pages'][indx]['questions'][idx]
         ret['node']['registered_schema'] = serialize_meta_schema(meta_schema)
         return ret
     else:

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -46,6 +46,8 @@ REGISTRATION_APPROVAL_TIME = datetime.timedelta(days=2)
 # Date range for embargo periods
 EMBARGO_END_DATE_MIN = datetime.timedelta(days=2)
 EMBARGO_END_DATE_MAX = datetime.timedelta(days=1460)  # Four years
+# Question titles to be reomved for anonymized VOL
+ANONYMIZED_TITLES = ['Authors']
 
 LOAD_BALANCER = False
 PROXY_ADDRS = []


### PR DESCRIPTION
## Purpose:
[OSF-6526](https://openscience.atlassian.net/browse/OSF-6526)
Add facility for removing questions from anonymized VOL to registrations

## Changes:
Update  website/project/views/register.py add logic for removing questions from anon VOLs
Update website/settings/defaults.py add setting ANONYMIZED_TITLES list of titles to remove

## Side effects
Relies on list of titles being accurate and up to date.


[#OSF-6526]