### PR TITLE
[feature] Make Registration Terminology Consistent [OSF-6289]

### DIFF
--- a/website/project/metadata/aspredicted.json
+++ b/website/project/metadata/aspredicted.json
@@ -1,7 +1,7 @@
 {
     "name": "AsPredicted Preregistration",
     "version": 2,
-    "description": "You will be asked to answer 8 questions about your study. This preregistration uses the content recommended on the website AsPredicted.org.",
+    "description": "You will be asked to answer 8 questions about your study. This registration form uses the content recommended on the website AsPredicted.org.",
     "pages": [{
         "title": "AsPredicted Preregistration",
         "id": "page1",

--- a/website/project/metadata/brandt-postcomp-2.json
+++ b/website/project/metadata/brandt-postcomp-2.json
@@ -1,7 +1,7 @@
 {
     "name": "Replication Recipe (Brandt et al., 2013): Post-Completion",
     "version": 2,
-    "description": "Replication Recipe: Post-Completion: This template is intended for use upon completion of a replication study, as outlined by Brandt et al., \"The Replication Recipe: What Makes for a Convincing Replication?\" You will be asked to answer a series of questions about the outcomes of your replication and how they compare to the original study.",
+    "description": "Replication Recipe: Post-Completion: This registration form is intended for use upon completion of a replication study, as outlined by Brandt et al., \"The Replication Recipe: What Makes for a Convincing Replication?\" You will be asked to answer a series of questions about the outcomes of your replication and how they compare to the original study.",
     "pages": [{
         "id": "page1",
         "title": "Registering the Replication Attempt",

--- a/website/project/metadata/brandt-prereg-2.json
+++ b/website/project/metadata/brandt-prereg-2.json
@@ -1,7 +1,7 @@
 {
     "name": "Replication Recipe (Brandt et al., 2013): Pre-Registration",
     "version": 2,
-    "description": "This template is intended for use when conducting a replication. You will be asked a series of questions about the study you intend to replicate. This template is not a valid submission for the Pre-registration Prize.",
+    "description": "This registration form is intended for use when conducting a replication. You will be asked a series of questions about the study you intend to replicate. This registration form is not a valid submission for the Pre-registration Prize.",
     "pages": [{
         "id": "page1",
         "title": "The Nature of the Effect",

--- a/website/project/metadata/osf-open-ended-2.json
+++ b/website/project/metadata/osf-open-ended-2.json
@@ -1,7 +1,7 @@
 {
     "name": "Open-Ended Registration",
     "version": 2,
-    "description": "You will be asked to provide a narrative summary of what is contained in your project. There is no minimum character length. This template is not a valid submission for the Pre-registration Prize.",
+    "description": "You will be asked to provide a narrative summary of what is contained in your project. There is no minimum character length. This registration form is not a valid submission for the Pre-registration Prize.",
     "pages": [{
         "id": "page1",
         "title": "Summary",

--- a/website/project/metadata/osf-standard-2.json
+++ b/website/project/metadata/osf-standard-2.json
@@ -1,7 +1,7 @@
 {
     "name": "OSF-Standard Pre-Data Collection Registration",
     "version": 2,
-    "description": "You will be asked if data collection is underway and if you have looked at your data already. You will be provided an opportunity to post other comments about your project. This template is not a valid submission for the Pre-registration Prize.",
+    "description": "You will be asked if data collection is underway and if you have looked at your data already. You will be provided an opportunity to post other comments about your project. This registration form is not a valid submission for the Pre-registration Prize.",
     "pages": [{
         "title": "OSF-Standard Pre-Data Collection Registration",
         "id": "page1",

--- a/website/project/metadata/prereg-prize.json
+++ b/website/project/metadata/prereg-prize.json
@@ -21,7 +21,7 @@
             "info": "http://centerforopenscience.org/prereg/"
         }]
     },
-    "description": "Preregistration Challenge (pre-data collection): You will be asked a series of questions to ensure that your sampling, design, and analysis plans are solidified prior to beginning your study. Publications that pre register with this template may be eligible for a $1,000 prize. See project page for complete information.",
+    "description": "Preregistration Challenge (pre-data collection): You will be asked a series of questions to ensure that your sampling, design, and analysis plans are solidified prior to beginning your study. Publications that pre register with this registration form may be eligible for a $1,000 prize. See project page for complete information.",
     "pages": [{
         "id": "page1",
         "title": "Study Information",

--- a/website/project/metadata/veer-1.json
+++ b/website/project/metadata/veer-1.json
@@ -1,7 +1,7 @@
 {
     "name": "Pre-Registration in Social Psychology (van 't Veer & Giner-Sorolla, 2016): Pre-Registration",
     "version": 2,
-    "description": "This template is intended for use when conducting a pre-registration. You will be asked to fill out the elements for a pre-registration as described in: van 't Veer & Giner-Sorolla (2016). This template is not a valid submission for the Pre-registration Prize.",
+    "description": "This registration form is intended for use when conducting a pre-registration. You will be asked to fill out the elements for a pre-registration as described in: van 't Veer & Giner-Sorolla (2016). This preregistration form is not a valid submission for the Pre-registration Prize.",
     "config": {
         "hasFiles": true
     },

--- a/website/templates/project/modal_generate_private_link.mako
+++ b/website/templates/project/modal_generate_private_link.mako
@@ -29,7 +29,7 @@
                             <input type="checkbox" data-bind="checked: anonymous"/>
                             <strong>Anonymize</strong> contributor list for this link (e.g., for blind peer review).
                             <br>
-                            <i>Ensure the wiki pages, files, registration supplements and add-ons do not contain identifying information.</i>
+                            <i>Ensure the wiki pages, files, registration forms and add-ons do not contain identifying information.</i>
                         </label>
                     </div>
 

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -155,7 +155,7 @@
                 % endif
                 % if node['is_registration']:
                     <p>
-                    Registration Supplement:
+                    Registration Form:
                     % for meta_schema in node['registered_schemas']:
                     <a href="${node['url']}register/${meta_schema['id']}">${meta_schema['schema_name']}</a>
                       % if len(node['registered_schemas']) > 1:

--- a/website/templates/project/retracted_registration.mako
+++ b/website/templates/project/retracted_registration.mako
@@ -26,7 +26,7 @@
                     <span data-bind="text: dateForked.local, tooltip: {title: dateForked.utc}"></span>
                 % endif
                 <p>
-                  Registration Supplement:
+                  Registration Form:
                   % for meta_schema in node.get('registered_schemas', []):
                   <span> ${meta_schema['schema_name']}</span>
                   % if len(node['registered_schemas']) > 1:


### PR DESCRIPTION
- continuation of @amyshi188's work in #6150 

#### Purpose
- Make user-facing registration terminology more consistent. 
- The registration form a user chooses when making a registration (e.g. "Open-ended Registration", "Preregistration Challenge", etc.) were referred to as forms, templates, and supplements. This PR makes the terminology consistent by using "registration form" throughout the OSF.

#### Side effects
- None expected.

#### Ticket
- [OSF-6289](https://openscience.atlassian.net/browse/OSF-6289)

#### Changes

- Registration form tooltips (before):
    ![screen shot 2016-09-28 at 3 42 19 pm](https://cloud.githubusercontent.com/assets/7913604/18929361/2ea1554e-8592-11e6-8e9c-7305a43807e0.png)

- Registration form tooltips (after):
    ![screen shot 2016-09-28 at 3 37 59 pm](https://cloud.githubusercontent.com/assets/7913604/18929241/b2ec845a-8591-11e6-8614-30595fabd584.png)

- Registration overview (before):
    ![screen shot 2016-09-28 at 3 41 45 pm](https://cloud.githubusercontent.com/assets/7913604/18929386/44b35986-8592-11e6-8454-0cc3b4f4eba2.png)

- Registration overview (after):
    ![screen shot 2016-09-28 at 3 38 22 pm](https://cloud.githubusercontent.com/assets/7913604/18929248/b9e640d4-8591-11e6-9e5c-1f55b824bff1.png)

- Add VOL modal (before):
    ![screen shot 2016-09-28 at 3 41 28 pm](https://cloud.githubusercontent.com/assets/7913604/18929407/572f7cac-8592-11e6-83b7-9e2a3f88b17a.png)

- Add VOL modal (after):
    ![screen shot 2016-09-28 at 3 38 41 pm](https://cloud.githubusercontent.com/assets/7913604/18929254/c1eb0a26-8591-11e6-9dec-f2edae8ca353.png)
