### PR TITLE
Replace TokuTransaction with django.db.transaction.atomic

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -25,7 +25,6 @@ from framework.auth.decorators import collect_auth, must_be_logged_in, must_be_s
 from framework.exceptions import HTTPError
 from framework.routing import json_renderer
 from framework.sentry import log_exception
-from framework.transactions.context import TokuTransaction
 from framework.transactions.handlers import no_auto_transaction
 from website import mails
 from website import settings

--- a/framework/transactions/context.py
+++ b/framework/transactions/context.py
@@ -1,52 +1,33 @@
 # -*- coding: utf-8 -*-
-
 import logging
 import functools
-
-from pymongo.errors import OperationFailure
+from django.db import transaction as dj_transaction
 
 from framework.mongo import database as proxy_database
-from framework.transactions import commands, messages, utils
 
 
 logger = logging.getLogger(__name__)
 
 
 class TokuTransaction(object):
-    """Transaction context manager. Begin transaction on enter; rollback or
-    commit on exit. TokuMX does not support nested transactions; catch and
-    ignore attempts to nest transactions.
+    """DEPRECATED. Transaction context manager. Begin transaction on enter; rollback or
+    commit on exit. This behaves like `django.db.transaction.atomic` and exists only to
+    support legacy code.
+
+    This class is deprecated: use `django.db.transaction.atomic` instead.
     """
     def __init__(self, database=None):
         self.database = database or proxy_database
         self.pending = False
+        self.atomic = dj_transaction.atomic()
 
     def __enter__(self):
-        try:
-            commands.begin(self.database)
-            self.pending = True
-        except OperationFailure as error:
-            message = utils.get_error_message(error)
-            if messages.TRANSACTION_EXISTS_ERROR not in message:
-                raise
-            logger.warn('Transaction already in progress')
-        return self
+        self.pending = True
+        return self.atomic.__enter__()
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if self.pending:
-            if exc_type:
-                commands.rollback(self.database)
-                self.pending = False
-                raise exc_type, exc_val, exc_tb
-            try:
-                commands.commit(self.database)
-                self.pending = False
-            except OperationFailure as error:
-                message = utils.get_error_message(error)
-                if messages.LOCK_ERROR in message:
-                    commands.rollback(self.database)
-                    self.pending = False
-                raise
+        self.pending = False
+        return self.atomic.__exit__(exc_type, exc_val, exc_tb)
 
 
 def transaction(database=None):

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -15,7 +15,7 @@ import sys
 import logging
 from website.app import init_app
 from scripts import utils as script_utils
-from framework.transactions.context import TokuTransaction
+from django.db import transaction
 
 
 logger = logging.getLogger(__name__)
@@ -30,7 +30,7 @@ def main(dry=True):
     init_app(set_backends=True, routes=False)  # Sets the storage backends on all models
 
     # Start a transaction that will be rolled back if any exceptions are un
-    with TokuTransaction():
+    with transaction.atomic():
         do_migration()
         if dry:
             # When running in dry mode force the transaction to rollback

--- a/scripts/approve_embargo_terminations.py
+++ b/scripts/approve_embargo_terminations.py
@@ -14,9 +14,9 @@ import logging
 import sys
 
 from django.utils import timezone
+from django.db import transaction
 from modularodm import Q
 
-from framework.transactions.context import TokuTransaction
 from framework.celery_tasks import app as celery_app
 
 from website import models, settings
@@ -67,7 +67,7 @@ def run_main(dry_run=True):
     if not dry_run:
         scripts_utils.add_file_logger(logger, __file__)
     init_app(routes=False)
-    with TokuTransaction():
+    with transaction.atomic():
         main()
         if dry_run:
             raise RuntimeError("Dry run, rolling back transaction")

--- a/scripts/approve_registrations.py
+++ b/scripts/approve_registrations.py
@@ -6,10 +6,10 @@ import logging
 import datetime
 
 from django.utils import timezone
+from django.db import transaction
 from modularodm import Q
 
 from framework.celery_tasks import app as celery_app
-from framework.transactions.context import TokuTransaction
 
 from website.app import init_app
 from website import models, settings
@@ -39,7 +39,7 @@ def main(dry_run=True):
                     registration_approval.save()
                     continue
 
-                with TokuTransaction():
+                with transaction.atomic():
                     try:
                         # Ensure no `User` is associated with the final approval
                         registration_approval._on_complete(None)

--- a/scripts/embargo_registrations.py
+++ b/scripts/embargo_registrations.py
@@ -11,7 +11,6 @@ from django.db import transaction
 from modularodm import Q
 
 from framework.celery_tasks import app as celery_app
-from framework.transactions.context import TokuTransaction
 
 from website.app import init_app
 from website import models, settings
@@ -42,7 +41,7 @@ def main(dry_run=True):
                     embargo.save()
                     continue
 
-                with TokuTransaction():
+                with transaction.atomic():
                     try:
                         embargo.state = models.Embargo.APPROVED
                         parent_registration.registered_from.add_log(

--- a/scripts/populate_institutions.py
+++ b/scripts/populate_institutions.py
@@ -7,10 +7,10 @@ import sys
 import urllib
 
 import django
+from django.db import transaction
 from modularodm import Q
 django.setup()
 
-from framework.transactions.context import TokuTransaction
 from website import settings
 from website.app import init_app
 from website.models import Institution, Node
@@ -468,7 +468,7 @@ def main(env):
         ]
 
     init_app(routes=False)
-    with TokuTransaction():
+    with transaction.atomic():
         for inst_data in INSTITUTIONS:
             new_inst, inst_created = update_or_create(inst_data)
             # update the nodes elastic docs, to have current names of institutions. This will

--- a/scripts/populate_new_and_noteworthy_projects.py
+++ b/scripts/populate_new_and_noteworthy_projects.py
@@ -6,6 +6,7 @@ import logging
 import datetime
 import dateutil
 from django.utils import timezone
+from django.db import transaction
 from modularodm import Q
 from website.app import init_app
 from website import models
@@ -13,7 +14,6 @@ from framework.auth.core import Auth
 from scripts import utils as script_utils
 from framework.mongo import database as db
 from framework.celery_tasks import app as celery_app
-from framework.transactions.context import TokuTransaction
 from website.project.utils import activity
 from website.settings import \
     POPULAR_LINKS_NODE, NEW_AND_NOTEWORTHY_LINKS_NODE,\
@@ -119,7 +119,7 @@ def main(dry_run=True):
 def run_main(dry_run=True):
     if not dry_run:
         script_utils.add_file_logger(logger, __file__)
-    with TokuTransaction():
+    with transaction.atomic():
         main(dry_run=dry_run)
 
 if __name__ == "__main__":

--- a/scripts/populate_popular_projects_and_registrations.py
+++ b/scripts/populate_popular_projects_and_registrations.py
@@ -3,13 +3,15 @@ This will update node links on POPULAR_LINKS_NODE, POPULAR_LINKS_REGISTRATIONS a
 """
 import sys
 import logging
+
+from django.db import transaction
 from modularodm import Q
+
 from website.app import init_app
 from website import models
 from framework.auth.core import Auth
 from scripts import utils as script_utils
 from framework.celery_tasks import app as celery_app
-from framework.transactions.context import TokuTransaction
 from website.project.utils import activity
 from website.settings import POPULAR_LINKS_NODE, POPULAR_LINKS_REGISTRATIONS
 
@@ -66,7 +68,7 @@ def main(dry_run=True):
 def run_main(dry_run=True):
     if not dry_run:
         script_utils.add_file_logger(logger, __file__)
-    with TokuTransaction():
+    with transaction.atomic():
         main(dry_run=dry_run)
 
 if __name__ == "__main__":

--- a/scripts/populate_preprint_providers.py
+++ b/scripts/populate_preprint_providers.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-"""Populate development database with Preprint Provicer elements"""
-
+"""Populate development database with PreprintProvider fixtures"""
 import logging
 import sys
 
+from django.db import transaction
 from modularodm import Q
 from modularodm.exceptions import NoResultsFound
-from framework.transactions.context import TokuTransaction
 from website.app import init_app
 from website.models import Subject, PreprintProvider, NodeLicense
 
@@ -364,7 +363,7 @@ def main():
         },
     ]
 
-    with TokuTransaction():
+    with transaction.atomic():
         for provider_data in PREPRINT_PROVIDERS:
             update_or_create(provider_data)
 


### PR DESCRIPTION

## Purpose

In Django-land, we should use `django.db.transaction.atomic` rather than `TokuTransaction`.

## Changes

- Change relevant usages of `with TokuTransaction()` to `with transaction.atomic()`.
- Modify `TokuTransaction` so that it behaves the same as `transaction.atomic` (just in case there are lingering usages in the legacy API)

## Side effects

<!--Any possible side effects? -->


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
