### PR TITLE
Fix serialization for TaxonomyField

### DIFF
--- a/api/taxonomies/serializers.py
+++ b/api/taxonomies/serializers.py
@@ -5,7 +5,8 @@ from api.base.serializers import JSONAPISerializer, LinksField, JSONAPIListField
 class TaxonomyField(ser.Field):
     def to_representation(self, obj):
         if obj is not None:
-            return obj._id
+            return {'id': obj._id,
+                    'text': obj.text}
         return None
 
     def to_internal_value(self, data):

--- a/api_tests/taxonomies/views/test_taxonomy_list.py
+++ b/api_tests/taxonomies/views/test_taxonomy_list.py
@@ -42,8 +42,11 @@ class TestTaxonomy(ApiTestCase):
     def test_taxonomy_parents(self):
         for index, subject in enumerate(self.subjects):
             if index >= len(self.data): break
+            parents_ids = []
+            for parent in self.data[index]['attributes']['parents']:
+                parents_ids.append(parent['id'])
             for parent in subject.parents:
-                assert parent._id in self.data[index]['attributes']['parents']
+                assert parent._id in parents_ids
 
     def test_taxonomy_filter_top_level(self):
         top_level_subjects = Subject.find(
@@ -71,5 +74,9 @@ class TestTaxonomy(ApiTestCase):
 
         data = res.json['data']
         assert_equal(len(children_subjects), len(data))
+
         for subject in data:
-            assert_in(self.subject1._id, subject['attributes']['parents'])
+            parents_ids = []
+            for parent in subject['attributes']['parents']:
+                parents_ids.append(parent['id'])
+            assert_in(self.subject1._id, parents_ids)


### PR DESCRIPTION
## Purpose
Fix serialization for `TaxonomyField`

## Changes
`[<subj.id>, ...]` -> `[{'id': <subj.id>, 'text': <subj.text>}, ...]` 

## Side effects
None expected

## Notes
Preprint attributes:
```
"attributes": {
    "doi": "10.123/0",
    "date_modified": "2016-08-21T13:35:07.960000",
    "abstract": "Ambiparous cosmic habitat instance  monolith zone demonstrating salinity. Formations sedentary aspects of doldrums aquifer meridian formations. Range whitewater vista transfer rain forest aquifer ornithology precipitation.",
    "title": "Dominant shard equation meiosis proton components incandescent metamorphosis.",
    "subjects": [
        {
            "text": "Example Subject #0",
            "id": "57b9ae09c2babb68c151ff7e"
        }
    ],
    "provider": "osf",
    "date_created": "2016-08-21T13:35:05.779000",
    "tags": [
        "invisible",
        "bacteria",
        "realm",
        "crepuscular",
        "whitewater"
    ]
},
```
from `/v2/taxonomies/`
```
{
    "links": {
        "self": "http://localhost:8000/v2/taxonomies/57b93194c2babb98a0fc7798/"
    },
    "attributes": {
        "text": "Biology and life sciences",
        "parents": []
    },
    "type": "taxonomies",
    "id": "57b93194c2babb98a0fc7798"
},
{
    "links": {
        "self": "http://localhost:8000/v2/taxonomies/57b93194c2babb98a0fc7799/",
        "parents": [
            "http://localhost:8000/v2/taxonomies/57b93194c2babb98a0fc7798/"
        ]
    },
    "attributes": {
        "text": "Agriculture",
        "parents": [
            {
                "text": "Biology and life sciences",
                "id": "57b93194c2babb98a0fc7798"
            }
        ]
    },
    "type": "taxonomies",
    "id": "57b93194c2babb98a0fc7799"
}, [...]
```
Relevant tests:
```
~/D/osf.io ❯ DJANGO_SETTINGS_MODULE=api.base.settings nosetests api_tests/taxonomies api_tests/preprints                   feature/fix-taxonomy-serialization ✭
.............................
----------------------------------------------------------------------
Ran 29 tests in 15.827s

OK
```