### PR TITLE
Fix figshare logging [OSF-6394]

### DIFF
--- a/website/addons/figshare/model.py
+++ b/website/addons/figshare/model.py
@@ -149,9 +149,9 @@ class FigshareNodeSettings(StorageAddonBase, AddonOAuthNodeSettingsBase):
         self.folder_id = info['id']
         self.folder_name = info['name']
         self.folder_path = info['path']
-
-        self.nodelogger.log(action='folder_selected')
         self.save()
+
+        self.nodelogger.log(action='folder_selected', save=True)
 
     #############
     # Callbacks #

--- a/website/addons/figshare/static/figshareAnonymousLogActionList.json
+++ b/website/addons/figshare/static/figshareAnonymousLogActionList.json
@@ -1,9 +1,9 @@
 {
-    "figshare_folder_selected" : "A user linked content from Figshare in a project",
-    "figshare_content_unlinked" : "A user unlinked content from Figshare in a project",
-    "figshare_file_added" : "A user added a file to Figshare in a project",
-    "figshare_file_removed" : "A user removed a file from Figshare in a project",
-    "figshare_node_authorized" : "A user authorized the Figshare addon from a project",
-    "figshare_node_deauthorized" : "A user deauthorized the Figshare addon from a project",
+    "figshare_folder_selected" : "A user linked content from figshare in a project",
+    "figshare_content_unlinked" : "A user unlinked content from figshare in a project",
+    "figshare_file_added" : "A user added a file to figshare in a project",
+    "figshare_file_removed" : "A user removed a file from figshare in a project",
+    "figshare_node_authorized" : "A user authorized the figshare addon for a project",
+    "figshare_node_deauthorized" : "A user deauthorized the figshare addon for a project",
     "figshare_node_deauthorized_no_user" : "figshare addon for a project deauthorized"
 }

--- a/website/addons/figshare/static/figshareLogActionList.json
+++ b/website/addons/figshare/static/figshareLogActionList.json
@@ -3,7 +3,7 @@
   "figshare_content_unlinked": "${user} unlinked content from figshare in ${node}",
   "figshare_file_added" : "${user} added file ${path} to figshare in ${node}",
   "figshare_file_removed" : "${user} removed file ${path} from figshare in ${node}",
-  "figshare_node_authorized" : "${user} authorized the figshare addon from ${node}",
-  "figshare_node_deauthorized" : "${user} deauthorized the figshare addon from ${node}",
+  "figshare_node_authorized" : "${user} authorized the figshare addon for ${node}",
+  "figshare_node_deauthorized" : "${user} deauthorized the figshare addon for ${node}",
   "figshare_node_deauthorized_no_user" : "figshare addon for ${node} deauthorized"
 }

--- a/website/addons/figshare/tests/test_views.py
+++ b/website/addons/figshare/tests/test_views.py
@@ -38,6 +38,10 @@ class TestConfigViews(FigshareAddonTestCase, testing.views.OAuthAddonConfigViews
             self.project.logs[-1].action,
             '{0}_folder_selected'.format(self.ADDON_SHORT_NAME)
         )
+        assert_equal(
+            self.project.logs[-1].params['folder'],
+            self.folder['path']
+        )
         assert_equal(res.json['result']['folder']['path'], self.folder['path'])
 
     @mock.patch.object(FigshareClient, 'userinfo')


### PR DESCRIPTION
## Purpose
Fix figshare logging.

## Changes
* Save `FigshareNodeSettings` object before `NodeLogger`'s call to `.get_addon` finds stale data
* Update log language
* Update test to ensure correct param is saved

### Before
![screen shot 2016-12-08 at 20 00 45](https://cloud.githubusercontent.com/assets/5659262/21033783/1ce4ed62-bd81-11e6-9f40-bffe5c9ad94c.png)
The first `figshare_folder_selected` log added would have no folder-related params saved, causing the front-end to default to `a folder` for both `params.folder` and `params.folder_name`. Subsequent logs would have the params intended for the previous log.

### After
![screen shot 2016-12-08 at 20 00 08](https://cloud.githubusercontent.com/assets/5659262/21033807/511d982c-bd81-11e6-84c0-9578b68aaa47.png)
Behavior is as expected.

## Side effects
None expected. 

## Ticket
[`[#OSF-6394]`](https://openscience.atlassian.net/browse/OSF-6394)