### PR TITLE
[feature] Add Institution Specific Text for Empty Collections [OSF-6825]

### DIFF
--- a/website/static/js/myProjects.js
+++ b/website/static/js/myProjects.js
@@ -620,9 +620,15 @@ var MyProjects = {
                         template = m('.db-non-load-template.m-md.p-md.osf-box',
                             'You have not created any projects yet.');
                     } else if (lastcrumb.data.nodeType === 'registrations'){
-                        template = m('.db-non-load-template.m-md.p-md.osf-box',
+                        if (self.institutionId) {
+                            template = m('.db-non-load-template.m-md.p-md.osf-box',
+                            'There have been no completed registrations affiliated with this institution. For a list of the most viewed and most recent public registrations on the Open Science Framework, click ',
+                            m('a', {href: 'http://help.osf.io/m/registrations'}, 'here'), '.' );
+                        } else {
+                            template = m('.db-non-load-template.m-md.p-md.osf-box',
                             'You have not made any registrations yet. Go to ',
                             m('a', {href: 'http://help.osf.io/m/registrations'}, 'Getting Started'), ' to learn how registrations work.' );
+                        }
                     } else if (lodashGet(lastcrumb, 'data.node.attributes.bookmarks')) {
                         template = m('.db-non-load-template.m-md.p-md.osf-box', 'You have no bookmarks. You can add projects or registrations by dragging them into your bookmarks or by clicking the Add to Bookmark button on the project or registration.');
                     } else {

--- a/website/static/js/myProjects.js
+++ b/website/static/js/myProjects.js
@@ -622,8 +622,10 @@ var MyProjects = {
                     } else if (lastcrumb.data.nodeType === 'registrations'){
                         if (self.institutionId) {
                             template = m('.db-non-load-template.m-md.p-md.osf-box',
-                            'There have been no completed registrations affiliated with this institution. For a list of the most viewed and most recent public registrations on the Open Science Framework, click ',
-                            m('a', {href: 'http://help.osf.io/m/registrations'}, 'here'), '.' );
+                                'There have been no completed registrations for this institution, but you can view the ',
+                                m('a', {href: 'https://osf.io/explore/activity/#newPublicRegistrations'}, 'newest public registrations'),
+                                ' or ',
+                                m('a', {href: 'https://osf.io/explore/activity/#popularPublicRegistrations'}, 'popular public registrations.'));
                         } else {
                             template = m('.db-non-load-template.m-md.p-md.osf-box',
                             'You have not made any registrations yet. Go to ',


### PR DESCRIPTION
#### Purpose
- This PR adds institution-specific help text when viewing an empty registrations collection. 
- h/t to @amyshi188 for starting work on this PR 

#### Side effects
- None expected.

#### Ticket
- [OSF-6825](https://openscience.atlassian.net/browse/OSF-6825)

#### Screenshots
- Before:
![screen shot 2016-07-29 at 1 07 12 pm](https://cloud.githubusercontent.com/assets/7913604/17862307/b3a5aa9e-6862-11e6-8bd8-67a61edda342.png)


- After (institution view):
![screen shot 2016-08-22 at 12 18 36 pm](https://cloud.githubusercontent.com/assets/7913604/17862293/a453f8f2-6862-11e6-9597-d5767580b750.png)


- After (user view):
![screen shot 2016-08-22 at 12 19 14 pm](https://cloud.githubusercontent.com/assets/7913604/17862297/a6b0acda-6862-11e6-8f95-9c740913ab1e.png)

