### PR TITLE
[Feature] Allow read/write to modify all nested affiliations [OSF-7105]

### DIFF
--- a/website/static/js/institutionProjectSettings.js
+++ b/website/static/js/institutionProjectSettings.js
@@ -9,7 +9,7 @@ var projectSettingsTreebeardBase = require('js/projectSettingsTreebeardBase');
 
 var ViewModel = function(data) {
     var self = this;
-    self.url = $osf.apiV2Url('/nodes/', {'query': 'filter[root]=' + data.node.rootId + '&format=json&embed=affiliated_institutions&version=2.1&embed=parent'});
+    self.url = $osf.apiV2Url('/nodes/', {'query': 'filter[root]=' + data.node.rootId + '&format=json&embed=affiliated_institutions&version=2.1'});
     self.loading = ko.observable(false);
     self.showAdd = ko.observable(false);
     self.institutionHref = ko.observable('');
@@ -263,10 +263,9 @@ ViewModel.prototype.fetchNodes = function(url) {
         return;
     }
     var responseArray = new $osf.getAllPagesAjaxJSON('GET', url, {isCors: true});
-
     responseArray.done(function(data) {
         var rd = $osf.mergePagesAjaxJSON(data);
-        var rawNodes = self.nodeId() === self.rootId() ? rd : $osf.getAllChildren(self.nodeId(), rd);
+        var rawNodes = self.nodeId() === self.rootId() ? rd : $osf.getAllNodeChildrenFromNodeList(self.nodeId(), rd);
         self.formatNodes(rawNodes);
 
     }).fail(function (xhr, status, error) {

--- a/website/static/js/institutionProjectSettings.js
+++ b/website/static/js/institutionProjectSettings.js
@@ -243,7 +243,7 @@ ViewModel.prototype.formatNodes = function(rawNodes) {
         branch.hasPermissions = rawNodes[n].attributes.current_user_permissions.indexOf('write') > -1;
         branch.institutions = [];
 
-        // This does not handle pagination for institutions. Is there a situation where someone can have 10 institutions?
+        // This does not handle pagination for institutions.
         var institutionData = rawNodes[n].embeds.affiliated_institutions.data;
         $.each(institutionData, function(i){
             branch.institutions.push(institutionData[i].id);

--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -112,13 +112,13 @@ var ajaxJSON = function(method, url, options) {
 /**
  * Returns a promise of an array of ajaxJSON response objects
  */
-function getAllPagesAjaxJSON(method, url, options) {
+var getAllPagesAjaxJSON = function(method, url, options) {
     var responses = [];
     var fetch = function(method, url, options) {
         var request = ajaxJSON(method, url, options);
         request.done(function(response) {
             deferred.notify(response);
-            responses.push(response);
+            responses = responses.concat(response);
             if (response.links.next !== null) {
                 fetch(method, response.links.next, options);
             } else {
@@ -132,7 +132,23 @@ function getAllPagesAjaxJSON(method, url, options) {
   var deferred = new $.Deferred();
   fetch(method, url, options);
   return deferred.promise();
-}
+};
+
+/**
+ * Takes an array of response objects and returns a single object
+ * @param {Array of Objects}
+ * @return {Object data}
+ */
+var mergePagesAjaxJSON = function(pages){
+    var map = {};
+    $.each(pages, function(page) {
+        $.each(pages[page].data, function(n){
+            var node = pages[page].data[n]
+            map[node.id] = node;
+        });
+    });
+    return map;
+};
 
 /**
 * Posts JSON data.
@@ -976,6 +992,7 @@ module.exports = window.$.osf = {
     putJSON: putJSON,
     ajaxJSON: ajaxJSON,
     getAllPagesAjaxJSON: getAllPagesAjaxJSON,
+    mergePagesAjaxJSON: mergePagesAjaxJSON,
     squashAPIAttributes: squashAPIAttributes,
     setXHRAuthorization: setXHRAuthorization,
     handleAddonApiHTTPError: handleAddonApiHTTPError,

--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -151,7 +151,7 @@ var mergePagesAjaxJSON = function(pages) {
 };
 
 /**
- * Takes an array of response objects and returns a single object
+ * Takes an array of response objects and returns just the children from the parent
  * @param {Array of Objects}
  * @return {Object data}
  */
@@ -161,7 +161,6 @@ var getAllChildren = function(parent, nodeList) {
     retval[parent] = nodeList[parent];
     delete nodeList[parent];
 
-    // remove root
     $.each(nodeList, function(key){
         if(!('parent' in nodeList[key].embeds)) {
             delete nodeList[key];

--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -171,17 +171,17 @@ var getAllNodeChildrenFromNodeList = function(parent, nodeList) {
             tree[parent] = [];
         }
         tree[parent].push(n);
-    })
+    });
 
-    var children = {}
+    var children = {};
     var remaining = [parent];
     while (remaining.length > 0) {
         var node = remaining.pop();
-        $.each(tree[node], function(c) {
+        for (var c in tree[node]){
             var child = tree[node][c];
             remaining.push(tree[child]);
             children[child] = nodeList[child];    
-        })
+        }
     }
     return children;
 };

--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -140,14 +140,14 @@ var getAllPagesAjaxJSON = function(method, url, options) {
  * @return {Object data}
  */
 var mergePagesAjaxJSON = function(pages) {
-    var nodeList = {};
+    var mergedData = {};
     $.each(pages, function(page) {
         $.each(pages[page].data, function(n) {
             var node = pages[page].data[n];
-            nodeList[node.id] = node;
+            mergedData[node.id] = node;
         });
     });
-    return nodeList;
+    return mergedData;
 };
 
 /**

--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -139,15 +139,48 @@ var getAllPagesAjaxJSON = function(method, url, options) {
  * @param {Array of Objects}
  * @return {Object data}
  */
-var mergePagesAjaxJSON = function(pages){
+var mergePagesAjaxJSON = function(pages) {
     var map = {};
     $.each(pages, function(page) {
-        $.each(pages[page].data, function(n){
-            var node = pages[page].data[n]
+        $.each(pages[page].data, function(n) {
+            var node = pages[page].data[n];
             map[node.id] = node;
         });
     });
     return map;
+};
+
+/**
+ * Takes an array of response objects and returns a single object
+ * @param {Array of Objects}
+ * @return {Object data}
+ */
+var getAllChildren = function(parent, nodeList) {
+    var remaining = [parent];
+    var retval = {};
+    retval[parent] = nodeList[parent];
+    delete nodeList[parent];
+
+    // remove root
+    $.each(nodeList, function(key){
+        if(!('parent' in nodeList[key].embeds)) {
+            delete nodeList[key];
+            return false;
+        }
+    });
+    
+    while(remaining.length > 0) {
+        var currentParent = remaining.pop();
+        for(var node in nodeList) {
+            var nodeParent = nodeList[node].embeds.parent.data.id;
+            if(nodeParent === currentParent){
+                remaining.push(node);
+                retval[node] = nodeList[node];
+                delete nodeList[node];
+            }
+        }
+    }
+    return retval;
 };
 
 /**
@@ -993,6 +1026,7 @@ module.exports = window.$.osf = {
     ajaxJSON: ajaxJSON,
     getAllPagesAjaxJSON: getAllPagesAjaxJSON,
     mergePagesAjaxJSON: mergePagesAjaxJSON,
+    getAllChildren: getAllChildren,
     squashAPIAttributes: squashAPIAttributes,
     setXHRAuthorization: setXHRAuthorization,
     handleAddonApiHTTPError: handleAddonApiHTTPError,

--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -175,9 +175,9 @@ var getAllNodeChildrenFromNodeList = function(parent, nodeList) {
 
     var children = {}
     var remaining = [parent];
-    while(remaining.length > 0) {
+    while (remaining.length > 0) {
         var node = remaining.pop();
-        $.each(tree[node], function(c){
+        $.each(tree[node], function(c) {
             var child = tree[node][c];
             remaining.push(tree[child]);
             children[child] = nodeList[child];    

--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -110,6 +110,31 @@ var ajaxJSON = function(method, url, options) {
 };
 
 /**
+ * Returns a promise of an array of ajaxJSON response objects
+ */
+function getAllPagesAjaxJSON(method, url, options) {
+    var responses = [];
+    var fetch = function(method, url, options) {
+        var request = ajaxJSON(method, url, options);
+        request.done(function(response) {
+            deferred.notify(response);
+            responses.push(response);
+            if (response.links.next !== null) {
+                fetch(method, response.links.next, options);
+            } else {
+                deferred.resolve(responses);
+            }
+        });
+        request.fail(function(xhr, status, error) {
+            deferred.reject(error);
+        });
+    };
+  var deferred = new $.Deferred();
+  fetch(method, url, options);
+  return deferred.promise();
+}
+
+/**
 * Posts JSON data.
 *
 * NOTE: The `success` and `error` callbacks are deprecated. Prefer the Promise
@@ -950,6 +975,7 @@ module.exports = window.$.osf = {
     postJSON: postJSON,
     putJSON: putJSON,
     ajaxJSON: ajaxJSON,
+    getAllPagesAjaxJSON: getAllPagesAjaxJSON,
     squashAPIAttributes: squashAPIAttributes,
     setXHRAuthorization: setXHRAuthorization,
     handleAddonApiHTTPError: handleAddonApiHTTPError,

--- a/website/static/js/tests/institutionsProjectSettings.test.js
+++ b/website/static/js/tests/institutionsProjectSettings.test.js
@@ -84,14 +84,14 @@ describe('InstitutionSettings', () => {
     });
 
     it('shows a dialog if the Node has children', () => {
-        viewModel.hasChildren(true);
+        viewModel.childExists(true);
         viewModel.submitInst(item);
         assert(modifyStub.called);
     });
 
     it('does not show dialog if the Node has no children', () => {
 
-        viewModel.hasChildren(false);
+        viewModel.childExists(false);
         viewModel.submitInst(item);
         assert.isFalse(modifyStub.called);
     });

--- a/website/static/js/tests/institutionsProjectSettings.test.js
+++ b/website/static/js/tests/institutionsProjectSettings.test.js
@@ -56,10 +56,6 @@ describe('InstitutionSettings', () => {
 
     var viewModel = new InstitutionProjectSettings.ViewModel(data);
 
-    viewModel.institutionInAllChildren = function() {
-        return false;
-    };
-
     it('user variables set', () => {
         assert.equal(viewModel.userInstitutions, data.currentUser.institutions);
         assert.equal(viewModel.userInstitutionsIds.length, 2);

--- a/website/templates/project/project_base.mako
+++ b/website/templates/project/project_base.mako
@@ -57,6 +57,7 @@
        parent_exists = parent_node['exists']
        parent_title = ''
        parent_registration_url = ''
+       root_id = node['root_id']
        if parent_exists:
            parent_title = "Private {0}".format(parent_node['category'])
            parent_registration_url = ''
@@ -98,6 +99,7 @@
             preprintFileId: ${ node.get('preprint_file_id', None) | sjson, n },
             anonymous: ${ node['anonymous'] | sjson, n },
             category: ${node['category_short'] | sjson, n },
+            rootId: ${ root_id | sjson, n },
             parentTitle: ${ parent_title | sjson, n },
             parentRegisterUrl: ${parent_registration_url | sjson, n },
             parentExists: ${ parent_exists | sjson, n},


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->
## Purpose

Currently only admins are given the dialogue option to add/remove affiliations to all nested components. This was a side effect of the data provided by the API V1 route used. Read/Write contributors are now given the add/remove all dialogue box.
## Changes
1. Strip out api v1 functionality
2. Add 3 osf helper functions to get all paginated data, concat the data, and return all children of a node from a paginated response.
3. Using API v2 calls, allows read/write users to modify nested nodes.
## Side effects

The logic of when to show the modal (add/remove from node or node and all children) was simplified to avoid some fun/edgy cases (e.g., extremely edgy case if a node has more than 10 institutions) and generally reduce complexity. Now, so long as the node you are on has at least one child, the modal will appear. 

Previously, it only appeared if at least one child would be affected by the change (or a few weird edge cases like if you don't have permission over one of the children). 

This also makes the action of pressing the add/remove button more consistent. For example, the user likely does not know the affiliation status of all of their nodes children, and might wonder why clicking the button to add the institution to the parent did not show a modal, but then clicking it again does show the modal. And then clicking it again shows the modal again, despite seeming like the same action as the first click. 
## Ticket

https://openscience.atlassian.net/browse/OSF-7105
[#OSF-7105]
## QA Considerations
1. Test that admins and read/write users get the dialogue option at the appropriate times
2. Test both root (highest level project settings page) and nested components with further nested components work properly. 
3. Test situations where nested status is mixed (some affiliated, some not) and that the nodes affiliation is what you would expect.
4. Test that removing an institution as an admin when you are no longer affiliated with the institution correctly has the warning `If you remove it from your project, you cannot add it back.`
