### PR TITLE
[#OSF-6892][Hotfix] Delete, Check Out, and Download buttons missing from certain file types

### DIFF
--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -108,6 +108,7 @@ var FileViewPage = {
         self.editorMeta = self.context.editor;
         self.file.checkoutUser = null;
         self.requestDone = false;
+        self.isLatestVersion = false;
         self.isCheckoutUser = function() {
             $.ajax({
                 headers: {
@@ -303,6 +304,10 @@ var FileViewPage = {
             userId: self.context.currentUser.id
         };
 
+        self.selectLatest = function() {
+            self.isLatestVersion = true;
+        };
+
         self.editHeader = function() {
             return m('.row', [
                 m('.col-sm-12', m('span[style=display:block;]', [
@@ -367,7 +372,7 @@ var FileViewPage = {
 
         //Hack to polyfill the Panel interface
         //Ran into problems with mithrils caching messing up with multiple "Panels"
-        self.revisions = m.component(FileRevisionsTable, self.file, self.node, self.enableEditing, self.canEdit);
+        self.revisions = m.component(FileRevisionsTable, self.file, self.node, self.enableEditing, self.canEdit, self.selectLatest);
         self.revisions.selected = false;
         self.revisions.title = 'Revisions';
 
@@ -489,22 +494,22 @@ var FileViewPage = {
         m.render(document.getElementById('toggleBar'), m('.btn-toolbar.m-t-md', [
             // Special case whether or not to show the delete button for published Dataverse files
             (ctrl.canEdit() && (ctrl.file.provider !== 'osfstorage' || !ctrl.file.checkoutUser) && ctrl.requestDone && $(document).context.URL.indexOf('version=latest-published') < 0 ) ? m('.btn-group.m-l-xs.m-t-xs', [
-                ctrl.editor ? m('button.btn.btn-sm.btn-danger.file-delete', {onclick: $(document).trigger.bind($(document), 'fileviewpage:delete')}, 'Delete') : null
+                ctrl.isLatestVersion ? m('button.btn.btn-sm.btn-danger.file-delete', {onclick: $(document).trigger.bind($(document), 'fileviewpage:delete')}, 'Delete') : null
             ]) : '',
             ctrl.context.currentUser.canEdit && (!ctrl.canEdit()) && ctrl.requestDone && (ctrl.context.currentUser.isAdmin) ? m('.btn-group.m-l-xs.m-t-xs', [
-                ctrl.editor ? m('.btn.btn-sm.btn-danger', {onclick: $(document).trigger.bind($(document), 'fileviewpage:force_checkin')}, 'Force check in') : null
+                ctrl.isLatestVersion ? m('.btn.btn-sm.btn-danger', {onclick: $(document).trigger.bind($(document), 'fileviewpage:force_checkin')}, 'Force check in') : null
             ]) : '',
             ctrl.canEdit() && (!ctrl.file.checkoutUser) && ctrl.requestDone && (ctrl.file.provider === 'osfstorage') ? m('.btn-group.m-l-xs.m-t-xs', [
-                ctrl.editor ? m('.btn.btn-sm.btn-warning', {onclick: $(document).trigger.bind($(document), 'fileviewpage:checkout')}, 'Check out') : null
+                ctrl.isLatestVersion ? m('.btn.btn-sm.btn-warning', {onclick: $(document).trigger.bind($(document), 'fileviewpage:checkout')}, 'Check out') : null
             ]) : '',
             (ctrl.canEdit() && (ctrl.file.checkoutUser === ctrl.context.currentUser.id) && ctrl.requestDone) ? m('.btn-group.m-l-xs.m-t-xs', [
-                ctrl.editor ? m('.btn.btn-sm.btn-warning', {onclick: $(document).trigger.bind($(document), 'fileviewpage:checkin')}, 'Check in') : null
+                ctrl.isLatestVersion ? m('.btn.btn-sm.btn-warning', {onclick: $(document).trigger.bind($(document), 'fileviewpage:checkin')}, 'Check in') : null
             ]) : '',
             window.contextVars.node.isPublic? m('.btn-group.m-t-xs', [
                 m.component(SharePopover, {link: link, height: height})
             ]) : '',
             m('.btn-group.m-t-xs', [
-                ctrl.editor ? m('button.btn.btn-sm.btn-primary.file-download', {onclick: $(document).trigger.bind($(document), 'fileviewpage:download')}, 'Download') : null
+                ctrl.isLatestVersion ? m('button.btn.btn-sm.btn-primary.file-download', {onclick: $(document).trigger.bind($(document), 'fileviewpage:download')}, 'Download') : null
             ]),
             m('.btn-group.btn-group-sm.m-t-xs', [
                ctrl.editor ? m( '.btn.btn-default.disabled', 'Toggle view: ') : null

--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -109,6 +109,11 @@ var FileViewPage = {
         self.file.checkoutUser = null;
         self.requestDone = false;
         self.isLatestVersion = false;
+
+        self.selectLatest = function() {
+            self.isLatestVersion = true;
+        };
+
         self.isCheckoutUser = function() {
             $.ajax({
                 headers: {
@@ -302,10 +307,6 @@ var FileViewPage = {
             activeUsers: m.prop([]),
             status: m.prop('connecting'),
             userId: self.context.currentUser.id
-        };
-
-        self.selectLatest = function() {
-            self.isLatestVersion = true;
         };
 
         self.editHeader = function() {

--- a/website/static/js/filepage/revisions.js
+++ b/website/static/js/filepage/revisions.js
@@ -25,13 +25,14 @@ var model = {
 
 
 var FileRevisionsTable = {
-    controller: function(file, node, enableEditing, canEdit) {
+    controller: function(file, node, enableEditing, canEdit, selectLatest) {
         var self = {};
         self.node = node;
         self.file = file;
         self.canEdit = canEdit;
         self.enableEditing = enableEditing;
         self.baseUrl = (window.location.href).split('?')[0];
+        self.selectLatest = selectLatest;
 
         model.hasDate = self.file.provider !== 'dataverse';
 
@@ -57,6 +58,7 @@ var FileRevisionsTable = {
                 // Can only edit the latest version of a file
                 if (model.selectedRevision === 0) {
                     self.enableEditing();
+                    self.selectLatest();
                 }
                 model.hasUser = model.revisions[0] && model.revisions[0].extra && model.revisions[0].extra.user;
                 model.hasHashes = model.revisions && model.revisions[0] && model.revisions[0].extra.hashes;


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Fix the problem that "delete", "check out", and "download" buttons are missing from certain file types. Now those buttons will show up on all files on latest version and won't show up for any old version files.
<!-- Describe the purpose of your changes -->

## Changes
Before changes:
![screen shot 2016-08-13 at 5 29 45 pm](https://cloud.githubusercontent.com/assets/4974056/17645714/8eedfa28-617b-11e6-99be-0821d9060f52.png)

After change:
for latest version of file cannot be edited on OSF, the delete, checkout, download button still show up
![screen shot 2016-08-13 at 5 30 33 pm](https://cloud.githubusercontent.com/assets/4974056/17645721/b4b6e65c-617b-11e6-8522-de2abc73cd92.png)

for previous version of file cannot be edited on OSF, the delete, checkout, download button will NOT show up
![screen shot 2016-08-13 at 5 30 43 pm](https://cloud.githubusercontent.com/assets/4974056/17645726/e25fd26c-617b-11e6-8303-88c67e2329fd.png)

<!-- Briefly describe or list your changes  -->

## Side effects

<!--Any possible side effects? -->
I think the download button should still be there but with changes to make it to download the current version instead of the most recent version. This can be another improvement ticket.

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
https://openscience.atlassian.net/browse/OSF-6892