### PR TITLE
[Feature] Optimize guid queries (Update) [OSF-7462]

### DIFF
--- a/osf/models/base.py
+++ b/osf/models/base.py
@@ -421,6 +421,9 @@ class OptionalGuidMixin(BaseIDMixin):
     """
     __guid_min_length__ = 5
 
+    objects = GuidMixinManager()
+    subselect = MODMCompatibilityManager()
+
     guids = GenericRelation(Guid, related_name='referent', related_query_name='referents')
     guid_string = ArrayField(models.CharField(max_length=255, null=True, blank=True), null=True, blank=True)
     content_type_pk = models.PositiveIntegerField(null=True, blank=True)
@@ -460,6 +463,7 @@ class GuidMixin(BaseIDMixin):
     primary_identifier_name = 'guid_string'
 
     objects = GuidMixinManager()
+    subselect = MODMCompatibilityManager()
 
     guids = GenericRelation(Guid, related_name='referent', related_query_name='referents')
     guid_string = ArrayField(models.CharField(max_length=255, null=True, blank=True), null=True, blank=True)

--- a/osf/models/base.py
+++ b/osf/models/base.py
@@ -404,7 +404,6 @@ class GuidMixinQuerySet(QuerySet):
 
 
 class GuidMixinManager(MODMCompatibilityManager):
-
     def get_queryset(self):
         queryset = GuidMixinQuerySet(model=self.model, using=self._db, hints=self._hints)
 

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -61,12 +61,12 @@ from website.util.permissions import (ADMIN, CREATOR_PERMISSIONS,
                                       DEFAULT_CONTRIBUTOR_PERMISSIONS, READ,
                                       WRITE, expand_permissions,
                                       reduce_permissions)
-from .base import BaseModel, Guid, GuidMixin, GuidMODMCompatibilityQuerySet
+from .base import BaseModel, Guid, GuidMixin, GuidMixinManager
 
 logger = logging.getLogger(__name__)
 
 
-class AbstractNodeQueryset(GuidMODMCompatibilityQuerySet):
+class AbstractNodeManager(GuidMixinManager):
     def get_roots(self):
         return self.extra(
             where=['"osf_abstractnode".id in (SELECT id FROM osf_abstractnode WHERE id NOT IN (SELECT child_id FROM '
@@ -227,7 +227,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
                                     through_fields=('parent', 'child'),
                                     related_name='parent_nodes')
 
-    objects = AbstractNodeQueryset.as_manager()
+    objects = AbstractNodeManager()
 
     @property
     def parent_node(self):

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -16,7 +16,6 @@ from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
 from django.db import models, transaction, connection
 from django.db.models import F
-from django.db.models import QuerySet
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.utils import timezone
@@ -74,7 +73,6 @@ class AbstractNodeQuerySet(GuidMixinQuerySet):
             where=['"osf_abstractnode".id in (SELECT id FROM osf_abstractnode WHERE id NOT IN (SELECT child_id FROM '
                    'osf_noderelation WHERE is_node_link IS false))'])
 
-
     def get_children(self, root, primary_keys=False):
         sql = """
             WITH RECURSIVE descendants AS (
@@ -116,6 +114,12 @@ class AbstractNodeManager(GuidMixinManager):
                 F(field), field, is_summary=False
             )
         return queryset
+
+    def get_roots(self, *args, **kwargs):
+        return self.get_queryset().get_roots(*args, **kwargs)
+
+    def get_children(self, *args, **kwargs):
+        return self.get_queryset().get_children(*args, **kwargs)
 
 
 class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixin,


### PR DESCRIPTION
## Purpose
Updates #6842, #6803 
h/t @cwisecarver 

## Changes
* Put annotations on in the managers
* Expose previously exposed (with `.as_manager` magick) queryset methods on manager
* Set `_default_manager` on (most) models to have the Mixins included in related fields' mro

## Side effects
`<Node>.forks`, `<Node>.logs`, etc. are still being inefficient. `AbstractNode` is a `TypedModel`, and overriding the `_default_manager` leads to `save` calls on untyped objects. Inheriting from `TypedModelManager` on `AbstractNodeManager` did not change this. To be fixed, along with `OSFUserManager`, in a follow-up PR.

## Ticket

[[OSF-7462]](https://openscience.atlassian.net/browse/OSF-7462)
