### PR TITLE
[Feature][Fix] Public project DOI/ARK creation [OSF-6754]

### DIFF
--- a/website/identifiers/metadata.py
+++ b/website/identifiers/metadata.py
@@ -54,6 +54,6 @@ def datacite_metadata_for_node(node, doi, pretty_print=False):
         title=node.title,
         creators=creators,
         publisher='Open Science Framework',
-        publication_year=node.registered_date.year,
+        publication_year=getattr(node.registered_date or node.date_created, 'year'),
         pretty_print=pretty_print
     )


### PR DESCRIPTION
## Purpose
Fix issue from #6028 -- public, non-registered nodes don't have a `registration_date`

## Changes
* Get `year` from `registration_date` or `date_created`

## Side effects
None expected

## Ticket
[\[OSF-6754\]](https://openscience.atlassian.net/browse/OSF-6754)
