### PR TITLE
[feature] pin modm to current release (0.4.0) [OSF-7053]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -39,8 +39,7 @@ citeproc-py==0.3.0
 # Support SSL SNI on Python < 2.7.9
 # (http://docs.python-requests.org/en/latest/community/faq/#what-are-hostname-doesn-t-match-errors)
 ndg-httpsclient==0.3.0
-# Development version of modular-odm
-git+https://github.com/CenterForOpenScience/modular-odm.git@develop
+git+https://github.com/CenterForOpenScience/modular-odm.git@0.4.0
 # Python markdown extensions for comment emails
 git+git://github.com/CenterForOpenScience/mdx_del_ins.git
 


### PR DESCRIPTION
## Purpose / Changes

Our Modular-ODM dep was tracking `develop` instead of commits or releases.  To avoid pulling in untested versions of modm, pin the dep via the release tags to v0.4.0.

## Side effects

None expected.

## Ticket

[#OSF-7053] - [JIRA](https://openscience.atlassian.net/browse/OSF-7053)
