### PR TITLE
Ensure discovery page loads with no popular node settings [#OSF-7021]

### DIFF
--- a/scripts/tests/test_populate_popular_projects_and_registrations.py
+++ b/scripts/tests/test_populate_popular_projects_and_registrations.py
@@ -44,8 +44,6 @@ class TestPopulateNewAndNoteworthy(OsfTestCase):
         popular_nodes = [self.pop1, self.pop2]
         popular_registrations = [self.popreg1, self.popreg2]
 
-        # mock_client.count.return_value = {
-
         node_pageviews = [
             {
                 'result': 5,

--- a/tests/webtest_tests.py
+++ b/tests/webtest_tests.py
@@ -792,6 +792,9 @@ class TestExplorePublicActivity(OsfTestCase):
         self.popular_links_registrations.add_pointer(self.popular_registration, auth=Auth(self.popular_links_registrations.creator), save=True)
 
     def test_explore_page_loads_when_settings_not_configured(self):
+
+        old_settings_values = settings.POPULAR_LINKS_NODE, settings.NEW_AND_NOTEWORTHY_LINKS_NODE, settings.POPULAR_LINKS_REGISTRATIONS
+
         settings.POPULAR_LINKS_NODE = 'notanode'
         settings.NEW_AND_NOTEWORTHY_LINKS_NODE = 'alsototallywrong'
         settings.POPULAR_LINKS_REGISTRATIONS = 'nopenope'
@@ -799,6 +802,8 @@ class TestExplorePublicActivity(OsfTestCase):
         url = self.project.web_url_for('activity')
         res = self.app.get(url)
         assert_equal(res.status_code, 200)
+
+        settings.POPULAR_LINKS_NODE, settings.NEW_AND_NOTEWORTHY_LINKS_NODE, settings.POPULAR_LINKS_REGISTRATIONS = old_settings_values
 
     def test_new_and_noteworthy_and_popular_nodes_show_in_explore_activity(self):
 

--- a/tests/webtest_tests.py
+++ b/tests/webtest_tests.py
@@ -791,6 +791,15 @@ class TestExplorePublicActivity(OsfTestCase):
         self.popular_links_registrations._id = settings.POPULAR_LINKS_REGISTRATIONS
         self.popular_links_registrations.add_pointer(self.popular_registration, auth=Auth(self.popular_links_registrations.creator), save=True)
 
+    def test_explore_page_loads_when_settings_not_configured(self):
+        settings.POPULAR_LINKS_NODE = 'notanode'
+        settings.NEW_AND_NOTEWORTHY_LINKS_NODE = 'alsototallywrong'
+        settings.POPULAR_LINKS_REGISTRATIONS = 'nopenope'
+
+        url = self.project.web_url_for('activity')
+        res = self.app.get(url)
+        assert_equal(res.status_code, 200)
+
     def test_new_and_noteworthy_and_popular_nodes_show_in_explore_activity(self):
 
         url = self.project.web_url_for('activity')

--- a/tests/webtest_tests.py
+++ b/tests/webtest_tests.py
@@ -21,6 +21,7 @@ from tests.base import fake
 from tests.factories import (UserFactory, AuthUserFactory, ProjectFactory, WatchConfigFactory, NodeFactory,
                              NodeWikiFactory, RegistrationFactory,  UnregUserFactory, UnconfirmedUserFactory,
                              PrivateLinkFactory)
+from website.project import Node
 from website import settings, language
 from website.util import web_url_for, api_url_for
 
@@ -790,6 +791,10 @@ class TestExplorePublicActivity(OsfTestCase):
         self.popular_links_registrations = ProjectFactory()
         self.popular_links_registrations._id = settings.POPULAR_LINKS_REGISTRATIONS
         self.popular_links_registrations.add_pointer(self.popular_registration, auth=Auth(self.popular_links_registrations.creator), save=True)
+
+    def tearDown(self):
+        super(TestExplorePublicActivity, self).tearDown()
+        Node.remove()
 
     def test_explore_page_loads_when_settings_not_configured(self):
 

--- a/website/discovery/views.py
+++ b/website/discovery/views.py
@@ -2,8 +2,6 @@ from website import settings
 from website.project import Node
 from website.project import utils
 
-from modularodm.query.querydialect import DefaultQueryDialect as Q
-
 
 def activity():
     """Reads node activity from pre-generated popular projects and registrations.

--- a/website/discovery/views.py
+++ b/website/discovery/views.py
@@ -16,10 +16,16 @@ def activity():
     new_and_noteworthy_projects = [pointer.node for pointer in new_and_noteworthy_pointers]
 
     # Popular Projects
-    popular_public_projects = Node.find_one(Q('_id', 'eq', settings.POPULAR_LINKS_NODE)).nodes_pointer
+    try:
+        popular_public_projects = Node.load(Q('_id', 'eq', settings.POPULAR_LINKS_NODE)).nodes_pointer
+    except AttributeError:
+        popular_public_projects = []
 
     # Popular Registrations
-    popular_public_registrations = Node.find_one(Q('_id', 'eq', settings.POPULAR_LINKS_REGISTRATIONS)).nodes_pointer
+    try:
+        popular_public_registrations = Node.load(Q('_id', 'eq', settings.POPULAR_LINKS_REGISTRATIONS)).nodes_pointer
+    except AttributeError:
+        popular_public_registrations = []
 
     return {
         'new_and_noteworthy_projects': new_and_noteworthy_projects,

--- a/website/discovery/views.py
+++ b/website/discovery/views.py
@@ -13,20 +13,20 @@ def activity():
 
     # New and Noreworthy Projects
     try:
-        new_and_noteworthy_pointers = Node.load(Q('_id', 'eq', settings.NEW_AND_NOTEWORTHY_LINKS_NODE)).nodes_pointer
+        new_and_noteworthy_pointers = Node.load(settings.NEW_AND_NOTEWORTHY_LINKS_NODE).nodes_pointer
         new_and_noteworthy_projects = [pointer.node for pointer in new_and_noteworthy_pointers]
     except AttributeError:
         new_and_noteworthy_projects = []
 
     # Popular Projects
     try:
-        popular_public_projects = Node.load(Q('_id', 'eq', settings.POPULAR_LINKS_NODE)).nodes_pointer
+        popular_public_projects = Node.load(settings.POPULAR_LINKS_NODE).nodes_pointer
     except AttributeError:
         popular_public_projects = []
 
     # Popular Registrations
     try:
-        popular_public_registrations = Node.load(Q('_id', 'eq', settings.POPULAR_LINKS_REGISTRATIONS)).nodes_pointer
+        popular_public_registrations = Node.load(settings.POPULAR_LINKS_REGISTRATIONS).nodes_pointer
     except AttributeError:
         popular_public_registrations = []
 

--- a/website/discovery/views.py
+++ b/website/discovery/views.py
@@ -12,8 +12,11 @@ def activity():
     """
 
     # New and Noreworthy Projects
-    new_and_noteworthy_pointers = Node.find_one(Q('_id', 'eq', settings.NEW_AND_NOTEWORTHY_LINKS_NODE)).nodes_pointer
-    new_and_noteworthy_projects = [pointer.node for pointer in new_and_noteworthy_pointers]
+    try:
+        new_and_noteworthy_pointers = Node.load(Q('_id', 'eq', settings.NEW_AND_NOTEWORTHY_LINKS_NODE)).nodes_pointer
+        new_and_noteworthy_projects = [pointer.node for pointer in new_and_noteworthy_pointers]
+    except AttributeError:
+        new_and_noteworthy_projects = []
 
     # Popular Projects
     try:


### PR DESCRIPTION
## Purpose
An addendum to https://github.com/CenterForOpenScience/osf.io/pull/6394 -- if `settings.NEW_AND_NOTEWORTHY_LINKS_NODE`, `settings.POPULAR_LINKS_NODE` or `settings.POPULAR_LINKS_REGISTRATIONS` weren't set properly, the page at `explore/activity/` wouldn't load at all.

Fix that!

## Changes

- Catch errors that the nodes specified in settings did't work as planned
- Add tests for the missing settings

## Side effects
- Page should load on staging now...


## Ticket
https://openscience.atlassian.net/browse/OSF-7021