### PR TITLE
[Hotfix] Update share search url [OSF-7262]

### DIFF
--- a/website/static/js/search.js
+++ b/website/static/js/search.js
@@ -458,7 +458,7 @@ var ViewModel = function(params) {
                 self.pushState();
             }
 
-            $osf.postJSON(window.contextVars.shareUrl + 'api/v2/search/abstractcreativework/_count', shareQuery).success(function(data) {
+            $osf.postJSON(window.contextVars.shareUrl + 'api/v2/search/creativeworks/_count', shareQuery).success(function(data) {
                 self.shareCategory(new Category('SHARE', data.count, 'SHARE'));
             });
 


### PR DESCRIPTION
## Purpose

The current URL for the number of share search results is deprecated and therefore always returns `0`. See ticket for screen shot.

## Changes

Update the share search URL so that the count is accurate.

## Side effects

None


## Ticket

https://openscience.atlassian.net/browse/OSF-7262
