### PR TITLE
[feature] Validate Relationships Resource Key [OSF-5268]

### DIFF
--- a/api/base/parsers.py
+++ b/api/base/parsers.py
@@ -42,6 +42,10 @@ class JSONAPIParser(JSONParser):
         if not target_type:
             raise JSONAPIException(source={'pointer': 'data/relationships/{}/data/type'.format(related_resource)}, detail=NO_TYPE_ERROR)
 
+        if target_type != related_resource:
+            raise JSONAPIException(source={'pointer': 'data/relationships/{}'.format(related_resource)},
+                                   detail='Request relationships key "{}" does not match target_type "{}"'.format(related_resource, target_type))
+
         id = data.get('id')
         return {'id': id, 'target_type': target_type}
 

--- a/api_tests/nodes/views/test_node_comments_list.py
+++ b/api_tests/nodes/views/test_node_comments_list.py
@@ -328,7 +328,7 @@ class TestNodeCommentCreate(NodeCommentsCreateMixin, ApiTestCase):
                     'content': 'This is a comment'
                 },
                 'relationships': {
-                    'target': {
+                    'nodes': {
                         'data': {
                             'type': 'nodes',
                             'id': target_id
@@ -465,7 +465,7 @@ class TestNodeCommentCreate(NodeCommentsCreateMixin, ApiTestCase):
                     'content': 'This is a comment'
                 },
                 'relationships': {
-                    'target': {
+                    'nodes': {
                         'data': {
                             'type': 'nodes',
                             'id': ''
@@ -495,7 +495,7 @@ class TestNodeCommentCreate(NodeCommentsCreateMixin, ApiTestCase):
                     'content': 'This is a comment'
                 },
                 'relationships': {
-                    'target': {
+                    'Invalid': {
                         'data': {
                             'type': 'Invalid',
                             'id': self.private_project._id
@@ -517,7 +517,7 @@ class TestNodeCommentCreate(NodeCommentsCreateMixin, ApiTestCase):
                     'content': 'This is a comment'
                 },
                 'relationships': {
-                    'target': {
+                    'nodes': {
                         'data': {
                             'id': self.private_project._id
                         }
@@ -538,7 +538,7 @@ class TestNodeCommentCreate(NodeCommentsCreateMixin, ApiTestCase):
                     'content': 'This is a comment'
                 },
                 'relationships': {
-                    'target': {
+                    'nodes': {
                         'data': {
                             'type': 'nodes',
                             'id': self.private_project._id
@@ -561,7 +561,7 @@ class TestNodeCommentCreate(NodeCommentsCreateMixin, ApiTestCase):
                     'content': 'This is a comment'
                 },
                 'relationships': {
-                    'target': {
+                    'nodes': {
                         'data': {
                             'type': 'nodes',
                             'id': self.private_project._id
@@ -583,7 +583,7 @@ class TestNodeCommentCreate(NodeCommentsCreateMixin, ApiTestCase):
                     'content': ''
                 },
                 'relationships': {
-                    'target': {
+                    'nodes': {
                         'data': {
                             'type': 'nodes',
                             'id': self.private_project._id
@@ -606,7 +606,7 @@ class TestNodeCommentCreate(NodeCommentsCreateMixin, ApiTestCase):
                     'content': '   '
                 },
                 'relationships': {
-                    'target': {
+                    'nodes': {
                         'data': {
                             'type': 'nodes',
                             'id': self.private_project._id
@@ -628,7 +628,7 @@ class TestNodeCommentCreate(NodeCommentsCreateMixin, ApiTestCase):
                     'content': '<em>Cool</em> <strong>Comment</strong>'
                 },
                 'relationships': {
-                    'target': {
+                    'nodes': {
                         'data': {
                             'type': 'nodes',
                             'id': self.private_project._id
@@ -650,7 +650,7 @@ class TestNodeCommentCreate(NodeCommentsCreateMixin, ApiTestCase):
                     'content': ('c' * (osf_settings.COMMENT_MAXLENGTH + 3))
                 },
                 'relationships': {
-                    'target': {
+                    'nodes': {
                         'data': {
                             'type': 'nodes',
                             'id': self.private_project._id
@@ -682,7 +682,7 @@ class TestFileCommentCreate(NodeCommentsCreateMixin, ApiTestCase):
                     'content': 'This is a comment'
                 },
                 'relationships': {
-                    'target': {
+                    'files': {
                         'data': {
                             'type': 'files',
                             'id': target_id
@@ -742,7 +742,7 @@ class TestFileCommentCreate(NodeCommentsCreateMixin, ApiTestCase):
                     'content': 'This is a comment'
                 },
                 'relationships': {
-                    'target': {
+                    'Invalid': {
                         'data': {
                             'type': 'Invalid',
                             'id': self.test_file.get_guid()._id
@@ -766,7 +766,7 @@ class TestWikiCommentCreate(NodeCommentsCreateMixin, ApiTestCase):
                     'content': 'This is a comment'
                 },
                 'relationships': {
-                    'target': {
+                    'wiki': {
                         'data': {
                             'type': 'wiki',
                             'id': target_id
@@ -826,7 +826,7 @@ class TestWikiCommentCreate(NodeCommentsCreateMixin, ApiTestCase):
                     'content': 'This is a comment'
                 },
                 'relationships': {
-                    'target': {
+                    'Invalid': {
                         'data': {
                             'type': 'Invalid',
                             'id': self.wiki._id
@@ -850,7 +850,7 @@ class TestCommentRepliesCreate(NodeCommentsCreateMixin, ApiTestCase):
                     'content': 'This is a comment'
                 },
                 'relationships': {
-                    'target': {
+                    'comments': {
                         'data': {
                             'type': 'comments',
                             'id': comment_id

--- a/api_tests/nodes/views/test_node_contributors_list.py
+++ b/api_tests/nodes/views/test_node_contributors_list.py
@@ -402,6 +402,27 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
         assert_equal(res.status_code, 400)
         assert_equal(res.json['errors'][0]['detail'], 'Malformed request.')
 
+    def test_add_contributor_incorrect_key_in_relationships(self):
+        data = {
+            'data': {
+                'type': 'contributors',
+                'attributes': {
+                    'bibliographic': True
+                },
+                'relationships': {
+                    'incorrect': {
+                        'data': {
+                            'id': self.user_two._id,
+                            'type': 'users'
+                        }
+                    }
+                }
+            }
+        }
+        res = self.app.post_json_api(self.public_url, data, auth=self.user.auth, expect_errors=True)
+        assert_equal(res.status_code, 400)
+        assert_equal(res.json['errors'][0]['detail'], 'Request relationships key "incorrect" does not match target_type "users"')
+
     def test_add_contributor_no_data_in_relationships(self):
         data = {
             'data': {

--- a/api_tests/nodes/views/test_node_links_list.py
+++ b/api_tests/nodes/views/test_node_links_list.py
@@ -299,9 +299,9 @@ class TestNodeLinkCreate(ApiTestCase):
             'data': {
                 'type': 'nodes',
                 'relationships': {
-                    'nodes': {
+                    'node': {
                         'data': {
-                            'type': 'Incorrect!',
+                            'type': 'node',
                             'id': self.public_pointer_project._id
                         }
                     }


### PR DESCRIPTION
#### Purpose
- Currently, there is no validation for the relationships resource key that is required in the request body when creating a relationship. This PR adds validation by requiring that the resource key matches the target type, which is followed by validation that the target type is correct.

#### Changes
- Added validation in `JSONAPIParser.flatten_relationships()` 

#### Side effects
- None expected.

#### QA Note
To verify this, just add a contributor via the v2 API (we should have tests already for that) and try adding a contributor with a user type of something incorrect to see it fail.

#### Ticket
- [OSF-5268](https://openscience.atlassian.net/browse/OSF-5268)
