### PR TITLE
[fix] [django-osf] Fix Default ODM Query for Preprint Provider [no ticket]

### DIFF
--- a/api/preprint_providers/views.py
+++ b/api/preprint_providers/views.py
@@ -64,8 +64,9 @@ class PreprintProviderList(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin
 
     ordering = ('name', )
 
+    # implement ODMFilterMixin
     def get_default_odm_query(self):
-        return Q('is_deleted', 'ne', True)
+        return None
 
     # overrides ListAPIView
     def get_queryset(self):


### PR DESCRIPTION
@sloria @cwisecarver 

There is no `is_deleted` field for `osf_preprints_provider`. Mongo does not complain in OSF but Postgres fails in Django-OSF.