### PR TITLE
Ensure comment_node exists before trying to access is_registration [OSF-7056][OSF-6994]

### DIFF
--- a/api/comments/views.py
+++ b/api/comments/views.py
@@ -170,6 +170,7 @@ class CommentDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, Comm
     # overrides RetrieveAPIView
     def get_object(self):
         comment = self.get_comment()
+        comment_node = None
 
         if isinstance(comment.target.referent, Node):
             comment_node = comment.target.referent
@@ -177,7 +178,7 @@ class CommentDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, Comm
                                                   StoredFileNode)):
             comment_node = Guid.load(comment.target.referent.node).referent
 
-        if comment_node.is_registration:
+        if comment_node and comment_node.is_registration:
             self.serializer_class = RegistrationCommentDetailSerializer
 
         return comment

--- a/api_tests/comments/views/test_comment_detail.py
+++ b/api_tests/comments/views/test_comment_detail.py
@@ -232,6 +232,27 @@ class CommentDetailMixin(object):
         res = self.app.delete_json_api(self.private_url, auth=self.user.auth)
         assert_equal(res.status_code, 204)
 
+    def test_private_node_only_logged_in_contributor_commenter_can_delete_own_reply(self):
+        self._set_up_private_project_with_comment()
+        reply_target = Guid.load(self.comment._id)
+        reply = CommentFactory(node=self.private_project, target=reply_target, user=self.user)
+        reply_url = '/{}comments/{}/'.format(API_BASE, reply)
+        res = self.app.delete_json_api(reply_url, auth=self.user.auth)
+        assert_equal(res.status_code, 204)        
+
+    def test_private_node_only_logged_in_contributor_commenter_can_undelete_own_reply(self):
+        self._set_up_private_project_with_comment()
+        reply_target = Guid.load(self.comment._id)
+        reply = CommentFactory(node=self.private_project, target=reply_target, user=self.user)
+        reply_url = '/{}comments/{}/'.format(API_BASE, reply)
+        reply.is_deleted = True
+        reply.save()
+        payload = self._set_up_payload(reply._id, has_content=False)
+        res = self.app.patch_json_api(reply_url, payload, auth=self.user.auth)
+        assert_equal(res.status_code, 200)
+        assert_false(res.json['data']['attributes']['deleted'])
+        assert_equal(res.json['data']['attributes']['content'], reply.content)
+
     def test_private_node_contributor_cannot_delete_other_users_comment(self):
         self._set_up_private_project_with_comment()
         res = self.app.delete_json_api(self.private_url, auth=self.contributor.auth, expect_errors=True)


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
comment_node did not always exist before comment_node.is_registration was checked. This error caused comment replies not to be deleted as it failed out.

## Changes
Initialize comment_node to false and make sure comment_node exists.

## Side effects
None known.

## Ticket
https://openscience.atlassian.net/browse/OSF-7056
This might also solve: https://openscience.atlassian.net/browse/OSF-6994
[#OSF-7056]