### PR TITLE
[OSF-7481] Ensure usernames are unique when user is merged

### DIFF
--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -1020,7 +1020,6 @@ class User(GuidStoredObject, AddonModelMixin):
         if unregistered_user:
             self.merge_user(unregistered_user)
             self.save()
-            unregistered_user.username = None
 
         if email not in self.emails:
             self.emails.append(email)
@@ -1579,9 +1578,8 @@ class User(GuidStoredObject, AddonModelMixin):
 
         remove_sessions_for_user(user)
 
-        # - username is set to None so the resultant user can set it primary
-        #   in the future.
-        user.username = None
+        # - username is set to _id to ensure uniqueness
+        user.username = user._id
         user.password = None
         user.verification_key = None
         user.osf_mailing_lists = {}

--- a/scripts/set_null_usernames_to_guid.py
+++ b/scripts/set_null_usernames_to_guid.py
@@ -1,0 +1,32 @@
+"""Find all User records that have username equal to None, and set their
+username to their GUID in order to ensure uniqueness on the username field.
+This was run as a prerequisite to the mongo -> postgres migration.
+"""
+import sys
+import logging
+
+from modularodm import Q
+
+from website.app import init_app
+from website.models import User
+from scripts import utils as script_utils
+
+logger = logging.getLogger(__name__)
+
+def main(dry=True):
+    count = 0
+    for user in User.find(Q('username', 'eq', None)):
+        logger.info('Setting username for {}'.format(user._id))
+        if not dry:
+            user.username = user._id
+            user.save()
+        count += 1
+    logger.info('Migrated {} users.'.format(count))
+
+
+if __name__ == "__main__":
+    dry = '--dry' in sys.argv
+    if not dry:
+        script_utils.add_file_logger(logger, __file__)
+    init_app(set_backends=True, routes=False)
+    main(dry=dry)

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -481,7 +481,6 @@ class TestUserMerging(base.OsfTestCase):
         # TODO: test external_accounts
 
         assert_equal(self.unconfirmed.email_verifications, {})
-        assert_is_none(self.unconfirmed.username)
         assert_is_none(self.unconfirmed.password)
         assert_is_none(self.unconfirmed.verification_key)
         # The mergee's email no longer needs to be confirmed by merger


### PR DESCRIPTION


## Purpose

<!-- Describe the purpose of your changes -->

Ensure uniqueness on the `User.username` field.

## Changes

<!-- Briefly describe or list your changes  -->

Instead of setting username to None, set to the GUID to
ensure uniqueness. Add a migration to fix existing users
whose username equals None.

## Side effects

<!--Any possible side effects? -->


## Ticket

https://openscience.atlassian.net/browse/OSF-7481
