### PR TITLE
fix broken API preprint parser

### DIFF
--- a/api/preprints/parsers.py
+++ b/api/preprints/parsers.py
@@ -12,7 +12,7 @@ class PreprintsJSONAPIParser(JSONAPIParser):
 
 class PreprintsJSONAPIParserForRegularJSON(JSONAPIParserForRegularJSON):
     def flatten_relationships(self, relationships):
-        ret = super(PreprintsJSONAPIParser, self).flatten_relationships(relationships)
+        ret = super(PreprintsJSONAPIParserForRegularJSON, self).flatten_relationships(relationships)
         related_resource = relationships.keys()[0]
         if ret.get('target_type') and ret.get('id'):
             return {related_resource: ret['id']}


### PR DESCRIPTION
## Purpose

Trying to create a new preprint via the API was breaking for me, with the following error:

````
    parsed = parser.parse(stream, media_type, self.parser_context)
  File "/Users/fitz/code/osf/osf.io/api/base/parsers.py", line 112, in parse
    return self.flatten_data(data, parser_context, is_list=False)
  File "/Users/fitz/code/osf/osf.io/api/base/parsers.py", line 84, in flatten_data
    relationships = self.flatten_relationships(relationships)
  File "/Users/fitz/code/osf/osf.io/api/preprints/parsers.py", line 16, in flatten_relationships
    ret = super(PreprintsJSONAPIParser, self).flatten_relationships(relationships)
TypeError: super(type, obj): obj must be an instance or subtype of type
````

## Changes

Pass the correct class to the `super()` call.

## Side effects

None expected.

## Ticket

No ticket.