### PR TITLE
Remove the create preprint button from files

### DIFF
--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -502,9 +502,6 @@ var FileViewPage = {
         var height = $('iframe').attr('height') ? $('iframe').attr('height') : '0px';
 
         m.render(document.getElementById('toggleBar'), m('.btn-toolbar.m-t-md', [
-            (!ctrl.context.node.isPreprint && ctrl.file.provider === 'osfstorage') ? m('.btn-group.m-l-xs.m-t-xs', [
-                m('a.btn.btn-sm.btn-default', {href: '/preprints/submit/?file_guid=' + window.contextVars.file.guid }, 'Create preprint')
-            ]) : '',
             // Special case whether or not to show the delete button for published Dataverse files
             (ctrl.canEdit() && (ctrl.file.provider !== 'osfstorage' || !ctrl.file.checkoutUser) && ctrl.requestDone && $(document).context.URL.indexOf('version=latest-published') < 0 ) ? m('.btn-group.m-l-xs.m-t-xs', [
                 ctrl.isLatestVersion ? m('button.btn.btn-sm.btn-danger.file-delete', {onclick: $(document).trigger.bind($(document), 'fileviewpage:delete') }, 'Delete') : null


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Files in OSF Storage have a "Create preprint" button on them. Clicking on it just leads to a blank Add Preprint form asking you to upload a file. Since creating preprints from pre-existing project files is not part of the current functionality, the "Create preprint" button should be removed from files.

## Changes

- remove create preprint button from files

## Side effects

none

## Ticket
https://trello.com/c/YVCh0mcO/17-create-preprint-button-on-osf-files-leads-to-blank-add-preprint-form