### PR TITLE
[WIP] Fix some sentry bugs and make naive datetimes illegal

### DIFF
--- a/addons/base/tests/models.py
+++ b/addons/base/tests/models.py
@@ -3,6 +3,8 @@ import datetime
 
 import mock
 import pytest
+from django.utils import timezone
+
 from addons.base.tests.utils import MockFolder
 from framework.auth import Auth
 from framework.exceptions import HTTPError
@@ -611,7 +613,7 @@ class CitationAddonProviderTestSuiteMixin(OAuthCitationsTestSuiteMixinBase):
         # The first call to .client returns a new client
         with mock.patch.object(self.OAuthProviderClass, '_get_client') as mock_get_client:
             mock_account = mock.Mock()
-            mock_account.expires_at = datetime.datetime.now()
+            mock_account.expires_at = timezone.now()
             self.provider.account = mock_account
             self.provider.client
             mock_get_client.assert_called

--- a/addons/box/tests/factories.py
+++ b/addons/box/tests/factories.py
@@ -1,6 +1,7 @@
 """Factory boy factories for the Box addon."""
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
+from django.utils import timezone
 
 from factory import SubFactory, Sequence
 from factory.django import DjangoModelFactory
@@ -15,7 +16,7 @@ class BoxAccountFactory(ExternalAccountFactory):
     provider = 'box'
     provider_id = Sequence(lambda n: 'id-{0}'.format(n))
     oauth_key = Sequence(lambda n: 'key-{0}'.format(n))
-    expires_at = datetime.now() + relativedelta(seconds=3600)
+    expires_at = timezone.now() + relativedelta(seconds=3600)
 
 
 class BoxUserSettingsFactory(DjangoModelFactory):

--- a/admin/metrics/utils.py
+++ b/admin/metrics/utils.py
@@ -2,7 +2,7 @@
 Metrics scripts
 """
 from django.db.models import F, timezone
-from datetime import datetime, timedelta
+from datetime import timedelta
 from modularodm import Q
 from website.project.model import User, Node
 from website.project.utils import CONTENT_NODE_QUERY

--- a/admin/metrics/utils.py
+++ b/admin/metrics/utils.py
@@ -1,7 +1,7 @@
 """
 Metrics scripts
 """
-from django.db.models import F
+from django.db.models import F, timezone
 from datetime import datetime, timedelta
 from modularodm import Q
 from website.project.model import User, Node
@@ -23,7 +23,7 @@ def get_list_of_dates(start, end):
 
 def get_previous_midnight(time=None):
     if time is None:
-        time = datetime.utcnow()
+        time = timezone.now()
     return time - timedelta(  # As close to midnight utc as possible
         hours=time.hour,
         minutes=time.minute,

--- a/admin/nodes/views.py
+++ b/admin/nodes/views.py
@@ -1,6 +1,8 @@
 from __future__ import unicode_literals
 
 from datetime import datetime
+
+from django.utils import timezone
 from django.views.generic import ListView, DeleteView
 from django.shortcuts import redirect
 from django.views.defaults import page_not_found
@@ -63,7 +65,7 @@ class NodeRemoveContributorView(OSFAdmin, DeleteView):
                         'node': node.pk,
                         'contributors': user.pk
                     },
-                    date=datetime.utcnow(),
+                    date=timezone.now(),
                     should_hide=True,
                 )
                 osf_log.save()
@@ -125,7 +127,7 @@ class NodeDeleteView(NodeDeleteBase):
                 osf_flag = NodeLog.NODE_CREATED
             elif not node.is_registration:
                 node.is_deleted = True
-                node.deleted_date = datetime.utcnow()
+                node.deleted_date = timezone.now()
                 flag = NODE_REMOVED
                 message = 'Node {} removed.'.format(node.pk)
                 osf_flag = NodeLog.NODE_REMOVED
@@ -146,7 +148,7 @@ class NodeDeleteView(NodeDeleteBase):
                     params={
                         'project': node.parent_id,
                     },
-                    date=datetime.utcnow(),
+                    date=timezone.now(),
                     should_hide=True,
                 )
                 osf_log.save()

--- a/admin/nodes/views.py
+++ b/admin/nodes/views.py
@@ -1,7 +1,5 @@
 from __future__ import unicode_literals
 
-from datetime import datetime
-
 from django.utils import timezone
 from django.views.generic import ListView, DeleteView
 from django.shortcuts import redirect

--- a/admin/sales_analytics/utils.py
+++ b/admin/sales_analytics/utils.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from django.utils import timezone
+
 from admin.base.settings import ENTRY_POINTS
 from datetime import datetime, timedelta
 from framework.mongo import database as db
@@ -56,7 +58,7 @@ def get_multi_product_metrics(db=db, timedelta=timedelta(days=365)):
     """
     Get the number of users using 2+ products within a period of time
     """
-    start_date = datetime.now() - timedelta
+    start_date = timezone.now() - timedelta
     pipeline = [
         {'$match': {'date': {'$gt': start_date}}},
         {'$group': {'_id': '$user', 'node_id': {'$addToSet': '$params.node'},
@@ -100,7 +102,7 @@ def get_repeat_action_user_count(db=db, timedelta=timedelta(days=30)):
     Get the number of users that have repetitive actions (with a 3 second difference)
     during the last month.
     """
-    start_date = datetime.now() - timedelta
+    start_date = timezone.now() - timedelta
     pipeline = [
         {'$match': {'date': {'$gt': start_date}}},
         {'$group': {'_id': '$user', 'nodelog_id': {'$addToSet': '$_id'}}},

--- a/admin/sales_analytics/utils.py
+++ b/admin/sales_analytics/utils.py
@@ -2,7 +2,7 @@
 from django.utils import timezone
 
 from admin.base.settings import ENTRY_POINTS
-from datetime import datetime, timedelta
+from datetime import timedelta
 from framework.mongo import database as db
 
 

--- a/admin_tests/metrics/test_utils.py
+++ b/admin_tests/metrics/test_utils.py
@@ -1,3 +1,4 @@
+from django.utils import timezone
 from nose import tools as nt
 from datetime import timedelta, datetime
 
@@ -59,16 +60,16 @@ class TestMetricsGetDaysStatistics(AdminTestCase):
         NodeFactory(category='data')
 
     def test_time_now(self):
-        get_days_statistics(datetime.utcnow())
+        get_days_statistics(timezone.now())
         nt.assert_equal(OSFWebsiteStatistics.objects.count(), 1)
         nt.assert_equal(OSFWebsiteStatistics.objects.latest('date').projects, 2)
 
     def test_delta(self):
-        get_days_statistics(datetime.utcnow())
+        get_days_statistics(timezone.now())
         ProjectFactory()
         ProjectFactory()
         latest = OSFWebsiteStatistics.objects.latest('date')
-        get_days_statistics(datetime.utcnow(), latest)
+        get_days_statistics(timezone.now(), latest)
         even_later = OSFWebsiteStatistics.objects.latest('date')
         nt.assert_equal(even_later.delta_projects, 2)
 
@@ -102,14 +103,14 @@ class TestMetricsGetOSFStatistics(AdminTestCase):
 
 class TestMetricListDays(AdminTestCase):
     def test_five_days(self):
-        time_now = datetime.utcnow()
+        time_now = timezone.now()
         time_past = time_now - timedelta(days=5)
         dates = get_list_of_dates(time_past, time_now)
         nt.assert_equal(len(dates), 5)
         nt.assert_in(time_now, dates)
 
     def test_month_transition(self):
-        time_now = datetime.utcnow()
+        time_now = timezone.now()
         time_end = time_now - timedelta(
             days=(time_now.day - 2)
         )
@@ -118,7 +119,7 @@ class TestMetricListDays(AdminTestCase):
         nt.assert_equal(len(dates), 5)
 
     def test_off_by_seconds(self):
-        time_now = datetime.utcnow()
+        time_now = timezone.now()
         time_start = time_now - timedelta(
             seconds=DAY_LEEWAY + 1
         )
@@ -126,7 +127,7 @@ class TestMetricListDays(AdminTestCase):
         nt.assert_equal(len(dates), 1)
 
     def test_on_exact_time(self):
-        time_now = datetime.utcnow()
+        time_now = timezone.now()
         time_start = time_now - timedelta(
             seconds=DAY_LEEWAY
         )
@@ -134,7 +135,7 @@ class TestMetricListDays(AdminTestCase):
         nt.assert_equal(len(dates), 0)
 
     def test_just_missed_time(self):
-        time_now = datetime.utcnow()
+        time_now = timezone.now()
         time_start = time_now - timedelta(
             seconds=DAY_LEEWAY - 1
         )
@@ -144,7 +145,7 @@ class TestMetricListDays(AdminTestCase):
 
 class TestMetricPreviousMidnight(AdminTestCase):
     def test_midnight(self):
-        time_now = datetime.utcnow()
+        time_now = timezone.now()
         midnight = get_previous_midnight(time_now)
         nt.assert_equal(midnight.date(), time_now.date())
         nt.assert_equal(midnight.hour, 0)
@@ -153,7 +154,7 @@ class TestMetricPreviousMidnight(AdminTestCase):
         nt.assert_equal(midnight.microsecond, 1)
 
     def test_no_time_given(self):
-        time_now = datetime.utcnow()
+        time_now = timezone.now()
         midnight = get_previous_midnight()
         nt.assert_equal(midnight.date(), time_now.date())
 
@@ -176,7 +177,7 @@ class TestUserGet(AdminTestCase):
         self.user_4 = AuthUserFactory()
 
     def test_get_all_user_count(self):
-        time_now = datetime.utcnow()
+        time_now = timezone.now()
         count = get_active_user_count(time_now)
         nt.assert_equal(count, 2)
 

--- a/admin_tests/metrics/test_utils.py
+++ b/admin_tests/metrics/test_utils.py
@@ -1,6 +1,6 @@
 from django.utils import timezone
 from nose import tools as nt
-from datetime import timedelta, datetime
+from datetime import timedelta
 
 from tests.base import AdminTestCase
 from tests.factories import (

--- a/admin_tests/spam/test_views.py
+++ b/admin_tests/spam/test_views.py
@@ -3,7 +3,7 @@ from django.test import RequestFactory
 from django.http import Http404
 from django.utils import timezone
 from nose import tools as nt
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from website.project.model import Comment
 

--- a/admin_tests/spam/test_views.py
+++ b/admin_tests/spam/test_views.py
@@ -1,6 +1,7 @@
 from django.db import transaction
 from django.test import RequestFactory
 from django.http import Http404
+from django.utils import timezone
 from nose import tools as nt
 from datetime import datetime, timedelta
 
@@ -34,7 +35,7 @@ class TestSpamListView(AdminTestCase):
         self.project.save()
         self.user_1.save()
         self.user_2.save()
-        date = datetime.utcnow()
+        date = timezone.now()
         self.comment_1 = CommentFactory(node=self.project, user=self.user_1)
         self.comment_2 = CommentFactory(node=self.project, user=self.user_1)
         self.comment_3 = CommentFactory(node=self.project, user=self.user_1)

--- a/admin_tests/users/test_serializers.py
+++ b/admin_tests/users/test_serializers.py
@@ -1,4 +1,6 @@
 from datetime import datetime
+
+from django.utils import timezone
 from nose import tools as nt
 
 from tests.base import AdminTestCase
@@ -39,7 +41,7 @@ class TestUserSerializers(AdminTestCase):
         info = serialize_user(user)
         nt.assert_almost_equal(
             int(info['disabled'].strftime('%s')),
-            int(datetime.utcnow().strftime('%s')),
+            int(timezone.now().strftime('%s')),
             delta=50)
         nt.assert_is_instance(info['disabled'], datetime)
 

--- a/admin_tests/users/test_views.py
+++ b/admin_tests/users/test_views.py
@@ -1,6 +1,7 @@
 from django.test import RequestFactory
 from django.http import Http404
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.utils import timezone
 from nose import tools as nt
 import mock
 import csv
@@ -221,7 +222,7 @@ class TestUserWorkshopFormView(AdminTestCase):
         self.user_1 = AuthUserFactory()
         self.auth_1 = Auth(self.user_1)
         self.view = UserWorkshopFormView()
-        self.workshop_date = datetime.now()
+        self.workshop_date = timezone.now()
         self.data = [
             ['none', 'date', 'none', 'none', 'none', 'email', 'none'],
             [None, self.workshop_date.strftime('%m/%d/%y'), None, None, None, self.user_1.username, None],
@@ -276,7 +277,7 @@ class TestUserWorkshopFormView(AdminTestCase):
         nt.assert_equal(user_nodes_created_since_workshop, 0)
 
     def test_user_activity_before_workshop_only(self):
-        activity_date = datetime.now() - timedelta(days=1)
+        activity_date = timezone.now() - timedelta(days=1)
         self._create_nodes_and_add_logs(first_activity_date=activity_date)
 
         result_csv = self._create_and_parse_test_file(self.data)
@@ -287,7 +288,7 @@ class TestUserWorkshopFormView(AdminTestCase):
         nt.assert_equal(user_nodes_created_since_workshop, 0)
 
     def test_user_activity_after_workshop_only(self):
-        activity_date = datetime.now() + timedelta(days=1)
+        activity_date = timezone.now() + timedelta(days=1)
         self._create_nodes_and_add_logs(first_activity_date=activity_date)
 
         result_csv = self._create_and_parse_test_file(self.data)
@@ -298,7 +299,7 @@ class TestUserWorkshopFormView(AdminTestCase):
         nt.assert_equal(user_nodes_created_since_workshop, 1)
 
     def test_user_activity_day_of_workshop_and_before(self):
-        activity_date = datetime.now() - timedelta(days=1)
+        activity_date = timezone.now() - timedelta(days=1)
         self._create_nodes_and_add_logs(
             first_activity_date=self.workshop_date,
             second_activity_date=activity_date
@@ -312,7 +313,7 @@ class TestUserWorkshopFormView(AdminTestCase):
         nt.assert_equal(user_nodes_created_since_workshop, 0)
 
     def test_user_activity_day_of_workshop_and_after(self):
-        activity_date = datetime.now() + timedelta(days=1)
+        activity_date = timezone.now() + timedelta(days=1)
         self._create_nodes_and_add_logs(
             first_activity_date=self.workshop_date,
             second_activity_date=activity_date
@@ -326,8 +327,8 @@ class TestUserWorkshopFormView(AdminTestCase):
         nt.assert_equal(user_nodes_created_since_workshop, 1)
 
     def test_user_activity_before_workshop_and_after(self):
-        before_activity_date = datetime.now() - timedelta(days=1)
-        after_activity_date = datetime.now() + timedelta(days=1)
+        before_activity_date = timezone.now() - timedelta(days=1)
+        after_activity_date = timezone.now() + timedelta(days=1)
         self._create_nodes_and_add_logs(
             first_activity_date=before_activity_date,
             second_activity_date=after_activity_date

--- a/admin_tests/users/test_views.py
+++ b/admin_tests/users/test_views.py
@@ -6,7 +6,7 @@ from nose import tools as nt
 import mock
 import csv
 import os
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from tests.base import AdminTestCase
 from website import settings

--- a/api/institutions/authentication.py
+++ b/api/institutions/authentication.py
@@ -5,6 +5,7 @@ import jwt
 
 from datetime import datetime
 
+from django.utils import timezone
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.authentication import BaseAuthentication
 
@@ -59,7 +60,7 @@ class InstitutionAuthentication(BaseAuthentication):
             user.middle_names = provider['user'].get('middleNames')
             user.family_name = provider['user'].get('familyName')
             user.suffix = provider['user'].get('suffix')
-            user.date_last_login = datetime.utcnow()
+            user.date_last_login = timezone.now()
             user.save()
 
             # User must be saved in order to have a valid _id

--- a/api/institutions/authentication.py
+++ b/api/institutions/authentication.py
@@ -3,8 +3,6 @@ import json
 import jwe
 import jwt
 
-from datetime import datetime
-
 from django.utils import timezone
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.authentication import BaseAuthentication

--- a/api_tests/base/test_filters.py
+++ b/api_tests/base/test_filters.py
@@ -6,6 +6,7 @@ import re
 
 import pytz
 from dateutil import parser
+from django.utils import timezone
 
 from modularodm import Q
 
@@ -54,8 +55,8 @@ class FakeRecord(object):
             string_field='foo',
             second_string_field='bar',
             list_field=None,
-            date_field=datetime.datetime.now(),
-            datetime_field=datetime.datetime.now(),
+            date_field=timezone.now(),
+            datetime_field=timezone.now(),
             int_field=42,
             float_field=41.99999,
             foobar=True

--- a/api_tests/comments/views/test_comment_report_detail.py
+++ b/api_tests/comments/views/test_comment_report_detail.py
@@ -1,5 +1,6 @@
 import mock
 import pytest
+from django.utils import timezone
 from nose.tools import *  # flake8: noqa
 from datetime import datetime
 
@@ -83,7 +84,7 @@ class ReportDetailViewMixin(object):
         self.public_comment.reports[self.non_contributor._id] = {
             'category': 'spam',
             'text': 'This is spam',
-            'date': datetime.utcnow(),
+            'date': timezone.now(),
             'retracted': False,
         }
         self.public_comment.save()
@@ -140,7 +141,7 @@ class ReportDetailViewMixin(object):
         self.public_comment.reports[self.non_contributor._id] = {
             'category': 'spam',
             'text': 'This is spam',
-            'date': datetime.utcnow(),
+            'date': timezone.now(),
             'retracted': False,
         }
         self.public_comment.save()
@@ -165,7 +166,7 @@ class ReportDetailViewMixin(object):
         comment.reports = {self.user._id: {
             'category': 'spam',
             'text': 'This is spam',
-            'date': datetime.utcnow(),
+            'date': timezone.now(),
             'retracted': False,
         }}
         comment.save()
@@ -213,7 +214,7 @@ class ReportDetailViewMixin(object):
         self.public_comment.reports[self.non_contributor._id] = {
             'category': 'spam',
             'text': 'This is spam',
-            'date': datetime.utcnow(),
+            'date': timezone.now(),
             'retracted': False,
         }
         self.public_comment.save()
@@ -231,7 +232,7 @@ class TestReportDetailView(ReportDetailViewMixin, ApiTestCase):
         self.comment.reports = {self.user._id: {
             'category': 'spam',
             'text': 'This is spam',
-            'date': datetime.utcnow(),
+            'date': timezone.now(),
             'retracted': False,
         }}
         self.comment.save()
@@ -244,7 +245,7 @@ class TestReportDetailView(ReportDetailViewMixin, ApiTestCase):
         self.public_comment.reports = {self.user._id: {
             'category': 'spam',
             'text': 'This is spam',
-            'date': datetime.utcnow(),
+            'date': timezone.now(),
             'retracted': False,
         }}
         self.public_comment.save()
@@ -262,7 +263,7 @@ class TestFileCommentReportDetailView(ReportDetailViewMixin, ApiTestCase):
         self.comment.reports = {self.user._id: {
             'category': 'spam',
             'text': 'This is spam',
-            'date': datetime.utcnow(),
+            'date': timezone.now(),
             'retracted': False,
         }}
         self.comment.save()
@@ -276,7 +277,7 @@ class TestFileCommentReportDetailView(ReportDetailViewMixin, ApiTestCase):
         self.public_comment.reports = {self.user._id: {
             'category': 'spam',
             'text': 'This is spam',
-            'date': datetime.utcnow(),
+            'date': timezone.now(),
             'retracted': False,
         }}
         self.public_comment.save()
@@ -294,7 +295,7 @@ class TestWikiCommentReportDetailView(ReportDetailViewMixin, ApiTestCase):
         self.comment.reports = {self.user._id: {
             'category': 'spam',
             'text': 'This is spam',
-            'date': datetime.utcnow(),
+            'date': timezone.now(),
             'retracted': False,
         }}
         self.comment.save()
@@ -309,7 +310,7 @@ class TestWikiCommentReportDetailView(ReportDetailViewMixin, ApiTestCase):
         self.public_comment.reports = {self.user._id: {
             'category': 'spam',
             'text': 'This is spam',
-            'date': datetime.utcnow(),
+            'date': timezone.now(),
             'retracted': False,
         }}
         self.public_comment.save()

--- a/api_tests/comments/views/test_comment_report_list.py
+++ b/api_tests/comments/views/test_comment_report_list.py
@@ -1,5 +1,6 @@
 import mock
 import pytest
+from django.utils import timezone
 from nose.tools import *  # flake8: noqa
 from datetime import datetime
 
@@ -95,7 +96,7 @@ class CommentReportsMixin(object):
         self.public_comment.reports[self.non_contributor._id] = {
             'category': 'spam',
             'text': 'This is spam',
-            'date': datetime.utcnow(),
+            'date': timezone.now(),
             'retracted': False,
         }
         self.public_comment.save()
@@ -253,7 +254,7 @@ class TestCommentReportsView(CommentReportsMixin, ApiTestCase):
         self.comment.reports[self.user._id] = {
             'category': 'spam',
             'text': 'This is spam',
-            'date': datetime.utcnow(),
+            'date': timezone.now(),
             'retracted': False,
         }
         self.comment.save()
@@ -267,7 +268,7 @@ class TestCommentReportsView(CommentReportsMixin, ApiTestCase):
         self.public_comment.reports[self.user._id] = {
             'category': 'spam',
             'text': 'This is spam',
-            'date': datetime.utcnow(),
+            'date': timezone.now(),
             'retracted': False,
         }
         self.public_comment.save()
@@ -286,7 +287,7 @@ class TestWikiCommentReportsView(CommentReportsMixin, ApiTestCase):
         self.comment.reports[self.user._id] = {
             'category': 'spam',
             'text': 'This is spam',
-            'date': datetime.utcnow(),
+            'date': timezone.now(),
             'retracted': False,
         }
         self.comment.save()
@@ -302,7 +303,7 @@ class TestWikiCommentReportsView(CommentReportsMixin, ApiTestCase):
         self.public_comment.reports[self.user._id] = {
             'category': 'spam',
             'text': 'This is spam',
-            'date': datetime.utcnow(),
+            'date': timezone.now(),
             'retracted': False,
         }
         self.public_comment.save()
@@ -320,7 +321,7 @@ class TestFileCommentReportsView(CommentReportsMixin, ApiTestCase):
         self.comment.reports[self.user._id] = {
             'category': 'spam',
             'text': 'This is spam',
-            'date': datetime.utcnow(),
+            'date': timezone.now(),
             'retracted': False,
         }
         self.comment.save()
@@ -335,7 +336,7 @@ class TestFileCommentReportsView(CommentReportsMixin, ApiTestCase):
         self.public_comment.reports[self.user._id] = {
             'category': 'spam',
             'text': 'This is spam',
-            'date': datetime.utcnow(),
+            'date': timezone.now(),
             'retracted': False,
         }
         self.public_comment.save()

--- a/api_tests/nodes/views/test_node_files_list.py
+++ b/api_tests/nodes/views/test_node_files_list.py
@@ -3,6 +3,7 @@ import json
 
 import httpretty
 import pytest
+from django.utils import timezone
 from nose.tools import *  # flake8: noqa
 
 from framework.auth.core import Auth
@@ -376,7 +377,7 @@ class TestNodeFilesListFiltering(ApiTestCase):
         assert_equal(res.json['data'][0]['attributes']['name'], 'abc')
 
     def test_node_files_external_provider_can_filter_by_last_touched(self):
-        yesterday_stamp = datetime.datetime.utcnow() - datetime.timedelta(days=1)
+        yesterday_stamp = timezone.now() - datetime.timedelta(days=1)
         self.add_github()
         url = '/{}nodes/{}/files/github/?filter[last_touched][gt]={}'.format(API_BASE,
                                                                              self.project._id,
@@ -386,7 +387,7 @@ class TestNodeFilesListFiltering(ApiTestCase):
         assert_equal(len(res.json['data']), 2)
 
     def test_node_files_osfstorage_cannot_filter_by_last_touched(self):
-        yesterday_stamp = datetime.datetime.utcnow() - datetime.timedelta(days=1)
+        yesterday_stamp = timezone.now() - datetime.timedelta(days=1)
         self.file = api_utils.create_test_file(self.project, self.user)
 
         url = '/{}nodes/{}/files/osfstorage/?filter[last_touched][gt]={}'.format(API_BASE,

--- a/api_tests/registrations/views/test_registration_list.py
+++ b/api_tests/registrations/views/test_registration_list.py
@@ -2,6 +2,8 @@ import mock
 import datetime
 import dateutil.relativedelta
 from urlparse import urlparse
+
+from django.utils import timezone
 from nose.tools import *  # flake8: noqa
 
 from website.project.model import ensure_schemas
@@ -647,7 +649,7 @@ class TestRegistrationCreate(DraftRegistrationTestCase):
 
     @mock.patch('framework.celery_tasks.handlers.enqueue_task')
     def test_embargo_must_be_less_than_four_years(self, mock_enqueue):
-        today = datetime.datetime.utcnow()
+        today = timezone.now()
         five_years = (today + dateutil.relativedelta.relativedelta(years=5)).strftime('%Y-%m-%dT%H:%M:%S')
         payload = {
             "data": {
@@ -666,7 +668,7 @@ class TestRegistrationCreate(DraftRegistrationTestCase):
 
     @mock.patch('framework.celery_tasks.handlers.enqueue_task')
     def test_embargo_registration(self, mock_enqueue):
-        today = datetime.datetime.utcnow()
+        today = timezone.now()
         next_week = (today + dateutil.relativedelta.relativedelta(months=1)).strftime('%Y-%m-%dT%H:%M:%S')
         payload = {
             "data": {
@@ -686,7 +688,7 @@ class TestRegistrationCreate(DraftRegistrationTestCase):
         assert_equal(data['pending_embargo_approval'], True)
 
     def test_embargo_end_date_must_be_in_the_future(self):
-        today = datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S')
+        today = timezone.now().strftime('%Y-%m-%dT%H:%M:%S')
         payload = {
             "data": {
                 "type": "registrations",
@@ -703,7 +705,7 @@ class TestRegistrationCreate(DraftRegistrationTestCase):
         assert_equal(res.json['errors'][0]['detail'], 'Embargo end date must be at least three days in the future.')
 
     def test_invalid_embargo_end_date_format(self):
-        today = datetime.datetime.utcnow().isoformat()
+        today = timezone.now().isoformat()
         payload = {
             "data": {
                 "type": "registrations",

--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -629,7 +629,7 @@ class User(GuidStoredObject, AddonModelMixin):
             self.emails.append(username)
         self.is_registered = True
         self.is_claimed = True
-        self.date_confirmed = dt.datetime.utcnow()
+        self.date_confirmed = timezone.now()
         self.update_search()
         self.update_search_nodes()
 
@@ -722,7 +722,7 @@ class User(GuidStoredObject, AddonModelMixin):
             return False
         valid = record['token'] == token
         if 'expires' in record:
-            valid = valid and record['expires'] > dt.datetime.utcnow()
+            valid = valid and record['expires'] > timezone.now()
         return valid
 
     def get_claim_url(self, project_id, external=False):
@@ -753,7 +753,7 @@ class User(GuidStoredObject, AddonModelMixin):
         if token and self.verification_key_v2:
             try:
                 return (self.verification_key_v2['token'] == token and
-                        self.verification_key_v2['expires'] > dt.datetime.utcnow())
+                        self.verification_key_v2['expires'] > timezone.now())
             except AttributeError:
                 return False
         return False
@@ -927,7 +927,7 @@ class User(GuidStoredObject, AddonModelMixin):
                     new_token = self.add_unconfirmed_email(email)
                     self.save()
                     return new_token
-                if not expiration or (expiration and expiration < dt.datetime.utcnow()):
+                if not expiration or (expiration and expiration < timezone.now()):
                     if not force:
                         raise ExpiredTokenError('Token for email "{0}" is expired'.format(email))
                     else:
@@ -973,7 +973,7 @@ class User(GuidStoredObject, AddonModelMixin):
         # Not all tokens are guaranteed to have expiration dates
         if (
             'expiration' in verification and
-            verification['expiration'] < dt.datetime.utcnow()
+            verification['expiration'] < timezone.now()
         ):
             raise ExpiredTokenError
 
@@ -1028,7 +1028,7 @@ class User(GuidStoredObject, AddonModelMixin):
         # Complete registration if primary email
         if email.lower() == self.username.lower():
             self.register(self.username)
-            self.date_confirmed = dt.datetime.utcnow()
+            self.date_confirmed = timezone.now()
         # Revoke token
         del self.email_verifications[token]
 
@@ -1240,7 +1240,7 @@ class User(GuidStoredObject, AddonModelMixin):
     def is_disabled(self, val):
         """Set whether or not this account has been disabled."""
         if val and not self.date_disabled:
-            self.date_disabled = dt.datetime.utcnow()
+            self.date_disabled = timezone.now()
         elif val is False:
             self.date_disabled = None
 
@@ -1376,7 +1376,7 @@ class User(GuidStoredObject, AddonModelMixin):
         log_ids = []
         # Default since to 60 days before today if since is None
         # timezone aware utcnow
-        utcnow = dt.datetime.utcnow().replace(tzinfo=pytz.utc)
+        utcnow = timezone.now()
         since_date = since or (utcnow - dt.timedelta(days=60))
         for config in self.watched:
             # Extract the timestamps for each log from the log_id (fast!)
@@ -1394,7 +1394,7 @@ class User(GuidStoredObject, AddonModelMixin):
         '''Return a generator of log ids generated in the past day
         (starting at UTC 00:00).
         '''
-        utcnow = dt.datetime.utcnow()
+        utcnow = timezone.now()
         midnight = dt.datetime(
             utcnow.year, utcnow.month, utcnow.day,
             0, 0, 0, tzinfo=pytz.utc

--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -4,6 +4,7 @@ import furl
 import httplib as http
 
 import markupsafe
+from django.utils import timezone
 from flask import request
 import uuid
 
@@ -178,7 +179,7 @@ def forgot_password_post():
                 else:
                     # new random verification key (v2)
                     user_obj.verification_key_v2 = generate_verification_key(verification_type='password')
-                    user_obj.email_last_sent = datetime.datetime.utcnow()
+                    user_obj.email_last_sent = timezone.now()
                     user_obj.save()
                     reset_link = furl.urljoin(
                         settings.DOMAIN,
@@ -475,7 +476,7 @@ def external_login_confirm_email_get(auth, uid, token):
     if email.lower() not in user.emails:
         user.emails.append(email.lower())
 
-    user.date_last_logged_in = datetime.datetime.utcnow()
+    user.date_last_logged_in = timezone.now()
     user.external_identity[provider][provider_id] = 'VERIFIED'
     user.social[provider.lower()] = provider_id
     del user.email_verifications[token]
@@ -554,7 +555,7 @@ def confirm_email_get(token, auth=None, **kwargs):
         })
 
     if is_initial_confirmation:
-        user.date_last_login = datetime.datetime.utcnow()
+        user.date_last_login = timezone.now()
         user.save()
 
         # send out our welcome message
@@ -808,7 +809,7 @@ def resend_confirmation_post(auth):
                     # already confirmed, redirect to dashboard
                     status_message = 'This email {0} has already been confirmed.'.format(clean_email)
                     kind = 'warning'
-                user.email_last_sent = datetime.datetime.utcnow()
+                user.email_last_sent = timezone.now()
                 user.save()
             else:
                 status_message = ('You have recently requested to resend your confirmation email. '

--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import datetime
 import furl
 import httplib as http
 

--- a/osf/exceptions.py
+++ b/osf/exceptions.py
@@ -105,3 +105,7 @@ class ValidationValueError(ValidationError, MODMValidationValueError):
 class ValidationTypeError(ValidationError, MODMValidationTypeError):
     """ Raised during validation if the value of the input is unacceptable and type is incorrect """
     pass
+
+
+class NaiveDatetimeException(Exception):
+    pass

--- a/osf/models/identifiers.py
+++ b/osf/models/identifiers.py
@@ -39,7 +39,7 @@ class IdentifierMixin(models.Model):
         return identifier.value if identifier else None
 
     def set_identifier_value(self, category, value):
-        identifier, created = Identifier.objects.get_or_create(nodes=self,
+        identifier, created = Identifier.objects.get_or_create(referent=self,
                                                                category=category,
                                                                defaults=dict(value=value))
         if not created:

--- a/osf/models/private_link.py
+++ b/osf/models/private_link.py
@@ -2,6 +2,7 @@ from django.utils import timezone
 from django.db import models
 
 from framework.utils import iso8601format
+from osf.utils.fields import NonNaiveDatetimeField
 from website.util import sanitize
 
 from osf.models.base import BaseModel, ObjectIDMixin
@@ -12,7 +13,7 @@ class PrivateLink(ObjectIDMixin, BaseModel):
     modm_model_path = 'website.project.model.PrivateLink'
     modm_query = None
     # /TODO DELETE ME POST MIGRATION
-    date_created = models.DateTimeField(default=timezone.now)
+    date_created = NonNaiveDatetimeField(default=timezone.now)
     key = models.CharField(max_length=512, null=False, unique=True, blank=False)
     name = models.CharField(max_length=255, blank=True, null=True)
     is_deleted = models.BooleanField(default=False)

--- a/osf/models/queued_mail.py
+++ b/osf/models/queued_mail.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.utils import timezone
 
+from osf.utils.fields import NonNaiveDatetimeField
 from website.mails import Mail, send_mail
 from website.mails import presends
 from website import settings as osf_settings
@@ -17,7 +18,7 @@ class QueuedMail(ObjectIDMixin, BaseModel):
     # /TODO DELETE ME POST MIGRATION
     user = models.ForeignKey('OSFUser', db_index=True, null=True)
     to_addr = models.CharField(max_length=255)
-    send_at = models.DateTimeField(db_index=True, null=False)
+    send_at = NonNaiveDatetimeField(db_index=True, null=False)
 
     # string denoting the template, presend to be used. Has to be an index of queue_mail types
     email_type = models.CharField(max_length=255, db_index=True, null=False)
@@ -29,7 +30,7 @@ class QueuedMail(ObjectIDMixin, BaseModel):
     #    'fullname': 'Florence Welch',
     #}
     data = DateTimeAwareJSONField(default=dict, blank=True)
-    sent_at = models.DateTimeField(db_index=True, null=True, blank=True)
+    sent_at = NonNaiveDatetimeField(db_index=True, null=True, blank=True)
 
     def __repr__(self):
         if self.sent_at is not None:

--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -6,6 +6,7 @@ from django.db import models
 
 from framework.auth import Auth
 from framework.exceptions import PermissionsError
+from osf.utils.fields import NonNaiveDatetimeField
 from website.exceptions import NodeStateError
 from website.util import api_v2_url
 from website import settings
@@ -32,7 +33,7 @@ class Registration(AbstractNode):
     modm_query = MQ('is_registration', 'eq', True)
     # /TODO DELETE ME POST MIGRATION
 
-    registered_date = models.DateTimeField(db_index=True, null=True, blank=True)
+    registered_date = NonNaiveDatetimeField(db_index=True, null=True, blank=True)
     registered_user = models.ForeignKey(OSFUser,
                                         related_name='related_to',
                                         on_delete=models.SET_NULL,
@@ -360,7 +361,7 @@ class DraftRegistrationLog(ObjectIDMixin, BaseModel):
     modm_model_path = 'website.project.model.DraftRegistrationLog'
     modm_query = None
     # /TODO DELETE ME POST MIGRATION
-    date = models.DateTimeField(default=timezone.now)
+    date = NonNaiveDatetimeField(default=timezone.now)
     action = models.CharField(max_length=255)
     draft = models.ForeignKey('DraftRegistration', related_name='logs', null=True, blank=True)
     user = models.ForeignKey('OSFUser', null=True)
@@ -383,8 +384,8 @@ class DraftRegistration(ObjectIDMixin, BaseModel):
     # /TODO DELETE ME POST MIGRATION
     URL_TEMPLATE = settings.DOMAIN + 'project/{node_id}/drafts/{draft_id}'
 
-    datetime_initiated = models.DateTimeField(default=timezone.now)  # auto_now_add=True)
-    datetime_updated = models.DateTimeField(auto_now=True)
+    datetime_initiated = NonNaiveDatetimeField(default=timezone.now)  # auto_now_add=True)
+    datetime_updated = NonNaiveDatetimeField(auto_now=True)
     # Original Node a draft registration is associated with
     branched_from = models.ForeignKey('Node', null=True, related_name='registered_draft')
 

--- a/osf/models/sanctions.py
+++ b/osf/models/sanctions.py
@@ -5,6 +5,8 @@ from dateutil.parser import parse as parse_date
 from django.apps import apps
 from django.conf import settings
 from django.db import models
+
+from osf.utils.fields import NonNaiveDatetimeField
 from website.prereg import utils as prereg_utils
 
 from framework.auth import Auth
@@ -71,8 +73,8 @@ class Sanction(ObjectIDMixin, BaseModel):
     # Expiration date-- Sanctions in the UNAPPROVED state that are older than their end_date
     # are automatically made ACTIVE by a daily cron job
     # Use end_date=None for a non-expiring Sanction
-    end_date = models.DateTimeField(null=True, blank=True, default=None)
-    initiation_date = models.DateTimeField(null=True, blank=True)  # auto_now=True)
+    end_date = NonNaiveDatetimeField(null=True, blank=True, default=None)
+    initiation_date = NonNaiveDatetimeField(null=True, blank=True)  # auto_now=True)
 
     state = models.CharField(choices=STATE_CHOICES,
                              default=UNAPPROVED,

--- a/osf/models/session.py
+++ b/osf/models/session.py
@@ -2,6 +2,7 @@ from django.db import models
 
 from osf.utils.datetime_aware_jsonfield import DateTimeAwareJSONField
 from osf.models.base import BaseModel, ObjectIDMixin
+from osf.utils.fields import NonNaiveDatetimeField
 
 
 class Session(ObjectIDMixin, BaseModel):
@@ -10,8 +11,8 @@ class Session(ObjectIDMixin, BaseModel):
     modm_query = None
     migration_page_size = 30000
     # /TODO DELETE ME POST MIGRATION
-    date_created = models.DateTimeField(auto_now_add=True)
-    date_modified = models.DateTimeField(auto_now=True)
+    date_created = NonNaiveDatetimeField(auto_now_add=True)
+    date_modified = NonNaiveDatetimeField(auto_now=True)
     data = DateTimeAwareJSONField(default=dict, blank=True)
 
     @property

--- a/osf/models/session.py
+++ b/osf/models/session.py
@@ -1,5 +1,3 @@
-from django.db import models
-
 from osf.utils.datetime_aware_jsonfield import DateTimeAwareJSONField
 from osf.models.base import BaseModel, ObjectIDMixin
 from osf.utils.fields import NonNaiveDatetimeField

--- a/osf/models/spam.py
+++ b/osf/models/spam.py
@@ -5,6 +5,7 @@ from django.db import models
 from django.utils import timezone
 from osf.exceptions import ValidationValueError, ValidationTypeError
 from osf.utils.datetime_aware_jsonfield import DateTimeAwareJSONField
+from osf.utils.fields import NonNaiveDatetimeField
 
 from website import settings
 from website.project.model import User
@@ -64,7 +65,7 @@ class SpamMixin(models.Model):
     #   - User-Agent: user agent from request
     #   - Referer: referrer header from request (typo +1, rtd)
     spam_data = DateTimeAwareJSONField(default=dict, blank=True)
-    date_last_reported = models.DateTimeField(default=None, null=True, blank=True, db_index=True)
+    date_last_reported = NonNaiveDatetimeField(default=None, null=True, blank=True, db_index=True)
 
     # Reports is a dict of reports keyed on reporting user
     # Each report is a dictionary including:

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -31,6 +31,7 @@ from framework.auth.core import generate_verification_key
 from framework.sessions.utils import remove_sessions_for_user
 from framework.exceptions import PermissionsError
 from framework.sentry import log_exception
+from osf.utils.fields import NonNaiveDatetimeField
 from website import filters
 from website import mails
 from website import settings as website_settings
@@ -205,7 +206,7 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel,
     #   'expires': <verification expiration time>
     # }
 
-    email_last_sent = models.DateTimeField(null=True, blank=True)
+    email_last_sent = NonNaiveDatetimeField(null=True, blank=True)
 
     # confirmed emails
     #   emails should be stripped of whitespace and lower-cased before appending
@@ -244,7 +245,7 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel,
     # }
 
     # the date this user was registered
-    date_registered = models.DateTimeField(db_index=True, default=timezone.now,
+    date_registered = NonNaiveDatetimeField(db_index=True, default=timezone.now,
                                            )  # auto_now_add=True)
 
     # list of collaborators that this user recently added to nodes as a contributor
@@ -319,13 +320,13 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel,
     piwik_token = models.CharField(max_length=255, blank=True)
 
     # date the user last sent a request
-    date_last_login = models.DateTimeField(null=True, blank=True)
+    date_last_login = NonNaiveDatetimeField(null=True, blank=True)
 
     # date the user first successfully confirmed an email address
-    date_confirmed = models.DateTimeField(db_index=True, null=True, blank=True)
+    date_confirmed = NonNaiveDatetimeField(db_index=True, null=True, blank=True)
 
     # When the user was disabled.
-    date_disabled = models.DateTimeField(db_index=True, null=True, blank=True)
+    date_disabled = NonNaiveDatetimeField(db_index=True, null=True, blank=True)
 
     # when comments were last viewed
     comments_viewed_timestamp = DateTimeAwareJSONField(default=dict, blank=True)

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -245,8 +245,7 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel,
     # }
 
     # the date this user was registered
-    date_registered = NonNaiveDatetimeField(db_index=True, default=timezone.now,
-                                           )  # auto_now_add=True)
+    date_registered = NonNaiveDatetimeField(db_index=True, default=timezone.now)  # auto_now_add=True)
 
     # list of collaborators that this user recently added to nodes as a contributor
     # recently_added = fields.ForeignField("user", list=True)

--- a/osf/utils/datetime_aware_jsonfield.py
+++ b/osf/utils/datetime_aware_jsonfield.py
@@ -7,13 +7,9 @@ from dateutil import parser
 from django.contrib.postgres import lookups
 from django.contrib.postgres.fields.jsonb import JSONField
 from django.core.serializers.json import DjangoJSONEncoder
-
-from osf.exceptions import ValidationError
 from psycopg2.extras import Json
 
-
-class NaiveDatetimeException(BaseException):
-    pass
+from osf.exceptions import ValidationError, NaiveDatetimeException
 
 
 class DateTimeAwareJSONEncoder(DjangoJSONEncoder):

--- a/osf/utils/datetime_aware_jsonfield.py
+++ b/osf/utils/datetime_aware_jsonfield.py
@@ -12,13 +12,23 @@ from osf.exceptions import ValidationError
 from psycopg2.extras import Json
 
 
+class NaiveDatetimeException(BaseException):
+    pass
+
+
 class DateTimeAwareJSONEncoder(DjangoJSONEncoder):
     def default(self, o):
         if isinstance(o, dt.datetime):
+            if o.tzinfo is None or o.tzinfo.utcoffset(o) is None:
+                raise NaiveDatetimeException('Tried to encode a naive datetime.')
             return dict(type='encoded_datetime', value=o.isoformat())
         elif isinstance(o, dt.date):
+            if o.tzinfo is None or o.tzinfo.utcoffset(o) is None:
+                raise NaiveDatetimeException('Tried to encode a naive date.')
             return dict(type='encoded_date', value=o.isoformat())
         elif isinstance(o, dt.time):
+            if o.tzinfo is None or o.tzinfo.utcoffset(o) is None:
+                raise NaiveDatetimeException('Tried to encode a naive time.')
             return dict(type='encoded_time', value=o.isoformat())
         elif isinstance(o, Decimal):
             return dict(type='encoded_decimal', value=str(o))

--- a/osf/utils/fields.py
+++ b/osf/utils/fields.py
@@ -2,7 +2,7 @@ import jwe
 from django.db import models
 from website import settings
 
-from osf.utils.datetime_aware_jsonfield import NaiveDatetimeException
+from osf.exceptions import NaiveDatetimeException
 
 SENSITIVE_DATA_KEY = jwe.kdf(settings.SENSITIVE_DATA_SECRET.encode('utf-8'),
                              settings.SENSITIVE_DATA_SALT.encode('utf-8'))

--- a/osf_tests/test_queued_mail.py
+++ b/osf_tests/test_queued_mail.py
@@ -3,6 +3,7 @@ import datetime as dt
 
 import pytest
 import mock
+from django.utils import timezone
 
 from .factories import UserFactory, NodeFactory
 
@@ -12,7 +13,7 @@ from website import mails
 @pytest.fixture()
 def user():
     # TODO: Remove date_registered after migration is complete
-    return UserFactory(is_registered=True, date_registered=dt.datetime.utcnow())
+    return UserFactory(is_registered=True, date_registered=timezone.now())
 
 @pytest.mark.django_db
 class TestQueuedMail:
@@ -20,7 +21,7 @@ class TestQueuedMail:
     def queue_mail(self, mail, user, send_at=None, **kwargs):
         mail = queue_mail(
             to_addr=user.username if user else self.user.username,
-            send_at=send_at or dt.datetime.utcnow(),
+            send_at=send_at or timezone.now(),
             user=user,
             mail=mail,
             fullname=user.fullname if user else self.user.username,
@@ -31,16 +32,16 @@ class TestQueuedMail:
     @mock.patch('osf.models.queued_mail.send_mail')
     def test_no_login_presend_for_active_user(self, mock_mail, user):
         mail = self.queue_mail(mail=mails.NO_LOGIN, user=user)
-        user.date_last_login = dt.datetime.utcnow() + dt.timedelta(seconds=10)
+        user.date_last_login = timezone.now() + dt.timedelta(seconds=10)
         user.save()
         assert mail.send_mail() is False
 
     @mock.patch('osf.models.queued_mail.send_mail')
     def test_no_login_presend_for_inactive_user(self, mock_mail, user):
         mail = self.queue_mail(mail=mails.NO_LOGIN, user=user)
-        user.date_last_login = dt.datetime.utcnow() - dt.timedelta(weeks=10)
+        user.date_last_login = timezone.now() - dt.timedelta(weeks=10)
         user.save()
-        assert dt.datetime.utcnow() - dt.timedelta(days=1) > user.date_last_login
+        assert timezone.now() - dt.timedelta(days=1) > user.date_last_login
         assert bool(mail.send_mail()) is True
 
     @mock.patch('osf.models.queued_mail.send_mail')
@@ -72,7 +73,7 @@ class TestQueuedMail:
     # TODO: Uncomment when FileNodeModel is implemented
     # @mock.patch('osf.models.queued_mail.send_mail')
     # def test_welcome_osf4m_presend(self, mock_mail, user):
-    #     user.date_last_login = dt.datetime.utcnow() - dt.timedelta(days=13)
+    #     user.date_last_login = timezone.now() - dt.timedelta(days=13)
     #     user.save()
     #     mail = self.queue_mail(
     #         mail=mails.WELCOME_OSF4M,
@@ -133,7 +134,7 @@ class TestQueuedMail:
 
     @mock.patch('osf.models.queued_mail.send_mail')
     def test_user_is_not_active_is_disabled(self, mock_mail):
-        user = UserFactory(date_disabled=dt.datetime.utcnow())
+        user = UserFactory(date_disabled=timezone.now())
         mail = self.queue_mail(
             user=user,
             mail=mails.NO_ADDON,

--- a/osf_tests/test_sanctions.py
+++ b/osf_tests/test_sanctions.py
@@ -4,6 +4,8 @@ import mock
 import pytest
 import datetime
 
+from django.utils import timezone
+
 from osf.modm_compat import Q
 from osf.models import DraftRegistrationApproval, MetaSchema
 from osf_tests import factories
@@ -109,7 +111,7 @@ class TestDraftRegistrationApprovals:
     @mock.patch('framework.celery_tasks.handlers.enqueue_task')
     def test_on_complete_embargo_creates_registration_for_draft_initiator(self, mock_enquque):
         user = factories.UserFactory()
-        end_date = datetime.datetime.now() + datetime.timedelta(days=366)  # <- leap year
+        end_date = timezone.now() + datetime.timedelta(days=366)  # <- leap year
         approval = DraftRegistrationApproval(
             meta={
                 'registration_choice': 'embargo',

--- a/scripts/admin_permission_email.py
+++ b/scripts/admin_permission_email.py
@@ -4,6 +4,7 @@
 import logging
 import datetime
 
+from django.utils import timezone
 from modularodm import Q
 
 from framework.email.tasks import send_email
@@ -43,7 +44,7 @@ def send_security_message(user, label, mail):
         password=settings.MANDRILL_PASSWORD,
         mail_server=settings.MANDRILL_MAIL_SERVER,
     )
-    user.security_messages[label] = datetime.datetime.utcnow()
+    user.security_messages[label] = timezone.now()
     user.save()
 
 
@@ -91,7 +92,7 @@ class TestSendSecurityMessage(OsfTestCase):
 
     def test_get_targets(self):
         users = [UserFactory() for _ in range(3)]
-        users[0].security_messages[MESSAGE_NAME] = datetime.datetime.utcnow()
+        users[0].security_messages[MESSAGE_NAME] = timezone.now()
         users[0].save()
         targets = get_targets()
         assert_equal(set(targets), set(users[1:]))

--- a/scripts/analytics/benchmarks.py
+++ b/scripts/analytics/benchmarks.py
@@ -7,6 +7,7 @@ import collections
 
 import tabulate
 from django.db.models import F
+from django.utils import timezone
 from dateutil.relativedelta import relativedelta
 from modularodm import Q
 
@@ -134,7 +135,7 @@ def get_log_counts(users):
         counts = count_users_logs(
             users,
             (
-                Q('date', 'gte', datetime.datetime.utcnow() - counter.delta)
+                Q('date', 'gte', timezone.now() - counter.delta)
                 if counter.delta
                 else None
             ),

--- a/scripts/analytics/tabulate_emails.py
+++ b/scripts/analytics/tabulate_emails.py
@@ -7,6 +7,8 @@ import datetime
 import collections
 from cStringIO import StringIO
 
+from django.utils import timezone
+
 from framework.mongo import database
 
 from website import models
@@ -30,7 +32,7 @@ def get_emails_since(delta):
         'is_registered': True,
         'password': {'$ne': None},
         'is_merged': {'$ne': True},
-        'date_confirmed': {'$gte': datetime.datetime.utcnow() - delta},
+        'date_confirmed': {'$gte': timezone.now() - delta},
     })
 
 

--- a/scripts/analytics/tabulate_files_usage.py
+++ b/scripts/analytics/tabulate_files_usage.py
@@ -8,6 +8,8 @@ Currently outputs results to .csv files in the current working directory.
 import datetime
 import collections
 
+from django.utils import timezone
+
 from website import models
 from website.app import init_app
 
@@ -66,7 +68,7 @@ def write_counts(counts, outname):
 
 
 def main():
-    now = datetime.datetime.now().strftime('%Y-%m-%d')
+    now = timezone.now().strftime('%Y-%m-%d')
     personal, group = count_usage()
     write_counts(personal, 'usage-personal-{0}.csv'.format(now))
     write_counts(group, 'usage-group-{0}.csv'.format(now))

--- a/scripts/analytics/tabulate_logs.py
+++ b/scripts/analytics/tabulate_logs.py
@@ -8,6 +8,7 @@ import datetime
 from cStringIO import StringIO
 
 import pymongo
+from django.utils import timezone
 
 from framework.mongo import database
 
@@ -47,7 +48,7 @@ def run_map_reduce(**kwargs):
 def main():
     node = models.Node.load(settings.TABULATE_LOGS_NODE_ID)
     user = models.User.load(settings.TABULATE_LOGS_USER_ID)
-    cutoff = datetime.datetime.utcnow() - settings.TABULATE_LOGS_TIME_OFFSET
+    cutoff = timezone.now() - settings.TABULATE_LOGS_TIME_OFFSET
     result = run_map_reduce(query={'date': {'$gt': cutoff}})
     sio = StringIO()
     utils.make_csv(

--- a/scripts/approve_embargo_terminations.py
+++ b/scripts/approve_embargo_terminations.py
@@ -13,6 +13,7 @@ import datetime
 import logging
 import sys
 
+from django.utils import timezone
 from modularodm import Q
 
 from framework.transactions.context import TokuTransaction
@@ -27,7 +28,7 @@ logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
 def get_pending_embargo_termination_requests():
-    auto_approve_time = datetime.datetime.now() - settings.EMBARGO_TERMINATION_PENDING_TIME
+    auto_approve_time = timezone.now() - settings.EMBARGO_TERMINATION_PENDING_TIME
 
     return models.EmbargoTerminationApproval.find(
         Q('initiation_date', 'lt', auto_approve_time) &

--- a/scripts/approve_registrations.py
+++ b/scripts/approve_registrations.py
@@ -5,6 +5,7 @@ elapsed the pending approval time..
 import logging
 import datetime
 
+from django.utils import timezone
 from modularodm import Q
 
 from framework.celery_tasks import app as celery_app
@@ -51,7 +52,7 @@ def main(dry_run=True):
 
 def should_be_approved(pending_registration):
     """Returns true if pending_registration has surpassed its pending time."""
-    return (datetime.datetime.utcnow() - pending_registration.initiation_date) >= settings.REGISTRATION_APPROVAL_TIME
+    return (timezone.now() - pending_registration.initiation_date) >= settings.REGISTRATION_APPROVAL_TIME
 
 
 @celery_app.task(name='scripts.approve_registrations')

--- a/scripts/cleanup_failed_registrations.py
+++ b/scripts/cleanup_failed_registrations.py
@@ -3,6 +3,7 @@ import sys
 from datetime import datetime
 import logging
 
+from django.utils import timezone
 from modularodm import Q
 
 from website.archiver import (
@@ -26,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 
 def find_failed_registrations():
-    expired_if_before = datetime.utcnow() - ARCHIVE_TIMEOUT_TIMEDELTA
+    expired_if_before = timezone.now() - ARCHIVE_TIMEOUT_TIMEDELTA
     jobs = ArchiveJob.find(
         Q('sent', 'eq', False) &
         Q('datetime_initiated', 'lt', expired_if_before) &

--- a/scripts/clear_sessions.py
+++ b/scripts/clear_sessions.py
@@ -5,6 +5,7 @@ import logging
 import datetime
 
 from dateutil import relativedelta
+from django.utils import timezone
 
 from website.models import Session
 
@@ -32,6 +33,6 @@ def clear_sessions_relative(months=1, dry_run=False):
     """Remove all sessions last modified over `months` months ago.
     """
     logger.warn('Clearing sessions older than {0} months'.format(months))
-    now = datetime.datetime.utcnow()
+    now = timezone.now()
     delta = relativedelta.relativedelta(months=months)
     clear_sessions(now - delta, dry_run=dry_run)

--- a/scripts/email_registration_contributors.py
+++ b/scripts/email_registration_contributors.py
@@ -3,6 +3,7 @@
 import datetime
 import logging
 
+from django.utils import timezone
 from modularodm import Q
 
 from website import models
@@ -28,7 +29,7 @@ def send_retraction_and_embargo_addition_message(contrib, label, mail, dry_run=T
     logger.info('Sending message to user {0!r}'.format(contrib))
     if not dry_run:
         send_mail(contrib.username, mail, user=contrib)
-        contrib.security_messages[MESSAGE_NAME] = datetime.datetime.utcnow()
+        contrib.security_messages[MESSAGE_NAME] = timezone.now()
         contrib.save()
 
 

--- a/scripts/embargo_registrations.py
+++ b/scripts/embargo_registrations.py
@@ -6,6 +6,7 @@ embargo end dates have been passed.
 import logging
 import datetime
 
+from django.utils import timezone
 from modularodm import Q
 
 from framework.celery_tasks import app as celery_app
@@ -61,7 +62,7 @@ def main(dry_run=True):
 
     active_embargoes = models.Embargo.find(Q('state', 'eq', models.Embargo.APPROVED))
     for embargo in active_embargoes:
-        if embargo.end_date < datetime.datetime.utcnow():
+        if embargo.end_date < timezone.now():
             if dry_run:
                 logger.warn('Dry run mode')
             parent_registration = models.Node.find_one(Q('embargo', 'eq', embargo))
@@ -100,7 +101,7 @@ def main(dry_run=True):
 
 def should_be_embargoed(embargo):
     """Returns true if embargo was initiated more than 48 hours prior."""
-    return (datetime.datetime.utcnow() - embargo.initiation_date) >= settings.EMBARGO_PENDING_TIME
+    return (timezone.now() - embargo.initiation_date) >= settings.EMBARGO_PENDING_TIME
 
 
 @celery_app.task(name='scripts.embargo_registrations')

--- a/scripts/ensure_log_dates.py
+++ b/scripts/ensure_log_dates.py
@@ -11,6 +11,7 @@ import datetime
 import logging
 import sys
 
+from django.utils import timezone
 from modularodm import Q
 
 from website.models import NodeLog
@@ -74,7 +75,7 @@ class TestEnsureLogDates(OsfTestCase):
 
         self.mongo.update(
             {'_id': self.bad_log._id},
-            {'$set': {'date': datetime.datetime.utcnow() - datetime.timedelta(weeks=52)}},
+            {'$set': {'date': timezone.now() - datetime.timedelta(weeks=52)}},
         )
         self.bad_log.reload()
 

--- a/scripts/migrate_unconfirmed_valid_users.py
+++ b/scripts/migrate_unconfirmed_valid_users.py
@@ -5,6 +5,8 @@
 import sys
 import logging
 
+from django.utils import timezone
+
 from website.app import init_app
 from website.models import User
 from scripts import utils as script_utils
@@ -54,7 +56,7 @@ def main():
 class TestMigrateNodeCategories(OsfTestCase):
 
     def test_get_targets(self):
-        today = dt.datetime.utcnow()
+        today = timezone.now()
         user1 = UserFactory.build(date_confirmed=today, date_last_login=today)
         user2 = UserFactory.build(date_confirmed=None, date_last_login=today)
         user1.save()
@@ -70,7 +72,7 @@ class TestMigrateNodeCategories(OsfTestCase):
         assert len(user_list) is 2
 
     def test_do_migration(self):
-        today = dt.datetime.utcnow()
+        today = timezone.now()
         user1 = UserFactory.build(date_confirmed=None, date_last_login=today, is_registered=False)
         user2 = UserFactory.build(date_confirmed=None, date_last_login=today, is_registered=True)
         user1.save()

--- a/scripts/migration/migrate_date_last_login_for_current_users.py
+++ b/scripts/migration/migrate_date_last_login_for_current_users.py
@@ -6,6 +6,8 @@ import sys
 import logging
 import datetime
 
+from django.utils import timezone
+
 from website import models
 from website.app import init_app
 
@@ -22,7 +24,7 @@ def main():
         if user.is_active:
             logger.info('User {0} "date_last_login" updated'.format(user._id))
             if not dry_run:
-                user.date_last_login = datetime.datetime.utcnow()
+                user.date_last_login = timezone.now()
                 user.save()
 
 if __name__ == '__main__':

--- a/scripts/osfstorage/glacier_inventory.py
+++ b/scripts/osfstorage/glacier_inventory.py
@@ -8,6 +8,7 @@ import logging
 import datetime
 
 from boto.glacier.layer2 import Layer2
+from django.utils import timezone
 
 from framework.celery_tasks import app as celery_app
 
@@ -31,7 +32,7 @@ def get_vault():
 def main():
     vault = get_vault()
     job = vault.retrieve_inventory_job(
-        description='glacier-audit-{}'.format(datetime.datetime.utcnow().strftime('%c')),
+        description='glacier-audit-{}'.format(timezone.now().strftime('%c')),
         sns_topic=storage_settings.AWS_SNS_ARN,
     )
     logger.info('Started retrieve inventory job with id {}'.format(job.id))

--- a/scripts/osfstorage/migrate_to_generic.py
+++ b/scripts/osfstorage/migrate_to_generic.py
@@ -3,6 +3,8 @@ from __future__ import unicode_literals
 import sys
 import logging
 import datetime
+
+from django.utils import timezone
 from modularodm import Q
 from modularodm.storage.base import KeyExistsException
 
@@ -14,7 +16,7 @@ from website.files import models
 from website.app import init_app
 from website.addons.osfstorage import model as osfstorage_model
 
-NOW = datetime.datetime.utcnow()
+NOW = timezone.now()
 logger = logging.getLogger(__name__)
 
 

--- a/scripts/populate_new_and_noteworthy_projects.py
+++ b/scripts/populate_new_and_noteworthy_projects.py
@@ -5,6 +5,7 @@ import sys
 import logging
 import datetime
 import dateutil
+from django.utils import timezone
 from modularodm import Q
 from website.app import init_app
 from website import models
@@ -50,7 +51,7 @@ def get_new_and_noteworthy_nodes():
     Mainly: public top-level projects with the greatest number of unique log actions
 
     """
-    today = datetime.datetime.now()
+    today = timezone.now()
     last_month = (today - dateutil.relativedelta.relativedelta(months=1))
     data = db.node.find({'date_created': {'$gt': last_month}, 'is_public': True, 'is_registration': False, 'parent_node': None,
                          'is_deleted': False, 'is_collection': False})

--- a/scripts/prereg/reject_draft_registrations.py
+++ b/scripts/prereg/reject_draft_registrations.py
@@ -5,6 +5,8 @@ import sys
 import logging
 import datetime as dt
 
+from django.utils import timezone
+
 from website.app import init_app
 from website.project.model import DraftRegistration, Sanction
 
@@ -20,7 +22,7 @@ def add_comments(draft):
             'name': 'Mario!'
         },
         'value': 'Ahoy! This is a comment!',
-        'lastModified': dt.datetime.utcnow().isoformat()
+        'lastModified': timezone.now().isoformat()
     }]
     for question_id, value in draft.registration_metadata.iteritems():
         value['comments'] = comment

--- a/scripts/refresh_addon_tokens.py
+++ b/scripts/refresh_addon_tokens.py
@@ -2,8 +2,8 @@
 # encoding: utf-8
 
 import logging
-import datetime
 import time
+from django.utils import timezone
 
 from modularodm import Q
 from oauthlib.oauth2 import OAuth2Error
@@ -35,7 +35,7 @@ def get_targets(delta, addon_short_name):
     # NOTE: expires_at is the  access_token's expiration date,
     # NOT the refresh token's
     return ExternalAccount.find(
-        Q('expires_at', 'lt', datetime.datetime.utcnow() - delta) &
+        Q('expires_at', 'lt', timezone.now() - delta) &
         Q('provider', 'eq', addon_short_name)
     )
 
@@ -57,7 +57,7 @@ def main(delta, Provider, rate_limit, dry_run):
         )
         if not dry_run:
             if allowance < 1:
-                try: 
+                try:
                     time.sleep(rate_limit[1] - (time.time() - last_call))
                 except (ValueError, IOError):
                     pass  # Value/IOError indicates negative sleep time in Py 3.5/2.7, respectively

--- a/scripts/retract_registrations.py
+++ b/scripts/retract_registrations.py
@@ -3,6 +3,7 @@
 import datetime
 import logging
 
+from django.utils import timezone
 from modularodm import Q
 
 from framework.auth import Auth
@@ -63,7 +64,7 @@ def main(dry_run=True):
 
 def should_be_retracted(retraction):
     """Returns true if retraction was initiated more than 48 hours prior"""
-    return (datetime.datetime.utcnow() - retraction.initiation_date) >= settings.RETRACTION_PENDING_TIME
+    return (timezone.now() - retraction.initiation_date) >= settings.RETRACTION_PENDING_TIME
 
 
 @celery_app.task(name='scripts.retract_registrations')

--- a/scripts/send_queued_mails.py
+++ b/scripts/send_queued_mails.py
@@ -2,6 +2,7 @@ import logging
 
 from datetime import datetime
 
+from django.utils import timezone
 from modularodm import Q
 
 from framework.celery_tasks import app as celery_app
@@ -28,7 +29,7 @@ def main(dry_run=True):
 
     emails_to_be_sent = pop_and_verify_mails_for_each_user(user_queue)
 
-    logger.info('Emails being sent at {0}'.format(datetime.utcnow().isoformat()))
+    logger.info('Emails being sent at {0}'.format(timezone.now().isoformat()))
 
     for mail in emails_to_be_sent:
         if not dry_run:
@@ -48,7 +49,7 @@ def main(dry_run=True):
 
 def find_queued_mails_ready_to_be_sent():
     return mails.QueuedMail.find(
-        Q('send_at', 'lt', datetime.utcnow()) &
+        Q('send_at', 'lt', timezone.now()) &
         Q('sent_at', 'eq', None)
     )
 
@@ -58,7 +59,7 @@ def pop_and_verify_mails_for_each_user(user_queue):
         mail = user_emails[0]
         mails_past_week = mails.QueuedMail.find(
             Q('user', 'eq', mail.user) &
-            Q('sent_at', 'gt', datetime.utcnow() - settings.WAIT_BETWEEN_MAILS)
+            Q('sent_at', 'gt', timezone.now() - settings.WAIT_BETWEEN_MAILS)
         )
         if not mails_past_week.count():
             yield mail

--- a/scripts/tests/test_approve_embargo_terminations.py
+++ b/scripts/tests/test_approve_embargo_terminations.py
@@ -2,6 +2,8 @@
 
 import mock
 from datetime import datetime, timedelta
+
+from django.utils import timezone
 from nose.tools import *  # noqa
 
 from tests.base import OsfTestCase
@@ -41,7 +43,7 @@ class TestApproveEmbargoTerminations(OsfTestCase):
 
         # requesting termination and older than 48 hours
         with mock_archive(self.node, embargo=True, autoapprove=True) as registration:
-            old_time = datetime.now() - timedelta(days=5)
+            old_time = timezone.now() - timedelta(days=5)
             approval = registration.request_embargo_termination(auth=Auth(self.user))
             EmbargoTerminationApproval._storage[0].store.update(
                 {'_id': approval._id},
@@ -51,7 +53,7 @@ class TestApproveEmbargoTerminations(OsfTestCase):
 
         # requesting termination and older than 48 hours, but approved
         with mock_archive(self.node, embargo=True, autoapprove=True) as registration:
-            old_time = datetime.now() - timedelta(days=5)
+            old_time = timezone.now() - timedelta(days=5)
             approval = registration.request_embargo_termination(auth=Auth(self.user))
             EmbargoTerminationApproval._storage[0].store.update(
                 {'_id': approval._id},

--- a/scripts/tests/test_approve_registrations.py
+++ b/scripts/tests/test_approve_registrations.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
 from datetime import datetime, timedelta
+
+from django.utils import timezone
 from nose.tools import *  # noqa
 
 from tests.base import OsfTestCase
@@ -29,7 +31,7 @@ class TestApproveRegistrations(OsfTestCase):
         # RegistrationApproval#iniation_date is read only
         self.registration.registration_approval._fields['initiation_date'].__set__(
             self.registration.registration_approval,
-            (datetime.utcnow() - timedelta(hours=47)),
+            (timezone.now() - timedelta(hours=47)),
             safe=True
         )
         self.registration.registration_approval.save()
@@ -43,7 +45,7 @@ class TestApproveRegistrations(OsfTestCase):
         # RegistrationApproval#iniation_date is read only
         self.registration.registration_approval._fields['initiation_date'].__set__(
             self.registration.registration_approval,
-            (datetime.utcnow() - timedelta(hours=48)),
+            (timezone.now() - timedelta(hours=48)),
             safe=True
         )
         self.registration.registration_approval.save()
@@ -57,7 +59,7 @@ class TestApproveRegistrations(OsfTestCase):
         # RegistrationApproval#iniation_date is read only
         self.registration.registration_approval._fields['initiation_date'].__set__(
             self.registration.registration_approval,
-            (datetime.utcnow() - timedelta(days=365)),
+            (timezone.now() - timedelta(days=365)),
             safe=True
         )
         self.registration.registration_approval.save()
@@ -71,7 +73,7 @@ class TestApproveRegistrations(OsfTestCase):
         # RegistrationApproval#iniation_date is read only
         self.registration.registration_approval._fields['initiation_date'].__set__(
             self.registration.registration_approval,
-            (datetime.utcnow() - timedelta(days=365)),
+            (timezone.now() - timedelta(days=365)),
             safe=True
         )
         self.registration.registration_approval.save()

--- a/scripts/tests/test_clear_sessions.py
+++ b/scripts/tests/test_clear_sessions.py
@@ -1,4 +1,4 @@
-
+from django.utils import timezone
 from nose.tools import *  # noqa
 from tests.base import OsfTestCase
 
@@ -11,7 +11,7 @@ class TestClearSessions(OsfTestCase):
 
     def setUp(self):
         super(TestClearSessions, self).setUp()
-        now = datetime.datetime.utcnow()
+        now = timezone.now()
         self.dates = [
             now,
             now - relativedelta.relativedelta(months=2),

--- a/scripts/tests/test_embargo_registrations.py
+++ b/scripts/tests/test_embargo_registrations.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
 from datetime import date, datetime, timedelta
+
+from django.utils import timezone
 from nose.tools import *  # noqa
 
 from tests.base import OsfTestCase
@@ -18,7 +20,7 @@ class TestRetractRegistrations(OsfTestCase):
         self.registration = RegistrationFactory(creator=self.user)
         self.registration.embargo_registration(
             self.user,
-            datetime.utcnow() + timedelta(days=10)
+            timezone.now() + timedelta(days=10)
         )
         self.registration.save()
 
@@ -34,7 +36,7 @@ class TestRetractRegistrations(OsfTestCase):
         # Embargo#iniation_date is read only
         self.registration.embargo._fields['initiation_date'].__set__(
             self.registration.embargo,
-            (datetime.utcnow() - timedelta(hours=47)),
+            (timezone.now() - timedelta(hours=47)),
             safe=True
         )
         self.registration.embargo.save()
@@ -47,7 +49,7 @@ class TestRetractRegistrations(OsfTestCase):
         # Embargo#iniation_date is read only
         self.registration.embargo._fields['initiation_date'].__set__(
             self.registration.embargo,
-            (datetime.utcnow() - timedelta(hours=48)),
+            (timezone.now() - timedelta(hours=48)),
             safe=True
         )
         self.registration.embargo.save()
@@ -62,7 +64,7 @@ class TestRetractRegistrations(OsfTestCase):
         # Embargo#iniation_date is read only
         self.registration.embargo._fields['initiation_date'].__set__(
             self.registration.embargo,
-            (datetime.utcnow() - timedelta(days=365)),
+            (timezone.now() - timedelta(days=365)),
             safe=True
         )
         self.registration.embargo.save()
@@ -83,7 +85,7 @@ class TestRetractRegistrations(OsfTestCase):
         # Embargo#iniation_date is read only
         self.registration.embargo._fields['end_date'].__set__(
             self.registration.embargo,
-            (datetime.utcnow() - timedelta(days=1)),
+            (timezone.now() - timedelta(days=1)),
             safe=True
         )
         self.registration.embargo.save()
@@ -105,7 +107,7 @@ class TestRetractRegistrations(OsfTestCase):
         # Embargo#iniation_date is read only
         self.registration.embargo._fields['end_date'].__set__(
             self.registration.embargo,
-            (datetime.utcnow() + timedelta(days=1)),
+            (timezone.now() + timedelta(days=1)),
             safe=True
         )
         self.registration.embargo.save()
@@ -121,7 +123,7 @@ class TestRetractRegistrations(OsfTestCase):
         # Embargo#iniation_date is read only
         self.registration.embargo._fields['initiation_date'].__set__(
             self.registration.embargo,
-            (datetime.utcnow() - timedelta(days=365)),
+            (timezone.now() - timedelta(days=365)),
             safe=True
         )
         self.registration.embargo.save()
@@ -141,7 +143,7 @@ class TestRetractRegistrations(OsfTestCase):
         # Embargo#iniation_date is read only
         self.registration.embargo._fields['end_date'].__set__(
             self.registration.embargo,
-            (datetime.utcnow() - timedelta(days=1)),
+            (timezone.now() - timedelta(days=1)),
             safe=True
         )
         self.registration.embargo.save()

--- a/scripts/tests/test_migrate_dates.py
+++ b/scripts/tests/test_migrate_dates.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 import datetime
+
+from django.utils import timezone
 from nose.tools import *  # noqa
 
 from scripts.osfstorage.utils import ensure_osf_files
@@ -29,7 +31,7 @@ class TestMigrateDates(OsfTestCase):
         self.date = self.node_file.date_modified
         self.project.files_versions['old_pizza'] = [self.node_file._id]
         self.project.save()
-        self.version = FileVersionFactory(date_modified=datetime.datetime.now())
+        self.version = FileVersionFactory(date_modified=timezone.now())
         self.record, _ = OsfStorageFileRecord.get_or_create(self.node_file.path, self.node_settings)
         self.record.versions = [self.version]
         self.record.save()

--- a/scripts/tests/test_migrate_spam.py
+++ b/scripts/tests/test_migrate_spam.py
@@ -1,4 +1,6 @@
 from datetime import datetime, timedelta
+
+from django.utils import timezone
 from nose import tools as nt
 
 from tests.base import OsfTestCase
@@ -15,7 +17,7 @@ class TestMigrateSpam(OsfTestCase):
         self.generic_report = {
             'category': 'spam',
             'text': 'spammer spam',
-            'date': datetime.utcnow(),
+            'date': timezone.now(),
             'retracted': False
         }
         Comment.remove()

--- a/scripts/tests/test_refresh_addon_tokens.py
+++ b/scripts/tests/test_refresh_addon_tokens.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import mock
+from django.utils import timezone
 from nose.tools import *  # noqa
 
 from tests.base import OsfTestCase
@@ -38,7 +39,7 @@ class TestRefreshTokens(OsfTestCase):
         assert_equal(fake_result, None)
 
     def test_get_targets(self):
-        now = datetime.datetime.utcnow()
+        now = timezone.now()
         records = [
             BoxAccountFactory(expires_at=now + datetime.timedelta(days=4)),
             BoxAccountFactory(expires_at=now + datetime.timedelta(days=2)),
@@ -61,9 +62,9 @@ class TestRefreshTokens(OsfTestCase):
     @mock.patch('scripts.refresh_addon_tokens.GoogleDriveProvider.refresh_oauth_key')
     @mock.patch('scripts.refresh_addon_tokens.Box.refresh_oauth_key')
     def test_refresh(self, mock_box_refresh, mock_drive_refresh, mock_mendeley_refresh):
-        fake_box_account = BoxAccountFactory(expires_at=datetime.datetime.utcnow())
-        fake_drive_account = GoogleDriveAccountFactory(expires_at=datetime.datetime.utcnow())
-        fake_mendeley_account = MendeleyAccountFactory(expires_at=datetime.datetime.utcnow())
+        fake_box_account = BoxAccountFactory(expires_at=timezone.now())
+        fake_drive_account = GoogleDriveAccountFactory(expires_at=timezone.now())
+        fake_mendeley_account = MendeleyAccountFactory(expires_at=timezone.now())
         for addon in self.addons:
             Provider = look_up_provider(addon)
             main(delta=relativedelta(days=-3), Provider=Provider, dry_run=False)

--- a/scripts/tests/test_retract_registrations.py
+++ b/scripts/tests/test_retract_registrations.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
 from datetime import datetime, timedelta
+
+from django.utils import timezone
 from nose.tools import *  # noqa
 
 from tests.base import OsfTestCase
@@ -30,10 +32,10 @@ class TestRetractRegistrations(OsfTestCase):
         # Retraction#iniation_date is read only
         self.registration.retraction._fields['initiation_date'].__set__(
             self.registration.retraction,
-            (datetime.utcnow() - timedelta(hours=47)),
+            (timezone.now() - timedelta(hours=47)),
             safe=True
         )
-        # setattr(self.registration.retraction, 'initiation_date', (datetime.utcnow() - timedelta(hours=47)))
+        # setattr(self.registration.retraction, 'initiation_date', (timezone.now() - timedelta(hours=47)))
         self.registration.retraction.save()
         assert_false(self.registration.is_retracted)
 
@@ -44,7 +46,7 @@ class TestRetractRegistrations(OsfTestCase):
         # Retraction#iniation_date is read only
         self.registration.retraction._fields['initiation_date'].__set__(
             self.registration.retraction,
-            (datetime.utcnow() - timedelta(hours=48)),
+            (timezone.now() - timedelta(hours=48)),
             safe=True
         )
         self.registration.retraction.save()
@@ -57,7 +59,7 @@ class TestRetractRegistrations(OsfTestCase):
         # Retraction#iniation_date is read only
         self.registration.retraction._fields['initiation_date'].__set__(
             self.registration.retraction,
-            (datetime.utcnow() - timedelta(days=365)),
+            (timezone.now() - timedelta(days=365)),
             safe=True
         )
         self.registration.retraction.save()
@@ -71,7 +73,7 @@ class TestRetractRegistrations(OsfTestCase):
         # Retraction#iniation_date is read only
         self.registration.retraction._fields['initiation_date'].__set__(
             self.registration.retraction,
-            (datetime.utcnow() - timedelta(days=365)),
+            (timezone.now() - timedelta(days=365)),
             safe=True
         )
         self.registration.retraction.save()

--- a/scripts/tests/test_send_queued_mails.py
+++ b/scripts/tests/test_send_queued_mails.py
@@ -1,5 +1,7 @@
 import mock  # noqa
 from datetime import datetime, timedelta
+
+from django.utils import timezone
 from nose.tools import *
 
 from tests.base import OsfTestCase
@@ -14,7 +16,7 @@ class TestSendQueuedMails(OsfTestCase):
         super(TestSendQueuedMails, self).setUp()
         mails.QueuedMail.remove()
         self.user = UserFactory()
-        self.user.date_last_login = datetime.utcnow()
+        self.user.date_last_login = timezone.now()
         self.user.osf_mailing_lists[settings.OSF_HELP_LIST] = True
         self.user.save()
 
@@ -22,7 +24,7 @@ class TestSendQueuedMails(OsfTestCase):
         return mails.queue_mail(
             to_addr=user.username if user else self.user.username,
             mail=mail_type,
-            send_at=send_at or datetime.utcnow(),
+            send_at=send_at or timezone.now(),
             user=user if user else self.user,
             fullname=user.fullname if user else self.user.fullname,
         )
@@ -48,7 +50,7 @@ class TestSendQueuedMails(OsfTestCase):
         user_with_multiple_emails = UserFactory()
         user_with_no_emails_sent = UserFactory()
         mail_sent = mails.QueuedMail(user=user_with_email_sent,
-                                     sent_at=datetime.utcnow() - timedelta(days=1),
+                                     sent_at=timezone.now() - timedelta(days=1),
                                      to_addr=user_with_email_sent.username)
         mail_sent.save()
         mail1 = self.queue_mail(user=user_with_email_sent)
@@ -69,7 +71,7 @@ class TestSendQueuedMails(OsfTestCase):
 
     def test_find_queued_mails_ready_to_be_sent(self):
         mail1 = self.queue_mail()
-        mail2 = self.queue_mail(send_at=datetime.utcnow()+timedelta(days=1))
-        mail3 = self.queue_mail(send_at=datetime.utcnow())
+        mail2 = self.queue_mail(send_at=timezone.now()+timedelta(days=1))
+        mail3 = self.queue_mail(send_at=timezone.now())
         mails = find_queued_mails_ready_to_be_sent()
         assert_equal(len(mails), 2)

--- a/scripts/tests/test_triggered_mails.py
+++ b/scripts/tests/test_triggered_mails.py
@@ -1,5 +1,7 @@
 import mock
 from datetime import datetime, timedelta
+
+from django.utils import timezone
 from nose.tools import * # noqa
 
 from tests.base import OsfTestCase
@@ -13,19 +15,19 @@ class TestTriggeredMails(OsfTestCase):
     def setUp(self):
         super(TestTriggeredMails, self).setUp()
         self.user = UserFactory()
-        self.user.date_last_login = datetime.utcnow()
+        self.user.date_last_login = timezone.now()
         self.user.save()
 
     @mock.patch('website.mails.queue_mail')
     def test_dont_trigger_no_login_mail(self, mock_queue):
-        self.user.date_last_login = datetime.utcnow() - timedelta(seconds=6)
+        self.user.date_last_login = timezone.now() - timedelta(seconds=6)
         self.user.save()
         main(dry_run=False)
         assert_false(mock_queue.called)
 
     @mock.patch('website.mails.queue_mail')
     def test_trigger_no_login_mail(self, mock_queue):
-        self.user.date_last_login = datetime.utcnow() - timedelta(weeks=6)
+        self.user.date_last_login = timezone.now() - timedelta(weeks=6)
         self.user.save()
         main(dry_run=False)
         mock_queue.assert_called_with(
@@ -41,14 +43,14 @@ class TestTriggeredMails(OsfTestCase):
         user_active = UserFactory(fullname='Spot')
         user_inactive = UserFactory(fullname='Nucha')
         user_already_received_mail = UserFactory(fullname='Pep')
-        user_active.date_last_login = datetime.utcnow() - timedelta(seconds=6)
-        user_inactive.date_last_login = datetime.utcnow() - timedelta(weeks=6)
-        user_already_received_mail.date_last_login = datetime.utcnow() - timedelta(weeks=6)
+        user_active.date_last_login = timezone.now() - timedelta(seconds=6)
+        user_inactive.date_last_login = timezone.now() - timedelta(weeks=6)
+        user_already_received_mail.date_last_login = timezone.now() - timedelta(weeks=6)
         user_active.save()
         user_inactive.save()
         user_already_received_mail.save()
         mails.queue_mail(to_addr=user_already_received_mail.username,
-                         send_at=datetime.utcnow(),
+                         send_at=timezone.now(),
                          user=user_already_received_mail,
                          mail=mails.NO_LOGIN)
         users = find_inactive_users_with_no_inactivity_email_sent_or_queued()

--- a/scripts/tests/test_update_comments.py
+++ b/scripts/tests/test_update_comments.py
@@ -1,4 +1,7 @@
 from datetime import datetime
+
+from django.utils import timezone
+
 from framework.auth.core import User
 from scripts.update_comments import update_comments_viewed_timestamp
 from tests.base import OsfTestCase
@@ -22,7 +25,7 @@ class TestUpdateCommentFields(OsfTestCase):
 
     def test_update_comments_viewed_timestamp(self):
         user = UserFactory()
-        timestamp = datetime.utcnow().replace(microsecond=0)
+        timestamp = timezone.now().replace(microsecond=0)
         user.comments_viewed_timestamp = {
             'node_id': {
                 'node': timestamp,

--- a/scripts/triggered_mails.py
+++ b/scripts/triggered_mails.py
@@ -2,6 +2,7 @@ import logging
 
 from datetime import datetime
 
+from django.utils import timezone
 from modularodm import Q
 
 from framework.auth import User
@@ -27,7 +28,7 @@ def main(dry_run=True):
                 mails.queue_mail(
                     to_addr=user.username,
                     mail=mails.NO_LOGIN,
-                    send_at=datetime.utcnow(),
+                    send_at=timezone.now(),
                     user=user,
                     fullname=user.fullname,
                 )
@@ -35,8 +36,8 @@ def main(dry_run=True):
 
 def find_inactive_users_with_no_inactivity_email_sent_or_queued():
     inactive_users = User.find(
-        (Q('date_last_login', 'lt', datetime.utcnow() - settings.NO_LOGIN_WAIT_TIME) & Q('osf4m', 'ne', 'system_tags')) |
-        (Q('date_last_login', 'lt', datetime.utcnow() - settings.NO_LOGIN_OSF4M_WAIT_TIME) & Q('osf4m', 'eq', 'system_tags'))
+        (Q('date_last_login', 'lt', timezone.now() - settings.NO_LOGIN_WAIT_TIME) & Q('osf4m', 'ne', 'system_tags')) |
+        (Q('date_last_login', 'lt', timezone.now() - settings.NO_LOGIN_OSF4M_WAIT_TIME) & Q('osf4m', 'eq', 'system_tags'))
     )
     inactive_emails = mails.QueuedMail.find(Q('email_type', 'eq', mails.NO_LOGIN_TYPE))
 

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -4,11 +4,13 @@ import os
 import logging
 import datetime
 
+from django.utils import timezone
+
 from website import settings
 
 
 def format_now():
-    return datetime.datetime.now().isoformat()
+    return timezone.now().isoformat()
 
 
 def add_file_logger(logger, script_name, suffix=None):

--- a/tests/framework_tests/test_analytics.py
+++ b/tests/framework_tests/test_analytics.py
@@ -6,6 +6,7 @@ Unit tests for analytics logic in framework/analytics/__init__.py
 import unittest
 
 import pytest
+from django.utils import timezone
 from nose.tools import *  # flake8: noqa  (PEP8 asserts)
 from flask import Flask
 
@@ -24,7 +25,7 @@ class TestAnalytics(OsfTestCase):
 
     def test_get_total_activity_count(self):
         user = UserFactory()
-        date = datetime.utcnow()
+        date = timezone.now()
 
         assert_equal(analytics.get_total_activity_count(user._id), 0)
         assert_equal(analytics.get_total_activity_count(user._id), user.get_activity_points(db=None))
@@ -36,7 +37,7 @@ class TestAnalytics(OsfTestCase):
 
     def test_increment_user_activity_counters(self):
         user = UserFactory()
-        date = datetime.utcnow()
+        date = timezone.now()
 
         assert_equal(user.get_activity_points(db=None), 0)
         analytics.increment_user_activity_counters(user._id, 'project_created', date.isoformat(), db=None)

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -1,6 +1,7 @@
 import mock
 import datetime
 
+from django.utils import timezone
 from modularodm import Q
 from nose.tools import *  # flake8: noqa (PEP8 asserts)
 
@@ -292,7 +293,7 @@ class TestUserMerging(base.OsfTestCase):
         other_user.save()
 
         # define values for users' fields
-        today = datetime.datetime.now()
+        today = timezone.now()
         yesterday = today - datetime.timedelta(days=1)
 
         self.user.comments_viewed_timestamp['shared_gt'] = today
@@ -506,7 +507,7 @@ class TestUserMerging(base.OsfTestCase):
         assert_equal(linking_user.external_identity, {'ORCID': {'1234-1234-1234-1234': 'VERIFIED'}})
         linking_user.merge_user(different_id_user)
         assert_equal(linking_user.external_identity,
-            {'ORCID': 
+            {'ORCID':
                 {
                     '1234-1234-1234-1234': 'VERIFIED',
                     '4321-4321-4321-4321': 'VERIFIED'
@@ -521,7 +522,7 @@ class TestUserMerging(base.OsfTestCase):
         no_provider_user.merge_user(linking_user)
         assert_equal(linking_user.external_identity, {})
         assert_equal(no_provider_user.external_identity,
-            {'ORCID': 
+            {'ORCID':
                 {
                     '1234-1234-1234-1234': 'VERIFIED',
                     '4321-4321-4321-4321': 'VERIFIED'

--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -6,6 +6,7 @@ import datetime
 import unittest
 from nose.tools import *  # noqa
 import httplib as http
+from django.utils import timezone
 
 import jwe
 import jwt
@@ -111,7 +112,7 @@ class TestAddonAuth(OsfTestCase):
             nid=self.node._id,
             provider=self.node_addon.config.short_name,
             ), **kwargs),
-            'exp': datetime.datetime.utcnow() + datetime.timedelta(seconds=settings.WATERBUTLER_JWT_EXPIRATION),
+            'exp': timezone.now() + datetime.timedelta(seconds=settings.WATERBUTLER_JWT_EXPIRATION),
         }, settings.WATERBUTLER_JWT_SECRET, algorithm=settings.WATERBUTLER_JWT_ALGORITHM), self.JWE_KEY)}
         return api_url_for('get_auth', **options)
 
@@ -181,7 +182,7 @@ class TestAddonLogs(OsfTestCase):
         self.oauth_settings = GitHubAccountFactory(display_name='john')
         self.oauth_settings.save()
         self.user.external_accounts.append(self.oauth_settings)
-        self.user.save()        
+        self.user.save()
         self.node.add_addon('github', self.auth_obj)
         self.node_addon = self.node.get_addon('github')
         self.node_addon.user = 'john'

--- a/tests/test_auth_basic_auth.py
+++ b/tests/test_auth_basic_auth.py
@@ -4,6 +4,7 @@
 
 from __future__ import absolute_import
 
+from django.utils import timezone
 from nose.tools import *  # noqa PEP8 asserts
 from datetime import datetime, timedelta
 
@@ -87,7 +88,7 @@ class TestAuthBasicAuthentication(OsfTestCase):
         assert_equal(res.status_code, 200)
 
     def test_expired_cookie(self):
-        self.session = SessionFactory(user=self.user1, date_created=(datetime.utcnow() - timedelta(seconds=settings.OSF_SESSION_TIMEOUT)))
+        self.session = SessionFactory(user=self.user1, date_created=(timezone.now() - timedelta(seconds=settings.OSF_SESSION_TIMEOUT)))
         cookie = self.user1.get_or_create_cookie()
         self.app.set_cookie(settings.COOKIE_NAME, str(cookie))
         res = self.app.get(self.reachable_url)

--- a/tests/test_citations.py
+++ b/tests/test_citations.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
 import datetime
+
+from django.utils import timezone
 from nose.tools import *  # noqa
 
 from scripts import parse_citation_styles
@@ -17,7 +19,7 @@ from tests.factories import ProjectFactory, UserFactory, AuthUserFactory
 class CitationsUtilsTestCase(OsfTestCase):
     def test_datetime_to_csl(self):
         # Convert a datetime instance to csl's date-variable schema
-        now = datetime.datetime.utcnow()
+        now = timezone.now()
 
         assert_equal(
             datetime_to_csl(now),

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -178,7 +178,7 @@ class TestFileUpdated(OsfTestCase):
     @mock.patch('website.notifications.emails.notify')
     def test_file_updated(self, mock_notify):
         self.event.perform()
-        # notify('exd', 'file_updated', 'user', self.project, datetime.utcnow())
+        # notify('exd', 'file_updated', 'user', self.project, timezone.now())
         assert_true(mock_notify.called)
 
 
@@ -205,7 +205,7 @@ class TestFileAdded(NotificationTestCase):
     @mock.patch('website.notifications.emails.notify')
     def test_file_added(self, mock_notify):
         self.event.perform()
-        # notify('exd', 'file_updated', 'user', self.project, datetime.utcnow())
+        # notify('exd', 'file_updated', 'user', self.project, timezone.now())
         assert_true(mock_notify.called)
 
 
@@ -240,7 +240,7 @@ class TestFileRemoved(NotificationTestCase):
     @mock.patch('website.notifications.emails.notify')
     def test_file_removed(self, mock_notify):
         self.event.perform()
-        # notify('exd', 'file_updated', 'user', self.project, datetime.utcnow())
+        # notify('exd', 'file_updated', 'user', self.project, timezone.now())
         assert_true(mock_notify.called)
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,6 +3,7 @@
 import mock
 import unittest
 from nose.tools import *  # noqa (PEP8 asserts)
+from django.utils import timezone
 
 import os.path
 import json
@@ -462,7 +463,7 @@ class TestUser(OsfTestCase):
     def test_get_confirmation_token_when_token_is_expired_raises_error(self):
         u = UserFactory()
         # Make sure token is already expired
-        expiration = datetime.datetime.utcnow() - datetime.timedelta(seconds=1)
+        expiration = timezone.now() - datetime.timedelta(seconds=1)
         u.add_unconfirmed_email('foo@bar.com', expiration=expiration)
 
         with assert_raises(ExpiredTokenError):
@@ -473,7 +474,7 @@ class TestUser(OsfTestCase):
         random_string.return_value = '12345'
         u = UserFactory()
         # Make sure token is already expired
-        expiration = datetime.datetime.utcnow() - datetime.timedelta(seconds=1)
+        expiration = timezone.now() - datetime.timedelta(seconds=1)
         u.add_unconfirmed_email('foo@bar.com', expiration=expiration)
 
         # sanity check
@@ -519,7 +520,7 @@ class TestUser(OsfTestCase):
     def test_get_confirmation_url_when_token_is_expired_raises_error(self):
         u = UserFactory()
         # Make sure token is already expired
-        expiration = datetime.datetime.utcnow() - datetime.timedelta(seconds=1)
+        expiration = timezone.now() - datetime.timedelta(seconds=1)
         u.add_unconfirmed_email('foo@bar.com', expiration=expiration)
 
         with assert_raises(ExpiredTokenError):
@@ -530,7 +531,7 @@ class TestUser(OsfTestCase):
         random_string.return_value = '12345'
         u = UserFactory()
         # Make sure token is already expired
-        expiration = datetime.datetime.utcnow() - datetime.timedelta(seconds=1)
+        expiration = timezone.now() - datetime.timedelta(seconds=1)
         u.add_unconfirmed_email('foo@bar.com', expiration=expiration)
 
         # sanity check
@@ -564,7 +565,7 @@ class TestUser(OsfTestCase):
 
         valid_token = u.get_confirmation_token('foo@bar.com')
         assert_true(u.get_unconfirmed_email_for_token(valid_token))
-        manual_expiration = datetime.datetime.utcnow() - datetime.timedelta(0, 10)
+        manual_expiration = timezone.now() - datetime.timedelta(0, 10)
         u.email_verifications[valid_token]['expiration'] = manual_expiration
 
         with assert_raises(auth_exc.ExpiredTokenError):
@@ -942,8 +943,8 @@ class TestDisablingUsers(OsfTestCase):
 
     @mock.patch('website.mailchimp_utils.get_mailchimp_api')
     def test_disable_account_and_remove_sessions(self, mock_mail):
-        session1 = SessionFactory(user=self.user, date_created=(datetime.datetime.utcnow() - datetime.timedelta(seconds=settings.OSF_SESSION_TIMEOUT)))
-        session2 = SessionFactory(user=self.user, date_created=(datetime.datetime.utcnow() - datetime.timedelta(seconds=settings.OSF_SESSION_TIMEOUT)))
+        session1 = SessionFactory(user=self.user, date_created=(timezone.now() - datetime.timedelta(seconds=settings.OSF_SESSION_TIMEOUT)))
+        session2 = SessionFactory(user=self.user, date_created=(timezone.now() - datetime.timedelta(seconds=settings.OSF_SESSION_TIMEOUT)))
 
         self.user.mailchimp_mailing_lists[settings.MAILCHIMP_GENERAL_LIST] = True
         self.user.save()
@@ -1111,7 +1112,7 @@ class TestApiOAuth2Application(OsfTestCase):
 
     def test_cant_edit_creation_date(self):
         with assert_raises(AttributeError):
-            self.api_app.date_created = datetime.datetime.utcnow()
+            self.api_app.date_created = timezone.now()
 
     def test_invalid_home_url_raises_exception(self):
         with assert_raises(ValidationError):
@@ -2559,7 +2560,7 @@ class TestProject(OsfTestCase):
         assert_equal(node.category, 'project')
         assert_true(node._id)
         assert_almost_equal(
-            node.date_created, datetime.datetime.utcnow(),
+            node.date_created, timezone.now(),
             delta=datetime.timedelta(seconds=5),
         )
         assert_false(node.is_public)
@@ -3219,7 +3220,7 @@ class TestProject(OsfTestCase):
         registration = RegistrationFactory(project=self.project)
         registration.embargo_registration(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10)
+            timezone.now() + datetime.timedelta(days=10)
         )
         assert_true(registration.is_pending_embargo)
 
@@ -3234,7 +3235,7 @@ class TestProject(OsfTestCase):
         registration = RegistrationFactory(project=self.project)
         registration.embargo_registration(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10)
+            timezone.now() + datetime.timedelta(days=10)
         )
         assert_equal(len([a for a in registration.get_admin_contributors_recursive(unique_users=True)]), 4)
         with mock.patch('website.project.model.Node.is_embargoed', mock.PropertyMock(return_value=True)):
@@ -3286,7 +3287,7 @@ class TestProject(OsfTestCase):
     def test_check_spam_on_private_node_bans_new_spam_user(self, mock_send_mail):
         with mock.patch('website.project.model.Node._get_spam_content', mock.Mock(return_value='some content!')):
             with mock.patch('website.project.model.Node.do_check_spam', mock.Mock(return_value=True)):
-                self.project.creator.date_confirmed = datetime.datetime.utcnow()
+                self.project.creator.date_confirmed = timezone.now()
                 self.project.set_privacy('public')
                 user2 = UserFactory()
                 # project w/ one contributor
@@ -3312,7 +3313,7 @@ class TestProject(OsfTestCase):
     def test_check_spam_on_private_node_does_not_ban_existing_user(self, mock_send_mail):
         with mock.patch('website.project.model.Node._get_spam_content', mock.Mock(return_value='some content!')):
             with mock.patch('website.project.model.Node.do_check_spam', mock.Mock(return_value=True)):
-                self.project.creator.date_confirmed = datetime.datetime.utcnow() - datetime.timedelta(days=9001)
+                self.project.creator.date_confirmed = timezone.now() - datetime.timedelta(days=9001)
                 self.project.set_privacy('public')
                 assert_true(self.project.check_spam(self.user, None, None))
                 assert_true(self.project.is_public)
@@ -3893,7 +3894,7 @@ class TestForkNode(OsfTestCase):
         self.subproject.add_addon('github', self.auth)
 
         # Log time
-        fork_date = datetime.datetime.utcnow()
+        fork_date = timezone.now()
 
         # Fork node
         with mock.patch.object(Node, 'bulk_update_search'):
@@ -4012,7 +4013,7 @@ class TestForkNode(OsfTestCase):
         # Compare fork to original
         self._cmp_fork_original(
             self.user,
-            datetime.datetime.utcnow(),
+            timezone.now(),
             fork,
             self.registration,
         )
@@ -4211,7 +4212,7 @@ class TestRegisterNode(OsfTestCase):
     def test_registered_date(self):
         assert_almost_equal(
             self.registration.registered_date,
-            datetime.datetime.utcnow(),
+            timezone.now(),
             delta=datetime.timedelta(seconds=30),
         )
 

--- a/tests/test_registrations/base.py
+++ b/tests/test_registrations/base.py
@@ -1,5 +1,6 @@
 import datetime as dt
 
+from django.utils import timezone
 from modularodm import Q
 
 from framework.auth import Auth
@@ -42,10 +43,10 @@ class RegistrationsTestBase(OsfTestCase):
             }
         )
 
-        current_month = dt.datetime.now().strftime("%B")
-        current_year = dt.datetime.now().strftime("%Y")
+        current_month = timezone.now().strftime("%B")
+        current_year = timezone.now().strftime("%Y")
 
-        valid_date = dt.datetime.now() + dt.timedelta(days=180)
+        valid_date = timezone.now() + dt.timedelta(days=180)
         self.embargo_payload = {
             u'embargoEndDate': unicode(valid_date.strftime('%a, %d, %B %Y %H:%M:%S')) + u' GMT',
             u'registrationChoice': 'embargo'

--- a/tests/test_registrations/test_approvals.py
+++ b/tests/test_registrations/test_approvals.py
@@ -3,6 +3,7 @@ import datetime
 import httplib as http
 import json
 
+from django.utils import timezone
 from modularodm import Q
 
 import mock
@@ -40,5 +41,5 @@ class DraftRegistrationApprovalTestCase(OsfTestCase):
         )
         self.registration = RegistrationFactory(project=self.project)
         self.embargo = EmbargoFactory(user=self.user)
-        self.valid_embargo_end_date = datetime.datetime.utcnow() + datetime.timedelta(days=3)
+        self.valid_embargo_end_date = timezone.now() + datetime.timedelta(days=3)
 

--- a/tests/test_registrations/test_archiver.py
+++ b/tests/test_registrations/test_archiver.py
@@ -11,6 +11,8 @@ import re
 import celery
 import mock  # noqa
 from contextlib import nested
+
+from django.utils import timezone
 from mock import call
 from nose.tools import *  # noqa PEP8 asserts
 import httpretty
@@ -1022,7 +1024,7 @@ class TestArchiverListeners(ArchiverTestCase):
     @mock.patch('website.mails.send_mail')
     @mock.patch('website.archiver.tasks.archive_success.delay')
     def test_archive_callback_done_embargoed(self, mock_send, mock_archive_success):
-        end_date = datetime.datetime.now() + datetime.timedelta(days=30)
+        end_date = timezone.now() + datetime.timedelta(days=30)
         self.dst.archive_job.meta = {
             'embargo_urls': {
                 contrib._id: None
@@ -1138,7 +1140,7 @@ class TestArchiverScripts(ArchiverTestCase):
             reg = factories.RegistrationFactory()
             reg.archive_job._fields['datetime_initiated'].__set__(
                 reg.archive_job,
-                datetime.datetime.now() - delta,
+                timezone.now() - delta,
                 safe=True
             )
             reg.save()
@@ -1148,7 +1150,7 @@ class TestArchiverScripts(ArchiverTestCase):
             reg = factories.RegistrationFactory()
             reg.archive_job._fields['datetime_initiated'].__set__(
                 reg.archive_job,
-                datetime.datetime.now() - delta,
+                timezone.now() - delta,
                 safe=True
             )
             reg.archive_job.status = ARCHIVER_INITIATED

--- a/tests/test_registrations/test_embargoes.py
+++ b/tests/test_registrations/test_embargoes.py
@@ -3,6 +3,7 @@ import datetime
 import httplib as http
 import json
 
+from django.utils import timezone
 from modularodm import Q
 from modularodm.exceptions import ValidationValueError
 
@@ -41,7 +42,7 @@ class RegistrationEmbargoModelsTestCase(OsfTestCase):
         self.project = ProjectFactory(creator=self.user)
         self.registration = RegistrationFactory(project=self.project)
         self.embargo = EmbargoFactory(user=self.user)
-        self.valid_embargo_end_date = datetime.datetime.utcnow() + datetime.timedelta(days=3)
+        self.valid_embargo_end_date = timezone.now() + datetime.timedelta(days=3)
 
     # Node#_initiate_embargo tests
     def test__initiate_embargo_saves_embargo(self):
@@ -128,7 +129,7 @@ class RegistrationEmbargoModelsTestCase(OsfTestCase):
         with assert_raises(ValidationValueError):
             self.registration.embargo_registration(
                 self.user,
-                datetime.datetime.utcnow()
+                timezone.now()
             )
 
     def test_embargo_end_date_in_far_future_raises_ValidationValueError(self):
@@ -141,7 +142,7 @@ class RegistrationEmbargoModelsTestCase(OsfTestCase):
     def test_embargo_with_valid_end_date_starts_pending_embargo(self):
         self.registration.embargo_registration(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10)
+            timezone.now() + datetime.timedelta(days=10)
         )
         self.registration.save()
         assert_true(self.registration.is_pending_embargo)
@@ -151,7 +152,7 @@ class RegistrationEmbargoModelsTestCase(OsfTestCase):
         assert_true(self.registration.is_public)
         self.registration.embargo_registration(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10)
+            timezone.now() + datetime.timedelta(days=10)
         )
         self.registration.save()
         assert_true(self.registration.is_pending_embargo)
@@ -163,7 +164,7 @@ class RegistrationEmbargoModelsTestCase(OsfTestCase):
         with assert_raises(NodeStateError):
             self.registration.embargo_registration(
                 self.user,
-                datetime.datetime.utcnow() + datetime.timedelta(days=10)
+                timezone.now() + datetime.timedelta(days=10)
             )
         assert_false(self.registration.is_pending_embargo)
 
@@ -171,7 +172,7 @@ class RegistrationEmbargoModelsTestCase(OsfTestCase):
     def test_invalid_approval_token_raises_InvalidSanctionApprovalToken(self):
         self.registration.embargo_registration(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10)
+            timezone.now() + datetime.timedelta(days=10)
         )
         self.registration.save()
         assert_true(self.registration.is_pending_embargo)
@@ -185,7 +186,7 @@ class RegistrationEmbargoModelsTestCase(OsfTestCase):
         non_admin = UserFactory()
         self.registration.embargo_registration(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10)
+            timezone.now() + datetime.timedelta(days=10)
         )
         self.registration.save()
         assert_true(self.registration.is_pending_embargo)
@@ -198,7 +199,7 @@ class RegistrationEmbargoModelsTestCase(OsfTestCase):
     def test_one_approval_with_one_admin_embargoes(self):
         self.registration.embargo_registration(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10)
+            timezone.now() + datetime.timedelta(days=10)
         )
         self.registration.save()
         assert_true(self.registration.is_pending_embargo)
@@ -212,7 +213,7 @@ class RegistrationEmbargoModelsTestCase(OsfTestCase):
         initial_project_logs = len(self.registration.registered_from.logs)
         self.registration.embargo_registration(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10)
+            timezone.now() + datetime.timedelta(days=10)
         )
         self.registration.save()
 
@@ -227,7 +228,7 @@ class RegistrationEmbargoModelsTestCase(OsfTestCase):
         self.registration.add_permission(admin2, 'admin', save=True)
         self.registration.embargo_registration(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10)
+            timezone.now() + datetime.timedelta(days=10)
         )
         self.registration.save()
 
@@ -250,7 +251,7 @@ class RegistrationEmbargoModelsTestCase(OsfTestCase):
     def test_invalid_rejection_token_raises_InvalidSanctionRejectionToken(self):
         self.registration.embargo_registration(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10)
+            timezone.now() + datetime.timedelta(days=10)
         )
         self.registration.save()
         assert_true(self.registration.is_pending_embargo)
@@ -262,7 +263,7 @@ class RegistrationEmbargoModelsTestCase(OsfTestCase):
         non_admin = UserFactory()
         self.registration.embargo_registration(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10)
+            timezone.now() + datetime.timedelta(days=10)
         )
         self.registration.save()
         assert_true(self.registration.is_pending_embargo)
@@ -275,7 +276,7 @@ class RegistrationEmbargoModelsTestCase(OsfTestCase):
     def test_one_disapproval_cancels_embargo(self):
         self.registration.embargo_registration(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10)
+            timezone.now() + datetime.timedelta(days=10)
         )
         self.registration.save()
         assert_true(self.registration.is_pending_embargo)
@@ -289,7 +290,7 @@ class RegistrationEmbargoModelsTestCase(OsfTestCase):
         initial_project_logs = len(self.registration.registered_from.logs)
         self.registration.embargo_registration(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10)
+            timezone.now() + datetime.timedelta(days=10)
         )
         self.registration.save()
 
@@ -302,7 +303,7 @@ class RegistrationEmbargoModelsTestCase(OsfTestCase):
     def test_cancelling_embargo_deletes_parent_registration(self):
         self.registration.embargo_registration(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10)
+            timezone.now() + datetime.timedelta(days=10)
         )
         self.registration.save()
 
@@ -327,7 +328,7 @@ class RegistrationEmbargoModelsTestCase(OsfTestCase):
         subcomponent_registration = component_registration.nodes[0]
         project_registration.embargo_registration(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10)
+            timezone.now() + datetime.timedelta(days=10)
         )
         project_registration.save()
 
@@ -341,7 +342,7 @@ class RegistrationEmbargoModelsTestCase(OsfTestCase):
     def test_cancelling_embargo_for_existing_registration_does_not_delete_registration(self):
         self.registration.embargo_registration(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10),
+            timezone.now() + datetime.timedelta(days=10),
             for_existing_registration=True
         )
         self.registration.save()
@@ -367,7 +368,7 @@ class RegistrationEmbargoModelsTestCase(OsfTestCase):
         subcomponent_registration = component_registration.nodes[0]
         project_registration.embargo_registration(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10),
+            timezone.now() + datetime.timedelta(days=10),
             for_existing_registration=True
         )
 
@@ -383,7 +384,7 @@ class RegistrationEmbargoModelsTestCase(OsfTestCase):
     def test_new_registration_is_pending_registration(self):
         self.registration.embargo_registration(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10)
+            timezone.now() + datetime.timedelta(days=10)
         )
         self.registration.save()
         assert_true(self.registration.is_pending_embargo_for_existing_registration)
@@ -391,7 +392,7 @@ class RegistrationEmbargoModelsTestCase(OsfTestCase):
     def test_existing_registration_is_not_pending_registration(self):
         self.registration.embargo_registration(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10),
+            timezone.now() + datetime.timedelta(days=10),
             for_existing_registration=True
         )
         self.registration.save()
@@ -400,7 +401,7 @@ class RegistrationEmbargoModelsTestCase(OsfTestCase):
     def test_on_complete_notify_initiator(self):
         self.registration.embargo_registration(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10),
+            timezone.now() + datetime.timedelta(days=10),
             notify_initiator_on_complete=True
         )
         self.registration.save()
@@ -411,7 +412,7 @@ class RegistrationEmbargoModelsTestCase(OsfTestCase):
     def test_on_complete_raises_error_if_registration_is_spam(self):
         self.registration.embargo_registration(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10),
+            timezone.now() + datetime.timedelta(days=10),
             notify_initiator_on_complete=True
         )
         self.registration.spam_status = SpamStatus.FLAGGED
@@ -428,7 +429,7 @@ class RegistrationWithChildNodesEmbargoModelTestCase(OsfTestCase):
         super(RegistrationWithChildNodesEmbargoModelTestCase, self).setUp()
         self.user = AuthUserFactory()
         self.auth = self.user.auth
-        self.valid_embargo_end_date = datetime.datetime.utcnow() + datetime.timedelta(days=3)
+        self.valid_embargo_end_date = timezone.now() + datetime.timedelta(days=3)
         self.project = ProjectFactory(title='Root', is_public=False, creator=self.user)
         self.component = NodeFactory(
             creator=self.user,
@@ -528,7 +529,7 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
     def test_GET_approve_with_invalid_token_returns_HTTPBad_Request(self):
         self.registration.embargo_registration(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10)
+            timezone.now() + datetime.timedelta(days=10)
         )
         self.registration.save()
         assert_true(self.registration.is_pending_embargo)
@@ -546,7 +547,7 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
         self.registration.add_permission(admin2, 'admin', save=True)
         self.registration.embargo_registration(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10)
+            timezone.now() + datetime.timedelta(days=10)
         )
         self.registration.save()
         assert_true(self.registration.is_pending_embargo)
@@ -565,7 +566,7 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
         self.registration.add_permission(admin2, 'admin', save=True)
         self.registration.embargo_registration(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10)
+            timezone.now() + datetime.timedelta(days=10)
         )
         self.registration.save()
         assert_true(self.registration.is_pending_embargo)
@@ -583,7 +584,7 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
     def test_GET_approve_with_valid_token_redirects(self, mock_redirect):
         self.registration.embargo_registration(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10)
+            timezone.now() + datetime.timedelta(days=10)
         )
         self.registration.save()
         assert_true(self.registration.is_pending_embargo)
@@ -619,7 +620,7 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
     def test_GET_disapprove_with_invalid_token_returns_HTTPBad_Request(self):
         self.registration.embargo_registration(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10)
+            timezone.now() + datetime.timedelta(days=10)
         )
         self.registration.save()
         assert_true(self.registration.is_pending_embargo)
@@ -639,7 +640,7 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
         self.registration.add_permission(admin2, 'admin', save=True)
         self.registration.embargo_registration(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10)
+            timezone.now() + datetime.timedelta(days=10)
         )
         self.registration.save()
         assert_true(self.registration.is_pending_embargo)
@@ -658,7 +659,7 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
         registration = RegistrationFactory(project=project)
         registration.embargo_registration(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10)
+            timezone.now() + datetime.timedelta(days=10)
         )
         registration.save()
         assert_true(registration.is_pending_embargo)
@@ -678,7 +679,7 @@ class RegistrationEmbargoApprovalDisapprovalViewsTestCase(OsfTestCase):
     def test_GET_disapprove_for_existing_registration_returns_200(self):
         self.registration.embargo_registration(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10),
+            timezone.now() + datetime.timedelta(days=10),
             for_existing_registration=True
         )
         self.registration.save()
@@ -705,8 +706,8 @@ class RegistrationEmbargoViewsTestCase(OsfTestCase):
         self.draft = DraftRegistrationFactory(branched_from=self.project)
         self.registration = RegistrationFactory(project=self.project, creator=self.user)
 
-        current_month = datetime.datetime.now().strftime("%B")
-        current_year = datetime.datetime.now().strftime("%Y")
+        current_month = timezone.now().strftime("%B")
+        current_year = timezone.now().strftime("%Y")
 
         self.valid_make_public_payload = json.dumps({
             u'embargoEndDate': u'Fri, 01, {month} {year} 00:00:00 GMT'.format(
@@ -716,7 +717,7 @@ class RegistrationEmbargoViewsTestCase(OsfTestCase):
             u'registrationChoice': 'immediate',
             u'summary': unicode(fake.sentence())
         })
-        valid_date = datetime.datetime.now() + datetime.timedelta(days=180)
+        valid_date = timezone.now() + datetime.timedelta(days=180)
         self.valid_embargo_payload = json.dumps({
             u'embargoEndDate': unicode(valid_date.strftime('%a, %d, %B %Y %H:%M:%S')) + u' GMT',
             u'registrationChoice': 'embargo',
@@ -922,7 +923,7 @@ class RegistrationEmbargoViewsTestCase(OsfTestCase):
         self.registration.save()
         self.registration.embargo_registration(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10)
+            timezone.now() + datetime.timedelta(days=10)
         )
         for user_id, embargo_tokens in self.registration.embargo.approval_state.iteritems():
             approval_token = embargo_tokens['approval_token']
@@ -960,7 +961,7 @@ class RegistrationEmbargoViewsTestCase(OsfTestCase):
         self.registration.save()
         self.registration.embargo_registration(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10)
+            timezone.now() + datetime.timedelta(days=10)
         )
         for user_id, embargo_tokens in self.registration.embargo.approval_state.iteritems():
             approval_token = embargo_tokens['approval_token']
@@ -987,7 +988,7 @@ class RegistrationEmbargoViewsTestCase(OsfTestCase):
 
         registration.embargo_registration(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10)
+            timezone.now() + datetime.timedelta(days=10)
         )
         for user_id, embargo_tokens in registration.embargo.approval_state.iteritems():
             approval_token = embargo_tokens['approval_token']
@@ -1007,7 +1008,7 @@ class RegistrationEmbargoViewsTestCase(OsfTestCase):
         non_contributor = AuthUserFactory()
         self.registration.embargo_registration(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10)
+            timezone.now() + datetime.timedelta(days=10)
         )
         self.registration.save()
         assert_true(self.registration.is_pending_embargo)
@@ -1024,7 +1025,7 @@ class RegistrationEmbargoViewsTestCase(OsfTestCase):
         non_contributor = AuthUserFactory()
         self.registration.embargo_registration(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10)
+            timezone.now() + datetime.timedelta(days=10)
         )
         self.registration.save()
         assert_true(self.registration.is_pending_embargo)

--- a/tests/test_registrations/test_models.py
+++ b/tests/test_registrations/test_models.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Unit tests for models and their factories."""
+from django.utils import timezone
 from nose.tools import *  # noqa (PEP8 asserts)
 import mock
 
@@ -158,7 +159,7 @@ class TestDraftRegistrationApprovals(RegistrationsTestBase):
 
     @mock.patch('framework.celery_tasks.handlers.enqueue_task')
     def test_on_complete_embargo_creates_registration_for_draft_initiator(self, mock_enquque):
-        end_date = dt.datetime.now() + dt.timedelta(days=366)  # <- leap year
+        end_date = timezone.now() + dt.timedelta(days=366)  # <- leap year
         self.approval = DraftRegistrationApproval(
             initiated_by=self.user,
             meta={

--- a/tests/test_registrations/test_registration_approvals.py
+++ b/tests/test_registrations/test_registration_approvals.py
@@ -1,6 +1,7 @@
 import datetime
 
 import mock
+from django.utils import timezone
 from nose.tools import *  # noqa
 from tests.base import fake, OsfTestCase
 from website.project.spam.model import SpamStatus
@@ -34,7 +35,7 @@ class RegistrationApprovalModelTestCase(OsfTestCase):
         self.project = ProjectFactory(creator=self.user)
         self.registration = RegistrationFactory(project=self.project)
         self.embargo = EmbargoFactory(user=self.user)
-        self.valid_embargo_end_date = datetime.datetime.utcnow() + datetime.timedelta(days=3)
+        self.valid_embargo_end_date = timezone.now() + datetime.timedelta(days=3)
 
     def test__require_approval_saves_approval(self):
         initial_count = RegistrationApproval.find().count()
@@ -195,7 +196,7 @@ class RegistrationApprovalModelTestCase(OsfTestCase):
         initial_project_logs = len(self.registration.registered_from.logs)
         self.registration.require_approval(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10)
+            timezone.now() + datetime.timedelta(days=10)
         )
         self.registration.save()
 

--- a/tests/test_registrations/test_retractions.py
+++ b/tests/test_registrations/test_retractions.py
@@ -4,6 +4,7 @@ import datetime
 import httplib as http
 
 import mock
+from django.utils import timezone
 from nose.tools import *  # noqa
 
 from modularodm.exceptions import ValidationValueError
@@ -100,7 +101,7 @@ class RegistrationRetractionModelsTestCase(OsfTestCase):
         assert_equal(self.registration.retraction.initiated_by, self.user)
         assert_equal(
             self.registration.retraction.initiation_date.date(),
-            datetime.datetime.utcnow().date()
+            timezone.now().date()
         )
 
     def test_retract_component_raises_NodeStateError(self):
@@ -228,7 +229,7 @@ class RegistrationRetractionModelsTestCase(OsfTestCase):
         self.registration.is_public = True
         self.registration.embargo_registration(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10),
+            timezone.now() + datetime.timedelta(days=10),
             for_existing_registration=True
         )
         self.registration.save()
@@ -250,7 +251,7 @@ class RegistrationRetractionModelsTestCase(OsfTestCase):
         self.registration.is_public = True
         self.registration.embargo_registration(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10),
+            timezone.now() + datetime.timedelta(days=10),
             for_existing_registration=True
         )
         self.registration.save()
@@ -267,7 +268,7 @@ class RegistrationRetractionModelsTestCase(OsfTestCase):
         self.registration.is_public = True
         self.registration.embargo_registration(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10),
+            timezone.now() + datetime.timedelta(days=10),
             for_existing_registration=True
         )
         self.registration.save()
@@ -469,7 +470,7 @@ class RegistrationWithChildNodesRetractionModelTestCase(OsfTestCase):
         # Initiate embargo for registration
         self.registration.embargo_registration(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10),
+            timezone.now() + datetime.timedelta(days=10),
             for_existing_registration=True
         )
         self.registration.save()
@@ -502,7 +503,7 @@ class RegistrationWithChildNodesRetractionModelTestCase(OsfTestCase):
         # Initiate embargo for registration
         self.registration.embargo_registration(
             self.user,
-            datetime.datetime.utcnow() + datetime.timedelta(days=10),
+            timezone.now() + datetime.timedelta(days=10),
             for_existing_registration=True
         )
         self.registration.save()
@@ -754,7 +755,7 @@ class RegistrationRetractionViewsTestCase(OsfTestCase):
     def test_POST_pending_embargo_returns_HTTPError_HTTPOK(self):
         self.registration.embargo_registration(
             self.user,
-            (datetime.datetime.utcnow() + datetime.timedelta(days=10)),
+            (timezone.now() + datetime.timedelta(days=10)),
             for_existing_registration=True
         )
         self.registration.save()
@@ -773,7 +774,7 @@ class RegistrationRetractionViewsTestCase(OsfTestCase):
     def test_POST_active_embargo_returns_HTTPOK(self):
         self.registration.embargo_registration(
             self.user,
-            (datetime.datetime.utcnow() + datetime.timedelta(days=10)),
+            (timezone.now() + datetime.timedelta(days=10)),
             for_existing_registration=True
         )
         self.registration.save()

--- a/tests/test_registrations/test_sanctions.py
+++ b/tests/test_registrations/test_sanctions.py
@@ -2,6 +2,8 @@
 import httplib as http
 import mock
 import unittest  # noqa
+
+from django.utils import timezone
 from nose.tools import *  # noqa (PEP8 asserts)
 
 import datetime
@@ -60,7 +62,7 @@ class TestSanction(SanctionsTestCase):
         self.invalid_user = factories.UserFactory()
         self.sanction = SanctionTestClass(
             initiated_by=self.user,
-            end_date=datetime.datetime.now() + datetime.timedelta(days=2)
+            end_date=timezone.now() + datetime.timedelta(days=2)
         )
         self.registration = factories.RegistrationFactory()
         self.sanction.add_authorizer(self.user, self.registration, save=True)
@@ -164,7 +166,7 @@ class TestEmailApprovableSanction(SanctionsTestCase):
         self.user = factories.UserFactory()
         self.sanction = EmailApprovableSanctionTestClass(
             initiated_by=self.user,
-            end_date=datetime.datetime.now() + datetime.timedelta(days=2)
+            end_date=timezone.now() + datetime.timedelta(days=2)
         )
         self.sanction.add_authorizer(self.user, self.sanction._get_registration())
 
@@ -248,7 +250,7 @@ class TestEmailApprovableSanction(SanctionsTestCase):
     def test_on_complete_notify_initiator(self):
         sanction = EmailApprovableSanctionTestClass(
             initiated_by=self.user,
-            end_date=datetime.datetime.now() + datetime.timedelta(days=2),
+            end_date=timezone.now() + datetime.timedelta(days=2),
             notify_initiator_on_complete=True
         )
         sanction.add_authorizer(self.user, sanction._get_registration())
@@ -260,7 +262,7 @@ class TestEmailApprovableSanction(SanctionsTestCase):
     def test_on_complete_errors_if_registration_is_spam(self):
         sanction = EmailApprovableSanctionTestClass(
             initiated_by=self.user,
-            end_date=datetime.datetime.now() + datetime.timedelta(days=2),
+            end_date=timezone.now() + datetime.timedelta(days=2),
             notify_initiator_on_complete=True
         )
         sanction.add_authorizer(self.user, sanction._get_registration())

--- a/tests/test_registrations/test_views.py
+++ b/tests/test_registrations/test_views.py
@@ -6,6 +6,7 @@ import datetime as dt
 import mock
 import httplib as http
 from dateutil.parser import parse as parse_date
+from django.utils import timezone
 
 from nose.tools import *  # noqa PEP8 asserts
 
@@ -190,7 +191,7 @@ class TestDraftRegistrationViews(RegistrationsTestBase):
     @mock.patch('framework.celery_tasks.handlers.enqueue_task')
     def test_register_draft_registration_with_embargo_creates_embargo(self, mock_enqueue):
         url = self.node.api_url_for('register_draft_registration', draft_id=self.draft._id)
-        end_date = dt.datetime.utcnow() + dt.timedelta(days=3)
+        end_date = timezone.now() + dt.timedelta(days=3)
         res = self.app.post_json(
             url,
             {

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -1,5 +1,7 @@
 import datetime
 import unittest
+
+from django.utils import timezone
 from nose.tools import *  # flake8: noqa
 from website.util import sanitize
 
@@ -46,7 +48,7 @@ class TestSanitize(unittest.TestCase):
         assert_equal(sanitize.strip_html(12), 12)
         assert_equal(sanitize.strip_html(12.3), 12.3)
 
-        dtime = datetime.datetime.now()
+        dtime = timezone.now()
         assert_equal(sanitize.strip_html(dtime), dtime)
 
     def test_strip_html_sanitizes_collection_types_as_strings(self):

--- a/tests/test_spam_mixin.py
+++ b/tests/test_spam_mixin.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 from datetime import datetime
+
+from django.utils import timezone
 from nose.tools import *  # noqa PEP8 asserts
 from modularodm.exceptions import ValidationValueError, ValidationTypeError
 
@@ -19,7 +21,7 @@ class TestSpamMixin(OsfTestCase):
 
     def test_report_abuse(self):
         user = UserFactory()
-        time = datetime.utcnow()
+        time = timezone.now()
         self.comment.report_abuse(
                 user, date=time, category='spam', text='ads', save=True)
         assert_equal(self.comment.spam_status, SpamStatus.FLAGGED)
@@ -43,7 +45,7 @@ class TestSpamMixin(OsfTestCase):
 
     def test_retract_report(self):
         user = UserFactory()
-        time = datetime.utcnow()
+        time = timezone.now()
         self.comment.report_abuse(
                 user, date=time, category='spam', text='ads', save=True
         )
@@ -72,7 +74,7 @@ class TestSpamMixin(OsfTestCase):
     def test_retract_one_report_of_many(self):
         user_1 = UserFactory()
         user_2 = UserFactory()
-        time = datetime.utcnow()
+        time = timezone.now()
         self.comment.report_abuse(
                 user_1, date=time, category='spam', text='ads', save=True
         )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,6 +4,7 @@ import mock
 import os
 import time
 import unittest
+from django.utils import timezone
 
 from flask import Flask
 from nose.tools import *  # noqa (PEP8 asserts)
@@ -37,7 +38,7 @@ class TestTimeUtils(unittest.TestCase):
         assert_true(is_expired)
 
     def test_throttle_period_expired_using_datetime(self):
-        timestamp = datetime.datetime.utcnow()
+        timestamp = timezone.now()
         is_expired = throttle_period_expired(timestamp=(timestamp + datetime.timedelta(seconds=29)),  throttle=30)
         assert_false(is_expired)
 
@@ -401,7 +402,7 @@ class TestProjectUtils(OsfTestCase):
             reg = RegistrationFactory()
             reg.is_public = True
             count = count + 1
-            tdiff = datetime.datetime.now() - datetime.timedelta(days=count)
+            tdiff = timezone.now() - datetime.timedelta(days=count)
             self.set_registered_date(reg, tdiff)
         regs = [r for r in project_utils.recent_public_registrations()]
         assert_equal(len(regs), 5)
@@ -411,7 +412,7 @@ class TestProjectUtils(OsfTestCase):
             reg = RegistrationFactory()
             reg.is_public = True
             count = count + 1
-            tdiff = datetime.datetime.now() - datetime.timedelta(days=count)
+            tdiff = timezone.now() - datetime.timedelta(days=count)
             self.set_registered_date(reg, tdiff)
         regs = [r for r in project_utils.recent_public_registrations(7)]
         assert_equal(len(regs), 7)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2753,7 +2753,7 @@ class TestWatchViews(OsfTestCase):
             NodeLog.TAG_ADDED,
             params={'node': self.project._primary_key},
             auth=self.consolidate_auth,
-            log_date=dt.datetime.utcnow(),
+            log_date=timezone.now(),
             save=True,
         )
         # Clear watched list
@@ -3527,7 +3527,7 @@ class TestAuthViews(OsfTestCase):
         # Do not return expired token and removes it from user.email_verifications
         email = 'test@mail.com'
         token = self.user.add_unconfirmed_email(email)
-        self.user.email_verifications[token]['expiration'] = dt.datetime.utcnow() - dt.timedelta(days=100)
+        self.user.email_verifications[token]['expiration'] = timezone.now() - dt.timedelta(days=100)
         self.user.save()
         self.user.reload()
         assert_equal(self.user.email_verifications[token]['email'], email)
@@ -3540,7 +3540,7 @@ class TestAuthViews(OsfTestCase):
         # Do not return bad token and removes it from user.email_verifications
         email = 'test@mail.com'
         token = 'blahblahblah'
-        self.user.email_verifications[token] = {'expiration': dt.datetime.utcnow() + dt.timedelta(days=1),
+        self.user.email_verifications[token] = {'expiration': timezone.now() + dt.timedelta(days=1),
                                                 'email': email,
                                                 'confirmed': False }
         self.user.save()
@@ -4537,7 +4537,7 @@ class TestCommentViews(OsfTestCase):
         self.user.reload()
 
         user_timestamp = self.user.comments_viewed_timestamp[test_file._id]
-        view_timestamp = dt.datetime.utcnow()
+        view_timestamp = timezone.now()
         assert_datetime_equal(user_timestamp, view_timestamp)
 
         # Regression test for https://openscience.atlassian.net/browse/OSF-5193

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import
 import unittest
 import datetime as dt
+from django.utils import timezone
 
 from pytz import utc
 from nose.tools import *  # flake8: noqa (PEP8 asserts)
@@ -29,7 +30,7 @@ class TestWatching(OsfTestCase):
             'tag_added',
             params={'project': self.project._primary_key},
             auth=self.consolidate_auth,
-            log_date=dt.datetime.utcnow() - dt.timedelta(days=100),
+            log_date=timezone.now() - dt.timedelta(days=100),
             save=True,
         )
         # Set the ObjectId to correspond with the log date
@@ -37,7 +38,7 @@ class TestWatching(OsfTestCase):
         self.last_log = self.project.add_log(
             'tag_added',
             params={'project': self.project._primary_key},
-            auth=self.consolidate_auth, log_date=dt.datetime.utcnow(),
+            auth=self.consolidate_auth, log_date=timezone.now(),
             save=True,
         )
         # Clear watched list
@@ -75,7 +76,7 @@ class TestWatching(OsfTestCase):
 
     def test_get_recent_log_ids_since(self):
         self._watch_project(self.project)
-        since = dt.datetime.utcnow().replace(tzinfo=utc) - dt.timedelta(days=101)
+        since = timezone.now() - dt.timedelta(days=101)
         log_ids = list(self.user.get_recent_log_ids(since=since))
         assert_equal(len(log_ids), 3)
 

--- a/tests/test_websitefiles.py
+++ b/tests/test_websitefiles.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import datetime
 
+from django.utils import timezone
 from nose.tools import *  # noqa
 import mock
 from modularodm import Q
@@ -319,7 +320,7 @@ class TestFileNodeObj(FilesTestCase):
         assert_equal(trashed.path, 'afile')
         assert_equal(trashed.node, self.node)
         assert_equal(trashed.materialized_path, '/long/path/to/name')
-        assert_less((trashed.deleted_on - datetime.datetime.utcnow()).total_seconds(), 5)
+        assert_less((trashed.deleted_on - timezone.now()).total_seconds(), 5)
 
     def test_delete_with_user(self):
         fn = models.StoredFileNode(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,6 +4,7 @@ import mock
 import datetime
 
 from django.http import HttpRequest
+from django.utils import timezone
 from nose import SkipTest
 from nose.tools import assert_equal, assert_not_equal
 
@@ -118,7 +119,7 @@ def mock_archive(project, schema=None, auth=None, data=None, parent=None,
         )
     if embargo:
         embargo_end_date = embargo_end_date or (
-            datetime.datetime.now() + datetime.timedelta(days=20)
+            timezone.now() + datetime.timedelta(days=20)
         )
         registration.root.embargo_registration(
             project.creator,

--- a/website/addons/badges/model/badges.py
+++ b/website/addons/badges/model/badges.py
@@ -4,6 +4,7 @@ import calendar
 from bson import ObjectId
 from datetime import datetime
 
+from django.utils import timezone
 from modularodm import fields, Q
 
 from framework.mongo import StoredObject
@@ -141,7 +142,7 @@ class BadgeAssertion(StoredObject):
         b.badge = badge
         b.node = node
         b.evidence = evidence
-        b.issued_on = calendar.timegm(datetime.utctimetuple(datetime.utcnow()))
+        b.issued_on = calendar.timegm(datetime.utctimetuple(timezone.now()))
         b._awarder = awarder
         if save:
             b.save()

--- a/website/addons/base/testing/models.py
+++ b/website/addons/base/testing/models.py
@@ -3,6 +3,7 @@ import abc
 import datetime
 
 import mock
+from django.utils import timezone
 from nose.tools import *  # noqa (PEP8 asserts)
 
 from framework.auth import Auth
@@ -604,7 +605,7 @@ class CitationAddonProviderTestSuiteMixin(OAuthCitationsTestSuiteMixinBase):
         # The first call to .client returns a new client
         with mock.patch.object(self.OAuthProviderClass, '_get_client') as mock_get_client:
             mock_account = mock.Mock()
-            mock_account.expires_at = datetime.datetime.now()
+            mock_account.expires_at = timezone.now()
             self.provider.account = mock_account
             self.provider.client
             mock_get_client.assert_called

--- a/website/addons/base/testing/models.py
+++ b/website/addons/base/testing/models.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import abc
-import datetime
 
 import mock
 from django.utils import timezone

--- a/website/addons/base/views.py
+++ b/website/addons/base/views.py
@@ -3,7 +3,7 @@ import httplib
 import os
 import uuid
 import markupsafe
-
+from django.utils import timezone
 
 from flask import make_response
 from flask import redirect
@@ -281,7 +281,7 @@ def get_auth(auth, **kwargs):
         raise HTTPError(httplib.BAD_REQUEST)
 
     return {'payload': jwe.encrypt(jwt.encode({
-        'exp': datetime.datetime.utcnow() + datetime.timedelta(seconds=settings.WATERBUTLER_JWT_EXPIRATION),
+        'exp': timezone.now() + datetime.timedelta(seconds=settings.WATERBUTLER_JWT_EXPIRATION),
         'data': {
             'auth': make_auth(auth.user),  # A waterbutler auth dict not an Auth object
             'credentials': credentials,

--- a/website/addons/box/tests/factories.py
+++ b/website/addons/box/tests/factories.py
@@ -3,6 +3,7 @@
 import mock
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
+from django.utils import timezone
 
 from factory import SubFactory, Sequence
 from tests.factories import ModularOdmFactory, UserFactory, ProjectFactory, ExternalAccountFactory
@@ -16,7 +17,7 @@ class BoxAccountFactory(ExternalAccountFactory):
     provider = 'box'
     provider_id = Sequence(lambda n: 'id-{0}'.format(n))
     oauth_key = Sequence(lambda n: 'key-{0}'.format(n))
-    expires_at = datetime.now() + relativedelta(seconds=3600)
+    expires_at = timezone.now() + relativedelta(seconds=3600)
 
 
 class BoxUserSettingsFactory(ModularOdmFactory):

--- a/website/addons/box/tests/test_views.py
+++ b/website/addons/box/tests/test_views.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """Views tests for the Box addon."""
 import unittest
+
+from django.utils import timezone
 from nose.tools import *  # noqa (PEP8 asserts)
 import mock
 import httplib
@@ -182,7 +184,7 @@ class TestRestrictions(BoxAddonTestCase):
         self.user.add_addon('box')
         settings = self.user.get_addon('box')
         settings.access_token = '12345abc'
-        settings.last_refreshed = datetime.utcnow()
+        settings.last_refreshed = timezone.now()
         settings.save()
 
         self.patcher = mock.patch('website.addons.box.model.BoxNodeSettings.fetch_folder_name')

--- a/website/addons/dataverse/views.py
+++ b/website/addons/dataverse/views.py
@@ -1,6 +1,5 @@
 """Views for the node settings page."""
 # -*- coding: utf-8 -*-
-import datetime
 import httplib as http
 
 from django.utils import timezone

--- a/website/addons/dataverse/views.py
+++ b/website/addons/dataverse/views.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 import datetime
 import httplib as http
+
+from django.utils import timezone
 from requests.exceptions import SSLError
 
 from flask import request
@@ -180,7 +182,7 @@ def dataverse_publish_dataset(node_addon, auth, **kwargs):
     node = node_addon.owner
     publish_both = request.json.get('publish_both', False)
 
-    now = datetime.datetime.utcnow()
+    now = timezone.now()
 
     connection = client.connect_from_settings_or_401(node_addon)
 

--- a/website/addons/github/tests/test_views.py
+++ b/website/addons/github/tests/test_views.py
@@ -5,6 +5,7 @@ import mock
 import datetime
 import unittest
 
+from django.utils import timezone
 from nose.tools import *  # noqa (PEP8 asserts)
 from tests.base import OsfTestCase, get_default_metaschema
 from tests.factories import ProjectFactory, UserFactory, AuthUserFactory
@@ -28,7 +29,7 @@ from website.addons.github.tests.factories import GitHubAccountFactory
 
 
 class TestGitHubAuthViews(GitHubAddonTestCase, OAuthAddonAuthViewsTestCaseMixin):
-    
+
     @mock.patch(
         'website.addons.github.model.GitHubUserSettings.revoke_remote_oauth_access',
         mock.PropertyMock()
@@ -180,7 +181,7 @@ class TestGithubViews(OsfTestCase):
         url = self.project.api_url + 'beforeregister/'
         res = self.app.get(url, auth=self.user.auth).maybe_follow()
         assert_true('GitHub' in res.json['prompts'][1])
-        
+
     def test_get_refs_sha_no_branch(self):
         with assert_raises(HTTPError):
             utils.get_refs(self.node_settings, sha='12345')
@@ -263,7 +264,7 @@ class TestGithubViews(OsfTestCase):
     @mock.patch('website.addons.github.views.verify_hook_signature')
     def test_hook_callback_add_file_not_thro_osf(self, mock_verify):
         url = "/api/v1/project/{0}/github/hook/".format(self.project._id)
-        timestamp = str(datetime.datetime.utcnow())
+        timestamp = str(timezone.now())
         self.app.post_json(
             url,
             {
@@ -296,7 +297,7 @@ class TestGithubViews(OsfTestCase):
     @mock.patch('website.addons.github.views.verify_hook_signature')
     def test_hook_callback_modify_file_not_thro_osf(self, mock_verify):
         url = "/api/v1/project/{0}/github/hook/".format(self.project._id)
-        timestamp = str(datetime.datetime.utcnow())
+        timestamp = str(timezone.now())
         self.app.post_json(
             url,
             {"test": True,
@@ -323,7 +324,7 @@ class TestGithubViews(OsfTestCase):
     @mock.patch('website.addons.github.views.verify_hook_signature')
     def test_hook_callback_remove_file_not_thro_osf(self, mock_verify):
         url = "/api/v1/project/{0}/github/hook/".format(self.project._id)
-        timestamp = str(datetime.datetime.utcnow())
+        timestamp = str(timezone.now())
         self.app.post_json(
             url,
             {"test": True,

--- a/website/addons/googledrive/tests/factories.py
+++ b/website/addons/googledrive/tests/factories.py
@@ -3,6 +3,7 @@
 import datetime
 
 from dateutil.relativedelta import relativedelta
+from django.utils import timezone
 
 from factory import SubFactory, Sequence
 from tests.factories import (
@@ -22,7 +23,7 @@ class GoogleDriveAccountFactory(ExternalAccountFactory):
     provider_id = Sequence(lambda n: 'id-{0}'.format(n))
     oauth_key = Sequence(lambda n: 'key-{0}'.format(n))
     oauth_secret = Sequence(lambda n: 'secret-{0}'.format(n))
-    expires_at = datetime.datetime.now() + relativedelta(days=1)
+    expires_at = timezone.now() + relativedelta(days=1)
 
 # TODO(sloria): make an abstract UserSettingsFactory that just includes the owner field
 class GoogleDriveUserSettingsFactory(ModularOdmFactory):

--- a/website/addons/mendeley/tests/factories.py
+++ b/website/addons/mendeley/tests/factories.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+from django.utils import timezone
 from factory import SubFactory, Sequence
 
 from tests.factories import ModularOdmFactory, UserFactory, ProjectFactory, ExternalAccountFactory
@@ -16,7 +16,7 @@ class MendeleyAccountFactory(ExternalAccountFactory):
     provider_id = Sequence(lambda n: 'id-{0}'.format(n))
     oauth_key = Sequence(lambda n: 'key-{0}'.format(n))
     oauth_secret = Sequence(lambda n: 'secret-{0}'.format(n))
-    expires_at = datetime.datetime.now() + relativedelta(days=1)
+    expires_at = timezone.now() + relativedelta(days=1)
 
 
 class MendeleyUserSettingsFactory(ModularOdmFactory):

--- a/website/addons/mendeley/tests/test_api.py
+++ b/website/addons/mendeley/tests/test_api.py
@@ -4,6 +4,7 @@ import mock
 import mendeley
 import time
 import datetime
+from django.utils import timezone
 
 from tests.base import OsfTestCase
 
@@ -25,7 +26,7 @@ class MendeleyApiTestCase(OsfTestCase):
         self.mock_credentials = {
             'access_token': '1234567890987654321',
             'refresh_token': 'asdfghjklkjhgfdsa',
-            'expires_at': time.mktime((datetime.datetime.utcnow() + datetime.timedelta(days=10)).timetuple()),
+            'expires_at': time.mktime((timezone.now() + datetime.timedelta(days=10)).timetuple()),
             'token_type': 'bearer',
         }
 

--- a/website/addons/osfstorage/tests/factories.py
+++ b/website/addons/osfstorage/tests/factories.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # encoding: utf-8
-
+from django.utils import timezone
 from factory import SubFactory, post_generation
 
 from tests.factories import ModularOdmFactory, AuthUserFactory
@@ -23,7 +23,7 @@ class FileVersionFactory(ModularOdmFactory):
         model = models.FileVersion
 
     creator = SubFactory(AuthUserFactory)
-    date_modified = datetime.datetime.utcnow()
+    date_modified = timezone.now()
     location = generic_location
     identifier = 0
 

--- a/website/addons/osfstorage/tests/test_models.py
+++ b/website/addons/osfstorage/tests/test_models.py
@@ -2,6 +2,8 @@ from __future__ import unicode_literals
 
 import mock
 import unittest
+
+from django.utils import timezone
 from nose.tools import *  # noqa
 
 from tests.factories import ProjectFactory, NodeFactory, CommentFactory
@@ -97,7 +99,7 @@ class TestOsfstorageFileNode(StorageTestCase):
             'sha256': None,
         })
 
-        date = datetime.datetime.now()
+        date = timezone.now()
         version.update_metadata({
             'modified': date.isoformat()
         })
@@ -551,7 +553,7 @@ class TestOsfStorageFileVersion(StorageTestCase):
         version = factories.FileVersionFactory(
             size=1024,
             content_type='application/json',
-            date_modified=datetime.datetime.now(),
+            date_modified=timezone.now(),
         )
         retrieved = models.FileVersion.load(version._id)
         assert_true(retrieved.creator)

--- a/website/addons/zotero/tests/factories.py
+++ b/website/addons/zotero/tests/factories.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+from django.utils import timezone
 from factory import SubFactory, Sequence
 
 from tests.factories import ModularOdmFactory, UserFactory, ProjectFactory, ExternalAccountFactory
@@ -17,7 +17,7 @@ class ZoteroAccountFactory(ExternalAccountFactory):
     provider_name = 'Fake Provider'
     oauth_key = Sequence(lambda n: 'key-{0}'.format(n))
     oauth_secret = Sequence(lambda n: 'secret-{0}'.format(n))
-    expires_at = datetime.datetime.now() + relativedelta(days=1)
+    expires_at = timezone.now() + relativedelta(days=1)
 
 
 class ZoteroUserSettingsFactory(ModularOdmFactory):

--- a/website/files/models/base.py
+++ b/website/files/models/base.py
@@ -4,7 +4,6 @@ import os
 import bson
 import logging
 import pymongo
-import datetime
 import requests
 import functools
 

--- a/website/files/models/base.py
+++ b/website/files/models/base.py
@@ -8,6 +8,7 @@ import datetime
 import requests
 import functools
 
+from django.utils import timezone
 from modularodm import fields, Q
 from modularodm.exceptions import NoResultsFound
 from dateutil.parser import parse as parse_date
@@ -540,7 +541,7 @@ class FileNode(object):
         """
         self.name = data['name']
         self.materialized_path = data['materialized']
-        self.last_touched = datetime.datetime.utcnow()
+        self.last_touched = timezone.now()
         if save:
             self.save()
 
@@ -690,7 +691,7 @@ class File(FileNode):
             data['modified'] = parse_date(
                 data['modified'],
                 ignoretz=True,
-                default=datetime.datetime.utcnow()  # Just incase nothing can be parsed
+                default=timezone.now()  # Just incase nothing can be parsed
             )
 
         # if revision is none then version is the latest version
@@ -707,7 +708,7 @@ class File(FileNode):
             utils.insort(self.history, data, lambda x: x['modified'])
 
         # Finally update last touched
-        self.last_touched = datetime.datetime.utcnow()
+        self.last_touched = timezone.now()
 
         self.save()
         return version

--- a/website/mails/listeners.py
+++ b/website/mails/listeners.py
@@ -1,7 +1,6 @@
 """Functions that listen for event signals and queue up emails.
 All triggered emails live here.
 """
-from datetime import datetime
 
 from django.utils import timezone
 from modularodm import Q

--- a/website/mails/listeners.py
+++ b/website/mails/listeners.py
@@ -3,6 +3,7 @@ All triggered emails live here.
 """
 from datetime import datetime
 
+from django.utils import timezone
 from modularodm import Q
 
 from website import mails, settings
@@ -19,7 +20,7 @@ def queue_no_addon_email(user):
     mails.queue_mail(
         to_addr=user.username,
         mail=mails.NO_ADDON,
-        send_at=datetime.utcnow() + settings.NO_ADDON_WAIT_TIME,
+        send_at=timezone.now() + settings.NO_ADDON_WAIT_TIME,
         user=user,
         fullname=user.fullname
     )
@@ -36,7 +37,7 @@ def queue_first_public_project_email(user, node, meeting_creation):
             mails.queue_mail(
                 to_addr=user.username,
                 mail=mails.NEW_PUBLIC_PROJECT,
-                send_at=datetime.utcnow() + settings.NEW_PUBLIC_PROJECT_WAIT_TIME,
+                send_at=timezone.now() + settings.NEW_PUBLIC_PROJECT_WAIT_TIME,
                 user=user,
                 nid=node._id,
                 fullname=user.fullname,
@@ -51,7 +52,7 @@ def queue_osf4m_welcome_email(user, conference, node):
     mails.queue_mail(
         to_addr=user.username,
         mail=mails.WELCOME_OSF4M,
-        send_at=datetime.utcnow() + settings.WELCOME_OSF4M_WAIT_TIME,
+        send_at=timezone.now() + settings.WELCOME_OSF4M_WAIT_TIME,
         user=user,
         conference=conference.name,
         fullname=user.fullname,

--- a/website/mails/presends.py
+++ b/website/mails/presends.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from datetime import datetime
-
 from django.utils import timezone
 from modularodm import Q
 

--- a/website/mails/presends.py
+++ b/website/mails/presends.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime
+
+from django.utils import timezone
 from modularodm import Q
 
 from website import settings
@@ -13,7 +15,7 @@ def no_login(email):
     sent = QueuedMail.find(Q('user', 'eq', email.user) & Q('email_type', 'eq', NO_LOGIN_TYPE) & Q('_id', 'ne', email._id))
     if sent.count():
         return False
-    return email.user.date_last_login < datetime.utcnow() - settings.NO_LOGIN_WAIT_TIME
+    return email.user.date_last_login < timezone.now() - settings.NO_LOGIN_WAIT_TIME
 
 def new_public_project(email):
     """ Will check to make sure the project that triggered this presend is still public
@@ -46,7 +48,7 @@ def welcome_osf4m(email):
     # In line import to prevent circular importing
     from website.files.models import OsfStorageFileNode
     if email.user.date_last_login:
-        if email.user.date_last_login > datetime.utcnow() - settings.WELCOME_OSF4M_WAIT_TIME_GRACE:
+        if email.user.date_last_login > timezone.now() - settings.WELCOME_OSF4M_WAIT_TIME_GRACE:
             return False
     upload = OsfStorageFileNode.load(email.data['fid'])
     if upload:

--- a/website/mails/queued_mails.py
+++ b/website/mails/queued_mails.py
@@ -1,6 +1,7 @@
 import bson
 from datetime import datetime
 
+from django.utils import timezone
 from modularodm import fields, Q
 from framework.mongo import StoredObject
 from .mails import Mail, send_mail
@@ -53,7 +54,7 @@ class QueuedMail(StoredObject):
         self.data['osf_url'] = settings.DOMAIN
         if presend and self.user.is_active and self.user.osf_mailing_lists.get(settings.OSF_HELP_LIST):
             send_mail(self.to_addr or self.user.username, mail, mimetype='html', **(self.data or {}))
-            self.sent_at = datetime.utcnow()
+            self.sent_at = timezone.now()
             self.save()
             return True
         else:

--- a/website/mails/queued_mails.py
+++ b/website/mails/queued_mails.py
@@ -1,5 +1,4 @@
 import bson
-from datetime import datetime
 
 from django.utils import timezone
 from modularodm import fields, Q

--- a/website/maintenance.py
+++ b/website/maintenance.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 
 from dateutil.parser import parse
+from django.utils import timezone
 
 from pymongo.errors import CollectionInvalid
 import pytz
@@ -26,7 +27,7 @@ def set_maintenance(start=None, end=None):
     """
     if not database:
         return None
-    start = parse(start) if start else datetime.utcnow()
+    start = parse(start) if start else timezone.now()
     end = parse(end) if end else start + timedelta(1)
 
     if not start.tzinfo:

--- a/website/maintenance.py
+++ b/website/maintenance.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from dateutil.parser import parse
 from django.utils import timezone

--- a/website/notifications/events/base.py
+++ b/website/notifications/events/base.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 """Basic Event handling for events that need subscriptions"""
 
-from datetime import datetime
-
 from django.utils import timezone
 
 from website.notifications import emails

--- a/website/notifications/events/base.py
+++ b/website/notifications/events/base.py
@@ -3,6 +3,8 @@
 
 from datetime import datetime
 
+from django.utils import timezone
+
 from website.notifications import emails
 
 
@@ -29,7 +31,7 @@ class Event(object):
         self.gravatar_url = user.profile_image_url()
         self.node = node
         self.action = action
-        self.timestamp = datetime.utcnow()
+        self.timestamp = timezone.now()
 
     def perform(self):
         """Call emails.notify to notify users of an action"""

--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-
-import datetime
 import logging
 import httplib
 import httplib as http  # TODO: Inconsistent usage of aliased import

--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -7,6 +7,7 @@ import httplib as http  # TODO: Inconsistent usage of aliased import
 from dateutil.parser import parse as parse_date
 
 from django.db.models import F
+from django.utils import timezone
 from flask import request
 import markupsafe
 from modularodm.exceptions import ValidationError, NoResultsFound, MultipleResultsFound
@@ -125,7 +126,7 @@ def resend_confirmation(auth):
     # TODO: This setting is now named incorrectly.
     if settings.CONFIRM_REGISTRATIONS_BY_EMAIL:
         send_confirm_email(user, email=address)
-        user.email_last_sent = datetime.datetime.utcnow()
+        user.email_last_sent = timezone.now()
 
     user.save()
 
@@ -819,7 +820,7 @@ def request_export(auth):
         mail=mails.REQUEST_EXPORT,
         user=auth.user,
     )
-    user.email_last_sent = datetime.datetime.utcnow()
+    user.email_last_sent = timezone.now()
     user.save()
     return {'message': 'Sent account export request'}
 
@@ -839,7 +840,7 @@ def request_deactivation(auth):
         mail=mails.REQUEST_DEACTIVATION,
         user=auth.user,
     )
-    user.email_last_sent = datetime.datetime.utcnow()
+    user.email_last_sent = timezone.now()
     user.requested_deactivation = True
     user.save()
     return {'message': 'Sent account deactivation request'}

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -15,6 +15,7 @@ from django.apps import apps
 from django.core.urlresolvers import reverse
 from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator
+from django.utils import timezone
 
 from modularodm import Q
 from modularodm import fields
@@ -373,7 +374,7 @@ class Comment(GuidStoredObject, SpamMixin, Commentable):
         log_dict.update(self.root_target.referent.get_extra_log_params(self))
         self.content = content
         self.modified = True
-        self.date_modified = datetime.datetime.utcnow()
+        self.date_modified = timezone.now()
         new_mentions = get_valid_mentioned_users_guids(self, self.node.contributors)
 
         if save:
@@ -400,7 +401,7 @@ class Comment(GuidStoredObject, SpamMixin, Commentable):
         }
         self.is_deleted = True
         log_dict.update(self.root_target.referent.get_extra_log_params(self))
-        self.date_modified = datetime.datetime.utcnow()
+        self.date_modified = timezone.now()
         if save:
             self.save()
             self.node.add_log(
@@ -422,7 +423,7 @@ class Comment(GuidStoredObject, SpamMixin, Commentable):
             'comment': self._id,
         }
         log_dict.update(self.root_target.referent.get_extra_log_params(self))
-        self.date_modified = datetime.datetime.utcnow()
+        self.date_modified = timezone.now()
         if save:
             self.save()
             self.node.add_log(
@@ -1569,7 +1570,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable, Spam
         # there is no preprint file yet! This is the first time!
         if not self.preprint_file:
             self.preprint_file = preprint_file
-            self.preprint_created = datetime.datetime.utcnow()
+            self.preprint_created = timezone.now()
             self.add_log(action=NodeLog.PREPRINT_INITIATED, params={}, auth=auth, save=False)
         elif preprint_file != self.preprint_file:
             # if there was one, check if it's a new file
@@ -1864,7 +1865,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable, Spam
         # Slight hack - date_created is a read-only field.
         new._fields['date_created'].__set__(
             new,
-            datetime.datetime.utcnow(),
+            timezone.now(),
             safe=True
         )
 
@@ -2313,7 +2314,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable, Spam
             if message:
                 status.push_status_message(message, kind='info', trust=False)
 
-        log_date = date or datetime.datetime.utcnow()
+        log_date = date or timezone.now()
 
         # Add log to parent
         if self.node__parent:
@@ -2359,7 +2360,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable, Spam
         if not (self.is_public or self.has_permission(user, 'read')):
             raise PermissionsError('{0!r} does not have permission to fork node {1!r}'.format(user, self._id))
 
-        when = datetime.datetime.utcnow()
+        when = timezone.now()
 
         original = self.load(self._primary_key)
 
@@ -2473,7 +2474,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable, Spam
         if self.is_collection:
             raise NodeStateError('Folders may not be registered')
 
-        when = datetime.datetime.utcnow()
+        when = timezone.now()
 
         original = self.load(self._primary_key)
 
@@ -3383,7 +3384,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable, Spam
                 self.add_contributor(contributor=contributor, auth=auth, visible=bibliographic,
                                      send_email=send_email, permissions=permissions, save=True)
 
-        auth.user.email_last_sent = datetime.datetime.utcnow()
+        auth.user.email_last_sent = timezone.now()
         auth.user.save()
 
         if index is not None:
@@ -3447,7 +3448,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable, Spam
     def _check_spam_user(self, user):
         if (
             settings.SPAM_ACCOUNT_SUSPENSION_ENABLED
-            and (datetime.datetime.utcnow() - user.date_confirmed) <= settings.SPAM_ACCOUNT_SUSPENSION_THRESHOLD
+            and (timezone.now() - user.date_confirmed) <= settings.SPAM_ACCOUNT_SUSPENSION_THRESHOLD
         ):
             self.set_privacy('private', log=False, save=False)
 
@@ -3827,7 +3828,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable, Spam
         return retraction
 
     def _is_embargo_date_valid(self, end_date):
-        today = datetime.datetime.utcnow()
+        today = timezone.now()
         if (end_date - today) >= settings.EMBARGO_END_DATE_MIN:
             if (end_date - today) <= settings.EMBARGO_END_DATE_MAX:
                 return True
@@ -3868,7 +3869,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable, Spam
         if not self.has_permission(user, 'admin'):
             raise PermissionsError('Only admins may embargo a registration')
         if not self._is_embargo_date_valid(end_date):
-            if (end_date - datetime.datetime.utcnow()) >= settings.EMBARGO_END_DATE_MIN:
+            if (end_date - timezone.now()) >= settings.EMBARGO_END_DATE_MIN:
                 raise ValidationValueError('Registrations can only be embargoed for up to four years.')
             raise ValidationValueError('Embargo end date must be at least three days in the future.')
 
@@ -3980,7 +3981,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable, Spam
             user.is_active)
 
     def _initiate_approval(self, user, notify_initiator_on_complete=False):
-        end_date = datetime.datetime.now() + settings.REGISTRATION_APPROVAL_TIME
+        end_date = timezone.now() + settings.REGISTRATION_APPROVAL_TIME
         approval = RegistrationApproval(
             initiated_by=user,
             end_date=end_date,

--- a/website/project/sanctions.py
+++ b/website/project/sanctions.py
@@ -1,4 +1,3 @@
-import datetime
 import functools
 from dateutil.parser import parse as parse_date
 from django.utils import timezone

--- a/website/project/sanctions.py
+++ b/website/project/sanctions.py
@@ -1,6 +1,7 @@
 import datetime
 import functools
 from dateutil.parser import parse as parse_date
+from django.utils import timezone
 
 from modularodm import (
     fields,
@@ -74,7 +75,7 @@ class Sanction(StoredObject):
     UNANIMOUS = 'unanimous'
     mode = UNANIMOUS
 
-    initiation_date = fields.DateTimeField(auto_now_add=datetime.datetime.utcnow)
+    initiation_date = fields.DateTimeField(auto_now_add=timezone.now)
     # Expiration date-- Sanctions in the UNAPPROVED state that are older than their end_date
     # are automatically made ACTIVE by a daily cron job
     # Use end_date=None for a non-expiring Sanction
@@ -696,7 +697,7 @@ class Retraction(EmailApprovableSanction):
             node.set_privacy('public', auth=None, save=True, log=False)
             node.update_search()
 
-        parent_registration.date_modified = datetime.datetime.utcnow()
+        parent_registration.date_modified = timezone.now()
         parent_registration.save()
 
     def approve_retraction(self, user, token):

--- a/website/project/spam/model.py
+++ b/website/project/spam/model.py
@@ -2,6 +2,7 @@ import abc
 import logging
 from datetime import datetime
 
+from django.utils import timezone
 from modularodm import fields
 from modularodm.exceptions import ValidationTypeError, ValidationValueError
 
@@ -111,7 +112,7 @@ class SpamMixin(StoredObject):
         if user == self.user:
             raise ValueError('User cannot report self.')
         self.flag_spam()
-        date = datetime.utcnow()
+        date = timezone.now()
         report = {'date': date, 'retracted': False}
         report.update(kwargs)
         if 'text' not in report:

--- a/website/project/spam/model.py
+++ b/website/project/spam/model.py
@@ -1,6 +1,5 @@
 import abc
 import logging
-from datetime import datetime
 
 from django.utils import timezone
 from modularodm import fields

--- a/website/project/tasks.py
+++ b/website/project/tasks.py
@@ -1,4 +1,3 @@
-import datetime
 from django.apps import apps
 
 import requests

--- a/website/project/tasks.py
+++ b/website/project/tasks.py
@@ -2,6 +2,7 @@ import datetime
 from django.apps import apps
 
 import requests
+from django.utils import timezone
 
 from framework.celery_tasks import app as celery_app
 
@@ -30,7 +31,7 @@ def on_node_updated(node_id, user_id, first_save, saved_fields, request_headers=
 
         if settings.SHARE_URL and settings.SHARE_API_TOKEN:
             requests.post('{}api/normalizeddata/'.format(settings.SHARE_URL), json={
-                'created_at': datetime.datetime.utcnow().isoformat(),
+                'created_at': timezone.now().isoformat(),
                 'normalized_data': {
                     '@graph': [{
                         '@id': '_:123',

--- a/website/project/views/comment.py
+++ b/website/project/views/comment.py
@@ -1,10 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from datetime import datetime
-
 import markdown
 from django.utils import timezone
-import pytz
 from flask import request
 
 from api.caching.tasks import ban_url
@@ -124,7 +121,7 @@ def send_comment_added_notification(comment, auth):
         parent_comment=target.referent.content if is_reply(target) else '',
         url=comment.get_comment_page_url()
     )
-    time_now = datetime.utcnow().replace(tzinfo=pytz.utc)
+    time_now = timezone.now()
     sent_subscribers = notify(
         event='comments',
         user=auth.user,
@@ -160,7 +157,7 @@ def send_mention_added_notification(comment, new_mentions, auth):
         new_mentions=new_mentions,
         url=comment.get_comment_page_url()
     )
-    time_now = datetime.utcnow().replace(tzinfo=pytz.utc)
+    time_now = timezone.now()
     notify_mentions(
         event='global_mentions',
         user=auth.user,

--- a/website/project/views/drafts.py
+++ b/website/project/views/drafts.py
@@ -6,6 +6,7 @@ import itertools
 from operator import itemgetter
 
 from dateutil.parser import parse as parse_date
+from django.utils import timezone
 from flask import request, redirect
 
 from modularodm import Q
@@ -68,7 +69,7 @@ def validate_embargo_end_date(end_date_string, node):
     max embargo end date
     """
     end_date = parse_date(end_date_string, ignoretz=True)
-    today = datetime.datetime.utcnow()
+    today = timezone.now()
     if (end_date - today) <= settings.DRAFT_REGISTRATION_APPROVAL_PERIOD:
         raise HTTPError(http.BAD_REQUEST, data={
             'message_short': 'Invalid embargo end date',

--- a/website/project/views/drafts.py
+++ b/website/project/views/drafts.py
@@ -1,6 +1,5 @@
 import functools
 import httplib as http
-import datetime
 import itertools
 
 from operator import itemgetter

--- a/website/util/rubeus.py
+++ b/website/util/rubeus.py
@@ -6,6 +6,7 @@ import logging
 import datetime
 
 import hurry.filesize
+from django.utils import timezone
 
 from framework import sentry
 from framework.auth.decorators import Auth
@@ -302,6 +303,6 @@ def collect_addon_css(node, visited=None):
 
 
 def delta_date(d):
-    diff = d - datetime.datetime.utcnow()
+    diff = d - timezone.now()
     s = diff.total_seconds()
     return s

--- a/website/util/rubeus.py
+++ b/website/util/rubeus.py
@@ -3,7 +3,6 @@
 formatted hgrid list/folders.
 """
 import logging
-import datetime
 
 import hurry.filesize
 from django.utils import timezone

--- a/website/util/time.py
+++ b/website/util/time.py
@@ -16,6 +16,6 @@ def throttle_period_expired(timestamp, throttle):
         if timestamp.tzinfo:
             return (timezone.now() - timestamp).total_seconds() > throttle
         else:
-            return (datetime.utcnow() - timestamp).total_seconds() > throttle
+            return (timezone.now() - timestamp).total_seconds() > throttle
     else:
         return (get_timestamp() - timestamp) > throttle


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->
## Purpose

Bugs:
- https://sentry.cos.io/sentry/osf-back-end/issues/258283/
- https://sentry.cos.io/sentry/osf-back-end/issues/257147/

I also added a NonNaiveDatetimeField and changed the DatetimeAwareJSONField to disallow naive datetimes. They will both throw an exception if someone tries to give them a naive datetime. I also changed all usages throughout the models to use NonNaiveDatetimeField instead of django's DatetimeField.
## Changes

<!-- Briefly describe or list your changes  -->
## Side effects

<!--Any possible side effects? -->
## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
