### PR TITLE
Alert that user cannot delete project on "Delete" click [OSF-6840]

### DIFF
--- a/website/static/js/pages/project-settings-page.js
+++ b/website/static/js/pages/project-settings-page.js
@@ -84,7 +84,7 @@ $(document).ready(function() {
 
     $('#deleteNode').on('click', function() {
         if(ctx.node.childExists){
-            $osf.growl('Error', 'Any child components must be deleted prior to deleting this project.','danger', 30000)
+            $osf.growl('Error', 'Any child components must be deleted prior to deleting this project.','danger', 30000);
         }else{
             ProjectSettings.getConfirmationCode(ctx.node.nodeType);
         }

--- a/website/static/js/pages/project-settings-page.js
+++ b/website/static/js/pages/project-settings-page.js
@@ -83,7 +83,11 @@ $(document).ready(function() {
     }
 
     $('#deleteNode').on('click', function() {
-        ProjectSettings.getConfirmationCode(ctx.node.nodeType);
+        if(ctx.node.childExists){
+            $osf.growl('Error', 'Any child components must be deleted prior to deleting this project.','danger', 30000)
+        }else{
+            ProjectSettings.getConfirmationCode(ctx.node.nodeType);
+        }
     });
 
     // TODO: Knockout-ify me

--- a/website/templates/project/project_base.mako
+++ b/website/templates/project/project_base.mako
@@ -99,6 +99,7 @@
             parentTitle: ${ parent_title | sjson, n },
             parentRegisterUrl: ${parent_registration_url | sjson, n },
             parentExists: ${ parent_exists | sjson, n},
+            childExists: ${ node['children'] | sjson, n},
             registrationMetaSchemas: ${ node['registered_schemas'] | sjson, n },
             registrationMetaData: ${ node['registered_meta'] | sjson, n },
             contributors: ${ node['contributors'] | sjson, n }


### PR DESCRIPTION
## Purpose

This stops the using from entering an the confirmation string before they get an error message telling them they can't delete a nested component.

## Changes

Changes the project base mako so contextvars include info on wheater a node has children, then uses that info to pre-validate on clicking the delete button.

## Side effects

None that I know of

## Ticket

https://openscience.atlassian.net/browse/OSF-6840