### PR TITLE
[hotfix] Fix Custom Throttle Classes [OSF-7189]

### DIFF
--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -115,7 +115,7 @@ REST_FRAMEWORK = {
     'DEFAULT_THROTTLE_RATES': {
         'user': '10000/day',
         'non-cookie-auth': '100/hour',
-        'add-contributor': '10/hour',
+        'add-contributor': '10/second',
         'create-guid': '1000/hour',
         'root-anon-throttle': '1000/hour',
         'test-user': '2/hour',

--- a/api/base/throttling.py
+++ b/api/base/throttling.py
@@ -3,9 +3,6 @@ from rest_framework.throttling import UserRateThrottle, AnonRateThrottle, Simple
 
 class BaseThrottle(SimpleRateThrottle):
 
-    def failure(self, request):
-        return False
-
     def allow_request(self, request, view):
         """
         Implement the check to see if the request should be throttled.
@@ -25,7 +22,7 @@ class BaseThrottle(SimpleRateThrottle):
             self.history.pop()
 
         if len(self.history) >= self.num_requests:
-            return self.failure(request)
+            return self.throttle_failure()
         return self.throttle_success()
 
 
@@ -33,27 +30,42 @@ class NonCookieAuthThrottle(BaseThrottle, AnonRateThrottle):
 
     scope = 'non-cookie-auth'
 
-    def failure(self, request):
-        return bool(request.COOKIES)
+    def allow_request(self, request, view):
+        """
+        Allow all unauthenticated requests that are made with a cookie.
+        """
+        if bool(request.COOKIES):
+            return True
+
+        super(NonCookieAuthThrottle, self).allow_request(request, view)
 
 
 class AddContributorThrottle(BaseThrottle, UserRateThrottle):
 
     scope = 'add-contributor'
 
-    def failure(self, request):
-        if request.method == 'POST' and request.query_params.get('send_email') != 'false':
-            return False
-        return True
+    def allow_request(self, request, view):
+        """
+        Allow all add contributor requests that do not send contributor emails.
+        """
+        if not request.method == 'POST' and not request.query_params.get('send_email') != 'false':
+            return True
+
+        super(AddContributorThrottle, self).allow_request(request, view)
+
 
 class CreateGuidThrottle(BaseThrottle, UserRateThrottle):
 
     scope = 'create-guid'
 
-    def failure(self, request):
-        if request.query_params.get('create_guid'):
-            return False
-        return True
+    def allow_request(self, request, view):
+        """
+        Allow all create file requests that do not create new guids.
+        """
+        if not request.query_params.get('create_guid'):
+            return True
+
+        super(CreateGuidThrottle, self).allow_request(request, view)
 
 
 class RootAnonThrottle(AnonRateThrottle):

--- a/api/base/throttling.py
+++ b/api/base/throttling.py
@@ -48,7 +48,7 @@ class AddContributorThrottle(BaseThrottle, UserRateThrottle):
         """
         Allow all add contributor requests that do not send contributor emails.
         """
-        if not request.method == 'POST' and not request.query_params.get('send_email') != 'false':
+        if request.method == 'POST' and request.query_params.get('send_email') == 'false':
             return True
 
         return super(AddContributorThrottle, self).allow_request(request, view)

--- a/api/base/throttling.py
+++ b/api/base/throttling.py
@@ -37,7 +37,7 @@ class NonCookieAuthThrottle(BaseThrottle, AnonRateThrottle):
         if bool(request.COOKIES):
             return True
 
-        super(NonCookieAuthThrottle, self).allow_request(request, view)
+        return super(NonCookieAuthThrottle, self).allow_request(request, view)
 
 
 class AddContributorThrottle(BaseThrottle, UserRateThrottle):
@@ -51,7 +51,7 @@ class AddContributorThrottle(BaseThrottle, UserRateThrottle):
         if not request.method == 'POST' and not request.query_params.get('send_email') != 'false':
             return True
 
-        super(AddContributorThrottle, self).allow_request(request, view)
+        return super(AddContributorThrottle, self).allow_request(request, view)
 
 
 class CreateGuidThrottle(BaseThrottle, UserRateThrottle):
@@ -65,7 +65,7 @@ class CreateGuidThrottle(BaseThrottle, UserRateThrottle):
         if not request.query_params.get('create_guid'):
             return True
 
-        super(CreateGuidThrottle, self).allow_request(request, view)
+        return super(CreateGuidThrottle, self).allow_request(request, view)
 
 
 class RootAnonThrottle(AnonRateThrottle):


### PR DESCRIPTION
#### Purpose
- Previously, **all** requests were contributing to the throttle counts of our custom throttle classes, not just the undesired ones. This PR overrides `allow_request` in each throttle class so that only the bad requests are processed further by `BaseThrottle.allow_request()` and added to the request history.  
- Also, the throttle rate for adding contributors somehow became 10 requests/hour (probably my bad), it's back to 10 requests/second now. 

#### Side effects
- Better throttling. 

#### Ticket
- [OSF-7189](https://openscience.atlassian.net/browse/OSF-7189)
