### PR TITLE
[Hotfix] Check perms when changing contrib perms

### DIFF
--- a/website/project/model.py
+++ b/website/project/model.py
@@ -3237,7 +3237,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
             if auth is not None:
                 user = auth.user
                 if not self.has_permission(user, ADMIN):
-                    raise PermissionsError('Must be an admin to change add contributors.')
+                    raise PermissionsError('Must be an admin to add contributors.')
                 if contrib_to_add in user.recently_added:
                     user.recently_added.remove(contrib_to_add)
                 user.recently_added.insert(0, contrib_to_add)
@@ -3265,6 +3265,9 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable):
 
         # Permissions must be overridden if changed when contributor is added to parent he/she is already on a child of.
         elif contrib_to_add in self.contributors and permissions is not None:
+            if auth is not None:
+                if not self.has_permission(auth.user, ADMIN):
+                    raise PermissionsError('Must be an admin to edit contributor permissions.')
             self.set_permissions(contrib_to_add, permissions)
             if save:
                 self.save()


### PR DESCRIPTION
## Purpose

Extends https://github.com/CenterForOpenScience/osf.io/commit/cf68848c0cba14288104186163d1f36d532b61b1
## Changes
- Ensure permissions are checked whether adding a contrib or modifying perms for existing contrib
- Fix typo
## Side effects

None expected.
