### PR TITLE
Block preprint file deletion or move, remove warnings [OSF-7156]

### DIFF
--- a/api/files/permissions.py
+++ b/api/files/permissions.py
@@ -25,7 +25,7 @@ class IsPreprintFile(permissions.BasePermission):
     def has_object_permission(self, request, view, obj):
         assert isinstance(obj, FileNode), 'obj must be a FileNode, got {}'.format(obj)
 
-        if request.method not in permissions.SAFE_METHODS and len(Node.find(Q('preprint_file', 'eq', obj))):
+        if request.method not in permissions.SAFE_METHODS and len(Node.find(Q('preprint_file', 'eq', obj) & Q('_has_abandoned_preprint', 'eq', False))):
             return False
 
         return True

--- a/api/files/permissions.py
+++ b/api/files/permissions.py
@@ -1,7 +1,9 @@
+from modularodm import Q
 from rest_framework import permissions
 
 from api.base.utils import get_user_auth
 from website.files.models import FileNode
+from website.models import Node
 
 class CheckedOutOrAdmin(permissions.BasePermission):
     def has_object_permission(self, request, view, obj):
@@ -17,3 +19,16 @@ class CheckedOutOrAdmin(permissions.BasePermission):
         return obj.checkout is None \
             or obj.checkout == auth.user \
             or obj.node.has_permission(auth.user, 'admin')
+
+
+class IsPreprintFile(permissions.BasePermission):
+    def has_object_permission(self, request, view, obj):
+        assert isinstance(obj, FileNode), 'obj must be a FileNode, got {}'.format(obj)
+
+        if request.method not in permissions.SAFE_METHODS and len(Node.find(Q('preprint_file', 'eq', obj))):
+            return False
+
+        return True
+
+        
+

--- a/api/files/permissions.py
+++ b/api/files/permissions.py
@@ -1,9 +1,7 @@
-from modularodm import Q
 from rest_framework import permissions
 
 from api.base.utils import get_user_auth
 from website.files.models import FileNode
-from website.models import Node
 
 class CheckedOutOrAdmin(permissions.BasePermission):
     def has_object_permission(self, request, view, obj):
@@ -25,7 +23,7 @@ class IsPreprintFile(permissions.BasePermission):
     def has_object_permission(self, request, view, obj):
         assert isinstance(obj, FileNode), 'obj must be a FileNode, got {}'.format(obj)
 
-        if request.method not in permissions.SAFE_METHODS and len(Node.find(Q('preprint_file', 'eq', obj) & Q('_has_abandoned_preprint', 'eq', False))):
+        if request.method not in permissions.SAFE_METHODS and obj.node.preprint_file == obj and not obj.node._has_abandoned_preprint:
             return False
 
         return True

--- a/api/files/permissions.py
+++ b/api/files/permissions.py
@@ -29,6 +29,3 @@ class IsPreprintFile(permissions.BasePermission):
             return False
 
         return True
-
-        
-

--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -142,6 +142,7 @@ class FileSerializer(JSONAPISerializer):
     tags = JSONAPIListField(child=FileTagField(), required=False)
     current_user_can_comment = ser.SerializerMethodField(help_text='Whether the current user is allowed to post comments')
     current_version = ser.SerializerMethodField(help_text='Latest file version')
+    delete_allowed = ser.BooleanField(read_only=True, required=False)
 
     files = NodeFileHyperLinkField(
         related_view='nodes:node-files',

--- a/api/files/views.py
+++ b/api/files/views.py
@@ -19,6 +19,7 @@ from api.base.views import JSONAPIBaseView
 from api.base import permissions as base_permissions
 from api.nodes.permissions import ContributorOrPublic
 from api.nodes.permissions import ReadOnlyIfRegistration
+from api.files.permissions import IsPreprintFile
 from api.files.permissions import CheckedOutOrAdmin
 from api.files.serializers import FileSerializer
 from api.files.serializers import FileDetailSerializer
@@ -310,6 +311,7 @@ class FileDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView, FileMixin):
     """
     permission_classes = (
         drf_permissions.IsAuthenticatedOrReadOnly,
+        IsPreprintFile,
         CheckedOutOrAdmin,
         base_permissions.TokenHasScope,
         PermissionWithGetter(ContributorOrPublic, 'node'),

--- a/api_tests/users/views/test_user_nodes_list.py
+++ b/api_tests/users/views/test_user_nodes_list.py
@@ -115,7 +115,6 @@ class TestUserNodesPreprintsFiltering(ApiTestCase):
         self.valid_preprint = PreprintFactory(project=self.valid_preprint_node)
         self.abandoned_preprint = PreprintFactory(project=self.abandoned_preprint_node, is_published=False)
         self.orphaned_preprint = PreprintFactory(project=self.orphaned_preprint_node)
-        self.orphaned_preprint.node.preprint_file.wrapped().delete()
         self.orphaned_preprint.node._is_preprint_orphan = True
         self.orphaned_preprint.node.save()
 

--- a/website/addons/osfstorage/tests/test_models.py
+++ b/website/addons/osfstorage/tests/test_models.py
@@ -512,6 +512,21 @@ class TestOsfstorageFileNode(StorageTestCase):
             '/'+folder._id, provider='osfstorage', node=node)
         assert [] == all_guids
 
+    def test_delete_allowed(self):
+        node = self.node_settings.owner
+        file = models.OsfStorageFile(name='Godspeed', node=node)
+        file.save()
+        assert_true(file.delete_allowed)
+        node.preprint_file = file.stored_object
+        node.save()
+        assert_false(file.delete_allowed)
+        node._has_abandoned_preprint = True
+        node.save()
+        assert_true(file.delete_allowed)
+        file.check_in_or_out(self.user, self.user, save=True)
+        file.save()
+        assert_false(file.delete_allowed)
+
 
 class TestNodeSettingsModel(StorageTestCase):
 

--- a/website/addons/osfstorage/tests/test_views.py
+++ b/website/addons/osfstorage/tests/test_views.py
@@ -577,6 +577,15 @@ class TestDeleteHook(HookTestCase):
         res = self.delete(file_checked, expect_errors=True)
         assert_equal(res.status_code, 403)
 
+    def test_attempt_delete_while_preprint(self):
+        file = self.root_node.append_file('Nights')
+        self.node.preprint_file = file.stored_object
+        self.node.save()
+        res = self.delete(file, expect_errors=True)
+
+        assert_equal(res.status_code, 405)
+
+
 class TestMoveHook(HookTestCase):
 
     def setUp(self):
@@ -626,6 +635,31 @@ class TestMoveHook(HookTestCase):
             expect_errors=True,
         )
         assert_equal(res.status_code, 405)
+
+    def test_attempt_move_while_preprint(self):
+
+        file = self.root_node.append_file('Self Control')
+        self.node.preprint_file = file.stored_object
+        self.node.save()
+        folder = self.root_node.append_folder('Frank Ocean')
+        res = self.send_hook(
+            'osfstorage_move_hook',
+            {'nid': self.root_node.node._id},
+            payload={
+                'source': file._id,
+                'node': self.root_node._id,
+                'user': self.user._id,
+                'destination': {
+                    'parent': folder._id,
+                    'node': folder.node._id,
+                    'name': folder.name,
+                }
+            },
+            method='post_json',
+            expect_errors=True,
+        )
+        assert_equal(res.status_code, 403)
+
 
 class TestFileTags(StorageTestCase):
 

--- a/website/addons/osfstorage/tests/test_views.py
+++ b/website/addons/osfstorage/tests/test_views.py
@@ -583,7 +583,7 @@ class TestDeleteHook(HookTestCase):
         self.node.save()
         res = self.delete(file, expect_errors=True)
 
-        assert_equal(res.status_code, 405)
+        assert_equal(res.status_code, 403)
 
 
 class TestMoveHook(HookTestCase):

--- a/website/addons/osfstorage/views.py
+++ b/website/addons/osfstorage/views.py
@@ -102,7 +102,7 @@ def osfstorage_move_hook(source, destination, name=None, **kwargs):
             'message_long': 'Cannot move file as it is checked out.'
         })
     except exceptions.FileNodeIsPrimaryFile:
-        raise HTTPError(httplib.METHOD_NOT_ALLOWED, data={
+        raise HTTPError(httplib.FORBIDDEN, data={
             'message_long': 'Cannot move file as it is the primary file of preprint.'
         })
 
@@ -223,7 +223,7 @@ def osfstorage_delete(file_node, payload, node_addon, **kwargs):
     except exceptions.FileNodeCheckedOutError:
         raise HTTPError(httplib.FORBIDDEN)
     except exceptions.FileNodeIsPrimaryFile:
-        raise HTTPError(httplib.FORBIDDEN, data={
+        raise HTTPError(httplib.METHOD_NOT_ALLOWED, data={
             'message_long': 'Cannot delete file as it is the primary file of preprint.'
         })
 

--- a/website/addons/osfstorage/views.py
+++ b/website/addons/osfstorage/views.py
@@ -223,7 +223,7 @@ def osfstorage_delete(file_node, payload, node_addon, **kwargs):
     except exceptions.FileNodeCheckedOutError:
         raise HTTPError(httplib.FORBIDDEN)
     except exceptions.FileNodeIsPrimaryFile:
-        raise HTTPError(httplib.METHOD_NOT_ALLOWED, data={
+        raise HTTPError(httplib.FORBIDDEN, data={
             'message_long': 'Cannot delete file as it is the primary file of preprint.'
         })
 

--- a/website/addons/osfstorage/views.py
+++ b/website/addons/osfstorage/views.py
@@ -224,7 +224,7 @@ def osfstorage_delete(file_node, payload, node_addon, **kwargs):
         raise HTTPError(httplib.FORBIDDEN)
     except exceptions.FileNodeIsPrimaryFile:
         raise HTTPError(httplib.FORBIDDEN, data={
-            'message_long': 'Cannot move file as it is the primary file of preprint.'
+            'message_long': 'Cannot delete file as it is the primary file of preprint.'
         })
 
     return {'status': 'success'}

--- a/website/addons/osfstorage/views.py
+++ b/website/addons/osfstorage/views.py
@@ -101,6 +101,11 @@ def osfstorage_move_hook(source, destination, name=None, **kwargs):
         raise HTTPError(httplib.METHOD_NOT_ALLOWED, data={
             'message_long': 'Cannot move file as it is checked out.'
         })
+    except exceptions.FileNodeIsPrimaryFile:
+        raise HTTPError(httplib.METHOD_NOT_ALLOWED, data={
+            'message_long': 'Cannot move file as it is the primary file of preprint.'
+        })
+
 
 @must_be_signed
 @decorators.autoload_filenode(default_root=True)
@@ -217,6 +222,10 @@ def osfstorage_delete(file_node, payload, node_addon, **kwargs):
 
     except exceptions.FileNodeCheckedOutError:
         raise HTTPError(httplib.FORBIDDEN)
+    except exceptions.FileNodeIsPrimaryFile:
+        raise HTTPError(httplib.FORBIDDEN, data={
+            'message_long': 'Cannot move file as it is the primary file of preprint.'
+        })
 
     return {'status': 'success'}
 

--- a/website/files/exceptions.py
+++ b/website/files/exceptions.py
@@ -16,3 +16,7 @@ class FileNodeCheckedOutError(FileException):
     out, or if any of its children is checked out
     '''
     pass
+
+
+class FileNodeIsPrimaryFile(FileException):
+    pass

--- a/website/files/models/osfstorage.py
+++ b/website/files/models/osfstorage.py
@@ -107,12 +107,23 @@ class OsfStorageFileNode(FileNode):
     def is_checked_out(self):
         return self.checkout is not None
 
-    def delete(self, user=None, parent=None):
+    @property
+    def _delete_allowed(self):
         if self.node.preprint_file == self and not self.node._has_abandoned_preprint:
             raise exceptions.FileNodeIsPrimaryFile()
         if self.is_checked_out:
             raise exceptions.FileNodeCheckedOutError()
-        return super(OsfStorageFileNode, self).delete(user=user, parent=parent)
+        return True
+
+    @property
+    def delete_allowed(self):
+        try:
+            return self._delete_allowed
+        except:
+            return False
+
+    def delete(self, user=None, parent=None):
+        return super(OsfStorageFileNode, self).delete(user=user, parent=parent) if self._delete_allowed else None
 
     def move_under(self, destination_parent, name=None):
         if self.node.preprint_file == self and not self.node._has_abandoned_preprint:

--- a/website/files/models/osfstorage.py
+++ b/website/files/models/osfstorage.py
@@ -108,14 +108,14 @@ class OsfStorageFileNode(FileNode):
         return self.checkout is not None
 
     def delete(self, user=None, parent=None):
-        if self.node.preprint_file == self:
+        if self.node.preprint_file == self and not self.node._has_abandoned_preprint:
             raise exceptions.FileNodeIsPrimaryFile()
         if self.is_checked_out:
             raise exceptions.FileNodeCheckedOutError()
         return super(OsfStorageFileNode, self).delete(user=user, parent=parent)
 
     def move_under(self, destination_parent, name=None):
-        if self.node.preprint_file == self:
+        if self.node.preprint_file == self and not self.node._has_abandoned_preprint:
             raise exceptions.FileNodeIsPrimaryFile()
         if self.is_checked_out:
             raise exceptions.FileNodeCheckedOutError()

--- a/website/files/models/osfstorage.py
+++ b/website/files/models/osfstorage.py
@@ -127,6 +127,7 @@ class OsfStorageFileNode(FileNode):
 
     def move_under(self, destination_parent, name=None):
         if self.node.preprint_file == self and not self.node._has_abandoned_preprint:
+            self.copy_under(destination_parent, name)
             raise exceptions.FileNodeIsPrimaryFile()
         if self.is_checked_out:
             raise exceptions.FileNodeCheckedOutError()

--- a/website/files/models/osfstorage.py
+++ b/website/files/models/osfstorage.py
@@ -127,7 +127,6 @@ class OsfStorageFileNode(FileNode):
 
     def move_under(self, destination_parent, name=None):
         if self.node.preprint_file == self and not self.node._has_abandoned_preprint:
-            self.copy_under(destination_parent, name)
             raise exceptions.FileNodeIsPrimaryFile()
         if self.is_checked_out:
             raise exceptions.FileNodeCheckedOutError()

--- a/website/files/models/osfstorage.py
+++ b/website/files/models/osfstorage.py
@@ -109,13 +109,14 @@ class OsfStorageFileNode(FileNode):
 
     def delete(self, user=None, parent=None):
         if self.node.preprint_file == self:
-            self.node._is_preprint_orphan = True
-            self.node.save()
+            raise exceptions.FileNodeIsPrimaryFile()
         if self.is_checked_out:
             raise exceptions.FileNodeCheckedOutError()
         return super(OsfStorageFileNode, self).delete(user=user, parent=parent)
 
     def move_under(self, destination_parent, name=None):
+        if self.node.preprint_file == self:
+            raise exceptions.FileNodeIsPrimaryFile()
         if self.is_checked_out:
             raise exceptions.FileNodeCheckedOutError()
         return super(OsfStorageFileNode, self).move_under(destination_parent, name)

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -432,13 +432,7 @@ function checkConflicts(tb, item, folder, cb) {
         var child = folder.children[i];
         if (child.data.name === item.data.name && child.id !== item.id) {
             messageArray.push(m('p', 'An item named "' + child.data.name + '" already exists in this location.'));
-
-            if (window.contextVars.node.preprintFileId === child.data.path.replace('/', '')) {
-                messageArray = messageArray.concat([
-                    m('p', 'The file "' + child.data.name + '" is the primary file for a preprint, so it should not be replaced.'),
-                    m('strong', 'Replacing this file will remove this preprint from circulation.')
-                ]);
-            }
+            
             tb.modal.update(
                 m('', messageArray), [
                     m('span.btn.btn-default', {onclick: function() {tb.modal.dismiss();}}, 'Cancel'), //jshint ignore:line
@@ -590,8 +584,8 @@ function doItemOp(operation, to, from, rename, conflict) {
 
         var message;
 
-        if (xhr.status !== 500 && xhr.responseJSON && xhr.responseJSON.message) {
-            message = xhr.responseJSON.message;
+        if (xhr.status !== 500 && xhr.responseJSON && (xhr.responseJSON.message || xhr.responseJSON.message_long)) {
+            message = xhr.responseJSON.message || xhr.responseJSON.message_long;
         } else if (xhr.status === 503) {
             message = textStatus;
         } else {
@@ -1055,6 +1049,9 @@ function _removeEvent (event, items, col) {
         .fail(function(data){
             tb.modal.dismiss();
             tb.clearMultiselect();
+            if (data.responseJSON.message_long.indexOf('preprint') !== -1) {
+                $osf.growl('Delete failed', data.responseJSON.message_long);
+            }
             item.notify.update('Delete failed.', 'danger', undefined, 3000);
         });
     }
@@ -1084,13 +1081,6 @@ function _removeEvent (event, items, col) {
     // If there is only one item being deleted, don't complicate the issue:
     if(items.length === 1) {
         var detail = 'This action is irreversible.';
-        if (window.contextVars.node.preprintFileId === items[0].data.path.replace('/', '')) {
-            // title = 'Delete the primary preprint file "' + items[0].data.name + '"?';
-            detail = [
-                m('p', 'This is the primary file for a preprint.'),
-                m('p', m('strong', 'Deleting this file will remove this preprint from circulation.'))
-            ];
-        }
         if(items[0].kind !== 'folder'){
             var mithrilContentSingle = m('div', [
                 m('p', detail)
@@ -1128,12 +1118,6 @@ function _removeEvent (event, items, col) {
             }
             if(item.kind === 'folder' && deleteMessage.length === 1) {
                 deleteMessage.push(m('p.text-danger', 'Some of the selected items are folders. This will delete the folder(s) and ALL of their content.'));
-            }
-            if (window.contextVars.node.preprintFileId === item.data.path.replace('/', '')) {
-                deleteMessage.push([
-                    m('p', 'One of the files you have selected is the primary file for a preprint.'),
-                    m('p', m('strong', 'Deleting this file will remove this preprint from circulation.'))
-                ]);
             }
         });
         // If all items can be deleted
@@ -2311,27 +2295,6 @@ function _dropLogic(event, items, folder) {
     }
 
     $.each(items, function(index, item) {
-        // Check all the ways that the primary preprint file could be moved out of its current node
-        // TODO: this will break when preprints can be created from existing projects -- it relies on
-        //     the fact that the current node is the preprint, not and node in the component tree. [#PREP-132]
-        if (
-            window.contextVars.node.preprintFileId === item.data.path.replace('/', '') &&
-            item.data.nodeId === window.contextVars.node.id &&
-            (folder.data.nodeId !== window.contextVars.node.id || folder.data.provider !== 'osfstorage')
-        ) {
-            tb.modal.update(m('', [
-                m('p', 'The file "' + item.data.name + '" is the primary file for a preprint and so should not be moved.'),
-                m('strong', 'Moving this file will remove this preprint from circulation.')
-            ]), m('', [
-                m('span.btn.btn-default', {onclick: function() {tb.modal.dismiss();}}, 'Cancel'), // jshint ignore:line
-                m('span.btn.btn-default', {onclick: function() {
-                        checkConflicts(tb, item, folder, doItemOp.bind(tb, copyMode === 'move' ? OPERATIONS.MOVE : OPERATIONS.COPY, folder, item, undefined));
-                }}, 'Move anyway'), // jshint ignore:line
-
-            ]), m('h3.break-word.modal-title', 'Move "' + item.data.name + '"?'));
-            return;
-        }
-
         checkConflicts(tb, item, folder, doItemOp.bind(tb, copyMode === 'move' ? OPERATIONS.MOVE : OPERATIONS.COPY, folder, item, undefined));
     });
 }

--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -179,13 +179,7 @@ var FileViewPage = {
                     'Are you sure you want to delete <strong>' +
                     self.file.safeName + '</strong>?' + '</p>';
 
-            if (self.file.id === self.node.preprintFileId) {
-                title = 'Delete primary preprint file?';
-                message = '<p class="overflow">' +
-                    'Are you sure you want to delete <strong>' +
-                    self.file.safeName + '</strong>?' + ' It is currently the primary file ' +
-                    'for a preprint.</p> <p><strong>Deleting this file will remove this preprint from circulation.</strong></p>';
-            }
+
             bootbox.confirm({
                 title: title,
                 message: message,

--- a/website/static/js/projectSettings.js
+++ b/website/static/js/projectSettings.js
@@ -158,11 +158,6 @@ var getConfirmationCode = function(nodeType) {
     // point; only construct the HTML for the list of contributors if the contribs list is populated
     var message = '<p>It will no longer be available to other contributors on the project.';
 
-    if (window.contextVars.node.isPreprint) {
-        message += '<p>This project represents a preprint.</p>' +
-            '<p><strong>Deleting this project will remove the preprint from circulation.</strong></p>';
-    }
-
     $osf.confirmDangerousAction({
         title: 'Are you sure you want to delete this ' + nodeType + '?',
         message: message,


### PR DESCRIPTION


## Purpose
Prevent the deletion of preprints (or making it an orphan preprint) by not allowing the primary file of preprints to be deleted or moved to another folder, component or addon.

## Changes
Remove all the preprint related file operation warnings. As a replacement, when such actions fail, a growl message informs the user that such action is prohibited due to preprint status.

## Side effects
Preprint files can no longer be moved into folders or deleted, from apiV2 or the OSF web client.

## Ticket

https://openscience.atlassian.net/browse/OSF-7156
