### PR TITLE
[hotfix] Handle unicode in encryption [OSF-7200]

### DIFF
--- a/framework/encryption/__init__.py
+++ b/framework/encryption/__init__.py
@@ -6,13 +6,22 @@ from website import settings
 
 SENSITIVE_DATA_KEY = jwe.kdf(settings.SENSITIVE_DATA_SECRET.encode('utf-8'), settings.SENSITIVE_DATA_SALT.encode('utf-8'))
 
+def ensure_str(value):
+    """Helper function to ensure all inputs are encoded to the proper value utf-8 value regardless of input type"""
+    try:
+        return value.encode('utf-8')
+    except UnicodeDecodeError:
+        return value.decode('utf-8').encode('utf-8')
+
 def encrypt(value):
     if value:
+        value = ensure_str(value)
         return jwe.encrypt(bytes(value), SENSITIVE_DATA_KEY)
     return None
 
 def decrypt(value):
     if value:
+        value = ensure_str(value)
         return jwe.decrypt(bytes(value), SENSITIVE_DATA_KEY)
     return None
 

--- a/framework/encryption/__init__.py
+++ b/framework/encryption/__init__.py
@@ -6,22 +6,21 @@ from website import settings
 
 SENSITIVE_DATA_KEY = jwe.kdf(settings.SENSITIVE_DATA_SECRET.encode('utf-8'), settings.SENSITIVE_DATA_SALT.encode('utf-8'))
 
-def ensure_str(value):
+def ensure_bytes(value):
     """Helper function to ensure all inputs are encoded to the proper value utf-8 value regardless of input type"""
-    try:
-        return value.encode('utf-8')
-    except UnicodeDecodeError:
-        return value.decode('utf-8').encode('utf-8')
+    if isinstance(value, bytes):
+        return value
+    return value.encode('utf-8')
 
 def encrypt(value):
     if value:
-        value = ensure_str(value)
+        value = ensure_bytes(value)
         return jwe.encrypt(bytes(value), SENSITIVE_DATA_KEY)
     return None
 
 def decrypt(value):
     if value:
-        value = ensure_str(value)
+        value = ensure_bytes(value)
         return jwe.decrypt(bytes(value), SENSITIVE_DATA_KEY)
     return None
 

--- a/tests/framework_tests/test_encryption.py
+++ b/tests/framework_tests/test_encryption.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import unittest
 from nose.tools import *  # noqa
 

--- a/tests/framework_tests/test_encryption.py
+++ b/tests/framework_tests/test_encryption.py
@@ -1,74 +1,82 @@
-# -*- coding: utf-8 -*-
-
 import unittest
 from nose.tools import *  # noqa
 
-from framework.encryption import encrypt, decrypt, ensure_str
+from framework.encryption import encrypt, decrypt, ensure_bytes
 
 class EncryptionTestCase(unittest.TestCase):
 
-    def test_ensure_str_encodes_no_unicode_in_string_type_str(self):
+    def test_ensure_bytes_encodes_no_unicode_in_string_type_str(self):
         my_value = 'hello'
-        my_str = ensure_str(my_value)
-        assert_true(isinstance(my_str, str))
+        assert_true(isinstance(my_value, bytes))
+        my_str = ensure_bytes(my_value)
+        assert_true(isinstance(my_str, bytes))
 
-    def test_ensure_str_encodes_unicode_in_string_type_str(self):
+    def test_ensure_bytes_encodes_unicode_in_string_type_str(self):
         my_value = 'hellü'
-        my_str = ensure_str(my_value)
-        assert_true(isinstance(my_str, str))
+        assert_true(isinstance(my_value, bytes))
+        my_str = ensure_bytes(my_value)
+        assert_true(isinstance(my_str, bytes))
 
-    def test_ensure_str_encodes_no_unicode_in_string_type_unicode(self):
+    def test_ensure_bytes_encodes_no_unicode_in_string_type_unicode(self):
         my_value = u'hello'
-        my_str = ensure_str(my_value)
-        assert_true(isinstance(my_str, str))
+        assert_true(isinstance(my_value, unicode))
+        my_str = ensure_bytes(my_value)
+        assert_true(isinstance(my_str, bytes))
 
-    def test_ensure_str_encodes_unicode_in_string_type_unicode(self):
+    def test_ensure_bytes_encodes_unicode_in_string_type_unicode(self):
         my_value = u'hellü'
-        my_str = ensure_str(my_value)
-        assert_true(isinstance(my_str, str))
+        assert_true(isinstance(my_value, unicode))
+        my_str = ensure_bytes(my_value)
+        assert_true(isinstance(my_str, bytes))
 
     def test_encrypt_and_decrypt_no_unicode_in_string_type_str(self):
         my_value = 'hello'
+        assert_true(isinstance(my_value, bytes))
         my_value_encrypted = encrypt(my_value)
-        assert_true(isinstance(my_value_encrypted, str))
+        assert_true(isinstance(my_value_encrypted, bytes))
 
         my_value_decrypted = decrypt(my_value_encrypted)
-        assert_true(isinstance(my_value_decrypted, str))
-        assert_equal(my_value_decrypted, ensure_str(my_value))
+        assert_true(isinstance(my_value_decrypted, bytes))
+        assert_equal(my_value_decrypted, ensure_bytes(my_value))
 
     def test_encrypt_and_decrypt_unicode_in_string_type_str(self):
         my_value = 'hellü'
+        assert_true(isinstance(my_value, bytes))
         my_value_encrypted = encrypt(my_value)
-        assert_true(isinstance(my_value_encrypted, str))
+        assert_true(isinstance(my_value_encrypted, bytes))
 
         my_value_decrypted = decrypt(my_value_encrypted)
-        assert_equal(my_value_decrypted, ensure_str(my_value))
+        assert_equal(my_value_decrypted, ensure_bytes(my_value))
 
         my_value = '찦차КЛМНО💁◕‿◕｡)╱i̲̬͇̪͙n̝̗͕v̟̜̘̦͟o̶̙̰̠kè͚̮̺̪̹̱̤  ǝɹol'
+        assert_true(isinstance(my_value, bytes))
         my_value_encrypted = encrypt(my_value)
         my_value_decrypted = decrypt(my_value_encrypted)
-        assert_true(isinstance(my_value_decrypted, str))
-        assert_equal(my_value_decrypted, ensure_str(my_value))
+        assert_true(isinstance(my_value_decrypted, bytes))
+        assert_equal(my_value_decrypted, ensure_bytes(my_value))
 
     def test_encrypt_and_decrypt_no_unicode_in_string_type_unicode(self):
         my_value = u'hello'
+        assert_true(isinstance(my_value, unicode))
         my_value_encrypted = encrypt(my_value)
-        assert_true(isinstance(my_value_encrypted, str))
+        assert_true(isinstance(my_value_encrypted, bytes))
 
         my_value_decrypted = decrypt(my_value_encrypted)
-        assert_true(isinstance(my_value_decrypted, str))
-        assert_equal(my_value_decrypted, ensure_str(my_value))
+        assert_true(isinstance(my_value_decrypted, bytes))
+        assert_equal(my_value_decrypted, ensure_bytes(my_value))
 
     def test_encrypt_and_decrypt_unicode_in_string_type_unicode(self):
         my_value = u'hellü'
+        assert_true(isinstance(my_value, unicode))
         my_value_encrypted = encrypt(my_value)
-        assert_true(isinstance(my_value_encrypted, str))
+        assert_true(isinstance(my_value_encrypted, bytes))
 
         my_value_decrypted = decrypt(my_value_encrypted)
-        assert_equal(my_value_decrypted, ensure_str(my_value))
+        assert_equal(my_value_decrypted, ensure_bytes(my_value))
 
         my_value = u'찦차КЛМНО💁◕‿◕｡)╱i̲̬͇̪͙n̝̗͕v̟̜̘̦͟o̶̙̰̠kè͚̮̺̪̹̱̤  ǝɹol'
+        assert_true(isinstance(my_value, unicode))
         my_value_encrypted = encrypt(my_value)
         my_value_decrypted = decrypt(my_value_encrypted)
-        assert_true(isinstance(my_value_decrypted, str))
-        assert_equal(my_value_decrypted, ensure_str(my_value))
+        assert_true(isinstance(my_value_decrypted, bytes))
+        assert_equal(my_value_decrypted, ensure_bytes(my_value))

--- a/tests/framework_tests/test_encryption.py
+++ b/tests/framework_tests/test_encryption.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+from nose.tools import *  # noqa
+
+from framework.encryption import encrypt, decrypt, ensure_str
+
+class EncryptionTestCase(unittest.TestCase):
+
+    def test_ensure_str_encodes_no_unicode_in_string_type_str(self):
+        my_value = 'hello'
+        my_str = ensure_str(my_value)
+        assert_true(isinstance(my_str, str))
+
+    def test_ensure_str_encodes_unicode_in_string_type_str(self):
+        my_value = 'hellü'
+        my_str = ensure_str(my_value)
+        assert_true(isinstance(my_str, str))
+
+    def test_ensure_str_encodes_no_unicode_in_string_type_unicode(self):
+        my_value = u'hello'
+        my_str = ensure_str(my_value)
+        assert_true(isinstance(my_str, str))
+
+    def test_ensure_str_encodes_unicode_in_string_type_unicode(self):
+        my_value = u'hellü'
+        my_str = ensure_str(my_value)
+        assert_true(isinstance(my_str, str))
+
+    def test_encrypt_and_decrypt_no_unicode_in_string_type_str(self):
+        my_value = 'hello'
+        my_value_encrypted = encrypt(my_value)
+        assert_true(isinstance(my_value_encrypted, str))
+
+        my_value_decrypted = decrypt(my_value_encrypted)
+        assert_true(isinstance(my_value_decrypted, str))
+        assert_equal(my_value_decrypted, ensure_str(my_value))
+
+    def test_encrypt_and_decrypt_unicode_in_string_type_str(self):
+        my_value = 'hellü'
+        my_value_encrypted = encrypt(my_value)
+        assert_true(isinstance(my_value_encrypted, str))
+
+        my_value_decrypted = decrypt(my_value_encrypted)
+        assert_equal(my_value_decrypted, ensure_str(my_value))
+
+        my_value = '찦차КЛМНО💁◕‿◕｡)╱i̲̬͇̪͙n̝̗͕v̟̜̘̦͟o̶̙̰̠kè͚̮̺̪̹̱̤  ǝɹol'
+        my_value_encrypted = encrypt(my_value)
+        my_value_decrypted = decrypt(my_value_encrypted)
+        assert_true(isinstance(my_value_decrypted, str))
+        assert_equal(my_value_decrypted, ensure_str(my_value))
+
+    def test_encrypt_and_decrypt_no_unicode_in_string_type_unicode(self):
+        my_value = u'hello'
+        my_value_encrypted = encrypt(my_value)
+        assert_true(isinstance(my_value_encrypted, str))
+
+        my_value_decrypted = decrypt(my_value_encrypted)
+        assert_true(isinstance(my_value_decrypted, str))
+        assert_equal(my_value_decrypted, ensure_str(my_value))
+
+    def test_encrypt_and_decrypt_unicode_in_string_type_unicode(self):
+        my_value = u'hellü'
+        my_value_encrypted = encrypt(my_value)
+        assert_true(isinstance(my_value_encrypted, str))
+
+        my_value_decrypted = decrypt(my_value_encrypted)
+        assert_equal(my_value_decrypted, ensure_str(my_value))
+
+        my_value = u'찦차КЛМНО💁◕‿◕｡)╱i̲̬͇̪͙n̝̗͕v̟̜̘̦͟o̶̙̰̠kè͚̮̺̪̹̱̤  ǝɹol'
+        my_value_encrypted = encrypt(my_value)
+        my_value_decrypted = decrypt(my_value_encrypted)
+        assert_true(isinstance(my_value_decrypted, str))
+        assert_equal(my_value_decrypted, ensure_str(my_value))


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Names on Dropbox and Google drive break when we try to encrypt them.

## Changes

1. Add helper function to ensure incoming strings to be encoded are in the proper utf-8 format
2. Add tests for helper function and encryption in general since it was untested.

## Side effects

None known


## Ticket
https://openscience.atlassian.net/browse/OSF-7200

[#OSF-7200]

## QA Considerations
1. Test auth on at least 1 addon. I did dropbox locally and it worked. Per MattF if it works for one, there is no reason it shouldn't work for all of them. Worth testing at least one or two for a sanity check, but probably not worth checking all of them (especially if you can't easily change your name on the service).
2. Change your name on <addon> to contain unicode madness and try to authorize the addon on the osf
3. Ensure it also works with non-unicode madness
