### PR TITLE
[EOSF-436] Add SIPS link to psyarxiv info

### DIFF
--- a/scripts/populate_preprint_providers.py
+++ b/scripts/populate_preprint_providers.py
@@ -227,7 +227,7 @@ def main():
             '_id': 'psyarxiv',
             'name': 'PsyArXiv',
             'logo_name': 'psyarxiv-logo.png',
-            'description': 'A free preprint service for the psychological sciences.',
+            'description': 'A free preprint service for the psychological sciences. Maintained by <a href="http://improvingpsych.org">SIPS</a>',
             'banner_name': 'psyarxiv-banner.png',
             'external_url': 'http://psyarxiv.com',
             'example': 'k9mn3',

--- a/scripts/populate_preprint_providers.py
+++ b/scripts/populate_preprint_providers.py
@@ -227,7 +227,7 @@ def main():
             '_id': 'psyarxiv',
             'name': 'PsyArXiv',
             'logo_name': 'psyarxiv-logo.png',
-            'description': 'A free preprint service for the psychological sciences. Maintained by <a href="http://improvingpsych.org">SIPS</a>',
+            'description': 'A free preprint service for the psychological sciences.<div>Maintained by <a href="http://improvingpsych.org">The Society for the Improvement of Psychological Science</a>.</div>',
             'banner_name': 'psyarxiv-banner.png',
             'external_url': 'http://psyarxiv.com',
             'example': 'k9mn3',


### PR DESCRIPTION
## Requires:
https://github.com/CenterForOpenScience/ember-preprints/pull/262

## Purpose
Add SIPS link to psyarxiv description.

## Changes
![screen shot 2017-02-06 at 11 58 37 am](https://cloud.githubusercontent.com/assets/6268982/22657245/d1e39644-ec63-11e6-85f1-215ca582dd71.png)



## Ticket
https://openscience.atlassian.net/browse/EOSF-436
