### PR TITLE
[HotFix] Add Missing Title on Sign-up Page for SciELO and BITSS [OSF-7536]

### DIFF
--- a/website/templates/public/register.mako
+++ b/website/templates/public/register.mako
@@ -49,6 +49,18 @@
         </div>
     %endif
 
+    %if campaign == "bitss-preprints":
+        <div class="text-center m-t-lg">
+            <h3>BITSS Preprints</h3><hr>
+        </div>
+    %endif
+
+    %if campaign == "scielo-preprints":
+        <div class="text-center m-t-lg">
+            <h3>SciELO Preprints</h3><hr>
+        </div>
+    %endif
+
     <div class="row m-t-xl">
     %if campaign != "institution" or not enable_institutions:
         <div id="signUpScope" class="col-sm-10 col-sm-offset-1 col-md-9 col-md-offset-2 col-lg-8 signup-form p-b-md m-b-m bg-color-light">


### PR DESCRIPTION
### Purpose

Add missing title on the sign up page for SciELO and BITSS preprints

### Deployment Notes

- [x] blocked by https://github.com/CenterForOpenScience/cas-overlay/pull/49
- [x] on hold
  - if the two preprints goes before Django-OSF release, use this PR
  - if after, rebase this to develop

### QA Notes

Verify that sign in and login page for SciELO and BITSS has branded content.

### Main OSF Ticket
https://openscience.atlassian.net/browse/OSF-7536

### Related CAS Tickets
https://openscience.atlassian.net/browse/CAS-40
https://openscience.atlassian.net/browse/CAS-41