### PR TITLE
[Hotfix] Avoid checking AnonymousUsers for _id

### DIFF
--- a/api/logs/serializers.py
+++ b/api/logs/serializers.py
@@ -36,7 +36,10 @@ class NodeLogFileParamsSerializer(RestrictedDictSerializer):
         user = self.context['request'].user
         node_title = obj['node']['title']
         node = Node.load(obj['node']['_id'])
-        if node.has_permission(user, osf_permissions.READ):
+        if not user.is_authenticated():
+            if node.is_public:
+                return node_title
+        elif node.has_permission(user, osf_permissions.READ):
             return node_title
         return 'Private Component'
 


### PR DESCRIPTION
## Purpose
Prevent AttributeError from a `node.has_permission` check

## Changes
 * Handle unauthenticated users separately

## Side effects
None expected

## Ticket
No known Jira ticket. [Sentry error](https://sentry.cos.io/sentry/osf/issues/7948/)