### PR TITLE
[Feature] Allow nodeId if no resource exists [OSF-6319]

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -520,7 +520,7 @@ function doItemOp(operation, to, from, rename, conflict) {
             action: 'move',
             path: to.data.path || '/',
             conflict: conflict,
-            resource: to.data.resource,
+            resource: to.data.resource || to.data.nodeId,
             provider: to.data.provider
         };
     }


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Osfstorage does not have a .resource value, causing dragging from one component directly to the osfstorage icon to fail.

## Changes
If there is no .resource default to .nodeId, which is the same value.

## Side effects
None known. By leaving .resource first this should only fix situations where .resource doesn't exist.


## Ticket

https://openscience.atlassian.net/browse/OSF-6319

[#OSF-6319]

## QA Notes
1. Test that you can move a folder from an osf storage in a component directly to osf storage (not a nested folder) in the project or another component
2. Test that you can still drag from folder to folder. 
3. Test dragging between other storage providers as well.