### PR TITLE
Truncate Wiki Preview [OSF-5781]

### DIFF
--- a/website/addons/wiki/templates/wiki_widget.mako
+++ b/website/addons/wiki/templates/wiki_widget.mako
@@ -1,6 +1,6 @@
 <%inherit file="project/addon/widget.mako"/>
 
-<div id="markdownRender" class="break-word scripted">
+<div id="markdownRender" class="break-word scripted preview">
     % if wiki_content:
         ${wiki_content}
     % else:
@@ -23,3 +23,11 @@
         }
     })
 </script>
+
+<style>
+.preview {
+    max-height:300px; 
+    overflow-y: scroll; 
+    padding-right: 10px;
+}
+</style>


### PR DESCRIPTION
## Purpose
The wiki preview size should be a fixed size and scrollable so that the preview isn't too long when many images are involved.

## Changes
Added a CSS class to the preview div to make it fixed-size and scrollable.

## Side effects
None, this change is purely cosmetic.


## Ticket
[https://openscience.atlassian.net/browse/OSF-5781](https://openscience.atlassian.net/browse/OSF-5781)

