### PR TITLE
[OSF-7324] Registries Migration to SHARE and hook

### DIFF
--- a/scripts/migration/migrate_share_registration_data.py
+++ b/scripts/migration/migrate_share_registration_data.py
@@ -1,0 +1,59 @@
+import logging
+import sys
+
+from framework.mongo import database as db
+from framework.transactions.context import TokuTransaction
+from scripts import utils as script_utils
+from website.app import init_app
+from website.models import Node
+from website.project.tasks import on_registration_updated
+from website import settings
+
+logger = logging.getLogger(__name__)
+
+
+def get_targets():
+    return [p['_id'] for p in db['node'].find({'is_registration': True})]
+
+def migrate():
+    assert settings.SHARE_URL, 'SHARE_URL must be set to migrate.'
+    assert settings.SHARE_API_TOKEN, 'SHARE_API_TOKEN must be set to migrate.'
+    targets = get_targets()
+    target_count = len(targets)
+    successes = []
+    failures = []
+    count = 0
+
+    logger.info('Preparing to migrate {} registrations.'.format(target_count))
+    for registration_id in targets:
+        node = Node.load(registration_id)
+        if not node.is_public or node.is_deleted:
+            pass
+        count += 1
+        logger.info('{}/{} - {}'.format(count, target_count, registration_id))
+        try:
+            on_registration_updated(node)
+        except Exception as e:
+            # TODO: This reliably fails for certain nodes with
+            # IncompleteRead(0 bytes read)
+            failures.append(registration_id)
+            logger.warn('Encountered exception {} while posting to SHARE for registration {}'.format(e, registration_id))
+        else:
+            successes.append(registration_id)
+
+    logger.info('Successes: {}'.format(successes))
+    logger.info('Failures: {}'.format(failures))
+
+
+def main():
+    dry_run = '--dry' in sys.argv
+    if not dry_run:
+        script_utils.add_file_logger(logger, __file__)
+    init_app(set_backends=True, routes=False)
+    with TokuTransaction():
+        migrate()
+        if dry_run:
+            raise RuntimeError('Dry run, transaction rolled back.')
+
+if __name__ == "__main__":
+    main()

--- a/website/preprints/tasks.py
+++ b/website/preprints/tasks.py
@@ -1,5 +1,4 @@
 import logging
-import uuid
 import urlparse
 
 import requests
@@ -7,7 +6,7 @@ import requests
 from framework.celery_tasks import app as celery_app
 
 from website import settings
-
+from website.util.share import GraphNode, format_contributor
 
 logger = logging.getLogger(__name__)
 
@@ -34,67 +33,6 @@ def on_preprint_updated(preprint_id):
         }, headers={'Authorization': 'Bearer {}'.format(preprint.provider.access_token), 'Content-Type': 'application/vnd.api+json'})
         logger.debug(resp.content)
         resp.raise_for_status()
-
-
-class GraphNode(object):
-
-    @property
-    def ref(self):
-        return {'@id': self.id, '@type': self.type}
-
-    def __init__(self, type_, **attrs):
-        self.id = '_:{}'.format(uuid.uuid4())
-        self.type = type_.lower()
-        self.attrs = attrs
-
-    def get_related(self):
-        for value in self.attrs.values():
-            if isinstance(value, GraphNode):
-                yield value
-            elif isinstance(value, list):
-                for val in value:
-                    yield val
-
-    def serialize(self):
-        ser = {}
-        for key, value in self.attrs.items():
-            if isinstance(value, GraphNode):
-                ser[key] = value.ref
-            elif isinstance(value, list) or value in {None, ''}:
-                continue
-            else:
-                ser[key] = value
-
-        return dict(self.ref, **ser)
-
-
-def format_user(user):
-    person = GraphNode('person', **{
-        'suffix': user.suffix,
-        'given_name': user.given_name,
-        'family_name': user.family_name,
-        'additional_name': user.middle_names,
-    })
-
-    person.attrs['identifiers'] = [GraphNode('agentidentifier', agent=person, uri='mailto:{}'.format(uri)) for uri in user.emails]
-
-    if user.is_registered:
-        person.attrs['identifiers'].append(GraphNode('agentidentifier', agent=person, uri=user.profile_image_url()))
-        person.attrs['identifiers'].append(GraphNode('agentidentifier', agent=person, uri=urlparse.urljoin(settings.DOMAIN, user.profile_url)))
-
-    person.attrs['related_agents'] = [GraphNode('isaffiliatedwith', subject=person, related=GraphNode('institution', name=institution.name)) for institution in user.affiliated_institutions]
-
-    return person
-
-
-def format_contributor(preprint, user, bibliographic, index):
-    return GraphNode(
-        'creator' if bibliographic else 'contributor',
-        agent=format_user(user),
-        order_cited=index if bibliographic else None,
-        creative_work=preprint,
-        cited_as=user.fullname,
-    )
 
 
 def format_preprint(preprint):

--- a/website/project/tasks.py
+++ b/website/project/tasks.py
@@ -1,10 +1,11 @@
 import logging
-
+import urlparse
 import requests
 
 from framework.celery_tasks import app as celery_app
 
 from website import settings
+from website.util.share import GraphNode, format_contributor
 
 
 logger = logging.getLogger(__name__)
@@ -55,3 +56,56 @@ def on_node_updated(node_id, user_id, first_save, saved_fields, request_headers=
             }, headers={'Authorization': 'Bearer {}'.format(settings.SHARE_API_TOKEN), 'Content-Type': 'application/vnd.api+json'})
             logger.debug(resp.content)
             resp.raise_for_status()
+
+            if node.is_registration:
+                resp = requests.post('{}api/v2/normalizeddata/'.format(settings.SHARE_URL), json={
+                    'data': {
+                        'type': 'NormalizedData',
+                        'attributes': {
+                            'tasks': [],
+                            'raw': None,
+                            'data': {'@graph': format_registration(node)}
+                        }
+                    }
+                }, headers={'Authorization': 'Bearer {}'.format(settings.SHARE_API_TOKEN), 'Content-Type': 'application/vnd.api+json'})
+                logger.debug(resp.content)
+                resp.raise_for_status()
+
+
+def format_registration(node):
+    registration_graph = GraphNode('registration', **{
+        'title': node.title,
+        'description': node.description or '',
+        'is_deleted': not node.is_published or not node.is_public or node.is_preprint_orphan or 'qatest' in (node.tags or []) or node.is_deleted,
+        'date_published': node.registered_date.isoformat() if node.registered_date else None,
+        'registration_type': node.registered_schema[0].name if node.registered_schema else None
+    })
+
+    to_visit = [
+        registration_graph,
+        GraphNode('workidentifier', creative_work=registration_graph, uri=urlparse.urljoin(settings.DOMAIN, node.url))
+    ]
+
+
+    registration_graph.attrs['tags'] = [
+        GraphNode('throughtags', creative_work=registration_graph, tag=GraphNode('tag', name=tag._id))
+        for tag in node.tags or [] if tag._id
+    ]
+
+
+    to_visit.extend(format_contributor(registration_graph, user, bool(user._id in node.visible_contributor_ids), i) for i, user in enumerate(node.contributors))
+    to_visit.extend(GraphNode('AgentWorkRelation', creative_work=registration_graph, agent=GraphNode('institution', name=institution.name)) for institution in node.affiliated_institutions)
+
+    visited = set()
+    to_visit.extend(registration_graph.get_related())
+
+    while True:
+        if not to_visit:
+            break
+        n = to_visit.pop(0)
+        if n in visited:
+            continue
+        visited.add(n)
+        to_visit.extend(list(n.get_related()))
+
+    return [node_.serialize() for node_ in visited]

--- a/website/project/tasks.py
+++ b/website/project/tasks.py
@@ -90,12 +90,10 @@ def format_registration(node):
         GraphNode('workidentifier', creative_work=registration_graph, uri=urlparse.urljoin(settings.DOMAIN, node.url))
     ]
 
-
     registration_graph.attrs['tags'] = [
         GraphNode('throughtags', creative_work=registration_graph, tag=GraphNode('tag', name=tag._id))
         for tag in node.tags or [] if tag._id
     ]
-
 
     to_visit.extend(format_contributor(registration_graph, user, bool(user._id in node.visible_contributor_ids), i) for i, user in enumerate(node.contributors))
     to_visit.extend(GraphNode('AgentWorkRelation', creative_work=registration_graph, agent=GraphNode('institution', name=institution.name)) for institution in node.affiliated_institutions)

--- a/website/project/tasks.py
+++ b/website/project/tasks.py
@@ -76,10 +76,10 @@ def format_registration(node):
     registration_graph = GraphNode('registration', **{
         'title': node.title,
         'description': node.description or '',
-        'is_deleted': not node.is_published or not node.is_public or node.is_preprint_orphan or 'qatest' in (node.tags or []) or node.is_deleted,
+        'is_deleted': not node.retraction or not node.is_public or node.is_preprint_orphan or 'qatest' in (node.tags or []) or node.is_deleted,
         'date_published': node.registered_date.isoformat() if node.registered_date else None,
         'registration_type': node.registered_schema[0].name if node.registered_schema else None,
-        'withdrawal': True if node.retraction else False,
+        'withdrawn': True if node.retraction else False,
         'justification': node.retraction.justification if node.retraction else None,
     })
 

--- a/website/project/tasks.py
+++ b/website/project/tasks.py
@@ -78,7 +78,7 @@ def format_registration(node):
     registration_graph = GraphNode('registration', **{
         'title': node.title,
         'description': node.description or '',
-        'is_deleted': not node.retraction or not node.is_public or 'qatest' in (node.tags or []) or node.is_deleted,
+        'is_deleted': node.retraction or not node.is_public or 'qatest' in (node.tags or []) or node.is_deleted,
         'date_published': node.registered_date.isoformat() if node.registered_date else None,
         'registration_type': node.registered_schema[0].name if node.registered_schema else None,
         'withdrawn': True if node.retraction else False,
@@ -111,5 +111,4 @@ def format_registration(node):
             continue
         visited.add(n)
         to_visit.extend(list(n.get_related()))
-
     return [node_.serialize() for node_ in visited]

--- a/website/project/tasks.py
+++ b/website/project/tasks.py
@@ -58,19 +58,22 @@ def on_node_updated(node_id, user_id, first_save, saved_fields, request_headers=
             resp.raise_for_status()
 
             if node.is_registration:
-                resp = requests.post('{}api/v2/normalizeddata/'.format(settings.SHARE_URL), json={
-                    'data': {
-                        'type': 'NormalizedData',
-                        'attributes': {
-                            'tasks': [],
-                            'raw': None,
-                            'data': {'@graph': format_registration(node)}
-                        }
-                    }
-                }, headers={'Authorization': 'Bearer {}'.format(settings.SHARE_API_TOKEN), 'Content-Type': 'application/vnd.api+json'})
-                logger.debug(resp.content)
-                resp.raise_for_status()
+                on_registration_updated(node)
 
+
+def on_registration_updated(node):
+    resp = requests.post('{}api/v2/normalizeddata/'.format(settings.SHARE_URL), json={
+        'data': {
+            'type': 'NormalizedData',
+            'attributes': {
+                'tasks': [],
+                'raw': None,
+                'data': {'@graph': format_registration(node)}
+            }
+        }
+    }, headers={'Authorization': 'Bearer {}'.format(settings.SHARE_API_TOKEN), 'Content-Type': 'application/vnd.api+json'})
+    logger.debug(resp.content)
+    resp.raise_for_status()
 
 def format_registration(node):
     registration_graph = GraphNode('registration', **{

--- a/website/project/tasks.py
+++ b/website/project/tasks.py
@@ -78,7 +78,9 @@ def format_registration(node):
         'description': node.description or '',
         'is_deleted': not node.is_published or not node.is_public or node.is_preprint_orphan or 'qatest' in (node.tags or []) or node.is_deleted,
         'date_published': node.registered_date.isoformat() if node.registered_date else None,
-        'registration_type': node.registered_schema[0].name if node.registered_schema else None
+        'registration_type': node.registered_schema[0].name if node.registered_schema else None,
+        'withdrawal': True if node.retraction else False,
+        'justification': node.retraction.justification if node.retraction else None,
     })
 
     to_visit = [

--- a/website/project/tasks.py
+++ b/website/project/tasks.py
@@ -34,31 +34,30 @@ def on_node_updated(node_id, user_id, first_save, saved_fields, request_headers=
         if settings.SHARE_URL:
             if not settings.SHARE_API_TOKEN:
                 return logger.warning('SHARE_API_TOKEN not set. Could not send %s to SHARE.'.format(node))
-
-            resp = requests.post('{}api/normalizeddata/'.format(settings.SHARE_URL), json={
-                'data': {
-                    'type': 'NormalizedData',
-                    'attributes': {
-                        'tasks': [],
-                        'raw': None,
-                        'data': {'@graph': [{
-                            '@id': '_:123',
-                            '@type': 'workidentifier',
-                            'creative_work': {'@id': '_:789', '@type': 'project'},
-                            'uri': '{}{}/'.format(settings.DOMAIN, node._id),
-                        }, {
-                            '@id': '_:789',
-                            '@type': 'project',
-                            'is_deleted': not node.is_public or node.is_deleted or node.is_spammy,
-                        }]}
-                    }
-                }
-            }, headers={'Authorization': 'Bearer {}'.format(settings.SHARE_API_TOKEN), 'Content-Type': 'application/vnd.api+json'})
-            logger.debug(resp.content)
-            resp.raise_for_status()
-
             if node.is_registration:
                 on_registration_updated(node)
+            else:
+                resp = requests.post('{}api/normalizeddata/'.format(settings.SHARE_URL), json={
+                    'data': {
+                        'type': 'NormalizedData',
+                        'attributes': {
+                            'tasks': [],
+                            'raw': None,
+                            'data': {'@graph': [{
+                                '@id': '_:123',
+                                '@type': 'workidentifier',
+                                'creative_work': {'@id': '_:789', '@type': 'project'},
+                                'uri': '{}{}/'.format(settings.DOMAIN, node._id),
+                            }, {
+                                '@id': '_:789',
+                                '@type': 'project',
+                                'is_deleted': not node.is_public or node.is_deleted or node.is_spammy,
+                            }]}
+                        }
+                    }
+                }, headers={'Authorization': 'Bearer {}'.format(settings.SHARE_API_TOKEN), 'Content-Type': 'application/vnd.api+json'})
+                logger.debug(resp.content)
+                resp.raise_for_status()
 
 
 def on_registration_updated(node):
@@ -79,7 +78,7 @@ def format_registration(node):
     registration_graph = GraphNode('registration', **{
         'title': node.title,
         'description': node.description or '',
-        'is_deleted': not node.retraction or not node.is_public or node.is_preprint_orphan or 'qatest' in (node.tags or []) or node.is_deleted,
+        'is_deleted': not node.retraction or not node.is_public or 'qatest' in (node.tags or []) or node.is_deleted,
         'date_published': node.registered_date.isoformat() if node.registered_date else None,
         'registration_type': node.registered_schema[0].name if node.registered_schema else None,
         'withdrawn': True if node.retraction else False,

--- a/website/settings/local-dist.py
+++ b/website/settings/local-dist.py
@@ -30,7 +30,7 @@ EXTERNAL_EMBER_APPS = {
     # 'registries': {
     #     'url': '/registries/',
     #     'server': 'http://localhost:4200',
-    #     'path': '../ember-osf2/ember-osf-registries/dist/'
+    #     'path': '../ember-osf-registries/dist/'
     # }
 }
 

--- a/website/settings/local-dist.py
+++ b/website/settings/local-dist.py
@@ -26,6 +26,11 @@ EXTERNAL_EMBER_APPS = {
     #     'url': '/meetings/',
     #     'server': 'http://localhost:4201',
     #     'path': '../osf-meetings/dist/'
+    # },
+    # 'registries': {
+    #     'url': '/registries/',
+    #     'server': 'http://localhost:4200',
+    #     'path': '../ember-osf2/ember-osf-registries/dist/'
     # }
 }
 

--- a/website/templates/nav.mako
+++ b/website/templates/nav.mako
@@ -31,7 +31,7 @@
           <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false">Browse <span class="caret"></span></a>
           <ul class="dropdown-menu" role="menu">
               <li><a href="${domain}explore/activity/">New Projects</a></li>
-              <li><a href="${domain}search/?q=*&amp;filter=registration">Registry</a></li>
+              <li><a href="${domain}registries/">Registries</a></li>
               <li><a href="${web_url_for('conference_view', _absolute=True)}">Meetings</a></li>
               <li><a href="${domain}preprints/">Preprints</a></li>
           </ul>

--- a/website/util/share.py
+++ b/website/util/share.py
@@ -1,0 +1,69 @@
+import logging
+import uuid
+import urlparse
+
+from website import settings
+
+
+logger = logging.getLogger(__name__)
+
+
+class GraphNode(object):
+
+    @property
+    def ref(self):
+        return {'@id': self.id, '@type': self.type}
+
+    def __init__(self, type_, **attrs):
+        self.id = '_:{}'.format(uuid.uuid4())
+        self.type = type_.lower()
+        self.attrs = attrs
+
+    def get_related(self):
+        for value in self.attrs.values():
+            if isinstance(value, GraphNode):
+                yield value
+            elif isinstance(value, list):
+                for val in value:
+                    yield val
+
+    def serialize(self):
+        ser = {}
+        for key, value in self.attrs.items():
+            if isinstance(value, GraphNode):
+                ser[key] = value.ref
+            elif isinstance(value, list) or value in {None, ''}:
+                continue
+            else:
+                ser[key] = value
+
+        return dict(self.ref, **ser)
+
+
+def format_user(user):
+    person = GraphNode('person', **{
+        'suffix': user.suffix,
+        'given_name': user.given_name,
+        'family_name': user.family_name,
+        'additional_name': user.middle_names,
+    })
+
+    person.attrs['identifiers'] = [GraphNode('agentidentifier', agent=person, uri='mailto:{}'.format(uri)) for uri in user.emails]
+
+    if user.is_registered:
+        person.attrs['identifiers'].append(GraphNode('agentidentifier', agent=person, uri=user.profile_image_url()))
+        person.attrs['identifiers'].append(GraphNode('agentidentifier', agent=person, uri=urlparse.urljoin(settings.DOMAIN, user.profile_url)))
+
+    person.attrs['related_agents'] = [GraphNode('isaffiliatedwith', subject=person, related=GraphNode('institution', name=institution.name)) for institution in user.affiliated_institutions]
+
+    return person
+
+
+def format_contributor(preprint, user, bibliographic, index):
+    return GraphNode(
+        'creator' if bibliographic else 'contributor',
+        agent=format_user(user),
+        order_cited=index if bibliographic else None,
+        creative_work=preprint,
+        cited_as=user.fullname,
+    )


### PR DESCRIPTION
## Purpose
Update SHAre with registrations to use in ember app

## Changes
Add hook to send new registrations to SHARE 
Migration to send current registrations to SHARE.

## Ticket

https://openscience.atlassian.net/browse/OSF-7324

## Notes
This is the hotfix version of https://github.com/CenterForOpenScience/osf.io/pull/6710

## Testing considerations
This should send newly created registrations, once made public, to SHARE. To test, send a post request to `https://staging-share.osf.io/api/v2/search/creativeworks/_search` with this (slightly modified) payload.
```
{  
   "query":{  
      "bool":{  
         "must":{  
            "query_string":{  
               "query":"*"
            }
         },
         "filter":[  
            {  
               "terms":{  
                  "type":[  
                     "registration"
                  ]
               }
            },
            {  
               "terms":{  
                  "sources":[  
                     "OSF" ? (might be something else, this can also be ignored
                  ]
               }
            },
            {  
               "terms":{  
                  "registration_type":[  
                     <INSERT NAME OF THE REGISTRATION TYPE, such as Open Ended Registration >
                  ]
               }
            }
         ]
      }
   },
   "sort":{  

   },
   "from":0
}
```