### PR TITLE
Add example links for Preprint Providers [PREP-284]

### DIFF
--- a/api/preprint_providers/serializers.py
+++ b/api/preprint_providers/serializers.py
@@ -18,6 +18,7 @@ class PreprintProviderSerializer(JSONAPISerializer):
     advisory_board = ser.CharField(required=False, allow_null=True)
     email_contact = ser.CharField(required=False, allow_null=True)
     email_support = ser.CharField(required=False, allow_null=True)
+    example = ser.CharField(required=False, allow_null=True)
     social_twitter = ser.CharField(required=False, allow_null=True)
     social_facebook = ser.CharField(required=False, allow_null=True)
     social_instagram = ser.CharField(required=False, allow_null=True)

--- a/scripts/populate_preprint_providers.py
+++ b/scripts/populate_preprint_providers.py
@@ -85,7 +85,7 @@ def main():
             'description': 'The open archive of engineering.',
             'banner_name': 'engrxiv-banner.png',
             'external_url': 'http://engrxiv.org',
-            'example': '',
+            'example': 's58q7',
             'advisory_board': '''
                 <div class="col-xs-12">
                     <h2>Steering Committee</h2>
@@ -227,7 +227,7 @@ def main():
             'description': 'A free preprint service for the psychological sciences.',
             'banner_name': 'psyarxiv-banner.png',
             'external_url': 'http://psyarxiv.com',
-            'example': '',
+            'example': 'k9mn3',
             'advisory_board': '''
                 <div class="col-xs-12">
                     <h2>Steering Committee</h2>
@@ -315,7 +315,7 @@ def main():
             'description': 'Open archive of the social sciences',
             'banner_name': 'socarxiv-banner.png',
             'external_url': 'http://socarxiv.org',
-            'example': '',
+            'example': 'qmdc4',
             'advisory_board': '''
                 <div class="col-xs-12">
                     <h2>Steering Committee</h2>

--- a/website/preprints/model.py
+++ b/website/preprints/model.py
@@ -208,6 +208,7 @@ class PreprintProvider(StoredObject):
     external_url = fields.StringField()
     email_contact = fields.StringField()
     email_support = fields.StringField()
+    example = fields.StringField()
     access_token = EncryptedStringField()
     advisory_board = fields.StringField()
     social_twitter = fields.StringField()


### PR DESCRIPTION
## Purpose
Adds links for the providers to a example for their particular brand

## Changes
* Updates model and serializer for PreprintProvider
* Updates populate_preprint_providers script

## Side effects
N/A

## Ticket
https://openscience.atlassian.net/browse/PREP-284

## Notes for QA
Links will only work on prod. Please only verify that they're using the correct GUID.

![screen shot 2016-12-07 at 10 36 26](https://cloud.githubusercontent.com/assets/3374510/20974201/66987ba4-bc69-11e6-862b-f00c26b6498c.png)


# Notes for Deployment
Need to run populate_preprint_providers script after the the merge

