### PR TITLE
[feature/django-osf] Fix BCrypt [#CAS-9]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ lxml==3.4.1
 mailchimp==2.0.9
 nameparser==0.3.3
 nose-parameterized==0.5.0
-py-bcrypt==0.4
+bcrypt==3.1.1
 pymongo==2.5.1
 python-dateutil==2.5.0
 python-gnupg==0.3.6


### PR DESCRIPTION
### Purpose

@sloria 

Django 1.9 no longer support `py-bcrypt==0.4`:

```python
    ...
    
    File "/Users/longzechen/.virtualenvs/osf-postgres/lib/python2.7/site-packages/django/contrib/auth/hashers.py", line 289, in salt
        return bcrypt.gensalt(rounds=self.rounds)
    TypeError: gensalt() got an unexpected keyword argument 'rounds'
```

In addition, `py-bcrypt==0.40` inherits OpenBSD `u_int8_t` vulnerability.


## Changes

Use `bcrypt==3.1.1` (latest version).

## Side effects

No

## Ticket

https://openscience.atlassian.net/browse/CAS-9