### PR TITLE
Add preprints links on the OSF

### DIFF
--- a/website/static/js/home-page/preprintsPlugin.js
+++ b/website/static/js/home-page/preprintsPlugin.js
@@ -1,0 +1,37 @@
+/**
+ * Preprints
+ */
+
+var m = require('mithril');
+var $osf = require('js/osfHelpers');
+
+// CSS
+require('css/meetings-and-conferences.css');
+
+
+var Preprints = {
+    view: function(ctrl) {
+        return m('.p-v-sm',
+            m('.row',
+                [
+                    m('.col-md-8',
+                        [
+                            m('div.conference-centering',  m('h3', 'Browse the latest research')),
+                            m('div.conference-centering.m-t-lg',
+                                m('p.text-bigger', 'Check out the latest Preprints hosted on the OSF covering a variety of research areas.')
+                            )
+                        ]
+                    ),
+                    m('.col-md-4.text-center',
+                        m('div',  m('a.btn.btn-success.btn-lg.btn-success-high-contrast.m-v-xl.f-w-xl', { style : 'box-shadow: 0 0 9px -4px #000;', type:'button',  href:'/preprints/', onclick: function() {
+                            $osf.trackClick('Preprints', 'navigate', 'navigate-to-preprints');
+                        }}, 'View preprints'))
+                    )
+                ]
+            )
+        );
+    }
+};
+
+
+module.exports = Preprints;

--- a/website/static/js/pages/home-page.js
+++ b/website/static/js/pages/home-page.js
@@ -11,6 +11,7 @@ var lodashGet = require('lodash.get');
 var QuickSearchProject = require('js/home-page/quickProjectSearchPlugin');
 var NewAndNoteworthy = require('js/home-page/newAndNoteworthyPlugin');
 var MeetingsAndConferences = require('js/home-page/meetingsAndConferencesPlugin');
+var Preprints = require('js/home-page/preprintsPlugin');
 var InstitutionsPanel = require('js/home-page/institutionsPanelPlugin');
 var ensureUserTimezone = require('js/ensureUserTimezone');
 
@@ -62,6 +63,14 @@ $(document).ready(function(){
                     [
                         m('.row', [
                             m(columnSizeClass,  m.component(MeetingsAndConferences, {}))
+                        ])
+
+                    ]
+                )),
+                m('.preprints', m('.container',
+                    [
+                        m('.row', [
+                            m(columnSizeClass,  m.component(Preprints, {}))
                         ])
 
                     ]

--- a/website/templates/nav.mako
+++ b/website/templates/nav.mako
@@ -33,6 +33,7 @@
               <li><a href="${domain}explore/activity/">New Projects</a></li>
               <li><a href="${domain}search/?q=*&amp;filter=registration">Registry</a></li>
               <li><a href="${web_url_for('conference_view', _absolute=True)}">Meetings</a></li>
+              <li><a href="${domain}preprints/">Preprints</a></li>
           </ul>
         </li>
         % if not user_name:


### PR DESCRIPTION

## Purpose

Add a link to Preprints in the Browse navbar, and as a bar on the homepage

## Changes
![screen shot 2016-08-23 at 12 44 37 am](https://cloud.githubusercontent.com/assets/801594/17880589/cf82e278-68ca-11e6-8399-adf68a8ceb77.png)
- Add link to preprints in Browse menu in navbar


![screen shot 2016-08-23 at 10 19 13 am](https://cloud.githubusercontent.com/assets/801594/17903761/a0c51f12-693a-11e6-86bd-9f0527a939c5.png)
- Add bar at the bottom of the page with links to preprints, below meetings


## Side effects
None anticipated


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->

