### PR TITLE
[OSF-7381] Fix Add Merged User Contributor

### DIFF
--- a/api_tests/nodes/views/test_node_contributors_list.py
+++ b/api_tests/nodes/views/test_node_contributors_list.py
@@ -998,6 +998,30 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
         index = list(self.public_project.get_contributor_order()).index(contributor_obj.pk)
         assert_equal(index, 3)
 
+    def test_add_inactive_merged_user_as_contributor(self):
+        primary_user = UserFactory()
+        merged_user = UserFactory(merged_by=primary_user)
+
+        payload = {
+            'data': {
+                'type': 'contributors',
+                'attributes': {},
+                'relationships': {
+                    'users': {
+                        'data': {
+                            'type': 'users',
+                            'id': merged_user._id
+                        }
+                    }
+                }
+            }
+        }
+
+        res = self.app.post_json_api(self.public_url, payload, auth=self.user.auth)
+        assert_equal(res.status_code, 201)
+        contributor_added = res.json['data']['embeds']['users']['data']['id']
+        assert_equal(contributor_added, primary_user._id)
+
 
 class TestNodeContributorCreateValidation(NodeCRUDTestCase):
 

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -1071,7 +1071,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
                                                        contributor=contributor,
                                                        auth=auth, email_template=send_email)
 
-            return True
+            return contrib_to_add, True
 
         # Permissions must be overridden if changed when contributor is
         # added to parent he/she is already on a child of.
@@ -1163,7 +1163,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
                 raise ValueError('User with id {} was not found.'.format(user_id))
             if self.contributor_set.filter(user=contributor).exists():
                 raise ValidationValueError('{} is already a contributor.'.format(contributor.fullname))
-            self.add_contributor(contributor=contributor, auth=auth, visible=bibliographic,
+            contributor, _ = self.add_contributor(contributor=contributor, auth=auth, visible=bibliographic,
                                  permissions=permissions, send_email=send_email, save=True)
         else:
 


### PR DESCRIPTION
#### Purpose
- Attempting to add an inactive merged user as a contributor on staging3/djangosf results in a 500 with the following (shortened) traceback:
```
api/nodes/serializers.py:799: in create
    permissions=permissions, bibliographic=bibliographic, index=index, save=True
osf/models/node.py:1189: in add_contributor_registered_or_not
    contributor_obj = self.contributor_set.get(user=contributor)
../../miniconda/envs/osf/lib/python2.7/site-packages/django/db/models/manager.py:122: in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
../../miniconda/envs/osf/lib/python2.7/site-packages/django/db/models/query.py:387: in get
    self.model._meta.object_name
E   DoesNotExist: Contributor matching query does not exist.
```
- This PR fixes things so that the active merged user will be added as a contributor, returning a 201.

#### Changes
- Update the contributor in `add_contributor_registered_or_not()` with the contributor returned from `add_contributor()` (in the case of a merged user, the referenced contributor changes [here](https://github.com/CenterForOpenScience/osf.io/blob/develop/website/project/model.py#L3165), and that change was being ignored)
- Adds a test because we like those.

#### Ticket
- [OSF-7381](https://openscience.atlassian.net/browse/OSF-7381)
