### PR TITLE
Script to Backfill, Smooth, or Transfer Keen Data [OSF-7223]

### DIFF
--- a/scripts/analytics/migrate_analytics.py
+++ b/scripts/analytics/migrate_analytics.py
@@ -256,7 +256,7 @@ def remove_events_from_keen(client, source_collection, events, dry):
             filtered_event = filtered_event[0]
             filtered_event['keen'].pop('id')
             filtered_event['keen'].pop('created_at')
-            filtered_event['keen']['timestamp'] = filtered_event['keen']['timestamp'][:10]
+            filtered_event['keen']['timestamp'] = filtered_event['keen']['timestamp'][:10]  # ends of timestamps differ
             event['keen']['timestamp'] = event['keen']['timestamp'][:10]
             if event != filtered_event:
                 logger.error('Filtered event not equal to the event you have gathered, not removing...')

--- a/scripts/analytics/migrate_analytics.py
+++ b/scripts/analytics/migrate_analytics.py
@@ -279,8 +279,8 @@ def import_old_events_from_spreadsheet():
         'active-users': 'active',
         'logs-gte-11-total': 'depth',
         'number_users': 'unconfirmed',  # really is active - number_users
-        'number_projects': 'nodes.total',
-        'number_projects_public': 'nodes.public',
+        'number_projects': 'projects.total',
+        'number_projects_public': 'projects.public',
         'number_projects_registered': 'registrations.total',
         'Date': 'timestamp',
         'dropbox-users-enabled': 'enabled',
@@ -304,7 +304,7 @@ def import_old_events_from_spreadsheet():
         events.append(event)
 
     user_summary_cols = ['active', 'depth', 'unconfirmed', 'timestamp']
-    node_summary_cols = ['registrations.total', 'nodes.total', 'nodes.public', 'timestamp']
+    node_summary_cols = ['registrations.total', 'projects.total', 'projects.public', 'timestamp']
     addon_summary_cols = ['enabled', 'authorized', 'linked', 'timestamp']
 
     user_events = []
@@ -356,8 +356,8 @@ def format_event(event, analytics_type):
     }
 
     node_event_template = {
-        "nodes": {},
-        "registered_nodes": {},
+        "projects": {},
+        "registered_projects": {},
         "keen": {}
     }
 
@@ -377,14 +377,14 @@ def format_event(event, analytics_type):
     elif analytics_type == 'node':
         template_to_use = node_event_template
 
-        if event['nodes.total']:
-            template_to_use['nodes']['total'] = comma_int(event['nodes.total'])
-        if event['nodes.public']:
-            template_to_use['nodes']['public'] = comma_int(event['nodes.public'])
+        if event['projects.total']:
+            template_to_use['projects']['total'] = comma_int(event['projects.total'])
+        if event['projects.public']:
+            template_to_use['projects']['public'] = comma_int(event['projects.public'])
         if event['registrations.total']:
-            template_to_use['registered_nodes']['total'] = comma_int(event['registrations.total'])
-        if event['nodes.total'] and event['nodes.public']:
-            template_to_use['nodes']['private'] = template_to_use['nodes']['total'] - template_to_use['nodes']['public']
+            template_to_use['registered_projects']['total'] = comma_int(event['registrations.total'])
+        if event['projects.total'] and event['projects.public']:
+            template_to_use['projects']['private'] = template_to_use['projects']['total'] - template_to_use['projects']['public']
     elif analytics_type == 'addon':
         template_to_use = addon_event_template
 
@@ -445,3 +445,10 @@ def main():
 
 if __name__ == '__main__':
     main()
+
+    # client = get_keen_client()
+    # filters = [{'property_name': 'imported', 'operator': 'eq', 'property_value': True}]
+    #
+    # client.delete_events('node_summary', filters=filters)
+    # client.delete_events('user_summary', filters=filters)
+    # client.delete_events('addon_snapshot', filters=filters)

--- a/scripts/analytics/migrate_analytics.py
+++ b/scripts/analytics/migrate_analytics.py
@@ -111,10 +111,9 @@ def fill_in_event_gaps(collection_name, events):
                             ]
                         if first_event:
                             events_to_add += generate_events_between_events(date_pair, first_event[0])
-
         else:
             for date_pair in date_chunks:
-                if date_pair[1] - date_pair[0] > datetime.timedelta(1):
+                if date_pair[1] - date_pair[0] > datetime.timedelta(1) and date_pair[0] != date_pair[1]:
                     first_event = [event for event in events if date_from_event_ts(event) == date_pair[0] and not event.get('generated')]
                     if first_event:
                         events_to_add += generate_events_between_events(date_pair, first_event[0])
@@ -456,12 +455,11 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    # main()
 
-    # client = get_keen_client()
-    # ids = ['583c3a9c0727190d899757d7', '583c3a9c0727190d899757d3', '583c3a9c0727190d899757d2', '583c3a9c0727190d899757d6', '58359dbd709a3972e0156dde', '58359dbd709a3972e0156ddb', '58359dbd709a3972e0156dd6', '583c3a9c0727190d899757cf', '583c3a9c0727190d899757cd', '58359dbd709a3972e0156ddf', '583c3a9c0727190d899757d0']
-    #
-    # for ident in ids:
-    #     filters = [{'property_name': 'keen.id', 'operator': 'eq', 'property_value': ident}]
-    #     client.delete_events('institution_summary', filters=filters)
-    #     time.sleep(2)
+    client = get_keen_client()
+    ids = ['583f27d3709a3972feb78569' '583f27d3709a3972feb7856a', '583f27d3709a3972feb7856b', '583f27d3709a3972feb7856c']
+    for ident in ids:
+        filters = [{'property_name': 'keen.id', 'operator': 'eq', 'property_value': ident}]
+        client.delete_events('user_summary', filters=filters)
+        time.sleep(2)

--- a/scripts/analytics/migrate_analytics.py
+++ b/scripts/analytics/migrate_analytics.py
@@ -91,22 +91,34 @@ def fill_in_event_gaps(collection_name, events):
     date_chunks = [given_days[x-1:x+1] for x in range(1, len(given_days))]
     events_to_add = []
     if given_days:
-        if collection_name != 'addon_snapshot':
-            for date_pair in date_chunks:
-                if date_pair[1] - date_pair[0] > datetime.timedelta(1):
-                    first_event = [event for event in events if date_from_event_ts(event) == date_pair[0] and not event.get('generated')]
-                    if first_event:
-                        events_to_add += generate_events_between_events(date_pair, first_event[0])
-        else:
+        if collection_name == 'addon_snapshot':
             all_providers = list(set([event['provider']['name'] for event in events]))
             for provider in all_providers:
                 for date_pair in date_chunks:
-                    if date_pair[1] - date_pair[0] > datetime.timedelta(1):
+                    if date_pair[1] - date_pair[0] > datetime.timedelta(1) and date_pair[0] != date_pair[1]:
                         first_event = [
                             event for event in events if date_from_event_ts(event) == date_pair[0] and event['provider']['name'] == provider and not event.get('generated')
                             ]
                         if first_event:
                             events_to_add += generate_events_between_events(date_pair, first_event[0])
+        elif collection_name == 'institution_summary':
+            all_instutitions = list(set([event['institution']['name'] for event in events]))
+            for institution in all_instutitions:
+                for date_pair in date_chunks:
+                    if date_pair[1] - date_pair[0] > datetime.timedelta(1) and date_pair[0] != date_pair[1]:
+                        first_event = [
+                            event for event in events if date_from_event_ts(event) == date_pair[0] and event['institution']['name'] == institution and not event.get('generated')
+                            ]
+                        if first_event:
+                            events_to_add += generate_events_between_events(date_pair, first_event[0])
+
+        else:
+            for date_pair in date_chunks:
+                if date_pair[1] - date_pair[0] > datetime.timedelta(1):
+                    first_event = [event for event in events if date_from_event_ts(event) == date_pair[0] and not event.get('generated')]
+                    if first_event:
+                        events_to_add += generate_events_between_events(date_pair, first_event[0])
+
         logger.info('Generated {} events to add to the {} collection.'.format(len(events_to_add), collection_name))
     else:
         logger.info('Could not retrieve events for the date range you provided.')
@@ -445,3 +457,11 @@ def main():
 
 if __name__ == '__main__':
     main()
+
+    # client = get_keen_client()
+    # ids = ['583c3a9c0727190d899757d7', '583c3a9c0727190d899757d3', '583c3a9c0727190d899757d2', '583c3a9c0727190d899757d6', '58359dbd709a3972e0156dde', '58359dbd709a3972e0156ddb', '58359dbd709a3972e0156dd6', '583c3a9c0727190d899757cf', '583c3a9c0727190d899757cd', '58359dbd709a3972e0156ddf', '583c3a9c0727190d899757d0']
+    #
+    # for ident in ids:
+    #     filters = [{'property_name': 'keen.id', 'operator': 'eq', 'property_value': ident}]
+    #     client.delete_events('institution_summary', filters=filters)
+    #     time.sleep(2)

--- a/scripts/analytics/migrate_analytics.py
+++ b/scripts/analytics/migrate_analytics.py
@@ -455,11 +455,4 @@ def main():
 
 
 if __name__ == '__main__':
-    # main()
-
-    client = get_keen_client()
-    ids = ['583f27d3709a3972feb78569' '583f27d3709a3972feb7856a', '583f27d3709a3972feb7856b', '583f27d3709a3972feb7856c']
-    for ident in ids:
-        filters = [{'property_name': 'keen.id', 'operator': 'eq', 'property_value': ident}]
-        client.delete_events('user_summary', filters=filters)
-        time.sleep(2)
+    main()

--- a/scripts/analytics/migrate_analytics.py
+++ b/scripts/analytics/migrate_analytics.py
@@ -301,7 +301,8 @@ def import_old_events_from_spreadsheet():
         'Date': 'timestamp',
         'dropbox-users-enabled': 'enabled',
         'dropbox-users-authorized': 'authorized',
-        'dropbox-users-linked': 'linked'
+        'dropbox-users-linked': 'linked',
+        'profile-edits': 'profile_edited'
     }
 
     with open(spreadsheet_path) as csvfile:
@@ -319,7 +320,7 @@ def import_old_events_from_spreadsheet():
                 event[equiv_key] = row[key]
         events.append(event)
 
-    user_summary_cols = ['active', 'depth', 'total_users', 'timestamp']
+    user_summary_cols = ['active', 'depth', 'total_users', 'timestamp', 'profile_edited']
     node_summary_cols = ['registrations.total', 'projects.total', 'projects.public', 'timestamp']
     addon_summary_cols = ['enabled', 'authorized', 'linked', 'timestamp']
 
@@ -390,6 +391,8 @@ def format_event(event, analytics_type):
             template_to_use['status']['active'] = comma_int(event['active'])
         if event['total_users'] and event['active']:
             template_to_use['status']['unconfirmed'] = comma_int(event['total_users']) - comma_int(event['active'])
+        if event['profile_edited']:
+            template_to_use['status']['profile_edited'] = comma_int(event['profile_edited'])
     elif analytics_type == 'node':
         template_to_use = node_event_template
 

--- a/scripts/analytics/migrate_analytics.py
+++ b/scripts/analytics/migrate_analytics.py
@@ -278,7 +278,7 @@ def import_old_events_from_spreadsheet():
     key_map = {
         'active-users': 'active',
         'logs-gte-11-total': 'depth',
-        'number_users': 'unconfirmed',  # really is active - number_users
+        'number_users': 'total_users',  # really is active - number_users
         'number_projects': 'projects.total',
         'number_projects_public': 'projects.public',
         'number_projects_registered': 'registrations.total',
@@ -303,7 +303,7 @@ def import_old_events_from_spreadsheet():
                 event[equiv_key] = row[key]
         events.append(event)
 
-    user_summary_cols = ['active', 'depth', 'unconfirmed', 'timestamp']
+    user_summary_cols = ['active', 'depth', 'total_users', 'timestamp']
     node_summary_cols = ['registrations.total', 'projects.total', 'projects.public', 'timestamp']
     addon_summary_cols = ['enabled', 'authorized', 'linked', 'timestamp']
 
@@ -372,8 +372,8 @@ def format_event(event, analytics_type):
 
         if event['active'] and event['active'] != 'MISSING':
             template_to_use['status']['active'] = comma_int(event['active'])
-        if event['unconfirmed'] and event['active']:
-            template_to_use['status']['unconfirmed'] = comma_int(event['active']) - comma_int(event['unconfirmed'])
+        if event['total_users'] and event['active']:
+            template_to_use['status']['unconfirmed'] = comma_int(event['total_users']) - comma_int(event['active'])
     elif analytics_type == 'node':
         template_to_use = node_event_template
 
@@ -445,10 +445,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-
-    # client = get_keen_client()
-    # filters = [{'property_name': 'imported', 'operator': 'eq', 'property_value': True}]
-    #
-    # client.delete_events('node_summary', filters=filters)
-    # client.delete_events('user_summary', filters=filters)
-    # client.delete_events('addon_snapshot', filters=filters)

--- a/scripts/analytics/migrate_analytics.py
+++ b/scripts/analytics/migrate_analytics.py
@@ -1,0 +1,244 @@
+# A script to migrate old keen analytics to a new collection, generate in-between points for choppy
+# data, or a little of both
+
+import os
+import csv
+import copy
+import time
+import logging
+import argparse
+import datetime
+from dateutil.parser import parse
+from keen.client import KeenClient
+
+from website.settings import KEEN as keen_settings
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+DELETE_WAIT_TIME = 10
+VERY_LONG_TIMEFRAME = 'this_20_years'
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description='Enter a start date and end date to gather, smooth, and send back analytics for keen'
+    )
+    parser.add_argument('-s', '--start', dest='start_date')
+    parser.add_argument('-e', '--end', dest='end_date')
+
+    parser.add_argument('-t', '--transfer', dest='transfer_collection', action='store_true')
+    parser.add_argument('-sc', '--source', dest='source_collection')
+    parser.add_argument('-dc', '--destination', dest='destination_collection')
+    parser.add_argument('-d', '--delete', dest='delete', action='store_true')
+
+    parser.add_argument('-sm', '--smooth', dest='smooth_events', action='store_true')
+
+    parser.add_argument('-sm', '--import', dest='import_events', action='store_true')
+
+    parsed = parser.parse_args()
+
+    validate_args(parsed)
+
+    return parsed
+
+
+def validate_args(args):
+    """ Go through supplied command line args an determine if you have enough to continue
+
+    :param args: argparse args object, to sift through and figure out if you need more info
+    :return: None, just raise errors if it finds something wrong
+    """
+    if args.smooth and not (args.start_date and args.end_date):
+        raise ValueError('To smooth data, please enter both a start date and end date.')
+
+    if args.smooth and not args.source_colletion:
+        raise ValueError('Please specify a source collection to smooth data from.')
+
+    if args.transfer and not (args.source_colletion and args.destination_collection):
+        raise ValueError('To transfer between keen collections, enter both a source and a destination collection.')
+
+    if args.delete and not args.transfer:
+        raise ValueError('To delete anything you will need to transfer analytics from one collection to another.')
+
+    if any([args.start_date, args.end_date]) and not all([args.start_date, args.end_date]):
+        raise ValueError('You must provide both a start and an end date if you provide either.')
+
+
+def fill_in_event_gaps(collection_name, events):
+    """ A method to help fill in gaps between events that might be far apart,
+    so that one event happens per day.
+
+    :param collection_name: keen collection events are from
+    :param events: events to fill in gaps between
+    :return: list of "generated and estimated" events to send that will fill in gaps.
+    """
+
+    given_days = [parse(event['keen']['timestamp']).date() for event in events]
+    given_days.sort()
+    events_to_add = []
+    if given_days:
+        if collection_name != 'addon_snapshot':
+            first_event = [event for event in events if date_from_event_ts(event) == given_days[0]][0]
+            events_to_add = generate_events_between_events(given_days, first_event)
+        else:
+            all_providers = list(set([event['provider']['name'] for event in events]))
+            for provider in all_providers:
+                first_event = [
+                    event for event in events if date_from_event_ts(event) == given_days[0] and event['provider']['name'] == provider
+                ][0]
+                events_to_add += generate_events_between_events(given_days, first_event)
+        logger.info('Generated {} events to add to the {} collection.'.format(len(events_to_add), collection_name))
+    else:
+        logger.info('Could not retrieve events for the date range you provided.')
+
+    return events_to_add
+
+
+def date_from_event_ts(event):
+    return parse(event['keen']['timestamp']).date()
+
+
+def generate_events_between_events(given_days, first_event):
+    first_day = given_days[0]
+    last_day = given_days[-1]
+    next_day = first_day + datetime.timedelta(1)
+
+    first_event['keen'].pop('created_at')
+    first_event['keen'].pop('id')
+    first_event['generated'] = True  # Add value to tag generated data
+
+    generated_events = []
+    while next_day < last_day:
+        new_event = copy.deepcopy(first_event)
+        new_event['keen']['timestamp'] = next_day.isoformat()
+        if next_day not in given_days:
+            generated_events.append(new_event)
+        next_day += datetime.timedelta(1)
+
+    return generated_events
+
+
+def get_keen_client():
+    keen_project = keen_settings['private'].get('project_id')
+    read_key = keen_settings['private'].get('read_key')
+    master_key = keen_settings['private'].get('master_key')
+    write_key = keen_settings['private'].get('write_key')
+    if keen_project and read_key and master_key:
+        client = KeenClient(
+            project_id=keen_project,
+            read_key=read_key,
+            master_key=master_key,
+            write_key=write_key
+        )
+    else:
+        raise ValueError('Cannot connect to Keen clients - all keys not provided.')
+
+    return client
+
+
+def extract_events_from_keen(client, event_collection, start_date=None, end_date=None):
+    """ Get analytics from keen to use as a starting point for smoothing or transferring
+
+    :param client: keen client to use for connection
+    :param start_date: datetime object, datetime to start gathering from keen
+    :param end_date: datetime object, datetime to stop gathering from keen
+    :param event_collection: str, name of the event collection to gather from
+    :return: a list of keen events to use in other methods
+    """
+    timeframe = VERY_LONG_TIMEFRAME
+    if start_date and end_date:
+        logger.info('Gathering events from the {} collection between {} and {}'.format(event_collection, start_date, end_date))
+        timeframe = {"start": start_date.isoformat(), "end": end_date.isoformat()}
+    else:
+        logger.info('Gathering events from the {} collection using timeframe {}'.format(event_collection, VERY_LONG_TIMEFRAME))
+
+    return client.extraction(event_collection, timeframe=timeframe)
+
+
+def make_sure_keen_schemas_match(source_collection, destination_collection, keen_client):
+    """ Helper function to check if two given collections have matching schemas in keen, to make sure
+    they can be transfered between one another
+
+    :param source_collection: str, collection that events are stored now
+    :param destination_collection: str, collection to transfer to
+    :param keen_client: KeenClient, instantiated for the connection
+    :return: bool, if the two schemas match in keen
+    """
+    source_schema = keen_client.get_collection(source_collection)
+    destination_schema = keen_client.get_collection(destination_collection)
+
+    return source_schema == destination_schema
+
+
+def transfer_events_to_another_collection(client, source_collection, destination_collection, delete=False):
+    """ Transfer analytics from source collection to the destination collection.
+    Will only work if the source and destination have the same schemas attached, will error if they don't
+
+    :param client: KeenClient, client to use to make connection to keen
+    :param source_collection: str, keen collection to transfer from
+    :param destination_collection: str, keen collection to transfer to
+    :param delete: bool, whether or not delete items from the old collection after transferred
+    :return: None
+    """
+    schemas_match = make_sure_keen_schemas_match(source_collection, destination_collection, client)
+    if not schemas_match:
+        raise ValueError('The two provided schemas in keen do not match, you will need to do a bit more work.')
+
+    events_from_source = extract_events_from_keen(client, source_collection)
+
+    for event in events_from_source:
+        event['keen'].pop('created_at')
+        event['keen'].pop('id')
+
+    add_events_to_keen(client, destination_collection, events_from_source)
+
+    if delete:
+        logger.warning('Will delete all events from the {} collection in {} seconds'.format(source_collection, DELETE_WAIT_TIME))
+        for i in range(DELETE_WAIT_TIME):
+            logger.info(i)
+            time.sleep(1)
+        client.delete_events(source_collection)
+
+    logger.info(
+        'Transferred {} events from the {} collection to the {} collection'.format(
+            len(events_from_source),
+            source_collection,
+            destination_collection
+        )
+    )
+
+
+def add_events_to_keen(client, collection, events):
+    logger.info('Adding {} events to the {} collection...'.format(len(events), collection))
+    client.add_events({collection: events})
+
+
+def smooth_events_in_keen(client, source_collection, start_date, end_date):
+    base_events = extract_events_from_keen(client, source_collection, start_date, end_date)
+    events_to_fill_in = fill_in_event_gaps(source_collection, base_events)
+    add_events_to_keen(client, source_collection, events_to_fill_in)
+
+
+def main():
+    """ Main function for moving around and adjusting analytics gotten from keen and sending them back to keen.
+
+    Usage:
+        * Transfer all events from the 'institution_analytics' to the 'institution_summary' collection:
+            `python -m scripts.analytics.migrate_analytics.py -t -sc institution_analytics -dc institution_summary
+        * Fill in the gaps in analytics for the 'addon_snapshot' collection between 2016-11-01 and 2016-11-15:
+            `python -m scripts.analytics.migrate_analytics.py -sm -s 2016-11-01 -e 2016-11-15
+    """
+    args = parse_args()
+    client = get_keen_client()
+
+    if args.smooth:
+        smooth_events_in_keen(client, args.source_colletion, parse(args.start_date), parse(args.end_date))
+    if args.transfer:
+        transfer_events_to_another_collection(client, args.source_collection, args.destination_collection, args.delete)
+
+
+if __name__ == '__main__':
+    # main()
+
+    import_events_from_spreadsheet()

--- a/scripts/tests/test_addon_snapshot.py
+++ b/scripts/tests/test_addon_snapshot.py
@@ -74,7 +74,6 @@ class TestAddonCount(OsfTestCase):
         results = AddonSnapshot().get_events()
         github_res = [res for res in results if res['provider']['name'] == 'github'][0]
         assert_equal(github_res['users']['enabled'], 1)
-        # import ipdb; ipdb.set_trace()
 
     def test_one_user_with_multiple_addons(self):
         results = AddonSnapshot().get_events()

--- a/scripts/tests/test_migrate_analytics.py
+++ b/scripts/tests/test_migrate_analytics.py
@@ -35,15 +35,20 @@ class TestMigrateAnalytics(OsfTestCase):
             },
             "nodes": {
                 "deleted": 0,
-                "total": 1,
-                "connected": 1,
-                "disconnected": 0
+                "total": 5,
+                "connected": 4,
+                "disconnected": 1
             }
         }
 
     def test_generate_events_between_events(self):
-        generated_events = generate_events_between_events([self.day_one, self.day_two], self.keen_event_2)
+        generated_events = generate_events_between_events([self.day_one, self.day_two], self.keen_event)
         assert_equal(len(generated_events), 3)
         returned_dates = [event['keen']['timestamp'] for event in generated_events]
         expected_dates = ['2016-03-{}T00:00:00'.format(i) for i in range(13, 16)]
         assert_items_equal(returned_dates, expected_dates)
+
+        # check the totals are the same as the first event
+        returned_totals = [event['nodes']['total'] for event in generated_events]
+        expected_totals = [self.keen_event["nodes"]["total"] for i in range(len(generated_events))]
+        assert_items_equal(returned_totals, expected_totals)

--- a/scripts/tests/test_migrate_analytics.py
+++ b/scripts/tests/test_migrate_analytics.py
@@ -58,6 +58,8 @@ class TestMigrateAnalytics(OsfTestCase):
 
     def test_generate_events_between_events(self):
         generated_events = generate_events_between_events([self.day_one, self.day_two], self.keen_event)
+
+        # Only for the first gap, so 3/13, 3/14, 3/15
         assert_equal(len(generated_events), 3)
         returned_dates = [event['keen']['timestamp'] for event in generated_events]
         expected_dates = ['2016-03-{}T00:00:00+00:00'.format(i) for i in range(13, 16)]

--- a/scripts/tests/test_migrate_analytics.py
+++ b/scripts/tests/test_migrate_analytics.py
@@ -1,0 +1,49 @@
+import datetime
+from dateutil.parser import parse
+from nose.tools import *  # noqa
+
+from tests.base import OsfTestCase
+from scripts.analytics.migrate_analytics import generate_events_between_events
+
+
+class TestMigrateAnalytics(OsfTestCase):
+    def setUp(self):
+        super(TestMigrateAnalytics, self).setUp()
+
+        self.day_one = parse('2016-03-12')
+        self.day_two = parse('2016-03-16')
+
+        self.keen_event = {
+            "keen": {
+                "timestamp": self.day_one.isoformat(),
+                "created_at": self.day_one.isoformat(),
+                "id": 1
+            },
+            "nodes": {
+                "deleted": 0,
+                "total": 1,
+                "connected": 1,
+                "disconnected": 0
+            }
+        }
+
+        self.keen_event_2 = {
+            "keen": {
+                "timestamp": self.day_two.isoformat(),
+                "created_at": self.day_two.isoformat(),
+                "id": 2
+            },
+            "nodes": {
+                "deleted": 0,
+                "total": 1,
+                "connected": 1,
+                "disconnected": 0
+            }
+        }
+
+    def test_generate_events_between_events(self):
+        generated_events = generate_events_between_events([self.day_one, self.day_two], self.keen_event_2)
+        assert_equal(len(generated_events), 3)
+        returned_dates = [event['keen']['timestamp'] for event in generated_events]
+        expected_dates = ['2016-03-{}T00:00:00'.format(i) for i in range(13, 16)]
+        assert_items_equal(returned_dates, expected_dates)

--- a/scripts/tests/test_migrate_analytics.py
+++ b/scripts/tests/test_migrate_analytics.py
@@ -1,17 +1,18 @@
-import datetime
+import pytz
 from dateutil.parser import parse
 from nose.tools import *  # noqa
 
 from tests.base import OsfTestCase
-from scripts.analytics.migrate_analytics import generate_events_between_events
+from scripts.analytics.migrate_analytics import generate_events_between_events, fill_in_event_gaps
 
 
 class TestMigrateAnalytics(OsfTestCase):
     def setUp(self):
         super(TestMigrateAnalytics, self).setUp()
 
-        self.day_one = parse('2016-03-12')
-        self.day_two = parse('2016-03-16')
+        self.day_one = parse('2016-03-12').replace(tzinfo=pytz.UTC)
+        self.day_two = parse('2016-03-16').replace(tzinfo=pytz.UTC)
+        self.day_three = parse('2016-03-19').replace(tzinfo=pytz.UTC)
 
         self.keen_event = {
             "keen": {
@@ -41,14 +42,39 @@ class TestMigrateAnalytics(OsfTestCase):
             }
         }
 
+        self.keen_event_3 = {
+            "keen": {
+                "timestamp": self.day_three.isoformat(),
+                "created_at": self.day_three.isoformat(),
+                "id": 2
+            },
+            "nodes": {
+                "deleted": 0,
+                "total": 8,
+                "connected": 6,
+                "disconnected": 2
+            }
+        }
+
     def test_generate_events_between_events(self):
         generated_events = generate_events_between_events([self.day_one, self.day_two], self.keen_event)
         assert_equal(len(generated_events), 3)
         returned_dates = [event['keen']['timestamp'] for event in generated_events]
-        expected_dates = ['2016-03-{}T00:00:00'.format(i) for i in range(13, 16)]
+        expected_dates = ['2016-03-{}T00:00:00+00:00'.format(i) for i in range(13, 16)]
         assert_items_equal(returned_dates, expected_dates)
 
         # check the totals are the same as the first event
         returned_totals = [event['nodes']['total'] for event in generated_events]
         expected_totals = [self.keen_event["nodes"]["total"] for i in range(len(generated_events))]
         assert_items_equal(returned_totals, expected_totals)
+
+    def test_fill_in_event_gaps(self):
+        filled_in_events = fill_in_event_gaps('test', [self.keen_event, self.keen_event_2, self.keen_event_3])
+
+        # Should generate for 5 days total - 3/13, 3/14, 3/15, 3/17 and  3/18
+        assert_equal(len(filled_in_events), 5)
+
+        returned_dates = [event['keen']['timestamp'] for event in filled_in_events]
+        expected_dates = ['2016-03-{}T00:00:00+00:00'.format(i) for i in range(13, 16)]
+        expected_dates += ['2016-03-{}T00:00:00+00:00'.format(i) for i in range(17, 19)]
+        assert_items_equal(returned_dates, expected_dates)


### PR DESCRIPTION
## Purpose

Command line tool for Keen analytics that shouldn't need to be run very often, but can update Keen from the daily users spreadsheet, or smooth out event data from a given collection, or transfer between collections if they have the same schema.

Examples:
* Transfer all events from the 'institution_analytics' to the 'institution_summary' collection as a dry run:
    - `python -m scripts.analytics.migrate_analytics -d -t -sc institution_analytics -dc institution_summary`
* Fill in the gaps in analytics for the 'addon_snapshot' collection between 2016-11-01 and 2016-11-15:
    - `python -m scripts.analytics.migrate_analytics -sm -sc addon_snapshot -s 2016-11-01 -e 2016-11-15`
* Reverse the above action by adding -r:
    -  `python -m scripts.analytics.migrate_analytics -sm -sc addon_snapshot -s 2016-11-01 -e 2016-11-15 -r`
* Parse old analytics from the old analytics CSV stored on your filesystem in home directory
    - `python -m scripts.analytics.migrate_analytics -o`

![screen shot 2016-12-01 at 12 04 34 pm](https://cloud.githubusercontent.com/assets/801594/20803794/75a02980-b7be-11e6-994f-93984c80f0d4.png)

## Changes

- Script for running these keen analytics commands
- Tests for data smoothing


## Side effects
The old importing from csv never needs to be run again, unless the keen data is deleted for whatever reason, so is a bit superflouous. Already has been run on Keen production data, this is more if we ever need to easily smooth data or transfer data in Keen again.


## Ticket
https://openscience.atlassian.net/browse/OSF-7223