### PR TITLE
[Feature Fix] Use promise to stop Editor ajax double call [OSF-6883]

### DIFF
--- a/website/static/js/filepage/editor.js
+++ b/website/static/js/filepage/editor.js
@@ -26,11 +26,11 @@ var FileFetcher = {
                 url: url,
                 dataType: 'text',
                 beforeSend: $osf.setXHRAuthorization,
-            })
+            });
         }
         return self.promise;
     }
-}
+};
 
 var FileEditor = {
     controller: function(contentUrl, shareWSUrl, editorMeta, observables) {
@@ -67,7 +67,7 @@ var FileEditor = {
                     model.editor.setValue(self.initialText);
                 }
                 m.endComputation();
-            })
+            });
 
             response.fail(function (xhr, textStatus, error) {
                 $osf.growl('Error','The file content could not be loaded.');

--- a/website/static/js/filepage/editor.js
+++ b/website/static/js/filepage/editor.js
@@ -15,6 +15,23 @@ var util = require('./util.js');
 
 var model = {};
 
+// This stops the FileEditor Ajax from being called twice on load when
+// Mithril reloads the controller twice
+var FileHandler = {
+    fetchUrl: function(url, reload){
+        self = this;
+        if(typeof self.promise === 'undefined' || reload){
+            self.promise = $.ajax({
+                type: 'GET',
+                url: url,
+                dataType: 'text',
+                beforeSend: $osf.setXHRAuthorization,
+            })
+        }
+        return self.promise;
+    }
+}
+
 var FileEditor = {
     controller: function(contentUrl, shareWSUrl, editorMeta, observables) {
         var self = {};
@@ -38,27 +55,21 @@ var FileEditor = {
             new ShareJSDoc(shareWSUrl, self.editorMeta, model.editor, self.observables);
         };
 
-        self.handleResponse = function(response) {
-            m.startComputation();
-            self.loaded = true;
-            self.initialText = response;
-            if (model.editor) {
-                model.editor.setValue(self.initialText);
-            }
-            m.endComputation();
-        };
-
-        self.reloadFile = function() {
+        self.loadFile = function(reload) {
             self.loaded = false;
-            $.ajax({
-                type: 'GET',
-                url: self.url,
-                dataType: 'text',
-                beforeSend: $osf.setXHRAuthorization,
-            }).done(function (parsed, status, response) {
-                model.loadedResponse = response.responseText;
-                self.handleResponse(response.responseText);
-            }).fail(function (xhr, textStatus, error) {
+            var response = FileHandler.fetchUrl(self.url, reload);
+
+            response.done(function (parsed, status, response) {
+                m.startComputation();
+                self.loaded = true;
+                self.initialText = response.responseText;
+                if (model.editor) {
+                    model.editor.setValue(self.initialText);
+                }
+                m.endComputation();
+            })
+
+            response.fail(function (xhr, textStatus, error) {
                 $osf.growl('Error','The file content could not be loaded.');
                 Raven.captureMessage('Could not GET file contents.', {
                     extra: {
@@ -68,7 +79,7 @@ var FileEditor = {
                     }
                 });
             });
-        };
+        }
 
         self.saveFile = $osf.throttle(function() {
             var oldstatus = self.observables.status();
@@ -120,13 +131,7 @@ var FileEditor = {
             return clean1 !== clean2;
         };
         
-        // Hack to prevent double downloads of files from controllers being called twice
-        // Double download is caused by treebeard and fileviewpage both being mounted by mithril        
-        if(model.loadedResponse){
-            self.handleResponse(model.loadedResponse);
-        }else{
-            self.reloadFile();
-        }
+        self.loadFile(false);
 
         return self;
     },
@@ -159,7 +164,7 @@ var FileEditor = {
             m('[style=position:inherit]', [
                 m('.row', m('.col-sm-12', [
                     m('.pull-right', [
-                        m('button#fileEditorRevert.btn.btn-sm.btn-danger', {onclick: function(){ctrl.reloadFile();}}, 'Revert'),
+                        m('button#fileEditorRevert.btn.btn-sm.btn-danger', {onclick: function(){ctrl.loadFile(true);}}, 'Revert'),
                         ' ',
                         m('button#fileEditorSave.btn.btn-sm.btn-success', {onclick: function() {ctrl.saveFile();}}, 'Save')
                     ])

--- a/website/static/js/filepage/editor.js
+++ b/website/static/js/filepage/editor.js
@@ -17,8 +17,8 @@ var model = {};
 
 // This stops the FileEditor Ajax from being called twice on load when
 // Mithril reloads the controller twice
-var FileHandler = {
-    fetchUrl: function(url, reload){
+var FileFetcher = {
+    fetch: function(url, reload){
         self = this;
         if(typeof self.promise === 'undefined' || reload){
             self.promise = $.ajax({
@@ -57,7 +57,7 @@ var FileEditor = {
 
         self.loadFile = function(reload) {
             self.loaded = false;
-            var response = FileHandler.fetchUrl(self.url, reload);
+            var response = FileFetcher.fetch(self.url, reload);
 
             response.done(function (parsed, status, response) {
                 m.startComputation();
@@ -79,7 +79,7 @@ var FileEditor = {
                     }
                 });
             });
-        }
+        };
 
         self.saveFile = $osf.throttle(function() {
             var oldstatus = self.observables.status();


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Reworks my previous changes to [OSF-6883]
## Changes

Instead of doing a check if created, this extracts the ajax call into a separate object. The FileEditor then checks for a previous call if reload=false, or simply reloads if reload=true;

## Side effects

None known.

## Ticket

https://openscience.atlassian.net/browse/OSF-6883
[#OSF-6883]

## New QA considerations.
Since this change has more of a chance of breaking things, the basic functionality of the file editor should be checked to ensure editing/saving/reverting works properly.