### PR TITLE
Update Metrics on OSF Admin [OSF-7253]

### DIFF
--- a/admin/static/css/keen-dashboards.css
+++ b/admin/static/css/keen-dashboards.css
@@ -96,3 +96,7 @@ body.application .return-link:hover,
   font-size: 12px;
   padding: 8px 10px 5px;
 }
+
+.keen-dataviz-table-dataset td{
+  min-width: 100px !important;
+}

--- a/admin/static/css/keen-dashboards.css
+++ b/admin/static/css/keen-dashboards.css
@@ -98,7 +98,7 @@ body.application .return-link:hover,
 }
 
 .keen-dataviz-table-dataset td{
-  min-width: 100px !important;
+  min-width: 60px !important;
 }
 
 #dropdownMenuButton {

--- a/admin/static/css/keen-dashboards.css
+++ b/admin/static/css/keen-dashboards.css
@@ -106,7 +106,7 @@ body.application .return-link:hover,
   margin-right: 20px;
 }
 
-thead {
+.institution-tables thead {
   display: none;
 }
 

--- a/admin/static/css/keen-dashboards.css
+++ b/admin/static/css/keen-dashboards.css
@@ -103,6 +103,7 @@ body.application .return-link:hover,
 
 #dropdownMenuButton {
   margin-top: 20px;
+  margin-right: 20px;
 }
 
 thead {
@@ -112,4 +113,8 @@ thead {
 .hr-menu {
   background-color: lightgray;
   height: 1px;
+}
+
+#reload-node-logs {
+  margin-left: 20px;
 }

--- a/admin/static/css/keen-dashboards.css
+++ b/admin/static/css/keen-dashboards.css
@@ -100,3 +100,11 @@ body.application .return-link:hover,
 .keen-dataviz-table-dataset td{
   min-width: 100px !important;
 }
+
+#dropdownMenuButton {
+  margin-top: 15px;
+}
+
+thead {
+  display: none;
+}

--- a/admin/static/css/keen-dashboards.css
+++ b/admin/static/css/keen-dashboards.css
@@ -102,9 +102,14 @@ body.application .return-link:hover,
 }
 
 #dropdownMenuButton {
-  margin-top: 15px;
+  margin-top: 20px;
 }
 
 thead {
   display: none;
+}
+
+.hr-menu {
+  background-color: lightgray;
+  height: 1px;
 }

--- a/admin/static/js/metrics/metrics.js
+++ b/admin/static/js/metrics/metrics.js
@@ -886,7 +886,7 @@ var RawNumberMetrics = function() {
 
             if (values[i].query.target_property.includes('public')) {
                 chart.colors([publicColor]);
-            } else if (values[i].query.target_property.includes('private')) {
+            } else if (values[i].query.target_property.includes('private') || values[i].query.target_property.includes('embargoed')) {
                 chart.colors([privateColor]);
             }
             chart.data(values[i]).render();

--- a/admin/static/js/metrics/metrics.js
+++ b/admin/static/js/metrics/metrics.js
@@ -424,6 +424,101 @@ Keen.ready(function () {
 
     renderCalculationBetweenTwoMetrics(yesterday_unconfirmed_user_count, week_ago_user_count, "unverified-new-users", 'day', 'subtraction');
 
+    // Institutional Users over past 100 Days
+    var institutional_user_chart = new Keen.Query("sum", {
+        eventCollection: "institution_summary",
+        interval: "daily",
+        targetProperty: "users.total",
+        groupBy: "institution.name",
+        timeframe: "previous_100_days",
+        timezone: "UTC"
+    });
+
+    client.draw(institutional_user_chart, document.getElementById("institution-growth"), {
+        chartType: "line",
+        library: "c3",
+        title: ' '
+    });
+
+    // Total Institutional Users
+    var institutional_user_count = new Keen.Query("sum", {
+        eventCollection: "institution_summary",
+        targetProperty: "users.total",
+        timeframe: "previous_1_day",
+        timezone: "UTC"
+    });
+
+    client.draw(institutional_user_count, document.getElementById("total-institutional-users"), {
+        chartType: "metric",
+        title: " "
+    });
+
+    // Total Instutional Users / Total OSF Users
+    renderCalculationBetweenTwoMetrics(institutional_user_count, active_user_count, "percentage-institutional-users", null, 'percentage');
+
+
+    //                _        _
+    //  _ __ _ _ ___ (_)___ __| |_ ___
+    // | '_ \ '_/ _ \| / -_) _|  _(_-<
+    // | .__/_| \___// \___\__|\__/__/
+    // |_|         |__/
+
+    // Affiliated Public Nodes
+    var affiliated_public_chart = new Keen.Query("sum", {
+        eventCollection: "institution_summary",
+        targetProperty: "nodes.public",
+        timeframe: "previous_1_days",
+        groupBy: "institution.name",
+        timezone: "UTC"
+    });
+
+    client.draw(affiliated_public_chart, document.getElementById("affiliated-public-nodes"), {
+        chartType: "table",
+        title: ' '
+    });
+
+    // Affiliated Private Nodes
+    var affiliated_private_node_chart = new Keen.Query("sum", {
+        eventCollection: "institution_summary",
+        targetProperty: "nodes.private",
+        timeframe: "previous_1_days",
+        groupBy: "institution.name",
+        timezone: "UTC"
+    });
+
+    client.draw(affiliated_private_node_chart, document.getElementById("affiliated-private-nodes"), {
+        chartType: "table",
+        title: ' '
+    });
+
+    // Affiliated Public Registrations
+    var affiliated_public_registered_nodes_chart = new Keen.Query("sum", {
+        eventCollection: "institution_summary",
+        targetProperty: "registered_nodes.public",
+        timeframe: "previous_1_days",
+        groupBy: "institution.name",
+        timezone: "UTC"
+    });
+
+    client.draw(affiliated_public_registered_nodes_chart, document.getElementById("affiliated-public-registered-nodes"), {
+        chartType: "table",
+        title: ' '
+    });
+
+    // Affiliated Private Registrations
+    var affiliated_private_registered_node_chart = new Keen.Query("sum", {
+        eventCollection: "institution_summary",
+        targetProperty: "registered_nodes.private",
+        timeframe: "previous_1_days",
+        groupBy: "institution.name",
+        timezone: "UTC"
+    });
+
+    client.draw(affiliated_private_node_chart, document.getElementById("affiliated-private-registered-nodes"), {
+        chartType: "table",
+        title: ' '
+    });
+
     // Registrations by Email Domain
     var email_domains = new Keen.Query("count", {
         eventCollection: "user_domain_events",

--- a/admin/static/js/metrics/metrics.js
+++ b/admin/static/js/metrics/metrics.js
@@ -782,6 +782,90 @@ Keen.ready(function () {
 
     renderPublicPrivatePercent(public_nodes, private_nodes, "total-nodes-pie");
 
+
+    // Total Project Registrations
+    var total_registered_projects = new Keen.Query("sum", {
+        eventCollection: "node_summary",
+        targetProperty: "registered_projects.total",
+        timeframe: "previous_1_days",
+        timezone: "UTC"
+    });
+
+    client.draw(total_registered_projects, document.getElementById("total-registered-projects"), {
+        chartType: "metric",
+        title: ' '
+    });
+
+    // Total Public Registered Projects
+    var public_registered_projects = new Keen.Query("sum", {
+        eventCollection: "node_summary",
+        targetProperty: "registered_projects.public",
+        timeframe: "previous_1_days",
+        timezone: "UTC"
+    });
+
+    client.draw(public_registered_projects, document.getElementById("public-registered-projects"), {
+        chartType: "metric",
+        title: ' '
+    });
+
+    // Total Embargoed Registered Projects
+    var embargoed_registered_projects = new Keen.Query("sum", {
+        eventCollection: "node_summary",
+        targetProperty: "registered_projects.embargoed",
+        timeframe: "previous_1_days",
+        timezone: "UTC"
+    });
+
+    client.draw(embargoed_registered_projects, document.getElementById("embargoed-registered-projects"), {
+        chartType: "metric",
+        title: ' '
+    });
+
+    renderPublicPrivatePercent(public_registered_projects, embargoed_registered_projects, "total-registered-projects-pie");
+
+    // Total Nodes
+    var total_registered_nodes = new Keen.Query("sum", {
+        eventCollection: "node_summary",
+        targetProperty: "registered_nodes.total",
+        timeframe: "previous_1_days",
+        timezone: "UTC"
+    });
+
+    client.draw(total_registered_nodes, document.getElementById("total-registered-nodes"), {
+        chartType: "metric",
+        title: ' '
+    });
+
+    // Total Public Nodes
+    var public_registered_nodes = new Keen.Query("sum", {
+        eventCollection: "node_summary",
+        targetProperty: "registered_nodes.public",
+        timeframe: "previous_1_days",
+        timezone: "UTC"
+    });
+
+    client.draw(public_registered_nodes, document.getElementById("public-registered-nodes"), {
+        chartType: "metric",
+        title: ' '
+    });
+
+    // Total Embargoed Nodes
+    var embargoed_registered_nodes = new Keen.Query("sum", {
+        eventCollection: "node_summary",
+        targetProperty: "registered_nodes.embargoed",
+        timeframe: "previous_1_days",
+        timezone: "UTC"
+    });
+
+    client.draw(embargoed_registered_nodes, document.getElementById("embargoed-registered-nodes"), {
+        chartType: "metric",
+        title: ' '
+    });
+
+    renderPublicPrivatePercent(public_registered_nodes, embargoed_registered_nodes, "total-registered-nodes-pie");
+
+
  //          _    _
  //  __ _ __| |__| |___ _ _  ___
  // / _` / _` / _` / _ \ ' \(_-<

--- a/admin/static/js/metrics/metrics.js
+++ b/admin/static/js/metrics/metrics.js
@@ -137,8 +137,34 @@ var differenceGrowthBetweenMetrics = function(metric1, metric2, totalMetric, ele
 
         differenceMetric.parseRawData(data).render();
     });
-}
+};
 
+
+var renderPublicPrivatePercent = function(publicMetric, privateMetric, element) {
+    var result;
+    var differenceMetric = new Keen.Dataviz()
+        .library('c3')
+        .el(document.getElementById(element))
+        .chartType("pie")
+        .title(' ')
+        .prepare();
+
+    client.run([
+        publicMetric,
+        privateMetric,
+    ], function(err, res) {
+
+        result = [
+            {'result': res[0].result, 'label': 'public'}, {'result': res[1].result, 'label': 'private'}
+        ];
+
+        var data = {
+            "result": result
+        };
+
+        differenceMetric.parseRawData(data).render();
+    });
+};
 
 
 var renderCalculationBetweenTwoMetrics = function(metric1, metric2, element, differenceType, calculationType) {
@@ -398,45 +424,6 @@ Keen.ready(function () {
 
     renderCalculationBetweenTwoMetrics(yesterday_unconfirmed_user_count, week_ago_user_count, "unverified-new-users", 'day', 'subtraction');
 
-
-    //                _        _
-    //  _ __ _ _ ___ (_)___ __| |_ ___
-    // | '_ \ '_/ _ \| / -_) _|  _(_-<
-    // | .__/_| \___// \___\__|\__/__/
-    // |_|         |__/
-
-    // Affiliated Public Projects!
-    var affiliated_public_chart = new Keen.Query("sum", {
-        eventCollection: "institution_summary",
-        targetProperty: "nodes.public",
-        timeframe: "previous_1_days",
-        groupBy: "institution.name",
-        timezone: "UTC"
-    });
-
-    client.draw(affiliated_public_chart, document.getElementById("affiliated-public-projects"), {
-        chartType: "table",
-        height: "auto",
-        width: "auto",
-        title: ' '
-    });
-
-    // Affiliated Private Projects!
-    var affiliated_private_chart = new Keen.Query("sum", {
-        eventCollection: "institution_summary",
-        targetProperty: "nodes.private",
-        timeframe: "previous_1_days",
-        groupBy: "institution.name",
-        timezone: "UTC"
-    });
-
-    client.draw(affiliated_private_chart, document.getElementById("affiliated-private-projects"), {
-        chartType: "table",
-        height: "auto",
-        width: "auto",
-        title: ' '
-    });
-
     // Registrations by Email Domain
     var email_domains = new Keen.Query("count", {
         eventCollection: "user_domain_events",
@@ -578,6 +565,127 @@ Keen.ready(function () {
             i++;
         }
     });
+
+
+//                _        _
+//  _ __ _ _ ___ (_)___ __| |_ ___
+// | '_ \ '_/ _ \| / -_) _|  _(_-<
+// | .__/_| \___// \___\__|\__/__/
+// |_|         |__/
+
+    // Affiliated Public Projects!
+    var affiliated_public_chart = new Keen.Query("sum", {
+        eventCollection: "institution_summary",
+        targetProperty: "nodes.public",
+        timeframe: "previous_1_days",
+        groupBy: "institution.name",
+        timezone: "UTC"
+    });
+
+    client.draw(affiliated_public_chart, document.getElementById("affiliated-public-projects"), {
+        chartType: "table",
+        height: "auto",
+        width: "auto",
+        title: ' '
+    });
+
+    // Affiliated Private Projects!
+    var affiliated_private_chart = new Keen.Query("sum", {
+        eventCollection: "institution_summary",
+        targetProperty: "nodes.private",
+        timeframe: "previous_1_days",
+        groupBy: "institution.name",
+        timezone: "UTC"
+    });
+
+    client.draw(affiliated_private_chart, document.getElementById("affiliated-private-projects"), {
+        chartType: "table",
+        height: "auto",
+        width: "auto",
+        title: ' '
+    });
+
+    // Total Projects
+    var total_projects = new Keen.Query("sum", {
+        eventCollection: "node_summary",
+        targetProperty: "projects.total",
+        timeframe: "previous_1_days",
+        timezone: "UTC"
+    });
+
+    client.draw(total_projects, document.getElementById("total-projects"), {
+        chartType: "metric",
+        title: ' '
+    });
+
+    // Total Public Projects
+    var public_projects = new Keen.Query("sum", {
+        eventCollection: "node_summary",
+        targetProperty: "projects.public",
+        timeframe: "previous_1_days",
+        timezone: "UTC"
+    });
+
+    client.draw(public_projects, document.getElementById("public-projects"), {
+        chartType: "metric",
+        title: ' '
+    });
+
+    // Total Private Projects
+    var private_projects = new Keen.Query("sum", {
+        eventCollection: "node_summary",
+        targetProperty: "projects.private",
+        timeframe: "previous_1_days",
+        timezone: "UTC"
+    });
+
+    client.draw(private_projects, document.getElementById("private-projects"), {
+        chartType: "metric",
+        title: ' '
+    });
+
+    renderPublicPrivatePercent(public_projects, private_projects, "total-projects-pie");
+
+    // Total Nodes
+    var total_nodes = new Keen.Query("sum", {
+        eventCollection: "node_summary",
+        targetProperty: "nodes.total",
+        timeframe: "previous_1_days",
+        timezone: "UTC"
+    });
+
+    client.draw(total_nodes, document.getElementById("total-nodes"), {
+        chartType: "metric",
+        title: ' '
+    });
+
+    // Total Public Nodes
+    var public_nodes = new Keen.Query("sum", {
+        eventCollection: "node_summary",
+        targetProperty: "nodes.public",
+        timeframe: "previous_1_days",
+        timezone: "UTC"
+    });
+
+    client.draw(public_nodes, document.getElementById("public-nodes"), {
+        chartType: "metric",
+        title: ' '
+    });
+
+    // Total Private Nodes
+    var private_nodes = new Keen.Query("sum", {
+        eventCollection: "node_summary",
+        targetProperty: "nodes.private",
+        timeframe: "previous_1_days",
+        timezone: "UTC"
+    });
+
+    client.draw(private_nodes, document.getElementById("private-nodes"), {
+        chartType: "metric",
+        title: ' '
+    });
+
+    renderPublicPrivatePercent(public_nodes, private_nodes, "total-nodes-pie");
 
  //          _    _
  //  __ _ __| |__| |___ _ _  ___

--- a/admin/static/js/metrics/metrics.js
+++ b/admin/static/js/metrics/metrics.js
@@ -21,7 +21,12 @@ var publicClient = new keenAnalysis({
 });
 
 var defaultHeight = 200;
+var bigMetricHeight = 300;
+var defaultColor = '#00BBDE';
+var institutionTableHeight = "auto";
 
+var monthColor = '#0CF5DB';
+var yearColor = '#0CEB92';
 
 /**
  * Configure a timeframe for the past day for a keen query
@@ -91,7 +96,7 @@ var getMetricTitle = function(metric, type) {
 };
 
 
-var differenceGrowthBetweenMetrics = function(metric1, metric2, totalMetric, element) {
+var differenceGrowthBetweenMetrics = function(metric1, metric2, totalMetric, element, colors=null) {
     var percentOne;
     var percentTwo;
     var differenceMetric = new keenDataviz()
@@ -101,7 +106,12 @@ var differenceGrowthBetweenMetrics = function(metric1, metric2, totalMetric, ele
             suffix: '%'
         })
         .title(' ')
+        .height(defaultHeight)
         .prepare();
+
+    if (colors) {
+        differenceMetric.colors([colors]);
+    }
 
     client.run([
         metric1,
@@ -152,7 +162,7 @@ var renderPublicPrivatePercent = function(publicMetric, privateMetric, element) 
 };
 
 
-var renderCalculationBetweenTwoQueries = function(query1, query2, element, differenceType, calculationType) {
+var renderCalculationBetweenTwoQueries = function(query1, query2, element, differenceType, calculationType, colors=null) {
     var result;
     var differenceMetric;
 
@@ -173,6 +183,10 @@ var renderCalculationBetweenTwoQueries = function(query1, query2, element, diffe
             .chartType("metric")
             .title(' ')
             .prepare();
+    }
+
+    if (colors) {
+        differenceMetric.colors([colors]);
     }
 
     differenceMetric.title(getMetricTitle(query1, differenceType));
@@ -221,17 +235,18 @@ var getWeeklyUserGain = function() {
 
 };
 
-var renderKeenMetric = function(element, type, query, height, keenClient) {
+var renderKeenMetric = function(element, type, query, height, colors=null, keenClient=client) {
 
-    if (!keenClient) {
-        keenClient = client;
-    }
     var chart = new keenDataviz()
         .el(element)
         .height(height)
         .title(' ')
         .type(type)
         .prepare();
+
+    if (colors) {
+        chart.colors([colors]);
+    }
 
     keenClient
         .run(query)
@@ -325,9 +340,9 @@ var renderMainCounts = function() {
         timeframe: "previous_800_days",
         timezone: "UTC"
     });
-    renderKeenMetric("#active-user-chart", "line", activeUserChartQuery, defaultHeight);
+    renderKeenMetric("#active-user-chart", "line", activeUserChartQuery, bigMetricHeight);
 
-    renderKeenMetric("#active-user-count", "metric", activeUsersQuery, defaultHeight);
+    renderKeenMetric("#active-user-count", "metric", activeUsersQuery, bigMetricHeight);
 
     // Daily Gain
     var yesterday_user_count = new keenAnalysis.Query("sum", {
@@ -355,7 +370,7 @@ var renderMainCounts = function() {
         targetProperty: "status.active",
         timeframe: getOneDayTimeframe(null, 2)
     });
-    renderCalculationBetweenTwoQueries(last_month_user_count, two_months_ago_user_count, "#monthly-user-increase", 'month', 'subtraction');
+    renderCalculationBetweenTwoQueries(last_month_user_count, two_months_ago_user_count, "#monthly-user-increase", 'month', 'subtraction', monthColor);
 
     var week_ago_user_count = new keenAnalysis.Query("sum", {
         eventCollection: "user_summary",
@@ -370,7 +385,6 @@ var renderMainCounts = function() {
         timeframe: getOneDayTimeframe(1, null)
     });
     renderCalculationBetweenTwoQueries(yesterday_unconfirmed_user_count, week_ago_user_count, "#unverified-new-users", 'week', 'subtraction');
-
 
 };
 
@@ -622,8 +636,6 @@ var InstitutionMetrics = function() {
     // Total Instutional Users / Total OSF Users
     renderCalculationBetweenTwoQueries(institutional_user_count, activeUsersQuery, "#percentage-institutional-users", null, 'percentage');
 
-    var institutionTableHeight = "auto";
-
     // Affiliated Public Nodes
     var affiliated_public_chart = new keenAnalysis.Query("sum", {
         eventCollection: "institution_summary",
@@ -699,11 +711,11 @@ var ActiveUserMetrics = function() {
     renderCalculationBetweenTwoQueries(dailyActiveUsersQuery, activeUsersQuery, "#daily-active-over-total-users", null, "percentage");
 
 
-    renderKeenMetric("#monthly-active-users", "metric", monthlyActiveUsersQuery, defaultHeight);
+    renderKeenMetric("#monthly-active-users", "metric", monthlyActiveUsersQuery, defaultHeight, monthColor);
 
 
     // Monthly Active Users / Total Users
-    renderCalculationBetweenTwoQueries(monthlyActiveUsersQuery, activeUsersQuery, "#monthly-active-over-total-users", null, 'percentage');
+    renderCalculationBetweenTwoQueries(monthlyActiveUsersQuery, activeUsersQuery, "#monthly-active-over-total-users", null, 'percentage', monthColor);
 
 
     // Monthly Growth of MAU% -- Two months ago vs 1 month ago
@@ -713,7 +725,7 @@ var ActiveUserMetrics = function() {
         timeframe: "previous_2_months",
         timezone: "UTC"
     });
-    differenceGrowthBetweenMetrics(twoMonthsAgoActiveUsersQuery, monthlyActiveUsersQuery, activeUsersQuery, "#monthly-active-user-increase", 'day', 'subtraction');
+    differenceGrowthBetweenMetrics(twoMonthsAgoActiveUsersQuery, monthlyActiveUsersQuery, activeUsersQuery, "#monthly-active-user-increase", monthColor);
 
     // Yearly Active Users
     var yearlyActiveUsersQuery = new keenAnalysis.Query("count_unique", {
@@ -722,10 +734,10 @@ var ActiveUserMetrics = function() {
         timeframe: "previous_1_years",
         timezone: "UTC"
     });
-    renderKeenMetric("#yearly-active-users", "metric", yearlyActiveUsersQuery, defaultHeight);
+    renderKeenMetric("#yearly-active-users", "metric", yearlyActiveUsersQuery, defaultHeight, yearColor);
 
     // Yearly Active Users / Total Users
-    renderCalculationBetweenTwoQueries(yearlyActiveUsersQuery, activeUsersQuery, "#yearly-active-over-total-users", null, 'percentage');
+    renderCalculationBetweenTwoQueries(yearlyActiveUsersQuery, activeUsersQuery, "#yearly-active-over-total-users", null, 'percentage', yearColor);
 
     // Average Projects per User
     renderCalculationBetweenTwoQueries(totalProjectsQuery, activeUsersQuery, "#projects-per-user", null, 'division');
@@ -762,7 +774,7 @@ var RawNumberMetrics = function() {
             timezone: "UTC"
         }]
     });
-    renderKeenMetric("#number-of-downloads", "metric", totalDownloadsQuery, defaultHeight, publicClient);
+    renderKeenMetric("#number-of-downloads", "metric", totalDownloadsQuery, defaultHeight, defaultColor, publicClient);
 
     var uniqueDownloadsQuery = new keenAnalysis.Query("count_unique", {
         eventCollection: "file_stats",
@@ -775,7 +787,7 @@ var RawNumberMetrics = function() {
             timezone: "UTC"
         }]
     });
-    renderKeenMetric("#number-of-unique-downloads", "metric", uniqueDownloadsQuery, defaultHeight, publicClient);
+    renderKeenMetric("#number-of-unique-downloads", "metric", uniqueDownloadsQuery, defaultHeight, defaultColor, publicClient);
 
     renderKeenMetric("#total-projects", "metric", totalProjectsQuery, defaultHeight);
 

--- a/admin/static/js/metrics/metrics.js
+++ b/admin/static/js/metrics/metrics.js
@@ -20,6 +20,8 @@ var publicClient = new keenAnalysis({
     readKey: keenPublicReadKey
 });
 
+// Heights and Colors for the below rendered
+// Keen and c3 Data visualizations
 var defaultHeight = 200;
 var bigMetricHeight = 350;
 var institutionTableHeight = "auto";
@@ -28,6 +30,8 @@ var defaultColor = '#00BBDE';
 var monthColor = '#0CF5DB';
 var yearColor = '#0CEB92';
 var dayColor = '#0C93F5';
+var privateColor = '#F20066';
+var publicColor = '#FFD300';
 
 /**
  * Configure a timeframe for the past day for a keen query
@@ -875,8 +879,6 @@ var RawNumberMetrics = function() {
     }
 
     var results = {};
-    var privateColor = '#F20066';
-    var publicColor = '#FFD300';
     Promise.all(graphPromises).then(values => {
         for (var i=0; i<values.length; i++) {
             var chart = new keenDataviz()

--- a/admin/static/js/metrics/metrics.js
+++ b/admin/static/js/metrics/metrics.js
@@ -22,11 +22,12 @@ var publicClient = new keenAnalysis({
 
 var defaultHeight = 200;
 var bigMetricHeight = 300;
-var defaultColor = '#00BBDE';
 var institutionTableHeight = "auto";
 
+var defaultColor = '#00BBDE';
 var monthColor = '#0CF5DB';
 var yearColor = '#0CEB92';
+var dayColor = '#0C93F5';
 
 /**
  * Configure a timeframe for the past day for a keen query

--- a/admin/static/js/metrics/metrics.js
+++ b/admin/static/js/metrics/metrics.js
@@ -243,7 +243,7 @@ var renderNodeLogsForOneUserChart = function(user_id) {
     var chart = new keenDataviz()
         .el('#yesterdays-node-logs-by-user')
         .height(defaultHeight)
-        .title('Individual Logs for ' + '<a href=../users/' + user_id + '>' + user_id + '/</a>')
+        .title('Individual Logs for ' + '<a href=../users/' + user_id + '>' + user_id + '</a>')
         .type('line')
         .prepare();
 
@@ -590,7 +590,7 @@ var InstitutionMetrics = function() {
         timeframe: "previous_100_days",
         timezone: "UTC"
     });
-    renderKeenMetric("#institution-growth", "line", institutional_user_chart, defaultHeight);
+    renderKeenMetric("#institution-growth", "line", institutional_user_chart, 400);
 
 
     // Total Institutional Users

--- a/admin/static/js/metrics/metrics.js
+++ b/admin/static/js/metrics/metrics.js
@@ -182,6 +182,8 @@ var renderCalculationBetweenTwoQueries = function(query1, query2, element, diffe
             result = metricOneResult - metricTwoResult;
         } else if (calculationType === "percentage") {
             result = (metricOneResult/metricTwoResult) * 100;
+        } else if (calculationType === "division") {
+            result = metricOneResult/metricTwoResult;
         }
 
         var data = {
@@ -294,6 +296,13 @@ var dailyActiveUsersQuery = new keenAnalysis.Query("count_unique", {
     target_property: "user.id",
     timeframe: "previous_1_days",
     timezone: "UTC"
+});
+
+var totalProjectsQuery = new keenAnalysis.Query("sum", {
+    eventCollection: "node_summary",
+    targetProperty: "projects.total",
+    timezone: "UTC",
+    timeframe: "previous_1_days",
 });
 
 // <+><+><+><+><+><+
@@ -712,6 +721,12 @@ var ActiveUserMetrics = function() {
     // Yearly Active Users / Total Users
     renderCalculationBetweenTwoQueries(yearlyActiveUsersQuery, activeUsersQuery, "#yearly-active-over-total-users", null, 'percentage');
 
+    // Average Projects per User
+    renderCalculationBetweenTwoQueries(totalProjectsQuery, activeUsersQuery, "#projects-per-user", null, 'division');
+
+    // Average Projects per MAU
+    renderCalculationBetweenTwoQueries(totalProjectsQuery, monthlyActiveUsersQuery, "#projects-per-monthly-user", null, 'division');
+
 };
 
 // <+><+><+><+><+><+><+<+>+
@@ -730,8 +745,10 @@ var HealthyUserMetrics = function() {
 // ><+><+><+><><+><+
 
 var RawNumberMetrics = function() {
+
+    renderKeenMetric("#total-projects", "metric", totalProjectsQuery);
+
     var propertiesAndElements = {
-        'projects.total': '#total-projects',
         'projects.public': '#public-projects',
         'projects.private': '#private-projects',
         'nodes.total': '#total-nodes',

--- a/admin/static/js/metrics/metrics.js
+++ b/admin/static/js/metrics/metrics.js
@@ -21,7 +21,7 @@ var publicClient = new keenAnalysis({
 });
 
 var defaultHeight = 200;
-var bigMetricHeight = 300;
+var bigMetricHeight = 350;
 var institutionTableHeight = "auto";
 
 var defaultColor = '#00BBDE';
@@ -266,7 +266,7 @@ var renderKeenMetric = function(element, type, query, height, colors=null, keenC
 var renderNodeLogsForOneUserChart = function(user_id) {
     var chart = new keenDataviz()
         .el('#yesterdays-node-logs-by-user')
-        .height(defaultHeight)
+        .height(bigMetricHeight)
         .title('Individual Logs for ' + '<a href=../users/' + user_id + '>' + user_id + '</a>')
         .type('line')
         .prepare();
@@ -554,6 +554,7 @@ var NodeLogsPerUser = function() {
     var chart = new keenDataviz()
         .el('#yesterdays-node-logs-by-user')
         .title(' ')
+        .height(bigMetricHeight)
         .chartOptions({
             data: {
                 onclick: function (d, element) {

--- a/admin/static/js/metrics/metrics.js
+++ b/admin/static/js/metrics/metrics.js
@@ -545,7 +545,7 @@ var NodeLogsPerUser = function() {
             chartWithData.dataset.filterColumns(function (column, index) {
                 var logThreshhold = 25;
                 for (var i = 0; i < column.length; i++) {
-                    if (column[i] > logThreshhold && column[0] != 'null') {
+                    if (column[i] > logThreshhold && column[0] != 'null' && column[0] != 'uj57r') {
                         return column;
                     }
                 }

--- a/admin/static/js/metrics/metrics.js
+++ b/admin/static/js/metrics/metrics.js
@@ -638,6 +638,8 @@ var InstitutionMetrics = function() {
     // Total Instutional Users / Total OSF Users
     renderCalculationBetweenTwoQueries(institutional_user_count, activeUsersQuery, "#percentage-institutional-users", null, 'percentage');
 
+    // Nodes!
+
     // Affiliated Public Nodes
     var affiliated_public_chart = new keenAnalysis.Query("sum", {
         eventCollection: "institution_summary",
@@ -679,6 +681,50 @@ var InstitutionMetrics = function() {
         timezone: "UTC"
     });
     renderKeenMetric("#affiliated-embargoed-registered-nodes", "table", affiliated_private_registered_node_chart, institutionTableHeight);
+
+    // Projcets!
+
+    // Affiliated Public Projects
+    var affiliated_public_projects_chart = new keenAnalysis.Query("sum", {
+        eventCollection: "institution_summary",
+        targetProperty: "projects.public",
+        timeframe: "previous_1_days",
+        groupBy: "institution.name",
+        timezone: "UTC"
+    });
+    renderKeenMetric("#affiliated-public-projects", "table", affiliated_public_projects_chart, institutionTableHeight);
+
+
+    // Affiliated Private Projects
+    var affiliated_private_project_chart = new keenAnalysis.Query("sum", {
+        eventCollection: "institution_summary",
+        targetProperty: "projects.private",
+        timeframe: "previous_1_days",
+        groupBy: "institution.name",
+        timezone: "UTC"
+    });
+    renderKeenMetric("#affiliated-private-projects", "table", affiliated_private_project_chart, institutionTableHeight);
+
+
+    // Affiliated Public Projects Registrations
+    var affiliated_public_registered_projects_chart = new keenAnalysis.Query("sum", {
+        eventCollection: "institution_summary",
+        targetProperty: "registered_projects.public",
+        timeframe: "previous_1_days",
+        groupBy: "institution.name",
+        timezone: "UTC"
+    });
+    renderKeenMetric("#affiliated-public-registered-projects", "table", affiliated_public_registered_projects_chart, institutionTableHeight);
+
+    // Affiliated Private Projects Registrations
+    var affiliated_private_registered_projects_chart = new keenAnalysis.Query("sum", {
+        eventCollection: "institution_summary",
+        targetProperty: "registered_projects.private",
+        timeframe: "previous_1_days",
+        groupBy: "institution.name",
+        timezone: "UTC"
+    });
+    renderKeenMetric("#affiliated-embargoed-registered-projects", "table", affiliated_private_registered_projects_chart, institutionTableHeight);
 
 };
 

--- a/admin/static/js/metrics/metrics.js
+++ b/admin/static/js/metrics/metrics.js
@@ -428,7 +428,6 @@ var renderWeeklyUserGainChart = function (results) {
         }
         userGainChart.parseRawData({result: data}).render();
     });
-
 };
 
 
@@ -604,7 +603,6 @@ var UserGainMetrics = function() {
     renderPreviousWeekOfUsersByStatus();
 
     NodeLogsPerUser();
-
 };
 
 
@@ -792,7 +790,6 @@ var ActiveUserMetrics = function() {
 
     // Average Projects per MAU
     renderCalculationBetweenTwoQueries(totalProjectsQuery, monthlyActiveUsersQuery, "#projects-per-monthly-user", null, 'division');
-
 };
 
 // <+><+><+><+><+><+><+<+>+
@@ -917,7 +914,6 @@ var RawNumberMetrics = function() {
             }
         }
     });
-
 };
 
 // <+><+><+><><>+

--- a/admin/static/js/metrics/metrics.js
+++ b/admin/static/js/metrics/metrics.js
@@ -97,7 +97,7 @@ var getMetricTitle = function(metric, type) {
 };
 
 
-var differenceGrowthBetweenMetrics = function(metric1, metric2, totalMetric, element, colors=null) {
+var differenceGrowthBetweenMetrics = function(metric1, metric2, totalMetric, element, colors) {
     var percentOne;
     var percentTwo;
     var differenceMetric = new keenDataviz()
@@ -163,7 +163,7 @@ var renderPublicPrivatePercent = function(publicMetric, privateMetric, element) 
 };
 
 
-var renderCalculationBetweenTwoQueries = function(query1, query2, element, differenceType, calculationType, colors=null) {
+var renderCalculationBetweenTwoQueries = function(query1, query2, element, differenceType, calculationType, colors) {
     var result;
     var differenceMetric;
 
@@ -221,7 +221,8 @@ var getWeeklyUserGain = function() {
     var queries = [];
     var timeframes = [];
 
-    for (var i = 3; i < 12; i++) {
+    // get timeframes from 1 day back through 7 days back for the full week
+    for (var i = 1; i < 8; i++) {
         var timeframe = getOneDayTimeframe(i, null);
         var query = new keenAnalysis.Query("sum", {
             eventCollection: "user_summary",
@@ -236,7 +237,11 @@ var getWeeklyUserGain = function() {
 
 };
 
-var renderKeenMetric = function(element, type, query, height, colors=null, keenClient=client) {
+var renderKeenMetric = function(element, type, query, height, colors, keenClient) {
+
+    if (!keenClient) {
+        keenClient = client;
+    }
 
     var chart = new keenDataviz()
         .el(element)

--- a/admin/static/js/metrics/metrics.js
+++ b/admin/static/js/metrics/metrics.js
@@ -355,6 +355,8 @@ var renderMainCounts = function() {
         timeframe: getOneDayTimeframe(1, null)
     });
     renderCalculationBetweenTwoQueries(yesterday_unconfirmed_user_count, week_ago_user_count, "#unverified-new-users", 'week', 'subtraction');
+
+
 };
 
 //  Weekly User Gain metric
@@ -657,6 +659,16 @@ var InstitutionMetrics = function() {
 
 
 var ActiveUserMetrics = function() {
+
+    // Recent Daily Unique Sessions
+    var recentDailyUniqueSessions = new keenAnalysis.Query("count_unique", {
+        eventCollection: "pageviews",
+        targetProperty: "visitor.session",
+        interval: "daily",
+        timeframe: "previous_14_days",
+        timezone: "UTC"
+    });
+    renderKeenMetric("#recent-daily-unique-sessions", "line", recentDailyUniqueSessions);
 
     // Daily Active Users
     var dailyActiveUsersQuery = new keenAnalysis.Query("count_unique", {

--- a/admin/static/js/metrics/metrics.js
+++ b/admin/static/js/metrics/metrics.js
@@ -723,7 +723,8 @@ Keen.ready(function () {
 
     client.draw(public_projects, document.getElementById("public-projects"), {
         chartType: "metric",
-        title: ' '
+        title: ' ',
+        colors: ["#00BBDE"]
     });
 
     // Total Private Projects
@@ -736,7 +737,8 @@ Keen.ready(function () {
 
     client.draw(private_projects, document.getElementById("private-projects"), {
         chartType: "metric",
-        title: ' '
+        title: ' ',
+        colors: ["#FE6672"]
     });
 
     renderPublicPrivatePercent(public_projects, private_projects, "total-projects-pie");
@@ -764,7 +766,8 @@ Keen.ready(function () {
 
     client.draw(public_nodes, document.getElementById("public-nodes"), {
         chartType: "metric",
-        title: ' '
+        title: ' ',
+        colors: ["#00BBDE"]
     });
 
     // Total Private Nodes
@@ -777,7 +780,8 @@ Keen.ready(function () {
 
     client.draw(private_nodes, document.getElementById("private-nodes"), {
         chartType: "metric",
-        title: ' '
+        title: ' ',
+        colors: ["#FE6672"]
     });
 
     renderPublicPrivatePercent(public_nodes, private_nodes, "total-nodes-pie");
@@ -806,7 +810,8 @@ Keen.ready(function () {
 
     client.draw(public_registered_projects, document.getElementById("public-registered-projects"), {
         chartType: "metric",
-        title: ' '
+        title: ' ',
+        colors: ["#00BBDE"]
     });
 
     // Total Embargoed Registered Projects
@@ -819,7 +824,8 @@ Keen.ready(function () {
 
     client.draw(embargoed_registered_projects, document.getElementById("embargoed-registered-projects"), {
         chartType: "metric",
-        title: ' '
+        title: ' ',
+        colors: ["#FE6672"]
     });
 
     renderPublicPrivatePercent(public_registered_projects, embargoed_registered_projects, "total-registered-projects-pie");
@@ -847,7 +853,8 @@ Keen.ready(function () {
 
     client.draw(public_registered_nodes, document.getElementById("public-registered-nodes"), {
         chartType: "metric",
-        title: ' '
+        title: ' ',
+        colors: ["#00BBDE"]
     });
 
     // Total Embargoed Nodes
@@ -860,7 +867,8 @@ Keen.ready(function () {
 
     client.draw(embargoed_registered_nodes, document.getElementById("embargoed-registered-nodes"), {
         chartType: "metric",
-        title: ' '
+        title: ' ',
+        colors: ["#FE6672"]
     });
 
     renderPublicPrivatePercent(public_registered_nodes, embargoed_registered_nodes, "total-registered-nodes-pie");

--- a/admin/static/js/metrics/metrics.js
+++ b/admin/static/js/metrics/metrics.js
@@ -82,7 +82,7 @@ var getMetricTitle = function(metric, type) {
 
         if (type === "month") {
             date = new Date(metric.params.timeframe.start);
-            title =  monthNames[date.getUTCMonth()] + " to " + monthNames[date.getUTCMonth() + 1];
+            title =  monthNames[date.getUTCMonth()] + " to " + monthNames[(date.getUTCMonth() + 1)%12];
         } else if (type === "day") {
             date = metric.params.timeframe.start.replace('T00:00:00.000Z', '');
             end = metric.params.timeframe.end.replace('T00:00:00.000Z', '');

--- a/admin/static/js/metrics/metrics.js
+++ b/admin/static/js/metrics/metrics.js
@@ -782,6 +782,8 @@ var RawNumberMetrics = function() {
     }
 
     var results = {};
+    var privateColor = '#F20066';
+    var publicColor = '#FFD300';
     Promise.all(graphPromises).then(values => {
         for (var i=0; i<values.length; i++) {
             var chart = new keenDataviz()
@@ -791,6 +793,11 @@ var RawNumberMetrics = function() {
                 .type('metric')
                 .prepare();
 
+            if (values[i].query.target_property.includes('public')) {
+                chart.colors([publicColor]);
+            } else if (values[i].query.target_property.includes('private')) {
+                chart.colors([privateColor]);
+            }
             chart.data(values[i]).render();
 
             var targetProperty = values[i].query.target_property.toString();
@@ -809,6 +816,10 @@ var RawNumberMetrics = function() {
                             ['public', results[publicData]],
                             ['private', results[privateData]],
                         ],
+                        colors: {
+                            public: publicColor,
+                            private: privateColor
+                        },
                         type : 'pie',
                     }
                 });

--- a/admin/static/js/pages/metrics-page.js
+++ b/admin/static/js/pages/metrics-page.js
@@ -1,0 +1,33 @@
+'use strict';
+
+var $  = require('jquery');
+var keenAnalysis = require('keen-analysis');
+var Metrics = require('js/metrics/metrics');
+
+
+
+keenAnalysis.ready(function() {
+
+    Metrics.UserGainMetrics();
+
+    $('#reload-node-logs')[0].onclick = function() {
+        Metrics.NodeLogsPerUser();
+    };
+
+    $('#institution-tab')[0].onclick = function() {
+        Metrics.InstitutionMetrics();
+    };
+
+    $('#active-user-tab')[0].onclick = function() {
+        Metrics.ActiveUserMetrics();
+    };
+
+    $('#healthy-user-tab')[0].onclick = function() {
+        Metrics.HealthyUserMetrics();
+    };
+
+    $('#raw-numbers-tab')[0].onclick = function() {
+        Metrics.RawNumberMetrics();
+    };
+
+});

--- a/admin/static/js/pages/metrics-page.js
+++ b/admin/static/js/pages/metrics-page.js
@@ -29,5 +29,8 @@ keenAnalysis.ready(function() {
     $('#raw-numbers-tab')[0].onclick = function() {
         Metrics.RawNumberMetrics();
     };
+    $('#addons-tab')[0].onclick = function() {
+        Metrics.AddonMetrics();
+    };
 
 });

--- a/admin/templates/base.html
+++ b/admin/templates/base.html
@@ -123,7 +123,6 @@
             <li><a href="{% url 'pre_reg:prereg' %}"><i class='fa fa-link'></i> <span>OSF Prereg</span></a></li>
             {% endif %}
             <li><a href="{% url 'metrics:metrics' %}"><i class='fa fa-link'></i> <span>OSF Metrics</span></a></li>
-            <li><a href="{% url 'sales_analytics:dashboard' %}"><i class='fa fa-link'></i> <span>OSF Sales Analytics</span></a></li>
           </ul><!-- /.sidebar-menu -->
         </section>
         <!-- /.sidebar -->

--- a/admin/templates/metrics/osf_metrics.html
+++ b/admin/templates/metrics/osf_metrics.html
@@ -408,26 +408,33 @@
                 <h2>Coming soon!</h2>
             </div>
             <div role="tabpanel" class="tab-pane" id="raw-numbers">
-                <h3>Raw Numbers</h3>
-
-                <div class="dropdown">
-                    <button class="btn btn-default btn-large dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown">
-                        Jump to...
-                        <span class="caret"></span>
-                    </button>
-                    <ul class="dropdown-menu">
-                        <li><a href="#downloads">Downloads</a></li>
-                        <li><a href="#projects">Projects - Top Level</a></li>
-                        <li><a href="#nodes">Nodes - Projects & Components</a></li>
-                        <li><a href="#registered-projects">Registered Projects</a></li>
-                        <li><a href="#registered-nodes">Registered Nodes</a></li>
-                    </ul>
-                </div>
-
-
                 <div class="container-fluid">
+
                     <div class="row">
-                        <h3 id="downloads">Downloads</h3>
+                        <div class="col-sm-3">
+                            <h3>Raw Numbers</h3>
+                        </div>
+                        <div class="col-sm-9">
+                            <div class="dropdown">
+                                <button class="btn btn-default btn-large dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown">
+                                    Jump to...
+                                    <span class="caret"></span>
+                                </button>
+                                <ul class="dropdown-menu">
+                                    <li><a href="#downloads">Downloads</a></li>
+                                    <li><a href="#projects">Projects - Top Level</a></li>
+                                    <li><a href="#nodes">Nodes - Projects & Components</a></li>
+                                    <li><a href="#registered-projects">Registered Projects</a></li>
+                                    <li><a href="#registered-nodes">Registered Nodes</a></li>
+                                </ul>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="row" id="downloads">
+                        <h3>Downloads</h3>
+                    </div>
+                    <div class="row">
                         <div class="col-sm-6">
                             <div class="chart-wrapper">
                                 <div class="chart-title">
@@ -455,8 +462,10 @@
                             </div>
                         </div>
                     </div>
+                    <div class="row" id="projects">
+                        <h3>Projects</h3>
+                    </div>
                     <div class="row">
-                        <h3 id="projects">Projects</h3>
                         <div class="col-sm-12">
                             <div class="chart-wrapper">
                                 <div class="chart-title">
@@ -518,8 +527,10 @@
                             </div>
                         </div>
                     </div>
+                    <div class="row" id="nodes">
+                        <h3>Nodes</h3>
+                    </div>
                     <div class="row">
-                        <h3 id="nodes">Nodes</h3>
                         <div class="col-sm-12">
                             <div class="chart-wrapper">
                                 <div class="chart-title">
@@ -581,8 +592,11 @@
                             </div>
                         </div>
                     </div>
+                    <div class="row" id="registered-projects">
+                        <h3>Registered Projects</h3>
+                    </div>
                     <div class="row">
-                        <div class="col-sm-6 col-md-4">
+                        <div class="col-sm-12">
                             <div class="chart-wrapper">
                                 <div class="chart-title">
                                     Total Registered Projects
@@ -595,131 +609,123 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="col-sm-6 col-md-4">
-                            <div class="chart-wrapper">
-                                <div class="chart-title">
-                                    Total Public Registered Projects
+                    </div>
+                    <div class="row">
+                        <div class="col-sm-6">
+                            <div class="row">
+                                <div class="col-sm-12">
+                                    <div class="chart-wrapper">
+                                        <div class="chart-title">
+                                            Public Registered Projects
+                                        </div>
+                                        <div class="chart-stage">
+                                            <div id="public-registered-projects"></div>
+                                        </div>
+                                        <div class="chart-notes">
+                                            The total number of public registered top level projects
+                                        </div>
+                                    </div>
                                 </div>
-                                <div class="chart-stage">
-                                    <div id="total-registered-public-projects"></div>
-                                </div>
-                                <div class="chart-notes">
-                                    The number of all public registered top level projects on the OSF.
+                            </div>
+                            <div class="row">
+                                <div class="col-sm-12">
+                                    <div class="chart-wrapper">
+                                        <div class="chart-title">
+                                            Embargoed Registered Projects
+                                        </div>
+                                        <div class="chart-stage">
+                                            <div id="embargoed-registered-projects"></div>
+                                        </div>
+                                        <div class="chart-notes">
+                                            The number of private registered top level projects
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
                         </div>
-                        <div class="col-sm-6 col-md-4">
+                        <div class="col-sm-6">
                             <div class="chart-wrapper">
                                 <div class="chart-title">
-                                    Total Private Nodes
+                                    Public vs Embargoed Registered Top-Level Projects
                                 </div>
                                 <div class="chart-stage">
-                                    <div id="total-registered-private-projects"></div>
+                                    <div id="total-registered-projects-pie"></div>
                                 </div>
                                 <div class="chart-notes">
-                                    The number of all private projects and components of all levels on the OSF
+                                    The percentages of public vs embargoed top-level project registrations on the OSF.
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row" id="registered-nodes">
+                        <h3>Registered Nodes</h3>
+                    </div>
+                    <div class="row">
+                        <div class="col-sm-12">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    Total Registered Nodes - Projects & Components
+                                </div>
+                                <div class="chart-stage">
+                                    <div id="total-registered-nodes"></div>
+                                </div>
+                                <div class="chart-notes">
+                                    The total number of all registered nodes - projects & components on the OSF.
                                 </div>
                             </div>
                         </div>
                     </div>
                     <div class="row">
-                        <div class="col-sm-6 col-md-4">
-                            <div class="chart-wrapper">
-                                <div class="chart-title">
-                                    Total Registered Nodes
+                        <div class="col-sm-6">
+                            <div class="row">
+                                <div class="col-sm-12">
+                                    <div class="chart-wrapper">
+                                        <div class="chart-title">
+                                            Public Registered Nodes
+                                        </div>
+                                        <div class="chart-stage">
+                                            <div id="public-registered-nodes"></div>
+                                        </div>
+                                        <div class="chart-notes">
+                                            The total number of public registered nodes - projects & components
+                                        </div>
+                                    </div>
                                 </div>
-                                <div class="chart-stage">
-                                    <div id="number-of-registered-nodes"></div>
-                                </div>
-                                <div class="chart-notes">
-                                    The total number of all registered projects and components on the OSF.
+                            </div>
+                            <div class="row">
+                                <div class="col-sm-12">
+                                    <div class="chart-wrapper">
+                                        <div class="chart-title">
+                                            Embargoed Registered Nodes
+                                        </div>
+                                        <div class="chart-stage">
+                                            <div id="embargoed-registered-nodes"></div>
+                                        </div>
+                                        <div class="chart-notes">
+                                            The number of embargoed registered projects and components
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
                         </div>
-                        <div class="col-sm-6 col-md-4">
+                        <div class="col-sm-6">
                             <div class="chart-wrapper">
                                 <div class="chart-title">
-                                    Total Public Registered Nodes
+                                    Public vs Embargoed Registered Nodes
                                 </div>
                                 <div class="chart-stage">
-                                    <div id="total-registered-public-nodes"></div>
+                                    <div id="total-registered-nodes-pie"></div>
                                 </div>
                                 <div class="chart-notes">
-                                    The number of all registered public projects and components of all levels on the OSF
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-sm-6 col-md-4">
-                            <div class="chart-wrapper">
-                                <div class="chart-title">
-                                    Total Private Registered Nodes
-                                </div>
-                                <div class="chart-stage">
-                                    <div id="total-registered-private-nodes"></div>
-                                </div>
-                                <div class="chart-notes">
-                                    The number of all registered private projects and components of all levels on the OSF
+                                    The percentages of public vs embargoed top-level project registrations on the OSF.
                                 </div>
                             </div>
                         </div>
                     </div>
-
                 </div>
             </div>
         </div>
     </div>
-
-
-
-
-
-    <div><h2>User Data</h2></div>
-    <div>
-        <h3>Yearly Active Users / Total Users</h3>
-        <div id="yearly-active-over-total-users">Loading...</div>
-    </div>
-
-    <div class="row">
-        <div class="col-md-12">
-            <h3>User Gain Per Day</h3>
-            <div id="user-gain-chart">Loading...</div>
-        </div>
-    </div>
-
-    <div class="row">
-        <div class="col-md-12" id="active_users_over_time">
-            <h3>Active Users Over Time</h3>
-            <div id="active-user-chart">Loading...</div>
-        </div>
-    </div>
-
-    <div class="row" id="affiliated_projects">
-        <div class="col-md-6">
-            <h3>Affiliated Public projects by Institution</h3>
-            <div id="affiliated-public-projects">Loading...</div>
-        </div>
-
-        <div class="col-md-6">
-            <h3>Affiliated Private projects by Institution</h3>
-            <div id="affiliated-private-projects">Loading...</div>
-        </div>
-    </div>
-
-
-
-    <div id="users_by_status">
-        <h3>Previous 7 days of users by status</h3>
-        <div id="previous-7-days-of-users-by-status">Loading...</div>
-    </div>
-
-    <div id="linked_addon_by_name">
-        <h3>Previous 7 days of linked addon by addon name</h3>
-        <div id="previous-7-days-of-linked-addon-by-addon-name">Loading...</div>
-    </div>
-
-
-
-
 
 {% endblock content %}
 

--- a/admin/templates/metrics/osf_metrics.html
+++ b/admin/templates/metrics/osf_metrics.html
@@ -23,10 +23,10 @@
     <div>
         <!-- Nav tabs -->
         <ul class="nav nav-tabs" role="tablist">
-            <li role="presentation" class="active"><a href="#user-data" role="tab" data-toggle="tab">User Data</a></li>
-            <li role="presentation"><a href="#institution-metrics" role="tab" data-toggle="tab">Institution Metrics</a></li>
-            <li role="presentation"><a href="#active-user-metrics" role="tab" data-toggle="tab">Active User Metrics</a></li>
-            <li role="presentation"><a href="#healthy-user-metrics" role="tab" data-toggle="tab">Healthy User Metrics</a></li>
+            <li role="presentation" class="active" id="user-tab"><a href="#user-data" role="tab" data-toggle="tab">User Data</a></li>
+            <li role="presentation" id="institution-tab"><a href="#institution-metrics" role="tab" data-toggle="tab">Institution Metrics</a></li>
+            <li role="presentation" id="active-user-tab"><a href="#active-user-metrics" role="tab" data-toggle="tab">Active User Metrics</a></li>
+            <li role="presentation" id="healthy-user-tab"><a href="#healthy-user-metrics" role="tab" data-toggle="tab">Healthy User Metrics</a></li>
             <li role="presentation" id="raw-numbers-tab"><a href="#raw-numbers" role="tab" data-toggle="tab">Raw Numbers</a></li>
         </ul>
 
@@ -735,5 +735,5 @@
 
 
 {% block bottom_js %}
-    <script src="{% static 'public/js/metrics.js' %}"></script>
+    <script src="{% static 'public/js/metrics-page.js' %}"></script>
 {% endblock %}

--- a/admin/templates/metrics/osf_metrics.html
+++ b/admin/templates/metrics/osf_metrics.html
@@ -35,112 +35,108 @@
         <div class="tab-content">
             <div role="tabpanel" class="tab-pane active" id="user-data">
                 <h3>User Data</h3>
-                <div class="row">
-                    <div class="col-sm-8">
-                        <div class="chart-wrapper">
-                            <div class="chart-title">
-                                User Growth
+
+                <div class="container-fluid">
+
+                    <div class="row">
+                        <div class="col-sm-8">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    User Growth
+                                </div>
+                                <div class="chart-stage">
+                                    <div id="active-user-chart"></div>
+                                </div>
+                                <div class="chart-notes">
+                                    The growth of OSF Confirmed Users over the past 800 days.
+                                </div>
                             </div>
-                            <div class="chart-stage">
-                                <div id="active-user-chart"></div>
-                            </div>
-                            <div class="chart-notes">
-                                The growth of OSF Confirmed Users over the past 800 days.
+                        </div>
+                        <div class="col-sm-4">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    Total Users
+                                </div>
+                                <div class="chart-stage">
+                                    <div id="active-user-count"></div>
+                                </div>
+                                <div class="chart-notes">
+                                    This is the total number of OSF Users with confirmed accounts.
+                                </div>
                             </div>
                         </div>
                     </div>
-                    <div class="col-sm-4">
-                        <div class="chart-wrapper">
-                            <div class="chart-title">
-                                Total Users
+
+                    <div class="row">
+                        <div class="col-sm-6 col-md-4">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    Monthly User Increase
+                                </div>
+                                <div class="chart-stage">
+                                    <div id="monthly-user-increase"></div>
+                                </div>
+                                <div class="chart-notes">
+                                    The number of users gained in the past month.
+                                </div>
                             </div>
-                            <div class="chart-stage">
-                                <div id="active-user-count"></div>
+                        </div>
+                        <div class="col-sm-6 col-md-4">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    Daily User Increase
+                                </div>
+                                <div class="chart-stage">
+                                    <div id="daily-user-increase"></div>
+                                </div>
+                                <div class="chart-notes">
+                                    The number of users gained from two days ago until yesterday.
+                                </div>
                             </div>
-                            <div class="chart-notes">
-                                This is the total number of OSF Users with confirmed accounts.
+                        </div>
+                        <div class="col-sm-6 col-md-4">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    Average Daily User Gain
+                                </div>
+                                <div class="chart-stage">
+                                    <div id="average-gain-metric"></div>
+                                </div>
+                                <div class="chart-notes">
+                                    The average daily user gain over the past 7 days.
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-sm-6 col-md-4">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    Unverified New Users
+                                </div>
+                                <div class="chart-stage">
+                                    <div id="unverified-new-users"></div>
+                                </div>
+                                <div class="chart-notes">
+                                    Users created within the last 7 days that have not been confirmed.
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-sm-8">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    User Growth
+                                </div>
+                                <div class="chart-stage">
+                                    <div id="previous-7-days-of-users-by-status"></div>
+                                </div>
+                                <div class="chart-notes">
+                                    The last 7 days of users, organized by status.
+                                </div>
                             </div>
                         </div>
                     </div>
                 </div>
-
-                <div class="row">
-                    <div class="col-sm-6 col-md-4">
-                        <div class="chart-wrapper">
-                            <div class="chart-title">
-                                Monthly User Increase
-                            </div>
-                            <div class="chart-stage">
-                                <div id="monthly-user-increase"></div>
-                            </div>
-                            <div class="chart-notes">
-                                The number of users gained in the past month.
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-sm-6 col-md-4">
-                        <div class="chart-wrapper">
-                            <div class="chart-title">
-                                Cell Title
-                            </div>
-                            <div class="chart-stage">
-                            </div>
-                            <div class="chart-notes">
-                                Notes about this chart
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-sm-6 col-md-4">
-                        <div class="chart-wrapper">
-                            <div class="chart-title">
-                                Cell Title
-                            </div>
-                            <div class="chart-stage">
-                            </div>
-                            <div class="chart-notes">
-                                Notes about this chart
-                            </div>
-                        </div>
-                    </div>
-                    <!-- end of three -->
-                    <div class="col-sm-6 col-md-4">
-                        <div class="chart-wrapper">
-                            <div class="chart-title">
-                                Cell Title
-                            </div>
-                            <div class="chart-stage">
-                            </div>
-                            <div class="chart-notes">
-                                Notes about this chart
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-sm-6 col-md-4">
-                        <div class="chart-wrapper">
-                            <div class="chart-title">
-                                Cell Title
-                            </div>
-                            <div class="chart-stage">
-                            </div>
-                            <div class="chart-notes">
-                                Notes about this chart
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-sm-6 col-md-4">
-                        <div class="chart-wrapper">
-                            <div class="chart-title">
-                                Cell Title
-                            </div>
-                            <div class="chart-stage">
-                            </div>
-                            <div class="chart-notes">
-                                Notes about this chart
-                            </div>
-                        </div>
-                    </div>
-                </div>
-
             </div>
 
 
@@ -176,12 +172,54 @@
                     <div class="col-sm-6 col-md-4">
                         <div class="chart-wrapper">
                             <div class="chart-title">
-                                Cell Title
+                                Monthly Active Users (MAU)
                             </div>
                             <div class="chart-stage">
+                                <div id="monthly-active-users"></div>
                             </div>
                             <div class="chart-notes">
-                                Notes about this chart
+                                Users who visited at least one page on the OSF from last month.
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-sm-6 col-md-4">
+                        <div class="chart-wrapper">
+                            <div class="chart-title">
+                                 Last Month's Active Users / Total Users
+                            </div>
+                            <div class="chart-stage">
+                                <div id="monthly-active-over-total-users"></div>
+                            </div>
+                            <div class="chart-notes">
+                                Last month's active users / total confirmed users
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-sm-6 col-md-4">
+                        <div class="chart-wrapper">
+                            <div class="chart-title">
+                                Monthly Growth of MAU%
+                            </div>
+                            <div class="chart-stage">
+                                <div id="monthly-active-user-increase"></div>
+                            </div>
+                            <div class="chart-notes">
+                                The percent increase from two months ago to one month ago of what percentage of users with an account were active on the OSF.
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-sm-6 col-md-4">
+                        <div class="chart-wrapper">
+                            <div class="chart-title">
+                                Yearly Active Users
+                            </div>
+                            <div class="chart-stage">
+                                <div id="yearly-active-users"></div>
+                            </div>
+                            <div class="chart-notes">
+                                Users who were active on the OSF over the past year.
                             </div>
                         </div>
                     </div>
@@ -197,7 +235,134 @@
                 Cohorts
             </div>
             <div role="tabpanel" class="tab-pane" id="raw-numbers">
-                Raw Numbers
+                <h3>Raw Numbers</h3>
+
+                <div class="container-fluid">
+
+                    <div class="row">
+                        <div class="col-sm-6 col-md-4">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    Cell Title
+                                </div>
+                                <div class="chart-stage">
+                                    <div id="grid-1-1">
+                                        <img data-src="holder.js/100%x180/white/text:#grid-1-1">
+                                    </div>
+                                </div>
+                                <div class="chart-notes">
+                                    Notes about this chart
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-sm-6 col-md-4">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    Cell Title
+                                </div>
+                                <div class="chart-stage">
+                                    <img data-src="holder.js/100%x180/white">
+                                </div>
+                                <div class="chart-notes">
+                                    Notes about this chart
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-sm-6 col-md-4">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    Cell Title
+                                </div>
+                                <div class="chart-stage">
+                                    <img data-src="holder.js/100%x180/white">
+                                </div>
+                                <div class="chart-notes">
+                                    Notes about this chart
+                                </div>
+                            </div>
+                        </div>
+                        <!-- end of three -->
+                        <div class="col-sm-6 col-md-4">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    Cell Title
+                                </div>
+                                <div class="chart-stage">
+                                    <img data-src="holder.js/100%x180/white">
+                                </div>
+                                <div class="chart-notes">
+                                    Notes about this chart
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-sm-6 col-md-4">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    Cell Title
+                                </div>
+                                <div class="chart-stage">
+                                    <img data-src="holder.js/100%x180/white">
+                                </div>
+                                <div class="chart-notes">
+                                    Notes about this chart
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-sm-6 col-md-4">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    Cell Title
+                                </div>
+                                <div class="chart-stage">
+                                    <img data-src="holder.js/100%x180/white">
+                                </div>
+                                <div class="chart-notes">
+                                    Notes about this chart
+                                </div>
+                            </div>
+                        </div>
+                        <!-- end of three -->
+                        <div class="col-sm-6 col-md-4">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    Cell Title
+                                </div>
+                                <div class="chart-stage">
+                                    <img data-src="holder.js/100%x180/white">
+                                </div>
+                                <div class="chart-notes">
+                                    Notes about this chart
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-sm-6 col-md-4">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    Cell Title
+                                </div>
+                                <div class="chart-stage">
+                                    <img data-src="holder.js/100%x180/white">
+                                </div>
+                                <div class="chart-notes">
+                                    Notes about this chart
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-sm-6 col-md-4">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    Cell Title
+                                </div>
+                                <div class="chart-stage">
+                                    <img data-src="holder.js/100%x180/white">
+                                </div>
+                                <div class="chart-notes">
+                                    Notes about this chart
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
@@ -221,51 +386,6 @@
     </div>
 
     <div><h2>User Data</h2></div>
-
-    <div id="active_users">
-        <h3>Yesterday's Total Users with Active Accounts</h3>
-        <div id="active-user-count">Loading...</div>
-    </div>
-    <div id="active_users">
-        <h3>Daily Increase of Users</h3>
-        <div id="daily-user-increase">Loading...</div>
-    </div>
-    <div id="active_users">
-        <h3>Monthly Increase of Users</h3>
-        <div id="monthly-user-increase">Loading...</div>
-    </div>
-    <div id="active_users">
-        <h3>Average Daily Gain Over past 7 Days</h3>
-        <div id="average-gain-metric">Loading...</div>
-    </div>
-
-    <div>
-        <h3>Yesterday's Active Logged In Users</h3>
-        <div id="daily-active-users">Loading...</div>
-    </div>
-
-    <div>
-        <h3>Active Users / Total Users</h3>
-        <div id="daily-active-over-total-users">Loading...</div>
-    </div>
-
-    <div>
-        <h3>Last Month's Active Logged In Users</h3>
-        <div id="monthly-active-users">Loading...</div>
-    </div>
-
-    <div>
-        <h3>Last Month's Active Users / Total Users</h3>
-        <div id="monthly-active-over-total-users">Loading...</div>
-    </div>
-    <div>
-        <h3>Monthly growth of MAU%</h3>
-        <div id="monthly-active-user-increase">Loading...</div>
-    </div>
-    <div>
-        <h3>Yearly Active Logged In Users</h3>
-        <div id="yearly-active-users">Loading...</div>
-    </div>
     <div>
         <h3>Yearly Active Users / Total Users</h3>
         <div id="yearly-active-over-total-users">Loading...</div>

--- a/admin/templates/metrics/osf_metrics.html
+++ b/admin/templates/metrics/osf_metrics.html
@@ -27,8 +27,6 @@
             <li role="presentation"><a href="#institution-metrics" role="tab" data-toggle="tab">Institution Metrics</a></li>
             <li role="presentation"><a href="#active-user-metrics" role="tab" data-toggle="tab">Active User Metrics</a></li>
             <li role="presentation"><a href="#healthy-user-metrics" role="tab" data-toggle="tab">Healthy User Metrics</a></li>
-            <li role="presentation"><a href="#expansion-metrics" role="tab" data-toggle="tab">Expansion Metrics</a></li>
-            <li role="presentation"><a href="#cohorts" role="tab" data-toggle="tab">Cohorts</a></li>
             <li role="presentation"><a href="#raw-numbers" role="tab" data-toggle="tab">Raw Numbers</a></li>
         </ul>
 
@@ -172,24 +170,10 @@
                             <div class="chart-wrapper">
                                 <div class="chart-title">
                                     Yesterday's Node logs by user
+                                    <button type="button" class="btn btn-default btn-xs" id="reload-node-logs">reload</button>
                                 </div>
                                 <div class="chart-stage">
                                     <div id="yesterdays-node-logs-by-user"></div>
-                                </div>
-                                <div class="chart-notes">
-                                    The last day of node logs by user, if a user had over 100 node logs.
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="row">
-                        <div class="col-sm-12">
-                            <div class="chart-wrapper">
-                                <div class="chart-title">
-                                    Yesterday's Node logs by user
-                                </div>
-                                <div class="chart-stage">
-                                    <div id="yesterdays-node-logs-by-user-c3-experiment"></div>
                                 </div>
                                 <div class="chart-notes">
                                     The last day of node logs by user, if a user had over 100 node logs.
@@ -246,6 +230,21 @@
                         </div>
                     </div>
 
+                </div>
+                <div class="row">
+                    <div class="col-sm-12">
+                        <div class="chart-wrapper">
+                            <div class="chart-title">
+                                Affiliated Nodes Test
+                            </div>
+                            <div class="chart-stage">
+                                <div id="affiliated-nodes-test"></div>
+                            </div>
+                            <div class="chart-notes">
+                                Total number of public nodes (at all levels, projects and components) created by each institution as of yesterday.
+                            </div>
+                        </div>
+                    </div>
                 </div>
                 <div class="row">
                     <div class="col-sm-6">
@@ -412,14 +411,6 @@
                     <h3>Stickiness Ratio</h3>
                     <div id="stickiness-ratio">Loading...</div>
                 </div>
-            </div>
-            <div role="tabpanel" class="tab-pane" id="expansion-metrics">
-                <h3>Expansion Metrics</h3>
-                <h2>Coming Soon!</h2>
-            </div>
-            <div role="tabpanel" class="tab-pane" id="cohorts">
-                <h3>Cohorts</h3>
-                <h2>Coming soon!</h2>
             </div>
             <div role="tabpanel" class="tab-pane" id="raw-numbers">
                 <div class="container-fluid">
@@ -732,6 +723,21 @@
                                 </div>
                                 <div class="chart-notes">
                                     The percentages of public vs embargoed top-level project registrations on the OSF.
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-sm-12">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    Pevious 7 days of addon by name
+                                </div>
+                                <div class="chart-stage">
+                                    <div id="previous-7-days-of-linked-addon-by-addon-name"></div>
+                                </div>
+                                <div class="chart-notes">
+                                    The total number of all registered nodes - projects & components on the OSF.
                                 </div>
                             </div>
                         </div>

--- a/admin/templates/metrics/osf_metrics.html
+++ b/admin/templates/metrics/osf_metrics.html
@@ -41,7 +41,7 @@
                         <div class="col-sm-8">
                             <div class="chart-wrapper">
                                 <div class="chart-title">
-                                    User Growth
+                                    User Growth - Previous 800 days
                                 </div>
                                 <div class="chart-stage">
                                     <div id="active-user-chart"></div>
@@ -139,13 +139,13 @@
                         <div class="col-sm-8">
                             <div class="chart-wrapper">
                                 <div class="chart-title">
-                                    User Growth
+                                    User Growth over the Last Seven Days
                                 </div>
                                 <div class="chart-stage">
                                     <div id="previous-7-days-of-users-by-status"></div>
                                 </div>
                                 <div class="chart-notes">
-                                    The last 7 days of users, organized by status.
+                                    The last 7 days of users, organized by status. Click a category in the legend to resize the axes.
                                 </div>
                             </div>
                         </div>
@@ -225,7 +225,7 @@
                                 <div id="institution-growth"></div>
                             </div>
                             <div class="chart-notes">
-                                The growth of users who have accounts associated with their institutions.
+                                The growth of users who have accounts associated with their institutions. Click on an institution name in the key to remove its line and resize the chart axes.
                             </div>
                         </div>
                     </div>

--- a/admin/templates/metrics/osf_metrics.html
+++ b/admin/templates/metrics/osf_metrics.html
@@ -192,7 +192,7 @@
                             <div class="chart-wrapper">
                                 <div class="chart-title">
                                     Yesterday's Node logs by user
-                                    <button type="button" class="btn btn-default btn-xs" id="reload-node-logs">reload</button>
+                                    <a id="reload-node-logs" class="glyphicon glyphicon-refresh"></a>
                                 </div>
                                 <div class="chart-stage">
                                     <div id="yesterdays-node-logs-by-user"></div>

--- a/admin/templates/metrics/osf_metrics.html
+++ b/admin/templates/metrics/osf_metrics.html
@@ -36,11 +36,30 @@
         <!-- Tab panes -->
         <div class="tab-content">
             <div role="tabpanel" class="tab-pane active" id="user-data">
-                <h3>User Data</h3>
+                <div class="row">
+                    <div class="col-sm-3">
+                        <h3>User Data</h3>
+                    </div>
+                    <div class="col-sm-9">
+                        <div class="dropdown">
+                            <button class="btn btn-default btn-large dropdown-toggle pull-right" type="button" id="dropdownMenuButton" data-toggle="dropdown">
+                                Jump to...
+                                <span class="caret"></span>
+                            </button>
+                            <ul class="dropdown-menu pull-right">
+                                <li><a href="#user-growth-row">User Growth</a></li>
+                                <li><a href="#user-gain-per-day">User gain per day</a></li>
+                                <li><a href="#registration-by-email-domain">Registrations by Email Domain</a></li>
+                                <li><a href="#node-logs-by-user-row">Node Logs by User</a></li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+                <hr class="hr-menu">
 
                 <div class="container-fluid">
 
-                    <div class="row">
+                    <div class="row" id="user-growth-row">
                         <div class="col-sm-8">
                             <div class="chart-wrapper">
                                 <div class="chart-title">
@@ -110,7 +129,7 @@
                             </div>
                         </div>
                     </div>
-                    <div class="row">
+                    <div class="row" id="user-gain-per-day">
                         <div class="col-sm-12">
                             <div class="chart-wrapper">
                                 <div class="chart-title">
@@ -153,7 +172,7 @@
                             </div>
                         </div>
                     </div>
-                    <div class="row">
+                    <div class="row" id="registration-by-email-domain">
                         <div class="col-sm-12">
                             <div class="chart-wrapper">
                                 <div class="chart-title">
@@ -168,7 +187,7 @@
                             </div>
                         </div>
                     </div>
-                    <div class="row">
+                    <div class="row" id="node-logs-by-user-row">
                         <div class="col-sm-12">
                             <div class="chart-wrapper">
                                 <div class="chart-title">
@@ -188,8 +207,26 @@
             </div>
 
             <div role="tabpanel" class="tab-pane" id="institution-metrics">
-                <h3>Institution Metrics</h3>
                 <div class="row">
+                    <div class="col-sm-3">
+                        <h3>Institution Metrics</h3>
+                    </div>
+                    <div class="col-sm-9">
+                        <div class="dropdown">
+                            <button class="btn btn-default btn-large dropdown-toggle pull-right" type="button" id="dropdownMenuButton" data-toggle="dropdown">
+                                Jump to...
+                                <span class="caret"></span>
+                            </button>
+                            <ul class="dropdown-menu pull-right">
+                                <li><a href="#institutional-users-row">Total Institutional Users</a></li>
+                                <li><a href="#institutional-users-growth-row">Institutional Users Growth</a></li>
+                                <li><a href="#affiliated-nodes-and-projects">Affiliated Nodes and Projects</a></li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+                <hr class="hr-menu">
+                <div class="row" id="institutional-users-row">
                     <div class="col-sm-6">
                         <div class="chart-wrapper">
                             <div class="chart-title">
@@ -218,7 +255,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="row">
+                <div class="row" id="institutional-users-growth-row">
                     <div class="col-sm-12">
                         <div class="chart-wrapper">
                             <div class="chart-title">
@@ -231,6 +268,11 @@
                                 The growth of users who have accounts associated with their institutions. Click on an institution name in the key to remove its line and resize the chart axes.
                             </div>
                         </div>
+                    </div>
+                </div>
+                <div class="row" id="affiliated-nodes-and-projects">
+                    <div class="col-sm-12">
+                        <h4>Affiliated Nodes and Projects</h4>
                     </div>
                 </div>
                 <div class="row">
@@ -293,8 +335,27 @@
             </div>
 
             <div role="tabpanel" class="tab-pane" id="active-user-metrics">
-                <h3>Active User Metrics!</h3>
                 <div class="row">
+                    <div class="col-sm-3">
+                        <h3>Active User Metrics!</h3>
+                    </div>
+                    <div class="col-sm-9">
+                        <div class="dropdown">
+                            <button class="btn btn-default btn-large dropdown-toggle pull-right" type="button" id="dropdownMenuButton" data-toggle="dropdown">
+                                Jump to...
+                                <span class="caret"></span>
+                            </button>
+                            <ul class="dropdown-menu pull-right">
+                                <li><a href="#daily-active-users-row">Daily Active Users</a></li>
+                                <li><a href="#monthly-and-yearly-active-users">Monthly and Yearly Users</a></li>
+                                <li><a href="#project-to-user-ratio">Project to User Ratios</a></li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+                <h3></h3>
+                <hr class="hr-menu">
+                <div class="row" id="daily-active-users-row">
                     <div class="col-sm-12">
                         <div class="chart-wrapper">
                             <div class="chart-title">
@@ -337,7 +398,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="row">
+                <div class="row" id="monthly-and-yearly-active-users">
                     <div class="col-sm-4">
                         <div class="chart-wrapper">
                             <div class="chart-title">
@@ -406,6 +467,11 @@
                         </div>
                     </div>
                 </div>
+                <div class="row" id="project-to-user-ratio">
+                    <div class="col-sm-12">
+                        <h4>Project to User Ratios</h4>
+                    </div>
+                </div>
                 <div class="row">
                     <div class="col-sm-6">
                         <div class="chart-wrapper">
@@ -437,6 +503,7 @@
             </div>
             <div role="tabpanel" class="tab-pane" id="healthy-user-metrics">
                 <div><h2>Healthy User Metrics</h2></div>
+                <hr class="hr-menu">
                 <div class="row">
                     <div class="col-sm-12">
                         <div class="chart-wrapper">
@@ -462,11 +529,11 @@
                         </div>
                         <div class="col-sm-9">
                             <div class="dropdown">
-                                <button class="btn btn-default btn-large dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown">
+                                <button class="btn btn-default btn-large dropdown-toggle pull-right" type="button" id="dropdownMenuButton" data-toggle="dropdown">
                                     Jump to...
                                     <span class="caret"></span>
                                 </button>
-                                <ul class="dropdown-menu">
+                                <ul class="dropdown-menu pull-right">
                                     <li><a href="#downloads">Downloads</a></li>
                                     <li><a href="#projects">Projects - Top Level</a></li>
                                     <li><a href="#nodes">Nodes - Projects & Components</a></li>
@@ -476,9 +543,11 @@
                             </div>
                         </div>
                     </div>
-
+                    <hr class="hr-menu">
                     <div class="row" id="downloads">
-                        <h3>Downloads</h3>
+                        <div class="col-sm-12">
+                            <h3>Downloads</h3>
+                        </div>
                     </div>
                     <div class="row">
                         <div class="col-sm-6">
@@ -509,7 +578,9 @@
                         </div>
                     </div>
                     <div class="row" id="projects">
-                        <h3>Projects</h3>
+                        <div class="col-sm-12">
+                            <h3>Projects</h3>
+                        </div>
                     </div>
                     <div class="row">
                         <div class="col-sm-12">
@@ -574,7 +645,9 @@
                         </div>
                     </div>
                     <div class="row" id="nodes">
-                        <h3>Nodes</h3>
+                        <div class="col-sm-12">
+                            <h3>Nodes</h3>
+                        </div>
                     </div>
                     <div class="row">
                         <div class="col-sm-12">
@@ -639,7 +712,9 @@
                         </div>
                     </div>
                     <div class="row" id="registered-projects">
-                        <h3>Registered Projects</h3>
+                        <div class="col-sm-12">
+                            <h3>Registered Projects</h3>
+                        </div>
                     </div>
                     <div class="row">
                         <div class="col-sm-12">
@@ -704,7 +779,9 @@
                         </div>
                     </div>
                     <div class="row" id="registered-nodes">
-                        <h3>Registered Nodes</h3>
+                        <div class="col-sm-12">
+                            <h3>Registered Nodes</h3>
+                        </div>
                     </div>
                     <div class="row">
                         <div class="col-sm-12">
@@ -772,6 +849,7 @@
             </div>
             <div role="tabpanel" class="tab-pane" id="addons">
                 <div><h2>Addons</h2></div>
+                <hr class="hr-menu">
                 <div class="row">
                     <div class="col-sm-12">
                         <div class="chart-wrapper">

--- a/admin/templates/metrics/osf_metrics.html
+++ b/admin/templates/metrics/osf_metrics.html
@@ -13,7 +13,8 @@
             var keenReadKey = '{{ keen_read_key }}';
         }
     </script>
-
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.6/d3.min.js" charset="utf-8"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/c3/0.4.10/c3.min.js"></script>
 {% endblock top_includes %}
 
 {% block content %}
@@ -39,17 +40,28 @@
     <div><h2>User Data</h2></div>
 
     <div class="row">
-        <div class="col-md-4" id="active_users">
+        <div class="col-md-3" id="active_users">
             <h3>Yesterday's Active Users</h3>
             <div id="active-user-count">Loading...</div>
         </div>
-        <div class="col-md-4" id="active_users">
+        <div class="col-md-3" id="active_users">
             <h3>Daily Increase of Users</h3>
             <div id="daily-user-increase">Loading...</div>
         </div>
-        <div class="col-md-4" id="active_users">
+        <div class="col-md-3" id="active_users">
             <h3>Monthly Increase of Users</h3>
             <div id="monthly-user-increase">Loading...</div>
+        </div>
+        <div class="col-md-3" id="active_users">
+            <h3>Average Daily Gain Over past 7 Days</h3>
+            <div id="average-gain-metric">Loading...</div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-md-12">
+            <h3>User Gain Per Day</h3>
+            <div id="user-gain-chart">Loading...</div>
         </div>
     </div>
 

--- a/admin/templates/metrics/osf_metrics.html
+++ b/admin/templates/metrics/osf_metrics.html
@@ -27,7 +27,7 @@
             <li role="presentation"><a href="#institution-metrics" role="tab" data-toggle="tab">Institution Metrics</a></li>
             <li role="presentation"><a href="#active-user-metrics" role="tab" data-toggle="tab">Active User Metrics</a></li>
             <li role="presentation"><a href="#healthy-user-metrics" role="tab" data-toggle="tab">Healthy User Metrics</a></li>
-            <li role="presentation"><a href="#raw-numbers" role="tab" data-toggle="tab">Raw Numbers</a></li>
+            <li role="presentation" id="raw-numbers-tab"><a href="#raw-numbers" role="tab" data-toggle="tab">Raw Numbers</a></li>
         </ul>
 
         <!-- Tab panes -->
@@ -229,22 +229,6 @@
                             </div>
                         </div>
                     </div>
-
-                </div>
-                <div class="row">
-                    <div class="col-sm-12">
-                        <div class="chart-wrapper">
-                            <div class="chart-title">
-                                Affiliated Nodes Test
-                            </div>
-                            <div class="chart-stage">
-                                <div id="affiliated-nodes-test"></div>
-                            </div>
-                            <div class="chart-notes">
-                                Total number of public nodes (at all levels, projects and components) created by each institution as of yesterday.
-                            </div>
-                        </div>
-                    </div>
                 </div>
                 <div class="row">
                     <div class="col-sm-6">
@@ -291,10 +275,10 @@
                     <div class="col-sm-6">
                         <div class="chart-wrapper">
                             <div class="chart-title">
-                                Affiliated Private Registrations
+                                Affiliated Embargoed Registrations
                             </div>
                             <div class="chart-stage">
-                                <div id="affiliated-public-registered-nodes"></div>
+                                <div id="affiliated-embargoed-registered-nodes"></div>
                             </div>
                             <div class="chart-notes">
                                 Total number of private registered nodes (at all levels, projects and components) created by each institution as of yesterday.

--- a/admin/templates/metrics/osf_metrics.html
+++ b/admin/templates/metrics/osf_metrics.html
@@ -28,6 +28,7 @@
             <li role="presentation" id="active-user-tab"><a href="#active-user-metrics" role="tab" data-toggle="tab">Active User Metrics</a></li>
             <li role="presentation" id="healthy-user-tab"><a href="#healthy-user-metrics" role="tab" data-toggle="tab">Healthy User Metrics</a></li>
             <li role="presentation" id="raw-numbers-tab"><a href="#raw-numbers" role="tab" data-toggle="tab">Raw Numbers</a></li>
+            <li role="presentation" id="addons-tab"><a href="#addons" role="tab" data-toggle="tab">Addons</a></li>
         </ul>
 
         <!-- Tab panes -->
@@ -711,18 +712,21 @@
                             </div>
                         </div>
                     </div>
-                    <div class="row">
-                        <div class="col-sm-12">
-                            <div class="chart-wrapper">
-                                <div class="chart-title">
-                                    Pevious 7 days of addon by name
-                                </div>
-                                <div class="chart-stage">
-                                    <div id="previous-7-days-of-linked-addon-by-addon-name"></div>
-                                </div>
-                                <div class="chart-notes">
-                                    The total number of all registered nodes - projects & components on the OSF.
-                                </div>
+                </div>
+            </div>
+            <div role="tabpanel" class="tab-pane" id="addons">
+                <div><h2>Addons</h2></div>
+                <div class="row">
+                    <div class="col-sm-12">
+                        <div class="chart-wrapper">
+                            <div class="chart-title">
+                                Pevious 7 days of addon by name
+                            </div>
+                            <div class="chart-stage">
+                                <div id="previous-7-days-of-linked-addon-by-addon-name"></div>
+                            </div>
+                            <div class="chart-notes">
+                                The total number of all registered nodes - projects & components on the OSF.
                             </div>
                         </div>
                     </div>

--- a/admin/templates/metrics/osf_metrics.html
+++ b/admin/templates/metrics/osf_metrics.html
@@ -24,6 +24,7 @@
         <!-- Nav tabs -->
         <ul class="nav nav-tabs" role="tablist">
             <li role="presentation" class="active"><a href="#user-data" role="tab" data-toggle="tab">User Data</a></li>
+            <li role="presentation"><a href="#institution-metrics" role="tab" data-toggle="tab">Institution Metrics</a></li>
             <li role="presentation"><a href="#active-user-metrics" role="tab" data-toggle="tab">Active User Metrics</a></li>
             <li role="presentation"><a href="#healthy-user-metrics" role="tab" data-toggle="tab">Healthy User Metrics</a></li>
             <li role="presentation"><a href="#expansion-metrics" role="tab" data-toggle="tab">Expansion Metrics</a></li>
@@ -109,6 +110,21 @@
                         </div>
                     </div>
                     <div class="row">
+                        <div class="col-sm-12">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    User Gain per Day
+                                </div>
+                                <div class="chart-stage">
+                                    <div id="user-gain-chart"></div>
+                                </div>
+                                <div class="chart-notes">
+                                    The number of users gained in the past month.
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
                         <div class="col-sm-6 col-md-4">
                             <div class="chart-wrapper">
                                 <div class="chart-title">
@@ -136,14 +152,150 @@
                             </div>
                         </div>
                     </div>
+                    <div class="row">
+                        <div class="col-sm-12">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    Previous 7 days of user registrations by email domain
+                                </div>
+                                <div class="chart-stage">
+                                    <div id="user-registration-by-email-domain"></div>
+                                </div>
+                                <div class="chart-notes">
+                                    The last 7 days of users, organized by status.
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-sm-12">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    Yesterday's Node logs by user<
+                                </div>
+                                <div class="chart-stage">
+                                    <div id="yesterdays-node-logs-by-user"></div>
+                                </div>
+                                <div class="chart-notes">
+                                    The last 7 days of users, organized by status.
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
                 </div>
             </div>
 
+            <div role="tabpanel" class="tab-pane" id="institution-metrics">
+                <h3>Institution Metrics</h3>
+                <div class="row">
+                    <div class="col-sm-6">
+                        <div class="chart-wrapper">
+                            <div class="chart-title">
+                                Total institutional Users
+                            </div>
+                            <div class="chart-stage">
+                                <div id="total-institutional-users"></div>
+                            </div>
+                            <div class="chart-notes">
+                                Total number of users who have accounts associated with their institutions.
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="col-sm-6">
+                        <div class="chart-wrapper">
+                            <div class="chart-title">
+                                Institutional Users / Total OSF Users
+                            </div>
+                            <div class="chart-stage">
+                                <div id="percentage-institutional-users"></div>
+                            </div>
+                            <div class="chart-notes">
+                                The percentage of users who created an account through their institution.
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-sm-12">
+                        <div class="chart-wrapper">
+                            <div class="chart-title">
+                                Institutional Users over the past 100 Days
+                            </div>
+                            <div class="chart-stage">
+                                <div id="institution-growth"></div>
+                            </div>
+                            <div class="chart-notes">
+                                The growth of users who have accounts associated with their institutions.
+                            </div>
+                        </div>
+                    </div>
+
+                </div>
+                <div class="row">
+                    <div class="col-sm-6">
+                        <div class="chart-wrapper">
+                            <div class="chart-title">
+                                Affiliated Public Nodes
+                            </div>
+                            <div class="chart-stage">
+                                <div id="affiliated-public-nodes"></div>
+                            </div>
+                            <div class="chart-notes">
+                                Total number of public nodes (at all levels, projects and components) created by each institution as of yesterday.
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-sm-6">
+                        <div class="chart-wrapper">
+                            <div class="chart-title">
+                                Affiliated Private Nodes
+                            </div>
+                            <div class="chart-stage">
+                                <div id="affiliated-private-nodes"></div>
+                            </div>
+                            <div class="chart-notes">
+                                Total number of private nodes (at all levels, projects and components) created by each institution as of yesterday.
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-sm-6">
+                        <div class="chart-wrapper">
+                            <div class="chart-title">
+                                Affiliated Public Registrations
+                            </div>
+                            <div class="chart-stage">
+                                <div id="affiliated-public-registered-nodes"></div>
+                            </div>
+                            <div class="chart-notes">
+                                Total number of public registered nodes (at all levels, projects and components) created by each institution as of yesterday.
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-sm-6">
+                        <div class="chart-wrapper">
+                            <div class="chart-title">
+                                Affiliated Private Registrations
+                            </div>
+                            <div class="chart-stage">
+                                <div id="affiliated-public-registered-nodes"></div>
+                            </div>
+                            <div class="chart-notes">
+                                Total number of private registered nodes (at all levels, projects and components) created by each institution as of yesterday.
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+            </div>
 
             <div role="tabpanel" class="tab-pane" id="active-user-metrics">
                 <h3>Active User Metrics!</h3>
                 <div class="row">
-                    <div class="col-sm-6 col-md-4">
+                    <div class="col-sm-6">
                         <div class="chart-wrapper">
                             <div class="chart-title">
                                 Daily Active Users
@@ -156,7 +308,7 @@
                             </div>
                         </div>
                     </div>
-                    <div class="col-sm-6 col-md-4">
+                    <div class="col-sm-6">
                         <div class="chart-wrapper">
                             <div class="chart-title">
                                 Daily Active Users / Total Users
@@ -169,6 +321,8 @@
                             </div>
                         </div>
                     </div>
+                </div>
+                <div class="row">
                     <div class="col-sm-6 col-md-4">
                         <div class="chart-wrapper">
                             <div class="chart-title">
@@ -182,12 +336,10 @@
                             </div>
                         </div>
                     </div>
-                </div>
-                <div class="row">
                     <div class="col-sm-6 col-md-4">
                         <div class="chart-wrapper">
                             <div class="chart-title">
-                                 Last Month's Active Users / Total Users
+                                Last Month's Active Users / Total Users
                             </div>
                             <div class="chart-stage">
                                 <div id="monthly-active-over-total-users"></div>
@@ -210,7 +362,9 @@
                             </div>
                         </div>
                     </div>
-                    <div class="col-sm-6 col-md-4">
+                </div>
+                <div class="row">
+                    <div class="col-sm-6">
                         <div class="chart-wrapper">
                             <div class="chart-title">
                                 Yearly Active Users
@@ -220,6 +374,19 @@
                             </div>
                             <div class="chart-notes">
                                 Users who were active on the OSF over the past year.
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-sm-6">
+                        <div class="chart-wrapper">
+                            <div class="chart-title">
+                                Yearly Active Users / Total Users
+                            </div>
+                            <div class="chart-stage">
+                                <div id="yearly-active-over-total-users"></div>
+                            </div>
+                            <div class="chart-notes">
+                                The percentage of our yearly active users compared to our total users with confirmed accounts.
                             </div>
                         </div>
                     </div>
@@ -538,15 +705,7 @@
         </div>
     </div>
 
-    <div id="email_domain">
-        <h3>Previous 7 days of user registrations by email domain</h3>
-        <div id="user-registration-by-email-domain">Loading...</div>
-    </div>
 
-    <div id="node_logs_by_user">
-        <h3>Yesterday's Node logs by user</h3>
-        <div id="yesterdays-node-logs-by-user">Loading...</div>
-    </div>
 
     <div id="users_by_status">
         <h3>Previous 7 days of users by status</h3>

--- a/admin/templates/metrics/osf_metrics.html
+++ b/admin/templates/metrics/osf_metrics.html
@@ -271,126 +271,128 @@
                         </div>
                     </div>
                 </div>
-                <div class="row" id="affiliated-nodes">
-                    <div class="col-sm-12">
-                        <h4>Affiliated Nodes</h4>
-                        <p>Nodes (at all levels, projects and components) created by each institution as of yesterday.</p>
+                <div class="institution-tables">
+                    <div class="row" id="affiliated-nodes">
+                        <div class="col-sm-12">
+                            <h4>Affiliated Nodes</h4>
+                            <p>Nodes (at all levels, projects and components) created by each institution as of yesterday.</p>
+                        </div>
                     </div>
-                </div>
-                <div class="row">
-                    <div class="col-sm-6">
-                        <div class="chart-wrapper">
-                            <div class="chart-title">
-                                Affiliated Public Nodes
+                    <div class="row">
+                        <div class="col-sm-6">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    Affiliated Public Nodes
+                                </div>
+                                <div class="chart-stage">
+                                    <div id="affiliated-public-nodes"></div>
+                                </div>
+                                <div class="chart-notes">
+                                    Total number of public nodes (at all levels, projects and components) created by each institution as of yesterday.
+                                </div>
                             </div>
-                            <div class="chart-stage">
-                                <div id="affiliated-public-nodes"></div>
-                            </div>
-                            <div class="chart-notes">
-                                Total number of public nodes (at all levels, projects and components) created by each institution as of yesterday.
+                        </div>
+                        <div class="col-sm-6">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    Affiliated Private Nodes
+                                </div>
+                                <div class="chart-stage">
+                                    <div id="affiliated-private-nodes"></div>
+                                </div>
+                                <div class="chart-notes">
+                                    Total number of private nodes (at all levels, projects and components) created by each institution as of yesterday.
+                                </div>
                             </div>
                         </div>
                     </div>
-                    <div class="col-sm-6">
-                        <div class="chart-wrapper">
-                            <div class="chart-title">
-                                Affiliated Private Nodes
+                    <div class="row">
+                        <div class="col-sm-6">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    Affiliated Public Registrations
+                                </div>
+                                <div class="chart-stage">
+                                    <div id="affiliated-public-registered-nodes"></div>
+                                </div>
+                                <div class="chart-notes">
+                                    Total number of public registered nodes (at all levels, projects and components) created by each institution as of yesterday.
+                                </div>
                             </div>
-                            <div class="chart-stage">
-                                <div id="affiliated-private-nodes"></div>
-                            </div>
-                            <div class="chart-notes">
-                                Total number of private nodes (at all levels, projects and components) created by each institution as of yesterday.
+                        </div>
+                        <div class="col-sm-6">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    Affiliated Embargoed Registrations
+                                </div>
+                                <div class="chart-stage">
+                                    <div id="affiliated-embargoed-registered-nodes"></div>
+                                </div>
+                                <div class="chart-notes">
+                                    Total number of private registered nodes (at all levels, projects and components) created by each institution as of yesterday.
+                                </div>
                             </div>
                         </div>
                     </div>
-                </div>
-                <div class="row">
-                    <div class="col-sm-6">
-                        <div class="chart-wrapper">
-                            <div class="chart-title">
-                                Affiliated Public Registrations
+                    <div class="row" id="affiliated-projects">
+                        <div class="col-sm-12">
+                            <h4>Affiliated Projects</h4>
+                            <p>Top level projects created by each institution as of yesterday.</p>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-sm-6">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    Affiliated Public Projects
+                                </div>
+                                <div class="chart-stage">
+                                    <div id="affiliated-public-projects"></div>
+                                </div>
+                                <div class="chart-notes">
+                                    Total number of public top level projects created by each institution as of yesterday.
+                                </div>
                             </div>
-                            <div class="chart-stage">
-                                <div id="affiliated-public-registered-nodes"></div>
-                            </div>
-                            <div class="chart-notes">
-                                Total number of public registered nodes (at all levels, projects and components) created by each institution as of yesterday.
+                        </div>
+                        <div class="col-sm-6">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    Affiliated Private Projects
+                                </div>
+                                <div class="chart-stage">
+                                    <div id="affiliated-private-projects"></div>
+                                </div>
+                                <div class="chart-notes">
+                                    Total number of private top level projects created by each institution as of yesterday.
+                                </div>
                             </div>
                         </div>
                     </div>
-                    <div class="col-sm-6">
-                        <div class="chart-wrapper">
-                            <div class="chart-title">
-                                Affiliated Embargoed Registrations
-                            </div>
-                            <div class="chart-stage">
-                                <div id="affiliated-embargoed-registered-nodes"></div>
-                            </div>
-                            <div class="chart-notes">
-                                Total number of private registered nodes (at all levels, projects and components) created by each institution as of yesterday.
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="row" id="affiliated-projects">
-                    <div class="col-sm-12">
-                        <h4>Affiliated Projects</h4>
-                        <p>Top level projects created by each institution as of yesterday.</p>
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="col-sm-6">
-                        <div class="chart-wrapper">
-                            <div class="chart-title">
-                                Affiliated Public Projects
-                            </div>
-                            <div class="chart-stage">
-                                <div id="affiliated-public-projects"></div>
-                            </div>
-                            <div class="chart-notes">
-                                Total number of public top level projects created by each institution as of yesterday.
+                    <div class="row">
+                        <div class="col-sm-6">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    Affiliated Public Project Registrations
+                                </div>
+                                <div class="chart-stage">
+                                    <div id="affiliated-public-registered-projects"></div>
+                                </div>
+                                <div class="chart-notes">
+                                    Total number of public registeredtop level projects created by each institution as of yesterday.
+                                </div>
                             </div>
                         </div>
-                    </div>
-                    <div class="col-sm-6">
-                        <div class="chart-wrapper">
-                            <div class="chart-title">
-                                Affiliated Private Projects
-                            </div>
-                            <div class="chart-stage">
-                                <div id="affiliated-private-projects"></div>
-                            </div>
-                            <div class="chart-notes">
-                                Total number of private top level projects created by each institution as of yesterday.
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="col-sm-6">
-                        <div class="chart-wrapper">
-                            <div class="chart-title">
-                                Affiliated Public Project Registrations
-                            </div>
-                            <div class="chart-stage">
-                                <div id="affiliated-public-registered-projects"></div>
-                            </div>
-                            <div class="chart-notes">
-                                Total number of public registeredtop level projects created by each institution as of yesterday.
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-sm-6">
-                        <div class="chart-wrapper">
-                            <div class="chart-title">
-                                Affiliated Embargoed Project Registrations
-                            </div>
-                            <div class="chart-stage">
-                                <div id="affiliated-embargoed-registered-projects"></div>
-                            </div>
-                            <div class="chart-notes">
-                                Total number of private registered top level projects created by each institution as of yesterday.
+                        <div class="col-sm-6">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    Affiliated Embargoed Project Registrations
+                                </div>
+                                <div class="chart-stage">
+                                    <div id="affiliated-embargoed-registered-projects"></div>
+                                </div>
+                                <div class="chart-notes">
+                                    Total number of private registered top level projects created by each institution as of yesterday.
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/admin/templates/metrics/osf_metrics.html
+++ b/admin/templates/metrics/osf_metrics.html
@@ -63,7 +63,29 @@
 
     <div>
         <h3>Active Users / Total Users</h3>
-        <div id="daily-active--over-total-users">Loading...</div>
+        <div id="daily-active-over-total-users">Loading...</div>
+    </div>
+
+    <div>
+        <h3>Last Month's Active Logged In Users</h3>
+        <div id="monthly-active-users">Loading...</div>
+    </div>
+
+    <div>
+        <h3>Last Month's Active Users / Total Users</h3>
+        <div id="monthly-active-over-total-users">Loading...</div>
+    </div>
+    <div>
+        <h3>Monthly growth of MAU%</h3>
+        <div id="monthly-active-user-increase">Loading...</div>
+    </div>
+    <div>
+        <h3>Yearly Active Logged In Users</h3>
+        <div id="yearly-active-users">Loading...</div>
+    </div>
+    <div>
+        <h3>Yearly Active Users / Total Users</h3>
+        <div id="yearly-active-over-total-users">Loading...</div>
     </div>
 
     <div class="row">

--- a/admin/templates/metrics/osf_metrics.html
+++ b/admin/templates/metrics/osf_metrics.html
@@ -36,10 +36,20 @@
         </ul>
     </div>
 
+    <div><h2>User Data</h2></div>
+
     <div class="row">
-        <div class="col-md-12" id="active_users">
+        <div class="col-md-4" id="active_users">
             <h3>Yesterday's Active Users</h3>
             <div id="active-user-count">Loading...</div>
+        </div>
+        <div class="col-md-4" id="active_users">
+            <h3>Daily Increase of Users</h3>
+            <div id="daily-user-increase">Loading...</div>
+        </div>
+        <div class="col-md-4" id="active_users">
+            <h3>Monthly Increase of Users</h3>
+            <div id="monthly-user-increase">Loading...</div>
         </div>
     </div>
 

--- a/admin/templates/metrics/osf_metrics.html
+++ b/admin/templates/metrics/osf_metrics.html
@@ -404,6 +404,34 @@
                         </div>
                     </div>
                 </div>
+                <div class="row">
+                    <div class="col-sm-6">
+                        <div class="chart-wrapper">
+                            <div class="chart-title">
+                                Projects / Users
+                            </div>
+                            <div class="chart-stage">
+                                <div id="projects-per-user"></div>
+                            </div>
+                            <div class="chart-notes">
+                                The number of projects divided by the number of users with active accounts.
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-sm-6">
+                        <div class="chart-wrapper">
+                            <div class="chart-title">
+                                 Projects / Monthly Active Users
+                            </div>
+                            <div class="chart-stage">
+                                <div id="projects-per-monthly-user"></div>
+                            </div>
+                            <div class="chart-notes">
+                                The number of projects divided by the number of people who had accounts and were active last month.
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
             <div role="tabpanel" class="tab-pane" id="healthy-user-metrics">
                 <div><h2>Healthy User Metrics</h2></div>

--- a/admin/templates/metrics/osf_metrics.html
+++ b/admin/templates/metrics/osf_metrics.html
@@ -226,135 +226,124 @@
                 </div>
             </div>
             <div role="tabpanel" class="tab-pane" id="healthy-user-metrics">
-                Healthy User Metrics
+                <div><h2>Healthy User Metrics</h2></div>
+                <div>
+                    <h3>Stickiness Ratio</h3>
+                    <div id="stickiness-ratio">Loading...</div>
+                </div>
             </div>
             <div role="tabpanel" class="tab-pane" id="expansion-metrics">
-                Expansion Metrics
+                <h3>Expansion Metrics</h3>
+                <h2>Coming Soon!</h2>
             </div>
             <div role="tabpanel" class="tab-pane" id="cohorts">
-                Cohorts
+                <h3>Cohorts</h3>
+                <h2>Coming soon!</h2>
             </div>
             <div role="tabpanel" class="tab-pane" id="raw-numbers">
                 <h3>Raw Numbers</h3>
 
-                <div class="container-fluid">
+                <div class="dropdown">
+                    <button class="btn btn-default btn-large dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown">
+                        Jump to...
+                        <span class="caret"></span>
+                    </button>
+                    <ul class="dropdown-menu">
+                        <li><a href="#downloads">Downloads</a></li>
+                        <li><a href="#projects">Projects - Top Level</a></li>
+                        <li><a href="#nodes">Nodes - Projects & Components</a></li>
+                        <li><a href="#registered-projects">Registered Projects</a></li>
+                        <li><a href="#registered-nodes">Registered Nodes</a></li>
+                    </ul>
+                </div>
 
+
+                <div class="container-fluid">
                     <div class="row">
-                        <div class="col-sm-6 col-md-4">
+                        <h3 id="downloads">Downloads</h3>
+                        <div class="col-sm-6">
                             <div class="chart-wrapper">
                                 <div class="chart-title">
-                                    Cell Title
+                                    Downloads
                                 </div>
                                 <div class="chart-stage">
-                                    <div id="grid-1-1">
-                                        <img data-src="holder.js/100%x180/white/text:#grid-1-1">
+                                    <div id="number-of-downloads"></div>
+                                </div>
+                                <div class="chart-notes">
+                                    The total number of files downloaded from the OSF
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-sm-6">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    Unique Downloads
+                                </div>
+                                <div class="chart-stage">
+                                    <div id="number-of-unique-downloads"></div>
+                                </div>
+                                <div class="chart-notes">
+                                    The number of unique downloads of files on the OSF.
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <h3 id="projects">Projects</h3>
+                        <div class="col-sm-12">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    Total Projects
+                                </div>
+                                <div class="chart-stage">
+                                    <div id="total-projects"></div>
+                                </div>
+                                <div class="chart-notes">
+                                    The total number of all top level projects on the OSF
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-sm-6">
+                            <div class="row">
+                                <div class="col-sm-12">
+                                    <div class="chart-wrapper">
+                                        <div class="chart-title">
+                                            Public Projects
+                                        </div>
+                                        <div class="chart-stage">
+                                            <div id="public-projects"></div>
+                                        </div>
+                                        <div class="chart-notes">
+                                            Notes about this chart
+                                        </div>
                                     </div>
                                 </div>
-                                <div class="chart-notes">
-                                    Notes about this chart
+                            </div>
+                            <div class="row">
+                                <div class="col-sm-12">
+                                    <div class="chart-wrapper">
+                                        <div class="chart-title">
+                                            Private Projects
+                                        </div>
+                                        <div class="chart-stage">
+                                            <div id="private-projects"></div>
+                                        </div>
+                                        <div class="chart-notes">
+                                            Notes about this chart
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
                         </div>
-                        <div class="col-sm-6 col-md-4">
+                        <div class="col-sm-6">
                             <div class="chart-wrapper">
                                 <div class="chart-title">
-                                    Cell Title
+                                    Public vs Private Projects
                                 </div>
                                 <div class="chart-stage">
-                                    <img data-src="holder.js/100%x180/white">
-                                </div>
-                                <div class="chart-notes">
-                                    Notes about this chart
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-sm-6 col-md-4">
-                            <div class="chart-wrapper">
-                                <div class="chart-title">
-                                    Cell Title
-                                </div>
-                                <div class="chart-stage">
-                                    <img data-src="holder.js/100%x180/white">
-                                </div>
-                                <div class="chart-notes">
-                                    Notes about this chart
-                                </div>
-                            </div>
-                        </div>
-                        <!-- end of three -->
-                        <div class="col-sm-6 col-md-4">
-                            <div class="chart-wrapper">
-                                <div class="chart-title">
-                                    Cell Title
-                                </div>
-                                <div class="chart-stage">
-                                    <img data-src="holder.js/100%x180/white">
-                                </div>
-                                <div class="chart-notes">
-                                    Notes about this chart
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-sm-6 col-md-4">
-                            <div class="chart-wrapper">
-                                <div class="chart-title">
-                                    Cell Title
-                                </div>
-                                <div class="chart-stage">
-                                    <img data-src="holder.js/100%x180/white">
-                                </div>
-                                <div class="chart-notes">
-                                    Notes about this chart
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-sm-6 col-md-4">
-                            <div class="chart-wrapper">
-                                <div class="chart-title">
-                                    Cell Title
-                                </div>
-                                <div class="chart-stage">
-                                    <img data-src="holder.js/100%x180/white">
-                                </div>
-                                <div class="chart-notes">
-                                    Notes about this chart
-                                </div>
-                            </div>
-                        </div>
-                        <!-- end of three -->
-                        <div class="col-sm-6 col-md-4">
-                            <div class="chart-wrapper">
-                                <div class="chart-title">
-                                    Cell Title
-                                </div>
-                                <div class="chart-stage">
-                                    <img data-src="holder.js/100%x180/white">
-                                </div>
-                                <div class="chart-notes">
-                                    Notes about this chart
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-sm-6 col-md-4">
-                            <div class="chart-wrapper">
-                                <div class="chart-title">
-                                    Cell Title
-                                </div>
-                                <div class="chart-stage">
-                                    <img data-src="holder.js/100%x180/white">
-                                </div>
-                                <div class="chart-notes">
-                                    Notes about this chart
-                                </div>
-                            </div>
-                        </div>
-                        <div class="col-sm-6 col-md-4">
-                            <div class="chart-wrapper">
-                                <div class="chart-title">
-                                    Cell Title
-                                </div>
-                                <div class="chart-stage">
-                                    <img data-src="holder.js/100%x180/white">
+                                    <div id="total-projects-pie"></div>
                                 </div>
                                 <div class="chart-notes">
                                     Notes about this chart
@@ -362,6 +351,152 @@
                             </div>
                         </div>
                     </div>
+                    <div class="row">
+                        <h3 id="nodes">Nodes</h3>
+                        <div class="col-sm-12">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    Total Nodes - Projects and Components
+                                </div>
+                                <div class="chart-stage">
+                                    <div id="total-nodes"></div>
+                                </div>
+                                <div class="chart-notes">
+                                    The total number of all projects and components on the OSF.
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-sm-6">
+                            <div class="row">
+                                <div class="col-sm-12">
+                                    <div class="chart-wrapper">
+                                        <div class="chart-title">
+                                            Public Nodes
+                                        </div>
+                                        <div class="chart-stage">
+                                            <div id="public-nodes"></div>
+                                        </div>
+                                        <div class="chart-notes">
+                                            The total number of private nodes - inccluding projects and components
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-sm-12">
+                                    <div class="chart-wrapper">
+                                        <div class="chart-title">
+                                            Private Nodes
+                                        </div>
+                                        <div class="chart-stage">
+                                            <div id="private-nodes"></div>
+                                        </div>
+                                        <div class="chart-notes">
+                                            Notes about this chart
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-sm-6">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    Public vs Private Nodes - Components & Projects
+                                </div>
+                                <div class="chart-stage">
+                                    <div id="total-nodes-pie"></div>
+                                </div>
+                                <div class="chart-notes">
+                                    The percentages of public vs private combined projects and components on the OSF.
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-sm-6 col-md-4">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    Total Registered Projects
+                                </div>
+                                <div class="chart-stage">
+                                    <div id="total-registered-projects"></div>
+                                </div>
+                                <div class="chart-notes">
+                                    The total number of all registered top level projects on the OSF.
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-sm-6 col-md-4">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    Total Public Registered Projects
+                                </div>
+                                <div class="chart-stage">
+                                    <div id="total-registered-public-projects"></div>
+                                </div>
+                                <div class="chart-notes">
+                                    The number of all public registered top level projects on the OSF.
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-sm-6 col-md-4">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    Total Private Nodes
+                                </div>
+                                <div class="chart-stage">
+                                    <div id="total-registered-private-projects"></div>
+                                </div>
+                                <div class="chart-notes">
+                                    The number of all private projects and components of all levels on the OSF
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-sm-6 col-md-4">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    Total Registered Nodes
+                                </div>
+                                <div class="chart-stage">
+                                    <div id="number-of-registered-nodes"></div>
+                                </div>
+                                <div class="chart-notes">
+                                    The total number of all registered projects and components on the OSF.
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-sm-6 col-md-4">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    Total Public Registered Nodes
+                                </div>
+                                <div class="chart-stage">
+                                    <div id="total-registered-public-nodes"></div>
+                                </div>
+                                <div class="chart-notes">
+                                    The number of all registered public projects and components of all levels on the OSF
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-sm-6 col-md-4">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    Total Private Registered Nodes
+                                </div>
+                                <div class="chart-stage">
+                                    <div id="total-registered-private-nodes"></div>
+                                </div>
+                                <div class="chart-notes">
+                                    The number of all registered private projects and components of all levels on the OSF
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
                 </div>
             </div>
         </div>
@@ -369,21 +504,7 @@
 
 
 
-    <div class="dropdown">
-        <button class="btn btn-default btn-large dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown">
-            Jump to...
-            <span class="caret"></span>
-        </button>
-        <ul class="dropdown-menu">
-            <li><a href="#active_users">Yesterday's Active Users</a></li>
-            <li><a href="#active_users_over_time">Active Users Over Time</a></li>
-            <li><a href="#affiliated_projects">Affiliated Public and Private projects by Institution</a></li>
-            <li><a href="#email_domain">Previous 7 days of user registrations by email domain</a></li>
-            <li><a href="#node_logs_by_user">Yesterday's Node logs by user</a></li>
-            <li><a href="#users_by_status">Previous 7 days of users by status</a></li>
-            <li><a href="#linked_addon_by_name">Previous 7 days of linked addon by addon name</a></li>
-        </ul>
-    </div>
+
 
     <div><h2>User Data</h2></div>
     <div>
@@ -437,31 +558,8 @@
         <div id="previous-7-days-of-linked-addon-by-addon-name">Loading...</div>
     </div>
 
-    <div><h2>Healthy User Metrics</h2></div>
 
-    <div>
-        <h3>Stickiness Ratio</h3>
-        <div id="stickiness-ratio">Loading...</div>
-    </div>
 
-    <div><h2>Raw Numbers</h2></div>
-
-    <div>
-        <h3>Downloads</h3>
-        <div id="downloads">Loading...</div>
-    </div>
-    <div>
-        <h3>Unique Downloads</h3>
-        <div id="unique-downloads">Loading...</div>
-    </div>
-    <div>
-        <h3>Number of Projects</h3>
-        <div id="total-projects">Loading...</div>
-    </div>
-    <div>
-        <h3>Number of Registrations</h3>
-        <div id="total-registrations">Loading...</div>
-    </div>
 
 
 {% endblock content %}

--- a/admin/templates/metrics/osf_metrics.html
+++ b/admin/templates/metrics/osf_metrics.html
@@ -392,9 +392,20 @@
             </div>
             <div role="tabpanel" class="tab-pane" id="healthy-user-metrics">
                 <div><h2>Healthy User Metrics</h2></div>
-                <div>
-                    <h3>Stickiness Ratio</h3>
-                    <div id="stickiness-ratio">Loading...</div>
+                <div class="row">
+                    <div class="col-sm-12">
+                        <div class="chart-wrapper">
+                            <div class="chart-title">
+                                Stickiness Ratio
+                            </div>
+                            <div class="chart-stage">
+                                <div id="stickiness-ratio"></div>
+                            </div>
+                            <div class="chart-notes">
+                                Of those that are active in the last month, how many are active daily? Daily Active Users / Monthly Active Users.
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
             <div role="tabpanel" class="tab-pane" id="raw-numbers">

--- a/admin/templates/metrics/osf_metrics.html
+++ b/admin/templates/metrics/osf_metrics.html
@@ -19,7 +19,190 @@
 
 {% block content %}
 
-    <h2>OSF Metrics</h2>
+    <h1>OSF Metrics</h1>
+    <div>
+        <!-- Nav tabs -->
+        <ul class="nav nav-tabs" role="tablist">
+            <li role="presentation" class="active"><a href="#user-data" role="tab" data-toggle="tab">User Data</a></li>
+            <li role="presentation"><a href="#active-user-metrics" role="tab" data-toggle="tab">Active User Metrics</a></li>
+            <li role="presentation"><a href="#healthy-user-metrics" role="tab" data-toggle="tab">Healthy User Metrics</a></li>
+            <li role="presentation"><a href="#expansion-metrics" role="tab" data-toggle="tab">Expansion Metrics</a></li>
+            <li role="presentation"><a href="#cohorts" role="tab" data-toggle="tab">Cohorts</a></li>
+            <li role="presentation"><a href="#raw-numbers" role="tab" data-toggle="tab">Raw Numbers</a></li>
+        </ul>
+
+        <!-- Tab panes -->
+        <div class="tab-content">
+            <div role="tabpanel" class="tab-pane active" id="user-data">
+                <h3>User Data</h3>
+                <div class="row">
+                    <div class="col-sm-8">
+                        <div class="chart-wrapper">
+                            <div class="chart-title">
+                                User Growth
+                            </div>
+                            <div class="chart-stage">
+                                <div id="active-user-chart"></div>
+                            </div>
+                            <div class="chart-notes">
+                                The growth of OSF Confirmed Users over the past 800 days.
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-sm-4">
+                        <div class="chart-wrapper">
+                            <div class="chart-title">
+                                Total Users
+                            </div>
+                            <div class="chart-stage">
+                                <div id="active-user-count"></div>
+                            </div>
+                            <div class="chart-notes">
+                                This is the total number of OSF Users with confirmed accounts.
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="row">
+                    <div class="col-sm-6 col-md-4">
+                        <div class="chart-wrapper">
+                            <div class="chart-title">
+                                Monthly User Increase
+                            </div>
+                            <div class="chart-stage">
+                                <div id="monthly-user-increase"></div>
+                            </div>
+                            <div class="chart-notes">
+                                The number of users gained in the past month.
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-sm-6 col-md-4">
+                        <div class="chart-wrapper">
+                            <div class="chart-title">
+                                Cell Title
+                            </div>
+                            <div class="chart-stage">
+                            </div>
+                            <div class="chart-notes">
+                                Notes about this chart
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-sm-6 col-md-4">
+                        <div class="chart-wrapper">
+                            <div class="chart-title">
+                                Cell Title
+                            </div>
+                            <div class="chart-stage">
+                            </div>
+                            <div class="chart-notes">
+                                Notes about this chart
+                            </div>
+                        </div>
+                    </div>
+                    <!-- end of three -->
+                    <div class="col-sm-6 col-md-4">
+                        <div class="chart-wrapper">
+                            <div class="chart-title">
+                                Cell Title
+                            </div>
+                            <div class="chart-stage">
+                            </div>
+                            <div class="chart-notes">
+                                Notes about this chart
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-sm-6 col-md-4">
+                        <div class="chart-wrapper">
+                            <div class="chart-title">
+                                Cell Title
+                            </div>
+                            <div class="chart-stage">
+                            </div>
+                            <div class="chart-notes">
+                                Notes about this chart
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-sm-6 col-md-4">
+                        <div class="chart-wrapper">
+                            <div class="chart-title">
+                                Cell Title
+                            </div>
+                            <div class="chart-stage">
+                            </div>
+                            <div class="chart-notes">
+                                Notes about this chart
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+            </div>
+
+
+            <div role="tabpanel" class="tab-pane" id="active-user-metrics">
+                <h3>Active User Metrics!</h3>
+                <div class="row">
+                    <div class="col-sm-6 col-md-4">
+                        <div class="chart-wrapper">
+                            <div class="chart-title">
+                                Daily Active Users
+                            </div>
+                            <div class="chart-stage">
+                                <div id="daily-active-users"></div>
+                            </div>
+                            <div class="chart-notes">
+                                This is the number of users who had at least one pageview on the OSF yesterday.
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-sm-6 col-md-4">
+                        <div class="chart-wrapper">
+                            <div class="chart-title">
+                                Daily Active Users / Total Users
+                            </div>
+                            <div class="chart-stage">
+                                <div id="daily-active-over-total-users"></div>
+                            </div>
+                            <div class="chart-notes">
+                                Notes about this chart
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-sm-6 col-md-4">
+                        <div class="chart-wrapper">
+                            <div class="chart-title">
+                                Cell Title
+                            </div>
+                            <div class="chart-stage">
+                            </div>
+                            <div class="chart-notes">
+                                Notes about this chart
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div role="tabpanel" class="tab-pane" id="healthy-user-metrics">
+                Healthy User Metrics
+            </div>
+            <div role="tabpanel" class="tab-pane" id="expansion-metrics">
+                Expansion Metrics
+            </div>
+            <div role="tabpanel" class="tab-pane" id="cohorts">
+                Cohorts
+            </div>
+            <div role="tabpanel" class="tab-pane" id="raw-numbers">
+                Raw Numbers
+            </div>
+        </div>
+    </div>
+
+
 
     <div class="dropdown">
         <button class="btn btn-default btn-large dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown">
@@ -133,6 +316,33 @@
         <h3>Previous 7 days of linked addon by addon name</h3>
         <div id="previous-7-days-of-linked-addon-by-addon-name">Loading...</div>
     </div>
+
+    <div><h2>Healthy User Metrics</h2></div>
+
+    <div>
+        <h3>Stickiness Ratio</h3>
+        <div id="stickiness-ratio">Loading...</div>
+    </div>
+
+    <div><h2>Raw Numbers</h2></div>
+
+    <div>
+        <h3>Downloads</h3>
+        <div id="downloads">Loading...</div>
+    </div>
+    <div>
+        <h3>Unique Downloads</h3>
+        <div id="unique-downloads">Loading...</div>
+    </div>
+    <div>
+        <h3>Number of Projects</h3>
+        <div id="total-projects">Loading...</div>
+    </div>
+    <div>
+        <h3>Number of Registrations</h3>
+        <div id="total-registrations">Loading...</div>
+    </div>
+
 
 {% endblock content %}
 

--- a/admin/templates/metrics/osf_metrics.html
+++ b/admin/templates/metrics/osf_metrics.html
@@ -171,18 +171,32 @@
                         <div class="col-sm-12">
                             <div class="chart-wrapper">
                                 <div class="chart-title">
-                                    Yesterday's Node logs by user<
+                                    Yesterday's Node logs by user
                                 </div>
                                 <div class="chart-stage">
                                     <div id="yesterdays-node-logs-by-user"></div>
                                 </div>
                                 <div class="chart-notes">
-                                    The last 7 days of users, organized by status.
+                                    The last day of node logs by user, if a user had over 100 node logs.
                                 </div>
                             </div>
                         </div>
                     </div>
-
+                    <div class="row">
+                        <div class="col-sm-12">
+                            <div class="chart-wrapper">
+                                <div class="chart-title">
+                                    Yesterday's Node logs by user
+                                </div>
+                                <div class="chart-stage">
+                                    <div id="yesterdays-node-logs-by-user-c3-experiment"></div>
+                                </div>
+                                <div class="chart-notes">
+                                    The last day of node logs by user, if a user had over 100 node logs.
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
 

--- a/admin/templates/metrics/osf_metrics.html
+++ b/admin/templates/metrics/osf_metrics.html
@@ -11,6 +11,8 @@
         if ('{{ keen_ready }}' == 'True') {
             var keenProjectId = '{{ keen_project_id }}';
             var keenReadKey = '{{ keen_read_key }}';
+            var keenPublicProjectId = '{{ keen_public_project_id }}';
+            var keenPublicReadKey = '{{ keen_public_read_key }}';
         }
     </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.6/d3.min.js" charset="utf-8"></script>

--- a/admin/templates/metrics/osf_metrics.html
+++ b/admin/templates/metrics/osf_metrics.html
@@ -220,7 +220,8 @@
                             <ul class="dropdown-menu pull-right">
                                 <li><a href="#institutional-users-row">Total Institutional Users</a></li>
                                 <li><a href="#institutional-users-growth-row">Institutional Users Growth</a></li>
-                                <li><a href="#affiliated-nodes-and-projects">Affiliated Nodes and Projects</a></li>
+                                <li><a href="#affiliated-nodes">Affiliated Nodes</a></li>
+                                <li><a href="#affiliated-projects">Affiliated Projects</a></li>
                             </ul>
                         </div>
                     </div>
@@ -270,9 +271,10 @@
                         </div>
                     </div>
                 </div>
-                <div class="row" id="affiliated-nodes-and-projects">
+                <div class="row" id="affiliated-nodes">
                     <div class="col-sm-12">
-                        <h4>Affiliated Nodes and Projects</h4>
+                        <h4>Affiliated Nodes</h4>
+                        <p>Nodes (at all levels, projects and components) created by each institution as of yesterday.</p>
                     </div>
                 </div>
                 <div class="row">
@@ -331,9 +333,69 @@
                         </div>
                     </div>
                 </div>
-
+                <div class="row" id="affiliated-projects">
+                    <div class="col-sm-12">
+                        <h4>Affiliated Projects</h4>
+                        <p>Top level projects created by each institution as of yesterday.</p>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-sm-6">
+                        <div class="chart-wrapper">
+                            <div class="chart-title">
+                                Affiliated Public Projects
+                            </div>
+                            <div class="chart-stage">
+                                <div id="affiliated-public-projects"></div>
+                            </div>
+                            <div class="chart-notes">
+                                Total number of public top level projects created by each institution as of yesterday.
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-sm-6">
+                        <div class="chart-wrapper">
+                            <div class="chart-title">
+                                Affiliated Private Projects
+                            </div>
+                            <div class="chart-stage">
+                                <div id="affiliated-private-projects"></div>
+                            </div>
+                            <div class="chart-notes">
+                                Total number of private top level projects created by each institution as of yesterday.
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-sm-6">
+                        <div class="chart-wrapper">
+                            <div class="chart-title">
+                                Affiliated Public Project Registrations
+                            </div>
+                            <div class="chart-stage">
+                                <div id="affiliated-public-registered-projects"></div>
+                            </div>
+                            <div class="chart-notes">
+                                Total number of public registeredtop level projects created by each institution as of yesterday.
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-sm-6">
+                        <div class="chart-wrapper">
+                            <div class="chart-title">
+                                Affiliated Embargoed Project Registrations
+                            </div>
+                            <div class="chart-stage">
+                                <div id="affiliated-embargoed-registered-projects"></div>
+                            </div>
+                            <div class="chart-notes">
+                                Total number of private registered top level projects created by each institution as of yesterday.
+                            </div>
+                        </div>
+                    </div>
+                </div>
             </div>
-
             <div role="tabpanel" class="tab-pane" id="active-user-metrics">
                 <div class="row">
                     <div class="col-sm-3">

--- a/admin/templates/metrics/osf_metrics.html
+++ b/admin/templates/metrics/osf_metrics.html
@@ -70,7 +70,7 @@
                     </div>
 
                     <div class="row">
-                        <div class="col-sm-6 col-md-4">
+                        <div class="col-sm-4">
                             <div class="chart-wrapper">
                                 <div class="chart-title">
                                     Monthly User Increase
@@ -83,7 +83,7 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="col-sm-6 col-md-4">
+                        <div class="col-sm-4">
                             <div class="chart-wrapper">
                                 <div class="chart-title">
                                     Daily User Increase
@@ -96,7 +96,7 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="col-sm-6 col-md-4">
+                        <div class="col-sm-4">
                             <div class="chart-wrapper">
                                 <div class="chart-title">
                                     Average Daily User Gain
@@ -126,7 +126,7 @@
                         </div>
                     </div>
                     <div class="row">
-                        <div class="col-sm-6 col-md-4">
+                        <div class="col-sm-4">
                             <div class="chart-wrapper">
                                 <div class="chart-title">
                                     Unverified New Users
@@ -338,7 +338,7 @@
                     </div>
                 </div>
                 <div class="row">
-                    <div class="col-sm-6 col-md-4">
+                    <div class="col-sm-4">
                         <div class="chart-wrapper">
                             <div class="chart-title">
                                 Monthly Active Users (MAU)
@@ -351,7 +351,7 @@
                             </div>
                         </div>
                     </div>
-                    <div class="col-sm-6 col-md-4">
+                    <div class="col-sm-4">
                         <div class="chart-wrapper">
                             <div class="chart-title">
                                 Last Month's Active Users / Total Users
@@ -364,7 +364,7 @@
                             </div>
                         </div>
                     </div>
-                    <div class="col-sm-6 col-md-4">
+                    <div class="col-sm-4">
                         <div class="chart-wrapper">
                             <div class="chart-title">
                                 Monthly Growth of MAU%

--- a/admin/templates/metrics/osf_metrics.html
+++ b/admin/templates/metrics/osf_metrics.html
@@ -293,16 +293,31 @@
             <div role="tabpanel" class="tab-pane" id="active-user-metrics">
                 <h3>Active User Metrics!</h3>
                 <div class="row">
+                    <div class="col-sm-12">
+                        <div class="chart-wrapper">
+                            <div class="chart-title">
+                                Recent Daily Unique Sessions
+                            </div>
+                            <div class="chart-stage">
+                                <div id="recent-daily-unique-sessions"></div>
+                            </div>
+                            <div class="chart-notes">
+                                The previous 14 days of unique visitor sessions.
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="row">
                     <div class="col-sm-6">
                         <div class="chart-wrapper">
                             <div class="chart-title">
-                                Daily Active Users
+                                Daily Active Logged In Users
                             </div>
                             <div class="chart-stage">
                                 <div id="daily-active-users"></div>
                             </div>
                             <div class="chart-notes">
-                                This is the number of users who had at least one pageview on the OSF yesterday.
+                                This is the number of logged in users with user ids who had at least one pageview on the OSF yesterday.
                             </div>
                         </div>
                     </div>

--- a/admin/templates/metrics/osf_metrics.html
+++ b/admin/templates/metrics/osf_metrics.html
@@ -39,23 +39,31 @@
 
     <div><h2>User Data</h2></div>
 
-    <div class="row">
-        <div class="col-md-3" id="active_users">
-            <h3>Yesterday's Active Users</h3>
-            <div id="active-user-count">Loading...</div>
-        </div>
-        <div class="col-md-3" id="active_users">
-            <h3>Daily Increase of Users</h3>
-            <div id="daily-user-increase">Loading...</div>
-        </div>
-        <div class="col-md-3" id="active_users">
-            <h3>Monthly Increase of Users</h3>
-            <div id="monthly-user-increase">Loading...</div>
-        </div>
-        <div class="col-md-3" id="active_users">
-            <h3>Average Daily Gain Over past 7 Days</h3>
-            <div id="average-gain-metric">Loading...</div>
-        </div>
+    <div id="active_users">
+        <h3>Yesterday's Total Users with Active Accounts</h3>
+        <div id="active-user-count">Loading...</div>
+    </div>
+    <div id="active_users">
+        <h3>Daily Increase of Users</h3>
+        <div id="daily-user-increase">Loading...</div>
+    </div>
+    <div id="active_users">
+        <h3>Monthly Increase of Users</h3>
+        <div id="monthly-user-increase">Loading...</div>
+    </div>
+    <div id="active_users">
+        <h3>Average Daily Gain Over past 7 Days</h3>
+        <div id="average-gain-metric">Loading...</div>
+    </div>
+
+    <div>
+        <h3>Yesterday's Active Logged In Users</h3>
+        <div id="daily-active-users">Loading...</div>
+    </div>
+
+    <div>
+        <h3>Active Users / Total Users</h3>
+        <div id="daily-active--over-total-users">Loading...</div>
     </div>
 
     <div class="row">

--- a/admin/templates/sales_analytics/dashboard.html
+++ b/admin/templates/sales_analytics/dashboard.html
@@ -29,7 +29,7 @@
 
     <div class="row">
       <div class="col-sm-12 col-md-6">
-        <div class="row", style="display: none;">
+        <div class="row">
           <div class="col-xs-12">
             <div class="chart-wrapper">
               <div class="chart-title">
@@ -79,7 +79,7 @@
       </div>
       <div class="col-sm-12 col-md-6">
         <div class="row">
-          <div class="col-sm-12 col-md-6", style="display: none;">
+          <div class="col-sm-12 col-md-6">
             <div class="chart-wrapper">
               <div class="chart-title">
                 OSF Products Users View in the Past Month
@@ -93,7 +93,7 @@
               </div>
             </div>
           </div>
-          <div class="col-sm-12 col-md-6", style="display: none;">
+          <div class="col-sm-12 col-md-6">
             <div class="chart-wrapper">
               <div class="chart-title">
                 OSF Products Users View in the Past Month
@@ -109,7 +109,7 @@
           </div>
 
 
-          <div class="col-sm-12 col-md-6", style="display: none;">
+          <div class="col-sm-12 col-md-6">
             <div class="chart-wrapper">
               <div class="chart-title">
                 Average User Session Length of Previous 7 days

--- a/admin/webpack.admin.config.js
+++ b/admin/webpack.admin.config.js
@@ -31,7 +31,7 @@ var config = assign({}, common, {
         'prereg-admin-page': staticAdminPath('js/pages/prereg-admin-page.js'),
         'admin-registration-edit-page': staticAdminPath('js/pages/admin-registration-edit-page.js'),
         'dashboard': staticAdminPath('js/sales_analytics/dashboard.js'),
-        'metrics': staticAdminPath('js/metrics/metrics.js'),
+        'metrics-page': staticAdminPath('js/pages/metrics-page.js'),
     },
     plugins: plugins,
     debug: true,


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

OSF Admin Metrics changes, according to the needs and requests of the community team.  Redo the gathering of keen analytics in a new style and broken into new sections for clarity, speed, and usability.

![screen shot 2017-01-03 at 1 45 20 pm](https://cloud.githubusercontent.com/assets/801594/21618847/f421d022-d1ba-11e6-8274-c56104f52267.png)

## Changes

- Revamp all calls to keen - now use the newer Keen dataviz  and analytics libraries
- Add a wide variety of new charts
- New chart organization
- add metrics-page that does the keen initializing and calls seperate analytics sections when a new tab is clicked
- All new layout, colors and organization.
- Removed link to old OSF Sales Analytics, as those charts aren't working at the moment.

## Side effects

Removed sidebar link to OSF Sales Analytics, so any documentation that says to look for that will be wrong. I left the page itself intact for now though. 


## Ticket
https://openscience.atlassian.net/browse/OSF-7253