### PR TITLE
[Hotfix] Index ORCiD-registered unreg contribs [#OSF-6979]

### DIFF
--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -381,7 +381,7 @@ def external_login_confirm_email_get(auth, uid, token):
         raise HTTPError(http.FORBIDDEN, e.message)
 
     if not user.is_registered:
-        user.register(email)
+        user.register(email, password=uuid.uuid4())
 
     if email.lower() not in user.emails:
         user.emails.append(email.lower())


### PR DESCRIPTION
## Purpose
Unregistered contributors should be searchable after registering, regardless of whether they set a password or signed in with ORCiD for the first time.

## Changes
Ensure `user.is_active` when `user.register` calls `user.update_search`

## Side effects
None

## Ticket
[#OSF-6979](https://openscience.atlassian.net/browse/OSF-6979)

### Note
Verified with @icereval that only QA accounts were affected. They were manually migrated; no script is necessary.
