### PR TITLE
[feature] Update fangorn to use WaterButler v1 API [OSF-5847]

### DIFF
--- a/website/addons/dataverse/static/dataverseFangornConfig.js
+++ b/website/addons/dataverse/static/dataverseFangornConfig.js
@@ -308,10 +308,6 @@ function _fangornFolderIcons(item) {
     return undefined;
 }
 
-function _fangornDeleteUrl(item) {
-    return waterbutler.buildTreeBeardDelete(item, {full_path: item.data.path + '?' + $.param({name: item.data.name})});
-}
-
 function _fangornLazyLoad(item) {
     return waterbutler.buildTreeBeardMetadata(item, {version: item.data.version});
 }
@@ -325,7 +321,6 @@ function _canDrop(item) {
 
 Fangorn.config.dataverse = {
     folderIcon: _fangornFolderIcons,
-    resolveDeleteUrl: _fangornDeleteUrl,
     resolveRows: _fangornColumns,
     lazyload:_fangornLazyLoad,
     canDrop: _canDrop,

--- a/website/addons/github/static/githubFangornConfig.js
+++ b/website/addons/github/static/githubFangornConfig.js
@@ -14,7 +14,18 @@ var $osf = require('js/osfHelpers');
 var commandKeys = [224, 17, 91, 93];
 
 function _uploadUrl(item, file) {
-    return waterbutler.buildTreeBeardUpload(item, file, {branch: item.data.branch});
+    // WB v1 update syntax is PUT <file_path>?kind=file
+    // WB v1 upload syntax is PUT <parent_path>/?kind=file&name=<filename>
+    // If upload target file name already exists don't pass file.name.  WB v1 rejects updates that
+    // include a filename.
+    var updateUrl;
+    $.each(item.children, function( index, value ) {
+        if (file.name === value.data.name) {
+            updateUrl = waterbutler.buildTreeBeardUpload(value, {branch: value.data.branch});
+            return false;
+        }
+    });
+    return updateUrl || waterbutler.buildTreeBeardUpload(item, {name: file.name, branch: item.data.branch});
 }
 
 function _removeEvent (event, items) {

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -501,26 +501,45 @@ function doItemOp(operation, to, from, rename, conflict) {
     }
     orderFolder.call(tb, from.parent());
 
+    var moveSpec;
+    if (operation === OPERATIONS.RENAME) {
+        moveSpec = {
+            action: 'rename',
+            rename: rename
+        };
+    } else if (operation === OPERATIONS.COPY) {
+        moveSpec = {
+            action: 'copy',
+            path: to.data.path || '/',
+            conflict: conflict,
+            resource: to.data.resource,
+            provider: to.data.provider
+        };
+    } else if (operation === OPERATIONS.MOVE) {
+        moveSpec = {
+            action: 'move',
+            path: to.data.path || '/',
+            conflict: conflict,
+            resource: to.data.resource,
+            provider: to.data.provider
+        };
+    }
+
     $.ajax({
         type: 'POST',
         beforeSend: $osf.setXHRAuthorization,
-        url: operation === OPERATIONS.COPY ? waterbutler.copyUrl() : waterbutler.moveUrl(),
+        url: waterbutler.buildTreeBeardFileOp(from),
         headers: {
             'Content-Type': 'Application/json'
         },
-        data: JSON.stringify({
-            'rename': rename,
-            'conflict': conflict,
-            'source': waterbutler.toJsonBlob(from),
-            'destination': waterbutler.toJsonBlob(to),
-        })
+        data: JSON.stringify(moveSpec)
     }).done(function(resp, _, xhr) {
         if (to.data.provider === from.provider) {
             tb.pendingFileOps.pop();
         }
         if (xhr.status === 202) {
             var mithrilContent = m('div', [
-                m('h3.break-word', operation.action + ' "' + from.data.materialized + '" to "' + (to.data.materialized || '/') + '" is taking a bit longer than expected.'),
+                m('h3.break-word', operation.action + ' "' + (from.data.materialized || '/') + '" to "' + (to.data.materialized || '/') + '" is taking a bit longer than expected.'),
                 m('p', 'We\'ll send you an email when it has finished.'),
                 m('p', 'In the mean time you can leave this page; your ' + operation.status + ' will still be completed.')
             ]);
@@ -530,7 +549,7 @@ function doItemOp(operation, to, from, rename, conflict) {
             tb.modal.update(mithrilContent, mithrilButtons);
             return;
         }
-        from.data = resp;
+        from.data = tb.options.lazyLoadPreprocess.call(this, resp).data;
         from.data.status = undefined;
         from.notify.update('Successfully ' + operation.passed + '.', 'success', null, 1000);
 
@@ -585,12 +604,7 @@ function doItemOp(operation, to, from, rename, conflict) {
         Raven.captureMessage('Failed to move or copy file', {
             extra: {
                 xhr: xhr,
-                requestData: {
-                    rename: rename,
-                    conflict: conflict,
-                    source: waterbutler.toJsonBlob(from),
-                    destination: waterbutler.toJsonBlob(to),
-                }
+                requestData: moveSpec
             }
         });
 
@@ -607,8 +621,23 @@ function doItemOp(operation, to, from, rename, conflict) {
  * @private
  */
 function _fangornResolveUploadUrl(item, file) {
+    // WB v1 update syntax is PUT <file_path>?kind=file
+    // WB v1 upload syntax is PUT <parent_path>/?kind=file&name=<filename>
+    // If upload target file name already exists don't pass file.name.  WB v1 rejects updates that
+    // include a filename.
     var configOption = resolveconfigOption.call(this, item, 'uploadUrl', [item, file]); // jshint ignore:line
-    return configOption || waterbutler.buildTreeBeardUpload(item, file);
+    if (configOption) {
+        return configOption;
+    }
+    var updateUrl;
+    $.each(item.children, function( index, value ) {
+        if (file.name === value.data.name) {
+            updateUrl = waterbutler.buildTreeBeardUpload(value);
+            return false;
+        }
+    });
+
+    return updateUrl || waterbutler.buildTreeBeardUpload(item, {name: file.name});
 }
 
 /**
@@ -808,7 +837,7 @@ function _fangornDropzoneSuccess(treebeard, file, response) {
     // Dataverse : Object, actionTaken : file_uploaded
     revisedItem = resolveconfigOption.call(treebeard, item.parent(), 'uploadSuccess', [file, item, response]);
     if (!revisedItem && response) {
-        item.data = response;
+        item.data = treebeard.options.lazyLoadPreprocess.call(this, response).data;
         inheritFromParent(item, item.parent());
     }
     if (item.data.tmpID) {
@@ -959,18 +988,20 @@ function _createFolder(event, dismissCallback, helpText) {
     }
 
     var extra = {};
-    var path = (parent.data.path || '/') + val + '/';
+    var path = parent.data.path || '/';
+    var options = {name: val, kind: 'folder'};
 
     if (parent.data.provider === 'github') {
         extra.branch = parent.data.branch;
     }
 
     m.request({
-        method: 'POST',
+        method: 'PUT',
         background: true,
         config: $osf.setXHRAuthorization,
-        url: waterbutler.buildCreateFolderUrl(path, parent.data.provider, parent.data.nodeId)
+        url: waterbutler.buildCreateFolderUrl(path, parent.data.provider, parent.data.nodeId, options)
     }).then(function(item) {
+        item = tb.options.lazyLoadPreprocess.call(this, item).data;
         inheritFromParent({data: item}, parent, ['branch']);
         item = tb.createItem(item, parent.id);
         orderFolder.call(tb, parent);
@@ -2422,6 +2453,7 @@ tbOptions = {
     uploads : true,         // Turns dropzone on/off.
     columnTitles : _fangornColumnTitles,
     resolveRows : _fangornResolveRows,
+    lazyLoadPreprocess: waterbutler.wbLazyLoadPreprocess,
     hoverClassMultiselect : 'fangorn-selected',
     multiselect : true,
     placement : 'files',

--- a/website/static/js/filepage/revisions.js
+++ b/website/static/js/filepage/revisions.js
@@ -45,6 +45,7 @@ var FileRevisionsTable = {
                 url: self.file.urls.revisions,
                 beforeSend: $osf.setXHRAuthorization
             }).done(function(response) {
+                response = waterbutler.wbLazyLoadPreprocess.call(this, response);
                 m.startComputation();
                 var urlParmas = $osf.urlParams();
                 model.revisions = response.data.map(function(rev, index) {
@@ -82,6 +83,7 @@ var FileRevisionsTable = {
                         url: self.file.urls.metadata,
                         beforeSend: $osf.setXHRAuthorization
                     }).done(function(resp) {
+                        resp = waterbutler.wbLazyLoadPreprocess.call(this, resp);
                         self.canEdit(self.canEdit() && resp.data.extra.canDelete);
                         m.redraw();
                     }).fail(function(xhr) {

--- a/website/static/js/pages/file-page.js
+++ b/website/static/js/pages/file-page.js
@@ -2,7 +2,6 @@ var $ = require('jquery');
 var m = require('mithril');
 var $osf = require('js/osfHelpers');
 var FileViewPage = require('js/filepage');
-var waterbutler = require('js/waterbutler');
 var Raven = require('raven-js');
 
 require('jquery-tagsinput');

--- a/website/static/js/registrationEditorExtensions.js
+++ b/website/static/js/registrationEditorExtensions.js
@@ -6,7 +6,6 @@ var bootbox = require('bootbox');  // TODO: Why is this required? Is it? See [#O
 var FilesWidget = require('js/filesWidget');
 var Fangorn = require('js/fangorn');
 var $osf = require('js/osfHelpers');
-var waterbutler = require('js/waterbutler');
 var ContribAdder = require('js/contribAdder');
 
 var node = window.contextVars.node;

--- a/website/static/js/waterbutler.js
+++ b/website/static/js/waterbutler.js
@@ -3,15 +3,14 @@
 var $ = require('jquery');
 var $osf = require('./osfHelpers');
 
-function getViewOnly() {
-    return $osf.urlParams().view_only;
+function buildUrl(path, provider, nid, options) {
+    path = path || '/';
+    var baseUrl = window.contextVars.waterbutlerURL + 'v1/resources/' + nid + '/providers/' + provider + path + '?';
+    return baseUrl + $.param($.extend(getDefaultOptions(), options));
 }
 
-function getDefaultOptions(path, provider) {
-    var options = {
-        path: path,
-        provider: provider
-    };
+function getDefaultOptions() {
+    var options = {};
     var viewOnly = getViewOnly();
     if (viewOnly) {
         options.view_only = viewOnly;
@@ -22,67 +21,79 @@ function getDefaultOptions(path, provider) {
     return options;
 }
 
-function buildUrl(suffix, path, provider, nid, options) {
-    path = path || '/';
-    var baseUrl = window.contextVars.waterbutlerURL + suffix;
-    return baseUrl + $.param($.extend(getDefaultOptions(path, provider), {nid: nid}, options));
+function getViewOnly() {
+    return $osf.urlParams().view_only;
 }
 
-var buildCrudUrl = buildUrl.bind(this, 'file?');
-var buildCopyUrl = buildUrl.bind(this, 'copy?');
-var buildMoveUrl = buildUrl.bind(this, 'move?');
-var buildMetadataUrl = buildUrl.bind(this, 'data?');
-var buildRevisionsUrl = buildUrl.bind(this, 'revisions?');
-var buildCreateFolderUrl = buildUrl.bind(this, 'folders?');
-
-
-function buildUploadUrl(path, provider, nid, file, options) {
-    path = (path || '/') + file.name;
-    return buildUrl('file?', path, provider, nid, options);
+function buildFromTreebeard(item, options) {
+    return buildUrl(item.data.path, item.data.provider, item.data.nodeId, options);
 }
 
-function buildFromTreebeard(suffix, item, options) {
-    return buildUrl(suffix, item.data.path, item.data.provider, item.data.nodeId, options);
+function addToken(options) {
+    var wb_options = $.extend({}, options || {}, {token: window.contextVars.accessToken});
+    return wb_options;
 }
 
-function buildFromTreebeardFile(item, file, options) {
-    return buildUploadUrl(item.data.path, item.data.provider, item.data.nodeId, file, options);
+function _promoteAttrs(obj_data) {
+    var saved_attributes = obj_data.attributes;
+    // delete before extending in case saved_attributes has its own
+    // attributes property
+    delete obj_data.attributes;
+    $.extend(true, obj_data, saved_attributes);
+    return obj_data;
 }
 
-function toJsonBlob(item, options) {
-    return $.extend(getDefaultOptions(item.data.path || '/', item.data.provider), {nid: item.data.nodeId}, options);
+// This function turns a WB structure into a TB structure
+// WB returns a structure like:
+//      data: { attributes: { name: 'foo', kind: 'file', ... } }
+// TB wants a structure like:
+//      data: { name: 'foo', kind: 'file', ... }
+function wbLazyLoadPreprocess(obj) {
+    if (!$.isArray(obj.data)) {
+        obj.data = _promoteAttrs(obj.data);
+        return obj;
+    }
+    for (var i = 0; i < obj.data.length; i++) {
+        obj.data[i] = _promoteAttrs(obj.data[i]);
+    }
+    return obj;
 }
 
 module.exports = {
-    toJsonBlob: toJsonBlob,
-    buildDeleteUrl: buildCrudUrl,
-    buildUploadUrl: buildUploadUrl,
-    buildDownloadUrl: function(path, provider, nid, options) {
-        if (window.contextVars.accessToken) {
-            options = $.extend(options || {}, {token: window.contextVars.accessToken});
-        }
-        return buildCrudUrl(path, provider, nid, options);
+    buildDeleteUrl: buildUrl,
+    buildDownloadUrl: buildUrl,
+    buildUploadUrl: function _buildUploadUrl(path, provider, nid, options) {
+        var wb_options = $.extend({}, options || {}, {kind: 'files'});
+        return buildUrl(path, provider, nid, wb_options);
     },
-    buildMetadataUrl: buildMetadataUrl,
-    buildCreateFolderUrl: buildCrudUrl,
-    buildRevisionsUrl: buildRevisionsUrl,
-    buildTreeBeardUpload: buildFromTreebeardFile,
-    buildTreeBeardCopy: buildFromTreebeard.bind(this, 'copy?'),
-    buildTreeBeardMove: buildFromTreebeard.bind(this, 'move?'),
-    buildTreeBeardDelete: buildFromTreebeard.bind(this, 'file?'),
-    buildTreeBeardDownload: function(item, options) {
-        if (window.contextVars.accessToken) {
-            options = $.extend(options || {}, {token: window.contextVars.accessToken});
-        }
-        return buildFromTreebeard('file?', item, options);
+    buildMetadataUrl: function _buildMetadataUrl(path, provider, nid, options) {
+        var wb_options = $.extend({}, options || {}, {meta: null});
+        return buildUrl(path, provider, nid, wb_options);
     },
-    buildTreeBeardMetadata: buildFromTreebeard.bind(this, 'data?'),
-    buildTreeBeardDownloadZip: function(item, options) {
-        if (window.contextVars.accessToken) {
-            options = $.extend(options || {}, {token: window.contextVars.accessToken});
-        }
-        return buildFromTreebeard('zip?', item, options);
+    buildCreateFolderUrl: buildUrl,
+    buildRevisionsUrl: function _buildRevisionsUrl(path, provider, nid, options) {
+        var wb_options = $.extend({}, options || {}, {revisions: null});
+        return buildUrl(path, provider, nid, wb_options);
     },
-    copyUrl: function(){return window.contextVars.waterbutlerURL + 'ops/copy';},
-    moveUrl: function(){return window.contextVars.waterbutlerURL + 'ops/move';}
+    // covers upload (parent item and file name) and update (item, no file name)
+    buildTreeBeardUpload: function _buildTreeBeardUpload(item, options) {
+        var wb_options = $.extend({}, options || {}, {kind: 'file'});
+        return buildFromTreebeard(item, wb_options);
+    },
+    buildTreeBeardFileOp: buildFromTreebeard,
+    buildTreeBeardDelete: buildFromTreebeard,
+    buildTreeBeardMetadata: function _buildTreeBeardMetadata(item, options) {
+        var wb_options = $.extend({}, options || {}, {meta: null});
+        return buildFromTreebeard(item, wb_options);
+    },
+    buildTreeBeardDownload: function _buildTreeBeardDownload(item, options) {
+        var wb_options = addToken(options);
+        return buildFromTreebeard(item, wb_options);
+    },
+    buildTreeBeardDownloadZip: function _buildTreeBeardDownloadZip(item, options) {
+        var wb_options = addToken(options);
+        $.extend(wb_options, {zip: null});
+        return buildFromTreebeard(item, wb_options);
+    },
+    wbLazyLoadPreprocess: wbLazyLoadPreprocess
 };


### PR DESCRIPTION
*Note:  This is a rebased and updated version of #5240.*

## Purpose

Update fangorn to use WaterButler v1 API, hopefully hastening the retirement of v0.

## Changes

update website/addons/github/static/githubFangornConfig.js for WB v1 upload URL
update website/static/js/fangorn.js for URLS, and lazyLoadPreprocess
update website/static/js/waterbutler.js for WB v1 URLS
update website/static/js/filepage/revisions.js for lazyLoadPreprocess
remove unused waterbutler imports
remove obsolete delete url formatting for dataverse

## Side effects

None expected.

## Ticket

[#OSF-5847] - [JIRA](https://openscience.atlassian.net/browse/OSF-5847)
