### PR TITLE
[OSF-7440] Change Project Description Prompt text

### DIFF
--- a/website/static/js/nodeControl.js
+++ b/website/static/js/nodeControl.js
@@ -106,7 +106,7 @@ var ProjectViewModel = function(data, options) {
         $('#nodeDescriptionEditable').editable($.extend({}, editableOptions, {
             name: 'description',
             title: 'Edit Description',
-            emptytext: 'No description',
+            emptytext: 'Add a brief description of your ' + self.categoryValue(),
             emptyclass: 'text-muted',
             value: self.description(),
             success: function(response, newValue) {

--- a/website/static/js/nodeControl.js
+++ b/website/static/js/nodeControl.js
@@ -106,7 +106,7 @@ var ProjectViewModel = function(data, options) {
         $('#nodeDescriptionEditable').editable($.extend({}, editableOptions, {
             name: 'description',
             title: 'Edit Description',
-            emptytext: 'Add a brief description of your ' + self.categoryValue(),
+            emptytext: 'Add a brief description',
             emptyclass: 'text-muted',
             value: self.description(),
             success: function(response, newValue) {

--- a/website/static/js/nodeControl.js
+++ b/website/static/js/nodeControl.js
@@ -103,10 +103,11 @@ var ProjectViewModel = function(data, options) {
             }
         }));
 
+        var project_or_component_label = self.categoryValue() == 'project' ? 'project' : 'component';
         $('#nodeDescriptionEditable').editable($.extend({}, editableOptions, {
             name: 'description',
             title: 'Edit Description',
-            emptytext: 'Add a brief description',
+            emptytext: 'Add a brief description to your ' + project_or_component_label,
             emptyclass: 'text-muted',
             value: self.description(),
             success: function(response, newValue) {

--- a/website/static/js/nodeControl.js
+++ b/website/static/js/nodeControl.js
@@ -103,7 +103,7 @@ var ProjectViewModel = function(data, options) {
             }
         }));
 
-        var project_or_component_label = self.categoryValue() == 'project' ? 'project' : 'component';
+        var project_or_component_label = self.categoryValue() === 'project' ? 'project' : 'component';
         $('#nodeDescriptionEditable').editable($.extend({}, editableOptions, {
             name: 'description',
             title: 'Edit Description',


### PR DESCRIPTION
## Purpose

This change encourages users to add a description to their project by changing the prompt text from "No Description" to "'Add a brief description of your [node category]"

## Changes

minor textual change to JS.

## Side effects

None that I know of.

## Ticket 

https://openscience.atlassian.net/browse/OSF-7440

## Figure
<img width="1283" alt="screen shot 2017-03-01 at 9 23 47 am" src="https://cloud.githubusercontent.com/assets/9688518/23463867/15fa6722-fe61-11e6-9bf6-72a981bb56f7.png">
