### PR TITLE
[Feature] Fix fangorn move actions [OSF-7164]

### DIFF
--- a/website/addons/dataverse/static/dataverseFangornConfig.js
+++ b/website/addons/dataverse/static/dataverseFangornConfig.js
@@ -5,7 +5,7 @@ var URI = require('URIjs');
 var $ = require('jquery');
 var Raven = require('raven-js');
 
-var Fangorn = require('js/fangorn');
+var Fangorn = require('js/fangorn').Fangorn;
 var waterbutler = require('js/waterbutler');
 var $osf = require('js/osfHelpers');
 

--- a/website/addons/figshare/static/figshareFangornConfig.js
+++ b/website/addons/figshare/static/figshareFangornConfig.js
@@ -2,7 +2,7 @@
 
 var m = require('mithril');
 
-var Fangorn = require('js/fangorn');
+var Fangorn = require('js/fangorn').Fangorn;
 
 
 // Define Fangorn Button Actions

--- a/website/addons/github/static/githubFangornConfig.js
+++ b/website/addons/github/static/githubFangornConfig.js
@@ -6,7 +6,7 @@
 var m = require('mithril');
 var $ = require('jquery');
 var URI = require('URIjs');
-var Fangorn = require('js/fangorn');
+var Fangorn = require('js/fangorn').Fangorn;
 var waterbutler = require('js/waterbutler');
 var $osf = require('js/osfHelpers');
 

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -2467,7 +2467,6 @@ function getCopyMode(folder, items) {
 
     for(var i = 0; i < items.length; i++) {
         var item = items[i];
-        if (typeof item.inProgress !== 'undefined' && item.inProgress)
         if(isInvalidDropItem(folder, item, cannotBeFolder, mustBeIntra)){
             return 'forbidden';
         }

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -558,7 +558,6 @@ function doItemOp(operation, to, from, rename, conflict) {
         from.notify.update('Successfully ' + operation.passed + '.', 'success', null, 1000);
 
         if (xhr.status === 200) {
-            from.inProgress = false;
             to.children.forEach(function(child) {
                 if (child.data.name === from.data.name && child.id !== from.id) {
                     child.removeSelf();
@@ -614,6 +613,8 @@ function doItemOp(operation, to, from, rename, conflict) {
         });
 
         orderFolder.call(tb, from.parent());
+    }).always(function(){
+        from.inProgress = false;
     });
 }
 
@@ -2458,6 +2459,10 @@ function allowedToMove(folder, item, mustBeIntra) {
 
 function getCopyMode(folder, items) {
     var tb = this;
+    // Prevents side effects from rare instance where folders not fully populated
+    if (typeof folder.data === 'undefined'){
+        return 'forbidden';
+    }
     var canMove = true;
     var mustBeIntra = (folder.data.provider === 'github');
     var cannotBeFolder = (folder.data.provider === 'figshare' || folder.data.provider === 'dataverse');

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -182,7 +182,7 @@ var uploadRowTemplate = function(item) {
             var uploadColumns = [
                 m('.col-xs-7', {style: 'overflow: hidden;text-overflow: ellipsis;'}, [
                     m('span', { style : 'padding-left:' + padding + 'px;'}, tb.options.resolveIcon.call(tb, item)),
-                    m('span',{ style : 'margin-left: 9px;'}, item.data.name)
+                    m('span', { style : 'margin-left: 9px;'}, item.data.name)
                 ]),
                 m('.col-xs-3',
                     m('.progress', [
@@ -206,7 +206,7 @@ var uploadRowTemplate = function(item) {
                                 e.stopImmediatePropagation();
                                 cancelUpload.call(tb, item);
                             }},
-                         m('span.text-muted','×')
+                         m('span.text-muted', '×')
                     ))
                 ]));
             }
@@ -295,9 +295,9 @@ function _fangornResolveIcon(item) {
     if (item.data.unavailable)
         return m('div', {style: {width:'16px', height:'16px', background:'url(' + item.data.iconUrl+ ')', display:'inline-block', opacity: 0.4}}, '');
 
-    var privateFolder =  m('i.fa.fa-lock', ' '),
+    var privateFolder = m('i.fa.fa-lock', ' '),
         pointerFolder = m('i.fa.fa-link', ' '),
-        openFolder  = m('i.fa.fa-folder-open', ' '),
+        openFolder = m('i.fa.fa-folder-open', ' '),
         closedFolder = m('i.fa.fa-folder', ' '),
         configOption = item.data.provider ? resolveconfigOption.call(this, item, 'folderIcon', [item]) : undefined,  // jshint ignore:line
         icon;
@@ -443,7 +443,7 @@ function checkConflicts(tb, item, folder, cb) {
                 m('', messageArray), [
                     m('span.btn.btn-default', {onclick: function() {tb.modal.dismiss();}}, 'Cancel'), //jshint ignore:line
                     m('span.btn.btn-primary', {onclick: cb.bind(tb, 'keep')}, 'Keep Both'),
-                    m('span.btn.btn-primary', {onclick: cb.bind(tb, 'replace')},'Replace')
+                    m('span.btn.btn-primary', {onclick: cb.bind(tb, 'replace')}, 'Replace')
                 ],
                 m('h3.break-word.modal-title', 'Replace "' + child.data.name + '"?')
             );
@@ -471,7 +471,7 @@ function checkConflictsRename(tb, item, name, cb) {
                 m('', messageArray), [
                     m('span.btn.btn-default', {onclick: function() {tb.modal.dismiss();}}, 'Cancel'), //jshint ignore:line
                     m('span.btn.btn-primary', {onclick: cb.bind(tb, 'keep')}, 'Keep Both'),
-                    m('span.btn.btn-primary', {onclick: cb.bind(tb, 'replace')},'Replace')
+                    m('span.btn.btn-primary', {onclick: cb.bind(tb, 'replace')}, 'Replace')
                 ],
                 m('h3.break-word.modal-title', 'Replace "' + child.data.name + '"?')
             );
@@ -1073,7 +1073,7 @@ function _removeEvent (event, items, col) {
                     ]);
                 var mithrilButtons = m('div', [
                         m('span.btn.btn-default', { onclick : function() { cancelDelete.call(tb); } }, 'Cancel'),
-                        m('span.btn.btn-danger', {  onclick : function() { runDelete(folder); }  }, 'Delete')
+                        m('span.btn.btn-danger', { onclick : function() { runDelete(folder); } }, 'Delete')
                     ]);
                 tb.modal.update(mithrilContent, mithrilButtons, m('h3.break-word.modal-title', 'Delete "' + folder.data.name+ '"?'));
         } else {
@@ -1097,7 +1097,7 @@ function _removeEvent (event, items, col) {
             ]);
             var mithrilButtonsSingle = m('div', [
                 m('span.btn.btn-default', { onclick : function() { cancelDelete(); } }, 'Cancel'),
-                m('span.btn.btn-danger', { onclick : function() { runDelete(items[0]); }  }, 'Delete')
+                m('span.btn.btn-danger', { onclick : function() { runDelete(items[0]); } }, 'Delete')
             ]);
             // This is already being checked before this step but will keep this edit permission check
             if(items[0].data.permissions.edit){
@@ -1143,15 +1143,15 @@ function _removeEvent (event, items, col) {
                     deleteList.map(function(n){
                         if(n.kind === 'folder'){
                             return m('.fangorn-canDelete.text-success.break-word', [
-                                m('i.fa.fa-folder'),m('b', ' ' + n.data.name)
+                                m('i.fa.fa-folder'), m('b', ' ' + n.data.name)
                                 ]);
                         }
                         return m('.fangorn-canDelete.text-success.break-word', n.data.name);
                     })
                 ]);
-            mithrilButtonsMultiple =  m('div', [
+            mithrilButtonsMultiple = m('div', [
                     m('span.btn.btn-default', { onclick : function() { tb.modal.dismiss(); } }, 'Cancel'),
-                    m('span.btn.btn-danger', { onclick : function() { runDeleteMultiple.call(tb, deleteList); }  }, 'Delete All')
+                    m('span.btn.btn-danger', { onclick : function() { runDeleteMultiple.call(tb, deleteList); } }, 'Delete All')
                 ]);
         } else {
             mithrilContentMultiple = m('div', [
@@ -1159,7 +1159,7 @@ function _removeEvent (event, items, col) {
                     deleteList.map(function(n){
                         if(n.kind === 'folder'){
                             return m('.fangorn-canDelete.text-success.break-word', [
-                                m('i.fa.fa-folder'),m('b', ' ' + n.data.name)
+                                m('i.fa.fa-folder'), m('b', ' ' + n.data.name)
                                 ]);
                         }
                         return m('.fangorn-canDelete.text-success.break-word', n.data.name);
@@ -1168,9 +1168,9 @@ function _removeEvent (event, items, col) {
                         return m('.fangorn-noDelete.text-warning.break-word', n.data.name);
                     })
                 ]);
-            mithrilButtonsMultiple =  m('div', [
-                    m('span.btn.btn-default', { 'class' : 'text-default', onclick : function() {  tb.modal.dismiss(); } }, 'Cancel'),
-                    m('span.btn.btn-danger', { 'class' : 'text-danger', onclick : function() { runDeleteMultiple.call(tb, deleteList); }  }, 'Delete Some')
+            mithrilButtonsMultiple = m('div', [
+                    m('span.btn.btn-default', { 'class' : 'text-default', onclick : function() { tb.modal.dismiss(); } }, 'Cancel'),
+                    m('span.btn.btn-danger', { 'class' : 'text-danger', onclick : function() { runDeleteMultiple.call(tb, deleteList); } }, 'Delete Some')
                 ]);
         }
         tb.modal.update(mithrilContentMultiple, mithrilButtonsMultiple, m('h3.break-word.modal-title', 'Delete multiple files?'));
@@ -1321,46 +1321,42 @@ function gotoFileEvent (item, toUrl) {
  * @returns {Array} Returns an array of mithril template objects using m()
  * @private
  */
-function _fangornTitleColumnHelper(tb,item,col,nameTitle,toUrl,classNameOption){
+function _fangornTitleColumnHelper(tb, item, col, nameTitle, toUrl, classNameOption){
     if (typeof tb.options.links === 'undefined') {
         tb.options.links = true;
     }
-    if (item.data.isAddonRoot && item.connected === false) { // as opposed to undefined, avoids unnecessary setting of this value
+    // as opposed to undefined, avoids unnecessary setting of this value
+    if (item.data.isAddonRoot && item.connected === false) { 
         return _connectCheckTemplate.call(this, item);
     }
     if (item.kind === 'file' && item.data.permissions.view) {
         var attrs = {};
         if (tb.options.links) {
-            attrs =  {
+            attrs = {
                 className: classNameOption,
                 onclick: function(event) {
-                event.stopImmediatePropagation();
-                gotoFileEvent.call(tb, item, toUrl);
-            }
+                    event.stopImmediatePropagation();
+                    gotoFileEvent.call(tb, item, toUrl);
+                }
             };
         }
-        return m(
-            'span',
-            attrs,
-            nameTitle
-        );
+        return m('span', attrs, nameTitle);
     }
     if ((item.data.nodeType === 'project' || item.data.nodeType ==='component') && item.data.permissions.view) {
-      return m('a.' + classNameOption,{ href: '/' + item.data.nodeID.toString() + toUrl},
-              nameTitle);
+        return m('a.' + classNameOption, {href: '/' + item.data.nodeID.toString() + toUrl}, nameTitle);
     }
     return m('span', nameTitle);
 }
 
 function _fangornTitleColumn(item, col) {
     var tb = this;
-    return _fangornTitleColumnHelper(tb,item,col,item.data.name,'/','fg-file-links');
+    return _fangornTitleColumnHelper(tb, item, col, item.data.name, '/', 'fg-file-links');
 }
 
-function _fangornVersionColumn(item,col) {
+function _fangornVersionColumn(item, col) {
     var tb = this;
     if (item.kind !== 'folder' && item.data.provider === 'osfstorage'){
-        return _fangornTitleColumnHelper(tb,item,col,String(item.data.extra.version),'/?show=revision','fg-version-links');
+        return _fangornTitleColumnHelper(tb, item, col, String(item.data.extra.version), '/?show=revision', 'fg-version-links');
     }
     return;
 }
@@ -1506,9 +1502,8 @@ function _fangornResolveRows(item) {
  */
 function _fangornColumnTitles () {
     var columns = [];
-    columns.push(
-    {
-        title: 'Name',
+    columns.push({
+        title : 'Name',
         width : '54%',
         sort : true,
         sortType : 'text'
@@ -1517,10 +1512,10 @@ function _fangornColumnTitles () {
         width : '8%',
         sort : false
     }, {
-        title: 'Version',
+        title : 'Version',
         width : '10%',
         sort : false
-    },{
+    }, {
         title : 'Downloads',
         width : '8%',
         sort : false
@@ -1700,8 +1695,8 @@ var FGInput = {
                 'id' : id,
                 className: 'pull-right form-control' + extraCSS,
                 onkeypress: onkeypress,
-                'data-toggle':  tooltipText ? 'tooltip' : '',
-                'title':  tooltipText,
+                'data-toggle': tooltipText ? 'tooltip' : '',
+                'title': tooltipText,
                 'data-placement' : 'bottom',
                 'placeholder' : placeholder
                 }),
@@ -1722,14 +1717,14 @@ var FGDropdown = {
         var onchange = args.onchange || noop;
         return m('span.fangorn-dropdown', {
                 className: extraCSS
-            },[
-                m('span.hidden-xs',label),
+            }, [
+                m('span.hidden-xs', label),
                 m('select.no-border', {
                     'name' : name,
                     'id' : id,
                     onchange: onchange,
-                    'data-toggle':  tooltipText ? 'tooltip' : '',
-                    'title':  tooltipText,
+                    'data-toggle': tooltipText ? 'tooltip' : '',
+                    'title': tooltipText,
                     'data-placement' : 'bottom'
                 }, children)
         ]);
@@ -1789,7 +1784,7 @@ var FGItemButtons = {
                         if (!item.data.extra.checkout){
                             rowButtons.push(
                                 m.component(FGButton, {
-                                    onclick: function(event) { _removeEvent.call(tb, event, [item]);  },
+                                    onclick: function(event) { _removeEvent.call(tb, event, [item]); },
                                     icon: 'fa fa-trash',
                                     className : 'text-danger'
                                 }, 'Delete'));
@@ -1849,7 +1844,7 @@ var FGItemButtons = {
                     }, 'Download as zip')
                 );
             }
-            if (item.data.provider && !item.data.isAddonRoot && item.data.permissions && item.data.permissions.edit &&  (item.data.provider !== 'osfstorage' || !item.data.extra.checkout)) {
+            if (item.data.provider && !item.data.isAddonRoot && item.data.permissions && item.data.permissions.edit && (item.data.provider !== 'osfstorage' || !item.data.extra.checkout)) {
                 rowButtons.push(
                     m.component(FGButton, {
                         onclick: function () {
@@ -1902,7 +1897,7 @@ var FGToolbar = {
                 onclick: ctrl.dismissToolbar,
                 icon : 'fa fa-times'
             }, '');
-        templates[toolbarModes.FILTER] =  [
+        templates[toolbarModes.FILTER] = [
             m('.col-xs-9', [
                 ctrl.tb.options.filterTemplate.call(ctrl.tb)
                 ]),
@@ -1974,7 +1969,7 @@ var FGToolbar = {
         if(items.length === 1){
             var addonButtons = resolveconfigOption.call(ctrl.tb, item, 'itemButtons', [item]);
             if (addonButtons) {
-                finalRowButtons = m.component(addonButtons, { treebeard : ctrl.tb, item : item }); // jshint ignore:line
+                finalRowButtons = m.component(addonButtons, {treebeard : ctrl.tb, item : item }); // jshint ignore:line
             } else if (ctrl.tb.options.placement !== 'fileview') {
                 finalRowButtons = m.component(FGItemButtons, {treebeard : ctrl.tb, mode : ctrl.mode, item : item }); // jshint ignore:line
             }
@@ -2030,7 +2025,7 @@ var FGToolbar = {
                         var mithrilContent = m('div', [
                             m('p', [ m('b', 'Select rows:'), m('span', ' Click on a row (outside the add-on, file, or folder name) to show further actions in the toolbar. Use Command or Shift keys to select multiple files.')]),
                             m('p', [ m('b', 'Open files:'), m('span', ' Click a file name to go to view the file in the OSF.')]),
-                            m('p', [ m('b', 'Open files in new tab:'), m('span',  ' Press Command (Ctrl in Windows) and click a file name to open it in a new tab.')]),
+                            m('p', [ m('b', 'Open files in new tab:'), m('span', ' Press Command (Ctrl in Windows) and click a file name to open it in a new tab.')]),
                             m('p', [ m('b', 'Download as zip:'), m('span', ' Click on the row of an add-on or folder and click the Download as Zip button in the toolbar.'), m('i', ' Not available for all storage add-ons.')]),
                             m('p', [ m('b', 'Copy files:'), m('span', ' Press Option (Alt in Windows) while dragging a file to a new folder or component.'), m('i', ' Only for contributors with write access.')])
                         ]);
@@ -2060,9 +2055,9 @@ var FGToolbar = {
         }
 
         if (item && item.connected !== false){ // as opposed to undefined, avoids unnecessary setting of this value
-            templates[toolbarModes.DEFAULT] =  m('.col-xs-12', m('.pull-right', [finalRowButtons,  m('span', generalButtons)]));
+            templates[toolbarModes.DEFAULT] = m('.col-xs-12', m('.pull-right', [finalRowButtons, m('span', generalButtons)]));
         } else {
-            templates[toolbarModes.DEFAULT] =  m('.col-xs-12', m('.pull-right', m('span', generalButtons)));
+            templates[toolbarModes.DEFAULT] = m('.col-xs-12', m('.pull-right', m('span', generalButtons)));
         }
         return m('.row.tb-header-row', [
             m('#folderRow', { config : function () {
@@ -2369,15 +2364,16 @@ function _dragLogic(event, items, ui) {
 }
 
 function getAllChildren(item){
+    var c;
     var children = [];
     var remaining = [];
-    for(var c in item.children){
+    for(c in item.children){
         remaining.push(item.children[c]);
     }
     while(remaining.length > 0){
         var current = remaining.pop();
         children.push(current.id);
-        for(var c in current.children){
+        for(c in current.children){
             remaining.push(current.children[c]);
         }
     }
@@ -2412,7 +2408,8 @@ function isInvalidFigshareDropFolder(folder) {
 }
 
 function isInvalidDropItem(folder, item, cannotBeFolder, mustBeIntra) {
-    if(// improper node type?
+    if (
+        // improper node type?
         item.data.nodeType ||
         // no roots
         item.data.isAddonRoot ||
@@ -2426,9 +2423,9 @@ function isInvalidDropItem(folder, item, cannotBeFolder, mustBeIntra) {
         (mustBeIntra && item.data.provider !== folder.data.provider) ||
         //Disallow moving OUT of a public figshare folder
         (item.data.provider === 'figshare' && item.data.extra && item.data.status && item.data.status !== 'public')
-    ){
+    ) {
         return true;
-    };
+    }
     return false;
 }
 
@@ -2458,7 +2455,7 @@ function getCopyMode(folder, items) {
         }
         if(canMove){
             mustBeIntra = mustBeIntra || item.data.provider === 'github';
-            canMove = allowedToMove(folder, item, mustBeIntra)
+            canMove = allowedToMove(folder, item, mustBeIntra);
         }
         // prevent dragging parent into child
         var children = getAllChildren(item);
@@ -2526,7 +2523,7 @@ tbOptions = {
         // }
         return undefined;
     },
-    showFilter : true,     // Gives the option to filter by showing the filter box.
+    showFilter : true,      // Gives the option to filter by showing the filter box.
     allowMove : true,       // Turn moving on or off.
     hoverClass : 'fangorn-hover',
     togglecheck : _fangornToggleCheck,
@@ -2611,11 +2608,11 @@ tbOptions = {
         maxFilesize: 10000000,
         url: function(files) {return files[0].url;},
         clickable : '#treeGrid',
-        addRemoveLinks: false,
-        previewTemplate: '<div></div>',
-        parallelUploads: 5,
-        acceptDirectories: false,
-        createImageThumbnails: false,
+        addRemoveLinks : false,
+        previewTemplate : '<div></div>',
+        parallelUploads : 5,
+        acceptDirectories : false,
+        createImageThumbnails : false,
         fallback: function(){},
     },
     resolveIcon : _fangornResolveIcon,
@@ -2623,7 +2620,7 @@ tbOptions = {
     // Pass ``null`` to avoid overwriting Dropzone URL resolver
     resolveUploadUrl: function() {return null;},
     resolveLazyloadUrl : _fangornResolveLazyLoad,
-    resolveUploadMethod: _fangornUploadMethod,
+    resolveUploadMethod : _fangornUploadMethod,
     lazyLoadError : _fangornLazyLoadError,
     lazyLoadOnLoad : _fangornLazyLoadOnLoad,
     ontogglefolder : expandStateLoad,
@@ -2637,7 +2634,7 @@ tbOptions = {
         dragover : _fangornDragOver,
         addedfile : _fangornAddedFile,
         drop : _fangornDropzoneDrop,
-        queuecomplete: _fangornQueueComplete
+        queuecomplete : _fangornQueueComplete
     },
     resolveRefreshIcon : function() {
         return m('i.fa.fa-refresh.fa-spin');
@@ -2659,7 +2656,7 @@ tbOptions = {
     onafterselectwitharrow : function(row, direction) {
         var tb = this;
         var item = tb.find(row.id);
-        _fangornMultiselect.call(tb,null,item);
+        _fangornMultiselect.call(tb, null, item);
     },
     hScroll : null,
     naturalScrollLimit : 0
@@ -2701,22 +2698,22 @@ Fangorn.Components = {
 };
 
 Fangorn.ButtonEvents = {
-    _downloadEvent: _downloadEvent,
+    _downloadEvent : _downloadEvent,
     _downloadZipEvent: _downloadZipEvent,
-    _uploadEvent: _uploadEvent,
-    _removeEvent: _removeEvent,
-    createFolder: _createFolder,
+    _uploadEvent : _uploadEvent,
+    _removeEvent : _removeEvent,
+    createFolder : _createFolder,
     _gotoFileEvent : gotoFileEvent,
 };
 
 Fangorn.DefaultColumns = {
-    _fangornTitleColumn: _fangornTitleColumn,
-    _fangornVersionColumn: _fangornVersionColumn,
-    _fangornModifiedColumn: _fangornModifiedColumn
+    _fangornTitleColumn : _fangornTitleColumn,
+    _fangornVersionColumn : _fangornVersionColumn,
+    _fangornModifiedColumn : _fangornModifiedColumn
 };
 
 Fangorn.Utils = {
-    inheritFromParent: inheritFromParent,
+    inheritFromParent : inheritFromParent,
     resolveconfigOption: resolveconfigOption,
     reapplyTooltips : reapplyTooltips,
     setCurrentFileID: setCurrentFileID,
@@ -2724,8 +2721,8 @@ Fangorn.Utils = {
     openParentFolders : openParentFolders,
     dismissToolbar : dismissToolbar,
     uploadRowTemplate : uploadRowTemplate,
-    resolveIconView: resolveIconView,
-    orderFolder: orderFolder,
+    resolveIconView : resolveIconView,
+    orderFolder : orderFolder,
     connectCheckTemplate : _connectCheckTemplate
 };
 
@@ -2737,4 +2734,4 @@ module.exports = {
     isInvalidFigshareDropFolder : isInvalidFigshareDropFolder,
     isInvalidDropItem : isInvalidDropItem,
     allowedToMove : allowedToMove
-}
+};

--- a/website/static/js/fileViewTreebeard.js
+++ b/website/static/js/fileViewTreebeard.js
@@ -1,4 +1,4 @@
-var Fangorn = require('js/fangorn');
+var Fangorn = require('js/fangorn').Fangorn;
 var m = require('mithril');
 var $osf = require('js/osfHelpers');
 

--- a/website/static/js/filesWidget.js
+++ b/website/static/js/filesWidget.js
@@ -3,7 +3,7 @@ var Raven = require('raven-js');
 
 var $osf = require('js/osfHelpers');
 var osfLanguage = require('js/osfLanguage');
-var Fangorn = require('js/fangorn');
+var Fangorn = require('js/fangorn').Fangorn;
 
 /**
  * @class FilesWidget

--- a/website/static/js/pages/files-page.js
+++ b/website/static/js/pages/files-page.js
@@ -2,7 +2,7 @@
 
 var $ = require('jquery');
 var $osf = require('js/osfHelpers');
-var Fangorn = require('js/fangorn');
+var Fangorn = require('js/fangorn').Fangorn;
 var node = window.contextVars.node;
 
 // Don't show dropped content if user drags outside grid

--- a/website/static/js/pages/project-dashboard-page.js
+++ b/website/static/js/pages/project-dashboard-page.js
@@ -7,7 +7,7 @@ require('bootstrap-editable');
 require('js/osfToggleHeight');
 
 var m = require('mithril');
-var Fangorn = require('js/fangorn');
+var Fangorn = require('js/fangorn').Fangorn;
 var Raven = require('raven-js');
 var lodashGet  = require('lodash.get');
 require('truncate');

--- a/website/static/js/projectSettingsTreebeardBase.js
+++ b/website/static/js/projectSettingsTreebeardBase.js
@@ -6,7 +6,7 @@
 'use strict';
 
 var m = require('mithril');
-var Fangorn = require('js/fangorn');
+var Fangorn = require('js/fangorn').Fangorn;
 
 
 function resolveToggle(item) {

--- a/website/static/js/registrationEditorExtensions.js
+++ b/website/static/js/registrationEditorExtensions.js
@@ -4,7 +4,7 @@ var m = require('mithril');
 var bootbox = require('bootbox');  // TODO: Why is this required? Is it? See [#OSF-6100]
 
 var FilesWidget = require('js/filesWidget');
-var Fangorn = require('js/fangorn');
+var Fangorn = require('js/fangorn').Fangorn;
 var $osf = require('js/osfHelpers');
 var ContribAdder = require('js/contribAdder');
 

--- a/website/static/js/tests/fangorn.test.js
+++ b/website/static/js/tests/fangorn.test.js
@@ -1,0 +1,198 @@
+/*global describe, it, expect, example, before, after, beforeEach, afterEach, mocha, sinon*/
+'use strict';
+
+var testUtils = require('./utils');
+var $osf = require('js/osfHelpers');
+var Fangorn = require('js/fangorn');
+
+var assert = require('chai').assert;
+var utils = require('tests/utils');
+var faker = require('faker');
+var $ = require('jquery');
+var Raven = require('raven-js');
+var language = require('js/osfLanguage').projectSettings;
+
+describe('fangorn', () => {
+    describe('FangornMoveUnitTests', () => {
+        // folder setup
+        var folder;
+        var item;
+        var getItem = function(kind, id){
+            if(typeof id === 'undefined'){
+                id = 2;
+            }
+            return {
+                'data': {
+                    'provider': 'osfstorage',
+                    'kind': kind,
+                    'permissions': {
+                        'edit': true
+                    }
+                },
+                'children': [],
+                'id': id,
+                'parentId': 1,
+            };
+        }
+
+        describe('isInvalidDropFolder', () => {
+            it('valid drop', () => {
+                assert.equal(Fangorn.isInvalidDropFolder(getItem('folder')), false);
+            });      
+
+            it('invalid drop if no parent id', () => {
+                folder = getItem('folder');
+                folder.parentId = 0;
+                assert.equal(Fangorn.isInvalidDropFolder(folder), true);
+            });
+
+            it('invalid drop if not folder', () => {
+                assert.equal(Fangorn.isInvalidDropFolder(getItem()), true);
+            });      
+
+            it('invalid drop if file', () => {
+                assert.equal(Fangorn.isInvalidDropFolder(getItem('file')), true);
+            });                
+
+            it('invalid drop if no edit permimssion', () => {
+                folder = getItem('folder');
+                folder.data.permissions.edit = false;
+                assert.equal(Fangorn.isInvalidDropFolder(folder), true);
+            });
+
+            it('invalid drop if no provider', () => {
+                folder = getItem('folder');
+                folder.data.provider = null;
+                assert.equal(Fangorn.isInvalidDropFolder(folder), true);
+            });          
+
+            it('invalid drop if status', () => {
+                folder = getItem('folder');
+                folder.data.status = true;
+                assert.equal(Fangorn.isInvalidDropFolder(folder), true);
+            });
+
+            it('invalid drop if provider dataverse', () => {
+                folder = getItem('folder');
+                folder.data.provider = 'dataverse';
+                assert.equal(Fangorn.isInvalidDropFolder(folder), true);
+            });
+        });
+
+        describe('isInvalidFigshareDropFolder', () => {
+            it('valid drop', () => {
+                assert.equal(Fangorn.isInvalidFigshareDropFolder(getItem('folder')), false);
+            });
+
+            it('valid drop if figshare private', () => {
+                folder = getItem('folder');
+                folder.data.provider = 'figshare';
+                folder.data.extra = {'status': 'private'};
+                assert.equal(Fangorn.isInvalidFigshareDropFolder(folder), false);
+            });
+
+            it('invalid drop if figshare public', () => {
+                folder = getItem('folder');
+                folder.data.provider = 'figshare';
+                folder.data.extra = {'status': 'public'};
+                assert.equal(Fangorn.isInvalidFigshareDropFolder(folder), true);
+            });
+        });
+
+        describe('isInvalidDropItem', () => {
+            it('valid drop', () => {
+                folder = getItem('folder', 2);
+                item = getItem('file', 3);
+                assert.equal(Fangorn.isInvalidDropItem(folder, item, false, false), false);
+            });
+
+            it('invalid drop if nodeType', () => {
+                folder = getItem('folder', 2);
+                item = getItem('folder', 3);
+                item.data.nodeType = 'project';
+                assert.equal(Fangorn.isInvalidDropItem(folder, item, false, false), true);
+            });
+
+            it('invalid drop if isAddonRoot', () => {
+                folder = getItem('folder', 2);
+                item = getItem('file', 3);
+                item.data.isAddonRoot = true;
+                assert.equal(Fangorn.isInvalidDropItem(folder, item, false, false), true);
+            });
+
+            it('invalid drop if item.id same as folder.id', () => {
+                folder = getItem('folder', 2);
+                item = getItem('file', 2);
+                assert.equal(Fangorn.isInvalidDropItem(folder, item, false, false), true);
+            });
+
+            it('invalid drop if item.parentId same as folder.id', () => {
+                folder = getItem('folder', 2);
+                item = getItem('file', 3);
+                item.parentID = 2;
+                assert.equal(Fangorn.isInvalidDropItem(folder, item, false, false), true);
+            });
+
+            it('invalid drop if provider dataverse', () => {
+                folder = getItem('folder', 2);
+                item = getItem('file', 3);
+                item.data.provider = 'dataverse';
+                assert.equal(Fangorn.isInvalidDropItem(folder, item, false, false), true);
+            });
+
+            it('valid drop if can be folder and is folder', () => {
+                folder = getItem('folder', 2);
+                item = getItem('folder', 3);
+                assert.equal(Fangorn.isInvalidDropItem(folder, item, false, false), false);
+            });            
+
+            it('invalid drop if cannot be folder and is folder', () => {
+                folder = getItem('folder', 2);
+                item = getItem('folder', 3);
+                assert.equal(Fangorn.isInvalidDropItem(folder, item, true, false), true);
+            });
+
+            it('valid drop if mustBeIntra and same provider', () => {
+                folder = getItem('folder', 2);
+                folder.data.provider = 'github';
+                item = getItem('file', 3);
+                item.data.provider = 'github';
+                assert.equal(Fangorn.isInvalidDropItem(folder, item, false, true), false);
+            });            
+
+            it('invalid drop if mustBeIntra and not same provider', () => {
+                folder = getItem('folder', 2);
+                item = getItem('file', 3);
+                item.data.provider = 'github';
+                assert.equal(Fangorn.isInvalidDropItem(folder, item, false, true), true);
+            });
+
+            it('valid drop if figshare and private', () => {
+                folder = getItem('folder', 2);
+                item = getItem('folder', 3);
+                item.data.provider = 'figshare';
+                item.data.extra = {};
+                item.data.extra.status = 'private';
+                assert.equal(Fangorn.isInvalidDropItem(folder, item, false, false), false);
+            });
+
+            // it('invalid drop if figshare and public', () => {
+            //     folder = getItem('folder', 2);
+            //     item = getItem('folder', 3);
+            //     item.data.provider = 'figshare';
+            //     item.data.extra = {};
+            //     item.data.extra.status = 'public';
+            //     assert.equal(Fangorn.isInvalidDropItem(folder, item, false, false), true)
+            // });            
+
+        });
+
+        describe('allowedToMove', () => {
+            it('can move', () => {
+                folder = getItem('folder', 2);
+                item = getItem('file', 3);
+                assert.equal(Fangorn.allowedToMove(folder, item, false), true);
+            });
+        });
+    });
+});

--- a/website/static/js/tests/fangorn.test.js
+++ b/website/static/js/tests/fangorn.test.js
@@ -17,6 +17,7 @@ describe('fangorn', () => {
         // folder setup
         var folder;
         var item;
+        var children;
         var getItem = function(kind, id){
             if(typeof id === 'undefined'){
                 id = 2;
@@ -31,9 +32,51 @@ describe('fangorn', () => {
                 },
                 'children': [],
                 'id': id,
-                'parentId': 1,
+                'parentID': 1,
             };
-        }
+        };
+        describe('getCopyMode integration', () => {
+            it('valid move drop', () => {
+                folder = getItem('folder', 2);
+                item = getItem('file', 3);
+                assert.equal(Fangorn.getCopyMode(folder, [item]), 'move');
+            });
+
+            it('valid copy drop', () => {
+                folder = getItem('folder', 2);
+                item = getItem('file', 3);
+                item.data.provider = 'github';
+                assert.equal(Fangorn.getCopyMode(folder, [item]), 'copy');
+            });            
+
+            it('invalid drop in isInvalidDropFolder', () => {
+                folder = getItem('file', 2);
+                item = getItem('file', 3);
+                assert.equal(Fangorn.getCopyMode(folder, [item]), 'forbidden');
+            });
+
+            it('invalid drop in isInvalidFigshareDrop', () => {
+                folder = getItem('folder', 2);
+                folder.data.provider = 'figshare';
+                folder.data.extra = {'status': 'public'};
+                item = getItem('file', 3);
+                assert.equal(Fangorn.getCopyMode(folder, [item]), 'forbidden');
+            });
+
+            it('invalid drop in isInvalidDropItem', () => {
+                folder = getItem('folder', 2);
+                item = getItem('file', 3);
+                item.data.nodeType = 'project';
+                assert.equal(Fangorn.getCopyMode(folder, [item]), 'forbidden');
+            });
+
+            it('invalid parent drop into child', () => {
+                folder = getItem('folder', 2);
+                item = getItem('folder', 3);
+                item.children = [folder];
+                assert.equal(Fangorn.getCopyMode(folder, [item]), 'forbidden');
+            });
+        });
 
         describe('isInvalidDropFolder', () => {
             it('valid drop', () => {
@@ -42,7 +85,7 @@ describe('fangorn', () => {
 
             it('invalid drop if no parent id', () => {
                 folder = getItem('folder');
-                folder.parentId = 0;
+                folder.parentID = 0;
                 assert.equal(Fangorn.isInvalidDropFolder(folder), true);
             });
 
@@ -79,23 +122,23 @@ describe('fangorn', () => {
             });
         });
 
-        describe('isInvalidFigshareDropFolder', () => {
+        describe('isInvalidFigshareDrop', () => {
             it('valid drop', () => {
-                assert.equal(Fangorn.isInvalidFigshareDropFolder(getItem('folder')), false);
+                assert.equal(Fangorn.isInvalidFigshareDrop(getItem('folder')), false);
             });
 
             it('valid drop if figshare private', () => {
                 folder = getItem('folder');
                 folder.data.provider = 'figshare';
-                folder.data.extra = {'status': 'private'};
-                assert.equal(Fangorn.isInvalidFigshareDropFolder(folder), false);
+                folder.data.extra = {'status' : 'private'};
+                assert.equal(Fangorn.isInvalidFigshareDrop(folder), false);
             });
 
             it('invalid drop if figshare public', () => {
                 folder = getItem('folder');
                 folder.data.provider = 'figshare';
-                folder.data.extra = {'status': 'public'};
-                assert.equal(Fangorn.isInvalidFigshareDropFolder(folder), true);
+                folder.data.extra = {'status' : 'public'};
+                assert.equal(Fangorn.isInvalidFigshareDrop(folder), true);
             });
         });
 
@@ -171,19 +214,17 @@ describe('fangorn', () => {
                 folder = getItem('folder', 2);
                 item = getItem('folder', 3);
                 item.data.provider = 'figshare';
-                item.data.extra = {};
-                item.data.extra.status = 'private';
+                item.data.extra = {'status' : 'private'};
                 assert.equal(Fangorn.isInvalidDropItem(folder, item, false, false), false);
             });
 
-            // it('invalid drop if figshare and public', () => {
-            //     folder = getItem('folder', 2);
-            //     item = getItem('folder', 3);
-            //     item.data.provider = 'figshare';
-            //     item.data.extra = {};
-            //     item.data.extra.status = 'public';
-            //     assert.equal(Fangorn.isInvalidDropItem(folder, item, false, false), true)
-            // });            
+            it('invalid drop if figshare and public', () => {
+                folder = getItem('folder', 2);
+                item = getItem('folder', 3);
+                item.data.provider = 'figshare';
+                item.data.extra = {'status' : 'public'};
+                assert.equal(Fangorn.isInvalidDropItem(folder, item, false, false), true)
+            });            
 
         });
 
@@ -193,6 +234,70 @@ describe('fangorn', () => {
                 item = getItem('file', 3);
                 assert.equal(Fangorn.allowedToMove(folder, item, false), true);
             });
+
+            it('cannot move if figshare', () => {
+                folder = getItem('folder', 2);
+                item = getItem('file', 3);
+                item.data.provider = 'figshare';
+                assert.equal(Fangorn.allowedToMove(folder, item, false), false);
+            });
+
+            it('cannot move if edit false', () => {
+                folder = getItem('folder', 2);
+                item = getItem('file', 3);
+                item.data.permissions.edit = false;
+                assert.equal(Fangorn.allowedToMove(folder, item, false), false);
+            });
+
+            it('cannot move if mustBeIntra and not same provider', () => {
+                folder = getItem('folder', 2);
+                item = getItem('file', 3);
+                item.data.provider = 'google';
+                assert.equal(Fangorn.allowedToMove(folder, item, true), false);
+            });
+
+            it('cannot move if mustBeIntra and not same node', () => {
+                folder = getItem('folder', 2);
+                item = getItem('file', 3);
+                folder.data.nodeId = 'abcde';
+                item.data.nodeId = 'ebcde';
+                assert.equal(Fangorn.allowedToMove(folder, item, true), false);
+            });
+
+            it('can move if mustBeIntra and same provider, same node', () => {
+                folder = getItem('folder', 2);
+                item = getItem('file', 3);
+                folder.data.nodeId = 'abcde';
+                item.data.nodeId = 'abcde';
+                assert.equal(Fangorn.allowedToMove(folder, item, true), true);
+            });
+        });
+
+        describe('getAllChildren', () => {
+            it('no children returns empty array', () => {
+                children = Fangorn.getAllChildren(getItem('folder'));
+                assert.equal(children.length, 0);
+            });
+
+            it('One child returns correct array', () => {
+                folder = getItem('folder');
+                folder.children = [getItem('file', 3)]
+                children = Fangorn.getAllChildren(folder);
+                assert.equal(children.length, 1);
+                assert.include(children, 3);
+            });
+
+            it('Two nested child returns correct array', () => {
+                folder = getItem('folder');
+                item = getItem('folder', 3);
+                item.children = [getItem('file', 4)];
+                folder.children = [item];
+                children = Fangorn.getAllChildren(folder);
+                assert.equal(children.length, 2);
+                assert.include(children, 3);
+                assert.include(children, 4);
+            });                
+
         });
     });
 });

--- a/website/static/js/tests/fangorn.test.js
+++ b/website/static/js/tests/fangorn.test.js
@@ -17,7 +17,6 @@ describe('fangorn', () => {
         // folder setup
         var folder;
         var item;
-        var children;
         var getItem = function(kind, id){
             if(typeof id === 'undefined'){
                 id = 2;
@@ -88,6 +87,12 @@ describe('fangorn', () => {
                 folder.parentID = 0;
                 assert.equal(Fangorn.isInvalidDropFolder(folder), true);
             });
+
+            it('invalid drop if inProgress', () => {
+                folder = getItem('folder');
+                folder.inProgress = true;
+                assert.equal(Fangorn.isInvalidDropFolder(folder), true);
+            });            
 
             it('invalid drop if not folder', () => {
                 assert.equal(Fangorn.isInvalidDropFolder(getItem()), true);
@@ -183,6 +188,13 @@ describe('fangorn', () => {
                 assert.equal(Fangorn.isInvalidDropItem(folder, item, false, false), true);
             });
 
+            it('invalid drop if inProgress', () => {
+                folder = getItem('folder', 2);
+                item = getItem('file', 3);
+                item.inProgress = true;
+                assert.equal(Fangorn.isInvalidDropItem(folder, item, false, false), true);
+            });            
+
             it('valid drop if can be folder and is folder', () => {
                 folder = getItem('folder', 2);
                 item = getItem('folder', 3);
@@ -223,7 +235,7 @@ describe('fangorn', () => {
                 item = getItem('folder', 3);
                 item.data.provider = 'figshare';
                 item.data.extra = {'status' : 'public'};
-                assert.equal(Fangorn.isInvalidDropItem(folder, item, false, false), true)
+                assert.equal(Fangorn.isInvalidDropItem(folder, item, false, false), true);
             });            
 
         });
@@ -273,31 +285,28 @@ describe('fangorn', () => {
             });
         });
 
-        describe('getAllChildren', () => {
-            it('no children returns empty array', () => {
-                children = Fangorn.getAllChildren(getItem('folder'));
-                assert.equal(children.length, 0);
+        describe('hasInvalidChildren', () => {
+            it('valid drop if no children', () => {
+                folder = getItem('folder', 2);
+                item = getItem('file', 3);
+                assert.equal(Fangorn.hasInvalidChildren(folder, item), false);
             });
 
-            it('One child returns correct array', () => {
-                folder = getItem('folder');
-                folder.children = [getItem('file', 3)]
-                children = Fangorn.getAllChildren(folder);
-                assert.equal(children.length, 1);
-                assert.include(children, 3);
+            it('invalid drop if item is parent', () => {
+                folder = getItem('folder', 2);
+                item = getItem('file', 3);
+                item.children = [folder];
+                assert.equal(Fangorn.hasInvalidChildren(folder, item), true);
             });
 
-            it('Two nested child returns correct array', () => {
-                folder = getItem('folder');
-                item = getItem('folder', 3);
-                item.children = [getItem('file', 4)];
-                folder.children = [item];
-                children = Fangorn.getAllChildren(folder);
-                assert.equal(children.length, 2);
-                assert.include(children, 3);
-                assert.include(children, 4);
-            });                
-
+            it('invalid drop if child inProgess', () => {
+                folder = getItem('folder', 2);
+                item = getItem('file', 3);
+                var item2 = getItem('file', 4);
+                item2.inProgress = true;
+                item.children = [item2];
+                assert.equal(Fangorn.hasInvalidChildren(folder, item), true);
+            });              
         });
     });
 });

--- a/website/static/js/tests/fangorn.test.js
+++ b/website/static/js/tests/fangorn.test.js
@@ -46,7 +46,14 @@ describe('fangorn', () => {
                 item = getItem('file', 3);
                 item.data.provider = 'github';
                 assert.equal(Fangorn.getCopyMode(folder, [item]), 'copy');
-            });            
+            });
+
+            it('invalid drop if folder.data undefined', () => {
+                folder = getItem('file', 2);
+                delete folder.data;
+                item = getItem('file', 3);
+                assert.equal(Fangorn.getCopyMode(folder, [item]), 'forbidden');
+            });                        
 
             it('invalid drop in isInvalidDropFolder', () => {
                 folder = getItem('file', 2);


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->
## Purpose

There are a number of issues with fangorn moving and dropping that lead to some strange WB issues that should not be able to occur at all. This PR helps block a few of those by locking down files while waiting for the WB ajax to respond before releasing the file. In addition, this includes a number of other fixes and brand new fangorn unit test file testing every bit of the move/copy/forbid logic. 

<!-- Describe the purpose of your changes -->
## Changes
1. Blocks clicking on files that have a pending waterbutler ajax (move/rename/copy) action. This releases when a response is returned. This means that `weird things` can still occur if the 202 'taking longer than expected' modal pops up, but was done this way to avoid infinite lockups that require a page refresh. [OSF-7164]
2. Blocks dragging of folders that have a child with a pending wb action. Folders will just not have any droppable targets allowed. [OSF-7164]
3. Parent folders can no longer be dragged into own children folders [OSF-7162]
4. Fangorn data undefined error on folder moves was occuring in the move/copy/forbidden logic. Returns forbidden if data is undefined. So rarely all drop actions will be disabled if folders are not fully populated when dragging starts [OSF-7162]
5. Add a boat load of unit tests for move/copy/forbidden drag and drop logic.
   <!-- Briefly describe or list your changes  -->
## Side effects
1. Figshare file drop logic was wrong and attempted to allow files in public figshare projects to be copied out. Waterbutler denied these calls. Now drops should be prevented. Private figshare projects might allow dropping out. If this is tested and throws an error, please let me know and I'll disable it.
2. Dropping on files was allowed and actually defaulted to moving the object to the parent of the child. After conferring with Nici and Sara this behavior was removed as it was strange, and possibly lead to some fun edge cases. 
   <!--Any possible side effects? -->
## Ticket

https://openscience.atlassian.net/browse/OSF-7162
https://openscience.atlassian.net/browse/OSF-7163
https://openscience.atlassian.net/browse/OSF-7164
[#OSF-7164]

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
## QA Considerations

This is unfortunately a beast of a changelog for file/folder dragging and dropping. This will probably require testing some addons that have weird move/copy/forbidden behavior. 

The ones that should be tested are figshare, dataverse, and github. Only the actions that result in different behaviors need to be tested for these specific addons (e.g., draft versus published figshare).
