### PR TITLE
Handle incomplete metadata from WB when addon's parent directory accessed [OSF-7148]

### DIFF
--- a/api/nodes/utils.py
+++ b/api/nodes/utils.py
@@ -29,7 +29,7 @@ def get_file_object(node, path, provider, request):
     if not node.get_addon(provider) or not node.get_addon(provider).configured:
         raise NotFound('The {} provider is not configured for this project.'.format(provider))
 
-    url = waterbutler_api_url_for(node._id, provider, path, meta=True)
+    url = waterbutler_api_url_for(node._id, provider, path, _internal=True, meta=True)
     waterbutler_request = requests.get(
         url,
         cookies=request.COOKIES,

--- a/osf/models/files.py
+++ b/osf/models/files.py
@@ -361,7 +361,11 @@ class BaseFileNode(TypedModel, CommentableMixin, OptionalGuidMixin, Taggable, Ob
                 break
         else:
             # Insert into history if there is no matching etag
-            utils.insort(self.history, data, lambda x: x['modified'])
+            if data.get('modified'):
+                utils.insort(self.history, data, lambda x: x['modified'])
+            # If modified not included in the metadata, insert at the end of the history
+            else:
+                self.history.append(data)
 
         # Finally update last touched
         self.last_touched = timezone.now()

--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -909,6 +909,18 @@ class TestAddonFileViews(OsfTestCase):
         trashed_node = second_file_node.delete()
         assert_false(trashed_node.copied_from)
 
+    @mock.patch('website.archiver.tasks.archive')
+    def test_missing_modified_date_in_file_data(self, mock_archive):
+        file_node = self.get_test_file()
+        file_data = {
+            'name': 'Test File Update',
+            'materialized': file_node.materialized_path,
+            'modified': None
+        }
+        file_node.update(revision=None, data=file_data)
+        assert_equal(len(file_node.history), 1)
+        assert_equal(file_node.history[0], file_data)
+
 
 class TestLegacyViews(OsfTestCase):
 


### PR DESCRIPTION
## Purpose

Waterbutler returns different metadata for a file when its accessed from its parent's endpoint or the file endpoint directly. Accessing the file endpoint directly (`/files/github/filename.txt`) includes "modified" information, and then editing and then going back to the parent (`/files/github/`) did not have the "modified" field for the new update. The OSF was breaking when trying to insert this edited entry with missing modified information into the file history.

As a fix, if there is no modified metadata available, append to the end of the history.

h/t to @felliott for much help and amazingly helpful github comments!

## Changes

- Update URL for accessing Waterbutler file info to use the internal waterbutler URL
- If there is no modified information included in the metadata, append to the end of the file history.

## Side effects

- If a file is accessed for metadata via the `/files/github/` endpoint after it's been edited, it might not be in the correct point of the file's history, if the commits that updated the file were from the past. 

## Ticket
Github issue: #6062 
Jira ticket: https://openscience.atlassian.net/browse/OSF-7148