### PR TITLE
[Fix] Do not set unusable password for new ORCiD created users [CAS-33]

### DIFF
--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -493,7 +493,6 @@ def external_login_confirm_email_get(auth, uid, token):
         raise HTTPError(http.FORBIDDEN, e.message)
 
     if not user.is_registered:
-        user.set_unusable_password()
         user.register(email)
 
     if email.lower() not in user.emails:

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -3937,6 +3937,7 @@ class TestExternalAuthViews(OsfTestCase):
         self.user.reload()
         assert_equal(self.user.external_identity['service'][self.provider_id], 'VERIFIED')
         assert_true(self.user.is_registered)
+        assert_true(self.user.has_usable_password())
 
     @mock.patch('website.mails.send_mail')
     def test_external_login_confirm_email_get_link(self, mock_link_confirm):
@@ -3954,6 +3955,7 @@ class TestExternalAuthViews(OsfTestCase):
         self.user.reload()
         assert_equal(self.user.external_identity['service'][self.provider_id], 'VERIFIED')
         assert_true(self.user.is_registered)
+        assert_true(self.user.has_usable_password())
 
     @mock.patch('website.mails.send_mail')
     def test_external_login_confirm_email_get_duped_id(self, mock_confirm):


### PR DESCRIPTION
### Issue

For a new OSF user login through ORCiD for the first time, a temporary user is created with an `usable` password pending email confirmation. During the confirmation process set the password `unusable`:

```python
    if not user.is_registered:
        user.set_unusable_password()
        user.register(email)
```

However, this violates `.is_active` check:

```python
    self.is_active = (
        self.is_registered and
        self.is_confirmed and
        self.has_usable_password() and
        not self.is_merged and
        not self.is_disabled
    )
```

### Fix

First, for "Flask" OSF on `master`, the password is set to an "usable password"m a hash of a random string: https://github.com/CenterForOpenScience/osf.io/blob/master/framework/auth/views.py#L496. This explains why Prod OSF works.

```python
    if not user.is_registered:
        user.set_password(uuid.uuid4(), notify=False)
        user.register(email)
```

Further investigation indicates that the `set_password` is redundant here since the password is already set the same way when this unconfirmed user is created: https://github.com/CenterForOpenScience/osf.io/blob/develop/framework/auth/views.py#L954.

```python
    else:
        # 1. create unconfirmed user with pending status
        external_identity[external_id_provider][external_id] = 'CREATE'
        user = User.create_unconfirmed(
        username=clean_email,
        password=str(uuid.uuid4()),
        fullname=fullname,
        external_identity=external_identity,
        campaign=None
    )
```

So the final fix is: do not set unusable password for new user created from ORCiD.

### Note

What we currently have does not break the normal ORCiD user create/link/login flow on Django-OSF However, OSF will be broken if any code tries to check if a ORCiD created user `.is_active`.

### Ticket
https://openscience.atlassian.net/browse/CAS-33