### PR TITLE
Make link to registered schemas a more prominent button  [OSF-7301]

### DIFF
--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -155,17 +155,6 @@
                 % endif
                 % if node['is_registration']:
                     <p>
-                    Registration Form:
-                    % for meta_schema in node['registered_schemas']:
-                    <a href="${node['url']}register/${meta_schema['id']}">${meta_schema['schema_name']}</a>
-                      % if len(node['registered_schemas']) > 1:
-                      ,
-                      % endif
-                    % endfor
-                    </p>
-                % endif
-                % if node['is_registration']:
-                    <p>
                     Date registered:
                     <span data-bind="text: dateRegistered.local, tooltip: {title: dateRegistered.utc}" class="date node-date-registered"></span>
                     </p>
@@ -210,19 +199,32 @@
                         ${node['description']}</span>
                     </p>
                 % endif
-                % if ('admin' in user['permissions'] or node['license'].get('name', 'No license') != 'No license'):
-                    <p>
-                      <license-picker params="saveUrl: '${node['update_url']}',
-                                              saveMethod: 'PUT',
-                                              license: window.contextVars.node.license,
-                                              saveLicenseKey: 'node_license',
-                                              readonly: ${ node['is_registration'] | sjson, n}">
-                        <span id="license">License:</span>
-                        <span class="text-muted"> ${node['license'].get('name', 'No license')} </span>
-                      </license-picker>
-                    </p>
-                 % endif
-
+                <div class="row">
+                    % if not node['is_registration']:
+                        <div class="col-xs-12">
+                    % else:
+                        <div class="col-xs-6">
+                    % endif
+                            % if ('admin' in user['permissions'] or node['license'].get('name', 'No license') != 'No license'):
+                                <p>
+                                  <license-picker params="saveUrl: '${node['update_url']}',
+                                                          saveMethod: 'PUT',
+                                                          license: window.contextVars.node.license,
+                                                          saveLicenseKey: 'node_license',
+                                                          readonly: ${ node['is_registration'] | sjson, n}">
+                                    <span id="license">License:</span>
+                                    <span class="text-muted"> ${node['license'].get('name', 'No license')} </span>
+                                  </license-picker>
+                                </p>
+                             % endif
+                        </div>
+                        % if node['is_registration']:
+                            <div class="col-xs-6">
+                                ##  Note - this will only show *one* registered_schema, even though its technically possible for there to be multiple
+                                <a class="btn btn-primary pull-right" href="${node['url']}register/${node['registered_schemas'][0]['id']}">View Registration Form</a>
+                            </div>
+                    % endif
+                </div>
             </div>
         </div>
 
@@ -261,6 +263,7 @@
     </div>
 </div>
 % endif
+
 
 <div class="row">
 

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -220,8 +220,22 @@
                         </div>
                         % if node['is_registration']:
                             <div class="col-xs-6">
-                                ##  Note - this will only show *one* registered_schema, even though its technically possible for there to be multiple
-                                <a class="btn btn-primary pull-right" href="${node['url']}register/${node['registered_schemas'][0]['id']}">View Registration Form</a>
+                                % if len(node['registered_schemas']) == 1:
+                                    <a class="btn btn-primary pull-right" href="${node['url']}register/${node['registered_schemas'][0]['id']}">View Registration Form</a>
+                                % else:
+                                    ## This is a special case that is right now only possible on 12 Nodes in production
+                                    <div class="dropdown">
+                                        <button class="btn btn-primary dropdown-toggle pull-right" type="button" id="RegFormMenu" data-toggle="dropdown">
+                                            View Registration Forms
+                                            <span class="caret"></span>
+                                        </button>
+                                        <ul class="dropdown-menu pull-right">
+                                            % for meta_schema in node['registered_schemas']:
+                                                <li><a href="${node['url']}register/${meta_schema['id']}">${meta_schema['schema_name']}</a></li>
+                                            % endfor
+                                        </ul>
+                                    </div>
+                                % endif
                             </div>
                     % endif
                 </div>


### PR DESCRIPTION
## Purpose
The link to view the Registration Form at the moment is obscured underneath the title in a link, and people are having trouble locating the information. Move the link into a more visible button.

![screen shot 2017-02-07 at 3 04 09 pm](https://cloud.githubusercontent.com/assets/801594/22710901/1ade64de-ed4d-11e6-9be9-12ee06f9bb5b.png)


## Changes
- If it's a normal project, show a plain old row with the license info
- If it's a registration, the row should also include the View Registration Form button
- Add note about only showing one registered schema, because this is different from the current implementation

## Side effects
This button, as it stands, only links to ONE registration form, as before it would show
multiple if there were multiple. However, in most cases there should only be one registration form per registration.

There are currently 12 registrations on production that have more than one registration schema.

## Ticket
https://openscience.atlassian.net/browse/OSF-7301