### PR TITLE
[feature fix] Set Bibliographic for Unregistered Contributors via API [OSF-6855]

### DIFF
--- a/api_tests/nodes/views/test_node_contributors_list.py
+++ b/api_tests/nodes/views/test_node_contributors_list.py
@@ -839,6 +839,30 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
         assert_equal(res.status_code, 201)
         assert_equal(res.json['data']['attributes']['unregistered_contributor'], 'John Doe')
         assert_equal(res.json['data']['attributes']['email'], 'john@doe.com')
+        assert_equal(res.json['data']['attributes']['bibliographic'], True)
+        assert_equal(res.json['data']['attributes']['permission'], permissions.WRITE)
+        assert_in(res.json['data']['embeds']['users']['data']['id'], self.public_project.contributors)
+
+    @assert_logs(NodeLog.CONTRIB_ADDED, 'public_project')
+    def test_add_contributor_with_fullname_and_email_unregistered_user_set_attributes(self):
+        payload = {
+            'data': {
+                'type': 'contributors',
+                'attributes': {
+                    'full_name': 'John Doe',
+                    'email': 'john@doe.com',
+                    'bibliographic': False,
+                    'permission': permissions.READ
+                }
+            }
+        }
+        res = self.app.post_json_api(self.public_url, payload, auth=self.user.auth)
+        self.public_project.reload()
+        assert_equal(res.status_code, 201)
+        assert_equal(res.json['data']['attributes']['unregistered_contributor'], 'John Doe')
+        assert_equal(res.json['data']['attributes']['email'], 'john@doe.com')
+        assert_equal(res.json['data']['attributes']['bibliographic'], False)
+        assert_equal(res.json['data']['attributes']['permission'], permissions.READ)
         assert_in(res.json['data']['embeds']['users']['data']['id'], self.public_project.contributors)
 
     @assert_logs(NodeLog.CONTRIB_ADDED, 'public_project')

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -3193,7 +3193,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
         if save:
             self.save()
 
-    def add_unregistered_contributor(self, fullname, email, auth, send_email='default', permissions=None, save=False):
+    def add_unregistered_contributor(self, fullname, email, auth, send_email='default', visible=True, permissions=None, save=False):
         """Add a non-registered contributor to the project.
 
         :param str fullname: The full name of the person.
@@ -3221,7 +3221,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
 
         self.add_contributor(
             contributor, permissions=permissions, auth=auth,
-            send_email=send_email, log=True, save=False
+            visible=visible, send_email=send_email, log=True, save=False
         )
         self.save()
         return contributor
@@ -3243,9 +3243,9 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
         else:
 
             try:
-                contributor = self.add_unregistered_contributor(fullname=full_name, email=email,
-                                                                auth=auth, send_email=send_email,
-                                                                permissions=permissions, save=True)
+                contributor = self.add_unregistered_contributor(fullname=full_name, email=email, auth=auth,
+                                                                send_email=send_email, permissions=permissions,
+                                                                visible=bibliographic, save=True)
             except ValidationValueError:
                 contributor = get_user(email=email)
                 if contributor in self.contributors:


### PR DESCRIPTION
#### Purpose
- When adding an unregistered contributor via the API, the visibility specified in the request was being ignored as it was not being passed to `add_unregistered_contributor`. It works now and tests have been updated.

#### Changes
- Add `visible` as a key word argument to `add_unregistered_contributor`. 
- Add and update tests.

#### Side effects
- None expected.

#### Ticket
- [OSF-6855](https://openscience.atlassian.net/browse/OSF-6855)
