### PR TITLE
Clean up Travis wiring [OSF-7270]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,9 @@ env:
     - LIBPCRE_DEB="libpcre3_8.31-2ubuntu2.3_amd64.deb"
     - VARNISH_DEB="varnish_4.1.0-1~trusty_amd64.deb"
   matrix:
-    - TEST_BUILD="osf"
-    - TEST_BUILD="else"
-    - TEST_BUILD="varnish"
+    - TEST_BUILD="osf_and_addons"
+    - TEST_BUILD="api_and_admin"
+    - TEST_BUILD="js_and_varnish"
 
 before_install:
     # cache directories

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ before_install:
       export LD_LIBRARY_PATH=/tmp/libpcre/lib/x86_64-linux-gnu:/tmp/libjemalloc/usr/lib/x86_64-linux-gnu:/tmp/varnish/usr/lib/varnish
       /tmp/varnish/usr/sbin/varnishd -n /tmp -p feature=+esi_disable_xml_check -p vmod_dir=/tmp/varnish/usr/lib/varnish/vmods -F -f $PROJECT_DIR/tests/test_files/varnish.vcl -a *:8080 > /dev/null &
     - |
-      if [ "$TEST_BUILD" = "varnish" ]; then
+      if [ "$TEST_BUILD" = "js_and_varnish" ]; then
         export ENABLE_VARNISH=True
       fi
 install:

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -628,36 +628,26 @@ def test_js(ctx):
     karma(ctx, single=True, browsers='PhantomJS')
 
 
+# For Travis, we split the test suite into multiple parts to help things go
+# faster. Lints and Flakes happen everywhere to keep from wasting test time.
+# The TEST_BUILD envvar controls which one gets run; see .travis.yml.
+
+def travis(ctx, *funcs):
+    for func in (flake, jshint) + funcs:
+        print('Running {0} ...'.format(func.__name__))
+        func(ctx)
+
 @task
 def test_travis_osf_and_addons(ctx):
-    """
-    Run half of the tests to help travis go faster. Lints and Flakes happen everywhere to keep from wasting test time.
-    """
-    flake(ctx)
-    jshint(ctx)
-    test_osf(ctx)
-    test_addons(ctx)
-
+    travis(ctx, test_osf, test_addons)
 
 @task
 def test_travis_api_and_admin(ctx):
-    """
-    Run other half of the tests to help travis go faster. Lints and Flakes happen everywhere to keep from
-    wasting test time.
-    """
-    flake(ctx)
-    jshint(ctx)
-    test_api(ctx)
-    test_admin(ctx)
-
+    travis(ctx, test_api, test_admin)
 
 @task
 def test_travis_js_and_varnish(ctx):
-    """
-    Run the fast and quirky JS tests and varnish tests in isolation
-    """
-    test_js(ctx)
-    test_varnish(ctx)
+    travis(ctx, test_js, test_varnish)
 
 
 @task

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -629,7 +629,7 @@ def test_js(ctx):
 
 
 @task
-def test_travis_osf(ctx):
+def test_travis_osf_and_addons(ctx):
     """
     Run half of the tests to help travis go faster. Lints and Flakes happen everywhere to keep from wasting test time.
     """
@@ -640,7 +640,7 @@ def test_travis_osf(ctx):
 
 
 @task
-def test_travis_else(ctx):
+def test_travis_api_and_admin(ctx):
     """
     Run other half of the tests to help travis go faster. Lints and Flakes happen everywhere to keep from
     wasting test time.
@@ -652,7 +652,7 @@ def test_travis_else(ctx):
 
 
 @task
-def test_travis_varnish(ctx):
+def test_travis_js_and_varnish(ctx):
     """
     Run the fast and quirky JS tests and varnish tests in isolation
     """


### PR DESCRIPTION
## Purpose

On #6655 I was confused why the JS tests were being run under `TEST_BUILD="varnish"`. Turns [out](https://github.com/CenterForOpenScience/osf.io/pull/6655#issuecomment-266419210) that is intentional, so this PR fixes up names to avoid future confusion. It also DRYs up the wiring a bit.

## Changes

No user-facing changes.

## Side effects

None.

## Ticket

https://openscience.atlassian.net/browse/OSF-7270