### PR TITLE
Update Preprint on save hooks [OSF-7242]

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4913,11 +4913,11 @@ class TestOnNodeUpdate(OsfTestCase):
         on_node_updated(self.node._id, self.user._id, False, {'is_public'})
 
         kwargs = requests.post.call_args[1]
-        graph = kwargs['json']['normalized_data']['@graph']
+        graph = kwargs['json']['data']['attributes']['data']['@graph']
 
         assert_true(requests.post.called)
         assert_equals(kwargs['headers']['Authorization'], 'Bearer Token')
-        assert_equals(graph[0]['url'], '{}{}/'.format(settings.DOMAIN, self.node._id))
+        assert_equals(graph[0]['uri'], '{}{}/'.format(settings.DOMAIN, self.node._id))
 
     @mock.patch('website.project.tasks.requests')
     def test_update_share_correctly(self, requests):
@@ -4947,8 +4947,8 @@ class TestOnNodeUpdate(OsfTestCase):
             on_node_updated(self.node._id, self.user._id, False, {'is_public'})
 
             kwargs = requests.post.call_args[1]
-            graph = kwargs['json']['normalized_data']['@graph']
-            assert_equals(graph[2]['is_deleted'], case['is_deleted'])
+            graph = kwargs['json']['data']['attributes']['data']['@graph']
+            assert_equals(graph[1]['is_deleted'], case['is_deleted'])
 
 
 

--- a/website/preprints/model.py
+++ b/website/preprints/model.py
@@ -3,6 +3,7 @@ import urlparse
 
 from modularodm import fields, Q
 
+from framework.encryption import EncryptedStringField
 from framework.celery_tasks.handlers import enqueue_task
 from framework.exceptions import PermissionsError
 from framework.guid.model import GuidStoredObject
@@ -16,6 +17,7 @@ from website.project.taxonomies import Subject, validate_subject_hierarchy
 from website.util import api_v2_url
 from website.util.permissions import ADMIN
 from website import settings
+
 
 @unique_on(['node', 'provider'])
 class PreprintService(GuidStoredObject):
@@ -213,6 +215,7 @@ class PreprintProvider(StoredObject):
     external_url = fields.StringField()
     email_contact = fields.StringField()
     email_support = fields.StringField()
+    access_token = EncryptedStringField()
     advisory_board = fields.StringField()
     social_twitter = fields.StringField()
     social_facebook = fields.StringField()

--- a/website/preprints/tasks.py
+++ b/website/preprints/tasks.py
@@ -1,4 +1,3 @@
-import datetime
 import logging
 import uuid
 import urlparse
@@ -9,7 +8,9 @@ from framework.celery_tasks import app as celery_app
 
 from website import settings
 
+
 logger = logging.getLogger(__name__)
+
 
 @celery_app.task(ignore_results=True)
 def on_preprint_updated(preprint_id):
@@ -18,13 +19,19 @@ def on_preprint_updated(preprint_id):
     from website.models import PreprintService
     preprint = PreprintService.load(preprint_id)
 
-    if settings.SHARE_URL and settings.SHARE_API_TOKEN:
+    if settings.SHARE_URL:
+        if not preprint.provider.access_token:
+            raise ValueError('No access_token for {}. Unable to send {} to SHARE.'.format(preprint.provider, preprint))
         resp = requests.post('{}api/v2/normalizeddata/'.format(settings.SHARE_URL), json={
-            'created_at': datetime.datetime.utcnow().isoformat(),
-            'normalized_data': {
-                '@graph': format_preprint(preprint)
-            },
-        }, headers={'Authorization': 'Bearer {}'.format(settings.SHARE_API_TOKEN)})
+            'data': {
+                'type': 'NormalizedData',
+                'attributes': {
+                    'tasks': [],
+                    'raw': None,
+                    'data': {'@graph': format_preprint(preprint)}
+                }
+            }
+        }, headers={'Authorization': 'Bearer {}'.format(preprint.provider.access_token), 'Content-Type': 'application/vnd.api+json'})
         logger.debug(resp.content)
         resp.raise_for_status()
 
@@ -51,10 +58,10 @@ class GraphNode(object):
     def serialize(self):
         ser = {}
         for key, value in self.attrs.items():
-            if isinstance(value, list):
-                ser[key] = [v.ref for v in value]
-            elif isinstance(value, GraphNode):
+            if isinstance(value, GraphNode):
                 ser[key] = value.ref
+            elif isinstance(value, list) or value in {None, ''}:
+                continue
             else:
                 ser[key] = value
 
@@ -69,28 +76,24 @@ def format_user(user):
         'additional_name': user.middle_names,
     })
 
-    person.attrs['identifiers'] = [
-        GraphNode('throughidentifiers', person=person, identifier=GraphNode('identifier', **{
-            'url': urlparse.urljoin(settings.DOMAIN, user.profile_url),
-            'base_url': settings.DOMAIN
-        }))
-    ]
+    person.attrs['identifiers'] = [GraphNode('agentidentifier', agent=person, uri='mailto:{}'.format(uri)) for uri in user.emails]
 
-    person.attrs['affiliations'] = [GraphNode('affiliation', person=person, entity=GraphNode('institution', name=institution.name)) for institution in user.affiliated_institutions]
+    if user.is_registered:
+        person.attrs['identifiers'].append(GraphNode('agentidentifier', agent=person, uri=user.profile_image_url()))
+        person.attrs['identifiers'].append(GraphNode('agentidentifier', agent=person, uri=urlparse.urljoin(settings.DOMAIN, user.profile_url)))
+
+    person.attrs['related_agents'] = [GraphNode('isaffiliatedwith', subject=person, related=GraphNode('institution', name=institution.name)) for institution in user.affiliated_institutions]
 
     return person
 
 
 def format_contributor(preprint, user, bibliographic, index):
-    person = format_user(user)
-
     return GraphNode(
-        'contributor',
-        person=person,
-        order_cited=index,
+        'creator' if bibliographic else 'contributor',
+        agent=format_user(user),
+        order_cited=index if bibliographic else None,
         creative_work=preprint,
-        cited_name=user.fullname,
-        bibliographic=bibliographic,
+        cited_as=user.fullname,
     )
 
 
@@ -103,20 +106,13 @@ def format_preprint(preprint):
         'date_published': preprint.date_published.isoformat()
     })
 
-    preprint_graph.attrs['links'] = [
-        GraphNode('throughlinks', creative_work=preprint_graph, link=GraphNode('link', **{
-            'type': 'provider',
-            'url': urlparse.urljoin(settings.DOMAIN, preprint.url),
-        }))
+    to_visit = [
+        preprint_graph,
+        GraphNode('workidentifier', creative_work=preprint_graph, uri=urlparse.urljoin(settings.DOMAIN, preprint.url))
     ]
 
     if preprint.article_doi:
-        preprint_graph.attrs['links'].append(
-            GraphNode('throughlinks', creative_work=preprint_graph, link=GraphNode('link', **{
-                'type': 'doi',
-                'url': 'http://dx.doi.org/{}'.format(preprint.article_doi.upper().strip('/')),
-            }))
-        )
+        to_visit.append(GraphNode('workidentifier', creative_work=preprint_graph, uri='http://dx.doi.org/{}'.format(preprint.article_doi)))
 
     preprint_graph.attrs['tags'] = [
         GraphNode('throughtags', creative_work=preprint_graph, tag=GraphNode('tag', name=tag._id))
@@ -128,11 +124,11 @@ def format_preprint(preprint):
         for subject in set(x['text'] for hier in preprint.get_subjects() for x in hier)
     ]
 
-    preprint_graph.attrs['contributors'] = [format_contributor(preprint_graph, user, bool(user._id in preprint.node.visible_contributor_ids), i) for i, user in enumerate(preprint.node.contributors)]
-    preprint_graph.attrs['institutions'] = [GraphNode('association', creative_work=preprint_graph, entity=GraphNode('institution', name=institution.name)) for institution in preprint.node.affiliated_institutions]
+    to_visit.extend(format_contributor(preprint_graph, user, bool(user._id in preprint.node.visible_contributor_ids), i) for i, user in enumerate(preprint.node.contributors))
+    to_visit.extend(GraphNode('isaffiliatedwith', creative_work=preprint_graph, entity=GraphNode('institution', name=institution.name)) for institution in preprint.node.affiliated_institutions)
 
     visited = set()
-    to_visit = list(preprint_graph.get_related())
+    to_visit.extend(preprint_graph.get_related())
 
     while True:
         if not to_visit:

--- a/website/project/tasks.py
+++ b/website/project/tasks.py
@@ -1,10 +1,13 @@
-import datetime
+import logging
 
 import requests
 
 from framework.celery_tasks import app as celery_app
 
 from website import settings
+
+
+logger = logging.getLogger(__name__)
 
 
 @celery_app.task(ignore_results=True)
@@ -27,25 +30,28 @@ def on_node_updated(node_id, user_id, first_save, saved_fields, request_headers=
     if need_update:
         node.update_search()
 
-        if settings.SHARE_URL and settings.SHARE_API_TOKEN:
-            requests.post('{}api/normalizeddata/'.format(settings.SHARE_URL), json={
-                'created_at': datetime.datetime.utcnow().isoformat(),
-                'normalized_data': {
-                    '@graph': [{
-                        '@id': '_:123',
-                        '@type': 'link',
-                        'type': 'provider',
-                        'url': '{}{}/'.format(settings.DOMAIN, node._id),
-                    }, {
-                        '@id': '_:456',
-                        '@type': 'throughlinks',
-                        'link': {'@type': 'link', '@id': '_:123'},
-                        'creative_work': {'@type': 'project', '@id': '_:789'},
-                    }, {
-                        '@id': '_:789',
-                        '@type': 'project',
-                        'is_deleted': not node.is_public or node.is_deleted or node.is_spammy,
-                        'links': [{'@id': '_:456', '@type': 'throughlinks'}],
-                    }]
-                },
-            }, headers={'Authorization': 'Bearer {}'.format(settings.SHARE_API_TOKEN)}).raise_for_status()
+        if settings.SHARE_URL:
+            if not settings.SHARE_API_TOKEN:
+                return logger.warning('SHARE_API_TOKEN not set. Could not send %s to SHARE.'.format(node))
+
+            resp = requests.post('{}api/normalizeddata/'.format(settings.SHARE_URL), json={
+                'data': {
+                    'type': 'NormalizedData',
+                    'attributes': {
+                        'tasks': [],
+                        'raw': None,
+                        'data': {'@graph': [{
+                            '@id': '_:123',
+                            '@type': 'workidentifier',
+                            'creative_work': {'@id': '_:789', '@type': 'project'},
+                            'uri': '{}{}/'.format(settings.DOMAIN, node._id),
+                        }, {
+                            '@id': '_:789',
+                            '@type': 'project',
+                            'is_deleted': not node.is_public or node.is_deleted or node.is_spammy,
+                        }]}
+                    }
+                }
+            }, headers={'Authorization': 'Bearer {}'.format(settings.SHARE_API_TOKEN), 'Content-Type': 'application/vnd.api+json'})
+            logger.debug(resp.content)
+            resp.raise_for_status()

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -311,7 +311,8 @@ EZID_PASSWORD = 'changeme'
 EZID_FORMAT = '{namespace}osf.io/{guid}'
 
 SHARE_REGISTRATION_URL = ''
-SHARE_URL = 'https://share.osf.io/'
+SHARE_URL = None
+SHARE_API_TOKEN = None  # Required to send project updates to SHARE
 
 CAS_SERVER_URL = 'http://localhost:8080'
 MFR_SERVER_URL = 'http://localhost:7778'


### PR DESCRIPTION
  * Update to use new SHARE format
  * Move access_token from settings onto preprint providers

## Side effects

  * PreprintProvider instances now require an access_token.


## Deployment

  * Add SHARE API Key for Provider Services ( @chrisseto )


Took a couple tries:
```
[29/Nov/2016 21:17:45] "POST /api/v2/normalizeddata/ HTTP/1.1" 400 110
[29/Nov/2016 21:18:12] "POST /api/v2/normalizeddata/ HTTP/1.1" 400 251
[29/Nov/2016 21:20:44] "POST /api/v2/normalizeddata/ HTTP/1.1" 400 259
[29/Nov/2016 21:20:57] "POST /api/v2/normalizeddata/ HTTP/1.1" 400 249
[29/Nov/2016 21:21:13] "POST /api/v2/normalizeddata/ HTTP/1.1" 400 110
[29/Nov/2016 21:21:45] "POST /api/v2/normalizeddata/ HTTP/1.1" 400 256
[29/Nov/2016 21:22:11] "POST /api/v2/normalizeddata/ HTTP/1.1" 400 256
[29/Nov/2016 21:22:35] "POST /api/v2/normalizeddata/ HTTP/1.1" 400 110
[29/Nov/2016 21:22:54] "POST /api/v2/normalizeddata/ HTTP/1.1" 202 104
[29/Nov/2016 21:23:06] "POST /api/v2/normalizeddata/ HTTP/1.1" 202 104 <-- WOO
```

## Link to ticket
https://openscience.atlassian.net/browse/OSF-7242