### PR TITLE
[Feature] ownCloud bug fixes

### DIFF
--- a/website/addons/owncloud/static/owncloudNodeConfig.js
+++ b/website/addons/owncloud/static/owncloudNodeConfig.js
@@ -13,7 +13,7 @@ var language = require('js/osfLanguage').Addons.owncloud;
 var ViewModel = oop.extend(OauthAddonFolderPicker,{
     constructor: function(addonName, url, selector, folderPicker, opts, tbOpts) {
         var self = this;
-        self.super.constructor(addonName, url, selector, folderPicker, tbOpts);
+        self.super.constructor.call(self, addonName, url, selector, folderPicker, tbOpts);
         // Non-Oauth fields:
         self.username = ko.observable('');
         self.password = ko.observable('');

--- a/website/addons/owncloud/static/owncloudUserConfig.js
+++ b/website/addons/owncloud/static/owncloudUserConfig.js
@@ -14,7 +14,7 @@ var ViewModel = oop.extend(OAuthAddonSettingsViewModel,{
         var self = this;
         self.super.constructor.call(self, 'owncloud', 'ownCloud');
 
-        const otherString = 'Other (Please Specify)';
+        var otherString = 'Other (Please Specify)';
 
         self.url = url;
         self.username = ko.observable();

--- a/website/addons/owncloud/static/owncloudUserConfig.js
+++ b/website/addons/owncloud/static/owncloudUserConfig.js
@@ -12,7 +12,7 @@ var $modal = $('#ownCloudCredentialsModal');
 var ViewModel = oop.extend(OAuthAddonSettingsViewModel,{
     constructor: function(url){
         var self = this;
-        self.super.constructor('owncloud','ownCloud');
+        self.super.constructor.call(self, 'owncloud', 'ownCloud');
 
         const otherString = 'Other (Please Specify)';
 

--- a/website/addons/owncloud/views.py
+++ b/website/addons/owncloud/views.py
@@ -54,7 +54,7 @@ def owncloud_add_user_account(auth, **kwargs):
     # Ensure that ownCloud uses https
     host_url = request.json.get('host')
     host = furl()
-    host.host = host_url.rstrip('/').strip('https://').strip('http://')
+    host.host = host_url.rstrip('/').replace('https://', '').replace('http://', '')
     host.scheme = 'https'
 
     username = request.json.get('username')

--- a/website/addons/s3/static/s3NodeConfig.js
+++ b/website/addons/s3/static/s3NodeConfig.js
@@ -17,7 +17,7 @@ var s3FolderPickerViewModel = oop.extend(OauthAddonFolderPicker, {
 
     constructor: function(addonName, url, selector, folderPicker, opts, tbOpts) {
         var self = this;
-        self.super.constructor(addonName, url, selector, folderPicker, tbOpts);
+        self.super.constructor.call(self, addonName, url, selector, folderPicker, tbOpts);
         // Non-OAuth fields
         self.accessKey = ko.observable('');
         self.secretKey = ko.observable('');


### PR DESCRIPTION
## Purpose
Fix minor bugs discovered with ownCloud addon

## Changes
* Safari objected to the use of `const`, use `var` instead
* Fix scoping issues when calling `super` functions
* `strip` removes any character, not matching substrings. Prefer `replace`. (Consider `re.match`?)

## Side effects
None expected