### PR TITLE
Prevent Preprint Creation from Deleted Node [OSF-7240]

### DIFF
--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -207,6 +207,8 @@ class PreprintCreateSerializer(PreprintSerializer):
         node = Node.load(validated_data.pop('node', None))
         if not node:
             raise exceptions.NotFound('Unable to find Node with specified id.')
+        elif node.is_deleted:
+            raise exceptions.ValidationError('Cannot create a preprint from a deleted node.')
 
         auth = get_user_auth(self.context['request'])
         if not node.has_permission(auth.user, permissions.ADMIN):

--- a/api_tests/preprints/views/test_preprint_list.py
+++ b/api_tests/preprints/views/test_preprint_list.py
@@ -242,3 +242,11 @@ class TestPreprintCreate(ApiTestCase):
 
             assert_equal(res.status_code, 201)
             assert_not_in(project_signals.contributor_added, mock_signals.signals_sent())
+
+    def test_create_preprint_with_deleted_node_should_fail(self):
+        self.public_project.is_deleted = True
+        self.public_project.save()
+        public_project_payload = build_preprint_create_payload(self.public_project._id, self.provider._id, self.file_one_public_project._id)
+        res = self.app.post_json_api(self.url, public_project_payload, auth=self.user.auth, expect_errors=True)
+        assert_equal(res.status_code, 400)
+        assert_equal(res.json['errors'][0]['detail'], 'Cannot create a preprint from a deleted node.')


### PR DESCRIPTION
#### Purpose
- Prevent a preprint from being created if the node included in the request has been deleted.

#### Ticket
- [OSF-7240](https://openscience.atlassian.net/browse/OSF-7240)

