### PR TITLE
[feature] Fix Wiki Serializer Relationships [OSF-7074]

### DIFF
--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -27,7 +27,7 @@ from api.files.serializers import FileSerializer
 from api.comments.serializers import NodeCommentSerializer, CommentCreateSerializer
 from api.comments.permissions import CanCommentOrPublic
 from api.users.views import UserMixin
-from api.wikis.serializers import WikiSerializer
+from api.wikis.serializers import NodeWikiSerializer
 from api.base.views import LinkedNodesRelationship, BaseContributorDetail, BaseContributorList, BaseNodeLinksDetail, BaseNodeLinksList, BaseLinkedList
 from api.base.throttling import (
     UserRateThrottle,
@@ -2873,7 +2873,7 @@ class NodeWikiList(JSONAPIBaseView, generics.ListAPIView, NodeMixin, ODMFilterMi
 
     required_read_scopes = [CoreScopes.WIKI_BASE_READ]
     required_write_scopes = [CoreScopes.NULL]
-    serializer_class = WikiSerializer
+    serializer_class = NodeWikiSerializer
 
     view_category = 'nodes'
     view_name = 'node-wikis'

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -17,7 +17,7 @@ from api.nodes.serializers import NodeContributorsSerializer, NodeTagField
 from api.base.serializers import (IDField, RelationshipField, LinksField, HideIfWithdrawal,
                                   FileCommentRelationshipField, NodeFileHyperLinkField, HideIfRegistration,
                                   JSONAPIListField, ShowIfVersion,)
-from api.wikis.serializers import WikiSerializer
+from api.wikis.serializers import NodeWikiSerializer
 
 
 class BaseRegistrationSerializer(NodeSerializer):
@@ -352,19 +352,4 @@ class RegistrationProviderSerializer(NodeProviderSerializer):
         related_view_kwargs={'node_id': '<node_id>', 'path': '<path>', 'provider': '<provider>'},
         kind='folder',
         never_embed=True
-    )
-
-
-class RegistrationWikiSerializer(WikiSerializer):
-
-    node = RelationshipField(
-        related_view='registrations:registration-detail',
-        related_view_kwargs={'node_id': '<node._id>'}
-    )
-
-    comments = RelationshipField(
-        related_view='registrations:registration-comments',
-        related_view_kwargs={'node_id': '<node._id>'},
-        related_meta={'unread': 'get_unread_comments_count'},
-        filter={'target': '<pk>'}
     )

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -16,6 +16,7 @@ from api.nodes.serializers import NodeLinksSerializer, NodeLicenseSerializer
 from api.nodes.serializers import NodeContributorsSerializer, NodeTagField
 from api.base.serializers import (IDField, RelationshipField, LinksField, HideIfWithdrawal,
                                   FileCommentRelationshipField, NodeFileHyperLinkField, HideIfRegistration, JSONAPIListField)
+from api.wikis.serializers import WikiSerializer
 
 
 class BaseRegistrationSerializer(NodeSerializer):
@@ -346,4 +347,19 @@ class RegistrationProviderSerializer(NodeProviderSerializer):
         related_view_kwargs={'node_id': '<node_id>', 'path': '<path>', 'provider': '<provider>'},
         kind='folder',
         never_embed=True
+    )
+
+
+class RegistrationWikiSerializer(WikiSerializer):
+
+    node = RelationshipField(
+        related_view='registrations:registration-detail',
+        related_view_kwargs={'node_id': '<node._id>'}
+    )
+
+    comments = RelationshipField(
+        related_view='registrations:registration-comments',
+        related_view_kwargs={'node_id': '<node._id>'},
+        related_meta={'unread': 'get_unread_comments_count'},
+        filter={'target': '<pk>'}
     )

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -17,7 +17,6 @@ from api.nodes.serializers import NodeContributorsSerializer, NodeTagField
 from api.base.serializers import (IDField, RelationshipField, LinksField, HideIfWithdrawal,
                                   FileCommentRelationshipField, NodeFileHyperLinkField, HideIfRegistration,
                                   JSONAPIListField, ShowIfVersion,)
-from api.wikis.serializers import NodeWikiSerializer
 
 
 class BaseRegistrationSerializer(NodeSerializer):

--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -37,7 +37,11 @@ from api.nodes.views import (
     NodeViewOnlyLinksList, NodeViewOnlyLinkDetail, NodeCitationDetail, NodeCitationStyleDetail
 )
 
-from api.registrations.serializers import RegistrationNodeLinksSerializer, RegistrationFileSerializer
+from api.registrations.serializers import (
+    RegistrationNodeLinksSerializer,
+    RegistrationFileSerializer,
+    RegistrationWikiSerializer,
+)
 
 from api.base.utils import get_object_or_error
 
@@ -860,6 +864,8 @@ class RegistrationWikiList(NodeWikiList, RegistrationMixin):
     """List of wikis for a registration."""
     view_category = 'registrations'
     view_name = 'registration-wikis'
+
+    serializer_class = RegistrationWikiSerializer
 
 
 class RegistrationLinkedNodesList(LinkedNodesList, RegistrationMixin):

--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -40,11 +40,8 @@ from api.nodes.views import (
     NodeViewOnlyLinksList, NodeViewOnlyLinkDetail, NodeCitationDetail, NodeCitationStyleDetail
 )
 
-from api.registrations.serializers import (
-    RegistrationNodeLinksSerializer,
-    RegistrationFileSerializer,
-    RegistrationWikiSerializer,
-)
+from api.registrations.serializers import RegistrationNodeLinksSerializer, RegistrationFileSerializer
+from api.wikis.serializers import RegistrationWikiSerializer
 
 from api.base.utils import get_object_or_error
 

--- a/api/wikis/serializers.py
+++ b/api/wikis/serializers.py
@@ -17,6 +17,14 @@ class WikiSerializer(JSONAPISerializer):
         serializer = NodeWikiSerializer(data, context=self.context)
         return NodeWikiSerializer.to_representation(serializer, data)
 
+    def get_absolute_url(self, obj):
+        return absolute_reverse(
+            view_name='wikis:wiki-detail',
+            kwargs={
+                'version': self.context['request'].parser_context['kwargs']['version']
+            }
+        )
+
 
 class NodeWikiSerializer(JSONAPISerializer):
 

--- a/api/wikis/serializers.py
+++ b/api/wikis/serializers.py
@@ -10,24 +10,6 @@ from framework.auth.core import Auth
 
 class WikiSerializer(JSONAPISerializer):
 
-    def to_representation(self, data, envelope='data'):
-        if data.node.is_registration:
-            serializer = RegistrationWikiSerializer(data, context=self.context)
-            return RegistrationWikiSerializer.to_representation(serializer, data)
-        serializer = NodeWikiSerializer(data, context=self.context)
-        return NodeWikiSerializer.to_representation(serializer, data)
-
-    def get_absolute_url(self, obj):
-        return absolute_reverse(
-            view_name='wikis:wiki-detail',
-            kwargs={
-                'version': self.context['request'].parser_context['kwargs']['version']
-            }
-        )
-
-
-class NodeWikiSerializer(JSONAPISerializer):
-
     filterable_fields = frozenset([
         'name',
         'date_modified'
@@ -48,18 +30,6 @@ class NodeWikiSerializer(JSONAPISerializer):
     user = RelationshipField(
         related_view='users:user-detail',
         related_view_kwargs={'user_id': '<user._id>'}
-    )
-
-    node = RelationshipField(
-        related_view='nodes:node-detail',
-        related_view_kwargs={'node_id': '<node._id>'}
-    )
-
-    comments = RelationshipField(
-        related_view='nodes:node-comments',
-        related_view_kwargs={'node_id': '<node._id>'},
-        related_meta={'unread': 'get_unread_comments_count'},
-        filter={'target': '<pk>'}
     )
 
     # LinksField.to_representation adds link to "self"
@@ -103,7 +73,22 @@ class NodeWikiSerializer(JSONAPISerializer):
         })
 
 
-class RegistrationWikiSerializer(NodeWikiSerializer):
+class NodeWikiSerializer(WikiSerializer):
+
+    node = RelationshipField(
+        related_view='nodes:node-detail',
+        related_view_kwargs={'node_id': '<node._id>'}
+    )
+
+    comments = RelationshipField(
+        related_view='nodes:node-comments',
+        related_view_kwargs={'node_id': '<node._id>'},
+        related_meta={'unread': 'get_unread_comments_count'},
+        filter={'target': '<pk>'}
+    )
+
+
+class RegistrationWikiSerializer(WikiSerializer):
 
     node = RelationshipField(
         related_view='registrations:registration-detail',
@@ -118,8 +103,15 @@ class RegistrationWikiSerializer(NodeWikiSerializer):
     )
 
 
-class WikiDetailSerializer(WikiSerializer):
+class NodeWikiDetailSerializer(NodeWikiSerializer):
     """
-    Overrides Wiki Serializer to make id required.
+    Overrides NodeWikiSerializer to make id required.
+    """
+    id = IDField(source='_id', required=True)
+
+
+class RegistrationWikiDetailSerializer(RegistrationWikiSerializer):
+    """
+    Overrides NodeWikiSerializer to make id required.
     """
     id = IDField(source='_id', required=True)

--- a/api/wikis/views.py
+++ b/api/wikis/views.py
@@ -7,7 +7,11 @@ from api.base.exceptions import Gone
 from api.base.views import JSONAPIBaseView
 from api.base.renderers import PlainTextRenderer
 from api.wikis.permissions import ContributorOrPublic, ExcludeWithdrawals
-from api.wikis.serializers import WikiSerializer, WikiDetailSerializer
+from api.wikis.serializers import (
+    WikiSerializer,
+    NodeWikiDetailSerializer,
+    RegistrationWikiDetailSerializer,
+)
 
 from framework.auth.oauth_scopes import CoreScopes
 from website.addons.wiki.model import NodeWikiPage
@@ -103,9 +107,14 @@ class WikiDetail(JSONAPIBaseView, generics.RetrieveAPIView, WikiMixin):
     required_read_scopes = [CoreScopes.WIKI_BASE_READ]
     required_write_scopes = [CoreScopes.NULL]
 
-    serializer_class = WikiDetailSerializer
+    serializer_class = NodeWikiDetailSerializer
     view_category = 'wikis'
     view_name = 'wiki-detail'
+
+    def get_serializer_class(self):
+        if self.get_wiki().node.is_registration:
+            return RegistrationWikiDetailSerializer
+        return NodeWikiDetailSerializer
 
     # overrides RetrieveAPIView
     def get_object(self):

--- a/api_tests/nodes/views/test_node_wiki_list.py
+++ b/api_tests/nodes/views/test_node_wiki_list.py
@@ -19,6 +19,14 @@ class TestNodeWikiList(ApiWikiTestCase):
         self.private_wiki = self._add_project_wiki_page(self.private_project, self.user)
         self.private_url = '/{}nodes/{}/wikis/'.format(API_BASE, self.private_project._id)
 
+    def _set_up_public_registration_with_wiki_page(self):
+        self._set_up_public_project_with_wiki_page()
+        self.public_registration = RegistrationFactory(project=self.public_project, user=self.user, is_public=True)
+        self.public_registration_wiki_id = self.public_registration.wiki_pages_versions['home'][0]
+        self.public_registration.wiki_pages_current = {'home': self.public_registration_wiki_id}
+        self.public_registration.save()
+        self.public_registration_url = '/{}registrations/{}/wikis/'.format(API_BASE, self.public_registration._id)
+
     def _set_up_registration_with_wiki_page(self):
         self._set_up_private_project_with_wiki_page()
         self.registration = RegistrationFactory(project=self.private_project, user=self.user)
@@ -96,6 +104,38 @@ class TestNodeWikiList(ApiWikiTestCase):
         res = self.app.get(self.registration_url, auth=self.user.auth, expect_errors=True)
         assert_equal(res.status_code, 403)
         assert_equal(res.json['errors'][0]['detail'], 'You do not have permission to perform this action.')
+
+    def test_public_node_wikis_relationship_links(self):
+        self._set_up_public_project_with_wiki_page()
+        res = self.app.get(self.public_url)
+        expected_nodes_relationship_url = '{}nodes/{}/'.format(API_BASE, self.public_project._id)
+        expected_comments_relationship_url = '{}nodes/{}/comments/'.format(API_BASE, self.public_project._id)
+        assert_in(expected_nodes_relationship_url, res.json['data'][0]['relationships']['node']['links']['related']['href'])
+        assert_in(expected_comments_relationship_url, res.json['data'][0]['relationships']['comments']['links']['related']['href'])
+
+    def test_private_node_wikis_relationship_links(self):
+        self._set_up_private_project_with_wiki_page()
+        res = self.app.get(self.private_url, auth=self.user.auth)
+        expected_nodes_relationship_url = '{}nodes/{}/'.format(API_BASE, self.private_project._id)
+        expected_comments_relationship_url = '{}nodes/{}/comments/'.format(API_BASE, self.private_project._id)
+        assert_in(expected_nodes_relationship_url, res.json['data'][0]['relationships']['node']['links']['related']['href'])
+        assert_in(expected_comments_relationship_url, res.json['data'][0]['relationships']['comments']['links']['related']['href'])
+
+    def test_public_registration_wikis_relationship_links(self):
+        self._set_up_public_registration_with_wiki_page()
+        res = self.app.get(self.public_registration_url)
+        expected_nodes_relationship_url = '{}registrations/{}/'.format(API_BASE, self.public_registration._id)
+        expected_comments_relationship_url = '{}registrations/{}/comments/'.format(API_BASE, self.public_registration._id)
+        assert_in(expected_nodes_relationship_url, res.json['data'][0]['relationships']['node']['links']['related']['href'])
+        assert_in(expected_comments_relationship_url, res.json['data'][0]['relationships']['comments']['links']['related']['href'])
+
+    def test_private_registration_wikis_relationship_links(self):
+        self._set_up_registration_with_wiki_page()
+        res = self.app.get(self.registration_url, auth=self.user.auth)
+        expected_nodes_relationship_url = '{}registrations/{}/'.format(API_BASE, self.registration._id)
+        expected_comments_relationship_url = '{}registrations/{}/comments/'.format(API_BASE, self.registration._id)
+        assert_in(expected_nodes_relationship_url, res.json['data'][0]['relationships']['node']['links']['related']['href'])
+        assert_in(expected_comments_relationship_url, res.json['data'][0]['relationships']['comments']['links']['related']['href'])
 
 
 class TestFilterNodeWikiList(ApiTestCase):

--- a/api_tests/nodes/views/test_node_wiki_list.py
+++ b/api_tests/nodes/views/test_node_wiki_list.py
@@ -137,6 +137,30 @@ class TestNodeWikiList(ApiWikiTestCase):
         assert_in(expected_nodes_relationship_url, res.json['data'][0]['relationships']['node']['links']['related']['href'])
         assert_in(expected_comments_relationship_url, res.json['data'][0]['relationships']['comments']['links']['related']['href'])
 
+    def test_registration_wikis_not_returned_from_nodes_endpoint(self):
+        self._set_up_public_project_with_wiki_page()
+        self._set_up_public_registration_with_wiki_page()
+        res = self.app.get(self.public_url)
+        node_relationships = [
+            node_wiki['relationships']['node']['links']['related']['href']
+            for node_wiki in res.json['data']
+        ]
+        assert_equal(res.status_code, 200)
+        assert_equal(len(node_relationships), 1)
+        assert_in(self.public_project._id, node_relationships[0])
+
+    def test_node_wikis_not_returned_from_registrations_endpoint(self):
+        self._set_up_public_project_with_wiki_page()
+        self._set_up_public_registration_with_wiki_page()
+        res = self.app.get(self.public_registration_url)
+        node_relationships = [
+            node_wiki['relationships']['node']['links']['related']['href']
+            for node_wiki in res.json['data']
+            ]
+        assert_equal(res.status_code, 200)
+        assert_equal(len(node_relationships), 1)
+        assert_in(self.public_registration._id, node_relationships[0])
+
 
 class TestFilterNodeWikiList(ApiTestCase):
 

--- a/api_tests/wikis/views/test_wiki_detail.py
+++ b/api_tests/wikis/views/test_wiki_detail.py
@@ -218,3 +218,35 @@ class TestWikiDetailView(ApiWikiTestCase):
         url = '/{}wikis/{}/'.format(API_BASE, old_version._id)
         res = self.app.get(url, expect_errors=True)
         assert_equal(res.status_code, 404)
+
+    def test_public_node_wiki_relationship_links(self):
+        self._set_up_public_project_with_wiki_page()
+        res = self.app.get(self.public_url)
+        expected_nodes_relationship_url = '{}nodes/{}/'.format(API_BASE, self.public_project._id)
+        expected_comments_relationship_url = '{}nodes/{}/comments/'.format(API_BASE, self.public_project._id)
+        assert_in(expected_nodes_relationship_url, res.json['data']['relationships']['node']['links']['related']['href'])
+        assert_in(expected_comments_relationship_url, res.json['data']['relationships']['comments']['links']['related']['href'])
+
+    def test_private_node_wiki_relationship_links(self):
+        self._set_up_private_project_with_wiki_page()
+        res = self.app.get(self.private_url, auth=self.user.auth)
+        expected_nodes_relationship_url = '{}nodes/{}/'.format(API_BASE, self.private_project._id)
+        expected_comments_relationship_url = '{}nodes/{}/comments/'.format(API_BASE, self.private_project._id)
+        assert_in(expected_nodes_relationship_url, res.json['data']['relationships']['node']['links']['related']['href'])
+        assert_in(expected_comments_relationship_url, res.json['data']['relationships']['comments']['links']['related']['href'])
+
+    def test_public_registration_wiki_relationship_links(self):
+        self._set_up_public_registration_with_wiki_page()
+        res = self.app.get(self.public_registration_url)
+        expected_nodes_relationship_url = '{}registrations/{}/'.format(API_BASE, self.public_registration._id)
+        expected_comments_relationship_url = '{}registrations/{}/comments/'.format(API_BASE, self.public_registration._id)
+        assert_in(expected_nodes_relationship_url, res.json['data']['relationships']['node']['links']['related']['href'])
+        assert_in(expected_comments_relationship_url, res.json['data']['relationships']['comments']['links']['related']['href'])
+
+    def test_private_registration_wiki_relationship_links(self):
+        self._set_up_private_registration_with_wiki_page()
+        res = self.app.get(self.private_registration_url, auth=self.user.auth)
+        expected_nodes_relationship_url = '{}registrations/{}/'.format(API_BASE, self.private_registration._id)
+        expected_comments_relationship_url = '{}registrations/{}/comments/'.format(API_BASE, self.private_registration._id)
+        assert_in(expected_nodes_relationship_url, res.json['data']['relationships']['node']['links']['related']['href'])
+        assert_in(expected_comments_relationship_url, res.json['data']['relationships']['comments']['links']['related']['href'])


### PR DESCRIPTION
#### Purpose
- Fixes the `node` and `comment` relationship links for registration wikis. 

#### Changes
- Separated current wiki serializers into a base `WikiSerializer`, `NodeWikiSerializer`, and `RegistrationWikiSerializer`.

#### Example JSON Reponses
- BEFORE `/v2/wikis/<wiki_id>/` (of a registration wiki)
![screen shot 2016-10-11 at 3 53 09 pm](https://cloud.githubusercontent.com/assets/7913604/19286222/e011b746-8fca-11e6-8847-b61a6df370af.png)

- AFTER `/v2/wikis/<wiki_id>/` (of a registration wiki)
![screen shot 2016-10-11 at 3 51 17 pm](https://cloud.githubusercontent.com/assets/7913604/19286149/965d480e-8fca-11e6-8759-a6a58f5d3d8c.png)

- BEFORE `/v2/registrations/<node_id>/wiki/`
![screen shot 2016-10-11 at 3 53 17 pm](https://cloud.githubusercontent.com/assets/7913604/19286220/dd2612e8-8fca-11e6-865c-71c7f85ac868.png)

- AFTER `/v2/registrations/<node_id>/wiki/`
![screen shot 2016-10-11 at 3 52 19 pm](https://cloud.githubusercontent.com/assets/7913604/19286188/b9b42ac0-8fca-11e6-99e8-69ba27dc8d06.png)


#### Side effects
- None expected.

#### Ticket
- [OSF-7074](https://openscience.atlassian.net/browse/OSF-7074)
