### PR TITLE
[feature fix] Fixed Width Banner Buttons on Dashboard [OSF-7009]

### DIFF
--- a/website/static/css/meetings-and-conferences.css
+++ b/website/static/css/meetings-and-conferences.css
@@ -3,7 +3,3 @@
         text-align: center;
     }
 }
-
-.btn {
-    width: 70%
-}

--- a/website/static/css/pages/home-page.css
+++ b/website/static/css/pages/home-page.css
@@ -25,9 +25,6 @@ h3, h4 {
     background-size: cover;
     color: #fff;
 }
-.meetings .btn {
-    box-shadow: 0 0 9px -4px #000;
-}
 
 .prereg {
     background: #C5D6E6 url("/static/img/bg6.jpg") no-repeat center top;
@@ -37,6 +34,11 @@ h3, h4 {
 .preprints {
     background: #34495e;
     color: #FFF;
+}
+
+.btn-banner {
+    box-shadow: 0 0 9px -4px #000;
+    width: 70%;
 }
 
 .footer {

--- a/website/static/js/home-page/meetingsAndConferencesPlugin.js
+++ b/website/static/js/home-page/meetingsAndConferencesPlugin.js
@@ -22,7 +22,7 @@ var MeetingsAndConferences = {
                         ]
                     ),
                     m('.col-md-4.text-center',
-                        m('div',  m('a.btn.btn-success.btn-lg.btn-success-high-contrast.m-v-xl.f-w-xl', { style : 'box-shadow: 0 0 9px -4px #000;', type:'button',  href:'/meetings/', onclick: function() {
+                        m('div',  m('a.btn.btn-banner.btn-success.btn-lg.btn-success-high-contrast.m-v-xl.f-w-xl', { type:'button',  href:'/meetings/', onclick: function() {
                             $osf.trackClick('meetingsAndConferences', 'navigate', 'navigate-to-view-meetings');
                         }}, 'View meetings'))
                     )

--- a/website/static/js/home-page/preprintsPlugin.js
+++ b/website/static/js/home-page/preprintsPlugin.js
@@ -23,7 +23,7 @@ var Preprints = {
                         ]
                     ),
                     m('.col-md-4.text-center',
-                        m('div',  m('a.btn.btn-success.btn-lg.btn-success-high-contrast.m-v-xl.f-w-xl', { style : 'box-shadow: 0 0 9px -4px #000;', type:'button',  href:'/preprints/', onclick: function() {
+                        m('div',  m('a.btn.btn-banner.btn-success.btn-lg.btn-success-high-contrast.m-v-xl.f-w-xl', { type:'button',  href:'/preprints/', onclick: function() {
                             $osf.trackClick('Preprints', 'navigate', 'navigate-to-preprints');
                         }}, 'View preprints'))
                     )

--- a/website/static/js/home-page/preregPlugin.js
+++ b/website/static/js/home-page/preregPlugin.js
@@ -22,7 +22,7 @@ var Prereg = {
                         ]
                     ),
                     m('.col-md-4.text-center',
-                        m('div',  m('a.btn.btn-success.btn-lg.btn-success-high-contrast.m-v-xl.f-w-xl', { style : 'box-shadow: 0 0 9px -4px #000;', type:'button',  href:'/prereg/', onclick: function() {
+                        m('div',  m('a.btn.btn-banner.btn-success.btn-lg.btn-success-high-contrast.m-v-xl.f-w-xl', { type:'button',  href:'/prereg/', onclick: function() {
                             $osf.trackClick('prereg', 'navigate', 'navigate-to-begin-prereg');
                         }}, 'Preregister'))
                     )


### PR DESCRIPTION
#### Purpose
- Adds `.banner` CSS class for fixed width, which is applied only to the banner buttons on the dashboard.
- Removes `.btn` class from `meetings-and-conferences.css` which caused the fixed width to be incorrectly applied to the "Create new project" button.

#### Ticket
- [OSF-7009](https://openscience.atlassian.net/browse/OSF-7009)

