### PR TITLE
 [feature] Upgrade django-cors-headers [OSF-7225]

### DIFF
--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -137,6 +137,7 @@ CORS_ALLOW_CREDENTIALS = True
 INSTITUTION_ORIGINS_WHITELIST = ()
 
 MIDDLEWARE_CLASSES = (
+    'api.base.middleware.CorsMiddleware',
     # TokuMX transaction support
     # Needs to go before CommonMiddleware, so that transactions are always started,
     # even in the event of a redirect. CommonMiddleware may cause other middlewares'
@@ -152,7 +153,6 @@ MIDDLEWARE_CLASSES = (
     # 'api.base.middleware.ProfileMiddleware',
 
     # 'django.contrib.sessions.middleware.SessionMiddleware',
-    'api.base.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     # 'django.contrib.auth.middleware.AuthenticationMiddleware',

--- a/api_tests/base/test_middleware.py
+++ b/api_tests/base/test_middleware.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-
+from django.http import HttpResponse
 from tests.base import ApiTestCase, fake
 
 from urlparse import urlparse
@@ -53,7 +53,7 @@ class TestCorsMiddleware(MiddlewareTestCase):
         )
         settings.load_institutions()
         request = self.request_factory.get(url, HTTP_ORIGIN=domain.geturl())
-        response = {}
+        response = HttpResponse()
         self.middleware.process_request(request)
         processed = self.middleware.process_response(request, response)
         assert_equal(response['Access-Control-Allow-Origin'], domain.geturl())
@@ -76,7 +76,7 @@ class TestCorsMiddleware(MiddlewareTestCase):
             HTTP_ORIGIN=domain.geturl(),
             HTTP_AUTHORIZATION="Bearer aqweqweohuweglbiuwefq"
         )
-        response = {}
+        response = HttpResponse()
         self.middleware.process_request(request)
         processed = self.middleware.process_response(request, response)
         assert_equal(response['Access-Control-Allow-Origin'], domain.geturl())
@@ -95,7 +95,7 @@ class TestCorsMiddleware(MiddlewareTestCase):
             processed = self.middleware.process_response(request, response)
         assert_not_in('Access-Control-Allow-Origin', response)
 
-    def test_non_institution_preflight_request_requesting_authorization_header_gets_cors_headers(self):        
+    def test_non_institution_preflight_request_requesting_authorization_header_gets_cors_headers(self):
         url = api_v2_url('users/me/')
         domain = urlparse("https://dinosaurs.sexy")
         request = self.request_factory.options(
@@ -104,7 +104,7 @@ class TestCorsMiddleware(MiddlewareTestCase):
             HTTP_ACCESS_CONTROL_REQUEST_METHOD='GET',
             HTTP_ACCESS_CONTROL_REQUEST_HEADERS='authorization'
         )
-        response = {}
+        response = HttpResponse()
         self.middleware.process_request(request)
         processed = self.middleware.process_response(request, response)
         assert_equal(response['Access-Control-Allow-Origin'], domain.geturl())

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,7 +66,7 @@ webcolors==1.4
 # API requirements
 Django==1.9
 djangorestframework==3.3.3
-django-cors-headers==1.1.0
+django-cors-headers==1.3.1
 django-rest-swagger==0.3.6
 djangorestframework-bulk==0.2.1
 pyjwt==1.4.0


### PR DESCRIPTION
#### Purpose
- Upgrades [django-cors-headers](https://github.com/ottoyiu/django-cors-headers) (in hopes that it will resolve [OSF-7225](https://openscience.atlassian.net/browse/OSF-7225)).

#### Changes
- django-cors-headers version bumped from 1.1.0 to 1.3.1 (current)
- `CorsMiddleware` class moved up in defaults.py `MIDDLEWARE_CLASSES`
  - Per https://github.com/ottoyiu/django-cors-headers#setup, "CorsMiddleware should be placed as high as possible, especially before any middleware that can generate responses such as Django's CommonMiddleware or Whitenoise's WhiteNoiseMiddleware. If it is not before, it will not be able to add the CORS headers to these responses."

#### Side effects

#### Ticket
- [OSF-7225](https://openscience.atlassian.net/browse/OSF-7225)
