### PR TITLE
[Feature] Fix VOL nesting [OSF-5507]

### DIFF
--- a/website/static/css/pages/contributor-page.css
+++ b/website/static/css/pages/contributor-page.css
@@ -18,6 +18,13 @@
 .more-link-node{
     margin-top: 5px;
 }
+.private-link-list-node {
+    width: 100px;
+    margin-left: -40px;
+    overflow: hidden; 
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
 
 .link-url{
     padding: 3px 0px;

--- a/website/templates/project/contributors.mako
+++ b/website/templates/project/contributors.mako
@@ -193,7 +193,7 @@
             <div class="header" data-bind="visible: $root.collapsed() && expanded()"></div>
             <div class="td-content" data-bind="visible: !$root.collapsed() || expanded()">
                 <ul class="private-link-list narrow-list" data-bind="foreach: nodesList">
-                    <li data-bind="style:{marginLeft: $data.scale}">
+                    <li class="private-link-list-node">
                         <span data-bind="getIcon: $data.category"></span>
                         <a data-bind="text:$data.title, attr: {href: $data.url}"></a>
                     </li>


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->
## Purpose

VOL view on the contributors page nests very poorly. This flattens the nesting.
## Changes

Nodes no longer nest in the list of associated nodes. Set to a static 100px width, trims overflow and adds ellipsis. 
Before:
![before](https://cloud.githubusercontent.com/assets/1322421/19605483/4e8e64c0-9788-11e6-8e4c-881583bee02e.png)
After:
![after](https://cloud.githubusercontent.com/assets/1322421/19605487/5289dc30-9788-11e6-9c6e-095c678c4942.png)
## Side effects

None known.
## Ticket

https://openscience.atlassian.net/browse/OSF-5507

[#OSF-5507]
## QA Considerations
1. Should show a flat list
2. Long titles should be truncated.
3. The modal that used to create a VOL should still indent properly (related code)
