### PR TITLE
Capitalize home wiki page in comment action log texts [OSF-7079]

### DIFF
--- a/website/static/js/logTextParser.js
+++ b/website/static/js/logTextParser.js
@@ -640,7 +640,8 @@ var LogPieces = {
             }
             // Comment left on wiki
             if (wiki) {
-                return m('span', ['on wiki page ', m('a', {href: $osf.toRelativeUrl(wiki.url, window)}, wiki.name)]);
+                var name = (wiki.name === 'home') ? 'Home' : wiki.name;
+                return m('span', ['on wiki page ', m('a', {href: $osf.toRelativeUrl(wiki.url, window)}, name)]);
             }
             // Comment left on project
             return m('span', '');


### PR DESCRIPTION
## Purpose
Continuation of [OSF-6367](https://openscience.atlassian.net/browse/OSF-6367). Capitalize home wiki page name in logs for comment actions.

## Changes
Added a line to the log text generator for wiki comments that capitalizes the wiki name if it is the home wiki.

## Side effects
None, this change is purely cosmetic

## Ticket
[https://openscience.atlassian.net/browse/OSF-7079](https://openscience.atlassian.net/browse/OSF-7079)

