### PR TITLE
Add check for too meny requests when adding contributors via API [OSF-6880]

### DIFF
--- a/website/exceptions.py
+++ b/website/exceptions.py
@@ -47,3 +47,8 @@ class UserNotAffiliatedError(OSFError):
     """
     message_short = 'User not affiliated'
     message_long = 'This user is not affiliated with this institution.'
+
+
+class TooManyRequests(Exception):
+    """Raised when throttle limit is reached, so view can return 429. e.g. Too many email producing requests, like contributor add."""
+    pass

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -37,6 +37,8 @@ CITATION_STYLES_PATH = os.path.join(BASE_PATH, 'static', 'vendor', 'bower_compon
 
 # Minimum seconds between forgot password email attempts
 SEND_EMAIL_THROTTLE = 30
+# Minimum seconds between API actions that generate emails
+API_SEND_EMAIL_THROTTLE = 6
 
 # Hours before pending embargo/retraction/registration automatically becomes active
 RETRACTION_PENDING_TIME = datetime.timedelta(days=2)


### PR DESCRIPTION
## Purpose:
[OSF-6880](https://openscience.atlassian.net/browse/OSF-6880)
Limit contributor adds to 1 per 6 seconds. Email spam mitigation.

## Changes:
Update  api/nodes/serializers.py add catch for TooManyRequests exception
Update  website/exceptions.py  add TooManyRequests exception
Update website/project/model.py add def throttle_add_contributor for API add contributor request
Update website/settings/defaults.py add API_SEND_EMAIL_THROTTLE = 6

## Side effects
None

[#OSF-6880]