### PR TITLE
[feature fix] Don't show logs from linked nodes [OSF-7378]

### DIFF
--- a/api_tests/registrations/views/test_registration_forks.py
+++ b/api_tests/registrations/views/test_registration_forks.py
@@ -127,7 +127,7 @@ class TestRegistrationForksList(ApiTestCase):
 
         forked_logs = data['embeds']['logs']['data']
         assert_equal(set(expected_logs), set(log['attributes']['action'] for log in forked_logs))
-        assert_equal(len(forked_logs), 6)
+        assert_equal(len(forked_logs), len(expected_logs))
 
         forked_from = data['embeds']['forked_from']['data']
         assert_equal(forked_from['id'], self.private_registration._id)

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -680,7 +680,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
 
     def get_aggregate_logs_query(self, auth):
         ids = [self._id] + [n._id
-                            for n in self.get_descendants_recursive()
+                            for n in self.get_descendants_recursive(primary_only=True)
                             if n.can_view(auth)]
         query = Q('node', 'in', ids) & Q('should_hide', 'ne', True)
         return query
@@ -692,15 +692,15 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
     @property
     def comment_level(self):
         if self.public_comments:
-            return 'public'
+            return self.PUBLIC
         else:
-            return 'private'
+            return self.PRIVATE
 
     @comment_level.setter
     def comment_level(self, value):
-        if value == 'public':
+        if value == self.PUBLIC:
             self.public_comments = True
-        elif value == 'private':
+        elif value == self.PRIVATE:
             self.public_comments = False
         else:
             raise ValidationError(

--- a/osf/models/sanctions.py
+++ b/osf/models/sanctions.py
@@ -808,7 +808,7 @@ class RegistrationApproval(PreregCallbackMixin, EmailApprovableSanction):
         # an admin on components (component admins had the opportunity
         # to disapprove the registration by this point)
         register.set_privacy('public', auth=None, log=False)
-        for child in register.get_descendants_recursive(lambda n: n.primary):
+        for child in register.get_descendants_recursive(primary_only=True):
             child.set_privacy('public', auth=None, log=False)
         # Accounts for system actions where no `User` performs the final approval
         auth = Auth(user) if user else None

--- a/website/project/views/register.py
+++ b/website/project/views/register.py
@@ -179,7 +179,7 @@ def project_before_register(auth, node, **kwargs):
     }
     errors = {}
 
-    addon_set = [n.get_addons() for n in itertools.chain([node], node.get_descendants_recursive(lambda n: n.primary))]
+    addon_set = [n.get_addons() for n in itertools.chain([node], node.get_descendants_recursive(primary_only=True))]
     for addon in itertools.chain(*addon_set):
         if not addon.complete:
             continue


### PR DESCRIPTION
## Purpose

Prevent logs from linked nodes from appearing. 

## Changes

- Pass `primary_only=True` when querying for a node's logs
- Passing a function to get_descendants_recursive was removed.
This fixes a few calls to use the newer primary_only parameter


## Side effects

<!--Any possible side effects? -->


## Ticket

Comment in https://openscience.atlassian.net/browse/OSF-7378
