### PR TITLE
Allow disabling of pty for 'wheelhouse', 'adminserver', and 'apiserver' tasks [OSF-7057]

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -86,7 +86,7 @@ def git_logs(ctx, branch=None):
 
 
 @task
-def apiserver(ctx, port=8000, wait=True, autoreload=True, host='127.0.0.1'):
+def apiserver(ctx, port=8000, wait=True, autoreload=True, host='127.0.0.1', pty=True):
     """Run the API server."""
     env = os.environ.copy()
     cmd = 'DJANGO_SETTINGS_MODULE=api.base.settings {} manage.py runserver {}:{} --nothreading'\
@@ -98,21 +98,21 @@ def apiserver(ctx, port=8000, wait=True, autoreload=True, host='127.0.0.1'):
         cmd += ' --certificate {} --key {}'.format(settings.OSF_SERVER_CERT, settings.OSF_SERVER_KEY)
 
     if wait:
-        return ctx.run(cmd, echo=True, pty=True)
+        return ctx.run(cmd, echo=True, pty=pty)
     from subprocess import Popen
 
     return Popen(cmd, shell=True, env=env)
 
 
 @task
-def adminserver(ctx, port=8001, host='127.0.0.1'):
+def adminserver(ctx, port=8001, host='127.0.0.1', pty=True):
     """Run the Admin server."""
     env = 'DJANGO_SETTINGS_MODULE="admin.base.settings"'
     cmd = '{} python manage.py runserver {}:{} --nothreading'.format(env, host, port)
     if settings.SECURE_MODE:
         cmd = cmd.replace('runserver', 'runsslserver')
         cmd += ' --certificate {} --key {}'.format(settings.OSF_SERVER_CERT, settings.OSF_SERVER_KEY)
-    ctx.run(cmd, echo=True, pty=True)
+    ctx.run(cmd, echo=True, pty=pty)
 
 
 SHELL_BANNER = """
@@ -628,7 +628,7 @@ def karma(ctx, single=False, sauce=False, browsers=None):
 
 
 @task
-def wheelhouse(ctx, addons=False, release=False, dev=False, metrics=False):
+def wheelhouse(ctx, addons=False, release=False, dev=False, metrics=False, pty=True):
     """Build wheels for python dependencies.
 
     Examples:
@@ -647,7 +647,7 @@ def wheelhouse(ctx, addons=False, release=False, dev=False, metrics=False):
                     cmd = 'pip wheel --find-links={} -r {} --wheel-dir={} -c {}'.format(
                         WHEELHOUSE_PATH, req_file, WHEELHOUSE_PATH, CONSTRAINTS_PATH,
                     )
-                    ctx.run(cmd, pty=True)
+                    ctx.run(cmd, pty=pty)
     if release:
         req_file = os.path.join(HERE, 'requirements', 'release.txt')
     elif dev:
@@ -659,7 +659,7 @@ def wheelhouse(ctx, addons=False, release=False, dev=False, metrics=False):
     cmd = 'pip wheel --find-links={} -r {} --wheel-dir={} -c {}'.format(
         WHEELHOUSE_PATH, req_file, WHEELHOUSE_PATH, CONSTRAINTS_PATH,
     )
-    ctx.run(cmd, pty=True)
+    ctx.run(cmd, pty=pty)
 
 
 @task


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Optionally disable the allocation of a pty when using `invoke` using the `--no-pty` flag.

## Changes

Adds a `pty` argument which defaults to `True` to the `apiserver`, `adminserver`, and `wheelhouse` tasks.

## Side effects

None.  The new flag defaults to `True` which maintains existing behavior.  Supplying `--no-pty` is optional.

## Discussion

See https://github.com/CenterForOpenScience/waterbutler/pull/167