### PR TITLE
[djangosf][WIP] Fix files tests

### DIFF
--- a/addons/dataverse/models.py
+++ b/addons/dataverse/models.py
@@ -8,7 +8,8 @@ from framework.exceptions import HTTPError
 
 from addons.base.models import (
     BaseOAuthNodeSettings, BaseOAuthUserSettings, BaseStorageAddon)
-from osf.models.files import FileNode, Folder, File
+from osf.models.files import FileNode, Folder, File, FileVersion
+from osf.utils.auth import _get_current_user
 
 from website.addons.base import exceptions
 from website.addons.dataverse.client import connect_from_settings_or_401
@@ -23,11 +24,33 @@ class DataverseFolder(DataverseFileNode, Folder):
     pass
 
 class DataverseFile(DataverseFileNode, File):
-    version_identifier = 'ref'
+    version_identifier = 'version'
 
-    def touch(self, auth_header, revision=None, ref=None, branch=None, **kwargs):
-        revision = revision or ref or branch
-        return super(DataverseFile, self).touch(auth_header, revision=revision, **kwargs)
+    def update(self, revision, data, user=None):
+        """Note: Dataverse only has psuedo versions, don't save them
+        Dataverse requires a user for the weird check below
+        and Django dies when _get_current_user is called
+        """
+        self.name = data['name']
+        self.materialized_path = data['materialized']
+        self.save()
+
+        version = FileVersion(identifier=revision)
+        version.update_metadata(data, save=False)
+
+        user = user or _get_current_user()
+        if not user or not self.node.can_edit(user=user):
+            try:
+                # Users without edit permission can only see published files
+                if not data['extra']['hasPublishedVersion']:
+                    # Blank out name and path for the render
+                    # Dont save because there's no reason to persist the change
+                    self.name = ''
+                    self.materialized_path = ''
+                    return (version, '<div class="alert alert-info" role="alert">This file does not exist.</div>')
+            except (KeyError, IndexError):
+                pass
+        return version
 
 class DataverseProvider(object):
     """An alternative to `ExternalProvider` not tied to OAuth"""

--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -105,11 +105,12 @@ class FilterMixin(object):
 
         :raises InvalidFilterError: If the filter field is not valid
         """
-        if field_name not in self.serializer_class._declared_fields:
+        serializer_class = self.get_serializer_class()
+        if field_name not in serializer_class._declared_fields:
             raise InvalidFilterError(detail="'{0}' is not a valid field for this endpoint.".format(field_name))
-        if field_name not in getattr(self.serializer_class, 'filterable_fields', set()):
+        if field_name not in getattr(serializer_class, 'filterable_fields', set()):
             raise InvalidFilterFieldError(parameter='filter', value=field_name)
-        return self.serializer_class._declared_fields[field_name]
+        return serializer_class._declared_fields[field_name]
 
     def _validate_operator(self, field, field_name, op):
         """
@@ -195,7 +196,6 @@ class FilterMixin(object):
                 fields = match_dict['fields']
                 field_names = re.findall(self.FILTER_FIELDS, fields.strip())
                 query.update({key: {}})
-
                 for field_name in field_names:
                     field = self._get_field_or_error(field_name)
                     op = match_dict.get('op') or self._get_default_operator(field)

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -25,9 +25,6 @@ from api.base.utils import get_object_or_error, is_bulk_request, get_user_auth, 
 from api.base.settings import ADDONS_OAUTH, API_BASE
 from api.caching.tasks import ban_url
 from api.addons.views import AddonSettingsMixin
-from api.files.serializers import FileSerializer
-from api.comments.serializers import NodeCommentSerializer, CommentCreateSerializer
-from api.comments.permissions import CanCommentOrPublic
 from api.users.views import UserMixin
 from api.wikis.serializers import NodeWikiSerializer
 from api.base.views import LinkedNodesRelationship, BaseContributorDetail, BaseContributorList, BaseNodeLinksDetail, BaseNodeLinksList, BaseLinkedList
@@ -59,10 +56,13 @@ from api.nodes.serializers import (
 )
 from api.nodes.utils import get_file_object
 from api.citations.utils import render_citation
-
 from api.addons.serializers import NodeAddonFolderSerializer
 from api.registrations.serializers import RegistrationSerializer
 from api.institutions.serializers import InstitutionSerializer
+from api.comments.permissions import CanCommentOrPublic
+from api.comments.serializers import (CommentCreateSerializer,
+                                      NodeCommentSerializer)
+from api.files.serializers import FileSerializer, OsfStorageFileSerializer
 from api.identifiers.serializers import NodeIdentifierSerializer
 from api.identifiers.views import IdentifierList
 from api.nodes.permissions import (
@@ -1893,6 +1893,11 @@ class NodeFilesList(JSONAPIBaseView, generics.ListAPIView, WaterButlerMixin, Lis
 
     view_category = 'nodes'
     view_name = 'node-files'
+
+    def get_serializer_class(self):
+        if self.kwargs[self.provider_lookup_url_kwarg] == 'osfstorage':
+            return OsfStorageFileSerializer
+        return FileSerializer
 
     def get_default_queryset(self):
         # Don't bother going to waterbutler for osfstorage

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -11,7 +11,7 @@ from website.project.metadata.utils import is_prereg_admin_not_project_admin
 from website.exceptions import NodeStateError
 from website.project.model import NodeUpdateError
 
-from api.files.serializers import FileSerializer
+from api.files.serializers import OsfStorageFileSerializer
 from api.nodes.serializers import NodeSerializer, NodeProviderSerializer
 from api.nodes.serializers import NodeLinksSerializer, NodeLicenseSerializer
 from api.nodes.serializers import NodeContributorsSerializer, NodeTagField
@@ -329,7 +329,7 @@ class RegistrationContributorsSerializer(NodeContributorsSerializer):
         )
 
 
-class RegistrationFileSerializer(FileSerializer):
+class RegistrationFileSerializer(OsfStorageFileSerializer):
 
     files = NodeFileHyperLinkField(
         related_view='registrations:registration-files',

--- a/api_tests/nodes/views/test_node_files_list.py
+++ b/api_tests/nodes/views/test_node_files_list.py
@@ -20,7 +20,7 @@ from osf_tests.factories import (
 )
 
 
-pytestmark = pytest.mark.skip('Unskip when addons are implemented')
+pytestmark = pytest.mark.django_db
 
 def prepare_mock_wb_response(
         node=None,
@@ -56,6 +56,7 @@ def prepare_mock_wb_response(
         u'provider': provider,
         u'size': None,
         u'materialized': '/',
+        u'etag': u'NewEtag'
     }
 
     if len(files):
@@ -111,7 +112,7 @@ class TestNodeFilesList(ApiTestCase):
         oauth_settings = GitHubAccountFactory()
         oauth_settings.save()
         self.user.add_addon('github')
-        self.user.external_accounts.append(oauth_settings)
+        self.user.external_accounts.add(oauth_settings)
         self.user.save()
         addon.user_settings = self.user.get_addon('github')
         addon.save()
@@ -193,7 +194,7 @@ class TestNodeFilesList(ApiTestCase):
         oauth_settings = GitHubAccountFactory()
         oauth_settings.save()
         self.user.add_addon('github')
-        self.user.external_accounts.append(oauth_settings)
+        self.user.external_accounts.add(oauth_settings)
         self.user.save()
         addon.user_settings = self.user.get_addon('github')
         addon.save()
@@ -338,7 +339,7 @@ class TestNodeFilesListFiltering(ApiTestCase):
         oauth_settings = GitHubAccountFactory()
         oauth_settings.save()
         self.user.add_addon('github')
-        self.user.external_accounts.append(oauth_settings)
+        self.user.external_accounts.add(oauth_settings)
         self.user.save()
         addon.user_settings = self.user.get_addon('github')
         addon.save()
@@ -419,7 +420,7 @@ class TestNodeFilesListPagination(ApiTestCase):
         oauth_settings = GitHubAccountFactory()
         oauth_settings.save()
         self.user.add_addon('github')
-        self.user.external_accounts.append(oauth_settings)
+        self.user.external_accounts.add(oauth_settings)
         self.user.save()
         addon.user_settings = self.user.get_addon('github')
         addon.save()

--- a/tests/base.py
+++ b/tests/base.py
@@ -6,6 +6,7 @@ import functools
 import logging
 import re
 import os
+import re
 import shutil
 import unittest
 


### PR DESCRIPTION
## Purpose
Fix tests in `test_node_files_list.py`

## Changes
* Update tests
* Subclass `FileSerializer` for OSFStorage to exhibit same filtering behavior

Incidental:
* Fix bad copy on `DataverseFileNode`
* Fix import error in `tests/base.py`

## Side effects
7 of 28 tests still fail, for two different reasons:

```
_________________________ TestNodeFilesList.test_returns_folder_data _________________________
api_tests/nodes/views/test_node_files_list.py:162: in test_returns_folder_data
    res = self.app.get('{}osfstorage/{}/'.format(self.private_url, fobj._id), auth=self.user.auth)
../../.virtualenvs/osf/lib/python2.7/site-packages/webtest_plus/app.py:95: in get
    expect_errors=expect_errors, xhr=xhr)
../../.virtualenvs/osf/lib/python2.7/site-packages/webtest/app.py:327: in get
    expect_errors=expect_errors)
tests/json_api_test_app.py:82: in do_request
    expect_errors)
../../.virtualenvs/osf/lib/python2.7/site-packages/webtest/app.py:610: in do_request
    res = req.get_response(app, catch_exc_info=True)
../../.virtualenvs/osf/lib/python2.7/site-packages/webob/request.py:1295: in send
    application, catch_exc_info=True)
../../.virtualenvs/osf/lib/python2.7/site-packages/webob/request.py:1263: in call_application
    app_iter = application(self.environ, start_response)
../../.virtualenvs/osf/lib/python2.7/site-packages/webtest/lint.py:198: in lint_app
    iterator = application(environ, start_response_wrapper)
../../.virtualenvs/osf/lib/python2.7/site-packages/django/contrib/staticfiles/handlers.py:63: in __call__
    return self.application(environ, start_response)
../../.virtualenvs/osf/lib/python2.7/site-packages/django/core/handlers/wsgi.py:177: in __call__
    response = self.get_response(request)
../../.virtualenvs/osf/lib/python2.7/site-packages/django/core/handlers/base.py:230: in get_response
    response = self.handle_uncaught_exception(request, resolver, sys.exc_info())
../../.virtualenvs/osf/lib/python2.7/site-packages/django/core/handlers/base.py:149: in get_response
    response = self.process_exception_by_middleware(e, request)
../../.virtualenvs/osf/lib/python2.7/site-packages/django/core/handlers/base.py:147: in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
../../.virtualenvs/osf/lib/python2.7/site-packages/django/utils/decorators.py:184: in inner
    return func(*args, **kwargs)
../../.virtualenvs/osf/lib/python2.7/site-packages/django/views/decorators/csrf.py:58: in wrapped_view
    return view_func(*args, **kwargs)
../../.virtualenvs/osf/lib/python2.7/site-packages/django/views/generic/base.py:68: in view
    return self.dispatch(request, *args, **kwargs)
../../.virtualenvs/osf/lib/python2.7/site-packages/rest_framework/views.py:466: in dispatch
    response = self.handle_exception(exc)
../../.virtualenvs/osf/lib/python2.7/site-packages/rest_framework/views.py:463: in dispatch
    response = handler(request, *args, **kwargs)
../../.virtualenvs/osf/lib/python2.7/site-packages/rest_framework/generics.py:201: in get
    return self.list(request, *args, **kwargs)
../../.virtualenvs/osf/lib/python2.7/site-packages/rest_framework/mixins.py:40: in list
    queryset = self.filter_queryset(self.get_queryset())
api/nodes/views.py:1912: in get_queryset
    return self.get_queryset_from_request()
api/base/filters.py:428: in get_queryset_from_request
    default_queryset = self.get_default_queryset()
api/nodes/views.py:1899: in get_default_queryset
    files_list = self.fetch_from_waterbutler()
api/nodes/views.py:163: in fetch_from_waterbutler
    return self.get_file_object(node, path, provider)
api/nodes/views.py:166: in get_file_object
    obj = get_file_object(node=node, path=path, provider=provider, request=self.request)
api/nodes/utils.py:24: in get_file_object
    Q('is_file', 'eq', not path.endswith('/'))
api/base/utils.py:80: in get_object_or_error
    obj = model_cls.find_one(query_or_pk, **kwargs)
website/files/models/base.py:405: in find_one
    return StoredFileNode.find_one(cls._filter(qs)).wrapped()
osf/models/base.py:110: in find_one
    return cls.objects.get(to_django_query(query, model_cls=cls))
../../.virtualenvs/osf/lib/python2.7/site-packages/django/db/models/manager.py:122: in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
../../.virtualenvs/osf/lib/python2.7/site-packages/django/db/models/query.py:378: in get
    clone = self.filter(*args, **kwargs)
../../.virtualenvs/osf/lib/python2.7/site-packages/django/db/models/query.py:790: in filter
    return self._filter_or_exclude(False, *args, **kwargs)
../../.virtualenvs/osf/lib/python2.7/site-packages/django/db/models/query.py:808: in _filter_or_exclude
    clone.query.add_q(Q(*args, **kwargs))
../../.virtualenvs/osf/lib/python2.7/site-packages/django/db/models/sql/query.py:1243: in add_q
    clause, _ = self._add_q(q_object, self.used_aliases)
../../.virtualenvs/osf/lib/python2.7/site-packages/django/db/models/sql/query.py:1263: in _add_q
    current_negated, allow_joins, split_subq)
../../.virtualenvs/osf/lib/python2.7/site-packages/django/db/models/sql/query.py:1269: in _add_q
    allow_joins=allow_joins, split_subq=split_subq,
../../.virtualenvs/osf/lib/python2.7/site-packages/django/db/models/sql/query.py:1199: in build_filter
    condition = lookup_class(lhs, value)
../../.virtualenvs/osf/lib/python2.7/site-packages/django/db/models/lookups.py:19: in __init__
    self.rhs = self.get_prep_lookup()
../../.virtualenvs/osf/lib/python2.7/site-packages/django/db/models/fields/related_lookups.py:98: in get_prep_lookup
    self.lookup_name, self.rhs)
../../.virtualenvs/osf/lib/python2.7/site-packages/django/db/models/fields/__init__.py:744: in get_prep_lookup
    return self.get_prep_value(value)
../../.virtualenvs/osf/lib/python2.7/site-packages/django/db/models/fields/__init__.py:976: in get_prep_value
    return int(value)
E   ValueError: invalid literal for int() with base 10: 'c4xe5'
```
```
____________________ TestNodeFilesListFiltering.test_node_files_are_filterable_by_kind _____________________
api_tests/nodes/views/test_node_files_list.py:375: in test_node_files_are_filterable_by_kind
    res = self.app.get(url, auth=self.user.auth)
../../.virtualenvs/osf/lib/python2.7/site-packages/webtest_plus/app.py:95: in get
    expect_errors=expect_errors, xhr=xhr)
../../.virtualenvs/osf/lib/python2.7/site-packages/webtest/app.py:327: in get
    expect_errors=expect_errors)
tests/json_api_test_app.py:82: in do_request
    expect_errors)
../../.virtualenvs/osf/lib/python2.7/site-packages/webtest/app.py:610: in do_request
    res = req.get_response(app, catch_exc_info=True)
../../.virtualenvs/osf/lib/python2.7/site-packages/webob/request.py:1295: in send
    application, catch_exc_info=True)
../../.virtualenvs/osf/lib/python2.7/site-packages/webob/request.py:1263: in call_application
    app_iter = application(self.environ, start_response)
../../.virtualenvs/osf/lib/python2.7/site-packages/webtest/lint.py:198: in lint_app
    iterator = application(environ, start_response_wrapper)
../../.virtualenvs/osf/lib/python2.7/site-packages/django/contrib/staticfiles/handlers.py:63: in __call__
    return self.application(environ, start_response)
../../.virtualenvs/osf/lib/python2.7/site-packages/django/core/handlers/wsgi.py:177: in __call__
    response = self.get_response(request)
../../.virtualenvs/osf/lib/python2.7/site-packages/django/core/handlers/base.py:230: in get_response
    response = self.handle_uncaught_exception(request, resolver, sys.exc_info())
../../.virtualenvs/osf/lib/python2.7/site-packages/django/core/handlers/base.py:149: in get_response
    response = self.process_exception_by_middleware(e, request)
../../.virtualenvs/osf/lib/python2.7/site-packages/django/core/handlers/base.py:147: in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
../../.virtualenvs/osf/lib/python2.7/site-packages/django/utils/decorators.py:184: in inner
    return func(*args, **kwargs)
../../.virtualenvs/osf/lib/python2.7/site-packages/django/views/decorators/csrf.py:58: in wrapped_view
    return view_func(*args, **kwargs)
../../.virtualenvs/osf/lib/python2.7/site-packages/django/views/generic/base.py:68: in view
    return self.dispatch(request, *args, **kwargs)
../../.virtualenvs/osf/lib/python2.7/site-packages/rest_framework/views.py:466: in dispatch
    response = self.handle_exception(exc)
../../.virtualenvs/osf/lib/python2.7/site-packages/rest_framework/views.py:463: in dispatch
    response = handler(request, *args, **kwargs)
../../.virtualenvs/osf/lib/python2.7/site-packages/rest_framework/generics.py:201: in get
    return self.list(request, *args, **kwargs)
../../.virtualenvs/osf/lib/python2.7/site-packages/rest_framework/mixins.py:40: in list
    queryset = self.filter_queryset(self.get_queryset())
api/nodes/views.py:1912: in get_queryset
    return self.get_queryset_from_request()
api/base/filters.py:430: in get_queryset_from_request
    param_queryset = self.param_queryset(self.request.query_params, default_queryset)
api/base/filters.py:443: in param_queryset
    queryset = queryset.filter(**{query_field_name: data['value']})
E   AttributeError: 'list' object has no attribute 'filter'
```

## Ticket

https://github.com/CenterForOpenScience/osf-models/issues/133