### PR TITLE
[feature] Hide Institution Logos with < 5 Affiliated Nodes [OSF-6980]

### DIFF
--- a/tests/framework_tests/test_routing.py
+++ b/tests/framework_tests/test_routing.py
@@ -8,6 +8,12 @@ from webtest_plus import TestApp
 from framework.exceptions import HTTPError
 from framework.routing import json_renderer, process_rules, Rule
 
+from tests import factories
+from tests.base import OsfTestCase
+
+from website import routes
+from website import settings
+
 def error_view():
     raise HTTPError(400)
 
@@ -40,3 +46,34 @@ class TestJSONRenderer(unittest.TestCase):
         data = res.json
         assert_equal(data['message_short'], 'Invalid')
         assert_equal(data['message_long'], 'Invalid request')
+
+
+class TestGetGlobals(OsfTestCase):
+
+    def setUp(self):
+        super(TestGetGlobals, self).setUp()
+
+        self.inst_one = factories.InstitutionFactory()
+        self.inst_two = factories.InstitutionFactory()
+
+        self.user = factories.AuthUserFactory()
+        self.user.affiliated_institutions.append(self.inst_one)
+        self.user.affiliated_institutions.append(self.inst_two)
+        self.user.save()
+
+        for i in range(settings.INSTITUTION_DISPLAY_NODE_THRESHOLD):
+            node = factories.NodeFactory(creator=self.user, is_public=True)
+            node.affiliated_institutions.append(self.inst_one)
+            node.save()
+
+        for i in range(settings.INSTITUTION_DISPLAY_NODE_THRESHOLD - 1):
+            node = factories.NodeFactory(creator=self.user, is_public=True)
+            node.affiliated_institutions.append(self.inst_two)
+            node.save()
+
+    def test_get_globals_dashboard_institutions(self):
+        globals = routes.get_globals()
+        dashboard_institutions = globals['dashboard_institutions']
+        assert_equal(len(dashboard_institutions), 1)
+        assert_equal(dashboard_institutions[0]['id'], self.inst_one._id)
+        assert_not_equal(dashboard_institutions[0]['id'], self.inst_two._id)

--- a/tests/framework_tests/test_routing.py
+++ b/tests/framework_tests/test_routing.py
@@ -55,26 +55,44 @@ class TestGetGlobals(OsfTestCase):
 
         self.inst_one = factories.InstitutionFactory()
         self.inst_two = factories.InstitutionFactory()
+        self.inst_three = factories.InstitutionFactory()
+        self.inst_four = factories.InstitutionFactory()
+        self.inst_five = factories.InstitutionFactory()
 
         self.user = factories.AuthUserFactory()
         self.user.affiliated_institutions.append(self.inst_one)
         self.user.affiliated_institutions.append(self.inst_two)
         self.user.save()
 
+        # tests 5 affiliated, non-registered, public projects
         for i in range(settings.INSTITUTION_DISPLAY_NODE_THRESHOLD):
-            node = factories.NodeFactory(creator=self.user, is_public=True)
+            node = factories.ProjectFactory(creator=self.user, is_public=True)
             node.affiliated_institutions.append(self.inst_one)
             node.save()
 
+        # tests 4 affiliated, non-registered, public projects
         for i in range(settings.INSTITUTION_DISPLAY_NODE_THRESHOLD - 1):
-            node = factories.NodeFactory(creator=self.user, is_public=True)
+            node = factories.ProjectFactory(creator=self.user, is_public=True)
             node.affiliated_institutions.append(self.inst_two)
             node.save()
 
+        # tests 5 affiliated, registered, public projects
         for i in range(settings.INSTITUTION_DISPLAY_NODE_THRESHOLD):
             registration = factories.RegistrationFactory(creator=self.user, is_public=True)
-            registration.affiliated_institutions.append(self.inst_two)
+            registration.affiliated_institutions.append(self.inst_three)
             registration.save()
+
+        # tests 5 affiliated, non-registered public components
+        for i in range(settings.INSTITUTION_DISPLAY_NODE_THRESHOLD):
+            node = factories.NodeFactory(creator=self.user, is_public=True)
+            node.affiliated_institutions.append(self.inst_four)
+            node.save()
+
+        # tests 5 affiliated, non-registered, private projects
+        for i in range(settings.INSTITUTION_DISPLAY_NODE_THRESHOLD):
+            node = factories.ProjectFactory(creator=self.user)
+            node.affiliated_institutions.append(self.inst_five)
+            node.save()
 
     def test_get_globals_dashboard_institutions(self):
         globals = routes.get_globals()
@@ -82,3 +100,6 @@ class TestGetGlobals(OsfTestCase):
         assert_equal(len(dashboard_institutions), 1)
         assert_equal(dashboard_institutions[0]['id'], self.inst_one._id)
         assert_not_equal(dashboard_institutions[0]['id'], self.inst_two._id)
+        assert_not_equal(dashboard_institutions[0]['id'], self.inst_three._id)
+        assert_not_equal(dashboard_institutions[0]['id'], self.inst_four._id)
+        assert_not_equal(dashboard_institutions[0]['id'], self.inst_five._id)

--- a/tests/framework_tests/test_routing.py
+++ b/tests/framework_tests/test_routing.py
@@ -71,6 +71,11 @@ class TestGetGlobals(OsfTestCase):
             node.affiliated_institutions.append(self.inst_two)
             node.save()
 
+        for i in range(settings.INSTITUTION_DISPLAY_NODE_THRESHOLD):
+            registration = factories.RegistrationFactory(creator=self.user, is_public=True)
+            registration.affiliated_institutions.append(self.inst_two)
+            registration.save()
+
     def test_get_globals_dashboard_institutions(self):
         globals = routes.get_globals()
         dashboard_institutions = globals['dashboard_institutions']

--- a/website/routes.py
+++ b/website/routes.py
@@ -63,7 +63,9 @@ def get_globals():
     dashboard_institutions = [
         {'id': inst._id, 'name': inst.name, 'logo_path': inst.logo_path_rounded_corners}
         for inst in all_institutions
-        if len(Node.find_by_institutions(inst, query=Q('is_public', 'eq', True))) >= settings.INSTITUTION_DISPLAY_NODE_THRESHOLD
+        if len(
+            Node.find_by_institutions(inst, query=(Q('is_public', 'eq', True) & Q('is_registration', 'eq', False)))
+        ) >= settings.INSTITUTION_DISPLAY_NODE_THRESHOLD
     ]
 
     location = geolite2.lookup(request.remote_addr) if request.remote_addr else None

--- a/website/routes.py
+++ b/website/routes.py
@@ -59,15 +59,19 @@ def get_globals():
 
     user_institutions = [{'id': inst._id, 'name': inst.name, 'logo_path': inst.logo_path_rounded_corners} for inst in user.affiliated_institutions] if user else []
     all_institutions = [inst for inst in Institution.find().sort('name')]
-    # currently only checking for >= 5 public nodes of any type (project or registration)
     dashboard_institutions = [
         {'id': inst._id, 'name': inst.name, 'logo_path': inst.logo_path_rounded_corners}
         for inst in all_institutions
         if len(
-            Node.find_by_institutions(inst, query=(Q('is_public', 'eq', True) & Q('is_registration', 'eq', False)))
+            Node.find_by_institutions(inst, query=(
+                Q('is_public', 'eq', True) &
+                Q('is_folder', 'ne', True) &
+                Q('is_deleted', 'ne', True) &
+                Q('parent_node', 'eq', None) &
+                Q('is_registration', 'eq', False)
+            ))
         ) >= settings.INSTITUTION_DISPLAY_NODE_THRESHOLD
     ]
-
     location = geolite2.lookup(request.remote_addr) if request.remote_addr else None
     if request.host_url != settings.DOMAIN:
         try:

--- a/website/routes.py
+++ b/website/routes.py
@@ -35,7 +35,7 @@ from website.util import metrics
 from website.util import paths
 from website.util import sanitize
 from website import maintenance
-from website.models import Institution
+from website.models import Institution, Node
 from website import landing_pages as landing_page_views
 from website import views as website_views
 from website.citations import views as citation_views
@@ -58,7 +58,14 @@ def get_globals():
     user = _get_current_user()
 
     user_institutions = [{'id': inst._id, 'name': inst.name, 'logo_path': inst.logo_path_rounded_corners} for inst in user.affiliated_institutions] if user else []
-    all_institutions = [{'id': inst._id, 'name': inst.name, 'logo_path': inst.logo_path_rounded_corners} for inst in Institution.find().sort('name')]
+    all_institutions = [inst for inst in Institution.find().sort('name')]
+    # currently only checking for >= 5 public nodes of any type (project or registration)
+    dashboard_institutions = [
+        {'id': inst._id, 'name': inst.name, 'logo_path': inst.logo_path_rounded_corners}
+        for inst in all_institutions
+        if len(Node.find_by_institutions(inst, query=Q('is_public', 'eq', True))) >= settings.INSTITUTION_DISPLAY_NODE_THRESHOLD
+    ]
+
     location = geolite2.lookup(request.remote_addr) if request.remote_addr else None
     if request.host_url != settings.DOMAIN:
         try:
@@ -81,7 +88,7 @@ def get_globals():
         'user_api_url': user.api_url if user else '',
         'user_entry_point': metrics.get_entry_point(user) if user else '',
         'user_institutions': user_institutions if user else None,
-        'all_institutions': all_institutions,
+        'dashboard_institutions': dashboard_institutions,
         'display_name': get_display_name(user.fullname) if user else '',
         'anon': {
             'continent': getattr(location, 'continent', None),

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -1751,3 +1751,6 @@ SPAM_FLAGGED_REMOVE_FROM_SEARCH = False
 
 SHARE_URL = 'http://localhost:8000/'
 SHARE_API_TOKEN = None
+
+# number of nodes that need to be affiliated with an institution before the institution logo is shown on the dashboard
+INSTITUTION_DISPLAY_NODE_THRESHOLD = 5

--- a/website/static/js/pages/home-page.js
+++ b/website/static/js/pages/home-page.js
@@ -26,8 +26,8 @@ $(document).ready(function(){
             var affiliatedInstitutions = _affiliatedInstitutions.map(function(inst) {
                 return {logoPath: inst.logo_path, id: inst.id, name: inst.name};
             });
-            var _allInstitutions = lodashGet(window, 'contextVars.allInstitutions') || [];
-            var allInstitutions = _allInstitutions.map(function(inst) {
+            var _dashboardInstitutions = lodashGet(window, 'contextVars.dashboardInstitutions') || [];
+            var dashboardInstitutions = _dashboardInstitutions.map(function(inst) {
                 return {logoPath: inst.logo_path, id: inst.id, name: inst.name};
             });
             return [
@@ -44,7 +44,7 @@ $(document).ready(function(){
                         m('.row', [
                             m(columnSizeClass,  m.component(InstitutionsPanel, {
                                 affiliatedInstitutions: affiliatedInstitutions,
-                                allInstitutions: allInstitutions
+                                allInstitutions: dashboardInstitutions
                             }))
                         ])
                     ]

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -188,7 +188,7 @@
                     emailsToAdd: ${ user_email_verifications | sjson, n },
                     anon: ${ anon | sjson, n },
                 },
-                allInstitutions: ${ all_institutions | sjson, n},
+                dashboardInstitutions: ${ dashboard_institutions | sjson, n},
                 popular: ${ popular_links_node | sjson, n },
                 newAndNoteworthy: ${ noteworthy_links_node | sjson, n },
                 maintenance: ${ maintenance | sjson, n},


### PR DESCRIPTION
#### Purpose
- Hides institution logos from the dashboard institution carousel until there are at least 5 projects (non-registered, public, top-level nodes) affiliated with the institution.

#### Changes
- Replaces `all_institutions` global with `dashboard_institutions`

#### Side effects
- Users may not know a given institution exists on the OSF until there are enough affiliated projects to display the logo. 

#### Ticket
- [OSF-6980](https://openscience.atlassian.net/browse/OSF-6980)
