### PR TITLE
Fix typo on modal

### DIFF
--- a/website/static/js/nodesPrivacy.js
+++ b/website/static/js/nodesPrivacy.js
@@ -32,7 +32,7 @@ var MESSAGES = {
         tooManyNodesWarning: 'You can only change the privacy of 100 projects and components at a time.  Please go back and limit your selection.'
     },
     preprintPrivateWarning: 'The project you are attempting to make private currently represents a preprint.' +
-    '<p><strong>Making this project private will remove this preprint from curculation.</strong></p>'
+    '<p><strong>Making this project private will remove this preprint from circulation.</strong></p>'
 };
 
 function _flattenNodeTree(nodeTree) {


### PR DESCRIPTION
## Purpose

"Circulation" is misspelled in the warning modal when a user attempts to make a project with a preprint file private.

Now it's better!

![screen shot 2016-08-26 at 4 22 18 pm](https://cloud.githubusercontent.com/assets/801594/18019290/4f1d0a64-6ba9-11e6-92d0-c50b957524f2.png)


## Changes

spell it right!

## Side effects

<!--Any possible side effects? -->


## Ticket
https://trello.com/c/3gjuXT55/18-make-project-private-modal-has-spelling-error
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->

