### PR TITLE
Get download count from file object for file serializer

### DIFF
--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -208,7 +208,10 @@ class FileSerializer(JSONAPISerializer):
             'md5': metadata.get('md5', None),
             'sha256': metadata.get('sha256', None),
         }
-        extras['downloads'] = obj.get_download_count()
+        if obj.provider == 'osfstorage' and obj.versions:
+            extras['downloads'] = obj.get_download_count(version=obj.versions[-1])
+        if obj.provider == 'osfstorage':
+            extras['downloads'] = obj.get_download_count()
         return extras
 
     def get_current_user_can_comment(self, obj):

--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -208,6 +208,7 @@ class FileSerializer(JSONAPISerializer):
             'md5': metadata.get('md5', None),
             'sha256': metadata.get('sha256', None),
         }
+        extras['downloads'] = obj.get_download_count()
         return extras
 
     def get_current_user_can_comment(self, obj):

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1630,7 +1630,7 @@ class NodeFilesList(JSONAPIBaseView, generics.ListAPIView, WaterButlerMixin, Lis
           hashes          object
             md5           string             md5 hash of file, null for folders
             sha256        string             SHA-256 hash of file, null for folders
-          downloads       integer            number of times the file has been downloaded
+          downloads       integer            number of times the file has been downloaded (for osfstorage files)
 
     * A note on timestamps: for files stored in osfstorage, `date_created` refers to the time the file was
     first uploaded to osfstorage, and `date_modified` is the time the file was last updated while in osfstorage.

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1630,6 +1630,7 @@ class NodeFilesList(JSONAPIBaseView, generics.ListAPIView, WaterButlerMixin, Lis
           hashes          object
             md5           string             md5 hash of file, null for folders
             sha256        string             SHA-256 hash of file, null for folders
+          downloads       integer            number of times the file has been downloaded
 
     * A note on timestamps: for files stored in osfstorage, `date_created` refers to the time the file was
     first uploaded to osfstorage, and `date_modified` is the time the file was last updated while in osfstorage.


### PR DESCRIPTION

## Purpose

We wanted to display download counts from the current file using the waterbutler info we currently have for the time being!

So now the download count is under `extras > downloads` like it is in waterbutler:

### Waterbutler:
![screen shot 2016-08-27 at 8 18 24 pm](https://cloud.githubusercontent.com/assets/801594/18030814/993c2206-6c94-11e6-881f-9ac6e686847c.png)

### API v2:
![screen shot 2016-08-27 at 8 18 10 pm](https://cloud.githubusercontent.com/assets/801594/18030812/96482a7c-6c94-11e6-803b-5adf640a4671.png)



## Changes
- Add download count for the current File

## Side effects
I think this is in total, and not for the current version? Is that confusing to anything?


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
