### PR TITLE
[fix] Update query in campaign initialization [OSF-7265] 

### DIFF
--- a/framework/auth/campaigns.py
+++ b/framework/auth/campaigns.py
@@ -1,9 +1,6 @@
 import furl
-import logging
 
 from django.utils import timezone
-from modularodm import Q
-from modularodm.exceptions import NoResultsFound, QueryException, ImproperConfigurationError
 
 from website import mails
 from website.models import PreprintProvider
@@ -19,8 +16,6 @@ def get_campaigns():
 
     global CAMPAIGNS
     global CAMPAIGNS_LAST_REFRESHED
-
-    logger = logging.getLogger(__name__)
 
     if not CAMPAIGNS or throttle_period_expired(CAMPAIGNS_LAST_REFRESHED, CAMPAIGN_REFRESH_THRESHOLD):
 
@@ -50,30 +45,27 @@ def get_campaigns():
         })
 
         # Proxy campaigns: Preprints, both OSF and branded ones
-        try:
-            preprint_providers = PreprintProvider.find(Q('_id', 'ne', None))
-            for provider in preprint_providers:
-                if provider._id == 'osf':
-                    template = 'osf'
-                    name = 'OSF'
-                    url_path = 'preprints/'
-                else:
-                    template = 'branded'
-                    name = provider.name
-                    url_path = 'preprints/{}'.format(provider._id)
-                campaign = '{}-preprints'.format(provider._id)
-                system_tag = '{}_preprints'.format(provider._id)
-                CAMPAIGNS.update({
-                    campaign: {
-                        'system_tag': system_tag,
-                        'redirect_url': furl.furl(DOMAIN).add(path=url_path).url,
-                        'confirmation_email_template': mails.CONFIRM_EMAIL_PREPRINTS(template, name),
-                        'login_type': 'proxy',
-                        'provider': name,
-                    }
-                })
-        except (NoResultsFound or QueryException or ImproperConfigurationError) as e:
-            logger.warn('An error has occurred during campaign initialization: {}', e)
+        preprint_providers = PreprintProvider.objects.all()
+        for provider in preprint_providers:
+            if provider._id == 'osf':
+                template = 'osf'
+                name = 'OSF'
+                url_path = 'preprints/'
+            else:
+                template = 'branded'
+                name = provider.name
+                url_path = 'preprints/{}'.format(provider._id)
+            campaign = '{}-preprints'.format(provider._id)
+            system_tag = '{}_preprints'.format(provider._id)
+            CAMPAIGNS.update({
+                campaign: {
+                    'system_tag': system_tag,
+                    'redirect_url': furl.furl(DOMAIN).add(path=url_path).url,
+                    'confirmation_email_template': mails.CONFIRM_EMAIL_PREPRINTS(template, name),
+                    'login_type': 'proxy',
+                    'provider': name,
+                }
+            })
 
         CAMPAIGNS_LAST_REFRESHED = timezone.now()
 


### PR DESCRIPTION
### Purpose & Changes

As requested: `preprint_providers = PreprintProvider.find(Q('_id', 'ne', None))` is replaced by ~~`preprint_providers = PreprintProvider.find()`~~.

Further replaced by `PreprintProvider.objects.all()` for Django-OSF.

### Side Effects

No

### QA and Deployment Notes

No

### Ticket

https://openscience.atlassian.net/browse/OSF-7265