### PR TITLE
Simplify implementation of AbstractNode.root; Fix [OSF-7378]

### DIFF
--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -114,6 +114,17 @@ def test_components_have_root():
     assert greatgrandchild3.root == root
     assert greatgrandchild_1.root == root
 
+# https://openscience.atlassian.net/browse/OSF-7378
+def test_root_for_linked_node_does_not_return_linking_parent():
+    project = ProjectFactory(title='Project')
+    root = ProjectFactory(title='Root')
+    child = NodeFactory(title='Child', parent=root)
+
+    project.add_node_link(root, auth=Auth(project.creator), save=True)
+    assert root.root == root
+    assert child.root == root
+
+
 def test_get_children():
     root = ProjectFactory()
     child = NodeFactory(parent=root)


### PR DESCRIPTION
Instead of doing a recursive query/cte, we just traverse up
the tree in Python. Though this is less performant, it is
much less bug-prone. Fixes [OSF-7378].

NOTE: Though the @cached_property decorator is used on `root`,
cached results only persist as long as the Node instance exists,
so it probably will not produce much benefit. We may want to
come up with a way to cache `root` across requests (ping
@cwisecarver for thoughts), but that may be unnecessary and can
happen in a separate PR.
