### PR TITLE
[feature] Add Prereg Banner to Dashboard [OSF-7009]

### DIFF
--- a/website/static/css/meetings-and-conferences.css
+++ b/website/static/css/meetings-and-conferences.css
@@ -3,3 +3,7 @@
         text-align: center;
     }
 }
+
+.btn {
+    width: 70%
+}

--- a/website/static/css/pages/home-page.css
+++ b/website/static/css/pages/home-page.css
@@ -29,6 +29,16 @@ h3, h4 {
     box-shadow: 0 0 9px -4px #000;
 }
 
+.prereg {
+    background: #C5D6E6 url("/static/img/bg6.jpg") no-repeat center top;
+    background-size: cover;
+}
+
+.preprints {
+    background: #34495e;
+    color: #FFF;
+}
+
 .footer {
     margin-top: 0; /* Override footer margin for this page only */
 }

--- a/website/static/js/home-page/preregPlugin.js
+++ b/website/static/js/home-page/preregPlugin.js
@@ -1,0 +1,36 @@
+/**
+ * Prereg Challenge
+ */
+
+var m = require('mithril');
+var $osf = require('js/osfHelpers');
+
+// CSS
+require('css/meetings-and-conferences.css');
+
+var Prereg = {
+    view: function(ctrl) {
+        return m('.p-v-sm',
+            m('.row',
+                [
+                    m('.col-md-8',
+                        [
+                            m('div.conference-centering',  m('h3', 'See how preregistration can improve your next study.')),
+                            m('div.conference-centering.m-t-lg',
+                                m('p.text-bigger', 'Publish the results of your preregistered study for a chance to win $1,000.')
+                            )
+                        ]
+                    ),
+                    m('.col-md-4.text-center',
+                        m('div',  m('a.btn.btn-success.btn-lg.btn-success-high-contrast.m-v-xl.f-w-xl', { style : 'box-shadow: 0 0 9px -4px #000;', type:'button',  href:'/prereg/', onclick: function() {
+                            $osf.trackClick('prereg', 'navigate', 'navigate-to-begin-prereg');
+                        }}, 'Preregister'))
+                    )
+                ]
+            )
+        );
+    }
+};
+
+
+module.exports = Prereg;

--- a/website/static/js/pages/home-page.js
+++ b/website/static/js/pages/home-page.js
@@ -12,6 +12,7 @@ var QuickSearchProject = require('js/home-page/quickProjectSearchPlugin');
 var NewAndNoteworthy = require('js/home-page/newAndNoteworthyPlugin');
 var MeetingsAndConferences = require('js/home-page/meetingsAndConferencesPlugin');
 var Preprints = require('js/home-page/preprintsPlugin');
+var Prereg = require('js/home-page/preregPlugin');
 var InstitutionsPanel = require('js/home-page/institutionsPanelPlugin');
 var ensureUserTimezone = require('js/ensureUserTimezone');
 
@@ -55,6 +56,14 @@ $(document).ready(function(){
                         ]),
                         m('.row', [
                             m(columnSizeClass, m.component(NewAndNoteworthy, {}))
+                        ])
+
+                    ]
+                )),
+                m('.prereg', m('.container',
+                    [
+                        m('.row', [
+                            m(columnSizeClass,  m.component(Prereg, {}))
                         ])
 
                     ]


### PR DESCRIPTION
#### Purpose
- Adds a banner for the Preregistration Challenge to the OSF dashboard page.

#### Changes
- Adds a background to the Preprints banner because it didn't have one. 
- Makes all of the banner buttons have the same fixed width.

#### Side effects
- None.

#### Final Screenshot
- (with "Preregister" text on button as opposed to "Begin a Preregistration")
![screen shot 2016-09-23 at 10 10 09 am](https://cloud.githubusercontent.com/assets/7913604/18788723/f9f14b94-8175-11e6-9775-f9bed3b3140c.png)


#### Product Notes
- @saradbowman, I chose the background for the Prereg banner just based on what I thought looked nice (repeating the three backgrounds that were already being used on the page), but I can change the background for this banner (and the others) to be whatever your ❤️  desires. Also, I can fit "Begin a Preregistration" on the button, but it does look a bit long compared to the other banners buttons (screenshots for both options shown below so you can which you prefer).

#### Ticket
- [OSF-7009](https://openscience.atlassian.net/browse/OSF-7009)
