### PR TITLE
[Feature] Redraw on dragstart to get fangorn in sync [OSF-6319]

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -2181,6 +2181,8 @@ var copyMode = null;
  * @private
  */
 function _fangornDragStart(event, ui) {
+    // Sync up the toolbar in case item was drag-clicked and not released
+    m.redraw(); 
     var itemID = $(event.target).attr('data-id'),
         item = this.find(itemID);
     if (this.multiselected().length < 2) {


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

When clicking file widget lines, if the item has not already been clicked, the toolbar will sometimes drop down mid drag, causing the event.target (what is highlighted by fangorn) and where the dropzone thinks the target is to be different.

## Changes
Runs a mithril redraw on initializing a drag, which should populate the toolbar and get them in sync 
<!-- Briefly describe or list your changes  -->

## Side effects
None known. There is a chance a similar problem can theoretically occur on load events, but I've never been able to replicate it that way.
<!--Any possible side effects? -->


## Ticket
[#OSF-6319]
https://openscience.atlassian.net/browse/OSF-6319

## QA Considerations
Make sure you cannot get the mouse and the event target it out of sync. Happy to demo this behavior for you as it can be difficult to replicate.
