### PR TITLE
Task / Install RabbitMQ in `invoke setup` [OSF-4222]

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -729,6 +729,7 @@ def packages(ctx):
         'install libxml2',
         'install libxslt',
         'install elasticsearch',
+        'install rabbitmq',
         'install gpg',
         'install node',
         'tap tokutek/tokumx',


### PR DESCRIPTION
## Purpose

Causes `invoke setup` to install rabbitmq as a package the osf depends on.

## Changes

Added an entry to the list of packages that are installed by brew

## Side effects

Probably not.

## Ticket

https://openscience.atlassian.net/browse/OSF-4222?orderby=priority+DESC%2C+updated+DESC
