### PR TITLE
Support test-level database isolation [OSF-7042]

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -157,6 +157,30 @@ class DbTestCase(unittest.TestCase):
         settings.BCRYPT_LOG_ROUNDS = cls._original_bcrypt_log_rounds
 
 
+class DbIsolationMixin(object):
+    """Use this mixin when test-level database isolation is desired.
+
+    For whatever reason (efficiency?), DbTestCase only wipes the database
+    during *class* setup and teardown. This leaks database state across test
+    cases, which smells pretty bad. Place this mixin before DbTestCase (or
+    derivatives, such as OsfTestCase) in your test class definition to wipe the
+    database during *test* setup and teardown.
+
+    """
+
+    def setUp(self):
+        super(DbIsolationMixin, self).setUp()
+        set_up_storage(
+            website.models.MODELS,
+            storage.MongoStorage,
+            addons=settings.ADDONS_AVAILABLE,
+        )
+
+    def tearDown(self):
+        super(DbIsolationMixin, self).tearDown()
+        teardown_database(database=database_proxy._get_current_object())
+
+
 class AppTestCase(unittest.TestCase):
     """Base `TestCase` for OSF tests that require the WSGI app (but no database).
     """

--- a/tests/base.py
+++ b/tests/base.py
@@ -160,11 +160,12 @@ class DbTestCase(unittest.TestCase):
 class DbIsolationMixin(object):
     """Use this mixin when test-level database isolation is desired.
 
-    For whatever reason (efficiency?), DbTestCase only wipes the database
-    during *class* setup and teardown. This leaks database state across test
-    cases, which smells pretty bad. Place this mixin before DbTestCase (or
-    derivatives, such as OsfTestCase) in your test class definition to wipe the
-    database during *test* setup and teardown.
+    As an optimization, DbTestCase only wipes the database during *class* setup
+    and teardown. This leaks database state across test cases, which smells
+    pretty bad. Place this mixin before DbTestCase (or derivatives, such as
+    OsfTestCase) in your test class definition to wipe the database during
+    *test* setup and teardown ... but be prepared to suffer a 20x performance
+    hit, ample time to pine and long for a glorious Postgres future.
 
     """
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -4,38 +4,16 @@ import unittest
 from nose.tools import *  # PEP8 asserts
 
 from framework.forms.utils import process_payload
-from framework.mongo import database as database_proxy, set_up_storage
-from modularodm import storage
 from modularodm.exceptions import KeyExistsException
 
-import website.models
-from website import settings
 from website.project.model import MetaSchema
 from website.project.model import ensure_schemas
 from website.project.metadata.schemas import OSF_META_SCHEMAS
 
-from tests.base import OsfTestCase, teardown_database
+from tests.base import DbIsolationMixin, OsfTestCase
 
 
-class TestMetaData(OsfTestCase):
-
-    # For whatever reason (efficiency?), DbTestCase only wipes the database
-    # during *class* setup and teardown. This leaks database state across test
-    # cases, which a) smells pretty bad, and b) breaks the test_metaschema_
-    # tests here.
-
-    def setUp(self):
-        super(TestMetaData, self).setUp()
-        set_up_storage(
-            website.models.MODELS,
-            storage.MongoStorage,
-            addons=settings.ADDONS_AVAILABLE,
-        )
-
-    def tearDown(self):
-        super(TestMetaData, self).tearDown()
-        teardown_database(database=database_proxy._get_current_object())
-
+class TestMetaData(DbIsolationMixin, OsfTestCase):
 
     def test_ensure_schemas(self):
 

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -8,7 +8,7 @@ from framework.auth import Auth
 
 from website.models import Node, NodeLog
 
-from tests.base import OsfTestCase
+from tests.base import DbIsolationMixin, OsfTestCase
 from tests.factories import ProjectFactory
 from tests import utils as test_utils
 
@@ -63,3 +63,32 @@ class TestUtilsTests(OsfTestCase):
         wrapped = test_utils.assert_not_logs(NodeLog.UPDATED_FIELDS, 'node')(add_log)
         assert_raises(AssertionError, lambda: wrapped(self))
 
+
+
+class DbIsolationMixinTests(object):
+
+    @classmethod
+    def setUpClass(cls, *a, **kw):
+        super(DbIsolationMixinTests, cls).setUpClass(*a, **kw)
+        cls.ntest_calls = 0  # set here instead of at class scope to avoid bleeding across
+                             # test case classes below
+
+    def check(self):
+        ProjectFactory()
+        self.__class__.ntest_calls += 1  # a little goofy, yes; each test gets its own instance
+        nexpected = self.__class__.ntest_calls if self.nexpected == 'ntest_calls' else 1
+        assert_equal(nexpected, len(Node.find()))
+
+    def test_1(self): self.check()
+    def test_2(self): self.check()
+    def test_3(self): self.check()
+
+
+class TestMissingDbIsolationMixin(DbIsolationMixinTests, OsfTestCase):
+    nexpected = 'ntest_calls'
+
+class TestOutOfOrderDbIsolationMixin(DbIsolationMixinTests, OsfTestCase, DbIsolationMixin):
+    nexpected = 'ntest_calls'
+
+class TestProperlyInstalledDbIsolationMixin(DbIsolationMixinTests, DbIsolationMixin, OsfTestCase):
+    nexpected = 'constant'

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -70,8 +70,9 @@ class DbIsolationMixinTests(object):
     @classmethod
     def setUpClass(cls, *a, **kw):
         super(DbIsolationMixinTests, cls).setUpClass(*a, **kw)
-        cls.ntest_calls = 0  # set here instead of at class scope to avoid bleeding across
-                             # test case classes below
+        cls.ntest_calls = 0  # If we set this at class scope on DbIsolationMixinTests then it
+                             # would be shared across the subclasses. Setting it directly on each
+                             # subclass here avoids such bleedthrough.
 
     def check(self):
         ProjectFactory()


### PR DESCRIPTION
## Purpose

Our current testing infrastructure scopes database isolation to the test class level. Better practice is to scope isolation to the test-case level, to avoid interference between one test and another. This PR factors out a `DbIsolationMixin` implementing test-level isolation for use across multiple test classes.

## Changes

No user-visible changes.

## Side effects

No side-effects.

## Ticket

https://openscience.atlassian.net/browse/OSF-7042