### PR TITLE
[feature] Handle Registered and Logged-out User Using Unregistered Claim Link [OSF-6857]

### DIFF
--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -3,7 +3,6 @@
 import httplib as http
 
 from flask import request
-from modularodm import Q
 from modularodm.exceptions import ValidationError, ValidationValueError
 
 from framework import forms, status

--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -671,8 +671,8 @@ def claim_user_form(auth, **kwargs):
     claimer_email = unclaimed_record.get('claimer_email') or unclaimed_record.get('email')
 
     # If there is a registered user with this email, redirect to 're-enter password' page
-    user = User.find_by_email(claimer_email)
-    user_from_email = user[0] if user else None
+    found_by_email = User.find_by_email(claimer_email)
+    user_from_email = found_by_email[0] if found_by_email else None
     if user_from_email and user_from_email.is_registered:
         return redirect(web_url_for('claim_user_registered', uid=uid, pid=pid, token=token))
 


### PR DESCRIPTION
#### Purpose
- In the workflow of adding unregistered contributors and claiming accounts, there is an uncovered condition of a logged-out user using an unregistered contributor claim link after they have created an account with the same email they claimed to be a contributor with. 
- Steps to reproduce:
 - As an admin on a public project, add an unregistered contributor by just their name, not email. 
 - As a logged-out user visiting said public project, click on the unregistered contributor name and enter an email to claim yourself. 
 - Note that two emails are sent: one sent to the project admin who added the unregistered contributor (with a claim link), and one sent to the email of the logged-out user who just claimed themselves.
 - *do not click the claim link yet* 
 - As a logged-out user, sign up for an account, using the same email the logged-out user used to claim themselves earlier.
 - Confirm the newly created account via the account confirmation email.
 - As a _**logged-out**_ user, click the unregistered contributor claim link that was sent to the project admin.
    - Current outcome:
      - The claim link goes to the "set a password" page. (This is incorrect because an account has been created and confirmed with this email and a password has already been set -- attempting to complete the form in this page will error because the user already exists.)
    - Outcome after this PR:
      - The claim link automatically redirects to the create account/login page, where the user can login and then will be redirected to the "verify password" page where after password verification, they will successfully be added as a contributor to the project.

#### Changes
- Adds a redirect to `claim_user_registered` if the "unregistered" email exists as a given registered username in the database.

#### Side effects
- None expected.

#### Ticket
- [OSF-6857](https://openscience.atlassian.net/browse/OSF-6857)

