### PR TITLE
[hotfix] increase mfr render limit to 200kb

### DIFF
--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -372,9 +372,9 @@ var FileViewPage = {
                 return;
             }
             var fileType = mime.lookup(self.file.name.toLowerCase());
-            // Only allow files < 64k to be editable
+            // Only allow files < 200kb to be editable (should sync with MFR limit)
             // No files on figshare are editable.
-            if (self.file.size < 65536 && fileType && self.file.provider !== 'figshare') { //May return false
+            if (self.file.size < 204800 && fileType && self.file.provider !== 'figshare') { //May return false
                 var editor = EDITORS[fileType.split('/')[0]];
                 if (editor) {
                     self.editor = new Panel('Edit', self.editHeader, editor, [self.file.urls.content, self.file.urls.sharejs, self.editorMeta, self.shareJSObservables], false);


### PR DESCRIPTION
## Purpose

The file page refuses to render text files larger than 64kb to avoid dumping masses of text into the user's browser.  There was a request to increase this limit to 200kb.  The corresponding setting in MFR has already been increased with the [v0.18.3 hotfix release](https://github.com/CenterForOpenScience/modular-file-renderer/commit/19afba382e7150659a9a0a43f031bacff692d36d).

## Changes

Bump file view page render limit to 200kb.

## Side effects

None expected.

## Ticket

No ticket.