### PR TITLE
Logs should capitalize wiki's home page [OSF-6367] 

### DIFF
--- a/website/static/js/logTextParser.js
+++ b/website/static/js/logTextParser.js
@@ -84,7 +84,7 @@ var returnTextParams = function (param, text, logObject, view_url) {
         }
         // If the user changed the home page, display logText with capitalized
         // name to reflect how home is displayed to user.
-        var type = logObject.attributes['action']
+        var type = logObject.attributes.action;
         if (type === 'wiki_updated' && source === 'home') {
             source = 'Home';
         }

--- a/website/static/js/logTextParser.js
+++ b/website/static/js/logTextParser.js
@@ -82,6 +82,10 @@ var returnTextParams = function (param, text, logObject, view_url) {
         if (param === 'path'){
             source = stripBackslash(source);
         }
+        var type = logObject.attributes['action']
+        if (type === 'wiki_updated' && source === 'home') {
+            source = 'Home';
+        }
         return view_url ? m('a', {href: $osf.toRelativeUrl(view_url, window)}, source) : m('span', source);
     }
     return m('span', text);

--- a/website/static/js/logTextParser.js
+++ b/website/static/js/logTextParser.js
@@ -82,6 +82,8 @@ var returnTextParams = function (param, text, logObject, view_url) {
         if (param === 'path'){
             source = stripBackslash(source);
         }
+        // If the user changed the home page, display logText with capitalized
+        // name to reflect how home is displayed to user.
         var type = logObject.attributes['action']
         if (type === 'wiki_updated' && source === 'home') {
             source = 'Home';


### PR DESCRIPTION
## Purpose

Capitalize the "Home" wiki page in the recent activity log text to reflect the name of the Home page as it is shown to the user. The user sees "home" in the log text when they should see "Home". This PR fixes that issue.

## Changes

In the ```logTextParser```, added a check for a ```wiki_update``` on the home page. When the check catches that event occurring, the ```source``` log text is capitalized (to "Home").

## Side effects

None, as the change is cosmetic and local to the ```logTextParser::returnTextParams``` function.


## Ticket

[https://openscience.atlassian.net/browse/OSF-6367](https://openscience.atlassian.net/browse/OSF-6367)
