### PR TITLE
[Hotfix] Update admin groups and permissions to allow more layers of access [OSF-7359]

### DIFF
--- a/admin/base/migrations/0002_groups.py
+++ b/admin/base/migrations/0002_groups.py
@@ -24,6 +24,14 @@ def add_groups(*args):
             logger.info('prereg group created')
 
 
+def remove_groups(*args):
+    Group.objects.filter(name='nodes_and_users').delete()
+
+    group = Group.objects.get(name='prereg')
+    group.name = 'prereg_group'
+    group.save()
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -31,5 +39,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(add_groups),
+        migrations.RunPython(add_groups, remove_groups),
     ]

--- a/admin/base/migrations/0002_groups.py
+++ b/admin/base/migrations/0002_groups.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+from django.contrib.auth.models import Group
+import logging
+
+logger = logging.getLogger(__file__)
+
+
+def add_groups(*args):
+    group, created = Group.objects.get_or_create(name='nodes_and_users')
+    if created:
+        logger.info('nodes_and_users group created')
+
+    try:
+        group = Group.objects.get(name='prereg_group')
+        group.name = 'prereg'
+        group.save()
+        logger.info('prereg_group renamed to prereg')
+    except Group.DoesNotExist:
+        group, created = Group.objects.get_or_create(name='prereg')
+        if created:
+            logger.info('prereg group created')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('base', '0001_groups'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_groups),
+    ]

--- a/admin/base/utils.py
+++ b/admin/base/utils.py
@@ -25,6 +25,16 @@ class OSFAdmin(UserPassesTestMixin):
         return self.request.user.is_authenticated() and self.request.user.is_in_group('osf_admin')
 
 
+class NodesAndUsers(OSFAdmin):
+    """User needs to be in the nodes_and_users group to be able to access views with node
+    and user information. Specific admin permissions to be checked template side
+    """
+    permission_denied_message = 'You are not allowed to access information about Nodes and Users on the OSF Admin.'
+
+    def test_func(self):
+        return self.request.user.is_authenticated() and self.request.user.is_in_group('nodes_and_users')
+
+
 class SuperUser(OSFAdmin):
     permission_denied_message = (
         'You are not a superuser,'
@@ -35,12 +45,12 @@ class SuperUser(OSFAdmin):
         return self.request.user.is_authenticated() and self.request.user.is_superuser
 
 
-class PreregAdmin(OSFAdmin):
+class Prereg(OSFAdmin):
     """For testing for Prereg credentials of user."""
     permission_denied_message = 'You are not in the Pre-reg admin group.'
 
     def test_func(self):
-        return self.request.user.is_authenticated() and self.request.user.is_in_group('prereg_group')
+        return self.request.user.is_authenticated() and self.request.user.is_in_group('prereg')
 
 
 def reverse_qs(view, urlconf=None, args=None, kwargs=None, current_app=None, query_kwargs=None):

--- a/admin/base/utils.py
+++ b/admin/base/utils.py
@@ -22,7 +22,7 @@ class OSFAdmin(UserPassesTestMixin):
             raise PermissionDenied(self.get_permission_denied_message())
 
     def test_func(self):
-        return self.request.user.is_authenticated() and self.request.user.is_in_group('osf_admin')
+        return self.request.user.is_authenticated() and (self.request.user.is_in_group('osf_admin') or self.request.user.is_superuser)
 
 
 class NodesAndUsers(OSFAdmin):
@@ -32,7 +32,7 @@ class NodesAndUsers(OSFAdmin):
     permission_denied_message = 'You are not allowed to access information about Nodes and Users on the OSF Admin.'
 
     def test_func(self):
-        return self.request.user.is_authenticated() and self.request.user.is_in_group('nodes_and_users')
+        return self.request.user.is_authenticated() and (self.request.user.is_in_group('nodes_and_users') or self.request.user.is_superuser)
 
 
 class SuperUser(OSFAdmin):
@@ -50,7 +50,7 @@ class Prereg(OSFAdmin):
     permission_denied_message = 'You are not in the Pre-reg admin group.'
 
     def test_func(self):
-        return self.request.user.is_authenticated() and self.request.user.is_in_group('prereg')
+        return self.request.user.is_authenticated() and (self.request.user.is_in_group('prereg') or self.request.user.is_superuser)
 
 
 def reverse_qs(view, urlconf=None, args=None, kwargs=None, current_app=None, query_kwargs=None):

--- a/admin/meetings/views.py
+++ b/admin/meetings/views.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 from copy import deepcopy
 
+from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.views.generic import ListView, FormView
 from django.core.urlresolvers import reverse
 from django.http import Http404
@@ -9,12 +10,12 @@ from framework.auth.core import get_user
 from website.conferences.model import Conference, DEFAULT_FIELD_NAMES
 from website.conferences.exceptions import ConferenceError
 
-from admin.base.utils import OSFAdmin
+from admin.base.utils import NodesAndUsers
 from admin.meetings.forms import MeetingForm
 from admin.meetings.serializers import serialize_meeting
 
 
-class MeetingListView(OSFAdmin, ListView):
+class MeetingListView(NodesAndUsers, ListView):
     template_name = 'meetings/list.html'
     paginate_by = 10
     paginate_orphans = 1
@@ -34,9 +35,10 @@ class MeetingListView(OSFAdmin, ListView):
         return super(MeetingListView, self).get_context_data(**kwargs)
 
 
-class MeetingFormView(OSFAdmin, FormView):
+class MeetingFormView(NodesAndUsers, FormView, PermissionRequiredMixin):
     template_name = 'meetings/detail.html'
     form_class = MeetingForm
+    permission_required = 'auth.admin'
 
     def dispatch(self, request, *args, **kwargs):
         endpoint = self.kwargs.get('endpoint')
@@ -83,9 +85,10 @@ class MeetingFormView(OSFAdmin, FormView):
                        kwargs={'endpoint': self.kwargs.get('endpoint')})
 
 
-class MeetingCreateFormView(OSFAdmin, FormView):
+class MeetingCreateFormView(NodesAndUsers, FormView, PermissionRequiredMixin):
     template_name = 'meetings/create.html'
     form_class = MeetingForm
+    permission_required = 'auth.admin'
 
     def get_initial(self):
         self.initial.update(DEFAULT_FIELD_NAMES)

--- a/admin/nodes/views.py
+++ b/admin/nodes/views.py
@@ -4,11 +4,13 @@ from datetime import datetime
 from django.views.generic import ListView, DeleteView
 from django.shortcuts import redirect
 from django.views.defaults import page_not_found
+from django.contrib.auth.mixins import PermissionRequiredMixin
+from django.http import HttpResponseForbidden
 from modularodm import Q
 
 from website.models import Node, User, NodeLog
 from admin.base.views import GuidFormView, GuidView
-from admin.base.utils import OSFAdmin
+from admin.base.utils import OSFAdmin, NodesAndUsers
 from admin.common_auth.logs import (
     update_admin_log,
     NODE_REMOVED,
@@ -20,7 +22,7 @@ from admin.nodes.serializers import serialize_node, serialize_simple_user
 from website.project.spam.model import SpamStatus
 
 
-class NodeFormView(OSFAdmin, GuidFormView):
+class NodeFormView(NodesAndUsers, GuidFormView):
     """ Allow authorized admin user to input specific node guid.
 
     Basic form. No admin models.
@@ -33,13 +35,14 @@ class NodeFormView(OSFAdmin, GuidFormView):
         return reverse_node(self.guid)
 
 
-class NodeRemoveContributorView(OSFAdmin, DeleteView):
+class NodeRemoveContributorView(NodesAndUsers, DeleteView, PermissionRequiredMixin):
     """ Allow authorized admin user to remove project contributor
 
     Interface with OSF database. No admin models.
     """
     template_name = 'nodes/remove_contributor.html'
     context_object_name = 'node'
+    permission_required = 'auth.admin'
 
     def delete(self, request, *args, **kwargs):
         try:
@@ -90,7 +93,7 @@ class NodeRemoveContributorView(OSFAdmin, DeleteView):
         return (Node.load(self.kwargs.get('node_id')),
                 User.load(self.kwargs.get('user_id')))
 
-class NodeDeleteBase(OSFAdmin, DeleteView):
+class NodeDeleteBase(NodesAndUsers, DeleteView):
     template_name = None
     context_object_name = 'node'
     object = None
@@ -103,13 +106,14 @@ class NodeDeleteBase(OSFAdmin, DeleteView):
     def get_object(self, queryset=None):
         return Node.load(self.kwargs.get('guid'))
 
-class NodeDeleteView(NodeDeleteBase):
+class NodeDeleteView(NodeDeleteBase, PermissionRequiredMixin):
     """ Allow authorized admin user to remove/hide nodes
 
     Interface with OSF database. No admin models.
     """
     template_name = 'nodes/remove_node.html'
     object = None
+    permission_required = 'auth.admin'
 
     def delete(self, request, *args, **kwargs):
         try:
@@ -163,7 +167,7 @@ class NodeDeleteView(NodeDeleteBase):
         return redirect(reverse_node(self.kwargs.get('guid')))
 
 
-class NodeView(OSFAdmin, GuidView):
+class NodeView(NodesAndUsers, GuidView):
     """ Allow authorized admin user to view nodes
 
     View of OSF database. No admin models.
@@ -180,7 +184,7 @@ class NodeView(OSFAdmin, GuidView):
         return serialize_node(Node.load(self.kwargs.get('guid')))
 
 
-class RegistrationListView(OSFAdmin, ListView):
+class RegistrationListView(NodesAndUsers, ListView):
     """ Allow authorized admin user to view list of registrations
 
     View of OSF database. No admin models.
@@ -207,7 +211,8 @@ class RegistrationListView(OSFAdmin, ListView):
             'page': page,
         }
 
-class NodeSpamList(OSFAdmin, ListView):
+
+class NodeSpamList(NodesAndUsers, ListView):
     SPAM_STATE = SpamStatus.UNKNOWN
 
     paginate_by = 25
@@ -261,8 +266,9 @@ class NodeKnownHamList(NodeSpamList):
     SPAM_STATE = SpamStatus.HAM
     template_name = 'nodes/known_spam_list.html'
 
-class NodeConfirmSpamView(NodeDeleteBase):
+class NodeConfirmSpamView(NodeDeleteBase, PermissionRequiredMixin):
     template_name = 'nodes/confirm_spam.html'
+    permission_required = 'auth.admin'
 
     def delete(self, request, *args, **kwargs):
         node = self.get_object()
@@ -276,8 +282,9 @@ class NodeConfirmSpamView(NodeDeleteBase):
         )
         return redirect(reverse_node(self.kwargs.get('guid')))
 
-class NodeConfirmHamView(NodeDeleteBase):
+class NodeConfirmHamView(NodeDeleteBase, PermissionRequiredMixin):
     template_name = 'nodes/confirm_ham.html'
+    permission_required = 'auth.admin'
 
     def delete(self, request, *args, **kwargs):
         node = self.get_object()

--- a/admin/nodes/views.py
+++ b/admin/nodes/views.py
@@ -5,12 +5,11 @@ from django.views.generic import ListView, DeleteView
 from django.shortcuts import redirect
 from django.views.defaults import page_not_found
 from django.contrib.auth.mixins import PermissionRequiredMixin
-from django.http import HttpResponseForbidden
 from modularodm import Q
 
 from website.models import Node, User, NodeLog
 from admin.base.views import GuidFormView, GuidView
-from admin.base.utils import OSFAdmin, NodesAndUsers
+from admin.base.utils import NodesAndUsers
 from admin.common_auth.logs import (
     update_admin_log,
     NODE_REMOVED,

--- a/admin/pre_reg/views.py
+++ b/admin/pre_reg/views.py
@@ -27,10 +27,10 @@ from website.project.model import DraftRegistration, Node
 from website.prereg.utils import get_prereg_schema
 from website.project.metadata.schemas import from_json
 
-from admin.base.utils import PreregAdmin
+from admin.base.utils import Prereg
 
 
-class DraftListView(PreregAdmin, ListView):
+class DraftListView(Prereg, ListView):
     template_name = 'pre_reg/draft_list.html'
     ordering = '-date'
     context_object_name = 'draft'
@@ -102,7 +102,7 @@ class DraftDownloadListView(DraftListView):
         return response
 
 
-class DraftDetailView(PreregAdmin, DetailView):
+class DraftDetailView(Prereg, DetailView):
     template_name = 'pre_reg/draft_detail.html'
     context_object_name = 'draft'
 
@@ -124,7 +124,7 @@ class DraftDetailView(PreregAdmin, DetailView):
             item.save()
 
 
-class DraftFormView(PreregAdmin, FormView):
+class DraftFormView(Prereg, FormView):
     template_name = 'pre_reg/draft_form.html'
     form_class = DraftRegistrationForm
     context_object_name = 'draft'
@@ -191,7 +191,7 @@ class DraftFormView(PreregAdmin, FormView):
                                    self.request.POST.get('page', 1))
 
 
-class CommentUpdateView(PreregAdmin, UpdateView):
+class CommentUpdateView(Prereg, UpdateView):
     context_object_name = 'draft'
 
     def post(self, request, *args, **kwargs):

--- a/admin/spam/views.py
+++ b/admin/spam/views.py
@@ -1,14 +1,13 @@
 from __future__ import unicode_literals
 
 from django.views.generic import FormView, ListView, DetailView
-from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.http import Http404
 
 from modularodm import Q
 from website.project.model import Comment
 from website.project.spam.model import SpamStatus
 
-from admin.base.utils import OSFAdmin, NodesAndUsers
+from admin.base.utils import NodesAndUsers
 from admin.common_auth.logs import (
     update_admin_log,
     CONFIRM_HAM,

--- a/admin/spam/views.py
+++ b/admin/spam/views.py
@@ -1,13 +1,14 @@
 from __future__ import unicode_literals
 
 from django.views.generic import FormView, ListView, DetailView
+from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.http import Http404
 
 from modularodm import Q
 from website.project.model import Comment
 from website.project.spam.model import SpamStatus
 
-from admin.base.utils import OSFAdmin
+from admin.base.utils import OSFAdmin, NodesAndUsers
 from admin.common_auth.logs import (
     update_admin_log,
     CONFIRM_HAM,
@@ -18,7 +19,7 @@ from admin.spam.forms import ConfirmForm
 from admin.spam.templatetags.spam_extras import reverse_spam_detail
 
 
-class EmailView(OSFAdmin, DetailView):
+class EmailView(NodesAndUsers, DetailView):
     template_name = 'spam/email.html'
     context_object_name = 'spam'
 
@@ -30,7 +31,7 @@ class EmailView(OSFAdmin, DetailView):
             raise Http404('Spam with id {} not found.'.format(spam_id))
 
 
-class SpamList(OSFAdmin, ListView):
+class SpamList(NodesAndUsers, ListView):
     """ Allow authorized admin user to see the things people have marked as spam
 
     Interface with OSF database. No admin models.
@@ -83,7 +84,7 @@ class UserSpamList(SpamList):
         return super(UserSpamList, self).get_context_data(**kwargs)
 
 
-class SpamDetail(OSFAdmin, FormView):
+class SpamDetail(NodesAndUsers, FormView):
     """ Allow authorized admin user to see details of reported spam.
 
     Interface with OSF database. Logs action (confirming spam) on admin db.

--- a/admin/templates/base.html
+++ b/admin/templates/base.html
@@ -120,7 +120,7 @@
             <li><a href="{% url 'spam:spam' %}"><i class='fa fa-link'></i> <span>OSF Spam</span></a></li>
             <li><a href="{% url 'nodes:registrations' %}"><i class='fa fa-link'></i> <span>OSF Registrations</span></a></li>
             <li><a href="{% url 'meetings:list' %}"><i class='fa fa-link'></i> <span>OSF Meetings</span></a></li>
-            {% if 'prereg_group' in request.user.group_names %}
+            {% if 'prereg' in request.user.group_names %}
             <li><a href="{% url 'pre_reg:prereg' %}"><i class='fa fa-link'></i> <span>OSF Prereg</span></a></li>
             {% endif %}
           {% endif %}

--- a/admin/templates/base.html
+++ b/admin/templates/base.html
@@ -100,6 +100,7 @@
           <!-- Sidebar Menu -->
           <ul class="sidebar-menu">
             <li class="header">Menu</li>
+            {% if 'nodes_and_users' in request.user.group_names %}
             <li><a href="{% url 'nodes:search' %}"><i class='fa fa-link'></i><span> OSF Nodes</span> </a></li>
             <li>
               <ul class="sidebar-menu" style="position:relative; left: 20px;">
@@ -122,6 +123,7 @@
             {% if 'prereg_group' in request.user.group_names %}
             <li><a href="{% url 'pre_reg:prereg' %}"><i class='fa fa-link'></i> <span>OSF Prereg</span></a></li>
             {% endif %}
+          {% endif %}
             <li><a href="{% url 'metrics:metrics' %}"><i class='fa fa-link'></i> <span>OSF Metrics</span></a></li>
           </ul><!-- /.sidebar-menu -->
         </section>

--- a/admin/templates/meetings/list.html
+++ b/admin/templates/meetings/list.html
@@ -6,9 +6,11 @@
     <title>OSF Admin | Meetings</title>
 {% endblock title %}
 {% block content %}
-    <a href="{% url 'meetings:create' %}" class="btn btn-primary">
-        Add meeting
-    </a>
+    {%  if perms.auth.admin %}
+        <a href="{% url 'meetings:create' %}" class="btn btn-primary">
+            Add meeting
+        </a>
+    {% endif %}
     <h2>List of Meetings</h2>
     {% include "util/pagination.html" with items=page status=status %}
     <table class="table table-striped, table-hover table-responsive">
@@ -24,12 +26,14 @@
     <tbody>
     {% for meeting in meetings %}
         <tr>
-            <td>
-                <a href="{% url 'meetings:detail' endpoint=meeting.endpoint %}"
-                   target="_blank" class="btn btn-primary">
-                    {{ meeting.endpoint }}
-                </a>
-            </td>
+            {%  if perms.auth.admin %}
+                <td>
+                    <a href="{% url 'meetings:detail' endpoint=meeting.endpoint %}"
+                       target="_blank" class="btn btn-primary">
+                        {{ meeting.endpoint }}
+                    </a>
+                </td>
+            {%  endif %}
             <td>
                 {{ meeting.name }}
             </td>

--- a/admin/templates/nodes/node.html
+++ b/admin/templates/nodes/node.html
@@ -16,32 +16,33 @@
                class="btn btn-primary col-md-1">
                 <i class="fa fa-search"></i>
             </a>
-            {% if not node.is_registration %}
-                {% if not node.deleted %}
-                    <span class="col-md-2">
-                    <a href="{% url 'nodes:remove' guid=node.id %}"
-                       data-toggle="modal" data-target="#deleteModal"
-                       class="btn btn-danger">
-                        Delete Node
-                    </a>
-                    </span>
-                    <div class="modal" id="deleteModal">
-                        <div class="modal-dialog">
-                            <div class="modal-content"></div>
-                            {# Data from above link #}
+            {%  if perms.auth.admin %}
+                {% if not node.is_registration %}
+                    {% if not node.deleted %}
+                        <span class="col-md-2">
+                        <a href="{% url 'nodes:remove' guid=node.id %}"
+                           data-toggle="modal" data-target="#deleteModal"
+                           class="btn btn-danger">
+                            Delete Node
+                        </a>
+                        </span>
+                        <div class="modal" id="deleteModal">
+                            <div class="modal-dialog">
+                                <div class="modal-content"></div>
+                                {# Data from above link #}
+                            </div>
                         </div>
-                    </div>
-                {% else %}
-                    <span class="col-md-2">
-                    <form method="post"
-                          action="{% url 'nodes:restore' guid=node.id %}">
-                        {% csrf_token %}
-                        <input class="btn btn-success" type="submit"
-                               value="Restore Node" />
-                    </form>
-                    </span>
+                    {% else %}
+                        <span class="col-md-2">
+                        <form method="post"
+                              action="{% url 'nodes:restore' guid=node.id %}">
+                            {% csrf_token %}
+                            <input class="btn btn-success" type="submit"
+                                   value="Restore Node" />
+                        </form>
+                        </span>
+                    {% endif %}
                 {% endif %}
-            {% endif %}
             <span class="col-md-2">
                 <a href="{% url 'nodes:confirm-spam' guid=node.id %}"
                    data-toggle="modal" data-target="#confirmSpamModal"
@@ -67,7 +68,8 @@
                     <div class="modal-content"></div>
                     {# Data from above link #}
                 </div>
-            </div>                
+            </div>
+            {% endif %}
         </div>
         <div class="row">
             {% if node.is_registration %}
@@ -141,23 +143,25 @@
                             </td>
                             <td>{{ user.name }}</td>
                             <td>{{ user.permission|capfirst }}</td>
-                            <td>
-                            {% if not node.is_registration %}
-                                <a href="{% url 'nodes:remove_user' node_id=node.id user_id=user.id %}"
-                                   data-toggle="modal"
-                                   data-target="#{{ user.id }}Modal"
-                                   class="btn btn-danger">
-                                    Remove
-                                </a>
-                                <div class="modal" id="{{ user.id }}Modal">
-                                    <div class="modal-dialog">
-                                        <div class="modal-content">
-                                        {# from remove_contributor.html#}
+                            {%  if perms.auth.admin %}
+                                <td>
+                                {% if not node.is_registration %}
+                                    <a href="{% url 'nodes:remove_user' node_id=node.id user_id=user.id %}"
+                                       data-toggle="modal"
+                                       data-target="#{{ user.id }}Modal"
+                                       class="btn btn-danger">
+                                        Remove
+                                    </a>
+                                    <div class="modal" id="{{ user.id }}Modal">
+                                        <div class="modal-dialog">
+                                            <div class="modal-content">
+                                            {# from remove_contributor.html#}
+                                            </div>
                                         </div>
                                     </div>
-                                </div>
+                                {% endif %}
+                                </td>
                             {% endif %}
-                            </td>
                         </tr>
                     {% endfor %}
                     </tbody>
@@ -188,6 +192,7 @@
                             <td>{{ child.title }}</td>
                             <td>{{ child.public }}</td>
                             <td>{{ child.number_contributors }}</td>
+                            {%  if perms.auth.admin %}
                             <td>
                                 {% if not child.is_registration %}
                                     {% if child.deleted %}
@@ -214,6 +219,7 @@
                                     {% endif %}
                                 {% endif %}
                             </td>
+                        {% endif %}
                         </tr>
                     {% endfor %}
                     </tbody>

--- a/admin/templates/pre_reg/draft_detail.html
+++ b/admin/templates/pre_reg/draft_detail.html
@@ -99,7 +99,9 @@
         <a data-bind="click: nextPage" class="btn btn-primary">Next Page</a>
     </div>
 </div>
-{% include "pre_reg/comment_editor.html" %}
+    {% if perms.auth.prereg_admin %}
+        {% include "pre_reg/comment_editor.html" %}
+    {% endif %}
 {% endblock %}
 
 {% block bottom_js %}

--- a/admin/templates/pre_reg/draft_list.html
+++ b/admin/templates/pre_reg/draft_list.html
@@ -9,12 +9,14 @@
 
 {% block content %}
     <h2>List of Preregistration Drafts</h2>
+    {% if perms.auth.prereg_admin %}
     <div>
         {# Add types here #}
         <a href="{% url 'pre_reg:download' %}" class="btn btn-primary">
             Download all
         </a>
     </div>
+    {%  endif %}
     {% include "util/pagination.html" with items=page status=status pagin=p order=order %}
     <table class="table table-striped table-hover table-responsive">
     <thead>
@@ -87,6 +89,7 @@
             {{ draft.submitted | date:"N dS Y g:i a"}}
         </td>
         <td>
+            {% if perms.auth.prereg_admin %}
             <a href="{% url 'pre_reg:update_draft' draft.pk %}"
                class="btn btn-success" data-toggle="modal"
                data-target="#form{{ draft.pk }}">
@@ -99,6 +102,7 @@
                     </div>
                 </div>
             </div>
+            {%  endif %}
             <a href="{% url 'pre_reg:view_draft' draft.pk %}" target="_blank"
                class="btn btn-primary">
                 View Draft

--- a/admin/templates/spam/detail.html
+++ b/admin/templates/spam/detail.html
@@ -16,11 +16,13 @@
                class="btn btn-primary">
                 Back to user's list
             </a>
+            {%  if perms.auth.admin %}
             <a href="{% url 'spam:email' comment.id %}"
                data-toggle="modal" data-target="#email"
                class="btn btn-default">
                 Email
             </a>
+            {% endif %}
             <div class="modal" id="email">
                 <div class="modal-dialog">
                     <div class="modal-content"></div>
@@ -31,6 +33,7 @@
 
         <br>
 
+        {%  if perms.auth.admin %}
         <div class="row">
         <div class="panel col-md-6">
         <form action="{% reverse_spam_detail comment.id page=page_number status=status %}"
@@ -52,6 +55,7 @@
         </form>
         </div>
         </div>
+        {% endif %}
 
         {# General info about the comment #}
         <div class="row">

--- a/admin/templates/users/user.html
+++ b/admin/templates/users/user.html
@@ -41,65 +41,68 @@
                     <div class="modal-content"></div>
                 </div>
             </div>
-            <span class="col-md-2">
-            <a href="{% url 'users:reset_password' user.id %}"
-               data-toggle="modal" data-target="#resetModal"
-               class="btn btn-primary">
-                Send reset
-            </a>
-            </span>
-            <div class="modal" id="resetModal" style="display: none">
-                <div class="modal-dialog">
-                    <div class="modal-content"></div>
-                    {# Data from above link #}
-                </div>
-            </div>
-            <span class="col-md-2">
-            {% if not user.disabled %}
-                <a href="{% url 'users:disable' user.id %}"
-                   data-toggle="modal" data-target="#disableModal"
-                   class="btn btn-danger">
-                    Disable account
+
+            {%  if perms.auth.admin %}
+                <span class="col-md-2">
+                <a href="{% url 'users:reset_password' user.id %}"
+                   data-toggle="modal" data-target="#resetModal"
+                   class="btn btn-primary">
+                    Send reset
                 </a>
-            <div class="modal" id="disableModal">
-                <div class="modal-dialog">
-                    <div class="modal-content"></div>
+                </span>
+                <div class="modal" id="resetModal" style="display: none">
+                    <div class="modal-dialog">
+                        <div class="modal-content"></div>
+                        {# Data from above link #}
+                    </div>
                 </div>
-            </div>
-            {% else %}
-                <form method="post"
-                      action="{% url 'users:reactivate' user.id %}">
-                    {% csrf_token %}
-                    <input class="btn btn-success" type="submit"
-                           value="Reactivate account"/>
-                </form>
-            {% endif %}
-            </span>
-            <span class="col-md-2">
-                {% if not user.disabled or 'spam_flagged' in user.system_tags %}
-                    <a href="{% url 'users:spam_disable' user.id %}"
-                       data-toggle="modal" data-target="#disableSpamModal"
+                <span class="col-md-2">
+                {% if not user.disabled %}
+                    <a href="{% url 'users:disable' user.id %}"
+                       data-toggle="modal" data-target="#disableModal"
                        class="btn btn-danger">
-                        Disable Spam account
+                        Disable account
                     </a>
-                <div class="modal" id="disableSpamModal">
+                <div class="modal" id="disableModal">
                     <div class="modal-dialog">
                         <div class="modal-content"></div>
                     </div>
                 </div>
                 {% else %}
-                    <a href="{% url 'users:ham_enable' user.id %}"
-                       data-toggle="modal" data-target="#enableHamModal"
-                       class="btn btn-danger">
-                        Re-enable Ham account
-                    </a>
-                <div class="modal" id="enableHamModal">
-                    <div class="modal-dialog">
-                        <div class="modal-content"></div>
-                    </div>
-                </div>
+                    <form method="post"
+                          action="{% url 'users:reactivate' user.id %}">
+                        {% csrf_token %}
+                        <input class="btn btn-success" type="submit"
+                               value="Reactivate account"/>
+                    </form>
                 {% endif %}
-            </span>
+                </span>
+                <span class="col-md-2">
+                    {% if not user.disabled or 'spam_flagged' in user.system_tags %}
+                        <a href="{% url 'users:spam_disable' user.id %}"
+                           data-toggle="modal" data-target="#disableSpamModal"
+                           class="btn btn-danger">
+                            Disable Spam account
+                        </a>
+                    <div class="modal" id="disableSpamModal">
+                        <div class="modal-dialog">
+                            <div class="modal-content"></div>
+                        </div>
+                    </div>
+                    {% else %}
+                        <a href="{% url 'users:ham_enable' user.id %}"
+                           data-toggle="modal" data-target="#enableHamModal"
+                           class="btn btn-danger">
+                            Re-enable Ham account
+                        </a>
+                    <div class="modal" id="enableHamModal">
+                        <div class="modal-dialog">
+                            <div class="modal-content"></div>
+                        </div>
+                    </div>
+                    {% endif %}
+                </span>
+            {% endif %}
         </div>
         <div class="row">
             <h3>User details</h3>
@@ -221,31 +224,33 @@
                                         <span class="label label-success">Ham</span>
                                     {% endif %}
                                 </td>
+                                {%  if perms.auth.admin %}
                                 <td>
-                                {% if node.number_contributors < 2 and not node.is_registration %}
-                                    {% if node.deleted %}
-                                        <form method="post"
-                                              action="{% url 'nodes:restore' guid=node.id %}">
-                                            {% csrf_token %}
-                                            <input class="btn btn-success"
-                                                   type="submit"
-                                                   value="Restore Node" />
-                                        </form>
-                                    {% else %}
-                                    <a href="{% url 'nodes:remove' guid=node.id %}"
-                                       data-toggle="modal" data-target="#deleteModal{{ node.id }}"
-                                       class="btn btn-danger">
-                                        Delete Node
-                                    </a>
-                                    <div class="modal" id="deleteModal{{ node.id }}">
-                                        <div class="modal-dialog">
-                                            <div class="modal-content">
+                                    {% if node.number_contributors < 2 and not node.is_registration %}
+                                        {% if node.deleted %}
+                                            <form method="post"
+                                                  action="{% url 'nodes:restore' guid=node.id %}">
+                                                {% csrf_token %}
+                                                <input class="btn btn-success"
+                                                       type="submit"
+                                                       value="Restore Node" />
+                                            </form>
+                                        {% else %}
+                                        <a href="{% url 'nodes:remove' guid=node.id %}"
+                                           data-toggle="modal" data-target="#deleteModal{{ node.id }}"
+                                           class="btn btn-danger">
+                                            Delete Node
+                                        </a>
+                                        <div class="modal" id="deleteModal{{ node.id }}">
+                                            <div class="modal-dialog">
+                                                <div class="modal-content">
+                                                </div>
                                             </div>
                                         </div>
-                                    </div>
+                                        {% endif %}
                                     {% endif %}
+                                    </td>
                                 {% endif %}
-                                </td>
                             </tr>
                         {% endfor %}
                         </tbody>

--- a/admin/users/views.py
+++ b/admin/users/views.py
@@ -4,9 +4,10 @@ from furl import furl
 import csv
 from datetime import datetime, timedelta
 from django.views.generic import FormView, DeleteView, ListView
+from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.core.mail import send_mail
 from django.shortcuts import redirect
-from django.http import Http404, HttpResponse
+from django.http import Http404, HttpResponse, HttpResponseForbidden
 from modularodm import Q
 
 from website.project.spam.model import SpamStatus
@@ -20,7 +21,7 @@ from website.mailchimp_utils import subscribe_on_confirm
 
 from admin.base.views import GuidFormView, GuidView
 from admin.users.templatetags.user_extras import reverse_user
-from admin.base.utils import OSFAdmin
+from admin.base.utils import OSFAdmin, NodesAndUsers
 from admin.common_auth.logs import (
     update_admin_log,
     USER_2_FACTOR,
@@ -33,7 +34,7 @@ from admin.users.serializers import serialize_user
 from admin.users.forms import EmailResetForm, WorkshopForm
 
 
-class UserDeleteView(OSFAdmin, DeleteView):
+class UserDeleteView(NodesAndUsers, DeleteView, PermissionRequiredMixin):
     """ Allow authorised admin user to remove/restore user
 
     Interface with OSF database. No admin models.
@@ -41,10 +42,13 @@ class UserDeleteView(OSFAdmin, DeleteView):
     template_name = 'users/remove_user.html'
     context_object_name = 'user'
     object = None
+    permission_required = 'auth.admin'
 
     def delete(self, request, *args, **kwargs):
         try:
             user = self.get_object()
+            if not user.has_perm('auth.admin'):
+                raise HttpResponseForbidden('You do not have permission to delete this user.')
             if user.date_disabled is None or kwargs.get('is_spam'):
                 user.disable_account()
                 user.is_registered = False
@@ -95,13 +99,14 @@ class UserDeleteView(OSFAdmin, DeleteView):
         return User.load(self.kwargs.get('guid'))
 
 
-class SpamUserDeleteView(UserDeleteView):
+class SpamUserDeleteView(UserDeleteView, PermissionRequiredMixin):
     """
     Allow authorized admin user to delete a spam user and mark all their nodes as private
 
     """
 
     template_name = 'users/remove_spam_user.html'
+    permission_required = 'auth.admin'
 
     def delete(self, request, *args, **kwargs):
         try:
@@ -159,7 +164,7 @@ class HamUserRestoreView(UserDeleteView):
         return super(HamUserRestoreView, self).delete(request, *args, **kwargs)
 
 
-class UserSpamList(OSFAdmin, ListView):
+class UserSpamList(NodesAndUsers, ListView):
     SPAM_TAG = 'spam_flagged'
 
     paginate_by = 25
@@ -244,7 +249,7 @@ class User2FactorDeleteView(UserDeleteView):
         return redirect(reverse_user(self.kwargs.get('guid')))
 
 
-class UserFormView(OSFAdmin, GuidFormView):
+class UserFormView(NodesAndUsers, GuidFormView):
     template_name = 'users/search.html'
     object_type = 'user'
 
@@ -253,7 +258,7 @@ class UserFormView(OSFAdmin, GuidFormView):
         return reverse_user(self.guid)
 
 
-class UserView(OSFAdmin, GuidView):
+class UserView(NodesAndUsers, GuidView):
     template_name = 'users/user.html'
     context_object_name = 'user'
 
@@ -370,10 +375,11 @@ class UserWorkshopFormView(OSFAdmin, FormView):
         super(UserWorkshopFormView, self).form_invalid(form)
 
 
-class ResetPasswordView(OSFAdmin, FormView):
+class ResetPasswordView(OSFAdmin, FormView, PermissionRequiredMixin):
     form_class = EmailResetForm
     template_name = 'users/reset.html'
     context_object_name = 'user'
+    permission_required = 'auth.admin'
 
     def get_context_data(self, **kwargs):
         user = User.load(self.kwargs.get('guid'))

--- a/admin/users/views.py
+++ b/admin/users/views.py
@@ -7,7 +7,7 @@ from django.views.generic import FormView, DeleteView, ListView
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.core.mail import send_mail
 from django.shortcuts import redirect
-from django.http import Http404, HttpResponse, HttpResponseForbidden
+from django.http import Http404, HttpResponse
 from modularodm import Q
 
 from website.project.spam.model import SpamStatus

--- a/admin/users/views.py
+++ b/admin/users/views.py
@@ -47,8 +47,6 @@ class UserDeleteView(NodesAndUsers, DeleteView, PermissionRequiredMixin):
     def delete(self, request, *args, **kwargs):
         try:
             user = self.get_object()
-            if not user.has_perm('auth.admin'):
-                raise HttpResponseForbidden('You do not have permission to delete this user.')
             if user.date_disabled is None or kwargs.get('is_spam'):
                 user.disable_account()
                 user.is_registered = False


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Right now there is no way to grant access to the OSF Admin app without granting access to everything. This PR adds a few new groups and makes use of new permissions to instead grant a few layers of access:

basic - can log in and see OSF Metrics
read only - can view information about nodes, users, and meetings but cannot perform any actions
admin - can view and modify things
prereg - can view prereg submissions but not perform any actions
prereg_admin - can view and provide feedback on prereg submissions
superuser - has access to all groups and modifications

This will use a combination of groups and specific edit permissions for each user. The groups a user is in will define which pages they can visit, while if a user specifically is given the `auth.admin` or `auth.prereg_admin` permission will be able to make changes on those pages.

In summary:
- Those in the `osf_admin` group can log in and access metrics
- Those in the `nodes_and_users` group can visit Meetings, Node and User summary pages, but not make changes.
- Those in the `nodes_and_users` group AND whose users have the `auth.admin` permission can make changes 
- Those in the `prereg` group can visit the prereg submissions page
- Those in the `prereg` group AND whose users have the `auth.prereg_admin` permission can make changes on the prereg submissions.
- Superusers can do everything.

## Changes

- Migration that:
    - adds the `nodes_and_users` group 
    - changes the `prereg_group` name to `prereg`
- Use the `nodes_and_users` group to restrict access to Nodes and Users altogether
- Update edit views to check user permissions
- Update templates to check for users with specific permissions set. Users will need to have `auth.admin` set to change node, user and meeting information, and will need to have `auth.prereg_admin` set to change prereg information. See the side effects section for more info.
- Superusers can now access and modify all things in the admin app, including prereg.

## Side effects

1. Migrations will need to be run to add the new groups necessary.

2. Permissions are usually tied to a specific model, and in this case I didn't want to tie any permissions to `MyUser` because that is going away with the next OSF release. Instead I added some permissions via the admin interface, namely `auth.admin` and `auth.prereg_admin`. Those should be created manually with the admin app and then permissions added to the appropriate users also with the admin's admin app via an admin app superuser.

![screen shot 2017-01-19 at 11 09 30 pm](https://cloud.githubusercontent.com/assets/801594/22150614/fa80ecb6-dee7-11e6-830f-83a4fda56200.png)


## Ticket
https://openscience.atlassian.net/browse/OSF-7359