### PR TITLE
[djangosf] Fix behavior of addon methods for consistency with v1

### DIFF
--- a/api_tests/base/test_auth.py
+++ b/api_tests/base/test_auth.py
@@ -52,7 +52,6 @@ class TestBasicAuthenticationValidation(ApiTestCase):
         res = self.app.get(self.unreachable_url, auth=self.user1.auth, expect_errors=True)
         assert_equal(res.status_code, 403, msg=res.json)
 
-    @pytest.mark.skip('Addons not yet implemented')
     def test_valid_credential_but_twofactor_required(self):
         user1_addon = self.user1.get_or_add_addon('twofactor')
         user1_addon.totp_drift = 1
@@ -65,7 +64,6 @@ class TestBasicAuthenticationValidation(ApiTestCase):
         assert_equal(res.headers['X-OSF-OTP'], 'required; app')
         assert_equal(res.json.get("errors")[0]['detail'], 'Must specify two-factor authentication OTP code.')
 
-    @pytest.mark.skip('Addons not yet implemented')
     def test_valid_credential_twofactor_invalid_otp(self):
         user1_addon = self.user1.get_or_add_addon('twofactor')
         user1_addon.totp_drift = 1
@@ -78,7 +76,6 @@ class TestBasicAuthenticationValidation(ApiTestCase):
         assert_true('X-OSF-OTP' not in res.headers)
         assert_equal(res.json.get("errors")[0]['detail'], 'Invalid two-factor authentication OTP code.')
 
-    @pytest.mark.skip('Addons not yet implemented')
     def test_valid_credential_twofactor_valid_otp(self):
         user1_addon = self.user1.get_or_add_addon('twofactor')
         user1_addon.totp_drift = 1

--- a/osf_tests/test_user.py
+++ b/osf_tests/test_user.py
@@ -378,10 +378,9 @@ class TestOSFUser:
         size = urlparse.parse_qs(urlparse.urlparse(user.profile_image_url()).query).get('size')
         assert size is None
 
-    @pytest.mark.skip('activity points not yet implemented')
     def test_activity_points(self, user):
         assert(
-            user.get_activity_points(db=self.db) == get_total_activity_count(self.user._primary_key)
+            user.get_activity_points() == get_total_activity_count(user._primary_key)
         )
 
     def test_contributed_property(self):


### PR DESCRIPTION
## Purpose

Various fixes for addon methods to make the behavior consistent with v1. Adds and unskips tests.

## Changes
- Don't allow deletion of mandatory addons
- Fix signature of add_addon
- Unskip valid TFA tests
- Add test for Node addon methods