### PR TITLE
[OSF-6527] Auto-linking should be enabled in Wiki MarkdownIt

### DIFF
--- a/website/static/js/markdown.js
+++ b/website/static/js/markdown.js
@@ -32,8 +32,9 @@ var oldMarkdownList = function(md) {
 };
 
 // Full markdown renderer for views / wiki pages / pauses between typing
-var markdown = new MarkdownIt('commonmark', {
+var markdown = new MarkdownIt({
     highlight: highlighter,
+    html: true,
     linkify: true
 })
     .use(require('markdown-it-video'))
@@ -46,11 +47,11 @@ var markdown = new MarkdownIt('commonmark', {
 
 
 // Fast markdown renderer for active editing to prevent slow loading/rendering tasks
-var markdownQuick = new MarkdownIt(('commonmark'), {
+var markdownQuick = new MarkdownIt({
+    html: true,
     linkify: true
 })
     .use(require('markdown-it-sanitizer'))
-    .disable('link')
     .disable('image')
     .use(insDel)
     .enable('table')
@@ -58,7 +59,7 @@ var markdownQuick = new MarkdownIt(('commonmark'), {
     .disable('strikethrough');
 
 // Markdown renderer for older wikis rendered before switch date
-var markdownOld = new MarkdownIt(('commonmark'), { })
+var markdownOld = new MarkdownIt('commonmark', {})
     .use(require('markdown-it-sanitizer'))
     .use(insDel)
     .enable('table')

--- a/website/static/js/markdown.js
+++ b/website/static/js/markdown.js
@@ -48,10 +48,10 @@ var markdown = new MarkdownIt({
 
 // Fast markdown renderer for active editing to prevent slow loading/rendering tasks
 var markdownQuick = new MarkdownIt({
-    html: true,
-    linkify: true
+    html: true
 })
     .use(require('markdown-it-sanitizer'))
+    .disable('link')
     .disable('image')
     .use(insDel)
     .enable('table')

--- a/website/static/js/markdown.js
+++ b/website/static/js/markdown.js
@@ -33,7 +33,8 @@ var oldMarkdownList = function(md) {
 
 // Full markdown renderer for views / wiki pages / pauses between typing
 var markdown = new MarkdownIt('commonmark', {
-    highlight: highlighter
+    highlight: highlighter,
+    linkify: true
 })
     .use(require('markdown-it-video'))
     .use(require('markdown-it-toc'))
@@ -45,7 +46,9 @@ var markdown = new MarkdownIt('commonmark', {
 
 
 // Fast markdown renderer for active editing to prevent slow loading/rendering tasks
-var markdownQuick = new MarkdownIt(('commonmark'), { })
+var markdownQuick = new MarkdownIt(('commonmark'), {
+    linkify: true
+})
     .use(require('markdown-it-sanitizer'))
     .disable('link')
     .disable('image')


### PR DESCRIPTION
## Purpose
Auto-linking is already enabled in other parts of the OSF, and is a common feature of Markdown.

## Changes
The main Markdown renderer is no longer set to the restrictive "commonmark" specification which forbids autolinking, and autolinking is enabled.

The quick Markdown renderer (used when the user is actively editing the wiki), however, was previously not generating any links at all; therefor, autolinking is not enabled in it either. It seems to me that making links and autolinking should not significantly slow down the renderer, so perhaps this question should be reconsidered. The commit just prior to the current one has the changes applied to both the full and quick renderers.

Before:
![noautolinking](https://cloud.githubusercontent.com/assets/1449974/20862325/74450e12-b975-11e6-8c5b-22bf4a954648.png)

After:
![autolinking](https://cloud.githubusercontent.com/assets/1449974/20862327/780db832-b975-11e6-97be-0021a33c02ef.png)

## Side effects
It is possible that certain additional features previously disabled by the commonmark setting of MarkdownIt are unwanted and may need to be disabled. These should only be cosmetic, however, as MarkdownIt prides themselves on being safe with _all_ their default settings.

## Ticket
https://openscience.atlassian.net/browse/OSF-6527
