### PR TITLE
[RFR][Feature][OSF-6780]Raise minimum password length to 8 characters

### DIFF
--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -730,8 +730,8 @@ class User(GuidStoredObject, AddonModelMixin):
             issues.append('Password cannot be the same as your email address')
         if not raw_old_password or not raw_new_password or not raw_confirm_password:
             issues.append('Passwords cannot be blank')
-        elif len(raw_new_password) < 6:
-            issues.append('Password should be at least six characters')
+        elif len(raw_new_password) < 8:
+            issues.append('Password should be at least eight characters')
         elif len(raw_new_password) > 256:
             issues.append('Password should not be longer than 256 characters')
 

--- a/framework/auth/forms.py
+++ b/framework/auth/forms.py
@@ -100,8 +100,8 @@ confirm_email_field = TextField(
 password_field = PasswordField('Password',
     [
         validators.Required(message=u'Password is required'),
-        validators.Length(min=6, message=u'Password is too short. '
-            'Password should be at least 6 characters.'),
+        validators.Length(min=8, message=u'Password is too short. '
+            'Password should be at least 8 characters.'),
         validators.Length(max=256, message=u'Password is too long. '
             'Password should be at most 256 characters.'),
     ],
@@ -123,8 +123,8 @@ class ResetPasswordForm(Form):
     password = PasswordField('New Password',
         [
             validators.Required(message=u'Password is required'),
-            validators.Length(min=6, message=u'Password is too short. '
-                'Password should be at least 6 characters.'),
+            validators.Length(min=8, message=u'Password is too short. '
+                'Password should be at least 8 characters.'),
             validators.Length(max=256, message=u'Password is too long. '
                 'Password should be at most 256 characters.'),
         ],

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -636,7 +636,7 @@ class TestUser(OsfTestCase):
             'password',
             '12345',
             '12345',
-            'Password should be at least six characters',
+            'Password should be at least eight characters',
         )
 
     def test_change_password_invalid_confirm_password(self):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1763,7 +1763,7 @@ class TestUserAccount(OsfTestCase):
             old_password='password',
             new_password='12345',
             confirm_password='12345',
-            error_message='Password should be at least six characters',
+            error_message='Password should be at least eight characters',
         )
 
     def test_password_change_invalid_blank_password(self, old_password='', new_password='', confirm_password=''):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1704,10 +1704,11 @@ class TestUserAccount(OsfTestCase):
         self.user.save()
 
     @mock.patch('website.profile.views.push_status_message')
-    def test_password_change_valid(self, mock_push_status_message):
-        old_password = 'password'
-        new_password = 'Pa$$w0rd'
-        confirm_password = new_password
+    def test_password_change_valid(self,
+                                   mock_push_status_message,
+                                   old_password='password',
+                                   new_password='Pa$$w0rd',
+                                   confirm_password='Pa$$w0rd'):
         url = web_url_for('user_account_password')
         post_data = {
             'old_password': old_password,
@@ -1761,9 +1762,16 @@ class TestUserAccount(OsfTestCase):
     def test_password_change_invalid_new_password_length(self):
         self.test_password_change_invalid(
             old_password='password',
-            new_password='12345',
-            confirm_password='12345',
+            new_password='1234567',
+            confirm_password='1234567',
             error_message='Password should be at least eight characters',
+        )
+
+    def test_password_change_valid_new_password_length(self):
+        self.test_password_change_valid(
+            old_password='password',
+            new_password='12345678',
+            confirm_password='12345678',
         )
 
     def test_password_change_invalid_blank_password(self, old_password='', new_password='', confirm_password=''):

--- a/website/static/js/passwordForms.js
+++ b/website/static/js/passwordForms.js
@@ -53,7 +53,7 @@ var BaseViewModel = oop.extend(ChangeMessageMixin, {
 
         self.password = ko.observable('').extend({
             required: true,
-            minLength: 6,
+            minLength: 8,
             maxLength: 256,
             complexity: 2,
         });

--- a/website/templates/landing.mako
+++ b/website/templates/landing.mako
@@ -65,7 +65,7 @@
                           </div>
                           <div class="form-group" data-bind="css: {'has-error': password() && !password.isValid(), 'has-success': password() && password.isValid()}">
                               <label class="placeholder-replace" style="display:none">Password</label>
-                              <input type="password" class="form-control" placeholder="Password (Must be 6 to 256 characters)" data-bind=", textInput: typedPassword, value: password, disable: submitted(), event: {blur: trim.bind($data, password)}">
+                              <input type="password" class="form-control" placeholder="Password (Must be 8 to 256 characters)" data-bind=", textInput: typedPassword, value: password, disable: submitted(), event: {blur: trim.bind($data, password)}">
 
                               <div class="row" data-bind="visible: typedPassword().length > 0">
                                   <div class="col-xs-8">


### PR DESCRIPTION
## Purpose:
[OSF-6780](https://openscience.atlassian.net/browse/OSF-6780)
Change minimum password length from 6 to 8

## Changes:
Change 6 to 8 for all of the following
Update framework/auth/core.py
Update framework/auth/forms.py
Update website/static/js/passwordForms.js
Update website/templates/landing.mako


## Side effects
None

[#OSF-6780]