### PR TITLE
Disallow changing primary preprint file after publishing [#OSF-7190]

### DIFF
--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -112,8 +112,9 @@ class PreprintSerializer(JSONAPISerializer):
 
         primary_file = validated_data.pop('primary_file', None)
         if primary_file:
-            self.set_field(preprint.set_primary_file, primary_file, auth)
-            save_node = True
+            raise exceptions.ValidationError(
+                detail='You may not change the primary file of a preprint. Please update the version of the file instead.'
+            )
 
         if 'subjects' in validated_data:
             subjects = validated_data.pop('subjects', None)

--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -112,9 +112,8 @@ class PreprintSerializer(JSONAPISerializer):
 
         primary_file = validated_data.pop('primary_file', None)
         if primary_file:
-            raise exceptions.ValidationError(
-                detail='You may not change the primary file of a preprint. Please update the version of the file instead.'
-            )
+            self.set_field(preprint.set_primary_file, primary_file, auth)
+            save_node = True
 
         if 'subjects' in validated_data:
             subjects = validated_data.pop('subjects', None)

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -196,6 +196,14 @@ class PreprintDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, Pre
                                 "subjects":     [({root_subject_id}, {child_subject_id}), ...]  # optional
                                 "is_published": true,                                           # optional
                                 "doi":          {valid_doi}                                     # optional
+                            },
+                            "relationships": {
+                                "primary_file": {                                               # optional
+                                    "data": {
+                                        "type": "primary_files",
+                                        "id": {file_id}
+                                    }
+                                }
                             }
                         }
                     }

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -185,6 +185,7 @@ class PreprintDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, Pre
     ###Updating Preprints
 
     Update a preprint by sending a patch request to the guid of the existing preprint node that you'd like to update.
+    Updating a preprint's primary_file by patch is only possible if the preprint hasn't already been published.
 
         Method:        PATCH
         URL:           /preprints/{node_id}/

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -196,14 +196,6 @@ class PreprintDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, Pre
                                 "subjects":     [({root_subject_id}, {child_subject_id}), ...]  # optional
                                 "is_published": true,                                           # optional
                                 "doi":          {valid_doi}                                     # optional
-                            },
-                            "relationships": {
-                                "primary_file": {                                               # optional
-                                    "data": {
-                                        "type": "primary_files",
-                                        "id": {file_id}
-                                    }
-                                }
                             }
                         }
                     }

--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -116,7 +116,8 @@ class TestPreprintUpdate(ApiTestCase):
         self.preprint.reload()
         assert_equal(self.preprint.subjects, subjects)
 
-    def test_update_primary_file(self):
+    def test_update_primary_file_fails(self):
+        original_file = self.preprint.primary_file
         new_file = test_utils.create_test_file(self.preprint.node, 'openupthatwindow.pdf')
         relationships = {
             "primary_file": {
@@ -129,11 +130,11 @@ class TestPreprintUpdate(ApiTestCase):
         assert_not_equal(self.preprint.primary_file, new_file)
         update_file_payload = build_preprint_update_payload(self.preprint._id, relationships=relationships)
 
-        res = self.app.patch_json_api(self.url, update_file_payload, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
+        res = self.app.patch_json_api(self.url, update_file_payload, auth=self.user.auth, expect_errors=True)
+        assert_equal(res.status_code, 400)
 
         self.preprint.node.reload()
-        assert_equal(self.preprint.primary_file, new_file)
+        assert_equal(self.preprint.primary_file, original_file)
 
     def test_new_primary_not_in_node(self):
         project = ProjectFactory()

--- a/website/preprints/model.py
+++ b/website/preprints/model.py
@@ -102,6 +102,9 @@ class PreprintService(GuidStoredObject):
         if not self.node.has_permission(auth.user, ADMIN):
             raise PermissionsError('Only admins can change a preprint\'s primary file.')
 
+        if self.is_published:
+            raise ValueError('You may not change the primary file of a preprint. Please update the version of the file instead')
+
         if not isinstance(preprint_file, StoredFileNode):
             preprint_file = preprint_file.stored_object
 


### PR DESCRIPTION
## Purpose
You may no longer entirely change the primary file of a preprint, only update the version by directly dealing with the file stored on the node. Therefore, don't let the API change the primary file of the preprint either!

## Changes
- Update preprint detail docstring
- Raise validation error in serializer if the preprint file is updated
- Update test

## Side effects
QA Automated runscope tests trying to update preprint files might fail if there are any!

## Ticket
https://openscience.atlassian.net/browse/OSF-7190