### PR TITLE
Add Institutions matching query to API search results [OSF-7370]

### DIFF
--- a/api/base/pagination.py
+++ b/api/base/pagination.py
@@ -323,6 +323,7 @@ class SearchPagination(JSONAPIPagination):
                     ('components', self.get_search_field('component', query)),
                     ('registrations', self.get_search_field('registration', query)),
                     ('users', self.get_search_field('user', query)),
+                    ('institutions', self.get_search_field('institution', query)),
                 ])),
                 ('meta', OrderedDict([
                     ('total', self.page.paginator.count),
@@ -350,6 +351,7 @@ class SearchPagination(JSONAPIPagination):
                     ('components', self.get_search_field('component', query)),
                     ('registrations', self.get_search_field('registration', query)),
                     ('users', self.get_search_field('user', query)),
+                    ('institutions', self.get_search_field('institution', query)),
                 ])),
                 ('links', OrderedDict([
                     ('first', self.get_first_real_link(url)),

--- a/api/search/serializers.py
+++ b/api/search/serializers.py
@@ -6,11 +6,14 @@ from api.files.serializers import FileSerializer
 from api.nodes.serializers import NodeSerializer
 from api.registrations.serializers import RegistrationSerializer
 from api.users.serializers import UserSerializer
+from api.institutions.serializers import InstitutionSerializer
 from osf.models import AbstractNode
 
 from osf.models import OSFUser as User
 
 from osf.models import FileNode
+
+from osf.models import Institution
 
 
 class SearchSerializer(JSONAPISerializer):
@@ -31,6 +34,10 @@ class SearchSerializer(JSONAPISerializer):
         if isinstance(data, FileNode):
             serializer = FileSerializer(data, context=self.context)
             return FileSerializer.to_representation(serializer, data)
+
+        if isinstance(data, Institution):
+            serializer = InstitutionSerializer(data, context=self.context)
+            return InstitutionSerializer.to_representation(serializer, data)
 
         return None
 

--- a/api/search/urls.py
+++ b/api/search/urls.py
@@ -9,7 +9,7 @@ urlpatterns = [
     url(r'^projects/$', views.SearchProjects.as_view(), name=views.SearchProjects.view_name),
     url(r'^registrations/$', views.SearchRegistrations.as_view(), name=views.SearchRegistrations.view_name),
     url(r'^users/$', views.SearchUsers.as_view(), name=views.SearchUsers.view_name),
-    url(r'^institution/$', views.SearchInstitutions.as_view(), name=views.SearchInstitutions.view_name),
+    url(r'^institutions/$', views.SearchInstitutions.as_view(), name=views.SearchInstitutions.view_name),
 
     # not currently supported by v1, but should be supported by v2
     # url(r'^nodes/$', views.SearchProjects.as_view(), name=views.SearchProjects.view_name),

--- a/api/search/urls.py
+++ b/api/search/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     url(r'^projects/$', views.SearchProjects.as_view(), name=views.SearchProjects.view_name),
     url(r'^registrations/$', views.SearchRegistrations.as_view(), name=views.SearchRegistrations.view_name),
     url(r'^users/$', views.SearchUsers.as_view(), name=views.SearchUsers.view_name),
+    url(r'^institution/$', views.SearchInstitutions.as_view(), name=views.SearchInstitutions.view_name),
 
     # not currently supported by v1, but should be supported by v2
     # url(r'^nodes/$', views.SearchProjects.as_view(), name=views.SearchProjects.view_name),

--- a/api/search/views.py
+++ b/api/search/views.py
@@ -54,13 +54,13 @@ class Search(BaseSearchView):
     """
     *Read-Only*
 
-    Objects (including projects, components, registrations, users, and files) that have been found by the given
+    Objects (including projects, components, registrations, users, files, and institutions) that have been found by the given
     Elasticsearch query. Each object is serialized with the appropriate serializer for its type (files are serialized as
     files, users are serialized as users, etc.) and returned collectively.
 
     ## Search Fields
 
-        <type>  # either projects, components, registrations, users, or files
+        <type>  # either projects, components, registrations, users, files, or institutions
             related
                 href    # the canonical api endpoint to search within a certain object type, e.g `/v2/search/users/`
                 meta

--- a/api/search/views.py
+++ b/api/search/views.py
@@ -12,10 +12,11 @@ from api.nodes.serializers import NodeSerializer
 from api.registrations.serializers import RegistrationSerializer
 from api.search.serializers import SearchSerializer
 from api.users.serializers import UserSerializer
+from api.institutions.serializers import InstitutionSerializer
 
 from framework.auth.oauth_scopes import CoreScopes
 
-from osf.models import FileNode, AbstractNode as Node, OSFUser as User
+from osf.models import Institution, FileNode, AbstractNode as Node, OSFUser as User
 from website.search import search
 from website.search.exceptions import MalformedQueryError
 from website.search.util import build_query
@@ -580,3 +581,46 @@ class SearchUsers(BaseSearchView):
     doc_type = 'user'
     view_category = 'search'
     view_name = 'search-user'
+
+
+class SearchInstitutions(BaseSearchView):
+    """
+    *Read-Only*
+
+    Institutions that have been found by the given Elasticsearch query.
+
+    <!-- Copied spiel from InstitutionDetail -->
+
+    ##Attributes
+
+    OSF Institutions have the "institutions" `type`.
+
+        name           type               description
+        =========================================================================
+        name           string             title of the institution
+        id             string             unique identifier in the OSF
+        logo_path      string             a path to the institution's static logo
+
+    ##Relationships
+
+    ###Nodes
+    List of nodes that have this institution as its primary institution.
+
+    ###Users
+    List of users that are affiliated with this institution.
+
+    ##Links
+
+        self:  the canonical api endpoint of this institution
+        html:  this institution's page on the OSF website
+
+    # This Request/Response
+
+    """
+
+    model_class = Institution
+    serializer_class = InstitutionSerializer
+
+    doc_type = 'institution'
+    view_category = 'search'
+    view_name = 'search-institution'

--- a/osf/models/institution.py
+++ b/osf/models/institution.py
@@ -1,3 +1,4 @@
+import logging
 from django.conf import settings
 from django.contrib.postgres import fields
 from django.core.urlresolvers import reverse
@@ -6,6 +7,8 @@ from modularodm import Q as MQ
 from osf.models import base
 from osf.models.contributor import InstitutionalContributor
 from osf.models.mixins import Loggable
+
+logger = logging.getLogger(__name__)
 
 
 class Institution(Loggable, base.ObjectIDMixin, base.BaseModel):
@@ -92,3 +95,15 @@ class Institution(Loggable, base.ObjectIDMixin, base.BaseModel):
             return '/static/img/institutions/banners/{}'.format(self.banner_name)
         else:
             return None
+
+    def update_search(self):
+        from website.search.search import update_institution
+        from website.search.exceptions import SearchUnavailableError
+        try:
+            update_institution(self)
+        except SearchUnavailableError as e:
+            logger.exception(e)
+
+    def save(self, *args, **kwargs):
+        self.update_search()
+        return super(Institution, self).save(*args, **kwargs)

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -21,6 +21,7 @@ from modularodm import Q
 from osf.models import AbstractNode as Node
 from osf.models import OSFUser as User
 from osf.models import FileNode
+from osf.models import Institution
 from website import settings
 from website.filters import gravatar
 from website.project.licenses import serialize_node_license_record
@@ -49,6 +50,7 @@ DOC_TYPE_TO_MODEL = {
     'registration': Node,
     'user': User,
     'file': FileNode,
+    'institution': Institution
 }
 
 # Prevent tokenizing and stop word removal.


### PR DESCRIPTION
## Purpose

Search results from the API were not equipped to deal with showing found Institutions matching the query search terms. Add the means for Institutions to show up in search results now without throwing a 500 error!

## Changes

- Update search views, urls, and serializers to also show Institution information in results
- Add Institution results in the pagination view for search results
- Add key to `elastic_search.py`'s `DOC_TYPE_TO_MODEL`
- Update elastic search when an institution is saved
- Add tests

## Side effects

None internally, but external uses of the search endpoint of the URL will now have to account for another key, and another type of serialized search result.


## Ticket
https://openscience.atlassian.net/browse/OSF-7370