### PR TITLE
[feature] Clarify Prereg Comments [OSF-7007]

### DIFF
--- a/website/templates/project/registration_editor_templates.mako
+++ b/website/templates/project/registration_editor_templates.mako
@@ -143,6 +143,7 @@
 <script type="text/html" id="commentable">
   <div class="registration-editor-comments">
     <h4> Comments </h4>
+    <p class="text-muted">(Comments are not included in your preregistration and are not made public)</p>
     <ul class="list-group" id="commentList" data-bind="foreach: {data: comments, as: 'comment'}">
         <li class="list-group-item">
           <div class="row" data-bind="visible: comment.isDeleted">


### PR DESCRIPTION
#### Purpose
- Adds text to the comments section of a preregistration draft to clarify that preregistration comments are not registered.

#### Side effects
- None expected.

#### Ticket
- [OSF-7007](https://openscience.atlassian.net/browse/OSF-7007)

