### PR TITLE
[hotfix] Fix Duplicate Preprint Licensing Logs [OSF-7260]

### DIFF
--- a/api/logs/serializers.py
+++ b/api/logs/serializers.py
@@ -57,6 +57,7 @@ class NodeLogParamsSerializer(RestrictedDictSerializer):
     kind = ser.CharField(read_only=True)
     folder = ser.CharField(read_only=True)
     folder_name = ser.CharField(read_only=True)
+    license = ser.CharField(read_only=True, source='new_license')
     identifiers = NodeLogIdentifiersSerializer(read_only=True)
     institution = NodeLogInstitutionSerializer(read_only=True)
     old_page = ser.CharField(read_only=True)

--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -1421,3 +1421,33 @@ class TestNodeUpdateLicense(ApiTestCase):
 
         assert_not_equal(logs_before_update, logs_after_update)
         assert_equal(self.node.logs[-1].action, 'license_changed')
+
+    def test_update_node_license_without_change_does_not_add_log(self):
+        self.node.set_node_license(
+            {
+                'id': self.no_license.id,
+                'year': '2015',
+                'copyrightHolders': ['Kim', 'Kanye']
+            },
+            auth=Auth(self.admin_contributor),
+            save=True
+        )
+
+        before_num_logs = len(self.node.logs)
+        before_update_log = self.node.logs[-1]
+
+        data = self.make_payload(
+            node_id=self.node._id,
+            license_id=self.no_license._id,
+            license_year='2015',
+            copyright_holders=['Kanye', 'Kim']
+        )
+        res = self.make_request(self.url, data, auth=self.admin_contributor.auth)
+        self.node.reload()
+
+        after_num_logs = len(self.node.logs)
+        after_update_log = self.node.logs[-1]
+
+        assert_equal(res.status_code, 200)
+        assert_equal(before_num_logs, after_num_logs)
+        assert_equal(before_update_log._id, after_update_log._id)

--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -573,3 +573,33 @@ class TestPreprintUpdateLicense(ApiTestCase):
 
         assert_equal(self.preprint.license.node_license, self.cc0_license)
         assert_equal(self.preprint.node.node_license.node_license, self.no_license)
+
+    def test_update_preprint_license_without_change_does_not_add_log(self):
+        self.preprint.set_preprint_license(
+            {
+                'id': self.no_license.id,
+                'year': '2015',
+                'copyrightHolders': ['Kim', 'Kanye']
+            },
+            auth=Auth(self.admin_contributor),
+            save=True
+        )
+
+        before_num_logs = len(self.preprint.node.logs)
+        before_update_log = self.preprint.node.logs[-1]
+
+        data = self.make_payload(
+            node_id=self.preprint._id,
+            license_id=self.no_license._id,
+            license_year='2015',
+            copyright_holders=['Kanye', 'Kim']
+        )
+        res = self.make_request(self.url, data, auth=self.admin_contributor.auth)
+        self.preprint.node.reload()
+
+        after_num_logs = len(self.preprint.node.logs)
+        after_update_log = self.preprint.node.logs[-1]
+
+        assert_equal(res.status_code, 200)
+        assert_equal(before_num_logs, after_num_logs)
+        assert_equal(before_update_log._id, after_update_log._id)

--- a/scripts/remove_duplicate_preprint_logs.py
+++ b/scripts/remove_duplicate_preprint_logs.py
@@ -1,0 +1,73 @@
+import sys
+import logging
+
+from modularodm import Q
+
+from framework.transactions.context import TokuTransaction
+from scripts import utils as script_utils
+from website.app import init_app
+from website.project.model import Node, NodeLog
+
+
+logger = logging.getLogger(__name__)
+
+
+# This is where all your migration log will go
+def do_migration():
+    dupe_nodes = [n for n in Node.find(Q('_id', 'in', list(set([l.node._id for l in NodeLog.find(Q('action', 'eq', 'preprint_license_updated'))])))) if NodeLog.find(Q('action', 'eq', 'preprint_license_updated') & Q('node', 'eq', n._id)).count() > 1]
+    logger.info('Found {} nodes with multiple preprint_license_updated logs'.format(len(dupe_nodes)))
+
+    for node in dupe_nodes:
+        preprint_license_updated_logs = [log for log in node.logs if log.action == 'preprint_license_updated']
+
+        log = preprint_license_updated_logs.pop()
+        while(preprint_license_updated_logs):
+            next_log = preprint_license_updated_logs.pop()
+            timedelta = log.date - next_log.date
+            if timedelta.seconds < 1:
+                logger.info(
+                    'Hiding duplicate preprint_license_updated log with ID {} from node {}, timedelta was {}'.format(
+                        log._id, node._id, timedelta
+                    )
+                )
+                log.should_hide = True
+                log.save()
+            else:
+                logger.info(
+                    'Skipping preprint_license_updated log with ID {} from node {}, timedelta was {}'.format(
+                        log._id, node._id, timedelta
+                    )
+                )
+
+            log = next_log
+
+
+def main(dry=True):
+    init_app(set_backends=True, routes=False)  # Sets the storage backends on all models
+
+    # Start a transaction that will be rolled back if any exceptions are un
+    with TokuTransaction():
+        do_migration()
+        if dry:
+            # When running in dry mode force the transaction to rollback
+            raise Exception('Abort Transaction - Dry Run')
+
+
+if __name__ == '__main__':
+    dry = '--dry' in sys.argv
+    if not dry:
+        # If we're not running in dry mode log everything to a file
+        script_utils.add_file_logger(logger, __file__)
+
+    # Allow setting the log level just by appending the level to the command
+    if 'debug' in sys.argv:
+        logger.setLevel(logging.DEBUG)
+    elif 'warning' in sys.argv:
+        logger.setLevel(logging.WARNING)
+    elif 'info' in sys.argv:
+        logger.setLevel(logging.INFO)
+    elif 'error' in sys.argv:
+        logger.setLevel(logging.ERROR)
+
+    # Finally run the migration
+    main(dry=dry)

--- a/scripts/remove_duplicate_preprint_logs.py
+++ b/scripts/remove_duplicate_preprint_logs.py
@@ -24,7 +24,7 @@ def do_migration():
         while(preprint_license_updated_logs):
             next_log = preprint_license_updated_logs.pop()
             timedelta = log.date - next_log.date
-            if timedelta.seconds < 1:
+            if timedelta.seconds < 60:
                 logger.info(
                     'Hiding duplicate preprint_license_updated log with ID {} from node {}, timedelta was {}'.format(
                         log._id, node._id, timedelta

--- a/website/preprints/model.py
+++ b/website/preprints/model.py
@@ -184,7 +184,8 @@ class PreprintService(GuidStoredObject):
             self.node.add_log(
                 action=NodeLog.PREPRINT_LICENSE_UPDATED,
                 params={
-                    'preprint': self._id
+                    'preprint': self._id,
+                    'new_license': license_record.node_license.name
                 },
                 auth=auth,
                 save=False

--- a/website/preprints/model.py
+++ b/website/preprints/model.py
@@ -178,16 +178,17 @@ class PreprintService(GuidStoredObject):
 
     def set_preprint_license(self, license_detail, auth, save=False):
 
-        set_license(self, license_detail, auth, node_type='preprint')
+        license_record, license_changed = set_license(self, license_detail, auth, node_type='preprint')
 
-        self.node.add_log(
-            action=NodeLog.PREPRINT_LICENSE_UPDATED,
-            params={
-                'preprint': self._id
-            },
-            auth=auth,
-            save=False
-        )
+        if license_changed:
+            self.node.add_log(
+                action=NodeLog.PREPRINT_LICENSE_UPDATED,
+                params={
+                    'preprint': self._id
+                },
+                auth=auth,
+                save=False
+            )
 
         if save:
             self.save()

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -1515,18 +1515,19 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable, Spam
 
     def set_node_license(self, license_detail, auth, save=False):
 
-        license_record = set_license(self, license_detail, auth)
+        license_record, license_changed = set_license(self, license_detail, auth)
 
-        self.add_log(
-            action=NodeLog.CHANGED_LICENSE,
-            params={
-                'parent_node': self.parent_id,
-                'node': self._primary_key,
-                'new_license': license_record.node_license.name
-            },
-            auth=auth,
-            save=False,
-        )
+        if license_changed:
+            self.add_log(
+                action=NodeLog.CHANGED_LICENSE,
+                params={
+                    'parent_node': self.parent_id,
+                    'node': self._primary_key,
+                    'new_license': license_record.node_license.name
+                },
+                auth=auth,
+                save=False,
+            )
 
         if save:
             self.save()

--- a/website/static/js/anonymousLogActionsList.json
+++ b/website/static/js/anonymousLogActionsList.json
@@ -76,5 +76,5 @@
     "affiliated_institution_removed": "A user removed an affiliation from a project",
     "preprint_initiated": "A user made a project a preprint",
     "preprint_file_updated": "A user updated the primary file of a preprint",
-    "preprint_license_updated": "A user updated the license of the primary file for a preprint"
+    "preprint_license_updated": "A user updated the license of a preprint"
 }

--- a/website/static/js/logActionsList.json
+++ b/website/static/js/logActionsList.json
@@ -65,7 +65,7 @@
     "node_created":     "${user} created ${node}",
     "node_forked":  "${user} created fork from ${forked_from}",
     "node_removed":  "${user} removed ${node}",
-    "license_changed" : "${user} updated the license of ${node}",
+    "license_changed" : "${user} updated the license of ${node} ${license}",
     "file_tag_added": "${user} added tag ${tag} to ${path} in OSF Storage in ${node}",
     "file_tag_removed": "${user} removed tag ${tag} from ${path} in OSF Storage in ${node}",
     "osf_storage_file_added" : "${user} added file ${path} to OSF Storage in ${node}",
@@ -76,5 +76,5 @@
     "affiliated_institution_removed": "${user} removed ${institution} affiliation from ${node}",
     "preprint_initiated": "${user} made ${node} a ${preprint} on ${preprint_provider} Preprints",
     "preprint_file_updated": "${user} updated the primary file of this ${preprint} on {preprint_provider} Preprints",
-    "preprint_license_updated": "${user} updated the license of the primary file of this {preprint} on {preprint_provider} Preprints"
+    "preprint_license_updated": "${user} updated the license of this ${preprint} on ${preprint_provider} Preprints ${license}"
 }

--- a/website/static/js/logTextParser.js
+++ b/website/static/js/logTextParser.js
@@ -661,8 +661,18 @@ var LogPieces = {
     preprint_provider: {
         view: function(ctrl, logObject){
             var preprint_provider = logObject.attributes.params.preprint_provider;
-            if (paramIsReturned((preprint_provider, logObject))) {
+            if (paramIsReturned(preprint_provider, logObject)) {
                 return m('a', {href: preprint_provider.url}, preprint_provider.name);
+            }
+            return m('span', '');
+        }
+    },
+
+    license: {
+        view: function(ctrl, logObject){
+            var license_name = logObject.attributes.params.license;
+            if (license_name) {
+                return m('span', 'to ' + license_name);
             }
             return m('span', '');
         }


### PR DESCRIPTION
#### Purpose
- When editing a preprint, multiple PATCH requests are sent to the API, which results in duplicate `perprint_license_updated` logs being added to the preprint node.
- This PR prevents duplicate logs by checking that the update license record differs from the current license record before adding a log to the node. 
- Additionally, this PR updates the language of both node and preprint license logs to include the license that was applied (screenshots below).

#### Changes
- Adds a check to ensure a log is only added if the updated license record is different from the current license record. 
- Adds tests to ensure duplicate logs are not added.
- Adds a migration to remove the duplicate `preprint_license_updated` logs.
- Update `license_changed` and `preprint_license_updated` log language.
- Add `license` to logTextParser.js and `NodeLogParamsSerializer`.

#### Migration
```
python -m scripts.remove_duplicate_preprint_logs --dry 
```

#### Screenshots 
- "preprint_license_updated" (logs created before this PR -- without license information)
![screen shot 2016-12-07 at 10 30 28 am](https://cloud.githubusercontent.com/assets/7913604/20973912/6200e46a-bc68-11e6-940e-c40d6426c6f9.png)

- "preprint_license_updated" (logs created after this PR -- will have license information)
![screen shot 2016-12-07 at 10 30 21 am](https://cloud.githubusercontent.com/assets/7913604/20973884/4a7f577c-bc68-11e6-9da7-d7c21ad5047b.png)

- "node_license_changed" (all project license updated logs)
![screen shot 2016-12-07 at 10 30 09 am](https://cloud.githubusercontent.com/assets/7913604/20973886/4a816e40-bc68-11e6-9a06-f7a194d723ec.png)


#### Ticket
- [OSF-7260](https://openscience.atlassian.net/browse/OSF-7260)
