### PR TITLE
Catch key error for accessing old OSFStorageGuidFile objects [OSF-7146]

### DIFF
--- a/website/views.py
+++ b/website/views.py
@@ -175,8 +175,11 @@ def resolve_guid(guid, suffix=None):
     try:
         # Look up
         guid_object = Guid.load(guid)
-    except KeyError('osfstorageguidfile'):  # Used when an old detached OsfStorageGuidFile object is accessed
-        raise HTTPError(http.NOT_FOUND)
+    except KeyError as e:
+        if e.message == 'osfstorageguidfile':  # Used when an old detached OsfStorageGuidFile object is accessed
+            raise HTTPError(http.NOT_FOUND)
+        else:
+            raise e
     if guid_object:
 
         # verify that the object implements a GuidStoredObject-like interface. If a model

--- a/website/views.py
+++ b/website/views.py
@@ -172,8 +172,11 @@ def resolve_guid(guid, suffix=None):
     :param str suffix: Remainder of URL after the GUID
     :return: Return value of proxied view function
     """
-    # Look up GUID
-    guid_object = Guid.load(guid)
+    try:
+        # Look up
+        guid_object = Guid.load(guid)
+    except KeyError('osfstorageguidfile'):  # Used when an old detached OsfStorageGuidFile object is accessed
+        raise HTTPError(http.NOT_FOUND)
     if guid_object:
 
         # verify that the object implements a GuidStoredObject-like interface. If a model


### PR DESCRIPTION
## Purpose

Sentry had been getting errors when someone attempted to access a guid url that was attached to an old `OsfStorageGuidFile` object. 

## Changes
- Catch this particular `KeyError` and return 404 Not Found instead.

## Side effects
None anticipated


## Ticket
https://openscience.atlassian.net/browse/OSF-7146
