### PR TITLE
[Feature] Handle smart quotes in registration withdraw form [OSF-7082]

### DIFF
--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -575,7 +575,7 @@ function humanFileSize(bytes, si) {
 /**
 *  returns a random name from this list to use as a confirmation string
 */
-var _confirmationString = function() {
+var getConfirmationString = function() {
     // TODO: Generate a random string here instead of using pre-set values
     //       per Jeff, use ~10 characters
     var scientists = [
@@ -654,7 +654,7 @@ var confirmDangerousAction = function (options) {
     //       sustained attention and will prevent the user from copy/pasting a
     //       random string.
 
-    var confirmationString = _confirmationString();
+    var confirmationString = getConfirmationString();
 
     // keep the users' callback for re-use; we'll pass ours to bootbox
     var callback = options.callback;
@@ -987,5 +987,6 @@ module.exports = window.$.osf = {
     onScrollToBottom: onScrollToBottom,
     getDomain: getDomain,
     toRelativeUrl: toRelativeUrl,
-    linkifyText: linkifyText
+    linkifyText: linkifyText,
+    getConfirmationString: getConfirmationString
 };

--- a/website/static/js/pages/registration-retraction-page.js
+++ b/website/static/js/pages/registration-retraction-page.js
@@ -8,4 +8,4 @@ var submitUrl = window.contextVars.node.urls.api + 'withdraw/';
 
 var registrationTitle = window.contextVars.node.title;
 
-new RegistrationRetraction.RegistrationRetraction('#registrationRetraction', submitUrl, registrationTitle);
+new RegistrationRetraction.RegistrationRetraction('#registrationRetraction', submitUrl);

--- a/website/static/js/registrationRetraction.js
+++ b/website/static/js/registrationRetraction.js
@@ -18,7 +18,7 @@ var Raven = require('raven-js');
 var RegistrationRetractionViewModel = oop.extend(
     ChangeMessageMixin,
     {
-        constructor: function(submitUrl, registrationTitle) {
+        constructor: function(submitUrl) {
             this.super.constructor.call(this);
 
             ko.validation.registerExtenders();
@@ -26,24 +26,14 @@ var RegistrationRetractionViewModel = oop.extend(
             var self = this;
 
             self.submitUrl = submitUrl;
-            // Strips smart quotes and replaces them with typeable quotes
-            self.registrationTitle = $osf.htmlDecode(registrationTitle).replace(/[\u2018\u2019]/g, '\'').replace(/[\u201C\u201D]/g, '"');
 
-            // Truncate title to around 50 chars
-            var parts = self.registrationTitle.slice(0, 50).split(' ');
-            if (parts.length > 1) {
-                self.truncatedTitle = parts.slice(0, -1).join(' ');
-            }
-            else {
-                self.truncatedTitle = parts[0];
-            }
-
+            self.confirmationString = $osf.getConfirmationString();
             self.justification = ko.observable('').extend({
                 maxLength: 2048
             });
             self.confirmationText = ko.observable().extend({
                 required: true,
-                mustEqual: self.truncatedTitle
+                mustEqual: self.confirmationString
             });
             self.disableSave = ko.observable(false);
             self.valid = ko.computed(function(){
@@ -90,8 +80,8 @@ var RegistrationRetractionViewModel = oop.extend(
         }
 });
 
-var RegistrationRetraction = function(selector, submitUrl, registrationTitle) {
-    this.viewModel = new RegistrationRetractionViewModel(submitUrl, registrationTitle);
+var RegistrationRetraction = function(selector, submitUrl) {
+    this.viewModel = new RegistrationRetractionViewModel(submitUrl);
     $osf.applyBindings(this.viewModel, selector);
 };
 

--- a/website/static/js/registrationRetraction.js
+++ b/website/static/js/registrationRetraction.js
@@ -26,7 +26,8 @@ var RegistrationRetractionViewModel = oop.extend(
             var self = this;
 
             self.submitUrl = submitUrl;
-            self.registrationTitle = $osf.htmlDecode(registrationTitle);
+            // Strips smart quotes and replaces them with typeable quotes
+            self.registrationTitle = $osf.htmlDecode(registrationTitle).replace(/[\u2018\u2019]/g, '\'').replace(/[\u201C\u201D]/g, '"');
             // Truncate title to around 50 chars
             var parts = self.registrationTitle.slice(0, 50).split(' ');
             if (parts.length > 1) {

--- a/website/static/js/registrationRetraction.js
+++ b/website/static/js/registrationRetraction.js
@@ -26,8 +26,7 @@ var RegistrationRetractionViewModel = oop.extend(
             var self = this;
 
             self.submitUrl = submitUrl;
-            // Strips smart quotes and replaces them with typeable quotes
-            self.registrationTitle = $osf.htmlDecode(registrationTitle).replace(/[\u2018\u2019]/g, '\'').replace(/[\u201C\u201D]/g, '"');
+            self.registrationTitle = $osf.htmlDecode(registrationTitle);
             // Truncate title to around 50 chars
             var parts = self.registrationTitle.slice(0, 50).split(' ');
             if (parts.length > 1) {

--- a/website/static/js/registrationRetraction.js
+++ b/website/static/js/registrationRetraction.js
@@ -26,7 +26,9 @@ var RegistrationRetractionViewModel = oop.extend(
             var self = this;
 
             self.submitUrl = submitUrl;
-            self.registrationTitle = $osf.htmlDecode(registrationTitle);
+            // Strips smart quotes and replaces them with typeable quotes
+            self.registrationTitle = $osf.htmlDecode(registrationTitle).replace(/[\u2018\u2019]/g, '\'').replace(/[\u201C\u201D]/g, '"');
+
             // Truncate title to around 50 chars
             var parts = self.registrationTitle.slice(0, 50).split(' ');
             if (parts.length > 1) {

--- a/website/static/js/tests/registrationRetraction.test.js
+++ b/website/static/js/tests/registrationRetraction.test.js
@@ -19,8 +19,7 @@ describe('registrationRetraction', () => {
 
         describe('RegistrationRetractionViewModel', () => {
             var vm;
-            var registrationTitle = 'This is a fake registration';
-            var truncatedTitle = registrationTitle.slice(0, 50).split(' ').slice(0, -1).join(' ');
+            var confirmationString = $osf.getConfirmationString();
             var invalidJustification = faker.lorem.paragraphs(50);
             var invalidConfirmationText = 'abcd';
             var submitUrl = '/project/abcdef/withdraw/';
@@ -52,7 +51,7 @@ describe('registrationRetraction', () => {
 
             var onSubmitSuccessStub;
             beforeEach(() => {
-                vm = new registrationRetraction.ViewModel(submitUrl, registrationTitle);
+                vm = new registrationRetraction.ViewModel(submitUrl);
                 onSubmitSuccessStub = sinon.stub(vm, 'onSubmitSuccess');
             });
 
@@ -66,13 +65,8 @@ describe('registrationRetraction', () => {
             });
 
             it('matching registration title is valid', () => {
-                 vm.confirmationText(truncatedTitle);
+                 vm.confirmationText(confirmationString);
                 assert.isTrue(vm.confirmationText.isValid());
-            });
-
-            it('decodes html entities in project title', () => {
-                var test = new registrationRetraction.ViewModel(submitUrl, 'Carrot &gt;== Cake');
-                assert.equal(test.registrationTitle, 'Carrot >== Cake');
             });
 
             describe('submit', () => {
@@ -96,14 +90,14 @@ describe('registrationRetraction', () => {
                     assert.notCalled(postSpy);
                 });
                 it('calls changeMessage if justification is too long', () => {
-                    vm.confirmationText(registrationTitle);
+                    vm.confirmationText(confirmationString);
                     vm.justification(invalidJustification);
                     vm.submit();
                     assert.calledOnce(changeMessageSpy);
                     assert.notCalled(postSpy);
                 });
                 it('submits successfully with valid confirmation text', (done) => {
-                    vm.confirmationText(truncatedTitle);
+                    vm.confirmationText(confirmationString);
                     vm.submit().always(() => {
                         assert.equal(response.redirectUrl, redirectUrl);
                         assert.called(onSubmitSuccessStub);
@@ -115,11 +109,11 @@ describe('registrationRetraction', () => {
 
                 it('logs error with Raven if submit fails', (done) => {
                     sinon.collection.restore();
-                    vm = new registrationRetraction.ViewModel(invalidSubmitUrl, registrationTitle);
+                    vm = new registrationRetraction.ViewModel(invalidSubmitUrl);
                     var onSubmitErrorSpy = new sinon.spy(vm, 'onSubmitError');
                     var ravenStub = new sinon.stub(Raven, 'captureMessage');
 
-                    vm.confirmationText(truncatedTitle);
+                    vm.confirmationText(confirmationString);
                     vm.submit().always((xhr) => {
                         assert.equal(xhr.status, 500);
                         assert.equal(response.redirectUrl, redirectUrl);

--- a/website/static/js/tests/registrationRetraction.test.js
+++ b/website/static/js/tests/registrationRetraction.test.js
@@ -19,7 +19,6 @@ describe('registrationRetraction', () => {
 
         describe('RegistrationRetractionViewModel', () => {
             var vm;
-            var confirmationString = $osf.getConfirmationString();
             var invalidJustification = faker.lorem.paragraphs(50);
             var invalidConfirmationText = 'abcd';
             var submitUrl = '/project/abcdef/withdraw/';
@@ -65,7 +64,7 @@ describe('registrationRetraction', () => {
             });
 
             it('matching registration title is valid', () => {
-                 vm.confirmationText(confirmationString);
+                vm.confirmationText(vm.confirmationString);
                 assert.isTrue(vm.confirmationText.isValid());
             });
 
@@ -90,14 +89,14 @@ describe('registrationRetraction', () => {
                     assert.notCalled(postSpy);
                 });
                 it('calls changeMessage if justification is too long', () => {
-                    vm.confirmationText(confirmationString);
+                    vm.confirmationText(vm.confirmationString);
                     vm.justification(invalidJustification);
                     vm.submit();
                     assert.calledOnce(changeMessageSpy);
                     assert.notCalled(postSpy);
                 });
                 it('submits successfully with valid confirmation text', (done) => {
-                    vm.confirmationText(confirmationString);
+                    vm.confirmationText(vm.confirmationString);
                     vm.submit().always(() => {
                         assert.equal(response.redirectUrl, redirectUrl);
                         assert.called(onSubmitSuccessStub);
@@ -113,7 +112,7 @@ describe('registrationRetraction', () => {
                     var onSubmitErrorSpy = new sinon.spy(vm, 'onSubmitError');
                     var ravenStub = new sinon.stub(Raven, 'captureMessage');
 
-                    vm.confirmationText(confirmationString);
+                    vm.confirmationText(vm.confirmationString);
                     vm.submit().always((xhr) => {
                         assert.equal(xhr.status, 500);
                         assert.equal(response.redirectUrl, redirectUrl);

--- a/website/templates/project/retract_registration.mako
+++ b/website/templates/project/retract_registration.mako
@@ -29,7 +29,7 @@
 
             <div class="form-group">
                 <label style="font-weight:normal" class="control-label">
-                    Type <span data-bind="text: truncatedTitle" style="font-weight:bold"></span> and click Withdraw Registration if you are sure you want to continue.
+                    Type <span data-bind="text: confirmationString" style="font-weight:bold"></span> and click Withdraw Registration if you are sure you want to continue.
                 </label>
                 <input  type="text"
                         class="form-control"


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Project titles with smart quotes currently need to copy/pasted to withdraw a registration as they are not easily typeable.

## Changes
Retooled to match project deletion script. Now requires typing of a scientists name. 

## Side effects

None known.

## Ticket

https://openscience.atlassian.net/browse/OSF-7082


## QA Considerations
1. Test that you can withdraw registrations with the new text.
2. Test that you can delete projects (this change touched a tiny portion of that code).