### PR TITLE
[Production& Staging] Add change folder toggle button [OSF-3655]

### DIFF
--- a/website/addons/s3/templates/s3_node_settings.mako
+++ b/website/addons/s3/templates/s3_node_settings.mako
@@ -53,7 +53,8 @@
                 <!-- Folder buttons -->
                 <div class="form-group" data-bind="visible: userIsOwner() && validCredentials()">
                     <button data-bind="click: togglePicker,
-                                   css: {active: currentDisplay() === PICKER}" class="btn btn-primary">Change</button>
+                                       css: {active: currentDisplay() === PICKER}" class="btn btn-primary">
+                                       <span data-bind="text: toggleChangeText"></span></button>
                     <button data-bind="visible: userIsOwner() && validCredentials(), click: openCreateBucket" class="btn btn-success" id="newBucket">Create bucket</button>
                 </div>
                 <!-- Folder picker -->

--- a/website/static/js/folderPickerNodeConfig.js
+++ b/website/static/js/folderPickerNodeConfig.js
@@ -77,6 +77,8 @@ var FolderPickerViewModel = oop.defclass({
         self.currentDisplay = ko.observable(null);
         // Whether the folders have been loaded from the API
         self.loadedFolders = ko.observable(false);
+        // Button text for changing folders
+        self.toggleChangeText = ko.observable('Change');
 
         var addonSafeName = $osf.htmlEscape(self.addonName);
         self.messages = {
@@ -432,14 +434,17 @@ var FolderPickerViewModel = oop.defclass({
         this.selected(null);
     },
     /**
-     *  Toggles the visibility of the folder picker.
+     *  Toggles the visibility of the folder picker and toggles
+     *  Change button text between 'Change' and 'Close'
      */
     togglePicker: function() {
         var shown = this.currentDisplay() === this.PICKER;
         if (!shown) {
             this.currentDisplay(this.PICKER);
+            this.toggleChangeText('Close');
             this.activatePicker();
         } else {
+            this.toggleChangeText('Change');
             this.currentDisplay(null);
             // Clear selection
             this.cancelSelection();

--- a/website/templates/project/addon/node_settings_default.mako
+++ b/website/templates/project/addon/node_settings_default.mako
@@ -49,7 +49,8 @@
                 <!-- Folder buttons -->
                 <div class="btn-group" data-bind="visible: userIsOwner() && validCredentials()">
                     <button data-bind="click: togglePicker,
-                                       css: {active: currentDisplay() === PICKER}" class="btn btn-primary">Change</button>
+                                       css: {active: currentDisplay() === PICKER}" class="btn btn-primary">
+                                       <span data-bind="text: toggleChangeText"></span></button>
                 </div>
                 <!-- Folder picker -->
                 <div class="m-t-sm addon-folderpicker-widget ${addon_short_name}-widget">


### PR DESCRIPTION
## Purpose

On the add-on settings page, when one presses the “Change” button to change folders, it toggles a folder change dialog. The same “Change” button then has to be used to close the folder change dialog, leading to confusion over what the button does. This fixes that by changing the button text after the button is pressed to “Close”. Thus, users will be able to tell that the button functions as a toggle for a panel.

## Changes

`folderPickerNodeConfig.js`
 - added button text as a knockout observable
 - added logic to ```togglePicker``` function that toggles button text between “Change” and “Close”

`node_settings_default.mako` and ```s3_node_settings.mako`
 - changed button to use `<span>` for button text that binds to the knockout observable (and thus changes the button text on click)

## Side effects

None; the change is purely cosmetic.

## Ticket
[https://openscience.atlassian.net/browse/OSF-3655]
(https://openscience.atlassian.net/browse/OSF-3655)
