### PR TITLE
[feature] Preserve New Lines in Registration Forms [OSF-7019]

### DIFF
--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -908,7 +908,7 @@ var RegistrationEditor = function(urls, editorId, preview) {
 		$elem.append(
 		    $('<span class="col-md-12">').append(
 			$('<p class="breaklines"><small><em>' + $osf.htmlEscape(question.description) + '</em></small></p>'),
-                            $('<span class="well col-xs-12">').append(value)
+                            $('<span class="well breaklines col-xs-12">').append(value)
 		));
             }
 	    return $elem;


### PR DESCRIPTION
#### Purpose
- Preserves line breaks that are entered while filling out a registration form.

#### Changes
- Adds back the `breaklines` class which was added [here](8b567fe564bc5550b47daa596016707bbd728b4c) and then somehow removed around [here](ceea8db61b8693a9ecdb5f5b884797a781c9223e).

#### Screenshots 
- Registration form preview (before):
    ![screen shot 2016-09-29 at 12 23 00 pm](https://cloud.githubusercontent.com/assets/7913604/18962674/ca527b32-863f-11e6-8147-4e4814135812.png)

- Registration form preview (after):
    ![screen shot 2016-09-29 at 12 23 36 pm](https://cloud.githubusercontent.com/assets/7913604/18962682/d2e7450c-863f-11e6-8721-57d3a71f19cd.png)

- Admin review preview (before):
    ![screen shot 2016-09-29 at 12 24 54 pm](https://cloud.githubusercontent.com/assets/7913604/18962696/e3983744-863f-11e6-8fa7-77d7063b8b59.png)

- Admin review preview (after):
    ![screen shot 2016-09-29 at 12 24 08 pm](https://cloud.githubusercontent.com/assets/7913604/18962702/e8be364c-863f-11e6-8dd5-95cc6cb68719.png)
    

#### Side effects
- None expected.

#### Ticket
- [OSF-7019](https://openscience.atlassian.net/browse/OSF-7019)

