### PR TITLE
[OSF-4770]MFR Dynamic Embed should include dependent Bootstrap CSS styles

### DIFF
--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -67,7 +67,11 @@ var SharePopover =  {
                         m('.tab-pane#embed', [
                             m('p', 'Dynamically render iframe with JavaScript'),
                             m('textarea.form-control[readonly][type="text"][value="' +
-                                '<script>window.jQuery || document.write(\'<script src="//code.jquery.com/jquery-1.11.2.min.js">\\x3C/script>\') </script>'+
+                                '<style>' +
+                                '.embed-responsive{position:relative;height:100%;}' +
+                                '.embed-responsive iframe{position:absolute;height:100%;}' +
+                                '</style>' +
+                                '<script>window.jQuery || document.write(\'<script src="//code.jquery.com/jquery-1.11.2.min.js">\\x3C/script>\') </script>' +
                                 '<link href="' + mfrHost + 'static/css/mfr.css" media="all" rel="stylesheet">' +
                                 '<div id="mfrIframe" class="mfr mfr-file"></div>' +
                                 '<script src="' + mfrHost + 'static/js/mfr.js">' +


### PR DESCRIPTION
## Purpose
The MFR embed for PDF's was calculating the height incorrectly:
![screen shot 2016-08-08 at 3 25 16 pm](https://cloud.githubusercontent.com/assets/1449974/17493061/af6f82ec-5d7c-11e6-9280-08d3bf97ed83.png)

But we want it to be like this:
![screen shot 2016-08-08 at 3 25 30 pm](https://cloud.githubusercontent.com/assets/1449974/17493069/b58937a4-5d7c-11e6-9db6-3dc2f7110565.png)


## Changes
The dynamic MFR embed now starts with the following:
`<style>.embed-responsive{position:relative;height:100%;}.embed-responsive iframe  {position:absolute;height:100%;}</style>`

These styles are from Bootstrap and are required for the correct dynamic calculation of the embed's height. The OSF page already includes Bootstrap, so they are already present. But if the embed is on a page without Bootstrap, they have to be manually added, which we do here.

## Side effects
None

## Ticket
https://openscience.atlassian.net/browse/OSF-4770