### PR TITLE
[feature] Stop api breaking on v2.2 with null date [OSF-7316]

### DIFF
--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -197,7 +197,7 @@ class FileSerializer(JSONAPISerializer):
         elif obj.provider != 'osfstorage' and obj.history:
             mod_dt = obj.history[-1].get('modified', None)
 
-        if self.context['request'].version >= '2.2' and obj.is_file:
+        if self.context['request'].version >= '2.2' and obj.is_file and mod_dt:
             return datetime.strftime(mod_dt, '%Y-%m-%dT%H:%M:%S.%fZ')
 
         return mod_dt and mod_dt.replace(tzinfo=pytz.utc)
@@ -211,7 +211,7 @@ class FileSerializer(JSONAPISerializer):
             # earliest entry in the file history.
             creat_dt = obj.history[0].get('modified', None)
 
-        if self.context['request'].version >= '2.2' and obj.is_file:
+        if self.context['request'].version >= '2.2' and obj.is_file and creat_dt:
             return datetime.strftime(creat_dt, '%Y-%m-%dT%H:%M:%S.%fZ')
 
         return creat_dt and creat_dt.replace(tzinfo=pytz.utc)


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Dates break on v2.2 api serializer when date is none.
I spent longer than I care to admit trying to get a working test, but to no avail. I couldn't find a way to set dates to null that stuck when pushing it through the serializer, because of datetime validation for most of the prebuild factories/file creator helpers. 

<!-- Describe the purpose of your changes -->

## Changes
Stops trying to conform none dates to datetime spec and allow return of null
<!-- Briefly describe or list your changes  -->

## Side effects
None known
<!--Any possible side effects? -->

## QA Notes
See jira example. Just go to the api view of files/github with version tag. If no 500 error, all is well.

## Ticket
[#OSF-7316]
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
https://openscience.atlassian.net/browse/OSF-7316