### PR TITLE
[hotfix] Handle Unicode Names in CAS [OSF-7195]

### DIFF
--- a/framework/auth/cas.py
+++ b/framework/auth/cas.py
@@ -290,7 +290,7 @@ def make_response_from_ticket(ticket, service_url):
         if not user and external_credential and action == 'external_first_login':
             from website.util import web_url_for
             # orcid attributes can be marked private and not shared, default to orcid otherwise
-            fullname = '{} {}'.format(cas_resp.attributes.get('given-names', ''), cas_resp.attributes.get('family-name', '')).strip()
+            fullname = u'{} {}'.format(cas_resp.attributes.get('given-names', ''), cas_resp.attributes.get('family-name', '')).strip()
             if not fullname:
                 fullname = external_credential['id']
             user = {

--- a/tests/test_cas_authentication.py
+++ b/tests/test_cas_authentication.py
@@ -26,14 +26,14 @@ def make_failure_response():
     )
 
 
-def make_external_response(release=True):
+def make_external_response(release=True, unicode=False):
     attributes = {
             'accessToken': fake.md5(),
     }
     if release:
         attributes.update({
-            'given-names': fake.first_name(),
-            'family-name': fake.last_name(),
+            'given-names': fake.first_name() if not unicode else u'нет',
+            'family-name': fake.last_name() if not unicode else u'Да',
         })
     return cas.CasResponse(
         authenticated=True,
@@ -312,3 +312,29 @@ class TestCASExternalLogin(OsfTestCase):
         ticket = fake.md5()
         service_url = 'http://accounts.osf.io/?ticket=' + ticket
         resp = cas.make_response_from_ticket(ticket, service_url)
+
+    @mock.patch('framework.auth.cas.CasClient.service_validate')
+    def test_make_response_from_ticket_handles_unicode(self, mock_service_validate):
+        mock_response = make_external_response(unicode=True)
+        mock_service_validate.return_value = mock_response
+        ticket = fake.md5()
+        service_url = 'http://accounts.osf.io/?ticket=' + ticket
+        resp = cas.make_response_from_ticket(ticket, service_url)
+        assert_equal(resp.status_code, 302)
+        assert_equal(mock_service_validate.call_count, 1)
+        first_call_args = mock_service_validate.call_args[0]
+        assert_equal(first_call_args[0], ticket)
+        assert_equal(first_call_args[1], 'http://accounts.osf.io/')
+
+    @mock.patch('framework.auth.cas.CasClient.service_validate')
+    def test_make_response_from_ticket_handles_non_unicode(self, mock_service_validate):
+        mock_response = make_external_response()
+        mock_service_validate.return_value = mock_response
+        ticket = fake.md5()
+        service_url = 'http://accounts.osf.io/?ticket=' + ticket
+        resp = cas.make_response_from_ticket(ticket, service_url)
+        assert_equal(resp.status_code, 302)
+        assert_equal(mock_service_validate.call_count, 1)
+        first_call_args = mock_service_validate.call_args[0]
+        assert_equal(first_call_args[0], ticket)
+        assert_equal(first_call_args[1], 'http://accounts.osf.io/')


### PR DESCRIPTION
#### Purpose
- Handle unicode names in CAS. 

#### Changes
- Makes [`fullname`](https://github.com/caseyrollins/osf.io/blob/c2814b34d4c608546ada118ddd7316f4f3ceb345/framework/auth/cas.py#L293) a unicode string.

#### Side effects
- None expected.

#### Ticket
- [OSF-7195](https://openscience.atlassian.net/browse/OSF-7195)