### PR TITLE
[feature] Bump django-cors-headers Version [OSF-7225]

### DIFF
--- a/api_tests/base/test_middleware.py
+++ b/api_tests/base/test_middleware.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from django.http import HttpResponse
 from tests.base import ApiTestCase, fake
 
 from urlparse import urlparse
@@ -53,7 +54,7 @@ class TestCorsMiddleware(MiddlewareTestCase):
         )
         settings.load_institutions()
         request = self.request_factory.get(url, HTTP_ORIGIN=domain.geturl())
-        response = {}
+        response = HttpResponse()
         self.middleware.process_request(request)
         processed = self.middleware.process_response(request, response)
         assert_equal(response['Access-Control-Allow-Origin'], domain.geturl())
@@ -76,7 +77,7 @@ class TestCorsMiddleware(MiddlewareTestCase):
             HTTP_ORIGIN=domain.geturl(),
             HTTP_AUTHORIZATION="Bearer aqweqweohuweglbiuwefq"
         )
-        response = {}
+        response = HttpResponse()
         self.middleware.process_request(request)
         processed = self.middleware.process_response(request, response)
         assert_equal(response['Access-Control-Allow-Origin'], domain.geturl())
@@ -95,7 +96,7 @@ class TestCorsMiddleware(MiddlewareTestCase):
             processed = self.middleware.process_response(request, response)
         assert_not_in('Access-Control-Allow-Origin', response)
 
-    def test_non_institution_preflight_request_requesting_authorization_header_gets_cors_headers(self):        
+    def test_non_institution_preflight_request_requesting_authorization_header_gets_cors_headers(self):
         url = api_v2_url('users/me/')
         domain = urlparse("https://dinosaurs.sexy")
         request = self.request_factory.options(
@@ -104,7 +105,7 @@ class TestCorsMiddleware(MiddlewareTestCase):
             HTTP_ACCESS_CONTROL_REQUEST_METHOD='GET',
             HTTP_ACCESS_CONTROL_REQUEST_HEADERS='authorization'
         )
-        response = {}
+        response = HttpResponse()
         self.middleware.process_request(request)
         processed = self.middleware.process_response(request, response)
         assert_equal(response['Access-Control-Allow-Origin'], domain.geturl())

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,7 +66,7 @@ webcolors==1.4
 # API requirements
 Django==1.9
 djangorestframework==3.3.3
-django-cors-headers==1.1.0
+django-cors-headers==1.3.1
 django-rest-swagger==0.3.6
 djangorestframework-bulk==0.2.1
 pyjwt==1.4.0


### PR DESCRIPTION
#### Purpose
- Upgrade django-cors-headers (will hopefully resolve [OSF-7225](https://openscience.atlassian.net/browse/OSF-7225)) 

#### Changes
- Bump version.
- Fix tests that should now be using a response object.

#### Ticket
- [OSF-7225](https://openscience.atlassian.net/browse/OSF-7225)