### PR TITLE
[WIP] Let preprints fetch comments (via the nodes endpoint) [#PREP-135]

### DIFF
--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -2,19 +2,18 @@ from modularodm.exceptions import ValidationValueError
 from rest_framework import exceptions
 from rest_framework import serializers as ser
 
+from api.base.exceptions import Conflict, RelationshipPostMakesNoChanges
 from api.base.serializers import (
     JSONAPISerializer, IDField, JSONAPIListField, LinksField,
     RelationshipField, JSONAPIRelationshipSerializer, relationship_diff
 )
-from api.base.exceptions import Conflict, RelationshipPostMakesNoChanges
 from api.base.utils import absolute_reverse, get_user_auth
 from api.nodes.serializers import NodeTagField
 from api.taxonomies.serializers import TaxonomyField
 from framework.exceptions import PermissionsError
-from website.util import permissions
-from website.project import signals as project_signals
 from website.models import StoredFileNode, PreprintProvider, Node
-
+from website.project import signals as project_signals
+from website.util import permissions
 
 class PrimaryFileRelationshipField(RelationshipField):
     def get_object(self, file_id):

--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -54,6 +54,14 @@ class PreprintSerializer(JSONAPISerializer):
         read_only=False
     )
 
+    # Intentionally use the existing node endpoint for preprint comments
+    comments = RelationshipField(
+        related_view='nodes:node-comments',
+        related_view_kwargs={'node_id': '<pk>'},
+        related_meta={'unread': 'get_unread_comments_count'},
+        filter={'target': '<pk>'}
+    )
+
     files = RelationshipField(
         related_view='nodes:node-providers',
         related_view_kwargs={'node_id': '<pk>'}


### PR DESCRIPTION
## Purpose

Support fetching comments for preprints.
## Changes
- Add a `comments` relationship field to preprint representation. It should point to `nodes/<nid>/comments` (with appropriate filter parameter).
## Side effects

None expected. However, since preprints are implemented as nodes with an extra flag, this re-uses the `/nodes/comments` endpoint. This design choice can and should be revisited if the underlying implementation changes.
## Ticket

https://openscience.atlassian.net/browse/PREP-135
