### PR TITLE
Warn users when moving or replacing a preprint file

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -2255,6 +2255,20 @@ function _dropLogic(event, items, folder) {
     }
 
     $.each(items, function(index, item) {
+        if (window.contextVars.node.preprintFileId === item.data.path.replace('/', '') && item.data.nodeId === window.contextVars.node.id && folder.data.nodeId != window.contextVars.node.id) {
+            tb.modal.update(m('', [
+                m('p', 'The file "' + item.data.name + '" is the primary file for a preprint and so should not be moved.'),
+                m('strong', 'Moving this file will remove this preprint from circulation.')
+            ]), m('', [
+                m('span.btn.btn-default', {onclick: function() {tb.modal.dismiss();}}, 'Cancel'), // jshint ignore:line
+                m('span.btn.btn-default', {onclick: () => {
+                        checkConflicts(tb, item, folder, doItemOp.bind(tb, copyMode === 'move' ? OPERATIONS.MOVE : OPERATIONS.COPY, folder, item, undefined));
+                }}, 'Move anyway'), // jshint ignore:line
+
+            ]), m('h3.break-word.modal-title', 'Move "' + name + '"?'));
+            return;
+        }
+
         checkConflicts(tb, item, folder, doItemOp.bind(tb, copyMode === 'move' ? OPERATIONS.MOVE : OPERATIONS.COPY, folder, item, undefined));
     });
 }

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -454,17 +454,27 @@ function checkConflicts(tb, item, folder, cb) {
 }
 
 function checkConflictsRename(tb, item, name, cb) {
+    var messageArray = [];
     var parent = item.parent();
     for(var i = 0; i < parent.children.length; i++) {
         var child = parent.children[i];
         if (child.data.name === name && child.id !== item.id) {
-            tb.modal.update(m('', [
-                m('p', 'An item named "' + name + '" already exists in this location.')
-            ]), m('', [
-                m('span.btn.btn-info', {onclick: cb.bind(tb, 'keep')}, 'Keep Both'),
-                m('span.btn.btn-default', {onclick: function() {tb.modal.dismiss();}}, 'Cancel'), // jshint ignore:line
-                m('span.btn.btn-primary', {onclick: cb.bind(tb, 'replace')},'Replace'),
-            ]), m('h3.break-word.modal-title', 'Replace "' + name + '"?'));
+            messageArray.push(m('p', 'An item named "' + item.data.name + '" already exists in this location.'));
+
+            if (window.contextVars.node.preprintFileId === child.data.path.replace('/', '')) {
+                messageArray = messageArray.concat([
+                    m('p', 'The file "' + item.data.name + '" is the primary file for a preprint, so it should not be replaced.'),
+                    m('strong', 'Replacing this file will remove this preprint from circulation.')
+                ]);
+            }
+            tb.modal.update(
+                m('', messageArray), [
+                    m('span.btn.btn-default', {onclick: function() {tb.modal.dismiss();}}, 'Cancel'), //jshint ignore:line
+                    m('span.btn.btn-primary', {onclick: cb.bind(tb, 'keep')}, 'Keep Both'),
+                    m('span.btn.btn-primary', {onclick: cb.bind(tb, 'replace')},'Replace')
+                ],
+                m('h3.break-word.modal-title', 'Replace "' + item.data.name + '"?')
+            );
             return;
         }
     }

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -2284,7 +2284,7 @@ function _dropLogic(event, items, folder) {
                         checkConflicts(tb, item, folder, doItemOp.bind(tb, copyMode === 'move' ? OPERATIONS.MOVE : OPERATIONS.COPY, folder, item, undefined));
                 }}, 'Move anyway'), // jshint ignore:line
 
-            ]), m('h3.break-word.modal-title', 'Move "' + name + '"?'));
+            ]), m('h3.break-word.modal-title', 'Move "' + item.data.name + '"?'));
             return;
         }
 

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -427,16 +427,25 @@ function _fangornToggleCheck(item) {
 }
 
 function checkConflicts(tb, item, folder, cb) {
+    var messageArray = [];
     for(var i = 0; i < folder.children.length; i++) {
         var child = folder.children[i];
         if (child.data.name === item.data.name && child.id !== item.id) {
-            tb.modal.update(m('', [
-                    m('p', 'An item named "' + item.data.name + '" already exists in this location.')
-                ]), m('', [
+            messageArray.push(m('p', 'An item named "' + item.data.name + '" already exists in this location.'));
+
+            if (window.contextVars.node.preprintFileId === child.data.path.replace('/', '')) {
+                messageArray = messageArray.concat([
+                    m('p', 'The file "' + item.data.name + '" is the primary file for a preprint, so it should not be replaced.'),
+                    m('strong', 'Replacing this file will remove this preprint from circulation.')
+                ]);
+            }
+            tb.modal.update(
+                m('', messageArray), [
                     m('span.btn.btn-default', {onclick: function() {tb.modal.dismiss();}}, 'Cancel'), //jshint ignore:line
                     m('span.btn.btn-primary', {onclick: cb.bind(tb, 'keep')}, 'Keep Both'),
-                    m('span.btn.btn-primary', {onclick: cb.bind(tb, 'replace')},'Replace'),
-                ]), m('h3.break-word.modal-title', 'Replace "' + item.data.name + '"?')
+                    m('span.btn.btn-primary', {onclick: cb.bind(tb, 'replace')},'Replace')
+                ],
+                m('h3.break-word.modal-title', 'Replace "' + item.data.name + '"?')
             );
             return;
         }


### PR DESCRIPTION
replaces https://github.com/CenterForOpenScience/osf.io/pull/6222

## Purpose

Preprints are normal nodes, so users can currently do anything to those nodes and files that one can do with normal nodes and files.

This is a fangorn update that warns a user when they try to move a file out of a preprint project, but then ultimately allows them to do it anyway if they really want to. If they move it, the preprint will become orphaned.

![move_file_warning](https://cloud.githubusercontent.com/assets/801594/18024391/d56578a4-6bd6-11e6-85b2-27f2931e1b6c.gif)

### Things that should happen:
- Moving a preprint file out of a component should trigger a preprint warning
- Moving a preprint file into a folder should be OK
- Moving a preprint file into a component with a file that has the same name should trigger a move preprint warning modal, and then a same filename choice modal afterwards.
- Moving a file into the component should trigger a replace warning that mentions that if it was replaced, it will remove the preprint. 
- Trying to rename a file to the same name as the preprint file should trigger a preprint warning that it shouldn't be renamed

In all of these cases, the warning shows, but they can still complete the action.

## Changes

- Update `checkConflictsRename` and `checkConflicts` to check for preprint files and add an appropriate warning in
- On a normal move, check to see if the primary file is being moved out of the project, and 

## Side effects

Tested a bunch of things related to moving and renaming non preprint related files, but more tests really cannot hurt.


## Ticket
https://trello.com/c/pNvkyoEF/41-no-warning-when-moving-a-primary-file-to-another-component
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
