### PR TITLE
[feature/django-osf] Handle `User.object.get(pk=cas_resp.user)` exceptions [Part of #7064]

### DIFF
--- a/framework/auth/cas.py
+++ b/framework/auth/cas.py
@@ -5,6 +5,7 @@ import httplib as http
 import json
 import urllib
 
+from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
 from lxml import etree
 import requests
 
@@ -301,7 +302,10 @@ def get_user_from_cas_resp(cas_resp):
     """
 
     if cas_resp.user:
-        user = User.objects.get(pk=cas_resp.user)
+        try:
+            user = User.objects.get(pk=cas_resp.user)
+        except(ObjectDoesNotExist, MultipleObjectsReturned, ValueError):
+            user = None
         # cas returns a valid OSF user id
         if user:
             return user, None, 'authenticate'


### PR DESCRIPTION
### Purpose

@sloria 

Django's `.object.get()` will throw `ObjectDoesNotExist` exception when query fails to find the object. It also throws `ValueError` exception if `cas_resp.user` cannot be converted to Integer as primary key, in the case for ORCiD login.

### Changes

Please refer to the code.

### Side Effects

User can now login or create/link accounts through ORCiD.

### Tickets

No Ticket