### PR TITLE
[preprints] Fix appearance of campaign login page create account form

### DIFF
--- a/website/templates/public/login.mako
+++ b/website/templates/public/login.mako
@@ -185,8 +185,8 @@
 
                         <div>
                             <!-- ko if: passwordFeedback() -->
-                            <p class="help-block osf-box-lt p-xs" data-bind="validationMessage: password" style="display: none;"></p>
-                            <p class="help-block osf-box-lt " data-bind="css : { 'p-xs': passwordFeedback().warning }, visible: typedPassword().length > 0, text: passwordFeedback().warning"></p>
+                                <p class="help-block osf-box-lt p-xs" data-bind="validationMessage: password" style="display: none;"></p>
+                                <p class="help-block osf-box-lt " data-bind="css : { 'p-xs': passwordFeedback().warning }, visible: typedPassword().length > 0, text: passwordFeedback().warning"></p>
                             <!-- /ko -->
                         </div>
                     </div>
@@ -194,25 +194,23 @@
                     <div class="help-block osf-box-lt" >
                         <p data-bind="html: message, attr: {class: messageClass}" class=""></p>
                     </div>
-                </br>
-                <div class="form-group">
-                    <div class="col-md-8 col-sm-12" style="padding-left: 25px">
-                        <a href="${login_url}" >Already have an account?</a>
-                    </div>
-                    %if redirect_url:
+                    <br>
+                    <div class="form-group m-t-md">
                         <div class="col-md-8 col-sm-12" style="padding-left: 25px">
-                            <a href="${domain}login/?campaign=institution&redirect_url=${redirect_url}">Login through your institution  <i class="fa fa-arrow-right"></i></a>
+                            <a href="${login_url}" >Already have an account?</a><br>
+
+                            %if redirect_url:
+                                <a href="${domain}login/?campaign=institution&redirect_url=${redirect_url}">Login through your institution  <i class="fa fa-arrow-right"></i></a>
+                            %else:
+                                <a href="${domain}login/?campaign=institution">Login through your institution  <i class="fa fa-arrow-right"></i></a>
+                            %endif
                         </div>
-                    %else:
-                        <div class="col-md-8 col-sm-12" style="padding-left: 25px">
-                            <a href="${domain}login/?campaign=institution">Login through your institution  <i class="fa fa-arrow-right"></i></a>
+
+                        <div class="col-md-4 col-sm-12">
+                            <span class="pull-right p-r-md"><button type="submit" class="btn btn-success" data-bind="disable: submitted()">Create account</button></span>
                         </div>
-                    %endif
-                    <div class="col-md-4 col-sm-12">
-                        <button type="submit" class="btn pull-right btn-success" data-bind="disable: submitted()">Create account</button>
                     </div>
                 </div>
-
             </form>
 
         </div>


### PR DESCRIPTION
## Purpose
Fix spacing to top and right of create account button on OSF login page create account form

Before:
![screen shot 2016-08-27 at 2 48 51 pm](https://cloud.githubusercontent.com/assets/2957073/18029502/aa65102e-6c67-11e6-9dc8-7de738c5e40c.png)

After:
![screen shot 2016-08-27 at 2 48 38 pm](https://cloud.githubusercontent.com/assets/2957073/18029504/af088c46-6c67-11e6-90d3-1e78476e42a4.png)


## Changes
Columns should add to twelve, not 16. Add spacing around items.

Affects:
- Login page signup form for campaigns (eg preprints): `http://staging2.osf.io/login/?campaign=osf-preprints`
- Login page signup form for institutions, `http://staging2.osf.io/login/?campaign=institution`


## Side effects

None expected. Cosmetic/ display only.


## Ticket

Trello card: https://trello.com/c/gAqDGxBk/81-cosmetic-bug-for-campaign-signup-page
