### PR TITLE
Update to getConfirmationCode to put in warning about deleting preprint

### DIFF
--- a/website/static/js/projectSettings.js
+++ b/website/static/js/projectSettings.js
@@ -151,6 +151,11 @@ var getConfirmationCode = function(nodeType) {
     // point; only construct the HTML for the list of contributors if the contribs list is populated
     var message = '<p>It will no longer be available to other contributors on the project.';
 
+    if (window.contextVars.node.isPreprint) {
+        message += '<p>This project represents a preprint.</p>' +
+            '<p><strong>Deleting this project will remove the preprint from circulation.</strong></p>';
+    }
+
     $osf.confirmDangerousAction({
         title: 'Are you sure you want to delete this ' + nodeType + '?',
         message: message,


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Other node actions dealing with preprints have warnings when doing something destrictive to the preprint -- add a notice for deleting a project that represents a preprint as well

![screen shot 2016-08-26 at 11 13 10 pm](https://cloud.githubusercontent.com/assets/801594/18024873/99178e02-6be3-11e6-8bbc-6e0e1f19fdae.png)

<!-- Describe the purpose of your changes -->
## Changes
- add conditional message to delete confirmation dialog

## Side effects
-nope!

## Ticket
https://trello.com/c/w373G0FY/20-delete-project-modal-should-be-updated-for-preprints
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->

