### PR TITLE
[Feature] Fix file seach result path [OSF-7078]

### DIFF
--- a/tests/test_search/test_elastic.py
+++ b/tests/test_search/test_elastic.py
@@ -920,3 +920,19 @@ class TestSearchFiles(SearchTestCase):
             node.save()
         find = query_file('The Dock of the Bay.mp3')['results']
         assert_equal(len(find), 0)
+
+    def test_file_download_url_guid(self):
+        file_ = self.root.append_file('Timber.mp3')
+        file_guid = file_.get_guid(create=True)
+        file_.save()
+        find = query_file('Timber.mp3')['results']
+        assert_equal(find[0]['guid_url'], '/' + file_guid._id + '/')
+
+
+    def test_file_download_url_no_guid(self):
+        file_ = self.root.append_file('Timber.mp3')
+        deep_url = '/' + file_.node._id + '/files/osfstorage' + file_.path + '/'
+        find = query_file('Timber.mp3')['results']        
+        assert_equal(len(file_.path), 25)
+        assert_equal(find[0]['guid_url'], None)
+        assert_equal(find[0]['deep_url'], deep_url)

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -355,7 +355,7 @@ def update_node(node, index=None, bulk=False, async=False):
 
     from website.files.models.osfstorage import OsfStorageFile
     for file_ in paginated(OsfStorageFile, Q('node', 'eq', node)):
-        update_file(file_, index=index)
+        update_file(file_.wrapped(), index=index)
 
     if node.is_deleted or not node.is_public or node.archiving or (node.is_spammy and settings.SPAM_FLAGGED_REMOVE_FROM_SEARCH):
         delete_doc(node._id, node, index=index)

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -355,7 +355,7 @@ def update_node(node, index=None, bulk=False, async=False):
 
     from website.files.models.osfstorage import OsfStorageFile
     for file_ in paginated(OsfStorageFile, Q('node', 'eq', node)):
-        update_file(file_.wrapped(), index=index)
+        update_file(file_, index=index)
 
     if node.is_deleted or not node.is_public or node.archiving or (node.is_spammy and settings.SPAM_FLAGGED_REMOVE_FROM_SEARCH):
         delete_doc(node._id, node, index=index)


### PR DESCRIPTION
## Purpose
Files without guids in search lead to file not found page. This fixes the broken url.

## Changes

Wraps the file_ object with .wrapper() to properly update the file_.path for OsfStorage files.

## Side effects

None known

## Deployment notes
```
invoke migrate_search
```

## Ticket

https://openscience.atlassian.net/browse/OSF-7078

## QA Considerations
1. Test that files found through search with and without guids lead to the file when clicked.
2. Test that files on OsfStorage and at least one other provider properly redirect.