### PR TITLE
[feature-fix] Move dashboard_institutions to Dashboard View [OSF-6980]

### DIFF
--- a/tests/framework_tests/test_routing.py
+++ b/tests/framework_tests/test_routing.py
@@ -8,12 +8,6 @@ from webtest_plus import TestApp
 from framework.exceptions import HTTPError
 from framework.routing import json_renderer, process_rules, Rule
 
-from tests import factories
-from tests.base import OsfTestCase
-
-from website import routes
-from website import settings
-
 def error_view():
     raise HTTPError(400)
 
@@ -46,60 +40,3 @@ class TestJSONRenderer(unittest.TestCase):
         data = res.json
         assert_equal(data['message_short'], 'Invalid')
         assert_equal(data['message_long'], 'Invalid request')
-
-
-class TestGetGlobals(OsfTestCase):
-
-    def setUp(self):
-        super(TestGetGlobals, self).setUp()
-
-        self.inst_one = factories.InstitutionFactory()
-        self.inst_two = factories.InstitutionFactory()
-        self.inst_three = factories.InstitutionFactory()
-        self.inst_four = factories.InstitutionFactory()
-        self.inst_five = factories.InstitutionFactory()
-
-        self.user = factories.AuthUserFactory()
-        self.user.affiliated_institutions.append(self.inst_one)
-        self.user.affiliated_institutions.append(self.inst_two)
-        self.user.save()
-
-        # tests 5 affiliated, non-registered, public projects
-        for i in range(settings.INSTITUTION_DISPLAY_NODE_THRESHOLD):
-            node = factories.ProjectFactory(creator=self.user, is_public=True)
-            node.affiliated_institutions.append(self.inst_one)
-            node.save()
-
-        # tests 4 affiliated, non-registered, public projects
-        for i in range(settings.INSTITUTION_DISPLAY_NODE_THRESHOLD - 1):
-            node = factories.ProjectFactory(creator=self.user, is_public=True)
-            node.affiliated_institutions.append(self.inst_two)
-            node.save()
-
-        # tests 5 affiliated, registered, public projects
-        for i in range(settings.INSTITUTION_DISPLAY_NODE_THRESHOLD):
-            registration = factories.RegistrationFactory(creator=self.user, is_public=True)
-            registration.affiliated_institutions.append(self.inst_three)
-            registration.save()
-
-        # tests 5 affiliated, non-registered public components
-        for i in range(settings.INSTITUTION_DISPLAY_NODE_THRESHOLD):
-            node = factories.NodeFactory(creator=self.user, is_public=True)
-            node.affiliated_institutions.append(self.inst_four)
-            node.save()
-
-        # tests 5 affiliated, non-registered, private projects
-        for i in range(settings.INSTITUTION_DISPLAY_NODE_THRESHOLD):
-            node = factories.ProjectFactory(creator=self.user)
-            node.affiliated_institutions.append(self.inst_five)
-            node.save()
-
-    def test_get_globals_dashboard_institutions(self):
-        globals = routes.get_globals()
-        dashboard_institutions = globals['dashboard_institutions']
-        assert_equal(len(dashboard_institutions), 1)
-        assert_equal(dashboard_institutions[0]['id'], self.inst_one._id)
-        assert_not_equal(dashboard_institutions[0]['id'], self.inst_two._id)
-        assert_not_equal(dashboard_institutions[0]['id'], self.inst_three._id)
-        assert_not_equal(dashboard_institutions[0]['id'], self.inst_four._id)
-        assert_not_equal(dashboard_institutions[0]['id'], self.inst_five._id)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -54,6 +54,7 @@ from website.project.views.contributor import (
 from website.project.views.node import _should_show_wiki_widget, _view_project, abbrev_authors
 from website.util import api_url_for, web_url_for
 from website.util import permissions, rubeus
+from website.views import index
 
 
 class Addon(MockAddonNodeSettings):
@@ -4419,6 +4420,62 @@ class TestUserConfirmSignal(OsfTestCase):
             assert_equal(res.status_code, 302)
 
         assert_equal(mock_signals.signals_sent(), set([auth.signals.user_confirmed]))
+
+
+class TestIndexView(OsfTestCase):
+
+    def setUp(self):
+        super(TestIndexView, self).setUp()
+
+        self.inst_one = InstitutionFactory()
+        self.inst_two = InstitutionFactory()
+        self.inst_three = InstitutionFactory()
+        self.inst_four = InstitutionFactory()
+        self.inst_five = InstitutionFactory()
+
+        self.user = AuthUserFactory()
+        self.user.affiliated_institutions.append(self.inst_one)
+        self.user.affiliated_institutions.append(self.inst_two)
+        self.user.save()
+
+        # tests 5 affiliated, non-registered, public projects
+        for i in range(settings.INSTITUTION_DISPLAY_NODE_THRESHOLD):
+            node = ProjectFactory(creator=self.user, is_public=True)
+            node.affiliated_institutions.append(self.inst_one)
+            node.save()
+
+        # tests 4 affiliated, non-registered, public projects
+        for i in range(settings.INSTITUTION_DISPLAY_NODE_THRESHOLD - 1):
+            node = ProjectFactory(creator=self.user, is_public=True)
+            node.affiliated_institutions.append(self.inst_two)
+            node.save()
+
+        # tests 5 affiliated, registered, public projects
+        for i in range(settings.INSTITUTION_DISPLAY_NODE_THRESHOLD):
+            registration = RegistrationFactory(creator=self.user, is_public=True)
+            registration.affiliated_institutions.append(self.inst_three)
+            registration.save()
+
+        # tests 5 affiliated, non-registered public components
+        for i in range(settings.INSTITUTION_DISPLAY_NODE_THRESHOLD):
+            node = NodeFactory(creator=self.user, is_public=True)
+            node.affiliated_institutions.append(self.inst_four)
+            node.save()
+
+        # tests 5 affiliated, non-registered, private projects
+        for i in range(settings.INSTITUTION_DISPLAY_NODE_THRESHOLD):
+            node = ProjectFactory(creator=self.user)
+            node.affiliated_institutions.append(self.inst_five)
+            node.save()
+
+    def test_dashboard_institutions(self):
+        dashboard_institutions = index()['dashboard_institutions']
+        assert_equal(len(dashboard_institutions), 1)
+        assert_equal(dashboard_institutions[0]['id'], self.inst_one._id)
+        assert_not_equal(dashboard_institutions[0]['id'], self.inst_two._id)
+        assert_not_equal(dashboard_institutions[0]['id'], self.inst_three._id)
+        assert_not_equal(dashboard_institutions[0]['id'], self.inst_four._id)
+        assert_not_equal(dashboard_institutions[0]['id'], self.inst_five._id)
 
 if __name__ == '__main__':
     unittest.main()

--- a/website/routes.py
+++ b/website/routes.py
@@ -34,7 +34,7 @@ from website.util import metrics
 from website.util import paths
 from website.util import sanitize
 from website import maintenance
-from website.models import Institution, Node
+from website.models import Institution
 from website import landing_pages as landing_page_views
 from website import views as website_views
 from website.citations import views as citation_views
@@ -57,20 +57,6 @@ def get_globals():
     user = _get_current_user()
 
     user_institutions = [{'id': inst._id, 'name': inst.name, 'logo_path': inst.logo_path_rounded_corners} for inst in user.affiliated_institutions] if user else []
-    all_institutions = [inst for inst in Institution.find().sort('name')]
-    dashboard_institutions = [
-        {'id': inst._id, 'name': inst.name, 'logo_path': inst.logo_path_rounded_corners}
-        for inst in all_institutions
-        if len(
-            Node.find_by_institutions(inst, query=(
-                Q('is_public', 'eq', True) &
-                Q('is_folder', 'ne', True) &
-                Q('is_deleted', 'ne', True) &
-                Q('parent_node', 'eq', None) &
-                Q('is_registration', 'eq', False)
-            ))
-        ) >= settings.INSTITUTION_DISPLAY_NODE_THRESHOLD
-    ]
     location = geolite2.lookup(request.remote_addr) if request.remote_addr else None
     if request.host_url != settings.DOMAIN:
         try:
@@ -93,7 +79,6 @@ def get_globals():
         'user_api_url': user.api_url if user else '',
         'user_entry_point': metrics.get_entry_point(user) if user else '',
         'user_institutions': user_institutions if user else None,
-        'dashboard_institutions': dashboard_institutions,
         'display_name': get_display_name(user.fullname) if user else '',
         'anon': {
             'continent': getattr(location, 'continent', None),

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -188,7 +188,6 @@
                     emailsToAdd: ${ user_email_verifications | sjson, n },
                     anon: ${ anon | sjson, n },
                 },
-                dashboardInstitutions: ${ dashboard_institutions | sjson, n},
                 popular: ${ popular_links_node | sjson, n },
                 newAndNoteworthy: ${ noteworthy_links_node | sjson, n },
                 maintenance: ${ maintenance | sjson, n},

--- a/website/templates/home.mako
+++ b/website/templates/home.mako
@@ -26,5 +26,10 @@
 
 <%def name="javascript_bottom()">
     ${parent.javascript_bottom()}
+    <script type="text/javascript">
+        window.contextVars = $.extend(true, {}, window.contextVars, {
+            dashboardInstitutions: ${ dashboard_institutions | sjson, n},
+        });
+    </script>
     <script src=${"/static/public/js/home-page.js" | webpack_asset}></script>
 </%def>

--- a/website/views.py
+++ b/website/views.py
@@ -21,6 +21,7 @@ from website.institutions.views import view_institution
 from website.models import Guid
 from website.models import Node, Institution
 from website.project import new_bookmark_collection
+from website.settings import INSTITUTION_DISPLAY_NODE_THRESHOLD
 from website.util import permissions
 
 logger = logging.getLogger(__name__)
@@ -74,17 +75,37 @@ def _render_nodes(nodes, auth=None, show_path=False):
 def index():
     try:
         #TODO : make this way more robust
-        inst = Institution.find_one(Q('domains', 'eq', request.host.lower()))
-        inst_dict = view_institution(inst._id)
+        institution = Institution.find_one(Q('domains', 'eq', request.host.lower()))
+        inst_dict = view_institution(institution._id)
         inst_dict.update({
             'home': False,
             'institution': True,
-            'redirect_url': '/institutions/{}/'.format(inst._id)
+            'redirect_url': '/institutions/{}/'.format(institution._id)
         })
+
         return inst_dict
     except NoResultsFound:
         pass
-    return {'home': True}
+
+    all_institutions = [inst for inst in Institution.find().sort('name')]
+    dashboard_institutions = [
+        {'id': inst._id, 'name': inst.name, 'logo_path': inst.logo_path_rounded_corners}
+        for inst in all_institutions
+        if len(
+            Node.find_by_institutions(inst, query=(
+                Q('is_public', 'eq', True) &
+                Q('is_folder', 'ne', True) &
+                Q('is_deleted', 'ne', True) &
+                Q('parent_node', 'eq', None) &
+                Q('is_registration', 'eq', False)
+            ))
+        ) >= INSTITUTION_DISPLAY_NODE_THRESHOLD
+    ]
+
+    return {
+        'home': True,
+        'dashboard_institutions': dashboard_institutions
+    }
 
 
 def find_bookmark_collection(user):


### PR DESCRIPTION
#### Purpose/Changes
- Moves all of the logic from #6351 from `get_globals()` in routes.py to the dashboard view so that every request does not have to undergo the expensive query to find the institutions that should be displayed on the dashboard (as [pointed out](https://github.com/CenterForOpenScience/osf.io/pull/6351/files#r85000979) by @sloria).

#### Side effects
- None expected, everything should still function as described in #6351 

#### Ticket
- [OSF-6980](https://openscience.atlassian.net/browse/OSF-6980)