### PR TITLE
[hotfix ]Allow Admin users who ONLY have access to prereg to see this on the sidebar

### DIFF
--- a/admin/templates/base.html
+++ b/admin/templates/base.html
@@ -120,10 +120,10 @@
             <li><a href="{% url 'spam:spam' %}"><i class='fa fa-link'></i> <span>OSF Spam</span></a></li>
             <li><a href="{% url 'nodes:registrations' %}"><i class='fa fa-link'></i> <span>OSF Registrations</span></a></li>
             <li><a href="{% url 'meetings:list' %}"><i class='fa fa-link'></i> <span>OSF Meetings</span></a></li>
+          {% endif %}
             {% if 'prereg' in request.user.group_names %}
             <li><a href="{% url 'pre_reg:prereg' %}"><i class='fa fa-link'></i> <span>OSF Prereg</span></a></li>
             {% endif %}
-          {% endif %}
             <li><a href="{% url 'metrics:metrics' %}"><i class='fa fa-link'></i> <span>OSF Metrics</span></a></li>
           </ul><!-- /.sidebar-menu -->
         </section>


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

The view of prereg in the sidebar was included in the if statement checking if they could see nodes and users information, preventing those who can see prereg but not nodes and users from seeing the prereg link.

## Changes

- Move the if statement end to the appropriate place in base.html

## Side effects

nope


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
