### PR TITLE
Make sure "cannot upload folder" error is shown in a timely manor [#OSF-6910]

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -892,6 +892,7 @@ function _fangornDropzoneError(treebeard, file, message, xhr) {
     if (msgText !== 'Upload canceled.') {
         addFileStatus(treebeard, file, false, msgText, '');
     }
+    treebeard.dropzone.options.queuecomplete(file);
 }
 
 /**


### PR DESCRIPTION

## Purpose
The error message for not being able to upload a folder wasn't being called on treebeard instances until another action was complete such as successfully uploading a file. Make sure that the modal is triggered when there's just an error and not an error bundled along with a success

## Changes

- make sure `queuecomplete` is called when an error has happened

## Side effects
Tested as best I could, but I hope that no errors cause other things not to upload - things in the file tree seem to happen the way they should!


## Ticket
https://openscience.atlassian.net/browse/OSF-6910