### PR TITLE
[feature] Update s3 "Learn More" Link [OSF-7121]

### DIFF
--- a/website/addons/s3/static/s3NodeConfig.js
+++ b/website/addons/s3/static/s3NodeConfig.js
@@ -209,7 +209,7 @@ var s3FolderPickerViewModel = oop.extend(OauthAddonFolderPicker, {
                                 '</div>' +
                             '</form>' +
                             '<span>For more information on locations, click ' +
-                                '<a href="http://www.bucketexplorer.com/documentation/amazon-s3--amazon-s3-buckets-and-regions.html">here</a>' + 
+                                '<a href="http://help.osf.io/m/addons/l/524149#BucketLocations">here</a>' +
                             '</span>' +
                         '</div>' +
                     '</div>',


### PR DESCRIPTION
#### Purpose
- Updates the Amazon s3 "learn more" link to point to the OSF guides instead of an external Amazon URL. 
#### Ticket
- [OSF-7121](https://openscience.atlassian.net/browse/OSF-7121)
