### PR TITLE
Implement workaround for recursive scoping bug

### DIFF
--- a/website/addons/owncloud/static/owncloudNodeConfig.js
+++ b/website/addons/owncloud/static/owncloudNodeConfig.js
@@ -13,7 +13,9 @@ var language = require('js/osfLanguage').Addons.owncloud;
 var ViewModel = oop.extend(OauthAddonFolderPicker,{
     constructor: function(addonName, url, selector, folderPicker, opts, tbOpts) {
         var self = this;
-        self.super.constructor.call(self, addonName, url, selector, folderPicker, tbOpts);
+        // TODO: [OSF-7069]
+        self.super.super.constructor.call(self, addonName, url, selector, folderPicker, tbOpts);
+        self.super.construct.call(self, addonName, url, selector, folderPicker, opts, tbOpts);
         // Non-Oauth fields:
         self.username = ko.observable('');
         self.password = ko.observable('');

--- a/website/addons/s3/static/s3NodeConfig.js
+++ b/website/addons/s3/static/s3NodeConfig.js
@@ -17,7 +17,9 @@ var s3FolderPickerViewModel = oop.extend(OauthAddonFolderPicker, {
 
     constructor: function(addonName, url, selector, folderPicker, opts, tbOpts) {
         var self = this;
-        self.super.constructor.call(self, addonName, url, selector, folderPicker, tbOpts);
+        // TODO: [OSF-7069]
+        self.super.super.constructor.call(self, addonName, url, selector, folderPicker, tbOpts);
+        self.super.construct.call(self, addonName, url, selector, folderPicker, opts, tbOpts);
         // Non-OAuth fields
         self.accessKey = ko.observable('');
         self.secretKey = ko.observable('');

--- a/website/static/js/oauthAddonNodeConfig.js
+++ b/website/static/js/oauthAddonNodeConfig.js
@@ -28,6 +28,12 @@ var OauthAddonFolderPickerViewModel = oop.extend(FolderPickerViewModel, {
     constructor: function(addonName, url, selector, folderPicker, opts, tbOpts) {
         var self = this;
         self.super.constructor.call(self, addonName, url, selector, folderPicker);
+        self.construct(addonName, url, selector, folderPicker, opts, tbOpts);
+    },
+    construct: function(addonName, url, selector, folderPicker, opts, tbOpts){
+        // Broken out from `constructor` due to recursive scoping issue with oop super calls
+        // TODO: [OSF-7069]
+        var self = this;
         // externalAccounts
         self.accounts = ko.observableArray();
         self.selectedFolderType = ko.pureComputed(function() {


### PR DESCRIPTION
## Purpose
Workaround for `oop.js` recursion bug

## Changes
* Break the bulk of `constructor` out to `construct` so that the child class can call both `<grandparent>.constructor` and `<parent>.construct`

## Side effects
None expected