### PR TITLE
Properly exclude DOI url if DOI is none

### DIFF
--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -88,7 +88,7 @@ class PreprintSerializer(JSONAPISerializer):
         return self.get_preprint_url(obj)
 
     def get_doi_url(self, obj):
-        return 'https://dx.doi.org/{}'.format(obj.preprint_doi)
+        return 'https://dx.doi.org/{}'.format(obj.preprint_doi) if obj.preprint_doi else None
 
     def create(self, validated_data):
         node = Node.load(validated_data.pop('_id', None))


### PR DESCRIPTION
## Purpose
Don't include the DOI link if there is no doi
Before: 
![screen shot 2016-08-23 at 8 47 27 pm](https://cloud.githubusercontent.com/assets/801594/17914773/05e4bd7a-6973-11e6-82b4-0aa587a37caa.png)

After: 
![screen shot 2016-08-23 at 8 49 24 pm](https://cloud.githubusercontent.com/assets/801594/17914782/2343ece2-6973-11e6-81f1-293d938c9622.png)


## Changes

Return `None` if there's not a DOI to format

## Side effects
@chrisseto might have to update the SHARE harvester with a `Maybe` field for DOI harvesting preprints


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->

