### PR TITLE
Fix admin app meetings form 'Homepage link text' [#OSF-6854]

### DIFF
--- a/admin/meetings/forms.py
+++ b/admin/meetings/forms.py
@@ -44,7 +44,7 @@ class MeetingForm(forms.Form):
     )
     homepage_link_text = forms.CharField(
         label='Homepage link text (Default: "Conference homepage")',
-        widget = forms.TextInput(attrs={'size': '60'}),
+        widget=forms.TextInput(attrs={'size': '60'}),
         required=False,
     )
     location = forms.CharField(

--- a/admin/meetings/forms.py
+++ b/admin/meetings/forms.py
@@ -42,6 +42,11 @@ class MeetingForm(forms.Form):
         required=False,
         widget=forms.TextInput(attrs={'size': '60'}),
     )
+    homepage_link_text = forms.CharField(
+        label='Homepage link text (Default: "Conference homepage")',
+        widget = forms.TextInput(attrs={'size': '60'}),
+        required=False,
+    )
     location = forms.CharField(
         label='Location',
         required=False,
@@ -114,9 +119,6 @@ class MeetingForm(forms.Form):
     mail_attachment = forms.CharField(
         label='Mail attachment message',
         widget=forms.TextInput(attrs={'size': '60'}),
-    )
-    homepage_link_text = forms.CharField(
-        label='Homepage link text (Default: "Conference homepage")'
     )
 
     def clean_start_date(self):

--- a/admin/meetings/serializers.py
+++ b/admin/meetings/serializers.py
@@ -5,6 +5,7 @@ def serialize_meeting(meeting):
         'endpoint': meeting.endpoint,
         'name': meeting.name,
         'info_url': meeting.info_url,
+        'homepage_link_text': meeting.homepage_link_text,
         'logo_url': meeting.logo_url,
         'active': meeting.active,
         'admins': ', '.join([u.emails[0] for u in meeting.admins]),

--- a/admin/meetings/serializers.py
+++ b/admin/meetings/serializers.py
@@ -5,7 +5,7 @@ def serialize_meeting(meeting):
         'endpoint': meeting.endpoint,
         'name': meeting.name,
         'info_url': meeting.info_url,
-        'homepage_link_text': meeting.homepage_link_text,
+        'homepage_link_text': meeting.field_names['homepage_link_text'],
         'logo_url': meeting.logo_url,
         'active': meeting.active,
         'admins': ', '.join([u.emails[0] for u in meeting.admins]),

--- a/admin/meetings/views.py
+++ b/admin/meetings/views.py
@@ -64,6 +64,7 @@ class MeetingFormView(OSFAdmin, FormView):
             self.conf.admins = admin_users
         self.conf.name = data.get('name')
         self.conf.info_url = data.get('info_url')
+        self.conf.homepage_link_text = data.get('homepage_link_text')
         self.conf.logo_url = data.get('logo_url')
         self.conf.active = data.get('active')
         self.conf.public_projects = data.get('public_projects')

--- a/website/conferences/model.py
+++ b/website/conferences/model.py
@@ -8,6 +8,7 @@ from framework.mongo import StoredObject
 from website.conferences.exceptions import ConferenceError
 
 DEFAULT_FIELD_NAMES = {
+    'homepage_link_text': 'Conference homepage',
     'submission1': 'poster',
     'submission2': 'talk',
     'submission1_plural': 'posters',
@@ -17,7 +18,6 @@ DEFAULT_FIELD_NAMES = {
     'mail_subject': 'Presentation title',
     'mail_message_body': 'Presentation abstract (if any)',
     'mail_attachment': 'Your presentation file (e.g., PowerPoint, PDF, etc.)',
-    'homepage_link_text': 'Conference homepage',
 }
 
 
@@ -30,6 +30,7 @@ class Conference(StoredObject):
     #: Full name, e.g. "SPSP 2014"
     name = fields.StringField(required=True)
     info_url = fields.StringField(required=False, default=None)
+    homepage_link_text = fields.StringField(required=False, default='Conference homepage')
     logo_url = fields.StringField(required=False, default=None)
     location = fields.StringField(required=False, default=None)
     start_date = fields.DateTimeField(default=None)

--- a/website/conferences/model.py
+++ b/website/conferences/model.py
@@ -30,7 +30,6 @@ class Conference(StoredObject):
     #: Full name, e.g. "SPSP 2014"
     name = fields.StringField(required=True)
     info_url = fields.StringField(required=False, default=None)
-    homepage_link_text = fields.StringField(required=False, default='Conference homepage')
     logo_url = fields.StringField(required=False, default=None)
     location = fields.StringField(required=False, default=None)
     start_date = fields.DateTimeField(default=None)


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Fix bug where even if a meeting has a homepage link text it does not show up in the form and you cannot submit the form without entering another one.
<!-- Describe the purpose of your changes -->

## Changes

Fixed bug mentioned above so now if a meeting has a homepage link text it will appear in the field.
Also made it so that if you do not enter a homepage link text it will default to 'Conference homepage' so that field is no longer required to submit the form.
<!-- Briefly describe or list your changes  -->

## Side effects
None that I can see
<!--Any possible side effects? -->


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
https://openscience.atlassian.net/browse/OSF-6854
