### PR TITLE
Old meetings' is_meeting field default to true [#OSF-5645]

### DIFF
--- a/admin/meetings/serializers.py
+++ b/admin/meetings/serializers.py
@@ -2,7 +2,7 @@
 
 def serialize_meeting(meeting):
     is_meeting = True
-    if hasattr(meeting, 'is_meeting'):
+    if meeting.is_meeting is not None:
         is_meeting = meeting.is_meeting
     return {
         'endpoint': meeting.endpoint,

--- a/admin/meetings/serializers.py
+++ b/admin/meetings/serializers.py
@@ -2,7 +2,7 @@
 
 def serialize_meeting(meeting):
     is_meeting = True
-    if meeting.is_meeting is not None:
+    if hasattr(meeting, 'is_meeting') and meeting.is_meeting is not None:
         is_meeting = meeting.is_meeting
     return {
         'endpoint': meeting.endpoint,


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Make it so that old meetings' is_meeting field defaults to true so that when editing an older meeting you don't accidently submit the form without setting is_meeting to true
<!-- Describe the purpose of your changes -->

## Changes
Changed serializer to set is_meeting to true is it is none
<!-- Briefly describe or list your changes  -->

## Side effects
None
<!--Any possible side effects? -->


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->

https://openscience.atlassian.net/browse/OSF-5645