### PR TITLE
Use JS rendering for all wiki markdown regardless of age [OSF-6412] [OSF-7038]

### DIFF
--- a/website/addons/wiki/static/wikiPage.js
+++ b/website/addons/wiki/static/wikiPage.js
@@ -6,6 +6,7 @@ var $osf = require('js/osfHelpers');
 var mathrender = require('js/mathrender');
 var md = require('js/markdown').full;
 var mdQuick = require('js/markdown').quick;
+var mdOld = require('js/markdown').old;
 var diffTool = require('js/diffTool');
 
 var THROTTLE = 500;
@@ -86,10 +87,10 @@ function ViewWidget(visible, version, viewText, rendered, contentURL, allowMathj
                     if(self.visible()) {
                         var $markdownElement = $('#wikiViewRender');
                         var rawContent = resp.wiki_content || '*No wiki content*';
-                        if (resp.wiki_rendered) {
-                            // Use pre-rendered python, if provided. Don't mathjaxify
+                        if (resp.rendered_before_update) {
+                            // Use old md renderer. Don't mathjaxify
                             self.allowMathjaxification(false);
-                            self.rendered(resp.wiki_rendered);
+                            self.rendered(mdOld.render(rawContent));
                             $markdownElement.css('display', 'inherit');
 
                         } else {

--- a/website/addons/wiki/templates/edit.mako
+++ b/website/addons/wiki/templates/edit.mako
@@ -366,7 +366,7 @@ ${parent.javascript_bottom()}
     window.contextVars.wiki = {
         canEdit: canEditBody,
         canEditPageName: canEditPageName,
-        usePythonRender: ${ use_python_render | sjson, n },
+        renderedBeforeUpdate: ${ rendered_before_update | sjson, n },
         versionSettings: ${ version_settings | sjson, n },
         panelsUsed: ${ panels_used | sjson, n },
         wikiID: ${ wiki_id | sjson, n },

--- a/website/addons/wiki/templates/wiki_widget.mako
+++ b/website/addons/wiki/templates/wiki_widget.mako
@@ -17,7 +17,7 @@
 <script>
     window.contextVars = $.extend(true, {}, window.contextVars, {
         wikiWidget: true,
-        usePythonRender: ${ use_python_render | sjson, n },
+        renderedBeforeUpdate: ${ rendered_before_update | sjson, n },
         urls: {
             wikiContent: ${wiki_content_url | sjson, n }
         }

--- a/website/addons/wiki/views.py
+++ b/website/addons/wiki/views.py
@@ -151,7 +151,7 @@ def wiki_widget(**kwargs):
             more = True
         else:
             wiki_html = BeautifulSoup(wiki_html)
-            rendered_before_update = wiki_page.rendered_before_update
+        rendered_before_update = wiki_page.rendered_before_update
     else:
         wiki_html = None
 

--- a/website/addons/wiki/views.py
+++ b/website/addons/wiki/views.py
@@ -143,7 +143,7 @@ def wiki_widget(**kwargs):
     # Show "Read more" link if there are multiple pages or has > 400 characters
     more = len(node.wiki_pages_current.keys()) >= 2
     MAX_DISPLAY_LENGTH = 400
-    use_python_render = False
+    rendered_before_update = False
     if wiki_page and wiki_page.html(node):
         wiki_html = wiki_page.html(node)
         if len(wiki_html) > MAX_DISPLAY_LENGTH:
@@ -151,7 +151,7 @@ def wiki_widget(**kwargs):
             more = True
         else:
             wiki_html = BeautifulSoup(wiki_html)
-        use_python_render = wiki_page.rendered_before_update
+            rendered_before_update = wiki_page.rendered_before_update
     else:
         wiki_html = None
 
@@ -159,7 +159,7 @@ def wiki_widget(**kwargs):
         'complete': True,
         'wiki_content': unicode(wiki_html) if wiki_html else None,
         'wiki_content_url': node.api_url_for('wiki_page_content', wname='home'),
-        'use_python_render': use_python_render,
+        'rendered_before_update': rendered_before_update,
         'more': more,
         'include': False,
     }
@@ -187,12 +187,11 @@ def wiki_page_draft(wname, **kwargs):
 def wiki_page_content(wname, wver=None, **kwargs):
     node = kwargs['node'] or kwargs['project']
     wiki_page = node.get_wiki_page(wname, version=wver)
-    use_python_render = wiki_page.rendered_before_update if wiki_page else False
+    rendered_before_update = wiki_page.rendered_before_update if wiki_page else False
 
     return {
         'wiki_content': wiki_page.content if wiki_page else '',
-        # Only return rendered version if page was saved before wiki change
-        'wiki_rendered': wiki_page.html(node) if use_python_render else '',
+        'rendered_before_update': rendered_before_update
     }
 
 
@@ -267,12 +266,12 @@ def project_wiki_view(auth, wname, path=None, **kwargs):
         version = wiki_page.version
         is_current = wiki_page.is_current
         content = wiki_page.html(node)
-        use_python_render = wiki_page.rendered_before_update
+        rendered_before_update = wiki_page.rendered_before_update
     else:
         version = 'NA'
         is_current = False
         content = ''
-        use_python_render = False
+        rendered_before_update = False
 
     if can_edit:
         if wiki_key not in node.wiki_private_uuids:
@@ -301,7 +300,7 @@ def project_wiki_view(auth, wname, path=None, **kwargs):
         'wiki_id': wiki_page._primary_key if wiki_page else None,
         'wiki_name': wiki_page.page_name if wiki_page else wiki_name,
         'wiki_content': content,
-        'use_python_render': use_python_render,
+        'rendered_before_update': rendered_before_update,
         'page': wiki_page,
         'version': version,
         'versions': versions,

--- a/website/static/js/markdown-it-pymarkdown-lists.js
+++ b/website/static/js/markdown-it-pymarkdown-lists.js
@@ -93,10 +93,11 @@ function markTightParagraphs(state, idx) {
 
 function hideOldListContent(state, idx) {
     var i, l;
-
-    for (i = idx - 2, l = state.tokens.length; i < l; i++) {
-        state.tokens[i].hidden = true;
-        state.tokens[i].content = '';
+    if (idx > 1) {
+        for (i = idx - 2, l = state.tokens.length; i < l; i++) {
+            state.tokens[i].hidden = true;
+            state.tokens[i].content = '';
+        }
     }
 }
 
@@ -137,7 +138,7 @@ module.exports = function list(state, startLine, endLine, silent) {
     }
 
     // save variable to state to check if the list should be rendered
-    if (!state.isEmpty(startLine - 1)) {
+    if (!state.isEmpty(startLine - 1) && startLine !== 0) {
         state.renderList = false;
     } else {
         state.renderList = true;

--- a/website/static/js/markdown-it-pymarkdown-lists.js
+++ b/website/static/js/markdown-it-pymarkdown-lists.js
@@ -1,0 +1,335 @@
+// Lists
+
+'use strict';
+
+// var isSpace = require('../common/utils').isSpace;
+
+
+// Search `[-+*][\n ]`, returns next pos arter marker on success
+// or -1 on fail.
+function skipBulletListMarker(state, startLine) {
+  var marker, pos, max, ch;
+
+  pos = state.bMarks[startLine] + state.tShift[startLine];
+  max = state.eMarks[startLine];
+
+  marker = state.src.charCodeAt(pos++);
+  // Check bullet
+  if (marker !== 0x2A/* * */ &&
+      marker !== 0x2D/* - */ &&
+      marker !== 0x2B/* + */) {
+    return -1;
+  }
+
+  if (pos < max) {
+    ch = state.src.charCodeAt(pos);
+
+    // if (!isSpace(ch)) {
+    //   // " -test " - is not a list item
+    //   return -1;
+    // }
+  }
+
+  return pos;
+}
+
+// Search `\d+[.)][\n ]`, returns next pos arter marker on success
+// or -1 on fail.
+function skipOrderedListMarker(state, startLine) {
+  var ch,
+      start = state.bMarks[startLine] + state.tShift[startLine],
+      pos = start,
+      max = state.eMarks[startLine];
+
+  // List marker should have at least 2 chars (digit + dot)
+  if (pos + 1 >= max) { return -1; }
+
+  ch = state.src.charCodeAt(pos++);
+
+  if (ch < 0x30/* 0 */ || ch > 0x39/* 9 */) { return -1; }
+
+  for (;;) {
+    // EOL -> fail
+    if (pos >= max) { return -1; }
+
+    ch = state.src.charCodeAt(pos++);
+
+    if (ch >= 0x30/* 0 */ && ch <= 0x39/* 9 */) {
+
+      // List marker should have no more than 9 digits
+      // (prevents integer overflow in browsers)
+      if (pos - start >= 10) { return -1; }
+
+      continue;
+    }
+
+    // found valid marker
+    if (ch === 0x29/* ) */ || ch === 0x2e/* . */) {
+      break;
+    }
+
+    return -1;
+  }
+
+
+  if (pos < max) {
+    ch = state.src.charCodeAt(pos);
+
+    // if (!isSpace(ch)) {
+    //   // " 1.test " - is not a list item
+    //   return -1;
+    // }
+  }
+  return pos;
+}
+
+function markTightParagraphs(state, idx) {
+  var i, l,
+      level = state.level + 2;
+
+  for (i = idx + 2, l = state.tokens.length - 2; i < l; i++) {
+    if (state.tokens[i].level === level && state.tokens[i].type === 'paragraph_open') {
+      state.tokens[i + 2].hidden = true;
+      state.tokens[i].hidden = true;
+      i += 2;
+    }
+  }
+}
+
+
+module.exports = function pymark_list(state, startLine, endLine, silent) {
+    debugger;
+  var ch,
+      contentStart,
+      i,
+      indent,
+      indentAfterMarker,
+      initial,
+      isOrdered,
+      itemLines,
+      l,
+      listLines,
+      listTokIdx,
+      markerCharCode,
+      markerValue,
+      max,
+      nextLine,
+      offset,
+      oldIndent,
+      oldLIndent,
+      oldParentType,
+      oldTShift,
+      oldTight,
+      pos,
+      posAfterMarker,
+      prevEmptyEnd,
+      start,
+      terminate,
+      terminatorRules,
+      token,
+      isTerminatingParagraph = false,
+      tight = true;
+
+  // limit conditions when list can interrupt
+  // a paragraph (validation mode only)
+  if (silent && state.parentType === 'paragraph') {
+    // Next list item should still terminate previous list item;
+    //
+    // This code can fail if plugins use blkIndent as well as lists,
+    // but I hope the spec gets fixed long before that happens.
+    //
+    if (state.tShift[startLine] >= state.blkIndent) {
+      isTerminatingParagraph = true;
+    }
+  }
+  // Detect list type and position after marker
+  if ((posAfterMarker = skipOrderedListMarker(state, startLine)) >= 0) {
+    isOrdered = true;
+    start = state.bMarks[startLine] + state.tShift[startLine];
+    markerValue = Number(state.src.substr(start, posAfterMarker - start - 1));
+
+    // If we're starting a new ordered list right after
+    // a paragraph, it should start with 1.
+    if (isTerminatingParagraph && markerValue !== 1) return false;
+
+  } else if ((posAfterMarker = skipBulletListMarker(state, startLine)) >= 0) {
+    isOrdered = false;
+
+  } else {
+    return false;
+  }
+
+  // If we're starting a new unordered list right after
+  // a paragraph, first line should not be empty.
+  if (isTerminatingParagraph) {
+    if (state.skipSpaces(posAfterMarker) >= state.eMarks[startLine]) return false;
+  }
+
+  // We should terminate list on style change. Remember first one to compare.
+  markerCharCode = state.src.charCodeAt(posAfterMarker - 1);
+
+  // For validation mode we can terminate immediately
+  if (silent) { return true; }
+
+  // Start list
+  listTokIdx = state.tokens.length;
+
+  if (isOrdered) {
+    token       = state.push('ordered_list_open', 'ol', 1);
+    if (markerValue !== 1) {
+      token.attrs = [ [ 'start', markerValue ] ];
+    }
+
+  } else {
+    token       = state.push('bullet_list_open', 'ul', 1);
+  }
+
+  token.map    = listLines = [ startLine, 0 ];
+  token.markup = String.fromCharCode(markerCharCode);
+
+  //
+  // Iterate list items
+  //
+
+  nextLine = startLine;
+  prevEmptyEnd = false;
+  terminatorRules = state.md.block.ruler.getRules('list');
+
+  oldParentType = state.parentType;
+  state.parentType = 'list';
+
+  while (nextLine < endLine) {
+    pos = posAfterMarker;
+    max = state.eMarks[nextLine];
+
+    initial = offset = state.sCount[nextLine] + posAfterMarker - (state.bMarks[startLine] + state.tShift[startLine]);
+
+    while (pos < max) {
+      ch = state.src.charCodeAt(pos);
+
+      // if (isSpace(ch)) {
+      //   if (ch === 0x09) {
+      //     offset += 4 - (offset + state.bsCount[nextLine]) % 4;
+      //   } else {
+      //     offset++;
+      //   }
+      // } else {
+      //   break;
+      // }
+
+      pos++;
+    }
+
+    contentStart = pos;
+
+    if (contentStart >= max) {
+      // trimming space in "-    \n  3" case, indent is 1 here
+      indentAfterMarker = 1;
+    } else {
+      indentAfterMarker = offset - initial;
+    }
+
+    // If we have more than 4 spaces, the indent is 1
+    // (the rest is just indented code block)
+    if (indentAfterMarker > 4) { indentAfterMarker = 1; }
+
+    // "  -  test"
+    //  ^^^^^ - calculating total length of this thing
+    indent = initial + indentAfterMarker;
+
+    // Run subparser & write tokens
+    token        = state.push('list_item_open', 'li', 1);
+    token.markup = String.fromCharCode(markerCharCode);
+    token.map    = itemLines = [ startLine, 0 ];
+
+    oldIndent = state.blkIndent;
+    oldTight = state.tight;
+    oldTShift = state.tShift[startLine];
+    oldLIndent = state.sCount[startLine];
+    state.blkIndent = indent;
+    state.tight = true;
+    state.tShift[startLine] = contentStart - state.bMarks[startLine];
+    state.sCount[startLine] = offset;
+
+    if (contentStart >= max && state.isEmpty(startLine + 1)) {
+      // workaround for this case
+      // (list item is empty, list terminates before "foo"):
+      // ~~~~~~~~
+      //   -
+      //
+      //     foo
+      // ~~~~~~~~
+      state.line = Math.min(state.line + 2, endLine);
+    } else {
+      state.md.block.tokenize(state, startLine, endLine, true);
+    }
+
+    // If any of list item is tight, mark list as tight
+    if (!state.tight || prevEmptyEnd) {
+      tight = false;
+    }
+    // Item become loose if finish with empty line,
+    // but we should filter last element, because it means list finish
+    prevEmptyEnd = (state.line - startLine) > 1 && state.isEmpty(state.line - 1);
+
+    state.blkIndent = oldIndent;
+    state.tShift[startLine] = oldTShift;
+    state.sCount[startLine] = oldLIndent;
+    state.tight = oldTight;
+
+    token        = state.push('list_item_close', 'li', -1);
+    token.markup = String.fromCharCode(markerCharCode);
+
+    nextLine = startLine = state.line;
+    itemLines[1] = nextLine;
+    contentStart = state.bMarks[startLine];
+
+    if (nextLine >= endLine) { break; }
+
+    //
+    // Try to check if list is terminated or continued.
+    //
+    if (state.sCount[nextLine] < state.blkIndent) { break; }
+
+    // fail if terminating block found
+    terminate = false;
+    for (i = 0, l = terminatorRules.length; i < l; i++) {
+      if (terminatorRules[i](state, nextLine, endLine, true)) {
+        terminate = true;
+        break;
+      }
+    }
+    if (terminate) { break; }
+
+    // fail if list has another type
+    if (isOrdered) {
+      posAfterMarker = skipOrderedListMarker(state, nextLine);
+      if (posAfterMarker < 0) { break; }
+    } else {
+      posAfterMarker = skipBulletListMarker(state, nextLine);
+      if (posAfterMarker < 0) { break; }
+    }
+
+    if (markerCharCode !== state.src.charCodeAt(posAfterMarker - 1)) { break; }
+  }
+
+  // Finilize list
+  if (isOrdered) {
+    token = state.push('ordered_list_close', 'ol', -1);
+  } else {
+    token = state.push('bullet_list_close', 'ul', -1);
+  }
+  token.markup = String.fromCharCode(markerCharCode);
+
+  listLines[1] = nextLine;
+  state.line = nextLine;
+
+  state.parentType = oldParentType;
+
+  // mark paragraphs tight if needed
+  if (tight) {
+    markTightParagraphs(state, listTokIdx);
+  }
+
+  return true;
+};

--- a/website/static/js/markdown-it-pymarkdown-lists.js
+++ b/website/static/js/markdown-it-pymarkdown-lists.js
@@ -1,5 +1,5 @@
 // Lists -- markdown-it to pymarkdown!
-// Adapted from markdown-it block list rule at https://github.com/markdown-it/markdown-it/
+// Adapted from markdown-it.js block list rule (MIT Licensed)
 
 'use strict';
 
@@ -322,9 +322,6 @@ module.exports = function list(state, startLine, endLine, silent) {
         hideOldListContent(state, listTokIdx);
 
         // now render everything into one paragraph!
-        token = state.push('paragraph_open', 'p', 1);
-        token.map  = [ firstStartLine, nextLine ];
-
         content = state.getLines(firstStartLine - 1, nextLine, 0, true);
 
         token = state.push('inline', '', 0);
@@ -332,7 +329,7 @@ module.exports = function list(state, startLine, endLine, silent) {
         token.map = [ firstStartLine, nextLine ];
         token.children = [];
 
-        token = state.push('paragraph_close', 'p', -1);
+        state.push('paragraph_close', 'p', -1);
     }
 
     state.line = nextLine;

--- a/website/static/js/markdown-it-pymarkdown-lists.js
+++ b/website/static/js/markdown-it-pymarkdown-lists.js
@@ -4,261 +4,261 @@
 
 
 function isSpace(code) {
-  switch (code) {
-    case 0x09:
-    case 0x20:
-      return true;
-  }
-  return false;
+    switch (code) {
+        case 0x09:
+        case 0x20:
+            return true;
+    }
+    return false;
 }
 
 // Search `[-+*][\n ]`, returns next pos arter marker on success
 // or -1 on fail.
 function skipBulletListMarker(state, startLine) {
-  var marker, pos, max;
+    var marker, pos, max;
 
-  pos = state.bMarks[startLine] + state.tShift[startLine];
-  max = state.eMarks[startLine];
+    pos = state.bMarks[startLine] + state.tShift[startLine];
+    max = state.eMarks[startLine];
 
-  marker = state.src.charCodeAt(pos++);
-  // Check bullet
-  if (marker !== 0x2A/* * */ &&
-      marker !== 0x2D/* - */ &&
-      marker !== 0x2B/* + */) {
-    return -1;
-  }
+    marker = state.src.charCodeAt(pos++);
+    // Check bullet
+    if (marker !== 0x2A/* * */ &&
+            marker !== 0x2D/* - */ &&
+            marker !== 0x2B/* + */) {
+        return -1;
+    }
 
-  if (pos < max && !isSpace(state.src.charCodeAt(pos))) {
-    // " 1.test " - is not a list item
-    return -1;
-  }
+    if (pos < max && !isSpace(state.src.charCodeAt(pos))) {
+        // " 1.test " - is not a list item
+        return -1;
+    }
 
-  return pos;
+    return pos;
 }
 
 // Search `\d+[.)][\n ]`, returns next pos arter marker on success
 // or -1 on fail.
 function skipOrderedListMarker(state, startLine) {
-  var ch,
-      pos = state.bMarks[startLine] + state.tShift[startLine],
-      max = state.eMarks[startLine];
+    var ch,
+            pos = state.bMarks[startLine] + state.tShift[startLine],
+            max = state.eMarks[startLine];
 
-  // List marker should have at least 2 chars (digit + dot)
-  if (pos + 1 >= max) { return -1; }
-
-  ch = state.src.charCodeAt(pos++);
-
-  if (ch < 0x30/* 0 */ || ch > 0x39/* 9 */) { return -1; }
-
-  for (;;) {
-    // EOL -> fail
-    if (pos >= max) { return -1; }
+    // List marker should have at least 2 chars (digit + dot)
+    if (pos + 1 >= max) { return -1; }
 
     ch = state.src.charCodeAt(pos++);
 
-    if (ch >= 0x30/* 0 */ && ch <= 0x39/* 9 */) {
-      continue;
+    if (ch < 0x30/* 0 */ || ch > 0x39/* 9 */) { return -1; }
+
+    for (;;) {
+        // EOL -> fail
+        if (pos >= max) { return -1; }
+
+        ch = state.src.charCodeAt(pos++);
+
+        if (ch >= 0x30/* 0 */ && ch <= 0x39/* 9 */) {
+            continue;
+        }
+
+        // found valid marker
+        if (ch === 0x29/* ) */ || ch === 0x2e/* . */) {
+            break;
+        }
+
+        return -1;
     }
 
-    // found valid marker
-    if (ch === 0x29/* ) */ || ch === 0x2e/* . */) {
-      break;
+
+    if (pos < max && !isSpace(state.src.charCodeAt(pos))/* space */) {
+        // " 1.test " - is not a list item
+        return -1;
     }
-
-    return -1;
-  }
-
-
-  if (pos < max && !isSpace(state.src.charCodeAt(pos))/* space */) {
-    // " 1.test " - is not a list item
-    return -1;
-  }
-  return pos;
+    return pos;
 }
 
 function markTightParagraphs(state, idx) {
-  var i, l,
-      level = state.level + 2;
+    var i, l,
+            level = state.level + 2;
 
-  for (i = idx + 2, l = state.tokens.length - 2; i < l; i++) {
-    if (state.tokens[i].level === level && state.tokens[i].type === 'paragraph_open') {
-      state.tokens[i + 2].hidden = true;
-      state.tokens[i].hidden = true;
-      i += 2;
+    for (i = idx + 2, l = state.tokens.length - 2; i < l; i++) {
+        if (state.tokens[i].level === level && state.tokens[i].type === 'paragraph_open') {
+            state.tokens[i + 2].hidden = true;
+            state.tokens[i].hidden = true;
+            i += 2;
+        }
     }
-  }
 }
 
 
 module.exports = function list(state, startLine, endLine, silent) {
-  var nextLine,
-      indent,
-      oldTShift,
-      oldIndent,
-      oldTight,
-      oldParentType,
-      start,
-      posAfterMarker,
-      max,
-      indentAfterMarker,
-      markerValue,
-      markerCharCode,
-      isOrdered,
-      contentStart,
-      listTokIdx,
-      prevEmptyEnd,
-      listLines,
-      itemLines,
-      tight = true,
-      terminatorRules,
-      token,
-      i, l, terminate;
+    var nextLine,
+            indent,
+            oldTShift,
+            oldIndent,
+            oldTight,
+            oldParentType,
+            start,
+            posAfterMarker,
+            max,
+            indentAfterMarker,
+            markerValue,
+            markerCharCode,
+            isOrdered,
+            contentStart,
+            listTokIdx,
+            prevEmptyEnd,
+            listLines,
+            itemLines,
+            tight = true,
+            terminatorRules,
+            token,
+            i, l, terminate;
 
-  // Detect list type and position after marker
-  if ((posAfterMarker = skipOrderedListMarker(state, startLine)) >= 0) {
-    isOrdered = true;
-  } else if ((posAfterMarker = skipBulletListMarker(state, startLine)) >= 0) {
-    isOrdered = false;
-  } else {
-    return false;
-  }
-
-  // We should terminate list on style change. Remember first one to compare.
-  markerCharCode = state.src.charCodeAt(posAfterMarker - 1);
-
-  // For validation mode we can terminate immediately
-  if (silent) { return true; }
-
-  // Start list
-  listTokIdx = state.tokens.length;
-
-  if (isOrdered) {
-    start = state.bMarks[startLine] + state.tShift[startLine];
-    markerValue = Number(state.src.substr(start, posAfterMarker - start - 1));
-
-    token       = state.push('ordered_list_open', 'ol', 1);
-    if (markerValue > 1) {
-      token.attrs = [ [ 'start', markerValue ] ];
-    }
-
-  } else {
-    token       = state.push('bullet_list_open', 'ul', 1);
-  }
-
-  token.map    = listLines = [ startLine, 0 ];
-  token.markup = String.fromCharCode(markerCharCode);
-
-  //
-  // Iterate list items
-  //
-
-  nextLine = startLine;
-  prevEmptyEnd = false;
-  terminatorRules = state.md.block.ruler.getRules('list');
-
-  while (nextLine < endLine) {
-    contentStart = state.skipSpaces(posAfterMarker);
-    max = state.eMarks[nextLine];
-
-    if (contentStart >= max) {
-      // trimming space in "-    \n  3" case, indent is 1 here
-      indentAfterMarker = 1;
+    // Detect list type and position after marker
+    if ((posAfterMarker = skipOrderedListMarker(state, startLine)) >= 0) {
+        isOrdered = true;
+    } else if ((posAfterMarker = skipBulletListMarker(state, startLine)) >= 0) {
+        isOrdered = false;
     } else {
-      indentAfterMarker = contentStart - posAfterMarker;
+        return false;
     }
 
-    // If we have more than 4 spaces, the indent is 1
-    // (the rest is just indented code block)
-    if (indentAfterMarker > 4) { indentAfterMarker = 1; }
+    // We should terminate list on style change. Remember first one to compare.
+    markerCharCode = state.src.charCodeAt(posAfterMarker - 1);
 
-    // "  -  test"
-    //  ^^^^^ - calculating total length of this thing
-    indent = (posAfterMarker - state.bMarks[nextLine]) + indentAfterMarker;
+    // For validation mode we can terminate immediately
+    if (silent) { return true; }
 
-    // Run subparser & write tokens
-    token        = state.push('list_item_open', 'li', 1);
-    token.markup = String.fromCharCode(markerCharCode);
-    token.map    = itemLines = [ startLine, 0 ];
+    // Start list
+    listTokIdx = state.tokens.length;
 
-    oldIndent = state.blkIndent;
-    oldTight = state.tight;
-    oldTShift = state.tShift[startLine];
-    oldParentType = state.parentType;
-    state.tShift[startLine] = contentStart - state.bMarks[startLine];
-    state.blkIndent = indent;
-    state.tight = true;
-    state.parentType = 'list';
-
-    state.md.block.tokenize(state, startLine, endLine, true);
-
-    // If any of list item is tight, mark list as tight
-    if (!state.tight || prevEmptyEnd) {
-      tight = false;
-    }
-    // Item become loose if finish with empty line,
-    // but we should filter last element, because it means list finish
-    prevEmptyEnd = (state.line - startLine) > 1 && state.isEmpty(state.line - 1);
-
-    state.blkIndent = oldIndent;
-    state.tShift[startLine] = oldTShift;
-    state.tight = oldTight;
-    state.parentType = oldParentType;
-
-    token        = state.push('list_item_close', 'li', -1);
-    token.markup = String.fromCharCode(markerCharCode);
-
-    nextLine = startLine = state.line;
-    itemLines[1] = nextLine;
-    contentStart = state.bMarks[startLine];
-
-    if (nextLine >= endLine) { break; }
-
-    if (state.isEmpty(nextLine)) {
-      break;
-    }
-
-    //
-    // Try to check if list is terminated or continued.
-    //
-    if (state.tShift[nextLine] < state.blkIndent) { break; }
-
-    // fail if terminating block found
-    terminate = false;
-    for (i = 0, l = terminatorRules.length; i < l; i++) {
-      if (terminatorRules[i](state, nextLine, endLine, true)) {
-        terminate = true;
-        break;
-      }
-    }
-    if (terminate) { break; }
-
-    // fail if list has another type
     if (isOrdered) {
-      posAfterMarker = skipOrderedListMarker(state, nextLine);
-      if (posAfterMarker < 0) { break; }
+        start = state.bMarks[startLine] + state.tShift[startLine];
+        markerValue = Number(state.src.substr(start, posAfterMarker - start - 1));
+
+        token       = state.push('ordered_list_open', 'ol', 1);
+        if (markerValue > 1) {
+            token.attrs = [ [ 'start', markerValue ] ];
+        }
+
     } else {
-      posAfterMarker = skipBulletListMarker(state, nextLine);
-      if (posAfterMarker < 0) { break; }
+        token       = state.push('bullet_list_open', 'ul', 1);
     }
 
-    if (markerCharCode !== state.src.charCodeAt(posAfterMarker - 1)) { break; }
-  }
+    token.map    = listLines = [ startLine, 0 ];
+    token.markup = String.fromCharCode(markerCharCode);
 
-  // Finilize list
-  if (isOrdered) {
-    token = state.push('ordered_list_close', 'ol', -1);
-  } else {
-    token = state.push('bullet_list_close', 'ul', -1);
-  }
-  token.markup = String.fromCharCode(markerCharCode);
+    //
+    // Iterate list items
+    //
 
-  listLines[1] = nextLine;
-  state.line = nextLine;
+    nextLine = startLine;
+    prevEmptyEnd = false;
+    terminatorRules = state.md.block.ruler.getRules('list');
 
-  // mark paragraphs tight if needed
-  if (tight) {
-    markTightParagraphs(state, listTokIdx);
-  }
+    while (nextLine < endLine) {
+        contentStart = state.skipSpaces(posAfterMarker);
+        max = state.eMarks[nextLine];
 
-  return true;
+        if (contentStart >= max) {
+            // trimming space in "-    \n  3" case, indent is 1 here
+            indentAfterMarker = 1;
+        } else {
+            indentAfterMarker = contentStart - posAfterMarker;
+        }
+
+        // If we have more than 4 spaces, the indent is 1
+        // (the rest is just indented code block)
+        if (indentAfterMarker > 4) { indentAfterMarker = 1; }
+
+        // "  -  test"
+        //  ^^^^^ - calculating total length of this thing
+        indent = (posAfterMarker - state.bMarks[nextLine]) + indentAfterMarker;
+
+        // Run subparser & write tokens
+        token        = state.push('list_item_open', 'li', 1);
+        token.markup = String.fromCharCode(markerCharCode);
+        token.map    = itemLines = [ startLine, 0 ];
+
+        oldIndent = state.blkIndent;
+        oldTight = state.tight;
+        oldTShift = state.tShift[startLine];
+        oldParentType = state.parentType;
+        state.tShift[startLine] = contentStart - state.bMarks[startLine];
+        state.blkIndent = indent;
+        state.tight = true;
+        state.parentType = 'list';
+
+        state.md.block.tokenize(state, startLine, endLine, true);
+
+        // If any of list item is tight, mark list as tight
+        if (!state.tight || prevEmptyEnd) {
+            tight = false;
+        }
+        // Item become loose if finish with empty line,
+        // but we should filter last element, because it means list finish
+        prevEmptyEnd = (state.line - startLine) > 1 && state.isEmpty(state.line - 1);
+
+        state.blkIndent = oldIndent;
+        state.tShift[startLine] = oldTShift;
+        state.tight = oldTight;
+        state.parentType = oldParentType;
+
+        token        = state.push('list_item_close', 'li', -1);
+        token.markup = String.fromCharCode(markerCharCode);
+
+        nextLine = startLine = state.line;
+        itemLines[1] = nextLine;
+        contentStart = state.bMarks[startLine];
+
+        if (nextLine >= endLine) { break; }
+
+        if (state.isEmpty(nextLine)) {
+            break;
+        }
+
+        //
+        // Try to check if list is terminated or continued.
+        //
+        if (state.tShift[nextLine] < state.blkIndent) { break; }
+
+        // fail if terminating block found
+        terminate = false;
+        for (i = 0, l = terminatorRules.length; i < l; i++) {
+            if (terminatorRules[i](state, nextLine, endLine, true)) {
+                terminate = true;
+                break;
+            }
+        }
+        if (terminate) { break; }
+
+        // fail if list has another type
+        if (isOrdered) {
+            posAfterMarker = skipOrderedListMarker(state, nextLine);
+            if (posAfterMarker < 0) { break; }
+        } else {
+            posAfterMarker = skipBulletListMarker(state, nextLine);
+            if (posAfterMarker < 0) { break; }
+        }
+
+        if (markerCharCode !== state.src.charCodeAt(posAfterMarker - 1)) { break; }
+    }
+
+    // Finilize list
+    if (isOrdered) {
+        token = state.push('ordered_list_close', 'ol', -1);
+    } else {
+        token = state.push('bullet_list_close', 'ul', -1);
+    }
+    token.markup = String.fromCharCode(markerCharCode);
+
+    listLines[1] = nextLine;
+    state.line = nextLine;
+
+    // mark paragraphs tight if needed
+    if (tight) {
+        markTightParagraphs(state, listTokIdx);
+    }
+
+    return true;
 };

--- a/website/static/js/markdown-it-pymarkdown-lists.js
+++ b/website/static/js/markdown-it-pymarkdown-lists.js
@@ -1,4 +1,5 @@
-// Lists
+// Lists -- markdown-it to pymarkdown!
+// Adapted from markdown-it block list rule at https://github.com/markdown-it/markdown-it/
 
 'use strict';
 
@@ -232,8 +233,8 @@ module.exports = function list(state, startLine, endLine, silent) {
             tight = false;
         }
 
-        // Item becomes loose if it emds with an empty line,
-        // should filter last element, because it means list is finished
+        // Item becomes loose if it ends with an empty line,
+        // should filter last element, because it means the list is finished
         prevEmptyEnd = (state.line - startLine) > 1 && state.isEmpty(state.line - 1);
 
         state.blkIndent = oldIndent;
@@ -290,6 +291,11 @@ module.exports = function list(state, startLine, endLine, silent) {
                     break;
                 }
             }
+        }
+
+        // if there's a space in a previously un-rendered list, start anew
+        if (!state.renderList && state.isEmpty(state.line - 1)) {
+            break;
         }
     }
 

--- a/website/static/js/markdown-it-pymarkdown-lists.js
+++ b/website/static/js/markdown-it-pymarkdown-lists.js
@@ -235,13 +235,23 @@ module.exports = function list(state, startLine, endLine, silent) {
         // fail if list has another type
         if (isOrdered) {
             posAfterMarker = skipOrderedListMarker(state, nextLine);
-            if (posAfterMarker < 0) { break; }
+            if (posAfterMarker < 0) {
+                posAfterMarker = skipBulletListMarker(state, nextLine);
+                if (posAfterMarker < 0) {
+                    break;
+                }
+            }
         } else {
             posAfterMarker = skipBulletListMarker(state, nextLine);
-            if (posAfterMarker < 0) { break; }
+            if (posAfterMarker < 0) {
+                posAfterMarker = skipOrderedListMarker(state, nextLine);
+                if (posAfterMarker < 0) {
+                    break;
+                }
+            }
         }
 
-        if (markerCharCode !== state.src.charCodeAt(posAfterMarker - 1)) { break; }
+        // if (markerCharCode !== state.src.charCodeAt(posAfterMarker - 1)) { break; }
     }
 
     // Finilize list

--- a/website/static/js/markdown-it-pymarkdown-lists.js
+++ b/website/static/js/markdown-it-pymarkdown-lists.js
@@ -145,7 +145,7 @@ module.exports = function list(state, startLine, endLine, silent) {
     }
 
     // Save the first start line for putting into one token if list shouldn't be rendered
-    var firstStartLine = startLine;
+    firstStartLine = startLine;
 
     // Remember char code to set it later on
     markerCharCode = state.src.charCodeAt(posAfterMarker - 1);

--- a/website/static/js/markdown.js
+++ b/website/static/js/markdown.js
@@ -26,6 +26,19 @@ var bootstrapTable = function(md) {
     md.renderer.rules.table_open = function() { return '<table class="table">'; };
 };
 
+var oldMarkdownList = function(md) {
+    console.log(md.renderer.rules);
+
+    md.block.ruler.before('list', 'my_rule', function replace(state) {
+
+        if (state.parentType === 'list') {
+            // do something here
+        }
+
+        return false;
+    });
+};
+
 // Full markdown renderer for views / wiki pages / pauses between typing
 var markdown = new MarkdownIt('commonmark', {
     highlight: highlighter
@@ -50,11 +63,12 @@ var markdownQuick = new MarkdownIt(('commonmark'), { })
     .disable('strikethrough');
 
 // Markdown renderer for older wikis rendered before switch date
-var markdownOld = new MarkdownIt(('commonmark'), { })
+var markdownOld = new MarkdownIt(('commonmark'), { html: true })
     .use(require('markdown-it-sanitizer'))
     .use(insDel)
     .enable('table')
     .use(bootstrapTable)
+    .use(oldMarkdownList)
     .disable('strikethrough');
 
 module.exports = {

--- a/website/static/js/markdown.js
+++ b/website/static/js/markdown.js
@@ -49,7 +49,16 @@ var markdownQuick = new MarkdownIt(('commonmark'), { })
     .use(bootstrapTable)
     .disable('strikethrough');
 
+// Markdown renderer for older wikis rendered before switch date
+var markdownOld = new MarkdownIt(('commonmark'), { })
+    .use(require('markdown-it-sanitizer'))
+    .use(insDel)
+    .enable('table')
+    .use(bootstrapTable)
+    .disable('strikethrough');
+
 module.exports = {
     full: markdown,
-    quick: markdownQuick
+    quick: markdownQuick,
+    old: markdownOld
 };

--- a/website/static/js/markdown.js
+++ b/website/static/js/markdown.js
@@ -4,6 +4,7 @@ require('highlight-css');
 var MarkdownIt = require('markdown-it');
 
 var insDel = require('markdown-it-ins-del');
+var pymarkdownList = require('js/markdown-it-pymarkdown-lists');
 
 var highlighter = function (str, lang) {
         if (lang && hljs.getLanguage(lang)) {
@@ -27,27 +28,7 @@ var bootstrapTable = function(md) {
 };
 
 var oldMarkdownList = function(md) {
-
-    md.block.ruler.after('list', 'pymark_list', function replace(state) {
-
-        var this_list_markup;
-        var list_type;
-
-        if (state.tokens.length > 0) {
-            if (state.tokens.slice(-2)[0].type === 'ordered_list_open') {
-                list_type = 'ordered';
-            }
-
-        }
-        for (var i = 0; i < state.tokens.length; i++) {
-            if (list_type === 'ordered') {
-                if (state.tokens[i].markup === '*') {
-                    state.tokens[i].markup = '1';
-                }
-            }
-        }
-
-    });
+    md.block.ruler.after('hr', 'pyMarkdownList', pymarkdownList);
 };
 
 // Full markdown renderer for views / wiki pages / pauses between typing

--- a/website/static/js/markdown.js
+++ b/website/static/js/markdown.js
@@ -55,7 +55,7 @@ var markdownQuick = new MarkdownIt(('commonmark'), { })
     .disable('strikethrough');
 
 // Markdown renderer for older wikis rendered before switch date
-var markdownOld = new MarkdownIt(('commonmark'), { html: true })
+var markdownOld = new MarkdownIt(('commonmark'), { })
     .use(require('markdown-it-sanitizer'))
     .use(insDel)
     .enable('table')

--- a/website/static/js/markdown.js
+++ b/website/static/js/markdown.js
@@ -27,15 +27,26 @@ var bootstrapTable = function(md) {
 };
 
 var oldMarkdownList = function(md) {
-    console.log(md.renderer.rules);
 
-    md.block.ruler.before('list', 'my_rule', function replace(state) {
+    md.block.ruler.after('list', 'pymark_list', function replace(state) {
 
-        if (state.parentType === 'list') {
-            // do something here
+        var this_list_markup;
+        var list_type;
+
+        if (state.tokens.length > 0) {
+            if (state.tokens.slice(-2)[0].type === 'ordered_list_open') {
+                list_type = 'ordered';
+            }
+
+        }
+        for (var i = 0; i < state.tokens.length; i++) {
+            if (list_type === 'ordered') {
+                if (state.tokens[i].markup === '*') {
+                    state.tokens[i].markup = '1';
+                }
+            }
         }
 
-        return false;
     });
 };
 

--- a/website/static/js/pages/project-dashboard-page.js
+++ b/website/static/js/pages/project-dashboard-page.js
@@ -21,6 +21,7 @@ var CitationList = require('js/citationList');
 var CitationWidget = require('js/citationWidget');
 var mathrender = require('js/mathrender');
 var md = require('js/markdown').full;
+var oldMd = require('js/markdown').old;
 var AddProject = require('js/addProjectPlugin');
 var mHelpers = require('js/mithrilHelpers');
 var SocialShare = require('js/components/socialshare');
@@ -260,21 +261,17 @@ $(document).ready(function () {
         mathrender.mathjaxify(markdownElement);
 
         // Render the raw markdown of the wiki
-        if (!ctx.usePythonRender) {
-            var request = $.ajax({
-                url: ctx.urls.wikiContent
-            });
-            request.done(function(resp) {
-                var rawText = resp.wiki_content || '*No wiki content*';
-                var renderedText = md.render(rawText);
-                var truncatedText = $.truncate(renderedText, {length: 400});
-                markdownElement.html(truncatedText);
-                mathrender.mathjaxify(markdownElement);
-                markdownElement.show();
-            });
-        } else {
-            markdownElement.css('display', 'inherit');
-        }
+        var request = $.ajax({
+            url: ctx.urls.wikiContent
+        });
+        request.done(function(resp) {
+            var rawText = resp.wiki_content || '*No wiki content*';
+            var renderedText = ctx.renderedBeforeUpdate ? md.render(rawText) : oldMd.render(rawText);
+            var truncatedText = $.truncate(renderedText, {length: 400});
+            markdownElement.html(truncatedText);
+            mathrender.mathjaxify(markdownElement);
+            markdownElement.show();
+        });
     }
 
     // Remove delete UI if not contributor

--- a/website/static/js/pages/project-dashboard-page.js
+++ b/website/static/js/pages/project-dashboard-page.js
@@ -266,7 +266,7 @@ $(document).ready(function () {
         });
         request.done(function(resp) {
             var rawText = resp.wiki_content || '*No wiki content*';
-            var renderedText = ctx.renderedBeforeUpdate ? md.render(rawText) : oldMd.render(rawText);
+            var renderedText = ctx.renderedBeforeUpdate ? oldMd.render(rawText) : md.render(rawText);
             var truncatedText = $.truncate(renderedText, {length: 400});
             markdownElement.html(truncatedText);
             mathrender.mathjaxify(markdownElement);

--- a/website/static/js/tests/oldMarkdownFormatting.test.js
+++ b/website/static/js/tests/oldMarkdownFormatting.test.js
@@ -20,5 +20,16 @@ describe('oldMarkdown', () => {
             assert.equal(rendered, html);
         });
     });
+    describe('orderedListChangeSymbols', () => {
+
+        it('returns a numbered list even when the symbols change', () => {
+            var text = '1. hello \n 2. there \n * friend';
+
+            var rendered = mdOld.render(text);
+
+            var html = '<ol>\n<li>hello</li><li>there</li><li>friend</li></ol>';
+            assert.equal(rendered, html);
+        });
+    });
 
 });

--- a/website/static/js/tests/oldMarkdownFormatting.test.js
+++ b/website/static/js/tests/oldMarkdownFormatting.test.js
@@ -16,7 +16,7 @@ describe('oldMarkdown', () => {
 
             var rendered = mdOld.render(text);
 
-            var html = '<ol>\n<li>hello</li><li>there</li></ol>';
+            var html = '<ol>\n<li>hello</li>\n<li>there</li>\n</ol>\n';
             assert.equal(rendered, html);
         });
     });
@@ -27,7 +27,7 @@ describe('oldMarkdown', () => {
 
             var rendered = mdOld.render(text);
 
-            var html = '<ol>\n<li>hello</li><li>there</li><li>friend</li></ol>';
+            var html = '<ol>\n<li>hello</li>\n<li>there</li>\n<li>friend</li>\n</ol>\n';
             assert.equal(rendered, html);
         });
 
@@ -35,11 +35,11 @@ describe('oldMarkdown', () => {
     describe('listNoSpace', () => {
 
         it('returns a paragraph because there is not a blank line before list starts', () => {
-            var text = 'This Should Not Render\n1. hello \n 2. there \n * friend';
+            var text = 'Not a list but a paragraph\n1. hello\n2. there\n* friend';
 
             var rendered = mdOld.render(text);
 
-            var html = '<p>1. hello 2. there * friend</p>';
+            var html = '<p>Not a list but a paragraph\n1. hello\n2. there\n* friend</p>\n';
             assert.equal(rendered, html);
         });
 

--- a/website/static/js/tests/oldMarkdownFormatting.test.js
+++ b/website/static/js/tests/oldMarkdownFormatting.test.js
@@ -1,0 +1,24 @@
+/*global describe, it, expect, example, before, after, beforeEach, afterEach, mocha, sinon*/
+'use strict';
+var assert = require('chai').assert;
+var mdOld = require('js/markdown').old;
+
+
+// Add sinon asserts to chai.assert, so we can do assert.calledWith instead of sinon.assert.calledWith
+sinon.assert.expose(assert, {prefix: ''});
+
+describe('oldMarkdown', () => {
+
+    describe('orderedList', () => {
+
+        it('returns a numbered list', () => {
+            var text = '1. hello \n 2. there';
+
+            var rendered = mdOld.render(text);
+
+            var html = '<ol>\n<li>hello</li><li>there</li></ol>';
+            assert.equal(rendered, html);
+        });
+    });
+
+});

--- a/website/static/js/tests/oldMarkdownFormatting.test.js
+++ b/website/static/js/tests/oldMarkdownFormatting.test.js
@@ -12,7 +12,7 @@ describe('oldMarkdown', () => {
     describe('orderedList', () => {
 
         it('returns a numbered list', () => {
-            var text = '1. hello \n 2. there';
+            var text = '1. hello\n2. there';
 
             var rendered = mdOld.render(text);
 
@@ -30,6 +30,18 @@ describe('oldMarkdown', () => {
             var html = '<ol>\n<li>hello</li><li>there</li><li>friend</li></ol>';
             assert.equal(rendered, html);
         });
-    });
 
+    });
+    describe('listNoSpace', () => {
+
+        it('returns a paragraph because there is not a blank line before list starts', () => {
+            var text = 'This Should Not Render\n1. hello \n 2. there \n * friend';
+
+            var rendered = mdOld.render(text);
+
+            var html = '<p>1. hello 2. there * friend</p>';
+            assert.equal(rendered, html);
+        });
+
+    });
 });


### PR DESCRIPTION
## Purpose

While wikis nowadays are rendered in Javascript, wikis created before Febuary 12, 2015 we
    - saved the wiki to the database as markdown
    - rendered the markdown in Python
    - saved the rendered markdown as html into the database for use later

If it was an old wiki, we were using that pre-rendered wiki html put that into the view pane and wiki widget instead of rendering the plain markdown with JS as we do with newer wikis.

We no longer want to trust html, and want to use JS to render all markdown from now on. **But** we want to keep the look of the old python markdown! Which has [some key differences from javascript markdown](http://pythonhosted.org/Markdown/#differences).  Of these differences, the most notable is list behavior.

For example! The following raw markdown:

    1. first
    2. second
    * third

... would render differently in javascript and python.

new, javascript:

1. first
2. second

* third

old, python:

1. first
2. second
3. third

## Changes
- Add new version of markdown-it list parsing that will happen before the "hr" rule - thus going before the "list" rule in markdown-it parsing. Replacing the list rule entirely results in unwanted behavior!
- Make a new mdOld instance of MarkdownIt for more customization if we want
- Change variables to `renderedBeforeUpdate` or `rendered_before_update` because they were more general because there's no more python renderer
- Update tests to look for `rendered_before_update` as `True` when it's an older wiki
- Add some "old" markdown rendering JS tests that test for mimicking how python was rendering content

## Side effects
All old wiki markdown will be rendered with javascript and MarkdownIt instead of py-markdown, and there will be a few differences:

1. Words emphasized with * hello * will not be italicized in javascript rendering, where as they were in python, only \*hello\* will be italicized
2. HTML will all be rendered in plain text, where as with python, link attributes (aka \<a href=http://osf.io>\link</\a>) would be rendered as an actual link. 
 
## Ticket
https://openscience.atlassian.net/browse/OSF-6412
https://openscience.atlassian.net/browse/OSF-7038

## Notes for QA --
This might be kind of tricky to test! My thoughts are it might involve a few steps:

1. **Before this gets merged to staging!** Make a wiki that has lots of markdown in it including lists. [Here's the wiki I've been working with](https://staging.osf.io/uwbsc/wiki/home/) - lemmie know who's working on it and I'll make you a contributor!
2. A dev will need to temporarially change the variable `WIKI_CHANGE_DATE` in [website/addons/wiki/settings/defaults.py](https://github.com/CenterForOpenScience/osf.io/blob/develop/website/addons/wiki/settings/defaults.py#L13) on staging to a timestamp that's after the wiki was last saved. I found [this website](http://www.epochconverter.com/) incredibly helpful for getting the  Unix epoch time needed to be used for that variable. This will make the wiki render in old python!
3. Make note of how all of the lists are rendered and whatnot in python. It should look like this!
![python_md_list_rendering](https://cloud.githubusercontent.com/assets/801594/19016134/cebb3de8-87df-11e6-8602-4c1abe0d5da6.png)
4. **After this gets merged to staging!** Go back to the same wiki, which will now be rendered using javascript. It should look pretty darn similar to the python one, with a few changes noted above in the "side effects" section

This is a lot of info! Please let me know if I can help clarify this at all!