### PR TITLE
[djangosf] Modify transaction handlers for djangosf compat

### DIFF
--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -174,12 +174,7 @@ CORS_ALLOW_CREDENTIALS = True
 INSTITUTION_ORIGINS_WHITELIST = ()
 
 MIDDLEWARE_CLASSES = (
-    # TokuMX transaction support
-    # Needs to go before CommonMiddleware, so that transactions are always started,
-    # even in the event of a redirect. CommonMiddleware may cause other middlewares'
-    # process_request to be skipped, e.g. when a trailing slash is omitted
     'api.base.middleware.DjangoGlobalMiddleware',
-    'api.base.middleware.MongoConnectionMiddleware',
     'api.base.middleware.CeleryTaskMiddleware',
     'api.base.middleware.PostcommitTaskMiddleware',
 

--- a/framework/transactions/handlers.py
+++ b/framework/transactions/handlers.py
@@ -2,11 +2,11 @@
 
 import httplib
 import logging
+from framework.exceptions import HTTPError
 
-from flask import request, current_app
-from pymongo.errors import OperationFailure
-
-from framework.transactions import utils, commands, messages
+from django.db import transaction
+from flask import request, current_app, has_request_context, _request_ctx_stack
+from werkzeug.local import LocalProxy
 
 
 LOCK_ERROR_CODE = httplib.BAD_REQUEST
@@ -14,6 +14,13 @@ NO_AUTO_TRANSACTION_ATTR = '_no_auto_transaction'
 
 logger = logging.getLogger(__name__)
 
+def _get_current_atomic():
+    if has_request_context():
+        ctx = _request_ctx_stack.top
+        return getattr(ctx, 'current_atomic', None)
+    return None
+
+current_atomic = LocalProxy(_get_current_atomic)
 
 def no_auto_transaction(func):
     setattr(func, NO_AUTO_TRANSACTION_ATTR, True)
@@ -34,17 +41,10 @@ def transaction_before_request():
     """
     if view_has_annotation(NO_AUTO_TRANSACTION_ATTR):
         return None
-    try:
-        commands.rollback()
-        logger.error('Transaction already in progress prior to request; rolling back.')
-    except OperationFailure as error:
-        #  expected error, transaction shouldn't be started prior to request
-        message = utils.get_error_message(error)
-        if messages.NO_TRANSACTION_ERROR not in message:
-            #  exception not a transaction error, reraise
-            raise
-    commands.begin()
-
+    ctx = _request_ctx_stack.top
+    atomic = transaction.atomic()
+    atomic.__enter__()
+    ctx.current_atomic = atomic
 
 def transaction_after_request(response, base_status_code_error=500):
     """Teardown transaction after handling the request. Rollback if an
@@ -54,20 +54,12 @@ def transaction_after_request(response, base_status_code_error=500):
     if view_has_annotation(NO_AUTO_TRANSACTION_ATTR):
         return response
     if response.status_code >= base_status_code_error:
-        try:
-            commands.rollback()
-        except OperationFailure:
-            logger.exception('Transaction rollback failed after request')
+        # Construct an error in order to trigger rollback in transaction.atomic().__exit__
+        exc_type = HTTPError
+        exc_value = HTTPError(response.status_code)
+        current_atomic.__exit__(exc_type, exc_value, None)
     else:
-        try:
-            commands.commit()
-        except OperationFailure as error:
-            #  transaction commit failed, log and reraise
-            message = utils.get_error_message(error)
-            if messages.LOCK_ERROR in message:
-                commands.rollback()
-                return utils.handle_error(LOCK_ERROR_CODE)
-            raise
+        current_atomic.__exit__(None, None, None)
     return response
 
 
@@ -79,14 +71,7 @@ def transaction_teardown_request(error=None):
     if view_has_annotation(NO_AUTO_TRANSACTION_ATTR):
         return
     if error is not None:
-        try:
-            commands.rollback()
-        except OperationFailure as error:
-            #  expected error, transaction should have closed in after_request
-            message = utils.get_error_message(error)
-            if messages.NO_TRANSACTION_ERROR not in message:
-                #  unexpected error, not a transaction error, reraise
-                raise
+        current_atomic.__exit__(error.__class__, error, None)
 
 
 handlers = {

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -16,7 +16,6 @@ import pytest
 from nose.tools import *  # noqa PEP8 asserts
 from django.utils import timezone
 from django.apps import apps
-from flask import jsonify
 
 
 from modularodm import Q

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -12,13 +12,15 @@ import pytz
 import unittest
 
 import mock
+import pytest
 from nose.tools import *  # noqa PEP8 asserts
 from django.utils import timezone
 from django.apps import apps
+from flask import jsonify
+
 
 from modularodm import Q
 from modularodm.exceptions import ValidationError
-from osf.models import Comment
 
 from framework.auth import cas
 from framework.auth.core import generate_verification_key
@@ -28,14 +30,7 @@ from framework.auth.exceptions import InvalidTokenError
 from framework.auth.utils import impute_names_model, ensure_external_identity_uniqueness
 from framework.celery_tasks import handlers
 from framework.exceptions import HTTPError
-from tests.base import (
-    assert_is_redirect,
-    capture_signals,
-    fake,
-    get_default_metaschema,
-    OsfTestCase,
-    assert_datetime_equal,
-)
+from framework.transactions.handlers import no_auto_transaction
 from tests.factories import MockAddonNodeSettings
 from website import mailchimp_utils
 from website import mails, settings
@@ -57,8 +52,18 @@ from website.project.views.node import _should_show_wiki_widget, _view_project, 
 from website.util import api_url_for, web_url_for
 from website.util import permissions, rubeus
 from website.views import index
+from osf.models import Comment
+from osf.models import OSFUser as User
+from tests.base import (
+    assert_is_redirect,
+    capture_signals,
+    fake,
+    get_default_metaschema,
+    OsfTestCase,
+    assert_datetime_equal,
+    test_app,
+)
 
-import pytest
 
 pytestmark = pytest.mark.django_db
 
@@ -96,6 +101,43 @@ class Addon2(MockAddonNodeSettings):
 
     def archive_errors(self):
         return 'Error'
+
+
+class TestViewsAreAtomic(OsfTestCase):
+
+    def test_error_response_rolls_back_transaction(self):
+        @test_app.route('/errorexc')
+        def error_exc():
+            u = UserFactory()
+            raise RuntimeError
+
+        @test_app.route('/error500')
+        def error500():
+            u = UserFactory()
+            return 'error', 500
+
+        @test_app.route('/noautotransact')
+        @no_auto_transaction
+        def no_auto_transact():
+            u = UserFactory()
+            return 'error', 500
+
+        assert_equal(User.objects.count(), 0)
+        self.app.get('/error500', expect_errors=True)
+        assert_equal(User.objects.count(), 0)
+
+        # Need to set debug = False in order to rollback transactions in transaction_teardown_request
+        test_app.debug = False
+        try:
+            self.app.get('/errorexc', expect_errors=True)
+        except RuntimeError:
+            pass
+        test_app.debug = True
+
+        assert_equal(User.objects.count(), 0)
+
+        self.app.get('/noautotransact', expect_errors=True)
+        assert_equal(User.objects.count(), 1)
 
 
 class TestViewingProjectWithPrivateLink(OsfTestCase):


### PR DESCRIPTION
## Purpose

Make views atomic in the Flask app.

## Notes
django.db.transaction.atomic() provides high-level interface for
starting, rolling back, and committing transactions. It can only
be used as either a decorator or context manager, so I call
__enter__ and __exit__