### PR TITLE
[Hotfix] Tags and Folders Bugs

### DIFF
--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -208,7 +208,7 @@ class FileSerializer(JSONAPISerializer):
             'md5': metadata.get('md5', None),
             'sha256': metadata.get('sha256', None),
         }
-        if obj.provider == 'osfstorage':
+        if obj.provider == 'osfstorage' and obj.kind == 'file':
             extras['downloads'] = obj.get_download_count()
         return extras
 

--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -208,7 +208,7 @@ class FileSerializer(JSONAPISerializer):
             'md5': metadata.get('md5', None),
             'sha256': metadata.get('sha256', None),
         }
-        if obj.provider == 'osfstorage' and obj.kind == 'file':
+        if obj.provider == 'osfstorage' and obj.is_file:
             extras['downloads'] = obj.get_download_count()
         return extras
 

--- a/api_tests/nodes/views/test_node_files_list.py
+++ b/api_tests/nodes/views/test_node_files_list.py
@@ -137,6 +137,15 @@ class TestNodeFilesList(ApiTestCase):
         assert_equal(res.json['data']['attributes']['kind'], 'file')
         assert_equal(res.json['data']['attributes']['name'], 'NewFile')
 
+    def test_list_returns_folder_data(self):
+        fobj = self.project.get_addon('osfstorage').get_root().append_folder('NewFolder')
+        fobj.save()
+        res = self.app.get('{}osfstorage/'.format(self.private_url, fobj._id), auth=self.user.auth)
+        assert_equal(res.status_code, 200)
+        assert_equal(len(res.json['data']), 1)
+        assert_equal(res.content_type, 'application/vnd.api+json')
+        assert_equal(res.json['data'][0]['attributes']['name'], 'NewFolder')
+
     def test_returns_folder_data(self):
         fobj = self.project.get_addon('osfstorage').get_root().append_folder('NewFolder')
         fobj.save()

--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -56,6 +56,29 @@ class TestPreprintUpdate(ApiTestCase):
         self.preprint.reload()
         assert_equal(self.preprint.title, 'A new title')
 
+    def test_update_preprint_tags(self):
+        update_tags_payload = build_preprint_update_payload(self.preprint._id, attributes={'tags': ['newtag', 'bluetag']})
+
+        res = self.app.patch_json_api(self.url, update_tags_payload, auth=self.user.auth)
+        assert_equal(res.status_code, 200)
+
+        self.preprint.reload()
+        assert_in('newtag', self.preprint.tags)
+        assert_in('bluetag', self.preprint.tags)
+        assert_in('tag_added', [l.action for l in self.preprint.logs])
+
+    def test_update_preprint_tags_not_list(self):
+        update_tags_payload = build_preprint_update_payload(self.preprint._id, attributes={'tags': 'newtag'})
+
+        res = self.app.patch_json_api(self.url, update_tags_payload, auth=self.user.auth, expect_errors=True)
+        assert_equal(res.status_code, 400)
+
+    def test_update_preprint_none_tags(self):
+        update_tags_payload = build_preprint_update_payload(self.preprint._id, attributes={'tags': [None]})
+
+        res = self.app.patch_json_api(self.url, update_tags_payload, auth=self.user.auth, expect_errors=True)
+        assert_equal(res.status_code, 400)
+
     def test_update_preprint_subjects(self):
         assert_not_equal(self.preprint.preprint_subjects[0], self.subject._id)
         update_subjects_payload = build_preprint_update_payload(self.preprint._id, attributes={"subjects": [self.subject._id]})

--- a/api_tests/preprints/views/test_preprint_list.py
+++ b/api_tests/preprints/views/test_preprint_list.py
@@ -155,6 +155,18 @@ class TestPreprintCreate(ApiTestCase):
 
         assert_equal(res.status_code, 201)
 
+    def test_create_preprint_with_tags(self):
+        public_project_payload = build_preprint_create_payload(self.public_project._id, self.subject._id, self.file_one_public_project._id)
+        public_project_payload['data']['attributes']['tags'] = ['newtag', 'bluetag']
+        res = self.app.post_json_api(self.url, public_project_payload, auth=self.user.auth)
+
+        assert_equal(res.status_code, 201)
+
+        self.public_project.reload()
+        assert_in('newtag', self.public_project.tags)
+        assert_in('bluetag', self.public_project.tags)
+        assert_not_in('tag_added', [l.action for l in self.public_project.logs])
+
     def test_create_preprint_from_private_project(self):
         private_project_payload = build_preprint_create_payload(self.private_project._id, self.subject._id, self.file_one_private_project._id)
         res = self.app.post_json_api(self.url, private_project_payload, auth=self.user.auth)


### PR DESCRIPTION
## Purpose
Fix bugs

## Changes
* Tags for `preprints` are built the way they are with `nodes`
* Check `obj.kind` for `file` before calling `File`-specific method

## Side effects
Increased test coverage

## Ticket
https://trello.com/c/LZ6F68HO/121-keep-receiving-a-a-cannot-upload-folders-error-when-adding-files-to-the-preprint-project
