### PR TITLE
Change calling of entered scripts from args for analytics

### DIFF
--- a/scripts/analytics/base.py
+++ b/scripts/analytics/base.py
@@ -162,9 +162,8 @@ class BaseAnalyticsHarness(object):
         analytics_classes = self.analytics_classes
         if command_line:
             args = self.parse_args()
-            entered_scripts = args.analytics_scripts
-            if args.entered_scripts:
-                analytics_classes = self.try_to_import_from_args(entered_scripts)
+            if args.analytics_scripts:
+                analytics_classes = self.try_to_import_from_args(args.analytics_scripts)
 
         for analytics_class in analytics_classes:
             class_instance = analytics_class()
@@ -199,7 +198,7 @@ class DateAnalyticsHarness(BaseAnalyticsHarness):
                 except AttributeError:
                     raise AttributeError('You must either specify a date or use the yesterday argument to gather analytics for yesterday.')
             if args.analytics_scripts:
-                analytics_classes = self.try_to_import_from_args(entered_scripts)
+                analytics_classes = self.try_to_import_from_args(args.analytics_scripts)
 
         for analytics_class in analytics_classes:
             class_instance = analytics_class()

--- a/scripts/analytics/base.py
+++ b/scripts/analytics/base.py
@@ -128,7 +128,7 @@ class EventAnalytics(SummaryAnalytics):
 class BaseAnalyticsHarness(object):
 
     def __init__(self):
-        init_app()
+        init_app(routes=False)
 
     @property
     def analytics_classes(self):


### PR DESCRIPTION

## Purpose
Attribute error when calling analytics snapshots 

## Changes

- Call analytics scripts directly from args instead of saving to variable 
- init_app without setting up URL routes

## Side effects
None anticipated

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->

