### PR TITLE
Add some Keen analytics in the OSF Admin! [OSF-7085]

### DIFF
--- a/admin/metrics/urls.py
+++ b/admin/metrics/urls.py
@@ -4,7 +4,5 @@ from django.contrib.auth.decorators import login_required as login
 from . import views
 
 urlpatterns = [
-    url(r'^$', login(views.OSFStatisticsListView.as_view()), name='stats_list'),
-    url(r'^update/$', login(views.update_metrics), name='update'),
-    url(r'^download/$', login(views.download_csv), name='download'),
+    url(r'^$', login(views.MetricsView.as_view()), name='stats_list'),
 ]

--- a/admin/metrics/urls.py
+++ b/admin/metrics/urls.py
@@ -4,5 +4,5 @@ from django.contrib.auth.decorators import login_required as login
 from . import views
 
 urlpatterns = [
-    url(r'^$', login(views.MetricsView.as_view()), name='stats_list'),
+    url(r'^$', login(views.MetricsView.as_view()), name='metrics'),
 ]

--- a/admin/metrics/views.py
+++ b/admin/metrics/views.py
@@ -1,79 +1,15 @@
-import csv
+from django.views.generic import TemplateView
 
-from django.core.urlresolvers import reverse
-from django.http import HttpResponse
-from django.shortcuts import redirect
-from django.utils.text import slugify
-from django.views.generic import ListView
-
-from admin.metrics.models import OSFWebsiteStatistics
-from admin.metrics.utils import get_osf_statistics
+from admin.base.settings import KEEN_CREDENTIALS
 
 
-def update_metrics(request):
-    get_osf_statistics()
-    return redirect(reverse('metrics:stats_list'))
+from admin.base.utils import OSFAdmin
 
 
-def dump(qs, response):
-    """
-    source from http://palewi.re/posts/2009/03/03/django-recipe-dump-your-queryset-out-as-a-csv-file/
+class MetricsView(OSFAdmin, TemplateView):
+    template_name = 'metrics/osf_metrics.html'
 
-    Takes in a Django queryset and spits out a CSV file.
+    def get_context_data(self, **kwargs):
 
-    Usage::
-
-        >> from utils import dump2csv
-        >> from dummy_app.models import *
-        >> qs = DummyModel.objects.all()
-        >> dump2csv.dump(qs, './data/dump.csv')
-
-    Based on a snippet by zbyte64::
-
-        http://www.djangosnippets.org/snippets/790/
-
-    """
-    model = qs.model
-    writer = csv.writer(response)
-
-    headers = []
-    for field in model._meta.fields:
-        headers.append(field.name)
-    writer.writerow(headers)
-
-    for obj in qs:
-        row = []
-        for field in headers:
-            val = getattr(obj, field)
-            if callable(val):
-                val = val()
-            if type(val) == unicode:
-                val = val.encode('utf-8')
-            row.append(val)
-        writer.writerow(row)
-
-
-def render_to_csv_response(queryset):
-    filename = slugify(unicode(queryset.model.__name__)) + '_export.csv'
-
-    response = HttpResponse(content_type='text/csv')
-    response['Content-Disposition'] = 'attachment; filename=%s;' % filename
-    response['Cache-Control'] = 'no-cache'
-
-    dump(queryset, response)
-
-    return response
-
-
-def download_csv(request):
-    queryset = OSFWebsiteStatistics.objects.all().order_by('-date')
-    return render_to_csv_response(queryset)
-
-
-class OSFStatisticsListView(ListView):
-    model = OSFWebsiteStatistics
-    template_name = 'metrics/osf_statistics.html'
-    context_object_name = 'metrics'
-    paginate_by = 50
-    paginate_orphans = 5
-    ordering = '-date'
+        kwargs.update(KEEN_CREDENTIALS.copy())
+        return super(MetricsView, self).get_context_data(**kwargs)

--- a/admin/static/js/metrics/metrics.js
+++ b/admin/static/js/metrics/metrics.js
@@ -82,12 +82,117 @@ Keen.ready(function () {
             "domain"
         ],
         interval: "daily",
-        timeframe: "previous_7_days",
+        timeframe: "previous_1_week",
         timezone: "UTC"
     });
 
     client.draw(email_domains, document.getElementById("user-registration-by-email-domain"), {
         chartType: "linechart",
+        height: "auto",
+        width: "auto",
+        title: ' '
+    });
+
+    // Yesterday's Node Logs by User
+
+    // Previous 7 Days of Users by Status
+    var previous_week_active_users = new Keen.Query("sum",  {
+        eventCollection: "user_summary",
+        interval: "daily",
+        targetProperty: "status.active",
+        timeframe: "previous_1_week",
+        timezone: "UTC"
+    });
+
+    var previous_week_unconfirmed_users = new Keen.Query("sum",  {
+        eventCollection: "user_summary",
+        interval: "daily",
+        targetProperty: "status.unconfirmed",
+        timeframe: "previous_1_week",
+        timezone: "UTC"
+    });
+
+    var previous_week_merged_users = new Keen.Query("sum",  {
+        eventCollection: "user_summary",
+        interval: "daily",
+        targetProperty: "status.merged",
+        timeframe: "previous_1_week",
+        timezone: "UTC"
+    });
+
+    var previous_week_depth_users = new Keen.Query("sum",  {
+        eventCollection: "user_summary",
+        interval: "daily",
+        targetProperty: "status.depth",
+        timeframe: "previous_1_week",
+        timezone: "UTC"
+    });
+
+    var previous_week_deactivated_users = new Keen.Query("sum",  {
+        eventCollection: "user_summary",
+        interval: "daily",
+        targetProperty: "status.deactivated",
+        timeframe: "previous_1_week",
+        timezone: "UTC"
+    });
+
+    var chart = new Keen.Dataviz()
+        .el(document.getElementById("previous-7-days-of-users-by-status"))
+        .chartType("linechart")
+        .chartOptions({
+            legend: {position: "top"}
+        }).prepare();
+
+    client.run([
+        previous_week_active_users,
+        previous_week_unconfirmed_users,
+        previous_week_merged_users,
+        previous_week_depth_users,
+        previous_week_deactivated_users
+    ], function(err, res) {
+        var active_result = res[0].result;
+        var unconfirmed_result = res[1].result;
+        var merged_result = res[2].result;
+        var depth_result = res[3].result;
+        var deactivated_result = res[4].result;
+        var data = [];
+        var i=0;
+
+        while (i < active_result.length) {
+            data[i] = {
+                timeframe: active_result[i]["timeframe"],
+                value: [
+                    {category: "Active", result: active_result[i].value},
+                    {category: "Unconfirmed", result: unconfirmed_result[i].value},
+                    {category: "Merged", result: merged_result[i].value},
+                    {category: "Depth", result: depth_result[i].value},
+                    {category: "Deactivated", result: deactivated_result[i].value}
+                ]
+            };
+            if (i === active_result.length - 1) {
+                chart.parseRawData({result: data}).render();
+            }
+            i++;
+        }
+    });
+
+    // Previous 7 days of linked addon by addon name
+    var linked_addon = new Keen.Query("sum", {
+        eventCollection: "addon_snapshot",
+        targetProperty: "users.linked",
+        groupBy: [
+            "provider.name"
+        ],
+        interval: "daily",
+        timeframe: "previous_1_week",
+        timezone: "UTC"
+    });
+
+    client.draw(linked_addon, document.getElementById("previous-7-days-of-linked-addon-by-addon-name"), {
+        chartType: "linechart",
+        chartOptions: {
+            legend: {position: "top"}
+        },
         height: "auto",
         width: "auto",
         title: ' '

--- a/admin/static/js/metrics/metrics.js
+++ b/admin/static/js/metrics/metrics.js
@@ -24,6 +24,9 @@ Keen.ready(function () {
         chartType: "metric",
         height: "auto",
         width: "auto",
+        chartOptions: {
+            legend: {position: "top"}
+        },
         title: ' '
     });
 
@@ -39,6 +42,9 @@ Keen.ready(function () {
     client.draw(active_user_chart, document.getElementById("active-user-chart"), {
         chartType: "linechart",
         height: "auto",
+        chartOptions: {
+            legend: {position: "top"}
+        },
         width: "auto",
         title: ' '
     });
@@ -90,6 +96,9 @@ Keen.ready(function () {
         chartType: "linechart",
         height: "auto",
         width: "auto",
+        chartOptions: {
+            legend: {position: "top"}
+        },
         title: ' '
     });
 
@@ -104,6 +113,9 @@ Keen.ready(function () {
     client.draw(logs_by_user, document.getElementById("yesterdays-node-logs-by-user"), {
         chartType: "linechart",
         height: "auto",
+        chartOptions: {
+            legend: {position: "top"}
+        },
         width: "auto",
         title: " "
     });

--- a/admin/static/js/metrics/metrics.js
+++ b/admin/static/js/metrics/metrics.js
@@ -64,21 +64,6 @@ Keen.ready(function () {
         title: ' '
     });
 
-    // Yesterday's Node Logs!
-    var logs_by_user = new Keen.Query("count", {
-        eventCollection: "node_log_events",
-        interval: "hourly",
-        groupBy: "user_id",
-        timeframe: "previous_1_days",
-        timezone: "UTC"
-    });
-    client.draw(logs_by_user, document.getElementById("yesterdays-node-logs-by-user"), {
-        chartType: "linechart",
-        title: '',
-        height: "auto",
-        width: "auto"
-    });
-
     // Registrations by Email Domain
     var email_domains = new Keen.Query("count", {
         eventCollection: "user_domain_events",

--- a/admin/static/js/metrics/metrics.js
+++ b/admin/static/js/metrics/metrics.js
@@ -82,7 +82,7 @@ Keen.ready(function () {
             "domain"
         ],
         interval: "daily",
-        timeframe: "previous_1_week",
+        timeframe: "previous_7_days",
         timezone: "UTC"
     });
 
@@ -94,6 +94,19 @@ Keen.ready(function () {
     });
 
     // Yesterday's Node Logs by User
+    var logs_by_user = new Keen.Query("count", {
+        eventCollection: "node_log_events",
+        interval: "hourly",
+        groupBy: "user_id",
+        timeframe: "previous_1_days",
+        timezone: "UTC"
+    });
+    client.draw(logs_by_user, document.getElementById("yesterdays-node-logs-by-user"), {
+        chartType: "linechart",
+        height: "auto",
+        width: "auto",
+        title: " "
+    });
 
     // Previous 7 Days of Users by Status
     var previous_week_active_users = new Keen.Query("sum",  {

--- a/admin/static/js/metrics/metrics.js
+++ b/admin/static/js/metrics/metrics.js
@@ -59,6 +59,22 @@ Keen.ready(function () {
         title: ' '
     });
 
+    // Affiliated Private Projects!
+    var affiliated_private_chart = new Keen.Query("sum", {
+        eventCollection: "institution_summary",
+        targetProperty: "nodes.private",
+        timeframe: "previous_1_days",
+        groupBy: "institution.name",
+        timezone: "UTC"
+    });
+
+    client.draw(affiliated_private_chart, document.getElementById("affiliated-private-projects"), {
+        chartType: "table",
+        height: "auto",
+        width: "auto",
+        title: ' '
+    });
+
     // Registrations by Email Domain
     var email_domains = new Keen.Query("count", {
         eventCollection: "user_domain_events",

--- a/admin/static/js/metrics/metrics.js
+++ b/admin/static/js/metrics/metrics.js
@@ -1,0 +1,100 @@
+"use_strict";
+
+require('bootstrap');
+require('jquery');
+require('c3/c3.css');
+
+var c3 = require('c3/c3.js');
+var keen = require('keen-js');
+var ss = require('simple-statistics');
+
+
+var client = new Keen({
+    projectId: keenProjectId,
+    readKey : keenReadKey
+});
+
+
+Keen.ready(function () {
+
+    // Active user count!
+    var active_user_count = new Keen.Query("sum", {
+        eventCollection: "user_summary",
+        targetProperty: "status.active",
+        timeframe: "previous_1_days",
+        timezone: "UTC"
+    });
+
+    client.draw(active_user_count, document.getElementById("active-user-count"), {
+        chartType: "metric",
+        height: "auto",
+        width: "auto",
+        title: ' '
+    });
+
+    // Active user chart!
+    var active_user_chart = new Keen.Query("sum", {
+        eventCollection: "user_summary",
+        interval: "daily",
+        targetProperty: "status.active",
+        timeframe: "previous_800_days",
+        timezone: "UTC"
+    });
+
+    client.draw(active_user_chart, document.getElementById("active-user-chart"), {
+        chartType: "linechart",
+        height: "auto",
+        width: "auto",
+        title: ' '
+    });
+
+    // Affiliated Public Projects!
+    var affiliated_public_chart = new Keen.Query("sum", {
+        eventCollection: "institution_summary",
+        targetProperty: "nodes.public",
+        timeframe: "previous_1_days",
+        groupBy: "institution.name",
+        timezone: "UTC"
+    });
+
+    client.draw(affiliated_public_chart, document.getElementById("affiliated-public-projects"), {
+        chartType: "table",
+        height: "auto",
+        width: "auto",
+        title: ' '
+    });
+
+    // Yesterday's Node Logs!
+    var logs_by_user = new Keen.Query("count", {
+        eventCollection: "node_log_events",
+        interval: "hourly",
+        groupBy: "user_id",
+        timeframe: "previous_1_days",
+        timezone: "UTC"
+    });
+    client.draw(logs_by_user, document.getElementById("yesterdays-node-logs-by-user"), {
+        chartType: "linechart",
+        title: '',
+        height: "auto",
+        width: "auto"
+    });
+
+    // Registrations by Email Domain
+    var email_domains = new Keen.Query("count", {
+        eventCollection: "user_domain_events",
+        groupBy: [
+            "domain"
+        ],
+        interval: "daily",
+        timeframe: "previous_7_days",
+        timezone: "UTC"
+    });
+
+    client.draw(email_domains, document.getElementById("user-registration-by-email-domain"), {
+        chartType: "linechart",
+        height: "auto",
+        width: "auto",
+        title: ' '
+    });
+
+});

--- a/admin/static/js/metrics/metrics.js
+++ b/admin/static/js/metrics/metrics.js
@@ -1,12 +1,7 @@
 "use_strict";
 
-require('bootstrap');
-require('jquery');
-require('c3/c3.css');
 
-var c3 = require('c3/c3.js');
 var keen = require('keen-js');
-var ss = require('simple-statistics');
 
 
 var client = new Keen({

--- a/admin/templates/base.html
+++ b/admin/templates/base.html
@@ -122,7 +122,7 @@
             {% if 'prereg_group' in request.user.group_names %}
             <li><a href="{% url 'pre_reg:prereg' %}"><i class='fa fa-link'></i> <span>OSF Prereg</span></a></li>
             {% endif %}
-            <li><a href="{% url 'metrics:stats_list' %}"><i class='fa fa-link'></i> <span>OSF Stats</span></a></li>
+            <li><a href="{% url 'metrics:metrics' %}"><i class='fa fa-link'></i> <span>OSF Metrics</span></a></li>
             <li><a href="{% url 'sales_analytics:dashboard' %}"><i class='fa fa-link'></i> <span>OSF Sales Analytics</span></a></li>
           </ul><!-- /.sidebar-menu -->
         </section>

--- a/admin/templates/metrics/osf_metrics.html
+++ b/admin/templates/metrics/osf_metrics.html
@@ -30,8 +30,13 @@
     </div>
 
     <div>
-        <h3>Affiliated public projects by Institution</h3>
+        <h3>Affiliated Public projects by Institution</h3>
         <div id="affiliated-public-projects">Loading...</div>
+    </div>
+
+    <div>
+        <h3>Affiliated Private projects by Institution</h3>
+        <div id="affiliated-private-projects">Loading...</div>
     </div>
 
     <div>

--- a/admin/templates/metrics/osf_metrics.html
+++ b/admin/templates/metrics/osf_metrics.html
@@ -39,11 +39,6 @@
         <div id="user-registration-by-email-domain">Loading...</div>
     </div>
 
-    <div>
-        <h3>Yesterday's Node logs by user</h3>
-        <div id="yesterdays-node-logs-by-user">Loading...</div>
-    </div>
-
 {% endblock content %}
 
 

--- a/admin/templates/metrics/osf_metrics.html
+++ b/admin/templates/metrics/osf_metrics.html
@@ -66,14 +66,6 @@
         <div id="previous-7-days-of-linked-addon-by-addon-name">Loading...</div>
     </div>
 
-    <div>
-        <h2>Coming Soon!</h2>
-
-        <div>
-            <h3>Previous 7 days of profile edits</h3>
-        </div>
-    </div>
-
 {% endblock content %}
 
 

--- a/admin/templates/metrics/osf_metrics.html
+++ b/admin/templates/metrics/osf_metrics.html
@@ -6,6 +6,7 @@
 {% endblock title %}
 
 {% block top_includes %}
+    <link rel="stylesheet" type="text/css" href="/static/css/keen-dashboards.css" />
     <script>
         if ('{{ keen_ready }}' == 'True') {
             var keenProjectId = '{{ keen_project_id }}';
@@ -19,24 +20,30 @@
 
     <h2>OSF Metrics</h2>
 
-    <div>
-        <h3>Yesterday's Active Users</h3>
-        <div id="active-user-count">Loading...</div>
+    <div class="row">
+        <div class="col-md-12">
+            <h3>Yesterday's Active Users</h3>
+            <div id="active-user-count">Loading...</div>
+        </div>
     </div>
 
-    <div>
-        <h3>Active Users Over Time</h3>
-        <div id="active-user-chart">Loading...</div>
+    <div class="row">
+        <div class="col-md-12">
+            <h3>Active Users Over Time</h3>
+            <div id="active-user-chart">Loading...</div>
+        </div>
     </div>
 
-    <div>
-        <h3>Affiliated Public projects by Institution</h3>
-        <div id="affiliated-public-projects">Loading...</div>
-    </div>
+    <div class="row">
+        <div class="col-md-6">
+            <h3>Affiliated Public projects by Institution</h3>
+            <div id="affiliated-public-projects">Loading...</div>
+        </div>
 
-    <div>
-        <h3>Affiliated Private projects by Institution</h3>
-        <div id="affiliated-private-projects">Loading...</div>
+        <div class="col-md-6">
+            <h3>Affiliated Private projects by Institution</h3>
+            <div id="affiliated-private-projects">Loading...</div>
+        </div>
     </div>
 
     <div>

--- a/admin/templates/metrics/osf_metrics.html
+++ b/admin/templates/metrics/osf_metrics.html
@@ -20,21 +20,37 @@
 
     <h2>OSF Metrics</h2>
 
+    <div class="dropdown">
+        <button class="btn btn-default btn-large dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown">
+            Jump to...
+            <span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu">
+            <li><a href="#active_users">Yesterday's Active Users</a></li>
+            <li><a href="#active_users_over_time">Active Users Over Time</a></li>
+            <li><a href="#affiliated_projects">Affiliated Public and Private projects by Institution</a></li>
+            <li><a href="#email_domain">Previous 7 days of user registrations by email domain</a></li>
+            <li><a href="#node_logs_by_user">Yesterday's Node logs by user</a></li>
+            <li><a href="#users_by_status">Previous 7 days of users by status</a></li>
+            <li><a href="#linked_addon_by_name">Previous 7 days of linked addon by addon name</a></li>
+        </ul>
+    </div>
+
     <div class="row">
-        <div class="col-md-12">
+        <div class="col-md-12" id="active_users">
             <h3>Yesterday's Active Users</h3>
             <div id="active-user-count">Loading...</div>
         </div>
     </div>
 
     <div class="row">
-        <div class="col-md-12">
+        <div class="col-md-12" id="active_users_over_time">
             <h3>Active Users Over Time</h3>
             <div id="active-user-chart">Loading...</div>
         </div>
     </div>
 
-    <div class="row">
+    <div class="row" id="affiliated_projects">
         <div class="col-md-6">
             <h3>Affiliated Public projects by Institution</h3>
             <div id="affiliated-public-projects">Loading...</div>
@@ -46,22 +62,22 @@
         </div>
     </div>
 
-    <div>
+    <div id="email_domain">
         <h3>Previous 7 days of user registrations by email domain</h3>
         <div id="user-registration-by-email-domain">Loading...</div>
     </div>
 
-    <div>
+    <div id="node_logs_by_user">
         <h3>Yesterday's Node logs by user</h3>
         <div id="yesterdays-node-logs-by-user">Loading...</div>
     </div>
 
-    <div>
+    <div id="users_by_status">
         <h3>Previous 7 days of users by status</h3>
         <div id="previous-7-days-of-users-by-status">Loading...</div>
     </div>
 
-    <div>
+    <div id="linked_addon_by_name">
         <h3>Previous 7 days of linked addon by addon name</h3>
         <div id="previous-7-days-of-linked-addon-by-addon-name">Loading...</div>
     </div>

--- a/admin/templates/metrics/osf_metrics.html
+++ b/admin/templates/metrics/osf_metrics.html
@@ -44,6 +44,29 @@
         <div id="user-registration-by-email-domain">Loading...</div>
     </div>
 
+    <div>
+        <h3>Yesterday's Node logs by user</h3>
+        <div id="yesterdays-node-logs-by-user">Loading...</div>
+    </div>
+
+    <div>
+        <h3>Previous 7 days of users by status</h3>
+        <div id="previous-7-days-of-users-by-status">Loading...</div>
+    </div>
+
+    <div>
+        <h3>Previous 7 days of linked addon by addon name</h3>
+        <div id="previous-7-days-of-linked-addon-by-addon-name">Loading...</div>
+    </div>
+
+    <div>
+        <h2>Coming Soon!</h2>
+
+        <div>
+            <h3>Previous 7 days of profile edits</h3>
+        </div>
+    </div>
+
 {% endblock content %}
 
 

--- a/admin/templates/metrics/osf_metrics.html
+++ b/admin/templates/metrics/osf_metrics.html
@@ -1,0 +1,52 @@
+{% extends 'base.html' %}
+{% load static %}
+
+{% block title %}
+    <title>OSF Metrics</title>
+{% endblock title %}
+
+{% block top_includes %}
+    <script>
+        if ('{{ keen_ready }}' == 'True') {
+            var keenProjectId = '{{ keen_project_id }}';
+            var keenReadKey = '{{ keen_read_key }}';
+        }
+    </script>
+
+{% endblock top_includes %}
+
+{% block content %}
+
+    <h2>OSF Metrics</h2>
+
+    <div>
+        <h3>Yesterday's Active Users</h3>
+        <div id="active-user-count">Loading...</div>
+    </div>
+
+    <div>
+        <h3>Active Users Over Time</h3>
+        <div id="active-user-chart">Loading...</div>
+    </div>
+
+    <div>
+        <h3>Affiliated public projects by Institution</h3>
+        <div id="affiliated-public-projects">Loading...</div>
+    </div>
+
+    <div>
+        <h3>Previous 7 days of user registrations by email domain</h3>
+        <div id="user-registration-by-email-domain">Loading...</div>
+    </div>
+
+    <div>
+        <h3>Yesterday's Node logs by user</h3>
+        <div id="yesterdays-node-logs-by-user">Loading...</div>
+    </div>
+
+{% endblock content %}
+
+
+{% block bottom_js %}
+    <script src="{% static 'public/js/metrics.js' %}"></script>
+{% endblock %}

--- a/admin/webpack.admin.config.js
+++ b/admin/webpack.admin.config.js
@@ -31,6 +31,7 @@ var config = assign({}, common, {
         'prereg-admin-page': staticAdminPath('js/pages/prereg-admin-page.js'),
         'admin-registration-edit-page': staticAdminPath('js/pages/admin-registration-edit-page.js'),
         'dashboard': staticAdminPath('js/sales_analytics/dashboard.js'),
+        'metrics': staticAdminPath('js/metrics/metrics.js'),
     },
     plugins: plugins,
     debug: true,

--- a/admin_tests/metrics/test_utils.py
+++ b/admin_tests/metrics/test_utils.py
@@ -5,11 +5,8 @@ from tests.base import AdminTestCase
 from tests.factories import (
     AuthUserFactory, NodeFactory, ProjectFactory, RegistrationFactory
 )
-from admin.metrics.views import render_to_csv_response
 from website.project.model import Node, User
 from framework.auth import Auth
-from webtest_plus import TestApp
-from tests.base import test_app
 
 from admin.metrics.utils import (
     get_projects,
@@ -192,51 +189,3 @@ def construct_query(id, time):
         get_projects(time),
         time.strftime('%Y-%m-%d %H:%M:%S.%f')
     )
-
-
-class TestRenderToCSVResponse(AdminTestCase):
-
-    def setUp(self):
-        super(TestRenderToCSVResponse, self).setUp()
-        self.app = TestApp(test_app)
-        Node.remove()
-        time_now = get_previous_midnight()
-        NodeFactory(category='project', date_created=time_now)
-        NodeFactory(category='project',
-                    date_created=time_now - timedelta(days=1))
-        last_time = time_now - timedelta(days=2)
-        NodeFactory(category='project', date_created=last_time)
-        NodeFactory(category='project', date_created=last_time)
-        initial_time = last_time + timedelta(seconds=1)
-        get_days_statistics(initial_time)
-        midtime = last_time + timedelta(days=1, seconds=1)
-        self.time = time_now + timedelta(seconds=1)
-
-        self.initial_static = [
-            'id,users,delta_users,unregistered_users,projects,delta_projects,public_projects,'
-            'delta_public_projects,registered_projects,delta_registered_projects,date\r',
-            construct_query(1, initial_time), '']
-        self.latest_static = [
-            'id,users,delta_users,unregistered_users,projects,delta_projects,public_projects,'
-            'delta_public_projects,registered_projects,delta_registered_projects,date\r',
-            construct_query(3, self.time),
-            construct_query(2, midtime),
-            construct_query(1, initial_time), '']
-
-    def test_render_to_csv_response(self):
-        queryset = OSFWebsiteStatistics.objects.all().order_by('-date')
-        response = render_to_csv_response(queryset)
-        self.assertEqual(response['Content-Type'], 'text/csv')
-        self.assertEqual(response.content.split('\n'),
-                         self.initial_static)
-        self.assertRegexpMatches(response['Content-Disposition'],
-                                 r'attachment; filename=osfwebsitestatistics_export.csv;')
-
-        get_osf_statistics()
-        new_queryset = OSFWebsiteStatistics.objects.all().order_by('-date')
-        new_res = render_to_csv_response(new_queryset)
-        self.assertEqual(new_res['Content-Type'], 'text/csv')
-        self.assertEqual(new_res.content.split('\n'),
-                         self.latest_static)
-        self.assertRegexpMatches(new_res['Content-Disposition'],
-                                 r'attachment; filename=osfwebsitestatistics_export.csv;')

--- a/scripts/analytics/base.py
+++ b/scripts/analytics/base.py
@@ -162,9 +162,8 @@ class BaseAnalyticsHarness(object):
         analytics_classes = self.analytics_classes
         if command_line:
             args = self.parse_args()
-            entered_scripts = args.analytics_scripts
-            if args.entered_scripts:
-                analytics_classes = self.try_to_import_from_args(entered_scripts)
+            if args.analytics_scripts:
+                analytics_classes = self.try_to_import_from_args(args.analytics_scripts)
 
         for analytics_class in analytics_classes:
             class_instance = analytics_class()


### PR DESCRIPTION
## Purpose
Analytics in the OSF Admin have not been updating. Let's change that over to Keen!

![screen shot 2016-12-05 at 4 45 52 pm](https://cloud.githubusercontent.com/assets/801594/20903693/5b68401c-bb0a-11e6-921b-339412321859.png)

![screen shot 2016-12-02 at 10 13 21 am](https://cloud.githubusercontent.com/assets/801594/20903721/70f85b42-bb0a-11e6-8424-ed5c72462baa.png)


## Changes
- Remove old CSV rendering routes and views
- Now render results from keen collections in javascript
- Fix calling snapshot analytics from command line

Metrics added:

- Yesterday's Active Users
- Active Users Over Time
- Affiliated Public projects by Institution
- Affiliated Private projects by Institution
- Previous 7 days of user registrations by email domain
- Yesterday's Node logs by user
- Previous 7 days of users by status
- Previous 7 days of linked addon by addon name

## Side effects
- Correct keen API keys will need to be added in `local.py` if they're not there already


## Ticket
https://openscience.atlassian.net/browse/OSF-7085