### PR TITLE
[Hotfix] spam email test

### DIFF
--- a/framework/auth/utils.py
+++ b/framework/auth/utils.py
@@ -28,7 +28,7 @@ def validate_email(email):
     if not email or '@' not in email:
         raise ValidationError('Invalid Email')
 
-    if email.split('@')[1] in settings.BLACKLISTED_DOMAINS:
+    if email.split('@')[1].lower() in settings.BLACKLISTED_DOMAINS:
         raise ValidationError('Invalid Email')
 
     user_part, domain_part = email.rsplit('@', 1)

--- a/tests/test_conferences.py
+++ b/tests/test_conferences.py
@@ -119,7 +119,7 @@ class TestConferenceUtils(OsfTestCase):
         username = 'kanye@mailinator.com'
         with assert_raises(ValidationError) as e:
             get_or_create_user(fullname, username, True)
-        assert_equal(e.exception.message, 'Invalid email address.')
+        assert_equal(e.exception.message, 'Invalid Email')
 
 
 class ContextTestCase(OsfTestCase):


### PR DESCRIPTION
## Purpose
Fix failing test

## Changes
* Update error message in test
* Call `.lower` on possibly-spammy email domain when verifying

## Side effects
None