### PR TITLE
[Feature] Add extra search terms [OSF-7071]

### DIFF
--- a/tests/test_search/test_elastic.py
+++ b/tests/test_search/test_elastic.py
@@ -391,6 +391,27 @@ class TestPublicNodes(SearchTestCase):
         docs = query('category:component AND ' + self.title)['results']
         assert_equal(len(docs), 0)
 
+    def test_search_node_partial(self):
+        self.project.set_title('Blue Rider-Express', self.consolidate_auth)
+        with run_celery_tasks():
+            self.project.save()
+        find = query('Blue')['results']
+        assert_equal(len(find), 1)      
+
+    def test_search_node_partial_with_sep(self):
+        self.project.set_title('Blue Rider-Express', self.consolidate_auth)
+        with run_celery_tasks():
+            self.project.save()        
+        find = query('Express')['results']
+        assert_equal(len(find), 1)
+
+    def test_search_node_not_name(self):
+        self.project.set_title('Blue Rider-Express', self.consolidate_auth)
+        with run_celery_tasks():
+            self.project.save()        
+        find = query('Green Flyer-Slow')['results']
+        assert_false(len(find), 1)      
+
     def test_public_parent_title(self):
         self.project.set_title('hello &amp; world', self.consolidate_auth)
         with run_celery_tasks():
@@ -854,6 +875,11 @@ class TestSearchFiles(SearchTestCase):
     def test_search_file(self):
         self.root.append_file('Shake.wav')
         find = query_file('Shake.wav')['results']
+        assert_equal(len(find), 1)
+
+    def test_search_file_name_without_separator(self):
+        self.root.append_file('Shake.wav')
+        find = query_file('Shake')['results']
         assert_equal(len(find), 1)
 
     def test_delete_file(self):

--- a/tests/test_search/test_elastic.py
+++ b/tests/test_search/test_elastic.py
@@ -410,7 +410,7 @@ class TestPublicNodes(SearchTestCase):
         with run_celery_tasks():
             self.project.save()        
         find = query('Green Flyer-Slow')['results']
-        assert_false(len(find), 1)      
+        assert_equal(len(find), 0)
 
     def test_public_parent_title(self):
         self.project.set_title('hello &amp; world', self.consolidate_auth)

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -30,7 +30,7 @@ from website.filters import gravatar
 from website.models import User, Node
 from website.project.licenses import serialize_node_license_record
 from website.search import exceptions
-from website.search.util import build_query
+from website.search.util import build_query, clean_splitters 
 from website.util import sanitize
 from website.views import validate_page_num
 
@@ -308,7 +308,6 @@ def serialize_node(node, category):
     except TypeError:
         normalized_title = node.title
     normalized_title = unicodedata.normalize('NFKD', normalized_title).encode('ascii', 'ignore')
-
     elastic_document = {
         'id': node._id,
         'contributors': [
@@ -339,6 +338,8 @@ def serialize_node(node, category):
         'license': serialize_node_license_record(node.license),
         'affiliated_institutions': [inst.name for inst in node.affiliated_institutions],
         'boost': int(not node.is_registration) + 1,  # This is for making registered projects less relevant
+        'extra_search_terms': clean_splitters(node.title),
+
     }
     if not node.is_retracted:
         for wiki in [
@@ -491,7 +492,8 @@ def update_file(file_, index=None, delete=False):
         'node_title': file_.node.title,
         'parent_id': file_.node.parent_node._id if file_.node.parent_node else None,
         'is_registration': file_.node.is_registration,
-        'is_retracted': file_.node.is_retracted
+        'is_retracted': file_.node.is_retracted,
+        'extra_search_terms': clean_splitters(file_.name),
     }
 
     es.index(

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -30,7 +30,7 @@ from website.filters import gravatar
 from website.models import User, Node
 from website.project.licenses import serialize_node_license_record
 from website.search import exceptions
-from website.search.util import build_query, clean_splitters
+from website.search.util import build_query, clean_splitters 
 from website.util import sanitize
 from website.views import validate_page_num
 
@@ -399,7 +399,8 @@ def serialize_contributors(node):
                 'fullname': user.fullname,
                 'url': user.profile_url if user.is_active else None
             } for user in node.visible_contributors
-            if user is not None and user.is_active
+            if user is not None
+            and user.is_active
         ]
     }
 

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -30,7 +30,7 @@ from website.filters import gravatar
 from website.models import User, Node
 from website.project.licenses import serialize_node_license_record
 from website.search import exceptions
-from website.search.util import build_query, clean_splitters 
+from website.search.util import build_query, clean_splitters
 from website.util import sanitize
 from website.views import validate_page_num
 
@@ -339,7 +339,6 @@ def serialize_node(node, category):
         'affiliated_institutions': [inst.name for inst in node.affiliated_institutions],
         'boost': int(not node.is_registration) + 1,  # This is for making registered projects less relevant
         'extra_search_terms': clean_splitters(node.title),
-
     }
     if not node.is_retracted:
         for wiki in [

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -30,7 +30,7 @@ from website.filters import gravatar
 from website.models import User, Node
 from website.project.licenses import serialize_node_license_record
 from website.search import exceptions
-from website.search.util import build_query, clean_splitters 
+from website.search.util import build_query, clean_splitters
 from website.util import sanitize
 from website.views import validate_page_num
 
@@ -399,8 +399,7 @@ def serialize_contributors(node):
                 'fullname': user.fullname,
                 'url': user.profile_url if user.is_active else None
             } for user in node.visible_contributors
-            if user is not None
-            and user.is_active
+            if user is not None and user.is_active
         ]
     }
 

--- a/website/search/util.py
+++ b/website/search/util.py
@@ -67,6 +67,8 @@ def build_query_string(qs):
         }
     }
 
+def clean_splitters(text):
+    return text.replace('_', ' ').replace('-', ' ').replace('.', ' ')
 
 def compute_start(page, size):
     try:

--- a/website/search/util.py
+++ b/website/search/util.py
@@ -68,7 +68,10 @@ def build_query_string(qs):
     }
 
 def clean_splitters(text):
-    return text.replace('_', ' ').replace('-', ' ').replace('.', ' ')
+    new_text = text.replace('_', ' ').replace('-', ' ').replace('.', ' ')
+    if new_text == text:
+        return ''
+    return new_text
 
 def compute_start(page, size):
     try:


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Allow search queries with dashes, periods, and underscores to be searchable. Specifically, files and nodes ares now searchable ignoring - _ and .

Previously the project named Bohemian_Rhapsody would only be found by searching the full name with the underscore. Now  Bohemian_Rhapsody can be found via searching Bohemian or Rhapsody. 

## Changes

Add extra_search_terms elasticdoc and filedoc in elastic_search. extra_search_terms is just a version of the file name or node name with - _ and . replaced with spaces allowing all values to be indexed. If no - _ or . are in the file/node name then no extra search terms are added.

## Side effects

1. This change should only increase the number of search results and not remove any results.
2. It is possible that files and nodes with - _ and . will slightly increase in search ranking due to more matching terms
3. This will increase the size of the elasticsearch index, but the amount is limited by only adding extra search terms for those containing - _ or .
4. Will need to `invoke migrate_search` when deploying.

## Ticket
https://openscience.atlassian.net/browse/OSF-7071

## QA Considerations
1. Files/Nodes containing - _ and . should be tested to ensure they are findable via search
2. This should not affect contributors searching, although it is possible they already handle - for hyphenated names. Testing contributors is probably overkill.
3. Test a file/node can be found both ways: Bohemian_Rhapsody should be found via searching Bohemian_Rhapsody, Bohemian, and Rhapsody. 