### PR TITLE
API Multi Field Filtering [OSF-6851]

### DIFF
--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -61,6 +61,7 @@ class FilterMixin(object):
     """ View mixin with helper functions for filtering. """
 
     QUERY_PATTERN = re.compile(r'^filter\[(?P<fields>((?:,*\s*\w+)*))\](\[(?P<op>\w+)\])?$')
+    FILTER_FIELDS = re.compile(r'(?:,*\s*(\w+)+)')
 
     MATCH_OPERATORS = ('contains', 'icontains')
     MATCHABLE_FIELDS = (ser.CharField, ser.ListField)
@@ -192,7 +193,7 @@ class FilterMixin(object):
             if match:
                 match_dict = match.groupdict()
                 fields = match_dict['fields']
-                field_names = re.findall(r'(?:,*\s*(\w+)+)', fields.strip())
+                field_names = re.findall(self.FILTER_FIELDS, fields.strip())
                 query.update({key: {}})
 
                 for field_name in field_names:


### PR DESCRIPTION
#### Purpose
- Allows for multi-field filtering in the API, i.e. ```/v2/users/?filter[given_name, family_name]=roll``` will filter users whose ```given_name``` **OR** ```family_name``` contains 'roll'.

#### Changes
- Updated ```QUERY_PATTERN``` regex in the ```FilterMixin``` class (note: I'm not 100% confident in this regex). 
- Changes to ```parse_query_params()``` in ```FilterMixin``` and the format of the query dict that is returned. 

#### Notes
- The multiple fields included in the filter must be the same type, i.e. ```/v2/nodes/?filter[title, public]=science``` will give an error. 
- Multi-field filters can be combined with other multi-field or single-field filters.
 - ```/v2/nodes/?filter[title,description]=music&filter[public]=true``` will filter by:
   - ```(title contains 'music' OR description contains 'music') AND (public equals true)```
 - ```/v2/nodes/?filter[title,description]=music&filter[category,description]=hypothesis``` will filter by:
   - ```(title contains 'music' OR description contains 'music') AND (category contains 'hypothesis' OR description contains 'hypothesis')```

#### Ticket
- [OSF-6851](https://openscience.atlassian.net/browse/OSF-6851)