### PR TITLE
Keen analytics cursor error/fix celery tasks [OSF-7234]

### DIFF
--- a/scripts/analytics/addon_snapshot.py
+++ b/scripts/analytics/addon_snapshot.py
@@ -3,6 +3,7 @@ from modularodm import Q
 
 from website.app import init_app
 from website.models import Node, User
+from framework.mongo.utils import paginated
 from website.addons.base import AddonNodeSettingsBase
 from scripts.analytics.base import SnapshotAnalytics
 
@@ -70,9 +71,12 @@ class AddonSnapshot(SnapshotAnalytics):
         addons_available = {k: v for k, v in [(addon.short_name, addon) for addon in ADDONS_AVAILABLE]}
 
         for short_name, addon in addons_available.iteritems():
-
-            user_settings_list = addon.settings_models['user'].find() if addon.settings_models.get('user') else []
-            node_settings_list = addon.settings_models['node'].find() if addon.settings_models.get('node') else []
+            user_settings_list = []
+            node_settings_list = []
+            if addon.settings_models.get('user'):
+                user_settings_list = [setting for setting in paginated(addon.settings_models['user'], increment=200, each=True)]
+            if addon.settings_models.get('node'):
+                node_settings_list = [setting for setting in paginated(addon.settings_models['node'], increment=200, each=True)]
 
             has_external_account = True
             # Check out the first element in node_settings_list to see if it has an external account to check for

--- a/scripts/analytics/addon_snapshot.py
+++ b/scripts/analytics/addon_snapshot.py
@@ -74,9 +74,9 @@ class AddonSnapshot(SnapshotAnalytics):
             user_settings_list = []
             node_settings_list = []
             if addon.settings_models.get('user'):
-                user_settings_list = [setting for setting in paginated(addon.settings_models['user'], increment=200, each=True)]
+                user_settings_list = [setting for setting in paginated(addon.settings_models['user'])]
             if addon.settings_models.get('node'):
-                node_settings_list = [setting for setting in paginated(addon.settings_models['node'], increment=200, each=True)]
+                node_settings_list = [setting for setting in paginated(addon.settings_models['node'])]
 
             has_external_account = True
             # Check out the first element in node_settings_list to see if it has an external account to check for

--- a/scripts/analytics/base.py
+++ b/scripts/analytics/base.py
@@ -158,13 +158,13 @@ class BaseAnalyticsHarness(object):
 
             return imported_script_classes
 
-    def main(self):
-        args = self.parse_args()
-        entered_scripts = args.analytics_scripts
-        if entered_scripts:
-            analytics_classes = self.try_to_import_from_args(entered_scripts)
-        else:
-            analytics_classes = self.analytics_classes
+    def main(self, command_line=True):
+        analytics_classes = self.analytics_classes
+        if command_line:
+            args = self.parse_args()
+            entered_scripts = args.analytics_scripts
+            if args.entered_scripts:
+                analytics_classes = self.try_to_import_from_args(entered_scripts)
 
         for analytics_class in analytics_classes:
             class_instance = analytics_class()
@@ -184,21 +184,22 @@ class DateAnalyticsHarness(BaseAnalyticsHarness):
         parser.add_argument('-y', '--yesterday', dest='yesterday', action='store_true')
         return parser.parse_args()
 
-    def main(self, date=None, yesterday=False):
-        args = self.parse_args()
-        entered_scripts = args.analytics_scripts
-        yesterday = yesterday or args.yesterday
+    def main(self, date=None, yesterday=False, command_line=True):
+        analytics_classes = self.analytics_classes
         if yesterday:
             date = (datetime.today() - timedelta(1)).date()
-        if not date:
-            try:
-                date = parse(args.date).date()
-            except AttributeError:
-                raise AttributeError('You must either specify a date or use the yesterday argument to gather analytics for yesterday.')
-        if entered_scripts:
-            analytics_classes = self.try_to_import_from_args(entered_scripts)
-        else:
-            analytics_classes = self.analytics_classes
+
+        if command_line:
+            args = self.parse_args()
+            if args.yesterday:
+                date = (datetime.today() - timedelta(1)).date()
+            if not date:
+                try:
+                    date = parse(args.date).date()
+                except AttributeError:
+                    raise AttributeError('You must either specify a date or use the yesterday argument to gather analytics for yesterday.')
+            if args.analytics_scripts:
+                analytics_classes = self.try_to_import_from_args(entered_scripts)
 
         for analytics_class in analytics_classes:
             class_instance = analytics_class()

--- a/scripts/analytics/node_log_events.py
+++ b/scripts/analytics/node_log_events.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 
 from website.app import init_app
 from website.project.model import NodeLog
+from framework.mongo.utils import paginated
 from scripts.analytics.base import EventAnalytics
 
 logger = logging.getLogger(__name__)
@@ -33,7 +34,7 @@ class NodeLogEvents(EventAnalytics):
 
         node_log_query = Q('date', 'lt', date + timedelta(1)) & Q('date', 'gte', date)
 
-        node_logs = NodeLog.find(node_log_query)
+        node_logs = paginated(NodeLog, query=node_log_query)
         node_log_events = []
         for node_log in node_logs:
             log_date = node_log.date.replace(tzinfo=pytz.UTC)

--- a/scripts/analytics/run_keen_events.py
+++ b/scripts/analytics/run_keen_events.py
@@ -11,9 +11,9 @@ class EventAnalyticsHarness(DateAnalyticsHarness):
         return [NodeLogEvents, UserDomainEvents]
 
 
-@celery_app.task(name='scripts.run_keen_events')
+@celery_app.task(name='scripts.analytics.run_keen_events')
 def run_main(date=None, yesterday=False):
-    EventAnalyticsHarness().main(date, yesterday)
+    EventAnalyticsHarness().main(date, yesterday, False)
 
 
 if __name__ == '__main__':

--- a/scripts/analytics/run_keen_events.py
+++ b/scripts/analytics/run_keen_events.py
@@ -12,8 +12,8 @@ class EventAnalyticsHarness(DateAnalyticsHarness):
 
 
 @celery_app.task(name='scripts.run_keen_events')
-def run_main(date):
-    EventAnalyticsHarness().main(date)
+def run_main(date=None, yesterday=False):
+    EventAnalyticsHarness().main(date, yesterday)
 
 
 if __name__ == '__main__':

--- a/scripts/analytics/run_keen_snapshots.py
+++ b/scripts/analytics/run_keen_snapshots.py
@@ -10,9 +10,9 @@ class SnapshotHarness(BaseAnalyticsHarness):
         return [AddonSnapshot]
 
 
-@celery_app.task(name='scripts.run_keen_snapshots')
+@celery_app.task(name='scripts.analytics.run_keen_snapshots')
 def run_main():
-    SnapshotHarness().main()
+    SnapshotHarness().main(command_line=False)
 
 if __name__ == '__main__':
     SnapshotHarness().main()

--- a/scripts/analytics/run_keen_summaries.py
+++ b/scripts/analytics/run_keen_summaries.py
@@ -12,9 +12,9 @@ class SummaryHarness(DateAnalyticsHarness):
         return [NodeSummary, UserSummary, InstitutionSummary]
 
 
-@celery_app.task(name='scripts.run_keen_summaries')
+@celery_app.task(name='scripts.analytics.run_keen_summaries')
 def run_main(date=None, yesterday=False):
-    SummaryHarness().main(date, yesterday)
+    SummaryHarness().main(date, yesterday, False)
 
 
 if __name__ == '__main__':

--- a/scripts/analytics/run_keen_summaries.py
+++ b/scripts/analytics/run_keen_summaries.py
@@ -13,8 +13,8 @@ class SummaryHarness(DateAnalyticsHarness):
 
 
 @celery_app.task(name='scripts.run_keen_summaries')
-def run_main(date):
-    SummaryHarness().main(date)
+def run_main(date=None, yesterday=False):
+    SummaryHarness().main(date, yesterday)
 
 
 if __name__ == '__main__':

--- a/scripts/analytics/user_domain_events.py
+++ b/scripts/analytics/user_domain_events.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 
 from website.models import User
 from website.app import init_app
+from framework.mongo.utils import paginated
 from scripts.analytics.base import EventAnalytics
 
 logger = logging.getLogger(__name__)
@@ -32,7 +33,7 @@ class UserDomainEvents(EventAnalytics):
         ))
 
         user_query = Q('date_confirmed', 'lt', date + timedelta(1)) & Q('date_confirmed', 'gte', date)
-        users = User.find(user_query)
+        users = paginated(User, query=user_query)
         user_domain_events = []
         for user in users:
             user_date = user.date_confirmed.replace(tzinfo=pytz.UTC)

--- a/scripts/analytics/user_summary.py
+++ b/scripts/analytics/user_summary.py
@@ -51,7 +51,7 @@ class UserSummary(SummaryAnalytics):
 
         active_users = 0
         depth_users = 0
-        user_pages = paginated(User, query=active_user_query, increment=200, each=True)
+        user_pages = paginated(User, query=active_user_query)
         for user in user_pages:
             active_users += 1
             log_count = count_user_logs(user)


### PR DESCRIPTION
## Purpose
On production, very large queries were making the summary keen statistics fail with mongo cursor errors. Also the celery tasks weren't functioning properly.


## Changes
- Use pagination instead of direct queries for statistics
- Update main function of stats to be called via command line or celery task
- Pass in correct args to celery task

## Side effects

None anticipated


## Ticket
https://openscience.atlassian.net/browse/OSF-7234