### PR TITLE
[OSF-6552] Fix bottom margin for quick project search

### DIFF
--- a/website/static/css/quick-project-search-plugin.css
+++ b/website/static/css/quick-project-search-plugin.css
@@ -108,4 +108,5 @@
     padding: 10px 15px;
     border-radius: 2px;
     margin-top: 20px;
+    margin-bottom: 50px;
 }


### PR DESCRIPTION
## Purpose

After the arrow used to display more projects is clicked the bottom margin disappears.

## Changes

Simple CSS fix.

# Before:
![screen shot 2016-06-24 at 1 45 48 pm](https://cloud.githubusercontent.com/assets/9688518/18553268/d0e33134-7b2d-11e6-933c-c6574c4a41cc.png)

# After:
<img width="1180" alt="screen shot 2016-09-15 at 10 17 12 am" src="https://cloud.githubusercontent.com/assets/9688518/18553281/d92e545e-7b2d-11e6-9acd-311bb40abeda.png">


## Side effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/OSF-6552