### PR TITLE
Fix licenses serialization for search

### DIFF
--- a/osf/models/licenses.py
+++ b/osf/models/licenses.py
@@ -3,8 +3,8 @@ import functools
 
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
+from osf.models.base import BaseModel, ObjectIDMixin
 
-from osf.models.base import ObjectIDMixin, BaseModel
 
 def _serialize(fields, instance):
     return {
@@ -12,7 +12,7 @@ def _serialize(fields, instance):
         for field in fields
     }
 
-serialize_node_license = functools.partial(_serialize, ('id', 'name', 'text'))
+serialize_node_license = functools.partial(_serialize, ('_id', 'name', 'text'))
 
 def serialize_node_license_record(node_license_record):
     if node_license_record is None:

--- a/website/project/licenses/__init__.py
+++ b/website/project/licenses/__init__.py
@@ -25,7 +25,7 @@ def _serialize(fields, instance):
         for field in fields
     }
 
-serialize_node_license = functools.partial(_serialize, ('id', 'name', 'text'))
+serialize_node_license = functools.partial(_serialize, ('_id', 'name', 'text'))
 
 
 def serialize_node_license_record(node_license_record):

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -8,26 +8,21 @@ import logging
 import math
 import re
 import unicodedata
+from framework import sentry
 
-from django.apps import apps
-from elasticsearch import (
-    ConnectionError,
-    Elasticsearch,
-    NotFoundError,
-    RequestError,
-    TransportError,
-    helpers,
-)
-from modularodm import Q
 import six
 
-from framework import sentry
+from django.apps import apps
+from elasticsearch import (ConnectionError, Elasticsearch, NotFoundError,
+                           RequestError, TransportError, helpers)
 from framework.celery_tasks import app as celery_app
 from framework.mongo.utils import paginated
-
+from modularodm import Q
+from osf.models import AbstractNode as Node
+from osf.models import OSFUser as User
+from osf.models import FileNode
 from website import settings
 from website.filters import gravatar
-from osf.models import OSFUser as User, FileNode, AbstractNode as Node
 from website.project.licenses import serialize_node_license_record
 from website.search import exceptions
 from website.search.util import build_query, clean_splitters


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Fix search for things with licenses.

## Changes

Node serialization for ES was using `id` for licenses instead of `_id`. Now it uses `_id` and it works.

## Side effects

Search might work now. There could also be other bugs this doesn't cover.


## Ticket

https://trello.com/c/ikKIGc4t/95-search-results-empty