### PR TITLE
Fix institution logo paths

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "OSF",
+  "name": "osf",
   "dependencies": {
     "jquery": "^1.11.2",
     "jquery-ui": "~1.10.4",

--- a/osf/models/institution.py
+++ b/osf/models/institution.py
@@ -89,6 +89,6 @@ class Institution(Loggable, base.ObjectIDMixin, base.BaseModel):
     @property
     def banner_path(self):
         if self.banner_name:
-            return '/static/img/institutions/{}'.format(self.banner_name)
+            return '/static/img/institutions/banners/{}'.format(self.banner_name)
         else:
             return None

--- a/scripts/populate_institutions.py
+++ b/scripts/populate_institutions.py
@@ -6,8 +6,9 @@ import logging
 import sys
 import urllib
 
+import django
 from modularodm import Q
-
+django.setup()
 
 from framework.transactions.context import TokuTransaction
 from website import settings


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

The banners for institutions were moved into a banners directory but those changes never made it into the Institution model in django-osf.

## Changes

I added `'banners'` to a path and ran Django setup in the populate institutions script.

## Side effects

None expected.

## Ticket
https://trello.com/c/D0R7ZG8g/37-institutional-logos-not-rendering-loading-on-project-page