### PR TITLE
[feature] Preprint Citations [OSF-7243]

### DIFF
--- a/api/citations/utils.py
+++ b/api/citations/utils.py
@@ -1,16 +1,48 @@
 import os
+import re
 
 from citeproc import CitationStylesStyle, CitationStylesBibliography
 from citeproc import Citation, CitationItem
 from citeproc import formatter
 from citeproc.source.json import CiteProcJSON
 
+from website.preprints.model import PreprintService
+from website.project.model import Node
 from website.settings import CITATION_STYLES_PATH
+
+
+def display_absolute_url(node):
+    url = node.absolute_url
+    if url is not None:
+        return re.sub(r'https?:', '', url).strip('/')
+
+
+def preprint_csl(preprint, node):
+    csl = node.csl
+
+    csl['id'] = preprint._id
+    csl['publisher'] = preprint.provider.name
+    csl['URL'] = display_absolute_url(preprint)
+
+    if csl.get('DOI'):
+        csl.pop('DOI')
+
+    doi = preprint.article_doi
+    if doi:
+        csl['DOI'] = doi
+
+    return csl
 
 
 def render_citation(node, style='apa'):
     """Given a node, return a citation"""
-    data = [node.csl, ]
+    if isinstance(node, Node):
+        data = [node.csl, ]
+    elif isinstance(node, PreprintService):
+        csl = preprint_csl(node, node.node)
+        data = [csl, ]
+    else:
+        raise ValueError
 
     bib_source = CiteProcJSON(data)
 

--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -10,7 +10,11 @@ from api.base.serializers import (
 )
 from api.base.utils import absolute_reverse, get_user_auth
 from api.taxonomies.serializers import TaxonomyField
-from api.nodes.serializers import NodeLicenseSerializer, get_license_details
+from api.nodes.serializers import (
+    NodeCitationSerializer,
+    NodeLicenseSerializer,
+    get_license_details
+)
 from framework.exceptions import PermissionsError
 from website.util import permissions
 from website.exceptions import NodeStateError
@@ -68,6 +72,11 @@ class PreprintSerializer(JSONAPISerializer):
     is_published = ser.BooleanField(required=False)
     is_preprint_orphan = ser.BooleanField(read_only=True)
     license_record = NodeLicenseSerializer(required=False, source='license')
+
+    citation = RelationshipField(
+        related_view='preprints:preprint-citation',
+        related_view_kwargs={'preprint_id': '<_id>'}
+    )
 
     node = NodeRelationshipField(
         related_view='nodes:node-detail',
@@ -215,3 +224,9 @@ class PreprintCreateSerializer(PreprintSerializer):
         preprint.node.save()
 
         return self.update(preprint, validated_data)
+
+
+class PreprintCitationSerializer(NodeCitationSerializer):
+
+    class Meta:
+        type_ = 'preprint-citation'

--- a/api/preprints/urls.py
+++ b/api/preprints/urls.py
@@ -5,4 +5,6 @@ from . import views
 urlpatterns = [
     url(r'^$', views.PreprintList.as_view(), name=views.PreprintList.view_name),
     url(r'^(?P<preprint_id>\w+)/$', views.PreprintDetail.as_view(), name=views.PreprintDetail.view_name),
+    url(r'^(?P<preprint_id>\w+)/citation/$', views.PreprintCitationDetail.as_view(), name=views.PreprintCitationDetail.view_name),
+    url(r'^(?P<preprint_id>\w+)/citation/(?P<style_id>[-\w]+)/$', views.PreprintCitationStyleDetail.as_view(), name=views.PreprintCitationStyleDetail.view_name),
 ]

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -1,3 +1,5 @@
+import re
+
 from modularodm import Q
 from rest_framework import generics
 from rest_framework.exceptions import NotFound
@@ -15,7 +17,15 @@ from api.base.parsers import (
 )
 from api.base.utils import get_object_or_error
 from api.base import permissions as base_permissions
-from api.preprints.serializers import PreprintSerializer, PreprintCreateSerializer
+from api.citations.utils import render_citation, preprint_csl
+from api.preprints.serializers import (
+    PreprintSerializer,
+    PreprintCreateSerializer,
+    PreprintCitationSerializer,
+)
+from api.nodes.serializers import (
+    NodeCitationStyleSerializer,
+)
 from api.nodes.views import NodeMixin, WaterButlerMixin
 from api.nodes.permissions import ContributorOrPublic
 
@@ -245,3 +255,69 @@ class PreprintDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, Pre
         if instance.is_published:
             raise Conflict('Published preprints cannot be deleted.')
         PreprintService.remove_one(instance)
+
+
+class PreprintCitationDetail(JSONAPIBaseView, generics.RetrieveAPIView, PreprintMixin):
+    """ The citation details for a preprint, in CSL format *Read Only*
+
+    ##PreprintCitationDetail Attributes
+
+        name                     type                description
+        =================================================================================
+        id                       string               unique ID for the citation
+        title                    string               title of project or component
+        author                   list                 list of authors for the preprint
+        publisher                string               publisher - the preprint provider
+        type                     string               type of citation - web
+        doi                      string               doi of the resource
+
+    """
+    permission_classes = (
+        drf_permissions.IsAuthenticatedOrReadOnly,
+        base_permissions.TokenHasScope,
+    )
+
+    required_read_scopes = [CoreScopes.NODE_CITATIONS_READ]
+    required_write_scopes = [CoreScopes.NULL]
+
+    serializer_class = PreprintCitationSerializer
+    view_category = 'preprints'
+    view_name = 'preprint-citation'
+
+    def get_object(self):
+        preprint = self.get_preprint()
+        return preprint_csl(preprint, preprint.node)
+
+
+class PreprintCitationStyleDetail(JSONAPIBaseView, generics.RetrieveAPIView, PreprintMixin):
+    """ The citation for a preprint in a specific style's format. *Read Only*
+
+    ##NodeCitationDetail Attributes
+
+        name                     type                description
+        =================================================================================
+        citation                string               complete citation for a preprint in the given style
+
+    """
+    permission_classes = (
+        drf_permissions.IsAuthenticatedOrReadOnly,
+        base_permissions.TokenHasScope,
+    )
+
+    required_read_scopes = [CoreScopes.NODE_CITATIONS_READ]
+    required_write_scopes = [CoreScopes.NULL]
+
+    serializer_class = NodeCitationStyleSerializer
+    view_category = 'preprint'
+    view_name = 'preprint-citation'
+
+    def get_object(self):
+        preprint = self.get_preprint()
+        style = self.kwargs.get('style_id')
+        try:
+            citation = render_citation(node=preprint, style=style)
+        except ValueError as err:  # style requested could not be found
+            csl_name = re.findall('[a-zA-Z]+\.csl', err.message)[0]
+            raise NotFound('{} is not a known style.'.format(csl_name))
+
+        return {'citation': citation, 'id': style}

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -275,6 +275,7 @@ class PreprintCitationDetail(JSONAPIBaseView, generics.RetrieveAPIView, Preprint
     permission_classes = (
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
+        ContributorOrPublic,
     )
 
     required_read_scopes = [CoreScopes.NODE_CITATIONS_READ]
@@ -302,6 +303,7 @@ class PreprintCitationStyleDetail(JSONAPIBaseView, generics.RetrieveAPIView, Pre
     permission_classes = (
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
+        ContributorOrPublic,
     )
 
     required_read_scopes = [CoreScopes.NODE_CITATIONS_READ]

--- a/api_tests/preprints/views/test_preprint_citations.py
+++ b/api_tests/preprints/views/test_preprint_citations.py
@@ -2,6 +2,7 @@
 from nose.tools import *  # flake8: noqa
 
 from api.base.settings.defaults import API_BASE
+from api.citations.utils import display_absolute_url
 
 from tests.base import ApiTestCase
 from tests.factories import (
@@ -44,7 +45,7 @@ class TestPreprintCitations(PreprintCitationsMixin, ApiTestCase):
 	def test_citation_url_is_preprint_url_not_project(self):
 		res = self.app.get(self.published_preprint_url)
 		assert_equal(res.status_code, 200)
-		assert_equal(res.json['data']['links']['self'], self.published_preprint.display_absolute_url)
+		assert_equal(res.json['data']['links']['self'], display_absolute_url(self.published_preprint))
 
 
 class TestPreprintCitationsStyle(PreprintCitationsMixin, ApiTestCase):

--- a/api_tests/preprints/views/test_preprint_citations.py
+++ b/api_tests/preprints/views/test_preprint_citations.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+from nose.tools import *  # flake8: noqa
+
+from api.base.settings.defaults import API_BASE
+
+from tests.base import ApiTestCase
+from tests.factories import (
+    AuthUserFactory,
+    PreprintFactory,
+)
+
+
+class PreprintCitationsMixin(object):
+
+	def setUp(self):
+		super(PreprintCitationsMixin, self).setUp()
+		self.admin_contributor = AuthUserFactory()
+		self.published_preprint = PreprintFactory(creator=self.admin_contributor)
+
+	def test_unauthenticated_can_view_published_preprint_citations(self):
+		res = self.app.get(self.published_preprint_url)
+		assert_equal(res.status_code, 200)
+
+	def test_preprint_citations_are_read_only(self):
+		post_res = self.app.post_json_api(self.published_preprint_url, {}, auth=self.admin_contributor.auth, expect_errors=True)
+		assert_equal(post_res.status_code, 405)
+		put_res = self.app.put_json_api(self.published_preprint_url, {}, auth=self.admin_contributor.auth, expect_errors=True)
+		assert_equal(put_res.status_code, 405)
+		delete_res = self.app.delete_json_api(self.published_preprint_url, auth=self.admin_contributor.auth, expect_errors=True)
+		assert_equal(delete_res.status_code, 405)
+
+
+class TestPreprintCitations(PreprintCitationsMixin, ApiTestCase):
+
+	def setUp(self):
+		super(TestPreprintCitations, self).setUp()
+		self.published_preprint_url = '/{}preprints/{}/citation/'.format(API_BASE, self.published_preprint._id)
+
+	def test_citation_publisher_is_preprint_provider(self):
+		res = self.app.get(self.published_preprint_url)
+		assert_equal(res.status_code, 200)
+		assert_equal(res.json['data']['attributes']['publisher'], self.published_preprint.provider.name)
+
+	def test_citation_url_is_preprint_url_not_project(self):
+		res = self.app.get(self.published_preprint_url)
+		assert_equal(res.status_code, 200)
+		assert_equal(res.json['data']['links']['self'], self.published_preprint.display_absolute_url)
+
+
+class TestPreprintCitationsStyle(PreprintCitationsMixin, ApiTestCase):
+
+	def setUp(self):
+		super(TestPreprintCitationsStyle, self).setUp()
+		self.published_preprint_url = '/{}preprints/{}/citation/apa/'.format(API_BASE, self.published_preprint._id)

--- a/api_tests/preprints/views/test_preprint_citations.py
+++ b/api_tests/preprints/views/test_preprint_citations.py
@@ -17,10 +17,15 @@ class PreprintCitationsMixin(object):
 		super(PreprintCitationsMixin, self).setUp()
 		self.admin_contributor = AuthUserFactory()
 		self.published_preprint = PreprintFactory(creator=self.admin_contributor)
+		self.unpublished_preprint = PreprintFactory(creator=self.admin_contributor, is_published=False)
 
 	def test_unauthenticated_can_view_published_preprint_citations(self):
 		res = self.app.get(self.published_preprint_url)
 		assert_equal(res.status_code, 200)
+
+	def test_unauthenticated_cannot_view_unpublished_preprint_citations(self):
+		res = self.app.get(self.unpublished_preprint_url, expect_errors=True)
+		assert_equal(res.status_code, 401)
 
 	def test_preprint_citations_are_read_only(self):
 		post_res = self.app.post_json_api(self.published_preprint_url, {}, auth=self.admin_contributor.auth, expect_errors=True)
@@ -36,6 +41,7 @@ class TestPreprintCitations(PreprintCitationsMixin, ApiTestCase):
 	def setUp(self):
 		super(TestPreprintCitations, self).setUp()
 		self.published_preprint_url = '/{}preprints/{}/citation/'.format(API_BASE, self.published_preprint._id)
+		self.unpublished_preprint_url = '/{}preprints/{}/citation/'.format(API_BASE, self.unpublished_preprint._id)
 
 	def test_citation_publisher_is_preprint_provider(self):
 		res = self.app.get(self.published_preprint_url)
@@ -53,3 +59,4 @@ class TestPreprintCitationsStyle(PreprintCitationsMixin, ApiTestCase):
 	def setUp(self):
 		super(TestPreprintCitationsStyle, self).setUp()
 		self.published_preprint_url = '/{}preprints/{}/citation/apa/'.format(API_BASE, self.published_preprint._id)
+		self.unpublished_preprint_url = '/{}preprints/{}/citation/apa/'.format(API_BASE, self.unpublished_preprint._id)


### PR DESCRIPTION
#### Purpose
- Adds citations to preprints. 
  - Previously, citations only existed for a preprint's OSF node, which is not an accurate citation for the preprint as their GUIDs are different.

#### Changes
- Adds `/v2/preprints/<preprint_id>/citation/` endpoint
  - Adds `PreprintCitationDetail` view
  - Adds `PreprintCitationSerializer` class
- Adds `/v2/preprints/<preprint_id>/citation/<citation_style>/` endpoint
  - Adds `PreprintCitationStyleDetail` view
  - Utilizes the existing `NodeCitationStyleSerializer` class 
- Adds `citation` relationship field to `PreprintDetailSerializer` 
- Adds `preprint_csl()` and `display_absolute_url()` helpers to citation utils. 
- Adds preprint citations test file

#### Side effects
- None expected

#### Ticket
- [OSF-7243](https://openscience.atlassian.net/browse/OSF-7243)