### PR TITLE
Fix Figshare Pageload Messages [OSF-7267]

### DIFF
--- a/website/addons/figshare/client.py
+++ b/website/addons/figshare/client.py
@@ -76,6 +76,15 @@ class FigshareClient(BaseClient):
     def article_is_public(self, article_id):
         return self.article(article_id).get('is_public')
 
+    def project_is_public(self, project_id):
+        return bool(self.project(project_id).get('date_published'))
+
+    def container_is_public(self, container_id, container_type):
+        if container_type == 'project':
+            return self.project_is_public(container_id)
+        elif container_type == 'fileset':
+            return self.article_is_public(container_id)
+
     def article(self, article_id):
         return self._make_request(
             'GET',

--- a/website/addons/figshare/messages.py
+++ b/website/addons/figshare/messages.py
@@ -3,9 +3,9 @@ BEFORE_PAGE_LOAD_PRIVATE_NODE_MIXED_FS = 'Warning: This OSF {category} is privat
 
 BEFORE_PAGE_LOAD_PUBLIC_NODE_MIXED_FS = 'Warning: This OSF {category} is public but figshare project {project_id} may contain some private files or filesets.'
 
-BEFORE_PAGE_LOAD_PERM_MISMATCH = 'Warning: This OSF {category} is {node_perm}, but the figshare article {figshare_id} is {figshare_perm}. '
+BEFORE_PAGE_LOAD_PERM_MISMATCH = 'Warning: This OSF {category} is {node_perm}, but the figshare {folder_type} {figshare_id} is {figshare_perm}. '
 
-BEFORE_PAGE_LOAD_PUBLIC_NODE_PRIVATE_FS = 'Users can view the contents of this private figshare article. '
+BEFORE_PAGE_LOAD_PUBLIC_NODE_PRIVATE_FS = 'Users can view the contents of this private figshare {folder_type}. '
 # END MODEL MESSAGES
 
 # MFR MESSAGES :views/crud.py

--- a/website/addons/figshare/model.py
+++ b/website/addons/figshare/model.py
@@ -186,9 +186,9 @@ class FigshareNodeSettings(StorageAddonBase, AddonOAuthNodeSettingsBase):
                 message = messages.BEFORE_PAGE_LOAD_PUBLIC_NODE_MIXED_FS.format(category=node.project_or_component, project_id=figshare.folder_id)
 
         connect = FigshareClient(self.external_account.oauth_key)
-        article_is_public = connect.article_is_public(self.folder_id)
+        project_is_public = connect.container_is_public(self.folder_id, self.folder_path)
 
-        article_permissions = 'public' if article_is_public else 'private'
+        article_permissions = 'public' if project_is_public else 'private'
 
         if article_permissions != node_permissions:
             message = messages.BEFORE_PAGE_LOAD_PERM_MISMATCH.format(
@@ -196,8 +196,9 @@ class FigshareNodeSettings(StorageAddonBase, AddonOAuthNodeSettingsBase):
                 node_perm=node_permissions,
                 figshare_perm=article_permissions,
                 figshare_id=self.folder_id,
+                folder_type=self.folder_path,
             )
             if article_permissions == 'private' and node_permissions == 'public':
-                message += messages.BEFORE_PAGE_LOAD_PUBLIC_NODE_PRIVATE_FS
+                message += messages.BEFORE_PAGE_LOAD_PUBLIC_NODE_PRIVATE_FS.format(folder_type=self.folder_path)
             # No HTML snippets, so escape message all at once
             return [markupsafe.escape(message)]


### PR DESCRIPTION
## Purpose
Prevent misleading `403`s and `404`'s.

## Changes
* Ensure correct endpoints are hit
* Incidental: make messages reflect container type

## Side effects
None expected

## Ticket
https://openscience.atlassian.net/browse/OSF-7267