### PR TITLE
Put paginated back, instead deal with missing addon user and model settings

### DIFF
--- a/framework/mongo/utils.py
+++ b/framework/mongo/utils.py
@@ -154,20 +154,19 @@ def paginated(model, query=None, increment=200, each=True):
     :param bool each: If True, each record is yielded. If False, pages
         are yielded.
     """
-    if model:
-        last_id = ''
-        pages = (model.find(query).count() / increment) + 1
-        for i in xrange(pages):
-            q = Q('_id', 'gt', last_id)
-            if query:
-                q &= query
-            page = list(model.find(q).sort('_id').limit(increment))
-            if each:
-                for item in page:
-                    yield item
-                if page:
-                    last_id = item._id
-            else:
-                if page:
-                    yield page
-                    last_id = page[-1]._id
+    last_id = ''
+    pages = (model.find(query).count() / increment) + 1
+    for i in xrange(pages):
+        q = Q('_id', 'gt', last_id)
+        if query:
+            q &= query
+        page = list(model.find(q).sort('_id').limit(increment))
+        if each:
+            for item in page:
+                yield item
+            if page:
+                last_id = item._id
+        else:
+            if page:
+                yield page
+                last_id = page[-1]._id

--- a/scripts/analytics/addon_snapshot.py
+++ b/scripts/analytics/addon_snapshot.py
@@ -3,6 +3,7 @@ from modularodm import Q
 
 from website.app import init_app
 from website.models import Node, User
+from website.addons.forward.model import ForwardNodeSettings
 from framework.mongo.utils import paginated
 from website.addons.base import AddonNodeSettingsBase
 from scripts.analytics.base import SnapshotAnalytics
@@ -26,17 +27,18 @@ def get_enabled_authorized_linked(user_settings_list, has_external_account, shor
 
     # osfstorage and wiki don't have user_settings, so always assume they're enabled, authorized, linked
     if short_name == 'osfstorage' or short_name == 'wiki':
-        active = User.find(
+        num_enabled = num_authorized = num_linked = User.find(
                     Q('is_registered', 'eq', True) &
                     Q('password', 'ne', None) &
                     Q('merged_by', 'eq', None) &
                     Q('date_disabled', 'eq', None) &
                     Q('date_confirmed', 'ne', None)
                 ).count()
-        for user in xrange(active):
-            num_enabled += 1
-            num_authorized += 1
-            num_linked += 1
+
+    elif short_name == 'forward':
+        num_enabled = num_authorized = ForwardNodeSettings.find().count()
+        num_linked = ForwardNodeSettings.find(Q('url', 'ne', None)).count()
+
     else:
         for user_settings in paginated(user_settings_list):
             if has_external_account:
@@ -79,17 +81,21 @@ class AddonSnapshot(SnapshotAnalytics):
                     has_external_account = False
 
             connected_count = 0
-            for node_settings in paginated(addon.settings_models.get('node')):
-                if AddonNodeSettingsBase in node_settings.__class__.__bases__:
-                    has_external_account = False
-                if node_settings.owner and not node_settings.owner.is_bookmark_collection:
-                    connected_count += 1
-            deleted_count = addon.settings_models['node'].find(Q('deleted', 'eq', True)).count() if addon.settings_models.get('node') else 0
-            if has_external_account:
-                disconnected_count = addon.settings_models['node'].find(Q('external_account', 'eq', None) & Q('deleted', 'ne', True)).count() if addon.settings_models.get('node') else 0
-            else:
-                disconnected_count = addon.settings_models['node'].find(Q('configured', 'eq', True) & Q('complete', 'eq', False) & Q('deleted', 'ne', True)).count() if addon.settings_models.get('node') else 0
-            total = connected_count + deleted_count + disconnected_count
+            deleted_count = 0
+            disconnected_count = 0
+            node_settings_model = addon.settings_models.get('node')
+            if node_settings_model:
+                for node_settings in paginated(node_settings_model):
+                    if AddonNodeSettingsBase in node_settings.__class__.__bases__:
+                        has_external_account = False
+                    if node_settings.owner and not node_settings.owner.is_bookmark_collection:
+                        connected_count += 1
+                deleted_count = addon.settings_models['node'].find(Q('deleted', 'eq', True)).count() if addon.settings_models.get('node') else 0
+                if has_external_account:
+                    disconnected_count = addon.settings_models['node'].find(Q('external_account', 'eq', None) & Q('deleted', 'ne', True)).count() if addon.settings_models.get('node') else 0
+                else:
+                    disconnected_count = addon.settings_models['node'].find(Q('configured', 'eq', True) & Q('complete', 'eq', False) & Q('deleted', 'ne', True)).count() if addon.settings_models.get('node') else 0
+                total = connected_count + deleted_count + disconnected_count
             usage_counts = get_enabled_authorized_linked(addon.settings_models.get('user'), has_external_account, addon.short_name)
 
             counts.append({


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Not passing model to `paginated` should be a user error -- make better use of paginated instead by dealing with missing user and addon model settings

## Changes

- paginated back how it was
- forward special cased counting
- check fr user and model settings

## Side effects

none anticipated


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
