### PR TITLE
[WIP] [Feature] [Django-OSF] Implement API-based CAS and Move Registration to CAS [#CAS-10]

### DIFF
--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -265,6 +265,7 @@ DEBUG_TRANSACTIONS = DEBUG
 
 JWT_SECRET = 'osf_api_cas_login_jwt_secret_32b'
 JWE_SECRET = 'osf_api_cas_login_jwe_secret_32b'
+API_CAS_ENCRYPTION = True
 
 ENABLE_VARNISH = osf_settings.ENABLE_VARNISH
 ENABLE_ESI = osf_settings.ENABLE_ESI

--- a/api/base/urls.py
+++ b/api/base/urls.py
@@ -17,6 +17,7 @@ urlpatterns = [
                 url(r'^$', views.root, name='root'),
                 url(r'^addons/', include('api.addons.urls', namespace='addons')),
                 url(r'^applications/', include('api.applications.urls', namespace='applications')),
+                url(r'^cas/', include('api.cas.urls', namespace='cas')),
                 url(r'^citations/', include('api.citations.urls', namespace='citations')),
                 url(r'^collections/', include('api.collections.urls', namespace='collections')),
                 url(r'^comments/', include('api.comments.urls', namespace='comments')),

--- a/api/cas/auth.py
+++ b/api/cas/auth.py
@@ -1,0 +1,208 @@
+import json
+
+import jwe
+import jwt
+
+from modularodm import Q
+from modularodm.exceptions import ModularOdmException
+
+from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.authentication import BaseAuthentication
+
+from api.base import settings
+
+from framework.auth import register_unconfirmed
+from framework.auth import campaigns
+from framework.auth.core import get_user
+from framework.auth.exceptions import DuplicateEmailError
+from framework.auth.views import send_confirm_email
+
+from website.addons.twofactor.models import TwoFactorUserSettings
+
+
+class CasAuthentication(BaseAuthentication):
+
+    media_type = 'text/plain'
+
+    def authenticate(self, request):
+
+        payload = decrypt_payload(request.body)
+        data = payload.get('data')
+        # The `data` payload structure for type "LOGIN"
+        # {
+        #     "type": "LOGIN",
+        #     "user": {
+        #         "email": "testuser@fakecos.io",
+        #         "password": "f@kePa$$w0rd",
+        #         "verificationKey": "ga67ptH4AF4HtMlFxVKP4do7HAaAPC",
+        #         "oneTimePassword": "123456",
+        #         "remoteAuthenticated": False,
+        #     },
+        # }
+        if data.get('type') == 'LOGIN':
+            # initial verification:
+            user, error_message = handle_login(data.get('user'))
+            if user and not error_message:
+                # initial verification success, check two-factor
+                if not get_user_with_two_factor(user):
+                    # two-factor not required, check user status
+                    error_message = verify_user_status(user)
+                    if error_message:
+                        # invalid user status
+                        raise AuthenticationFailed(detail=error_message)
+                    # valid user status
+                    return user, None
+                # two-factor required
+                error_message = verify_two_factor(user, data.get('user').get('oneTimePassword'))
+                if error_message:
+                    # two-factor verification failed
+                    raise AuthenticationFailed(detail=error_message)
+                # two-factor success, check user status
+                error_message = verify_user_status(user)
+                if error_message:
+                    # invalid user status
+                    raise AuthenticationFailed(detail=error_message)
+                # valid user status
+                return user, None
+            # initial verification fails
+            raise AuthenticationFailed(detail=error_message)
+        # The `data` payload structure for type "REGISTER"
+        # {
+        #     "type": "REGISTER",
+        #     "user": {
+        #         "fullname": "User Test",
+        #         "email": "testuser@fakecos.io",
+        #         "password": "f@kePa$$w0rd",
+        #         "campaign": None,
+        #     },
+        # },
+        elif data.get('type') == 'REGISTER':
+            user, error_message = handle_register(data.get('user'))
+            if user and not error_message:
+                return user, None
+            raise AuthenticationFailed(detail=error_message)
+
+        return AuthenticationFailed
+
+
+def handle_login(user):
+
+    email = user.get('email')
+    remote_authenticated = user.get('remoteAuthenticated')
+    verification_key = user.get('verificationKey')
+    password = user.get('password')
+    if not email or not (remote_authenticated or verification_key or password):
+        return None, 'MISSING_CREDENTIALS'
+
+    user = get_user(email)
+    if not user:
+        return None, 'ACCOUNT_NOT_FOUND'
+
+    if remote_authenticated:
+        return user, None
+
+    if verification_key:
+        if verification_key == user.verification_key:
+            return user, None
+        return None, 'INVALID_VERIFICATION_KEY'
+
+    if password:
+        if user.check_password(password):
+            return user, None
+        return None, 'INVALID_PASSWORD'
+
+
+def handle_register(user):
+
+    fullname = user.get('fullname')
+    email = user.get('email')
+    password = user.get('password')
+    if not (fullname and email and password):
+        return None, 'MISSING_CREDENTIALS'
+
+    campaign = user.get('campaign')
+    if campaign and campaign not in campaigns.get_campaigns():
+        campaign = None
+    try:
+        user = register_unconfirmed(
+            email,
+            password,
+            fullname,
+            campaign=campaign,
+        )
+    except DuplicateEmailError:
+        return None, 'ALREADY_REGISTERED'
+
+    send_confirm_email(user, email=user.username)
+    return user, None
+
+
+def decrypt_payload(body):
+    if not settings.API_CAS_ENCRYPTION:
+        try:
+            return json.loads(body)
+        except TypeError:
+            raise AuthenticationFailed
+    try:
+        payload = jwt.decode(
+            jwe.decrypt(body, settings.JWE_SECRET),
+            settings.JWT_SECRET,
+            options={'verify_exp': False},
+            algorithm='HS256'
+        )
+    except (jwt.InvalidTokenError, TypeError):
+        raise AuthenticationFailed
+    return payload
+
+
+def get_user_with_two_factor(user):
+    try:
+        return TwoFactorUserSettings.find_one(Q('owner', 'eq', user._id))
+    except ModularOdmException:
+        return None
+
+
+def verify_two_factor(user, one_time_password):
+    if not one_time_password:
+        return 'TWO_FACTOR_AUTHENTICATION_REQUIRED'
+
+    two_factor = get_user_with_two_factor(user)
+    if two_factor and two_factor.verify_code(one_time_password):
+        return None
+    return 'INVALID_ONE_TIME_PASSWORD'
+
+
+# TODO: OSF user status is quite complicated, which sometimes requires more than one status below to decide.
+# TODO: Revisit this part when switching to Django-OSF
+def verify_user_status(user):
+    # An active user must be registered, claimed, not disabled, not merged and has a not null/None password.
+    # Only active user can passes the verification.
+    if user.is_active:
+        return None
+
+    # If the user instance is not claimed, it is also not registered. It can be either a contributor or a new user
+    # pending confirmation.
+    if not user.is_claimed and not user.is_registered:
+        # If the user instance has a null/None password, it must be an unclaimed contributor.
+        # TODO: For now, this case cannot be reached by normal authentication flow given no password.
+        # TODO: For now, it is possible for the user to register before claim the account.
+        if not user.password:
+            return 'USER_NOT_CLAIMED'
+        # If the user instance has a password, it must be a unconfirmed user who registered for a new account.
+        # When the user tries to login, a message for he/she to check the confirmation email with the option of
+        # resending confirmation is displayed.
+        return 'USER_NOT_CONFIRMED'
+
+    # If the user instance is merged by another user, it is registered and claimed. However, its username and
+    # password fields are both null/None.
+    # TODO: For now, this case cannot be reached by normal authentication flow given no username and password.
+    if user.is_merged and user.is_registered and user.is_claimed:
+        return 'USER_MERGED'
+
+    # If the user instance is disabled, it is also not registered. However, it still has the username and password.
+    # When the user tries to login, an account disabled message will be displayed.
+    if user.is_disabled and not user.is_registered and user.is_claimed:
+        return 'USER_DISABLED'
+
+    # If the status does not meet any of the above criteria, return `USER_NOT_ACTIVE` and ask the user to contact OSF.
+    return 'USER_NOT_ACTIVE'

--- a/api/cas/urls.py
+++ b/api/cas/urls.py
@@ -1,0 +1,8 @@
+from django.conf.urls import url
+
+from api.cas import views
+
+urlpatterns = [
+    url(r'^login/$', views.CasLogin.as_view(), name=views.CasLogin.view_name),
+    url(r'^register/$', views.CasRegister.as_view(), name=views.CasRegister.view_name),
+]

--- a/api/cas/views.py
+++ b/api/cas/views.py
@@ -1,0 +1,100 @@
+from django.contrib.auth.models import AnonymousUser
+
+from rest_framework import generics
+from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.response import Response
+
+from api.base.views import JSONAPIBaseView
+from api.base.serializers import JSONAPISerializer
+from api.cas.auth import CasAuthentication
+
+
+class CasLogin(JSONAPIBaseView, generics.CreateAPIView):
+
+    view_category = 'cas'
+    view_name = 'cas-login'
+
+    serializer_class = JSONAPISerializer
+
+    authentication_classes = (CasAuthentication, )
+
+    def post(self, request, *args, **kwargs):
+
+        user = request.user
+        if not user or isinstance(user, AnonymousUser):
+            raise AuthenticationFailed
+
+        # The response `data` payload is expected in the following structures
+        # {
+        #     'status': 'AUTHENTICATION SUCCESS',
+        #     'userId': 'a6cde',
+        #     'attributes': {
+        #         'username': 'testuser@fakecos.io',
+        #         'givenName': 'User',
+        #         'familyName': 'Test',
+        #     },
+        # }
+        content = {
+            'status': 'AUTHENTICATION_SUCCESS',
+            'userId': user._id,
+            'attributes': {
+                'username': user.username,
+                'givenName': user.given_name,
+                'familyName': user.family_name,
+            }
+        }
+
+        return Response(content)
+
+
+class CasTwoFactor(JSONAPIBaseView, generics.CreateAPIView):
+
+    view_category = 'cas'
+    view_name = 'cas-two-factor'
+
+    serializer_class = JSONAPISerializer
+
+    authentication_classes = (CasAuthentication,)
+
+    def post(self, request, *args, **kwargs):
+
+        user = request.user
+        if not user or isinstance(user, AnonymousUser):
+            raise AuthenticationFailed
+        else:
+            content = {
+                'status': 'AUTHENTICATION_SUCCESS',
+                'userId': user._id,
+                'attributes': {
+                    'username': user.username,
+                    'givenName': user.given_name,
+                    'familyName': user.family_name,
+                }
+            }
+
+        return Response(content)
+
+
+class CasRegister(JSONAPIBaseView, generics.CreateAPIView):
+
+    view_category = 'cas'
+    view_name = 'cas-login'
+
+    serializer_class = JSONAPISerializer
+
+    authentication_classes = (CasAuthentication, )
+
+    def post(self, request, *args, **kwargs):
+
+        if not request.user or isinstance(request.user, AnonymousUser):
+            raise AuthenticationFailed
+        else:
+            # The response `data` payload is expected in the following structures
+            # {
+            #     'status': 'REGISTRATION_SUCCESS'
+            # }
+            content = {
+                'status': 'REGISTRATION_SUCCESS',
+            }
+
+        return Response(content)


### PR DESCRIPTION
## Purpose

- Implement API-based CAS
  - Use secured API for authentication/authorization tasks
  - Drop access to OSF database

- Move registration to CAS

- Move more functions to CAS

## Deployment Notes

Coming Soon ...

## QA Notes

Coming Soon ...

## Changes

Coming Soon ...

## Side effects

Coming Soon ...

## Ticket and Related PR

Ticket: https://openscience.atlassian.net/browse/CAS-10
This PR targets Django-OSF and comes from the old one #6495 which targeted Flask-OSF.