### PR TITLE
Add character count to comments [#OSF-4002]

### DIFF
--- a/website/static/js/comment.js
+++ b/website/static/js/comment.js
@@ -185,6 +185,8 @@ var BaseComment = function() {
 
     self.loadingComments = ko.observable(true);
 
+    self.currentChars = ko.observable(0)
+
     self.underMaxLength = ko.observable(true);
 
     self.replyNotEmpty = ko.pureComputed(function() {
@@ -193,15 +195,29 @@ var BaseComment = function() {
     self.commentButtonText = ko.computed(function() {
         return self.submittingReply() ? 'Commenting' : 'Comment';
     });
-    self.validateReply = ko.pureComputed(function() {
-        return self.replyNotEmpty() && self.underMaxLength();
+    //Calculates the remaining character length
+    self.remainingLength = ko.computed(function() {
+        if (self.replyContent() === null) {
+            return 500;
+        } else {
+            return 500 - self.currentChars();
+        }
     });
-
+    //submittingReply ensures that user does not click comment button twice and submit comment twice
+    //remainingLength grays out comment button if less than 0
+    self.replyValid = ko.computed(function() {
+        return self.submittingReply() || self.remainingLength() < 0;
+    });
 };
 
 BaseComment.prototype.handleEditableUpdate = function(element, underMaxLength, charLimit) {
     var self = this;
-    self.underMaxLength(underMaxLength);
+    if (element.innerText.length >= 3) {
+        self.currentChars(element.innerText.length - 1);
+    } else {
+        self.currentChars(element.innerText.length);
+    }
+    self.underMaxLength(underMaxLength + 1);
     self.errorMessage(underMaxLength ? '' : 'Exceeds character limit. Please reduce to ' + charLimit + ' characters or less.');
 };
 

--- a/website/static/js/comment.js
+++ b/website/static/js/comment.js
@@ -185,7 +185,7 @@ var BaseComment = function() {
 
     self.loadingComments = ko.observable(true);
 
-    self.currentChars = ko.observable(0)
+    self.currentChars = ko.observable(0);
 
     self.underMaxLength = ko.observable(true);
 

--- a/website/templates/include/comment_pane_template.mako
+++ b/website/templates/include/comment_pane_template.mako
@@ -24,6 +24,7 @@
                 <form class="form">
                     <div class="form-group">
                         <span>
+                            <span>Characters Remaining: </span><span data-bind="css: {disabled: submittingReply}, text: remainingLength"></span>
                             <div class="form-control atwho-input" placeholder="Add a comment" data-bind="editableHTML: {observable: replyContent, onUpdate: handleEditableUpdate}, attr: {maxlength: $root.MAXLENGTH}" contenteditable="true"></div>
                         </span>
                     </div>
@@ -31,7 +32,7 @@
                         <div class="clearfix">
                             <div class="pull-right">
                                 <a class="btn btn-default btn-sm" data-bind="click: cancelReply, css: {disabled: submittingReply}">Cancel</a>
-                                <a class="btn btn-success btn-sm" data-bind="click: submitReply, visible: validateReply(), css: {disabled: submittingReply}, text: commentButtonText"></a>
+                                <a class="btn btn-success btn-sm" data-bind="click: submitReply, css: {disabled: submittingReply}, text: commentButtonText"></a>
                                 <span data-bind="text: replyErrorMessage" class="text-danger"></span>
                             </div>
                         </div>

--- a/website/templates/include/comment_template.mako
+++ b/website/templates/include/comment_template.mako
@@ -83,6 +83,7 @@
                         -->
                         <div data-bind="template {if: editing, afterRender: autosizeText.bind($data)}">
                             <div class="form-group" style="padding-top: 10px">
+                                <span>Characters Remaining: </span><span data-bind="css: {disabled: submittingReply}, text: remainingLength"></span>
                                 <div class="form-control atwho-input" placeholder="Edit comment" data-bind="editableHTML: {observable: content, onUpdate: handleEditableUpdate}, attr: {maxlength: $root.MAXLENGTH}" contenteditable="true"></div>
                             </div>
                             <div class="clearfix">
@@ -161,12 +162,13 @@
 
                 <div data-bind="template {afterRender: autosizeText.bind($data)}">
                     <div class="form-group" style="padding-top: 10px">
+                        <span>Characters Remaining: </span><span data-bind="css: {disabled: submittingReply}, text: remainingLength"></span>
                         <div class="form-control atwho-input" placeholder="Add a comment" data-bind="editableHTML: {observable: replyContent, onUpdate: handleEditableUpdate}, attr: {maxlength: $root.MAXLENGTH}" contenteditable="true"></div>
                     </div>
                     <div class="clearfix">
                         <div class="pull-right">
                             <a class="btn btn-default btn-sm" data-bind="click: cancelReply, css: {disabled: submittingReply}"> Cancel</a>
-                            <a class="btn btn-success btn-sm" data-bind="click: submitReply, visible: validateReply(), css: {disabled: submittingReply}, text: commentButtonText"></a>
+                            <a class="btn btn-success btn-sm" data-bind="click: submitReply, css: {disabled: submittingReply}, text: commentButtonText"></a>
                             <span data-bind="text: replyErrorMessage" class="text-danger"></span>
                         </div>
                     </div>


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
To allow user to know how many characters they have left in the comment pane.

<!-- Describe the purpose of your changes -->

## Changes

Added a character count feature that shows the user how many characters they have left. Once it count reaches 0, if the user continues to type, the number goes into the negatives but the Comment button disables.
This PR helped greatly: https://github.com/CenterForOpenScience/osf.io/pull/5924
<!-- Briefly describe or list your changes  -->

## Side effects

None that I see
<!--Any possible side effects? -->


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->

https://openscience.atlassian.net/browse/OSF-4002