### PR TITLE
[feature] Fix Password Reset Email Sent After Duplicate Sign-Up [OSF-7060]

### DIFF
--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -769,7 +769,7 @@ class User(GuidStoredObject, AddonModelMixin):
         :rtype: list
         :returns: Changed fields from the user save
         """
-        had_existing_password = bool(self.password)
+        had_existing_password = bool(self.password and self.is_confirmed)
         self.password = generate_password_hash(raw_password)
         if self.username == raw_password:
             raise ChangePasswordError(['Password cannot be the same as your email address'])

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -34,6 +34,7 @@ from website.project.decorators import (
     must_be_contributor_or_public_but_not_anonymized,
     must_have_addon, must_be_addon_authorizer,
 )
+from website.util import api_url_for
 
 from tests.test_cas_authentication import make_external_response, generate_external_user_with_resp
 
@@ -199,6 +200,35 @@ class TestAuthUtils(OsfTestCase):
     def test_validate_recaptcha_empty_response(self, req_post):
         # ensure None short circuits execution (no call to google)
         assert_false(validate_recaptcha(None))
+
+    @mock.patch('framework.auth.views.mails.send_mail')
+    def test_sign_up_twice_sends_two_confirmation_emails_only(self, mock_mail):
+        # Regression test for https://openscience.atlassian.net/browse/OSF-7060
+        url = api_url_for('register_user')
+        sign_up_data = {
+            'fullName': 'Julius Caesar',
+            'email1': 'caesar@romanempire.com',
+            'email2': 'caesar@romanempire.com',
+            'password': 'brutusisajerk'
+        }
+
+        self.app.post_json(url, sign_up_data)
+        assert_equal(len(mock_mail.call_args_list), 1)
+        args, kwargs = mock_mail.call_args
+        assert_equal(args, (
+            'caesar@romanempire.com',
+            mails.INITIAL_CONFIRM_EMAIL,
+            'plain'
+        ))
+
+        self.app.post_json(url, sign_up_data)
+        assert_equal(len(mock_mail.call_args_list), 2)
+        args, kwargs = mock_mail.call_args
+        assert_equal(args, (
+            'caesar@romanempire.com',
+            mails.INITIAL_CONFIRM_EMAIL,
+            'plain'
+        ))
 
 
 class TestAuthObject(OsfTestCase):


### PR DESCRIPTION
#### Purpose
- Currently, if you sign up for an OSF account multiple times without confirming your account after the first sign-up attempt you will receive multiple "confirm account" emails (good), but for each sign-up attempt after the first you will receive a "reset password" email (bad). 
- This PR makes it so that subsequent sign-up attempts will result only in "confirm account" emails, not "reset password" emails. 

#### Changes
- Only sends the "password reset" email if a password change occurs for a **confirmed** user. 

#### Side effects
- Are there any cases where an unconfirmed user should be able to change their password? This change would prevent that.

#### Ticket
- [OSF-7060](https://openscience.atlassian.net/browse/OSF-7060)

