### PR TITLE
Fix compatibility with docker-sync 0.2.0

### DIFF
--- a/docker-sync.yml
+++ b/docker-sync.yml
@@ -1,3 +1,4 @@
+version: "2"
 options:
 
 #  verbose: true


### PR DESCRIPTION
## Purpose

The latest release of docker-sync requires a "version" key in `docker-sync.yml`.
