### PR TITLE
Make logos on project page not a circle [#OSF-7026]

### DIFF
--- a/website/static/js/pages/project-dashboard-page.js
+++ b/website/static/js/pages/project-dashboard-page.js
@@ -74,7 +74,7 @@ var institutionLogos = {
         self.width = self.nLogos > 1 ? (self.nLogos === 2 ? '115px' : '86px') : '75px';
         self.makeLogo = function(institution){
             return m('a', {href: '/institutions/' + institution.id},
-                m('img.img-circle', {
+                m('img', {
                     height: self.side, width: self.side,
                     style: {margin: '3px'},
                     title: institution.name,


### PR DESCRIPTION
## Purpose
Institution logos on the project page were being forced into  a circle, making the non circular logos look a little odd. Instead of using the circular versions of the logos, go ahead and let the logos not be circles if they aren't.

### before
![screen shot 2016-09-14 at 2 58 52 pm](https://cloud.githubusercontent.com/assets/801594/18525749/d2a3fe92-7a8b-11e6-9c8e-3794ec517b05.png)

### after
![screen shot 2016-09-14 at 2 45 20 pm](https://cloud.githubusercontent.com/assets/801594/18527627/877c412e-7a93-11e6-9758-c70ea3c8600a.png)


## Changes

- remove the img-circle css class from project page institution images


## Side effects
Logos look a little larger next to project titles


## Ticket
https://openscience.atlassian.net/browse/OSF-7026