### PR TITLE
[WIP] Feature/Super Bulk Contributor Relationship

### DIFF
--- a/api/base/parsers.py
+++ b/api/base/parsers.py
@@ -145,6 +145,10 @@ class JSONAPIRelationshipParser(JSONParser):
                 if datum.get('type') is None:
                     raise JSONAPIException(source={'pointer': '/data/{}/type'.format(str(i))}, detail=NO_TYPE_ERROR)
 
+                if datum.get('attributes'):
+                    datum.update(datum.get('attributes'))
+                    del datum['attributes']
+
             return {'data': data}
 
         return {'data': []}

--- a/api/base/parsers.py
+++ b/api/base/parsers.py
@@ -138,6 +138,8 @@ class JSONAPIRelationshipParser(JSONParser):
             if not isinstance(data, list):
                 raise ParseError('Data must be an array')
             for i, datum in enumerate(data):
+                if not isinstance(datum, dict):
+                    raise ParseError('Resource object must be dictionary')
 
                 if datum.get('id') is None:
                     raise JSONAPIException(source={'pointer': '/data/{}/id'.format(str(i))}, detail=NO_ID_ERROR)

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -860,6 +860,9 @@ class NodeContributorsRelationshipSerializer(JSONAPISerializer):
         # If current user was not included in request data, remove current user last
         if current_user_request_data is None:
             node.remove_contributor(user, auth, save=True)
+            removed = node.remove_contributor(user, auth)
+            if not removed:
+                raise exceptions.ValidationError('Must have at least one registered admin contributor')
             return self.make_instance_obj(node)
 
         # If current user was removing their admin permissions, change this last

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -860,7 +860,7 @@ class NodeContributorsRelationshipSerializer(JSONAPISerializer):
 
         # If current user was removing their admin permissions, change this last
         if current_user_request_data['short_permission'] != 'admin':
-            self.update_contributor(node, contrib['user'], contrib['short_permission'], None, auth=auth, save=True)
+            self.update_contributor(node, current_user_request_data['user'], current_user_request_data['short_permission'], None, auth=auth, save=True)
             return self.make_instance_obj(node)
 
         return self.make_instance_obj(node)

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -785,8 +785,8 @@ class NodeContributorsRelationshipSerializer(JSONAPISerializer):
         for contrib in request_data:
             if contrib['user_id'] not in current_contrib_ids:
                 try:
-                    node.add_contributor_registered_or_not(
-                        auth=auth, user_id=contrib['user_id'], send_email='default',
+                    node.add_contributor(
+                        auth=auth, user_id=contrib['user_id'],
                         permissions=contrib['expanded_permissions'], bibliographic=contrib['bibliographic'], save=True
                     )
                     new_contrib_ids.append(contrib['user_id'])

--- a/api/nodes/urls.py
+++ b/api/nodes/urls.py
@@ -31,6 +31,7 @@ urlpatterns = [
     url(r'^(?P<node_id>\w+)/registrations/$', views.NodeRegistrationsList.as_view(), name=views.NodeRegistrationsList.view_name),
     url(r'^(?P<node_id>\w+)/relationships/institutions/$', views.NodeInstitutionsRelationship.as_view(), name=views.NodeInstitutionsRelationship.view_name),
     url(r'^(?P<node_id>\w+)/relationships/linked_nodes/$', views.NodeLinkedNodesRelationship.as_view(), name=views.NodeLinkedNodesRelationship.view_name),
+    url(r'^(?P<node_id>\w+)/relationships/contributors/$', views.NodeContributorsRelationship.as_view(), name=views.NodeContributorsRelationship.view_name),
     url(r'^(?P<node_id>\w+)/view_only_links/$', views.NodeViewOnlyLinksList.as_view(), name=views.NodeViewOnlyLinksList.view_name),
     url(r'^(?P<node_id>\w+)/view_only_links/(?P<link_id>\w+)/$', views.NodeViewOnlyLinkDetail.as_view(), name=views.NodeViewOnlyLinkDetail.view_name),
     url(r'^(?P<node_id>\w+)/wikis/$', views.NodeWikiList.as_view(), name=views.NodeWikiList.view_name),

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -46,6 +46,7 @@ from api.nodes.serializers import (
     NodeAlternativeCitationSerializer,
     NodeContributorsCreateSerializer,
     NodeViewOnlyLinkSerializer,
+    NodeContributorsRelationshipSerializer,
     NodeViewOnlyLinkUpdateSerializer
 )
 from api.nodes.utils import get_file_object
@@ -688,6 +689,38 @@ class NodeContributorsList(BaseContributorList, bulk_views.BulkUpdateJSONAPIView
 
         return resource_object_list
 
+class NodeContributorsRelationship(BaseContributorList, generics.CreateAPIView, NodeMixin):
+    """ Relationship Endpoint for Node Contributor relationships
+    """
+    view_category = 'nodes'
+    view_name = 'node-contributors-relationship'
+
+    permission_classes = (
+        AdminOrPublic,
+        drf_permissions.IsAuthenticatedOrReadOnly,
+        ReadOnlyIfRegistration,
+        base_permissions.TokenHasScope,
+    )
+
+    required_read_scopes = [CoreScopes.NODE_CONTRIBUTORS_READ]
+    required_write_scopes = [CoreScopes.NODE_CONTRIBUTORS_WRITE]
+
+    serializer_class = NodeContributorsRelationshipSerializer
+    parser_classes = (JSONAPIRelationshipParser, JSONAPIRelationshipParserForRegularJSON, )
+
+    def get_queryset(self):
+        queryset = self.get_queryset_from_request()
+        return queryset
+
+    def get_object(self):
+        contributors = self.get_queryset_from_request()
+        node = self.get_node()
+        obj = {'contributors': contributors, 'node': node}
+        return obj
+
+    def create(self, *args, **kwargs):
+        ret = super(NodeContributorsRelationship, self).create(*args, **kwargs)
+        return ret
 
 class NodeContributorDetail(BaseContributorDetail, generics.RetrieveUpdateDestroyAPIView, NodeMixin, UserMixin):
     """Detail of a contributor for a node. *Writeable*.

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -689,7 +689,7 @@ class NodeContributorsList(BaseContributorList, bulk_views.BulkUpdateJSONAPIView
 
         return resource_object_list
 
-class NodeContributorsRelationship(BaseContributorList, generics.CreateAPIView, NodeMixin):
+class NodeContributorsRelationship(BaseContributorList, generics.UpdateAPIView, NodeMixin):
     """ Relationship Endpoint for Node Contributor relationships
     """
     view_category = 'nodes'
@@ -713,14 +713,8 @@ class NodeContributorsRelationship(BaseContributorList, generics.CreateAPIView, 
         return queryset
 
     def get_object(self):
-        contributors = self.get_queryset_from_request()
-        node = self.get_node()
-        obj = {'contributors': contributors, 'node': node}
-        return obj
+        return self.get_node()
 
-    def create(self, *args, **kwargs):
-        ret = super(NodeContributorsRelationship, self).create(*args, **kwargs)
-        return ret
 
 class NodeContributorDetail(BaseContributorDetail, generics.RetrieveUpdateDestroyAPIView, NodeMixin, UserMixin):
     """Detail of a contributor for a node. *Writeable*.


### PR DESCRIPTION
## Purpose

Needed for preprints - to transform existing contributor list to the list in the request, happening under one transaction.

## Changes
Allows user to send a list of contributors as a PUT/PATCH to `/v2/nodes/{node_id}/relationships/contributors/`.  This endpoint will do all the crud operations to make the node contributors match the list that was sent in.  Operations have to occur in the correct order to keep the node always in the correct state.

Request body is a list of contributors:
```
{
    "data": [{
        "id": "xhrde-ak43n",
        "type": "contributors",
        "attributes": {
        	"permission": "write",
        	"bibliographic": true
        }
    },
    {
        "id": "xhrde-ya63j",
        "type": "contributors",
        "attributes": {
        	"permission": "admin",
        	"bibliographic": true
        }
    },{
        "id": "xhrde-gfduh",
        "type": "contributors",
        "attributes": {
        	"permission": "admin",
        	"bibliographic": true
        }
    }]
}
```
TODO
- [ ] Change request format so each individual contributor matches POST request (user id under relationships)
- [ ] Clean up serializer
- [ ] Parser improvement
- [ ] tests tests tests

## Side effects

<!--Any possible side effects? -->


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
