### PR TITLE
[hotfix] fix file editing [OSF-7144]

### DIFF
--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -152,7 +152,7 @@ var FileViewPage = {
             delete: waterbutler.buildDeleteUrl(self.file.path, self.file.provider, self.node.id),
             metadata: waterbutler.buildMetadataUrl(self.file.path, self.file.provider, self.node.id),
             revisions: waterbutler.buildRevisionsUrl(self.file.path, self.file.provider, self.node.id),
-            content: waterbutler.buildDownloadUrl(self.file.path, self.file.provider, self.node.id, {accept_url: false, mode: 'render'})
+            content: waterbutler.buildDownloadUrl(self.file.path, self.file.provider, self.node.id, {direct: true, mode: 'render'})
         });
 
         if ($osf.urlParams().branch) {
@@ -166,7 +166,7 @@ var FileViewPage = {
                 window.contextVars.file.urls.external = response.data.extra.webView;
             });
             self.file.urls.revisions = waterbutler.buildRevisionsUrl(self.file.path, self.file.provider, self.node.id, {sha: $osf.urlParams().branch});
-            self.file.urls.content = waterbutler.buildDownloadUrl(self.file.path, self.file.provider, self.node.id, {accept_url: false, mode: 'render', branch: $osf.urlParams().branch});
+            self.file.urls.content = waterbutler.buildDownloadUrl(self.file.path, self.file.provider, self.node.id, {direct: true, mode: 'render', branch: $osf.urlParams().branch});
         }
 
         $(document).on('fileviewpage:delete', function() {


### PR DESCRIPTION
## Purpose

The Fangorn WBv0 => WBv1 conversion didn't account for a query parameter that changed names. As a result, providers that can send a redirect to the file (osfstorage and s3) were failing their CORS check.

## Changes

Update the file view page to pass `direct=` to WB instead of `accept_url=`.

## Side effects

None expected.

## Ticket

[#OSF-7144] -- [Link](https://openscience.atlassian.net/browse/OSF-7144)

 * The WBv0 `accept_url` param has been renamed to `direct` in WBv1.
   Update the file view page to follow.  This fixes CORS issues when
   trying to download from osfstorage or s3.