### PR TITLE
[feature] Read-Only Contributors Affiliation Help Text [OSF-6651]

### DIFF
--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -307,6 +307,9 @@
                     </div>
                     <div class="panel-body">
                         <div class="help-block">
+                            % if 'write' not in user['permissions']:
+                                <p class="text-muted">Contributors with read-only permissions to this project cannot add or remove institutional affiliations.</p>
+                            % endif:
                             <!-- ko if: affiliatedInstitutions().length == 0 -->
                             Projects can be affiliated with institutions that have created OSF for Institutions accounts.
                             This allows:


### PR DESCRIPTION
#### Purpose
- Add text to explain to read-only contributors that they do not have the necessary permissions to affiliate their institution with a project.

#### Side effects
- None

#### Ticket
- [OSF-6651](https://openscience.atlassian.net/browse/OSF-6651)

#### Screenshots
- Admin/R+W Contributor View:
![screen shot 2016-08-22 at 4 37 55 pm](https://cloud.githubusercontent.com/assets/7913604/17870970/9ab79fd6-6887-11e6-9004-e8b741179257.png)


- Read-Only Contributor View:
![screen shot 2016-08-22 at 4 39 27 pm](https://cloud.githubusercontent.com/assets/7913604/17870977/9febca9a-6887-11e6-9c96-72971c3e4222.png)

