### PR TITLE
[Feature] Add support for revoking ORCID login

### DIFF
--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -381,6 +381,7 @@ def external_login_confirm_email_get(auth, uid, token):
         user.register(user.username)
         user.date_last_logged_in = datetime.datetime.utcnow()
         user.external_identity[provider][provider_id] = 'VERIFIED'
+        user.social[provider.lower()] = provider_id
         user.save()
         mails.send_mail(
             to_addr=user.username,
@@ -393,6 +394,7 @@ def external_login_confirm_email_get(auth, uid, token):
     elif external_status == 'LINK':
         user.date_last_logged_in = datetime.datetime.utcnow()
         user.external_identity[provider][provider_id] = 'VERIFIED'
+        user.social[provider.lower()] = provider_id
         user.save()
         mails.send_mail(
             user=user,

--- a/website/routes.py
+++ b/website/routes.py
@@ -750,7 +750,6 @@ def make_url_map(app):
             OsfWebRenderer('profile/personal_tokens_detail.mako', trust=False)
         ),
 
-
         # TODO: Uncomment once outstanding issues with this feature are addressed
         # Rule(
         #     '/@<twitter_handle>/',
@@ -793,6 +792,13 @@ def make_url_map(app):
             'post',
             profile_views.request_deactivation,
             json_renderer,
+        ),
+
+        Rule(
+            '/profile/logins/',
+            'delete',
+            profile_views.delete_external_identity,
+            json_renderer
         ),
 
         Rule(

--- a/website/static/js/accountSettings.js
+++ b/website/static/js/accountSettings.js
@@ -231,9 +231,6 @@ var UserProfileViewModel = oop.extend(ChangeMessageMixin, {
         } else {
             this.changeMessage('Email cannot be empty.', 'text-danger');
         }
-        
-        
-        
     },
     resendConfirmation: function(email){
         var self = this;
@@ -302,6 +299,51 @@ var UserProfileViewModel = oop.extend(ChangeMessageMixin, {
     }
 });
 
+var ExternalIdentityViewModel = oop.defclass({
+    constructor: function () {},
+    urls: {
+        'delete': '/api/v1/profile/logins/'
+    },
+    _removeIdentity: function(identity) {
+        var request = $osf.ajaxJSON('DELETE', this.urls.delete, {'data': {'identity': identity}});
+        request.done(function() {
+            $osf.growl('Success', 'You have revoked this connected identity.', 'success');
+            window.location.reload();
+        }.bind(this));
+        request.fail(function(xhr, status, error) {
+            $osf.growl('Error',
+                'Revocation request failed. Please contact <a href="mailto: support@osf.io">support@osf.io</a> if the problem persists.',
+                'danger'
+            );
+            Raven.captureMessage('Error revoking connected identity', {
+                extra: {
+                    url: this.urls.update,
+                    status: status,
+                    error: error
+                }
+            });
+        }.bind(this));
+        return request;
+    },
+    removeIdentity: function (identity) {
+        var self = this;
+        bootbox.confirm({
+            title: 'Remove authorization?',
+            message: 'Are you sure you want to remove this authorization?',
+            callback: function(confirmed) {
+                if (confirmed) {
+                    return self._removeIdentity(identity);
+                }
+            },
+            buttons:{
+                confirm:{
+                    label:'Remove',
+                    className:'btn-danger'
+                }
+            }
+        });
+    }
+});
 
 var DeactivateAccountViewModel = oop.defclass({
     constructor: function () {
@@ -410,5 +452,6 @@ var ExportAccountViewModel = oop.defclass({
 module.exports = {
     UserProfileViewModel: UserProfileViewModel,
     DeactivateAccountViewModel: DeactivateAccountViewModel,
-    ExportAccountViewModel: ExportAccountViewModel
+    ExportAccountViewModel: ExportAccountViewModel,
+    ExternalIdentityViewModel: ExternalIdentityViewModel
 };

--- a/website/static/js/pages/profile-account-settings-page.js
+++ b/website/static/js/pages/profile-account-settings-page.js
@@ -22,4 +22,9 @@ $(function() {
         new accountSettings.ExportAccountViewModel(),
         '#exportAccount'
     );
+
+    $osf.applyBindings(
+        new accountSettings.ExternalIdentityViewModel(),
+        '#externalIdentity'
+    );
 });

--- a/website/templates/profile/account.mako
+++ b/website/templates/profile/account.mako
@@ -88,6 +88,42 @@
                         </table>
                     </div>
                 </div>
+                <div id="externalIdentity" class="panel panel-default">
+                    <div class="panel-heading clearfix"><h3 class="panel-title">Connected Identities</h3></div>
+                    <div class="panel-body">
+                        <p> Connected identities allow you to log in to the OSF via a third-party service. <br/>
+                        You can revoke these authorizations here.</p>
+                        <hr />
+                        % if not external_identity:
+                        <p >You have not authorized any external services to log in to the OSF.</p>
+                        % endif
+                        <tbody>
+                        % for identity in external_identity:
+                        <div id="externalLogin-${identity}">
+                            % for id in external_identity[identity]:
+                            <div><tr>
+                                <td>
+                                    ${identity}: ${id} (
+                                    % if external_identity[identity][id] == "VERIFIED":
+                                        Verified
+                                    % else:
+                                        Pending
+                                    % endif
+                                    )
+                                </td>
+                                <td>
+                                    <a data-bind="click: $root.removeIdentity.bind($root, '${id}')"><i class="fa fa-times text-danger pull-right"></i></a>
+                                </td>
+                            </tr></div>                    
+                            % if not loop.last:
+                            <hr />
+                            % endif
+                            % endfor
+                        </div>
+                        % endfor
+                        </tbody>
+                    </div>
+                </div>
                 <div id="changePassword" class="panel panel-default">
                     <div class="panel-heading clearfix"><h3 class="panel-title">Change Password</h3></div>
                     <div class="panel-body">


### PR DESCRIPTION
## Purpose
Allow users to revoke prior external authorizations

## Changes
* `account` template updated
* v1 route/view added
* update `social` field on link

## Side effects
Additional V1 route to be destroyed. This isn't close to the final iteration of the "external service login" feature, so this is probably better than a v2 route that would need deprecating.