### PR TITLE
[feature] Warn Users Before Deleting Node With Preprint [OSF-7241]

### DIFF
--- a/website/static/js/pages/project-settings-page.js
+++ b/website/static/js/pages/project-settings-page.js
@@ -86,7 +86,7 @@ $(document).ready(function() {
         if(ctx.node.childExists){
             $osf.growl('Error', 'Any child components must be deleted prior to deleting this project.','danger', 30000);
         }else{
-            ProjectSettings.getConfirmationCode(ctx.node.nodeType);
+            ProjectSettings.getConfirmationCode(ctx.node.nodeType, ctx.node.isPreprint);
         }
     });
 

--- a/website/static/js/projectSettings.js
+++ b/website/static/js/projectSettings.js
@@ -152,11 +152,15 @@ request.fail(function(xhr, textStatus, err) {
  * Pulls a random name from the scientist list to use as confirmation string
  *  Ignores case and whitespace
  */
-var getConfirmationCode = function(nodeType) {
+var getConfirmationCode = function(nodeType, isPreprint) {
+
+    var preprint_message = '<p class="danger">This ' + nodeType + ' contains a preprint. Deleting this ' +
+        nodeType + ' will also delete your preprint. This action is irreversible.</p>';
 
     // It's possible that the XHR request for contributors has not finished before getting to this
     // point; only construct the HTML for the list of contributors if the contribs list is populated
-    var message = '<p>It will no longer be available to other contributors on the project.';
+    var message = '<p>It will no longer be available to other contributors on the project.' +
+        (isPreprint ? preprint_message : '');
 
     $osf.confirmDangerousAction({
         title: 'Are you sure you want to delete this ' + nodeType + '?',


### PR DESCRIPTION
#### Purpose
- Adds a warning when a user attempts to delete a node that contains a preprint.

#### Screenshot
![screen shot 2016-11-29 at 4 03 25 pm](https://cloud.githubusercontent.com/assets/7913604/20728809/6aae79b8-b64d-11e6-9ed7-200d25d8069a.png)

![screen shot 2016-11-29 at 4 06 42 pm](https://cloud.githubusercontent.com/assets/7913604/20728899/db55a998-b64d-11e6-800d-1d2adc9411ce.png)

#### Ticket
- [OSF-7241](https://openscience.atlassian.net/browse/OSF-7241)
