### PR TITLE
[Feature] Encrypt unicode properly for EncryptedTextFields [#OSF-7200]

### DIFF
--- a/osf_tests/test_external_accounts.py
+++ b/osf_tests/test_external_accounts.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import string
 import random
 
@@ -7,11 +8,11 @@ from django.db import connection
 from psycopg2._psycopg import AsIs
 
 from osf.models import ExternalAccount
-from osf.utils.fields import EncryptedTextField, SENSITIVE_DATA_KEY
+from osf.utils.fields import EncryptedTextField, SENSITIVE_DATA_KEY, ensure_bytes
 from .factories import ExternalAccountFactory
 
 @pytest.mark.django_db
-class TestEncryptedStringField(object):
+class TestEncryptedExternalAccountFields(object):
     def setup_class(self):
         self.magic_string = ''.join(random.choice(string.hexdigits) for _ in range(25))
 
@@ -39,3 +40,85 @@ class TestEncryptedStringField(object):
             row = cursor.fetchone()
             for blicky in row:
                 assert jwe.decrypt(bytes(blicky[len(EncryptedTextField.prefix):]), SENSITIVE_DATA_KEY) == self.magic_string
+
+
+class TestEncryptedTextField:
+    @pytest.fixture
+    def field(self):
+        return EncryptedTextField(null=True, blank=True)
+
+    def test_ensure_bytes_encodes_no_unicode_in_string_type_str(self):
+        my_value = 'hello'
+        assert isinstance(my_value, bytes)
+        my_str = ensure_bytes(my_value)
+        assert isinstance(my_str, bytes)
+
+    def test_ensure_bytes_encodes_unicode_in_string_type_str(self):
+        my_value = 'hellü'
+        assert isinstance(my_value, bytes)
+        my_str = ensure_bytes(my_value)
+        assert isinstance(my_str, bytes)
+
+    def test_ensure_bytes_encodes_no_unicode_in_string_type_unicode(self):
+        my_value = u'hello'
+        assert isinstance(my_value, unicode)
+        my_str = ensure_bytes(my_value)
+        assert isinstance(my_str, bytes)
+
+    def test_ensure_bytes_encodes_unicode_in_string_type_unicode(self):
+        my_value = u'hellü'
+        assert isinstance(my_value, unicode)
+        my_str = ensure_bytes(my_value)
+        assert isinstance(my_str, bytes)
+
+    def test_encrypt_and_decrypt_no_unicode_in_string_type_str(self, field):
+        my_value = 'hello'
+        assert isinstance(my_value, bytes)
+        my_value_encrypted = field.get_db_prep_value(my_value)
+        assert isinstance(my_value_encrypted, bytes)
+
+        my_value_decrypted = field.from_db_value(my_value_encrypted, None, None, None)
+        assert isinstance(my_value_decrypted, bytes)
+        assert my_value_decrypted == ensure_bytes(my_value)
+
+    def test_encrypt_and_decrypt_unicode_in_string_type_str(self, field):
+        my_value = 'hellü'
+        assert isinstance(my_value, bytes)
+        my_value_encrypted = field.get_db_prep_value(my_value)
+        assert isinstance(my_value_encrypted, bytes)
+
+        my_value_decrypted = field.from_db_value(my_value_encrypted, None, None, None)
+        assert my_value_decrypted == ensure_bytes(my_value)
+
+        my_value = '찦차КЛМНО💁◕‿◕｡)╱i̲̬͇̪͙n̝̗͕v̟̜̘̦͟o̶̙̰̠kè͚̮̺̪̹̱̤  ǝɹol'
+        assert isinstance(my_value, bytes)
+        my_value_encrypted = field.get_db_prep_value(my_value)
+        my_value_decrypted = field.from_db_value(my_value_encrypted, None, None, None)
+        assert isinstance(my_value_decrypted, bytes)
+        assert my_value_decrypted == ensure_bytes(my_value)
+
+    def test_encrypt_and_decrypt_no_unicode_in_string_type_unicode(self, field):
+        my_value = u'hello'
+        assert isinstance(my_value, unicode)
+        my_value_encrypted = field.get_db_prep_value(my_value)
+        assert isinstance(my_value_encrypted, bytes)
+
+        my_value_decrypted = field.from_db_value(my_value_encrypted, None, None, None)
+        assert isinstance(my_value_decrypted, bytes)
+        assert my_value_decrypted == ensure_bytes(my_value)
+
+    def test_encrypt_and_decrypt_unicode_in_string_type_unicode(self, field):
+        my_value = u'hellü'
+        assert isinstance(my_value, unicode)
+        my_value_encrypted = field.get_db_prep_value(my_value)
+        assert isinstance(my_value_encrypted, bytes)
+
+        my_value_decrypted = field.from_db_value(my_value_encrypted, None, None, None)
+        assert my_value_decrypted == ensure_bytes(my_value)
+
+        my_value = u'찦차КЛМНО💁◕‿◕｡)╱i̲̬͇̪͙n̝̗͕v̟̜̘̦͟o̶̙̰̠kè͚̮̺̪̹̱̤  ǝɹol'
+        assert isinstance(my_value, unicode)
+        my_value_encrypted = field.get_db_prep_value(my_value)
+        my_value_decrypted = field.from_db_value(my_value_encrypted, None, None, None)
+        assert isinstance(my_value_decrypted, bytes)
+        assert my_value_decrypted == ensure_bytes(my_value)


### PR DESCRIPTION
## Purpose
#6766, but for Django

h/t @alexschiller 

## Changes
>   1. Add helper function to ensure incoming strings to be encoded are in the proper utf-8 format
>   1. Add tests for helper function and encryption in general since it was untested.

## Side effects
None expected


## Ticket
[#OSF-7200](https://openscience.atlassian.net/browse/OSF-7200)