### PR TITLE
[Fix] Taxonomy parent filtering

### DIFF
--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -8,6 +8,7 @@ from api.base.serializers import (
 from api.base.exceptions import Conflict
 from api.base.utils import absolute_reverse, get_user_auth
 from api.nodes.serializers import NodeTagField
+from api.taxonomies.serializers import TaxonomyField
 from framework.exceptions import PermissionsError
 from website.models import Node, StoredFileNode
 
@@ -20,15 +21,6 @@ class PrimaryFileRelationshipField(RelationshipField):
         file = self.get_object(data)
         return {'primary_file': file}
 
-
-class PreprintSubjectField(ser.Field):
-    def to_representation(self, obj):
-        if obj is not None:
-            return obj._id
-        return None
-
-    def to_internal_value(self, data):
-        return data
 
 class PreprintSerializer(JSONAPISerializer):
 
@@ -45,7 +37,7 @@ class PreprintSerializer(JSONAPISerializer):
     ])
 
     title = ser.CharField(required=False)
-    subjects = JSONAPIListField(child=PreprintSubjectField(), required=False, source='preprint_subjects')
+    subjects = JSONAPIListField(child=TaxonomyField(), required=False, source='preprint_subjects')
     provider = ser.CharField(source='preprint_provider', required=False)
     date_created = ser.DateTimeField(read_only=True, source='preprint_created')
     date_modified = ser.DateTimeField(read_only=True)

--- a/api/taxonomies/serializers.py
+++ b/api/taxonomies/serializers.py
@@ -1,7 +1,15 @@
 from rest_framework import serializers as ser
 
-from api.base.serializers import JSONAPISerializer, LinksField
+from api.base.serializers import JSONAPISerializer, LinksField, JSONAPIListField
 
+class TaxonomyField(ser.Field):
+    def to_representation(self, obj):
+        if obj is not None:
+            return obj._id
+        return None
+
+    def to_internal_value(self, data):
+        return data
 
 class TaxonomySerializer(JSONAPISerializer):
     filterable_fields = frozenset([
@@ -11,15 +19,12 @@ class TaxonomySerializer(JSONAPISerializer):
     ])
     id = ser.CharField(source='_id', required=True)
     text = ser.CharField(max_length=200)
-    parents = ser.SerializerMethodField(method_name='get_parent_ids')
+    parents = JSONAPIListField(child=TaxonomyField())
 
     links = LinksField({
         'parents': 'get_parent_urls',
         'self': 'get_absolute_url',
     })
-
-    def get_parent_ids(self, obj):
-        return [p._id for p in obj.parents]
 
     def get_parent_urls(self, obj):
         return [p.get_absolute_url() for p in obj.parents]

--- a/api_tests/taxonomies/views/test_taxonomy_list.py
+++ b/api_tests/taxonomies/views/test_taxonomy_list.py
@@ -47,7 +47,7 @@ class TestTaxonomy(ApiTestCase):
 
     def test_taxonomy_filter_top_level(self):
         top_level_subjects = Subject.find(
-            Q('parents', 'eq', None)
+            Q('parents', 'eq', [])
         )
         top_level_url = self.url + '?filter[parents]=null'
 
@@ -56,6 +56,7 @@ class TestTaxonomy(ApiTestCase):
 
         data = res.json['data']
         assert_equal(len(top_level_subjects), len(data))
+        assert len(top_level_subjects) > 0
         for subject in data:
             assert_equal(subject['attributes']['parents'], [])
 


### PR DESCRIPTION
## Purpose
Fix bug introduced in #6178 

## Changes
* Use (renamed) `TaxonomyField` to serialize `Subject`s in `.parents`
* Fix test to not be a noop

## Side effects
None expected

## Relevant tests, local
Logging removed:
```
~/D/osf.io ❯ DJANGO_SETTINGS_MODULE=api.base.settings nosetests api_tests/taxonomies/ api_tests/preprints/
.............................
----------------------------------------------------------------------
Ran 29 tests in 13.886s

OK
```