### PR TITLE
[hotfix] Fix File Revisions Table w Anonymous VOL [OSF-7191]

### DIFF
--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -37,6 +37,10 @@ var CopyButton = {
     }
 };
 
+var formatUrl = function(urlParams, showParam) {
+    return 'view_only' in urlParams ? '?show=' + showParam + '&view_only=' + urlParams.view_only : '?show=' + showParam;
+};
+
 var SharePopover =  {
     view: function(ctrl, params) {
         var copyButtonHeight = '34px';
@@ -406,11 +410,11 @@ var FileViewPage = {
             if (viewable){
                 self.mfrIframeParent.toggle();
                 self.revisions.selected = true;
-                url = '?show=revision';
+                url = formatUrl(self.urlParams, 'revision');
             } else {
                 self.mfrIframeParent.toggle();
                 self.revisions.selected = false;
-                url = '?show=view';
+                url = formatUrl(self.urlParams, 'view');
             }
             var state = {
                 scrollTop: $(window).scrollTop(),
@@ -423,13 +427,13 @@ var FileViewPage = {
             m.render(document.getElementById('versionLink'), m('a', {onclick: toggleRevisions}, document.getElementById('versionLink').innerHTML));
         }
 
-        var urlParams = $osf.urlParams();
+        self.urlParams = $osf.urlParams();
         // The parser found a query so lets check what we need to do
-        if ('show' in urlParams){
-            if(urlParams.show === 'revision'){
+        if ('show' in self.urlParams){
+            if(self.urlParams.show === 'revision'){
                 self.mfrIframeParent.toggle();
                 self.revisions.selected = true;
-            } else if (urlParams.show === 'view' || urlParams.show === 'edit'){
+            } else if (self.urlParams.show === 'view' || self.urlParams.show === 'edit'){
                self.revisions.selected = false;
            }
         }
@@ -490,7 +494,7 @@ var FileViewPage = {
                         if ((!ctrl.editor.selected || panelsShown > 1)) {
                             ctrl.editor.selected = !ctrl.editor.selected;
                             ctrl.revisions.selected = false;
-                            var url = '?show=view';
+                            var url = formatUrl(ctrl.urlParams, 'view');
                             state = {
                                 scrollTop: $(window).scrollTop(),
                             };
@@ -535,11 +539,11 @@ var FileViewPage = {
                         if (!ctrl.mfrIframeParent.is(':visible') || panelsShown > 1) {
                             ctrl.mfrIframeParent.toggle();
                             ctrl.revisions.selected = false;
-                            History.pushState(state, 'OSF | ' + window.contextVars.file.name, '?show=view');
+                            History.pushState(state, 'OSF | ' + window.contextVars.file.name, formatUrl(ctrl.urlParams, 'view'));
                         } else if (ctrl.mfrIframeParent.is(':visible') && !ctrl.editor){
                             ctrl.mfrIframeParent.toggle();
                             ctrl.revisions.selected = true;
-                            History.pushState(state, 'OSF | ' + window.contextVars.file.name, '?show=revision');
+                            History.pushState(state, 'OSF | ' + window.contextVars.file.name, formatUrl(ctrl.urlParams, 'revision'));
                         }
                     }
                 }, 'View'), editButton())
@@ -556,14 +560,14 @@ var FileViewPage = {
                             ctrl.editor.selected = false;
                         }
                         ctrl.revisions.selected = true;
-                        History.pushState(state, 'OSF | ' + window.contextVars.file.name, '?show=revision');
+                        History.pushState(state, 'OSF | ' + window.contextVars.file.name, formatUrl(ctrl.urlParams, 'revision'));
                     } else {
                         ctrl.mfrIframeParent.toggle();
                         if (ctrl.editor) {
                             ctrl.editor.selected = false;
                         }
                         ctrl.revisions.selected = false;
-                        History.pushState(state, 'OSF | ' + window.contextVars.file.name, '?show=view');
+                        History.pushState(state, 'OSF | ' + window.contextVars.file.name, formatUrl(ctrl.urlParams, 'view'));
                     }
                 }}, 'Revisions')
             ])

--- a/website/static/js/filepage/revisions.js
+++ b/website/static/js/filepage/revisions.js
@@ -133,7 +133,7 @@ var FileRevisionsTable = {
                     m('td', revision.extra.user.url ?
                             m('a', {href: revision.extra.user.url}, revision.extra.user.name) :
                             revision.extra.user.name
-                    ) : m('td', 'anonymous contributor'),
+                    ) : m('td', 'Anonymous Contributor'),
                 m('td', revision.extra.downloads > -1 ? m('.badge', revision.extra.downloads) : ''),
                 m('td',
                     m('a.btn.btn-primary.btn-sm.file-download', {

--- a/website/static/js/filepage/revisions.js
+++ b/website/static/js/filepage/revisions.js
@@ -129,11 +129,11 @@ var FileRevisionsTable = {
                   m('a', {href: parseInt(revision.displayVersion) === model.revisions.length ? self.baseUrl : revision.osfViewUrl}, revision.displayVersion)
                 ),
                 model.hasDate ? m('td', revision.displayDate) : false,
-                model.hasUser ?
+                model.hasUser && !window.contextVars.node.anonymous ?
                     m('td', revision.extra.user.url ?
                             m('a', {href: revision.extra.user.url}, revision.extra.user.name) :
                             revision.extra.user.name
-                    ) : false,
+                    ) : m('td', 'anonymous contributor'),
                 m('td', revision.extra.downloads > -1 ? m('.badge', revision.extra.downloads) : ''),
                 m('td',
                     m('a.btn.btn-primary.btn-sm.file-download', {


### PR DESCRIPTION
#### Purpose
- Currently, when toggling between the `view` and `revisions` panels on the file view page, information about the `view_only` query parameter, if present, is lost. This PR retains the `view_only` query parameter when toggling so that if present, contributor names can be anonymized in the revisions table. 

#### Side effects
- None expected.

#### GIFs 
- *note the URL changes and the contributor name in the revisions table, ignore the fact that I don't have MFR running*
- File View Page (w/o an anonymous VOL)
![file page before](https://cloud.githubusercontent.com/assets/7913604/20012318/21e07db6-a285-11e6-9c0b-40f61200b09d.gif)

- File View Page (w/ an anoymous VOL) **BEFORE**
![anon vol file page before](https://cloud.githubusercontent.com/assets/7913604/20012421/8374dc34-a285-11e6-8e56-4c06254886f9.gif)

- File View Page (w/ an anoymous VOL) **AFTER**
![anon vol file page after](https://cloud.githubusercontent.com/assets/7913604/20012378/537155a8-a285-11e6-912c-c58bf9f612dd.gif)


#### Ticket
- [OSF-7191](https://openscience.atlassian.net/browse/OSF-7191)