### PR TITLE
[feature]Allow for mixed projects and registrations in a collection [OSF-6029]

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -1212,6 +1212,13 @@ class LinkedNode(JSONAPIRelationshipSerializer):
         type_ = 'linked_nodes'
 
 
+class LinkedRegistration(JSONAPIRelationshipSerializer):
+    id = ser.CharField(source='node._id', required=False, allow_null=True)
+
+    class Meta:
+        type_ = 'linked_registrations'
+
+
 class LinkedNodesRelationshipSerializer(ser.Serializer):
 
     data = ser.ListField(child=LinkedNode())
@@ -1247,7 +1254,78 @@ class LinkedNodesRelationshipSerializer(ser.Serializer):
         return {'data': [
             pointer for pointer in
             obj.nodes_pointer
-            if not pointer.node.is_deleted and not pointer.node.is_collection
+            if not pointer.node.is_deleted
+            and not pointer.node.is_registration
+            and not pointer.node.is_collection
+        ], 'self': obj}
+
+    def update(self, instance, validated_data):
+        collection = instance['self']
+        auth = utils.get_user_auth(self.context['request'])
+
+        add, remove = self.get_pointers_to_add_remove(pointers=instance['data'], new_pointers=validated_data['data'])
+
+        for pointer in remove:
+            collection.rm_pointer(pointer, auth)
+        for node in add:
+            collection.add_pointer(node, auth)
+
+        return self.make_instance_obj(collection)
+
+    def create(self, validated_data):
+        instance = self.context['view'].get_object()
+        auth = utils.get_user_auth(self.context['request'])
+        collection = instance['self']
+
+        add, remove = self.get_pointers_to_add_remove(pointers=instance['data'], new_pointers=validated_data['data'])
+
+        if not len(add):
+            raise RelationshipPostMakesNoChanges
+
+        for node in add:
+            collection.add_pointer(node, auth)
+
+        return self.make_instance_obj(collection)
+
+
+class LinkedRegistrationsRelationshipSerializer(ser.Serializer):
+
+    data = ser.ListField(child=LinkedRegistration())
+    links = LinksField({'self': 'get_self_url',
+                        'html': 'get_related_url'})
+
+    def get_self_url(self, obj):
+        return obj['self'].linked_registrations_self_url
+
+    def get_related_url(self, obj):
+        return obj['self'].linked_registrations_related_url
+
+    class Meta:
+        type_ = 'linked_registrations'
+
+    def get_pointers_to_add_remove(self, pointers, new_pointers):
+        diff = relationship_diff(
+            current_items={pointer.node._id: pointer for pointer in pointers},
+            new_items={val['node']['_id']: val for val in new_pointers}
+        )
+
+        nodes_to_add = []
+        for node_id in diff['add']:
+            node = Node.load(node_id)
+            if not node:
+                raise exceptions.NotFound(detail='Node with id "{}" was not found'.format(node_id))
+            nodes_to_add.append(node)
+
+        return nodes_to_add, diff['remove'].values()
+
+    def make_instance_obj(self, obj):
+        # Convenience method to format instance based on view's get_object
+        return {'data': [
+            pointer for pointer in
+            obj.nodes_pointer
+            if not pointer.node.is_deleted
+            and pointer.node.is_registration
+            and not pointer.node.is_collection
         ], 'self': obj}
 
     def update(self, instance, validated_data):

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -20,6 +20,7 @@ from api.base.parsers import JSONAPIRelationshipParser
 from api.base.parsers import JSONAPIRelationshipParserForRegularJSON
 from api.base.requests import EmbeddedRequest
 from api.base.serializers import LinkedNodesRelationshipSerializer
+from api.base.serializers import LinkedRegistrationsRelationshipSerializer
 from api.base import utils
 from api.nodes.permissions import ReadOnlyIfRegistration
 from api.nodes.permissions import ContributorOrPublicForRelationshipPointers
@@ -231,8 +232,10 @@ class LinkedNodesRelationship(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPI
         obj = {'data': [
             pointer for pointer in
             object.nodes_pointer
-            if not pointer.node.is_deleted and not pointer.node.is_collection and
-            pointer.node.can_view(auth)
+            if not pointer.node.is_deleted
+            and not pointer.node.is_collection
+            and not pointer.node.is_registration
+            and pointer.node.can_view(auth)
         ], 'self': object}
         self.check_object_permissions(self.request, obj)
         return obj
@@ -249,6 +252,113 @@ class LinkedNodesRelationship(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPI
     def create(self, *args, **kwargs):
         try:
             ret = super(LinkedNodesRelationship, self).create(*args, **kwargs)
+        except RelationshipPostMakesNoChanges:
+            return Response(status=status.HTTP_204_NO_CONTENT)
+        return ret
+
+
+class LinkedRegistrationsRelationship(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, generics.CreateAPIView):
+    """ Relationship Endpoint for Linked Registrations relationships
+
+    Used to set, remove, update and retrieve the ids of the linked registrations attached to this collection. For each id, there
+    exists a node link that contains that registration.
+
+    ##Actions
+
+    ###Create
+
+        Method:        POST
+        URL:           /links/self
+        Query Params:  <none>
+        Body (JSON):   {
+                         "data": [{
+                           "type": "linked_registrations",   # required
+                           "id": <node_id>   # required
+                         }]
+                       }
+        Success:       201
+
+    This requires both edit permission on the collection, and for the user that is
+    making the request to be able to read the registrations requested. Data can contain any number of
+    node identifiers. This will create a node_link for all node_ids in the request that
+    do not currently have a corresponding node_link in this collection.
+
+    ###Update
+
+        Method:        PUT || PATCH
+        URL:           /links/self
+        Query Params:  <none>
+        Body (JSON):   {
+                         "data": [{
+                           "type": "linked_registrations",   # required
+                           "id": <node_id>   # required
+                         }]
+                       }
+        Success:       200
+
+    This requires both edit permission on the collection and for the user that is
+    making the request to be able to read the registrations requested. Data can contain any number of
+    node identifiers. This will replace the contents of the node_links for this collection with
+    the contents of the request. It will delete all node links that don't have a node_id in the data
+    array, create node links for the node_ids that don't currently have a node id, and do nothing
+    for node_ids that already have a corresponding node_link. This means a update request with
+    {"data": []} will remove all node_links in this collection
+
+    ###Destroy
+
+        Method:        DELETE
+        URL:           /links/self
+        Query Params:  <none>
+        Body (JSON):   {
+                         "data": [{
+                           "type": "linked_registrations",   # required
+                           "id": <node_id>   # required
+                         }]
+                       }
+        Success:       204
+
+    This requires edit permission on the node. This will delete any node_links that have a
+    corresponding node_id in the request.
+    """
+    permission_classes = (
+        ContributorOrPublicForRelationshipPointers,
+        drf_permissions.IsAuthenticatedOrReadOnly,
+        base_permissions.TokenHasScope,
+        ReadOnlyIfRegistration,
+    )
+
+    required_read_scopes = [CoreScopes.NODE_LINKS_READ]
+    required_write_scopes = [CoreScopes.NODE_LINKS_WRITE]
+
+    serializer_class = LinkedRegistrationsRelationshipSerializer
+    parser_classes = (JSONAPIRelationshipParser, JSONAPIRelationshipParserForRegularJSON, )
+
+    def get_object(self):
+        object = self.get_node(check_object_permissions=False)
+        auth = utils.get_user_auth(self.request)
+        obj = {'data': [
+            pointer for pointer in
+            object.nodes_pointer
+            if not pointer.node.is_deleted
+            and not pointer.node.is_collection
+            and pointer.node.is_registration
+            and pointer.node.can_view(auth)
+        ], 'self': object}
+        self.check_object_permissions(self.request, obj)
+        return obj
+
+    def perform_destroy(self, instance):
+        data = self.request.data['data']
+        auth = utils.get_user_auth(self.request)
+        current_pointers = {pointer.node._id: pointer for pointer in instance['data']}
+        collection = instance['self']
+        for val in data:
+            if val['id'] in current_pointers:
+                collection.rm_pointer(current_pointers[val['id']], auth)
+
+    def create(self, *args, **kwargs):
+        try:
+            ret = super(LinkedRegistrationsRelationship, self).create(*args, **kwargs)
         except RelationshipPostMakesNoChanges:
             return Response(status=status.HTTP_204_NO_CONTENT)
         return ret

--- a/api/collections/serializers.py
+++ b/api/collections/serializers.py
@@ -44,6 +44,14 @@ class CollectionSerializer(JSONAPISerializer):
         self_view_kwargs={'collection_id': '<pk>'}
     )
 
+    linked_registrations = RelationshipField(
+        related_view='collections:linked-registrations',
+        related_view_kwargs={'collection_id': '<pk>'},
+        related_meta={'count': 'get_registration_links_count'},
+        self_view='collections:collection-registration-pointer-relationship',
+        self_view_kwargs={'collection_id': '<pk>'}
+    )
+
     class Meta:
         type_ = 'collections'
 
@@ -54,7 +62,15 @@ class CollectionSerializer(JSONAPISerializer):
         count = 0
         auth = get_user_auth(self.context['request'])
         for pointer in obj.nodes_pointer:
-            if not pointer.node.is_deleted and not pointer.node.is_collection and pointer.node.can_view(auth):
+            if not pointer.node.is_deleted and not pointer.node.is_registration and not pointer.node.is_collection and pointer.node.can_view(auth):
+                count += 1
+        return count
+
+    def get_registration_links_count(self, obj):
+        count = 0
+        auth = get_user_auth(self.context['request'])
+        for pointer in obj.nodes_pointer:
+            if not pointer.node.is_deleted and pointer.node.is_registration and not pointer.node.is_collection and pointer.node.can_view(auth):
                 count += 1
         return count
 

--- a/api/collections/urls.py
+++ b/api/collections/urls.py
@@ -6,7 +6,9 @@ urlpatterns = [
     url(r'^$', views.CollectionList.as_view(), name=views.CollectionList.view_name),
     url(r'^(?P<collection_id>\w+)/$', views.CollectionDetail.as_view(), name=views.CollectionDetail.view_name),
     url(r'^(?P<collection_id>\w+)/linked_nodes/$', views.LinkedNodesList.as_view(), name=views.LinkedNodesList.view_name),
+    url(r'^(?P<collection_id>\w+)/linked_registrations/$', views.LinkedRegistrationsList.as_view(), name=views.LinkedRegistrationsList.view_name),
     url(r'^(?P<collection_id>\w+)/node_links/$', views.NodeLinksList.as_view(), name=views.NodeLinksList.view_name),
     url(r'^(?P<collection_id>\w+)/node_links/(?P<node_link_id>\w+)/', views.NodeLinksDetail.as_view(), name=views.NodeLinksDetail.view_name),
     url(r'^(?P<collection_id>\w+)/relationships/linked_nodes/$', views.CollectionLinkedNodesRelationship.as_view(), name=views.CollectionLinkedNodesRelationship.view_name),
+    url(r'^(?P<collection_id>\w+)/relationships/linked_registrations/$', views.CollectionLinkedRegistrationsRelationship.as_view(), name=views.CollectionLinkedRegistrationsRelationship.view_name),
 ]

--- a/api/collections/views.py
+++ b/api/collections/views.py
@@ -9,6 +9,7 @@ from api.base import permissions as base_permissions
 from api.base.filters import ODMFilterMixin
 from api.base.views import JSONAPIBaseView
 from api.base.views import LinkedNodesRelationship
+from api.base.views import LinkedRegistrationsRelationship
 
 from api.base.utils import get_object_or_error, is_bulk_request, get_user_auth
 from api.collections.serializers import (
@@ -17,6 +18,7 @@ from api.collections.serializers import (
     CollectionNodeLinkSerializer,
 )
 from api.nodes.serializers import NodeSerializer
+from api.registrations.serializers import RegistrationSerializer
 
 from api.nodes.permissions import (
     ContributorOrPublic,
@@ -298,7 +300,7 @@ class CollectionDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, C
 class LinkedNodesList(JSONAPIBaseView, generics.ListAPIView, CollectionMixin):
     """List of nodes linked to this node. *Read-only*.
 
-    Linked nodes are the nodes pointed to by node links. This view will probably replace node_links in the near future.
+    Linked nodes are the project/component nodes pointed to by node links. This view will probably replace node_links in the near future.
 
     <!--- Copied Spiel from NodeDetail -->
 
@@ -364,8 +366,10 @@ class LinkedNodesList(JSONAPIBaseView, generics.ListAPIView, CollectionMixin):
         return sorted([
             pointer.node for pointer in
             self.get_node().nodes_pointer
-            if not pointer.node.is_deleted and not pointer.node.is_collection and
-            pointer.node.can_view(auth)
+            if not pointer.node.is_deleted
+            and not pointer.node.is_collection
+            and not pointer.node.is_registration
+            and pointer.node.can_view(auth)
         ], key=lambda n: n.date_modified, reverse=True)
 
     # overrides APIView
@@ -374,6 +378,107 @@ class LinkedNodesList(JSONAPIBaseView, generics.ListAPIView, CollectionMixin):
         Tells parser that we are creating a relationship
         """
         res = super(LinkedNodesList, self).get_parser_context(http_request)
+        res['is_relationship'] = True
+        return res
+
+
+class LinkedRegistrationsList(JSONAPIBaseView, generics.ListAPIView, CollectionMixin):
+    """List of registrations linked to this node. *Read-only*.
+
+    Linked registrations are the registration nodes pointed to by node links.
+
+    <!--- Copied Spiel from RegistrationDetail -->
+    Registrations are read-only snapshots of a project. This view shows details about the given registration.
+
+    Each resource contains the full representation of the registration, meaning additional requests to an individual
+    registration's detail view are not necessary. A withdrawn registration will display a limited subset of information,
+    namely, title, description, date_created, registration, withdrawn, date_registered, withdrawal_justification, and
+    registration supplement. All other fields will be displayed as null. Additionally, the only relationships permitted
+    to be accessed for a withdrawn registration are the contributors - other relationships will return a 403.
+
+    ##Linked Registration Attributes
+
+    <!--- Copied Attributes from RegistrationDetail -->
+
+    Registrations have the "registrations" `type`.
+
+        name                            type               description
+        =======================================================================================================
+        title                           string             title of the registered project or component
+        description                     string             description of the registered node
+        category                        string             bode category, must be one of the allowed values
+        date_created                    iso8601 timestamp  timestamp that the node was created
+        date_modified                   iso8601 timestamp  timestamp when the node was last updated
+        tags                            array of strings   list of tags that describe the registered node
+        current_user_can_comment        boolean            Whether the current user is allowed to post comments
+        current_user_permissions        array of strings   list of strings representing the permissions for the current user on this node
+        fork                            boolean            is this project a fork?
+        registration                    boolean            has this project been registered? (always true - may be deprecated in future versions)
+        collection                      boolean            is this registered node a collection? (always false - may be deprecated in future versions)
+        node_license                    object             details of the license applied to the node
+        year                            string             date range of the license
+        copyright_holders               array of strings   holders of the applied license
+        public                          boolean            has this registration been made publicly-visible?
+        withdrawn                       boolean            has this registration been withdrawn?
+        date_registered                 iso8601 timestamp  timestamp that the registration was created
+        embargo_end_date                iso8601 timestamp  when the embargo on this registration will be lifted (if applicable)
+        withdrawal_justification        string             reasons for withdrawing the registration
+        pending_withdrawal              boolean            is this registration pending withdrawal?
+        pending_withdrawal_approval     boolean            is this registration pending approval?
+        pending_embargo_approval        boolean            is the associated Embargo awaiting approval by project admins?
+        registered_meta                 dictionary         registration supplementary information
+        registration_supplement         string             registration template
+
+    ##Links
+
+    See the [JSON-API spec regarding pagination](http://jsonapi.org/format/1.0/#fetching-pagination).
+
+    ##Query Params
+
+    + `page=<Int>` -- page number of results to view, default 1
+
+    + `filter[<fieldname>]=<Str>` -- fields and values to filter the search results on.
+
+    Nodes may be filtered by their `title`, `category`, `description`, `public`, `registration`, or `tags`.  `title`,
+    `description`, and `category` are string fields and will be filtered using simple substring matching.  `public` and
+    `registration` are booleans, and can be filtered using truthy values, such as `true`, `false`, `0`, or `1`.  Note
+    that quoting `true` or `false` in the query will cause the match to fail regardless.  `tags` is an array of simple strings.
+
+    #This Request/Response
+    """
+    permission_classes = (
+        drf_permissions.IsAuthenticatedOrReadOnly,
+        ContributorOrPublic,
+        ReadOnlyIfRegistration,
+        base_permissions.TokenHasScope,
+    )
+
+    required_read_scopes = [CoreScopes.NODE_LINKS_READ]
+    required_write_scopes = [CoreScopes.NODE_LINKS_WRITE]
+
+    serializer_class = RegistrationSerializer
+    view_category = 'collections'
+    view_name = 'linked-registrations'
+
+    model_class = Pointer
+
+    def get_queryset(self):
+        auth = get_user_auth(self.request)
+        return sorted([
+            pointer.node for pointer in
+            self.get_node().nodes_pointer
+            if not pointer.node.is_deleted
+            and not pointer.node.is_collection
+            and pointer.node.is_registration
+            and pointer.node.can_view(auth)
+        ], key=lambda n: n.date_modified, reverse=True)
+
+    # overrides APIView
+    def get_parser_context(self, http_request):
+        """
+        Tells parser that we are creating a relationship
+        """
+        res = super(LinkedRegistrationsList, self).get_parser_context(http_request)
         res['is_relationship'] = True
         return res
 
@@ -601,3 +706,70 @@ class CollectionLinkedNodesRelationship(LinkedNodesRelationship, CollectionMixin
 
     view_category = 'collections'
     view_name = 'collection-node-pointer-relationship'
+
+class CollectionLinkedRegistrationsRelationship(LinkedRegistrationsRelationship, CollectionMixin):
+    """ Relationship Endpoint for Collection -> Linked Registration relationships
+
+    Used to set, remove, update and retrieve the ids of the linked registrations attached to this collection. For each id, there
+    exists a node link that contains that node.
+
+    ##Actions
+
+    ###Create
+
+        Method:        POST
+        URL:           /links/self
+        Query Params:  <none>
+        Body (JSON):   {
+                         "data": [{
+                           "type": "linked_registrations",   # required
+                           "id": <node_id>   # required
+                         }]
+                       }
+        Success:       201
+
+    This requires both edit permission on the collection, and for the user that is
+    making the request to be able to read the registrations requested. Data can contain any number of
+    node identifiers. This will create a node_link for all node_ids in the request that
+    do not currently have a corresponding node_link in this collection.
+
+    ###Update
+
+        Method:        PUT || PATCH
+        URL:           /links/self
+        Query Params:  <none>
+        Body (JSON):   {
+                         "data": [{
+                           "type": "linked_regisrations",   # required
+                           "id": <node_id>   # required
+                         }]
+                       }
+        Success:       200
+
+    This requires both edit permission on the collection, and for the user that is
+    making the request to be able to read the registrations requested. Data can contain any number of
+    node identifiers. This will replace the contents of the node_links for this collection with
+    the contents of the request. It will delete all node links that don't have a node_id in the data
+    array, create node links for the node_ids that don't currently have a node id, and do nothing
+    for node_ids that already have a corresponding node_link. This means a update request with
+    {"data": []} will remove all node_links in this collection
+
+    ###Destroy
+
+        Method:        DELETE
+        URL:           /links/self
+        Query Params:  <none>
+        Body (JSON):   {
+                         "data": [{
+                           "type": "linked_registrations",   # required
+                           "id": <node_id>   # required
+                         }]
+                       }
+        Success:       204
+
+    This requires edit permission on the node. This will delete any node_links that have a
+    corresponding node_id in the request.
+    """
+
+    view_category = 'collections'
+    view_name = 'collection-registration-pointer-relationship'

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -2941,8 +2941,10 @@ class LinkedNodesList(JSONAPIBaseView, generics.ListAPIView, NodeMixin):
         return sorted([
             pointer.node for pointer in
             self.get_node().nodes_pointer
-            if not pointer.node.is_deleted and not pointer.node.is_collection and
-            pointer.node.can_view(auth)
+            if not pointer.node.is_deleted
+            and not pointer.node.is_collection
+            and not pointer.node.is_registration
+            and pointer.node.can_view(auth)
         ], key=lambda n: n.date_modified, reverse=True)
 
     # overrides APIView

--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -867,32 +867,14 @@ class LinkedRegistrationsList(JSONAPIBaseView, generics.ListAPIView, Registratio
     Linked registrations are the registrations pointed to by node links.
 
     """
-    permission_classes = (
-        drf_permissions.IsAuthenticatedOrReadOnly,
-        ContributorOrPublic,
-        ReadOnlyIfRegistration,
-        base_permissions.TokenHasScope,
-    )
-
-    required_read_scopes = [CoreScopes.NODE_LINKS_READ]
-    required_write_scopes = [CoreScopes.NODE_LINKS_WRITE]
-
     serializer_class = RegistrationSerializer
     view_category = 'registrations'
     view_name = 'linked-registrations'
 
-    model_class = Pointer
-
     def get_queryset(self):
-        auth = get_user_auth(self.request)
-        return sorted([
-            pointer.node for pointer in
-            self.get_node().nodes_pointer
-            if not pointer.node.is_deleted
-            and not pointer.node.is_collection
-            and pointer.node.is_registration
-            and pointer.node.can_view(auth)
-        ], key=lambda n: n.date_modified, reverse=True)
+        return [node for node in
+            super(LinkedNodesList, self).get_queryset()
+            if node.is_registration]
 
     # overrides APIView
     def get_parser_context(self, http_request):
@@ -902,11 +884,6 @@ class LinkedRegistrationsList(JSONAPIBaseView, generics.ListAPIView, Registratio
         res = super(LinkedNodesList, self).get_parser_context(http_request)
         res['is_relationship'] = True
         return res
-
-
-class RegistrationLinkedRegistraionsList(LinkedRegistrationsList, RegistrationMixin):
-    view_category = 'registrations'
-    view_name = 'linked-registrations'
 
 
 class RegistrationViewOnlyLinksList(NodeViewOnlyLinksList, RegistrationMixin):

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2739,8 +2739,16 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable, Spam
         return self.absolute_api_v2_url + 'relationships/linked_nodes/'
 
     @property
+    def linked_registrations_self_url(self):
+        return self.absolute_api_v2_url + 'relationships/linked_registrations/'
+
+    @property
     def linked_nodes_related_url(self):
         return self.absolute_api_v2_url + 'linked_nodes/'
+
+    @property
+    def linked_registrations_related_url(self):
+        return self.absolute_api_v2_url + 'linked_registrations/'
 
     @property
     def csl(self):  # formats node information into CSL format for citation parsing

--- a/website/static/js/myProjects.js
+++ b/website/static/js/myProjects.js
@@ -505,7 +505,7 @@ var MyProjects = {
             var collectionNode = currentCollection.data.node; // If it's not a system collection like projects or registrations this will have a node
 
             var link_types = {'linked_nodes': {'data': []},
-                              'linked_registrations': {'data': []}}
+                              'linked_registrations': {'data': []}};
             self.selected().map(function(item){
                 if(item.data.type === 'nodes') {
                     link_types.linked_nodes.data.push({id: item.data.id,
@@ -514,7 +514,7 @@ var MyProjects = {
                     link_types.linked_registrations.data.push({id: item.data.id,
                                                  type: 'linked_registrations'});
                 }
-            })
+            });
 
             $.each(link_types, function(link_type, data) {
                 if(link_types[link_type].data.length > 0) {
@@ -539,7 +539,7 @@ var MyProjects = {
                         }
                         $osf.growl(message, 'Please try again.', 'danger', 5000);
                     });
-                };
+                }
             });
         };
 
@@ -1192,7 +1192,7 @@ var Collections = {
                     var collection = self.collections()[$(this).attr('data-index')];
                     // If multiple items are dragged they have to be selected to make it work
                     if (args.selected().length > 1) {
-                        var dataArray = args.selected().map(function(item){
+                        dataArray = args.selected().map(function(item){
                             return buildCollectionNodeData(item.data.id,
                                                            item.data.type);
                         });

--- a/website/static/js/myProjects.js
+++ b/website/static/js/myProjects.js
@@ -51,8 +51,10 @@ if (!window.Set) {
 }
 
 
-function NodeFetcher(type, link, handleOrphans) {
+function NodeFetcher(type, link, handleOrphans, regType, regLink) {
   this.type = type || 'nodes';
+  this.regType = regType || null;
+  this.regLink = regLink || null;
   this.loaded = 0;
   this._failed = 0;
   this.total = 0;
@@ -186,9 +188,11 @@ NodeFetcher.prototype = {
         this._cache[parentId].children.push(item);
         return false;
       }).bind(this));
-
-      // if (results.data[i].relationships.children.links.related.meta.count > 0)
-      //   this.fetchChildren(results.data[i]);
+    }
+    if(!this.nextLink && this.regLink) {
+        this.nextLink = this.regLink;
+        this.type = this.regType;
+        this.regLink = null;
     }
 
     this._callbacks.page.forEach((function(cb) {
@@ -304,10 +308,10 @@ var LinkObject = function _LinkObject (type, data, label, institutionId) {
  * @param id {String} unique id of the node like 'ez8f3'
  * @returns {{data: {type: string, relationships: {nodes: {data: {type: string, id: *}}}}}}
  */
-function buildCollectionNodeData (id) {
+function buildCollectionNodeData (id, type) {
     return {
         'data': [{
-            'type': 'linked_nodes',
+            'type': 'linked_'+type,
             'id': id
         }]
     };
@@ -442,7 +446,7 @@ var MyProjects = {
 
         /* filesData is the link that loads tree data. This function refreshes that information. */
         self.updateFilesData = function _updateFilesData(linkObject) {
-            if ((linkObject.type === 'node') && self.viewOnly){
+            if ((linkObject.type === 'node' || linkObject.type === 'registration') && self.viewOnly){
                 return;
             }
 
@@ -500,32 +504,42 @@ var MyProjects = {
             var currentCollection = self.currentView().collection;
             var collectionNode = currentCollection.data.node; // If it's not a system collection like projects or registrations this will have a node
 
-            var data = {
-              data: self.selected().map(function(item){
-                return {id: item.data.id, type: 'linked_nodes'};
-              })
-            };
-
-            m.request({
-                method : 'DELETE',
-                url : collectionNode.links.self + 'relationships/' + 'linked_nodes/',  //collection.links.self + 'node_links/' + item.data.id + '/', //collection.links.self + relationship/ + linked_nodes/
-                config : mHelpers.apiV2Config({withCredentials: window.contextVars.isOnRootDomain}),
-                data : data
-            }).then(function(result) {
-              data.data.forEach(function(item) {
-                  self.fetchers[currentCollection.id].remove(item.id);
-                  currentCollection.data.count(currentCollection.data.count()-1);
-                  self.updateSelected([]);
-              });
-              self.updateList();
-            }, function _removeProjectFromCollectionsFail(result){
-                var message = 'Some projects';
-                if(data.data.length === 1) {
-                    message = self.selected()[0].data.name;
+            var link_types = {'linked_nodes': {'data': []},
+                              'linked_registrations': {'data': []}}
+            self.selected().map(function(item){
+                if(item.data.type === 'nodes') {
+                    link_types.linked_nodes.data.push({id: item.data.id,
+                                                       type: 'linked_nodes'});
                 } else {
-                    message += ' could not be removed from the collection';
+                    link_types.linked_registrations.data.push({id: item.data.id,
+                                                 type: 'linked_registrations'});
                 }
-                $osf.growl(message, 'Please try again.', 'danger', 5000);
+            })
+
+            $.each(link_types, function(link_type, data) {
+                if(link_types[link_type].data.length > 0) {
+                    m.request({
+                        method : 'DELETE',
+                        url : collectionNode.links.self + 'relationships/' + link_type  + '/',
+                        config : mHelpers.apiV2Config({withCredentials: window.contextVars.isOnRootDomain}),
+                        data : data
+                    }).then(function(result) {
+                      data.data.forEach(function(item) {
+                          self.fetchers[currentCollection.id].remove(item.id);
+                          currentCollection.data.count(currentCollection.data.count()-1);
+                          self.updateSelected([]);
+                      });
+                      self.updateList();
+                    }, function _removeProjectFromCollectionsFail(result){
+                        var message = 'Some projects';
+                        if(data.data.length === 1) {
+                            message = self.selected()[0].data.name;
+                        } else {
+                            message += ' could not be removed from the collection';
+                        }
+                        $osf.growl(message, 'Please try again.', 'danger', 5000);
+                    });
+                };
             });
         };
 
@@ -559,8 +573,6 @@ var MyProjects = {
             var contributors = self.currentView().contributor;
 
             return self.currentView().fetcher._flat.filter(function(node) {
-              // var tagMatch = tags.length === 0;
-              // var contribMatch = contributors.length === 0;
               var tagMatch = true;
               var contribMatch = true;
 
@@ -805,12 +817,13 @@ var MyProjects = {
             var promise = m.request({method : 'GET', url : url, config : mHelpers.apiV2Config({withCredentials: window.contextVars.isOnRootDomain})});
             promise.then(function(result){
                 result.data.forEach(function(node){
-                    var count = node.relationships.linked_nodes.links.related.meta.count;
-                    self.collections().push(new LinkObject('collection', { path : 'collections/' + node.id + '/linked_nodes/', query : { 'related_counts' : 'children', 'embed' : 'contributors' }, nodeType : 'collection', node : node, count : m.prop(count), loaded: 1 }, node.attributes.title));
+                    var count = node.relationships.linked_registrations.links.related.meta.count + node.relationships.linked_nodes.links.related.meta.count;
+                    self.collections().push(new LinkObject('collection', {nodeType : 'collection', node : node, count : m.prop(count), loaded: 1 }, node.attributes.title));
 
+                    var regLink = $osf.apiV2Url('collections/' + node.id + '/linked_registrations/', { query : { 'related_counts' : 'children', 'embed' : 'contributors' }});
                     var link = $osf.apiV2Url('collections/' + node.id + '/linked_nodes/', { query : { 'related_counts' : 'children', 'embed' : 'contributors' }});
-                    self.fetchers[self.collections()[self.collections().length-1].id] = new NodeFetcher('nodes', link, false);
-                    self.fetchers[self.collections()[self.collections().length-1].id].on(['page', 'done'], self.onPageLoad);
+                    self.fetchers[self.collections()[self.collections().length-1].id] = new NodeFetcher('nodes', link, false, 'registraions', regLink);
+                    self.fetchers[self.collections()[self.collections().length-1].id].on(['page'], self.onPageLoad);
                 });
                 if(result.links.next){
                     self.loadCollections(result.links.next);
@@ -870,7 +883,7 @@ var MyProjects = {
                 self.fetchers[self.systemCollections[1].id].on(['page', 'done'], self.onPageLoad);
             });
             if (!self.viewOnly){
-                var collectionsUrl = $osf.apiV2Url('collections/', { query : {'related_counts' : 'linked_nodes', 'page[size]' : self.collectionsPageSize(), 'sort' : 'date_created', 'embed' : 'node_links'}});
+                var collectionsUrl = $osf.apiV2Url('collections/', { query : {'related_counts' : 'linked_registrations,linked_nodes', 'page[size]' : self.collectionsPageSize(), 'sort' : 'date_created', 'embed' : 'linked_nodes'}});
                 self.loadCollections(collectionsUrl);
             }
             // Add linkObject to the currentView
@@ -1177,16 +1190,16 @@ var Collections = {
                 drop: function( event, ui ) {
                     var dataArray = [];
                     var collection = self.collections()[$(this).attr('data-index')];
-                    var collectionLink = $osf.apiV2Url(collection.data.path, { query : collection.data.query});
                     // If multiple items are dragged they have to be selected to make it work
                     if (args.selected().length > 1) {
-                        dataArray = args.selected().map(function(item){
-                            $osf.trackClick('myProjects', 'projectOrganizer', 'multiple-projects-dragged-to-collection');
-                            return buildCollectionNodeData(item.data.id);
+                        var dataArray = args.selected().map(function(item){
+                            return buildCollectionNodeData(item.data.id,
+                                                           item.data.type);
                         });
+                        $osf.trackClick('myProjects', 'projectOrganizer', 'multiple-projects-dragged-to-collection');
                     } else {
                         // if single items are passed use the event information
-                        dataArray.push(buildCollectionNodeData(ui.draggable.find('.title-text>a').attr('data-nodeID'))); // data-nodeID attribute needs to be set in project organizer building title column
+                        dataArray.push(buildCollectionNodeData(ui.draggable.find('.title-text>a').attr('data-nodeID'), ui.draggable.find('.title-text>a').attr('data-nodeType'))); // data-nodeID and data-nodeType attribute needs to be set in project organizer building title column
                         var projectName = ui.draggable.find('.title-text>a').attr('data-nodeTitle');
                         $osf.trackClick('myProjects', 'projectOrganizer', 'single-project-dragged-to-collection');
                     }
@@ -1196,7 +1209,7 @@ var Collections = {
                         return args.currentView().fetcher === args.fetchers[collection.id] ? args.updateList() : null;
                       m.request({
                           method : 'POST',
-                          url : collection.data.node.links.self + 'relationships/linked_nodes/',
+                          url : collection.data.node.links.self + 'relationships/' + data[index].data[0].type  + '/',
                           config : mHelpers.apiV2Config({withCredentials: window.contextVars.isOnRootDomain}),
                           data : data[index]
                       }).then(function(result){

--- a/website/static/js/project-organizer.js
+++ b/website/static/js/project-organizer.js
@@ -39,12 +39,12 @@ function _poTitleColumn(item) {
     if (item.data.archiving) { // TODO check if this variable will be available
         return  m('span', {'class': 'registration-archiving'}, node.attributes.title + ' [Archiving]');
     } else if(node.links.html){
-        return [ m('a.fg-file-links', { 'class' : css, href : node.links.html, 'data-nodeID' : node.id, 'data-nodeTitle': node.attributes.title, onclick : function(event) {
+        return [ m('a.fg-file-links', { 'class' : css, href : node.links.html, 'data-nodeID' : node.id, 'data-nodeTitle': node.attributes.title, 'data-nodeType': node.type, onclick : function(event) {
             preventSelect.call(this, event);
             $osf.trackClick('myProjects', 'projectOrganizer', 'navigate-to-specific-project');
         }}, node.attributes.title) ];
     } else {
-        return  m('span', { 'class' : css, 'data-nodeID' : node.id, 'data-nodeTitle': node.attributes.title }, node.attributes.title);
+        return  m('span', { 'class' : css, 'data-nodeID' : node.id, 'data-nodeTitle': node.attributes.title, 'data-nodeType': node.type}, node.attributes.title);
     }
 }
 


### PR DESCRIPTION
## Purpose:
[OSF-6029](https://openscience.atlassian.net/browse/OSF-6029)
[My Projects] Registrations that aren't yours have blank contributor names and throw 404 error when expanded

## Changes:
Update  api/base/serializers.py
    Add class LinkedRegistration
    Update class LinkedNodesRelationshipSerializer do not return registrations
    Add class LinkedRegistrationsRelationshipSerializer

Update api/base/views.py
    Update class LinkedNodesRelationship do not return registrations
    Add class LinkedRegistrationsRelationship
    Add class BaseLinkedList

Update api/collections/serializers.py
    Update class CollectionSerializer
        Add attribute linked_registrations
        Update def get_node_links_count do not return registrations
        Add def get_registration_links_count

Update api/collections/urls.py
    Add /linked_registrations/
    Add /relationships/linked_registrations/

Update api/collections/views.py
    update class LinkedNodesList do not return registrations
    add class LinkedRegistrationsList
    add class CollectionLinkedRegistrationsRelationship

Update api/nodes/views.py
    Update class NodeLinkedNodesRelationship
        Update def get_queryset do not return registrations

Update api/registrations/views.py
    Add class LinkedRegistrationsList

Update website/project/model.py
    Update class Node
        Add def linked_registrations_self_url
        Add def linked_registrations_related_url

Update website/static/js/myProjects.js
    Update function NodeFetcher allow for fetching projects and registrations in one fetcher
    Update function buildCollectionNodeData now requires linke_type argument
    Update var MyProjects now handles combinations of projects and registrations
    Update var Collections now passes type to buildCollectionNodeData

Update website/static/js/project-organizer.js
    function _poTitleColumn  now returns type info, for website/static/js/myProjects.js var Collections

Update api_tests/collections/test_views.py
  Added many tests for linked registrations

## Side effects
The following no longer return registrations
LinkedNodesRelationshipSerializer
LinkedNodesRelationship
CollectionSerializer get_node_links_count
LinkedNodesList
NodeLinkedNodesRelationship get_queryset

[#OSF-6029]