### PR TITLE
make Subject factory try to use existing Subjects to avoid unique error

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -284,13 +284,14 @@ class SubjectFactory(ModularOdmFactory):
         model = Subject
 
     @classmethod
-    def _create(cls, target_class, text=None,
-                parents=[], *args, **kwargs):
-        subject = target_class(*args, **kwargs)
-        subject.text = text
-        subject.parents = parents
-        subject.save()
-
+    def _create(cls, target_class, text=None, parents=[], *args, **kwargs):
+        try:
+            subject = Subject.find_one(Q('text', 'eq', text))
+        except NoResultsFound:
+            subject = target_class(*args, **kwargs)
+            subject.text = text
+            subject.parents = parents
+            subject.save()
         return subject
 
 


### PR DESCRIPTION
## Purpose

Ever since adding the unique subject text requirement, new instances of `create_fakes` for preprints would fail with duplicate key errors. This PR searches for an existing key first for the SubjectFactory before making new ones

Now use `python -m scripts.create_fakes -u email@yay.io --nprojects 30 --preprint True --preprintprovider osf,engrxiv` with abandon! Woo!

## Changes
- Query for existing subjects first and use those in subject factories

## Side effects

<!--Any possible side effects? -->


## Ticket
