### PR TITLE
Check to see if primary file is being moved out of osf storage and al…

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -2274,7 +2274,12 @@ function _dropLogic(event, items, folder) {
     }
 
     $.each(items, function(index, item) {
-        if (window.contextVars.node.preprintFileId === item.data.path.replace('/', '') && item.data.nodeId === window.contextVars.node.id && folder.data.nodeId !== window.contextVars.node.id) {
+        // Check all the ways that the primary preprint file could be moved out of its current node
+        if (
+            window.contextVars.node.preprintFileId === item.data.path.replace('/', '') &&
+            item.data.nodeId === window.contextVars.node.id &&
+            (folder.data.nodeId !== window.contextVars.node.id || folder.data.provider !== 'osfstorage')
+        ) {
             tb.modal.update(m('', [
                 m('p', 'The file "' + item.data.name + '" is the primary file for a preprint and so should not be moved.'),
                 m('strong', 'Moving this file will remove this preprint from circulation.')


### PR DESCRIPTION
piggybacking on #6225

## Purpose
Users got a warning when moving their preprint file into another component outside of the current preprint project, but was a-ok with primary files getting lost in addons

## Changes

- make the preprint warning also check to see if it's being moved into not osfstorage
- break up that unwieldy if statement into multiple lines for clarity

## Side effects

<!--Any possible side effects? -->


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
https://trello.com/c/L9YTXSeS/88-no-warning-when-moving-primary-preprint-file-to-an-addon