### PR TITLE
[Hotfix] Decrement maxLength for passwords

### DIFF
--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -763,8 +763,8 @@ class User(GuidStoredObject, AddonModelMixin):
             issues.append('Passwords cannot be blank')
         elif len(raw_new_password) < 8:
             issues.append('Password should be at least eight characters')
-        elif len(raw_new_password) > 256:
-            issues.append('Password should not be longer than 256 characters')
+        elif len(raw_new_password) > 255:
+            issues.append('Password should not be longer than 255 characters')
 
         if raw_new_password != raw_confirm_password:
             issues.append('Password does not match the confirmation')

--- a/framework/auth/forms.py
+++ b/framework/auth/forms.py
@@ -102,8 +102,8 @@ password_field = PasswordField('Password',
         validators.Required(message=u'Password is required'),
         validators.Length(min=8, message=u'Password is too short. '
             'Password should be at least 8 characters.'),
-        validators.Length(max=256, message=u'Password is too long. '
-            'Password should be at most 256 characters.'),
+        validators.Length(max=255, message=u'Password is too long. '
+            'Password should be at most 255 characters.'),
     ],
     filters=[stripped],
     widget=BootstrapPasswordInput()
@@ -125,8 +125,8 @@ class ResetPasswordForm(Form):
             validators.Required(message=u'Password is required'),
             validators.Length(min=8, message=u'Password is too short. '
                 'Password should be at least 8 characters.'),
-            validators.Length(max=256, message=u'Password is too long. '
-                'Password should be at most 256 characters.'),
+            validators.Length(max=255, message=u'Password is too long. '
+                'Password should be at most 255 characters.'),
         ],
         filters=[stripped],
         widget=BootstrapPasswordInput()

--- a/website/static/js/passwordForms.js
+++ b/website/static/js/passwordForms.js
@@ -54,7 +54,7 @@ var BaseViewModel = oop.extend(ChangeMessageMixin, {
         self.password = ko.observable('').extend({
             required: true,
             minLength: 8,
-            maxLength: 256,
+            maxLength: 255,
             complexity: 2,
         });
 

--- a/website/templates/landing.mako
+++ b/website/templates/landing.mako
@@ -65,7 +65,7 @@
                           </div>
                           <div class="form-group" data-bind="css: {'has-error': password() && !password.isValid(), 'has-success': password() && password.isValid()}">
                               <label class="placeholder-replace" style="display:none">Password</label>
-                              <input type="password" class="form-control" placeholder="Password (Must be 8 to 256 characters)" data-bind=", textInput: typedPassword, value: password, disable: submitted(), event: {blur: trim.bind($data, password)}">
+                              <input type="password" class="form-control" placeholder="Password (Must be 8 to 255 characters)" data-bind=", textInput: typedPassword, value: password, disable: submitted(), event: {blur: trim.bind($data, password)}">
 
                               <div class="row" data-bind="visible: typedPassword().length > 0">
                                   <div class="col-xs-8">


### PR DESCRIPTION
## Purpose
Prevent issue when passwords are 256 characters.

## Changes
Set `maxLength` to `255`

## Side effects
None expected

## Ticket
None known.

Exactly 256 characters:

<img width="562" alt="screen shot 2016-09-23 at 12 27 35" src="https://cloud.githubusercontent.com/assets/5659262/18793528/28736174-8189-11e6-957c-fc22700007e8.png">
