### PR TITLE
Feature/preprint emails

### DIFF
--- a/api_tests/preprints/views/test_preprint_list.py
+++ b/api_tests/preprints/views/test_preprint_list.py
@@ -244,3 +244,10 @@ class TestPreprintCreate(ApiTestCase):
             assert_equal(res.status_code, 201)
             assert_equal(mock_signals.signals_sent(), set([project_signals.contributor_added]))
 
+    def test_preprint_contributor_signal_not_sent_one_contributor(self):
+        with capture_signals() as mock_signals:
+            private_project_payload = build_preprint_create_payload(self.private_project._id, self.subject._id,
+                                                                   self.file_one_private_project._id)
+            res = self.app.post_json_api(self.url, private_project_payload, auth=self.user.auth)
+            assert_equal(res.status_code, 201)
+            assert_not_equal(mock_signals.signals_sent(), set([project_signals.contributor_added]))

--- a/api_tests/preprints/views/test_preprint_list.py
+++ b/api_tests/preprints/views/test_preprint_list.py
@@ -3,8 +3,10 @@ from nose.tools import *  # flake8: noqa
 from framework.auth.core import Auth, Q
 from api.base.settings.defaults import API_BASE
 from website.models import Node
+from website.project import signals as project_signals
 
-from tests.base import ApiTestCase
+
+from tests.base import ApiTestCase, capture_signals
 from tests.factories import (
     ProjectFactory,
     PreprintFactory,
@@ -133,8 +135,11 @@ class TestPreprintCreate(ApiTestCase):
         super(TestPreprintCreate, self).setUp()
 
         self.user = AuthUserFactory()
+        self.other_user = AuthUserFactory()
         self.private_project = ProjectFactory(creator=self.user)
         self.public_project = ProjectFactory(creator=self.user, public=True)
+        self.public_project.add_contributor(self.other_user)
+        self.public_project.save()
         self.subject = SubjectFactory()
 
         self.user_two = AuthUserFactory()
@@ -229,4 +234,13 @@ class TestPreprintCreate(ApiTestCase):
 
         assert_equal(res.status_code, 400)
         assert_equal(res.json['errors'][0]['detail'], 'This file is not a valid primary file for this preprint.')
+
+    def test_preprint_contributor_signal_sent_on_creation(self):
+        with capture_signals() as mock_signals:
+            public_project_payload = build_preprint_create_payload(self.public_project._id, self.subject._id,
+                                                                   self.file_one_public_project._id)
+            res = self.app.post_json_api(self.url, public_project_payload, auth=self.user.auth)
+
+            assert_equal(res.status_code, 201)
+            assert_equal(mock_signals.signals_sent(), set([project_signals.contributor_added]))
 

--- a/website/templates/emails/contributor_added_preprint.txt.mako
+++ b/website/templates/emails/contributor_added_preprint.txt.mako
@@ -4,7 +4,7 @@
 
 Hello ${user.fullname},
 
-${referrer_name + ' has added you' if referrer_name else 'You have been added'} as a contributor to the project "${node.title}" on the Open Science Framework: ${node.absolute_url}
+${referrer_name + ' has added you' if referrer_name else 'You have been added'} as a contributor to the preprint "${node.title}" on the Open Science Framework: ${node.absolute_url}
 
 You will ${'not receive ' if all_global_subscriptions_none else 'be automatically subscribed to '} notification emails for this project. To change your email notification preferences, visit your project or your user settings: ${settings.DOMAIN + "settings/notifications/"}
 

--- a/website/templates/emails/invite_preprint.txt.mako
+++ b/website/templates/emails/invite_preprint.txt.mako
@@ -4,11 +4,11 @@
 
 Hello ${fullname},
 
-You have been added by ${referrer.fullname} as a contributor to the project "${node.title}" on the Open Science Framework. To set a password for your account, visit:
+You have been added by ${referrer.fullname} as a contributor to the preprint "${node.title}" on the Open Science Framework. To set a password for your account, visit:
 
 ${claim_url}
 
-Once you have set a password, you will be able to make contributions to ${node.title} and create your own projects. You will automatically be subscribed to notification emails for this project. To change your email notification preferences, visit your project or your user settings: ${settings.DOMAIN + "settings/notifications/"}
+Once you have set a password, you will be able to make contributions to ${node.title} and create your own preprints and projects. You will automatically be subscribed to notification emails for this project. To change your email notification preferences, visit your project or your user settings: ${settings.DOMAIN + "settings/notifications/"}
 
 To preview ${node.title} click the following link: ${node.absolute_url}
 


### PR DESCRIPTION
**note** Relies on:
https://github.com/CenterForOpenScience/ember-osf/pull/125
and
https://github.com/CenterForOpenScience/ember-preprints/pull/88

## Purpose

Preprints needed the ability to send an email to preprint authors after the whole preprint process has been completed, which does not happen until after a normal project has been created and contributors added to it.

After changes proposed in https://github.com/CenterForOpenScience/ember-osf/pull/125 and https://github.com/CenterForOpenScience/ember-preprints/pull/88 go through, the add_contributor signal will only be sent after the POST request is made creating a new preprint, and the newly added authors get a notification to that effect.

## Changes
- Send an email to all other contributors on the project through the create method of `preprints/serializers.py`
- Test to make sure the `contributor_added` signal is sent on receiving a POST through the preprints endpoint
- Template wording as proposed by https://openscience.atlassian.net/browse/PREP-130

## Side effects

If the changes in the other two PRs are not made, the contributors will receive two emails - one through the normal contributor being added in the preprint process, and one a short time later 



## Ticket
https://openscience.atlassian.net/browse/PREP-130