### PR TITLE
[feature] Pin elasticsearch version [OSF-7294]

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ Install Elasticsearch to use search features.
 ##### Mac OSX
 
 ```bash
-$ brew install elasticsearch
+$ brew install elasticsearch@1.7
 ```
 _note: Oracle JDK 7 must be installed for elasticsearch to run_
 

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -773,7 +773,7 @@ def packages(ctx):
         'upgrade',
         'install libxml2',
         'install libxslt',
-        'install elasticsearch',
+        'install elasticsearch@1.7',
         'install rabbitmq',
         'install node',
         'tap tokutek/tokumx',


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Elasticsearch is not pinned to the proper version. With recent update this broke search on machines with newer search installed.
<!-- Describe the purpose of your changes -->

## Changes
Pins to 1.7, changes readme.
<!-- Briefly describe or list your changes  -->

## Side effects
Might break people's previous install. 

Steps to fix:
1. brew uninstall elasticsearch
2. delete `/usr/local/bin/elasticsearch`
3. `brew install elasticsearch@1.7`
4. in osf venv `invoke rebuild_search`

<!--Any possible side effects? -->

## Ticket
[#OSF-7294]
https://openscience.atlassian.net/browse/OSF-7294
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
