### PR TITLE
Fix spurious test failure with "creates new identifiers" [OSF-6970]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@ env:
     - LIBPCRE_DEB="libpcre3_8.31-2ubuntu2.3_amd64.deb"
     - VARNISH_DEB="varnish_4.1.0-1~trusty_amd64.deb"
   matrix:
-    - TEST_BUILD="osf"
-    - TEST_BUILD="else"
     - TEST_BUILD="varnish"
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ env:
     - TEST_BUILD="varnish"
 
 before_install:
+    - npm ls sinon || echo ''
     # cache directories
     - |
       mkdir -p $HOME/.cache/downloads

--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,7 @@
     "zeroclipboard": "2.1.6",
     "osf-style": "https://github.com/CenterForOpenScience/osf-style.git#5dcf5997ad2808ffc7c8564f94cde102bf7a4a96",
     "At.js": "jquery.atwho#e18af47fdcb327605533a9da259225176e3013c8",
-    "academicons": "1.7.0"
+    "academicons": "1.7.0",
+    "stacktrace-js": "1.3.x"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "osf-panel": "https://github.com/CenterForOpenScience/osf-panel.git#fda8e05d9f3ba8ed7bd43b46ceffe265b3d73b39",
     "styles": "https://github.com/CenterForOpenScience/styles.git#master",
     "locales": "https://github.com/CenterForOpenScience/locales.git#d2b612f8a6f764cbd66e67238636fac3888a7736",
-    "raven-js": "2.1.0",
+    "raven-js": "3.x.x",
     "zeroclipboard": "2.1.6",
     "osf-style": "https://github.com/CenterForOpenScience/osf-style.git#5dcf5997ad2808ffc7c8564f94cde102bf7a4a96",
     "At.js": "jquery.atwho#e18af47fdcb327605533a9da259225176e3013c8",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "pikaday": "^1.3.2",
     "pretty-data": "^0.40.0",
     "pym.js": "^0.4.1",
-    "raven": "^0.7.2",
+    "raven": "1.x.x",
     "raw-loader": "^0.5.1",
     "share": "0.7.27",
     "style-loader": "^0.8.3",

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -657,7 +657,6 @@ def test_travis_varnish(ctx):
     Run the fast and quirky JS tests and varnish tests in isolation
     """
     test_js(ctx)
-    test_varnish(ctx)
 
 
 @task

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -79,6 +79,7 @@ var entry = {
         'lodash.get',
         'js-cookie',
         'URIjs',
+        'stacktrace-js',
         // Common internal modules
         'js/fangorn',
         'js/citations',

--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -19,6 +19,7 @@ var NodeSelectTreebeard = require('js/nodeSelectTreebeard');
 var m = require('mithril');
 var projectSettingsTreebeardBase = require('js/projectSettingsTreebeardBase');
 
+var StackTrace = require('stacktrace-js'); // XXX Debugging!
 
 function Contributor(data) {
     $.extend(this, data);
@@ -255,6 +256,18 @@ AddContributorViewModel = oop.extend(Paginator, {
             xhrFields: {withCredentials: true},
             processData: false
         }).done(function (response) {
+
+            // XXX Debugging!
+            StackTrace.get().then(function(frames) {
+                for (var f, i=0; f=frames[i]; i++) {
+                    console.log( f.fileName.replace(/http:\/\/localhost:9876\/base/, '')
+                                           .replace(/\.js\?[0-9a-f]+/, '.js')
+                               , f.lineNumber
+                               , f.functionName
+                                );
+                }
+            });
+
             var contributors = response.data.map(function (contributor) {
                 // contrib ID has the form <nodeid>-<userid>
                 return contributor.id.split('-')[1];

--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -245,6 +245,7 @@ AddContributorViewModel = oop.extend(Paginator, {
         self.notification(false);
         var url = $osf.apiV2Url('nodes/' + window.contextVars.node.id + '/contributors/');
 
+        console.log('contrib adding');
         return $.ajax({
             url: url,
             type: 'GET',

--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -19,7 +19,7 @@ var NodeSelectTreebeard = require('js/nodeSelectTreebeard');
 var m = require('mithril');
 var projectSettingsTreebeardBase = require('js/projectSettingsTreebeardBase');
 
-var StackTrace = require('stacktrace-js'); // XXX Debugging!
+var Raven = require('raven-js'); // XXX Debugging!
 
 function Contributor(data) {
     $.extend(this, data);
@@ -256,23 +256,14 @@ AddContributorViewModel = oop.extend(Paginator, {
             xhrFields: {withCredentials: true},
             processData: false
         }).done(function (response) {
-
-            // XXX Debugging!
-            StackTrace.get().then(function(frames) {
-                for (var f, i=0; f=frames[i]; i++) {
-                    console.log(
-                        f.fileName.replace(/http:\/\/localhost:9876\/base/, '')
-                                  .replace(/\.js\?[0-9a-f]+/, '.js'),
-                        f.lineNumber,
-                        f.functionName
-                    );
-                }
-            });
-
-            var contributors = response.data.map(function (contributor) {
-                // contrib ID has the form <nodeid>-<userid>
-                return contributor.id.split('-')[1];
-            });
+            try {
+                var contributors = response.data.map(function (contributor) {
+                    // contrib ID has the form <nodeid>-<userid>
+                    return contributor.id.split('-')[1];
+                });
+            } catch(e) {
+                Raven.captureException(e);
+            }
             self.contributors(contributors);
         });
     },

--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -256,6 +256,15 @@ AddContributorViewModel = oop.extend(Paginator, {
             xhrFields: {withCredentials: true},
             processData: false
         }).done(function (response) {
+            Raven.captureBreadcrumb({
+              message: 'done adding contrib',
+              category: 'debugging',
+              level: 'info',
+              data: {
+                 response: response,
+                 'response.data': response ? response.data : 'n/a'
+              }
+            });
             try {
                 var contributors = response.data.map(function (contributor) {
                     // contrib ID has the form <nodeid>-<userid>
@@ -263,6 +272,7 @@ AddContributorViewModel = oop.extend(Paginator, {
                 });
             } catch(e) {
                 Raven.captureException(e);
+                throw e;
             }
             self.contributors(contributors);
         });

--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -260,11 +260,12 @@ AddContributorViewModel = oop.extend(Paginator, {
             // XXX Debugging!
             StackTrace.get().then(function(frames) {
                 for (var f, i=0; f=frames[i]; i++) {
-                    console.log( f.fileName.replace(/http:\/\/localhost:9876\/base/, '')
-                                           .replace(/\.js\?[0-9a-f]+/, '.js')
-                               , f.lineNumber
-                               , f.functionName
-                                );
+                    console.log(
+                        f.fileName.replace(/http:\/\/localhost:9876\/base/, '')
+                                  .replace(/\.js\?[0-9a-f]+/, '.js'),
+                        f.lineNumber,
+                        f.functionName
+                    );
                 }
             });
 

--- a/website/static/js/nodeControl.js
+++ b/website/static/js/nodeControl.js
@@ -253,6 +253,7 @@ var ProjectViewModel = function(data, options) {
 
     self.createIdentifiers = function() {
         // Only show loading indicator for slow responses
+        console.log('creating identifiers');
         var timeout = setTimeout(function() {
             self.idCreationInProgress(true); // show loading indicator
         }, 500);

--- a/website/static/js/tests/addons/folderPickerNodeConfig.test.js
+++ b/website/static/js/tests/addons/folderPickerNodeConfig.test.js
@@ -33,7 +33,7 @@ var TestSubclassVM = oop.extend(FolderPickerNodeConfigVM, {
     }
 });
 
-describe.skip('FolderPickerNodeConfigViewModel', () => {
+describe('FolderPickerNodeConfigViewModel', () => {
 
     var settingsUrl = '/api/v1/12345/addon/config/';
     var endpoints = [{

--- a/website/static/js/tests/contributors.test.js
+++ b/website/static/js/tests/contributors.test.js
@@ -19,7 +19,7 @@ var URLs = {
     fetchUsers: '/api/v1/user/search'
 };
 
-describe.skip('addContributors', () => {
+describe('addContributors', () => {
    describe('viewModel', () => {
        var getContributorsResult = {
            contributors: [

--- a/website/static/js/tests/forgotPassword.test.js
+++ b/website/static/js/tests/forgotPassword.test.js
@@ -9,7 +9,7 @@ var formViewModel = require('js/formViewModel');
 // Add sinon asserts to chai.assert, so we can do assert.calledWith instead of sinon.assert.calledWith
 sinon.assert.expose(assert, {prefix: ''});
 
-describe.skip('forgotPassword', () => {
+describe('forgotPassword', () => {
     describe('ViewModels', () => {
 
         describe('ForgtoPasswordViewModel', () => {

--- a/website/static/js/tests/formModelView.test.js
+++ b/website/static/js/tests/formModelView.test.js
@@ -24,7 +24,7 @@ describe('formModelView', () => {
         });
     });
 
-    describe.skip('ViewModel', () => {
+    describe('ViewModel', () => {
         var vm;
 
         beforeEach(() => {

--- a/website/static/js/tests/licensePicker.test.js
+++ b/website/static/js/tests/licensePicker.test.js
@@ -17,7 +17,7 @@ var license = licenses.MIT;
 // proxy attribute to match server data
 license.copyright_holders = [];
 
-describe.skip('LicensePicker', () => {
+describe('LicensePicker', () => {
 
     before(() => {
         window.contextVars = $.extend({}, window.contextVars || {}, {

--- a/website/static/js/tests/nodeControl.test.js
+++ b/website/static/js/tests/nodeControl.test.js
@@ -17,7 +17,7 @@ var nodeData = {
     user: {permissions: ['read', 'write', 'admin']}
 };
 
-describe.skip('nodeControl', () => {
+describe('nodeControl', () => {
     describe('ViewModels', () => {
         describe('ProjectViewModel', () => {
             var server;

--- a/website/static/js/tests/nodeControl.test.js
+++ b/website/static/js/tests/nodeControl.test.js
@@ -77,6 +77,7 @@ describe('nodeControl', () => {
                 assert.equal(vm.arkUrl(), 'http://ezid.cdlib.org/id/ark:/24601');
             });
             it('creates new identifiers', (done) => {
+                console.log('wat?');
                 vm.createIdentifiers().always(() => {
                     assert.equal(vm.doi(), '24601');
                     assert.equal(vm.ark(), '24601');

--- a/website/static/js/tests/oop.test.js
+++ b/website/static/js/tests/oop.test.js
@@ -7,7 +7,7 @@ sinon.assert.expose(assert, {prefix: ''});
 var oop = require('js/oop');
 
 
-describe.skip('oop', () => {
+describe('oop', () => {
     var constructorSpy = new sinon.spy();
     var methodSpy = new sinon.spy();
     var overrideSpy = new sinon.spy();

--- a/website/static/js/tests/paginator.test.js
+++ b/website/static/js/tests/paginator.test.js
@@ -19,7 +19,7 @@ var TestPaginator = oop.extend(Paginator, {
 });
 
 
-describe.skip('Paginator', () => {
+describe('Paginator', () => {
     var paginator;
     var numberOfPages;
     var currentPage;

--- a/website/static/js/tests/profile.test.js
+++ b/website/static/js/tests/profile.test.js
@@ -11,7 +11,7 @@ var urlData = require('json!../../urlValidatorTest.json');
 // Add sinon asserts to chai.assert, so we can do assert.calledWith instead of sinon.assert.calledWith
 sinon.assert.expose(assert, {prefix: ''});
 
-describe.skip('profile', () => {
+describe('profile', () => {
     sinon.collection.restore();
     describe('ViewModels', () => {
 

--- a/website/static/js/tests/saveManager.test.js
+++ b/website/static/js/tests/saveManager.test.js
@@ -6,7 +6,7 @@ var SaveManager = require('js/saveManager');
 var url = 'http://foo.com';
 var sm = new SaveManager(url);
 
-describe.skip('SaveManager', () => {
+describe('SaveManager', () => {
     var server;
     beforeEach(() => {
         server = sinon.fakeServer.create();

--- a/website/static/js/tests/tests.webpack.js
+++ b/website/static/js/tests/tests.webpack.js
@@ -3,7 +3,7 @@
 
 // Configure raven with a fake DSN to avoid errors in test output
 var Raven = require('raven-js');
-Raven.config('http://abc@example.com:80/2');
+Raven.config('https://1332f6ba2dd04bca94b139bebbab7644@sentry.io/122808');
 
 // Include all files that end with .test.js (core tests)
 var context = require.context('.', true, /.*test\.js$/); //make sure you have your directory and regex test set correctly!


### PR DESCRIPTION
## Purpose

Debug and fix a [spurious test case failure](https://travis-ci.org/CenterForOpenScience/osf.io/jobs/156100208#L2556-L2557) with 37ae2bbc27de10bdc9cb3331aae408f719fbb881 under `TEST_BUILD="varnish"`, where `nodeControl > ViewModels > ProjectViewModel > create new identifiers` dies with a `TypeError` inside `contribAdder`:

```
TypeError: Fake XHR onreadystatechange handler threw exception:
'undefined' is not an object (evaluating 'response.data.map')
(/home/travis/build/CenterForOpenScience/osf.io/website/static/js/tests/tests.webpack.js:131102:0
<- webpack:///website/static/js/contribAdder.js:257:0)
```

![screen shot 2016-12-12 at 5 34 33 am](https://cloud.githubusercontent.com/assets/134455/21096143/b091c190-c02c-11e6-9031-1c2d38c26406.png)


## Changes

n/a

## Side effects

n/a

## Ticket

https://openscience.atlassian.net/browse/OSF-6970