### PR TITLE
Message when making Preprint Private

### DIFF
--- a/website/project/model.py
+++ b/website/project/model.py
@@ -1174,7 +1174,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
 
     @property
     def is_preprint(self):
-        if not self.preprint_file:
+        if not self.preprint_file or not self.is_public:
             return False
         if self.preprint_file.node == self:
             return True

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1036,7 +1036,7 @@ function _removeEvent (event, items, col) {
             // title = 'Delete the primary preprint file "' + items[0].data.name + '"?';
             detail = [
                 m('p', 'This is the primary file for a preprint.'),
-                m('p', m('strong', 'Deleting this file will remove your preprint from circulation.'))
+                m('p', m('strong', 'Deleting this file will remove this preprint from circulation.'))
             ];
         }
         if(items[0].kind !== 'folder'){
@@ -1080,7 +1080,7 @@ function _removeEvent (event, items, col) {
             if (window.contextVars.node.preprintFileId === item.data.path.replace('/', '')) {
                 deleteMessage.push([
                     m('p', 'One of the files you have selected is the primary file for a preprint.'),
-                    m('p', m('strong', 'Deleting this file will remove your preprint from circulation.'))
+                    m('p', m('strong', 'Deleting this file will remove this preprint from circulation.'))
                 ]);
             }
         });

--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -180,7 +180,7 @@ var FileViewPage = {
                 message = '<p class="overflow">' +
                     'Are you sure you want to delete <strong>' +
                     self.file.safeName + '</strong>?' + ' It is currently the primary file ' +
-                    'for a preprint.</p> <p><strong>Deleting this file will remove your preprint from circulation.</strong></p>';
+                    'for a preprint.</p> <p><strong>Deleting this file will remove this preprint from circulation.</strong></p>';
             }
             bootbox.confirm({
                 title: title,

--- a/website/static/js/nodesPrivacy.js
+++ b/website/static/js/nodesPrivacy.js
@@ -30,7 +30,9 @@ var MESSAGES = {
         nodesPrivate: 'The following projects and components will be made <b>private</b>.',
         nodesNotChangedWarning: 'No privacy settings were changed. Go back to make a change.',
         tooManyNodesWarning: 'You can only change the privacy of 100 projects and components at a time.  Please go back and limit your selection.'
-    }
+    },
+    preprintPrivateWarning: 'The project you are attempting to make private currently represents a preprint.' +
+    '<p><strong>Making this project private will remove this preprint from curculation.</strong></p>'
 };
 
 function _flattenNodeTree(nodeTree) {
@@ -109,6 +111,7 @@ var NodesPrivacyViewModel = function(node, onSetPrivacy) {
     self.parentIsEmbargoed = node.is_embargoed;
     self.parentIsPublic = node.is_public;
     self.parentNodeType = node.node_type;
+    self.isPreprint = node.is_preprint;
     self.treebeardUrl = window.contextVars.node.urls.api  + 'tree/';
     self.nodesOriginal = {};
     self.nodesChanged = ko.observable();
@@ -155,6 +158,10 @@ var NodesPrivacyViewModel = function(node, onSetPrivacy) {
     self.message = ko.computed(function() {
         if (self.page() === self.WARNING &&  self.parentIsEmbargoed) {
             return MESSAGES.makeEmbargoPublicWarning;
+        }
+
+        if (self.page() === self.WARNING &&  self.isPreprint) {
+            return MESSAGES.preprintPrivateWarning + MESSAGES.makeProjectPrivateWarning;
         }
 
         return {


### PR DESCRIPTION

## Purpose

Since a preprint is just a project on the OSF, users can make them private and perhaps not realize the concequences.

This adds at least a warning message to give a bit of a heads up
![screen shot 2016-08-24 at 1 41 15 pm](https://cloud.githubusercontent.com/assets/801594/17941583/fd7c5e88-6a01-11e6-9bb5-24363bc5d0c7.png)

<!-- Describe the purpose of your changes -->

## Changes
- Change to the model to make sure `is_preprint` also looks at Privacy of a node (`is_public=False > is_preprint=False)
- Add check in `nodesPrivacy.js` for when making private to add special preprints message.
- Small wording change from "your preprint" to "this preprint"

## Side effects
- Anywhere that uses the node's `is_preprint` property  will now accurately exclude former preprints that are now private (to match what the API does...)

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
