### PR TITLE
[Feature] Stop file editor from being created twice [OSF-6883]

### DIFF
--- a/website/static/js/filepage/editor.js
+++ b/website/static/js/filepage/editor.js
@@ -46,7 +46,7 @@ var FileEditor = {
                 model.editor.setValue(self.initialText);
             }
             m.endComputation();
-        }
+        };
 
         self.reloadFile = function() {
             self.loaded = false;
@@ -123,7 +123,7 @@ var FileEditor = {
         // Hack to prevent double downloads of files from controllers being called twice
         // Double download is caused by treebeard and fileviewpage both being mounted by mithril        
         if(model.loadedResponse){
-            self.handleResponse(model.loadedResponse)
+            self.handleResponse(model.loadedResponse);
         }else{
             self.reloadFile();
         }

--- a/website/static/js/filepage/editor.js
+++ b/website/static/js/filepage/editor.js
@@ -114,8 +114,14 @@ var FileEditor = {
 
             return clean1 !== clean2;
         };
-
-        self.reloadFile();
+        
+        // Hack to prevent double downloads of files from controllers being called twice
+        // Double download is caused by treebeard and fileviewpage both being mounted by mithril        
+        if(model.firstCall){
+            self.reloadFile();
+        }else{
+            model.firstCall = true;
+        }
 
         return self;
     },


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Add skip logic to prevent fileEditor from downloading the file twice.

## Changes

Checks for already loaded file data before making the call.

## Side effects
Without separating the reloadFile function from the fileEditor, there is still a small window in which the file could be accessed twice. Specifically, if the first ajax request has executed, but not finished, the call will be made again. In my testing I didn't experience this. 

## Ticket

https://openscience.atlassian.net/browse/OSF-6883
[#OSF-6883]

## QA Notes
1. The file editor should work properly (edit, save, and revert)
2. The file should be loaded up only once (see jira ticket for how this is tested, I recommend doing so in Firefox as conditions that cause the bug occur most often there).