### PR TITLE
Fix Institutions API routes for django-osf with version kwarg

### DIFF
--- a/osf/models/institution.py
+++ b/osf/models/institution.py
@@ -56,12 +56,12 @@ class Institution(Loggable, base.ObjectIDMixin, base.BaseModel):
 
     @property
     def api_v2_url(self):
-        return reverse('institutions:institution-detail', kwargs={'institution_id': self._id})
+        return reverse('institutions:institution-detail', kwargs={'institution_id': self._id, 'version': 'v2'})
 
     @property
     def absolute_api_v2_url(self):
         from api.base.utils import absolute_reverse
-        return absolute_reverse('institutions:institution-detail', kwargs={'institution_id': self._id})
+        return absolute_reverse('institutions:institution-detail', kwargs={'institution_id': self._id, 'version': 'v2'})
 
     @property
     def nodes_url(self):


### PR DESCRIPTION
## Purpose
`v2/institutions/` API routes were broken in new models -- also pass along the `version` kwarg to match old models for `api_v2_url`!

## Changes
- Pass `version` kwarg for `api_v2_url` and `absolute_api_v2_url`

## Side effects

Nope!


## Ticket
https://trello.com/c/5j5UzvCk/22-institution-detail-route-in-api-no-worky