### PR TITLE
[hotfix] fix build: flake8 correction + fix invoke wheel to support constraints

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -59,6 +59,7 @@ keyring==9.1
 
 requests==2.5.3
 urllib3==1.10.4
+oauthlib==1.1.2
 requests-oauthlib==0.5.0
 raven==5.10.2
 webcolors==1.4

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -640,7 +640,9 @@ def wheelhouse(ctx, addons=False, release=False, dev=False, metrics=False):
             if os.path.isdir(path):
                 req_file = os.path.join(path, 'requirements.txt')
                 if os.path.exists(req_file):
-                    cmd = 'pip wheel --find-links={} -r {} --wheel-dir={}'.format(WHEELHOUSE_PATH, req_file, WHEELHOUSE_PATH)
+                    cmd = 'pip wheel --find-links={} -r {} --wheel-dir={} -c {}'.format(
+                        WHEELHOUSE_PATH, req_file, WHEELHOUSE_PATH, CONSTRAINTS_PATH,
+                    )
                     ctx.run(cmd, pty=True)
     if release:
         req_file = os.path.join(HERE, 'requirements', 'release.txt')
@@ -650,7 +652,9 @@ def wheelhouse(ctx, addons=False, release=False, dev=False, metrics=False):
         req_file = os.path.join(HERE, 'requirements', 'metrics.txt')
     else:
         req_file = os.path.join(HERE, 'requirements.txt')
-    cmd = 'pip wheel --find-links={} -r {} --wheel-dir={}'.format(WHEELHOUSE_PATH, req_file, WHEELHOUSE_PATH)
+    cmd = 'pip wheel --find-links={} -r {} --wheel-dir={} -c {}'.format(
+        WHEELHOUSE_PATH, req_file, WHEELHOUSE_PATH, CONSTRAINTS_PATH,
+    )
     ctx.run(cmd, pty=True)
 
 

--- a/website/project/sanctions.py
+++ b/website/project/sanctions.py
@@ -22,7 +22,6 @@ from website import (
     settings,
     tokens,
 )
-from website.project.spam.model import SpamStatus
 from website.exceptions import (
     InvalidSanctionApprovalToken,
     InvalidSanctionRejectionToken,


### PR DESCRIPTION
*This is a tag-team PR!  @mfraezz has fixed a flake8 issue in current master that was making travis cry.  @felliott's code fixes dependency installation when wheels are involved.  By our powers combined!*

## Purpose

@emetsger encountered a problem when trying to build the OSF with JHU's custom Dockerfile.  All of the requirements were built as wheels, then `invoke req -q` was told to use those wheels.  `oauthlib` failed to install because v1.1.2 was required by the constraints file, but only v0.7.2 (required by Mendely) and v2.* (the latest) were available.

## Changes

`pip wheel` accepts a constraints file just like `pip install` does.  This PR updates our `invoke wheel` task to pass the constraints to the wheelbuilder.  While investigating this, I also found that the OSF (without addons) is missing an explicit dependency on `oauthlib` even though we use it in several modules.  I've added that, as well.

## Side effects

None expected.

## Ticket

No ticket.