### PR TITLE
Prevent initializing DevModeControls if git_log.json doesn't exist

### DIFF
--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -188,7 +188,8 @@ var plugins = [
     }),
     // Slight hack to make sure that CommonJS is always used
     new webpack.DefinePlugin({
-        'define.amd': false
+        'define.amd': false,
+        '__ENABLE_DEV_MODE_CONTROLS': fs.existsSync(staticPath(path.join('built', 'git_logs.json')))
     }),
 ];
 

--- a/website/static/js/pages/base-page.js
+++ b/website/static/js/pages/base-page.js
@@ -211,7 +211,9 @@ $(function() {
         $osf.initializeResponsiveAffix();
     }
     new NavbarControl('.osf-nav-wrapper');
-    new DevModeControls('#devModeControls', '/static/built/git_logs.json', '/static/built/git_branch.txt');
+    if (__ENABLE_DEV_MODE_CONTROLS) {
+        new DevModeControls('#devModeControls', '/static/built/git_logs.json', '/static/built/git_branch.txt');
+    }
     if (window.contextVars.keen){
         //Don't track PhantomJS visits with KeenIO
         if (!(/PhantomJS/.test(navigator.userAgent))){


### PR DESCRIPTION
## Purpose

Fixes this error in local dev environments:

![osf___home](https://cloud.githubusercontent.com/assets/2379650/22526457/522fec22-e899-11e6-85eb-d190c7d07e15.png)


## Changes

Don't initialize `DevModeControls` unless `website/static/built/git_logs.txt` exists
