### PR TITLE
Feature/quick institutions sales stats [OSF-6952]

### DIFF
--- a/scripts/analytics/institutions.py
+++ b/scripts/analytics/institutions.py
@@ -19,13 +19,48 @@ def get_count_by_institutions():
         user_query = Q('_affiliated_institutions', 'eq', institution.node)
         node_query = (
             Q('is_deleted', 'ne', True) &
-            Q('is_folder', 'ne', True) &
-            Q('parent_node', 'eq', None)
+            Q('is_folder', 'ne', True)
         )
+        registration_query = node_query & Q('is_registration', 'eq', True)
+        non_registration_query = node_query & Q('is_registration', 'eq', False)
+        project_query = non_registration_query & Q('parent_node', 'eq', None)
+        registered_project_query = non_registration_query & Q('parent_node', 'eq', None)
+        public_query = Q('is_public', 'eq', True)
+        private_query = Q('is_public', 'eq', False)
+        node_public_query = non_registration_query & public_query
+        node_private_query = non_registration_query & private_query
+        project_public_query = non_registration_query & public_query
+        project_private_query = non_registration_query & private_query
+        registered_node_public_query = registration_query & public_query
+        registered_node_private_query = registration_query & private_query
+        registered_project_public_query = registered_project_query & public_query
+        registered_project_private_query = registered_project_query & private_query
         count = {
+            'id': institution._id,
             'institution': institution.name,
-            'users': User.find(user_query).count(),
-            'nodes': Node.find_by_institutions(institution, node_query).count(),
+            'users': {
+                'total': User.find(user_query).count(),
+            },
+            'nodes': {
+                'total':Node.find_by_institutions(institution, node_query).count(),
+                'public': Node.find_by_institutions(institution, node_public_query).count(),
+                'private': Node.find_by_institutions(institution, node_private_query).count(),
+            },
+            'projects': {
+                'total': Node.find_by_institutions(institution, project_query).count(),
+                'public': Node.find_by_institutions(institution, project_public_query).count(),
+                'private': Node.find_by_institutions(institution, project_private_query).count(),
+            },
+            'registered_nodes': {
+                'total': Node.find_by_institutions(institution, registration_query).count(),
+                'public': Node.find_by_institutions(institution, registered_node_public_query).count(),
+                'private': Node.find_by_institutions(institution, registered_node_private_query).count(),
+            },
+            'registered_projects': {
+                'total': Node.find_by_institutions(institution, registered_project_query).count(),
+                'public': Node.find_by_institutions(institution, registered_project_public_query).count(),
+                'private': Node.find_by_institutions(institution, registered_project_private_query).count(),
+            },
         }
         counts.append(count)
     keen_payload = {'institution_analytics': counts}
@@ -36,12 +71,10 @@ def main():
     counts_by_institutions = get_count_by_institutions()
     keen_project = keen_settings['private']['project_id']
     write_key = keen_settings['private']['write_key']
-    read_key = keen_settings['private']['read_key']
     if keen_project and write_key:
         client = KeenClient(
             project_id=keen_project,
             write_key=write_key,
-            read_key=read_key
         )
         client.add_events(counts_by_institutions)
     else:

--- a/scripts/analytics/institutions.py
+++ b/scripts/analytics/institutions.py
@@ -36,8 +36,10 @@ def get_count_by_institutions():
         registered_project_public_query = registered_project_query & public_query
         registered_project_private_query = registered_project_query & private_query
         count = {
-            'id': institution._id,
-            'institution': institution.name,
+            'institution':{
+                'id': institution._id,
+                'name': institution.name,
+            },
             'users': {
                 'total': User.find(user_query).count(),
             },
@@ -54,12 +56,12 @@ def get_count_by_institutions():
             'registered_nodes': {
                 'total': Node.find_by_institutions(institution, registration_query).count(),
                 'public': Node.find_by_institutions(institution, registered_node_public_query).count(),
-                'private': Node.find_by_institutions(institution, registered_node_private_query).count(),
+                'embargoed': Node.find_by_institutions(institution, registered_node_private_query).count(),
             },
             'registered_projects': {
                 'total': Node.find_by_institutions(institution, registered_project_query).count(),
                 'public': Node.find_by_institutions(institution, registered_project_public_query).count(),
-                'private': Node.find_by_institutions(institution, registered_project_private_query).count(),
+                'embargoed': Node.find_by_institutions(institution, registered_project_private_query).count(),
             },
         }
         counts.append(count)

--- a/scripts/analytics/institutions.py
+++ b/scripts/analytics/institutions.py
@@ -1,0 +1,43 @@
+from modularodm import Q
+
+from website.app import init_app
+from website.models import User, Node, Institution
+
+
+def get_institutions():
+    institutions = Institution.find(Q('_id', 'ne', None))
+    return institutions
+
+
+def get_user_count_by_institutions():
+    institutions = get_institutions()
+    user_counts = []
+    for institution in institutions:
+        query = Q('_affiliated_institutions', 'eq', institution.node)
+        user_counts.append({institution.name: User.find(query).count()})
+    return user_counts
+
+
+def get_node_count_by_institutions():
+    institutions = get_institutions()
+    node_counts = []
+    for institution in institutions:
+        query = (
+            Q('is_deleted', 'ne', True) &
+            Q('is_folder', 'ne', True) &
+            Q('parent_node', 'eq', None)
+        )
+        node_counts.append({institution.name: Node.find_by_institutions(institution, query).count()})
+    return node_counts
+
+
+def main():
+    users_by_institutions = get_user_count_by_institutions()
+    nodes_by_institutions = get_node_count_by_institutions()
+    print(users_by_institutions)
+    print(nodes_by_institutions)
+
+
+if __name__ == '__main__':
+    init_app()
+    main()


### PR DESCRIPTION
## Purpose

Analytics gathering for getting user and node counts grouped by institutions.

## Changes

Add a script to the analytics module.

## Side effects

1. If the environment doesn't have a private keen project or private keen write key set, the script should output the dictionary rather than trying to send the data to keen
2. I'm not entirely sure how the analytics are run, so a celery beat task or cron job may need to be updated somewhere?


## Ticket

https://openscience.atlassian.net/browse/OSF-6952