### PR TITLE
Include index on node contributor detail [#OSF-7028]

### DIFF
--- a/api/base/views.py
+++ b/api/base/views.py
@@ -618,6 +618,7 @@ class BaseContributorDetail(JSONAPIBaseView, generics.RetrieveAPIView):
         user.permission = node.get_permissions(user)[-1]
         user.bibliographic = node.get_visible(user)
         user.node_id = node._id
+        user.index = node.contributors.index(user)
         return user
 
 class BaseContributorList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin):

--- a/api_tests/nodes/views/test_node_contributors_detail.py
+++ b/api_tests/nodes/views/test_node_contributors_detail.py
@@ -110,6 +110,19 @@ class TestContributorDetail(NodeCRUDTestCase):
         assert_equal(res.json['data']['embeds']['users']['data']['attributes']['full_name'], 'Robert Jackson')
         assert_equal(res.json['data']['attributes'].get('unregistered_contributor'), 'Bob Jackson')
 
+    def test_detail_includes_index(self):
+        res = self.app.get(self.public_url)
+        data = res.json['data']
+        assert_in('index', data['attributes'].keys())
+        assert_equal(data['attributes']['index'], 0)
+
+        other_contributor = AuthUserFactory()
+        self.public_project.add_contributor(other_contributor, auth=Auth(self.user), save=True)
+
+        other_contributor_detail = '/{}nodes/{}/contributors/{}/'.format(API_BASE, self.public_project, other_contributor._id)
+        res = self.app.get(other_contributor_detail)
+        assert_equal(res.json['data']['attributes']['index'], 1)
+
 
 class TestNodeContributorOrdering(ApiTestCase):
     def setUp(self):


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
The list view for BaseContributors grabs the index, but the detail view didn't return it.


## Changes
- assign the index in `get_object` method of `BaseContributorDetail`
- test to make sure index is there and it increments

## Side effects

- none anticipated


## Ticket
https://openscience.atlassian.net/browse/OSF-7028
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
