### PR TITLE
[Feature][Fix]Remove line break before "Identifiers"

### DIFF
--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -179,10 +179,11 @@
                     % endif
                     </p>
                 <span data-bind="if: hasIdentifiers()" class="scripted">
-                  <br />
+                  <p>
                     Identifiers:
                   DOI <span data-bind="text: doi"></span> |
                   ARK <span data-bind="text: ark"></span>
+                  </p>
                 </span>
                 <span data-bind="if: canCreateIdentifiers()" class="scripted">
                   <!-- ko if: idCreationInProgress() -->


### PR DESCRIPTION
## Purpose
Remove superfluous line break

## Changes
* Remove superfluous line break

## Side effects
None

## Ticket
Relates to [OSF-6753](https://openscience.atlassian.net/browse/OSF-6754) 

## After

<img width="517" alt="screen shot 2016-09-13 at 15 58 12" src="https://cloud.githubusercontent.com/assets/5659262/18489280/eb51c56c-79ca-11e6-9dbe-e4b97bdf1cee.png">
