### PR TITLE
Fix adding preprints breaking institutions [OSF-7032]

### DIFF
--- a/website/static/js/myProjects.js
+++ b/website/static/js/myProjects.js
@@ -366,6 +366,7 @@ var MyProjects = {
           self.fetchers[self.systemCollections[1].id] = new NodeFetcher('registrations');
           self.fetchers[self.systemCollections[2].id] = new NodeFetcher('preprints', self.systemCollections[2].data.link);
         } else {
+            // TODO: This assumes that there are two systemcolelctiosn passes and what they are. It should ideally loop through passed collections. 
           self.fetchers[self.systemCollections[0].id] = new NodeFetcher('nodes', self.systemCollections[0].data.link);
           self.fetchers[self.systemCollections[1].id] = new NodeFetcher('registrations', self.systemCollections[1].data.link);
         }

--- a/website/static/js/myProjects.js
+++ b/website/static/js/myProjects.js
@@ -368,7 +368,6 @@ var MyProjects = {
         } else {
           self.fetchers[self.systemCollections[0].id] = new NodeFetcher('nodes', self.systemCollections[0].data.link);
           self.fetchers[self.systemCollections[1].id] = new NodeFetcher('registrations', self.systemCollections[1].data.link);
-          self.fetchers[self.systemCollections[2].id] = new NodeFetcher('preprints', self.systemCollections[2].data.link);
         }
 
         // Initial Breadcrumb for All my projects
@@ -886,7 +885,9 @@ var MyProjects = {
             self.loadCategories().then(function(){
                 self.fetchers[self.systemCollections[0].id].on(['page', 'done'], self.onPageLoad);
                 self.fetchers[self.systemCollections[1].id].on(['page', 'done'], self.onPageLoad);
-                self.fetchers[self.systemCollections[2].id].on(['page', 'done'], self.onPageLoad);
+                if(self.systemCollections[2]){
+                    self.fetchers[self.systemCollections[2].id].on(['page', 'done'], self.onPageLoad);
+                }
             });
             if (!self.viewOnly){
                 var collectionsUrl = $osf.apiV2Url('collections/', { query : {'related_counts' : 'linked_registrations,linked_nodes', 'page[size]' : self.collectionsPageSize(), 'sort' : 'date_created', 'embed' : 'linked_nodes'}});


### PR DESCRIPTION
## Purpose
Adding All My Preprints broke the institutions My Projects view. This PR is attempting to fix that issue.

## Changes
- Removed third systemCollection (All my preprints) from the logic where user provides their systemCollections. NOTE: the current implementation of this is fragile and probably only works for the institutions use case. It should rather loop through the passed in systemCollections. But I didn't change that because I don't want to fix beyond the need of the issue and create QA concerns. 

## Side effects

None, All my preprints for individual user still works as expected. 

## Ticket
https://openscience.atlassian.net/browse/OSF-7032