### PR TITLE
[Hotfix] Encrypt unicode correctly

### DIFF
--- a/framework/encryption/__init__.py
+++ b/framework/encryption/__init__.py
@@ -8,12 +8,12 @@ SENSITIVE_DATA_KEY = jwe.kdf(settings.SENSITIVE_DATA_SECRET.encode('utf-8'), set
 
 def encrypt(value):
     if value:
-        return jwe.encrypt(value.encode('utf-8'), SENSITIVE_DATA_KEY)
+        return jwe.encrypt(bytes(value), SENSITIVE_DATA_KEY)
     return None
 
 def decrypt(value):
     if value:
-        return jwe.decrypt(value.encode('utf-8'), SENSITIVE_DATA_KEY)
+        return jwe.decrypt(bytes(value), SENSITIVE_DATA_KEY)
     return None
 
 class EncryptedStringField(StringField):

--- a/scripts/encrypt_external_accounts_unicode.py
+++ b/scripts/encrypt_external_accounts_unicode.py
@@ -1,0 +1,64 @@
+import logging
+import sys
+
+import jwe
+
+from framework.encryption import SENSITIVE_DATA_KEY
+from framework.mongo import database
+from framework.transactions.context import TokuTransaction
+
+from website.app import init_app
+from scripts import utils as script_utils
+
+logger = logging.getLogger(__name__)
+
+
+def verify_external_account(document):
+    assert '_id' in document, 'ExternalAccount {} has no _id'.format(document)
+    assert 'provider' in document, 'ExternalAccount {} has no provider'.format(document['_id'])
+    assert 'oauth_key' in document, 'ExternalAccount {} has no oauth_key'.format(document['_id'])
+    assert 'oauth_secret' in document, 'ExternalAccount {} has no oauth_secret'.format(document['_id'])
+    assert 'display_name' in document, 'ExternalAccount {} has no display_name'.format(document['_id'])
+
+def encrypt_key(document, key):
+    database['externalaccount'].find_and_modify(
+        {'_id': document['_id']},
+        {'$set': {
+            key: jwe.encrypt(bytes(jwe.decrypt(document[key].encode('utf-8'), SENSITIVE_DATA_KEY)), SENSITIVE_DATA_KEY)
+        }})
+
+def migrate(dry_run=True):
+    external_accounts = list(database['externalaccount'].find())
+    keys = ['oauth_key', 'oauth_secret', 'refresh_token', 'display_name', 'profile_url']
+
+    provider_key_count_map = {key: {} for key in keys}
+
+    logger.info('Preparing to migrate {} ExternalAccounts'.format(len(external_accounts)))
+
+    for account in external_accounts:
+        verify_external_account(account)
+        for key in keys:
+            if account.get(key) is not None:
+                logger.info('Migrating {} for {}:{}'.format(key, account['provider'], account['_id']))
+                encrypt_key(account, key)
+                if account['provider'] not in provider_key_count_map[key]:
+                    provider_key_count_map[key][account['provider']] = 0
+                provider_key_count_map[key][account['provider']] += 1
+
+    for key in provider_key_count_map:
+        for provider in provider_key_count_map[key]:
+            count = provider_key_count_map[key][provider]
+            logger.info('Migrated {} for {} {} accounts'.format(key, count, provider))
+
+def main():
+    dry_run = '--dry' in sys.argv
+    if not dry_run:
+        script_utils.add_file_logger(logger, __file__)
+    init_app(set_backends=True, routes=False)
+    with TokuTransaction():
+        migrate(dry_run=dry_run)
+        if dry_run:
+            raise RuntimeError('Dry run, transaction rolled back.')
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Purpose
Fix issue with encrypting unicode

## Changes
* `jwe` [wants bytes](https://github.com/chrisseto/pyjwe/blob/master/README.md), so give it `bytes`

## Migration
`python -m scripts.encrypt_external_accounts_unicode --dry`

## Side effects
None expected.

## Ticket
None

## Before
```
In [4]: name = 'mfräezz'

In [5]: jwe.encrypt(name.encode('utf-8'), SENSITIVE_DATA_KEY)
---------------------------------------------------------------------------
UnicodeDecodeError                        Traceback (most recent call last)
<ipython-input-5-ca1156250faa> in <module>()
----> 1 jwe.encrypt(name.encode('utf-8'), SENSITIVE_DATA_KEY)

UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 3: ordinal not in range(128)
```
## After
```
In [6]: jwe.encrypt(bytes(name), SENSITIVE_DATA_KEY)
Out[6]: 'eyJhbGciOiAiZGlyIiwgImVuYyI6ICJBMjU2R0NNIn0.._6_kjjv7JIsqlcy_ZfRkqg.hSZpb3ymal0.z-3k--QrsHW1ry_pmTlMHg'

In [7]: jwe.decrypt(bytes(_), SENSITIVE_DATA_KEY) == name
Out[7]: True
```