### PR TITLE
[feature] fix incorrect Raven.captureMessage invocations [OSF-7054]

### DIFF
--- a/website/addons/dataverse/static/dataverseFangornConfig.js
+++ b/website/addons/dataverse/static/dataverseFangornConfig.js
@@ -96,9 +96,11 @@ var _dataverseItemButtons = {
                     default:
                         message = 'Error: Something went wrong when attempting to publish your dataset.';
                         Raven.captureMessage('Could not publish dataset', {
-                            url: url,
-                            textStatus: status,
-                            error: error
+                            extra: {
+                                url: url,
+                                textStatus: status,
+                                error: error
+                            }
                         });
                     }
 

--- a/website/addons/dataverse/static/dataverseNodeConfig.js
+++ b/website/addons/dataverse/static/dataverseNodeConfig.js
@@ -223,9 +223,11 @@ function ViewModel(url) {
     }).fail(function(xhr, textStatus, error) {
         self.changeMessage(self.messages.userSettingsError, 'text-danger');
         Raven.captureMessage('Could not GET dataverse settings', {
-            url: url,
-            textStatus: textStatus,
-            error: error
+            extra: {
+                url: url,
+                textStatus: textStatus,
+                error: error
+            }
         });
     });
 
@@ -298,9 +300,11 @@ ViewModel.prototype.setInfo = function() {
             (xhr.status = 406) ? self.messages.forbiddenCharacters : self.messages.setDatasetError;
         self.changeMessage(errorMessage, 'text-danger');
         Raven.captureMessage('Could not authenticate with Dataverse', {
-            url: self.urls().set,
-            textStatus: textStatus,
-            error: error
+            extra: {
+                url: self.urls().set,
+                textStatus: textStatus,
+                error: error
+            }
         });
     });
 };
@@ -339,9 +343,11 @@ ViewModel.prototype.getDatasets = function() {
     }).fail(function(xhr, status, error) {
         self.changeMessage(self.messages.getDatasetsError, 'text-danger');
         Raven.captureMessage('Could not GET datasets', {
-            url: self.urls().getDatasets,
-            textStatus: status,
-            error: error
+            extra: {
+                url: self.urls().getDatasets,
+                textStatus: status,
+                error: error
+            }
         });
     });
 };
@@ -371,9 +377,11 @@ ViewModel.prototype.sendAuth = function() {
         var errorMessage = (xhr.status === 401) ? self.messages.authInvalid : self.messages.authError;
         self.changeMessage(errorMessage, 'text-danger');
         Raven.captureMessage('Could not authenticate with Dataverse', {
-            url: url,
-            textStatus: textStatus,
-            error: error
+            extra: {
+                url: url,
+                textStatus: textStatus,
+                error: error
+            }
         });
     });
 };
@@ -388,9 +396,11 @@ ViewModel.prototype.fetchAccounts = function() {
     request.fail(function(xhr, textStatus, error) {
         self.changeMessage(self.messages.updateAccountsError(), 'text-danger');
         Raven.captureMessage('Could not GET ' + self.addonName + ' accounts for user', {
-            url: self.url,
-            textStatus: textStatus,
-            error: error
+            extra: {
+                url: self.url,
+                textStatus: textStatus,
+                error: error
+            }
         });
         ret.reject(xhr, textStatus, error);
     });
@@ -424,9 +434,11 @@ ViewModel.prototype.onImportError = function(xhr, status, error) {
     var self = this;
     self.changeMessage(self.messages.tokenImportError(), 'text-danger');
     Raven.captureMessage('Failed to import ' + self.addonName + ' access token.', {
-        xhr: xhr,
-        status: status,
-        error: error
+        extra: {
+            xhr: xhr,
+            status: status,
+            error: error
+        }
     });
 };
 
@@ -523,9 +535,11 @@ ViewModel.prototype._deauthorizeConfirm = function() {
     request.fail(function(xhr, textStatus, error) {
         self.changeMessage(self.messages.deauthorizeFail(), 'text-danger');
         Raven.captureMessage('Could not deauthorize ' + self.addonName + ' account from node', {
-            url: self.urls().deauthorize,
-            textStatus: textStatus,
-            error: error
+            extra: {
+                url: self.urls().deauthorize,
+                textStatus: textStatus,
+                error: error
+            }
         });
     });
     return request;

--- a/website/addons/dataverse/static/dataverseUserConfig.js
+++ b/website/addons/dataverse/static/dataverseUserConfig.js
@@ -80,9 +80,11 @@ function ViewModel(url) {
         });
         request.fail(function(xhr, status, error) {
             Raven.captureMessage('Error while updating addon account', {
-                url: url,
-                status: status,
-                error: error
+                extra: {
+                    url: url,
+                    status: status,
+                    error: error
+                }
             });
         });
         return request;
@@ -124,9 +126,11 @@ function ViewModel(url) {
             var errorMessage = (xhr.status === 401) ? language.authInvalid : language.authError;
             self.changeMessage(errorMessage, 'text-danger');
             Raven.captureMessage('Could not authenticate with Dataverse', {
-                url: url,
-                textStatus: textStatus,
-                error: error
+                extra: {
+                    url: url,
+                    textStatus: textStatus,
+                    error: error
+                }
             });
         });
     };
@@ -165,9 +169,11 @@ function ViewModel(url) {
         });
         request.fail(function(xhr, status, error) {
             Raven.captureMessage('Error while removing addon authorization for ' + account.id, {
-                url: url,
-                status: status,
-                error: error
+                extra: {
+                    url: url,
+                    status: status,
+                    error: error
+                }
             });
         });
         return request;
@@ -202,9 +208,11 @@ function ViewModel(url) {
         }).fail(function (xhr, textStatus, error) {
             self.changeMessage(language.userSettingsError, 'text-danger');
             Raven.captureMessage('Could not GET Dataverse settings', {
-                url: url,
-                textStatus: textStatus,
-                error: error
+                extra: {
+                    url: url,
+                    textStatus: textStatus,
+                    error: error
+                }
             });
         });
     };

--- a/website/addons/forward/static/forwardConfig.js
+++ b/website/addons/forward/static/forwardConfig.js
@@ -64,9 +64,11 @@ var ViewModel = function(url, nodeId) {
                 '<a href="mailto:support@osf.io">support@osf.io</a>.',
                 'text-danger');
             Raven.captureMessage('Could not GET get Forward addon settings.', {
-                url: url,
-                textStatus: textStatus,
-                error: error
+                extra: {
+                    url: url,
+                    textStatus: textStatus,
+                    error: error
+                }
             });
         });
     };

--- a/website/addons/s3/static/s3NodeConfig.js
+++ b/website/addons/s3/static/s3NodeConfig.js
@@ -87,9 +87,11 @@ var s3FolderPickerViewModel = oop.extend(OauthAddonFolderPicker, {
             }
             self.changeMessage(message, 'text-danger');
             Raven.captureMessage('Could not add S3 credentials', {
-                url: self.urls().importAuth,
-                textStatus: status,
-                error: error
+                extra: {
+                    url: self.urls().importAuth,
+                    textStatus: status,
+                    error: error
+                }
             });
         });
     },

--- a/website/addons/s3/static/s3UserConfig.js
+++ b/website/addons/s3/static/s3UserConfig.js
@@ -70,9 +70,11 @@ function ViewModel(url) {
             var errorMessage = (xhr.status === 400 && xhr.responseJSON.message !== undefined) ? xhr.responseJSON.message : language.authError;
             self.changeMessage(errorMessage, 'text-danger');
             Raven.captureMessage('Could not authenticate with S3', {
-                url: self.account_url,
-                textStatus: textStatus,
-                error: error
+                extra: {
+                    url: self.account_url,
+                    textStatus: textStatus,
+                    error: error
+                }
             });
         });
     };
@@ -93,9 +95,11 @@ function ViewModel(url) {
         }).fail(function(xhr, status, error) {
             self.changeMessage(language.userSettingsError, 'text-danger');
             Raven.captureMessage('Error while updating addon account', {
-                url: url,
-                status: status,
-                error: error
+                extra: {
+                    url: url,
+                    status: status,
+                    error: error
+                }
             });
         });
     };
@@ -134,9 +138,11 @@ function ViewModel(url) {
         });
         request.fail(function(xhr, status, error) {
             Raven.captureMessage('Error while removing addon authorization for ' + account.id, {
-                url: url,
-                status: status,
-                error: error
+                extra: {
+                    url: url,
+                    status: status,
+                    error: error
+                }
             });
         });
         return request;

--- a/website/addons/twofactor/static/twoFactorUserConfig.js
+++ b/website/addons/twofactor/static/twoFactorUserConfig.js
@@ -58,9 +58,11 @@ ViewModel.prototype.fetchFromServer = function() {
         })
         .fail(function(xhr, status, error) {
             Raven.captureMessage('Failed to fetch two-factor settings.', {
-                xhr: xhr,
-                status: status,
-                error: error
+                extra: {
+                    xhr: xhr,
+                    status: status,
+                    error: error
+                }
             });
             self.changeMessage('Could not retrieve two-factor settings at ' +
                 'this time. Please refresh the page. ' +
@@ -80,9 +82,11 @@ ViewModel.prototype.submitSettings = function() {
         $('#TfaVerify').slideUp();
     }).fail(function(xhr, status, error) {
         Raven.captureMessage('Failed to update two-factor settings.', {
-            xhr: xhr,
-            status: status,
-            error: error
+            extra: {
+                xhr: xhr,
+                status: status,
+                error: error
+            }
         });
         if (xhr.status === 403) {
             self.changeMessage('Verification failed. Please enter your verification code again.',
@@ -111,9 +115,11 @@ ViewModel.prototype.disableTwofactorConfirm = function() {
         })
         .fail(function(xhr, status, error) {
             Raven.captureMessage('Failed to disable two-factor.', {
-                xhr: xhr,
-                status: status,
-                error: error
+                extra: {
+                    xhr: xhr,
+                    status: status,
+                    error: error
+                }
             });
             self.changeMessage(
                 'Could not disable two-factor authentication at this time. Please refresh ' +
@@ -150,9 +156,11 @@ ViewModel.prototype.enableTwofactorConfirm = function() {
         })
         .fail(function(xhr, status, error) {
             Raven.captureMessage('Failed to enable two-factor.', {
-                xhr: xhr,
-                status: status,
-                error: error
+                extra: {
+                    xhr: xhr,
+                    status: status,
+                    error: error
+                }
             });
             self.changeMessage(
                 'Could not enable two-factor authentication at this time. Please refresh ' +

--- a/website/addons/wiki/static/WikiEditor.js
+++ b/website/addons/wiki/static/WikiEditor.js
@@ -149,9 +149,11 @@ function ViewModel(url, viewText) {
         request.fail(function (xhr, textStatus, error) {
             $osf.growl('Error','The wiki content could not be loaded.');
             Raven.captureMessage('Could not GET wiki contents.', {
-                url: url,
-                textStatus: textStatus,
-                error: error
+                extra: {
+                    url: url,
+                    textStatus: textStatus,
+                    error: error
+                }
             });
         });
         return request;

--- a/website/addons/wiki/templates/add_wiki_page.mako
+++ b/website/addons/wiki/templates/add_wiki_page.mako
@@ -72,17 +72,21 @@
                     else if (response.status === 403){
                         $alert.text('You do not have permission to perform this action.');
                         Raven.captureMessage('Unauthorized user can view wiki add button', {
-                            url: ${ urls['api']['base'] | sjson, n } + encodeURIComponent(wikiName) + '/validate/',
-                            textStatus: textStatus,
-                            error: error
+                            extra: {
+                                url: ${ urls['api']['base'] | sjson, n } + encodeURIComponent(wikiName) + '/validate/',
+                                textStatus: textStatus,
+                                error: error
+                            }
                         });
                     }
                     else {
                         $alert.text('Could not validate wiki page. Please try again.'+response.status);
                         Raven.captureMessage('Error occurred while validating page', {
-                            url: ${ urls['api']['base'] | sjson, n } + encodeURIComponent(wikiName) + '/validate/',
-                            textStatus: textStatus,
-                            error: error
+                            extra: {
+                                url: ${ urls['api']['base'] | sjson, n } + encodeURIComponent(wikiName) + '/validate/',
+                                textStatus: textStatus,
+                                error: error
+                            }
                         });
                     }
                     $submitForm

--- a/website/static/js/comment.js
+++ b/website/static/js/comment.js
@@ -51,9 +51,11 @@ var getContributorList = function(url, contributors, ret) {
         });
         request.fail(function(xhr, status, error) {
             Raven.captureMessage('Error getting contributors', {
-                url: url,
-                status: status,
-                error: error
+                extra: {
+                    url: url,
+                    status: status,
+                    error: error
+                }
             });
             ret.reject(xhr, status, error);
         });

--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -513,7 +513,9 @@ AddContributorViewModel = oop.extend(Paginator, {
         }).fail(function (xhr, status, error) {
             $osf.growl('Error', 'Unable to retrieve project settings');
             Raven.captureMessage('Could not GET project settings.', {
-                url: treebeardUrl, status: status, error: error
+                extra: {
+                    url: treebeardUrl, status: status, error: error
+                }
             });
         });
     }

--- a/website/static/js/institutionProjectSettings.js
+++ b/website/static/js/institutionProjectSettings.js
@@ -247,7 +247,9 @@ ViewModel.prototype.fetchNodeTree = function(treebeardUrl) {
         }).fail(function (xhr, status, error) {
             $osf.growl('Error', 'Unable to retrieve project settings');
             Raven.captureMessage('Could not GET project settings.', {
-                url: treebeardUrl, status: status, error: error
+                extra: {
+                    url: treebeardUrl, status: status, error: error
+                }
             });
         });
 };

--- a/website/static/js/nodesPrivacy.js
+++ b/website/static/js/nodesPrivacy.js
@@ -202,7 +202,9 @@ NodesPrivacyViewModel.prototype.fetchNodeTree = function() {
     }).fail(function(xhr, status, error) {
         $osf.growl('Error', 'Unable to retrieve project settings');
         Raven.captureMessage('Could not GET project settings.', {
-            url: self.treebeardUrl, status: status, error: error
+            extra: {
+                url: self.treebeardUrl, status: status, error: error
+            }
         });
     });
 };

--- a/website/static/js/pages/base-page.js
+++ b/website/static/js/pages/base-page.js
@@ -147,9 +147,11 @@ function confirmEmails(emailsToAdd) {
                             confirmEmails(emailsToAdd.slice(1));
                         }).fail(function (xhr, textStatus, error) {
                             Raven.captureMessage('Could not remove email', {
-                                url: confirmedEmailURL,
-                                textStatus: textStatus,
-                                error: error
+                                extra: {
+                                    url: confirmedEmailURL,
+                                    textStatus: textStatus,
+                                    error: error
+                                }
                             });
                             $osf.growl('Error',
                                 cancelFailMessage,
@@ -170,9 +172,11 @@ function confirmEmails(emailsToAdd) {
                             confirmEmails(emailsToAdd.slice(1));
                         }).fail(function (xhr, textStatus, error) {
                             Raven.captureMessage('Could not add email', {
-                                url: confirmedEmailURL,
-                                textStatus: textStatus,
-                                error: error
+                                extra: {
+                                    url: confirmedEmailURL,
+                                    textStatus: textStatus,
+                                    error: error
+                                }
                             });
                             $osf.growl('Error',
                                 confirmFailMessage,


### PR DESCRIPTION
## Purpose / Changes

Fix a bunch of incorrect `Raven.captureMessage` calls that were passing log data at the wrong level.  Arbitrary log data should live under the `extra` key of the options argument.

## Side effects

None expected.

## Ticket

[#OSF-7054] - [JIRA](https://openscience.atlassian.net/browse/OSF-7054)
