### PR TITLE
Use Node.objects.get_children to get node children [OSF-7396]

### DIFF
--- a/addons/wiki/tests/test_wiki.py
+++ b/addons/wiki/tests/test_wiki.py
@@ -1219,6 +1219,35 @@ class TestPublicWiki(OsfTestCase):
 
         assert_equal(data, expected)
 
+    def test_serialize_wiki_settings(self):
+        node = NodeFactory(parent=self.project, creator=self.user, is_public=True)
+        node.get_addon('wiki').set_editing(
+            permissions=True, auth=self.consolidate_auth, log=True)
+        node.add_pointer(self.project, Auth(self.user))
+        node.save()
+        data = serialize_wiki_settings(self.user, [node._id])
+        expected = [{
+            'node': {
+                'id': node._id,
+                'title': node.title,
+                'url': node.url,
+            },
+            'children': [
+                {
+                    'select': {
+                        'title': 'permission',
+                        'permission': 'public'
+                    },
+                }
+            ],
+            'kind': 'folder',
+            'nodeType': 'component',
+            'category': 'hypothesis',
+            'permissions': {'view': True}
+        }]
+
+        assert_equal(data, expected)
+
     def test_serialize_wiki_settings_no_wiki(self):
         node = NodeFactory(parent=self.project, creator=self.user)
         node.delete_addon('wiki', self.consolidate_auth)

--- a/addons/wiki/utils.py
+++ b/addons/wiki/utils.py
@@ -174,6 +174,9 @@ def serialize_wiki_settings(user, node_ids):
         if not include_wiki_settings:
             continue
 
+        node_children = Node.objects.get_children(node)
+        if node_children:
+            node_children = node_children.exclude(is_deleted=True).values_list('guids___id', flat=True)
         children = []
 
         if node.admin_public_wiki(user):
@@ -186,15 +189,8 @@ def serialize_wiki_settings(user, node_ids):
                         else 'private'
                 },
             })
-        children.extend(serialize_wiki_settings(
-            user,
-            [
-                n._id
-                for n in node.nodes
-                if n.primary and
-                not n.is_deleted
-            ]
-        ))
+
+        children.extend(serialize_wiki_settings(user, node_children))
 
         item = {
             'node': {

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1182,6 +1182,18 @@ class TestGetNodeTree(OsfTestCase):
         assert_equal(child2_id, child2._primary_key)
         assert_equal(child3_id, child3._primary_key)
 
+    def test_get_node_with_child_linked_to_parent(self):
+        project = ProjectFactory(creator=self.user)
+        child1 = NodeFactory(parent=project, creator=self.user)
+        child1.add_pointer(project, Auth(self.user))
+        child1.save()
+        url = project.api_url_for('get_node_tree')
+        res = self.app.get(url, auth=self.user.auth)
+        tree = res.json[0]
+        parent_node_id = tree['node']['id']
+        child1_id = tree['children'][0]['node']['id']
+        assert_equal(child1_id, child1._primary_key)
+
     def test_get_node_not_parent_owner(self):
         project = ProjectFactory(creator=self.user2)
         child = NodeFactory(parent=project, creator=self.user2)

--- a/website/notifications/utils.py
+++ b/website/notifications/utils.py
@@ -5,6 +5,7 @@ from framework.postcommit_tasks.handlers import run_postcommit
 from modularodm.exceptions import NoResultsFound
 
 from osf.modm_compat import Q
+from website.models import Node
 from website.notifications import constants
 from website.notifications.exceptions import InvalidSubscriptionError
 from website.project import signals
@@ -257,6 +258,9 @@ def format_data(user, node_ids):
         if not can_read and not can_read_children:
             continue
 
+        node_children = Node.objects.get_children(node)
+        if node_children:
+            node_children = node_children.exclude(is_deleted=True).values_list('guids___id', flat=True)
         children = []
         # List project/node if user has at least 'read' permissions (contributor or admin viewer) or if
         # user is contributor on a component of the project/node
@@ -273,15 +277,7 @@ def format_data(user, node_ids):
                     children.append(serialize_event(user, node=node, event_description=node_sub))
             children.sort(key=lambda s: s['event']['title'])
 
-        children.extend(format_data(
-            user,
-            [
-                n._id
-                for n in node.nodes
-                if n.primary and
-                not n.is_deleted
-            ]
-        ))
+        children.extend(format_data(user, node_children))
 
         item = {
             'node': {

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -970,15 +970,14 @@ def node_child_tree(user, node_ids):
             'name': affiliated_institution.name
         } for affiliated_institution in node.affiliated_institutions.all()]
 
+        node_children = Node.objects.get_children(node)
+        if node_children:
+            node_children = node_children.exclude(is_deleted=True).values_list('guids___id', flat=True)
         children = []
         # List project/node if user has at least 'read' permissions (contributor or admin viewer) or if
         # user is contributor on a component of the project/node
-        children.extend(node_child_tree(
-            user,
-            list(node.node_relations.select_related('child')
-                 .exclude(child__is_deleted=True)
-                 .values_list('child__guids___id', flat=True))
-        ))
+        children.extend(node_child_tree(user, node_children))
+
         item = {
             'node': {
                 'id': node_id,


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Children of nodes are being accessed in ways that recurse FOREVER.
<!-- Describe the purpose of your changes -->

## Changes
Use a different method to get children.
<!-- Briefly describe or list your changes  -->

## Side effects
None known.
<!--Any possible side effects? -->


## Ticket
[#OSF-7396]
https://openscience.atlassian.net/browse/OSF-7396
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->

## QA Notes

Test:
See setup in jira ticket. Things that should work now:

1. Changing privacy settings (component and project)
2. Wiki settings (on project settings page)
3. Email Notification Settings (on project settings page)
4. Adding a contributor (select components modal)