### PR TITLE
Orphan Preprint-Nodes show up when using filter[preprint]=false on /v2/nodes/ [PREP-129]

### DIFF
--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -307,12 +307,12 @@ class NodeList(JSONAPIBaseView, bulk_views.BulkUpdateJSONAPIView, bulk_views.Bul
                 preprints = True if self.request.query_params.get('filter[preprint]') == 'true' else False
                 query = self.get_query_from_request()
                 if preprints:
-                    query = query & Q('preprint_file', 'ne', None) if query else Q('preprint_file', 'ne', None)
                     nodes = Node.find(query)
                     return [node for node in nodes if node.is_preprint]
                 else:
-                    query = query & Q('preprint_file', 'eq', None) if query else Q('preprint_file', 'eq', None)
-                    return Node.find(query)
+                    query.nodes = [node for node in query.nodes if hasattr(node, 'attribute') and node.attribute != 'preprint_file']
+                    nodes = Node.find(query)
+                    return [node for node in nodes if not node.is_preprint]
             query = self.get_query_from_request()
             return Node.find(query)
 

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -308,11 +308,11 @@ class NodeList(JSONAPIBaseView, bulk_views.BulkUpdateJSONAPIView, bulk_views.Bul
                 query = self.get_query_from_request()
                 if preprints:
                     nodes = Node.find(query)
-                    return [node for node in nodes if node.is_preprint]
+                    return (node for node in nodes if node.is_preprint)
                 else:
                     query.nodes = [node for node in query.nodes if hasattr(node, 'attribute') and node.attribute != 'preprint_file']
                     nodes = Node.find(query)
-                    return [node for node in nodes if not node.is_preprint]
+                    return (node for node in nodes if not node.is_preprint)
             query = self.get_query_from_request()
             return Node.find(query)
 

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -303,6 +303,16 @@ class NodeList(JSONAPIBaseView, bulk_views.BulkUpdateJSONAPIView, bulk_views.Bul
                     raise PermissionDenied
             return nodes
         else:
+            if self.request.query_params.get('filter[preprint]'):
+                preprints = True if self.request.query_params.get('filter[preprint]') == 'true' else False
+                query = self.get_query_from_request()
+                if preprints:
+                    query = query & Q('preprint_file', 'ne', None) if query else Q('preprint_file', 'ne', None)
+                    nodes = Node.find(query)
+                    return [node for node in nodes if node.is_preprint]
+                else:
+                    query = query & Q('preprint_file', 'eq', None) if query else Q('preprint_file', 'eq', None)
+                    return Node.find(query)
             query = self.get_query_from_request()
             return Node.find(query)
 


### PR DESCRIPTION
## Purpose
Allow finding all non-preprint nodes (`/v2/nodes?filter[preprint]=false`), which includes orphaned preprints (preprints without a file, so no longer actual preprints). 

## Changes
Change the behavior of filter[preprint] to more accurately find preprints when its value is true, and to include orphaned preprints when its value is false.

## Testing
To test, create some orphan preprints, then check that when the value of the filter is false on the nodes list endpoint (`/v2/nodes?filter[preprint]=false`), it includes those, and that the total number of nodes found with `/v2/nodes?filter[preprint]=false` + `/v2/nodes?filter[preprint]=true` is equal to `/v2/nodes`

## Ticket

https://openscience.atlassian.net/browse/PREP-129