### PR TITLE
Stop license picker from disappearing [OSF-7331]

### DIFF
--- a/website/static/js/licensePicker.js
+++ b/website/static/js/licensePicker.js
@@ -162,7 +162,7 @@ var LicensePicker = oop.extend(ChangeMessageMixin, {
         });
 
         self.hideLicensePicker = ko.computed(function() {
-            return !user.isAdmin && self.selectedLicenseId() === DEFAULT_LICENSE.id;
+            return !user.isAdmin && self.savedLicenseId() === DEFAULT_LICENSE.id;
         });
     },
     togglePreview: function(labelClicked) {


### PR DESCRIPTION

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
License picker does not stick around for non-admin users
<!-- Describe the purpose of your changes -->

## Changes
Use saved license instead of selected license (which defaults to none?) and causes it to disappear.
<!-- Briefly describe or list your changes  -->

## Side effects
None known
<!--Any possible side effects? -->


## Ticket
[#OSF-7331]
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->

## QA Notes
Try admin/write/read and not-logged in users to ensure proper viewing of license.
