### PR TITLE
[rfr][preprints] Add custom signup/ campaign page for OSF Preprints service

### DIFF
--- a/framework/auth/campaigns.py
+++ b/framework/auth/campaigns.py
@@ -21,7 +21,15 @@ CAMPAIGNS = ImmutableDict({
         'system_tag': 'erp_challenge_campaign',
         'redirect_url': lambda: furl.furl(DOMAIN).add(path='erpc/').url,
         'confirmation_email_template': mails.CONFIRM_EMAIL_ERPC,
-    }})
+    },
+    # Various preprint services
+    # Each preprint service will offer their own campaign with appropriate distinct branding
+    'osf-preprints': {
+        'system_tag': 'osf_preprints',
+        'redirect_url': lambda: furl.furl(DOMAIN).add(path='preprints/').url,
+        'confirmation_email_template': mails.CONFIRM_EMAIL_PREPRINTS_OSF
+    }
+})
 
 
 def system_tag_for_campaign(campaign):

--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -577,6 +577,8 @@ def send_confirm_email(user, email, external_id_provider=None, external_id=None)
         mail_template = mails.CONFIRM_EMAIL
         confirmation_url = '{}?logout=1'.format(confirmation_url)
     elif campaign:  # campaign
+        # TODO: In the future, we may want to make confirmation email configurable as well (send new user to
+        #   appropriate landing page or with redirect after)
         mail_template = campaigns.email_template_for_campaign(campaign)
     else:  # account creation
         mail_template = mails.INITIAL_CONFIRM_EMAIL

--- a/website/mails/mails.py
+++ b/website/mails/mails.py
@@ -136,6 +136,7 @@ INITIAL_CONFIRM_EMAIL = Mail('initial_confirm', subject='Open Science Framework 
 CONFIRM_EMAIL = Mail('confirm', subject='Add a new email to your OSF account')
 CONFIRM_EMAIL_PREREG = Mail('confirm_prereg', subject='Open Science Framework Account Verification, Preregistration Challenge')
 CONFIRM_EMAIL_ERPC = Mail('confirm_erpc', subject='Open Science Framework Account Verification, Election Research Preacceptance Competition')
+CONFIRM_EMAIL_PREPRINTS_OSF = Mail('confirm_preprints_osf', subject='Open Science Framework Account Verification, Preprints Service')
 
 CONFIRM_MERGE = Mail('confirm_merge', subject='Confirm account merge')
 

--- a/website/templates/emails/confirm_preprints_osf.txt.mako
+++ b/website/templates/emails/confirm_preprints_osf.txt.mako
@@ -1,6 +1,6 @@
 Hello ${user.fullname},
 
-Welcome to the Open Science Framework and the OSF Preprints service. To continue, please verify your email address by visiting this link:
+Welcome to the Open Science Framework and OSF Preprints. To continue, please verify your email address by visiting this link:
 
 ${confirmation_url}
 

--- a/website/templates/emails/confirm_preprints_osf.txt.mako
+++ b/website/templates/emails/confirm_preprints_osf.txt.mako
@@ -1,0 +1,7 @@
+Hello ${user.fullname},
+
+Welcome to the Open Science Framework and the OSF Preprints service. To continue, please verify your email address by visiting this link:
+
+${confirmation_url}
+
+From the team at the Center for Open Science

--- a/website/templates/public/login.mako
+++ b/website/templates/public/login.mako
@@ -35,6 +35,17 @@
             <p> If you do not currently have an OSF account, this will create one. By creating an account you agree to our <a href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/TERMS_OF_USE.md">Terms</a> and that you have read our <a href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/PRIVACY_POLICY.md">Privacy Policy</a>, including our information on <a href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/PRIVACY_POLICY.md#f-cookies">Cookie Use</a>.</p>
         </div>
     %endif
+
+    %if campaign == "osf-preprints":
+        <div class="text-center m-t-lg">
+            <h3>OSF Preprint Service</h3>
+            <hr>
+            <p>
+                Please login to the Open Science Framework or create a free account to continue.
+            </p>
+        </div>
+    %endif
+
     <div class="row m-t-xl">
     %if campaign == "institution" and enable_institutions:
         <div class="col-sm-6 col-sm-offset-3">

--- a/website/templates/public/login.mako
+++ b/website/templates/public/login.mako
@@ -41,7 +41,7 @@
             <h3>OSF Preprint Service</h3>
             <hr>
             <p>
-                Please login to the Open Science Framework or create a free account to continue.
+                Please login to the Open Science Framework or create a free account to contribute to OSF Preprints.
             </p>
         </div>
     %endif

--- a/website/util/metrics.py
+++ b/website/util/metrics.py
@@ -6,7 +6,7 @@ def get_entry_point(user):
     Given the user system_tags, return the user entry point (osf, osf4m, prereg, institution)
     In case of multiple entry_points existing in the system_tags, return only the first one.
     """
-    entry_points = ['osf4m', 'prereg_challenge_campaign', 'institution_campaign']
+    entry_points = ['osf4m', 'prereg_challenge_campaign', 'institution_campaign', 'osf_preprints']
     for i in user.system_tags:
         if i in entry_points:
             return i


### PR DESCRIPTION
## Purpose

Add a new campaign, so that users of the preprints service (through the OSF) will see a custom signup page and receive unique signup emails.

Sample URL: `http://staging.osf.io/login?campaign=osf-preprints`

If they click "use an existing account", then when they are done with the login process, they will be taken to `staging.osf.io/preprints` (the preprints landing page)

Upon confirming an account, they should be taken to the landing page for the campaign (eg `staging.osf.io/preprints`)

![screen shot 2016-08-25 at 1 33 06 pm](https://cloud.githubusercontent.com/assets/2957073/17979430/87e2a476-6ac8-11e6-9545-dfc4b79b6490.png)

## Changes

Add new `osf-preprints` campaign: custom signup page, and track users who came in this way via metrics.

## Side effects
None expected.


## Ticket
https://openscience.atlassian.net/browse/PREP-131


# TODO
- [x] Language approval for email and landing page
