### PR TITLE
Update uses of `nodes_pointer` ThroughRelation [#OSF-7372]

### DIFF
--- a/api/base/views.py
+++ b/api/base/views.py
@@ -808,16 +808,9 @@ class BaseContributorList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin
             queryset[:] = [contrib for contrib in queryset if contrib._id in contrib_ids]
         return queryset
 
-class BaseNodeLinksDetail(JSONAPIBaseView, generics.RetrieveAPIView):
 
-    def get_queryset(self):
-        auth = get_user_auth(self.request)
-        return sorted([
-            node for node in
-            self.get_node().nodes_pointer
-            if not node.is_deleted and not node.is_collection and
-            node.can_view(auth) and not node.is_retracted
-        ], key=lambda n: n.date_modified, reverse=True)
+class BaseNodeLinksDetail(JSONAPIBaseView, generics.RetrieveAPIView):
+    pass
 
 
 class BaseNodeLinksList(JSONAPIBaseView, generics.ListAPIView):

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -813,10 +813,10 @@ class BaseNodeLinksDetail(JSONAPIBaseView, generics.RetrieveAPIView):
     def get_queryset(self):
         auth = get_user_auth(self.request)
         return sorted([
-            pointer.node for pointer in
+            node for node in
             self.get_node().nodes_pointer
-            if not pointer.node.is_deleted and not pointer.node.is_collection and
-            pointer.node.can_view(auth) and not pointer.node.is_retracted
+            if not node.is_deleted and not node.is_collection and
+            node.can_view(auth) and not node.is_retracted
         ], key=lambda n: n.date_modified, reverse=True)
 
 

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -210,8 +210,8 @@ class BaseRegistrationSerializer(NodeSerializer):
     def get_node_links_count(self, obj):
         count = 0
         auth = get_user_auth(self.context['request'])
-        for pointer in obj.nodes_pointer:
-            if not pointer.node.is_deleted and not pointer.node.is_collection and pointer.node.can_view(auth):
+        for node in obj.nodes_pointer:
+            if not node.is_deleted and not node.is_collection and node.can_view(auth):
                 count += 1
         return count
 

--- a/api_tests/registrations/views/test_registration_linked_nodes.py
+++ b/api_tests/registrations/views/test_registration_linked_nodes.py
@@ -54,6 +54,13 @@ class TestNodeRelationshipNodeLinks(ApiTestCase):
         assert_in(self.linking_node.linked_nodes_related_url, res.json['links']['html'])
         assert_in(self.private_node._id, [e['id'] for e in res.json['data']])
 
+    def test_get_linked_nodes_related_counts(self):
+        res = self.app.get(
+            '/{}registrations/{}/?related_counts=linked_nodes'.format(API_BASE, self.linking_node._id),
+            auth=self.user.auth
+        )
+        assert_equal(res.json['data']['relationships']['linked_nodes']['links']['related']['meta']['count'], 2)
+
     def test_get_public_relationship_linked_nodes_logged_out(self):
         res = self.app.get(self.public_url)
 

--- a/website/discovery/views.py
+++ b/website/discovery/views.py
@@ -12,8 +12,7 @@ def activity():
 
     # New and Noreworthy Projects
     try:
-        new_and_noteworthy_pointers = Node.load(settings.NEW_AND_NOTEWORTHY_LINKS_NODE).nodes_pointer
-        new_and_noteworthy_projects = [pointer.node for pointer in new_and_noteworthy_pointers]
+        new_and_noteworthy_projects = Node.load(settings.NEW_AND_NOTEWORTHY_LINKS_NODE).nodes_pointer
     except AttributeError:
         new_and_noteworthy_projects = []
 

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -1982,7 +1982,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable, Spam
         """Recursively checks whether the current node or any of its nodes
         contains a pointer.
         """
-        if self.nodes_pointer:
+        if self.nodes_pointer.exists():
             return True
         for node in self.nodes_primary:
             if node.has_pointers_recursive:

--- a/website/project/utils.py
+++ b/website/project/utils.py
@@ -110,8 +110,7 @@ def activity():
                 break
 
     # New and Noteworthy projects are updated manually
-    new_and_noteworthy_pointers = Node.find_one(Q('_id', 'eq', settings.NEW_AND_NOTEWORTHY_LINKS_NODE)).nodes_pointer
-    new_and_noteworthy_projects = [pointer.node for pointer in new_and_noteworthy_pointers]
+    new_and_noteworthy_projects = list(Node.find_one(Q('_id', 'eq', settings.NEW_AND_NOTEWORTHY_LINKS_NODE)).nodes_pointer)
 
     return {
         'new_and_noteworthy_projects': new_and_noteworthy_projects,


### PR DESCRIPTION
## Purpose
Fix `AttributeErrors` relating to how `class Pointer` changed

## Changes
`nodes_pointer` now returns a queryset of nodes, rather than of pointers. Don't access fields that don't exist.

## Side effects
None expected

## Ticket
[#OSF-7372](https://openscience.atlassian.net/browse/OSF-7372)