### PR TITLE
Improve popular node gathering script [OSF-7021]

### DIFF
--- a/scripts/populate_popular_projects_and_registrations.py
+++ b/scripts/populate_popular_projects_and_registrations.py
@@ -18,7 +18,10 @@ logger = logging.getLogger(__name__)
 
 def update_node_links(designated_node, target_nodes, description):
     """ Takes designated node, removes current node links and replaces them with node links to target nodes """
-    logger.info('Repopulating {} with latest {} nodes.'.format(designated_node._id, description))
+    if len(target_nodes) == 0:
+        logger.info('No target nodes specified - no node links will be added!')
+    else:
+        logger.info('Repopulating {} with latest {} nodes.'.format(designated_node._id, description))
     user = designated_node.creator
     auth = Auth(user)
 
@@ -50,7 +53,7 @@ def main(dry_run=True):
 
     try:
         popular_links_registrations.save()
-        logger.info('Node links for registrations on {} updated.'.format(popular_links_node._id))
+        logger.info('Node links for registrations on {} updated.'.format(popular_links_registrations._id))
     except (KeyError, RuntimeError) as error:
         logger.error('Could not migrate popular nodes for registrations due to error')
         logger.exception(error)

--- a/website/project/utils.py
+++ b/website/project/utils.py
@@ -93,21 +93,13 @@ def activity():
     """
     popular_public_projects = []
     popular_public_registrations = []
-    max_popular_projects = 20
+    max_projects_to_display = settings.MAX_POPULAR_PROJECTS
 
     if settings.KEEN['public']['read_key']:
         keen_activity = get_keen_activity()
-        node_pageviews = keen_activity['node_pageviews']
         node_visits = keen_activity['node_visits']
 
-        node_data = [{'node': x['node.id'], 'views': x['result']} for x in node_pageviews[0:max_popular_projects]]
-
-        # Even though view counts won't be used, still gather this data for sorting
-        for node_visit in node_visits[0:max_popular_projects]:
-            for node_result in node_data:
-                if node_visit['node.id'] == node_result['node']:
-                    node_result.update({'visits': node_visit['result']})
-
+        node_data = [{'node': x['node.id'], 'views': x['result']} for x in node_visits]
         node_data.sort(key=lambda datum: datum['views'], reverse=True)
 
         node_data = [node_dict['node'] for node_dict in node_data]
@@ -117,12 +109,12 @@ def activity():
             if node is None:
                 continue
             if node.is_public and not node.is_registration and not node.is_deleted:
-                if len(popular_public_projects) < 10:
+                if len(popular_public_projects) < max_projects_to_display:
                     popular_public_projects.append(node)
             elif node.is_public and node.is_registration and not node.is_deleted and not node.is_retracted:
-                if len(popular_public_registrations) < 10:
+                if len(popular_public_registrations) < max_projects_to_display:
                     popular_public_registrations.append(node)
-            if len(popular_public_projects) >= 10 and len(popular_public_registrations) >= 10:
+            if len(popular_public_projects) >= max_projects_to_display and len(popular_public_registrations) >= max_projects_to_display:
                 break
 
     # New and Noteworthy projects are updated manually

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -278,6 +278,8 @@ POPULAR_LINKS_NODE = None  # TODO Override in local.py in production.
 POPULAR_LINKS_REGISTRATIONS = None  # TODO Override in local.py in production.
 NEW_AND_NOTEWORTHY_LINKS_NODE = None  # TODO Override in local.py in production.
 
+MAX_POPULAR_PROJECTS = 10
+
 NEW_AND_NOTEWORTHY_CONTRIBUTOR_BLACKLIST = []  # TODO Override in local.py in production.
 
 # FOR EMERGENCIES ONLY: Setting this to True will disable forks, registrations,


### PR DESCRIPTION
## Purpose
The previous code to grab popular nodes from keen for processing was limited by the fact that it was running every time the view was accessed, and so only grabbed a limited number of results from the recent keen results. It was also relying on a combination of unique views and total views, which we can leave out to make things simpler (since we're not displaying unique views for the time being). 

Since this script will now be run once a day, it can be a bit more intensive and actually sort through the keen results. 

## Changes
- Get popular nodes and registrations from all keen results in last 7 days
- Only rely on unique view count for popularity
- Add a setting for number of registrations and projects to show
- Add better logging so you know if it isn't actually updating any node links.

## Side effects
- Script itself will take longer to run, but shouldn't be bad. Haven't tested on production level data.

## Ticket
https://openscience.atlassian.net/browse/OSF-7021