### PR TITLE
[CR] enable moving files into public Figshare in Fangorn [OSF-7266]

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -2426,16 +2426,6 @@ function isInvalidDropFolder(folder) {
     return false;
 }
 
-// Disallow moving INTO a public figshare folder
-function isInvalidFigshareDrop(item) {
-    return (
-        item.data.provider === 'figshare' &&
-        typeof item.data.extra !== 'undefined' &&
-        typeof item.data.extra.status !== 'undefined' &&
-        item.data.extra.status === 'public'
-    );
-}
-
 function isInvalidDropItem(folder, item, cannotBeFolder, mustBeIntra) {
     if (
         // not a valid drop if is a node
@@ -2521,7 +2511,7 @@ function getCopyMode(folder, items) {
     var canMove = true;
     var mustBeIntra = (folder.data.provider === 'github');
     var cannotBeFolder = (folder.data.provider === 'figshare' || folder.data.provider === 'dataverse');
-    if (isInvalidDropFolder(folder) || isInvalidFigshareDrop(folder)) {
+    if (isInvalidDropFolder(folder)) {
         return 'forbidden';
     }
 
@@ -2818,7 +2808,6 @@ module.exports = {
     getAllChildren : getAllChildren,
     isInvalidDropFolder : isInvalidDropFolder,
     isInvalidDropItem : isInvalidDropItem,
-    isInvalidFigshareDrop : isInvalidFigshareDrop,
     getCopyMode : getCopyMode,
     multiselectContainsPreprint : multiselectContainsPreprint,
     showDeleteMultiple : showDeleteMultiple

--- a/website/static/js/tests/fangorn.test.js
+++ b/website/static/js/tests/fangorn.test.js
@@ -61,14 +61,6 @@ describe('fangorn', () => {
                 assert.equal(Fangorn.getCopyMode(folder, [item]), 'forbidden');
             });
 
-            it('cannot be dropped if isInvalidFigshareDrop returns true', () => {
-                folder = getItem('folder', 2);
-                folder.data.provider = 'figshare';
-                folder.data.extra = {'status': 'public'};
-                item = getItem('file', 3);
-                assert.equal(Fangorn.getCopyMode(folder, [item]), 'forbidden');
-            });
-
             it('cannot be dropped if isInvalidDropItem returns true', () => {
                 folder = getItem('folder', 2);
                 item = getItem('file', 3);
@@ -140,26 +132,6 @@ describe('fangorn', () => {
                 folder = getItem('folder');
                 folder.data.provider = 'dataverse';
                 assert.equal(Fangorn.isInvalidDropFolder(folder), true);
-            });
-        });
-
-        describe('isInvalidFigshareDrop', () => {
-            it('can be dropped if item provider not figshare', () => {
-                assert.equal(Fangorn.isInvalidFigshareDrop(getItem('folder')), false);
-            });
-
-            it('can be dropped if target status is private', () => {
-                folder = getItem('folder');
-                folder.data.provider = 'figshare';
-                folder.data.extra = {'status' : 'private'};
-                assert.equal(Fangorn.isInvalidFigshareDrop(folder), false);
-            });
-
-            it('cannot be dropped if target status is figshare public', () => {
-                folder = getItem('folder');
-                folder.data.provider = 'figshare';
-                folder.data.extra = {'status' : 'public'};
-                assert.equal(Fangorn.isInvalidFigshareDrop(folder), true);
             });
         });
 
@@ -242,7 +214,6 @@ describe('fangorn', () => {
                 folder = getItem('folder', 2);
                 item = getItem('folder', 3);
                 item.data.provider = 'figshare';
-                item.data.extra = {'status' : 'private'};
                 assert.equal(Fangorn.isInvalidDropItem(folder, item, false, false), true);
             });
 
@@ -250,7 +221,6 @@ describe('fangorn', () => {
                 folder = getItem('folder', 2);
                 item = getItem('folder', 3);
                 item.data.provider = 'figshare';
-                item.data.extra = {'status' : 'public'};
                 assert.equal(Fangorn.isInvalidDropItem(folder, item, false, false), true);
             });            
 


### PR DESCRIPTION
## Purpose

Files cannot be dragged-and-dropped from external providers to the Figshare root.  The reason is that there is old code that checks whether the root is public or private and is supposed to disallow drop if it's public.  However, the public/private flag was removed in the Figshare refactor.  It could be added back, but the Figshare V2 API now supports copying files to public projects.  Instead, remove the check altogether.

## Changes

Removed the `isInvalidFigshareDrop` method from `fangorn.js` and `fangorn.test.js`

## Side effects

None expected.

## Ticket

[#OSF-7266] - [JIRA](https://openscience.atlassian.net/browse/OSF-7266)
