### PR TITLE
Update README to reflect new path for addon settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,7 +508,7 @@ built when a file changes.
 ### Getting application credentials
 
 Many addons require application credentials (typically an app key and secret) to be able to authenticate through the
-OSF. These credentials go in each addon's `local.py` settings file (e.g. `website/addons/dropbox/settings/local.py`).
+OSF. These credentials go in each addon's `local.py` settings file (e.g. `addons/dropbox/settings/local.py`).
 
 ### COS is Hiring!
 


### PR DESCRIPTION
The currently used addon settings are now in the addons toplevel directory instead of inside the website directory

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Description was wrong in the readme and it confused me!

## Changes

- update path to find addon settings that are used on develop

## Side effects

nope


## Ticket
none