### PR TITLE
Allow users who have opted out of mailchimp emails to be disabled

### DIFF
--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -1115,6 +1115,8 @@ class User(GuidStoredObject, AddonModelMixin):
                 pass
             else:
                 raise
+        except mailchimp_utils.mailchimp.EmailNotExistsError:
+            pass
         self.is_disabled = True
 
     @property


### PR DESCRIPTION
## Purpose

Allow users of the Admin app to delete users who have unsubscribed to MailChimp emails.

## Changes

1. The error being caught was EmailNotExistsError, so I caught that and ignored it.

## Side effects

I can't think of any. If the email doesn't exist for some other reason which would still allow them to get MailChimp emails (seems unlikely), then we would have a harder time unsubscribing them.


## Ticket

https://openscience.atlassian.net/browse/OSF-6867