### PR TITLE
[Feature] Update At.js dependency to upstream [OSF-6948]

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,6 +20,6 @@
     "raven-js": "2.1.0",
     "zeroclipboard": "2.1.6",
     "osf-style": "https://github.com/CenterForOpenScience/osf-style.git#5dcf5997ad2808ffc7c8564f94cde102bf7a4a96",
-    "At.js": "https://github.com/CenterForOpenScience/At.js.git#d4c1c6ebce3808a275bac59740dabd9bcf76d96f"
+    "At.js": "jquery.atwho#e18af47fdcb327605533a9da259225176e3013c8"
   }
 }


### PR DESCRIPTION
## Purpose

At.js was using our fork of the library until a fix for the `contenteditable` bugs was taken integrated. The changes were merged 🎉  so we don't need the fork anymore.

## Changes

* point to upstream instead of fork

## Side effects

None


## Ticket

https://openscience.atlassian.net/browse/OSF-6948

