### PR TITLE
Update file revisions page to use WB utc timestamp

### DIFF
--- a/website/static/js/filepage/revisions.js
+++ b/website/static/js/filepage/revisions.js
@@ -192,7 +192,7 @@ var FileRevisionsTable = {
         }
         options[revision.versionIdentifier] = revision.version;
 
-        revision.date = new $osf.FormattableDate(revision.modified);
+        revision.date = new $osf.FormattableDate(revision.modified_utc);
         revision.displayDate = revision.date.local !== 'Invalid date' ?
             revision.date.local :
             revision.date;


### PR DESCRIPTION
## Purpose

OwnCloud uses a date format that isn't parseable by `FormattableDate`, meaning that timestamps don't show up on the file revisions page.

## Changes

Update the file revisions page to use the `modified_utc` field  in WB metadata responses.  This field translates the `modified` timestamps (which are returned in the provider's preferred format) to standard ISO8601 representation with a +00:00 offset (UTC).  This field was added to WB in v0.22.0 (released mid-August 2016).

## Side effects

None expected.

## Ticket

No ticket.