### PR TITLE
[Fix] Update TCI postgres image [No Ticket]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
     - PROJECT_DIR="$PWD"
     - WHEELHOUSE="$HOME/.cache/wheelhouse"
     - LIBXML2_DEB="libxml2_2.7.8.dfsg-5.1ubuntu4.15_amd64.deb"
-    - POSTGRES_DEB="postgresql-9.5_9.5.5-1.pgdg12.4+1_amd64.deb"
+    - POSTGRES_DEB="postgresql-9.6_9.6.2-1.pgdg12.4+1_amd64.deb"
     - ELASTICSEARCH_ARCHIVE="elasticsearch-1.5.0.tar.gz"
     - LIBJEMALLOC_DEB="libjemalloc1_3.5.1-2_amd64.deb"
     - LIBPCRE_DEB="libpcre3_8.31-2ubuntu2.3_amd64.deb"
@@ -47,18 +47,18 @@ before_install:
       fi
 
       if [ ! -f "$POSTGRES_DEB" ]; then
-        curl -SLO http://apt.postgresql.org/pub/repos/apt/pool/main/p/postgresql-9.5/$POSTGRES_DEB
+        curl -SLO http://apt.postgresql.org/pub/repos/apt/pool/main/p/postgresql-9.6/$POSTGRES_DEB
       fi
 
       dpkg -x $LIBXML2_DEB /tmp/libxml2
       dpkg -x $POSTGRES_DEB /tmp/postgres
     - |
       export LD_LIBRARY_PATH=/tmp/libxml2/usr/lib/x86_64-linux-gnu
-      /tmp/postgres/usr/lib/postgresql/9.5/bin/initdb /tmp/postgres/data --nosync -U postgres
+      /tmp/postgres/usr/lib/postgresql/9.6/bin/initdb /tmp/postgres/data --nosync -U postgres
       sed -i -e 's/#fsync.*/fsync = off/' /tmp/postgres/data/postgresql.conf
       sed -i -e 's/#synchronous_commit.*/synchronous_commit = off/' /tmp/postgres/data/postgresql.conf
       sed -i -e 's/#full_page_writes.*/full_page_writes = off/' /tmp/postgres/data/postgresql.conf
-      /tmp/postgres/usr/lib/postgresql/9.5/bin/postgres -k /tmp -D /tmp/postgres/data -p 54321 > /dev/null &
+      /tmp/postgres/usr/lib/postgresql/9.6/bin/postgres -k /tmp -D /tmp/postgres/data -p 54321 > /dev/null &
     # elasticsearch
     - |
       cd $HOME/.cache/downloads


### PR DESCRIPTION
## Purpose
Noticed my local builds were [erroring almost immediately](https://travis-ci.org/mfraezz/osf.io/jobs/201985167#L195).

This was because the 9.5.5 Postgres image we were using has disappeared from the [download page](https://apt.postgresql.org/pub/repos/apt/pool/main/p/postgresql-9.5/):

```
~/D/osf.io ❯ curl -SLO http://apt.postgresql.org/pub/repos/apt/pool/main/p/postgresql-9.5/postgresql-9.5_9.5.5-1.pgdg12.4+1_amd64.deb
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   345  100   345    0     0   2328      0 --:--:-- --:--:-- --:--:--  2331

~/D/osf.io ❯ file postgresql-9.5_9.5.5-1.pgdg12.4+1_amd64.deb
postgresql-9.5_9.5.5-1.pgdg12.4+1_amd64.deb: XML 1.0 document text, ASCII text

~/D/osf.io ❯ cat postgresql-9.5_9.5.5-1.pgdg12.4+1_amd64.deb
<?xml version="1.0" encoding="iso-8859-1"?>
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
         "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
  <title>404 - Not Found</title>
 </head>
 <body>
  <h1>404 - Not Found</h1>
 </body>
</html>
```


## Changes
* Upgrade TCI's postgres to 9.6.2

## Side effects
None expected. 