### PR TITLE
Fix NodeWikiPage path serialization [#OSF-7530]

### DIFF
--- a/api/wikis/serializers.py
+++ b/api/wikis/serializers.py
@@ -53,7 +53,7 @@ class WikiSerializer(JSONAPISerializer):
         return obj.get_absolute_url()
 
     def get_path(self, obj):
-        return '/{}'.format(obj)
+        return '/{}'.format(obj._id)
 
     def get_kind(self, obj):
         return 'file'


### PR DESCRIPTION
## Purpose
<img width="372" alt="screen shot 2017-02-22 at 11 54 06" src="https://cloud.githubusercontent.com/assets/5659262/23222383/b0f3005c-f8f5-11e6-8e75-503e92d9f1c3.png">

## Changes
* `repr` no longer exposes `._id`, so use `._id`

## Side effects
None expected

## Ticket
[[OSF-7530]](https://openscience.atlassian.net/browse/OSF-7530)