### PR TITLE
[Feature] Update Preprints models / API endpoints [PREP-????]

### DIFF
--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -11,7 +11,7 @@ from api.base import permissions as base_permissions
 from api.base.views import JSONAPIBaseView
 from api.base.filters import ODMFilterMixin
 from api.preprints.parsers import PreprintsJSONAPIParser, PreprintsJSONAPIParserForRegularJSON
-from api.preprints.serializers import PreprintSerializer, PreprintDetailSerializer, PreprintDetailRetrieveSerializer
+from api.preprints.serializers import PreprintSerializer
 from api.nodes.views import NodeMixin, WaterButlerMixin, NodeContributorsList, NodeContributorsSerializer
 from api.base.utils import get_object_or_error
 from rest_framework.exceptions import NotFound
@@ -33,8 +33,8 @@ class PreprintMixin(NodeMixin):
         return node
 
 
-class PreprintList(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin):
-    """Preprints that represent a special kind of preprint node. *Read Only*.
+class PreprintList(JSONAPIBaseView, generics.ListCreateAPIView, ODMFilterMixin):
+    """Preprints that represent a special kind of preprint node. *Writeable*.
 
     Paginated list of preprints ordered by their `date_created`.  Each resource contains a representation of the
     preprint.
@@ -85,47 +85,6 @@ class PreprintList(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin):
     Preprints may be filtered by their `id`, `title`, `public`, `tags`, `date_created`, `date_modified`, `provider`, and `subjects`
     Most are string fields and will be filtered using simple substring matching.
 
-    #This Request/Response
-    """
-    permission_classes = (
-        drf_permissions.IsAuthenticatedOrReadOnly,
-        base_permissions.TokenHasScope,
-    )
-
-    required_read_scopes = [CoreScopes.NODE_BASE_READ]
-    required_write_scopes = [CoreScopes.NODE_BASE_WRITE]
-
-    serializer_class = PreprintSerializer
-
-    ordering = ('-date_created')
-    view_category = 'preprints'
-    view_name = 'preprint-list'
-
-    # overrides ODMFilterMixin
-    def get_default_odm_query(self):
-        return (
-            Q('preprint_file', 'ne', None) &
-            Q('is_deleted', 'ne', True) &
-            Q('preprint_file', 'ne', None) &
-            Q('is_public', 'eq', True)
-        )
-
-    # overrides ListAPIView
-    def get_queryset(self):
-        query = self.get_query_from_request()
-        nodes = Node.find(query)
-
-        return [node for node in nodes if node.is_preprint]
-
-
-class PreprintDetail(JSONAPIBaseView, generics.CreateAPIView, generics.RetrieveUpdateAPIView, PreprintMixin, WaterButlerMixin):
-    """Preprint Detail  *Writeable*.
-
-    ##Preprint Attributes
-    See Preprints List
-
-    ##Actions
-
     ###Creating New Preprints
 
     Create a new preprint by posting to the guid of the existing **node**, including the file_id for the
@@ -133,23 +92,22 @@ class PreprintDetail(JSONAPIBaseView, generics.CreateAPIView, generics.RetrieveU
     preprints detail view until after the preprint has been created.
 
         Method:        POST
-        URL:           /preprints/<node_id>/
+        URL:           /preprints/
         Query Params:  <none>
         Body (JSON):   {
                         "data": {
                             "id": node_id,
                             "attributes": {
-                                "subjects":      {subject_id}      # required
-                                "description":   {description},    # optional
-                                "tags":          [{tag1}, {tag2}], # optional
-                                "provider":      {provider}        # optional
-
+                                "subjects":      [{subject_id}, ...]  # required
+                                "description":   {description},       # optional
+                                "tags":          [{tag1}, ...],       # optional
+                                "provider":      {provider}           # optional
                             },
                             "relationships": {
-                                "primary_file": {                   # required
+                                "primary_file": {                     # required
                                     "data": {
                                         "type": "primary",
-                                        "id": file_id
+                                        "id": {file_id}
                                     }
                                 }
                             }
@@ -167,29 +125,103 @@ class PreprintDetail(JSONAPIBaseView, generics.CreateAPIView, generics.RetrieveU
         base_permissions.TokenHasScope,
     )
 
-    required_read_scopes = [CoreScopes.NODE_BASE_READ]
-    required_write_scopes = [CoreScopes.NODE_BASE_WRITE]
-
     parser_classes = (PreprintsJSONAPIParser, PreprintsJSONAPIParserForRegularJSON,)
 
-    serializer_class = PreprintDetailSerializer
+    required_read_scopes = [CoreScopes.NODE_PREPRINTS_READ]
+    required_write_scopes = [CoreScopes.NODE_PREPRINTS_WRITE]
+
+    serializer_class = PreprintSerializer
+
+    ordering = ('-date_created')
+    view_category = 'preprints'
+    view_name = 'preprint-list'
+
+    # overrides ODMFilterMixin
+    def get_default_odm_query(self):
+        return (
+            Q('preprint_file', 'ne', None) &
+            Q('is_deleted', 'ne', True) &
+            Q('is_public', 'eq', True)
+        )
+
+    # overrides ListAPIView
+    def get_queryset(self):
+        nodes = Node.find(self.get_query_from_request())
+        return (node for node in nodes if node.is_preprint)
+
+class PreprintDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView, PreprintMixin, WaterButlerMixin):
+    """Preprint Detail  *Writeable*.
+
+    ##Preprint Attributes
+
+    Many of these preprint attributes are the same as node, with a few special fields added in.
+
+    OSF Preprint entities have the "preprint" `type`.
+
+        name                            type                  description
+        ====================================================================================
+        title                           string                title of preprint, same as its project or component
+        abstract                        string                description of the preprint
+        date_created                    iso8601 timestamp     timestamp that the preprint was created
+        date_modified                   iso8601 timestamp     timestamp when the preprint was last updated
+        tags                            array of strings      list of tags that describe the node
+        subjects                        array of dictionaries list ids of Subject in the PLOS taxonomy. Dictrionary, containing the subject text and subject ID
+        provider                        string                original source of the preprint
+        doi                             string                bare DOI for the manuscript, as entered by the user
+
+    ###Creating New Preprints
+
+    Create a new preprint by posting to the guid of the existing **node**, including the file_id for the
+    file you'd like to make the primary preprint file. Note that the **node id** will not be accessible via the
+    preprints detail view until after the preprint has been created.
+
+        Method:        PATCH
+        URL:           /preprints/{node_id}/
+        Query Params:  <none>
+        Body (JSON):   {
+                        "data": {
+                            "id": node_id,
+                            "attributes": {
+                                "subjects":      [{subject_id}, ...]  # optional
+                                "description":   {description},       # optional
+                                "tags":          [{tag}, ...],        # optional
+                                "provider":      {provider}           # optional
+                            },
+                            "relationships": {
+                                "primary_file": {                     # optional
+                                    "data": {
+                                        "type": "primary",
+                                        "id": {file_id}
+                                    }
+                                }
+                            }
+                        }
+                    }
+        Success:       200 OK + preprint representation
+
+    #This Request/Response
+    """
+    permission_classes = (
+        drf_permissions.IsAuthenticatedOrReadOnly,
+        base_permissions.TokenHasScope,
+    )
+    parser_classes = (PreprintsJSONAPIParser, PreprintsJSONAPIParserForRegularJSON,)
+
+    required_read_scopes = [CoreScopes.NODE_PREPRINTS_READ]
+    required_write_scopes = [CoreScopes.NODE_PREPRINTS_WRITE]
+
+    serializer_class = PreprintSerializer
+
     view_category = 'preprints'
     view_name = 'preprint-detail'
-
-    def get_serializer_class(self):
-        if self.request.method == 'GET':
-            return PreprintDetailRetrieveSerializer
-        else:
-            return PreprintDetailSerializer
 
     def get_object(self):
         return self.get_node()
 
-    def perform_create(self, serializer):
-        return serializer.save(node=self.get_node())
-
 
 class PreprintContributorsList(NodeContributorsList, PreprintMixin):
+    required_read_scopes = [CoreScopes.NODE_PREPRINTS_READ]
+    required_write_scopes = [CoreScopes.NODE_PREPRINTS_WRITE]
 
     view_category = 'preprint'
     view_name = 'preprint-contributors'

--- a/api/taxonomies/serializers.py
+++ b/api/taxonomies/serializers.py
@@ -1,20 +1,28 @@
 from rest_framework import serializers as ser
 
-from api.base.serializers import JSONAPISerializer
+from api.base.serializers import JSONAPISerializer, LinksField
 
 
 class TaxonomySerializer(JSONAPISerializer):
     filterable_fields = frozenset([
         'text',
-        'parent_ids',
-        'type',
+        'parents',
         'id'
     ])
-
-    type = ser.CharField(max_length=200)
+    id = ser.CharField(source='_id', required=True)
     text = ser.CharField(max_length=200)
-    parent_ids = ser.ListField(child=ser.CharField(max_length=50))
-    id = ser.CharField(max_length=200, source='_id')
+    parents = ser.SerializerMethodField(method_name='get_parent_ids')
+
+    links = LinksField({
+        'parents': 'get_parent_urls',
+        'self': 'get_absolute_url',
+    })
+
+    def get_parent_ids(self, obj):
+        return [p._id for p in obj.parents]
+
+    def get_parent_urls(self, obj):
+        return [p.get_absolute_url() for p in obj.parents]
 
     def get_absolute_url(self, obj):
         return obj.get_absolute_url()

--- a/api/taxonomies/urls.py
+++ b/api/taxonomies/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import url
 
 from api.taxonomies import views
 
-
 urlpatterns = [
-    url(r'^$', views.Taxonomy.as_view(), name=views.Taxonomy.view_name),
+    url(r'^$', views.TaxonomyList.as_view(), name=views.TaxonomyList.view_name),
+    url(r'^(?P<taxonomy_id>\w+)/$', views.TaxonomyDetail.as_view(), name=views.TaxonomyDetail.view_name),
 ]

--- a/api/taxonomies/views.py
+++ b/api/taxonomies/views.py
@@ -59,10 +59,7 @@ class TaxonomyDetail(JSONAPIBaseView, generics.RetrieveAPIView):
 
     ##Taxonomy Attributes
 
-        name           type                   description
-        ----------------------------------------------------------------------------
-        text           array of strings       Actual text of the subject
-        parents        array of subjects      Parent subjects, [] indicates a top level subject.
+    See TaxonomyList
 
     **Note:** Subjects are unique (e.g. there exists only one object in this list with `text='Biology and life sciences'`),
     but as per the structure of the PLOS taxonomy, subjects can exist in separate paths down the taxonomy and as such

--- a/api/taxonomies/views.py
+++ b/api/taxonomies/views.py
@@ -1,9 +1,7 @@
 from rest_framework import generics, permissions as drf_permissions
-from rest_framework import serializers as ser
-
-from modularodm import Q
 
 from api.base.views import JSONAPIBaseView
+from api.base.utils import get_object_or_error
 from api.base.filters import ODMFilterMixin
 from api.base import permissions as base_permissions
 from api.taxonomies.serializers import TaxonomySerializer
@@ -11,7 +9,7 @@ from website.project.taxonomies import Subject
 from framework.auth.oauth_scopes import CoreScopes
 
 
-class Taxonomy(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin):
+class TaxonomyList(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin):
     '''[PLOS taxonomy of subjects](http://journals.plos.org/plosone/browse/) in flattened form. *Read-only*
 
     ##Taxonomy Attributes
@@ -19,8 +17,7 @@ class Taxonomy(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin):
         name           type                   description
         ----------------------------------------------------------------------------
         text           array of strings       Actual text of the subject
-        type           string                 Origin of the subject term - all PLOS for now
-        parent_ids     array of strings       IDs of the parent subjects, [] indicates a top level subject.
+        parents        array of subjects      Parent subjects, [] indicates a top level subject.
 
     ##Query Params
 
@@ -28,10 +25,10 @@ class Taxonomy(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin):
     + `field['text']=<Str>` -- Find subjects with texts that match the passed string
 
     + `filter[<fieldname>]=<Str>` -- fields and values to filter the search results on.
-    + `filter['parent_ids']=<subject_id>` -- Find subjects that have a parent with the id passed
-    + `filter['parent_ids']=null` -- Find top level subjects
+    + `filter['parents']=<subject_id>` -- Find subjects that have a parent with the id passed
+    + `filter['parents']=null` -- Find top level subjects
 
-    Subjects may be filtered by their 'text', 'parent_ids', 'type' and 'id' fields.
+    Subjects may be filtered by their 'text', 'parents', and 'id' fields.
 
     **Note:** Subjects are unique (e.g. there exists only one object in this list with `text='Biology and life sciences'`),
     but as per the structure of the PLOS taxonomy, subjects can exist in separate paths down the taxonomy and as such
@@ -44,20 +41,45 @@ class Taxonomy(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin):
         base_permissions.TokenHasScope
     )
 
-    DEFAULT_OPERATOR_OVERRIDES = {
-        ser.CharField: 'icontains',
-        ser.ListField: 'eq',
-    }
+    required_read_scopes = [CoreScopes.ALWAYS_PUBLIC]
+    required_write_scopes = [CoreScopes.NULL]
+    serializer_class = TaxonomySerializer
+    view_category = 'taxonomies'
+    view_name = 'taxonomy-list'
+
+    # overrides ListAPIView
+    def get_default_odm_query(self):
+        return
+
+    def get_queryset(self):
+        return Subject.find(self.get_query_from_request())
+
+class TaxonomyDetail(JSONAPIBaseView, generics.RetrieveAPIView):
+    '''[PLOS taxonomy subject](http://journals.plos.org/plosone/browse/) instance. *Read-only*
+
+    ##Taxonomy Attributes
+
+        name           type                   description
+        ----------------------------------------------------------------------------
+        text           array of strings       Actual text of the subject
+        parents        array of subjects      Parent subjects, [] indicates a top level subject.
+
+    **Note:** Subjects are unique (e.g. there exists only one object in this list with `text='Biology and life sciences'`),
+    but as per the structure of the PLOS taxonomy, subjects can exist in separate paths down the taxonomy and as such
+    can have multiple parent subjects.
+
+    Only the top three levels of the PLOS taxonomy are included.
+    '''
+    permission_classes = (
+        drf_permissions.IsAuthenticatedOrReadOnly,
+        base_permissions.TokenHasScope
+    )
 
     required_read_scopes = [CoreScopes.ALWAYS_PUBLIC]
     required_write_scopes = [CoreScopes.NULL]
     serializer_class = TaxonomySerializer
     view_category = 'taxonomies'
-    view_name = 'taxonomy'
+    view_name = 'taxonomy-detail'
 
-    # overrides ListAPIView
-    def get_default_odm_query(self):
-        return Q('type', 'ne', None)
-
-    def get_queryset(self):
-        return Subject.find(self.get_query_from_request())
+    def get_object(self):
+        return get_object_or_error(Subject, self.kwargs['taxonomy_id'])

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -528,7 +528,10 @@ class UserPreprints(UserNodes):
 
     def get_queryset(self):
         nodes = Node.find(self.get_query_from_request())
-        return [node for node in nodes if node.is_preprint]
+        # TODO: Rearchitect how `.is_preprint` is determined,
+        # so that a query that is guaranteed to return only
+        # preprints can be contructed. Use generator in meantime.
+        return (node for node in nodes if node.is_preprint)
 
 
 class UserInstitutions(JSONAPIBaseView, generics.ListAPIView, UserMixin):

--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -5,6 +5,17 @@ from api.base.settings.defaults import API_BASE
 
 from website.files.models.osfstorage import OsfStorageFile
 from tests.factories import PreprintFactory, AuthUserFactory, ProjectFactory, SubjectFactory
+from api_tests import utils as test_utils
+
+def build_preprint_update_payload(node_id, attributes=None, relationships=None):
+    payload = {
+        "data": {
+            "id": node_id,
+            "attributes": attributes,
+            "relationships": relationships
+        }
+    }
+    return payload
 
 
 class TestPreprintDetail(ApiTestCase):
@@ -26,155 +37,6 @@ class TestPreprintDetail(ApiTestCase):
         assert_equal(self.data['id'], self.preprint._id)
 
 
-def create_file(node, filename):
-    file = OsfStorageFile.create(
-        is_file=True,
-        node=node,
-        path='/{}'.format(filename),
-        name=filename,
-        materialized_path='/{}'.format(filename))
-    file.save()
-    return file
-
-
-def build_preprint_update_payload(node_id, attributes=None, relationships=None):
-    payload = {
-        "data": {
-            "id": node_id,
-            "attributes": attributes,
-            "relationships": relationships
-        }
-    }
-    return payload
-
-
-def build_preprint_create_payload(node_id, subject_id, file_id=None):
-    payload = {
-        "data": {
-            "id": node_id,
-            "attributes": {
-                "subjects": [subject_id]
-            }
-        }
-    }
-    if file_id:
-        payload['data']['relationships'] = {
-            "primary_file": {
-                "data": {
-                    "type": "file",
-                    "id": file_id
-                }
-            }
-        }
-
-    return payload
-
-
-class TestPreprintCreate(ApiTestCase):
-    def setUp(self):
-        super(TestPreprintCreate, self).setUp()
-
-        self.user = AuthUserFactory()
-        self.private_project = ProjectFactory(creator=self.user)
-        self.public_project = ProjectFactory(creator=self.user, public=True)
-        self.subject = SubjectFactory()
-
-        self.user_two = AuthUserFactory()
-
-        self.file_one_public_project = create_file(self.public_project, 'millionsofdollars.pdf')
-        self.file_one_private_project = create_file(self.private_project, 'woowoowoo.pdf')
-
-    def test_create_preprint_from_public_project(self):
-        public_project_payload = build_preprint_create_payload(self.public_project._id, self.subject._id, self.file_one_public_project._id)
-        url = '/{}preprints/{}/'.format(API_BASE, self.public_project._id)
-        res = self.app.post_json_api(url, public_project_payload, auth=self.user.auth)
-
-        assert_equal(res.status_code, 201)
-
-    def test_create_preprint_from_private_project(self):
-        private_project_payload = build_preprint_create_payload(self.private_project._id, self.subject._id, self.file_one_private_project._id)
-        url = '/{}preprints/{}/'.format(API_BASE, self.private_project._id)
-        res = self.app.post_json_api(url, private_project_payload, auth=self.user.auth)
-
-        self.private_project.reload()
-        assert_equal(res.status_code, 201)
-        assert_true(self.private_project.is_public)
-
-    def test_non_authorized_user(self):
-        public_project_payload = build_preprint_create_payload(self.public_project._id, self.subject._id, self.file_one_public_project._id)
-        url = '/{}preprints/{}/'.format(API_BASE, self.public_project._id)
-        res = self.app.post_json_api(url, public_project_payload, auth=self.user_two.auth, expect_errors=True)
-
-        assert_equal(res.status_code, 403)
-
-    def test_file_is_not_in_node(self):
-        wrong_project_payload = build_preprint_create_payload(self.public_project._id, self.subject._id, self.file_one_private_project._id)
-        url = '/{}preprints/{}/'.format(API_BASE, self.public_project._id)
-        res = self.app.post_json_api(url, wrong_project_payload, auth=self.user.auth, expect_errors=True)
-
-        assert_equal(res.status_code, 400)
-
-    def test_already_a_preprint(self):
-        preprint = PreprintFactory(creator=self.user)
-        file_one_preprint = create_file(preprint, 'openupthatwindow.pdf')
-
-        already_preprint_payload = build_preprint_create_payload(preprint._id, self.subject._id, file_one_preprint._id)
-        url = '/{}preprints/{}/'.format(API_BASE, preprint._id)
-        res = self.app.post_json_api(url, already_preprint_payload, auth=self.user.auth, expect_errors=True)
-
-        assert_equal(res.status_code, 409)
-
-    def test_no_primary_file_passed(self):
-        no_file_payload = build_preprint_create_payload(self.public_project._id, self.subject._id)
-
-        url = '/{}preprints/{}/'.format(API_BASE, self.public_project._id)
-        res = self.app.post_json_api(url, no_file_payload, auth=self.user.auth, expect_errors=True)
-
-        assert_equal(res.status_code, 400)
-
-    def test_invalid_primary_file(self):
-        invalid_file_payload = build_preprint_create_payload(self.public_project._id, self.subject._id, 'totallynotanid')
-        url = '/{}preprints/{}/'.format(API_BASE, self.public_project._id)
-        res = self.app.post_json_api(url, invalid_file_payload, auth=self.user.auth, expect_errors=True)
-
-        assert_equal(res.status_code, 400)
-
-    def test_no_subjects_given(self):
-        no_subjects_payload = build_preprint_create_payload(self.public_project._id, self.subject._id, self.file_one_public_project._id)
-        del no_subjects_payload['data']['attributes']['subjects']
-
-        url = '/{}preprints/{}/'.format(API_BASE, self.public_project._id)
-        res = self.app.post_json_api(url, no_subjects_payload, auth=self.user.auth, expect_errors=True)
-
-        assert_equal(res.status_code, 400)
-
-    def test_invalid_subjects_given(self):
-        wrong_subjects_payload = build_preprint_create_payload(self.public_project._id, self.subject._id, self.file_one_public_project._id)
-        wrong_subjects_payload['data']['attributes']['subjects'] = ['jobbers']
-
-        url = '/{}preprints/{}/'.format(API_BASE, self.public_project._id)
-        res = self.app.post_json_api(url, wrong_subjects_payload, auth=self.user.auth, expect_errors=True)
-
-        assert_equal(res.status_code, 400)
-
-    def test_request_id_does_not_match_request_url_id(self):
-        public_project_payload = build_preprint_create_payload(self.private_project._id, self.subject._id, self.file_one_public_project._id)
-        url = '/{}preprints/{}/'.format(API_BASE, self.public_project._id)
-        res = self.app.post_json_api(url, public_project_payload, auth=self.user.auth, expect_errors=True)
-
-        assert_equal(res.status_code, 400)
-
-    def test_file_not_osfstorage(self):
-        github_file = self.file_one_public_project
-        github_file.provider = 'github'
-        github_file.save()
-        public_project_payload = build_preprint_create_payload(self.public_project._id, self.subject._id, github_file._id)
-        url = '/{}preprints/{}/'.format(API_BASE, self.public_project._id)
-        res = self.app.post_json_api(url, public_project_payload, auth=self.user.auth, expect_errors=True)
-
-        assert_equal(res.status_code, 400)
-
-
 class TestPreprintUpdate(ApiTestCase):
     def setUp(self):
         super(TestPreprintUpdate, self).setUp()
@@ -182,8 +44,6 @@ class TestPreprintUpdate(ApiTestCase):
 
         self.preprint = PreprintFactory(creator=self.user)
         self.url = '/{}preprints/{}/'.format(API_BASE, self.preprint._id)
-
-        # self.file_preprint = create_file(self.preprint, 'openupthatwindow.pdf')
 
         self.subject = SubjectFactory()
 
@@ -204,7 +64,7 @@ class TestPreprintUpdate(ApiTestCase):
         assert_equal(res.status_code, 200)
 
         self.preprint.reload()
-        assert_equal(self.preprint.preprint_subjects[0], self.subject._id)
+        assert_equal(self.preprint.preprint_subjects[0], self.subject)
 
     def test_update_invalid_subjects(self):
         preprint_subjects = self.preprint.preprint_subjects
@@ -217,7 +77,7 @@ class TestPreprintUpdate(ApiTestCase):
         assert_equal(self.preprint.preprint_subjects, preprint_subjects)
 
     def test_update_primary_file(self):
-        new_file = create_file(self.preprint, 'openupthatwindow.pdf')
+        new_file = test_utils.create_test_file(self.preprint, 'openupthatwindow.pdf')
         relationships = {
             "primary_file": {
                 "data": {
@@ -237,7 +97,7 @@ class TestPreprintUpdate(ApiTestCase):
 
     def test_new_primary_not_in_node(self):
         project = ProjectFactory()
-        file_for_project = create_file(project, 'letoutthatantidote.pdf')
+        file_for_project = test_utils.create_test_file(project, 'letoutthatantidote.pdf')
 
         relationships = {
             "primary_file": {

--- a/api_tests/preprints/views/test_preprint_list.py
+++ b/api_tests/preprints/views/test_preprint_list.py
@@ -8,9 +8,33 @@ from tests.base import ApiTestCase
 from tests.factories import (
     ProjectFactory,
     PreprintFactory,
-    AuthUserFactory
+    AuthUserFactory,
+    SubjectFactory
 )
 
+from api_tests import utils as test_utils
+
+def build_preprint_create_payload(node_id, subject_id, file_id=None):
+    payload = {
+        "data": {
+            "id": node_id,
+            "attributes": {
+                "subjects": [subject_id],
+                "abstract": "Much preprint. Very open. Wow"
+            },
+            "type": "preprints"
+        }
+    }
+    if file_id:
+        payload['data']['relationships'] = {
+            "primary_file": {
+                "data": {
+                    "type": "file",
+                    "id": file_id
+                }
+            }
+        }
+    return payload
 
 class TestPreprintList(ApiTestCase):
 
@@ -109,3 +133,107 @@ class TestPreprintFiltering(ApiTestCase):
         assert_equal(len(data), 1)
         for result in data:
             assert_equal(self.preprint._id, result['id'])
+
+
+class TestPreprintCreate(ApiTestCase):
+    def setUp(self):
+        super(TestPreprintCreate, self).setUp()
+
+        self.user = AuthUserFactory()
+        self.private_project = ProjectFactory(creator=self.user)
+        self.public_project = ProjectFactory(creator=self.user, public=True)
+        self.subject = SubjectFactory()
+
+        self.user_two = AuthUserFactory()
+
+        self.file_one_public_project = test_utils.create_test_file(self.public_project, self.user, 'millionsofdollars.pdf')
+        self.file_one_private_project = test_utils.create_test_file(self.private_project, self.user, 'woowoowoo.pdf')
+
+        self.url = '/{}preprints/'.format(API_BASE)
+
+    def test_create_preprint_from_public_project(self):
+        public_project_payload = build_preprint_create_payload(self.public_project._id, self.subject._id, self.file_one_public_project._id)
+        res = self.app.post_json_api(self.url, public_project_payload, auth=self.user.auth)
+
+        assert_equal(res.status_code, 201)
+
+    def test_create_preprint_from_private_project(self):
+        private_project_payload = build_preprint_create_payload(self.private_project._id, self.subject._id, self.file_one_private_project._id)
+        res = self.app.post_json_api(self.url, private_project_payload, auth=self.user.auth)
+
+        self.private_project.reload()
+        assert_equal(res.status_code, 201)
+        assert_true(self.private_project.is_public)
+
+    def test_non_authorized_user(self):
+        public_project_payload = build_preprint_create_payload(self.public_project._id, self.subject._id, self.file_one_public_project._id)
+        res = self.app.post_json_api(self.url, public_project_payload, auth=self.user_two.auth, expect_errors=True)
+
+        assert_equal(res.status_code, 403)
+
+    def test_file_is_not_in_node(self):
+        wrong_project_payload = build_preprint_create_payload(self.public_project._id, self.subject._id, self.file_one_private_project._id)
+        res = self.app.post_json_api(self.url, wrong_project_payload, auth=self.user.auth, expect_errors=True)
+
+        assert_equal(res.status_code, 400)
+        assert_equal(res.json['errors'][0]['detail'], 'This file is not a valid primary file for this preprint.')
+
+    def test_already_a_preprint(self):
+        preprint = PreprintFactory(creator=self.user)
+        file_one_preprint = test_utils.create_test_file(preprint, self.user, 'openupthatwindow.pdf')
+
+        already_preprint_payload = build_preprint_create_payload(preprint._id, self.subject._id, file_one_preprint._id)
+        res = self.app.post_json_api(self.url, already_preprint_payload, auth=self.user.auth, expect_errors=True)
+
+        assert_equal(res.status_code, 409)
+        assert_equal(res.json['errors'][0]['detail'], 'This node already stored as a preprint, use the update method instead.')
+
+    def test_no_primary_file_passed(self):
+        no_file_payload = build_preprint_create_payload(self.public_project._id, self.subject._id)
+
+        res = self.app.post_json_api(self.url, no_file_payload, auth=self.user.auth, expect_errors=True)
+
+        assert_equal(res.status_code, 400)
+        assert_equal(res.json['errors'][0]['detail'], 'You must specify a primary_file to create a preprint.')
+
+    def test_invalid_primary_file(self):
+        invalid_file_payload = build_preprint_create_payload(self.public_project._id, self.subject._id, 'totallynotanid')
+        res = self.app.post_json_api(self.url, invalid_file_payload, auth=self.user.auth, expect_errors=True)
+
+        assert_equal(res.status_code, 400)
+        assert_equal(res.json['errors'][0]['detail'], 'You must specify a primary_file to create a preprint.')
+
+    def test_no_subjects_given(self):
+        no_subjects_payload = build_preprint_create_payload(self.public_project._id, self.subject._id, self.file_one_public_project._id)
+        del no_subjects_payload['data']['attributes']['subjects']
+        res = self.app.post_json_api(self.url, no_subjects_payload, auth=self.user.auth, expect_errors=True)
+
+        assert_equal(res.status_code, 400)
+        assert_equal(res.json['errors'][0]['detail'], 'You must specify at least one subject to create a preprint.')
+
+    def test_invalid_subjects_given(self):
+        wrong_subjects_payload = build_preprint_create_payload(self.public_project._id, self.subject._id, self.file_one_public_project._id)
+        wrong_subjects_payload['data']['attributes']['subjects'] = ['jobbers']
+
+        res = self.app.post_json_api(self.url, wrong_subjects_payload, auth=self.user.auth, expect_errors=True)
+
+        assert_equal(res.status_code, 400)
+        assert_equal(res.json['errors'][0]['detail'], 'Subject with id <jobbers> could not be found.')
+
+    def test_request_id_does_not_match_request_url_id(self):
+        public_project_payload = build_preprint_create_payload(self.private_project._id, self.subject._id, self.file_one_public_project._id)
+        res = self.app.post_json_api(self.url, public_project_payload, auth=self.user.auth, expect_errors=True)
+
+        assert_equal(res.status_code, 400)
+        assert_equal(res.json['errors'][0]['detail'], 'This file is not a valid primary file for this preprint.')
+
+    def test_file_not_osfstorage(self):
+        github_file = self.file_one_public_project
+        github_file.provider = 'github'
+        github_file.save()
+        public_project_payload = build_preprint_create_payload(self.public_project._id, self.subject._id, github_file._id)
+        res = self.app.post_json_api(self.url, public_project_payload, auth=self.user.auth, expect_errors=True)
+
+        assert_equal(res.status_code, 400)
+        assert_equal(res.json['errors'][0]['detail'], 'This file is not a valid primary file for this preprint.')
+

--- a/framework/auth/oauth_scopes.py
+++ b/framework/auth/oauth_scopes.py
@@ -57,6 +57,9 @@ class CoreScopes(object):
     NODE_VIEW_ONLY_LINKS_READ = 'node.view_only_links_read'
     NODE_VIEW_ONLY_LINKS_WRITE = 'node.view_only_links_write'
 
+    NODE_PREPRINTS_READ = 'node.preprints_read'
+    NODE_PREPRINTS_WRITE = 'node.preprints_write'
+
     REGISTRATION_VIEW_ONLY_LINKS_READ = 'registration.view_only_links_read'
     REGISTRATION_VIEW_ONLY_LINKS_WRITE = 'registration.view_only_links_write'
 
@@ -145,13 +148,15 @@ class ComposedScopes(object):
     COMMENT_REPORTS_WRITE = COMMENT_REPORTS_READ + (CoreScopes.COMMENT_REPORTS_WRITE,)
 
     # Nodes collection.
-    # Base node data includes node metadata, links, and children.
+    # Base node data includes node metadata, links, children, and preprints.
     NODE_METADATA_READ = (CoreScopes.NODE_BASE_READ, CoreScopes.NODE_CHILDREN_READ, CoreScopes.NODE_LINKS_READ,
                           CoreScopes.NODE_CITATIONS_READ, CoreScopes.NODE_COMMENTS_READ, CoreScopes.NODE_LOG_READ,
-                          CoreScopes.NODE_FORKS_READ, CoreScopes.WIKI_BASE_READ, CoreScopes.LICENSE_READ, CoreScopes.IDENTIFIERS_READ)
+                          CoreScopes.NODE_FORKS_READ, CoreScopes.WIKI_BASE_READ, CoreScopes.LICENSE_READ,
+                          CoreScopes.IDENTIFIERS_READ, CoreScopes.NODE_PREPRINTS_READ)
     NODE_METADATA_WRITE = NODE_METADATA_READ + \
                     (CoreScopes.NODE_BASE_WRITE, CoreScopes.NODE_CHILDREN_WRITE, CoreScopes.NODE_LINKS_WRITE,
-                     CoreScopes.NODE_CITATIONS_WRITE, CoreScopes.NODE_COMMENTS_WRITE, CoreScopes.NODE_FORKS_WRITE)
+                     CoreScopes.NODE_CITATIONS_WRITE, CoreScopes.NODE_COMMENTS_WRITE, CoreScopes.NODE_FORKS_WRITE,
+                     CoreScopes.NODE_PREPRINTS_WRITE)
 
     # Organizer Collections collection
     # Using Organizer Collections and the node links they collect. Reads Node Metadata.

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -260,16 +260,15 @@ class PreprintFactory(AbstractNodeFactory):
 class SubjectFactory(ModularOdmFactory):
 
     text = Sequence(lambda n: 'Example Subject #{}'.format(n))
-    type = 'test'
     class Meta:
         model = Subject
 
     @classmethod
     def _create(cls, target_class, text=None,
-                parent_ids=[], *args, **kwargs):
+                parents=[], *args, **kwargs):
         subject = target_class(*args, **kwargs)
         subject.text = text
-        subject.parent_ids = parent_ids
+        subject.parents = parents
         subject.save()
 
         return subject

--- a/website/project/taxonomies/__init__.py
+++ b/website/project/taxonomies/__init__.py
@@ -6,13 +6,17 @@ from framework.mongo import (
     utils as mongo_utils
 )
 
+from website.util import api_v2_url
 
-@mongo_utils.unique_on(['id', '_id'])
+@mongo_utils.unique_on(['text'])
 class Subject(StoredObject):
     _id = fields.StringField(primary=True, default=lambda: str(ObjectId()))
-    type = fields.StringField(required=True)
     text = fields.StringField(required=True)
-    parent_ids = fields.StringField(list=True)
+    parents = fields.ForeignField('subject', list=True)
+
+    @property
+    def absolute_api_v2_url(self):
+        return api_v2_url('taxonomies/{}/'.format(self._id))
 
     def get_absolute_url(self):
-        return '{}taxonomies/?filter[id]={}'.format(self.absolute_api_v2_url, self._id)
+        return self.absolute_api_v2_url


### PR DESCRIPTION

## Purpose
Update Preprints from points noticed during CR

## Changes
* Add/correct OAuth scopes
* Maintain typical API conventions -- list endpoints creates, detail updates
* Improve efficiency of queries (prefer generators to optimize for pagination)
* Treat fields that point to models appropriately
*  Update docs
* Fix minor bugs

## Side effects
Minor changes required in `ember-preprints`:
* creating a preprints is now done through the list endpoint `/preprints/`  (`node_id` in json)
* Taxonomy `parent_ids` is now `parents`, still list of id's

@chrisseto may have already updated that side of things

## Ticket
Maybe something on the Preprints board? ¯\\\_(ツ)_/¯ 