### PR TITLE
[hotfix] fix rename conflicts [OSF-7145]

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -505,7 +505,8 @@ function doItemOp(operation, to, from, rename, conflict) {
     if (operation === OPERATIONS.RENAME) {
         moveSpec = {
             action: 'rename',
-            rename: rename
+            rename: rename,
+            conflict: conflict
         };
     } else if (operation === OPERATIONS.COPY) {
         moveSpec = {


### PR DESCRIPTION
## Purpose

When a user renames a file to a name that already exists, the OSF asks if they want to keep both files or overwrite the existing one.  This is currently broken, because the `conflict` parameter that indicates the desired behavior is not being sent with the rename request.  In the absence of the `conflict` param, WB defaults to throwing a 409 Naming Conflict error.

## Changes

Include the `conflict` parameter in the rename request body.

## Side effects

None expected.

## Ticket

[#OSF-7145] -- [Link](https://openscience.atlassian.net/browse/OSF-1234)
