### PR TITLE
[djangosf] Add remaining Box tests

### DIFF
--- a/addons/box/tests/test_client.py
+++ b/addons/box/tests/test_client.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from nose.tools import assert_true
+import pytest
+import unittest
+
+from osf_tests.factories import UserFactory
+
+from addons.box.models import UserSettings
+
+pytestmark = pytest.mark.django_db
+
+class TestCore(unittest.TestCase):
+
+    def setUp(self):
+
+        super(TestCore, self).setUp()
+
+        self.user = UserFactory()
+        self.user.add_addon('box')
+        self.user.save()
+
+        self.settings = self.user.get_addon('box')
+        self.settings.save()
+
+    def test_get_addon_returns_box_user_settings(self):
+        result = self.user.get_addon('box')
+        assert_true(isinstance(result, UserSettings))

--- a/addons/box/tests/test_serializer.py
+++ b/addons/box/tests/test_serializer.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+"""Serializer tests for the Box addon."""
+import mock
+import pytest
+
+from addons.base.tests.serializers import StorageAddonSerializerTestSuiteMixin
+from addons.box.tests.utils import MockBox
+from addons.box.tests.factories import BoxAccountFactory
+from tests.base import OsfTestCase
+from website.addons.box.serializer import BoxSerializer
+
+mock_client = MockBox()
+pytestmark = pytest.mark.django_db
+
+class TestBoxSerializer(StorageAddonSerializerTestSuiteMixin, OsfTestCase):
+
+    addon_short_name = 'box'
+
+    Serializer = BoxSerializer
+    ExternalAccountFactory = BoxAccountFactory
+    client = mock_client
+
+    def setUp(self):
+        self.mock_valid = mock.patch.object(
+            BoxSerializer,
+            'credentials_are_valid',
+            return_value=True
+        )
+        self.mock_valid.start()
+        super(TestBoxSerializer, self).setUp()
+
+    def tearDown(self):
+        self.mock_valid.stop()
+        super(TestBoxSerializer, self).tearDown()
+
+    def set_provider_id(self, pid):
+        self.node_settings.folder_id = pid

--- a/addons/box/tests/test_views.py
+++ b/addons/box/tests/test_views.py
@@ -1,0 +1,218 @@
+# -*- coding: utf-8 -*-
+"""Views tests for the Box addon."""
+from django.utils import timezone
+import httplib
+from nose.tools import *  # noqa (PEP8 asserts)
+import mock
+import pytest
+from urllib3.exceptions import MaxRetryError
+
+from framework.auth import Auth
+from website.util import api_url_for
+from box.client import BoxClientException
+from tests.base import OsfTestCase
+from osf_tests.factories import AuthUserFactory
+from addons.base.tests import views as views_testing
+
+from addons.box.models import NodeSettings
+from website.addons.box.serializer import BoxSerializer
+from addons.box.tests.utils import (
+    BoxAddonTestCase,
+    MockBox,
+    patch_client
+)
+
+mock_client = MockBox()
+pytestmark = pytest.mark.django_db
+
+class TestAuthViews(BoxAddonTestCase, views_testing.OAuthAddonAuthViewsTestCaseMixin, OsfTestCase):
+
+    def setUp(self):
+        self.mock_refresh = mock.patch("addons.box.models.Provider.refresh_oauth_key")
+        self.mock_refresh.return_value = True
+        self.mock_refresh.start()
+        super(TestAuthViews, self).setUp()
+
+    def tearDown(self):
+        self.mock_refresh.stop()
+        super(TestAuthViews, self).tearDown()
+
+    @mock.patch(
+        'addons.box.models.UserSettings.revoke_remote_oauth_access',
+        mock.PropertyMock()
+    )
+    def test_delete_external_account(self):
+        super(TestAuthViews, self).test_delete_external_account()
+
+
+class TestConfigViews(BoxAddonTestCase, views_testing.OAuthAddonConfigViewsTestCaseMixin, OsfTestCase):
+
+    folder = {
+        'path': '/Foo',
+        'id': '12234'
+    }
+    Serializer = BoxSerializer
+    client = mock_client
+
+    def setUp(self):
+        self.mock_data = mock.patch.object(
+            NodeSettings,
+            '_folder_data',
+            return_value=(self.folder['id'], self.folder['path'])
+        )
+        self.mock_data.start()
+        super(TestConfigViews, self).setUp()
+
+    def tearDown(self):
+        self.mock_data.stop()
+        super(TestConfigViews, self).tearDown()
+
+    @mock.patch.object(BoxSerializer, 'credentials_are_valid', return_value=True)
+    def test_import_auth(self, *args):
+        super(TestConfigViews, self).test_import_auth()
+
+class TestFilebrowserViews(BoxAddonTestCase, OsfTestCase):
+
+    def setUp(self):
+        super(TestFilebrowserViews, self).setUp()
+        self.user.add_addon('box')
+        self.node_settings.external_account = self.user_settings.external_accounts[0]
+        self.node_settings.save()
+        self.patcher_refresh = mock.patch('addons.box.models.Provider.refresh_oauth_key')
+        self.patcher_refresh.return_value = True
+        self.patcher_refresh.start()
+
+    def tearDown(self):
+        self.patcher_refresh.stop()
+
+    def test_box_list_folders(self):
+        with patch_client('addons.box.models.BoxClient'):
+            url = self.project.api_url_for('box_folder_list', folder_id='foo')
+            res = self.app.get(url, auth=self.user.auth)
+            contents = mock_client.get_folder('', list=True)['item_collection']['entries']
+            expected = [each for each in contents if each['type'] == 'folder']
+            assert_equal(len(res.json), len(expected))
+            first = res.json[0]
+            assert_in('kind', first)
+            assert_equal(first['name'], contents[0]['name'])
+
+    @mock.patch('addons.box.models.NodeSettings.folder_id')
+    def test_box_list_folders_if_folder_is_none(self, mock_folder):
+        # If folder is set to none, no data are returned
+        mock_folder.__get__ = mock.Mock(return_value=None)
+        url = self.project.api_url_for('box_folder_list')
+        res = self.app.get(url, auth=self.user.auth)
+        assert_equal(len(res.json), 1)
+
+    def test_box_list_folders_if_folder_is_none_and_folders_only(self):
+        with patch_client('addons.box.models.BoxClient'):
+            self.node_settings.folder_name = None
+            self.node_settings.save()
+            url = api_url_for('box_folder_list',
+                pid=self.project._primary_key, foldersOnly=True)
+            res = self.app.get(url, auth=self.user.auth)
+            contents = mock_client.get_folder('', list=True)['item_collection']['entries']
+            expected = [each for each in contents if each['type'] == 'folder']
+            assert_equal(len(res.json), len(expected))
+
+    def test_box_list_folders_folders_only(self):
+        with patch_client('addons.box.models.BoxClient'):
+            url = self.project.api_url_for('box_folder_list', foldersOnly=True)
+            res = self.app.get(url, auth=self.user.auth)
+            contents = mock_client.get_folder('', list=True)['item_collection']['entries']
+            expected = [each for each in contents if each['type'] == 'folder']
+            assert_equal(len(res.json), len(expected))
+
+    def test_box_list_folders_doesnt_include_root(self):
+        with patch_client('addons.box.models.BoxClient'):
+            url = self.project.api_url_for('box_folder_list', folder_id=0)
+            res = self.app.get(url, auth=self.user.auth)
+            contents = mock_client.get_folder('', list=True)['item_collection']['entries']
+            expected = [each for each in contents if each['type'] == 'folder']
+
+            assert_equal(len(res.json), len(expected))
+
+    @mock.patch('addons.box.models.BoxClient.get_folder')
+    def test_box_list_folders_deleted(self, mock_metadata):
+        # Example metadata for a deleted folder
+        mock_metadata.return_value = {
+            u'bytes': 0,
+            u'contents': [],
+            u'hash': u'e3c62eb85bc50dfa1107b4ca8047812b',
+            u'icon': u'folder_gray',
+            u'is_deleted': True,
+            u'is_dir': True,
+            u'modified': u'Sat, 29 Mar 2014 20:11:49 +0000',
+            u'path': u'/tests',
+            u'rev': u'3fed844002c12fc',
+            u'revision': 67033156,
+            u'root': u'box',
+            u'size': u'0 bytes',
+            u'thumb_exists': False
+        }
+        url = self.project.api_url_for('box_folder_list', folder_id='foo')
+        res = self.app.get(url, auth=self.user.auth, expect_errors=True)
+        assert_equal(res.status_code, httplib.NOT_FOUND)
+
+    @mock.patch('addons.box.models.BoxClient.get_folder')
+    def test_box_list_folders_returns_error_if_invalid_path(self, mock_metadata):
+        mock_metadata.side_effect = BoxClientException(status_code=404, message='File not found')
+        url = self.project.api_url_for('box_folder_list', folder_id='lolwut')
+        res = self.app.get(url, auth=self.user.auth, expect_errors=True)
+        assert_equal(res.status_code, httplib.NOT_FOUND)
+
+    @mock.patch('addons.box.models.BoxClient.get_folder')
+    def test_box_list_folders_handles_max_retry_error(self, mock_metadata):
+        mock_response = mock.Mock()
+        url = self.project.api_url_for('box_folder_list', folder_id='fo')
+        mock_metadata.side_effect = MaxRetryError(mock_response, url)
+        res = self.app.get(url, auth=self.user.auth, expect_errors=True)
+        assert_equal(res.status_code, httplib.BAD_REQUEST)
+
+
+class TestRestrictions(BoxAddonTestCase, OsfTestCase):
+
+    def setUp(self):
+        super(BoxAddonTestCase, self).setUp()
+
+        # Nasty contributor who will try to access folders that he shouldn't have
+        # access to
+        self.contrib = AuthUserFactory()
+        self.project.add_contributor(self.contrib, auth=Auth(self.user))
+        self.project.save()
+
+        self.user.add_addon('box')
+        settings = self.user.get_addon('box')
+        settings.access_token = '12345abc'
+        settings.last_refreshed = timezone.now()
+        settings.save()
+
+        self.patcher = mock.patch('addons.box.models.NodeSettings.fetch_folder_name')
+        self.patcher.return_value = 'foo bar/baz'
+        self.patcher.start()
+
+    @mock.patch('addons.box.models.NodeSettings.has_auth')
+    def test_restricted_hgrid_data_contents(self, mock_auth):
+        mock_auth.__get__ = mock.Mock(return_value=False)
+
+        # tries to access a parent folder
+        url = self.project.api_url_for('box_folder_list',
+            path='foo bar')
+        res = self.app.get(url, auth=self.contrib.auth, expect_errors=True)
+        assert_equal(res.status_code, httplib.FORBIDDEN)
+
+    def test_restricted_config_contrib_no_addon(self):
+        url = api_url_for('box_set_config', pid=self.project._primary_key)
+        res = self.app.put_json(url, {'selected': {'path': 'foo'}},
+            auth=self.contrib.auth, expect_errors=True)
+        assert_equal(res.status_code, httplib.BAD_REQUEST)
+
+    def test_restricted_config_contrib_not_owner(self):
+        # Contributor has box auth, but is not the node authorizer
+        self.contrib.add_addon('box')
+        self.contrib.save()
+
+        url = api_url_for('box_set_config', pid=self.project._primary_key)
+        res = self.app.put_json(url, {'selected': {'path': 'foo'}},
+            auth=self.contrib.auth, expect_errors=True)
+        assert_equal(res.status_code, httplib.FORBIDDEN)

--- a/addons/box/tests/utils.py
+++ b/addons/box/tests/utils.py
@@ -1,0 +1,194 @@
+# -*- coding: utf-8 -*-
+import mock
+from contextlib import contextmanager
+
+from addons.base.tests.base import OAuthAddonTestCaseMixin, AddonTestCase
+from addons.box.models import Provider
+from addons.box.tests.factories import BoxAccountFactory
+
+
+class BoxAddonTestCase(OAuthAddonTestCaseMixin, AddonTestCase):
+
+    ADDON_SHORT_NAME = 'box'
+    ExternalAccountFactory = BoxAccountFactory
+    Provider = Provider
+
+    def set_node_settings(self, settings):
+        super(BoxAddonTestCase, self).set_node_settings(settings)
+        settings.folder_id = '1234567890'
+        settings.folder_name = 'Foo'
+
+mock_responses = {
+    'folder': {
+        'name': 'anything',
+        'item_collection': {
+            'entries': [
+                {
+                    'name': 'anything', 'type': 'file', 'id': 'anything'
+                },
+                {
+                    'name': 'anything', 'type': 'folder', 'id': 'anything'
+                },
+                {
+                    'name': 'anything', 'type': 'anything', 'id': 'anything'
+                },
+            ]
+        },
+        'path_collection': {
+            'entries': [
+                {
+                    'name': 'anything', 'type': 'file', 'id': 'anything'
+                },
+                {
+                    'name': 'anything', 'type': 'folder', 'id': 'anything'
+                },
+                {
+                    'name': 'anything', 'type': 'anything', 'id': 'anything'
+                },
+            ]
+        }
+    },
+    'put_file': {
+        'bytes': 77,
+        'icon': 'page_white_text',
+        'is_dir': False,
+        'mime_type': 'text/plain',
+        'modified': 'Wed, 20 Jul 2011 22:04:50 +0000',
+        'path': '/magnum-opus.txt',
+        'rev': '362e2029684fe',
+        'revision': 221922,
+        'root': 'box',
+        'size': '77 bytes',
+        'thumb_exists': False
+    },
+    'metadata_list': {
+        "size": "0 bytes",
+        "hash": "37eb1ba1849d4b0fb0b28caf7ef3af52",
+        "bytes": 0,
+        "thumb_exists": False,
+        "rev": "714f029684fe",
+        "modified": "Wed, 27 Apr 2011 22:18:51 +0000",
+        "path": "/Public",
+        "is_dir": True,
+        "icon": "folder_public",
+        "root": "box",
+        "contents": [
+            {
+                "size": "0 bytes",
+                "rev": "35c1f029684fe",
+                "thumb_exists": False,
+                "bytes": 0,
+                "modified": "Mon, 18 Jul 2011 20:13:43 +0000",
+                "client_mtime": "Wed, 20 Apr 2011 16:20:19 +0000",
+                "path": "/Public/latest.txt",
+                "is_dir": False,
+                "icon": "page_white_text",
+                "root": "box",
+                "mime_type": "text/plain",
+                "revision": 220191
+            },
+            {
+                u'bytes': 0,
+                u'icon': u'folder',
+                u'is_dir': True,
+                u'modified': u'Sat, 22 Mar 2014 05:40:29 +0000',
+                u'path': u'/datasets/New Folder',
+                u'rev': u'3fed51f002c12fc',
+                u'revision': 67032351,
+                u'root': u'box',
+                u'size': u'0 bytes',
+                u'thumb_exists': False
+            }
+        ],
+        "revision": 29007
+    },
+    'metadata_single': {
+        u'id': 'id',
+        u'bytes': 74,
+        u'client_mtime': u'Mon, 13 Jan 2014 20:24:15 +0000',
+        u'icon': u'page_white',
+        u'is_dir': False,
+        u'mime_type': u'text/csv',
+        u'modified': u'Fri, 21 Mar 2014 05:46:36 +0000',
+        u'path': '/datasets/foo.txt',
+        u'rev': u'a2149fb64',
+        u'revision': 10,
+        u'root': u'app_folder',
+        u'size': u'74 bytes',
+        u'thumb_exists': False
+    },
+    'revisions': [{u'bytes': 0,
+                   u'client_mtime': u'Wed, 31 Dec 1969 23:59:59 +0000',
+                   u'icon': u'page_white_picture',
+                   u'is_deleted': True,
+                   u'is_dir': False,
+                   u'mime_type': u'image/png',
+                   u'modified': u'Tue, 25 Mar 2014 03:39:13 +0000',
+                   u'path': u'/svs-v-barks.png',
+                   u'rev': u'3fed741002c12fc',
+                   u'revision': 67032897,
+                   u'root': u'box',
+                   u'size': u'0 bytes',
+                   u'thumb_exists': True},
+                  {u'bytes': 151164,
+                   u'client_mtime': u'Sat, 13 Apr 2013 21:56:36 +0000',
+                   u'icon': u'page_white_picture',
+                   u'is_dir': False,
+                   u'mime_type': u'image/png',
+                   u'modified': u'Tue, 25 Mar 2014 01:45:51 +0000',
+                   u'path': u'/svs-v-barks.png',
+                   u'rev': u'3fed61a002c12fc',
+                   u'revision': 67032602,
+                   u'root': u'box',
+                   u'size': u'147.6 KB',
+                   u'thumb_exists': True}]
+}
+
+
+class MockBox(object):
+
+    def put_file(self, full_path, file_obj, overwrite=False, parent_rev=None):
+        return mock_responses['put_file']
+
+    def metadata(self, path, list=True, file_limit=25000, hash=None, rev=None,
+                 include_deleted=False):
+        if list:
+            ret = mock_responses['metadata_list']
+        else:
+            ret = mock_responses['metadata_single']
+            ret['path'] = path
+        return ret
+
+    def get_folder(*args, **kwargs):
+        return mock_responses['folder']
+
+    def get_file_and_metadata(*args, **kwargs):
+        pass
+
+    def file_delete(self, path):
+        return mock_responses['metadata_single']
+
+    def revisions(self, path):
+        ret = mock_responses['revisions']
+        for each in ret:
+            each['path'] = path
+        return ret
+
+    def get_user_info(self):
+        return {'display_name': 'Mr. Box'}
+
+
+@contextmanager
+def patch_client(target, mock_client=None):
+    """Patches a function that returns a BoxClient, returning an instance
+    of MockBox instead.
+
+    Usage: ::
+
+        with patch_client('website.addons.box.views.BoxClient') as client:
+            # test view that uses the box client.
+    """
+    with mock.patch(target) as client_getter:
+        client = mock_client or MockBox()
+        client_getter.return_value = client
+        yield client


### PR DESCRIPTION
## Purpose
Port Box's `test_(client|serializer|views).py` to Django OSF

## Changes

## Side effects
None expected

## Ticket

