### PR TITLE
[WIP] Port comment tests for osf_models

### DIFF
--- a/osf_models_tests/test_comment.py
+++ b/osf_models_tests/test_comment.py
@@ -1,11 +1,37 @@
 import pytest
 
-from osf_models.models import Comment
+from modularodm.exceptions import ValidationError
+
+from website import settings
+from website.util import permissions
+from website.project.signals import comment_added, mention_added, contributor_added
+from framework.exceptions import PermissionsError
+from tests.base import capture_signals
+from osf_models.models import Comment, NodeLog, Guid
 from osf_models.modm_compat import Q
-from .factories import CommentFactory, ProjectFactory
+from osf_models.utils.auth import Auth
+from .factories import (
+    CommentFactory,
+    ProjectFactory,
+    NodeFactory,
+    UserFactory,
+    AuthUserFactory
+)
 
 # All tests will require a databse
 pytestmark = pytest.mark.django_db
+
+@pytest.fixture()
+def user():
+    return UserFactory()
+
+@pytest.fixture()
+def node(user):
+    return NodeFactory(creator=user)
+
+@pytest.fixture()
+def auth(user):
+    return Auth(user)
 
 def test_comments_have_longer_guid():
     comment = CommentFactory()
@@ -15,3 +41,327 @@ def test_comments_are_queryable_by_root_target():
     root_target = ProjectFactory()
     comment = CommentFactory(node=root_target)
     assert Comment.find(Q('root_target', 'eq', root_target._id))[0] == comment
+
+
+class TestCommentModel:
+
+    def test_create(self):
+        first_comment = CommentFactory()
+        auth = Auth(user=first_comment.user)
+
+        comment = Comment.create(
+            auth=auth,
+            user=first_comment.user,
+            node=first_comment.node,
+            target=first_comment.target,
+            root_target=first_comment.root_target,
+            page='node',
+            content='This is a comment, and ya cant teach that.'
+        )
+        assert comment.user == first_comment.user
+        assert comment.node == first_comment.node
+        assert comment.target == first_comment.target
+        assert comment.node.logs.count() == 2
+        assert comment.node.logs.latest().action == NodeLog.COMMENT_ADDED
+        assert [] == first_comment.ever_mentioned
+
+    def test_create_comment_content_cannot_exceed_max_length_simple(self, node, user, auth):
+        with pytest.raises(ValidationError):
+            Comment.create(
+                auth=auth,
+                user=user,
+                node=node,
+                target=node.guid,
+                content=''.join(['c' for c in range(settings.COMMENT_MAXLENGTH + 3)])
+            )
+
+    def test_create_comment_content_cannot_exceed_max_length_complex(self, node, user, auth):
+        with pytest.raises(ValidationError):
+            Comment.create(
+                auth=auth,
+                user=user,
+                node=node,
+                target=node.guid,
+                content=''.join(['c' for c in range(settings.COMMENT_MAXLENGTH - 8)]) + '[@George Ant](http://localhost:5000/' + user._id + '/)'
+            )
+
+    def test_create_comment_content_does_not_exceed_max_length_complex(self, node, user, auth):
+        Comment.create(
+            auth=auth,
+            user=user,
+            node=node,
+            target=node.guid,
+            content=''.join(['c' for c in range(settings.COMMENT_MAXLENGTH - 12)]) + '[@George Ant](http://localhost:5000/' + user._id + '/)'
+        )
+
+    def test_create_comment_content_cannot_be_none(self, node, user, auth):
+
+        with pytest.raises(ValidationError) as error:
+            Comment.create(
+                auth=auth,
+                user=user,
+                node=node,
+                target=node.guid,
+                content=None
+            )
+        assert error.value.messages[0] == 'This field cannot be null.'
+
+    def test_create_comment_content_cannot_be_empty(self, node, user, auth):
+        with pytest.raises(ValidationError) as error:
+            Comment.create(
+                auth=auth,
+                user=user,
+                node=node,
+                target=node.guid,
+                content=''
+            )
+        assert error.value.messages[0] == 'This field cannot be blank.'
+
+    def test_create_comment_content_cannot_be_whitespace(self, node, user, auth):
+        with pytest.raises(ValidationError) as error:
+            Comment.create(
+                auth=auth,
+                user=user,
+                node=node,
+                target=node.guid,
+                content='    '
+            )
+        assert error.value.messages[0] == 'Value must not be empty.'
+
+    def test_create_sends_comment_added_signal(self, node, user, auth):
+        with capture_signals() as mock_signals:
+            Comment.create(
+                auth=auth,
+                user=user,
+                node=node,
+                target=node.guid,
+                content='This is a comment.'
+            )
+        assert mock_signals.signals_sent() == ({comment_added})
+
+    def test_create_sends_mention_added_signal_if_mentions(self, node, user, auth):
+        with capture_signals() as mock_signals:
+            Comment.create(
+                auth=auth,
+                user=user,
+                node=node,
+                target=node.guid,
+                content='This is a comment with a bad mention [@Unconfirmed User](http://localhost:5000/' + user._id + '/).'
+            )
+        assert mock_signals.signals_sent() == ({comment_added, mention_added})
+
+    def test_create_does_not_send_mention_added_signal_if_unconfirmed_contributor_mentioned(self, node, user, auth):
+        with pytest.raises(ValidationError) as error:
+            with capture_signals() as mock_signals:
+                user = UserFactory()
+                user.is_registered = False
+                user.is_claimed = False
+                user.save()
+                node.add_contributor(user, visible=False,permissions=[permissions.READ], save=True)
+
+                Comment.create(
+                    auth=auth,
+                    user=user,
+                    node=node,
+                    target=node.guid,
+                    content='This is a comment with a bad mention [@Unconfirmed User](http://localhost:5000/' + user._id + '/).'
+                )
+        assert mock_signals.signals_sent() == ({contributor_added})
+        assert error.value.message == 'User does not exist or is not active.'
+
+    def test_create_does_not_send_mention_added_signal_if_noncontributor_mentioned(self, node, user, auth):
+        with pytest.raises(ValidationError) as error:
+            with capture_signals() as mock_signals:
+                user = UserFactory()
+                Comment.create(
+                    auth=auth,
+                    user=user,
+                    node=node,
+                    target=node.guid,
+                    content='This is a comment with a bad mention [@Non-contributor User](http://localhost:5000/' + user._id + '/).'
+                )
+        assert mock_signals.signals_sent() == set([])
+        assert error.value.message == 'Mentioned user is not a contributor.'
+
+    def test_create_does_not_send_mention_added_signal_if_nonuser_mentioned(self, node, user, auth):
+        with pytest.raises(ValidationError) as error:
+            with capture_signals() as mock_signals:
+                Comment.create(
+                    auth=auth,
+                    user=user,
+                    node=node,
+                    target=node.guid,
+                    content='This is a comment with a bad mention [@Not a User](http://localhost:5000/qwert/).'
+                )
+        assert mock_signals.signals_sent() == set([])
+        assert error.value.message == 'User does not exist or is not active.'
+
+    def test_edit(self):
+        comment = CommentFactory()
+        auth = Auth(comment.user)
+        comment.edit(
+            auth=auth,
+            content='edited',
+            save=True
+        )
+        assert comment.content == 'edited'
+        assert comment.modified
+        assert comment.node.logs.count() == 2
+        assert comment.node.logs.latest().action == NodeLog.COMMENT_UPDATED
+
+    def test_edit_sends_mention_added_signal_if_mentions(self):
+        comment = CommentFactory()
+        auth = Auth(comment.user)
+        with capture_signals() as mock_signals:
+            comment.edit(
+                auth=auth,
+                content='This is a comment with a bad mention [@Mentioned User](http://localhost:5000/' + comment.user._id + '/).',
+                save=True
+            )
+        assert mock_signals.signals_sent() == ({mention_added})
+
+    def test_edit_does_not_send_mention_added_signal_if_nonuser_mentioned(self):
+        comment = CommentFactory()
+        auth = Auth(comment.user)
+        with pytest.raises(ValidationError) as error:
+            with capture_signals() as mock_signals:
+                comment.edit(
+                    auth=auth,
+                    content='This is a comment with a bad mention [@Not a User](http://localhost:5000/qwert/).',
+                    save=True
+                )
+        assert mock_signals.signals_sent() == set([])
+        assert error.value.message == 'User does not exist or is not active.'
+
+    def test_edit_does_not_send_mention_added_signal_if_noncontributor_mentioned(self):
+        comment = CommentFactory()
+        auth = Auth(comment.user)
+        with pytest.raises(ValidationError) as error:
+            with capture_signals() as mock_signals:
+                user = UserFactory()
+                comment.edit(
+                    auth=auth,
+                    content='This is a comment with a bad mention [@Non-contributor User](http://localhost:5000/' + user._id + '/).',
+                    save=True
+                )
+        assert mock_signals.signals_sent() == set([])
+        assert error.value.message == 'Mentioned user is not a contributor.'
+
+    def test_edit_does_not_send_mention_added_signal_if_unconfirmed_contributor_mentioned(self):
+        comment = CommentFactory()
+        auth = Auth(comment.user)
+        with pytest.raises(ValidationError) as error:
+            with capture_signals() as mock_signals:
+                user = UserFactory()
+                user.is_registered = False
+                user.is_claimed = False
+                user.save()
+                comment.node.add_contributor(user, visible=False, permissions=[permissions.READ])
+                comment.node.save()
+
+                comment.edit(
+                    auth=auth,
+                    content='This is a comment with a bad mention [@Unconfirmed User](http://localhost:5000/' + user._id + '/).',
+                    save=True
+                )
+        assert mock_signals.signals_sent() == ({contributor_added})
+        assert error.value.message == 'User does not exist or is not active.'
+
+    def test_edit_does_not_send_mention_added_signal_if_already_mentioned(self):
+        comment = CommentFactory()
+        auth = Auth(comment.user)
+        with capture_signals() as mock_signals:
+            comment.ever_mentioned=[comment.user._id]
+            comment.edit(
+                auth=auth,
+                content='This is a comment with a bad mention [@Already Mentioned User](http://localhost:5000/' + comment.user._id + '/).',
+                save=True
+            )
+        assert mock_signals.signals_sent() == set([])
+
+    def test_delete(self, node):
+        comment = CommentFactory(node=node)
+        auth = Auth(comment.user)
+
+        comment.delete(auth=auth, save=True)
+        assert comment.is_deleted, True
+        assert comment.node.logs.count() == 2
+        assert comment.node.logs.latest().action == NodeLog.COMMENT_REMOVED
+
+    def test_undelete(self):
+        comment = CommentFactory()
+        auth = Auth(comment.user)
+        comment.delete(auth=auth, save=True)
+        comment.undelete(auth=auth, save=True)
+        assert not comment.is_deleted
+        assert comment.node.logs.count() == 3
+        assert comment.node.logs.latest().action == NodeLog.COMMENT_RESTORED
+
+    def test_read_permission_contributor_can_comment(self):
+        project = ProjectFactory()
+        user = UserFactory()
+        project.set_privacy('private')
+        project.add_contributor(user, permissions=[permissions.READ])
+        project.save()
+
+        assert project.can_comment(Auth(user=user))
+
+    def test_get_content_for_not_deleted_comment(self):
+        project = ProjectFactory(is_public=True)
+        comment = CommentFactory(node=project)
+        content = comment.get_content(auth=Auth(comment.user))
+        assert content == comment.content
+
+    def test_get_content_returns_deleted_content_to_commenter(self):
+        comment = CommentFactory(is_deleted=True)
+        content = comment.get_content(auth=Auth(comment.user))
+        assert content == comment.content
+
+    def test_get_content_does_not_return_deleted_content_to_non_commenter(self):
+        user = AuthUserFactory()
+        comment = CommentFactory(is_deleted=True)
+        content = comment.get_content(auth=Auth(user))
+        assert content is None
+
+    def test_get_content_public_project_does_not_return_deleted_content_to_logged_out_user(self):
+        project = ProjectFactory(is_public=True)
+        comment = CommentFactory(node=project, is_deleted=True)
+        content = comment.get_content(auth=None)
+        assert content is None
+
+    def test_get_content_private_project_throws_permissions_error_for_logged_out_users(self):
+        project = ProjectFactory(is_public=False)
+        comment = CommentFactory(node=project, is_deleted=True)
+        with pytest.raises(PermissionsError):
+            comment.get_content(auth=None)
+
+    def test_find_unread_is_zero_when_no_comments(self):
+        n_unread = Comment.find_n_unread(user=UserFactory(), node=ProjectFactory(), page='node')
+        assert n_unread == 0
+
+    def test_find_unread_new_comments(self):
+        project = ProjectFactory()
+        user = UserFactory()
+        project.add_contributor(user, save=True)
+        CommentFactory(node=project, user=project.creator)
+        n_unread = Comment.find_n_unread(user=user, node=project, page='node')
+        assert n_unread == 1
+
+    def test_find_unread_includes_comment_replies(self):
+        project = ProjectFactory()
+        user = UserFactory()
+        project.add_contributor(user, save=True)
+        comment = CommentFactory(node=project, user=user)
+        CommentFactory(node=project, target=Guid.load(comment._id), user=project.creator)
+        n_unread = Comment.find_n_unread(user=user, node=project, page='node')
+        assert n_unread == 1
+
+
+    def test_find_unread_does_not_include_deleted_comments(self):
+        project = ProjectFactory()
+        user = AuthUserFactory()
+        project.add_contributor(user)
+        project.save()
+        CommentFactory(node=project, user=project.creator, is_deleted=True)
+        n_unread = Comment.find_n_unread(user=user, node=project, page='node')
+        assert n_unread == 0

--- a/tests/test_comments.py
+++ b/tests/test_comments.py
@@ -406,30 +406,6 @@ class TestCommentModel(OsfTestCase):
         n_unread = Comment.find_n_unread(user=user, node=project, page='node')
         assert_equal(n_unread, 1)
 
-    # Regression test for https://openscience.atlassian.net/browse/OSF-5193
-    def test_find_unread_includes_edited_comments(self):
-        project = ProjectFactory()
-        user = AuthUserFactory()
-        project.add_contributor(user)
-        project.save()
-        comment = CommentFactory(node=project, user=project.creator)
-
-        url = project.api_url_for('update_comments_timestamp')
-        payload = {'page': 'node', 'rootId': project._id}
-        res = self.app.put_json(url, payload, auth=user.auth)
-        user.reload()
-        n_unread = Comment.find_n_unread(user=user, node=project, page='node')
-        assert_equal(n_unread, 0)
-
-        # Edit previously read comment
-        comment.edit(
-            auth=Auth(project.creator),
-            content='edited',
-            save=True
-        )
-        n_unread = Comment.find_n_unread(user=user, node=project, page='node')
-        assert_equal(n_unread, 1)
-
     def test_find_unread_does_not_include_deleted_comments(self):
         project = ProjectFactory()
         user = AuthUserFactory()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -31,10 +31,12 @@ from tests.base import (
     fake,
     get_default_metaschema,
     OsfTestCase,
+    assert_datetime_equal,
 )
 from tests.factories import MockAddonNodeSettings
 from website import mailchimp_utils
 from website import mails, settings
+from website.addons.osfstorage import settings as osfstorage_settings
 from website.addons.github.tests.factories import GitHubAccountFactory
 from website.models import Node, NodeLog, Pointer
 from website.profile.utils import add_contributor_json, serialize_unregistered
@@ -4362,33 +4364,90 @@ class TestUserConfirmSignal(OsfTestCase):
         assert_equal(mock_signals.signals_sent(), set([auth.signals.user_confirmed]))
 
 
-class TestCommentsViews(OsfTestCase):
+# copied from tests/test_comments.py
+class TestCommentViews(OsfTestCase):
 
-    # Regression test for https://openscience.atlassian.net/browse/OSF-5193
-    # moved from tests/test_comments.py
-    def test_find_unread_includes_edited_comments(self):
-        project = ProjectFactory()
-        user = AuthUserFactory()
-        project.add_contributor(user, save=True)
-        comment = CommentFactory(node=project, user=project.creator)
-        n_unread = Comment.find_n_unread(user=user, node=project, page='node')
-        assert n_unread == 1
+    def setUp(self):
+        super(TestCommentViews, self).setUp()
+        self.project = ProjectFactory(is_public=True)
+        self.user = AuthUserFactory()
+        self.project.add_contributor(self.user)
+        self.project.save()
+        self.user.save()
 
-        url = project.api_url_for('update_comments_timestamp')
-        payload = {'page': 'node', 'rootId': project._id}
-        self.app.put_json(url, payload, auth=user.auth)
-        user.reload()
-        n_unread = Comment.find_n_unread(user=user, node=project, page='node')
-        assert n_unread == 0
+    def test_view_project_comments_updates_user_comments_view_timestamp(self):
+        url = self.project.api_url_for('update_comments_timestamp')
+        res = self.app.put_json(url, {
+            'page': 'node',
+            'rootId': self.project._id
+        }, auth=self.user.auth)
+        self.user.reload()
 
-        # Edit previously read comment
-        comment.edit(
-            auth=Auth(project.creator),
-            content='edited',
-            save=True
-        )
-        n_unread = Comment.find_n_unread(user=user, node=project, page='node')
-        assert n_unread == 1
+        user_timestamp = self.user.comments_viewed_timestamp[self.project._id]
+        view_timestamp = dt.datetime.utcnow()
+        assert_datetime_equal(user_timestamp, view_timestamp)
+
+    def test_confirm_non_contrib_viewers_dont_have_pid_in_comments_view_timestamp(self):
+        non_contributor = AuthUserFactory()
+        url = self.project.api_url_for('update_comments_timestamp')
+        res = self.app.put_json(url, {
+            'page': 'node',
+            'rootId': self.project._id
+        }, auth=self.user.auth)
+
+        non_contributor.reload()
+        assert_not_in(self.project._id, non_contributor.comments_viewed_timestamp)
+
+    @pytest.skip('Unskip when get_addon is implemented for nodes')
+    def test_view_comments_updates_user_comments_view_timestamp_files(self):
+        osfstorage = self.project.get_addon('osfstorage')
+        root_node = osfstorage.get_root()
+        test_file = root_node.append_file('test_file')
+        test_file.create_version(self.user, {
+            'object': '06d80e',
+            'service': 'cloud',
+            osfstorage_settings.WATERBUTLER_RESOURCE: 'osf',
+        }, {
+            'size': 1337,
+            'contentType': 'img/png'
+        }).save()
+
+        url = self.project.api_url_for('update_comments_timestamp')
+        res = self.app.put_json(url, {
+            'page': 'files',
+            'rootId': test_file._id
+        }, auth=self.user.auth)
+        self.user.reload()
+
+        user_timestamp = self.user.comments_viewed_timestamp[test_file._id]
+        view_timestamp = dt.datetime.utcnow()
+        assert_datetime_equal(user_timestamp, view_timestamp)
+
+        # Regression test for https://openscience.atlassian.net/browse/OSF-5193
+        # moved from tests/test_comments.py
+        def test_find_unread_includes_edited_comments(self):
+            project = ProjectFactory()
+            user = AuthUserFactory()
+            project.add_contributor(user, save=True)
+            comment = CommentFactory(node=project, user=project.creator)
+            n_unread = Comment.find_n_unread(user=user, node=project, page='node')
+            assert n_unread == 1
+
+            url = project.api_url_for('update_comments_timestamp')
+            payload = {'page': 'node', 'rootId': project._id}
+            self.app.put_json(url, payload, auth=user.auth)
+            user.reload()
+            n_unread = Comment.find_n_unread(user=user, node=project, page='node')
+            assert n_unread == 0
+
+            # Edit previously read comment
+            comment.edit(
+                auth=Auth(project.creator),
+                content='edited',
+                save=True
+            )
+            n_unread = Comment.find_n_unread(user=user, node=project, page='node')
+            assert n_unread == 1
 
 
 if __name__ == '__main__':

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4384,7 +4384,7 @@ class TestCommentViews(OsfTestCase):
         self.user.reload()
 
         user_timestamp = self.user.comments_viewed_timestamp[self.project._id]
-        view_timestamp = dt.datetime.utcnow()
+        view_timestamp = timezone.now()
         assert_datetime_equal(user_timestamp, view_timestamp)
 
     def test_confirm_non_contrib_viewers_dont_have_pid_in_comments_view_timestamp(self):

--- a/website/app.py
+++ b/website/app.py
@@ -178,6 +178,7 @@ PATCHED_MODELS = (
     'Identifier',
     'Subject',
     'PreprintProvider',
+    'NotificationDigest',
     'StoredFileNode',
 )
 

--- a/website/notifications/emails.py
+++ b/website/notifications/emails.py
@@ -134,9 +134,10 @@ def check_node(node, event):
         subscription = NotificationSubscription.load(utils.to_subscription_key(node._id, event))
         for notification_type in node_subscriptions:
             users = getattr(subscription, notification_type, [])
-            for user in users.all():
-                if node.has_permission(user, 'read'):
-                    node_subscriptions[notification_type].append(user._id)
+            if users:
+                for user in users.all():
+                    if node.has_permission(user, 'read'):
+                        node_subscriptions[notification_type].append(user._id)
     return node_subscriptions
 
 

--- a/website/notifications/emails.py
+++ b/website/notifications/emails.py
@@ -90,7 +90,7 @@ def store_emails(recipient_ids, notification_type, event, user, node, timestamp,
             timestamp=timestamp,
             send_type=notification_type,
             event=event,
-            user_id=user_id,
+            user_id=recipient.id,
             message=message,
             node_lineage=node_lineage_ids
         )

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -184,14 +184,10 @@ class MetaData(GuidStoredObject):
 
 
 def validate_contributor(guid, contributors):
-    user_id = User.load(guid).id
-    user = User.find(
-        Q('_id', 'eq', user_id) &
-        Q('is_claimed', 'eq', True)
-    )
-    if user.count() != 1:
+    user = User.load(guid)
+    if not user or not user.is_claimed:
         raise ValidationValueError('User does not exist or is not active.')
-    elif user[0] not in contributors:
+    elif user not in contributors:
         raise ValidationValueError('Mentioned user is not a contributor.')
     return True
 

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -22,6 +22,7 @@ from modularodm.validators import MaxLengthValidator
 from modularodm.exceptions import KeyExistsException, NoResultsFound, ValidationValueError
 
 from framework import status
+from framework.guid.model import Guid
 from framework.mongo import ObjectId, DummyRequest
 from framework.mongo import StoredObject
 from framework.mongo import validators
@@ -184,8 +185,9 @@ class MetaData(GuidStoredObject):
 
 
 def validate_contributor(guid, contributors):
+    guid_id = Guid.load(guid).id
     user = User.find(
-        Q('_id', 'eq', guid) &
+        Q('_id', 'eq', guid_id) &
         Q('is_claimed', 'eq', True)
     )
     if user.count() != 1:

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -22,7 +22,6 @@ from modularodm.validators import MaxLengthValidator
 from modularodm.exceptions import KeyExistsException, NoResultsFound, ValidationValueError
 
 from framework import status
-from framework.guid.model import Guid
 from framework.mongo import ObjectId, DummyRequest
 from framework.mongo import StoredObject
 from framework.mongo import validators
@@ -185,14 +184,14 @@ class MetaData(GuidStoredObject):
 
 
 def validate_contributor(guid, contributors):
-    guid_id = Guid.load(guid).id
+    user_id = User.load(guid).id
     user = User.find(
-        Q('_id', 'eq', guid_id) &
+        Q('_id', 'eq', user_id) &
         Q('is_claimed', 'eq', True)
     )
     if user.count() != 1:
         raise ValidationValueError('User does not exist or is not active.')
-    elif guid not in contributors:
+    elif user[0] not in contributors:
         raise ValidationValueError('Mentioned user is not a contributor.')
     return True
 


### PR DESCRIPTION
## Purpose
Move model tests from `tests/test_comments.py` into `osf_models_tests/test_comment.py`, and fix a few things along the way

## Changes
- port tests
- move `test_find_unread_includes_edited_comments` into `tests/test_views.py`
- Add `NotificationDigest` to app.py
- Check for users to send to in `emails.py`, as [] does not have `.all()` method
- refactor `validate_contributor` method a bit to get user from GUID and check after the fact

## Side effects
None anticipated


## Ticket
https://github.com/CenterForOpenScience/osf-models/issues/132