### PR TITLE
[Feature] Improve API DRF Authentication [OSF-7434]

### DIFF
--- a/api/base/authentication/drf.py
+++ b/api/base/authentication/drf.py
@@ -1,42 +1,87 @@
 import itsdangerous
+
+from django.contrib.auth import hashers
 from django.utils.translation import ugettext_lazy as _
 
 from rest_framework import authentication
 from rest_framework.authentication import BasicAuthentication
 from rest_framework import exceptions
 
+from addons.twofactor.models import UserSettings
+from api.base.exceptions import (UnconfirmedAccountError, UnclaimedAccountError, DeactivatedAccountError,
+                                 MergedAccountError, InvalidAccountError, TwoFactorRequiredError)
+from osf.models import OSFUser, Session
 from framework.auth import cas
-from framework.sessions.model import Session
-from framework.auth.core import User, get_user
+from framework.auth.core import get_user
 from website import settings
-from api.base.exceptions import UnconfirmedAccountError, DeactivatedAccountError, TwoFactorRequiredError
+
+UNUSABLE_PASSWORD_PREFIX = hashers.UNUSABLE_PASSWORD_PREFIX
 
 
 def get_session_from_cookie(cookie_val):
-    """Given a cookie value, return the `Session` object or `None`."""
+    """
+    Given a cookie value, return the `Session` object or `None`.
+
+    :param cookie_val: the cookie
+    :return: the `Session` object or None
+    """
+
     session_id = itsdangerous.Signer(settings.SECRET_KEY).unsign(cookie_val)
-    return Session.load(session_id)
+    return Session.objects.filter(_id=session_id).first()
 
 
 def check_user(user):
-    """Checks that the user is neither unconfirmed nor disabled.
-
-    :param User user:
-    :raises DeactivatedAccountError:
-    :raise UnconfirmedAccountError:
     """
+    Verify users' status.
+
+                        registered      confirmed       disabled        merged      usable password     claimed
+    ACTIVE:             x               x               o               o           x                   ?
+    NOT_CONFIRMED:      o               o               o               o           x                   ?
+    NOT_CLAIMED:        o               o               o               o           o                   ?
+    DISABLED:           o               ?               x               o           ?                   ?
+    USER_MERGED:        ?               ?               ?               x           o                   ?
+
+    OSF does not recognize other user status.
+
+    :param user: the user
+    :raises UnconfirmedAccountError
+    :raises UnclaimedAccountError
+    :raises DeactivatedAccountError
+    :raises MergedAccountError
+    :raises InvalidAccountError
+    """
+
     if user.is_disabled:
         raise DeactivatedAccountError
-    elif not user.is_confirmed:
-        raise UnconfirmedAccountError
+
+    if user.is_merged:
+        raise MergedAccountError
+
+    if not user.is_confirmed:
+        if user.password is None or user.password.startswith(UNUSABLE_PASSWORD_PREFIX):
+            raise UnclaimedAccountError
+        if user.has_usable_password():
+            raise UnconfirmedAccountError
+
+    if not user.is_active:
+        raise InvalidAccountError
 
 
-# http://www.django-rest-framework.org/api-guide/authentication/#custom-authentication
+# Three customized DRF authentication classes: basic, session/cookie and access token.
+# See http://www.django-rest-framework.org/api-guide/authentication/#custom-authentication
+
+
 class OSFSessionAuthentication(authentication.BaseAuthentication):
-    """Custom DRF authentication class which works with the OSF's Session object.
+    """Custom DRF authentication class for API call with OSF cookie/session.
     """
 
     def authenticate(self, request):
+        """
+        If request bears an OSF cookie, retrieve the session and verify the user.
+
+        :param request: the request
+        :return: the user
+        """
         cookie_val = request.COOKIES.get(settings.COOKIE_NAME)
         if not cookie_val:
             return None
@@ -44,17 +89,28 @@ class OSFSessionAuthentication(authentication.BaseAuthentication):
         if not session:
             return None
         user_id = session.data.get('auth_user_id')
-        user = User.load(user_id)
+        user = OSFUser.objects.filter(guids___id=user_id).first()
         if user:
             check_user(user)
             return user, None
         return None
 
 
+# TODO: is the API deprecated
 class OSFBasicAuthentication(BasicAuthentication):
+    """Custom DRF authentication class for API call with email, password, and two-factor if necessary.
+    """
 
-    # override BasicAuthentication
     def authenticate(self, request):
+        """
+        Overwrite BasicAuthentication.
+        `authenticate_credentials` handles email and password,
+        `authenticate_twofactor_credentials` handles two-factor.
+
+        :param request: the request
+        :return: a tuple of the user and error messages
+        """
+
         user_auth_tuple = super(OSFBasicAuthentication, self).authenticate(request)
         if user_auth_tuple is not None:
             self.authenticate_twofactor_credentials(user_auth_tuple[0], request)
@@ -62,8 +118,15 @@ class OSFBasicAuthentication(BasicAuthentication):
 
     def authenticate_credentials(self, userid, password):
         """
-        Authenticate the userid and password against username and password.
+        Authenticate the user by userid and password.
+
+        :param userid: the username or email
+        :param password: the password
+        :return: the User
+        :raises: NotAuthenticated
+        :raises: AuthenticationFailed
         """
+
         user = get_user(email=userid, password=password)
 
         if userid and not user:
@@ -73,16 +136,23 @@ class OSFBasicAuthentication(BasicAuthentication):
         check_user(user)
         return (user, None)
 
-    def authenticate_twofactor_credentials(self, user, request):
+    @staticmethod
+    def authenticate_twofactor_credentials(user, request):
         """
         Authenticate the user's two-factor one time password code.
+
+        :param user: the user
+        :param request: the request
+        :raises TwoFactorRequiredError
+        :raises AuthenticationFailed
         """
-        user_addon = user.get_addon('twofactor')
-        if user_addon and user_addon.is_confirmed:
+
+        twofator = UserSettings.objects.filter(owner_id=user.pk).first()
+        if twofator and twofator.is_confirmed:
             otp = request.META.get('HTTP_X_OSF_OTP')
             if otp is None:
                 raise TwoFactorRequiredError()
-            if not user_addon.verify_code(otp):
+            if not twofator.verify_code(otp):
                 raise exceptions.AuthenticationFailed(_('Invalid two-factor authentication OTP code.'))
 
     def authenticate_header(self, request):
@@ -119,7 +189,7 @@ class OSFCASAuthentication(authentication.BaseAuthentication):
         if cas_auth_response.authenticated is False:
             raise exceptions.NotAuthenticated(_('CAS server failed to authenticate this token'))
 
-        user = User.objects.filter(guids___id=cas_auth_response.user).first()
+        user = OSFUser.objects.filter(guids___id=cas_auth_response.user).first()
         if not user:
             raise exceptions.AuthenticationFailed(_('Could not find the user associated with this token'))
 

--- a/api/base/exceptions.py
+++ b/api/base/exceptions.py
@@ -209,9 +209,24 @@ class UnconfirmedAccountError(APIException):
     default_detail = _('Please confirm your account before using the API.')
 
 
+class UnclaimedAccountError(APIException):
+    status_code = 400
+    default_detail = _('Please claim your account before using the API.')
+
+
 class DeactivatedAccountError(APIException):
     status_code = 400
     default_detail = _('Making API requests with credentials associated with a deactivated account is not allowed.')
+
+
+class MergedAccountError(APIException):
+    status_code = 400
+    default_detail = _('Making API requests with credentials associated with a merged account is not allowed.')
+
+
+class InvalidAccountError(APIException):
+    status_code = 400
+    default_detail = _('Making API requests with credentials associated with an invalid account is not allowed.')
 
 
 class TwoFactorRequiredError(AuthenticationFailed):


### PR DESCRIPTION
### Purpose

Branded Preprints Phase 2 relies on CORS making API calls with OSF cookie for authentication. This ticket revisits `api/base/authentication/drf.py` in the following aspects:

- verify cookie based authentication for API
- update user status check
- use native Django model and query
- update comments and doc string

### Ticket

https://openscience.atlassian.net/browse/OSF-7434