### PR TITLE
Feature/Create Users Via Cookie Auth [OSF-6879]

### DIFF
--- a/api/base/permissions.py
+++ b/api/base/permissions.py
@@ -94,9 +94,12 @@ class RequiresScopedRequestOrReadOnly(TokenHasScope):
     def has_permission(self, request, view):
         token = request.auth
 
+        # User either needs properly scoped token or cookie. Otherwise, endpoint has restricted write.
         if token is None or not isinstance(token, CasResponse):
-            # Assumption: user authenticated via non-oauth means, and this endpoint has restricted write
-            return request.method in permissions.SAFE_METHODS
+            if request.COOKIES:
+                return True
+            else:
+                return request.method in permissions.SAFE_METHODS
 
         return self._verify_scopes(request, view, token)
 

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -103,6 +103,7 @@ class UserList(JSONAPIBaseView, generics.ListCreateAPIView, ODMFilterMixin):
     """
     permission_classes = (
         drf_permissions.IsAuthenticatedOrReadOnly,
+        base_permissions.RequiresScopedRequestOrReadOnly,
         base_permissions.TokenHasScope,
     )
 

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -103,7 +103,6 @@ class UserList(JSONAPIBaseView, generics.ListCreateAPIView, ODMFilterMixin):
     """
     permission_classes = (
         drf_permissions.IsAuthenticatedOrReadOnly,
-        base_permissions.RequiresScopedRequestOrReadOnly,
         base_permissions.TokenHasScope,
     )
 

--- a/api_tests/users/views/test_user_list.py
+++ b/api_tests/users/views/test_user_list.py
@@ -113,7 +113,7 @@ class TestUsersCreate(ApiTestCase):
         User.remove()
 
     @mock.patch('framework.auth.views.mails.send_mail')
-    def test_logged_in_user_can_create_other_user_or_send_mail(self, mock_mail):
+    def test_logged_in_user_with_basic_auth_cannot_create_other_user_or_send_mail(self, mock_mail):
         assert_equal(User.find(Q('username', 'eq', self.unconfirmed_email)).count(), 0)
         res = self.app.post_json_api(
             '{}?send_email=true'.format(self.base_url),
@@ -122,9 +122,9 @@ class TestUsersCreate(ApiTestCase):
             expect_errors=True
         )
 
-        assert_equal(res.status_code, 201)
-        assert_equal(User.find(Q('username', 'eq', self.unconfirmed_email)).count(), 1)
-        assert_equal(mock_mail.call_count, 1)
+        assert_equal(res.status_code, 403)
+        assert_equal(User.find(Q('username', 'eq', self.unconfirmed_email)).count(), 0)
+        assert_equal(mock_mail.call_count, 0)
 
     @mock.patch('framework.auth.views.mails.send_mail')
     def test_logged_out_user_cannot_create_other_user_or_send_mail(self, mock_mail):

--- a/api_tests/users/views/test_user_list.py
+++ b/api_tests/users/views/test_user_list.py
@@ -113,7 +113,7 @@ class TestUsersCreate(ApiTestCase):
         User.remove()
 
     @mock.patch('framework.auth.views.mails.send_mail')
-    def test_user_can_not_create_other_user_or_send_mail(self, mock_mail):
+    def test_logged_in_user_can_create_other_user_or_send_mail(self, mock_mail):
         assert_equal(User.find(Q('username', 'eq', self.unconfirmed_email)).count(), 0)
         res = self.app.post_json_api(
             '{}?send_email=true'.format(self.base_url),
@@ -122,12 +122,25 @@ class TestUsersCreate(ApiTestCase):
             expect_errors=True
         )
 
-        assert_equal(res.status_code, 403)
+        assert_equal(res.status_code, 201)
+        assert_equal(User.find(Q('username', 'eq', self.unconfirmed_email)).count(), 1)
+        assert_equal(mock_mail.call_count, 1)
+
+    @mock.patch('framework.auth.views.mails.send_mail')
+    def test_logged_out_user_cannot_create_other_user_or_send_mail(self, mock_mail):
+        assert_equal(User.find(Q('username', 'eq', self.unconfirmed_email)).count(), 0)
+        res = self.app.post_json_api(
+            '{}?send_email=true'.format(self.base_url),
+            self.data,
+            expect_errors=True
+        )
+
+        assert_equal(res.status_code, 401)
         assert_equal(User.find(Q('username', 'eq', self.unconfirmed_email)).count(), 0)
         assert_equal(mock_mail.call_count, 0)
 
     @mock.patch('framework.auth.views.mails.send_mail')
-    def test_cookied_requests_do_not_create_or_email(self, mock_mail):
+    def test_cookied_requests_can_create_and_email(self, mock_mail):
         session = Session(data={'auth_user_id': self.user._id})
         session.save()
         cookie = itsdangerous.Signer(settings.SECRET_KEY).sign(session._id)
@@ -135,14 +148,12 @@ class TestUsersCreate(ApiTestCase):
 
         assert_equal(User.find(Q('username', 'eq', self.unconfirmed_email)).count(), 0)
         res = self.app.post_json_api(
-            self.base_url,
-            self.data,
-            expect_errors=True
+            '{}?send_email=true'.format(self.base_url),
+            self.data
         )
-
-        assert_equal(res.status_code, 403)
-        assert_equal(User.find(Q('username', 'eq', self.unconfirmed_email)).count(), 0)
-        assert_equal(mock_mail.call_count, 0)
+        assert_equal(res.status_code, 201)
+        assert_equal(User.find(Q('username', 'eq', self.unconfirmed_email)).count(), 1)
+        assert_equal(mock_mail.call_count, 1)
 
     @mock.patch('framework.auth.views.mails.send_mail')
     @mock.patch('api.base.authentication.drf.OSFCASAuthentication.authenticate')


### PR DESCRIPTION
## Purpose

Changes permissions under which a user can create an unregistered user via the API v2.  Previously, a user could only create another user if they had a properly scoped token (users-create).  Creating them with cookie auth was not allowed.  This allows you to create users if you have a cookie.

Needed to create unregistered contributors for preprints and will eventually be needed for OSF unreg contrib functionality as well. 

## Changes

Removes RequiresScopedRequestOrReadOnly from permissions classes

## Ticket

https://openscience.atlassian.net/browse/OSF-6879