### PR TITLE
Fix links to view preprint on project and file page

### DIFF
--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -242,7 +242,7 @@
     <div class="col-xs-12">
         <div class="pp-notice m-b-md p-md clearfix">
             This project represents a preprint. <a href="http://help.osf.io/m/preprints">Learn more</a> about how to work with preprint files.
-            <a href="/preprints/content/${node['id']}/" class="btn btn-default btn-sm m-r-xs pull-right">View preprint</a>
+            <a href="/preprints/${node['id']}/" class="btn btn-default btn-sm m-r-xs pull-right">View preprint</a>
         </div>
     </div>
 </div>

--- a/website/templates/project/view_file.mako
+++ b/website/templates/project/view_file.mako
@@ -33,7 +33,7 @@
     <div class="col-xs-12">
         <div class="preprint-notice m-b-md p-md clearfix">
             This is the primary file for a preprint. <a href="http://help.osf.io/m/preprints">Learn more</a> about how to work with preprint files.
-            <a href="/preprints/content/${node['id']}/" class="btn btn-default btn-sm m-r-xs pull-right">View preprint</a>
+            <a href="/preprints/${node['id']}/" class="btn btn-default btn-sm m-r-xs pull-right">View preprint</a>
         </div>
     </div>
 </div>


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Links directly to preprints on ember preprints have changed from `/content/<guid>/` to just `/<guid>/` . This PR updates links on OSF Preprint projects to go to the right place.

<!-- Describe the purpose of your changes -->

## Changes
- Update link on preprint project page
- Update link on preprint primary file view page

## Side effects
None
<!--Any possible side effects? -->


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->

