### PR TITLE
Docker Shared Requirements Optimize for Python Byte Code

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,10 +101,16 @@ services:
 
   mfr_requirements:
     image: quay.io/centerforopenscience/mfr:develop
-    command: /bin/bash -c "invoke install --develop && rm -Rf /site-packages/* && cp -Rf /usr/local/lib/python3.5/site-packages /"
+    command: |-
+      /bin/bash -c "
+        invoke install --develop &&
+        (python -m compileall /usr/local/lib/python3.5 || true) &&
+        rm -Rf /python3.5/* &&
+        cp -Rf -p /usr/local/lib/python3.5 /
+      "
     restart: 'no'
     volumes:
-      - mfr_requirements_vol:/site-packages
+      - mfr_requirements_vol:/python3.5
 
   mfr:
     image: quay.io/centerforopenscience/mfr:develop
@@ -115,7 +121,7 @@ services:
     env_file:
       - .docker-compose.mfr.env
     volumes:
-      - mfr_requirements_vol:/usr/local/lib/python3.5/site-packages
+      - mfr_requirements_vol:/usr/local/lib/python3.5
     stdin_open: true
     tty: true
 
@@ -125,10 +131,16 @@ services:
 
   wb_requirements:
     image: quay.io/centerforopenscience/waterbutler:develop
-    command: /bin/bash -c "invoke install --develop && rm -Rf /site-packages/* && cp -Rf /usr/local/lib/python3.5/site-packages /"
+    command: |-
+      /bin/bash -c "
+        invoke install --develop &&
+        (python -m compileall /usr/local/lib/python3.5 || true) &&
+        rm -Rf /python3.5/* &&
+        cp -Rf -p /usr/local/lib/python3.5 /
+      "
     restart: 'no'
     volumes:
-      - wb_requirements_vol:/site-packages
+      - wb_requirements_vol:/python3.5
 
   wb:
     image: quay.io/centerforopenscience/waterbutler:develop
@@ -139,7 +151,7 @@ services:
     env_file:
       - .docker-compose.wb.env
     volumes:
-      - wb_requirements_vol:/usr/local/lib/python3.5/site-packages
+      - wb_requirements_vol:/usr/local/lib/python3.5
       - wb_osfstoragecache_vol:/code/website/osfstoragecache
     stdin_open: true
     tty: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -186,12 +186,18 @@ services:
 
   requirements:
     image: quay.io/centerforopenscience/osf:develop
-    command: /bin/bash -c "invoke requirements --quick && rm -Rf /site-packages/* && cp -Rf /usr/local/lib/python2.7/site-packages /"
+    command: |-
+      /bin/bash -c "
+        invoke requirements --quick &&
+        (python -m compileall /usr/local/lib/python2.7 || true) &&
+        rm -Rf /python2.7/* &&
+        cp -Rf -p /usr/local/lib/python2.7 /
+      "
     restart: 'no'
     environment:
       DJANGO_SETTINGS_MODULE: api.base.settings
     volumes:
-      - osf_requirements_vol:/site-packages
+      - osf_requirements_vol:/python2.7
 
   assets:
     image: quay.io/centerforopenscience/osf:develop
@@ -200,7 +206,7 @@ services:
     environment:
       DJANGO_SETTINGS_MODULE: api.base.settings
     volumes:
-      - osf_requirements_vol:/usr/local/lib/python2.7/site-packages
+      - osf_requirements_vol:/usr/local/lib/python2.7
       - osf_bower_components_vol:/code/website/static/vendor/bower_components
       - osf_node_modules_vol:/code/node_modules
     stdin_open: true
@@ -217,7 +223,7 @@ services:
     env_file:
       - .docker-compose.sharejs.env
     volumes:
-      - osf_requirements_vol:/usr/local/lib/python2.7/site-packages
+      - osf_requirements_vol:/usr/local/lib/python2.7
       - osf_node_modules_vol:/code/node_modules
     stdin_open: true
     tty: true
@@ -234,7 +240,7 @@ services:
 #    env_file:
 #      - .docker-compose.env
 #    volumes:
-#      - osf_requirements_vol:/usr/local/lib/python2.7/site-packages
+#      - osf_requirements_vol:/usr/local/lib/python2.7
 #      - osf_bower_components_vol:/code/website/static/vendor/bower_components
 #      - osf_node_modules_vol:/code/node_modules
 
@@ -252,7 +258,7 @@ services:
     env_file:
       - .docker-compose.env
     volumes:
-      - osf_requirements_vol:/usr/local/lib/python2.7/site-packages
+      - osf_requirements_vol:/usr/local/lib/python2.7
       - osf_bower_components_vol:/code/website/static/vendor/bower_components
       - osf_node_modules_vol:/code/node_modules
     stdin_open: true
@@ -263,7 +269,7 @@ services:
     command: invoke admin.assets -dw
     restart: unless-stopped
     volumes:
-      - osf_requirements_vol:/usr/local/lib/python2.7/site-packages
+      - osf_requirements_vol:/usr/local/lib/python2.7
       - osf_bower_components_vol:/code/admin/static/vendor/bower_components
       - osf_node_modules_vol:/code/admin/node_modules
       - osf_bower_components_vol:/code/website/static/vendor/bower_components
@@ -286,7 +292,7 @@ services:
     stdin_open: true
     tty: true
     volumes:
-      - osf_requirements_vol:/usr/local/lib/python2.7/site-packages
+      - osf_requirements_vol:/usr/local/lib/python2.7
       - osf_node_modules_vol:/code/admin/node_modules
       - osf_bower_components_vol:/code/website/static/vendor/bower_components
       - osf_bower_components_vol:/code/admin/static/vendor/bower_components
@@ -308,7 +314,7 @@ services:
     env_file:
       - .docker-compose.env
     volumes:
-      - osf_requirements_vol:/usr/local/lib/python2.7/site-packages
+      - osf_requirements_vol:/usr/local/lib/python2.7
       - osf_bower_components_vol:/code/website/static/vendor/bower_components
       - osf_node_modules_vol:/code/node_modules
     stdin_open: true
@@ -330,7 +336,7 @@ services:
     env_file:
       - .docker-compose.env
     volumes:
-      - osf_requirements_vol:/usr/local/lib/python2.7/site-packages
+      - osf_requirements_vol:/usr/local/lib/python2.7
       - osf_bower_components_vol:/code/website/static/vendor/bower_components
       - osf_node_modules_vol:/code/node_modules
       - preprints_dist_vol:/preprints


### PR DESCRIPTION
Due to `invoke`'s [default behavior](https://github.com/pyinvoke/invoke/blob/master/invoke/program.py#L57) to not write any pyc files this causes notable performance issues when restarting apps.

The application code is not necessarily an issue, testing indicates the `/usr/local/lib/python2.7` shared main library needed to be compiled (this won't change in docker envs).

_NOTE: be sure to copy files with timestamps `-p` or `*.pyc` files will not be considered valid, but rather simply ignored._

**Requires a full rebuild of the docker environment due to volume changes.**

e.g. 
- `docker-compose down -v`
- `docker-compose up requirements mfr_requirements wb_requirements`
- `docker-compose run --rm web python manage.py migrate`
- `...` other database population scripts
- `docker-compose up -d assets web api mfr wb fakecas preprints`