### PR TITLE
[hotfix] Properly embed preprint url [OSF-7188]

### DIFF
--- a/website/static/js/myProjects.js
+++ b/website/static/js/myProjects.js
@@ -359,7 +359,7 @@ var MyProjects = {
         self.systemCollections = options.systemCollections || [
             new LinkObject('collection', { nodeType : 'projects'}, 'All my projects'),
             new LinkObject('collection', { nodeType : 'registrations'}, 'All my registrations'),
-            new LinkObject('collection', { nodeType : 'preprints', link: $osf.apiV2Url('users/me/nodes/', { query : { 'filter[preprint]': true, 'related_counts' : 'children', 'embed' : 'contributors'}})}, 'All my preprints')
+            new LinkObject('collection', { nodeType : 'preprints', link: $osf.apiV2Url('users/me/nodes/', { query : { 'filter[preprint]': true, 'related_counts' : 'children', 'embed' : ['contributors', 'preprints']}})}, 'All my preprints')
         ];
 
         self.fetchers = {};

--- a/website/static/js/project-organizer.js
+++ b/website/static/js/project-organizer.js
@@ -36,12 +36,11 @@ function _poTitleColumn(item) {
     };
     var node = item.data; // Where actual data of the node is
     var css = ''; // Keep for future expandability -- Remove: item.data.isSmartFolder ? 'project-smart-folder smart-folder' : '';
-    var preprintLinkPre = '/preprints/';
     var isMypreprintsCollection = tb.options.currentView().collection.data.nodeType === 'preprints';
     if (item.data.archiving) { // TODO check if this variable will be available
         return  m('span', {'class': 'registration-archiving'}, node.attributes.title + ' [Archiving]');
     } else if (node.attributes.preprint && isMypreprintsCollection){
-        return [ m('a.fg-file-links', { 'class' : css, href : preprintLinkPre + node.id, 'data-nodeID' : node.id, 'data-nodeTitle': node.attributes.title,'data-nodeType': node.type, onclick : function(event) {
+        return [ m('a.fg-file-links', { 'class' : css, href : node.embeds.preprints.data[0].links.html, 'data-nodeID' : node.id, 'data-nodeTitle': node.attributes.title,'data-nodeType': node.type, onclick : function(event) {
             preventSelect.call(this, event);
             $osf.trackClick('myProjects', 'projectOrganizer', 'navigate-to-preprint');
         }}, node.attributes.title) ];


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

After the migration, guid routes changed for preprints. This PR fixes makes the preprints collection tab grab the working route to the preprint.

## Changes

Pull in preprint data to the nodes that have a preprint. Populate the route with that data.

## Side effects

Not a direct side effect of this PR, but a possible further improvement/bug:
Currently each line of the my projects page is populated from a single node that has a preprint. This does not check if the node has multiple preprints (e.g., more than one provider that has a preprint file). This means that only the first preprint value will be displayed here. It seemed sufficiently out of scope of this ticket to attempt a fix at that.

## Ticket
[#OSF-7188]
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
https://openscience.atlassian.net/browse/OSF-7188

## QA Considerations
1. Make sure that the link created properly goes to the preprint page (and not the node). 
2. Test both newly created preprints and migrated preprints of the various guid translation types (project kept the guid vs preprint kept the guid) if possible.