### PR TITLE
[feature fix] Preprints Relationship Validation [OSF-6969]

### DIFF
--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -104,7 +104,7 @@ class TestPreprintUpdate(ApiTestCase):
         relationships = {
             "primary_file": {
                 "data": {
-                    "type": "file",
+                    "type": "primary_file",
                     "id": new_file._id
                 }
             }
@@ -125,7 +125,7 @@ class TestPreprintUpdate(ApiTestCase):
         relationships = {
             "primary_file": {
                 "data": {
-                    "type": "file",
+                    "type": "primary_file",
                     "id": file_for_project._id
                 }
             }

--- a/api_tests/preprints/views/test_preprint_list.py
+++ b/api_tests/preprints/views/test_preprint_list.py
@@ -33,7 +33,7 @@ def build_preprint_create_payload(node_id, subject_id, file_id=None):
         payload['data']['relationships'] = {
             "primary_file": {
                 "data": {
-                    "type": "file",
+                    "type": "primary_file",
                     "id": file_id
                 }
             }


### PR DESCRIPTION
#### Purpose
- Fix preprints tests breaking due to relationship validation.

#### Side Effects
- ember-preprints needs to be updated ([#122](https://github.com/CenterForOpenScience/ember-preprints/pull/122))

#### Ticket
- [OSF-6969](https://openscience.atlassian.net/browse/OSF-6969)


