### PR TITLE
Feature/Make current_version a file serializer field [OSF-7067] [PREP-144]

### DIFF
--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -135,6 +135,7 @@ class FileSerializer(JSONAPISerializer):
     extra = ser.SerializerMethodField(read_only=True, help_text='Additional metadata about this file')
     tags = JSONAPIListField(child=FileTagField(), required=False)
     current_user_can_comment = ser.SerializerMethodField(help_text='Whether the current user is allowed to post comments')
+    current_version = ser.SerializerMethodField(help_text='Latest file version')
 
     files = NodeFileHyperLinkField(
         related_view='nodes:node-files',
@@ -166,6 +167,11 @@ class FileSerializer(JSONAPISerializer):
 
     class Meta:
         type_ = 'files'
+
+    def get_current_version(self, obj):
+        if obj.history:
+            return len(obj.history)
+        return 1
 
     def get_size(self, obj):
         if obj.versions:

--- a/api/files/views.py
+++ b/api/files/views.py
@@ -75,29 +75,30 @@ class FileDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView, FileMixin):
 
     ####File Entity
 
-        name          type       description
+        name            type              description
         =========================================================================
-        guid          string            OSF GUID for this file (if one has been assigned)
-        name          string            name of the file
-        path          string            unique identifier for this file entity for this
-                                        project and storage provider. may not end with '/'
-        materialized  string            the full path of the file relative to the storage
-                                        root.  may not end with '/'
-        kind          string            "file"
-        etag          string            etag - http caching identifier w/o wrapping quotes
-        modified      timestamp         last modified timestamp - format depends on provider
-        contentType   string            MIME-type when available
-        provider      string            id of provider e.g. "osfstorage", "s3", "googledrive".
-                                        equivalent to addon_short_name on the OSF
-        size          integer           size of file in bytes
-        tags          array of strings  list of tags that describes the file (osfstorage only)
-        extra         object            may contain additional data beyond what's described here,
-                                        depending on the provider
-          version     integer           version number of file. will be 1 on initial upload
-          downloads   integer           count of the number times the file has been downloaded
-          hashes      object
-            md5       string            md5 hash of file
-            sha256    string            SHA-256 hash of file
+        guid            string            OSF GUID for this file (if one has been assigned)
+        name            string            name of the file
+        path            string            unique identifier for this file entity for this
+                                          project and storage provider. may not end with '/'
+        materialized    string            the full path of the file relative to the storage
+                                          root.  may not end with '/'
+        kind            string            "file"
+        etag            string            etag - http caching identifier w/o wrapping quotes
+        modified        timestamp         last modified timestamp - format depends on provider
+        contentType     string            MIME-type when available
+        provider        string            id of provider e.g. "osfstorage", "s3", "googledrive".
+                                          equivalent to addon_short_name on the OSF
+        size            integer           size of file in bytes
+        current_version integer           current file version
+        tags            array of strings  list of tags that describes the file (osfstorage only)
+        extra           object            may contain additional data beyond what's described here,
+                                          depending on the provider
+          version       integer           version number of file. will be 1 on initial upload
+          downloads     integer           count of the number times the file has been downloaded
+          hashes        object
+            md5         string            md5 hash of file
+            sha256      string            SHA-256 hash of file
 
     ####Folder Entity
 

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1627,6 +1627,8 @@ class NodeFilesList(JSONAPIBaseView, generics.ListAPIView, WaterButlerMixin, Lis
         provider                    string            id of provider e.g. "osfstorage", "s3", "googledrive".
                                                         equivalent to addon_short_name on the OSF
         size                        integer           size of file in bytes
+        current_version             integer           current file version
+
         current_user_can_comment    boolean           Whether the current user is allowed to post comments
 
         tags                        array of strings  list of tags that describes the file (osfstorage only)

--- a/api_tests/files/views/test_file_detail.py
+++ b/api_tests/files/views/test_file_detail.py
@@ -398,6 +398,20 @@ class TestFileView(ApiTestCase):
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
         assert_equal(res.status_code, 404)
 
+    def test_current_version_is_equal_to_length_of_history(self):
+        res = self.app.get(self.file_url, auth=self.user.auth)
+        assert_equal(res.json['data']['attributes']['current_version'], 1)
+        for version in range(2, 4):
+            self.file.create_version(self.user, {
+                'object': '06d80e' + str(version),
+                'service': 'cloud',
+                osfstorage_settings.WATERBUTLER_RESOURCE: 'osf',
+            }, {'size': 1337,
+                'contentType': 'img/png'
+            }).save()
+            res = self.app.get(self.file_url, auth=self.user.auth)
+            assert_equal(res.json['data']['attributes']['current_version'], version)
+
 
 class TestFileVersionView(ApiTestCase):
     def setUp(self):

--- a/api_tests/files/views/test_file_detail.py
+++ b/api_tests/files/views/test_file_detail.py
@@ -71,6 +71,7 @@ class TestFileView(ApiTestCase):
         assert_equal(attributes['last_touched'], None)
         assert_equal(attributes['provider'], self.file.provider)
         assert_equal(attributes['size'], self.file.versions[-1].size)
+        assert_equal(attributes['current_version'], len(self.file.history))
         assert_equal(attributes['date_modified'], _dt_to_iso8601(self.file.versions[-1].date_created.replace(tzinfo=pytz.utc)))
         assert_equal(attributes['date_created'], _dt_to_iso8601(self.file.versions[0].date_created.replace(tzinfo=pytz.utc)))
         assert_equal(attributes['extra']['hashes']['md5'], None)


### PR DESCRIPTION
## Purpose

The version of the primary file for the preprint needs to be exposed in the view preprint page.

## Changes

Exposes current_version as a serializer field on file. Determined by the length of the history.

## Side effects

<!--Any possible side effects? -->


## Ticket
https://openscience.atlassian.net/browse/OSF-7067
Needed for https://openscience.atlassian.net/browse/PREP-144
