### PR TITLE
Add social icons for social profile [OSF-789]

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,6 +20,7 @@
     "raven-js": "2.1.0",
     "zeroclipboard": "2.1.6",
     "osf-style": "https://github.com/CenterForOpenScience/osf-style.git#5dcf5997ad2808ffc7c8564f94cde102bf7a4a96",
-    "At.js": "jquery.atwho#e18af47fdcb327605533a9da259225176e3013c8"
+    "At.js": "jquery.atwho#e18af47fdcb327605533a9da259225176e3013c8",
+    "academicons": "1.7.0"
   }
 }

--- a/website/static/css/pages/profile-page.css
+++ b/website/static/css/pages/profile-page.css
@@ -31,6 +31,59 @@ table.table.table-plain th, table.table.table-plain td {
     padding-left: 10px;
 }
 
+/* Social Links
+-------------------------------------------------- */
+
+.link-title {
+    vertical-align: middle !important;
+}
+
+.table-links .fa,
+.table-links .ai {
+    background-color: #FFF;
+}
+
+.table-links .fa-globe {
+    color:#17158E;
+}
+
+.table-links .fa-twitter-square {
+    color:#32CCFE;
+}
+
+.table-links .fa-github-square {
+    color: #070709;
+}
+
+.table-links .fa-linkedin-square {
+    color: #0085AE;
+}
+
+.table-links .ai-impactstory-square {
+    color: #ff4000;
+}
+
+.table-links .ai-orcid-square {
+    color: #a6ce39;
+}
+
+.table-links .ai-researchgate-square {
+    color: #0cb;
+}
+
+.table-links .ai-academia-square {
+    color: #5A5A5A;
+}
+
+.table-links .ai-google-scholar-square {
+    color: #4285f4;
+}
+
+.icon-image {
+    width:24px;
+    height:auto;
+}
+
 /* Profile gravatar
 -------------------------------------------------- */
 .profile-gravatar {

--- a/website/templates/include/profile/social.mako
+++ b/website/templates/include/profile/social.mako
@@ -1,6 +1,7 @@
 <script id="profileSocial" type="text/html">
 
     <link rel="stylesheet" href='/static/css/pages/profile-page.css'>
+    <link rel="stylesheet" href="/static/vendor/bower_components/academicons/css/academicons.css"/>
 
     <div data-bind="if: mode() === 'edit'">
 
@@ -168,6 +169,7 @@
 
             <tbody data-bind="foreach: values">
                 <tr data-bind="if: value">
+                    <td><a target="_blank" data-bind="attr: {href: value}"><span data-bind="html: iconName(label)"></span></a></td>
                     <td><span data-bind="text: label"></span></td>
                     <td><a target="_blank" data-bind="attr: {href: value}, text: text"></a></td>
                 </tr>
@@ -184,4 +186,22 @@
 
     </div>
 
+</script>
+<script>
+iconName = function(name) {
+    var nameToHtml = {
+        "ORCID": "<i class='ai ai-orcid-square ai-2x' />",
+        "ResearcherID": "<img src='http://tguillerme.github.io/images/logo-RID.png' class='icon-image'>",
+        "Twitter": "<i class='fa fa-twitter-square fa-2x' />",
+        "GitHub": "<i class='fa fa-github-square fa-2x' />",
+        "LinkedIn": "<i class='fa fa-linkedin-square fa-2x' />",
+        "ImpactStory": "<i class='ai ai-impactstory-square ai-2x' />",
+        "Google Scholar": "<i class='ai ai-google-scholar-square ai-2x' />",
+        "ResearchGate": "<i class='ai ai-researchgate-square ai-2x' />",
+        "Academia": "<i class='ai ai-academia-square ai-2x' />",
+        "Baidu Scholar": "<img src='http://www.baidu.com/favicon.ico' class='icon-image'>",
+        "SSRN": "<img src='https://www.google.com/s2/favicons?domain=http://www.ssrn.com/' class='icon-image'>"
+    };
+    return nameToHtml[name];
+}
 </script>


### PR DESCRIPTION
## Purpose

This PR is an update and clean-up of [https://github.com/CenterForOpenScience/osf.io/pull/6107](https://github.com/CenterForOpenScience/osf.io/pull/6107).
The purpose of this PR is to add icons for the social links on the profile page. 

## Changes
Changes include adding Academicons  (now via bower) to the OSF for academic icons, adding icons to the template, and adding formatting for the icons.

![screen shot 2016-09-15 at 3 46 45 pm](https://cloud.githubusercontent.com/assets/7026698/18564930/c51455d0-7b5b-11e6-8794-efe3a9ee3374.png)


## Side effects

No side effects can be seen.

## Ticket

https://openscience.atlassian.net/browse/OSF-789

