### PR TITLE
Additional Tests to reinforce API filtering for Preprints [OSF-7418]

### DIFF
--- a/api_tests/nodes/views/test_node_list.py
+++ b/api_tests/nodes/views/test_node_list.py
@@ -114,7 +114,6 @@ class TestNodeList(ApiTestCase):
             assert_equal(project_json['embeds']['root']['data']['id'], project.root._id)
 
 
-
 class TestNodeFiltering(ApiTestCase):
 
     def setUp(self):
@@ -630,6 +629,37 @@ class TestNodeFiltering(ApiTestCase):
         assert_not_in(self.project_one._id, ids)
         assert_not_in(self.project_two._id, ids)
         assert_not_in(self.project_three._id, ids)
+
+    def test_deleted_preprint_file_not_in_filtered_results(self):
+        orphan = PreprintFactory(creator=self.preprint.node.creator)
+
+        # orphan the preprint by deleting the file
+        orphan.primary_file.delete()
+        orphan.save()
+        orphan.refresh_from_db()
+
+        url = '/{}nodes/?filter[preprint]=true'.format(API_BASE)
+        res = self.app.get(url, auth=self.user_one.auth)
+        assert_equal(res.status_code, 200)
+        data = res.json['data']
+
+        ids = [each['id'] for each in data]
+
+        assert_in(self.preprint.node._id, ids)
+        assert_not_in(orphan.node._id, ids)
+
+    def test_unpublished_preprint_not_in_filtered_results(self):
+        unpublished = PreprintFactory(creator=self.preprint.node.creator, is_published=False)
+        assert_false(unpublished.is_published)
+
+        url = '/{}nodes/?filter[preprint]=true'.format(API_BASE)
+        res = self.app.get(url, auth=self.user_one.auth)
+        assert_equal(res.status_code, 200)
+        data = res.json['data']
+        ids = [each['id'] for each in data]
+
+        assert_in(self.preprint.node._id, ids)
+        assert_not_in(unpublished.node._id, ids)
 
 
 class TestNodeCreate(ApiTestCase):

--- a/api_tests/nodes/views/test_node_list.py
+++ b/api_tests/nodes/views/test_node_list.py
@@ -636,7 +636,6 @@ class TestNodeFiltering(ApiTestCase):
         # orphan the preprint by deleting the file
         orphan.primary_file.delete()
         orphan.save()
-        orphan.refresh_from_db()
 
         url = '/{}nodes/?filter[preprint]=true'.format(API_BASE)
         res = self.app.get(url, auth=self.user_one.auth)
@@ -648,7 +647,25 @@ class TestNodeFiltering(ApiTestCase):
         assert_in(self.preprint.node._id, ids)
         assert_not_in(orphan.node._id, ids)
 
-    def test_unpublished_preprint_not_in_filtered_results(self):
+    def test_deleted_preprint_file_in_preprint_false_filtered_results(self):
+        orphan = PreprintFactory(creator=self.preprint.node.creator)
+
+        # orphan the preprint by deleting the file
+        orphan.primary_file.delete()
+        orphan.save()
+        orphan.refresh_from_db()
+
+        url = '/{}nodes/?filter[preprint]=false'.format(API_BASE)
+        res = self.app.get(url, auth=self.user_one.auth)
+        assert_equal(res.status_code, 200)
+        data = res.json['data']
+
+        ids = [each['id'] for each in data]
+
+        assert_not_in(self.preprint.node._id, ids)
+        assert_in(orphan.node._id, ids)
+
+    def test_unpublished_preprint_not_in_preprint_true_filter_results(self):
         unpublished = PreprintFactory(creator=self.preprint.node.creator, is_published=False)
         assert_false(unpublished.is_published)
 
@@ -660,6 +677,19 @@ class TestNodeFiltering(ApiTestCase):
 
         assert_in(self.preprint.node._id, ids)
         assert_not_in(unpublished.node._id, ids)
+
+    def test_unpublished_preprint_in_preprint_false_filter_results(self):
+        unpublished = PreprintFactory(creator=self.preprint.node.creator, is_published=False)
+        assert_false(unpublished.is_published)
+
+        url = '/{}nodes/?filter[preprint]=false'.format(API_BASE)
+        res = self.app.get(url, auth=self.user_one.auth)
+        assert_equal(res.status_code, 200)
+        data = res.json['data']
+        ids = [each['id'] for each in data]
+
+        assert_not_in(self.preprint.node._id, ids)
+        assert_in(unpublished.node._id, ids)
 
 
 class TestNodeCreate(ApiTestCase):


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

There was some question previously about being able to get all "types" of preprints using the API preprint filter. 

The general understanding was that Preprints can be in a few states (from the linked Jira ticket)

1. Valid - has a published preprint with a non-orphaned file
2. Orphaned - has a published preprint with an orphaned file
3. Abandoned - has a non-published preprint, file status irrelevant
4. None - Has no preprints of any kind associated

2, 3, and 4 should be included when ?filter[preprint]=false, 1 for true

This PR adds a few tests that better ensure that these conditions are met, specifically for double checking **orphaned** and **abandoned** preprints

## Changes
- tests to check that orphaned preprints appear in `filter[preprint]=False` and NOT in `filter[preprint]=True`
- tests to check that un-pubublished (abandoned) preprints appear in `filter[preprint]=False` and NOT in `filter[preprint]=True`

## Side effects

None

## Notes!

I think some of the confusion on the Jira ticket revolved around API behavior when the `PreprintService` is deleted, what happens to the `Node` that corresponds? I do believe this ticket in general was for the preprint filter, in the above states, and not with `Node` - `PreprintService` object relationships.


## Ticket
https://openscience.atlassian.net/browse/OSF-7418