### PR TITLE
Fix Node.objects.get_children [OSF-7395]

### DIFF
--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -72,7 +72,8 @@ class AbstractNodeQueryset(MODMCompatibilityQuerySet):
         return self.extra(
             where=['"osf_abstractnode".id in (SELECT id FROM osf_abstractnode WHERE id NOT IN (SELECT child_id FROM '
                    'osf_noderelation WHERE is_node_link IS false))'])
-
+      
+    # TODO Optimize performance. This could be done in a recursive CTE for better performance.
     def get_children(self, root, primary_keys=False):
         children = list()
         if isinstance(root, int):

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -14,7 +14,7 @@ from django.contrib.contenttypes.fields import GenericRelation
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
-from django.db import connection, models, transaction
+from django.db import models, transaction
 from django.db.models import Model
 from django.db.models.signals import post_save
 from django.dispatch import receiver
@@ -22,7 +22,6 @@ from django.utils import timezone
 from django.utils.functional import cached_property
 from keen import scoped_keys
 from modularodm import Q as MQ
-from psycopg2._psycopg import AsIs
 from typedmodels.models import TypedModel
 
 from framework import status
@@ -73,7 +72,7 @@ class AbstractNodeQueryset(MODMCompatibilityQuerySet):
         return self.extra(
             where=['"osf_abstractnode".id in (SELECT id FROM osf_abstractnode WHERE id NOT IN (SELECT child_id FROM '
                    'osf_noderelation WHERE is_node_link IS false))'])
-      
+
     # TODO Optimize performance. This could be done in a recursive CTE for better performance.
     def get_children(self, root, primary_keys=False):
         children = list()

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -74,7 +74,7 @@ class AbstractNodeQueryset(MODMCompatibilityQuerySet):
                    'osf_noderelation WHERE is_node_link IS false))'])
 
     def get_children(self, root, primary_keys=False):
-        children = []
+        children = list()
         if isinstance(root, int):
             lookup_id = root
         elif isinstance(root, Model):
@@ -83,7 +83,7 @@ class AbstractNodeQueryset(MODMCompatibilityQuerySet):
             raise ValueError('Please submit a proper Node primary key or Node instance.')
 
         def get_child_ids(parent_id):
-            all_child_ids = []
+            all_child_ids = list()
             child_ids = NodeRelation.objects.filter(parent_id=parent_id, is_node_link=False).values_list('child_id', flat=True)
 
             all_child_ids += child_ids

--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -114,6 +114,7 @@ def test_components_have_root():
     assert greatgrandchild3.root == root
     assert greatgrandchild_1.root == root
 
+
 def test_get_children():
     root = ProjectFactory()
     child = NodeFactory(parent=root)
@@ -137,7 +138,42 @@ def test_get_children():
     greatgrandchild3 = NodeFactory(parent=grandchild3)
     greatgrandchild_1 = NodeFactory(parent=grandchild_1)
 
-    assert 20 == Node.objects.get_children(root).count()
+    assert 20 == len(Node.objects.get_children(root))
+
+def test_get_children_with_barren_parent():
+    root = ProjectFactory()
+
+    assert 0 == len(Node.objects.get_children(root))
+
+
+def test_get_children_with_links():
+    root = ProjectFactory()
+    child = NodeFactory(parent=root)
+    child1 = NodeFactory(parent=root)
+    child2 = NodeFactory(parent=root)
+    grandchild = NodeFactory(parent=child)
+    grandchild1 = NodeFactory(parent=child)
+    grandchild2 = NodeFactory(parent=child)
+    grandchild3 = NodeFactory(parent=child)
+    grandchild_1 = NodeFactory(parent=child1)
+    grandchild1_1 = NodeFactory(parent=child1)
+    grandchild2_1 = NodeFactory(parent=child1)
+    grandchild3_1 = NodeFactory(parent=child1)
+    grandchild_2 = NodeFactory(parent=child2)
+    grandchild1_2 = NodeFactory(parent=child2)
+    grandchild2_2 = NodeFactory(parent=child2)
+    grandchild3_2 = NodeFactory(parent=child2)
+    greatgrandchild = NodeFactory(parent=grandchild)
+    greatgrandchild1 = NodeFactory(parent=grandchild1)
+    greatgrandchild2 = NodeFactory(parent=grandchild2)
+    greatgrandchild3 = NodeFactory(parent=grandchild3)
+    greatgrandchild_1 = NodeFactory(parent=grandchild_1)
+
+    child.add_node_link(root, auth=Auth(root.creator))
+    child.add_node_link(greatgrandchild_1, auth=Auth(greatgrandchild_1.creator))
+    greatgrandchild_1.add_node_link(child, auth=Auth(child.creator))
+
+    assert 20 == len(Node.objects.get_children(root))
 
 def test_get_roots():
     top_level1 = ProjectFactory(is_public=True)


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Make node.objects.get_children stop killing the postgres server.

## Changes

Switch from recursive CTE to python.

## Side effects

Node links will not be followed or returned by this implementation. This was my understanding of the correct behavior. That makes it so that you can never create at circular loop that will run until maximum recursion depth.

Places where this is likely to affect:

- Anything in the API using node filters on root
- Probably the bulk change privacy for node and its children that was updated a year or so ago
- Showing orphaned children in the file viewer and component list
- Institution affiliation settings for projects


## Ticket
[#OSF-7395](https://openscience.atlassian.net/browse/OSF-7395)