### PR TITLE
[hotfix] make github wb logger less brittle [OSF-6947]

### DIFF
--- a/website/addons/github/model.py
+++ b/website/addons/github/model.py
@@ -238,15 +238,15 @@ class GitHubNodeSettings(StorageAddonBase, AddonOAuthNodeSettingsBase):
 
         url = self.owner.web_url_for('addon_view_or_download_file', path=path, provider='github')
 
-        if not metadata.get('extra'):
-            sha = None
-            urls = {}
-        else:
+        sha, urls = None, {}
+        try:
             sha = metadata['extra']['commit']['sha']
             urls = {
                 'view': '{0}?ref={1}'.format(url, sha),
                 'download': '{0}?action=download&ref={1}'.format(url, sha)
             }
+        except KeyError:
+            pass
 
         self.owner.add_log(
             'github_{0}'.format(action),


### PR DESCRIPTION
## Purpose

WB will soon start returning the applicable branch name in all Github action metadata.  The current `create_waterbutler_log` implementation for GH cannot handle this, as it expects a commit sha if any extra metadata is returned at all.

## Changes

Test directly for `extra.commit.sha` instead of just `extra`.

## Side effects

None expected.  This should have no visible effects.  It's purpose is to not break new functionality.

## Ticket

[OSF-6947]

https://openscience.atlassian.net/browse/OSF-6947
