### PR TITLE
Delete inaccurate comment from default settings

### DIFF
--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -263,8 +263,6 @@ KEEN = {
 SENTRY_DSN = None
 SENTRY_DSN_JS = None
 
-
-# TODO: Delete me after merging GitLab
 MISSING_FILE_NAME = 'untitled'
 
 # Project Organizer


### PR DESCRIPTION
## Purpose

This `TODO` should be a `TODONT`.

This comment was added in 2014 and is no longer accurate.  In fact, this setting is necessary, and GitLab stands a real chance of getting merged in the near future.  Let's not tempt anyone into doing something rash.

## Changes

Remove comment from `website/settings/defaults.py`. No functional changes.

## Side effects

Future suffering may be reduced.

## Ticket

No ticket.