### PR TITLE
ERPC Landing Page [OSF-6896]

### DIFF
--- a/website/templates/erpc_landing_info.mako
+++ b/website/templates/erpc_landing_info.mako
@@ -2,9 +2,7 @@
     preregistered analysis plan
 </%def>
 
-<%def name="challenge_word()">
-    Competition
-</%def>
+<%def name="challenge_word()">competition</%def>
 
 <%def name="description()">
     <p>The process of creating a <a href='http://www.erpc2016.com'>${kind()}</a> is beneficial to both the scientific field and to you, the scientist. By writing out detailed analysis plans before examining into the data, you can make important decisions that affect your workflow earlier, without the biases that occur once the data are in front of you.</p>
@@ -12,8 +10,10 @@
 
 <%def name="steps()">
   <ol>
-    <li>Specify all analysis decisions prior to investigating your data</li>
-    <li>Publish your study in an eligible journal</li>
-    <li>Receive $2,000</li>
+    <li>Review the <a href="https://osf.io/rxmpf/">ANES Pre-Election Questionnaire</a> and/or the <a href="https://osf.io/h8ubg/">ANES Post-Election Questionnaire</a>.</li>
+    <li>Specify all analysis decisions before the data become available by submitting a preregistered analysis plan (below).</li>
+    <li>Submit your study to a participating journal, which will consider your submission before data are available.</li>
+    <li>Win a cash award of $2,000 for publishing your article.</li>
   </ol>
+  <p>To learn more about the competition, please visit <a href="http://www.erpc2016.com">www.erpc2016.com</a>.</p>
 </%def>

--- a/website/templates/prereg_landing_info.mako
+++ b/website/templates/prereg_landing_info.mako
@@ -2,9 +2,7 @@
     preregistration
 </%def>
 
-<%def name="challenge_word()">
-    Challenge
-</%def>
+<%def name="challenge_word()">challenge</%def>
 
 <%def name="description()">
     <p>The process of <a href='http://www.cos.io/prereg'>${kind()}</a> your plans is beneficial to both the scientific field and to you, the scientist. By writing out detailed data collection methods, analysis plans, and rules for excluding or missing data, you can make important decisions that affect your workflow earlier, without the biases that occur once the data are in front of you.</p>

--- a/website/templates/prereg_landing_page.mako
+++ b/website/templates/prereg_landing_page.mako
@@ -82,7 +82,7 @@
 <div class="prereg-container">
     <h1 class="m-t-xl m-b-lg text-center">Welcome to the ${campaign_long}!</h1>
     <p>${description()}</p>
-    <p class="m-t-lg f-w-lg">Ready for the ${challenge_word()}?</p>
+    <p class="m-t-lg f-w-lg">Ready for the ${challenge_word()}? Please follow these steps:</p>
     <p>
         ${steps()}
     </p>


### PR DESCRIPTION
#### Purpose
- Update ERPC landing page language and links. 

#### Changes
- Language updates.
- Fix challenge word definitions for both ERPC and PreReg so that `Ready for the competition ?` becomes `Ready for the competition?`

#### Ticket
- [OSF-6896](https://openscience.atlassian.net/browse/OSF-6896)

#### Screenshots
- ERPC before:
![screen shot 2016-08-15 at 4 12 07 pm](https://cloud.githubusercontent.com/assets/7913604/17678044/84002d00-6303-11e6-8d83-89e1fe5d406f.png)
- ERPC after:
![screen shot 2016-08-15 at 4 11 11 pm](https://cloud.githubusercontent.com/assets/7913604/17678035/7ac11376-6303-11e6-9fd6-b1cdd6e5c103.png)

