### PR TITLE
Fix citation API endpoint lookup

### DIFF
--- a/api/citations/views.py
+++ b/api/citations/views.py
@@ -1,14 +1,14 @@
-from rest_framework import generics, permissions as drf_permissions
-
-from api.base.views import JSONAPIBaseView
-from api.base.utils import get_object_or_error
+from api.base import permissions as base_permissions
 from api.base.filters import ODMFilterMixin
 from api.base.pagination import NoMaxPageSizePagination
-from api.base import permissions as base_permissions
+from api.base.utils import get_object_or_error
+from api.base.views import JSONAPIBaseView
 from api.citations.serializers import CitationSerializer
 from framework.auth.oauth_scopes import CoreScopes
-
+from rest_framework import permissions as drf_permissions
+from rest_framework import generics
 from website.models import CitationStyle
+
 
 class CitationStyleList(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin):
     '''List of standard citation styles available for rendering citations. *Read-only*

--- a/osf/models/base.py
+++ b/osf/models/base.py
@@ -105,6 +105,10 @@ class BaseModel(models.Model):
                 return cls.objects.get(guids___id=data)
             elif issubclass(cls, ObjectIDMixin):
                 return cls.objects.get(_id=data)
+            elif isinstance(data, basestring):
+                # Some models (CitationStyle) have an _id that is not a bson
+                # Looking up things by pk will never work with a basestring
+                return cls.objects.get(_id=data)
             return cls.objects.get(pk=data)
         except cls.DoesNotExist:
             return None


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

See title ^-^

## Changes

Added an additional `elif` block to the BaseModel load method that forces lookups for basestring type queries to `_id`

## Side effects

It could break many things if primary keys are being sent in as basestring and django is automagically converting them to integers but I don't think it would do that because of blind faith.


## Ticket

https://trello.com/c/X4ztaboP/94-unable-to-get-details-for-citation-styles-on-staging3