### PR TITLE
[Feature] Make orderFolder maintain previous sorting [OSF-6570]

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "raw-loader": "^0.5.1",
     "share": "0.7.27",
     "style-loader": "^0.8.3",
-    "treebeard": "git://github.com/CenterForOpenScience/treebeard.git#87eb491dbe4adec3802fb5c592579f0b2588cf8b",
+    "treebeard": "git://github.com/CenterForOpenScience/treebeard.git#d2bb8f6f8104fcac040402727f431c26722b269e",
     "typeahead.js": "^0.10.5",
     "url-loader": "^0.5.5",
     "uuid": "^2.0.1",

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1238,14 +1238,9 @@ function _fangornLazyLoadOnLoad (tree, event) {
  * @private
  */
 function orderFolder(tree) {
-    // Checking if this column does in fact have sorting
-    var sortDirection = '';
-    if (this.isSorted[0]) {
-        sortDirection = this.isSorted[0].desc ? 'desc' : 'asc';
-    } else {
-        sortDirection = 'asc';
-    }
-    tree.sortChildren(this, sortDirection, 'text', 0, 1);
+    var sortColumn = this.isSorted[1].asc || this.isSorted[1].desc ? 1 : 0; 
+    var sortDirection = this.isSorted[sortColumn].desc ? 'desc' : 'asc';
+    tree.sortChildren(this, sortDirection, 'text', sortColumn, 1);
     this.redraw();
 }
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->
## Purpose
Previously, orderFolder always re-sorted on the first column (ascending or descending). This PR (and the corresponding treebeard PR) make orderFolder resort based on the users last sort method (defaulting to Alphabetically/Ascending). 


## Changes
sortOrder checks sort column status and sorts based on that.
Update treebeard version

## Side effects
None known.

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->

[#OSF-6570]

## QA Notes
The following I believe trigger the resorting:
1. Initial loading of the page
2. Renaming a file
3. Adding a folder
4. Adding a file

If no sort order is selected, the default is Alphabetical, Ascending.

I have only tested this with Dropbox and OSF Storage. I do not expect there to be addon specific problems for this change.