### PR TITLE
Allow prereg splash page to load for django-osf

### DIFF
--- a/website/prereg/utils.py
+++ b/website/prereg/utils.py
@@ -9,14 +9,13 @@ PREREG_CAMPAIGNS = {
 def drafts_for_user(user, campaign):
     from website import models  # noqa
 
-    all_user_projects = models.Node.objects.filter(is_deleted=False, _contributors=user)
-    user_projects = [node for node in all_user_projects if node.has_permission(user, 'admin')]
+    user_projects = models.Node.objects.filter(is_deleted=False, contributor__admin=True, contributor__user=user)
     PREREG_CHALLENGE_METASCHEMA = get_prereg_schema(campaign)
-    return models.DraftRegistration.find(
-        Q('registration_schema', 'eq', PREREG_CHALLENGE_METASCHEMA) &
-        Q('approval', 'eq', None) &
-        Q('registered_node', 'eq', None) &
-        Q('branched_from', 'in', [p._id for p in user_projects])
+    return models.DraftRegistration.objects.filter(
+        registration_schema=PREREG_CHALLENGE_METASCHEMA,
+        approval=None,
+        registered_node=None,
+        branched_from__in=[p.id for p in user_projects]
     )
 
 def get_prereg_schema(campaign='prereg'):

--- a/website/prereg/utils.py
+++ b/website/prereg/utils.py
@@ -9,14 +9,16 @@ PREREG_CAMPAIGNS = {
 def drafts_for_user(user, campaign):
     from website import models  # noqa
 
-    user_projects = models.Node.objects.filter(is_deleted=False, contributor__admin=True, contributor__user=user)
     PREREG_CHALLENGE_METASCHEMA = get_prereg_schema(campaign)
     return models.DraftRegistration.objects.filter(
         registration_schema=PREREG_CHALLENGE_METASCHEMA,
         approval=None,
         registered_node=None,
-        branched_from__in=[p.id for p in user_projects]
-    )
+        branched_from__in=models.Node.objects.filter(
+            is_deleted=False,
+            contributor__admin=True,
+            contributor__user=user).values_list('id', flat=True))
+
 
 def get_prereg_schema(campaign='prereg'):
     from website.models import MetaSchema  # noqa

--- a/website/prereg/utils.py
+++ b/website/prereg/utils.py
@@ -1,7 +1,5 @@
 from modularodm import Q
 
-from website.util import permissions
-
 
 PREREG_CAMPAIGNS = {
     'prereg': 'Prereg Challenge',
@@ -11,10 +9,8 @@ PREREG_CAMPAIGNS = {
 def drafts_for_user(user, campaign):
     from website import models  # noqa
 
-    user_projects = models.Node.find(
-        Q('is_deleted', 'eq', False) &
-        Q('permissions.{0}'.format(user._id), 'in', [permissions.ADMIN])
-    )
+    all_user_projects = models.Node.objects.filter(is_deleted=False, _contributors=user)
+    user_projects = [node for node in all_user_projects if node.has_permission(user, 'admin')]
     PREREG_CHALLENGE_METASCHEMA = get_prereg_schema(campaign)
     return models.DraftRegistration.find(
         Q('registration_schema', 'eq', PREREG_CHALLENGE_METASCHEMA) &


### PR DESCRIPTION
## Purpose

Fix query for a user's nodes on which they are admins!

## Changes

- Update node query for getting a user's nodes, then filter by admin

## Side effects
One query and a pairing down of results vs one modular ODM


## Ticket
https://trello.com/c/tA2FBEWb/16-prereg-splash-page-leads-to-unable-to-resolve