### PR TITLE
Change download count to not include contributors' downloads [OSF-3628]

### DIFF
--- a/website/addons/osfstorage/utils.py
+++ b/website/addons/osfstorage/utils.py
@@ -24,11 +24,14 @@ def update_analytics(node, file_id, version_idx):
     """
     # Pass in contributors to check that contributors' downloads
     # do not count towards total download count
+    contributors = []
+    if node.contributors:
+        contributors = node.contributors
     node_info = {
-        'contributors': node.contributors
+        'contributors': contributors
     }
-    update_counter(u'download:{0}:{1}'.format(node._id, file_id))
-    update_counter(u'download:{0}:{1}:{2}'.format(node._id, file_id, version_idx))
+    update_counter(u'download:{0}:{1}'.format(node._id, file_id), node_info=node_info)
+    update_counter(u'download:{0}:{1}:{2}'.format(node._id, file_id, version_idx), node_info=node_info)
 
 
 def serialize_revision(node, record, version, index, anon=False):

--- a/website/addons/osfstorage/utils.py
+++ b/website/addons/osfstorage/utils.py
@@ -12,7 +12,6 @@ from framework.analytics import update_counter
 
 from website.addons.osfstorage import settings
 
-
 logger = logging.getLogger(__name__)
 LOCATION_KEYS = ['service', settings.WATERBUTLER_RESOURCE, 'object']
 
@@ -23,6 +22,11 @@ def update_analytics(node, file_id, version_idx):
     :param str file_id: The _id field of a filenode
     :param int version_idx: Zero-based version index
     """
+    # Pass in contributors to check that contributors' downloads
+    # do not count towards total download count
+    node_info = {
+        'contributors': node.contributors
+    }
     update_counter(u'download:{0}:{1}'.format(node._id, file_id))
     update_counter(u'download:{0}:{1}:{2}'.format(node._id, file_id, version_idx))
 

--- a/website/addons/osfstorage/views.py
+++ b/website/addons/osfstorage/views.py
@@ -9,6 +9,7 @@ from modularodm.storage.base import KeyExistsException
 from flask import request
 
 from framework.auth import Auth
+from framework.sessions import get_session
 from framework.exceptions import HTTPError
 from framework.auth.decorators import must_be_signed
 
@@ -223,6 +224,13 @@ def osfstorage_delete(file_node, payload, node_addon, **kwargs):
 @must_be_signed
 @decorators.autoload_filenode(must_be='file')
 def osfstorage_download(file_node, payload, node_addon, **kwargs):
+    # Set user ID in session data for checking if user is contributor
+    # to project.
+    user_id = payload.get('user')
+    if user_id:
+        current_session = get_session()
+        current_session.data['auth_user_id'] = user_id
+
     if not request.args.get('version'):
         version_id = None
     else:


### PR DESCRIPTION
## Purpose

The download count for a file should increment every time any non-contributor downloads the file. This way, the download count is a measure of outside interest in the resource, not a measure of collaborators' downloads.

## Changes

The main change is to the analytics ```update_counter``` method. This has been changed to check if the user performing the download is one of the project's contributors. If they are, the download count will not be incremented. 

Secondary changes were:
- Changing the signature of ```update_counter``` to accept a ```node_info``` dict that contains a list of contributors.
- Changing ```update_analytics``` to pass the contributors list via ```node_info``` to the ```update_counter``` method.

The ```osfstorage_download``` method had to also be modified to add the user's id to the session data after a download. (See [https://github.com/CenterForOpenScience/waterbutler/pull/169](https://github.com/CenterForOpenScience/waterbutler/pull/169)).

Tests were added:
- ```test_update_counters_file_user_is_contributor```
- ```test_update_counters_file_user_is_not_contributor```

## Side effects

- It is possible that adding the user id to the session data will have some side effects, but this is unlikely; on most requests such as file deletes it is already there.

## Ticket

[https://openscience.atlassian.net/browse/OSF-3628](https://openscience.atlassian.net/browse/OSF-3628)
