### PR TITLE
Add forgotten field to S3's AppConfig [#OSF-7390]

### DIFF
--- a/addons/s3/apps.py
+++ b/addons/s3/apps.py
@@ -17,6 +17,7 @@ class S3AddonAppConfig(BaseAddonAppConfig):
     short_name = 's3'
     owners = ['user', 'node']
     configs = ['accounts', 'node']
+    categories = ['storage']
     has_hgrid_files = True
     max_file_size = 128  # MB
     node_settings_template = os.path.join(TEMPLATE_PATH, 's3_node_settings.mako')


### PR DESCRIPTION
## Purpose
Display S3 on settings pages

## Changes
* Set `categories` for S3

## Side effects
None expected. Consider follow-up during Phase 2 to increase strictness of `AppConfig` definitions

## Ticket

[#OSF-7390](https://openscience.atlassian.net/browse/OSF-7390)
