### PR TITLE
Add more analytics to Keen! [OSF-7206]

### DIFF
--- a/scripts/analytics/addon_snapshot.py
+++ b/scripts/analytics/addon_snapshot.py
@@ -2,10 +2,58 @@ import logging
 from modularodm import Q
 
 from website.app import init_app
+from website.models import Node, User
+from website.addons.base import AddonNodeSettingsBase
 from scripts.analytics.base import SnapshotAnalytics
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
+
+
+# Modified from scripts/analytics/benchmarks.py
+def get_enabled_authorized_linked(user_settings_list, has_external_account, short_name):
+    """ Gather the number of users who have at least one node in each of the stages for an addon
+
+    :param user_settings_list: list of user_settings for a particualr addon
+    :param has_external_account: where addon is derrived from, determines method to load node settings
+    :param short_name: short name of addon to get correct node_settings
+    :return:  dict with number of users that have at least one project at each stage
+    """
+    num_enabled = 0  # of users w/ 1+ addon account connected
+    num_authorized = 0  # of users w/ 1+ addon account connected to 1+ node
+    num_linked = 0  # of users w/ 1+ addon account connected to 1+ node and configured
+
+    # osfstorage and wiki don't have user_settings, so always assume they're enabled, authorized, linked
+    if short_name == 'osfstorage' or short_name == 'wiki':
+        active = User.find(
+                    Q('is_registered', 'eq', True) &
+                    Q('password', 'ne', None) &
+                    Q('merged_by', 'eq', None) &
+                    Q('date_disabled', 'eq', None) &
+                    Q('date_confirmed', 'ne', None)
+                ).count()
+        for user in xrange(active):
+            num_enabled += 1
+            num_authorized += 1
+            num_linked += 1
+
+    for user_settings in user_settings_list:
+        if has_external_account:
+            if user_settings.has_auth:
+                num_enabled += 1
+                node_settings_list = [Node.load(guid).get_addon(short_name) for guid in user_settings.oauth_grants.keys()]
+        else:
+            num_enabled += 1
+            node_settings_list = [Node.load(guid).get_addon(short_name) for guid in user_settings.nodes_authorized]
+        if any([ns.has_auth for ns in node_settings_list if ns]):
+            num_authorized += 1
+            if any([(ns.complete and ns.configured) for ns in node_settings_list if ns]):
+                num_linked += 1
+    return {
+        'enabled': num_enabled,
+        'authorized': num_authorized,
+        'linked': num_linked
+    }
 
 
 class AddonSnapshot(SnapshotAnalytics):
@@ -22,18 +70,35 @@ class AddonSnapshot(SnapshotAnalytics):
         addons_available = {k: v for k, v in [(addon.short_name, addon) for addon in ADDONS_AVAILABLE]}
 
         for short_name, addon in addons_available.iteritems():
-            user_count = addon.settings_models['user'].find().count() if addon.settings_models.get('user') else 0
-            connected_count = addon.settings_models['node'].find().count() if addon.settings_models.get('node') else 0
+
+            user_settings_list = addon.settings_models['user'].find() if addon.settings_models.get('user') else []
+            node_settings_list = addon.settings_models['node'].find() if addon.settings_models.get('node') else []
+
+            has_external_account = True
+            # Check out the first element in node_settings_list to see if it has an external account to check for
+            if node_settings_list:
+                if AddonNodeSettingsBase in node_settings_list[0].__class__.__bases__:
+                    has_external_account = False
+
+            connected_count = 0
+            for node_settings in node_settings_list:
+                if not node_settings.owner.is_bookmark_collection:
+                    connected_count += 1
+
             deleted_count = addon.settings_models['node'].find(Q('deleted', 'eq', True)).count() if addon.settings_models.get('node') else 0
-            disconnected_count = addon.settings_models['node'].find(Q('external_account', 'eq', None) & Q('deleted', 'ne', True)).count() if addon.settings_models.get('node') else 0
+
+            if has_external_account:
+                disconnected_count = addon.settings_models['node'].find(Q('external_account', 'eq', None) & Q('deleted', 'ne', True)).count() if addon.settings_models.get('node') else 0
+            else:
+                disconnected_count = addon.settings_models['node'].find(Q('configured', 'eq', True) & Q('complete', 'eq', False) & Q('deleted', 'ne', True)).count() if addon.settings_models.get('node') else 0
             total = connected_count + deleted_count + disconnected_count
+            usage_counts = get_enabled_authorized_linked(user_settings_list, has_external_account, addon.short_name)
+
             counts.append({
                 'provider': {
                     'name': short_name
                 },
-                'users': {
-                    'total': user_count
-                },
+                'users': usage_counts,
                 'nodes': {
                     'total': total,
                     'connected': connected_count,
@@ -42,8 +107,13 @@ class AddonSnapshot(SnapshotAnalytics):
                 }
             })
 
-            logger.info('{} counted. Users: {}, Total Nodes: {}'.format(addon.short_name, user_count, total))
-
+            logger.info(
+                '{} counted. Users with a linked node: {}, Total connected nodes: {}.'.format(
+                    addon.short_name,
+                    usage_counts['linked'],
+                    total
+                )
+            )
         return counts
 
 

--- a/scripts/analytics/base.py
+++ b/scripts/analytics/base.py
@@ -83,7 +83,8 @@ class SummaryAnalytics(BaseAnalytics):
                 self.collection_name
             )
         )
-        parser.add_argument('-d', '--date', dest='date', required=True)
+        parser.add_argument('-d', '--date', dest='date')
+        parser.add_argument('-y', '--yesterday', dest='yesterday', action='store_true')
 
         return parser.parse_args()
 

--- a/scripts/analytics/base.py
+++ b/scripts/analytics/base.py
@@ -2,7 +2,7 @@ import time
 import logging
 import argparse
 import importlib
-from datetime import datetime
+from datetime import datetime, timedelta
 from dateutil.parser import parse
 
 from website.app import init_app
@@ -24,7 +24,7 @@ class BaseAnalytics(object):
         raise NotImplementedError('Must specify the analytic type for logging purposes')
 
     def get_events(self, date):
-        pass
+        raise NotImplementedError('You must define a get_events method to gather analytic events')
 
     def send_events(self, events):
         keen_project = keen_settings['private']['project_id']
@@ -179,15 +179,21 @@ class DateAnalyticsHarness(BaseAnalyticsHarness):
             '-as', '--analytics_scripts', nargs='+', dest='analytics_scripts', required=False,
             help='Enter the names of scripts inside scripts/analytics you would like to run separated by spaces (ex: -as user_summary node_summary)'
         )
-        parser.add_argument('-d', '--date', dest='date', required=True)
+        parser.add_argument('-d', '--date', dest='date', required=False)
+        parser.add_argument('-y', '--yesterday', dest='yesterday', action='store_true')
         return parser.parse_args()
 
-
-    def main(self, date=None):
+    def main(self, date=None, yesterday=False):
         args = self.parse_args()
         entered_scripts = args.analytics_scripts
+        yesterday = yesterday or args.yesterday
+        if yesterday:
+            date = (datetime.today() - timedelta(1)).date()
         if not date:
-            date = parse(args.date).date()
+            try:
+                date = parse(args.date).date()
+            except AttributeError:
+                raise AttributeError('You must either specify a date or use the yesterday argument to gather analytics for yesterday.')
         if entered_scripts:
             analytics_classes = self.try_to_import_from_args(entered_scripts)
         else:

--- a/scripts/analytics/institution_summary.py
+++ b/scripts/analytics/institution_summary.py
@@ -111,9 +111,9 @@ if __name__ == '__main__':
     institution_summary = InstitutionSummary()
     args = institution_summary.parse_args()
     yesterday = args.yesterday
-    if not yesterday:
-        date = parse(args.date).date() if args.date else None
-    else:
+    if yesterday:
         date = (datetime.today() - timedelta(1)).date()
+    else:
+        date = parse(args.date).date() if args.date else None
     events = institution_summary.get_events(date)
     institution_summary.send_events(events)

--- a/scripts/analytics/institution_summary.py
+++ b/scripts/analytics/institution_summary.py
@@ -110,6 +110,10 @@ if __name__ == '__main__':
     init_app()
     institution_summary = InstitutionSummary()
     args = institution_summary.parse_args()
-    date = parse(args.date).date() if args.date else None
+    yesterday = args.yesterday
+    if not yesterday:
+        date = parse(args.date).date() if args.date else None
+    else:
+        date = (datetime.today() - timedelta(1)).date()
     events = institution_summary.get_events(date)
     institution_summary.send_events(events)

--- a/scripts/analytics/node_summary.py
+++ b/scripts/analytics/node_summary.py
@@ -99,9 +99,9 @@ if __name__ == '__main__':
     node_summary = NodeSummary()
     args = node_summary.parse_args()
     yesterday = args.yesterday
-    if not yesterday:
-        date = parse(args.date).date() if args.date else None
-    else:
+    if yesterday:
         date = (datetime.today() - timedelta(1)).date()
+    else:
+        date = parse(args.date).date() if args.date else None
     events = node_summary.get_events(date)
     node_summary.send_events(events)

--- a/scripts/analytics/node_summary.py
+++ b/scripts/analytics/node_summary.py
@@ -98,6 +98,10 @@ if __name__ == '__main__':
     init_app()
     node_summary = NodeSummary()
     args = node_summary.parse_args()
-    date = parse(args.date).date() if args.date else None
+    yesterday = args.yesterday
+    if not yesterday:
+        date = parse(args.date).date() if args.date else None
+    else:
+        date = (datetime.today() - timedelta(1)).date()
     events = node_summary.get_events(date)
     node_summary.send_events(events)

--- a/scripts/analytics/run_keen_events.py
+++ b/scripts/analytics/run_keen_events.py
@@ -1,13 +1,14 @@
 from framework.celery_tasks import app as celery_app
 from scripts.analytics.base import DateAnalyticsHarness
 from scripts.analytics.node_log_events import NodeLogEvents
+from scripts.analytics.user_domain_events import UserDomainEvents
 
 
 class EventAnalyticsHarness(DateAnalyticsHarness):
 
     @property
     def analytics_classes(self):
-        return [NodeLogEvents]
+        return [NodeLogEvents, UserDomainEvents]
 
 
 @celery_app.task(name='scripts.run_keen_events')

--- a/scripts/analytics/user_domain_events.py
+++ b/scripts/analytics/user_domain_events.py
@@ -1,0 +1,60 @@
+import pytz
+import logging
+from modularodm import Q
+from dateutil.parser import parse
+from datetime import datetime, timedelta
+
+from website.models import User
+from website.app import init_app
+from scripts.analytics.base import EventAnalytics
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+
+class UserDomainEvents(EventAnalytics):
+
+    @property
+    def collection_name(self):
+        return 'user_domain_events'
+
+    def get_events(self, date):
+        """ Get all node logs from a given date for a 24 hour period,
+        ending at the date given.
+        """
+        super(UserDomainEvents, self).get_events(date)
+
+        # In the end, turn the date back into a datetime at midnight for queries
+        date = datetime(date.year, date.month, date.day).replace(tzinfo=pytz.UTC)
+
+        logger.info('Gathering user domains between {} and {}'.format(
+            date, (date + timedelta(1)).isoformat()
+        ))
+
+        user_query = Q('date_confirmed', 'lt', date + timedelta(1)) & Q('date_confirmed', 'gte', date)
+        users = User.find(user_query)
+        user_domain_events = []
+        for user in users:
+            user_date = user.date_confirmed.replace(tzinfo=pytz.UTC)
+            event = {
+                'keen': {'timestamp': user_date.isoformat()},
+                'date': user_date.isoformat(),
+                'domain': user.username.split('@')[-1]
+            }
+            user_domain_events.append(event)
+
+        logger.info('User domains collected. {} users and their email domains.'.format(len(user_domain_events)))
+        return user_domain_events
+
+
+def get_class():
+    return UserDomainEvents
+
+
+if __name__ == '__main__':
+    init_app()
+    user_domain_events = UserDomainEvents()
+    args = user_domain_events.parse_args()
+    date = parse(args.date).date() if args.date else None
+    events = user_domain_events.get_events(date)
+    user_domain_events.send_events(events)

--- a/scripts/analytics/user_summary.py
+++ b/scripts/analytics/user_summary.py
@@ -98,9 +98,9 @@ if __name__ == '__main__':
     user_summary = UserSummary()
     args = user_summary.parse_args()
     yesterday = args.yesterday
-    if not yesterday:
-        date = parse(args.date).date() if args.date else None
-    else:
+    if yesterday:
         date = (datetime.today() - timedelta(1)).date()
+    else:
+        date = parse(args.date).date() if args.date else None
     events = user_summary.get_events(date)
     user_summary.send_events(events)

--- a/scripts/analytics/user_summary.py
+++ b/scripts/analytics/user_summary.py
@@ -19,7 +19,7 @@ LOG_THRESHOLD = 11
 def count_user_logs(user):
     logs = NodeLog.find(Q('user', 'eq', user._id))
     length = logs.count()
-    if length > 0:
+    if length >= LOG_THRESHOLD:
         item = logs[0]
         if item.action == 'project_created' and item.node.is_bookmark_collection:
             length -= 1
@@ -75,15 +75,20 @@ class UserSummary(SummaryAnalytics):
                 'deactivated': User.find(
                     Q('date_disabled', 'ne', None) &
                     Q('date_disabled', 'lt', query_datetime)
+                ).count(),
+                'merged': User.find(
+                    Q('date_registered', 'lt', query_datetime) &
+                    Q('merged_by', 'ne', None)
                 ).count()
             }
         }
         logger.info(
-            'Users counted. Active: {}, Depth: {}, Unconfirmed: {}, Deactivated: {}'.format(
+            'Users counted. Active: {}, Depth: {}, Unconfirmed: {}, Deactivated: {}, Merged: {}'.format(
                 counts['status']['active'],
                 counts['status']['depth'],
                 counts['status']['unconfirmed'],
-                counts['status']['deactivated']
+                counts['status']['deactivated'],
+                counts['status']['merged']
             )
         )
         return [counts]

--- a/scripts/analytics/user_summary.py
+++ b/scripts/analytics/user_summary.py
@@ -19,7 +19,7 @@ LOG_THRESHOLD = 11
 def count_user_logs(user):
     logs = NodeLog.find(Q('user', 'eq', user._id))
     length = logs.count()
-    if length >= LOG_THRESHOLD:
+    if length == LOG_THRESHOLD:
         item = logs[0]
         if item.action == 'project_created' and item.node.is_bookmark_collection:
             length -= 1

--- a/scripts/analytics/user_summary.py
+++ b/scripts/analytics/user_summary.py
@@ -97,6 +97,10 @@ if __name__ == '__main__':
     init_app()
     user_summary = UserSummary()
     args = user_summary.parse_args()
-    date = parse(args.date).date() if args.date else None
+    yesterday = args.yesterday
+    if not yesterday:
+        date = parse(args.date).date() if args.date else None
+    else:
+        date = (datetime.today() - timedelta(1)).date()
     events = user_summary.get_events(date)
     user_summary.send_events(events)

--- a/scripts/analytics/user_summary.py
+++ b/scripts/analytics/user_summary.py
@@ -6,11 +6,35 @@ from datetime import datetime, timedelta
 from modularodm import Q
 
 from website.app import init_app
-from website.models import User
+from website.models import User, NodeLog
 from scripts.analytics.base import SummaryAnalytics
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
+
+LOG_THRESHOLD = 11
+
+
+# Modified from scripts/analytics/depth_users.py
+def count_user_logs(user):
+    logs = NodeLog.find(Q('user', 'eq', user._id))
+    length = logs.count()
+    if length > 0:
+        item = logs[0]
+        if item.action == 'project_created' and item.node.is_bookmark_collection:
+            length -= 1
+    return length
+
+
+# Modified from scripts/analytics/depth_users.py
+def get_number_of_depth_users(active_users):
+    depth_users = 0
+    for user in active_users:
+        log_count = count_user_logs(user)
+        if log_count >= LOG_THRESHOLD:
+            depth_users += 1
+
+    return depth_users
 
 
 class UserSummary(SummaryAnalytics):
@@ -26,19 +50,24 @@ class UserSummary(SummaryAnalytics):
         timestamp_datetime = datetime(date.year, date.month, date.day).replace(tzinfo=pytz.UTC)
         query_datetime = timestamp_datetime + timedelta(1)
 
-        counts = {
-            'keen': {
-                'timestamp': timestamp_datetime.isoformat()
-            },
-            'status': {
-                'active': User.find(
+        active_users = User.find(
                     Q('is_registered', 'eq', True) &
                     Q('password', 'ne', None) &
                     Q('merged_by', 'eq', None) &
                     Q('date_disabled', 'eq', None) &
                     Q('date_confirmed', 'ne', None) &
                     Q('date_confirmed', 'lt', query_datetime)
-                ).count(),
+                )
+
+        depth_users = get_number_of_depth_users(active_users)
+
+        counts = {
+            'keen': {
+                'timestamp': timestamp_datetime.isoformat()
+            },
+            'status': {
+                'active': active_users.count(),
+                'depth': depth_users,
                 'unconfirmed': User.find(
                     Q('date_registered', 'lt', query_datetime) &
                     Q('date_confirmed', 'eq', None)
@@ -50,8 +79,9 @@ class UserSummary(SummaryAnalytics):
             }
         }
         logger.info(
-            'Users counted. Active: {}, Unconfirmed: {}, Deactivated: {}'.format(
+            'Users counted. Active: {}, Depth: {}, Unconfirmed: {}, Deactivated: {}'.format(
                 counts['status']['active'],
+                counts['status']['depth'],
                 counts['status']['unconfirmed'],
                 counts['status']['deactivated']
             )

--- a/scripts/tests/test_addon_snapshot.py
+++ b/scripts/tests/test_addon_snapshot.py
@@ -7,6 +7,7 @@ from tests.factories import AuthUserFactory, ProjectFactory
 
 from scripts.analytics.addon_snapshot import AddonSnapshot
 
+from website.models import User
 from website.settings import ADDONS_AVAILABLE
 from website.addons.github.tests.factories import GitHubAccountFactory
 from website.addons.github.model import GitHubNodeSettings, GitHubUserSettings
@@ -21,24 +22,31 @@ class TestAddonCount(OsfTestCase):
         self.node = ProjectFactory(creator=self.user)
         self.user.add_addon('github')
         self.user_addon = self.user.get_addon('github')
-        self.oauth_settings = GitHubAccountFactory(display_name='hmoco1')
-        self.oauth_settings.save()
-        self.user.external_accounts.append(self.oauth_settings)
+
+        self.external_account = GitHubAccountFactory(display_name='hmoco1')
+
+        self.user_settings = self.user.get_or_add_addon('github')
+
+        self.user_settings.save()
+        self.user.external_accounts.append(self.external_account)
         self.user.save()
         self.node.add_addon('github', Auth(self.user))
         self.node_addon = self.node.get_addon('github')
         self.node_addon.user = self.user.fullname
         self.node_addon.repo = '29 #Strafford APTS'
         self.node_addon.user_settings = self.user_addon
-        self.node_addon.external_account = self.oauth_settings
+        self.node_addon.external_account = self.external_account
         self.node_addon.save()
 
+        self.user_settings.grant_oauth_access(
+            node=self.node,
+            external_account=self.external_account,
+        )
     def tearDown(self):
         GitHubNodeSettings.remove()
         GitHubUserSettings.remove()
         GoogleDriveNodeSettings.remove()
         GoogleDriveUserSettings.remove()
-
 
     def test_run_for_all_addon(self):
         results = AddonSnapshot().get_events()
@@ -52,6 +60,12 @@ class TestAddonCount(OsfTestCase):
         assert_equal(github_res['users']['enabled'], 1)
         assert_equal(github_res['nodes']['total'], 1)
 
+    def test_one_user_one_node_one_addon_one_node_linked(self):
+        results = AddonSnapshot().get_events()
+        github_res = [res for res in results if res['provider']['name'] == 'github'][0]
+        assert_equal(github_res['users']['enabled'], 1)
+        assert_equal(github_res['nodes']['total'], 1)
+
     def test_one_user_with_multiple_githubs(self):
         oauth_settings2 = GitHubAccountFactory(display_name='hmoco2')
         oauth_settings2.save()
@@ -60,6 +74,7 @@ class TestAddonCount(OsfTestCase):
         results = AddonSnapshot().get_events()
         github_res = [res for res in results if res['provider']['name'] == 'github'][0]
         assert_equal(github_res['users']['enabled'], 1)
+        # import ipdb; ipdb.set_trace()
 
     def test_one_user_with_multiple_addons(self):
         results = AddonSnapshot().get_events()
@@ -89,15 +104,28 @@ class TestAddonCount(OsfTestCase):
         results = AddonSnapshot().get_events()
         github_res = [res for res in results if res['provider']['name'] == 'github'][0]
         assert_equal(github_res['users']['enabled'], 2)
+        assert_equal(github_res['users']['authorized'], 1)
+        assert_equal(github_res['users']['linked'], 1)
 
-    def test_many_users_each_with_the_same_github(self):
+    def test_many_users_each_with_the_same_github_enabled(self):
         user = AuthUserFactory()
         user.add_addon('github')
-        user.external_accounts.append(self.oauth_settings)
+        user.external_accounts.append(self.external_account)
         user.save()
         results = AddonSnapshot().get_events()
         github_res = [res for res in results if res['provider']['name'] == 'github'][0]
         assert_equal(github_res['users']['enabled'], 2)
+
+    def test_github_enabled_not_linked_or_authorized(self):
+        user = AuthUserFactory()
+        user.add_addon('github')
+        user.external_accounts.append(self.external_account)
+        user.save()
+        results = AddonSnapshot().get_events()
+        github_res = [res for res in results if res['provider']['name'] == 'github'][0]
+        assert_equal(github_res['users']['enabled'], 2)
+        assert_equal(github_res['users']['authorized'], 1)
+        assert_equal(github_res['users']['linked'], 1)
 
     def test_one_node_with_multiple_addons(self):
         results = AddonSnapshot().get_events()
@@ -135,7 +163,7 @@ class TestAddonCount(OsfTestCase):
         node_addon.user = self.user.fullname
         node_addon.repo = '8 (circle)'
         node_addon.user_settings = self.user_addon
-        node_addon.external_account = self.oauth_settings
+        node_addon.external_account = self.external_account
         node_addon.save()
         node.save()
 
@@ -171,3 +199,21 @@ class TestAddonCount(OsfTestCase):
         results = AddonSnapshot().get_events()
         github_res = [res for res in results if res['provider']['name'] == 'github'][0]
         assert_equal(github_res['nodes']['disconnected'], 1)
+
+    def test_all_users_have_wiki_osfstorage_enabled(self):
+        all_user_count = User.find().count()
+        results = AddonSnapshot().get_events()
+        osfstorage_res = [res for res in results if res['provider']['name'] == 'osfstorage'][0]
+        wiki_res = [res for res in results if res['provider']['name'] == 'osfstorage'][0]
+
+        assert_equal(osfstorage_res['users']['enabled'], all_user_count)
+        assert_equal(wiki_res['users']['enabled'], all_user_count)
+
+    def test_wiki_deleted_shows_as_deleted(self):
+        node = ProjectFactory(creator=self.user)
+        node.delete_addon('wiki', auth=Auth(self.user))
+
+        results = AddonSnapshot().get_events()
+        wiki_res = [res for res in results if res['provider']['name'] == 'wiki'][0]
+
+        assert_equal(wiki_res['nodes']['deleted'], 1)

--- a/scripts/tests/test_addon_snapshot.py
+++ b/scripts/tests/test_addon_snapshot.py
@@ -49,7 +49,7 @@ class TestAddonCount(OsfTestCase):
     def test_one_user_one_node_one_addon(self):
         results = AddonSnapshot().get_events()
         github_res = [res for res in results if res['provider']['name'] == 'github'][0]
-        assert_equal(github_res['users']['total'], 1)
+        assert_equal(github_res['users']['enabled'], 1)
         assert_equal(github_res['nodes']['total'], 1)
 
     def test_one_user_with_multiple_githubs(self):
@@ -59,14 +59,14 @@ class TestAddonCount(OsfTestCase):
         self.user.save()
         results = AddonSnapshot().get_events()
         github_res = [res for res in results if res['provider']['name'] == 'github'][0]
-        assert_equal(github_res['users']['total'], 1)
+        assert_equal(github_res['users']['enabled'], 1)
 
     def test_one_user_with_multiple_addons(self):
         results = AddonSnapshot().get_events()
         github_res = [res for res in results if res['provider']['name'] == 'github'][0]
         googledrive_res = [res for res in results if res['provider']['name'] == 'googledrive'][0]
-        assert_equal(github_res['users']['total'], 1)
-        assert_equal(googledrive_res['users']['total'], 0)
+        assert_equal(github_res['users']['enabled'], 1)
+        assert_equal(googledrive_res['users']['enabled'], 0)
 
         self.user.add_addon('googledrive')
         oauth_settings = GoogleDriveAccountFactory()
@@ -76,8 +76,8 @@ class TestAddonCount(OsfTestCase):
         results = AddonSnapshot().get_events()
         github_res = [res for res in results if res['provider']['name'] == 'github'][0]
         googledrive_res = [res for res in results if res['provider']['name'] == 'googledrive'][0]
-        assert_equal(github_res['users']['total'], 1)
-        assert_equal(googledrive_res['users']['total'], 1)
+        assert_equal(github_res['users']['enabled'], 1)
+        assert_equal(googledrive_res['users']['enabled'], 1)
 
     def test_many_users_each_with_a_different_github(self):
         user = AuthUserFactory()
@@ -88,7 +88,7 @@ class TestAddonCount(OsfTestCase):
         user.save()
         results = AddonSnapshot().get_events()
         github_res = [res for res in results if res['provider']['name'] == 'github'][0]
-        assert_equal(github_res['users']['total'], 2)
+        assert_equal(github_res['users']['enabled'], 2)
 
     def test_many_users_each_with_the_same_github(self):
         user = AuthUserFactory()
@@ -97,7 +97,7 @@ class TestAddonCount(OsfTestCase):
         user.save()
         results = AddonSnapshot().get_events()
         github_res = [res for res in results if res['provider']['name'] == 'github'][0]
-        assert_equal(github_res['users']['total'], 2)
+        assert_equal(github_res['users']['enabled'], 2)
 
     def test_one_node_with_multiple_addons(self):
         results = AddonSnapshot().get_events()

--- a/scripts/tests/test_user_summary.py
+++ b/scripts/tests/test_user_summary.py
@@ -62,6 +62,7 @@ class TestUserCount(OsfTestCase):
         assert_equal(data['status']['unconfirmed'], 2)
         assert_equal(data['status']['deactivated'], 2)
         assert_equal(data['status']['depth'], 2)
+        assert_equal(data['status']['merged'], 0)
 
     def test_gets_only_users_from_given_date(self):
         data = UserSummary().get_events(self.a_while_ago.date())[0]
@@ -69,3 +70,20 @@ class TestUserCount(OsfTestCase):
         assert_equal(data['status']['unconfirmed'], 0)
         assert_equal(data['status']['deactivated'], 1)
         assert_equal(data['status']['depth'], 1)
+        assert_equal(data['status']['merged'], 0)
+
+    def test_merged_user(self):
+        user = AuthUserFactory(fullname='Annie Lennox')
+        merged_user = AuthUserFactory(fullname='Lisa Stansfield')
+        user.save()
+        merged_user.save()
+
+        user.merge_user(merged_user)
+        user.save()
+        merged_user.save()
+        user.reload()
+        merged_user.reload()
+        modify_user_dates_in_mongo(self.yesterday)
+
+        data = UserSummary().get_events(self.yesterday.date())[0]
+        assert_equal(data['status']['merged'], 1)

--- a/scripts/tests/test_user_summary.py
+++ b/scripts/tests/test_user_summary.py
@@ -5,8 +5,8 @@ from framework.transactions.context import TokuTransaction
 
 from website.models import User
 from tests.base import OsfTestCase
-from tests.factories import AuthUserFactory
-from scripts.analytics.user_summary import UserSummary
+from tests.factories import AuthUserFactory, NodeLogFactory
+from scripts.analytics.user_summary import UserSummary, LOG_THRESHOLD
 
 
 def modify_user_dates_in_mongo(new_date):
@@ -30,11 +30,16 @@ class TestUserCount(OsfTestCase):
             u.password = 'wow' + str(i)
             u.date_confirmed = self.yesterday
             u.save()
+        # Make one of those 3 a depth user
+        for i in range(LOG_THRESHOLD + 1):
+            NodeLogFactory(action='file_added', user=u)
         u = AuthUserFactory()
         u.is_registered = True
         u.password = 'wow'
         u.date_confirmed = self.a_while_ago
         u.save()
+        for i in range(LOG_THRESHOLD + 1):
+            NodeLogFactory(action='file_added', user=u)
         for i in range(0, 2):
             u = AuthUserFactory()
             u.date_confirmed = None
@@ -56,9 +61,11 @@ class TestUserCount(OsfTestCase):
         assert_equal(data['status']['active'], 4)
         assert_equal(data['status']['unconfirmed'], 2)
         assert_equal(data['status']['deactivated'], 2)
+        assert_equal(data['status']['depth'], 2)
 
     def test_gets_only_users_from_given_date(self):
         data = UserSummary().get_events(self.a_while_ago.date())[0]
         assert_equal(data['status']['active'], 1)
         assert_equal(data['status']['unconfirmed'], 0)
         assert_equal(data['status']['deactivated'], 1)
+        assert_equal(data['status']['depth'], 1)

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -494,7 +494,7 @@ else:
         'run_keen_summaries': {
             'task': 'scripts.analytics.run_keen_summaries',
             'schedule': crontab(minute=00, hour=2),  # Daily 2:00 a.m.
-            'kwargs': {'date': (datetime.datetime.utcnow() - datetime.timedelta(1)).date()}
+            'kwargs': {'yesterday': True}
         },
         'run_keen_snapshots': {
             'task': 'scripts.analytics.run_keen_snapshots',
@@ -502,8 +502,8 @@ else:
         },
         'run_keen_events': {
             'task': 'scripts.analytics.run_keen_events',
-            'schedule': crontab(minute=0, hour=4),
-            'kwargs': {'date': (datetime.datetime.utcnow() - datetime.timedelta(1)).date()}
+            'schedule': crontab(minute=0, hour=4),  # Daily 4:00 a.m.
+            'kwargs': {'yesterday': True}
         }
     }
 


### PR DESCRIPTION
## Purpose
We did a cool first round of sending stats to Keen, but let's make that more awesome by making it more closely match the other stats that we've been gathering regarding projects and nodes and addons and whatnot.

Here are what the new keen analytics events look like:

### User domain events
```
[
    {
        "date": "2016-11-13T09:21:13.988000+00:00",
        "keen": {
            "timestamp": "2016-11-13T09:21:13.988000+00:00"
        },
        "domain": "schuppe.com"
    },
    {
        "date": "2016-11-13T09:21:13.988000+00:00",
        "keen": {
            "timestamp": "2016-11-13T09:21:13.988000+00:00"
        },
        "domain": "mail.com"
    }
]
```

### Addon snapshot
```
{
    "users": {
        "enabled": 5,
        "authorized": 3,
        "linked": 2
    },
    "nodes": {
        "deleted": 0,
        "total": 2,
        "connected": 2,
        "disconnected": 0
    },
    "provider": {
        "name": "github"
    }
}
```

### User summary
```
{
    "status": {
        "active": 5,
        "deactivated": 2,
        "depth": 1,
        "unconfirmed": 1
    },
    "keen": {
        "timestamp": "2016-11-14T00:00:00+00:00"
    }
}
```

## Changes
- Add a `yesterday` argument to the main parsers that will automatically harvest from the day before when the script was called
- Use `yesterday` kwarg when calling from celery
- Add new `user_domain_events` collection that sends an event for every user created in a 24 hour period with what email domain they used for their username (e.x a user who signed up with my_awesome_email@woohoo.com would send an event for the domain woohoo.com)
- For addon snapshot, add `enabled`, `authorized` and `linked` instead of just `total` for `users`, which mirrors current analytics. This captures the number of users who have addons in their different potential stages of use (clicking the checkbox vs actually authorizing with the app vs actually linking it successfully to a node), and might help track improvements in usability.
- For the user summary, add depth users (using the same threshold of those with 11+ logs as we're currently using)
- Add tests for this stuff!

## Side effects
- Celery task updated! Will it have to be loaded separately?
- Addon Snapshot analytics are different for the user - remove `total` and report instead on `enabled`, `authorized` and `linked` -- enabled now is essentially the same as total. Chose to replace the language to match the analytics we were gathering in the past.


## Ticket
https://openscience.atlassian.net/browse/OSF-7206