### PR TITLE
Update links to cos.io

### DIFF
--- a/scripts/populate_conferences.py
+++ b/scripts/populate_conferences.py
@@ -50,7 +50,7 @@ MEETING_DATA = {
     },
     'aps2014': {
         'name': 'Association for Psychological Science 2014',
-        'info_url': 'http://centerforopenscience.org/aps/',
+        'info_url': 'https://cos.io/aps/',
         'logo_url': '/static/img/2014_Convention_banner-with-APS_700px.jpg',
         'location': 'San Franscisco, CA',
         'start_date': 'May 22 2014',

--- a/website/project/metadata/prereg-prize.json
+++ b/website/project/metadata/prereg-prize.json
@@ -18,7 +18,7 @@
         },
         "fulfills": [{
             "name": "Prereg Challenge",
-            "info": "http://centerforopenscience.org/prereg/"
+            "info": "https://cos.io/prereg/"
         }]
     },
     "description": "Preregistration Challenge (pre-data collection): You will be asked a series of questions to ensure that your sampling, design, and analysis plans are solidified prior to beginning your study. Publications that pre register with this template may be eligible for a $1,000 prize. See project page for complete information.",

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -35,7 +35,7 @@
     % endif
 
     <!-- Facebook display -->
-    <meta name="og:image" content="http://centerforopenscience.org/static/img/cos_center_logo_small.png"/>
+    <meta name="og:image" content="https://cos.io/static/img/cos_center_logo_small.png"/>
     <meta name="og:title" content="${self.title()}"/>
     <meta name="og:ttl" content="3"/>
     <meta name="og:description" content="${self.og_description()}"/>

--- a/website/templates/copyright.mako
+++ b/website/templates/copyright.mako
@@ -1,7 +1,7 @@
 <div class="container copyright">
     <div class="row">
         <div class="col-md-12">
-            <p>Copyright &copy; 2011-2016 <a href="http://centerforopenscience.org">Center for Open Science</a> |
+            <p>Copyright &copy; 2011-2016 <a href="https://cos.io/">Center for Open Science</a> |
                 <a href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/TERMS_OF_USE.md">Terms of Use</a> |
                 <a href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/PRIVACY_POLICY.md">Privacy Policy</a>
             </p>

--- a/website/templates/public/pages/faq.mako
+++ b/website/templates/public/pages/faq.mako
@@ -28,7 +28,7 @@
                         </div>
                         <div class="support-item">
                             <h5 class="support-head f-w-xl"><i class="fa fa-angle-right"></i> How can it be free? How are you funded?</h5>
-                            <div class="support-body">The OSF is maintained and developed by the <a href="http://cos.io">Center for Open Science</a> (COS), a non-profit organization. COS is supported through grants from a variety of supporters, including <a href="http://centerforopenscience.org/about_sponsors/"> federal agencies, private foundations, and commercial entities</a>.</div>
+                            <div class="support-body">The OSF is maintained and developed by the <a href="http://cos.io">Center for Open Science</a> (COS), a non-profit organization. COS is supported through grants from a variety of supporters, including <a href="https://cos.io/about_sponsors/"> federal agencies, private foundations, and commercial entities</a>.</div>
                         </div>
                         <div class="support-item">
                             <h5 class="support-head f-w-xl"><i class="fa fa-angle-right"></i> What if you run out of funding? What happens to my data?</h5>


### PR DESCRIPTION
## Purpose

A bad SSL certificate on https://centerforopenscience.org/ is breaking links from OSF to cos.io. This PR works around this problem by updating the links to point directly to https://cos.io/, which is the terminal redirect.

## Changes

The main link to check is the one in the footer.

## Side effects

n/a

## Ticket

https://openscience.atlassian.net/browse/OSF-7043