### PR TITLE
Preprints - Save the children/documentation explainations

### DIFF
--- a/api/preprint_providers/views.py
+++ b/api/preprint_providers/views.py
@@ -20,6 +20,9 @@ class PreprintProviderList(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin
     """
     Paginated list of verified PreprintProviders available
 
+    ##Note
+    **This API endpoint is under active development, and is subject to change in the future.**
+
     ##PreprintProvider Attributes
 
     OSF Preprint Providers have the "preprint_providers" `type`.
@@ -65,6 +68,9 @@ class PreprintProviderList(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin
 class PreprintProviderDetail(JSONAPIBaseView, generics.RetrieveAPIView):
     """ Details about a given preprint provider.
 
+    ##Note
+    **This API endpoint is under active development, and is subject to change in the future.**
+
     ##Attributes
 
     OSF Preprint Providers have the "preprint_providers" `type`.
@@ -103,6 +109,9 @@ class PreprintProviderDetail(JSONAPIBaseView, generics.RetrieveAPIView):
 
 class PreprintProviderPreprintList(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin):
     """Preprints from a given preprint_provider. *Read Only*
+
+    ##Note
+    **This API endpoint is under active development, and is subject to change in the future.**
 
     To update preprints with a given preprint_provider, see the `<node_id>/relationships/preprint_provider` endpoint
 

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -40,6 +40,9 @@ class PreprintMixin(NodeMixin):
 class PreprintList(JSONAPIBaseView, generics.ListCreateAPIView, ODMFilterMixin):
     """Preprints that represent a special kind of preprint node. *Writeable*.
 
+    ##Note
+    **This API endpoint is under active development, and is subject to change in the future.**
+
     Paginated list of preprints ordered by their `date_created`.  Each resource contains a representation of the
     preprint.
 
@@ -157,6 +160,9 @@ class PreprintList(JSONAPIBaseView, generics.ListCreateAPIView, ODMFilterMixin):
 class PreprintDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView, PreprintMixin, WaterButlerMixin):
     """Preprint Detail  *Writeable*.
 
+    ##Note
+    **This API endpoint is under active development, and is subject to change in the future.**
+
     ##Preprint Attributes
 
     Many of these preprint attributes are the same as node, with a few special fields added in.
@@ -236,6 +242,9 @@ class PreprintPreprintProvidersList(JSONAPIBaseView, generics.ListAPIView, ODMFi
     """ Detail of the preprint providers a preprint has, if any. Returns [] if the preprint has no
     preprnt providers.
 
+    ##Note
+    **This API endpoint is under active development, and is subject to change in the future**
+
     ##Attributes
 
     OSF Preprint Providers have the "preprint_providers" `type`.
@@ -275,6 +284,9 @@ class PreprintToPreprintProviderRelationship(JSONAPIBaseView, generics.RetrieveU
     """ Relationship Endpoint for Preprint -> PreprintProvider
 
     Used to set preprint_provider of a preprint to a PreprintProvider
+
+    ##Note
+    **This API endpoint is under active development, and is subject to change in the future.**
 
     ##Actions
 

--- a/api/taxonomies/serializers.py
+++ b/api/taxonomies/serializers.py
@@ -21,6 +21,7 @@ class TaxonomySerializer(JSONAPISerializer):
     id = ser.CharField(source='_id', required=True)
     text = ser.CharField(max_length=200)
     parents = JSONAPIListField(child=TaxonomyField())
+    child_count = ser.IntegerField()
 
     links = LinksField({
         'parents': 'get_parent_urls',

--- a/api/taxonomies/views.py
+++ b/api/taxonomies/views.py
@@ -12,6 +12,9 @@ from framework.auth.oauth_scopes import CoreScopes
 class TaxonomyList(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin):
     '''[PLOS taxonomy of subjects](http://journals.plos.org/plosone/browse/) in flattened form. *Read-only*
 
+    ##Note
+    **This API endpoint is under active development, and is subject to change in the future**
+
     ##Taxonomy Attributes
 
         name           type                   description
@@ -56,6 +59,9 @@ class TaxonomyList(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin):
 
 class TaxonomyDetail(JSONAPIBaseView, generics.RetrieveAPIView):
     '''[PLOS taxonomy subject](http://journals.plos.org/plosone/browse/) instance. *Read-only*
+
+    ##Note
+    **This API endpoint is under active development, and is subject to change in the future**
 
     ##Taxonomy Attributes
 

--- a/scripts/update_taxonomies.py
+++ b/scripts/update_taxonomies.py
@@ -41,7 +41,7 @@ def update_taxonomies(filename):
 
             try:
                 subject = Subject.find_one(Q('text', 'eq', text))
-            except (NoResultsFound):    
+            except (NoResultsFound):
                 # If subject does not yet exist, create it
                 subject = Subject(
                     text=text,
@@ -67,10 +67,16 @@ def main():
     dry_run = '--dry' in sys.argv
     if not dry_run:
         script_utils.add_file_logger(logger, __file__)
-    set_up_storage([Subject], storage.MongoStorage)    
+    set_up_storage([Subject], storage.MongoStorage)
     with TokuTransaction():
         update_taxonomies('plos_taxonomy.json')
         update_taxonomies('other_taxonomy.json')
+        # Now that all subjects have been added to the db, compute and set
+        # the 'children' field for every subject
+        logger.info('Setting "children" field for each Subject')
+        for subject in Subject.find():
+            subject.set_children()
+            subject.save()
 
         if dry_run:
             raise RuntimeError('Dry run, transaction rolled back')

--- a/website/project/taxonomies/__init__.py
+++ b/website/project/taxonomies/__init__.py
@@ -1,4 +1,4 @@
-from modularodm import fields
+from modularodm import fields, Q
 
 from framework.mongo import (
     ObjectId,
@@ -13,10 +13,22 @@ class Subject(StoredObject):
     _id = fields.StringField(primary=True, default=lambda: str(ObjectId()))
     text = fields.StringField(required=True)
     parents = fields.ForeignField('subject', list=True)
+    children = fields.ForeignField('subject', list=True)
 
     @property
     def absolute_api_v2_url(self):
         return api_v2_url('taxonomies/{}/'.format(self._id))
+
+    @property
+    def child_count(self):
+        return len(self.children)
+
+    def set_children(self):
+        """
+        This gets called in scripts/update_taxonomies.py after all
+        subjects have been added. Done their to avoid API slowness"""
+        if not self.children:
+            self.children = Subject.find(Q('parents', 'eq', self))
 
     def get_absolute_url(self):
         return self.absolute_api_v2_url

--- a/website/project/taxonomies/__init__.py
+++ b/website/project/taxonomies/__init__.py
@@ -26,7 +26,7 @@ class Subject(StoredObject):
     def set_children(self):
         """
         This gets called in scripts/update_taxonomies.py after all
-        subjects have been added. Done their to avoid API slowness"""
+        subjects have been added."""
         if not self.children:
             self.children = Subject.find(Q('parents', 'eq', self))
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
A complicated fix for a seemingly easy problem! ember-preprints subjects on the discover page were showing a caret even if there were no children there to load - the request for more children wasn't being made until the carat was clicked, so there was no way to know weather or not to load the carrot or not.

This change adds children as another foreign field, which is set in the `update_taxonomies` script, so that ember-preprints can know how many children there are before making the request, thus weather or not to show the carrot in advance

h/t to @sloria for much help

Also at request of @brianjgeiger add message to preprint related API routes that the API routes are in flux!

## Changes
- add child count to the taxonomies serializer  (added here in attributes instead of in extra for simplicity when reading from ember for speed sake)
- add child_count property to Subjects
- add children as foreign field to Subjects cause why not be proper
- use update_taxonomies script to also set the children
- update preprints realted views with caveat message

## Side effects
Must run `update_taxonomies` again to make sure all children are saved, orelse all children counts will be 0
An ember-osf PR will rely on this to get accurate carrts or not

## Ticket
https://trello.com/c/GETV8yQ1/111-preprints-discover-the-caret-does-no-action