### PR TITLE
[hotfix] Extend popular projects timeframe to two weeks

### DIFF
--- a/website/discovery/views.py
+++ b/website/discovery/views.py
@@ -15,7 +15,7 @@ def activity():
     hits = {}
 
     # get the date for exactly one week ago
-    target_date = datetime.date.today() - datetime.timedelta(weeks=1)
+    target_date = datetime.date.today() - datetime.timedelta(weeks=2)
 
     if settings.PIWIK_HOST:
         client = PiwikClient(


### PR DESCRIPTION
## Purpose / Changes

Update the timeframe for finding popular projects to two weeks.  This will avoid running out of candidates before the data source can be updated from piwik to keen.

## Side effects

None expected.

## Ticket

None