### PR TITLE
Rename BaseAddonConfig -> BaseAddonAppConfig

### DIFF
--- a/addons/base/__init__.py
+++ b/addons/base/__init__.py
@@ -1,5 +1,5 @@
 from django.db.models import options
-default_app_config = 'addons.base.apps.BaseAddonConfig'
+default_app_config = 'addons.base.apps.BaseAddonAppConfig'
 
 
 # Patch to make abstractproperties overridable by djangofields

--- a/addons/base/apps.py
+++ b/addons/base/apps.py
@@ -26,7 +26,7 @@ USER_SETTINGS_TEMPLATE_DEFAULT = os.path.join(
 )
 
 
-class BaseAddonConfig(AppConfig):
+class BaseAddonAppConfig(AppConfig):
     name = 'addons.base'
     label = 'addons_base'
 
@@ -47,7 +47,7 @@ class BaseAddonConfig(AppConfig):
     accept_extensions = True
 
     def __init__(self, *args, **kwargs):
-        ret = super(BaseAddonConfig, self).__init__(*args, **kwargs).__init__()
+        ret = super(BaseAddonAppConfig, self).__init__(*args, **kwargs).__init__()
         # Build template lookup
         paths = [settings.TEMPLATES_PATH]
         if self.user_settings_template:

--- a/addons/box/__init__.py
+++ b/addons/box/__init__.py
@@ -1,1 +1,1 @@
-default_app_config = 'addons.box.apps.BoxAddonConfig'
+default_app_config = 'addons.box.apps.BoxAddonAppConfig'

--- a/addons/box/apps.py
+++ b/addons/box/apps.py
@@ -1,8 +1,8 @@
-from addons.base.apps import BaseAddonConfig
+from addons.base.apps import BaseAddonAppConfig
 
 from addons.box.views import box_root_folder
 
-class BoxAddonConfig(BaseAddonConfig):
+class BoxAddonAppConfig(BaseAddonAppConfig):
 
     name = 'addons.box'
     label = 'addons_box'

--- a/addons/dataverse/__init__.py
+++ b/addons/dataverse/__init__.py
@@ -1,1 +1,1 @@
-default_app_config = 'addons.dataverse.apps.DataverseAddonConfig'
+default_app_config = 'addons.dataverse.apps.DataverseAddonAppConfig'

--- a/addons/dataverse/apps.py
+++ b/addons/dataverse/apps.py
@@ -1,6 +1,6 @@
 import os
 
-from addons.base.apps import BaseAddonConfig
+from addons.base.apps import BaseAddonAppConfig
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 TEMPLATE_PATH = os.path.join(
@@ -8,7 +8,7 @@ TEMPLATE_PATH = os.path.join(
     'templates'
 )
 
-class DataverseAddonConfig(BaseAddonConfig):
+class DataverseAddonAppConfig(BaseAddonAppConfig):
 
     name = 'addons.dataverse'
     label = 'addons_dataverse'

--- a/addons/dropbox/__init__.py
+++ b/addons/dropbox/__init__.py
@@ -1,1 +1,1 @@
-default_app_config = 'addons.dropbox.apps.DropboxAddonConfig'
+default_app_config = 'addons.dropbox.apps.DropboxAddonAppConfig'

--- a/addons/dropbox/apps.py
+++ b/addons/dropbox/apps.py
@@ -1,9 +1,9 @@
-from addons.base.apps import BaseAddonConfig
+from addons.base.apps import BaseAddonAppConfig
 
 from addons.dropbox.views import dropbox_root_folder
 
 
-class DropboxAddonConfig(BaseAddonConfig):
+class DropboxAddonAppConfig(BaseAddonAppConfig):
 
     name = 'addons.dropbox'
     label = 'addons_dropbox'

--- a/addons/figshare/__init__.py
+++ b/addons/figshare/__init__.py
@@ -1,1 +1,1 @@
-default_app_config = 'addons.figshare.apps.FigshareAddonConfig'
+default_app_config = 'addons.figshare.apps.FigshareAddonAppConfig'

--- a/addons/figshare/apps.py
+++ b/addons/figshare/apps.py
@@ -1,9 +1,9 @@
-from addons.base.apps import BaseAddonConfig
+from addons.base.apps import BaseAddonAppConfig
 
 from addons.figshare.views import figshare_root_folder
 
 
-class FigshareAddonConfig(BaseAddonConfig):
+class FigshareAddonAppConfig(BaseAddonAppConfig):
 
     name = 'addons.figshare'
     label = 'addons_figshare'

--- a/addons/forward/__init__.py
+++ b/addons/forward/__init__.py
@@ -1,1 +1,1 @@
-default_app_config = 'addons.forward.apps.ForwardAddonConfig'
+default_app_config = 'addons.forward.apps.ForwardAddonAppConfig'

--- a/addons/forward/apps.py
+++ b/addons/forward/apps.py
@@ -1,6 +1,6 @@
 import os
 
-from addons.base.apps import BaseAddonConfig
+from addons.base.apps import BaseAddonAppConfig
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 NODE_SETTINGS_TEMPLATE = os.path.join(
@@ -9,7 +9,7 @@ NODE_SETTINGS_TEMPLATE = os.path.join(
     'forward_node_settings.mako',
 )
 
-class ForwardAddonConfig(BaseAddonConfig):
+class ForwardAddonAppConfig(BaseAddonAppConfig):
 
     name = 'addons.forward'
     label = 'addons_forward'

--- a/addons/github/apps.py
+++ b/addons/github/apps.py
@@ -1,5 +1,5 @@
 import os
-from addons.base.apps import BaseAddonConfig
+from addons.base.apps import BaseAddonAppConfig
 
 from addons.github.views import github_hgrid_data
 
@@ -10,7 +10,7 @@ NODE_SETTINGS_TEMPLATE = os.path.join(
     'github_node_settings.mako',
 )
 
-class GitHubAddonConfig(BaseAddonConfig):
+class GitHubAddonConfig(BaseAddonAppConfig):
 
     name = 'addons.github'
     label = 'addons_github'

--- a/addons/googledrive/apps.py
+++ b/addons/googledrive/apps.py
@@ -1,8 +1,8 @@
-from addons.base.apps import BaseAddonConfig
+from addons.base.apps import BaseAddonAppConfig
 
 from addons.googledrive.views import googledrive_root_folder
 
-class GoogleDriveAddonConfig(BaseAddonConfig):
+class GoogleDriveAddonConfig(BaseAddonAppConfig):
 
     name = 'addons.googledrive'
     label = 'addons_googledrive'

--- a/addons/mendeley/apps.py
+++ b/addons/mendeley/apps.py
@@ -1,7 +1,7 @@
-from addons.base.apps import BaseAddonConfig
+from addons.base.apps import BaseAddonAppConfig
 
 
-class MendeleyAddonConfig(BaseAddonConfig):
+class MendeleyAddonConfig(BaseAddonAppConfig):
 
     name = 'addons.mendeley'
     label = 'addons_mendeley'

--- a/addons/osfstorage/__init__.py
+++ b/addons/osfstorage/__init__.py
@@ -1,1 +1,1 @@
-default_app_config = 'addons.osfstorage.apps.OSFStorageAddonConfig'
+default_app_config = 'addons.osfstorage.apps.OSFStorageAddonAppConfig'

--- a/addons/osfstorage/apps.py
+++ b/addons/osfstorage/apps.py
@@ -1,12 +1,10 @@
-import os
-
-from addons.base.apps import BaseAddonConfig
+from addons.base.apps import BaseAddonAppConfig
 from website import settings
 from addons.osfstorage import settings as addon_settings
 from addons.osfstorage import views
 
 
-class OSFStorageAddonConfig(BaseAddonConfig):
+class OSFStorageAddonAppConfig(BaseAddonAppConfig):
     name = 'addons.osfstorage'
     label = 'addons_osfstorage'
     full_name = 'OSF Storage'

--- a/addons/owncloud/__init__.py
+++ b/addons/owncloud/__init__.py
@@ -1,1 +1,1 @@
-default_app_config = 'addons.owncloud.apps.OwnCloudAddonConfig'
+default_app_config = 'addons.owncloud.apps.OwnCloudAddonAppConfig'

--- a/addons/owncloud/apps.py
+++ b/addons/owncloud/apps.py
@@ -1,5 +1,5 @@
 import os
-from addons.base.apps import BaseAddonConfig
+from addons.base.apps import BaseAddonAppConfig
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 TEMPLATE_PATH = os.path.join(
@@ -7,7 +7,7 @@ TEMPLATE_PATH = os.path.join(
     'templates'
 )
 
-class OwnCloudAddonConfig(BaseAddonConfig):
+class OwnCloudAddonAppConfig(BaseAddonAppConfig):
 
     name = 'addons.owncloud'
     label = 'addons_owncloud'

--- a/addons/s3/__init__.py
+++ b/addons/s3/__init__.py
@@ -1,1 +1,1 @@
-default_app_config = 'addons.s3.apps.S3AddonConfig'
+default_app_config = 'addons.s3.apps.S3AddonAppConfig'

--- a/addons/s3/apps.py
+++ b/addons/s3/apps.py
@@ -1,5 +1,5 @@
 import os
-from addons.base.apps import BaseAddonConfig
+from addons.base.apps import BaseAddonAppConfig
 
 from addons.s3.views import s3_root_folder
 
@@ -9,7 +9,7 @@ TEMPLATE_PATH = os.path.join(
     'templates'
 )
 
-class S3AddonConfig(BaseAddonConfig):
+class S3AddonAppConfig(BaseAddonAppConfig):
 
     name = 'addons.s3'
     label = 'addons_s3'

--- a/addons/twofactor/__init__.py
+++ b/addons/twofactor/__init__.py
@@ -1,1 +1,1 @@
-default_app_config = 'addons.twofactor.apps.TwoFactorAddonConfig'
+default_app_config = 'addons.twofactor.apps.TwoFactorAddonAppConfig'

--- a/addons/twofactor/apps.py
+++ b/addons/twofactor/apps.py
@@ -1,7 +1,7 @@
-from addons.base.apps import BaseAddonConfig
+from addons.base.apps import BaseAddonAppConfig
 
 
-class TwoFactorAddonConfig(BaseAddonConfig):
+class TwoFactorAddonAppConfig(BaseAddonAppConfig):
 
     name = 'addons.twofactor'
     label = 'addons_twofactor'

--- a/addons/wiki/__init__.py
+++ b/addons/wiki/__init__.py
@@ -1,1 +1,1 @@
-default_app_config = 'addons.wiki.apps.WikiAddonConfig'
+default_app_config = 'addons.wiki.apps.WikiAddonAppConfig'

--- a/addons/wiki/apps.py
+++ b/addons/wiki/apps.py
@@ -1,7 +1,8 @@
-from addons.base.apps import BaseAddonConfig
+from addons.base.apps import BaseAddonAppConfig
 
 
-class WikiAddonConfig(BaseAddonConfig):
+
+class WikiAddonAppConfig(BaseAddonAppConfig):
 
     name = 'addons.wiki'
     label = 'addons_wiki'

--- a/addons/zotero/__init__.py
+++ b/addons/zotero/__init__.py
@@ -1,1 +1,1 @@
-default_app_config = 'addons.zotero.apps.ZoteroAddonConfig'
+default_app_config = 'addons.zotero.apps.ZoteroAddonAppConfig'

--- a/addons/zotero/apps.py
+++ b/addons/zotero/apps.py
@@ -1,7 +1,7 @@
-from addons.base.apps import BaseAddonConfig
+from addons.base.apps import BaseAddonAppConfig
 
 
-class ZoteroAddonConfig(BaseAddonConfig):
+class ZoteroAddonAppConfig(BaseAddonAppConfig):
 
     name = 'addons.zotero'
     label = 'addons_zotero'


### PR DESCRIPTION
Rename BaseAddonConfig to BaseAddonAppConfig well as rename subclasses of BaseAddonAppConfig.

This more clearly differentiates BaseAddonAppConfig from
website.addons.base.AddonConfig

