### PR TITLE
Preprint messages on the OSF

### DIFF
--- a/website/files/models/osfstorage.py
+++ b/website/files/models/osfstorage.py
@@ -108,6 +108,9 @@ class OsfStorageFileNode(FileNode):
         return self.checkout is not None
 
     def delete(self, user=None, parent=None):
+        if self.node.preprint_file == self:
+            self.node._is_preprint_orphan = True
+            self.node.save()
         if self.is_checked_out:
             raise exceptions.FileNodeCheckedOutError()
         return super(OsfStorageFileNode, self).delete(user=user, parent=parent)

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -735,8 +735,8 @@ def _view_project(node, auth, primary=False):
             'alternative_citations': [citation.to_json() for citation in node.alternative_citations],
             'has_draft_registrations': node.has_active_draft_registrations,
             'contributors': [contributor._id for contributor in node.contributors],
-            'is_preprint' : node.is_preprint,
-            'is_preprint_orphan' : node.is_preprint_orphan
+            'is_preprint': node.is_preprint,
+            'is_preprint_orphan': node.is_preprint_orphan
         },
         'parent_node': {
             'exists': parent is not None,

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -736,7 +736,8 @@ def _view_project(node, auth, primary=False):
             'has_draft_registrations': node.has_active_draft_registrations,
             'contributors': [contributor._id for contributor in node.contributors],
             'is_preprint': node.is_preprint,
-            'is_preprint_orphan': node.is_preprint_orphan
+            'is_preprint_orphan': node.is_preprint_orphan,
+            'preprint_file_id': node.preprint_file._id if node.preprint_file else None
         },
         'parent_node': {
             'exists': parent is not None,

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -735,6 +735,8 @@ def _view_project(node, auth, primary=False):
             'alternative_citations': [citation.to_json() for citation in node.alternative_citations],
             'has_draft_registrations': node.has_active_draft_registrations,
             'contributors': [contributor._id for contributor in node.contributors],
+            'is_preprint' : node.is_preprint,
+            'is_preprint_orphan' : node.is_preprint_orphan
         },
         'parent_node': {
             'exists': parent is not None,

--- a/website/static/css/pages/file-view-page.css
+++ b/website/static/css/pages/file-view-page.css
@@ -84,3 +84,8 @@
 	white-space: nowrap;
 	display: inline-block;
 }
+
+.preprint-notice {
+    background: #f5f5f5;
+    line-height: 30px;
+}

--- a/website/static/css/pages/project-page.css
+++ b/website/static/css/pages/project-page.css
@@ -152,3 +152,8 @@ span#nodeDescriptionEditable{
     white-space: -pre-wrap;      /* Opera 4-6 */
     white-space: -o-pre-wrap;    /* Opera 7 */
 }
+
+.preprint-notice {
+    background: #f5f5f5;
+    line-height: 30px;
+}

--- a/website/static/css/pages/project-page.css
+++ b/website/static/css/pages/project-page.css
@@ -153,7 +153,11 @@ span#nodeDescriptionEditable{
     white-space: -o-pre-wrap;    /* Opera 7 */
 }
 
-.preprint-notice {
+.pp-notice {
     background: #f5f5f5;
     line-height: 30px;
+}
+
+.pp-notice.pp-warning {
+    background: #FFF2DD;
 }

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1031,9 +1031,17 @@ function _removeEvent (event, items, col) {
 
     // If there is only one item being deleted, don't complicate the issue:
     if(items.length === 1) {
+        var detail = 'This action is irreversible.';
+        if (window.contextVars.node.preprintFileId === items[0].data.path.replace('/', '')) {
+            // title = 'Delete the primary preprint file "' + items[0].data.name + '"?';
+            detail = [
+                m('p', 'This is the primary file for a preprint.'),
+                m('p', m('strong', 'Deleting this file will remove your preprint from circulation.'))
+            ];
+        }
         if(items[0].kind !== 'folder'){
             var mithrilContentSingle = m('div', [
-                m('p', 'This action is irreversible.')
+                m('p', detail)
             ]);
             var mithrilButtonsSingle = m('div', [
                 m('span.btn.btn-default', { onclick : function() { cancelDelete(); } }, 'Cancel'),
@@ -1068,6 +1076,12 @@ function _removeEvent (event, items, col) {
             }
             if(item.kind === 'folder' && deleteMessage.length === 1) {
                 deleteMessage.push(m('p.text-danger', 'Some of the selected items are folders. This will delete the folder(s) and ALL of their content.'));
+            }
+            if (window.contextVars.node.preprintFileId === item.data.path.replace('/', '')) {
+                deleteMessage.push([
+                    m('p', 'One of the files you have selected is the primary file for a preprint.'),
+                    m('p', m('strong', 'Deleting this file will remove your preprint from circulation.'))
+                ]);
             }
         });
         // If all items can be deleted

--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -176,11 +176,11 @@ var FileViewPage = {
                     self.file.safeName + '</strong>?' + '</p>';
 
             if (self.file.id === self.node.preprintFileId) {
-                title = 'Delete <strong>preprint manuscript</strong>?';
+                title = 'Delete preprint manuscript?';
                 message = '<p class="overflow">' +
                     'Are you sure you want to delete <strong>' +
                     self.file.safeName + '</strong>?' + ' It is currently the primary file ' +
-                    'for a preprint. <strong>Deleting this file will remove your preprint from circulation.</strong></p>';
+                    'for a preprint.</p> <p><strong>Deleting this file will remove your preprint from circulation.</strong></p>';
             }
             bootbox.confirm({
                 title: title,

--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -493,7 +493,7 @@ var FileViewPage = {
         var height = $('iframe').attr('height') ? $('iframe').attr('height') : '0px';
 
         m.render(document.getElementById('toggleBar'), m('.btn-toolbar.m-t-md', [
-            (!ctrl.context.node.isPreprint && ctrl.file.provider == 'osfstorage') ? m('.btn-group.m-l-xs.m-t-xs', [
+            (!ctrl.context.node.isPreprint && ctrl.file.provider === 'osfstorage') ? m('.btn-group.m-l-xs.m-t-xs', [
                 m('a.btn.btn-sm.btn-default', {href: '/preprints/submit/?file_guid=' + window.contextVars.file.guid }, 'Create preprint')
             ]) : '',
             // Special case whether or not to show the delete button for published Dataverse files

--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -170,12 +170,21 @@ var FileViewPage = {
         }
 
         $(document).on('fileviewpage:delete', function() {
+            var title = 'Delete file?';
+            var message = '<p class="overflow">' +
+                    'Are you sure you want to delete <strong>' +
+                    self.file.safeName + '</strong>?' + '</p>';
+
+            if (self.file.id === self.node.preprintFileId) {
+                title = 'Delete <strong>preprint manuscript</strong>?';
+                message = '<p class="overflow">' +
+                    'Are you sure you want to delete <strong>' +
+                    self.file.safeName + '</strong>?' + ' It is currently the primary file ' +
+                    'for a preprint. <strong>Deleting this file will remove your preprint from circulation.</strong></p>';
+            }
             bootbox.confirm({
-                title: 'Delete file?',
-                message: '<p class="overflow">' +
-                        'Are you sure you want to delete <strong>' +
-                        self.file.safeName + '</strong>?' +
-                    '</p>',
+                title: title,
+                message: message,
                 callback: function(confirm) {
                     if (!confirm) {
                         return;
@@ -498,7 +507,7 @@ var FileViewPage = {
             ]) : '',
             // Special case whether or not to show the delete button for published Dataverse files
             (ctrl.canEdit() && (ctrl.file.provider !== 'osfstorage' || !ctrl.file.checkoutUser) && ctrl.requestDone && $(document).context.URL.indexOf('version=latest-published') < 0 ) ? m('.btn-group.m-l-xs.m-t-xs', [
-                ctrl.isLatestVersion ? m('button.btn.btn-sm.btn-danger.file-delete', {onclick: $(document).trigger.bind($(document), 'fileviewpage:delete')}, 'Delete') : null
+                ctrl.isLatestVersion ? m('button.btn.btn-sm.btn-danger.file-delete', {onclick: $(document).trigger.bind($(document), 'fileviewpage:delete'), onload: console.log(ctrl.file)}, 'Delete') : null
             ]) : '',
             ctrl.context.currentUser.canEdit && (!ctrl.canEdit()) && ctrl.requestDone && (ctrl.context.currentUser.isAdmin) ? m('.btn-group.m-l-xs.m-t-xs', [
                 ctrl.isLatestVersion ? m('.btn.btn-sm.btn-danger', {onclick: $(document).trigger.bind($(document), 'fileviewpage:force_checkin')}, 'Force check in') : null

--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -493,6 +493,7 @@ var FileViewPage = {
         var height = $('iframe').attr('height') ? $('iframe').attr('height') : '0px';
 
         m.render(document.getElementById('toggleBar'), m('.btn-toolbar.m-t-md', [
+            m('.btn-group.m-l-xs.m-t-xs', m('a.btn.btn-sm.btn-default', {href: '/preprints/add/?file_guid=' + window.contextVars.file.guid }, 'Create Preprint')),
             // Special case whether or not to show the delete button for published Dataverse files
             (ctrl.canEdit() && (ctrl.file.provider !== 'osfstorage' || !ctrl.file.checkoutUser) && ctrl.requestDone && $(document).context.URL.indexOf('version=latest-published') < 0 ) ? m('.btn-group.m-l-xs.m-t-xs', [
                 ctrl.isLatestVersion ? m('button.btn.btn-sm.btn-danger.file-delete', {onclick: $(document).trigger.bind($(document), 'fileviewpage:delete')}, 'Delete') : null

--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -176,7 +176,7 @@ var FileViewPage = {
                     self.file.safeName + '</strong>?' + '</p>';
 
             if (self.file.id === self.node.preprintFileId) {
-                title = 'Delete preprint manuscript?';
+                title = 'Delete primary preprint file?';
                 message = '<p class="overflow">' +
                     'Are you sure you want to delete <strong>' +
                     self.file.safeName + '</strong>?' + ' It is currently the primary file ' +

--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -507,7 +507,7 @@ var FileViewPage = {
             ]) : '',
             // Special case whether or not to show the delete button for published Dataverse files
             (ctrl.canEdit() && (ctrl.file.provider !== 'osfstorage' || !ctrl.file.checkoutUser) && ctrl.requestDone && $(document).context.URL.indexOf('version=latest-published') < 0 ) ? m('.btn-group.m-l-xs.m-t-xs', [
-                ctrl.isLatestVersion ? m('button.btn.btn-sm.btn-danger.file-delete', {onclick: $(document).trigger.bind($(document), 'fileviewpage:delete'), onload: console.log(ctrl.file)}, 'Delete') : null
+                ctrl.isLatestVersion ? m('button.btn.btn-sm.btn-danger.file-delete', {onclick: $(document).trigger.bind($(document), 'fileviewpage:delete') }, 'Delete') : null
             ]) : '',
             ctrl.context.currentUser.canEdit && (!ctrl.canEdit()) && ctrl.requestDone && (ctrl.context.currentUser.isAdmin) ? m('.btn-group.m-l-xs.m-t-xs', [
                 ctrl.isLatestVersion ? m('.btn.btn-sm.btn-danger', {onclick: $(document).trigger.bind($(document), 'fileviewpage:force_checkin')}, 'Force check in') : null

--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -493,7 +493,9 @@ var FileViewPage = {
         var height = $('iframe').attr('height') ? $('iframe').attr('height') : '0px';
 
         m.render(document.getElementById('toggleBar'), m('.btn-toolbar.m-t-md', [
-            m('.btn-group.m-l-xs.m-t-xs', m('a.btn.btn-sm.btn-default', {href: '/preprints/add/?file_guid=' + window.contextVars.file.guid }, 'Create Preprint')),
+            (!ctrl.context.node.isPreprint && ctrl.file.provider == 'osfstorage') ? m('.btn-group.m-l-xs.m-t-xs', [
+                m('a.btn.btn-sm.btn-default', {href: '/preprints/submit/?file_guid=' + window.contextVars.file.guid }, 'Create preprint')
+            ]) : '',
             // Special case whether or not to show the delete button for published Dataverse files
             (ctrl.canEdit() && (ctrl.file.provider !== 'osfstorage' || !ctrl.file.checkoutUser) && ctrl.requestDone && $(document).context.URL.indexOf('version=latest-published') < 0 ) ? m('.btn-group.m-l-xs.m-t-xs', [
                 ctrl.isLatestVersion ? m('button.btn.btn-sm.btn-danger.file-delete', {onclick: $(document).trigger.bind($(document), 'fileviewpage:delete')}, 'Delete') : null

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -241,9 +241,8 @@
 <div class="row">
     <div class="col-xs-12">
         <div class="pp-notice m-b-md p-md clearfix">
-            This component is a preprint. Learn more about how to work with preprint files.
-            <a href="/preprints/${node['id']}/" class="btn btn-default btn-sm m-r-xs pull-right">View preprint file</a>
-            <a href="/preprints/${node['id']}/edit/" class="btn btn-default btn-sm m-r-xs pull-right">Edit preprint details</a>
+            This component is a preprint. <a href="/preprints/help/">Learn more</a> about how to work with preprint files.
+            <a href="/preprints/content/${node['id']}/" class="btn btn-default btn-sm m-r-xs pull-right">View preprint</a>
         </div>
     </div>
 </div>

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -248,11 +248,11 @@
 </div>
 % endif
 
-% if node['is_preprint'] and node['is_preprint_orphan']:
+% if node['is_preprint_orphan']:
 <div class="row">
     <div class="col-xs-12">
         <div class="pp-notice pp-warning m-b-md p-md clearfix">
-            This component is a preprint but we couldn’t find a preprint file. You can Add a preprint file or Remove preprint designation for this component
+            This component used to be a preprint, but we couldn’t find the main manuscript for the preprint because it has been moved or deleted. <a href="/preprints/submit/" class="btn btn-default btn-sm m-r-xs pull-right">Create a new preprint</a>
         </div> 
     </div>
 </div>

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -241,7 +241,7 @@
 <div class="row">
     <div class="col-xs-12">
         <div class="pp-notice m-b-md p-md clearfix">
-            This component is a preprint. <a href="/preprints/help/">Learn more</a> about how to work with preprint files.
+            This component is a preprint. <a href="http://help.osf.io/s/support">Learn more</a> about how to work with preprint files.
             <a href="/preprints/content/${node['id']}/" class="btn btn-default btn-sm m-r-xs pull-right">View preprint</a>
         </div>
     </div>

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -237,11 +237,11 @@
     <%include file="include/comment_pane_template.mako"/>
 % endif
 
-% if node['is_preprint'] and not node['is_preprint_orphan']:
+% if node['is_preprint']:
 <div class="row">
     <div class="col-xs-12">
         <div class="pp-notice m-b-md p-md clearfix">
-            This component is a preprint. <a href="http://help.osf.io/s/support">Learn more</a> about how to work with preprint files.
+            This project represents a preprint. <a href="http://help.osf.io/m/preprints">Learn more</a> about how to work with preprint files.
             <a href="/preprints/content/${node['id']}/" class="btn btn-default btn-sm m-r-xs pull-right">View preprint</a>
         </div>
     </div>

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -237,11 +237,27 @@
     <%include file="include/comment_pane_template.mako"/>
 % endif
 
+% if node['is_preprint'] and not node['is_preprint_orphan']:
 <div class="row">
     <div class="col-xs-12">
-        <div class="preprint-notice m-b-md p-md clearfix">This component is a preprint. Learn more about how to work with preprint files. <button class="btn btn-default btn-sm m-r-xs pull-right">View preprint file</button><button class="btn btn-default btn-sm m-r-xs pull-right">Edit preprint details</button></div>
+        <div class="pp-notice m-b-md p-md clearfix">
+            This component is a preprint. Learn more about how to work with preprint files.
+            <a href="/preprints/${node['id']}/" class="btn btn-default btn-sm m-r-xs pull-right">View preprint file</a>
+            <a href="/preprints/${node['id']}/edit/" class="btn btn-default btn-sm m-r-xs pull-right">Edit preprint details</a>
+        </div>
     </div>
 </div>
+% endif
+
+% if node['is_preprint'] and node['is_preprint_orphan']:
+<div class="row">
+    <div class="col-xs-12">
+        <div class="pp-notice pp-warning m-b-md p-md clearfix">
+            This component is a preprint but we couldn’t find a preprint file. You can Add a preprint file or Remove preprint designation for this component
+        </div> 
+    </div>
+</div>
+% endif
 
 <div class="row">
 

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -252,7 +252,7 @@
 <div class="row">
     <div class="col-xs-12">
         <div class="pp-notice pp-warning m-b-md p-md clearfix">
-            This project used to represent a preprint, but the primary manuscript has been moved or deleted. <a href="/preprints/submit/" class="btn btn-default btn-sm m-r-xs pull-right">Create a new preprint</a>
+            This project used to represent a preprint, but the primary preprint file has been moved or deleted. <a href="/preprints/submit/" class="btn btn-default btn-sm m-r-xs pull-right">Create a new preprint</a>
         </div> 
     </div>
 </div>

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -238,6 +238,12 @@
 % endif
 
 <div class="row">
+    <div class="col-xs-12">
+        <div class="preprint-notice m-b-md p-md clearfix">This component is a preprint. Learn more about how to work with preprint files. <button class="btn btn-default btn-sm m-r-xs pull-right">View preprint file</button><button class="btn btn-default btn-sm m-r-xs pull-right">Edit preprint details</button></div>
+    </div>
+</div>
+
+<div class="row">
 
     <div class="col-sm-6 osf-dash-col">
 

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -248,11 +248,11 @@
 </div>
 % endif
 
-% if node['is_preprint_orphan']:
+% if node['is_preprint_orphan'] and user['is_admin']:
 <div class="row">
     <div class="col-xs-12">
         <div class="pp-notice pp-warning m-b-md p-md clearfix">
-            This component used to be a preprint, but we couldn’t find the main manuscript for the preprint because it has been moved or deleted. <a href="/preprints/submit/" class="btn btn-default btn-sm m-r-xs pull-right">Create a new preprint</a>
+            This project used to represent a preprint, but the primary manuscript has been moved or deleted. <a href="/preprints/submit/" class="btn btn-default btn-sm m-r-xs pull-right">Create a new preprint</a>
         </div> 
     </div>
 </div>

--- a/website/templates/project/project_base.mako
+++ b/website/templates/project/project_base.mako
@@ -94,6 +94,7 @@
             isPublic: ${ node.get('is_public', False) | sjson, n },
             isRegistration: ${ node.get('is_registration', False) | sjson, n },
             isRetracted: ${ node.get('is_retracted', False) | sjson, n },
+            isPreprint: ${ node.get('is_preprint', False) | sjson, n },
             anonymous: ${ node['anonymous'] | sjson, n },
             category: ${node['category_short'] | sjson, n },
             parentTitle: ${ parent_title | sjson, n },

--- a/website/templates/project/project_base.mako
+++ b/website/templates/project/project_base.mako
@@ -95,6 +95,7 @@
             isRegistration: ${ node.get('is_registration', False) | sjson, n },
             isRetracted: ${ node.get('is_retracted', False) | sjson, n },
             isPreprint: ${ node.get('is_preprint', False) | sjson, n },
+            preprintFileId: ${ node.get('preprint_file_id', None) | sjson, n },
             anonymous: ${ node['anonymous'] | sjson, n },
             category: ${node['category_short'] | sjson, n },
             parentTitle: ${ parent_title | sjson, n },

--- a/website/templates/project/view_file.mako
+++ b/website/templates/project/view_file.mako
@@ -32,7 +32,7 @@
 <div class="row">
     <div class="col-xs-12">
         <div class="preprint-notice m-b-md p-md clearfix">
-            This is the primary file for a preprint. <a href="http://help.osf.io/s/support">Learn more</a> about how to work with preprint files.
+            This is the primary file for a preprint. <a href="http://help.osf.io/m/preprints">Learn more</a> about how to work with preprint files.
             <a href="/preprints/content/${node['id']}/" class="btn btn-default btn-sm m-r-xs pull-right">View preprint</a>
         </div>
     </div>

--- a/website/templates/project/view_file.mako
+++ b/website/templates/project/view_file.mako
@@ -27,6 +27,18 @@
   </div>
 </div>
 <hr>
+
+%if file_id == node['preprint_file_id']:
+<div class="row">
+    <div class="col-xs-12">
+        <div class="preprint-notice m-b-md p-md clearfix">
+            This is the primary file for a preprint. <a href="http://help.osf.io/s/support">Learn more</a> about how to work with preprint files.
+            <a href="/preprints/content/${node['id']}/" class="btn btn-default btn-sm m-r-xs pull-right">View preprint</a>
+        </div>
+    </div>
+</div>
+% endif
+
 <div class="row">
 
   <div id="file-navigation" class="panel-toggle col-sm-3 file-tree">


### PR DESCRIPTION
## Purpose
Add various messages on the OSF for when users access the OSF Projects associated with Preprints.

Building on @caneruguz's work!

"Learn more" links will go to http://help.osf.io/m/preprints

### Preprint Project View
![screen shot 2016-08-23 at 6 59 59 pm](https://cloud.githubusercontent.com/assets/801594/17912779/d821ab96-6963-11e6-8727-bbcc5b749354.png)

### Primary File View
![screen shot 2016-08-23 at 7 04 29 pm](https://cloud.githubusercontent.com/assets/801594/17912865/7bb87992-6964-11e6-8b89-6565c25ed2cb.png)

### Delete Primary File View
![screen shot 2016-08-23 at 7 05 12 pm](https://cloud.githubusercontent.com/assets/801594/17912891/97370058-6964-11e6-9dc0-4cc7e4a94a8d.png)

### Deleting Single File on Fangorn
![screen shot 2016-08-23 at 8 26 38 pm](https://cloud.githubusercontent.com/assets/801594/17914414/f7ceb626-696f-11e6-83aa-d906ce7a1d4d.png)


### Delete Multiple Files on Fangorn
![screen shot 2016-08-23 at 8 25 11 pm](https://cloud.githubusercontent.com/assets/801594/17914405/cc27ca26-696f-11e6-98c8-f844c40c72db.png)


### Orphaned Preprint Project View
Only shown to **admins** on the project
![screen shot 2016-08-23 at 6 56 35 pm](https://cloud.githubusercontent.com/assets/801594/17912729/61b64016-6963-11e6-9dea-1cc537b8e69a.png)


## Changes
- On file delete from osfstorage, set `_is_preprint_orphan` if the file was the preprint's primary file
- Add banners about the preprint on the main project page, and the primary file page
- Add banner about preprint orphan to *project administrators*
- Make preprint properties and primary file information visible to templates and mithril
- Extra warning message when deleting a file that's a primary file

<!-- Briefly describe or list your changes  -->

## Side effects
Extra node save on file delete if primary file is being deleted?

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
