### PR TITLE
[Hotfix] fail gracefully when addons down [OSF-7142]

### DIFF
--- a/website/addons/github/api.py
+++ b/website/addons/github/api.py
@@ -49,7 +49,11 @@ class GitHubClient(object):
         :return: Dict of repo information
             See http://developer.github.com/v3/repos/#get
         """
-        rv = self.gh3.repository(user, repo)
+        try:
+            rv = self.gh3.repository(user, repo)
+        except:
+            raise NotFoundError
+
         if rv:
             return rv
         raise NotFoundError

--- a/website/addons/github/api.py
+++ b/website/addons/github/api.py
@@ -4,6 +4,7 @@ import itertools
 import github3
 import cachecontrol
 from requests.adapters import HTTPAdapter
+from requests.exceptions import ConnectionError
 
 from website.addons.github import settings as github_settings
 from website.addons.github.exceptions import NotFoundError
@@ -51,7 +52,7 @@ class GitHubClient(object):
         """
         try:
             rv = self.gh3.repository(user, repo)
-        except:
+        except ConnectionError:
             raise NotFoundError
 
         if rv:


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Pages do not load when github is down. This catches the error so the page at least loads.

## Changes

Catch the error, let page load. 

## Side effects
Sometimes the github logo showed up saying it couldn't load and sometimes it just didn't appear at all. Since this should be a rare occurrence it may not be worth worrying about, but wanted to mention.

## Ticket
https://openscience.atlassian.net/browse/OSF-7142
[#OSF-7142]