### PR TITLE
fix typo that was signaling files on wb errors

### DIFF
--- a/website/addons/base/views.py
+++ b/website/addons/base/views.py
@@ -404,7 +404,7 @@ def create_waterbutler_log(payload, **kwargs):
                     destination_addon=payload['destination']['addon'],
                 )
 
-            if payload.get('error'):
+            if payload.get('errors'):
                 # Action failed but our function succeeded
                 # Bail out to avoid file_signals
                 return {'status': 'success'}


### PR DESCRIPTION
## Purpose

`create_waterbutler_log` is using the wrong key to detect errors in WB responses. This means that we were signaling file updates at times when we shouldn't.  In some cases this could cause a recursive fetching of the addon contents, which is bogus.

## Changes

`s/error/errors/`

## Side effects

None expected.

## Ticket

No ticket.
