### PR TITLE
[feature fix] Append VOL Key to API Links [OSF-6733]

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -732,6 +732,9 @@ class LinksField(ser.Field):
         # not just the field attribute.
         return obj
 
+    def extend_absolute_url(self, obj):
+        return extend_querystring_if_key_exists(obj.get_absolute_url(), self.context['request'], 'view_only')
+
     def to_representation(self, obj):
         ret = {}
         for name, value in self.links.iteritems():
@@ -742,7 +745,7 @@ class LinksField(ser.Field):
             else:
                 ret[name] = url
         if hasattr(obj, 'get_absolute_url') and 'self' not in self.links:
-            ret['self'] = obj.get_absolute_url()
+            ret['self'] = self.extend_absolute_url(obj)
         return ret
 
 

--- a/api/base/utils.py
+++ b/api/base/utils.py
@@ -142,6 +142,11 @@ def default_node_permission_query(user):
 def extend_querystring_params(url, params):
     return furl.furl(url).add(args=params).url
 
+def extend_querystring_if_key_exists(url, request, key):
+    if key in request.query_params.keys():
+        return extend_querystring_params(url, {key: request.query_params.get(key)})
+    return url
+
 def has_admin_scope(request):
     """ Helper function to determine if a request should be treated
         as though it has the `osf.admin` scope. This includes both

--- a/api_tests/comments/views/test_comment_detail.py
+++ b/api_tests/comments/views/test_comment_detail.py
@@ -157,7 +157,9 @@ class CommentDetailMixin(object):
         assert_equal(res.status_code, 200)
         url = res.json['data']['relationships']['replies']['links']['related']['href']
         uri = test_utils.urlparse_drop_netloc(url)
-        assert_equal(self.app.get(uri).status_code, 200)
+        res = self.app.get(uri)
+        assert_equal(res.status_code, 200)
+        assert_equal(res.json['data'][0]['type'], 'comments')
 
     def test_comment_has_reports_link(self):
         self._set_up_public_project_with_comment()

--- a/api_tests/comments/views/test_comment_detail.py
+++ b/api_tests/comments/views/test_comment_detail.py
@@ -154,11 +154,10 @@ class CommentDetailMixin(object):
     def test_comment_has_replies_link(self):
         self._set_up_public_project_with_comment()
         res = self.app.get(self.public_url)
+        assert_equal(res.status_code, 200)
         url = res.json['data']['relationships']['replies']['links']['related']['href']
         uri = test_utils.urlparse_drop_netloc(url)
-        expected_url = '/{}nodes/{}/comments/?filter[target]={}'.format(API_BASE, self.public_project._id, self.public_comment._id)
-        assert_equal(res.status_code, 200)
-        assert_in(expected_url, uri)
+        assert_equal(self.app.get(uri).status_code, 200)
 
     def test_comment_has_reports_link(self):
         self._set_up_public_project_with_comment()

--- a/api_tests/files/views/test_file_detail.py
+++ b/api_tests/files/views/test_file_detail.py
@@ -92,6 +92,7 @@ class TestFileView(ApiTestCase):
         assert_in('comments', res.json['data']['relationships'].keys())
         url = res.json['data']['relationships']['comments']['links']['related']['href']
         assert_equal(self.app.get(url, auth=self.user.auth).status_code, 200)
+        assert_equal(res.json['data']['type'], 'files')
 
     def test_file_has_correct_unread_comments_count(self):
         contributor = AuthUserFactory()

--- a/api_tests/files/views/test_file_detail.py
+++ b/api_tests/files/views/test_file_detail.py
@@ -86,13 +86,12 @@ class TestFileView(ApiTestCase):
         assert_in(expected_url, actual_url)
 
     def test_file_has_comments_link(self):
-        guid = self.file.get_guid(create=True)
+        self.file.get_guid(create=True)
         res = self.app.get(self.file_url, auth=self.user.auth)
         assert_equal(res.status_code, 200)
         assert_in('comments', res.json['data']['relationships'].keys())
-        expected_url = '/{}nodes/{}/comments/?filter[target]={}'.format(API_BASE, self.node._id, guid._id)
         url = res.json['data']['relationships']['comments']['links']['related']['href']
-        assert_in(expected_url, url)
+        assert_equal(self.app.get(url, auth=self.user.auth).status_code, 200)
 
     def test_file_has_correct_unread_comments_count(self):
         contributor = AuthUserFactory()

--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -161,19 +161,19 @@ class TestNodeDetail(ApiTestCase):
         assert_equal(res.status_code, 200)
         assert_equal(res.json['data'][0]['type'], 'comments')
 
-    def test_node_comments_link_query_params_formattedg(self):
+    def test_node_comments_link_query_params_formatted(self):
         CommentFactory(node=self.public_project, user=self.user)
         self.private_project_link = PrivateLinkFactory(anonymous=False)
         self.private_project_link.nodes.append(self.private_project)
         self.private_project_link.save()
 
-        res = self.app.get('{}?view_only={}'.format(self.private_url, self.private_project_link.key))
-        assert_equal(res.status_code, 200)
-        assert_in('comments', res.json['data']['relationships'].keys())
+        res = self.app.get(self.private_url, auth=self.user.auth)
         url = res.json['data']['relationships']['comments']['links']['related']['href']
-        res = self.app.get(url)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.json['data'][0]['type'], 'comments')
+        assert_not_in(self.private_project_link.key, url)
+
+        res = self.app.get('{}?view_only={}'.format(self.private_url, self.private_project_link.key))
+        url = res.json['data']['relationships']['comments']['links']['related']['href']
+        assert_in(self.private_project_link.key, url)
 
     def test_node_has_correct_unread_comments_count(self):
         contributor = AuthUserFactory()

--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -22,6 +22,7 @@ from tests.factories import (
     CollectionFactory,
     CommentFactory,
     NodeLicenseRecordFactory,
+    PrivateLinkFactory
 )
 
 from website.project.licenses import ensure_licenses
@@ -151,11 +152,28 @@ class TestNodeDetail(ApiTestCase):
         assert_equal(urlparse(url).path, expected_url)
 
     def test_node_has_comments_link(self):
+        CommentFactory(node=self.public_project, user=self.user)
         res = self.app.get(self.public_url)
         assert_equal(res.status_code, 200)
         assert_in('comments', res.json['data']['relationships'].keys())
         url = res.json['data']['relationships']['comments']['links']['related']['href']
-        assert_equal(self.app.get(url).status_code, 200)
+        res = self.app.get(url)
+        assert_equal(res.status_code, 200)
+        assert_equal(res.json['data'][0]['type'], 'comments')
+
+    def test_node_comments_link_query_params_formattedg(self):
+        CommentFactory(node=self.public_project, user=self.user)
+        self.private_project_link = PrivateLinkFactory(anonymous=False)
+        self.private_project_link.nodes.append(self.private_project)
+        self.private_project_link.save()
+
+        res = self.app.get('{}?view_only={}'.format(self.private_url, self.private_project_link.key))
+        assert_equal(res.status_code, 200)
+        assert_in('comments', res.json['data']['relationships'].keys())
+        url = res.json['data']['relationships']['comments']['links']['related']['href']
+        res = self.app.get(url)
+        assert_equal(res.status_code, 200)
+        assert_equal(res.json['data'][0]['type'], 'comments')
 
     def test_node_has_correct_unread_comments_count(self):
         contributor = AuthUserFactory()

--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -154,8 +154,8 @@ class TestNodeDetail(ApiTestCase):
         res = self.app.get(self.public_url)
         assert_equal(res.status_code, 200)
         assert_in('comments', res.json['data']['relationships'].keys())
-        assert_in('filter[target]={}'.format(self.public_project._id),
-                  res.json['data']['relationships']['comments']['links']['related']['href'])
+        url = res.json['data']['relationships']['comments']['links']['related']['href']
+        assert_equal(self.app.get(url).status_code, 200)
 
     def test_node_has_correct_unread_comments_count(self):
         contributor = AuthUserFactory()

--- a/api_tests/nodes/views/test_view_only_query_parameter.py
+++ b/api_tests/nodes/views/test_view_only_query_parameter.py
@@ -195,7 +195,7 @@ class TestNodeDetailViewOnlyLinks(ViewOnlyTestCase):
         }, auth=self.creation_user.auth)
         assert_equal(res.status_code, 200)
 
-    def test_view_only_token_in_relationships_links(self):
+    def test_view_only_key_in_relationships_links(self):
         res = self.app.get(self.private_node_one_url, {'view_only': self.private_node_one_private_link.key})
         assert_equal(res.status_code, 200)
         res_relationships = res.json['data']['relationships']
@@ -204,6 +204,13 @@ class TestNodeDetailViewOnlyLinks(ViewOnlyTestCase):
                 assert_in(self.private_node_one_private_link.key, value['links']['related']['href'])
             if value['links'].get('self'):
                 assert_in(self.private_node_one_private_link.key, value['links']['self']['href'])
+
+    def test_view_only_key_in_self_and_html_links(self):
+        res = self.app.get(self.private_node_one_url, {'view_only': self.private_node_one_private_link.key})
+        assert_equal(res.status_code, 200)
+        links = res.json['data']['links']
+        assert_in(self.private_node_one_private_link.key, links['self'])
+        assert_in(self.private_node_one_private_link.key, links['html'])
 
 
 class TestNodeListViewOnlyLinks(ViewOnlyTestCase):

--- a/api_tests/wikis/views/test_wiki_detail.py
+++ b/api_tests/wikis/views/test_wiki_detail.py
@@ -159,10 +159,9 @@ class TestWikiDetailView(ApiWikiTestCase):
     def test_wiki_has_comments_link(self):
         self._set_up_public_project_with_wiki_page()
         res = self.app.get(self.public_url)
-        url = res.json['data']['relationships']['comments']['links']['related']['href']
-        expected_url = '/{}nodes/{}/comments/?filter[target]={}'.format(API_BASE, self.public_project._id, self.public_wiki._id)
         assert_equal(res.status_code, 200)
-        assert_in(expected_url, url)
+        url = res.json['data']['relationships']['comments']['links']['related']['href']
+        assert_equal(self.app.get(url).status_code, 200)
 
     def test_only_project_contrib_can_comment_on_closed_project(self):
         self._set_up_public_project_with_wiki_page(project_options={'comment_level': 'private'})

--- a/api_tests/wikis/views/test_wiki_detail.py
+++ b/api_tests/wikis/views/test_wiki_detail.py
@@ -3,10 +3,15 @@ from urlparse import urlparse
 from nose.tools import *  # flake8: noqa
 
 from api.base.settings.defaults import API_BASE
+
+from framework.guid.model import Guid
+
 from website.addons.wiki.model import NodeWikiPage
+
 from tests.base import ApiWikiTestCase
 from tests.factories import (ProjectFactory, RegistrationFactory,
-                             NodeWikiFactory, PrivateLinkFactory)
+                             NodeWikiFactory, PrivateLinkFactory,
+                             CommentFactory)
 
 
 class TestWikiDetailView(ApiWikiTestCase):
@@ -161,7 +166,10 @@ class TestWikiDetailView(ApiWikiTestCase):
         res = self.app.get(self.public_url)
         assert_equal(res.status_code, 200)
         url = res.json['data']['relationships']['comments']['links']['related']['href']
-        assert_equal(self.app.get(url).status_code, 200)
+        CommentFactory(node=self.public_project, target=Guid.load(self.public_wiki._id), user=self.user)
+        res = self.app.get(url)
+        assert_equal(res.status_code, 200)
+        assert_equal(res.json['data'][0]['type'], 'comments')
 
     def test_only_project_contrib_can_comment_on_closed_project(self):
         self._set_up_public_project_with_wiki_page(project_options={'comment_level': 'private'})


### PR DESCRIPTION
#### Purpose
- Fixes incorrectly formatted comment relationship links by using `furl` to build relationship links with multiple query parameters (`view_only` and `filter`)
- Appends VOL key to generated `self` and `html` links.

#### Changes
- Adds generic `extend_querystring_if_key_exists` helper to `api.base.utils.py` to append the VOL key query parameter if present.

#### Ticket
- [OSF-6733](https://openscience.atlassian.net/browse/OSF-6733)
