### PR TITLE
Add Ohio and Mumbai to list of s3 buckets [OSF-7140]

### DIFF
--- a/website/addons/s3/static/settings.json
+++ b/website/addons/s3/static/settings.json
@@ -1,6 +1,7 @@
 {
     "bucketLocations": {
         "": "US Standard",
+        "us-east-2": "Ohio",
         "eu-central-1": "Frankfurt",
         "eu-west-1": "Ireland",
         "us-west-1": "California",
@@ -9,6 +10,7 @@
         "ap-northeast-2": "Seoul",
         "ap-southeast-1": "Singapore",
         "ap-southeast-2": "Sydney",
+        "ap-south-1": "Mumbai",
         "sa-east-1": "Sao Paulo"
     },
     "encryptUploads": true

--- a/website/addons/s3/tests/test_view.py
+++ b/website/addons/s3/tests/test_view.py
@@ -230,6 +230,7 @@ class TestCreateBucket(S3AddonTestCase):
 
     def test_locations(self):
         assert_true(validate_bucket_location(''))
+        assert_true(validate_bucket_location('us-east-2'))
         assert_true(validate_bucket_location('eu-central-1'))
         assert_true(validate_bucket_location('us-west-1'))
         assert_true(validate_bucket_location('us-west-2'))
@@ -237,9 +238,9 @@ class TestCreateBucket(S3AddonTestCase):
         assert_true(validate_bucket_location('ap-northeast-2'))
         assert_true(validate_bucket_location('ap-southeast-1'))
         assert_true(validate_bucket_location('ap-southeast-2'))
+        assert_true(validate_bucket_location('ap-south-1'))
         assert_true(validate_bucket_location('sa-east-1'))
         assert_true(validate_bucket_location('eu-west-1'))
-
 
     @mock.patch('website.addons.s3.views.utils.create_bucket')
     @mock.patch('website.addons.s3.views.utils.get_bucket_names')


### PR DESCRIPTION
## Note
Relies on https://github.com/felliott/boto/pull/1 or something similar!

## Purpose

Ohio and Mumbai were new region options for amazon s3 buckets, but not available to select via creation on the OSF - a [PR to waterbutler](https://github.com/felliott/boto/pull/1) adds support for new regions with V4 Authentication, and so these regions should be available to create buckets in now. 

## Changes

- Add ohio and mumbai to list of bucket locations

## Side effects
None anticipated


## Notes for QA
You should now be able to attach buckets created via the Amazon s3 console located in Ohio and Mumbai to an OSF project, and create a bucket located in Ohio or Mumbai via the OSF project settings page, but only after waterbutler has been updated with aboved linked PR!


## Ticket
https://openscience.atlassian.net/browse/OSF-7140
https://openscience.atlassian.net/browse/OSF-7137