### PR TITLE
hotfix - use render_bundle to load metrics-page assets on admin metrics page

### DIFF
--- a/admin/templates/metrics/osf_metrics.html
+++ b/admin/templates/metrics/osf_metrics.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load render_bundle from webpack_loader %}
 {% load static %}
 
 {% block title %}
@@ -937,5 +938,5 @@
 
 
 {% block bottom_js %}
-    <script src="{% static 'public/js/metrics-page.js' %}"></script>
+    {% render_bundle 'metrics-page' %}
 {% endblock %}


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Static assets not loading properly for the admin module metrics.js

## Changes
Use `render_bundle` to load assets!

## Side effects
None anticipated


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
