### PR TITLE
figshare logs: add folder_created, correct file type

### DIFF
--- a/website/addons/figshare/static/figshareAnonymousLogActionList.json
+++ b/website/addons/figshare/static/figshareAnonymousLogActionList.json
@@ -2,7 +2,8 @@
     "figshare_folder_selected" : "A user linked content from figshare in a project",
     "figshare_content_unlinked" : "A user unlinked content from figshare in a project",
     "figshare_file_added" : "A user added a file to figshare in a project",
-    "figshare_file_removed" : "A user removed a file from figshare in a project",
+    "figshare_file_removed" : "A user removed a file or folder from figshare in a project",
+    "figshare_folder_created" : "A user created a folder in figshare in a project",
     "figshare_node_authorized" : "A user authorized the figshare addon for a project",
     "figshare_node_deauthorized" : "A user deauthorized the figshare addon for a project",
     "figshare_node_deauthorized_no_user" : "figshare addon for a project deauthorized"

--- a/website/addons/figshare/static/figshareLogActionList.json
+++ b/website/addons/figshare/static/figshareLogActionList.json
@@ -2,7 +2,8 @@
   "figshare_folder_selected" : "${user} linked figshare ${folder} ${folder_name} to ${node}",
   "figshare_content_unlinked": "${user} unlinked content from figshare in ${node}",
   "figshare_file_added" : "${user} added file ${path} to figshare in ${node}",
-  "figshare_file_removed" : "${user} removed file ${path} from figshare in ${node}",
+  "figshare_file_removed" : "${user} removed ${path_type} ${path} from figshare in ${node}",
+  "figshare_folder_created" : "${user} created folder ${path} in figshare in ${node}",
   "figshare_node_authorized" : "${user} authorized the figshare addon for ${node}",
   "figshare_node_deauthorized" : "${user} deauthorized the figshare addon for ${node}",
   "figshare_node_deauthorized_no_user" : "figshare addon for ${node} deauthorized"


### PR DESCRIPTION
## Purpose / Changes

Figshare is missing a log message for the create folder action. Add it.

Figshare's file_removed log message doesn't distinguish files and folders. Start doing so.

## Side effects

None expected.

## Ticket

No ticket.
