### PR TITLE
[SVCS-234][WIP] Support slashes in google drive file names

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -530,6 +530,10 @@ function doItemOp(operation, to, from, rename, conflict) {
         moveSpec.branch = from.data.branch;
     }
 
+    if(from.data.provider === 'googledrive'){
+        from.data.path = '/' + encodeURIComponent(from.data.path.slice(1, from.data.path.length));
+    }
+
     from.inProgress = true;
     tb.clearMultiselect();
 


### PR DESCRIPTION
## Purpose

Allows user to rename files using the googledrive addon with a slash in the title.

## Changes

Add line that encodes url for gdrive

## Side effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/SVCS-234