### PR TITLE
Prevent ValueErrors in rare edge cases

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -582,7 +582,7 @@ def addon_deleted_file(auth, node, error_type='BLAME_PROVIDER', **kwargs):
         'provider': file_node.provider,
         'materialized_path': file_node.materialized_path or file_path,
         'private': getattr(node.get_addon(file_node.provider), 'is_private', False),
-        'file_tags': list(file_node.tags.filter(system=False).values_list('name', flat=True)) if not file_node._state.adding else [],
+        'file_tags': list(file_node.tags.filter(system=False).values_list('name', flat=True)) if not file_node._state.adding else [],  # Only access ManyRelatedManager if saved
         'allow_comments': file_node.provider in settings.ADDONS_COMMENTABLE,
     })
 
@@ -724,7 +724,7 @@ def addon_view_file(auth, node, file_node, version):
         'extra': version.metadata.get('extra', {}),
         'size': version.size if version.size is not None else 9966699,
         'private': getattr(node.get_addon(file_node.provider), 'is_private', False),
-        'file_tags': list(file_node.tags.filter(system=False).values_list('name', flat=True)) if not file_node._state.adding else [],
+        'file_tags': list(file_node.tags.filter(system=False).values_list('name', flat=True)) if not file_node._state.adding else [],  # Only access ManyRelatedManager if saved
         'file_guid': file_node.get_guid()._id,
         'file_id': file_node._id,
         'allow_comments': file_node.provider in settings.ADDONS_COMMENTABLE

--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -582,7 +582,7 @@ def addon_deleted_file(auth, node, error_type='BLAME_PROVIDER', **kwargs):
         'provider': file_node.provider,
         'materialized_path': file_node.materialized_path or file_path,
         'private': getattr(node.get_addon(file_node.provider), 'is_private', False),
-        'file_tags': file_node.tags.filter(system=False).values_list('name', flat=True),
+        'file_tags': list(file_node.tags.filter(system=False).values_list('name', flat=True)) if not file_node._state.adding else [],
         'allow_comments': file_node.provider in settings.ADDONS_COMMENTABLE,
     })
 
@@ -724,7 +724,7 @@ def addon_view_file(auth, node, file_node, version):
         'extra': version.metadata.get('extra', {}),
         'size': version.size if version.size is not None else 9966699,
         'private': getattr(node.get_addon(file_node.provider), 'is_private', False),
-        'file_tags': list(file_node.tags.filter(system=False).values_list('name', flat=True)),
+        'file_tags': list(file_node.tags.filter(system=False).values_list('name', flat=True)) if not file_node._state.adding else [],
         'file_guid': file_node.get_guid()._id,
         'file_id': file_node._id,
         'allow_comments': file_node.provider in settings.ADDONS_COMMENTABLE


### PR DESCRIPTION
## Purpose
Resolve a [sentry error](https://sentry.cos.io/sentry/osf-back-end/issues/269323/)

## Changes
* Use default values if unsaved
* Serialize lists to JSON instead of complex objects

## Side effects
None expected

## Ticket
None known.

## Steps to Reproduce
* Upload a file to OSFS but **_do not_** navigate to it.
* Navigate to its "`info`" page in APIv2. This can be found at `http://<api_domain>/v2/nodes/<node_id>/files/osfstorage/` under `data['links']['info']`
* Delete file in UI
* Navigate to the "`html`" link from the APIv2 "`info`" page (e.g. http://localhost:5000/xzsur/files/osfstorage/588a951b701add011bbdd804?revision=1)