### PR TITLE
update specified invoke version

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ $ cp api/base/settings/local-dist.py api/base/settings/local.py
 - On MacOSX with [homebrew](http://brew.sh/), there is a script that should automate much of the install process:
 
 ```bash
-$ pip install invoke==0.12.2
+$ pip install invoke==0.13.0
 $ invoke setup
 ```
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

README.md specified an older version of invoke that did not work when installing the OSF locally on a clean install. ReadTheDocs specified a newer version which worked.
## Changes

Update invoke specified version

## Side effects

None

## Ticket

None

