### PR TITLE
[HotFix] User Unclaimed Record Key Error `expires` [#OSF-7088]

### DIFF
--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -720,7 +720,9 @@ class User(GuidStoredObject, AddonModelMixin):
             record = self.get_unclaimed_record(project_id)
         except ValueError:  # No unclaimed record for given pid
             return False
-        return record['token'] == token and record['expires'] > dt.datetime.utcnow()
+        expires = record.get('expires')
+        is_expired = (expires > dt.datetime.utcnow()) if expires else True
+        return record['token'] == token and is_expired
 
     def get_claim_url(self, project_id, external=False):
         """


### PR DESCRIPTION
## Purpose

HotFix, please refer to the ticket.

## Changes

If `expires` is not in user's unclaimed record, only check `token`.

## Side effects

No

## Ticket

https://openscience.atlassian.net/browse/OSF-7088

