### PR TITLE
Non admins get 403 Forbidden instead of 409 Conflict when Wrongly POSTing to existing preprint

### DIFF
--- a/api_tests/preprints/views/test_preprint_list.py
+++ b/api_tests/preprints/views/test_preprint_list.py
@@ -169,7 +169,8 @@ class TestPreprintCreate(ApiTestCase):
 
         assert_equal(res.status_code, 403)
 
-    def test_read_write_user_not_authorized(self):
+    def test_read_write_user_not_admin(self):
+        assert_in(self.other_user, self.public_project.contributors)
         public_project_payload = build_preprint_create_payload(self.public_project._id, self.subject._id, self.file_one_public_project._id)
         res = self.app.post_json_api(self.url, public_project_payload, auth=self.other_user.auth, expect_errors=True)
 

--- a/api_tests/preprints/views/test_preprint_list.py
+++ b/api_tests/preprints/views/test_preprint_list.py
@@ -193,6 +193,18 @@ class TestPreprintCreate(ApiTestCase):
         assert_equal(res.status_code, 409)
         assert_equal(res.json['errors'][0]['detail'], 'This node already stored as a preprint, use the update method instead.')
 
+    def test_read_write_user_already_a_preprint(self):
+        assert_in(self.other_user, self.public_project.contributors)
+
+        preprint = PreprintFactory(creator=self.user)
+        preprint.add_contributor(self.other_user, permissions=[permissions.DEFAULT_CONTRIBUTOR_PERMISSIONS], save=True)
+        file_one_preprint = test_utils.create_test_file(preprint, self.user, 'openupthatwindow.pdf')
+
+        already_preprint_payload = build_preprint_create_payload(preprint._id, self.subject._id, file_one_preprint._id)
+        res = self.app.post_json_api(self.url, already_preprint_payload, auth=self.other_user.auth, expect_errors=True)
+
+        assert_equal(res.status_code, 403)
+
     def test_no_primary_file_passed(self):
         no_file_payload = build_preprint_create_payload(self.public_project._id, self.subject._id)
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
When a read-write user tries to POST to create a preprint that already exists, the API returned a 409 error before the 403 forbidden. While 409 is techncally correct, 403 is way more appropraite for the user because they'll never be able to make a node a preprint. 

## Changes

- check permissions of auth user before 409 conflict

## Side effects

no?


## Ticket
https://trello.com/c/vc41eU5E/124-api-read-write-and-read-only-users-get-a-409-error-instead-of-a-403