### PR TITLE
[Feature] Configure External Link addon via APIv2 [OSF-6653]

### DIFF
--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -212,4 +212,4 @@ VARNISH_SERVERS = osf_settings.VARNISH_SERVERS
 ESI_MEDIA_TYPES = osf_settings.ESI_MEDIA_TYPES
 
 ADDONS_FOLDER_CONFIGURABLE = ['box', 'dropbox', 's3', 'googledrive']
-ADDONS_OAUTH = ADDONS_FOLDER_CONFIGURABLE + ['dataverse', 'github', 'mendeley', 'zotero']
+ADDONS_OAUTH = ADDONS_FOLDER_CONFIGURABLE + ['dataverse', 'github', 'mendeley', 'zotero', 'forward']

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1927,6 +1927,8 @@ class NodeAddonDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, ge
         folder_id               string              folder id of linked folder, from third-party service
         node_has_auth           boolean             is this node fully authorized to use an ExternalAccount?
         folder_path             boolean             folder path of linked folder, from third-party service
+        url                     string              Specific to the `forward` addon
+        label                   string              Specific to the `forward` addon
 
     ##Links
 
@@ -1946,6 +1948,8 @@ class NodeAddonDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, ge
                              "external_account_id": {account_id},   # optional
                              "folder_id":           {folder_id},    # optional
                              "folder_path":         {folder_path},  # optional - Google Drive specific
+                             "url":                 {url},          # optional - External Link specific
+                             "label":               {label}         # optional - External Link specific
                            }
                          }
                        }

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -29,6 +29,7 @@ from api.base.views import LinkedNodesRelationship
 
 from api.nodes.serializers import (
     NodeSerializer,
+    ForwardNodeAddonSettingsSerializer,
     NodeAddonSettingsSerializer,
     NodeLinksSerializer,
     NodeForksSerializer,
@@ -2002,6 +2003,15 @@ class NodeAddonDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, ge
             raise NotFound('Node {} does not have add-on {}'.format(node._id, addon))
 
         node.delete_addon(addon, auth=get_user_auth(self.request))
+
+    def get_serializer_class(self):
+        """
+        Use NodeDetailSerializer which requires 'id'
+        """
+        if self.kwargs['provider'] == 'forward':
+            return ForwardNodeAddonSettingsSerializer
+        else:
+            return NodeAddonSettingsSerializer
 
 
 class NodeAddonFolderList(JSONAPIBaseView, generics.ListAPIView, NodeMixin, AddonSettingsMixin):

--- a/api_tests/nodes/views/test_node_addons.py
+++ b/api_tests/nodes/views/test_node_addons.py
@@ -12,6 +12,7 @@ from tests.factories import AuthUserFactory
 from website.addons.box.tests.factories import BoxAccountFactory, BoxNodeSettingsFactory
 from website.addons.dataverse.tests.factories import DataverseAccountFactory, DataverseNodeSettingsFactory
 from website.addons.dropbox.tests.factories import DropboxAccountFactory, DropboxNodeSettingsFactory
+from website.addons.forward.tests.factories import ForwardSettingsFactory
 from website.addons.github.tests.factories import GitHubAccountFactory, GitHubNodeSettingsFactory
 from website.addons.googledrive.tests.factories import GoogleDriveAccountFactory, GoogleDriveNodeSettingsFactory
 from website.addons.mendeley.tests.factories import MendeleyAccountFactory, MendeleyNodeSettingsFactory
@@ -223,6 +224,8 @@ class NodeAddonDetailMixin(object):
             expect_errors=wrong_type)
         if not wrong_type:
             assert_equal(res.status_code, 204)
+            self.node.reload()
+            assert_false(self.node.has_addon(self.short_name))
         if wrong_type:
             assert_in(res.status_code, [404, 405])
 
@@ -597,11 +600,6 @@ class TestNodeInvalidAddon(NodeAddonTestSuiteMixin, ApiAddonTestCase):
 
 # UNMANAGEABLE
 
-
-class TestNodeForwardAddon(NodeUnmanageableAddonTestSuiteMixin, ApiAddonTestCase):
-    short_name = 'forward'
-
-
 class TestNodeOsfStorageAddon(NodeUnmanageableAddonTestSuiteMixin, ApiAddonTestCase):
     short_name = 'osfstorage'
 
@@ -831,3 +829,166 @@ class TestNodeGoogleDriveAddon(NodeConfigurableAddonTestSuiteMixin, ApiAddonTest
         assert_equal(res.status_code, 400)
         assert_equal('Must specify both folder_id and folder_path for {}'.format(self.short_name),
              res.json['errors'][0]['detail'])
+
+
+class TestNodeForwardAddon(NodeUnmanageableAddonTestSuiteMixin, ApiAddonTestCase):
+    short_name = 'forward'
+
+    @property
+    def _mock_folder_info(self):
+        return {
+            'url': 'http://google.com',
+            'label': 'Gewgle'
+        }
+
+    def setUp(self):
+        super(TestNodeForwardAddon, self).setUp()
+        self.addon_type = 'OAUTH'
+        self.node_settings = self.node.get_or_add_addon(self.short_name, auth=self.auth)
+        self.node_settings.url = 'http://google.com'
+        self.node_settings.save()
+
+    ## Overrides
+
+    def test_settings_detail_GET_enabled(self):
+        res = self.app.get(
+            self.setting_detail_url,
+            auth=self.user.auth)
+
+        addon_data = res.json['data']['attributes']
+        assert_equal(self.node_settings.url, addon_data['url'])
+        assert_equal(self.node_settings.label, addon_data['label'])
+
+    def test_settings_detail_POST_enables(self):
+        self.node.delete_addon(self.short_name, auth=self.auth)
+        res = self.app.post_json_api(self.setting_detail_url, 
+            {'data': { 
+                'id': self.short_name,
+                'type': 'node_addons',
+                'attributes': {
+                    }
+                }
+            },
+            auth=self.user.auth)
+
+        addon_data = res.json['data']['attributes']
+        assert_equal(addon_data['url'], None)
+        assert_equal(addon_data['label'], None)
+
+        self.node.reload()
+        assert_not_equal(self.node.logs[-1].action, 'forward_url_changed')
+
+    def test_settings_detail_noncontrib_public_can_view(self):
+        self.node.set_privacy('public', auth=self.auth)
+        noncontrib = AuthUserFactory()
+        res = self.app.get(
+            self.setting_detail_url,
+            auth=noncontrib.auth)
+
+        assert_equal(res.status_code, 200)
+        addon_data = res.json['data']['attributes']
+        assert_equal(self.node_settings.url, addon_data['url'])
+        assert_equal(self.node_settings.label, addon_data['label'])
+
+    def test_settings_list_GET_enabled(self):
+        res = self.app.get(
+            self.setting_list_url,
+            auth=self.user.auth)
+
+        addon_data = self.get_response_for_addon(res)
+        assert_equal(self.node_settings.url, addon_data['url'])
+        assert_equal(self.node_settings.label, addon_data['label'])
+
+    def test_settings_list_noncontrib_public_can_view(self):
+        self.node.set_privacy('public', auth=self.auth)
+        noncontrib = AuthUserFactory()
+        res = self.app.get(
+            self.setting_list_url,
+            auth=noncontrib.auth)
+        addon_data = self.get_response_for_addon(res)
+
+        assert_equal(self.node_settings.url, addon_data['url'])
+        assert_equal(self.node_settings.label, addon_data['label'])
+
+    def test_settings_detail_PATCH_to_add_folder_without_auth_conflict(self):
+        pass
+
+    def test_settings_detail_PATCH_to_enable_and_add_external_account_id(self):
+        pass
+
+    def test_settings_detail_PATCH_to_remove_external_account_id(self):
+        pass
+
+    def test_settings_detail_PUT_all_sets_settings(self):
+        self.node_settings.reset()
+        self.node_settings.save()
+        data = {'data': { 
+                'id': self.short_name,
+                'type': 'node_addons',
+                'attributes': {}
+                }
+            }
+        data['data']['attributes'].update(self._mock_folder_info)
+        res = self.app.put_json_api(self.setting_detail_url, 
+            data, auth=self.user.auth)
+        addon_data = res.json['data']['attributes']
+        assert_equal(addon_data['url'], self._mock_folder_info['url'])
+        assert_equal(addon_data['label'], self._mock_folder_info['label'])
+        
+        self.node.reload()
+        assert_equal(self.node.logs[-1].action, 'forward_url_changed')
+
+    def test_settings_detail_PUT_none_and_enabled_clears_settings(self):
+        res = self.app.put_json_api(self.setting_detail_url, 
+            {'data': { 
+                'id': self.short_name,
+                'type': 'node_addons',
+                'attributes': {
+                    'url': None,
+                    'label': None
+                    }
+                }
+            }, auth=self.user.auth)
+        addon_data = res.json['data']['attributes']
+        assert_false(addon_data['url'])
+        assert_false(addon_data['label'])
+
+        assert_not_equal(self.node.logs[-1].action, 'forward_url_changed')
+
+    def test_settings_detail_PUT_only_label_and_enabled_clears_settings(self):
+        res = self.app.put_json_api(self.setting_detail_url, 
+            {'data': { 
+                'id': self.short_name,
+                'type': 'node_addons',
+                'attributes': {
+                    'url': None,
+                    'label': 'A Link'
+                    }
+                }
+            }, auth=self.user.auth,
+            expect_errors=True)
+        
+        assert_equal(res.status_code, 400)
+
+    def test_settings_detail_PUT_only_url_sets_settings(self):
+        self.node_settings.reset()
+        self.node_settings.save()
+        data = {'data': { 
+                'id': self.short_name,
+                'type': 'node_addons',
+                'attributes': {
+                    'url': self._mock_folder_info['url']    
+                }
+            }
+        }
+        res = self.app.put_json_api(self.setting_detail_url, 
+            data, auth=self.user.auth)
+        addon_data = res.json['data']['attributes']
+        assert_equal(addon_data['url'], self._mock_folder_info['url'])
+        assert_false(addon_data['label'])
+        
+        self.node.reload()
+        assert_equal(self.node.logs[-1].action, 'forward_url_changed')
+
+    def test_settings_detail_PUT_none_and_disabled_deauthorizes(self):
+        pass

--- a/api_tests/nodes/views/test_node_addons.py
+++ b/api_tests/nodes/views/test_node_addons.py
@@ -911,12 +911,18 @@ class TestNodeForwardAddon(NodeUnmanageableAddonTestSuiteMixin, ApiAddonTestCase
         assert_equal(self.node_settings.label, addon_data['label'])
 
     def test_settings_detail_PATCH_to_add_folder_without_auth_conflict(self):
+        # This test doesn't apply forward, as it does not use ExternalAccounts.
+        # Overridden because it's required by the superclass.
         pass
 
     def test_settings_detail_PATCH_to_enable_and_add_external_account_id(self):
+        # This test doesn't apply forward, as it does not use ExternalAccounts.
+        # Overridden because it's required by the superclass.
         pass
 
     def test_settings_detail_PATCH_to_remove_external_account_id(self):
+        # This test doesn't apply forward, as it does not use ExternalAccounts.
+        # Overridden because it's required by the superclass.
         pass
 
     def test_settings_detail_PUT_all_sets_settings(self):
@@ -991,4 +997,6 @@ class TestNodeForwardAddon(NodeUnmanageableAddonTestSuiteMixin, ApiAddonTestCase
         assert_equal(self.node.logs[-1].action, 'forward_url_changed')
 
     def test_settings_detail_PUT_none_and_disabled_deauthorizes(self):
+        # This test doesn't apply forward, as it does not use ExternalAccounts.
+        # Overridden because it's required by the superclass.
         pass

--- a/api_tests/users/views/test_user_addons.py
+++ b/api_tests/users/views/test_user_addons.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import abc
 from nose.tools import *  # flake8: noqa
+import re
 
 from api.base.settings.defaults import API_BASE
 
@@ -129,7 +130,7 @@ class UserAddonDetailMixin(object):
         if not wrong_type:
             assert_in('Requested addon not enabled', res.json['errors'][0]['detail'])
         if wrong_type:
-            assert_in('Requested addon unavailable', res.json['errors'][0]['detail'])
+            assert re.match(r'Requested addon un(available|recognized)', (res.json['errors'][0]['detail']))
 
     def test_settings_detail_raises_error_if_PUT(self):
         res = self.app.put_json_api(self.setting_detail_url, {
@@ -210,7 +211,7 @@ class UserAddonAccountListMixin(object):
         if not wrong_type:
             assert_in('Requested addon not enabled', res.json['errors'][0]['detail'])
         if wrong_type:
-            assert_in('Requested addon unavailable', res.json['errors'][0]['detail'])
+            assert re.match(r'Requested addon un(available|recognized)', (res.json['errors'][0]['detail']))
 
     def test_account_list_raises_error_if_PUT(self):
         res = self.app.put_json_api(self.account_list_url, {
@@ -291,7 +292,7 @@ class UserAddonAccountDetailMixin(object):
         if not wrong_type:
             assert_in('Requested addon not enabled', res.json['errors'][0]['detail'])
         if wrong_type:
-            assert_in('Requested addon unavailable', res.json['errors'][0]['detail'])
+            assert re.match(r'Requested addon un(available|recognized)', (res.json['errors'][0]['detail']))
 
     def test_account_detail_raises_error_if_PUT(self):
         res = self.app.put_json_api(self.account_detail_url, {

--- a/website/addons/forward/model.py
+++ b/website/addons/forward/model.py
@@ -14,6 +14,7 @@ from website.addons.base import AddonNodeSettingsBase
 class ForwardNodeSettings(AddonNodeSettingsBase):
 
     complete = True
+    has_auth = True
 
     url = fields.StringField(validate=URLValidator())
     label = fields.StringField(validate=sanitized)


### PR DESCRIPTION
## Purpose
Allow users to configure forward via APIv2

## Changes
* Refactored AddonNodeSettingsSerializer
* Added `url` and `label` as serializer fields for forward
* Tests

## Side effects
None expected

## Ticket
[OSF-6653](https://openscience.atlassian.net/browse/OSF-6653)