### PR TITLE
Institution viewer text for empty collections should reference institutions [OSF-6825]

### DIFF
--- a/website/static/js/myProjects.js
+++ b/website/static/js/myProjects.js
@@ -621,8 +621,8 @@ var MyProjects = {
                             'You have not created any projects yet.');
                     } else if (lastcrumb.data.nodeType === 'registrations'){
                         template = m('.db-non-load-template.m-md.p-md.osf-box',
-                            'You have not made any registrations yet. Go to ',
-                            m('a', {href: 'http://help.osf.io/m/registrations'}, 'Getting Started'), ' to learn how registrations work.' );
+                            'There have been no completed registrations affiliated with this institution. For a list of the most viewed and most recent public registrations on the Open Science Framework, click ',
+                            m('a', {href: 'http://help.osf.io/m/registrations'}, 'here'), '.' );
                     } else if (lodashGet(lastcrumb, 'data.node.attributes.bookmarks')) {
                         template = m('.db-non-load-template.m-md.p-md.osf-box', 'You have no bookmarks. You can add projects or registrations by dragging them into your bookmarks or by clicking the Add to Bookmark button on the project or registration.');
                     } else {


### PR DESCRIPTION
## Purpose

The existing text for if no registrations have been made for an institution was ambiguous. It made sense under My Projects, but not under Institutions.

## Changes

Before
![image](https://cloud.githubusercontent.com/assets/8868219/17529287/bb5cabba-5e40-11e6-88a0-cf60fd6e2cfd.png)

After
![image](https://cloud.githubusercontent.com/assets/8868219/17529302/c594ba78-5e40-11e6-80e9-8b79e51a8ccf.png)

## Side effects

N/A


## Ticket

https://openscience.atlassian.net/browse/OSF-6825
