### PR TITLE
Exclude any branch that has 'django-osf' in the name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ sudo: false
 
 branches:
   except:
-    - feature/django-osf
+    - /django-osf/
 
 cache:
   directories:


### PR DESCRIPTION
Exclude any branch that has django-osf in the branch name from TravisCI.