### PR TITLE
Fix Varnish tests

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -86,11 +86,13 @@ def git_logs(ctx, branch=None):
 
 
 @task
-def apiserver(ctx, port=8000, wait=True, host='127.0.0.1'):
+def apiserver(ctx, port=8000, wait=True, autoreload=True, host='127.0.0.1'):
     """Run the API server."""
     env = os.environ.copy()
     cmd = 'DJANGO_SETTINGS_MODULE=api.base.settings {} manage.py runserver {}:{} --nothreading'\
         .format(sys.executable, host, port)
+    if not autoreload:
+        cmd += ' --noreload'
     if settings.SECURE_MODE:
         cmd = cmd.replace('runserver', 'runsslserver')
         cmd += ' --certificate {} --key {}'.format(settings.OSF_SERVER_CERT, settings.OSF_SERVER_KEY)
@@ -532,10 +534,12 @@ def test_admin(ctx):
 @task
 def test_varnish(ctx):
     """Run the Varnish test suite."""
-    proc = apiserver(ctx, wait=False)
-    sleep(5)
-    test_module(ctx, module='api/caching/tests/test_caching.py')
-    proc.kill()
+    proc = apiserver(ctx, wait=False, autoreload=False)
+    try:
+        sleep(5)
+        test_module(ctx, module='api/caching/tests/test_caching.py')
+    finally:
+        proc.kill()
 
 
 @task

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -19,20 +19,23 @@ from tests.base import OsfTestCase, teardown_database
 
 class TestMetaData(OsfTestCase):
 
-    def tearDown(self):
-        super(TestMetaData, self).tearDown()
+    # For whatever reason (efficiency?), DbTestCase only wipes the database
+    # during *class* setup and teardown. This leaks database state across test
+    # cases, which a) smells pretty bad, and b) breaks the test_metaschema_
+    # tests here.
 
-        # For whatever reason, DbTestCase only wipes the database during
-        # *class* setup and teardown. This leaks database state across test
-        # cases, which a) smells pretty bad, and b) breaks the test_metaschema_
-        # tests here.
-
-        teardown_database(database=database_proxy._get_current_object())
+    def setUp(self):
+        super(TestMetaData, self).setUp()
         set_up_storage(
             website.models.MODELS,
             storage.MongoStorage,
             addons=settings.ADDONS_AVAILABLE,
         )
+
+    def tearDown(self):
+        super(TestMetaData, self).tearDown()
+        teardown_database(database=database_proxy._get_current_object())
+
 
     def test_ensure_schemas(self):
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -19,12 +19,12 @@ from tests.base import OsfTestCase, teardown_database
 
 class TestMetaData(OsfTestCase):
 
-    def setUp(self):
-        super(TestMetaData, self).setUp()
+    def tearDown(self):
+        super(TestMetaData, self).tearDown()
 
         # For whatever reason, DbTestCase only wipes the database during
         # *class* setup and teardown. This leaks database state across test
-        # cases, which a) smells pretty bad, and b) breaks the test_metadata_
+        # cases, which a) smells pretty bad, and b) breaks the test_metaschema_
         # tests here.
 
         teardown_database(database=database_proxy._get_current_object())

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -4,15 +4,35 @@ import unittest
 from nose.tools import *  # PEP8 asserts
 
 from framework.forms.utils import process_payload
+from framework.mongo import database as database_proxy, set_up_storage
+from modularodm import storage
+from modularodm.exceptions import KeyExistsException
 
+import website.models
+from website import settings
 from website.project.model import MetaSchema
 from website.project.model import ensure_schemas
 from website.project.metadata.schemas import OSF_META_SCHEMAS
 
-from tests.base import OsfTestCase
+from tests.base import OsfTestCase, teardown_database
 
 
 class TestMetaData(OsfTestCase):
+
+    def setUp(self):
+        super(TestMetaData, self).setUp()
+
+        # For whatever reason, DbTestCase only wipes the database during
+        # *class* setup and teardown. This leaks database state across test
+        # cases, which a) smells pretty bad, and b) breaks the test_metadata_
+        # tests here.
+
+        teardown_database(database=database_proxy._get_current_object())
+        set_up_storage(
+            website.models.MODELS,
+            storage.MongoStorage,
+            addons=settings.ADDONS_AVAILABLE,
+        )
 
     def test_ensure_schemas(self):
 
@@ -27,6 +47,18 @@ class TestMetaData(OsfTestCase):
             MetaSchema.find().count(),
             len(OSF_META_SCHEMAS)
         )
+
+    def test_metaschema_uniqueness_is_enforced_in_the_database(self):
+        # Using MongoDB's uniqueness instead of modular-odm's allows us to
+        # kludge a race-less upsert in ensure_schema.
+        MetaSchema(name='foo', schema_version=1).save()
+        assert_raises(KeyExistsException, MetaSchema(name='foo', schema_version=1).save)
+        # modular-odm's uniqueness constraint would raise ValidationValueError instead.
+
+    def test_metaschema_is_fine_with_same_name_but_different_version(self):
+        MetaSchema(name='foo', schema_version=1).save()
+        MetaSchema(name='foo', schema_version=2).save()
+        assert_equal(MetaSchema.find(name='foo').count(), 2)
 
     def test_process(self):
         processed = process_payload({'foo': 'bar&baz'})

--- a/tests/test_node_licenses.py
+++ b/tests/test_node_licenses.py
@@ -125,15 +125,6 @@ class TestNodeLicenses(OsfTestCase):
         MIT = NodeLicense.find_one(
             Q('id', 'eq', 'MIT')
         )
-        assert_equal(MIT.text, CHANGED_TEXT)
-        assert_equal(MIT.properties, CHANGED_PROPERTIES)
-
-    def test_ensure_licenses_updates_existing(self):
-        with mock.patch.object(builtins, 'open', mock.mock_open(read_data=LICENSE_TEXT)):
-            ensure_licenses()
-        MIT = NodeLicense.find_one(
-            Q('id', 'eq', 'MIT')
-        )
         assert_equal(MIT.name, CHANGED_NAME)
         assert_equal(MIT.text, CHANGED_TEXT)
         assert_equal(MIT.properties, CHANGED_PROPERTIES)

--- a/tests/test_node_licenses.py
+++ b/tests/test_node_licenses.py
@@ -99,10 +99,8 @@ class TestNodeLicenses(OsfTestCase):
         assert_raises(KeyExistsException, NodeLicense(id='foo', name='buz', text='boo').save)
         # modular-odm's uniqueness constraint would raise ValidationValueError instead.
 
-    def test_ensure_licenses_existing_licenses(self):
-        with mock.patch('website.project.licenses.NodeLicense.__init__', autospec=True) as MockNodeLicense:
-            ensure_licenses()
-        assert_false(MockNodeLicense.called)
+    def test_ensure_licenses_updates_existing_licenses(self):
+        assert_equal(ensure_licenses(), (0, 16))
 
     def test_ensure_licenses_no_licenses(self):
         before_count = NodeLicense.find().count()

--- a/tests/test_registrations/test_archiver.py
+++ b/tests/test_registrations/test_archiver.py
@@ -15,6 +15,7 @@ from mock import call
 from nose.tools import *  # noqa PEP8 asserts
 import httpretty
 from modularodm import Q
+from modularodm.exceptions import KeyExistsException
 
 from scripts import cleanup_failed_registrations as scripts
 
@@ -254,25 +255,42 @@ def generate_schema_from_data(data):
             return {
                 'qid': qid,
                 'type': 'string'
-            }                
-    schema = MetaSchema(
-        name='Test',
-        schema={
-            'name': "Test",
-            'version': 2,
-            'config': {
-                'hasFiles': True
-            },
-            'pages':  [{
-                'id': 'page1',
-                'questions': [
-                    from_question(qid, q)
-                    for qid, q in data.items()
-                ]
-            }]
+            }
+
+    _schema = {
+        'name': "Test",
+        'version': 2,
+        'config': {
+            'hasFiles': True
         },
+        'pages':  [{
+            'id': 'page1',
+            'questions': [
+                from_question(qid, q)
+                for qid, q in data.items()
+            ]
+        }]
+    }
+    schema = MetaSchema(
+        name=_schema['name'],
+        schema_version=_schema['version'],
+        schema=_schema
     )
-    schema.save()
+    try:
+        schema.save()
+    except KeyExistsException:
+
+        # Unfortunately, we don't have db isolation between test cases for some
+        # reason. Update the doc currently in the db rather than saving a new
+        # one.
+
+        schema = MetaSchema.find_one(
+            Q('name', 'eq', _schema['name']) &
+            Q('schema_version', 'eq', _schema['version'])
+        )
+        schema.schema = _schema
+        schema.save()
+
     return schema
 
 def generate_metadata(file_trees, selected_files, node_index):

--- a/website/app.py
+++ b/website/app.py
@@ -3,6 +3,7 @@
 import importlib
 import json
 import os
+import thread
 from collections import OrderedDict
 
 import django
@@ -92,6 +93,10 @@ def init_app(settings_module='website.settings', set_backends=True, routes=True,
     :param routes: Whether to set the url map.
 
     """
+    logger.info('Initializing the application from process {}, thread {}.'.format(
+        os.getpid(), thread.get_ident()
+    ))
+
     # The settings module
     settings = importlib.import_module(settings_module)
 

--- a/website/project/licenses/__init__.py
+++ b/website/project/licenses/__init__.py
@@ -32,12 +32,18 @@ def serialize_node_license_record(node_license_record):
     return ret
 
 
-@mongo_utils.unique_on(['id', '_id'])
+@mongo_utils.unique_on(['id'])
 class NodeLicense(StoredObject):
 
     _id = fields.StringField(primary=True, default=lambda: str(ObjectId()))
 
-    id = fields.StringField(required=True, unique=True, editable=False)
+    id = fields.StringField(
+        required=True,
+        unique=False,   # Skip modular-odm's uniqueness implementation, depending on MongoDB's
+                        # instead (the decorator will install the proper index), so that we can
+                        # kludge a non-racey upsert in ensure_licenses.
+        editable=False
+    )
     name = fields.StringField(required=True, unique=True)
     text = fields.StringField(required=True)
     properties = fields.StringField(list=True)

--- a/website/project/licenses/__init__.py
+++ b/website/project/licenses/__init__.py
@@ -4,7 +4,7 @@ import os
 import warnings
 
 from modularodm import fields, Q
-from modularodm.exceptions import NoResultsFound
+from modularodm.exceptions import KeyExistsException
 
 from framework.mongo import (
     ObjectId,
@@ -33,6 +33,7 @@ def serialize_node_license_record(node_license_record):
 
 
 @mongo_utils.unique_on(['id'])
+@mongo_utils.unique_on(['name'])
 class NodeLicense(StoredObject):
 
     _id = fields.StringField(primary=True, default=lambda: str(ObjectId()))
@@ -44,7 +45,10 @@ class NodeLicense(StoredObject):
                         # kludge a non-racey upsert in ensure_licenses.
         editable=False
     )
-    name = fields.StringField(required=True, unique=True)
+    name = fields.StringField(
+        required=True,
+        unique=False    # Ditto.
+    )
     text = fields.StringField(required=True)
     properties = fields.StringField(list=True)
 
@@ -84,6 +88,13 @@ class NodeLicenseRecord(StoredObject):
 
 
 def ensure_licenses(warn=True):
+    """Upsert the licenses in our database based on a JSON file.
+
+    :return tuple: (number inserted, number updated)
+
+    """
+    ninserted = 0
+    nupdated = 0
     with open(
             os.path.join(
                 settings.APP_PATH,
@@ -95,27 +106,29 @@ def ensure_licenses(warn=True):
             name = info['name']
             text = info['text']
             properties = info.get('properties', [])
-            node_license = None
             try:
-                node_license = NodeLicense.find_one(
-                    Q('id', 'eq', id)
-                )
-            except NoResultsFound:
-                if warn:
-                    warnings.warn(
-                        'License {name} ({id}) not already in the database. Adding it now.'.format(
-                            name=name,
-                            id=id
-                        )
-                    )
-                node_license = NodeLicense(
+                NodeLicense(
                     id=id,
                     name=name,
                     text=text,
                     properties=properties
+                ).save()
+            except KeyExistsException:
+                node_license = NodeLicense.find_one(
+                    Q('id', 'eq', id)
                 )
-            else:
                 node_license.name = name
                 node_license.text = text
                 node_license.properties = properties
-            node_license.save()
+                node_license.save()
+                nupdated += 1
+            else:
+                if warn:
+                    warnings.warn(
+                        'License {name} ({id}) added to the database.'.format(
+                            name=name,
+                            id=id
+                        )
+                    )
+                ninserted += 1
+    return ninserted, nupdated

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -85,7 +85,7 @@ def has_anonymous_link(node, auth):
         return auth.private_link.anonymous
     return False
 
-@unique_on(['name', 'schema_version', '_id'])
+@unique_on(['name', 'schema_version'])
 class MetaSchema(StoredObject):
 
     _id = fields.StringField(default=lambda: str(ObjectId()))

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -17,8 +17,7 @@ from django.core.validators import URLValidator
 from modularodm import Q
 from modularodm import fields
 from modularodm.validators import MaxLengthValidator
-from modularodm.exceptions import NoResultsFound
-from modularodm.exceptions import ValidationValueError
+from modularodm.exceptions import KeyExistsException, NoResultsFound, ValidationValueError
 
 from framework import status
 from framework.mongo import ObjectId
@@ -142,24 +141,21 @@ class MetaSchema(StoredObject):
             raise ValidationValueError(e.message)
         return
 
+
 def ensure_schema(schema, name, version=1):
-    schema_obj = None
     try:
+        MetaSchema(
+            name=name,
+            schema_version=version,
+            schema=schema
+        ).save()
+    except KeyExistsException:
         schema_obj = MetaSchema.find_one(
             Q('name', 'eq', name) &
             Q('schema_version', 'eq', version)
         )
-    except NoResultsFound:
-        meta_schema = {
-            'name': name,
-            'schema_version': version,
-            'schema': schema,
-        }
-        schema_obj = MetaSchema(**meta_schema)
-    else:
         schema_obj.schema = schema
-    schema_obj.save()
-    return schema_obj
+        schema_obj.save()
 
 
 def ensure_schemas():


### PR DESCRIPTION
## Purpose

Our Varnish tests are occasionally failing at Travis, obscuring test results and adding drag to our development process. Let's fix 'em!

## Changes

Switch `ensure_{licenses,schema}` from a "look before you leap" (LBYL) model to "easier to ask forgiveness than permission" (EAFP), so that each can safely be run concurrently with itself. See the [commit log](https://github.com/CenterForOpenScience/osf.io/pull/6104/commits) for details.

## Side effects

- A couple uniqueness constraints are now implemented in the database instead of in Python, such that violations now raise `KeyExistsException` instead of `ValueValidationError`.
- We now log process and thread ids on calls to `init_app`.
- The `apiserver` task sprouted an `autoreload` knob.
- `ensure_licenses` now returns a tuple (number inserted, number updated) instead of `None` (this aids in testing)
- `ensure_schema` now returns `None` instead of a `MetaSchema` instance (this simplifies the code, allowing it to be mildly more parallel with `ensure_licenses`, though asymmetry yet predominates between the two, a misfortune itself adjudged to be out of scope for this PR).

## Ticket

[OSF-6861](https://openscience.atlassian.net/browse/OSF-6861)

## QA notes

This PR changes _how_ licenses and schemas are loaded, but shouldn't change _what_ is loaded. Therefore, check that the places where these show up in the UI still list the licenses and schemas (I believe these manifest as "registration types"?) that we expect.

## Todo

- [x] consider flipping `autoreload` flag—https://github.com/CenterForOpenScience/osf.io/pull/6104#discussion_r77021869 —addressed at https://github.com/CenterForOpenScience/osf.io/pull/6104#discussion_r77381938
- [ ] move teardown to `tearDown`—https://github.com/CenterForOpenScience/osf.io/pull/6104#discussion_r77040084 —ready for review in f559d4749701b213d8a12a76057b6788498b89e5