### PR TITLE
Specify provider in test factories, Documentation Improvements

### DIFF
--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -39,7 +39,7 @@ class PreprintSerializer(JSONAPISerializer):
     ])
 
     title = ser.CharField(required=False)
-    subjects = JSONAPIListField(required=False, source='preprint_subjects')
+    subjects = JSONAPIListField(required=False, source='get_preprint_subjects')
     provider = ser.CharField(source='preprint_provider', required=False)
     date_created = ser.DateTimeField(read_only=True, source='preprint_created')
     date_modified = ser.DateTimeField(read_only=True)

--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -35,7 +35,7 @@ class PreprintSerializer(JSONAPISerializer):
         'date_modified',
         'contributors',
         'provider',
-        'preprint_subjects'
+        'subjects'
     ])
 
     title = ser.CharField(required=False)

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -34,6 +34,89 @@ class PreprintMixin(NodeMixin):
 
 
 class PreprintList(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin):
+    """Preprints that represent a special kind of preprint node. *Read Only*.
+
+    Paginated list of preprints ordered by their `date_created`.  Each resource contains a representation of the
+    preprint.
+
+    ##Preprint Attributes
+
+    Many of these preprint attributes are the same as node, with a few special fields added in.
+
+    OSF Preprint entities have the "preprint" `type`.
+
+        name                            type                  description
+        ====================================================================================
+        title                           string                title of preprint, same as its project or component
+        abstract                        string                description of the preprint
+        date_created                    iso8601 timestamp     timestamp that the preprint was created
+        date_modified                   iso8601 timestamp     timestamp when the preprint was last updated
+        tags                            array of strings      list of tags that describe the node
+        subjects                        array of Subject ids  list ids of Subject in the PLOS taxonomy. Tuple, containing the subject text and subject ID
+        provider                        string                original source of the preprint
+
+    ##Relationships
+
+    ###Primary File
+    The file that is designated as the preprint's primary file, or the manuscript of the preprint.
+
+    ###Files
+    Link to list of files associated with this node/preprint
+
+    ###Contributors
+    Link to list of contributors that are affiliated with this institution.
+
+    ##Links
+
+    See the [JSON-API spec regarding pagination](http://jsonapi.org/format/1.0/#fetching-pagination).
+
+    ##Actions
+
+    ###Creating New Preprints
+
+    Create a new preprint by posting to the guid of the existing **node**, including the file_id for the
+    file you'd like to make the primary preprint file.
+
+        Method:        POST
+        URL:           /preprints/<node_id>/
+        Query Params:  <none>
+        Body (JSON):   {
+                        "data": {
+                            "id": node_id,
+                            "attributes": {
+                                "subjects":      {subject_id}      # required
+                                "description":   {description},    # optional
+                                "tags":          [{tag1}, {tag2}], # optional
+                                "provider":      {provider}        # optional
+
+                            },
+                            "relationships": {
+                                "preprint_file": {                 # required
+                                    "data": {
+                                        "type": "primary_file",
+                                        "id": file_id
+                                    }
+                                }
+                            }
+                        }
+                    }
+        Success:       201 CREATED + preprint representation
+
+    New preprints are created by issuing a POST request to this endpoint, along with the guid for the node to create a preprint from.
+    Provider defaults to osf.
+
+    ##Query Params
+
+    + `page=<Int>` -- page number of results to view, default 1
+
+    + `filter[<fieldname>]=<Str>` -- fields and values to filter the search results on.
+
+    Preprints may be filtered by their `id`, `title`, `public`, `tags`, `date_created`, `date_modified`, `provider`, and `subjects`
+    Most are string fields and will be filtered using simple substring matching.
+
+    #This Request/Response
+
+    """
     permission_classes = (
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -70,8 +70,6 @@ class PreprintList(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin):
 
     See the [JSON-API spec regarding pagination](http://jsonapi.org/format/1.0/#fetching-pagination).
 
-
-
     ##Query Params
 
     + `page=<Int>` -- page number of results to view, default 1

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -52,7 +52,7 @@ class PreprintList(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin):
         date_created                    iso8601 timestamp     timestamp that the preprint was created
         date_modified                   iso8601 timestamp     timestamp when the preprint was last updated
         tags                            array of strings      list of tags that describe the node
-        subjects                        array of Subject ids  list ids of Subject in the PLOS taxonomy. Tuple, containing the subject text and subject ID
+        subjects                        array of tuples       list ids of Subject in the PLOS taxonomy. Tuple, containing the subject text and subject ID
         provider                        string                original source of the preprint
 
     ##Relationships

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -70,40 +70,7 @@ class PreprintList(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin):
 
     See the [JSON-API spec regarding pagination](http://jsonapi.org/format/1.0/#fetching-pagination).
 
-    ##Actions
 
-    ###Creating New Preprints
-
-    Create a new preprint by posting to the guid of the existing **node**, including the file_id for the
-    file you'd like to make the primary preprint file.
-
-        Method:        POST
-        URL:           /preprints/<node_id>/
-        Query Params:  <none>
-        Body (JSON):   {
-                        "data": {
-                            "id": node_id,
-                            "attributes": {
-                                "subjects":      {subject_id}      # required
-                                "description":   {description},    # optional
-                                "tags":          [{tag1}, {tag2}], # optional
-                                "provider":      {provider}        # optional
-
-                            },
-                            "relationships": {
-                                "preprint_file": {                 # required
-                                    "data": {
-                                        "type": "primary_file",
-                                        "id": file_id
-                                    }
-                                }
-                            }
-                        }
-                    }
-        Success:       201 CREATED + preprint representation
-
-    New preprints are created by issuing a POST request to this endpoint, along with the guid for the node to create a preprint from.
-    Provider defaults to osf.
 
     ##Query Params
 
@@ -115,7 +82,6 @@ class PreprintList(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin):
     Most are string fields and will be filtered using simple substring matching.
 
     #This Request/Response
-
     """
     permission_classes = (
         drf_permissions.IsAuthenticatedOrReadOnly,
@@ -149,6 +115,49 @@ class PreprintList(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin):
 
 
 class PreprintDetail(JSONAPIBaseView, generics.CreateAPIView, generics.RetrieveUpdateAPIView, PreprintMixin, WaterButlerMixin):
+    """Preprint Detail  *Writeable*.
+
+    ##Preprint Attributes
+    See Preprints List
+
+    ##Actions
+
+    ###Creating New Preprints
+
+    Create a new preprint by posting to the guid of the existing **node**, including the file_id for the
+    file you'd like to make the primary preprint file. Note that the **node id** will not be accessible via the
+    preprints detail view until after the preprint has been created.
+
+        Method:        POST
+        URL:           /preprints/<node_id>/
+        Query Params:  <none>
+        Body (JSON):   {
+                        "data": {
+                            "id": node_id,
+                            "attributes": {
+                                "subjects":      {subject_id}      # required
+                                "description":   {description},    # optional
+                                "tags":          [{tag1}, {tag2}], # optional
+                                "provider":      {provider}        # optional
+
+                            },
+                            "relationships": {
+                                "preprint_file": {                 # required
+                                    "data": {
+                                        "type": "primary_file",
+                                        "id": file_id
+                                    }
+                                }
+                            }
+                        }
+                    }
+        Success:       201 CREATED + preprint representation
+
+    New preprints are created by issuing a POST request to this endpoint, along with the guid for the node to create a preprint from.
+    Provider defaults to osf.
+
+    #This Request/Response
+    """
     permission_classes = (
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,

--- a/api_tests/preprints/views/test_preprint_list.py
+++ b/api_tests/preprints/views/test_preprint_list.py
@@ -94,10 +94,9 @@ class TestPreprintFiltering(ApiTestCase):
 
     def test_filter_by_provider(self):
         url = '/{}preprints/?filter[provider]={}'.format(API_BASE, 'wwe')
-
         res = self.app.get(url, auth=self.user.auth)
-        res_json = res.json.data['data']
+        data = res.json['data']
 
-        assert_equal(len(res_json), 2)
-        for result in res_json:
-            assert 'wwe' in result['provider']
+        assert_equal(len(data), 2)
+        for result in data:
+            assert 'wwe' in result['attributes']['provider']

--- a/api_tests/preprints/views/test_preprint_list.py
+++ b/api_tests/preprints/views/test_preprint_list.py
@@ -47,19 +47,19 @@ class TestPreprintFiltering(ApiTestCase):
     def setUp(self):
         super(TestPreprintFiltering, self).setUp()
         self.user = AuthUserFactory()
-        self.preprint = PreprintFactory(creator=self.user)
+        self.preprint = PreprintFactory(creator=self.user, provider='wwe')
         self.url = "/{}registrations/".format(API_BASE)
 
         self.preprint.add_tag('nature boy', Auth(self.user), save=False)
         self.preprint.add_tag('ric flair', Auth(self.user), save=False)
         self.preprint.save()
 
-        self.preprint_two = PreprintFactory(creator=self.user, filename='woo.txt')
+        self.preprint_two = PreprintFactory(creator=self.user, filename='woo.txt', provider='wcw')
         self.preprint_two.add_tag('nature boy', Auth(self.user), save=False)
         self.preprint_two.add_tag('woo', Auth(self.user), save=False)
         self.preprint_two.save()
 
-        self.preprint_three = PreprintFactory(creator=self.user, filename='stonecold.txt')
+        self.preprint_three = PreprintFactory(creator=self.user, filename='stonecold.txt', provider='wwe')
         self.preprint_three.add_tag('stone', Auth(self.user), save=False)
         self.preprint_two.add_tag('cold', Auth(self.user), save=False)
         self.preprint_three.save()
@@ -92,15 +92,12 @@ class TestPreprintFiltering(ApiTestCase):
         assert_not_in(self.preprint_two._id, ids)
         assert_not_in(self.preprint_three._id, ids)
 
+    def test_filter_by_provider(self):
+        url = '/{}preprints/?filter[provider]={}'.format(API_BASE, 'wwe')
 
-class TestPreprintCreate(ApiTestCase):
-    def setUp(self):
-        super(TestPreprintCreate, self).setUp()
-        self.user = AuthUserFactory()
-        self.preprint = PreprintFactory(creator=self.user)
-        self.url = '{}/preprints/{}'.format(API_BASE, self.preprint._id)
+        res = self.app.get(url, auth=self.user.auth)
+        res_json = res.json.data['data']
 
-        # TODO - add a real payload
-        self.payload = {
-            "data": {}
-        }
+        assert_equal(len(res_json), 2)
+        for result in res_json:
+            assert 'wwe' in result['provider']

--- a/scripts/create_fakes.py
+++ b/scripts/create_fakes.py
@@ -287,18 +287,19 @@ def parse_args():
     parser.add_argument('--presentation', dest='presentation_name', type=str, default=None)
     parser.add_argument('-r', '--registration', dest='is_registration', type=bool, default=False)
     parser.add_argument('-pre', '--preprint', dest='is_preprint', type=bool, default=False)
+    parser.add_argument('-preprovider', '--preprintprovider', dest='preprint_provider', type=str, default='osf')
     return parser.parse_args()
 
 def evaluate_argument(string):
     return ast.literal_eval(string)
 
 
-def create_fake_project(creator, n_users, privacy, n_components, name, n_tags, presentation_name, is_registration, is_preprint):
+def create_fake_project(creator, n_users, privacy, n_components, name, n_tags, presentation_name, is_registration, is_preprint, preprint_provider):
     auth = Auth(user=creator)
     project_title = name if name else fake.science_sentence()
     if is_preprint:
         privacy = 'public'
-        project = PreprintFactory(title=project_title, description=fake.science_paragraph(), creator=creator)
+        project = PreprintFactory(title=project_title, description=fake.science_paragraph(), creator=creator, preprint_provider=preprint_provider)
     elif is_registration:
         project = RegistrationFactory(title=project_title, description=fake.science_paragraph(), creator=creator)
     else:
@@ -353,7 +354,7 @@ def main():
     for i in range(args.n_projects):
         name = args.name + str(i) if args.name else ''
         create_fake_project(creator, args.n_users, args.privacy, args.n_components, name, args.n_tags,
-                            args.presentation_name, args.is_registration, args.is_preprint)
+                            args.presentation_name, args.is_registration, args.is_preprint, args.preprint_provider)
     print('Created {n} fake projects.'.format(n=args.n_projects))
     sys.exit(0)
 

--- a/scripts/create_fakes.py
+++ b/scripts/create_fakes.py
@@ -299,7 +299,7 @@ def create_fake_project(creator, n_users, privacy, n_components, name, n_tags, p
     project_title = name if name else fake.science_sentence()
     if is_preprint:
         privacy = 'public'
-        project = PreprintFactory(title=project_title, description=fake.science_paragraph(), creator=creator, preprint_provider=preprint_provider)
+        project = PreprintFactory(title=project_title, description=fake.science_paragraph(), creator=creator, provider=preprint_provider)
     elif is_registration:
         project = RegistrationFactory(title=project_title, description=fake.science_paragraph(), creator=creator)
     else:

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -220,7 +220,7 @@ class PreprintFactory(AbstractNodeFactory):
     category = 'project'
 
     @classmethod
-    def _create(cls, target_class, project=None, is_public=True, filename='preprint_file.txt', *args, **kwargs):
+    def _create(cls, target_class, project=None, is_public=True, filename='preprint_file.txt', preprint_provider='osf', *args, **kwargs):
         save_kwargs(**kwargs)
         user = None
         if project:
@@ -249,6 +249,7 @@ class PreprintFactory(AbstractNodeFactory):
 
         project.set_preprint_file(file, auth=Auth(project.creator))
         project.preprint_subjects = [SubjectFactory()._id]
+        project.preprint_provider = preprint_provider
         project.save()
 
         return project

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -220,7 +220,7 @@ class PreprintFactory(AbstractNodeFactory):
     category = 'project'
 
     @classmethod
-    def _create(cls, target_class, project=None, is_public=True, filename='preprint_file.txt', preprint_provider='osf', *args, **kwargs):
+    def _create(cls, target_class, project=None, is_public=True, filename='preprint_file.txt', provider='osf', *args, **kwargs):
         save_kwargs(**kwargs)
         user = None
         if project:
@@ -249,7 +249,7 @@ class PreprintFactory(AbstractNodeFactory):
 
         project.set_preprint_file(file, auth=Auth(project.creator))
         project.preprint_subjects = [SubjectFactory()._id]
-        project.preprint_provider = preprint_provider
+        project.preprint_provider = provider
         project.save()
 
         return project


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Update serializer, add tests for preprint provider, add documentation

## Changes
- Create preprint documentation in preprint detail docstring on API v2
- Add ability to specify provider in preprint factory
- Add provider in create_fakes script
- Tests for filtering by provider
- Documentation in preprint list and detail view
- Documentation on creating a new preprint by POST-ing to a node that exists
- Update subjects serializer to show both ID and text

## Side effects

<!--Any possible side effects? -->


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
