### PR TITLE
Update addon_snapshot analytics to handle no owner error [OSF-7206]

### DIFF
--- a/scripts/analytics/addon_snapshot.py
+++ b/scripts/analytics/addon_snapshot.py
@@ -82,9 +82,9 @@ class AddonSnapshot(SnapshotAnalytics):
 
             connected_count = 0
             for node_settings in node_settings_list:
-                if not node_settings.owner.is_bookmark_collection:
-                    connected_count += 1
-
+                connected_count += 1
+                if not node_settings.owner or node_settings.owner.is_bookmark_collection:
+                    connected_count -= 1
             deleted_count = addon.settings_models['node'].find(Q('deleted', 'eq', True)).count() if addon.settings_models.get('node') else 0
 
             if has_external_account:

--- a/scripts/analytics/addon_snapshot.py
+++ b/scripts/analytics/addon_snapshot.py
@@ -82,9 +82,8 @@ class AddonSnapshot(SnapshotAnalytics):
 
             connected_count = 0
             for node_settings in node_settings_list:
-                connected_count += 1
-                if not node_settings.owner or node_settings.owner.is_bookmark_collection:
-                    connected_count -= 1
+                if node_settings.owner and not node_settings.owner.is_bookmark_collection:
+                    connected_count += 1
             deleted_count = addon.settings_models['node'].find(Q('deleted', 'eq', True)).count() if addon.settings_models.get('node') else 0
 
             if has_external_account:


### PR DESCRIPTION

## Purpose

Staging was getting the following error when running the `addon_snapshot` analytics:

```
...
  File "/code/scripts/analytics/run_keen_snapshots.py", line 18, in <module>
    SnapshotHarness().main()
  File "scripts/analytics/base.py", line 171, in main
    events = class_instance.get_events()
  File "scripts/analytics/addon_snapshot.py", line 85, in get_events
    if not node_settings.owner.is_bookmark_collection:
AttributeError: 'NoneType' object has no attribute 'is_bookmark_collection'
```

So, check for an owner and also don't include those nodes if the owner doesn't exist

## Changes
- Subtract from connected if there's no settings owner or if it's a bookmark collection
- Tests to make sure these scenarios work as expected

## Side effects
Nope


## Ticket
https://openscience.atlassian.net/browse/OSF-7206