### PR TITLE
Fix (most) failing views tests for django-osf

### DIFF
--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -571,7 +571,6 @@ def send_confirm_email(user, email, renew=False, external_id_provider=None, exte
         email,
         external=True,
         force=True,
-        renew=renew,
         external_id_provider=external_id_provider
     )
 

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -782,7 +782,7 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel,
         # Not all tokens are guaranteed to have expiration dates
         if (
             'expiration' in verification and
-            verification['expiration'] < timezone.now()
+            verification['expiration'].replace(tzinfo=pytz.utc) < timezone.now()
         ):
             raise ExpiredTokenError
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2087,6 +2087,7 @@ class TestAddingContributorViews(OsfTestCase):
         project.fork_node(auth=Auth(project.creator))
         assert_false(send_mail.called)
 
+    @pytest.mark.skip('Unskip when wiki addon is implemented')
     @mock.patch('website.mails.send_mail')
     def test_templating_project_does_not_send_contributor_added_email(self, send_mail):
         project = ProjectFactory()
@@ -3026,7 +3027,7 @@ class TestPointerViews(OsfTestCase):
         )
         self.project.reload()
         assert_equal(
-            self.project.nodes.count(),
+            len(list(self.project.nodes)),
             0
         )
 

--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -671,8 +671,10 @@ def claim_user_form(auth, **kwargs):
     claimer_email = unclaimed_record.get('claimer_email') or unclaimed_record.get('email')
 
     # If there is a registered user with this email, redirect to 're-enter password' page
-    found_by_email = User.find_by_email(claimer_email)
-    user_from_email = found_by_email[0] if found_by_email else None
+    try:
+        user_from_email = User.objects.get(username=claimer_email)
+    except User.DoesNotExist:
+        user_from_email = None
     if user_from_email and user_from_email.is_registered:
         return redirect(web_url_for('claim_user_registered', uid=uid, pid=pid, token=token))
 

--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -671,7 +671,7 @@ def claim_user_form(auth, **kwargs):
     claimer_email = unclaimed_record.get('claimer_email') or unclaimed_record.get('email')
     # If there is a registered user with this email, redirect to 're-enter password' page
     try:
-        user_from_email = User.objects.get(emails__icontains=claimer_email)
+        user_from_email = User.objects.get(emails__icontains=claimer_email) if claimer_email else None
     except User.DoesNotExist:
         user_from_email = None
     if user_from_email and user_from_email.is_registered:

--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -669,10 +669,9 @@ def claim_user_form(auth, **kwargs):
     user.update_guessed_names()
     # The email can be the original referrer email if no claimer email has been specified.
     claimer_email = unclaimed_record.get('claimer_email') or unclaimed_record.get('email')
-
     # If there is a registered user with this email, redirect to 're-enter password' page
     try:
-        user_from_email = User.objects.get(username=claimer_email)
+        user_from_email = User.objects.get(emails__icontains=claimer_email)
     except User.DoesNotExist:
         user_from_email = None
     if user_from_email and user_from_email.is_registered:

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -1304,8 +1304,10 @@ def fork_pointer(auth, node, **kwargs):
     or not present in `nodes`.
 
     """
+    from osf.models import NodeRelation
+
     pointer_id = request.json.get('pointerId')
-    pointer = Node.load(pointer_id)
+    pointer = NodeRelation.load(pointer_id)
 
     if pointer is None:
         # TODO: Change this to 404?

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -965,8 +965,8 @@ def node_child_tree(user, node_ids):
         children.extend(node_child_tree(
             user,
             list(node.node_relations.select_related('child')
-                 .exclude(child__is_deleted=False)
-                 .values_list('child__guid_string', flat=True))
+                 .exclude(child__is_deleted=True)
+                 .values_list('child__guids___id', flat=True))
         ))
         item = {
             'node': {

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -1152,12 +1152,12 @@ def _add_pointers(node, pointers, auth):
     """
 
     :param Node node: Node to which pointers will be added
-    :param list pointers: Nodes to add as pointers
+    :param list pointers: NodeRelations to add as pointers
 
     """
     added = False
     for pointer in pointers:
-        node.add_pointer(pointer, auth, save=False)
+        node.add_pointer(pointer.node, auth, save=False)
         added = True
 
     if added:
@@ -1169,6 +1169,7 @@ def move_pointers(auth):
     """Move pointer from one node to another node.
 
     """
+    from osf.models import NodeRelation
 
     from_node_id = request.json.get('fromNodeId')
     to_node_id = request.json.get('toNodeId')
@@ -1185,18 +1186,18 @@ def move_pointers(auth):
 
     for pointer_to_move in pointers_to_move:
         try:
-            pointer_node = from_node.linked_nodes.get(_id=pointer_to_move)
+            node_relation = NodeRelation.objects.get(_id=pointer_to_move)
         except Node.DoesNotExist:
             raise HTTPError(http.BAD_REQUEST)
 
         try:
-            from_node.rm_pointer(pointer_node, auth=auth)
+            from_node.rm_pointer(node_relation, auth=auth)
         except ValueError:
             raise HTTPError(http.BAD_REQUEST)
 
         from_node.save()
         try:
-            _add_pointers(to_node, [pointer_node], auth)
+            _add_pointers(to_node, [node_relation], auth)
         except ValueError:
             raise HTTPError(http.BAD_REQUEST)
 

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -42,6 +42,8 @@ from website.project.licenses import serialize_node_license_record
 from website.util.sanitize import strip_html
 from website.util import rapply
 
+from osf.models.base import Guid
+
 
 r_strip_html = lambda collection: rapply(collection, strip_html)
 logger = logging.getLogger(__name__)
@@ -401,11 +403,14 @@ def project_reorder_components(node, **kwargs):
         each.split(':')[0]
         for each in request.get_json().get('new_list', [])
     ]
-    new_node_ids = list(Node.objects.filter(_id__in=new_node_guids).values_list('pk', flat=True))
-    valid_node_ids = list(node.nodes.filter(is_deleted=False).values_list('pk', flat=True))
-    deleted_node_ids = list(node.nodes.filter(is_deleted=True).values_list('pk', flat=True))
+    guids = Guid.objects.filter(_id__in=new_node_guids)
+
+    new_node_ids = [guid.referent.id for guid in guids]
+    valid_node_ids = [link.id for link in node.nodes if not node.is_deleted]
+    deleted_node_ids = [link.id for link in node.nodes if node.is_deleted]
+
     if len(valid_node_ids) == len(new_node_ids) and set(valid_node_ids) == set(new_node_ids):
-        node.set_abstractnode_order(new_node_ids + deleted_node_ids)
+        node.set_noderelation_order(new_node_ids + deleted_node_ids)
         node.save()
         return {}
 

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -7,6 +7,7 @@ from itertools import islice
 from flask import request
 from modularodm import Q
 from modularodm.exceptions import ModularOdmException, ValidationError
+from django.apps import apps
 
 from framework import status
 from framework.utils import iso8601format
@@ -1174,7 +1175,7 @@ def move_pointers(auth):
     """Move pointer from one node to another node.
 
     """
-    from osf.models import NodeRelation
+    NodeRelation = apps.get_model('osf.NodeRelation')
 
     from_node_id = request.json.get('fromNodeId')
     to_node_id = request.json.get('toNodeId')
@@ -1310,7 +1311,7 @@ def fork_pointer(auth, node, **kwargs):
     or not present in `nodes`.
 
     """
-    from osf.models import NodeRelation
+    NodeRelation = apps.get_model('osf.NodeRelation')
 
     pointer_id = request.json.get('pointerId')
     pointer = NodeRelation.load(pointer_id)

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -1152,12 +1152,12 @@ def _add_pointers(node, pointers, auth):
     """
 
     :param Node node: Node to which pointers will be added
-    :param list pointers: NodeRelations to add as pointers
+    :param list pointers: Nodes to add as pointers
 
     """
     added = False
     for pointer in pointers:
-        node.add_pointer(pointer.node, auth, save=False)
+        node.add_pointer(pointer, auth, save=False)
         added = True
 
     if added:
@@ -1197,7 +1197,7 @@ def move_pointers(auth):
 
         from_node.save()
         try:
-            _add_pointers(to_node, [node_relation], auth)
+            _add_pointers(to_node, [node_relation.node], auth)
         except ValueError:
             raise HTTPError(http.BAD_REQUEST)
 


### PR DESCRIPTION
**note** A few views tests are still failing because the `osfstorage` addon is acting up -- which @sloria is currently workin on!

## Purpose
Make existing tests from `tests/test_views.py` pass!  Some changes to the tests (timezone assurances, generator/queryset fixes ) and a few updates to the views themselves to make sure they work with the new models and are passing along the right things!

## Changes
- Make sure a few things are in UTC when tests failed because of not being able to compare aware and naive datetimes
- Some things are generators now, update checking methods
- A few methods have new signatures, fix those when called
- Use queries in replace of the old `User. find_by_email`
- Changes in `website/project/views/node.py`:
    - Use a `Guid` object to get nodes, cause Guids are passed and not Node ids
    - Pass a `NodeRelation` to `rm_node_link` and a `Node` to `add_node_link` in new mixins

## Side effects
Most everything should stay the same, hopefully!


## Ticket
https://github.com/CenterForOpenScience/osf-models/issues/147