### PR TITLE
[OSF-7428] Fix fangorn 'operation taking to long' modal header

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -554,7 +554,8 @@ function doItemOp(operation, to, from, rename, conflict) {
             var mithrilButtons = m('div', [
                 m('span.tb-modal-btn', { 'class' : 'text-default', onclick : function() { tb.modal.dismiss(); }}, 'Close')
             ]);
-            tb.modal.update(mithrilContent, mithrilButtons);
+            var header =  m('h3.modal-title.break-word', "Operation Information')
+            tb.modal.update(mithrilContent, mithrilButtons, header);
             return;
         }
         from.data = tb.options.lazyLoadPreprocess.call(this, resp).data;

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -554,7 +554,7 @@ function doItemOp(operation, to, from, rename, conflict) {
             var mithrilButtons = m('div', [
                 m('span.tb-modal-btn', { 'class' : 'text-default', onclick : function() { tb.modal.dismiss(); }}, 'Close')
             ]);
-            var header =  m('h3.modal-title.break-word', "Operation Information')
+            var header =  m('h3.modal-title.break-word', "Operation Information")
             tb.modal.update(mithrilContent, mithrilButtons, header);
             return;
         }

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -554,7 +554,7 @@ function doItemOp(operation, to, from, rename, conflict) {
             var mithrilButtons = m('div', [
                 m('span.tb-modal-btn', { 'class' : 'text-default', onclick : function() { tb.modal.dismiss(); }}, 'Close')
             ]);
-            var header =  m('h3.modal-title.break-word', "Operation Information")
+            var header =  m('h3.modal-title.break-word', 'Operation Information');
             tb.modal.update(mithrilContent, mithrilButtons, header);
             return;
         }


### PR DESCRIPTION
## Purpose

If you have display a 'operation taking to long' modal in fangorn the header of the previous modal you displayed is redisplayed as the  'operation taking to long' modal header

## Changes

A couple lines of js overwrite old header replacing it with new one.

## Side effects

None that I know of

## Ticket

https://openscience.atlassian.net/browse/OSF-7428