### PR TITLE
Unable to access all pages of Meetings in Admin App[#OSF-6475]

### DIFF
--- a/admin/meetings/serializers.py
+++ b/admin/meetings/serializers.py
@@ -10,7 +10,7 @@ def serialize_meeting(meeting):
         'info_url': meeting.info_url,
         'logo_url': meeting.logo_url,
         'active': meeting.active,
-        'admins': ', '.join([u.emails[0] for u in meeting.admins]),
+        'admins': ', '.join([u.emails[0] for u in meeting.admins if u.is_confirmed]),
         'public_projects': meeting.public_projects,
         'poster': meeting.poster,
         'talk': meeting.talk,

--- a/admin/meetings/serializers.py
+++ b/admin/meetings/serializers.py
@@ -10,7 +10,7 @@ def serialize_meeting(meeting):
         'info_url': meeting.info_url,
         'logo_url': meeting.logo_url,
         'active': meeting.active,
-        'admins': ', '.join([u.emails[0] for u in meeting.admins if u.is_confirmed]),
+        'admins': ', '.join([u.username for u in meeting.admins]),
         'public_projects': meeting.public_projects,
         'poster': meeting.poster,
         'talk': meeting.talk,


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Fix the problem that admin for OSF for meetings cannot visit the second page.
<!-- Describe the purpose of your changes -->

## Changes
Remove unconfirmed user from OSF for meetings admin serializer.
<!-- Briefly describe or list your changes  -->

## Side effects

<!--Any possible side effects? -->


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
https://openscience.atlassian.net/browse/OSF-6475
