### PR TITLE
Update docker compose and documentation for developement on Ubuntu [SVCS-237]

### DIFF
--- a/README-docker-compose.md
+++ b/README-docker-compose.md
@@ -3,14 +3,18 @@
 
 1. Install the Docker Client
   - OSX: https://www.docker.com/products/docker#/mac
+  - Ubuntu
+    - docker: https://docs.docker.com/engine/installation/linux/ubuntulinux
+    - docker-compose: https://docs.docker.com/compose/install/
   - Windows: https://www.docker.com/products/docker#/windows
 2. Grant the docker client additional memory and cpu (minimum of 4GB and 2 CPU)
    - OSX: https://docs.docker.com/docker-for-mac/#/preferences
+   - Ubuntu: N/A
    - Windows: https://docs.docker.com/docker-for-windows/#advanced
 3. Setup the Operating System
   - OSX
     - Alias the loopback interface
-    
+
     ```bash
     export libdir='/Library/LaunchDaemons' \
       && export file='com.runlevel1.lo0.192.168.168.167.plist' \
@@ -19,6 +23,21 @@
       && sudo chown root:wheel $libdir/$file \
       && sudo launchctl load $libdir/$file
     ```
+  - Ubuntu
+    - Add loopback alias
+      `sudo ifconfig lo:0 192.168.168.167 netmask 255.255.255.255 up`
+      - For persistance, add to /etc/network/interfaces...
+        ```iface lo:0 inet static
+               address 192.168.168.167
+               netmask 255.255.255.255
+               network 192.168.168.167
+        ```
+    - If UFW enabled. Enable UFW forwarding.
+      - https://docs.docker.com/engine/installation/linux/ubuntulinux/#/enable-ufw-forwarding
+    - If needed. Configure a DNS server for use by Docker.
+      - https://docs.docker.com/engine/installation/linux/ubuntulinux/#/configure-a-dns-server-for-use-by-docker
+    - Configure docker to start at boot for Ubuntu 15.04 onwards
+      `sudo systemctl enable docker`
 
   - Windows
     - Install Microsoft Loopback Adapter (Windows 10 follow community comments as the driver was renamed)
@@ -91,10 +110,14 @@
 
 ## Docker Sync
 
+Ubuntu: Skip install of docker-sync, fswatch, and unison. instead...
+        `cp docker-compose.ubuntu.yml docker-compose.override.yml`
+        Ignore future steps that start, stop, or wait for docker-sync
+
 1. Install Docker Sync
   - Mac: `$ sudo gem install docker-sync`
   - [Instructions](http://docker-sync.io)
-  
+
 1. Install fswatch and unison
   - Mac: `$ brew install fswatch unison`
 
@@ -150,7 +173,7 @@
 - To view the logs for a given container: 
 
   ```
-  $ docker-compose logs -f -t 100 web
+  $ docker-compose logs -f --tail 100 web
   ```
 
 ## Running arbitrary commands

--- a/docker-compose.ubuntu.yml
+++ b/docker-compose.ubuntu.yml
@@ -1,0 +1,56 @@
+
+version: '2'
+
+services:
+
+#  fakecas:
+#    image: quay.io/centerforopenscience/fakecas:latest
+#    command: fakecas -host=0.0.0.0:8080 -dbaddress=172.19.0.7:27017
+
+#  wb:
+#    volumes:
+#      - ../waterbutler:/code
+
+#  mfr:
+#    volumes:
+#      - ../modular-file-renderer:/code
+
+#  preprints:
+#    volumes:
+#      - ../ember-preprints:/code
+
+  requirements:
+    volumes:
+      - ./:/code
+
+  assets:
+    volumes:
+      - ./:/code
+
+  sharejs:
+    volumes:
+      - ./:/code
+
+#  beat:
+#    volumes:
+#      - ./:/code
+
+  worker:
+    volumes:
+      - ./:/code
+
+#  adminassets:
+#    volumes:
+#      - ./:/code
+#
+#  admin:
+#    volumes:
+#      - ./:/code
+
+  web:
+    volumes:
+      - ./:/code
+
+  api:
+    volumes:
+      - ./:/code


### PR DESCRIPTION
## Purpose:
[SVCS-237](https://openscience.atlassian.net/browse/SVCS-237)
Get TomB's docker/django development setup on Ubuntu. Update Docs.

## Changes:
Update  README-docker-compose.md 
- docker/docker-compose install
- loopback alias
- alternative to docker-sync
Add docker-compose.ubuntu.yml
- Used in place of docker-compose.override.yml

## Side effects
None

[#SVCS-237]