### PR TITLE
Fix admin app meetings form 'Homepage link text' [#OSF-6854]

### DIFF
--- a/admin/meetings/forms.py
+++ b/admin/meetings/forms.py
@@ -44,7 +44,7 @@ class MeetingForm(forms.Form):
     )
     homepage_link_text = forms.CharField(
         label='Homepage link text (Default: "Conference homepage")',
-        required = False,
+        required=False,
         widget=forms.TextInput(attrs={'size': '60'}),
     )
     location = forms.CharField(

--- a/admin/meetings/forms.py
+++ b/admin/meetings/forms.py
@@ -42,6 +42,11 @@ class MeetingForm(forms.Form):
         required=False,
         widget=forms.TextInput(attrs={'size': '60'}),
     )
+    homepage_link_text = forms.CharField(
+        label='Homepage link text (Default: "Conference homepage")',
+        required = False,
+        widget=forms.TextInput(attrs={'size': '60'}),
+    )
     location = forms.CharField(
         label='Location',
         required=False,
@@ -119,9 +124,6 @@ class MeetingForm(forms.Form):
     mail_attachment = forms.CharField(
         label='Mail attachment message',
         widget=forms.TextInput(attrs={'size': '60'}),
-    )
-    homepage_link_text = forms.CharField(
-        label='Homepage link text (Default: "Conference homepage")'
     )
 
     def clean_start_date(self):

--- a/admin/meetings/serializers.py
+++ b/admin/meetings/serializers.py
@@ -8,6 +8,7 @@ def serialize_meeting(meeting):
         'endpoint': meeting.endpoint,
         'name': meeting.name,
         'info_url': meeting.info_url,
+        'homepage_link_text': meeting.field_names['homepage_link_text'],
         'logo_url': meeting.logo_url,
         'active': meeting.active,
         'admins': ', '.join([u.emails[0] for u in meeting.admins]),


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Fix bug where even if a meeting has a homepage link text it does not show up in the form and you cannot submit the form without entering another one.

## Changes

Fixed bug mentioned above so now if a meeting has a homepage link text it will appear in the field.
Also made it so that if you do not enter a homepage link text it will default to 'Conference homepage' so that field is no longer required to submit the form.

## Side effects

<!--Any possible side effects? -->
None that I can see 

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
https://openscience.atlassian.net/browse/OSF-6854
