### PR TITLE
Feature/Reordering Contributors via APIv2 was not updating visible_contributor_ids

### DIFF
--- a/website/project/model.py
+++ b/website/project/model.py
@@ -3105,7 +3105,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
                         project_signals.write_permissions_revoked.send(self)
         if visible is not None:
             self.set_visible(user, visible, auth=auth, save=save)
-            self.update_visible_ids()
+            self.update_visible_ids(save=save)
 
     def manage_contributors(self, user_dicts, auth, save=False):
         """Reorder and remove contributors.


### PR DESCRIPTION
## Purpose

Reordering contributors via the APIv2 was not updating the visible_contributor_ids which are used to populate the contributors on the project view page.  So reordering contributors on a preprint would have no effect on the order of contributors displayed on the project view page.

## Changes

Saves the order of visible contributor ids.

## Side effects

Just passed save=save into update_visible_ids.  Cannot think of any issues.

## Ticket
https://trello.com/c/Du2ygimQ/108-order-of-authors-on-view-page-not-consistent-with-what-was-saved-and-what-appears-on-project
