### PR TITLE
changing initial wording of registration header [OSF-3518]

### DIFF
--- a/website/templates/project/project_header.mako
+++ b/website/templates/project/project_header.mako
@@ -107,7 +107,7 @@
                         <div class="alert alert-info">This file is part of a registration and is being shown in its archived version (and cannot be altered).
                             The <a class="link-solid" href="${urls['archived_from']}">active file</a> is viewable from within the <a class="link-solid" href="${node['registered_from_url']}">live ${node['node_type']}</a>.</div>
                 % else:
-                    <div class="alert alert-info">This ${node['node_type']} is a registration of <a class="link-solid" href="${node['registered_from_url']}">this ${node['node_type']}</a>; the content of the ${node['node_type']} has been frozen and cannot be edited.</div>
+                    <div class="alert alert-info">This registration is a frozen, non-editable version of <a class="link-solid" href="${node['registered_from_url']}">this ${node['node_type']}</a></div>
                 % endif
             % else:
                 <div class="alert alert-info">


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

This PR rewords some of the project headers on registrations that specify what it is a registration of. 

## Changes

This PR edits the wording of the registration decorator from 
"This project is a registration of **this project**; the content of the project has been frozen and cannot be edited"
To:
This registration is a frozen, non-editable version of this project. (With link to "this project")

## Side effects

This change trickles to all node types, which is intended. 

## Ticket

https://openscience.atlassian.net/browse/OSF-3518
