### PR TITLE
Fix AddContributorThrottle [OSF-7065]

### DIFF
--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -29,8 +29,11 @@ from api.comments.permissions import CanCommentOrPublic
 from api.users.views import UserMixin
 from api.wikis.serializers import WikiSerializer
 from api.base.views import LinkedNodesRelationship, BaseContributorDetail, BaseContributorList, BaseNodeLinksDetail, BaseNodeLinksList, BaseLinkedList
-from api.base.throttling import AddContributorThrottle
-
+from api.base.throttling import (
+    UserRateThrottle,
+    NonCookieAuthThrottle,
+    AddContributorThrottle,
+)
 from api.nodes.serializers import (
     NodeSerializer,
     ForwardNodeAddonSettingsSerializer,
@@ -625,7 +628,7 @@ class NodeContributorsList(BaseContributorList, bulk_views.BulkUpdateJSONAPIView
     required_write_scopes = [CoreScopes.NODE_CONTRIBUTORS_WRITE]
     model_class = User
 
-    throttle_classes = (AddContributorThrottle,)
+    throttle_classes = (AddContributorThrottle, UserRateThrottle, NonCookieAuthThrottle, )
 
     pagination_class = NodeContributorPagination
     serializer_class = NodeContributorsSerializer

--- a/api_tests/base/test_throttling.py
+++ b/api_tests/base/test_throttling.py
@@ -105,3 +105,13 @@ class TestAddContributorEmailThrottle(ApiTestCase):
         res = self.app.post_json_api(self.public_url, self.data_user_two, auth=self.user.auth)
         assert_equal(res.status_code, 201)
         assert_equal(mock_allow.call_count, 1)
+
+    @mock.patch('api.base.throttling.NonCookieAuthThrottle.allow_request')
+    @mock.patch('rest_framework.throttling.UserRateThrottle.allow_request')
+    @mock.patch('api.base.throttling.AddContributorThrottle.allow_request')
+    def test_add_contrib_throttle_rate_and_default_rates_called(self, mock_contrib_allow, mock_user_allow, mock_anon_allow):
+        res = self.app.get(self.public_url, auth=self.user.auth)
+        assert_equal(res.status_code, 200)
+        assert_equal(mock_anon_allow.call_count, 1)
+        assert_equal(mock_user_allow.call_count, 1)
+        assert_equal(mock_contrib_allow.call_count, 1)


### PR DESCRIPTION
#### Purpose
- Currently, the only throttle class applied to the `NodeContributorsList` view is the custom `AddContributorThrottle`. Applying this custom class overrides the default throttle classes we are using (`UserRateThrottle` and `NonCookieAuthThrottle`) so that the default rates are not being checked when this endpoint is accessed. 
- This PR adds the default throttle classes to the `NodeContributorsList` view, and adds a test to confirm all three rates are being applied.

#### Changes
- Add the default `UserRateThrottle` and `NonCookieAuthThrottle` classes to `NodeContributorsList` view.

#### Side effects
- None expected.

#### Ticket
- [OSF-7065](https://openscience.atlassian.net/browse/OSF-7065)

h/t @mfraezz for discovering this bug.

