### PR TITLE
Fix datetimeawarejsonfield decoding and add tests

### DIFF
--- a/osf/tests.py
+++ b/osf/tests.py
@@ -4,7 +4,9 @@ from decimal import Decimal
 
 from django.test import TestCase
 from django.utils import timezone
-from osf.utils.datetime_aware_jsonfield import DateTimeAwareJSONEncoder, decode_datetime_objects
+from osf.models import StoredFileNode
+from osf.utils.datetime_aware_jsonfield import (DateTimeAwareJSONEncoder,
+                                                decode_datetime_objects)
 
 
 class DateTimeAwareJSONFieldTests(TestCase):
@@ -67,3 +69,13 @@ class DateTimeAwareJSONFieldTests(TestCase):
         json_string = json.dumps(self.json_list_data, cls=DateTimeAwareJSONEncoder)
         json_data = decode_datetime_objects(json.loads(json_string))
         assert json_data == self.json_list_data, 'Nope'
+
+    def test_list_field(self):
+        l = StoredFileNode.objects.create(history=self.json_list_data)
+        iden = l.id
+        assert StoredFileNode.objects.get(id=iden).history == self.json_list_data
+
+    def test_dict_field(self):
+        d = StoredFileNode.objects.create(history=self.json_dict_data)
+        iden = d.id
+        assert StoredFileNode.objects.get(id=iden).history == self.json_dict_data

--- a/osf/utils/datetime_aware_jsonfield.py
+++ b/osf/utils/datetime_aware_jsonfield.py
@@ -44,8 +44,6 @@ class DateTimeAwareJSONEncoder(DjangoJSONEncoder):
                 raise NaiveDatetimeException('Tried to encode a naive datetime.')
             return dict(type='encoded_datetime', value=o.isoformat())
         elif isinstance(o, dt.date):
-            if o.tzinfo is None or o.tzinfo.utcoffset(o) is None:
-                raise NaiveDatetimeException('Tried to encode a naive date.')
             return dict(type='encoded_date', value=o.isoformat())
         elif isinstance(o, dt.time):
             if o.tzinfo is None or o.tzinfo.utcoffset(o) is None:
@@ -84,7 +82,7 @@ class DateTimeAwareJSONField(JSONField):
             return Json(value, dumps=partial(json.dumps, cls=DateTimeAwareJSONEncoder))
         return value
 
-    def to_python(self, value):
+    def from_db_value(self, value, expression, connection, context):
         if value is None:
             return None
         return super(DateTimeAwareJSONField, self).to_python(decode_datetime_objects(value))


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

https://sentry.cos.io/sentry/osf-back-end/issues/269425/

## Changes

Switched from calling to_python which only runs when forms are used to using from_db_value which is called every time data is retrieved from the database.

## Side effects

<!--Any possible side effects? -->


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->