### PR TITLE
Adjust calls to iterate through a user's external accounts for citations Django-osf

### DIFF
--- a/website/citations/providers.py
+++ b/website/citations/providers.py
@@ -105,8 +105,7 @@ class CitationsProvider(object):
                 self.serializer(
                     user_settings=user.get_addon(self.provider_name) if user else None
                 ).serialize_account(each)
-                for each in user.external_accounts.all()
-                if each.provider == self.provider_name
+                for each in user.external_accounts.filter(provider=self.provider_name)
             ]
         }
 
@@ -204,10 +203,7 @@ class CitationsProvider(object):
                 folder['parent_list_id'] = 'ROOT'
 
         node_account = node_addon.external_account
-        user_accounts = [
-            account for account in user.external_accounts.all()
-            if account.provider == self.provider_name
-        ] if user else []
+        user_accounts = user.external_accounts.filter(provider=self.provider_name) if user else []
         user_is_owner = node_account in user_accounts
 
         # verify this list is the attached list or its descendant

--- a/website/citations/providers.py
+++ b/website/citations/providers.py
@@ -105,7 +105,7 @@ class CitationsProvider(object):
                 self.serializer(
                     user_settings=user.get_addon(self.provider_name) if user else None
                 ).serialize_account(each)
-                for each in user.external_accounts
+                for each in user.external_accounts.all()
                 if each.provider == self.provider_name
             ]
         }
@@ -205,7 +205,7 @@ class CitationsProvider(object):
 
         node_account = node_addon.external_account
         user_accounts = [
-            account for account in user.external_accounts
+            account for account in user.external_accounts.all()
             if account.provider == self.provider_name
         ] if user else []
         user_is_owner = node_account in user_accounts


### PR DESCRIPTION
## Purpose
Sentry errors happening on iterating through a user's external accounts!

## Changes
- Add `.all()` to two calls to `user.external_accounts` in `citations/providers.py`

## Side effects
None anticipated

## Note
The specific issue mentioned in the trello ticket wasn't solved for me locally until I'd re-run the script `python -m scripts.parse_citation_styles`


## Ticket
https://trello.com/c/q0aNJC9W/20-citations-widget-cannot-search-for-citations
https://sentry.cos.io/sentry/osf-back-end/issues/256168/