### PR TITLE
[Feature] Fix File Tree Renaming [OSF-6875][OSF-5267]

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1912,7 +1912,7 @@ var FGToolbar = {
                         },
                         id: 'renameInput',
                         helpTextId: 'renameHelpText',
-                        placeholder: "Enter name",
+                        placeholder: 'Enter name',
                     }, ctrl.helpText())
                 ),
                 m('.col-xs-3.tb-buttons-col',

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1842,7 +1842,6 @@ var FGToolbar = {
     controller : function(args) {
         var self = this;
         self.tb = args.treebeard;
-        self.tb.inputValue = m.prop('');
         self.tb.toolbarMode = m.prop(toolbarModes.DEFAULT);
         self.items = args.treebeard.multiselected;
         self.mode = self.tb.toolbarMode;
@@ -1905,15 +1904,13 @@ var FGToolbar = {
                 m('.col-xs-9',
                     m.component(FGInput, {
                         onkeypress: function (event) {
-                            ctrl.tb.inputValue($(event.target).val());
                             if (ctrl.tb.pressedKey === ENTER_KEY) {
                                 _renameEvent.call(ctrl.tb);
                             }
                         },
                         id: 'renameInput',
                         helpTextId: 'renameHelpText',
-                        placeholder: null,
-                        value: ctrl.tb.inputValue()
+                        placeholder: "Enter name",
                     }, ctrl.helpText())
                 ),
                 m('.col-xs-3.tb-buttons-col',
@@ -2115,7 +2112,6 @@ function openParentFolders (item) {
     } else if (tb.multiselected().length > 1) {
         tb.select('#tb-tbody').addClass('unselectable');
     }
-    tb.inputValue(tb.multiselected()[0].data.name);
     m.redraw();
     reapplyTooltips();
 }

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1835,7 +1835,7 @@ var dismissToolbar = function(helpText){
     tb.toolbarMode(toolbarModes.DEFAULT);
     tb.filterText('');
     if(typeof helpText === 'function'){
-        helpText(''); // TODO: dismissToolbar is being called when there is no helpText prop, helpText could be refactored as a growl instead
+        helpText('');
     }
     m.redraw();
 };

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -2098,13 +2098,13 @@ function openParentFolders (item) {
  function _fangornMultiselect (event, row) {
     var tb = this;
     var scrollToItem = false;
-    dismissToolbar.call(tb);
-    filterRowsNotInParent.call(tb, tb.multiselected());
     if (tb.toolbarMode() === 'filter') {
         scrollToItem = true;
         // recursively open parents of the selected item but do not lazyload;
         openParentFolders.call(tb, row);
-    }
+    }    
+    dismissToolbar.call(tb);
+    filterRowsNotInParent.call(tb, tb.multiselected());
 
     if (tb.multiselected().length === 1){
         tb.select('#tb-tbody').removeClass('unselectable');

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1834,7 +1834,9 @@ var dismissToolbar = function(helpText){
     }
     tb.toolbarMode(toolbarModes.DEFAULT);
     tb.filterText('');
-    helpText('');
+    if(typeof helpText === 'function'){
+        helpText(''); // TODO: dismissToolbar is being called when there is no helpText prop, that should be changed
+    }
     m.redraw();
 };
 

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -2098,9 +2098,9 @@ function openParentFolders (item) {
  function _fangornMultiselect (event, row) {
     var tb = this;
     var scrollToItem = false;
+    dismissToolbar.call(tb);
     filterRowsNotInParent.call(tb, tb.multiselected());
     if (tb.toolbarMode() === 'filter') {
-        dismissToolbar.call(tb);
         scrollToItem = true;
         // recursively open parents of the selected item but do not lazyload;
         openParentFolders.call(tb, row);

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1880,7 +1880,7 @@ var FGToolbar = {
                     m.component(FGInput, {
                         onkeypress: function (event) {
                             if (ctrl.tb.pressedKey === ENTER_KEY) {
-                                _createFolder.call(ctrl.tb, event, ctrl.dismissToolbar);
+                                ctrl.createFolder.call(ctrl.tb, event, ctrl.dismissToolbar);
                             }
                         },
                         id: 'createFolderInput',

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -431,11 +431,11 @@ function checkConflicts(tb, item, folder, cb) {
     for(var i = 0; i < folder.children.length; i++) {
         var child = folder.children[i];
         if (child.data.name === item.data.name && child.id !== item.id) {
-            messageArray.push(m('p', 'An item named "' + item.data.name + '" already exists in this location.'));
+            messageArray.push(m('p', 'An item named "' + child.data.name + '" already exists in this location.'));
 
             if (window.contextVars.node.preprintFileId === child.data.path.replace('/', '')) {
                 messageArray = messageArray.concat([
-                    m('p', 'The file "' + item.data.name + '" is the primary file for a preprint, so it should not be replaced.'),
+                    m('p', 'The file "' + child.data.name + '" is the primary file for a preprint, so it should not be replaced.'),
                     m('strong', 'Replacing this file will remove this preprint from circulation.')
                 ]);
             }
@@ -445,7 +445,7 @@ function checkConflicts(tb, item, folder, cb) {
                     m('span.btn.btn-primary', {onclick: cb.bind(tb, 'keep')}, 'Keep Both'),
                     m('span.btn.btn-primary', {onclick: cb.bind(tb, 'replace')},'Replace')
                 ],
-                m('h3.break-word.modal-title', 'Replace "' + item.data.name + '"?')
+                m('h3.break-word.modal-title', 'Replace "' + child.data.name + '"?')
             );
             return;
         }
@@ -459,11 +459,11 @@ function checkConflictsRename(tb, item, name, cb) {
     for(var i = 0; i < parent.children.length; i++) {
         var child = parent.children[i];
         if (child.data.name === name && child.id !== item.id) {
-            messageArray.push(m('p', 'An item named "' + item.data.name + '" already exists in this location.'));
+            messageArray.push(m('p', 'An item named "' + child.data.name + '" already exists in this location.'));
 
             if (window.contextVars.node.preprintFileId === child.data.path.replace('/', '')) {
                 messageArray = messageArray.concat([
-                    m('p', 'The file "' + item.data.name + '" is the primary file for a preprint, so it should not be replaced.'),
+                    m('p', 'The file "' + child.data.name + '" is the primary file for a preprint, so it should not be replaced.'),
                     m('strong', 'Replacing this file will remove this preprint from circulation.')
                 ]);
             }
@@ -473,7 +473,7 @@ function checkConflictsRename(tb, item, name, cb) {
                     m('span.btn.btn-primary', {onclick: cb.bind(tb, 'keep')}, 'Keep Both'),
                     m('span.btn.btn-primary', {onclick: cb.bind(tb, 'replace')},'Replace')
                 ],
-                m('h3.break-word.modal-title', 'Replace "' + item.data.name + '"?')
+                m('h3.break-word.modal-title', 'Replace "' + child.data.name + '"?')
             );
             return;
         }
@@ -1835,7 +1835,7 @@ var dismissToolbar = function(helpText){
     tb.toolbarMode(toolbarModes.DEFAULT);
     tb.filterText('');
     if(typeof helpText === 'function'){
-        helpText(''); // TODO: dismissToolbar is being called when there is no helpText prop, that should be changed
+        helpText(''); // TODO: dismissToolbar is being called when there is no helpText prop, helpText could be refactored as a growl instead
     }
     m.redraw();
 };


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

General fixes for the following file tree widget bugs:

Reported Bugs Fixed
1. OSF-6875 - When renaming files/folders, typing square closing brackets leads to odd behavior
2. OSF-5267 - When renaming files/folders, moving the mouse over a widget removes last entered values

Unreported Bugs Fixed
3. When creating a new folder, pressing the Enter key does not submit
4. When renaming a file/folder to a name that already exists, the help text lists the wrong file name to be replaced (needs to be tested on preprints as well).
5. When renaming a file/folder, clicking on a different file/folder allows you to modify that file/folder name (it should clear the toolbar).
6. When filtering and at least one letter is typed, clicking white space within the file picker removes the filtering but leaves the filter input. Typing then removes the filter input.
7. When creating a folder or renaming a file/folder, pressing escape does not clear the toolbar.
8. When filtering, pressing escape removes the filter toolbar, but still shows filtered results
9. When selecting a filtered item that is outside of the current view (below the visible line), it does not automatically scroll to it.


## Changes
1. Input box for renaming no longer pre-populates with previous name (Bugs 1 and 2)
2. Enter Key now works to submit folder creation (Bug 3)
3. File name overlaps now display the correct file name to be overwritten (Bug 4)
4. Any click on a file tree line or empty space should clear input toolbars (e.g., renaming, folder creation, and filtering; Bugs 5 and 6)
5. Escape key now properly clears input toolbars (Bugs 7 and 8)
6. Scrolling on filtering now works properly (Bug 9)

## Side effects

The current fix for Bugs 1 and 2 (no pre-populated input value for renaming files/folders) is not ideal. An ideal solution would maintain the pre-populating while fixing the bug. It is clear what is causing the bug but not why it is causing it. After discussing this with Nici and Sara, it was decided to go with this functionality and open a new improvement ticket to add back in old functionality.

## Ticket

Two tickets:
https://openscience.atlassian.net/browse/OSF-6875
https://openscience.atlassian.net/browse/OSF-5267

## QA Considerations

Test value accuracy in renaming input:
1. Closing square brackets ]
2. Moving mouse over another folder/file should not change the current input
3. Values in form match the renamed value upon submit
4. No placeholder text should remain in the input box upon opening, submitting and reopening, or closing and opening

Test create folder on Enter:
1. Enter key should submit form
2. Submit button should still submit form normally

Test scrolling of filtering:
1. When the file widget is scrollable (at least 12ish items, depending on screen size), filtering and clicking on a widget that is not visible should scroll to that widget.

Test file name change overwrite text
1. When renaming a file to match another file name, the overwrite text should display the correct file name.
2. This should also be tested for preprints warning message on file overwriting (overwriting will remove the preprint I believe)

Test dismiss toolbar (on filter, folder creation, and renaming):
1. Clicking white space dismisses input toolbar
2. Clicking on a folder/file widget dismisses input toolbar
3. Pressing ESCAPE dismisses input toolbar

