### PR TITLE
Reduce number of queries when reordering contributors and nodes [OSF-7426]

### DIFF
--- a/osf/models/comment.py
+++ b/osf/models/comment.py
@@ -24,13 +24,6 @@ class Comment(GuidMixin, SpamMixin, CommentableMixin, BaseModel):
     modm_query = None
     # /TODO DELETE ME POST MIGRATION
     __guid_min_length__ = 12
-
-    # FIELD_ALIASES = {
-    #     # TODO: Find a better way
-    #     'root_target': 'root_target___id',
-    #     'target': 'target___id'
-    # }
-
     OVERVIEW = 'node'
     FILES = 'files'
     WIKI = 'wiki'

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -2071,9 +2071,11 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
                 )
 
             if to_retain != users:
-                # TODO: Can we prevent n queries?
-                sorted_contribs = [self.contributor_set.get(user=user).pk for user in users]
-                self.set_contributor_order(sorted_contribs)
+                # Ordered Contributor PKs, sorted according to the passed list of user IDs
+                sorted_contrib_ids = [
+                    each.id for each in sorted(self.contributor_set.all(), key=lambda c: user_ids.index(c.user._id))
+                ]
+                self.set_contributor_order(sorted_contrib_ids)
                 self.add_log(
                     action=NodeLog.CONTRIB_REORDERED,
                     params={

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -91,7 +91,6 @@ class TestNodeSerializers(OsfTestCase):
         result = _get_summary(
             node, auth=Auth(user),
             primary=True,
-            link_id=None
         )
 
         # serialized result should have id and primary
@@ -182,7 +181,6 @@ class TestNodeSerializers(OsfTestCase):
         res = _get_summary(
             fork, auth=Auth(user),
             primary=True,
-            link_id=None
         )
         # serialized result should have is_fork
         assert_true(res['summary']['is_fork'])
@@ -200,7 +198,6 @@ class TestNodeSerializers(OsfTestCase):
         res = _get_summary(
             fork, auth=Auth(user),
             primary=True,
-            link_id=None
         )
         # serialized result should have is_fork
         assert_false(res['summary']['can_view'])

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2869,7 +2869,7 @@ class TestPointerViews(OsfTestCase):
         res = self.app.get(url, auth=self.user.auth).maybe_follow()
         assert_equal(res.status_code, 200)
 
-        has_controls = res.lxml.xpath('//li[@node_reference]/p[starts-with(normalize-space(text()), "Private Link")]//i[contains(@class, "remove-pointer")]')
+        has_controls = res.lxml.xpath('//li[@node_id]/p[starts-with(normalize-space(text()), "Private Link")]//i[contains(@class, "remove-pointer")]')
         assert_true(has_controls)
 
     def test_pointer_list_write_contributor_can_remove_public_component_entry(self):
@@ -2884,7 +2884,7 @@ class TestPointerViews(OsfTestCase):
         assert_equal(res.status_code, 200)
 
         has_controls = res.lxml.xpath(
-            '//li[@node_reference]//i[contains(@class, "remove-pointer")]')
+            '//li[@node_id]//i[contains(@class, "remove-pointer")]')
         assert_equal(len(has_controls), 3)
 
     def test_pointer_list_read_contributor_cannot_remove_private_component_entry(self):
@@ -2900,8 +2900,8 @@ class TestPointerViews(OsfTestCase):
         res = self.app.get(url, auth=user2.auth).maybe_follow()
         assert_equal(res.status_code, 200)
 
-        pointer_nodes = res.lxml.xpath('//li[@node_reference]')
-        has_controls = res.lxml.xpath('//li[@node_reference]/p[starts-with(normalize-space(text()), "Private Link")]//i[contains(@class, "remove-pointer")]')
+        pointer_nodes = res.lxml.xpath('//li[@node_id]')
+        has_controls = res.lxml.xpath('//li[@node_id]/p[starts-with(normalize-space(text()), "Private Link")]//i[contains(@class, "remove-pointer")]')
         assert_equal(len(pointer_nodes), 1)
         assert_false(has_controls)
 
@@ -2921,9 +2921,9 @@ class TestPointerViews(OsfTestCase):
         res = self.app.get(url, auth=user2.auth).maybe_follow()
         assert_equal(res.status_code, 200)
 
-        pointer_nodes = res.lxml.xpath('//li[@node_reference]')
+        pointer_nodes = res.lxml.xpath('//li[@node_id]')
         has_controls = res.lxml.xpath(
-            '//li[@node_reference]//i[contains(@class, "remove-pointer")]')
+            '//li[@node_id]//i[contains(@class, "remove-pointer")]')
         assert_equal(len(pointer_nodes), 1)
         assert_equal(len(has_controls), 0)
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4320,8 +4320,8 @@ class TestReorderComponents(OsfTestCase):
         # contrib tries to reorder components
         payload = {
             'new_list': [
-                '{0}:node'.format(self.private_component._primary_key),
-                '{0}:node'.format(self.public_component._primary_key),
+                '{0}'.format(self.private_component._id),
+                '{0}'.format(self.public_component._id),
             ]
         }
         url = self.project.api_url_for('project_reorder_components')

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -850,7 +850,7 @@ def get_recent_logs(node, **kwargs):
     return {'logs': logs}
 
 
-def _get_summary(node, auth, primary=True, link_id=None, show_path=False):
+def _get_summary(node, auth, primary=True, show_path=False):
     # TODO(sloria): Refactor this or remove (lots of duplication with _view_project)
     summary = {
         'id': node._id,
@@ -909,11 +909,10 @@ def _get_summary(node, auth, primary=True, link_id=None, show_path=False):
 @must_be_valid_project(retractions_valid=True)
 def get_summary(auth, node, **kwargs):
     primary = kwargs.get('primary')
-    link_id = kwargs.get('link_id')
     show_path = kwargs.get('show_path', False)
 
     return _get_summary(
-        node, auth, primary=primary, link_id=link_id, show_path=show_path
+        node, auth, primary=primary, show_path=show_path
     )
 
 @must_be_contributor_or_public

--- a/website/templates/util/render_node.mako
+++ b/website/templates/util/render_node.mako
@@ -3,7 +3,6 @@
 
     <li
             node_id="${summary['id']}"
-            node_reference="${summary['id']}"
             class="
                 project list-group-item list-group-item-node cite-container
                 ${'pointer' if not summary['primary'] else ''}
@@ -114,7 +113,7 @@
 
 % else:
     <li
-        node_reference="${summary['id']}:${'node' if summary['primary'] else 'pointer'}"
+        node_id="${summary['id']}"
         class="project list-group-item list-group-item-node">
         <p class="list-group-item-heading f-w-lg">
             %if summary['is_registration']:

--- a/website/templates/util/render_node.mako
+++ b/website/templates/util/render_node.mako
@@ -3,7 +3,7 @@
 
     <li
             node_id="${summary['id']}"
-            node_reference="${summary['id']}:${'node' if summary['primary'] else 'pointer'}"
+            node_reference="${summary['id']}"
             class="
                 project list-group-item list-group-item-node cite-container
                 ${'pointer' if not summary['primary'] else ''}

--- a/website/templates/util/render_nodes.mako
+++ b/website/templates/util/render_nodes.mako
@@ -26,7 +26,7 @@
                       var sortListElm = this;
                       var idList = $(sortListElm).sortable(
                           'toArray',
-                          {attribute: 'node_reference'}
+                          {attribute: 'node_id'}
                       );
                       NodeActions.reorderChildren(idList, sortListElm);
                   }

--- a/website/templates/util/render_nodes.mako
+++ b/website/templates/util/render_nodes.mako
@@ -7,7 +7,6 @@
                     "uri": "${each['api_url']}get_summary/",
                     "view_kwargs": {
                         "primary": ${int(each['primary'])},
-                        "link_id": "${each['id']}",
                         "uid": "${user_id}",
                         "show_path": ${"true" if show_path else "false"}
                     },


### PR DESCRIPTION


## Purpose

Optimize the views for reordering nodes and reordering contributors.

## Changes

- Simplify the request payload for the reorder_contributors v1 endpoint
- Fetch all `NodeRelations`/`Contributors` then sort them based on the request payload. This means doing one query rather than n queries
- Minor cleanup: Remove unnecessary `link_id` view kwarg and `node_reference` DOM attribute

## Side effects

## Ticket

https://openscience.atlassian.net/browse/OSF-7426