### PR TITLE
[fix] Preprint Citations Permissions [OSF-7243]

### DIFF
--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -2,7 +2,7 @@ import re
 
 from modularodm import Q
 from rest_framework import generics
-from rest_framework.exceptions import NotFound
+from rest_framework.exceptions import NotFound, PermissionDenied, NotAuthenticated
 from rest_framework import permissions as drf_permissions
 
 from website.models import PreprintService
@@ -15,7 +15,7 @@ from api.base.parsers import (
     JSONAPIMultipleRelationshipsParser,
     JSONAPIMultipleRelationshipsParserForRegularJSON,
 )
-from api.base.utils import get_object_or_error
+from api.base.utils import get_object_or_error, get_user_auth
 from api.base import permissions as base_permissions
 from api.citations.utils import render_citation, preprint_csl
 from api.preprints.serializers import (
@@ -275,7 +275,6 @@ class PreprintCitationDetail(JSONAPIBaseView, generics.RetrieveAPIView, Preprint
     permission_classes = (
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
-        ContributorOrPublic,
     )
 
     required_read_scopes = [CoreScopes.NODE_CITATIONS_READ]
@@ -287,7 +286,12 @@ class PreprintCitationDetail(JSONAPIBaseView, generics.RetrieveAPIView, Preprint
 
     def get_object(self):
         preprint = self.get_preprint()
-        return preprint_csl(preprint, preprint.node)
+        auth = get_user_auth(self.request)
+
+        if preprint.node.is_public or preprint.node.can_view(auth) or preprint.is_published:
+            return preprint_csl(preprint, preprint.node)
+
+        raise PermissionDenied if auth.user else NotAuthenticated
 
 
 class PreprintCitationStyleDetail(JSONAPIBaseView, generics.RetrieveAPIView, PreprintMixin):
@@ -303,7 +307,6 @@ class PreprintCitationStyleDetail(JSONAPIBaseView, generics.RetrieveAPIView, Pre
     permission_classes = (
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
-        ContributorOrPublic,
     )
 
     required_read_scopes = [CoreScopes.NODE_CITATIONS_READ]
@@ -315,11 +318,16 @@ class PreprintCitationStyleDetail(JSONAPIBaseView, generics.RetrieveAPIView, Pre
 
     def get_object(self):
         preprint = self.get_preprint()
+        auth = get_user_auth(self.request)
         style = self.kwargs.get('style_id')
-        try:
-            citation = render_citation(node=preprint, style=style)
-        except ValueError as err:  # style requested could not be found
-            csl_name = re.findall('[a-zA-Z]+\.csl', err.message)[0]
-            raise NotFound('{} is not a known style.'.format(csl_name))
 
-        return {'citation': citation, 'id': style}
+        if preprint.node.is_public or preprint.node.can_view(auth) or preprint.is_published:
+            try:
+                citation = render_citation(node=preprint, style=style)
+            except ValueError as err:  # style requested could not be found
+                csl_name = re.findall('[a-zA-Z]+\.csl', err.message)[0]
+                raise NotFound('{} is not a known style.'.format(csl_name))
+
+            return {'citation': citation, 'id': style}
+
+        raise PermissionDenied if auth.user else NotAuthenticated


### PR DESCRIPTION
#### Purpose
- Fix preprint citation 502s on staging.

#### Changes
- Remove `ContributorOrPublic` permissions class from preprint citation views as it expects a Node, Pointer, PreprintService, or AddonSettings object, not a dictionary describing a citation.
  - Traceback causing the 502:
```
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/wsgiref/handlers.py", line 85, in run
    self.result = application(self.environ, self.start_response)
  File "/Users/casey/.virtualenvs/osf/lib/python2.7/site-packages/django/contrib/staticfiles/handlers.py", line 63, in __call__
    return self.application(environ, start_response)
  File "/Users/casey/.virtualenvs/osf/lib/python2.7/site-packages/django/core/handlers/wsgi.py", line 177, in __call__
    response = self.get_response(request)
  File "/Users/casey/.virtualenvs/osf/lib/python2.7/site-packages/django/core/handlers/base.py", line 230, in get_response
    response = self.handle_uncaught_exception(request, resolver, sys.exc_info())
  File "/Users/casey/.virtualenvs/osf/lib/python2.7/site-packages/django/core/handlers/base.py", line 174, in get_response
    response = self.process_exception_by_middleware(e, request)
  File "/Users/casey/.virtualenvs/osf/lib/python2.7/site-packages/django/core/handlers/base.py", line 172, in get_response
    response = response.render()
  File "/Users/casey/.virtualenvs/osf/lib/python2.7/site-packages/django/template/response.py", line 160, in render
    self.content = self.rendered_content
  File "/Users/casey/.virtualenvs/osf/lib/python2.7/site-packages/rest_framework/response.py", line 71, in rendered_content
    ret = renderer.render(self.data, media_type, context)
  File "/Users/casey/.virtualenvs/osf/lib/python2.7/site-packages/rest_framework/renderers.py", line 676, in render
    context = self.get_context(data, accepted_media_type, renderer_context)
  File "/Users/casey/develop/cos/osf/api/base/renderers.py", line 28, in get_context
    context = super(BrowsableAPIRendererNoForms, self).get_context(*args, **kwargs)
  File "/Users/casey/.virtualenvs/osf/lib/python2.7/site-packages/rest_framework/renderers.py", line 653, in get_context
    'options_form': self.get_rendered_html_form(data, view, 'OPTIONS', request),
  File "/Users/casey/.virtualenvs/osf/lib/python2.7/site-packages/rest_framework/renderers.py", line 462, in get_rendered_html_form
    if not self.show_form_for_method(view, method, request, instance):
  File "/Users/casey/.virtualenvs/osf/lib/python2.7/site-packages/rest_framework/renderers.py", line 419, in show_form_for_method
    view.check_object_permissions(request, obj)
  File "/Users/casey/.virtualenvs/osf/lib/python2.7/site-packages/rest_framework/views.py", line 329, in check_object_permissions
    if not permission.has_object_permission(request, self, obj):
  File "/Users/casey/develop/cos/osf/api/nodes/permissions.py", line 20, in has_object_permission
    assert isinstance(obj, (Node, Pointer)), 'obj must be a Node, Pointer, PreprintService, or AddonSettings; got {}'.format(obj)
AssertionError: obj must be a Node, Pointer, PreprintService, or AddonSettings; got {'publisher': u'Open Science Framework', 'author': [{'given': u'OSF', 'family': u'Preprints'}], 'URL': 'localhost:5000/xx4cw', 'issued': {'date-parts': [[2016, 12, 19]]}, 'title': u'test preprint citation', 'type': 'webpage', 'id': u'xx4cw'}
```
- Add custom permissions check for `PreprintCitationDetail` and `PreprintCitationStyleDetail` views.

#### Side effects
- None expected.

#### Ticket
- [OSF-7243](https://openscience.atlassian.net/browse/OSF-7243)
