### PR TITLE
Anonymous links should not provide comment information [OSF-7062]

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -359,12 +359,13 @@ class AnonymizedRegexField(AuthorizedCharField):
     def get_attribute(self, obj):
         value = super(AnonymizedRegexField, self).get_attribute(obj)
 
-        user = self.context['request'].user
-        auth = auth_core.Auth(user)
-        if 'view_only' in self.context['request'].query_params:
-            auth.private_key = self.context['request'].query_params['view_only']
-            if has_anonymous_link(obj.node, auth):
-                value = re.sub(self.regex, self.replace, value)
+        if value:
+            user = self.context['request'].user
+            auth = auth_core.Auth(user)
+            if 'view_only' in self.context['request'].query_params:
+                auth.private_key = self.context['request'].query_params['view_only']
+                if has_anonymous_link(obj.node, auth):
+                    value = re.sub(self.regex, self.replace, value)
 
         return value
 

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -334,6 +334,8 @@ class AuthorizedCharField(ser.CharField):
     def get_attribute(self, obj):
         user = self.context['request'].user
         auth = auth_core.Auth(user)
+        if 'view_only' in self.context['request'].query_params:
+            auth.private_key = self.context['request'].query_params['view_only']
         field_source_method = getattr(obj, self.source)
         return field_source_method(auth=auth)
 

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -327,8 +327,7 @@ class AuthorizedCharField(ser.CharField):
         content = AuthorizedCharField(source='get_content')
     """
 
-    def __init__(self, source=None, **kwargs):
-        assert source is not None, 'The `source` argument is required.'
+    def __init__(self, source, **kwargs):
         self.source = source
         super(AuthorizedCharField, self).__init__(source=self.source, **kwargs)
 
@@ -347,12 +346,9 @@ class AnonymizedRegexField(AuthorizedCharField):
         content = AnonymizedRegexField(source='get_content', regex='\[@[^\]]*\]\([^\) ]*\)', replace='@A User')
     """
 
-    def __init__(self, source=None, regex=None, replace=None, **kwargs):
-        assert source is not None, 'The `source` argument is required.'
+    def __init__(self, source, regex, replace, **kwargs):
         self.source = source
-        assert regex is not None, 'The `regex` argument is required.'
         self.regex = regex
-        assert replace is not None, 'The `replace` argument is required.'
         self.replace = replace
         super(AnonymizedRegexField, self).__init__(source=self.source, **kwargs)
 

--- a/api/comments/permissions.py
+++ b/api/comments/permissions.py
@@ -4,7 +4,7 @@ from rest_framework import permissions
 from api.base.utils import get_user_auth
 from api.comments.serializers import CommentReport
 from website.models import Node, Comment
-
+from website.project.model import has_anonymous_link
 
 class CanCommentOrPublic(permissions.BasePermission):
 
@@ -16,6 +16,8 @@ class CanCommentOrPublic(permissions.BasePermission):
         elif isinstance(obj, Node):
             node = obj
 
+        if has_anonymous_link(node, auth):
+            return False
         if request.method in permissions.SAFE_METHODS:
             return node.is_public or node.can_view(auth)
         else:
@@ -29,6 +31,8 @@ class CommentDetailPermissions(permissions.BasePermission):
         auth = get_user_auth(request)
         comment = obj
         node = obj.node
+        if has_anonymous_link(node, auth):
+            return False
         if request.method in permissions.SAFE_METHODS:
             return node.is_public or node.can_view(auth)
         else:

--- a/api/comments/permissions.py
+++ b/api/comments/permissions.py
@@ -4,7 +4,6 @@ from rest_framework import permissions
 from api.base.utils import get_user_auth
 from api.comments.serializers import CommentReport
 from website.models import Node, Comment
-from website.project.model import has_anonymous_link
 
 class CanCommentOrPublic(permissions.BasePermission):
 
@@ -16,8 +15,6 @@ class CanCommentOrPublic(permissions.BasePermission):
         elif isinstance(obj, Node):
             node = obj
 
-        if has_anonymous_link(node, auth):
-            return False
         if request.method in permissions.SAFE_METHODS:
             return node.is_public or node.can_view(auth)
         else:
@@ -31,8 +28,7 @@ class CommentDetailPermissions(permissions.BasePermission):
         auth = get_user_auth(request)
         comment = obj
         node = obj.node
-        if has_anonymous_link(node, auth):
-            return False
+
         if request.method in permissions.SAFE_METHODS:
             return node.is_public or node.can_view(auth)
         else:

--- a/api/comments/serializers.py
+++ b/api/comments/serializers.py
@@ -16,7 +16,7 @@ from api.base.serializers import (JSONAPISerializer,
                                   TargetField,
                                   RelationshipField,
                                   IDField, TypeField, LinksField,
-                                  AuthorizedCharField)
+                                  AnonymizedRegexField)
 from website.project.spam.model import SpamStatus
 
 
@@ -39,7 +39,7 @@ class CommentSerializer(JSONAPISerializer):
 
     id = IDField(source='_id', read_only=True)
     type = TypeField()
-    content = AuthorizedCharField(source='get_content', required=True)
+    content = AnonymizedRegexField(source='get_content', regex='\[@[^\]]*\]\([^\) ]*\)', replace='@A User', required=True)
     page = ser.CharField(read_only=True)
 
     target = TargetField(link_type='related', meta={'type': 'get_target_type'})

--- a/api_tests/comments/views/test_comment_detail.py
+++ b/api_tests/comments/views/test_comment_detail.py
@@ -79,14 +79,27 @@ class CommentDetailMixin(object):
         assert_equal(self.comment._id, res.json['data']['id'])
         assert_equal(self.comment.content, res.json['data']['attributes']['content'])
 
-    def test_private_node_user_with_anonymous_link_cannot_see_comment(self):
+    def test_private_node_user_with_anonymous_link_cannot_see_commenter_info(self):
         self._set_up_private_project_with_comment()
         private_link = PrivateLinkFactory(anonymous=True)
         private_link.nodes.append(self.private_project)
         private_link.save()
-        res = self.app.get('/{}comments/{}/'.format(API_BASE, self.comment._id), {'view_only': private_link.key}, expect_errors=True)
-        assert_equal(res.status_code, 403)
-        assert_equal(res.json['errors'][0]['detail'], 'You do not have permission to perform this action.')
+        res = self.app.get('/{}comments/{}/'.format(API_BASE, self.comment._id), {'view_only': private_link.key})
+        assert_equal(res.status_code, 200)
+        assert_equal(self.comment._id, res.json['data']['id'])
+        assert_equal(self.comment.content, res.json['data']['attributes']['content'])
+        assert_not_in('user', res.json['data']['relationships'])
+
+    def test_private_node_user_with_anonymous_link_cannot_see_mention_info(self):
+        self._set_up_private_project_with_comment()
+        self.payload['data']['attributes']['content'] = 'test with [@username](userlink) and @mention'
+        private_link = PrivateLinkFactory(anonymous=True)
+        private_link.nodes.append(self.private_project)
+        private_link.save()
+        res = self.app.get('/{}comments/{}/'.format(API_BASE, self.comment._id), {'view_only': private_link.key})
+        assert_equal(res.status_code, 200)
+        assert_equal(self.comment._id, res.json['data']['id'])
+        assert_equal( 'test with @A User and @mention', res.json['data']['attributes']['content'])
 
     def test_public_node_logged_in_contributor_can_view_comment(self):
         self._set_up_public_project_with_comment()
@@ -361,6 +374,19 @@ class CommentDetailMixin(object):
         private_link.save()
 
         res = self.app.get('/{}comments/{}/'.format(API_BASE, self.comment._id), {'view_only': private_link.key}, expect_errors=True)
+        assert_equal(res.status_code, 200)
+        assert_is_none(res.json['data']['attributes']['content'])
+
+    def test_private_node_anonymous_view_only_link_user_cannot_see_deleted_comment(self):
+        self._set_up_private_project_with_comment()
+        self.comment.is_deleted = True
+        self.comment.save()
+
+        anonymous_link = PrivateLinkFactory(anonymous=True)
+        anonymous_link.nodes.append(self.private_project)
+        anonymous_link.save()
+
+        res = self.app.get('/{}comments/{}/'.format(API_BASE, self.comment._id), {'view_only': anonymous_link.key}, expect_errors=True)
         assert_equal(res.status_code, 200)
         assert_is_none(res.json['data']['attributes']['content'])
 

--- a/api_tests/comments/views/test_comment_detail.py
+++ b/api_tests/comments/views/test_comment_detail.py
@@ -92,7 +92,8 @@ class CommentDetailMixin(object):
 
     def test_private_node_user_with_anonymous_link_cannot_see_mention_info(self):
         self._set_up_private_project_with_comment()
-        self.payload['data']['attributes']['content'] = 'test with [@username](userlink) and @mention'
+        self.comment.content = 'test with [@username](userlink) and @mention'
+        self.comment.save()
         private_link = PrivateLinkFactory(anonymous=True)
         private_link.nodes.append(self.private_project)
         private_link.save()

--- a/website/addons/wiki/templates/edit.mako
+++ b/website/addons/wiki/templates/edit.mako
@@ -8,7 +8,7 @@
 ## Use full page width
 <%def name="container_class()">container-xxl</%def>
 
-% if (user['can_comment'] or node['has_comments']):
+% if (user['can_comment'] or node['has_comments']) and not node['anonymous']:
     <%include file="include/comment_pane_template.mako"/>
 % endif
 

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -282,7 +282,11 @@ class Comment(GuidStoredObject, SpamMixin, Commentable):
                                 or (auth and not auth.user.is_anonymous() and self.user._id != auth.user._id)):
             return None
 
-        return self.content
+        content = self.content
+        if has_anonymous_link(self.node, auth):
+            content = re.sub('\[@[^\]]*\]\([^\) ]*\)', '@A User', content)
+
+        return content
 
     def get_comment_page_title(self):
         if self.page == Comment.FILES:

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -282,11 +282,7 @@ class Comment(GuidStoredObject, SpamMixin, Commentable):
                                 or (auth and not auth.user.is_anonymous() and self.user._id != auth.user._id)):
             return None
 
-        content = self.content
-        if has_anonymous_link(self.node, auth):
-            content = re.sub('\[@[^\]]*\]\([^\) ]*\)', '@A User', content)
-
-        return content
+        return self.content
 
     def get_comment_page_title(self):
         if self.page == Comment.FILES:

--- a/website/static/js/comment.js
+++ b/website/static/js/comment.js
@@ -408,14 +408,7 @@ var CommentModel = function(data, $parent, $root) {
         return !self.isDeleted() && self.isAbuse();
     });
 
-    if (window.contextVars.node.anonymous) {
-        self.author = {
-            'id': null,
-            'urls': {'profile': ''},
-            'fullname': 'A User',
-            'gravatarUrl': ''
-        };
-    } else if ('embeds' in data && 'user' in data.embeds && 'data' in data.embeds.user) {
+    if ('embeds' in data && 'user' in data.embeds && 'data' in data.embeds.user) {
         var userData = data.embeds.user.data;
         self.author = {
             'id': userData.id,

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -234,7 +234,7 @@
 
 <%include file="project/modal_add_pointer.mako"/>
 
-% if user['can_comment'] or node['has_comments']:
+% if (user['can_comment'] or node['has_comments']) and not node['anonymous']:
     <%include file="include/comment_pane_template.mako"/>
 % endif
 
@@ -254,7 +254,7 @@
     <div class="col-xs-12">
         <div class="pp-notice pp-warning m-b-md p-md clearfix">
             This project used to represent a preprint, but the primary preprint file has been moved or deleted. <a href="/preprints/submit/" class="btn btn-default btn-sm m-r-xs pull-right">Create a new preprint</a>
-        </div> 
+        </div>
     </div>
 </div>
 % endif

--- a/website/templates/project/project_header.mako
+++ b/website/templates/project/project_header.mako
@@ -30,7 +30,7 @@
 
                     % endif
                         <li>
-                            <a href="${node['url']}"  class="project-title"> 
+                            <a href="${node['url']}"  class="project-title">
                                 ${ node['title'] }
                             </a>
                         </li>
@@ -67,7 +67,7 @@
                         % if not node['anonymous']:
                             <li><a href="${node['url']}forks/">Forks</a></li>
                         %endif
-                        
+
                         % if user['is_contributor']:
                             <li><a href="${node['url']}contributors/">Contributors</a></li>
                         % endif
@@ -76,7 +76,7 @@
                             <li><a href="${node['url']}settings/">Settings</a></li>
                         % endif
                     % endif
-                    % if user['can_comment'] or node['has_comments']:
+                    % if (user['can_comment'] or node['has_comments']) and not node['anonymous']:
                         <li id="commentsLink">
                             <a href="" class="visible-xs cp-handle" data-bind="click:removeCount" data-toggle="collapse" data-target="#projectSubnav .navbar-collapse">
                                 Comments
@@ -113,7 +113,7 @@
                 <div class="alert alert-info">
                     <div>This is a pending registration of <a class="link-solid" href="${node['registered_from_url']}">this ${node['node_type']}</a>, awaiting approval from project administrators. This registration will be final when all project administrators approve the registration or 48 hours pass, whichever comes first.</div>
 
-                    % if 'admin' in user['permissions']: 
+                    % if 'admin' in user['permissions']:
                         <div>
                             <br>
                             <button type="button" id="registrationCancelButton" class="btn btn-danger" data-toggle="modal" data-target="#registrationCancel">

--- a/website/templates/project/view_file.mako
+++ b/website/templates/project/view_file.mako
@@ -7,7 +7,7 @@
 
 <%def name="title()">${file_name | h}</%def>
 
-% if (user['can_comment'] or node['has_comments']) and allow_comments:
+% if (user['can_comment'] or node['has_comments']) and allow_comments and not node['anonymous']:
     <%include file="include/comment_pane_template.mako"/>
 % endif
 


### PR DESCRIPTION
## Purpose

Anonymous view-only links are supposed to remove all identifying information for a blind peer review of a private project, but comments have the potential for leaking information about contributors by nature of the discursive nature, including explicit @mentions and other more casual mentions.
## Changes

Comment API returns forbidden error when using an anonymous link.
Comment pane is not shown when using an anonymous link.
Comment API test checks for 403 error when using an anonymous link.
Removed dead code changing comment author to "A User."

Before:
![anonymouswithcomments](https://cloud.githubusercontent.com/assets/1449974/19156908/7556ea24-8bb1-11e6-99d7-4ef8f6546517.png)

After:
![anonymouswithoutcomments](https://cloud.githubusercontent.com/assets/1449974/19156733/e54fe336-8bb0-11e6-8094-fab0a284991a.png)
## Side effects

Comment API will be inaccessible from anonymous links.
## Ticket

https://openscience.atlassian.net/browse/OSF-7062
