### PR TITLE
Add ability to filter to NodeList with `?filter[preprint]=true|false`

### DIFF
--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -219,7 +219,8 @@ class FilterMixin(object):
                             }
                         })
                     elif source_field_name == 'is_preprint':
-                        op = 'eq' if value == 'false' else 'ne'
+                        # TODO: Make this also include _is_preprint_orphan when value is false [#PREP-129]
+                        op = 'ne' if utils.is_truthy(value) else 'eq'
                         query.get(key).update({
                             field_name: {
                                 'op': op,
@@ -227,13 +228,14 @@ class FilterMixin(object):
                                 'source_field_name': 'preprint_file'
                             }
                         })
-                        query['_is_preprint_orphan'] = {
-                            field_name: {
-                                'op': 'ne',
-                                'value': True,
-                                'source_field_name': '_is_preprint_orphan'
+                        if utils.is_truthy(value):
+                            query['_is_preprint_orphan'] = {
+                                field_name: {
+                                    'op': 'ne',
+                                    'value': True,
+                                    'source_field_name': '_is_preprint_orphan'
+                                }
                             }
-                        }
                     else:
                         query.get(key).update({
                             field_name: {

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -218,7 +218,22 @@ class FilterMixin(object):
                                 'source_field_name': source_field_name
                             }
                         })
-
+                    elif source_field_name == 'is_preprint':
+                        op = 'eq' if value == 'false' else 'ne'
+                        query.get(key).update({
+                            field_name: {
+                                'op': op,
+                                'value': None,
+                                'source_field_name': 'preprint_file'
+                            }
+                        })
+                        query['_is_preprint_orphan'] = {
+                            field_name: {
+                                'op': 'ne',
+                                'value': True,
+                                'source_field_name': '_is_preprint_orphan'
+                            }
+                        }
                     else:
                         query.get(key).update({
                             field_name: {

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -62,7 +62,8 @@ class NodeSerializer(JSONAPISerializer):
         'date_modified',
         'root',
         'parent',
-        'contributors'
+        'contributors',
+        'preprint'
     ])
 
     non_anonymized_fields = [
@@ -100,6 +101,7 @@ class NodeSerializer(JSONAPISerializer):
     date_created = ser.DateTimeField(read_only=True)
     date_modified = ser.DateTimeField(read_only=True)
     registration = ser.BooleanField(read_only=True, source='is_registration')
+    preprint = ser.BooleanField(read_only=True, source='is_preprint')
     fork = ser.BooleanField(read_only=True, source='is_fork')
     collection = ser.BooleanField(read_only=True, source='is_collection')
     tags = JSONAPIListField(child=NodeTagField(), required=False)

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -195,6 +195,7 @@ class NodeList(JSONAPIBaseView, bulk_views.BulkUpdateJSONAPIView, bulk_views.Bul
         registration                    boolean            is this a registration? (always false - may be deprecated in future versions)
         fork                            boolean            is this node a fork of another node?
         public                          boolean            has this node been made publicly-visible?
+        preprint                        boolean            is this a preprint?
         collection                      boolean            is this a collection? (always false - may be deprecated in future versions)
         node_license                    object             details of the license applied to the node
             year                        string             date range of the license
@@ -243,8 +244,8 @@ class NodeList(JSONAPIBaseView, bulk_views.BulkUpdateJSONAPIView, bulk_views.Bul
     users and contributors and missing serializer fields and relationships.
 
     Nodes may be filtered by their `id`, `title`, `category`, `description`, `public`, `tags`, `date_created`, `date_modified`,
-    `root`, `parent`, and `contributors`.  Most are string fields and will be filtered using simple substring matching.  `public`
-    is a boolean, and can be filtered using truthy values, such as `true`, `false`, `0`, or `1`.  Note that quoting `true`
+    `root`, `parent`, 'preprint', and `contributors`.  Most are string fields and will be filtered using simple substring matching.  `public`
+    and `preprint` are boolean values, and can be filtered using truthy values, such as `true`, `false`, `0`, or `1`.  Note that quoting `true`
     or `false` in the query will cause the match to fail regardless.  `tags` is an array of simple strings.
 
     #This Request/Response

--- a/api_tests/base/test_serializers.py
+++ b/api_tests/base/test_serializers.py
@@ -74,7 +74,7 @@ class TestNodeSerializerAndRegistrationSerializerDifferences(ApiTestCase):
     def test_registration_serializer(self):
 
         # fields that are visible for withdrawals
-        visible_on_withdrawals = ['contributors', 'date_created', 'description', 'id', 'links', 'registration', 'title', 'type', 'current_user_can_comment']
+        visible_on_withdrawals = ['contributors', 'date_created', 'description', 'id', 'links', 'registration', 'title', 'type', 'current_user_can_comment', 'preprint']
         # fields that do not appear on registrations
         non_registration_fields = ['registrations', 'draft_registrations']
 

--- a/api_tests/nodes/views/test_node_list.py
+++ b/api_tests/nodes/views/test_node_list.py
@@ -459,7 +459,7 @@ class TestNodeFiltering(ApiTestCase):
         res = self.app.get(url, auth=self.user_one.auth)
         assert_equal(res.status_code, 200)
         data = res.json['data']
-        assert_equal(len(data), 3)
+        assert_equal(len(data), 4)
 
         titles = [each['attributes']['title'] for each in data]
 
@@ -473,7 +473,7 @@ class TestNodeFiltering(ApiTestCase):
         res = self.app.get(url, auth=self.user_one.auth)
         assert_equal(res.status_code, 200)
         data = res.json['data']
-        assert_equal(len(data), 3)
+        assert_equal(len(data), 4)
 
         descriptions = [each['attributes']['description'] for each in data]
 

--- a/api_tests/nodes/views/test_node_list.py
+++ b/api_tests/nodes/views/test_node_list.py
@@ -18,6 +18,7 @@ from tests.factories import (
     RegistrationFactory,
     AuthUserFactory,
     UserFactory,
+    PreprintFactory,
 )
 
 
@@ -141,6 +142,8 @@ class TestNodeFiltering(ApiTestCase):
         self.project_one.save()
 
         self.project_two.add_tag(self.tag1, Auth(self.project_two.creator), save=True)
+
+        self.preprint = PreprintFactory(creator=self.user_one)
 
     def tearDown(self):
         super(TestNodeFiltering, self).tearDown()
@@ -478,6 +481,33 @@ class TestNodeFiltering(ApiTestCase):
         assert_in(self.project_one.description, descriptions)
         assert_in(self.project_three.description, descriptions)
         assert_in(self.private_project_user_one.description, descriptions)
+
+    def test_filtering_on_preprint(self):
+        url = '/{}nodes/?filter[preprint]=true'.format(API_BASE)
+        res = self.app.get(url, auth=self.user_one.auth)
+        assert_equal(res.status_code, 200)
+        data = res.json['data']
+        ids = [each['id'] for each in data]
+
+        preprints = Node.find(Q('preprint_file', 'ne', None) & Q('preprint_orphan', 'ne', True))
+        assert_equal(len(data), len(preprints))
+        assert_in(self.preprint._id, ids)
+        assert_not_in(self.project_one._id, ids)
+        assert_not_in(self.project_two._id, ids)
+        assert_not_in(self.project_three._id, ids)
+
+    def test_filtering_out_preprint(self):
+        url = '/{}nodes/?filter[preprint]=false'.format(API_BASE)
+        res = self.app.get(url, auth=self.user_one.auth)
+        assert_equal(res.status_code, 200)
+        data = res.json['data']
+
+        ids = [each['id'] for each in data]
+
+        assert_not_in(self.preprint._id, ids)
+        assert_in(self.project_one._id, ids)
+        assert_in(self.project_two._id, ids)
+        assert_in(self.project_three._id, ids)
 
 
 class TestNodeCreate(ApiTestCase):

--- a/api_tests/nodes/views/test_node_list.py
+++ b/api_tests/nodes/views/test_node_list.py
@@ -509,6 +509,24 @@ class TestNodeFiltering(ApiTestCase):
         assert_in(self.project_two._id, ids)
         assert_in(self.project_three._id, ids)
 
+    def test_preprint_filter_excludes_orphans(self):
+        orphan = PreprintFactory(creator=self.preprint.creator)
+        orphan._is_preprint_orphan = True
+        orphan.save()
+
+        url = '/{}nodes/?filter[preprint]=true'.format(API_BASE)
+        res = self.app.get(url, auth=self.user_one.auth)
+        assert_equal(res.status_code, 200)
+        data = res.json['data']
+
+        ids = [each['id'] for each in data]
+
+        assert_in(self.preprint._id, ids)
+        assert_not_in(orphan._id, ids)
+        assert_not_in(self.project_one._id, ids)
+        assert_not_in(self.project_two._id, ids)
+        assert_not_in(self.project_three._id, ids)
+
 
 class TestNodeCreate(ApiTestCase):
 


### PR DESCRIPTION
## Purpose
Since preprints are normal nodes, `v2/nodes` shows all preprints as well, without the ability to filter. This poses a problem when selecting a node you'd like to convert to a preprint, as trying to convert an already existing preprint.

Now you can filter on `preprint` with `?filter[preprint]=true` or `?filter[preprint]=false`

## Changes
- Add special case check in `filters.py` and convert to appropriate ODM query
- Preprint field on node serializer, added to filterable fields
- Node view documentation updates

## Side effects
None except the new ability to filter out preprints when needed from `v2/nodes/` with a filter. Any place we'd like to distinguish preprints from nodes is possible. 


## Ticket
None
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
