### PR TITLE
Feature/APIv2 500 Error on Node Provider [OSF-7238]

### DIFF
--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -198,7 +198,7 @@ class FileSerializer(JSONAPISerializer):
         elif obj.provider != 'osfstorage' and obj.history:
             mod_dt = obj.history[-1].get('modified', None)
 
-        if self.context['request'].version >= '2.2':
+        if self.context['request'].version >= '2.2' and obj.is_file:
             return datetime.strftime(mod_dt, '%Y-%m-%dT%H:%M:%S.%fZ')
 
         return mod_dt and mod_dt.replace(tzinfo=pytz.utc)
@@ -212,7 +212,7 @@ class FileSerializer(JSONAPISerializer):
             # earliest entry in the file history.
             creat_dt = obj.history[0].get('modified', None)
 
-        if self.context['request'].version >= '2.2':
+        if self.context['request'].version >= '2.2' and obj.is_file:
             return datetime.strftime(creat_dt, '%Y-%m-%dT%H:%M:%S.%fZ')
 
         return creat_dt and creat_dt.replace(tzinfo=pytz.utc)

--- a/api_tests/nodes/views/test_node_files_list.py
+++ b/api_tests/nodes/views/test_node_files_list.py
@@ -141,6 +141,18 @@ class TestNodeFilesList(ApiTestCase):
         assert_equal(res.json['data']['attributes']['kind'], 'file')
         assert_equal(res.json['data']['attributes']['name'], 'NewFile')
 
+    def test_returns_osfstorage_folder_version_two(self):
+        fobj = self.project.get_addon('osfstorage').get_root().append_folder('NewFolder')
+        fobj.save()
+        res = self.app.get('{}osfstorage/'.format(self.private_url), auth=self.user.auth)
+        assert_equal(res.status_code, 200)
+
+    def test_returns_osf_storage_folder_version_two_point_two(self):
+        fobj = self.project.get_addon('osfstorage').get_root().append_folder('NewFolder')
+        fobj.save()
+        res = self.app.get('{}osfstorage/?version=2.2'.format(self.private_url), auth=self.user.auth)
+        assert_equal(res.status_code, 200)
+
     def test_list_returns_folder_data(self):
         fobj = self.project.get_addon('osfstorage').get_root().append_folder('NewFolder')
         fobj.save()


### PR DESCRIPTION
## Purpose

For APIv2 versions greater than 2.1, the `Node Files List` endpoint will 500 if there are files in the folder.

## Changes

Bug fix on file serializer for date_created and date_modified fields. Only attempt to modify the date on versions > 2.1 if object is a file, not a folder.

## Side effects

<!--Any possible side effects? -->


## Ticket

https://openscience.atlassian.net/browse/OSF-7238