### PR TITLE
Feature/api reorder contributors

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -543,6 +543,7 @@ class NodeContributorsSerializer(JSONAPISerializer):
 
     id = ContributorIDField(read_only=True, source='_id')
     type = TypeField()
+    index = ser.IntegerField(required=False, read_only=True)
 
     bibliographic = ser.BooleanField(help_text='Whether the user will be included in citations for this node or not.',
                                      default=True)
@@ -579,6 +580,7 @@ class NodeContributorsSerializer(JSONAPISerializer):
         if unclaimed_records:
             return unclaimed_records.get('name', None)
 
+
 class NodeContributorsCreateSerializer(NodeContributorsSerializer):
     """
     Overrides NodeContributorsSerializer to add target_type and required id field
@@ -602,21 +604,33 @@ class NodeContributorsCreateSerializer(NodeContributorsSerializer):
         contributor.node_id = node._id
         return contributor
 
+
 class NodeContributorDetailSerializer(NodeContributorsSerializer):
     """
     Overrides node contributor serializer to add additional methods
     """
     id = ContributorIDField(required=True, source='_id')
+    index = ser.IntegerField(required=False, read_only=False)
+    # index = ser.IntegerField(required=False)
 
     def update(self, instance, validated_data):
+        index = None
+        if 'index' in validated_data:
+            index = validated_data.pop('index')
+
         contributor = instance
         auth = Auth(self.context['request'].user)
         node = self.context['view'].get_node()
 
-        visible = validated_data.get('bibliographic')
-        permission = validated_data.get('permission')
+        if 'bibliographic' in validated_data:
+            bibliographic = validated_data.get('bibliographic')
+        else:
+            bibliographic = node.get_visible(contributor)
+        permission = validated_data.get('permission') or contributor.permission
         try:
-            node.update_contributor(contributor, permission, visible, auth, save=True)
+            if index is not None:
+                node.move_contributor(contributor, auth, index, save=True)
+            node.update_contributor(contributor, permission, bibliographic, auth, save=True)
         except NodeStateError as e:
             raise exceptions.ValidationError(detail=e.message)
         except ValueError as e:

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -726,6 +726,7 @@ class NodeContributorDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIVi
         bibliographic               boolean  Whether the user will be included in citations for this node. Default is true.
         permission                  string   User permission level. Must be "read", "write", or "admin". Default is "write".
         unregistered_contributor    string   Contributor's assigned name if contributor hasn't yet claimed account
+        index                       integer  The position in the list of contributors reflected in the bibliography. Zero Indexed.
 
     ##Relationships
 
@@ -753,12 +754,14 @@ class NodeContributorDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIVi
                            "attributes": {
                              "bibliographic": true|false,             # optional
                              "permission": "read"|"write"|"admin"     # optional
+                             "index": "0"                             # optional
                            }
                          }
                        }
         Success:       200 OK + node representation
 
-    To update a contributor's bibliographic preferences or access permissions for the node, issue a PUT request to the
+    To update a contributor's bibliographic preferences, order in the bibliography,
+    or access permissions for the node, issue a PUT request to the
     `self` link. Since this endpoint has no mandatory attributes, PUT and PATCH are functionally the same.  If the given
     user is not already in the contributor list, a 404 Not Found error will be returned.  A node must always have at
     least one admin, and any attempt to downgrade the permissions of a sole admin will result in a 400 Bad Request
@@ -808,6 +811,8 @@ class NodeContributorDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIVi
         user.permission = node.get_permissions(user)[-1]
         user.bibliographic = node.get_visible(user)
         user.node_id = node._id
+        user.index = node.contributors.index(user)
+
         return user
 
     # overrides DestroyAPIView

--- a/api_tests/nodes/views/test_node_contributors_detail.py
+++ b/api_tests/nodes/views/test_node_contributors_detail.py
@@ -148,7 +148,8 @@ class TestNodeContributorOrdering(ApiTestCase):
             found_contributors = True
         assert_true(found_contributors, "Did not compare any contributors.")
 
-    def test_move_top_contributor_down_one(self):
+    @assert_logs(NodeLog.CONTRIB_REORDERED, 'project')
+    def test_move_top_contributor_down_one_and_also_log(self):
         contributor_to_move = self.contributors[0]._id
         contributor_id = '{}-{}'.format(self.project._id, contributor_to_move)
         former_second_contributor = self.contributors[1]

--- a/api_tests/nodes/views/test_node_contributors_detail.py
+++ b/api_tests/nodes/views/test_node_contributors_detail.py
@@ -111,6 +111,236 @@ class TestContributorDetail(NodeCRUDTestCase):
         assert_equal(res.json['data']['attributes'].get('unregistered_contributor'), 'Bob Jackson')
 
 
+class TestNodeContributorOrdering(ApiTestCase):
+    def setUp(self):
+        super(TestNodeContributorOrdering, self).setUp()
+        self.contributors = [AuthUserFactory() for number in range(1, 10)]
+        self.user_one = AuthUserFactory()
+
+        self.project = ProjectFactory(creator=self.user_one)
+        for contributor in self.contributors:
+            self.project.add_contributor(
+                contributor,
+                permissions=[permissions.READ, permissions.WRITE],
+                visible=True,
+                save=True
+            )
+
+        self.contributors.insert(0, self.user_one)
+        self.base_contributor_url = '/{}nodes/{}/contributors/'.format(API_BASE, self.project._id)
+        self.url_creator = '/{}nodes/{}/contributors/{}/'.format(API_BASE, self.project._id, self.user_one._id)
+        self.contributor_urls = ['/{}nodes/{}/contributors/{}/'.format(API_BASE, self.project._id, contributor._id)
+            for contributor in self.contributors]
+        self.last_position = len(self.contributors) - 1
+
+    @staticmethod
+    def _get_contributor_user_id(contributor):
+        return contributor['embeds']['users']['data']['id']
+
+    def test_initial_order(self):
+        res = self.app.get('/{}nodes/{}/contributors/'.format(API_BASE, self.project._id), auth=self.user_one.auth)
+        assert_equal(res.status_code, 200)
+        contributor_list = res.json['data']
+        found_contributors = False
+        for i in range(0, len(self.contributors)):
+            assert_equal(self.contributors[i]._id, self._get_contributor_user_id(contributor_list[i]))
+            assert_equal(i, contributor_list[i]['attributes']['index'])
+            found_contributors = True
+        assert_true(found_contributors, "Did not compare any contributors.")
+
+    def test_move_top_contributor_down_one(self):
+        contributor_to_move = self.contributors[0]._id
+        contributor_id = '{}-{}'.format(self.project._id, contributor_to_move)
+        former_second_contributor = self.contributors[1]
+        url = '{}{}/'.format(self.base_contributor_url, contributor_to_move)
+        data = {
+            'data': {
+                'id': contributor_id,
+                'type': 'contributors',
+                'attributes': {
+                    'index': 1
+                }
+            }
+        }
+        res_patch = self.app.patch_json_api(url, data, auth=self.user_one.auth)
+        assert_equal(res_patch.status_code, 200)
+        self.project.reload()
+        res = self.app.get('/{}nodes/{}/contributors/'.format(API_BASE, self.project._id), auth=self.user_one.auth)
+        assert_equal(res.status_code, 200)
+        contributor_list = res.json['data']
+        assert_equal(self._get_contributor_user_id(contributor_list[1]), contributor_to_move)
+        assert_equal(self._get_contributor_user_id(contributor_list[0]), former_second_contributor._id)
+
+    def test_move_second_contributor_up_one_to_top(self):
+        contributor_to_move = self.contributors[1]._id
+        contributor_id = '{}-{}'.format(self.project._id, contributor_to_move)
+        former_first_contributor = self.contributors[0]
+        url = '{}{}/'.format(self.base_contributor_url, contributor_to_move)
+        data = {
+            'data': {
+                'id': contributor_id,
+                'type': 'contributors',
+                'attributes': {
+                    'index': 0
+                }
+            }
+        }
+        res_patch = self.app.patch_json_api(url, data, auth=self.user_one.auth)
+        assert_equal(res_patch.status_code, 200)
+        self.project.reload()
+        res = self.app.get('/{}nodes/{}/contributors/'.format(API_BASE, self.project._id), auth=self.user_one.auth)
+        assert_equal(res.status_code, 200)
+        contributor_list = res.json['data']
+        assert_equal(self._get_contributor_user_id(contributor_list[0]), contributor_to_move)
+        assert_equal(self._get_contributor_user_id(contributor_list[1]), former_first_contributor._id)
+
+    def test_move_top_contributor_down_to_bottom(self):
+        contributor_to_move = self.contributors[0]._id
+        contributor_id = '{}-{}'.format(self.project._id, contributor_to_move)
+        former_second_contributor = self.contributors[1]
+        url = '{}{}/'.format(self.base_contributor_url, contributor_to_move)
+        data = {
+            'data': {
+                'id': contributor_id,
+                'type': 'contributors',
+                'attributes': {
+                    'index': self.last_position
+                }
+            }
+        }
+        res_patch = self.app.patch_json_api(url, data, auth=self.user_one.auth)
+        assert_equal(res_patch.status_code, 200)
+        self.project.reload()
+        res = self.app.get('/{}nodes/{}/contributors/'.format(API_BASE, self.project._id), auth=self.user_one.auth)
+        assert_equal(res.status_code, 200)
+        contributor_list = res.json['data']
+        assert_equal(self._get_contributor_user_id(contributor_list[self.last_position]), contributor_to_move)
+        assert_equal(self._get_contributor_user_id(contributor_list[0]), former_second_contributor._id)
+
+    def test_move_bottom_contributor_up_to_top(self):
+        contributor_to_move = self.contributors[self.last_position]._id
+        contributor_id = '{}-{}'.format(self.project._id, contributor_to_move)
+        former_second_to_last_contributor = self.contributors[self.last_position - 1]
+
+        url = '{}{}/'.format(self.base_contributor_url, contributor_to_move)
+        data = {
+            'data': {
+                'id': contributor_id,
+                'type': 'contributors',
+                'attributes': {
+                    'index': 0
+                }
+            }
+        }
+        res_patch = self.app.patch_json_api(url, data, auth=self.user_one.auth)
+        assert_equal(res_patch.status_code, 200)
+        self.project.reload()
+        res = self.app.get('/{}nodes/{}/contributors/'.format(API_BASE, self.project._id), auth=self.user_one.auth)
+        assert_equal(res.status_code, 200)
+        contributor_list = res.json['data']
+        assert_equal(self._get_contributor_user_id(contributor_list[0]), contributor_to_move)
+        assert_equal(
+            self._get_contributor_user_id(contributor_list[self.last_position]),
+            former_second_to_last_contributor._id
+        )
+
+    def test_move_second_to_last_contributor_down_past_bottom(self):
+        contributor_to_move = self.contributors[self.last_position - 1]._id
+        contributor_id = '{}-{}'.format(self.project._id, contributor_to_move)
+        former_last_contributor = self.contributors[self.last_position]
+
+        url = '{}{}/'.format(self.base_contributor_url, contributor_to_move)
+        data = {
+            'data': {
+                'id': contributor_id,
+                'type': 'contributors',
+                'attributes': {
+                    'index': self.last_position + 10
+                }
+            }
+        }
+        res_patch = self.app.patch_json_api(url, data, auth=self.user_one.auth)
+        assert_equal(res_patch.status_code, 200)
+        self.project.reload()
+        res = self.app.get('/{}nodes/{}/contributors/'.format(API_BASE, self.project._id), auth=self.user_one.auth)
+        assert_equal(res.status_code, 200)
+        contributor_list = res.json['data']
+        assert_equal(self._get_contributor_user_id(contributor_list[self.last_position]), contributor_to_move)
+        assert_equal(
+            self._get_contributor_user_id(contributor_list[self.last_position - 1]),
+            former_last_contributor._id
+        )
+
+    def test_move_top_contributor_down_to_second_to_last_position_with_negative_numbers(self):
+        contributor_to_move = self.contributors[0]._id
+        contributor_id = '{}-{}'.format(self.project._id, contributor_to_move)
+        former_second_contributor = self.contributors[1]
+        url = '{}{}/'.format(self.base_contributor_url, contributor_to_move)
+        data = {
+            'data': {
+                'id': contributor_id,
+                'type': 'contributors',
+                'attributes': {
+                    'index': -1
+                }
+            }
+        }
+        res_patch = self.app.patch_json_api(url, data, auth=self.user_one.auth)
+        assert_equal(res_patch.status_code, 200)
+        self.project.reload()
+        res = self.app.get('/{}nodes/{}/contributors/'.format(API_BASE, self.project._id), auth=self.user_one.auth)
+        assert_equal(res.status_code, 200)
+        contributor_list = res.json['data']
+        assert_equal(self._get_contributor_user_id(contributor_list[self.last_position - 1]), contributor_to_move)
+        assert_equal(self._get_contributor_user_id(contributor_list[0]), former_second_contributor._id)
+
+    def test_write_contributor_fails_to_move_top_contributor_down_one(self):
+        contributor_to_move = self.contributors[0]._id
+        contributor_id = '{}-{}'.format(self.project._id, contributor_to_move)
+        former_second_contributor = self.contributors[1]
+        url = '{}{}/'.format(self.base_contributor_url, contributor_to_move)
+        data = {
+            'data': {
+                'id': contributor_id,
+                'type': 'contributors',
+                'attributes': {
+                    'index': 1
+                }
+            }
+        }
+        res_patch = self.app.patch_json_api(url, data, auth=former_second_contributor.auth, expect_errors=True)
+        assert_equal(res_patch.status_code, 403)
+        self.project.reload()
+        res = self.app.get('/{}nodes/{}/contributors/'.format(API_BASE, self.project._id), auth=self.user_one.auth)
+        assert_equal(res.status_code, 200)
+        contributor_list = res.json['data']
+        assert_equal(self._get_contributor_user_id(contributor_list[0]), contributor_to_move)
+        assert_equal(self._get_contributor_user_id(contributor_list[1]), former_second_contributor._id)
+
+    def test_non_authenticated_fails_to_move_top_contributor_down_one(self):
+        contributor_to_move = self.contributors[0]._id
+        contributor_id = '{}-{}'.format(self.project._id, contributor_to_move)
+        former_second_contributor = self.contributors[1]
+        url = '{}{}/'.format(self.base_contributor_url, contributor_to_move)
+        data = {
+            'data': {
+                'id': contributor_id,
+                'type': 'contributors',
+                'attributes': {
+                    'index': 1
+                }
+            }
+        }
+        res_patch = self.app.patch_json_api(url, data, expect_errors=True)
+        assert_equal(res_patch.status_code, 401)
+        self.project.reload()
+        res = self.app.get('/{}nodes/{}/contributors/'.format(API_BASE, self.project._id), auth=self.user_one.auth)
+        assert_equal(res.status_code, 200)
+        contributor_list = res.json['data']
+        assert_equal(self._get_contributor_user_id(contributor_list[0]), contributor_to_move)
+        assert_equal(self._get_contributor_user_id(contributor_list[1]), former_second_contributor._id)
+
+
 class TestNodeContributorUpdate(ApiTestCase):
     def setUp(self):
         super(TestNodeContributorUpdate, self).setUp()

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2947,7 +2947,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
                 'node': self._id,
                 'contributors': [
                     user._id
-                    ],
+                ],
             },
             auth=auth,
             save=False,

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2935,6 +2935,14 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
 
         return all(results)
 
+    def move_contributor(self, user, auth, index, save=False):
+        if not self.has_permission(auth.user, ADMIN):
+            raise PermissionsError('Only admins can modify contributor order')
+        old_index = self.contributors.index(user)
+        self.contributors.insert(index, self.contributors.pop(old_index))
+        if save:
+            self.save()
+
     def update_contributor(self, user, permission, visible, auth, save=False):
         """ TODO: this method should be updated as a replacement for the main loop of
         Node#manage_contributors. Right now there are redundancies, but to avoid major

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2940,6 +2940,18 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
             raise PermissionsError('Only admins can modify contributor order')
         old_index = self.contributors.index(user)
         self.contributors.insert(index, self.contributors.pop(old_index))
+        self.add_log(
+            action=NodeLog.CONTRIB_REORDERED,
+            params={
+                'project': self.parent_id,
+                'node': self._id,
+                'contributors': [
+                    user._id
+                    ],
+            },
+            auth=auth,
+            save=False,
+        )
         if save:
             self.save()
 


### PR DESCRIPTION
## Purpose

Allow API v2 consumers to re-order contributors.
 
## Changes

1. Tests
2. Add a method on the node model to do single-contributor moves
3. Modify the API so that it can accept a re-order request and pass that along to the node.

## Side effects

Should be fairly isolated.


## Ticket

https://openscience.atlassian.net/browse/OSF-6832