### PR TITLE
[Feature] Storage Addon links / Filter by categories [#OSF-4681]

### DIFF
--- a/api/addons/serializers.py
+++ b/api/addons/serializers.py
@@ -37,6 +37,10 @@ class NodeAddonFolderSerializer(JSONAPISerializer):
         )
 
 class AddonSerializer(JSONAPISerializer):
+    filterable_fields = frozenset([
+        'categories',
+    ])
+
     class Meta:
         type_ = 'addon'
 

--- a/api/addons/views.py
+++ b/api/addons/views.py
@@ -6,6 +6,8 @@ from rest_framework import generics, permissions as drf_permissions
 from framework.auth.oauth_scopes import CoreScopes
 
 from api.addons.serializers import AddonSerializer
+from api.base.filters import ListFilterMixin
+from api.base.pagination import MaxSizePagination
 from api.base.permissions import TokenHasScope
 from api.base.settings import ADDONS_OAUTH
 from api.base.views import JSONAPIBaseView
@@ -46,7 +48,7 @@ class AddonSettingsMixin(object):
 
         return addon_settings
 
-class AddonList(JSONAPIBaseView, generics.ListAPIView):
+class AddonList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin):
     """List of addons configurable with the OSF *Read-only*.
 
     Paginated list of addons associated with third-party services
@@ -77,9 +79,13 @@ class AddonList(JSONAPIBaseView, generics.ListAPIView):
     required_read_scopes = [CoreScopes.ALWAYS_PUBLIC]
     required_write_scopes = [CoreScopes.NULL]
 
+    pagination_class = MaxSizePagination
     serializer_class = AddonSerializer
     view_category = 'addons'
     view_name = 'addon-list'
 
-    def get_queryset(self):
+    def get_default_queryset(self):
         return [conf for conf in osf_settings.ADDONS_AVAILABLE_DICT.itervalues() if 'accounts' in conf.configs]
+
+    def get_queryset(self):
+        return self.get_queryset_from_request()

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -581,6 +581,7 @@ def root(request, format=None):
             'institutions': utils.absolute_reverse('institutions:institution-list'),
             'licenses': utils.absolute_reverse('licenses:license-list'),
             'metaschemas': utils.absolute_reverse('metaschemas:metaschema-list'),
+            'addons': utils.absolute_reverse('addons:addon-list'),
         }
     }
 

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -789,7 +789,8 @@ class NodeProviderSerializer(JSONAPISerializer):
     )
     links = LinksField({
         'upload': WaterbutlerLink(),
-        'new_folder': WaterbutlerLink(kind='folder')
+        'new_folder': WaterbutlerLink(kind='folder'),
+        'storage_addons': 'get_storage_addons_url'
     })
 
     class Meta:
@@ -806,6 +807,12 @@ class NodeProviderSerializer(JSONAPISerializer):
                 'node_id': obj.node._id,
                 'provider': obj.provider
             }
+        )
+
+    def get_storage_addons_url(self, obj):
+        return absolute_reverse(
+            'addons:addon-list',
+            query_kwargs={'filter[categories]': 'storage'}
         )
 
 class InstitutionRelated(JSONAPIRelationshipSerializer):

--- a/api_tests/addons/test_addons_list.py
+++ b/api_tests/addons/test_addons_list.py
@@ -1,0 +1,24 @@
+from nose.tools import *  # flake8: noqa
+
+from api.base.settings.defaults import API_BASE
+
+from tests.base import ApiTestCase
+
+class TestAddonsList(ApiTestCase):
+
+    def setUp(self):
+        super(TestAddonsList, self).setUp()
+        self.url = '/{}addons/'.format(API_BASE)
+
+    def test_filter_by_category(self):
+        storage_url = '{}?filter[categories]=storage'.format(self.url)
+        citations_url = '{}?filter[categories]=citations'.format(self.url)
+
+        storage_data = self.app.get(storage_url).json['data']
+        citations_data = self.app.get(citations_url).json['data']
+
+        for addon in storage_data:
+            assert_in('storage', addon['attributes']['categories'])
+
+        for addon in citations_data:
+            assert_in('citations', addon['attributes']['categories'])

--- a/api_tests/nodes/views/test_node_files_list.py
+++ b/api_tests/nodes/views/test_node_files_list.py
@@ -127,6 +127,10 @@ class TestNodeFilesList(ApiTestCase):
         assert_equal(res.content_type, 'application/vnd.api+json')
         assert_equal(res.json['data'][0]['attributes']['provider'], 'osfstorage')
 
+    def test_returns_storage_addons_link(self):
+        res = self.app.get(self.private_url, auth=self.user.auth)
+        assert_in('storage_addons', res.json['data'][0]['links'])
+
     def test_returns_file_data(self):
         fobj = self.project.get_addon('osfstorage').get_root().append_file('NewFile')
         fobj.save()


### PR DESCRIPTION
## Purpose
Add link to list of storage addons, accessible on node providers page

## Changes
* Enable filtering addons by category
* Add link
* Add tests

## Side effects
Increased max page size of addons list.

## Ticket
[[#OSF-4681]](https://openscience.atlassian.net/browse/OSF-4681)

## Screenshots
<img width="787" alt="screen shot 2016-08-22 at 01 54 18" src="https://cloud.githubusercontent.com/assets/5659262/17844823/680bcff2-680b-11e6-8d01-9b99f16b3af1.png">
<img width="382" alt="screen shot 2016-08-22 at 01 22 39" src="https://cloud.githubusercontent.com/assets/5659262/17844824/680ec8f6-680b-11e6-9f71-5e36c3115ac3.png">