### PR TITLE
[djangosf] [WIP] fix root recursive

### DIFF
--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -1995,8 +1995,6 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             self.set_visible(user, visible, auth=auth)
 
     def save(self, *args, **kwargs):
-        if self.pk:
-            self.root = self._root
         if 'suppress_log' in kwargs.keys():
             self._suppress_log = kwargs['suppress_log']
             del kwargs['suppress_log']
@@ -2708,3 +2706,6 @@ def set_parent(sender, instance, created, *args, **kwargs):
             child=instance,
             is_node_link=False
         )
+
+    # Update root. Use .filter().update() to avoid sending signals
+    sender.objects.filter(id=instance.id).update(root=instance._root)

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -14,7 +14,8 @@ import pytz
 from dirtyfields import DirtyFieldsMixin
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
-from django.db import models, transaction
+from django.db import models, transaction, connection
+from psycopg2._psycopg import AsIs
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.utils import timezone
@@ -212,6 +213,35 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
         if self.is_fork:
             return self.forked_from.parent_node
         return None
+
+    def get_root(self):
+        sql = """
+            WITH RECURSIVE
+                node_relation_cte(id, parent_id, child_id, path) AS (
+                SELECT
+                    node_relation.id,
+                    node_relation.parent_id,
+                    node_relation.child_id,
+                    (node_relation.parent_id || '->' || node_relation.child_id :: TEXT) as path
+                FROM "%s" AS node_relation
+                UNION ALL
+                SELECT
+                    c.id,
+                    c.parent_id,
+                    c.child_id,
+                    (p.path || '->' || c.child_id::TEXT) as path
+                FROM node_relation_cte AS p, "%s" AS c
+                WHERE c.parent_id = p.child_id
+            )
+            SELECT path FROM node_relation_cte AS n WHERE n.child_id = %s;
+        """
+        with connection.cursor() as cursor:
+            node_relation_table = AsIs(NodeRelation._meta.db_table)
+            cursor.execute(sql, [node_relation_table, node_relation_table, self.pk])
+            row = cursor.fetchone()
+            if not row:
+                return row
+            return AbstractNode.objects.get(id=row[0])
 
     @property
     def nodes(self):

--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -62,9 +62,18 @@ def test_top_level_node_has_parent_node_none():
     assert project.parent_node is None
 
 def test_component_has_parent_node():
-    node = NodeFactory()
-    assert type(node.parent_node) is Node
+    project = ProjectFactory()
+    node = NodeFactory(parent=project)
+    assert node.parent_node == project
 
+def test_components_have_root():
+    root = ProjectFactory()
+    child = NodeFactory(parent=root)
+    grandchild = NodeFactory(parent=child)
+    child.reload()
+    grandchild.reload()
+    assert child.root == root
+    assert grandchild.root == root
 
 def test_license_searches_parent_nodes():
     license_record = NodeLicenseRecordFactory()
@@ -143,6 +152,10 @@ class TestProject:
 
     def test_parent_id(self, project):
         assert not project.parent_id
+
+    def test_root_id_is_same_as_own_id_for_top_level_nodes(self, project):
+        project.reload()
+        assert project.root_id == project.id
 
     def test_nodes_active(self, project, auth):
         node = NodeFactory(parent=project)

--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -70,10 +70,15 @@ def test_components_have_root():
     root = ProjectFactory()
     child = NodeFactory(parent=root)
     grandchild = NodeFactory(parent=child)
+    greatgrandchild = NodeFactory(parent=grandchild)
     child.reload()
     grandchild.reload()
     assert child.root == root
     assert grandchild.root == root
+
+    # assert child.get_root() == root
+    # assert grandchild.get_root() == rooo
+    assert greatgrandchild.get_root() == root
 
 def test_license_searches_parent_nodes():
     license_record = NodeLicenseRecordFactory()

--- a/website/project/utils.py
+++ b/website/project/utils.py
@@ -16,7 +16,8 @@ serialize_node = _view_project  # Not recommended practice
 CONTENT_NODE_QUERY = (
     # Can encompass accessible projects, registrations, or forks
     # Note: is_bookmark collection(s) are implicitly assumed to also be collections; that flag intentionally omitted
-    Q('is_deleted', 'eq', False)
+    Q('is_deleted', 'eq', False) &
+    Q('type', 'ne', 'osf.collection')
 )
 
 PROJECT_QUERY = CONTENT_NODE_QUERY


### PR DESCRIPTION
Includes #6468 . Switch to using a recursive query to get the root of a node.

**This currently does not work**. Given a node hierarchy "Root" -> "Child" -> "Grandchild", calling `get_root` on "Grandchild" returns "Child.id" -> "Grandchild.id" (the expected path is "Root.id" -> "Child.id" -> "Grandchild.id".

Submitting early for @cwisecarver 's review.
