### PR TITLE
Add profile edited count to user summary script [OSF-7085]

### DIFF
--- a/scripts/analytics/user_summary.py
+++ b/scripts/analytics/user_summary.py
@@ -51,12 +51,15 @@ class UserSummary(SummaryAnalytics):
 
         active_users = 0
         depth_users = 0
+        profile_edited = 0
         user_pages = paginated(User, query=active_user_query)
         for user in user_pages:
             active_users += 1
             log_count = count_user_logs(user)
             if log_count >= LOG_THRESHOLD:
                 depth_users += 1
+            if user.social or user.schools or user.jobs:
+                profile_edited += 1
 
         counts = {
             'keen': {
@@ -76,16 +79,18 @@ class UserSummary(SummaryAnalytics):
                 'merged': User.find(
                     Q('date_registered', 'lt', query_datetime) &
                     Q('merged_by', 'ne', None)
-                ).count()
+                ).count(),
+                'profile_edited': profile_edited
             }
         }
         logger.info(
-            'Users counted. Active: {}, Depth: {}, Unconfirmed: {}, Deactivated: {}, Merged: {}'.format(
+            'Users counted. Active: {}, Depth: {}, Unconfirmed: {}, Deactivated: {}, Merged: {}, Profile Edited: {}'.format(
                 counts['status']['active'],
                 counts['status']['depth'],
                 counts['status']['unconfirmed'],
                 counts['status']['deactivated'],
-                counts['status']['merged']
+                counts['status']['merged'],
+                counts['status']['profile_edited']
             )
         )
         return [counts]


### PR DESCRIPTION

## Purpose

Piggy-backing off of #6562, this adds the number of users with edited profiles to the list of tracked items.

## Changes
- Also include if a user has edited their profile in user summary counts


## Side effects

Old events gathered won't have it, but that's ok!

## Ticket
Adding final part of:
https://openscience.atlassian.net/browse/OSF-7085