### PR TITLE
[hotfix ] When an archive fails, set the draft registrations' approval to None

### DIFF
--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2205,6 +2205,11 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable, Spam
 
     def delete_registration_tree(self, save=False):
         self.is_deleted = True
+        for draft_registration in DraftRegistration.find(Q('registered_node', 'eq', self)):
+            # Allow draft registration to be submitted
+            if draft_registration.approval:
+                draft_registration.approval = None
+                draft_registration.save()
         if not getattr(self.embargo, 'for_existing_registration', False):
             self.registered_from = None
         if save:


### PR DESCRIPTION
...so that prereg drafts can be resubmitted

## Purpose

Fix a corner case that prevents some preregistration drafts from being submitted. This will happen when:

1. A prereg draft is submitted
2. Prereg is approved
3. Archiving fails, or the user rejects the registration

Under these conditions, the prereg draft fails to submit due to [these lines](https://github.com/CenterForOpenScience/osf.io/blob/930c225fdcb1f8d78452628e12eb8dbc73facdb6/website/project/views/drafts.py#L134-L135).

## Changes

When an archive fails or the user rejects the registration, set the draft registration's approval to `None`.

## Side effects

<!--Any possible side effects? -->


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
