### PR TITLE
[Fix] Fix OSF Preprints Campaign URL [OSF-7252]

### DIFF
--- a/framework/auth/campaigns.py
+++ b/framework/auth/campaigns.py
@@ -56,12 +56,13 @@ def get_campaigns():
                 if provider._id == 'osf':
                     template = 'osf'
                     name = 'OSF'
+                    url_path = 'preprints/'
                 else:
                     template = 'branded'
                     name = provider.name
+                    url_path = 'preprints/{}'.format(provider._id)
                 campaign = '{}-preprints'.format(provider._id)
                 system_tag = '{}_preprints'.format(provider._id)
-                url_path = 'preprints/{}'.format(provider._id)
                 CAMPAIGNS.update({
                     campaign: {
                         'system_tag': system_tag,


### PR DESCRIPTION
## Purpose

Fix a bug introduced by [OSF-7217], where OSF preprints campaign url is incorrectly set to `/preprints/osf`. The correct one should be `/preprints/`.

## Changes

No

## Side effects

No

## Ticket

https://openscience.atlassian.net/browse/OSF-7252
