### PR TITLE
Handle user error when patching licenses [#OSF-7383]

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -54,7 +54,9 @@ class NodeLicenseRelationshipField(RelationshipField):
 
     def to_internal_value(self, license_id):
         node_license = NodeLicense.load(license_id)
-        return {'license_type': node_license}
+        if node_license:
+            return {'license_type': node_license}
+        raise exceptions.NotFound('Unable to find specified license.')
 
 
 class NodeCitationSerializer(JSONAPISerializer):

--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -50,7 +50,9 @@ class PreprintProviderRelationshipField(RelationshipField):
 class PreprintLicenseRelationshipField(RelationshipField):
     def to_internal_value(self, license_id):
         license = NodeLicense.load(license_id)
-        return {'license_type': license}
+        if license:
+            return {'license_type': license}
+        raise exceptions.NotFound('Unable to find specified license.')
 
 
 class PreprintSerializer(JSONAPISerializer):

--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -1197,6 +1197,21 @@ class TestNodeUpdateLicense(ApiTestCase):
     def make_request(self, url, data, auth=None, expect_errors=False):
         return self.app.patch_json_api(url, data, auth=auth, expect_errors=expect_errors)
 
+    def test_admin_update_license_with_invalid_id(self):
+        data = self.make_payload(
+            node_id=self.node._id,
+            license_id='thisisafakelicenseid'
+        )
+
+        assert_equal(self.node.node_license, None)
+
+        res = self.make_request(self.url, data, auth=self.admin_contributor.auth, expect_errors=True)
+        assert_equal(res.status_code, 404)
+        assert_equal(res.json['errors'][0]['detail'], 'Unable to find specified license.')
+
+        self.node.reload()
+        assert_equal(self.node.node_license, None)
+
     def test_admin_can_update_license(self):
         data = self.make_payload(
             node_id=self.node._id,

--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -323,6 +323,21 @@ class TestPreprintUpdateLicense(ApiTestCase):
     def make_request(self, url, data, auth=None, expect_errors=False):
         return self.app.patch_json_api(url, data, auth=auth, expect_errors=expect_errors)
 
+    def test_admin_update_license_with_invalid_id(self):
+        data = self.make_payload(
+            node_id=self.preprint._id,
+            license_id='thisisafakelicenseid'
+        )
+
+        assert_equal(self.preprint.license, None)
+
+        res = self.make_request(self.url, data, auth=self.admin_contributor.auth, expect_errors=True)
+        assert_equal(res.status_code, 404)
+        assert_equal(res.json['errors'][0]['detail'], 'Unable to find specified license.')
+
+        self.preprint.reload()
+        assert_equal(self.preprint.license, None)
+
     def test_admin_can_update_license(self):
         data = self.make_payload(
             node_id=self.preprint._id,


### PR DESCRIPTION
## Purpose
Provide a useful error when `PATCH` an invalid `license`

## Changes
* Improve error handling
* Add regression tests

## Side effects
None expected

## Ticket
[#OSF-7383](https://openscience.atlassian.net/browse/OSF-7383)