### PR TITLE
Add provider specific docs in NodeFilesList view [OSF-4731]

### DIFF
--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1789,9 +1789,12 @@ class NodeFilesList(JSONAPIBaseView, generics.ListAPIView, WaterButlerMixin, Lis
     ###ownCloud
     ownCloud returns `null` for the following fields:
 
+    - `date_modified`
+    - `date_created`
     - hashes
         - `md5`
         - `sha256`
+    - `size`
 
     ##Links
 

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1778,6 +1778,21 @@ class NodeFilesList(JSONAPIBaseView, generics.ListAPIView, WaterButlerMixin, Lis
         - `sha256`
     - `size`
 
+    ###Box
+    Box returns `null` for the following fields:
+
+    - hashes
+        - `md5`
+        - `sha256`
+    - `size`
+
+    ###ownCloud
+    ownCloud returns `null` for the following fields:
+
+    - hashes
+        - `md5`
+        - `sha256`
+
     ##Links
 
     See the [JSON-API spec regarding pagination](http://jsonapi.org/format/1.0/#fetching-pagination).

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1709,7 +1709,7 @@ class NodeFilesList(JSONAPIBaseView, generics.ListAPIView, WaterButlerMixin, Lis
     OSF Storage is the only provider that has all file attributes (except "last_touched" which only applies to non-osfstorage files).
 
     ###Dataverse
-    Dataverse does not store metadata for the following fields:
+    Dataverse returns `null` for the following fields:
 
     - `last_touched`
     - `date_modified`
@@ -1720,7 +1720,7 @@ class NodeFilesList(JSONAPIBaseView, generics.ListAPIView, WaterButlerMixin, Lis
     - `size`
 
     ###Dropbox
-    Dropbox does not return metadata for the following fields:
+    Dropbox returns `null` for the following fields:
 
     - hashes
         - `md5`
@@ -1728,7 +1728,7 @@ class NodeFilesList(JSONAPIBaseView, generics.ListAPIView, WaterButlerMixin, Lis
     - `size`
 
     ###figshare
-    figshare does not store metadata for the following fields:
+    figshare returns `null` for the following fields:
 
     - `last_touched`
     - `date_modified`
@@ -1739,7 +1739,7 @@ class NodeFilesList(JSONAPIBaseView, generics.ListAPIView, WaterButlerMixin, Lis
     - `size`
 
     ###GitHub
-    GitHub does not store metadata for the following fields:
+    GitHub returns `null` for the following fields:
 
     - hashes
         - `md5`
@@ -1760,7 +1760,7 @@ class NodeFilesList(JSONAPIBaseView, generics.ListAPIView, WaterButlerMixin, Lis
 
 
     ###Google Drive
-    GoogleDrive does not store metadata for the following fields:
+    returns `null` for the following fields:
 
     - hashes
         - `md5`
@@ -1772,7 +1772,7 @@ class NodeFilesList(JSONAPIBaseView, generics.ListAPIView, WaterButlerMixin, Lis
 
 
     ###Amazon S3
-    Amazon s3 does not store metadata for the following fields:
+    Amazon s3 returns `null` for the following fields:
 
     - hashes
         - `sha256`

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1701,6 +1701,83 @@ class NodeFilesList(JSONAPIBaseView, generics.ListAPIView, WaterButlerMixin, Lis
     endpoint is cached.  The `last_touched` field describes the last time the metadata was retrieved from the external
     provider.  To force a metadata update, access the parent folder via its Node Files List endpoint.
 
+    ##Provider Specific File Attributes and Quirks
+    Some storage providers do not return all attributes depending on their internals.
+    For the most up to date information, see [the documentation for each provider in WaterButler](https://github.com/CenterForOpenScience/waterbutler)
+
+    ###OSF Storage
+    OSF Storage is the only provider that has all file attributes (except "last_touched" which only applies to non-osfstorage files).
+
+    ###Dataverse
+    Dataverse does not store metadata for the following fields:
+
+    - `last_touched`
+    - `date_modified`
+    - `date_created`
+    - hashes
+        - `md5`
+        - `sha256`
+    - `size`
+
+    ###Dropbox
+    Dropbox does not return metadata for the following fields:
+
+    - hashes
+        - `md5`
+        - `sha256`
+    - `size`
+
+    ###figshare
+    figshare does not store metadata for the following fields:
+
+    - `last_touched`
+    - `date_modified`
+    - `date_created`
+    - hashes
+        - `md5`
+        - `sha256`
+    - `size`
+
+    ###GitHub
+    GitHub does not store metadata for the following fields:
+
+    - hashes
+        - `md5`
+        - `sha256`
+    - `size`
+
+    Some quirks of the githb API:
+
+    * git doesn't have a concept of empty folders, so this provider creates 0-byte ``.gitkeep``
+    files in the requested folder.
+    * The ``contents`` endpoint cannot be used to fetch metadata reliably for all files. Requesting
+    a file that is larger than 1Mb will result in a error response directing you to the ``blob``
+    endpoint.  A recursive tree fetch may be used instead.
+    * The tree endpoint truncates results after a large number of files.  It does not provide a way
+    to page through the tree.  Since move, copy, and folder delete operations rely on whole-tree
+    replacement, they cannot be reliably supported for large repos.  Attempting to use them will
+    throw a 501 Not Implemented error.
+
+
+    ###Google Drive
+    GoogleDrive does not store metadata for the following fields:
+
+    - hashes
+        - `md5`
+        - `sha256`
+    - `size`
+
+    The attribute `materialized_path` for Google-type files (.gdoc etc.) does not have a file extension.
+    The file extension is displayed as a part of the `name` attribute.
+
+
+    ###Amazon S3
+    Amazon s3 does not store metadata for the following fields:
+
+    - hashes
+        - `sha256`
+    - `size`
+
     ##Links
 
     See the [JSON-API spec regarding pagination](http://jsonapi.org/format/1.0/#fetching-pagination).


### PR DESCRIPTION
## Purpose
Different addon storage providers reliably don't return values for some file attributes, and that's not documented in the API at the moment. So add those!

## Changes
- Add a " Provider Specific File Attributes and Quirks" section to `NodeFilesList` view docstring

![screen shot 2016-11-04 at 4 14 26 pm](https://cloud.githubusercontent.com/assets/801594/20020964/411927b2-a2aa-11e6-8486-368b6e567276.png)


## Side effects
None anticipated, but there might be some file attributes that I missed. These are compiled  from the ticket (and verified locally), and some were gathered from notes in Waterbutler.


## Ticket
https://openscience.atlassian.net/browse/OSF-4731
