### PR TITLE
Always make an other dataverse have the same URL to fetch API token [OSF-7213]

### DIFF
--- a/addons/dataverse/static/dataverseNodeConfig.js
+++ b/addons/dataverse/static/dataverseNodeConfig.js
@@ -61,9 +61,9 @@ function ViewModel(url) {
         return Boolean(self.selectedHost());
     });
     self.tokenUrl = ko.pureComputed(function() {
-        var tokenPath = self.host() === 'dataverse.lib.virginia.edu'
-                ? '/account/apitoken' : '/dataverseuser.xhtml?selectTab=apiTokenTab';
-        return self.host() ? 'https://' + self.host() + tokenPath : null;
+        var tokenPath = 'dataverseuser.xhtml?selectTab=apiTokenTab';
+        var extraSlash = self.host() && self.host().substr(self.host().length - 1) === '/' ? '' : '/';
+        return self.host() ? 'https://' + self.host() + extraSlash + tokenPath : null;
     });
     self.savedHostUrl = ko.pureComputed(function() {
         return 'https://' + self.savedHost();


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
"Other" dataverse URLs, particularly for UVA's dataverse, were being sent to the wrong place for API token retrieval

## Changes
- Make the URL for API token retrieval uniform across all "other" dataverse sources
- Account for the fact that they may or may not include a / and the end of the URL they enter

## Side effects
None anticipated

##Notes for QA

The "request API Token" link for Harvard Dataverse is: `https://dataverse.harvard.edu/dataverseuser.xhtml?selectTab=apiTokenTab`. Make sure every "other" dataverse you enter takes you to `http://whateveryoutype/dataverseuser.xhtml?selectTab=apiTokenTab`

## Ticket
https://openscience.atlassian.net/browse/OSF-7213

[#OSF-7213]