### PR TITLE
Update AgriXiv example project [EOSF-515]

### DIFF
--- a/scripts/populate_preprint_providers.py
+++ b/scripts/populate_preprint_providers.py
@@ -388,7 +388,7 @@ def main(env):
             'description': 'Preprints for Agriculture and Allied Sciences',
             'banner_name': 'agrixiv-banner.svg',
             'external_url': '',
-            'example': '',
+            'example': '8whkp',
             'advisory_board': '''
                 <div class="col-xs-6">
                     <h3>Advisory Board</h3>


### PR DESCRIPTION
## Purpose

Now that AgriXiv has been contributing content to their preprint server, they need the example project link updated to https://osf.io/preprints/agrixiv/8whkp/ instead of the current one from OSF.

## Changes

Update the populate_preprint_providrs.py script. Change the example entry from empty to 8whkp.

## Ticket

https://openscience.atlassian.net/browse/EOSF-515