### PR TITLE
Prevent AttributeError in `users_to_remove`

### DIFF
--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1313,6 +1313,15 @@ class TestMoveSubscription(NotificationTestCase):
         utils.move_subscription(self.blank, 'xyz42_file_updated', self.project, 'abc42_file_updated', self.private_node)
         assert_false(self.file_sub.email_digest.filter().exists())
 
+    # Regression test for commit ea15186
+    def test_garrulous_event_name(self):
+        self.file_sub.email_transactional.add(self.user_2, self.user_3, self.user_4)
+        self.file_sub.save()
+        self.private_node.add_contributor(self.user_2, permissions=['admin', 'write', 'read'], auth=self.auth)
+        self.private_node.add_contributor(self.user_3, permissions=['write', 'read'], auth=self.auth)
+        self.private_node.save()
+        results = utils.users_to_remove('complicated/path_to/some/file/ASDFASDF.txt_file_updated', self.project, self.private_node)
+        assert_equal({'email_transactional': [], 'email_digest': [], 'none': []}, results)
 
 class TestSendEmails(NotificationTestCase):
     def setUp(self):

--- a/website/notifications/utils.py
+++ b/website/notifications/utils.py
@@ -129,7 +129,11 @@ def users_to_remove(source_event, source_node, new_node):
     if not old_sub and not old_node_sub:
         return removed_users
     for notification_type in constants.NOTIFICATION_TYPES:
-        users = list(getattr(old_sub, notification_type).values_list('guids___id', flat=True)) + list(getattr(old_node_sub, notification_type).values_list('guids___id', flat=True))
+        users = []
+        if hasattr(old_sub, notification_type):
+            users += list(getattr(old_sub, notification_type).values_list('guids___id', flat=True))
+        if hasattr(old_node_sub, notification_type):
+            users += list(getattr(old_node_sub, notification_type).values_list('guids___id', flat=True))
         subbed, removed_users[notification_type] = separate_users(new_node, users)
     return removed_users
 


### PR DESCRIPTION
## Purpose
Fix https://sentry.cos.io/sentry/osf-back-end/issues/269410/

## Changes
Check if possible Object/NoneType has attribute before accessing it.

## Side effects
None expected

## Ticket
None known