### PR TITLE
[OSF-7441] Change no license prompt text

### DIFF
--- a/website/static/js/licensePicker.js
+++ b/website/static/js/licensePicker.js
@@ -59,7 +59,7 @@ var LicensePicker = oop.extend(ChangeMessageMixin, {
 
         self.savedLicense = ko.observable(license);
         self.savedLicenseName = ko.pureComputed(function() {
-            return self.savedLicense().name;
+            return self.savedLicense().name === 'No license' ? 'Add a license' : self.savedLicense().name;
         });
         self.savedLicenseId = ko.computed(function() {
             return self.savedLicense().id;


### PR DESCRIPTION
## Purpose
Encourages users to add a license to licenseless projects 

## Changes
swaps out button text "No license" for "Add a license"

## Side effects
None that I know of.

## Ticket
https://openscience.atlassian.net/browse/OSF-7441

## Figure
<img width="1347" alt="screen shot 2017-03-01 at 9 24 37 am" src="https://cloud.githubusercontent.com/assets/9688518/23463889/33f49bee-fe61-11e6-9de1-a28369db9cb3.png">
