### PR TITLE
Add preprint_doi field to Node and Preprints v2 view

### DIFF
--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -35,7 +35,8 @@ class PreprintSerializer(JSONAPISerializer):
         'date_modified',
         'contributors',
         'provider',
-        'subjects'
+        'subjects',
+        'doi'
     ])
 
     title = ser.CharField(required=False)
@@ -46,6 +47,7 @@ class PreprintSerializer(JSONAPISerializer):
     id = IDField(source='_id', required=False)
     abstract = ser.CharField(source='description', required=False)
     tags = JSONAPIListField(child=NodeTagField(), required=False)
+    doi = ser.CharField(source='preprint_doi', required=False)
 
     primary_file = PrimaryFileRelationshipField(
         related_view='files:file-detail',
@@ -59,7 +61,13 @@ class PreprintSerializer(JSONAPISerializer):
         related_view_kwargs={'node_id': '<pk>'}
     )
 
-    links = LinksField({'self': 'get_preprint_url', 'html': 'get_absolute_html_url'})
+    links = LinksField(
+        {
+            'self': 'get_preprint_url',
+            'html': 'get_absolute_html_url',
+            'doi': 'get_doi_url'
+        }
+    )
 
     contributors = RelationshipField(
         related_view='preprints:preprint-contributors',
@@ -75,6 +83,9 @@ class PreprintSerializer(JSONAPISerializer):
 
     def get_absolute_url(self, obj):
         return self.get_preprint_url(obj)
+
+    def get_doi_url(self, obj):
+        return 'https://dx.doi.org/{}'.format(obj.preprint_doi)
 
     def create(self, validated_data):
         node = validated_data.pop('node')

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -54,6 +54,8 @@ class PreprintList(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin):
         tags                            array of strings      list of tags that describe the node
         subjects                        array of tuples       list ids of Subject in the PLOS taxonomy. Tuple, containing the subject text and subject ID
         provider                        string                original source of the preprint
+        doi                             string                bare DOI for the manuscript, as entered by the user
+
 
     ##Relationships
 
@@ -67,6 +69,10 @@ class PreprintList(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin):
     Link to list of contributors that are affiliated with this institution.
 
     ##Links
+
+    - `self` -- Preprint detail page for the current preprint
+    - `html` -- Project on the OSF corresponding to the current preprint
+    - `doi` -- URL representation of the DOI entered by the user for the preprint manuscript
 
     See the [JSON-API spec regarding pagination](http://jsonapi.org/format/1.0/#fetching-pagination).
 

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -52,7 +52,7 @@ class PreprintList(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin):
         date_created                    iso8601 timestamp     timestamp that the preprint was created
         date_modified                   iso8601 timestamp     timestamp when the preprint was last updated
         tags                            array of strings      list of tags that describe the node
-        subjects                        array of tuples       list ids of Subject in the PLOS taxonomy. Tuple, containing the subject text and subject ID
+        subjects                        array of dictionaries list ids of Subject in the PLOS taxonomy. Dictrionary, containing the subject text and subject ID
         provider                        string                original source of the preprint
         doi                             string                bare DOI for the manuscript, as entered by the user
 

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -146,9 +146,9 @@ class PreprintDetail(JSONAPIBaseView, generics.CreateAPIView, generics.RetrieveU
 
                             },
                             "relationships": {
-                                "preprint_file": {                 # required
+                                "primary_file": {                   # required
                                     "data": {
-                                        "type": "primary_file",
+                                        "type": "primary",
                                         "id": file_id
                                     }
                                 }

--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -255,3 +255,14 @@ class TestPreprintUpdate(ApiTestCase):
 
         self.preprint.reload()
         assert_not_equal(self.preprint.preprint_file, file_for_project)
+
+    def test_update_doi(self):
+        new_doi = '10.123/456/789'
+        assert_not_equal(self.preprint.preprint_doi, new_doi)
+        update_subjects_payload = build_preprint_update_payload(self.preprint._id, attributes={"doi": new_doi})
+
+        res = self.app.patch_json_api(self.url, update_subjects_payload, auth=self.user.auth)
+        assert_equal(res.status_code, 200)
+
+        self.preprint.reload()
+        assert_equal(self.preprint.preprint_doi, new_doi)

--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -266,3 +266,6 @@ class TestPreprintUpdate(ApiTestCase):
 
         self.preprint.reload()
         assert_equal(self.preprint.preprint_doi, new_doi)
+
+        preprint_detail = self.app.get(self.url, auth=self.user.auth).json['data']
+        assert_equal(preprint_detail['links']['doi'], 'https://dx.doi.org/{}'.format(new_doi))

--- a/api_tests/preprints/views/test_preprint_list.py
+++ b/api_tests/preprints/views/test_preprint_list.py
@@ -41,7 +41,6 @@ class TestPreprintList(ApiTestCase):
         assert_not_in(self.project._id, ids)
 
 
-
 class TestPreprintFiltering(ApiTestCase):
 
     def setUp(self):
@@ -97,6 +96,16 @@ class TestPreprintFiltering(ApiTestCase):
         res = self.app.get(url, auth=self.user.auth)
         data = res.json['data']
 
-        assert_equal(len(data), 2)
         for result in data:
-            assert 'wwe' in result['attributes']['provider']
+            assert_in('wwe', result['attributes']['provider'])
+            assert_not_in('wcw', result['attributes']['provider'])
+
+    def test_filter_by_doi(self):
+        url = '/{}preprints/?filter[doi]={}'.format(API_BASE, self.preprint.preprint_doi)
+
+        res = self.app.get(url, auth=self.user.auth)
+        data = res.json['data']
+
+        assert_equal(len(data), 1)
+        for result in data:
+            assert_equal(self.preprint._id, result['id'])

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -218,9 +218,10 @@ class NodeFactory(AbstractNodeFactory):
 class PreprintFactory(AbstractNodeFactory):
     creator = None
     category = 'project'
+    doi = Sequence(lambda n: '10.123/{}'.format(n))
 
     @classmethod
-    def _create(cls, target_class, project=None, is_public=True, filename='preprint_file.txt', provider='osf', *args, **kwargs):
+    def _create(cls, target_class, project=None, is_public=True, filename='preprint_file.txt', provider='osf', doi=None, *args, **kwargs):
         save_kwargs(**kwargs)
         user = None
         if project:
@@ -250,6 +251,7 @@ class PreprintFactory(AbstractNodeFactory):
         project.set_preprint_file(file, auth=Auth(project.creator))
         project.preprint_subjects = [SubjectFactory()._id]
         project.preprint_provider = provider
+        project.preprint_doi = doi
         project.save()
 
         return project

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1568,6 +1568,20 @@ class TestNode(OsfTestCase):
         with assert_raises(ValidationError):
             Node(category='invalid').save()  # an invalid category
 
+    def test_validate_bad_doi(self):
+        with assert_raises(ValidationError):
+            Node(preprint_doi='nope').save()
+        with assert_raises(ValidationError):
+            Node(preprint_doi='https://dx.doi.org/10.123.456').save()  # should save the bare DOI, not a URL
+        with assert_raises(ValidationError):
+            Node(preprint_doi='doi:10.10.1038/nwooo1170').save()  # should save without doi: prefix
+
+    def test_validate_good_doi(self):
+        doi = '10.10.1038/nwooo1170'
+        self.node.preprint_doi = doi
+        self.node.save()
+        assert_equal(self.node.preprint_doi, doi)
+
     def test_web_url_for(self):
         result = self.parent.web_url_for('view_project')
         assert_equal(

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -770,7 +770,7 @@ def validate_subjects(value):
 
 def validate_doi(value):
     # DOI must start with 10 and have a slash in it - avoided getting too complicated
-    if not re.match(r"10\\.\\S*\\/", value):
+    if not re.match('10\\.\\S*\\/', value):
         raise ValidationValueError('')
     return True
 

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -760,10 +760,18 @@ class NodeUpdateError(Exception):
         self.key = key
         self.reason = reason
 
+
 def validate_subjects(value):
     subject = Subject.load(value)
     if not subject:
         raise ValidationValueError('Subject with id <{}> could nor be found.'.format(value))
+    return True
+
+
+def validate_doi(value):
+    # DOI must start with 10 and have a slash in it - avoided getting too complicated
+    if not re.match(r"10\\.\\S*\\/", value):
+        raise ValidationValueError('')
     return True
 
 
@@ -886,6 +894,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
     preprint_created = fields.DateTimeField()
     preprint_provider = fields.StringField()
     preprint_subjects = fields.StringField(list=True, validate=validate_subjects)
+    preprint_doi = fields.StringField(validate=validate_doi)
     _is_preprint_orphan = fields.BooleanField(default=False)
 
     # A list of all MetaSchemas for which this Node has registered_meta


### PR DESCRIPTION
## Purpose
Add DOI field to the node model as well as preprint serializer (in plain and URL form) so that 

## Changes
- `preprint_doi` field on node
- doi validation on node
- `doi` field in attributes and in links
- method to format DOI URL
- pass DOI in PreprintFactory
- tst for filtering by DOI
- test for update DOI via API v2

## Side effects
- Old generated preprints wont have DOIs to display on API


## Ticket
https://openscience.atlassian.net/browse/PREP-98