### PR TITLE
[feature] Redirect Swagger Docs to Root [OSF-7106]

### DIFF
--- a/api/base/urls.py
+++ b/api/base/urls.py
@@ -20,7 +20,7 @@ urlpatterns = [
                 url(r'^citations/', include('api.citations.urls', namespace='citations')),
                 url(r'^collections/', include('api.collections.urls', namespace='collections')),
                 url(r'^comments/', include('api.comments.urls', namespace='comments')),
-                url(r'^docs/', include('rest_framework_swagger.urls')),
+                url(r'^docs/', RedirectView.as_view(pattern_name=views.root), name='redirect-to-root', kwargs={'version': default_version}),
                 url(r'^files/', include('api.files.urls', namespace='files')),
                 url(r'^guids/', include('api.guids.urls', namespace='guids')),
                 url(r'^identifiers/', include('api.identifiers.urls', namespace='identifiers')),

--- a/api_tests/base/test_views.py
+++ b/api_tests/base/test_views.py
@@ -125,6 +125,8 @@ class TestJSONAPIBaseView(ApiTestCase):
 
 
 class TestSwaggerDocs(ApiTestCase):
-    def test_swagger_doc_json_route(self):
-        res = self.app.get('/v2/docs/api-docs/v2')
-        assert_equal(res.status_code, 200)
+
+    def test_swagger_docs_redirect_to_root(self):
+        res = self.app.get('/v2/docs/')
+        assert_equal(res.status_code, 302)
+        assert_equal(res.location, '/v2/')


### PR DESCRIPTION
#### Purpose
- Adding versioning (#6329) to the API resulted in broken swagger docs. Unfortunately, this [cannot be fixed](https://github.com/marcgibbons/django-rest-swagger/issues/344) without upgrading to django-rest-swagger 2.0 and DRF 3.4, which we aren't quite ready to do at the moment. 
- This PR temporarily redirects the docs route (`/v2/docs/`) to root (`/v2/`) until we decide to upgrade django-rest-swagger and DRF. 

#### Changes
- `/v2/docs/` -> `/v2/`

#### Ticket
- [OSF-7106](https://openscience.atlassian.net/browse/OSF-7106)

