### PR TITLE
Standardize terminology: Registration Form [OSF-6289]

### DIFF
--- a/website/project/metadata/aspredicted.json
+++ b/website/project/metadata/aspredicted.json
@@ -1,7 +1,7 @@
 {
     "name": "AsPredicted Preregistration",
     "version": 2,
-    "description": "You will be asked to answer 8 questions about your study. This preregistration uses the content recommended on the website AsPredicted.org.",
+    "description": "You will be asked to answer 8 questions about your study. This registration form uses the content recommended on the website AsPredicted.org.",
     "pages": [{
         "title": "AsPredicted Preregistration",
         "id": "page1",

--- a/website/project/metadata/brandt-postcomp-2.json
+++ b/website/project/metadata/brandt-postcomp-2.json
@@ -1,7 +1,7 @@
 {
     "name": "Replication Recipe (Brandt et al., 2013): Post-Completion",
     "version": 2,
-    "description": "Replication Recipe: Post-Completion: This template is intended for use upon completion of a replication study, as outlined by Brandt et al., \"The Replication Recipe: What Makes for a Convincing Replication?\" You will be asked to answer a series of questions about the outcomes of your replication and how they compare to the original study.",
+    "description": "Replication Recipe: Post-Completion: This registration form is intended for use upon completion of a replication study, as outlined by Brandt et al., \"The Replication Recipe: What Makes for a Convincing Replication?\" You will be asked to answer a series of questions about the outcomes of your replication and how they compare to the original study.",
     "pages": [{
         "id": "page1",
         "title": "Registering the Replication Attempt",

--- a/website/project/metadata/brandt-prereg-2.json
+++ b/website/project/metadata/brandt-prereg-2.json
@@ -1,7 +1,7 @@
 {
     "name": "Replication Recipe (Brandt et al., 2013): Pre-Registration",
     "version": 2,
-    "description": "This template is intended for use when conducting a replication. You will be asked a series of questions about the study you intend to replicate. This template is not a valid submission for the Pre-registration Prize.",
+    "description": "This registration form is intended for use when conducting a replication. You will be asked a series of questions about the study you intend to replicate. This registration form is not a valid submission for the Pre-registration Prize.",
     "pages": [{
         "id": "page1",
         "title": "The Nature of the Effect",

--- a/website/project/metadata/osf-open-ended-2.json
+++ b/website/project/metadata/osf-open-ended-2.json
@@ -1,7 +1,7 @@
 {
     "name": "Open-Ended Registration",
     "version": 2,
-    "description": "You will be asked to provide a narrative summary of what is contained in your project. There is no minimum character length. This template is not a valid submission for the Pre-registration Prize.",
+    "description": "You will be asked to provide a narrative summary of what is contained in your project. There is no minimum character length. This registration form is not a valid submission for the Pre-registration Prize.",
     "pages": [{
         "id": "page1",
         "title": "Summary",

--- a/website/project/metadata/osf-standard-2.json
+++ b/website/project/metadata/osf-standard-2.json
@@ -1,7 +1,7 @@
 {
     "name": "OSF-Standard Pre-Data Collection Registration",
     "version": 2,
-    "description": "You will be asked if data collection is underway and if you have looked at your data already. You will be provided an opportunity to post other comments about your project. This template is not a valid submission for the Pre-registration Prize.",
+    "description": "You will be asked if data collection is underway and if you have looked at your data already. You will be provided an opportunity to post other comments about your project. This registration form is not a valid submission for the Pre-registration Prize.",
     "pages": [{
         "title": "OSF-Standard Pre-Data Collection Registration",
         "id": "page1",

--- a/website/project/metadata/prereg-prize.json
+++ b/website/project/metadata/prereg-prize.json
@@ -21,7 +21,7 @@
             "info": "http://centerforopenscience.org/prereg/"
         }]
     },
-    "description": "Preregistration Challenge (pre-data collection): You will be asked a series of questions to ensure that your sampling, design, and analysis plans are solidified prior to beginning your study. Publications that pre register with this template may be eligible for a $1,000 prize. See project page for complete information.",
+    "description": "Preregistration Challenge (pre-data collection): You will be asked a series of questions to ensure that your sampling, design, and analysis plans are solidified prior to beginning your study. Publications that pre register with this registration form may be eligible for a $1,000 prize. See project page for complete information.",
     "pages": [{
         "id": "page1",
         "title": "Study Information",

--- a/website/project/metadata/veer-1.json
+++ b/website/project/metadata/veer-1.json
@@ -1,7 +1,7 @@
 {
     "name": "Pre-Registration in Social Psychology (van 't Veer & Giner-Sorolla, 2016): Pre-Registration",
     "version": 2,
-    "description": "This template is intended for use when conducting a pre-registration. You will be asked to fill out the elements for a pre-registration as described in: van 't Veer & Giner-Sorolla (2016). This template is not a valid submission for the Pre-registration Prize.",
+    "description": "This registration form is intended for use when conducting a pre-registration. You will be asked to fill out the elements for a pre-registration as described in: van 't Veer & Giner-Sorolla (2016). This preregistration form is not a valid submission for the Pre-registration Prize.",
     "config": {
         "hasFiles": true
     },

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -155,7 +155,7 @@
                 % endif
                 % if node['is_registration']:
                     <p>
-                    Registration Supplement:
+                    Registration Form:
                     % for meta_schema in node['registered_schemas']:
                     <a href="${node['url']}register/${meta_schema['id']}">${meta_schema['schema_name']}</a>
                       % if len(node['registered_schemas']) > 1:


### PR DESCRIPTION
## Purpose

The OSF has multiple ways of mentioning the same thing and this can be confusing to users. This ticket is to make all terminology referring to the registration form to be consistent. 

## Changes
Changed all instances of "template" to "registration form".

Before
![image](https://cloud.githubusercontent.com/assets/8868219/17625056/25e4f10a-6075-11e6-8015-025462aa3340.png)

After
![image](https://cloud.githubusercontent.com/assets/8868219/17624890/92ab0a0a-6074-11e6-94d9-42413ac9d804.png)

Side note: There was an instance where the registration form was referred to as a "supplement", but I could not access it through my local host because it could only be seen after a registration is successfully created. I was able to do this on staging.osf.io but could not replicate it on local host, so I cannot take a screenshot of my code change in this case. 

## Side effects

N/A

## Ticket

https://openscience.atlassian.net/browse/OSF-6289
