### PR TITLE
[feature] Return Affiliated Components in Institution's Node List [OSF-7081]

### DIFF
--- a/api/institutions/views.py
+++ b/api/institutions/views.py
@@ -157,7 +157,6 @@ class InstitutionNodeList(JSONAPIBaseView, ODMFilterMixin, generics.ListAPIView,
         Q('is_deleted', 'ne', True) &
         Q('is_folder', 'ne', True) &
         Q('is_registration', 'eq', False) &
-        Q('parent_node', 'eq', None) &
         Q('is_public', 'eq', True)
     )
 


### PR DESCRIPTION
#### Purpose
- Allows affiliated components to be returned in an institution's node list (`/v2/institutions/<inst-id>/nodes/`), even if their parent node is unaffiliated.

#### Changes
- Removes the `Q('parent_node', 'eq', None)` check in the `InstitutionNodesList` API view.

#### Side effects
- None expected.

#### QA Notes
- This changes the list of nodes affiliated with an institution returned from the API, which by default also changes the list of nodes displayed on an institution's dashboard (projects page). 

#### Ticket
- [OSF-7081](https://openscience.atlassian.net/browse/OSF-7081)

