### PR TITLE
[feature-fix] Remove License Year Validation [PREP-252]

### DIFF
--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -540,30 +540,6 @@ class TestPreprintUpdateLicense(ApiTestCase):
         assert_equal(res.status_code, 400)
         assert_equal(res.json['errors'][0]['detail'], 'copyrightHolders must be specified for this license')
 
-    def test_update_preprint_license_with_future_year(self):
-        data = self.make_payload(
-            node_id=self.preprint._id,
-            license_id=self.no_license._id,
-            license_year='2225',
-            copyright_holders=['Rick', 'Morty']
-        )
-
-        res = self.make_request(self.url, data, auth=self.admin_contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 400)
-        assert_equal(res.json['errors'][0]['detail'], 'Future license years are not allowed')
-
-    def test_update_preprint_license_with_invalid_year(self):
-        data = self.make_payload(
-            node_id=self.preprint._id,
-            license_id=self.no_license._id,
-            license_year='476',
-            copyright_holders=['Brutus', 'Julius']
-        )
-
-        res = self.make_request(self.url, data, auth=self.admin_contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 400)
-        assert_equal(res.json['errors'][0]['detail'], '476 is not a valid year')
-
     def test_update_preprint_license_adds_log(self):
         data = self.make_payload(
             node_id=self.preprint._id,

--- a/website/project/licenses/__init__.py
+++ b/website/project/licenses/__init__.py
@@ -1,10 +1,7 @@
 import functools
 import json
 import os
-import re
 import warnings
-
-from datetime import datetime
 
 from modularodm import fields, Q
 from modularodm import exceptions as modm_exceptions
@@ -166,15 +163,6 @@ def set_license(node, license_detail, auth, node_type='node'):
     for required_property in node_license.properties:
         if not license_detail.get(required_property):
             raise modm_exceptions.ValidationValueError('{} must be specified for this license'.format(required_property))
-
-    if license_year:
-        valid_year = re.compile(r'^\d{4}')
-        current_year = datetime.now().year
-        if not valid_year.match(license_year):
-            raise modm_exceptions.ValidationValueError('{} is not a valid year'.format(license_year))
-
-        if int(license_year) > int(current_year):
-            raise modm_exceptions.ValidationValueError('Future license years are not allowed')
 
     license_record = node.node_license if node_type == 'node' else node.license
     if license_record is None:


### PR DESCRIPTION
#### Purpose
- Removes the license year validation that was added in #6588. The `year` field on the `NodeLicense` model is a string field to allow for date ranges, but the additional date validation prevented that.

#### Changes
- Remove validation and related tests.

#### Side effects
- Users will be able to enter any string as a license year. 

#### Ticket 
- [PREP-252](https://openscience.atlassian.net/browse/PREP-252)
