### PR TITLE
[feature] Fix v2.1 Pagination [OSF-6473]

### DIFF
--- a/api/base/pagination.py
+++ b/api/base/pagination.py
@@ -186,7 +186,10 @@ class CommentPagination(JSONAPIPagination):
                             unread = 0
                         else:
                             unread = Comment.find_n_unread(user=user, node=node, page=page, root_id=target_id)
-                        response_dict['links']['meta']['unread'] = unread
+                        if self.request.version < '2.1':
+                            response_dict['links']['meta']['unread'] = unread
+                        else:
+                            response_dict['meta']['unread'] = unread
         return Response(response_dict)
 
 
@@ -200,7 +203,10 @@ class NodeContributorPagination(JSONAPIPagination):
         node_id = kwargs.get('node_id', None)
         node = Node.load(node_id)
         total_bibliographic = len(node.visible_contributor_ids)
-        response_dict['links']['meta']['total_bibliographic'] = total_bibliographic
+        if self.request.version < '2.1':
+            response_dict['links']['meta']['total_bibliographic'] = total_bibliographic
+        else:
+            response_dict['meta']['total_bibliographic'] = total_bibliographic
         return Response(response_dict)
 
 

--- a/api_tests/nodes/views/test_node_comments_list.py
+++ b/api_tests/nodes/views/test_node_comments_list.py
@@ -91,6 +91,20 @@ class NodeCommentsListMixin(object):
         assert_in(self.comment._id, comment_ids)
         assert_in(deleted_comment._id, comment_ids)
 
+    def test_node_comments_list_pagination(self):
+        self._set_up_public_project_with_comment()
+        url = '{}?filter[target]={}&related_counts=False'.format(self.public_url, self.public_project._id)
+        res = self.app.get(url, user=self.user, auth=self.user.auth)
+        assert_equal(res.status_code, 200)
+        assert_equal(res.json['links']['meta']['unread'], 0)
+
+    def test_node_comments_list_updated_pagination(self):
+        self._set_up_public_project_with_comment()
+        url = '{}?filter[target]={}&related_counts=False&version=2.1'.format(self.public_url, self.public_project._id)
+        res = self.app.get(url, user=self.user, auth=self.user.auth)
+        assert_equal(res.status_code, 200)
+        assert_equal(res.json['meta']['unread'], 0)
+
 
 class TestNodeCommentsList(NodeCommentsListMixin, ApiTestCase):
 

--- a/api_tests/nodes/views/test_node_embeds.py
+++ b/api_tests/nodes/views/test_node_embeds.py
@@ -87,3 +87,14 @@ class TestNodeEmbeds(ApiTestCase):
         assert_equal(res.status_code, 400)
         assert_equal(res.json['errors'][0]['detail'], "The following fields are not embeddable: title")
 
+    def test_embed_contributors_pagination(self):
+        url = '/{}nodes/{}/?embed=contributors'.format(API_BASE, self.root_node._id)
+        res = self.app.get(url, auth=self.contrib1.auth)
+        assert_equal(res.status_code, 200)
+        assert_equal(res.json['data']['embeds']['contributors']['links']['meta']['total_bibliographic'], 3)
+
+    def test_embed_contributors_updated_pagination(self):
+        url = '/{}nodes/{}/?version=2.1&embed=contributors'.format(API_BASE, self.root_node._id)
+        res = self.app.get(url, auth=self.contrib1.auth)
+        assert_equal(res.status_code, 200)
+        assert_equal(res.json['data']['embeds']['contributors']['meta']['total_bibliographic'], 3)


### PR DESCRIPTION
#### Purpose
- https://staging-api.osf.io/v2/nodes/?version=2.1&embed=contributors currently gives a `502`, we do not like mysterious `502`s.

#### Changes 
- This PR fixes the `NodeContributorPagination` and `CommentPagination` classes to no longer incorrectly look for pagination metadata in the old `2.0` location when version `2.1` is specified. 

#### Side effects
- None expected.

#### Ticket
- [OSF-6473](https://openscience.atlassian.net/browse/OSF-6473) (original versioning ticket)

