### PR TITLE
[djangosf] Update addon API tests

### DIFF
--- a/addons/base/apps.py
+++ b/addons/base/apps.py
@@ -36,6 +36,8 @@ class BaseAddonConfig(AppConfig):
     node_settings_template = NODE_SETTINGS_TEMPLATE_DEFAULT
     user_settings_template = USER_SETTINGS_TEMPLATE_DEFAULT
     views = []
+    added_default = []
+    added_mandatory = []
     include_js = {}  # TODO: Deprecate these elsewhere and remove
     include_css = {}  # TODO: Deprecate these elsewhere and remove
     configs = []

--- a/addons/osfstorage/apps.py
+++ b/addons/osfstorage/apps.py
@@ -11,6 +11,8 @@ class OSFStorageAddonConfig(BaseAddonConfig):
     label = 'addons_osfstorage'
     full_name = 'OSFStorage'
     short_name = 'osfstorage'
+    added_default = ['node']
+    added_mandatory = ['node']
 
     has_hgrid_files = True
 

--- a/api/nodes/permissions.py
+++ b/api/nodes/permissions.py
@@ -2,7 +2,7 @@
 from rest_framework import permissions
 from rest_framework import exceptions
 
-from website.addons.base import AddonSettingsBase
+from addons.base.models import BaseAddonSettings
 from website.models import Node, Pointer, User, Institution, DraftRegistration, PrivateLink
 from website.project.metadata.utils import is_prereg_admin
 from website.util import permissions as osf_permissions
@@ -13,7 +13,7 @@ from api.base.utils import get_user_auth, is_deprecated
 class ContributorOrPublic(permissions.BasePermission):
 
     def has_object_permission(self, request, view, obj):
-        if isinstance(obj, AddonSettingsBase):
+        if isinstance(obj, BaseAddonSettings):
             obj = obj.owner
         assert isinstance(obj, (Node, Pointer)), 'obj must be a Node, Pointer, or AddonSettings; got {}'.format(obj)
         auth = get_user_auth(request)
@@ -55,7 +55,7 @@ class IsAdminOrReviewer(permissions.BasePermission):
 class AdminOrPublic(permissions.BasePermission):
 
     def has_object_permission(self, request, view, obj):
-        assert isinstance(obj, (Node, User, Institution, AddonSettingsBase, DraftRegistration, PrivateLink)), 'obj must be a Node, User, Institution, Draft Registration, PrivateLink, or AddonSettings; got {}'.format(obj)
+        assert isinstance(obj, (Node, User, Institution, BaseAddonSettings, DraftRegistration, PrivateLink)), 'obj must be a Node, User, Institution, Draft Registration, PrivateLink, or AddonSettings; got {}'.format(obj)
         auth = get_user_auth(request)
         node = Node.load(request.parser_context['kwargs'][view.node_lookup_url_kwarg])
         if request.method in permissions.SAFE_METHODS:

--- a/api_tests/users/views/test_user_addons.py
+++ b/api_tests/users/views/test_user_addons.py
@@ -1,23 +1,24 @@
 # -*- coding: utf-8 -*-
 import abc
-import pytest
 from nose.tools import *  # flake8: noqa
 import re
+import pytest
 
 from api.base.settings.defaults import API_BASE
 
 from tests.base import ApiAddonTestCase
 from osf_tests.factories import AuthUserFactory
 
-from website.addons.box.tests.factories import BoxAccountFactory
-from website.addons.dataverse.tests.factories import DataverseAccountFactory
-from website.addons.dropbox.tests.factories import DropboxAccountFactory
-from website.addons.github.tests.factories import GitHubAccountFactory
-from website.addons.googledrive.tests.factories import GoogleDriveAccountFactory
+from addons.box.tests.factories import BoxAccountFactory
+from addons.dataverse.tests.factories import DataverseAccountFactory
+from addons.dropbox.tests.factories import DropboxAccountFactory
+from addons.github.tests.factories import GitHubAccountFactory
+from addons.googledrive.tests.factories import GoogleDriveAccountFactory
+from addons.s3.tests.factories import S3AccountFactory
+from addons.owncloud.tests.factories import OwnCloudAccountFactory
 from website.addons.mendeley.tests.factories import MendeleyAccountFactory
-from website.addons.s3.tests.factories import S3AccountFactory
 from website.addons.zotero.tests.factories import ZoteroAccountFactory
-from website.addons.owncloud.tests.factories import OwnCloudAccountFactory
+
 
 class UserAddonListMixin(object):
     def set_setting_list_url(self):
@@ -403,7 +404,6 @@ class TestUserGoogleDriveAddon(UserOAuthAddonTestSuiteMixin, ApiAddonTestCase):
     short_name = 'googledrive'
     AccountFactory = GoogleDriveAccountFactory
 
-
 @pytest.mark.skip('Unskip when zotero addon is implemented')
 class TestUserMendeleyAddon(UserOAuthAddonTestSuiteMixin, ApiAddonTestCase):
     short_name = 'mendeley'
@@ -413,7 +413,6 @@ class TestUserMendeleyAddon(UserOAuthAddonTestSuiteMixin, ApiAddonTestCase):
 class TestUserS3Addon(UserOAuthAddonTestSuiteMixin, ApiAddonTestCase):
     short_name = 's3'
     AccountFactory = S3AccountFactory
-
 
 @pytest.mark.skip('Unskip when zotero addon is implemented')
 class TestUserZoteroAddon(UserOAuthAddonTestSuiteMixin, ApiAddonTestCase):

--- a/tests/base.py
+++ b/tests/base.py
@@ -396,9 +396,9 @@ class ApiAddonTestCase(ApiTestCase):
             ProjectFactory,
             AuthUserFactory,
         )
-        from.addons.base.models import (
-            BaseOAuthUserSettings,
-            BaseOAuthNodeSettings
+        from addons.base.models import (
+            BaseOAuthNodeSettings,
+            BaseOAuthUserSettings
         )
         assert self.addon_type in ('CONFIGURABLE', 'OAUTH', 'UNMANAGEABLE', 'INVALID')
         self.account = None
@@ -424,6 +424,8 @@ class ApiAddonTestCase(ApiTestCase):
         if self.addon_type in ('OAUTH', 'CONFIGURABLE'):
             assert isinstance(self.node_settings, BaseOAuthNodeSettings)
             assert isinstance(self.user_settings, BaseOAuthUserSettings)
+            self.node_settings.reload()
+            self.user_settings.reload()
 
         self.account_id = self.account._id if self.account else None
         self.set_urls()


### PR DESCRIPTION
## Purpose
Fix `test_(node|user)_addons` tests

## Changes
* Fix bug causing OSFStorage to not be added to nodes
* Use correct models when checking permissions in the API
* Update tests

## Side effects
We should probably get the test suite running more quickly

```
~/D/osf.io ❯ DJANGO_SETTINGS_MODULE=api.base.settings py.test api_tests/nodes/views/test_node_addons.py api_tests/users/views/test_user_addons.py -s
.......................................................................................................................................................................................................................................ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss.sssss.ss.sssssss..ssssssssssssss.ssssssss.sssssss..ssssssssssssss.ssssssss.sssssss..ssss.sssssssss.sssss.ss.sssssss..ssss.sssssssss.sssss..sss..sssssss..sssssssssssssssssssssssssssssssssssssss........................................................................................................................................................................................................................................................................................ssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss
===================== 538 passed, 382 skipped in 654.53 seconds =====================