### PR TITLE
[Fix] Fix ucsd logout url on test environment [No Ticket]

### DIFF
--- a/scripts/populate_institutions.py
+++ b/scripts/populate_institutions.py
@@ -321,7 +321,7 @@ def main(env):
                 'banner_name': 'ucsd-banner.png',
                 'logo_name': 'ucsd-shield.png',
                 'auth_url': SHIBBOLETH_SP_LOGIN.format(encode_uri_component('urn:mace:incommon:ucsd.edu')),
-                'logout_url': SHIBBOLETH_SP_LOGOUT.format(encode_uri_component('https://osf.io/goodbye')),
+                'logout_url': SHIBBOLETH_SP_LOGOUT.format(encode_uri_component('https://test.osf.io/goodbye')),
                 'domains': ['test-osf-ucsd.cos.io'],
                 'email_domains': [],
             }, 


### PR DESCRIPTION
## Purpose

A quick fix of `logoutUrl` for UCSD on test environment. It should be "https://test.osf.io/goodbye" instead of "https://osf.io/goodbye".

## Changes

```
'logout_url': SHIBBOLETH_SP_LOGOUT.format(encode_uri_component('https://test.osf.io/goodbye'))
```

## QA Notes

No need to test for now.

## Side effects

No

## Ticket

No
