### PR TITLE
[Hotfix] Pin Dataverse client to commit

### DIFF
--- a/website/addons/dataverse/requirements.txt
+++ b/website/addons/dataverse/requirements.txt
@@ -1,4 +1,4 @@
 # Allow for optional timeout parameter.
 # https://github.com/IQSS/dataverse-client-python/pull/27
 #-e git+https://github.com/IQSS/dataverse-client-python.git@b6aec5bc3fd1cc3199e3c97ac9c71705b54c3d11#egg=dataverse
--e git+https://github.com/CenterForOpenScience/dataverse-client-python.git@master#egg=dataverse
+-e git+https://github.com/CenterForOpenScience/dataverse-client-python.git@5f20ad7aba11b0ce0bee6e791a91266e7ce4d76a#egg=dataverse


### PR DESCRIPTION
## Purpose
- Fix `data[fF]ile` key issue
- Prefer pinning to commits rather than branches

## Changes
* Pin to commit 

## Side effects
None

## Ticket

[OSF-7039](https://openscience.atlassian.net/browse/OSF-7039)
