### PR TITLE
[hotfix] Populate User Names From Institution Account Creation [OSF-7212]

### DIFF
--- a/api/institutions/authentication.py
+++ b/api/institutions/authentication.py
@@ -55,10 +55,10 @@ class InstitutionAuthentication(BaseAuthentication):
         user, created = get_or_create_user(fullname, username, reset_password=False)
 
         if created:
-            user.given_name = provider['user'].get('givenName')
-            user.middle_names = provider['user'].get('middleNames')
-            user.family_name = provider['user'].get('familyName')
-            user.suffix = provider['user'].get('suffix')
+            user.given_name = provider['user'].get('givenName') or user.given_name
+            user.middle_names = provider['user'].get('middleNames') or user.middle_names
+            user.family_name = provider['user'].get('familyName') or user.family_name
+            user.suffix = provider['user'].get('suffix') or user.suffix
             user.date_last_login = datetime.utcnow()
             user.save()
 

--- a/api_tests/institutions/views/test_institution_auth.py
+++ b/api_tests/institutions/views/test_institution_auth.py
@@ -28,15 +28,15 @@ class TestInstitutionAuth(ApiTestCase):
         self.institution.remove()
         User.remove()
 
-    def build_payload(self, username):
+    def build_payload(self, username, fullname='Fake User', given_name='', family_name=''):
         data = {
             'provider': {
                 'id': self.institution._id,
                 'user': {
                     'middleNames': '',
-                    'familyName': '',
-                    'givenName': '',
-                    'fullname': 'Fake User',
+                    'familyName': family_name,
+                    'givenName': given_name,
+                    'fullname': fullname,
                     'suffix': '',
                     'username': username
                 }
@@ -93,3 +93,29 @@ class TestInstitutionAuth(ApiTestCase):
     def test_bad_token(self):
         res = self.app.post(self.url, 'al;kjasdfljadf', expect_errors=True)
         assert_equal(res.status_code, 403)
+
+    def test_user_names_guessed_if_not_provided(self):
+        # Regression for https://openscience.atlassian.net/browse/OSF-7212
+        username = 'fake@user.edu'
+        res = self.app.post(self.url, self.build_payload(username))
+
+        assert_equal(res.status_code, 204)
+        user = User.find_one(Q('username', 'eq', username))
+
+        assert_true(user)
+        assert_equal(user.fullname, 'Fake User')
+        assert_equal(user.given_name, 'Fake')
+        assert_equal(user.family_name, 'User')
+
+    def test_user_names_used_when_provided(self):
+        # Regression for https://openscience.atlassian.net/browse/OSF-7212
+        username = 'fake@user.edu'
+        res = self.app.post(self.url, self.build_payload(username, family_name='West', given_name='Kanye'))
+
+        assert_equal(res.status_code, 204)
+        user = User.find_one(Q('username', 'eq', username))
+
+        assert_true(user)
+        assert_equal(user.fullname, 'Fake User')
+        assert_equal(user.given_name, 'Kanye')
+        assert_equal(user.family_name, 'West')


### PR DESCRIPTION
#### Purpose
- When signing up for an OSF account via institution login, the `fullname` field of the user is automatically populated, but the `given`/`middle`/`family` name fields are not. 

#### Changes
- These fields are guessed when the user is created, but the guessed name fields were being overwritten by the names provided by the institution (i.e. being overwritten with `None` when the institution didn't provide `given`/`middle`/`family` names).
- This PR changes things to use the institution provided names, if they are provided. Otherwise, the names that are guessed from the `fullname` will be used.

#### Ticket
- [OSF-7212](https://openscience.atlassian.net/browse/OSF-7212)
