### PR TITLE
[OSF-6951] Search Facet for Institutions not Displaying

### DIFF
--- a/website/search_migration/migrate.py
+++ b/website/search_migration/migrate.py
@@ -14,7 +14,7 @@ from framework.auth import User
 from website.models import Node
 from website.app import init_app
 import website.search.search as search
-from scripts import utils as script_utils
+from scripts import utils as script_utils, populate_institutions
 from website.search.elastic_search import es
 
 
@@ -71,6 +71,7 @@ def migrate(delete, index=None, app=None):
         delete_old(new_index)
 
     ctx.pop()
+    populate_institutions.main('prod')
 
 def set_up_index(idx):
     alias = es.indices.get_aliases(index=idx)


### PR DESCRIPTION
## Purpose

Migrating the search only includes non-institution nodes, and erases institution index making them disappear from ES and thus making the facet disappear.

## Changes

This re-populates institutions every time the search is migrated.

## Side effects

This is probably not a long-term solution to this problem, but will stop us from wiping institution's indexes inadvertently. Also worth noting populate_institution.py is the only way of adding institutions at the moment.
## Ticket

https://openscience.atlassian.net/browse/OSF-6951
