### PR TITLE
[feature] Fix Simplified Date Filtering [OSF-6936]

### DIFF
--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -333,7 +333,14 @@ class ODMFilterMixin(FilterMixin):
                 sub_query_parts = []
                 for field_name, data in field_names.iteritems():
                     # Query based on the DB field, not the name of the serializer parameter
-                    sub_query = Q(data['source_field_name'], data['op'], data['value'])
+                    if isinstance(data, list):
+                        sub_query = functools.reduce(operator.and_, [
+                            Q(item['source_field_name'], item['op'], item['value'])
+                            for item in data
+                        ])
+                    else:
+                        sub_query = Q(data['source_field_name'], data['op'], data['value'])
+
                     sub_query_parts.append(sub_query)
 
                 try:

--- a/api_tests/base/test_filters.py
+++ b/api_tests/base/test_filters.py
@@ -396,6 +396,19 @@ class TestFilterMixin(ApiTestCase):
         with assert_raises(InvalidFilterOperator):
             self.view.parse_query_params(query_params)
 
+    def test_simplified_date_filter(self):
+        query_params = {
+            'filter[date_field]': '2016-08-24'
+        }
+        query = self.view.query_params_to_odm_query(query_params)
+        assert_equals(
+            repr(query),
+            repr(functools.reduce(operator.and_, [
+                Q('date_field', 'gte', datetime.datetime(2016, 8, 24)),
+                Q('date_field', 'lt', datetime.datetime(2016, 8, 25)),
+            ]))
+        )
+
 
 class TestListFilterMixin(ApiTestCase):
 


### PR DESCRIPTION
#### Purpose
- Fixes an API bug that was recently introduced by the addition of multi-field filtering (my bad). 
- When filtering nodes by a simplified date (`/v2/nodes/?filter[date_created]=2016-08-24` v. `/v2/nodes/?filter[date_created]=2016-08-24T00:00:00`), a 500 error was being thrown because the simplified date filter resulted in two queries that were no longer being joined appropriately. This PR un-breaks it.

#### Side effects
- None expected.

#### Ticket
- [OSF-6936](https://openscience.atlassian.net/browse/OSF-6936)