### PR TITLE
[#OSF-6893]Show "in common" users on contributor search if query parameter is passed

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -457,7 +457,7 @@ class RelationshipField(ser.HyperlinkedIdentityField):
             elif key == 'projects_in_common':
                 if not get_user_auth(self.context['request']).user:
                     continue
-                if not self.context['request'].query_params:
+                if not self.context['request'].query_params.get('show_projects_in_common', False):
                     continue
                 meta[key] = website_utils.rapply(meta_data[key], _url_val, obj=value, serializer=self.parent)
             else:

--- a/api_tests/users/views/test_user_list.py
+++ b/api_tests/users/views/test_user_list.py
@@ -83,13 +83,23 @@ class TestUsers(ApiTestCase):
     def test_users_projects_in_common(self):
         self.user_one.fullname = 'hello'
         self.user_one.save()
-        url = "/{}users/?filter[full_name]={}".format(API_BASE, 'hello')
+        url = "/{}users/?show_projects_in_common=true".format(API_BASE)
         res = self.app.get(url, auth=self.user_two.auth)
         user_json = res.json['data']
         for user in user_json:
             meta = user['relationships']['nodes']['links']['related']['meta']
             assert_in('projects_in_common', meta)
             assert_equal(meta['projects_in_common'], 0)
+
+    def test_users_no_projects_in_common_with_wrong_query(self):
+        self.user_one.fullname = 'hello'
+        self.user_one.save()
+        url = "/{}users/?filter[full_name]={}".format(API_BASE, self.user_one.fullname)
+        res = self.app.get(url, auth=self.user_two.auth)
+        user_json = res.json['data']
+        for user in user_json:
+            meta = user['relationships']['nodes']['links']['related']['meta']
+            assert_not_in('projects_in_common', meta)
 
     def test_users_no_projects_in_common_without_filter(self):
         self.user_one.fullname = 'hello'

--- a/api_tests/users/views/test_user_list.py
+++ b/api_tests/users/views/test_user_list.py
@@ -118,7 +118,11 @@ class TestUsers(ApiTestCase):
 
     def test_users_projects_in_common_with_embed_and_right_query(self):
         project = ProjectFactory(creator=self.user_one)
-        project.add_contributor(contributor=self.user_two, permissions=CREATOR_PERMISSIONS, auth=Auth(user=self.user_one))
+        project.add_contributor(
+            contributor=self.user_two,
+            permissions=CREATOR_PERMISSIONS,
+            auth=Auth(user=self.user_one)
+        )
         project.save()
         url = "/{}users/{}/nodes/?embed=contributors&show_projects_in_common=true".format(API_BASE, self.user_two._id)
         res = self.app.get(url, auth=self.user_two.auth)
@@ -130,7 +134,11 @@ class TestUsers(ApiTestCase):
 
     def test_users_projects_in_common_with_embed_without_right_query(self):
         project = ProjectFactory(creator=self.user_one)
-        project.add_contributor(contributor=self.user_two, permissions=CREATOR_PERMISSIONS, auth=Auth(user=self.user_one))
+        project.add_contributor(
+            contributor=self.user_two,
+            permissions=CREATOR_PERMISSIONS,
+            auth=Auth(user=self.user_one)
+        )
         project.save()
         url = "/{}users/{}/nodes/?embed=contributors".format(API_BASE, self.user_two._id)
         res = self.app.get(url, auth=self.user_two.auth)


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Limit the "projects_in_common" meta only show when "show_projects_in_common=true" in query.

<!-- Describe the purpose of your changes -->

## Changes
before change:
![screen shot 2016-08-23 at 10 11 43 am](https://cloud.githubusercontent.com/assets/4974056/17895124/0aa24188-691a-11e6-8c1e-16baad0fdf5e.png)
After change:
![screen shot 2016-08-23 at 10 12 22 am](https://cloud.githubusercontent.com/assets/4974056/17895162/2ec54eac-691a-11e6-9146-03bccd99de2b.png)
![screen shot 2016-08-23 at 10 12 51 am](https://cloud.githubusercontent.com/assets/4974056/17895177/3e0055d8-691a-11e6-8128-f4c2e856c497.png)


<!-- Briefly describe or list your changes  -->

## Side effects

<!--Any possible side effects? -->


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
https://openscience.atlassian.net/browse/OSF-6893