### PR TITLE
Update Wiki Preview Length [OSF-5781]

### DIFF
--- a/website/addons/wiki/templates/wiki_widget.mako
+++ b/website/addons/wiki/templates/wiki_widget.mako
@@ -26,8 +26,8 @@
 
 <style>
 .preview {
-    max-height:300px; 
-    overflow-y: scroll; 
+    max-height: 300px;
+    overflow-y: auto;
     padding-right: 10px;
 }
 </style>


### PR DESCRIPTION
## Purpose

Additional development for [https://openscience.atlassian.net/browse/OSF-5781](https://openscience.atlassian.net/browse/OSF-5781). Changed scrollbar to hide when not needed.

Before:
![for wiki with no content](https://cloud.githubusercontent.com/assets/7026698/19775573/e22ec5f2-9c3e-11e6-9ed0-1aa3ad7b45b0.png)
The scrollbar (circled in magenta) is visible when it doesn't need to be.

After:
<img width="359" alt="screen shot 2016-10-27 at 12 13 25 pm" src="https://cloud.githubusercontent.com/assets/7026698/19775580/e79ffa60-9c3e-11e6-88fb-b0275457afab.png">
The scrollbar is no longer visible when not needed.


## Changes
Set ```overflow-y``` to ```auto```.

## Side effects
None visible.

## Ticket
[https://openscience.atlassian.net/browse/OSF-5781](https://openscience.atlassian.net/browse/OSF-5781)

