### PR TITLE
[WIP] Filter Users By Active [OSF-6906]

### DIFF
--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -332,8 +332,13 @@ class ODMFilterMixin(FilterMixin):
             for key, field_names in filters.iteritems():
                 sub_query_parts = []
                 for field_name, data in field_names.iteritems():
-                    # Query based on the DB field, not the name of the serializer parameter
-                    sub_query = Q(data['source_field_name'], data['op'], data['value'])
+                    field = self.serializer_class._declared_fields[field_name]
+                    if hasattr(field, 'get_odm_query'):
+                        sub_query = field.get_odm_query(data['value'])
+                    else:
+                        # Query based on the DB field, not the name of the serializer parameter
+                        sub_query = Q(data['source_field_name'], data['op'], data['value'])
+
                     sub_query_parts.append(sub_query)
 
                 try:

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -33,7 +33,7 @@ class UserIsActive(ser.BooleanField):
             Q('is_registered', 'eq', value),
             Q('date_confirmed', ne_if_value, None),
             Q('merged_by', eq_if_value, None),
-            Q('data_disabled', eq_if_value, None),
+            Q('date_disabled', eq_if_value, None),
             Q('password', ne_if_value, None)
         ]
 

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -1,5 +1,10 @@
+import functools
+
+import operator
+
 from rest_framework import serializers as ser
 
+from modularodm import Q
 from modularodm.exceptions import ValidationValueError
 
 from api.base.exceptions import InvalidModelValueError, JSONAPIException, Conflict
@@ -13,13 +18,36 @@ from api.base.utils import absolute_reverse
 
 from framework.auth.views import send_confirm_email
 
+
+class UserIsActive(ser.BooleanField):
+
+    def __init__(self, **kwargs):
+        super(UserIsActive, self).__init__(**kwargs)
+
+    def get_odm_query(self, value):
+        ne_if_value = 'ne' if value else 'eq'
+        eq_if_value = 'eq' if value else 'ne'
+        odm_operator = operator.and_ if value else operator.or_
+
+        query_parts = [
+            Q('is_registered', 'eq', value),
+            Q('date_confirmed', ne_if_value, None),
+            Q('merged_by', eq_if_value, None),
+            Q('data_disabled', eq_if_value, None),
+            Q('password', ne_if_value, None)
+        ]
+
+        return functools.reduce(odm_operator, query_parts)
+
+
 class UserSerializer(JSONAPISerializer):
     filterable_fields = frozenset([
         'full_name',
         'given_name',
         'middle_names',
         'family_name',
-        'id'
+        'id',
+        'active'
     ])
     non_anonymized_fields = ['type']
     id = IDField(source='_id', read_only=True)
@@ -30,7 +58,7 @@ class UserSerializer(JSONAPISerializer):
     family_name = ser.CharField(required=False, allow_blank=True, help_text='For bibliographic citations')
     suffix = HideIfDisabled(ser.CharField(required=False, allow_blank=True, help_text='For bibliographic citations'))
     date_registered = HideIfDisabled(ser.DateTimeField(read_only=True))
-    active = HideIfDisabled(ser.BooleanField(read_only=True, source='is_active'))
+    active = UserIsActive(read_only=True, source='is_active')
 
     # Social Fields are broken out to get around DRF complex object bug and to make API updating more user friendly.
     github = DevOnly(HideIfDisabled(AllowMissing(ser.CharField(required=False, source='social.github',

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -118,11 +118,7 @@ class UserList(JSONAPIBaseView, generics.ListCreateAPIView, ODMFilterMixin):
 
     # overrides ODMFilterMixin
     def get_default_odm_query(self):
-        return (
-            Q('is_registered', 'eq', True) &
-            Q('is_merged', 'ne', True) &
-            Q('date_disabled', 'eq', None)
-        )
+        return None
 
     # overrides ListCreateAPIView
     def get_queryset(self):

--- a/api_tests/users/views/test_user_list.py
+++ b/api_tests/users/views/test_user_list.py
@@ -129,6 +129,32 @@ class TestUsers(ApiTestCase):
         res = self.app.get(url, expect_errors=True)
         assert_equal(res.status_code, 400)
 
+    def test_users_list_active_filter_true(self):
+        url = '/{}users/?filter[active]=true'.format(API_BASE)
+        res = self.app.get(url)
+        assert_equal(res.status_code, 200)
+        assert_equal(len(res.json['data']), 2)
+
+    def test_users_list_active_filter_false_is_registered(self):
+        self.user_one.is_registered = False
+        self.user_one.save()
+        url = '/{}users/?filter[active]=false'.format(API_BASE)
+        res = self.app.get(url)
+        assert_equal(res.status_code, 200)
+        assert_equal(len(res.json['data']), 1)
+
+    def test_users_list_active_filter_false_date_confirmed(self):
+        pass
+
+    def test_users_list_active_filter_false_merged_by(self):
+        pass
+
+    def test_users_list_active_filter_false_date_disabled(self):
+        pass
+
+    def test_users_list_active_filter_false_password(self):
+        pass
+
 
 class TestUsersCreate(ApiTestCase):
 


### PR DESCRIPTION
#### Purpose
- Adds the ability to filter users by whether or not they are active.
 - `api.osf.io/v2/users/?filter[active]=true` or `api.osf.io/v2/users/?filter[active]=false`

#### Changes

#### Side Effects

#### Ticket
- [OSF-6906](https://openscience.atlassian.net/browse/OSF-6906)