### PR TITLE
[SVCS-5] Fix GitHub addon so you can rename with a percent sign

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -528,7 +528,7 @@ function doItemOp(operation, to, from, rename, conflict) {
     if(from.data.provider === 'github'){
         options.branch = from.data.branch;
         moveSpec.branch = from.data.branch;
-        from.data.path = '/' + encodeURIComponent(from.data.path].slice(1,from.data.path].length));
+        from.data.path = '/' + encodeURIComponent(from.data.path.slice(1,from.data.path.length));
     }
 
     from.inProgress = true;

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -528,6 +528,7 @@ function doItemOp(operation, to, from, rename, conflict) {
     if(from.data.provider === 'github'){
         options.branch = from.data.branch;
         moveSpec.branch = from.data.branch;
+        from['data']['path'] = '/' + encodeURIComponent(from['data']['path'].slice(1,from['data']['path'].length));
     }
 
     from.inProgress = true;

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -528,7 +528,7 @@ function doItemOp(operation, to, from, rename, conflict) {
     if(from.data.provider === 'github'){
         options.branch = from.data.branch;
         moveSpec.branch = from.data.branch;
-        from['data']['path'] = '/' + encodeURIComponent(from['data']['path'].slice(1,from['data']['path'].length));
+        from.data.path = '/' + encodeURIComponent(from.data.path].slice(1,from.data.path].length));
     }
 
     from.inProgress = true;


### PR DESCRIPTION
## Purpose

Allow the user to rename a folder or file using the % sign.

## Changes

Short line encoding the url for github properly.

## Side effects

None that I know of

## Ticket

https://openscience.atlassian.net/browse/SVCS-5