### PR TITLE
File page name and date modified filter fix [#OSF-6863]

### DIFF
--- a/website/addons/dataverse/static/dataverseFangornConfig.js
+++ b/website/addons/dataverse/static/dataverseFangornConfig.js
@@ -277,18 +277,18 @@ function _fangornColumns(item) {
             filter : false,
             custom : function() {return m('');}
         });
+        columns.push({
+            data: 'version',
+            filter: false,
+            sortInclude : false,
+            custom: function() {return m('');}
+        });
     }
     if(tb.options.placement !== 'fileview') {
         columns.push({
             data : 'modified',
             filter: false,
             custom : function() {return m('');}
-        });
-        columns.push({
-            data: 'version',
-            filter: false,
-            sortInclude : false,
-            custom: function() {return m('');}
         });
     }
     return columns;

--- a/website/addons/dataverse/static/dataverseFangornConfig.js
+++ b/website/addons/dataverse/static/dataverseFangornConfig.js
@@ -284,6 +284,12 @@ function _fangornColumns(item) {
             filter: false,
             custom : function() {return m('');}
         });
+        columns.push({
+            data: 'version',
+            filter: false,
+            sortInclude : false,
+            custom: function() {return m('');}
+        });
     }
     return columns;
 }

--- a/website/addons/github/static/githubFangornConfig.js
+++ b/website/addons/github/static/githubFangornConfig.js
@@ -384,8 +384,15 @@ function _fangornColumns (item) {
     if(tb.options.placement !== 'fileview') {
         columns.push({
             data : 'modified',
+            sortInclude : false,
             filter: false,
             custom : function() {return m('');}
+        });
+        columns.push({
+            data: 'version',
+            filter: false,
+            sortInclude : false,
+            custom: function() {return m('');}
         });
     }
     return columns;

--- a/website/addons/github/static/githubFangornConfig.js
+++ b/website/addons/github/static/githubFangornConfig.js
@@ -380,18 +380,18 @@ function _fangornColumns (item) {
             filter : false,
             custom : function() {return m('');}
         });
+        columns.push({
+            data: 'version',
+            filter: false,
+            sortInclude : false,
+            custom: function() {return m('');}
+        });
     }
     if(tb.options.placement !== 'fileview') {
         columns.push({
             data : 'modified',
             filter: false,
             custom : function() {return m('');}
-        });
-        columns.push({
-            data: 'version',
-            filter: false,
-            sortInclude : false,
-            custom: function() {return m('');}
         });
     }
     return columns;

--- a/website/addons/github/static/githubFangornConfig.js
+++ b/website/addons/github/static/githubFangornConfig.js
@@ -384,7 +384,6 @@ function _fangornColumns (item) {
     if(tb.options.placement !== 'fileview') {
         columns.push({
             data : 'modified',
-            sortInclude : false,
             filter: false,
             custom : function() {return m('');}
         });

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1431,7 +1431,7 @@ function _fangornResolveRows(item) {
     });
     defaultColumns.push({
         data: 'version',
-        filter: true,
+        filter: false,
         sortInclude : false,
         custom: _fangornVersionColumn
     });


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
The files view page didn't properly filter by file name, or allow sorting when Github or Dataverse were enabled.

## Changes
- Add blank version rows for github and dataverse on file view page
- Disallow sorting on the version column for file page

## Side effects

none anticipated


## Ticket
https://openscience.atlassian.net/browse/OSF-6863
[#OSF-6863]