### PR TITLE
[feature fix] Prevent duplicates from appearing in node lists [OSF-7400]

### DIFF
--- a/api_tests/nodes/views/test_node_children_list.py
+++ b/api_tests/nodes/views/test_node_children_list.py
@@ -158,7 +158,7 @@ class TestNodeChildCreate(ApiTestCase):
         assert_equal(res.status_code, 401)
 
         self.project.reload()
-        assert_equal(self.project.nodes.count(), 0)
+        assert_equal(len(self.project.nodes), 0)
 
     def test_creates_child_logged_in_owner(self):
         res = self.app.post_json_api(self.url, self.child, auth=self.user.auth)
@@ -168,8 +168,8 @@ class TestNodeChildCreate(ApiTestCase):
         assert_equal(res.json['data']['attributes']['category'], self.child['data']['attributes']['category'])
 
         self.project.reload()
-        assert_equal(res.json['data']['id'], self.project.nodes.first()._id)
-        assert_equal(self.project.nodes.first().logs.latest().action, NodeLog.PROJECT_CREATED)
+        assert_equal(res.json['data']['id'], self.project.nodes[0]._id)
+        assert_equal(self.project.nodes[0].logs.latest().action, NodeLog.PROJECT_CREATED)
 
     def test_creates_child_logged_in_write_contributor(self):
         self.project.add_contributor(self.user_two, permissions=[permissions.READ, permissions.WRITE], auth=Auth(self.user), save=True)
@@ -182,7 +182,7 @@ class TestNodeChildCreate(ApiTestCase):
 
         self.project.reload()
         child_id = res.json['data']['id']
-        assert_equal(child_id, self.project.nodes.first()._id)
+        assert_equal(child_id, self.project.nodes[0]._id)
         assert_equal(Node.load(child_id).logs.latest().action, NodeLog.PROJECT_CREATED)
 
     def test_creates_child_logged_in_read_contributor(self):
@@ -191,14 +191,14 @@ class TestNodeChildCreate(ApiTestCase):
         assert_equal(res.status_code, 403)
 
         self.project.reload()
-        assert_equal(self.project.nodes.count(), 0)
+        assert_equal(len(self.project.nodes), 0)
 
     def test_creates_child_logged_in_non_contributor(self):
         res = self.app.post_json_api(self.url, self.child, auth=self.user_two.auth, expect_errors=True)
         assert_equal(res.status_code, 403)
 
         self.project.reload()
-        assert_equal(self.project.nodes.count(), 0)
+        assert_equal(len(self.project.nodes), 0)
 
     def test_creates_child_creates_child_and_sanitizes_html_logged_in_owner(self):
         title = '<em>Cool</em> <strong>Project</strong>'
@@ -226,7 +226,7 @@ class TestNodeChildCreate(ApiTestCase):
 
         self.project.reload()
         child_id = res.json['data']['id']
-        assert_equal(child_id, self.project.nodes.first()._id)
+        assert_equal(child_id, self.project.nodes[0]._id)
         assert_equal(Node.load(child_id).logs.latest().action, NodeLog.PROJECT_CREATED)
 
     def test_cannot_create_child_on_a_registration(self):
@@ -333,7 +333,7 @@ class TestNodeChildrenBulkCreate(ApiTestCase):
         assert_equal(res.status_code, 401)
 
         self.project.reload()
-        assert_equal(self.project.nodes.count(), 0)
+        assert_equal(len(self.project.nodes), 0)
 
     def test_bulk_creates_children_logged_in_owner(self):
         res = self.app.post_json_api(self.url, {'data': [self.child, self.child_two]}, auth=self.user.auth, bulk=True)
@@ -346,7 +346,7 @@ class TestNodeChildrenBulkCreate(ApiTestCase):
         assert_equal(res.json['data'][1]['attributes']['category'], self.child_two['attributes']['category'])
 
         self.project.reload()
-        nodes = self.project.nodes.all()
+        nodes = self.project.nodes
         assert_equal(res.json['data'][0]['id'], nodes[0]._id)
         assert_equal(res.json['data'][1]['id'], nodes[1]._id)
 
@@ -369,7 +369,7 @@ class TestNodeChildrenBulkCreate(ApiTestCase):
         self.project.reload()
         child_id = res.json['data'][0]['id']
         child_two_id = res.json['data'][1]['id']
-        nodes = self.project.nodes.all()
+        nodes = self.project.nodes
         assert_equal(child_id, nodes[0]._id)
         assert_equal(child_two_id, nodes[1]._id)
 
@@ -383,7 +383,7 @@ class TestNodeChildrenBulkCreate(ApiTestCase):
         assert_equal(res.status_code, 403)
 
         self.project.reload()
-        assert_equal(self.project.nodes.count(), 0)
+        assert_equal(len(self.project.nodes), 0)
 
     def test_bulk_creates_children_logged_in_non_contributor(self):
         res = self.app.post_json_api(self.url, {'data': [self.child, self.child_two]},
@@ -391,7 +391,7 @@ class TestNodeChildrenBulkCreate(ApiTestCase):
         assert_equal(res.status_code, 403)
 
         self.project.reload()
-        assert_equal(self.project.nodes.count(), 0)
+        assert_equal(len(self.project.nodes), 0)
 
     def test_bulk_creates_children_and_sanitizes_html_logged_in_owner(self):
         title = '<em>Cool</em> <strong>Project</strong>'
@@ -419,7 +419,7 @@ class TestNodeChildrenBulkCreate(ApiTestCase):
 
         self.project.reload()
         child_id = res.json['data']['id']
-        assert_equal(child_id, self.project.nodes.first()._id)
+        assert_equal(child_id, self.project.nodes[0]._id)
         assert_equal(Node.load(child_id).logs.latest().action, NodeLog.PROJECT_CREATED)
 
     def test_cannot_bulk_create_children_on_a_registration(self):
@@ -439,7 +439,7 @@ class TestNodeChildrenBulkCreate(ApiTestCase):
         assert_equal(res.status_code, 404)
 
         self.project.reload()
-        assert_equal(self.project.nodes.count(), 0)
+        assert_equal(len(self.project.nodes), 0)
 
     def test_bulk_creates_children_no_type(self):
         child = {
@@ -457,7 +457,7 @@ class TestNodeChildrenBulkCreate(ApiTestCase):
         assert_equal(res.json['errors'][0]['source']['pointer'], '/data/1/type')
 
         self.project.reload()
-        assert_equal(self.project.nodes.count(), 0)
+        assert_equal(len(self.project.nodes), 0)
 
     def test_bulk_creates_children_incorrect_type(self):
         child = {
@@ -475,7 +475,7 @@ class TestNodeChildrenBulkCreate(ApiTestCase):
         assert_equal(res.json['errors'][0]['detail'], 'This resource has a type of "nodes", but you set the json body\'s type field to "Wrong type.". You probably need to change the type field to match the resource\'s type.')
 
         self.project.reload()
-        assert_equal(self.project.nodes.count(), 0)
+        assert_equal(len(self.project.nodes), 0)
 
     def test_bulk_creates_children_properties_not_nested(self):
         child = {
@@ -491,4 +491,5 @@ class TestNodeChildrenBulkCreate(ApiTestCase):
         assert_equal(res.json['errors'][0]['source']['pointer'], '/data/attributes')
 
         self.project.reload()
-        assert_equal(self.project.nodes.count(), 0)
+        assert_equal(len(self.project.nodes), 0)
+

--- a/api_tests/nodes/views/test_node_list.py
+++ b/api_tests/nodes/views/test_node_list.py
@@ -734,8 +734,8 @@ class TestNodeCreate(ApiTestCase):
         assert_equal(new_project.title, templated_project_title)
         assert_equal(new_project.description, '')
         assert_false(new_project.is_public)
-        assert_equal(new_project.nodes.count(), template_from.nodes.count())
-        assert_equal(new_project.nodes.first().title, template_component.title)
+        assert_equal(len(new_project.nodes), len(template_from.nodes))
+        assert_equal(new_project.nodes[0].title, template_component.title)
 
     def test_404_on_create_from_template_of_nonexistent_project(self):
         template_from_id = 'thisisnotavalidguid'

--- a/api_tests/registrations/views/test_registration_forks.py
+++ b/api_tests/registrations/views/test_registration_forks.py
@@ -111,7 +111,7 @@ class TestRegistrationForksList(ApiTestCase):
         assert_equal(fork_contributors['id'], self.user._id)
 
         forked_children = data['embeds']['children']['data'][0]
-        assert_equal(forked_children['id'], self.private_registration.forks.first().nodes.first()._id)
+        assert_equal(forked_children['id'], self.private_registration.forks.first().nodes[0]._id)
         assert_equal(forked_children['attributes']['title'], self.component.title)
 
         forked_node_links = data['embeds']['node_links']['data'][0]['embeds']['target_node']['data']
@@ -121,7 +121,7 @@ class TestRegistrationForksList(ApiTestCase):
         assert_equal(data['attributes']['fork'], True)
 
         expected_logs = list(self.private_registration.logs.values_list('action', flat=True))
-        expected_logs.append(self.private_registration.nodes.first().logs.latest().action)
+        expected_logs.append(self.private_registration.nodes[0].logs.latest().action)
         expected_logs.append('node_forked')
         expected_logs.append('node_forked')
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4432,7 +4432,7 @@ class TestProjectCreation(OsfTestCase):
         post_data = {'title': '<b>New <blink>Component</blink> Title</b>', 'category': ''}
         request = self.app.post(url, post_data, auth=user.auth).follow()
         project.reload()
-        child = project.nodes.first()
+        child = project.nodes[0]
         # HTML has been stripped
         assert_equal(child.title, 'New Component Title')
 
@@ -4491,7 +4491,7 @@ class TestProjectCreation(OsfTestCase):
         post_data = {'title': 'New Component With Contributors Title', 'category': '', 'inherit_contributors': True}
         res = self.app.post(url, post_data, auth=self.user1.auth)
         self.project.reload()
-        child = self.project.nodes.first()
+        child = self.project.nodes[0]
         assert_equal(child.title, 'New Component With Contributors Title')
         assert_in(self.user1, child.contributors)
         assert_in(self.user2, child.contributors)
@@ -4506,7 +4506,7 @@ class TestProjectCreation(OsfTestCase):
         post_data = {'title': 'New Component With Contributors Title', 'category': '', 'inherit_contributors': True}
         res = self.app.post(url, post_data, auth=non_admin.auth)
         self.project.reload()
-        child = self.project.nodes.first()
+        child = self.project.nodes[0]
         assert_equal(child.title, 'New Component With Contributors Title')
         assert_in(non_admin, child.contributors)
         assert_in(self.user1, child.contributors)
@@ -4529,7 +4529,7 @@ class TestProjectCreation(OsfTestCase):
         post_data = {'title': 'New Component With Contributors Title', 'category': ''}
         res = self.app.post(url, post_data, auth=self.user1.auth)
         self.project.reload()
-        child = self.project.nodes.first()
+        child = self.project.nodes[0]
         assert_equal(child.title, 'New Component With Contributors Title')
         assert_in(self.user1, child.contributors)
         assert_not_in(self.user2, child.contributors)


### PR DESCRIPTION
## Purpose

When a node is both a component of a project and linked to from
another project, the node would *sometimes* appear twice when
calling AbstractNode#get_nodes() on either the parent project or the
linking project.

## Changes

This filters out duplicates in `AbstractNode.get_nodes()`, but does so in Python, because there
is no way to both (1) ensure uniqueness of returned nodes and
(2) maintain ordering by NodeRelation._order in the same query.

## Side effects

- `AbstractNode.get_nodes()` and `AbstractNode.nodes` now return a list rather than a QuerySet. I verified that no application code treats the return values as a QuerySet.
- This is an ugly solution--I tried many different queries to do the filtering in SQL rather than in Python, but none produced the desired behavior 😞 
- The test added here is not sufficient to reproduce the issue. In other words, it still passes without the code changes. I was unable to reproduce the issue in an automated test; I could only reproduce it when creating projects manually 😞  . Here are the steps:
  - Create a project A and a component B
  - Make B public
  - Create a separate public project C.
  - Create a separate project D.
  - Add link from project D to component B.
  - Add link from project D to component D.
  - On project D, reorder the nodes so that D appears before B.
  - View project D and project A.

Expected: component B appears once
Actual: component B appears twice

## Ticket

https://openscience.atlassian.net/browse/OSF-7400
