### PR TITLE
Don't count OSF Collections while counting nodes and projects

### DIFF
--- a/scripts/analytics/node_summary.py
+++ b/scripts/analytics/node_summary.py
@@ -29,7 +29,8 @@ class NodeSummary(SummaryAnalytics):
         node_query = (
             Q('is_deleted', 'ne', True) &
             Q('is_folder', 'ne', True) &
-            Q('date_created', 'lt', query_datetime)
+            Q('date_created', 'lt', query_datetime) &
+            Q('type', 'ne', 'osf.collection')
         )
 
         registration_query = node_query & Q('is_registration', 'eq', True)

--- a/scripts/analytics/node_summary.py
+++ b/scripts/analytics/node_summary.py
@@ -30,7 +30,7 @@ class NodeSummary(SummaryAnalytics):
             Q('is_deleted', 'ne', True) &
             Q('is_folder', 'ne', True) &
             Q('date_created', 'lt', query_datetime) &
-            Q('type', 'ne', 'osf.collection')
+            Q('is_collection', 'ne', True)
         )
 
         registration_query = node_query & Q('is_registration', 'eq', True)


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Right now Keen counts are including all collections - don't count those!!!

## Changes
- don't include collections when querying for nodes

## Side effects
Numbers will jump down a lot! Will need to re-run node_summaries for these days!


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
