### PR TITLE
[Hotfix] Allow duplicate characters within the same GUID [OSF-7059]

### DIFF
--- a/framework/guid/model.py
+++ b/framework/guid/model.py
@@ -30,7 +30,7 @@ class Guid(StoredObject):
     def generate(self, referent=None, min_length=5):
         while True:
             # Create GUID
-            guid_id = ''.join(random.sample(ALPHABET, min_length))
+            guid_id = ''.join([random.choice(ALPHABET) for _ in range(min_length)])
 
             # Check GUID against blacklist
             blacklist_guid = BlacklistGuid.load(guid_id)


### PR DESCRIPTION
## Purpose
Allow duplicate characters in the same GUID, thus expanding the set of possible GUIDs

## Description
`random.sample` effectively pops the selected item from the population when sampling. For example, `random.sample('12345', 5)` will output exclusively permutations of `'12345'`:
```
In [1]: import random

In [2]: random.sample('12345', 5)
Out[2]: ['1', '5', '2', '3', '4']

In [3]: random.sample('12345', 5)
Out[3]: ['1', '2', '3', '4', '5']

In [4]: random.sample('12345', 5)
Out[4]: ['3', '1', '2', '4', '5']

In [5]: random.sample('12345', 5)
Out[5]: ['4', '3', '2', '1', '5']
```

This causes GUIDs to not have multiple instances of the same character -- you'd never see an `_id` of `aabcd` even if it wasn't on the `BlackListGuid` list. Because it is, however, and because of how many other `BlackListGuid`s have duplicate characters, this behavior appears to be unintentional, in addition to just limiting the set of possible GUIDs ( @icereval and @sloria were also uncertain if this was intentional).

This causes the number of possible GUIDs to drop by almost 30%:
```
In [1]: max = 31*31*31*31*31

In [2]: max
Out[2]: 28629151

In [3]: actual = 31*30*29*28*27

In [4]: actual
Out[4]: 20389320

In [5]: missing = max - actual

In [6]: float(missing) / max
Out[6]: 0.2878126214780173
```

There's about a 12% overlap between the set of BlackListGuids and those that would be freed up by this:
```
> db.getCollection('blacklistguid').find({'_id': {'$regex': '(.).*\\1'}}).count()
988243
```
```
In [7]: duped = 988243

In [8]: float(duped) / missing
Out[8]: 0.11993486274172371
```


## Changes
* Prefer `.choice` over `.sample`

## Side effects
None expected

## Before
```
In [4]: Guid.generate(referent=me)
Out[4]: <id:6jvnq, referent:(fh5em, user)>

In [5]: g = Guid.generate(referent=me, min_length=len(ALPHABET))

In [7]: g._id
Out[7]: 'kr6z7e92s3xvmqcbay5tp48gdufwhnj'

In [10]: sorted(ALPHABET) == sorted(g._id)
Out[10]: True

In [11]: Guid.generate(referent=me, min_length=((len(ALPHABET) + 1)))
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-11-fd7a5737b56c> in <module>()
----> 1 Guid.generate(referent=me, min_length=32)

/Users/matt/Devel/osf.io/framework/guid/model.pyc in generate(self, referent, min_length)
     31         while True:
     32             # Create GUID
---> 33             guid_id = ''.join(random.sample(ALPHABET, min_length))
     34
     35             # Check GUID against blacklist

/usr/local/Cellar/python/2.7.10_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/random.pyc in sample(self, population, k)
    321         n = len(population)
    322         if not 0 <= k <= n:
--> 323             raise ValueError("sample larger than population")
    324         random = self.random
    325         _int = int

ValueError: sample larger than population
```

## After

Note: I had to run `.generate` multiple times for the 5-character GUID to have a duplicate character.

```
In [16]: Guid.generate(referent=me)
Out[16]: <id:x7t47, referent:(fh5em, user)>

In [18]: Guid.generate(referent=me, min_length=(len(ALPHABET) + 1))
Out[18]: <id:hkpzc8zuzcexf4777cpnpstgt89zqsaa, referent:(fh5em, user)>
```