### PR TITLE
[Feature] Optimize get_aggregate_logs_query [No Ticket]

### DIFF
--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -686,10 +686,8 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
         )
 
     def get_aggregate_logs_query(self, auth):
-        ids = [self._id] + [n._id
-                            for n in self.get_descendants_recursive(primary_only=True)
-                            if n.can_view(auth)]
-        query = Q('node', 'in', ids) & Q('should_hide', 'ne', True)
+        ids = [self._id] + [n._id for n in Node.objects.get_children(self) if n.can_view(auth)]
+        query = Q('node', 'in', ids) & Q('should_hide', 'eq', False)
         return query
 
     def get_aggregate_logs_queryset(self, auth):


### PR DESCRIPTION
## Purpose
Improve load time of logs

## Changes
* Use already-optimized `Node.objects.get_children` instead of `get_descendants_recursive(primary=True)`, which does the same thing.

Rough benchmarking indicated this cuts query time to ~30% of what it currently is. Further improvements are likely possible, but converting `can_view` permissions checking to a sub-clause in an RCTE is Gehennic. This is ~90% of the benefit for ~1% of the effort.

## Side effects
None expected

## Ticket
None known