### PR TITLE
Keen analytics improvements - addon snapshot memory use and celery task times

### DIFF
--- a/framework/mongo/utils.py
+++ b/framework/mongo/utils.py
@@ -154,19 +154,20 @@ def paginated(model, query=None, increment=200, each=True):
     :param bool each: If True, each record is yielded. If False, pages
         are yielded.
     """
-    last_id = ''
-    pages = (model.find(query).count() / increment) + 1
-    for i in xrange(pages):
-        q = Q('_id', 'gt', last_id)
-        if query:
-            q &= query
-        page = list(model.find(q).sort('_id').limit(increment))
-        if each:
-            for item in page:
-                yield item
-            if page:
-                last_id = item._id
-        else:
-            if page:
-                yield page
-                last_id = page[-1]._id
+    if model:
+        last_id = ''
+        pages = (model.find(query).count() / increment) + 1
+        for i in xrange(pages):
+            q = Q('_id', 'gt', last_id)
+            if query:
+                q &= query
+            page = list(model.find(q).sort('_id').limit(increment))
+            if each:
+                for item in page:
+                    yield item
+                if page:
+                    last_id = item._id
+            else:
+                if page:
+                    yield page
+                    last_id = page[-1]._id

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -495,7 +495,7 @@ else:
         },
         'run_keen_summaries': {
             'task': 'scripts.analytics.run_keen_summaries',
-            'schedule': crontab(minute=00, hour=2),  # Daily 2:00 a.m.
+            'schedule': crontab(minute=00, hour=1),  # Daily 1:00 a.m.
             'kwargs': {'yesterday': True}
         },
         'run_keen_snapshots': {


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
The `run_keen_summaries` and `run_keen_snapshots` were having issues running. One was because of timing, the second because of a memory issue when paginating over too many nodes. This PR hopefully will fix those!

## Changes
- Change `run_keen_summaries` to run at 1 am instead of 2am
- Modify the `paginate` util to check if a model is passed
- Iterate only using the `paginate` method instead of saving the results 

## Side effects
- Any use of `paginated` that is expected to fail if a valid model isn't passed will no longer fail....


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
