### PR TITLE
[rfr] [djangosf] Fix setting root

### DIFF
--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -1995,8 +1995,6 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             self.set_visible(user, visible, auth=auth)
 
     def save(self, *args, **kwargs):
-        if self.pk:
-            self.root = self._root
         if 'suppress_log' in kwargs.keys():
             self._suppress_log = kwargs['suppress_log']
             del kwargs['suppress_log']
@@ -2708,3 +2706,6 @@ def set_parent(sender, instance, created, *args, **kwargs):
             child=instance,
             is_node_link=False
         )
+
+    # Update root. Use .filter().update() to avoid sending signals
+    sender.objects.filter(id=instance.id).update(root=instance._root)

--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -62,9 +62,18 @@ def test_top_level_node_has_parent_node_none():
     assert project.parent_node is None
 
 def test_component_has_parent_node():
-    node = NodeFactory()
-    assert type(node.parent_node) is Node
+    project = ProjectFactory()
+    node = NodeFactory(parent=project)
+    assert node.parent_node == project
 
+def test_components_have_root():
+    root = ProjectFactory()
+    child = NodeFactory(parent=root)
+    grandchild = NodeFactory(parent=child)
+    child.reload()
+    grandchild.reload()
+    assert child.root == root
+    assert grandchild.root == root
 
 def test_license_searches_parent_nodes():
     license_record = NodeLicenseRecordFactory()
@@ -143,6 +152,10 @@ class TestProject:
 
     def test_parent_id(self, project):
         assert not project.parent_id
+
+    def test_root_id_is_same_as_own_id_for_top_level_nodes(self, project):
+        project.reload()
+        assert project.root_id == project.id
 
     def test_nodes_active(self, project, auth):
         node = NodeFactory(parent=project)

--- a/website/project/utils.py
+++ b/website/project/utils.py
@@ -16,7 +16,8 @@ serialize_node = _view_project  # Not recommended practice
 CONTENT_NODE_QUERY = (
     # Can encompass accessible projects, registrations, or forks
     # Note: is_bookmark collection(s) are implicitly assumed to also be collections; that flag intentionally omitted
-    Q('is_deleted', 'eq', False)
+    Q('is_deleted', 'eq', False) &
+    Q('type', 'ne', 'osf.collection')
 )
 
 PROJECT_QUERY = CONTENT_NODE_QUERY


### PR DESCRIPTION
Now, root will be set upon first save of a Node. It needs
to be set in post_save because the NodeRelation to parent
must already exist.

We use `.filter(id=...).update(...)` in order to prevent signals
from being sent.

One side effect of this is that newly-created Nodes will
need to call node.reload() or node.refesh_from_db() if they
need to access `root`.
