### PR TITLE
[OSF-5360] Search in 'add link' should show all your projects by default

### DIFF
--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -715,6 +715,12 @@ div.ball-scale-blue>div {
     overflow: scroll;
 }
 
+/* Add Links Modal
+----------------------- */
+.node-dates {
+    white-space: pre;
+}
+
 /* Password strength check component colors for darker backgrounds  */
 .pv-darkbg .text-danger {
     color: #f97773;

--- a/website/static/js/pointers.js
+++ b/website/static/js/pointers.js
@@ -133,19 +133,6 @@ var AddPointerViewModel = oop.extend(Paginator, {
         self.searchMyProjectsSubmitText(SEARCH_MY_PROJECTS_SUBMIT_TEXT);
         self.loadingResults(false);
     },
-    addTips: function(elements, data) {
-        elements.forEach(function(element) {
-            var titleText = '';
-            if (data.type === 'registrations') {
-                titleText = 'Registered: ' + data.dateRegistered.local;
-            } else {
-                titleText = 'Created: ' + data.dateCreated.local + '\nModified: ' + data.dateModified.local;
-            }
-            $(element).tooltip({
-                title: titleText
-            });
-        });
-    },
     add: function(data) {
         var self = this;
         if (self.inputType() === 'nodes') {
@@ -259,20 +246,6 @@ var AddPointerViewModel = oop.extend(Paginator, {
         }
 
     },
-    // addAll: function() {
-    //     var self = this;
-    //     $.each(self.results(), function(idx, result) {
-    //         if (self.selection().indexOf(result) === -1) {
-    //             self.add(result);
-    //         }
-    //     });
-    // },
-    // removeAll: function() {
-    //     var self = this;
-    //     $.each(self.selection(), function(idx, selected) {
-    //         self.remove(selected);
-    //     });
-    // },
     selected: function(data) {
         var self = this;
         for (var idx = 0; idx < self.selection().length; idx++) {
@@ -282,31 +255,6 @@ var AddPointerViewModel = oop.extend(Paginator, {
         }
         return false;
     },
-    // submit: function() {
-    //     var self = this;
-    //     self.submitEnabled(false);
-    //     self.submitWarningMsg('');
-    //
-    //     var nodeIds = osfHelpers.mapByProperty(self.selection(), 'id');
-    //
-    //     osfHelpers.postJSON(
-    //         nodeApiUrl + 'pointer/', {
-    //             nodeIds: nodeIds
-    //         }
-    //     ).done(function() {
-    //         window.location.reload();
-    //     }).fail(function(data) {
-    //         self.submitEnabled(true);
-    //         self.submitWarningMsg(data.responseJSON && data.responseJSON.message_long);
-    //     });
-    // },
-    // clear: function() {
-    //     this.query('');
-    //     this.results([]);
-    //     this.selection([]);
-    //     this.searchWarningMsg('');
-    //     this.submitWarningMsg('');
-    // },
     authorText: function(node) {
         var contributors = node.embeds.contributors.data;
         var author = contributors[0].embeds.users.data.attributes.family_name;
@@ -332,6 +280,15 @@ var AddPointerViewModel = oop.extend(Paginator, {
             self.inputType('registrations');
             self.searchMyProjects();
         }
+    },
+    getDates: function(data){
+        var date = '';
+        if (data.type === 'registrations') {
+            date = 'Registered: ' + data.dateRegistered.local;
+        } else {
+            date = 'Created: ' + data.dateCreated.local + '\nModified: ' + data.dateModified.local;
+        }
+        return date;
     },
     done: function() {
         window.location.reload();

--- a/website/static/js/pointers.js
+++ b/website/static/js/pointers.js
@@ -19,8 +19,8 @@ var SEARCH_MY_PROJECTS_SUBMIT_TEXT = 'Search my projects';
 
 var AddPointerViewModel = oop.extend(Paginator, {
     constructor: function(nodeTitle) {
-        this.super.constructor.call(this);
         var self = this;
+        this.super.constructor.call(this);
         this.nodeTitle = nodeTitle;
         this.submitEnabled = ko.observable(true);
         this.searchAllProjectsSubmitText = ko.observable(SEARCH_ALL_SUBMIT_TEXT);
@@ -64,42 +64,8 @@ var AddPointerViewModel = oop.extend(Paginator, {
         if (self.query()) {
             self.results([]); // clears page for spinner
             self.loadingResults(true); // enables spinner
-
-            /*osfHelpers.postJSON(
-                '/api/v1/search/node/', {
-                    query: self.query(),
-                    nodeId: nodeId,
-                    includePublic: self.includePublic(),
-                    page: self.pageToGet()
-                }
-            ).done(function(result) {
-                if (!result.nodes.length) {
-                    self.errorMsg('No results found.');
-                } else {
-                    result.nodes.forEach(function(each) {
-                        if (each.isRegistration) {
-                            each.dateRegistered = new osfHelpers.FormattableDate(each.dateRegistered);
-                        } else {
-                            each.dateCreated = new osfHelpers.FormattableDate(each.dateCreated);
-                            each.dateModified = new osfHelpers.FormattableDate(each.dateModified);
-                        }
-                    });
-                }
-                self.results(result.nodes);
-                self.currentPage(result.page);
-                self.numberOfPages(result.pages);
-                self.addNewPaginators();
-            }).fail(function(xhr) {
-                self.searchWarningMsg(xhr.responseJSON && xhr.responseJSON.message_long);
-            }).always( function (){
-                self.searchAllProjectsSubmitText(SEARCH_ALL_SUBMIT_TEXT);
-                self.searchMyProjectsSubmitText(SEARCH_MY_PROJECTS_SUBMIT_TEXT);
-                self.loadingResults(false);
-            });*/
-
-            // -- ADDED >
-
-            var url = osfHelpers.apiV2Url('nodes/', {query: 'filter[title]='+self.query()});
+            var pageNum = self.pageToGet()+1;
+            var url = osfHelpers.apiV2Url('nodes/', {query: 'filter[title]='+self.query()+'&page='+pageNum+'&embed=contributors'});
             var request = osfHelpers.ajaxJSON(
                 'GET',
                 url,
@@ -110,7 +76,6 @@ var AddPointerViewModel = oop.extend(Paginator, {
                     self.errorMsg('No results found.');
                 }
                 else {
-                    console.log(response.data);
                     nodes.forEach(function(each) {
                         if (each.isRegistration) {
                             each.dateRegistered = new osfHelpers.FormattableDate(each.dateRegistered);
@@ -124,7 +89,6 @@ var AddPointerViewModel = oop.extend(Paginator, {
                 self.currentPage(self.pageToGet());
                 self.numberOfPages(Math.ceil(response.links.meta.total / response.links.meta.per_page));
                 self.addNewPaginators();
-
             });
             request.fail(function(xhr) {
                 self.searchWarningMsg(xhr.responseJSON && xhr.responseJSON.message_long);
@@ -132,9 +96,6 @@ var AddPointerViewModel = oop.extend(Paginator, {
             self.searchAllProjectsSubmitText(SEARCH_ALL_SUBMIT_TEXT);
             self.searchMyProjectsSubmitText(SEARCH_MY_PROJECTS_SUBMIT_TEXT);
             self.loadingResults(false);
-
-            // -- < ADDED
-
         } else {
             self.results([]);
             self.currentPage(0);
@@ -220,11 +181,12 @@ var AddPointerViewModel = oop.extend(Paginator, {
         this.submitWarningMsg('');
     },
     authorText: function(node) {
-        var rv = node.firstAuthor;
-        if (node.etal) {
-            rv += ' et al.';
+        var contributors = node.embeds.contributors.data;
+        var author = contributors[0].embeds.users.data.attributes.family_name;
+        if (contributors.length > 1) {
+            author += ' et al.';
         }
-        return rv;
+        return author;
     }
 });
 

--- a/website/static/js/pointers.js
+++ b/website/static/js/pointers.js
@@ -36,13 +36,16 @@ var AddPointerViewModel = oop.extend(Paginator, {
         this.submitWarningMsg = ko.observable('');
         this.loadingResults = ko.observable(false);
 
+        this.inputType = ko.observable('nodes');
+
         this.foundResults = ko.pureComputed(function() {
-            return self.query() && self.results().length;
+            return self.results().length;
         });
 
         this.noResults = ko.pureComputed(function() {
             return self.query() && !self.results().length;
         });
+        this.searchMyProjects();
     },
     searchAllProjects: function() {
         this.includePublic(true);
@@ -60,49 +63,77 @@ var AddPointerViewModel = oop.extend(Paginator, {
         var self = this;
         self.errorMsg('');
         self.searchWarningMsg('');
-
-        if (self.query()) {
-            self.results([]); // clears page for spinner
-            self.loadingResults(true); // enables spinner
-            var pageNum = self.pageToGet()+1;
-            var url = osfHelpers.apiV2Url('nodes/', {query: 'filter[title]='+self.query()+'&page='+pageNum+'&embed=contributors'});
-            var request = osfHelpers.ajaxJSON(
-                'GET',
-                url,
-                {'isCors': true});
-            request.done(function(response) {
-                var nodes = response.data;
-                if (!nodes.length) {
-                    self.errorMsg('No results found.');
-                }
-                else {
-                    nodes.forEach(function(each) {
-                        if (each.isRegistration) {
-                            each.dateRegistered = new osfHelpers.FormattableDate(each.dateRegistered);
-                        } else {
-                            each.dateCreated = new osfHelpers.FormattableDate(each.dateCreated);
-                            each.dateModified = new osfHelpers.FormattableDate(each.dateModified);
+        self.results([]); // clears page for spinner
+        self.selection([]);
+        self.loadingResults(true); // enables spinner
+        var query = '', myProjects = '', pageNum = self.pageToGet()+1;
+        if (self.query()){
+            query += 'filter[title]='+self.query()+'&';
+        }
+        if (!self.includePublic()){
+            myProjects = 'users/me/'
+        }
+        var url = osfHelpers.apiV2Url(myProjects+self.inputType()+'/', {query: query+'page='+pageNum+'&embed=contributors&page[size]=5'});
+        var request = osfHelpers.ajaxJSON(
+            'GET',
+            url,
+            {'isCors': true});
+        request.done(function(response) {
+            var nodes = response.data;
+            if (!nodes.length) {
+                self.errorMsg('No results found.');
+            }
+            else {
+                var count = nodes.length;
+                nodes.forEach(function(each) {
+                    console.log(each);
+                    if (each.isRegistration) {
+                        each.attributes.dateRegistered = new osfHelpers.FormattableDate(each.attributes.dateRegistered);
+                    } else {
+                        each.dateCreated = new osfHelpers.FormattableDate(each.attributes.dateCreated);
+                        each.dateModified = new osfHelpers.FormattableDate(each.attributes.dateModified);
+                    }
+                    //each.added = false;
+                    each.link = '';
+                    var url = osfHelpers.apiV2Url('nodes/'+nodeId+'/node_links/', {});
+                    var request = osfHelpers.ajaxJSON(
+                        'GET',
+                        url,
+                        {'isCors': true});
+                    request.done(function(nl_response) {
+                        var result = nl_response.data;
+                        var i;
+                        for (i = 0; i < result.length; i++) {
+                            if (result[i].embeds.target_node.data.id === each.id) {
+                                self.selection.push(each);
+                                break;
+                            }
+                        }
+                        if (--count === 0) {
+                            self.results(nodes);
+                            self.currentPage(self.pageToGet());
+                            self.numberOfPages(Math.ceil(response.links.meta.total / response.links.meta.per_page));
+                            self.addNewPaginators();
                         }
                     });
-                }
-                self.results(nodes);
-                self.currentPage(self.pageToGet());
-                self.numberOfPages(Math.ceil(response.links.meta.total / response.links.meta.per_page));
-                self.addNewPaginators();
-            });
-            request.fail(function(xhr) {
-                self.searchWarningMsg(xhr.responseJSON && xhr.responseJSON.message_long);
-            });
-            self.searchAllProjectsSubmitText(SEARCH_ALL_SUBMIT_TEXT);
-            self.searchMyProjectsSubmitText(SEARCH_MY_PROJECTS_SUBMIT_TEXT);
-            self.loadingResults(false);
-        } else {
-            self.results([]);
-            self.currentPage(0);
-            self.totalPages(0);
-            self.searchAllProjectsSubmitText(SEARCH_ALL_SUBMIT_TEXT);
-            self.searchMyProjectsSubmitText(SEARCH_MY_PROJECTS_SUBMIT_TEXT);
-        }
+                    request.fail(function(xhr) {
+                        self.searchWarningMsg(xhr.responseJSON && xhr.responseJSON.message_long);
+                        if (--count === 0) {
+                            self.results(nodes);
+                            self.currentPage(self.pageToGet());
+                            self.numberOfPages(Math.ceil(response.links.meta.total / response.links.meta.per_page));
+                            self.addNewPaginators();
+                        }
+                    });
+                });
+            }
+        });
+        request.fail(function(xhr) {
+            self.searchWarningMsg(xhr.responseJSON && xhr.responseJSON.message_long);
+        });
+        self.searchAllProjectsSubmitText(SEARCH_ALL_SUBMIT_TEXT);
+        self.searchMyProjectsSubmitText(SEARCH_MY_PROJECTS_SUBMIT_TEXT);
+        self.loadingResults(false);
     },
     addTips: function(elements, data) {
         elements.forEach(function(element) {
@@ -118,34 +149,132 @@ var AddPointerViewModel = oop.extend(Paginator, {
         });
     },
     add: function(data) {
-        this.selection.push(data);
-        // Hack: Hide and refresh tooltips
-        $('.tooltip').hide();
-        $('.pointer-row').tooltip();
+        var self = this;
+        if (self.inputType() === 'nodes') {
+            var url = osfHelpers.apiV2Url('nodes/'+nodeId+'/node_links/', {});
+            var request = osfHelpers.ajaxJSON(
+                'POST',
+                url,
+                {
+                    'isCors': true,
+                    'data': {
+                        'data': {
+                            'type': 'node_links',
+                            'relationships': {
+                                'nodes': {
+                                    'data': {
+                                        'type': 'nodes',
+                                        'id': data.id
+                                    }
+                                }
+                            }
+                        }
+                    }
+                });
+            request.done(function (response) {
+                    self.selection.push(data);
+            });
+        }
+        else{
+            // BLOCKER
+            // var url = osfHelpers.apiV2Url('nodes/'+nodeId+'/registration_links/', {});
+            // var request = osfHelpers.ajaxJSON(
+            //     'POST',
+            //     url,
+            //     {
+            //         'isCors': true,
+            //         'data': {
+            //             'data': {
+            //                 'type': 'registration_links',
+            //                 'relationships': {
+            //                     'nodes': {
+            //                         'data': {
+            //                             'type': 'registrations',
+            //                             'id': data.id
+            //                         }
+            //                     }
+            //                 }
+            //             }
+            //         }
+            //     });
+            // request.done(function (response) {
+            //     self.selection.push(data);
+            // });
+        }
     },
     remove: function(data) {
         var self = this;
-        self.selection.splice(
-            self.selection.indexOf(data), 1
-        );
-        // Hack: Hide and refresh tooltips
-        $('.tooltip').hide();
-        $('.pointer-row').tooltip();
+        if (self.inputType() === 'nodes'){
+            var url = osfHelpers.apiV2Url('nodes/'+nodeId+'/node_links/', {});
+            var request = osfHelpers.ajaxJSON(
+                'GET',
+                url,
+                {'isCors': true});
+            request.done(function(response) {
+                var i, nl_id;
+                for (i = 0; i < response.data.length; i++){
+                    if (response.data[i].embeds.target_node.data.id === data.id){
+                        nl_id = response.data[i].id;
+                    }
+                }
+                var url = osfHelpers.apiV2Url('nodes/'+nodeId+'/node_links/'+nl_id+'/', {});
+                var request = osfHelpers.ajaxJSON(
+                    'DELETE',
+                    url,
+                    {
+                        'isCors': true
+                    });
+                request.done(function(nl_response) {
+                    self.selection.splice(
+                        self.selection.indexOf(data), 1
+                    );
+                });
+            });
+        }
+        else {
+            // BLOCKER
+            // var url = osfHelpers.apiV2Url('nodes/'+nodeId+'/registration_links/', {});
+            // var request = osfHelpers.ajaxJSON(
+            //     'GET',
+            //     url,
+            //     {'isCors': true});
+            // request.done(function(response) {
+            //     var i, nl_id;
+            //     for (i = 0; i < response.data.length; i++){
+            //         if (response.data[i].embeds.target_node.data.id === data.id){
+            //             nl_id = response.data[i].id;
+            //         }
+            //     }
+            //     var url = osfHelpers.apiV2Url('nodes/'+nodeId+'/registration_links/'+nl_id+'/', {});
+            //     var request = osfHelpers.ajaxJSON(
+            //         'DELETE',
+            //         url,
+            //         {
+            //             'isCors': true
+            //         });
+            //     request.done(function(nl_response) {
+            //         self.selection.splice(
+            //             self.selection.indexOf(data), 1
+            //         );
+            //     });
+            // });
+        }
+
     },
-    addAll: function() {
-        var self = this;
-        $.each(self.results(), function(idx, result) {
-            if (self.selection().indexOf(result) === -1) {
-                self.add(result);
-            }
-        });
-    },
-    removeAll: function() {
-        var self = this;
-        $.each(self.selection(), function(idx, selected) {
-            self.remove(selected);
-        });
-    },
+    // addAll: function() {
+    //     var self = this;
+    //     $.each(self.results(), function(idx, result) {
+    //         if (self.selection().indexOf(result) === -1) {
+    //             self.add(result);
+    //         }
+    //     });
+    // },
+    // removeAll: function() {
+    //     var self = this;
+    //     $.each(self.selection(), function(idx, selected) {
+    //         self.remove(selected);
+    //     });
+    // },
     selected: function(data) {
         var self = this;
         for (var idx = 0; idx < self.selection().length; idx++) {
@@ -155,31 +284,31 @@ var AddPointerViewModel = oop.extend(Paginator, {
         }
         return false;
     },
-    submit: function() {
-        var self = this;
-        self.submitEnabled(false);
-        self.submitWarningMsg('');
-
-        var nodeIds = osfHelpers.mapByProperty(self.selection(), 'id');
-
-        osfHelpers.postJSON(
-            nodeApiUrl + 'pointer/', {
-                nodeIds: nodeIds
-            }
-        ).done(function() {
-            window.location.reload();
-        }).fail(function(data) {
-            self.submitEnabled(true);
-            self.submitWarningMsg(data.responseJSON && data.responseJSON.message_long);
-        });
-    },
-    clear: function() {
-        this.query('');
-        this.results([]);
-        this.selection([]);
-        this.searchWarningMsg('');
-        this.submitWarningMsg('');
-    },
+    // submit: function() {
+    //     var self = this;
+    //     self.submitEnabled(false);
+    //     self.submitWarningMsg('');
+    //
+    //     var nodeIds = osfHelpers.mapByProperty(self.selection(), 'id');
+    //
+    //     osfHelpers.postJSON(
+    //         nodeApiUrl + 'pointer/', {
+    //             nodeIds: nodeIds
+    //         }
+    //     ).done(function() {
+    //         window.location.reload();
+    //     }).fail(function(data) {
+    //         self.submitEnabled(true);
+    //         self.submitWarningMsg(data.responseJSON && data.responseJSON.message_long);
+    //     });
+    // },
+    // clear: function() {
+    //     this.query('');
+    //     this.results([]);
+    //     this.selection([]);
+    //     this.searchWarningMsg('');
+    //     this.submitWarningMsg('');
+    // },
     authorText: function(node) {
         var contributors = node.embeds.contributors.data;
         var author = contributors[0].embeds.users.data.attributes.family_name;
@@ -187,6 +316,27 @@ var AddPointerViewModel = oop.extend(Paginator, {
             author += ' et al.';
         }
         return author;
+    },
+    nodeView: function() {
+        var self = this;
+        if (self.inputType() !== 'nodes') {
+            $('#getLinksRegistrationsTab').removeClass('active');
+            $('#getLinksNodesTab').addClass('active');
+            self.inputType('nodes');
+            self.searchMyProjects();
+        }
+    },
+    registrationView: function() {
+        var self = this;
+        if (self.inputType() !== 'registrations') {
+            $('#getLinksNodesTab').removeClass('active');
+            $('#getLinksRegistrationsTab').addClass('active');
+            self.inputType('registrations');
+            self.searchMyProjects();
+        }
+    },
+    done: function() {
+        window.location.reload();
     }
 });
 

--- a/website/static/js/pointers.js
+++ b/website/static/js/pointers.js
@@ -86,14 +86,12 @@ var AddPointerViewModel = oop.extend(Paginator, {
             else {
                 var count = nodes.length;
                 nodes.forEach(function(each) {
-                    console.log(each);
-                    if (each.isRegistration) {
-                        each.attributes.dateRegistered = new osfHelpers.FormattableDate(each.attributes.dateRegistered);
+                    if (each.type === 'registrations') {
+                        each.dateRegistered = new osfHelpers.FormattableDate(each.attributes.date_registered);
                     } else {
-                        each.dateCreated = new osfHelpers.FormattableDate(each.attributes.dateCreated);
-                        each.dateModified = new osfHelpers.FormattableDate(each.attributes.dateModified);
+                        each.dateCreated = new osfHelpers.FormattableDate(each.attributes.date_created);
+                        each.dateModified = new osfHelpers.FormattableDate(each.attributes.date_modified);
                     }
-                    //each.added = false;
                     each.link = '';
                     var url = osfHelpers.apiV2Url('nodes/'+nodeId+'/node_links/', {});
                     var request = osfHelpers.ajaxJSON(
@@ -138,7 +136,7 @@ var AddPointerViewModel = oop.extend(Paginator, {
     addTips: function(elements, data) {
         elements.forEach(function(element) {
             var titleText = '';
-            if (data.isRegistration) {
+            if (data.type === 'registrations') {
                 titleText = 'Registered: ' + data.dateRegistered.local;
             } else {
                 titleText = 'Created: ' + data.dateCreated.local + '\nModified: ' + data.dateModified.local;

--- a/website/static/js/pointers.js
+++ b/website/static/js/pointers.js
@@ -71,7 +71,7 @@ var AddPointerViewModel = oop.extend(Paginator, {
             query += 'filter[title]='+self.query()+'&';
         }
         if (!self.includePublic()){
-            myProjects = 'users/me/'
+            myProjects = 'users/me/';
         }
         var url = osfHelpers.apiV2Url(myProjects+self.inputType()+'/', {query: query+'page='+pageNum+'&embed=contributors&page[size]=5'});
         var request = osfHelpers.ajaxJSON(

--- a/website/templates/project/modal_add_pointer.mako
+++ b/website/templates/project/modal_add_pointer.mako
@@ -34,7 +34,14 @@
                     </div>
                 </form>
 
-                <hr />
+                <br>
+                <div>
+                  <ul class="nav nav-tabs">
+                    <li id="getLinksNodesTab" class="active"><a data-bind="click: nodeView">Projects</a></li>
+                    <li id="getLinksRegistrationsTab"><a data-bind="click: registrationView">Registrations</a></li>
+                  </ul>
+                </div>
+                <br>
 
                 <!-- Choose which to add -->
                 <div class="row">
@@ -43,17 +50,24 @@
                         <div>
                             <span data-bind="if: includePublic" class="modal-subheader">Results: All Projects</span>
                             <span data-bind="ifnot: includePublic" class="modal-subheader">Results: My Projects</span>
-                            <a data-bind="click:addAll">Add all</a>
                         </div>
                         <div class="error" data-bind="text:errorMsg"></div>
                         <table class="table table-striped">
                             <tbody data-bind="foreach:{data:results, afterRender:addTips}">
-                                <tr class="pointer-row" data-bind="if:!($root.selected($data))">
+                                <tr class="pointer-tow">
                                     <td class="osf-icon-td">
-                                        <a
+                                        <div data-bind="if:!($root.selected($data))">
+                                          <a
                                                 class="btn btn-success contrib-button"
                                                 data-bind="click:$root.add.bind($root)"
                                             ><i class="fa fa-plus"></i></a>
+                                        </div>
+                                        <div data-bind="if:($root.selected($data))">
+                                          <a
+                                            class="btn btn-default contrib-button"
+                                            data-bind="click:$root.remove.bind($root)"
+                                            ><i class="fa fa-minus"></i></a>
+                                        </div>
                                     </td>
                                     <td data-bind="text:attributes.title" class="overflow"></td>
                                     <td style="width: 25%" data-bind="text:$root.authorText($data)"></td>
@@ -75,39 +89,13 @@
                             </div>
                         </div>
                     </div>
-
-                    <div class="col-md-6">
-                        <div>
-                            <span class="modal-subheader">Adding</span>
-                            <a data-bind="click:removeAll">Remove all</a>
-                        </div>
-                        <table class="table table-striped">
-                            <tbody data-bind="foreach:{data:selection, afterRender:addTips}">
-                                <tr class="pointer-row">
-                                    <td class="osf-icon-td">
-                                        <a
-                                                class="btn btn-default contrib-button"
-                                                data-bind="click:$root.remove.bind($root)"
-                                            ><i class="fa fa-minus"></i></a>
-                                    </td>
-                                    <td  data-bind="text:attributes.title" class="overflow"></td>
-                                    <td style="width: 25%" data-bind="text:$root.authorText($data)"></td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-
                 </div>
 
             </div><!-- end modal-body -->
 
             <div class="modal-footer">
 
-                <a class="btn btn-default" data-dismiss="modal">Cancel</a>
-
-                <span data-bind="if:selection().length">
-                    <a class="btn btn-success" data-bind="click:submit, css: {disabled: !submitEnabled() }">Add</a>
-                </span>
+                <a class="btn btn-default" data-bind='click:done' data-dismiss="modal">Done</a>
                 <div class="help-block">
                     <span class="text-danger" data-bind="html: submitWarningMsg"></span>
                 </div>

--- a/website/templates/project/modal_add_pointer.mako
+++ b/website/templates/project/modal_add_pointer.mako
@@ -48,29 +48,32 @@
 
                     <div class="col-md-12">
                         <div>
-                            <span data-bind="if: includePublic" class="modal-subheader">Results: All Projects</span>
-                            <span data-bind="ifnot: includePublic" class="modal-subheader">Results: My Projects</span>
+                            <span data-bind="if: (inputType() == 'nodes' && includePublic)" class="modal-subheader">Results: All Projects</span>
+                            <span data-bind="if: (inputType() == 'nodes' && !includePublic())" class="modal-subheader">Results: My Projects</span>
+                            <span data-bind="if: (inputType() != 'nodes' && includePublic)" class="modal-subheader">Results: All Registrations</span>
+                            <span data-bind="if: (inputType() != 'nodes' && !includePublic())" class="modal-subheader">Results: My Registrations</span>
                         </div>
                         <div class="error" data-bind="text:errorMsg"></div>
                         <table class="table table-striped">
-                            <tbody data-bind="foreach:{data:results, afterRender:addTips}">
+                            <tbody data-bind="foreach:{data:results}">
                                 <tr class="pointer-tow">
                                     <td class="osf-icon-td">
                                         <div data-bind="if:!($root.selected($data))">
-                                          <a
-                                                class="btn btn-success contrib-button"
-                                                data-bind="click:$root.add.bind($root)"
-                                            ><i class="fa fa-plus"></i></a>
+                                            <a
+                                                  class="btn btn-success contrib-button"
+                                                  data-bind="click:$root.add.bind($root)"
+                                              ><i class="fa fa-plus"></i></a>
                                         </div>
                                         <div data-bind="if:($root.selected($data))">
-                                          <a
-                                            class="btn btn-default contrib-button"
-                                            data-bind="click:$root.remove.bind($root)"
-                                            ><i class="fa fa-minus"></i></a>
+                                            <a
+                                              class="btn btn-default contrib-button"
+                                              data-bind="click:$root.remove.bind($root)"
+                                              ><i class="fa fa-minus"></i></a>
                                         </div>
                                     </td>
                                     <td data-bind="text:attributes.title" class="overflow"></td>
-                                    <td style="width: 25%" data-bind="text:$root.authorText($data)"></td>
+                                    <td class="node-dates" data-bind="text:$root.getDates($data)"></td>
+                                    <td style="width: 20%" data-bind="text:$root.authorText($data)"></td>
                                 </tr>
                             </tbody>
                         </table>

--- a/website/templates/project/modal_add_pointer.mako
+++ b/website/templates/project/modal_add_pointer.mako
@@ -41,7 +41,8 @@
 
                     <div class="col-md-6">
                         <div>
-                            <span class="modal-subheader">Results</span>
+                            <span data-bind="if: includePublic" class="modal-subheader">Results: All Projects</span>
+                            <span data-bind="ifnot: includePublic" class="modal-subheader">Results: My Projects</span>
                             <a data-bind="click:addAll">Add all</a>
                         </div>
                         <div class="error" data-bind="text:errorMsg"></div>
@@ -54,7 +55,7 @@
                                                 data-bind="click:$root.add.bind($root)"
                                             ><i class="fa fa-plus"></i></a>
                                     </td>
-                                    <td data-bind="text:title" class="overflow"></td>
+                                    <td data-bind="text:attributes.title" class="overflow"></td>
                                     <td style="width: 25%" data-bind="text:$root.authorText($data)"></td>
                                 </tr>
                             </tbody>
@@ -89,7 +90,7 @@
                                                 data-bind="click:$root.remove.bind($root)"
                                             ><i class="fa fa-minus"></i></a>
                                     </td>
-                                    <td  data-bind="text:title" class="overflow"></td>
+                                    <td  data-bind="text:attributes.title" class="overflow"></td>
                                     <td style="width: 25%" data-bind="text:$root.authorText($data)"></td>
                                 </tr>
                             </tbody>

--- a/website/templates/project/modal_add_pointer.mako
+++ b/website/templates/project/modal_add_pointer.mako
@@ -46,7 +46,7 @@
                 <!-- Choose which to add -->
                 <div class="row">
 
-                    <div class="col-md-6">
+                    <div class="col-md-12">
                         <div>
                             <span data-bind="if: includePublic" class="modal-subheader">Results: All Projects</span>
                             <span data-bind="ifnot: includePublic" class="modal-subheader">Results: My Projects</span>


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Allow for users to more easily search through their projects, even if they're unsure of the project names. Also to update to V2, and deal with any changes between V1 and V2.

## Changes

V1 API has been discarded. Instead V2 API has taken its place. If query is left blank, then it will search without a filter (ie. searches everything). The title informs you if you are currently searching "All" or "My" Projects. Due to V2 separating Projects and Registrations, two tabs have been added to distinguish which type you are looking for. Now, when clicking the "+" button next to a node, it adds it straight to the project, instead of a "node cart" for you to have to click save to add. The nodes become toggleable instead of removed.

## Side effects

BLOCKER: Needs /registration_links/ endpoint to be added to the API before this will work.

## Ticket

https://openscience.atlassian.net/browse/OSF-5360
