### PR TITLE
Append VOL to Relationship Links [OSF-6733]

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -516,7 +516,11 @@ class RelationshipField(ser.HyperlinkedIdentityField):
                             url = '{}?filter{}'.format(url, formatted_filter)
                         else:
                             url = None
+                    if 'view_only' in request.query_params.keys():
+                        url = '{}?view_only={}'.format(url, request.query_params.get('view_only'))
+
                     urls[view_name] = url
+
         if not urls['self'] and not urls['related']:
             urls = None
         return urls

--- a/api_tests/nodes/views/test_view_only_query_parameter.py
+++ b/api_tests/nodes/views/test_view_only_query_parameter.py
@@ -76,7 +76,6 @@ class TestNodeDetailViewOnlyLinks(ViewOnlyTestCase):
 
         assert_true(user_can_comment)
         assert_false(view_only_can_comment)
-        assert_equal(res_linked_json, res_normal_json)
 
     def test_private_node_with_link_unauthorized_when_not_using_link(self):
         res = self.app.get(self.private_node_one_url, expect_errors=True)
@@ -195,6 +194,16 @@ class TestNodeDetailViewOnlyLinks(ViewOnlyTestCase):
             'view_only': 'thisisnotarealprivatekey',
         }, auth=self.creation_user.auth)
         assert_equal(res.status_code, 200)
+
+    def test_view_only_token_in_relationships_links(self):
+        res = self.app.get(self.private_node_one_url, {'view_only': self.private_node_one_private_link.key})
+        assert_equal(res.status_code, 200)
+        res_relationships = res.json['data']['relationships']
+        for key, value in res_relationships.iteritems():
+            if value['links'].get('related'):
+                assert_in(self.private_node_one_private_link.key, value['links']['related']['href'])
+            if value['links'].get('self'):
+                assert_in(self.private_node_one_private_link.key, value['links']['self']['href'])
 
 
 class TestNodeListViewOnlyLinks(ViewOnlyTestCase):


### PR DESCRIPTION
#### Purpose
- Currently when a route is viewed on the API with a view only token, the view only token is not passed to the generated links of each relationship field. This PR adds the view only token to each relationship link, making the API browsable with a view only token. 

#### Changes
- `view_only` query parameter is retrieved and added to the relationship urls returned from `get_url()` in the `RelationshipField` class.

#### Side effects
- None expected.

#### Ticket
- [OSF-6733](https://openscience.atlassian.net/browse/OSF-6733)

