### PR TITLE
Upgrade version of Pyzotero to the MIT-licensed version [OSF-6983]

### DIFF
--- a/website/addons/zotero/requirements.txt
+++ b/website/addons/zotero/requirements.txt
@@ -1,1 +1,1 @@
-Pyzotero==1.1.1
+Pyzotero==1.1.9


### PR DESCRIPTION
## Purpose

The version of pyzotero we are using is GPL licensed. We are not compatible with GPL. So let's use the new version of Pyzotero which has a much more OSF-friendly license

## Changes

1. Change our requirements to use the new version

## Side effects

Could break everything zotero related.

## Ticket

https://openscience.atlassian.net/browse/OSF-6983
