### PR TITLE
[hotfix] update prereg files widget for WBv1

### DIFF
--- a/website/static/js/filesWidget.js
+++ b/website/static/js/filesWidget.js
@@ -27,9 +27,6 @@ var FilesWidget = function(divID, filesUrl, opts) {
         filterFullWidth: true, // Make the filter span the entire row for this view
         xhrconfig: $osf.setXHRAuthorization,
         hScroll: null,
-        lazyLoadPreprocess: function(data) {
-            return data.data;
-        },
         columnTitles: function() {
             return [{
                 title: 'Name',

--- a/website/static/js/registrationEditorExtensions.js
+++ b/website/static/js/registrationEditorExtensions.js
@@ -85,7 +85,8 @@ var osfUploader = function(element, valueAccessor, allBindings, viewModel, bindi
                 Fangorn.DefaultOptions.dropzoneEvents,
                 {
                     complete: function(tb, file, response) {
-                        var fileMeta = JSON.parse(file.xhr.response);
+                        var fileResponse = JSON.parse(file.xhr.response);
+                        var fileMeta = fileResponse.data.attributes;
                         fileMeta.nodeId = file.treebeardParent.data.nodeId;
                         onSelectRow({
                             kind: 'file',


### PR DESCRIPTION
## Purpose

The preregistration file picker is broken because it doesn't handle WBv1 responses.

## Changes

Remove FilesWidget-specific Fangorn overrides to take advantage of its WB response unrolling.  Update manual response parsing to handle the new response structure.

## Side effects

None expected. 

## Ticket

No ticket.

 * prereg was doing some custom overloading of fangorn and manual
   response processing and therefore didn't missed out on the WBv1 API
   conversion in Fagorn.