### PR TITLE
[CR] Figshare interface improvements [OSF-7272]

### DIFF
--- a/framework/addons/data/addons.json
+++ b/framework/addons/data/addons.json
@@ -67,15 +67,15 @@
             },
             "View / download file versions": {
                 "status": "partial",
-                "text": "figshare content can be viewed and downloaded via OSF provided it is \"published\" on figshare."
+                "text": "figshare files can be viewed/downloaded via OSF, but version history is not supported."
             },
             "Add / update files": {
                 "status": "partial",
                 "text": "Files can be added but not updated."
             },
             "Delete files": {
-                "status": "none",
-                "text": "figshare files cannot be deleted via OSF."
+                "status": "partial",
+                "text": "Private files and filesets can be deleted via OSF."
             },
             "Logs": {
                 "status": "partial",

--- a/website/addons/figshare/static/figshareFangornConfig.js
+++ b/website/addons/figshare/static/figshareFangornConfig.js
@@ -59,10 +59,9 @@ var _figshareItemButtons = {
                     }, 'View'));
             }
 
-            // Files can be deleted if private or if it is in a dataset that contains more than one file
-            var privateOrSiblings = (item.data.extra && item.data.extra.status !== 'public') ||
-                (!item.parent().data.isAddonRoot && item.parent().children.length > 1);
-            if (item.kind === 'file' && privateOrSiblings && item.data.permissions && item.data.permissions.edit) {
+            // Files and folders can be deleted if private.
+            var isPrivate = (item.data.extra && item.data.extra.status !== 'public');
+            if (isPrivate && item.data.permissions && item.data.permissions.edit) {
                 buttons.push(
                     m.component(Fangorn.Components.button, {
                         onclick: function (event) {

--- a/website/addons/figshare/static/figshareFangornConfig.js
+++ b/website/addons/figshare/static/figshareFangornConfig.js
@@ -23,7 +23,7 @@ var _figshareItemButtons = {
                         className: 'text-success'
                     }, 'Upload')
                 );
-                if (item.data.root_folder_type === 'project') {
+                if (item.data.rootFolderType === 'project') {
                     buttons.push(
                         m.component(Fangorn.Components.button, {
                             onclick: function () {

--- a/website/addons/figshare/static/figshareFangornConfig.js
+++ b/website/addons/figshare/static/figshareFangornConfig.js
@@ -35,9 +35,7 @@ var _figshareItemButtons = {
                     }, 'Download')
                 );
             }
-            // Files can be deleted if private or if it is in a dataset that contains more than one file
-            var privateOrSiblings = (item.data.extra && item.data.extra.status !== 'public') ||
-                (!item.parent().data.isAddonRoot && item.parent().children.length > 1);
+            // All files are viewable on the OSF.
             if (item.kind === 'file' && item.data.permissions && item.data.permissions.view) {
                 buttons.push(
                     m.component(Fangorn.Components.button, {
@@ -48,6 +46,10 @@ var _figshareItemButtons = {
                         className: 'text-info'
                     }, 'View'));
             }
+
+            // Files can be deleted if private or if it is in a dataset that contains more than one file
+            var privateOrSiblings = (item.data.extra && item.data.extra.status !== 'public') ||
+                (!item.parent().data.isAddonRoot && item.parent().children.length > 1);
             if (item.kind === 'file' && privateOrSiblings && item.data.permissions && item.data.permissions.edit) {
                 buttons.push(
                     m.component(Fangorn.Components.button, {
@@ -59,6 +61,8 @@ var _figshareItemButtons = {
                     }, 'Delete')
                 );
             }
+
+            // Files are only viewable on figshare if they are public
             if (item.kind === 'file' && item.data.permissions && item.data.permissions.view && item.data.extra.status === 'public') {
                 buttons.push(
                     m('a.text-info.fangorn-toolbar-icon', {href: item.data.extra.webView}, [

--- a/website/addons/figshare/static/figshareFangornConfig.js
+++ b/website/addons/figshare/static/figshareFangornConfig.js
@@ -24,7 +24,9 @@ var _figshareItemButtons = {
                     }, 'Upload')
                 );
             }
-            if (item.kind === 'file' && item.data.extra && item.data.extra.status === 'public') {
+
+            // Download file or Download-as-zip
+            if (item.kind === 'file') {
                 buttons.push(
                     m.component(Fangorn.Components.button, {
                         onclick: function (event) {
@@ -35,6 +37,16 @@ var _figshareItemButtons = {
                     }, 'Download')
                 );
             }
+            else {
+                buttons.push(
+                    m.component(Fangorn.Components.button, {
+                        onclick: function (event) { Fangorn.ButtonEvents._downloadZipEvent.call(tb, event, item); },
+                        icon: 'fa fa-download',
+                        className: 'text-primary'
+                    }, 'Download as zip')
+                );
+            }
+
             // All files are viewable on the OSF.
             if (item.kind === 'file' && item.data.permissions && item.data.permissions.view) {
                 buttons.push(

--- a/website/addons/figshare/static/figshareFangornConfig.js
+++ b/website/addons/figshare/static/figshareFangornConfig.js
@@ -23,6 +23,16 @@ var _figshareItemButtons = {
                         className: 'text-success'
                     }, 'Upload')
                 );
+                if (item.data.root_folder_type === 'project') {
+                    buttons.push(
+                        m.component(Fangorn.Components.button, {
+                            onclick: function () {
+                                tb.toolbarMode(Fangorn.Components.toolbarModes.ADDFOLDER);
+                            },
+                            icon: 'fa fa-plus',
+                            className: 'text-success'
+                        }, 'Create Folder'));
+                }
             }
 
             // Download file or Download-as-zip

--- a/website/addons/figshare/views.py
+++ b/website/addons/figshare/views.py
@@ -7,6 +7,9 @@ from website.project.decorators import (
     must_have_addon, must_be_addon_authorizer,
 )
 
+from website.util import rubeus
+
+
 SHORT_NAME = 'figshare'
 FULL_NAME = SHORT_NAME
 
@@ -40,9 +43,26 @@ figshare_set_config = generic_views.set_config(
     _set_folder
 )
 
-figshare_root_folder = generic_views.root_folder(
-    SHORT_NAME
-)
+def figshare_root_folder(node_settings, auth, **kwargs):
+    """Return the Rubeus/HGrid-formatted response for the root folder only.
+
+    Identical to the generic_views.root_folder except adds root_folder_type
+    to exported data.  Fangorn needs root_folder_type to decide whether to
+    display the 'Create Folder' button.
+    """
+    # Quit if node settings does not have authentication
+    if not node_settings.has_auth or not node_settings.folder_id:
+        return None
+    node = node_settings.owner
+    return [rubeus.build_addon_root(
+        node_settings=node_settings,
+        name=node_settings.fetch_folder_name(),
+        permissions=auth,
+        nodeUrl=node.url,
+        nodeApiUrl=node.api_url,
+        root_folder_type=node_settings.folder_path,
+        private_key=kwargs.get('view_only', None),
+    )]
 
 @must_have_addon(SHORT_NAME, 'node')
 @must_be_addon_authorizer(SHORT_NAME)

--- a/website/addons/figshare/views.py
+++ b/website/addons/figshare/views.py
@@ -60,7 +60,7 @@ def figshare_root_folder(node_settings, auth, **kwargs):
         permissions=auth,
         nodeUrl=node.url,
         nodeApiUrl=node.api_url,
-        root_folder_type=node_settings.folder_path,
+        rootFolderType=node_settings.folder_path,
         private_key=kwargs.get('view_only', None),
     )]
 

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -2343,8 +2343,6 @@ function _dropLogic(event, items, folder) {
         folder = folder.parent();
     }
 
-    // if (items[0].data.kind === 'folder' && ['github', 'figshare', 'dataverse'].indexOf(folder.data.provider) !== -1) { return; }
-
     if (!folder.open) {
         return tb.updateFolder(null, folder, _dropLogic.bind(tb, event, items, folder));
     }
@@ -2441,9 +2439,7 @@ function isInvalidDropItem(folder, item, cannotBeFolder, mustBeIntra) {
         // no dropping if waiting on waterbutler ajax
         item.inProgress ||
         (cannotBeFolder && item.data.kind === 'folder') ||
-        (mustBeIntra && item.data.provider !== folder.data.provider) ||
-        //Disallow moving OUT of figshare
-        item.data.provider === 'figshare'
+        (mustBeIntra && item.data.provider !== folder.data.provider)
     ) {
         return true;
     }

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -2506,7 +2506,13 @@ function getCopyMode(folder, items) {
     var preprintPath = getPreprintPath(window.contextVars.node.preprintFileId);
     var canMove = true;
     var mustBeIntra = (folder.data.provider === 'github');
-    var cannotBeFolder = (folder.data.provider === 'figshare' || folder.data.provider === 'dataverse');
+    // Folders cannot be copied to dataverse at all.  Folders may only be copied to figshare
+    // if the target is the addon root and the root is a project (not a fileset)
+    var cannotBeFolder = (
+        folder.data.provider === 'dataverse' ||
+            (folder.data.provider === 'figshare' &&
+             !(folder.data.isAddonRoot && folder.data.rootFolderType === 'project'))
+    );
     if (isInvalidDropFolder(folder)) {
         return 'forbidden';
     }

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -2449,7 +2449,8 @@ function isInvalidDropItem(folder, item, cannotBeFolder, mustBeIntra) {
 function allowedToMove(folder, item, mustBeIntra) {
     return (
         item.data.permissions.edit &&
-        (!mustBeIntra || (item.data.provider === folder.data.provider && item.data.nodeId === folder.data.nodeId))
+        (!mustBeIntra || (item.data.provider === folder.data.provider && item.data.nodeId === folder.data.nodeId)) &&
+            !(item.data.provider === 'figshare' && item.data.extra && item.data.extra.status === 'public')
     );
 }
 

--- a/website/static/js/tests/fangorn.test.js
+++ b/website/static/js/tests/fangorn.test.js
@@ -83,6 +83,31 @@ describe('fangorn', () => {
                 assert.equal(Fangorn.getCopyMode(folder, [item]), 'forbidden');
             });
 
+            it('folder can be dropped if target is figshare addon root with type project', () => {
+                folder = getItem('folder', 0);
+                folder.data.provider = 'figshare';
+                folder.data.isAddonRoot = true;
+                folder.data.rootFolderType = 'project';
+                item = getItem('folder', 3);
+                assert.equal(Fangorn.getCopyMode(folder, [item]), 'move');
+            });
+
+            it('folder cannot be dropped if target is figshare addon root with type fileset', () => {
+                folder = getItem('folder', 2);
+                folder.data.provider = 'figshare';
+                folder.data.isAddonRoot = false;
+                item = getItem('folder', 3);
+                assert.equal(Fangorn.getCopyMode(folder, [item]), 'forbidden');
+            });
+
+            it('folder cannot be dropped if target is figshare non-root fileset', () => {
+                folder = getItem('folder', 0);
+                folder.data.provider = 'figshare';
+                folder.data.isAddonRoot = true;
+                folder.data.rootFolderType = 'fileset';
+                item = getItem('folder', 3);
+                assert.equal(Fangorn.getCopyMode(folder, [item]), 'forbidden');
+            });
         });
 
         describe('isInvalidDropFolder', () => {

--- a/website/static/js/tests/fangorn.test.js
+++ b/website/static/js/tests/fangorn.test.js
@@ -271,7 +271,23 @@ describe('fangorn', () => {
                 folder.data.nodeId = 'abcde';
                 item.data.nodeId = 'abcde';
                 assert.equal(Fangorn.allowedToMove(folder, item, true), true);
-            });            
+            });
+
+            it('cannot move item from figshare if it is public', () => {
+                folder = getItem('folder', 2);
+                item = getItem('file', 3);
+                item.data.provider = 'figshare';
+                item.data.extra = {'status': 'public'};
+                assert.equal(Fangorn.allowedToMove(folder, item, false), false);
+            });
+
+            it('can move item from figshare if it is private', () => {
+                folder = getItem('folder', 2);
+                item = getItem('file', 3);
+                item.data.provider = 'figshare';
+                item.data.extra = {'status': 'draft'};
+                assert.equal(Fangorn.allowedToMove(folder, item, false), true);
+            });
         });
 
         describe('getAllChildren', () => {

--- a/website/static/js/tests/fangorn.test.js
+++ b/website/static/js/tests/fangorn.test.js
@@ -209,21 +209,6 @@ describe('fangorn', () => {
                 item.data.provider = 'github';
                 assert.equal(Fangorn.isInvalidDropItem(folder, item, false, true), true);
             });
-
-            it('cannot be dropped if item provider is figshare and private', () => {
-                folder = getItem('folder', 2);
-                item = getItem('folder', 3);
-                item.data.provider = 'figshare';
-                assert.equal(Fangorn.isInvalidDropItem(folder, item, false, false), true);
-            });
-
-            it('cannot be dropped if item provider is figshare and public', () => {
-                folder = getItem('folder', 2);
-                item = getItem('folder', 3);
-                item.data.provider = 'figshare';
-                assert.equal(Fangorn.isInvalidDropItem(folder, item, false, false), true);
-            });            
-
         });
 
         describe('allowedToMove', () => {


### PR DESCRIPTION
## Purpose

The update to the Figshare v2 API means that a bunch of common fangorn features that weren't supportable before now work.

## Changes

* Allow copying files and folders out of Figshare.
* Enable folder creation in Projects.
* Enable download button for all files & folders.
* Update Figshare delete logic. All private files and folders can be deleted.
* Update supported features modal.

## Side effects

None expected.

## Ticket

[#OSF-7272] - [JIRA](https://openscience.atlassian.net/browse/OSF-7272)