### PR TITLE
[feature] Check User Permissions When Serializing File Moved Log [OSF-6521]

### DIFF
--- a/api/logs/serializers.py
+++ b/api/logs/serializers.py
@@ -8,6 +8,7 @@ from api.base.serializers import (
     is_anonymized
 )
 from website.project.model import Node
+from website.util import permissions as osf_permissions
 from framework.auth.core import User
 
 
@@ -27,8 +28,15 @@ class NodeLogFileParamsSerializer(RestrictedDictSerializer):
     url = ser.URLField(read_only=True)
     addon = ser.CharField(read_only=True)
     node_url = ser.URLField(read_only=True, source='node.url')
-    node_title = ser.URLField(read_only=True, source='node.title')
+    node_title = ser.SerializerMethodField()
 
+    def get_node_title(self, obj):
+        user = self.context['request'].user
+        node_title = obj['node']['title']
+        node = Node.load(obj['node']['_id'])
+        if node.has_permission(user, osf_permissions.READ):
+            return node_title
+        return 'Private Component'
 
 class NodeLogParamsSerializer(RestrictedDictSerializer):
 


### PR DESCRIPTION
#### Purpose
- Currently, when a file is moved from a private component to a component a user has access to, the title of the private component is exposed in the API via the `/v2/nodes/<node-id>/logs/` endpoint. This PR checks user permissions before serializing the titles of source nodes in a file move log. 

#### Changes
- Adds a serializer method field to determine if this user has permission to see the source node title for a file moved log. 

#### Side effects
- None expected.

#### JSON Responses 
- `/v2/nodes/<node-id>/logs/`
- Before:
 - `params['source']['node_title']` ("Just Me") should not be visible to this contributor:
 - ![screen shot 2016-10-05 at 3 02 51 pm](https://cloud.githubusercontent.com/assets/7913604/19127418/d987ae2a-8b0c-11e6-8be7-1c2cdb29f47a.png)

- After 
 - `params['source']['node_title']` has changed to "Private Component":
 - ![screen shot 2016-10-05 at 3 02 22 pm](https://cloud.githubusercontent.com/assets/7913604/19127444/f83b79dc-8b0c-11e6-8f26-24b9d8dd3ac4.png)

#### Ticket
- [OSF-6521](https://openscience.atlassian.net/browse/OSF-6521)
