### PR TITLE
[featurefix] Fix broken DV downloads with Fangorn+WBv1 [OSF-5847]

### DIFF
--- a/website/addons/dataverse/static/dataverseFangornConfig.js
+++ b/website/addons/dataverse/static/dataverseFangornConfig.js
@@ -16,7 +16,7 @@ function changeState(grid, item, version) {
 
 function _downloadEvent(event, item, col) {
     event.stopPropagation();
-    window.location = waterbutler.buildTreeBeardDownload(item, {path: item.data.extra.fileId});
+    window.location = waterbutler.buildTreeBeardDownload(item);
 }
 
 // Define Fangorn Button Actions


### PR DESCRIPTION
## Purpose

Downloads from Dataverse were broken because DV's fangorn config was sending the path twice.

## Changes

Stop sending the path twice.

## Side effects

None expected.

## Ticket

Bugfix for: [#OSF-5847] -- [Link](https://openscience.atlassian.net/browse/OSF-5847)

 * WBv1 gets cranky if you try to set the file path in the url AND the
   query param. So don't do that.