### PR TITLE
[feature][fix] fangorn: send node id for x-node root folder moves [OSF-5847]

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -512,7 +512,7 @@ function doItemOp(operation, to, from, rename, conflict) {
             action: 'copy',
             path: to.data.path || '/',
             conflict: conflict,
-            resource: to.data.resource,
+            resource: to.data.nodeId,
             provider: to.data.provider
         };
     } else if (operation === OPERATIONS.MOVE) {
@@ -520,7 +520,7 @@ function doItemOp(operation, to, from, rename, conflict) {
             action: 'move',
             path: to.data.path || '/',
             conflict: conflict,
-            resource: to.data.resource,
+            resource: to.data.nodeId,
             provider: to.data.provider
         };
     }


### PR DESCRIPTION
## Purpose

Moving a file into the storage root of another project causes the move to fail and the file to be deleted.

## Changes

The Fangorn to WBv1 conversion was indicating the node id of the target node with a property that exists for subfolders but not the storage root.  This PR updates the code to use a common property instead.

## Side effects

None expected.

## Ticket

Bugfix for [OSF-5847] [Link](https://openscience.atlassian.net/browse/OSF-5847), caught by QA during testing. 