### PR TITLE
Filter URL serialization in Relationship Field [#OSF-7194]

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -4,7 +4,6 @@ import re
 import furl
 from django.core.urlresolvers import resolve, reverse, NoReverseMatch
 from django.core.exceptions import ImproperlyConfigured
-from django.http.request import QueryDict
 from rest_framework import exceptions
 from rest_framework import serializers as ser
 from rest_framework.fields import SkipField

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -583,6 +583,7 @@ class RelationshipField(ser.HyperlinkedIdentityField):
                         formatted_filter = self.format_filter(obj)
                         if formatted_filter:
                             url = extend_querystring_params(url, {'filter': formatted_filter})
+                            url = url.replace('?filter=', '?filter')
                         else:
                             url = None
 

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -613,6 +613,11 @@ class RelationshipField(ser.HyperlinkedIdentityField):
                 return '<esi:include src="{}"/>'.format(esi_url)
 
     def format_filter(self, obj):
+        """ Take filters specified in self.filter and format them in a way that can be easily parametrized
+
+        :param obj: RelationshipField object
+        :return: list of dictionaries with 'field_name' and 'value' for each filter
+        """
         filter_fields = self.filter.keys()
         filters = []
         for field_name in filter_fields:

--- a/api_tests/base/test_serializers.py
+++ b/api_tests/base/test_serializers.py
@@ -2,6 +2,8 @@
 import httplib as http
 from pytz import utc
 from datetime import datetime
+import urllib
+
 from nose.tools import *  # flake8: noqa
 import re
 
@@ -268,6 +270,12 @@ class TestRelationshipField(DbTestCase):
             }
         )
 
+        field_with_filters = base_serializers.RelationshipField(
+            related_view='nodes:node-detail',
+            related_view_kwargs={'node_id': '<pk>'},
+            filter={'target': 'hello', 'woop': 'yea'}
+        )
+
         class Meta:
             type_ = 'nodes'
 
@@ -308,6 +316,15 @@ class TestRelationshipField(DbTestCase):
         data = self.BasicNodeSerializer(node, context={'request': req}).data['data']
         field = data['relationships']['two_url_kwargs']['links']
         assert_in('/v2/nodes/{}/node_links/{}/'.format(node._id, node._id), field['related']['href'])
+
+    def test_field_with_two_filters(self):
+        req = make_drf_request_with_version(version='2.0')
+        project = factories.ProjectFactory()
+        node = factories.NodeFactory(parent=project)
+        data = self.BasicNodeSerializer(node, context={'request': req}).data['data']
+        field = data['relationships']['field_with_filters']['links']
+        assert_in(urllib.quote('filter[target]=hello', safe='?='), field['related']['href'])
+        assert_in(urllib.quote('filter[woop]=yea', safe='?='), field['related']['href'])
 
     def test_field_with_non_attribute(self):
         req = make_drf_request_with_version(version='2.0')

--- a/api_tests/comments/views/test_comment_detail.py
+++ b/api_tests/comments/views/test_comment_detail.py
@@ -463,6 +463,8 @@ class TestCommentDetailView(CommentDetailMixin, ApiTestCase):
         self.public_project = ProjectFactory.create(is_public=True, creator=self.user)
         self.public_project.add_contributor(self.contributor, save=True)
         self.public_comment = CommentFactory(node=self.public_project, user=self.user)
+        reply_target = Guid.load(self.public_comment._id)
+        self.public_comment_reply = CommentFactory(node=self.public_project, target=reply_target, user=self.user)
         self.public_url = '/{}comments/{}/'.format(API_BASE, self.public_comment._id)
         self.public_comment_payload = self._set_up_payload(self.public_comment._id)
 
@@ -557,6 +559,8 @@ class TestFileCommentDetailView(CommentDetailMixin, ApiTestCase):
         self.public_project.add_contributor(self.contributor, save=True)
         self.public_file = test_utils.create_test_file(self.public_project, self.user)
         self.public_comment = CommentFactory(node=self.public_project, target=self.public_file.get_guid(), user=self.user)
+        reply_target = Guid.load(self.public_comment._id)
+        self.public_comment_reply = CommentFactory(node=self.public_project, target=reply_target, user=self.user)
         self.public_url = '/{}comments/{}/'.format(API_BASE, self.public_comment._id)
         self.public_comment_payload = self._set_up_payload(self.public_comment._id)
 
@@ -634,6 +638,8 @@ class TestWikiCommentDetailView(CommentDetailMixin, ApiTestCase):
         self.public_project.add_contributor(self.contributor, save=True)
         self.public_wiki = NodeWikiFactory(node=self.public_project, user=self.user)
         self.public_comment = CommentFactory(node=self.public_project, target=Guid.load(self.public_wiki._id), user=self.user)
+        reply_target = Guid.load(self.public_comment._id)
+        self.public_comment_reply = CommentFactory(node=self.public_project, target=reply_target, user=self.user)
         self.public_url = '/{}comments/{}/'.format(API_BASE, self.public_comment._id)
         self.public_comment_payload = self._set_up_payload(self.public_comment._id)
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Filters added to the query params by the `RelationshipSeralizer` were using the normal way to add arguments, with `filter` as the name and the entire filter as the value: `filter=[field_name]=example`. This is done using the `extend_querystring_params` function which adds query string params with `furl`. So, pass the right thing to `extend_querystring_params`, and make sure it works with multiple filters!

### Before
![screen shot 2016-11-08 at 1 27 59 pm](https://cloud.githubusercontent.com/assets/801594/20111718/3c999e82-a5b7-11e6-90f0-ef50713bb547.png)

### After
![screen shot 2016-11-08 at 1 27 29 pm](https://cloud.githubusercontent.com/assets/801594/20111722/44022b6c-a5b7-11e6-8914-666df2ae6090.png)


## Changes
- Update `format_filters` method so that it returns a list of dicts with checked filter params, instead of a string with all the checked filters bundled together
- Add each of those checked filters to the url via `extend_querystring_params`
- Test to make sure adding multiple filters via the `RelationshipSerializer` looks as we expect


## Side effects
Any use of `format_filters` (couldn't find any others) will need to expect a list of dicts with formatted values instead of a pre-formatted string.

## Ticket
https://openscience.atlassian.net/browse/OSF-7194