### PR TITLE
[feature] Fix Preprint Logs [OSF-7245]

### DIFF
--- a/api_tests/preprints/views/test_preprint_list.py
+++ b/api_tests/preprints/views/test_preprint_list.py
@@ -250,3 +250,21 @@ class TestPreprintCreate(ApiTestCase):
         res = self.app.post_json_api(self.url, public_project_payload, auth=self.user.auth, expect_errors=True)
         assert_equal(res.status_code, 400)
         assert_equal(res.json['errors'][0]['detail'], 'Cannot create a preprint from a deleted node.')
+
+    def test_create_preprint_adds_log_if_published(self):
+        public_project_payload = build_preprint_create_payload(
+            self.public_project._id,
+            self.provider._id,
+            self.file_one_public_project._id,
+            {
+                'is_published': True,
+                'subjects': [[SubjectFactory()._id]],
+            }
+        )
+        res = self.app.post_json_api(self.url, public_project_payload, auth=self.user.auth)
+        assert_equal(res.status_code, 201)
+        preprint_id = res.json['data']['id']
+        preprint = PreprintService.load(preprint_id)
+        log = preprint.node.logs[-2]
+        assert_equal(log.action, 'preprint_initiated')
+        assert_equal(log.params.get('preprint'), preprint_id)

--- a/website/preprints/model.py
+++ b/website/preprints/model.py
@@ -113,23 +113,18 @@ class PreprintService(GuidStoredObject):
         if preprint_file.node != self.node or preprint_file.provider != 'osfstorage':
             raise ValueError('This file is not a valid primary file for this preprint.')
 
-        # there is no preprint file yet! This is the first time!
-        if not self.node.preprint_file:
-            self.node.preprint_file = preprint_file
-            self.node.add_log(action=NodeLog.PREPRINT_INITIATED, params={
-                'preprint': {'id': self._id, 'title': self.node.title},
-                'service': {'title': self.provider.name}
-            }, auth=auth, save=False)
-        elif preprint_file != self.node.preprint_file:
-            # if there was one, check if it's a new file
-            self.node.preprint_file = preprint_file
+        existing_file = self.node.preprint_file
+        self.node.preprint_file = preprint_file
+
+        # only log if updating the preprint file, not adding for the first time
+        if existing_file:
             self.node.add_log(
                 action=NodeLog.PREPRINT_FILE_UPDATED,
                 params={
                     'preprint': self._id
                 },
                 auth=auth,
-                save=False,
+                save=False
             )
 
         if save:
@@ -182,13 +177,7 @@ class PreprintService(GuidStoredObject):
         self.node.add_log(
             action=NodeLog.PREPRINT_LICENSE_UPDATED,
             params={
-                'preprint': {
-                    'id': self._id,
-                    'title': self.node.title
-                },
-                'service': {
-                    'title': self.provider.name
-                }
+                'preprint': self._id
             },
             auth=auth,
             save=False

--- a/website/static/js/logActionsList.json
+++ b/website/static/js/logActionsList.json
@@ -76,5 +76,5 @@
     "affiliated_institution_removed": "${user} removed ${institution} affiliation from ${node}",
     "preprint_initiated": "${user} made ${node} a ${preprint} on ${preprint_provider} Preprints",
     "preprint_file_updated": "${user} updated the primary file of this ${preprint} on {preprint_provider} Preprints",
-    "preprint_license_updated": "${user} updated the license of the primary file of this preprint"
+    "preprint_license_updated": "${user} updated the license of the primary file of this {preprint} on {preprint_provider} Preprints"
 }

--- a/website/static/js/logTextParser.js
+++ b/website/static/js/logTextParser.js
@@ -651,14 +651,20 @@ var LogPieces = {
     preprint: {
         view: function(ctrl, logObject){
             var preprint = logObject.attributes.params.preprint;
-            return m('a', {href: '/' + preprint}, 'preprint');
+            if (paramIsReturned(preprint, logObject)) {
+                return m('a', {href: '/' + preprint}, 'preprint');
+            }
+            return m('span', 'preprint');
         }
     },
 
     preprint_provider: {
         view: function(ctrl, logObject){
             var preprint_provider = logObject.attributes.params.preprint_provider;
-            return m('a', {href: preprint_provider.url}, preprint_provider.name);
+            if (paramIsReturned((preprint_provider, logObject))) {
+                return m('a', {href: preprint_provider.url}, preprint_provider.name);
+            }
+            return m('span', '');
         }
     },
 };


### PR DESCRIPTION
#### Purpose
- Removes a broken (and duplicated) preprint log that was breaking both the "My Projects" page for users with a preprint, and the project overview page of projects with preprints. 

#### Changes
- Fixes the `preprint_license_updated` log to set correct log params.
- Removes the broken `preprint_initiated` log from `set_primary_file()` as it was being duplicated in `set_published()`

#### Side effects
- None expected

#### Ticket
- [OSF-7245](https://openscience.atlassian.net/browse/OSF-7245)