### PR TITLE
Add language for a component inheriting a license! [OSF-7187]

### DIFF
--- a/website/static/js/addProjectPlugin.js
+++ b/website/static/js/addProjectPlugin.js
@@ -235,8 +235,7 @@ var AddProject = {
                                 m('i', ' Admins of ', m('b', options.parentTitle), ' will have read access to this component.')
                             )
                         ]) : '',
-
-                        m('.span', [
+                        ctrl.options.parentID !== null ? m('.span', [
                                 m('label.f-w-lg.text-bigger', 'License'),
                                 m('p',
                                     m('i', ' This component will inherit the same license as ',
@@ -245,8 +244,7 @@ var AddProject = {
                                         m('a[href="http://help.osf.io/m/sharing/l/524050-licenses?id=524050-licenses"]', 'Learn more.' )
                                     )
                                 )
-                        ]),
-
+                        ]): '',
                         m('.text-muted.pointer', { onclick : function(){
                             ctrl.showMore(!ctrl.showMore());
                             $osf.trackClick(options.trackingCategory, options.trackingAction, 'show-more-or-less');

--- a/website/static/js/addProjectPlugin.js
+++ b/website/static/js/addProjectPlugin.js
@@ -235,6 +235,18 @@ var AddProject = {
                                 m('i', ' Admins of ', m('b', options.parentTitle), ' will have read access to this component.')
                             )
                         ]) : '',
+
+                        m('.span', [
+                                m('label.f-w-lg.text-bigger', 'License'),
+                                m('p',
+                                    m('i', ' This component will inherit the same license as ',
+                                        m('b', options.parentTitle),
+                                        '. ',
+                                        m('a[href="http://help.osf.io/m/sharing/l/524050-licenses?id=524050-licenses"]', 'Learn more.' )
+                                    )
+                                )
+                        ]),
+
                         m('.text-muted.pointer', { onclick : function(){
                             ctrl.showMore(!ctrl.showMore());
                             $osf.trackClick(options.trackingCategory, options.trackingAction, 'show-more-or-less');


### PR DESCRIPTION
## Purpose
When making a new component, the license gets inherited from its immediate parent. Add a bit to the component creating modal to let the user know.

![screen shot 2016-11-07 at 4 46 41 pm](https://cloud.githubusercontent.com/assets/801594/20077482/a279dd0a-a50a-11e6-8924-67e5baa6e3b2.png)

## Changes
- Add "License" section to component creation modal that explains
- Add "learn more" link that leads to [OSF Help section on licenses](http://help.osf.io/m/sharing/l/524050-licenses?id=524050-licenses)

## Side effects
None anticipated!

## Ticket
https://openscience.atlassian.net/browse/OSF-7187

[#OSF-7187]