### PR TITLE
Add 'node' to contributor serialization

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -631,6 +631,11 @@ class NodeContributorsSerializer(JSONAPISerializer):
         always_embed=True
     )
 
+    node = RelationshipField(
+        related_view='nodes:node-detail',
+        related_view_kwargs={'node_id': '<node_id>'}
+    )
+
     class Meta:
         type_ = 'contributors'
 


### PR DESCRIPTION
## Purpose

Add 'node' relationship to contributor serialization. This is important for https://github.com/CenterForOpenScience/ember-osf/pull/117 to work-- Ember Data needs the node->contributor and contributor->node relationship to effectively manage state between the two when creating/deleting contributors.