### PR TITLE
[RFR] Work around case sensitive node id

### DIFF
--- a/osf/management/commands/migraterelations.py
+++ b/osf/management/commands/migraterelations.py
@@ -783,11 +783,11 @@ def migrate_node_through_models():
             for modm_obj in nodes[count:page_size + count]:
                 order = 0
                 clean_node_guid = unicode(modm_obj._id).lower()
+                perms = modm_obj.permissions
+                lower_case_perms = {unicode(k).lower(): v for k, v in perms.iteritems()}
+                lower_visible_contributor_ids = [unicode(i).lower() for i in modm_obj.visible_contributor_ids]
                 for modm_contributor in modm_obj.contributors:
                     clean_user_guid = unicode(modm_contributor._id).lower()
-                    perms = modm_obj.permissions
-                    lower_case_perms = {unicode(k).lower(): v for k, v in perms.iteritems()}
-                    lower_visible_contributor_ids = [unicode(i).lower() for i in modm_obj.visible_contributor_ids]
                     read = 'read' in lower_case_perms[clean_user_guid]
                     write = 'write' in lower_case_perms[clean_user_guid]
                     admin = 'admin' in lower_case_perms[clean_user_guid]

--- a/osf/management/commands/migraterelations.py
+++ b/osf/management/commands/migraterelations.py
@@ -785,10 +785,17 @@ def migrate_node_through_models():
                 clean_node_guid = unicode(modm_obj._id).lower()
                 for modm_contributor in modm_obj.contributors:
                     clean_user_guid = unicode(modm_contributor._id).lower()
-                    read = 'read' in modm_obj.permissions[clean_user_guid]
-                    write = 'write' in modm_obj.permissions[clean_user_guid]
-                    admin = 'admin' in modm_obj.permissions[clean_user_guid]
-                    visible = clean_user_guid in modm_obj.visible_contributor_ids
+                    if clean_node_guid == 'jyznd':
+                        # this one is case sensitive because reasons.
+                        read = 'read' in modm_obj.permissions['JYznd']
+                        write = 'write' in modm_obj.permissions['JYznd']
+                        admin = 'admin' in modm_obj.permissions['JYznd']
+                        visible = 'JYznd' in modm_obj.visible_contributor_ids
+                    else:
+                        read = 'read' in modm_obj.permissions[clean_user_guid]
+                        write = 'write' in modm_obj.permissions[clean_user_guid]
+                        admin = 'admin' in modm_obj.permissions[clean_user_guid]
+                        visible = clean_user_guid in modm_obj.visible_contributor_ids
 
                     if (
                             modm_to_django[format_lookup_key(clean_user_guid, model=OSFUser)],

--- a/osf/management/commands/migraterelations.py
+++ b/osf/management/commands/migraterelations.py
@@ -785,17 +785,13 @@ def migrate_node_through_models():
                 clean_node_guid = unicode(modm_obj._id).lower()
                 for modm_contributor in modm_obj.contributors:
                     clean_user_guid = unicode(modm_contributor._id).lower()
-                    if clean_node_guid == 'jyznd':
-                        # this one is case sensitive because reasons.
-                        read = 'read' in modm_obj.permissions['JYznd']
-                        write = 'write' in modm_obj.permissions['JYznd']
-                        admin = 'admin' in modm_obj.permissions['JYznd']
-                        visible = 'JYznd' in modm_obj.visible_contributor_ids
-                    else:
-                        read = 'read' in modm_obj.permissions[clean_user_guid]
-                        write = 'write' in modm_obj.permissions[clean_user_guid]
-                        admin = 'admin' in modm_obj.permissions[clean_user_guid]
-                        visible = clean_user_guid in modm_obj.visible_contributor_ids
+                    perms = modm_obj.permissions
+                    lower_case_perms = {unicode(k).lower(): v for k, v in perms.iteritems()}
+                    lower_visible_contributor_ids = [unicode(i).lower() for i in modm_obj.visible_contributor_ids]
+                    read = 'read' in lower_case_perms[clean_user_guid]
+                    write = 'write' in lower_case_perms[clean_user_guid]
+                    admin = 'admin' in lower_case_perms[clean_user_guid]
+                    visible = clean_user_guid in lower_visible_contributor_ids
 
                     if (
                             modm_to_django[format_lookup_key(clean_user_guid, model=OSFUser)],


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

JYznd is a cased node id and the permissions migration for contributors was failing on it.

## Changes

Created a lowercased, unicode version of node permissions and visible contributor ids and used those to do lookups against for contributor migration.

## Side effects

Unlikely.


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->