### PR TITLE
[Hotfix] Bookmark collection uniqueness [OSF-7551]

### DIFF
--- a/api_tests/collections/test_views.py
+++ b/api_tests/collections/test_views.py
@@ -15,6 +15,7 @@ from tests.factories import (
 )
 from tests.utils import assert_logs
 from framework.auth.core import Auth
+from website.views import find_bookmark_collection
 
 
 def node_url_for(node_id):
@@ -70,6 +71,15 @@ class TestCollectionCreate(ApiTestCase):
                     }
             }
         }
+
+        # Pretend these aren't created when the user is
+        user_one_bookmark = find_bookmark_collection(self.user_one)
+        user_two_bookmark = find_bookmark_collection(self.user_two)
+        user_one_bookmark.is_deleted = True
+        user_two_bookmark.is_deleted = True
+        user_one_bookmark.save()
+        user_two_bookmark.save()
+
 
     def test_collection_create_invalid_data(self):
         res = self.app.post_json_api(self.url, "Incorrect data", auth=self.user_one.auth, expect_errors=True)
@@ -194,7 +204,7 @@ class TestCollectionCreate(ApiTestCase):
                 }
             }
         }
-        res = self.app.post_json_api(self.url, collection, auth=self.user_one.auth)
+        res = self.app.post_json_api(self.url, collection, auth=self.user_one.auth, expect_errors=True)
         assert_equal(res.status_code, 201)
         res = self.app.post_json_api(self.url, collection, auth=self.user_one.auth, expect_errors=True)
         assert_equal(res.status_code, 400)
@@ -1174,6 +1184,14 @@ class TestCollectionBulkCreate(ApiTestCase):
         }
 
         self.empty_collection = {'type': 'collections', 'attributes': {'title': "",}}
+
+        # Pretend these aren't created when the user is
+        user_one_bookmark = find_bookmark_collection(self.user_one)
+        user_two_bookmark = find_bookmark_collection(self.user_two)
+        user_one_bookmark.is_deleted = True
+        user_two_bookmark.is_deleted = True
+        user_one_bookmark.save()
+        user_two_bookmark.save()
 
     def test_bulk_create_collections_blank_request(self):
         res = self.app.post_json_api(self.url, auth=self.user_one.auth, expect_errors=True, bulk=True)

--- a/api_tests/nodes/views/test_node_list.py
+++ b/api_tests/nodes/views/test_node_list.py
@@ -7,6 +7,7 @@ from framework.auth.core import Auth
 from website.models import Node, NodeLog
 from website.util import permissions
 from website.util.sanitize import strip_html
+from website.views import find_bookmark_collection
 
 from api.base.settings.defaults import API_BASE, MAX_PAGE_SIZE
 
@@ -132,7 +133,7 @@ class TestNodeFiltering(ApiTestCase):
                                                        is_public=False,
                                                        creator=self.user_two)
         self.folder = CollectionFactory()
-        self.bookmark_collection = BookmarkCollectionFactory()
+        self.bookmark_collection = find_bookmark_collection(self.user_one)
 
         self.url = "/{}nodes/".format(API_BASE)
 

--- a/api_tests/registrations/views/test_registration_list.py
+++ b/api_tests/registrations/views/test_registration_list.py
@@ -7,6 +7,7 @@ from nose.tools import *  # flake8: noqa
 from website.project.model import ensure_schemas
 from website.project.metadata.schemas import LATEST_SCHEMA_VERSION
 from website.models import Node, MetaSchema, DraftRegistration
+from website.views import find_bookmark_collection
 from framework.auth.core import Auth, Q
 from api.base.settings.defaults import API_BASE
 
@@ -114,7 +115,7 @@ class TestRegistrationFiltering(ApiTestCase):
         self.private_project_user_two_reg = RegistrationFactory(creator=self.user_two, project=self.private_project_user_two, is_public=False)
 
         self.folder = CollectionFactory()
-        self.bookmark_collection = BookmarkCollectionFactory()
+        self.bookmark_collection = find_bookmark_collection(self.user_one)
 
         self.url = "/{}registrations/".format(API_BASE)
 

--- a/api_tests/users/views/test_user_detail.py
+++ b/api_tests/users/views/test_user_detail.py
@@ -4,6 +4,7 @@ from nose.tools import *  # flake8: noqa
 
 from website.models import Node
 from website.util.sanitize import strip_html
+from website.views import find_bookmark_collection
 
 from tests.base import ApiTestCase
 from tests.factories import AuthUserFactory, BookmarkCollectionFactory, CollectionFactory, ProjectFactory
@@ -103,7 +104,7 @@ class TestUserRoutesNodeRoutes(ApiTestCase):
 
         self.folder = CollectionFactory()
         self.deleted_folder = CollectionFactory(title="Deleted Folder User One", is_public=False, creator=self.user_one, is_deleted=True)
-        self.bookmark_collection = BookmarkCollectionFactory()
+        self.bookmark_collection = find_bookmark_collection(self.user_one)
 
     def tearDown(self):
         super(TestUserRoutesNodeRoutes, self).tearDown()

--- a/api_tests/users/views/test_user_nodes_list.py
+++ b/api_tests/users/views/test_user_nodes_list.py
@@ -5,6 +5,7 @@ from tests.base import ApiTestCase
 from tests.factories import AuthUserFactory, BookmarkCollectionFactory, CollectionFactory, ProjectFactory, RegistrationFactory, PreprintFactory
 
 from api.base.settings.defaults import API_BASE
+from website.views import find_bookmark_collection
 
 
 class TestUserNodes(ApiTestCase):
@@ -37,7 +38,7 @@ class TestUserNodes(ApiTestCase):
                                                 is_public=False,
                                                 creator=self.user_one,
                                                 is_deleted=True)
-        self.bookmark_collection = BookmarkCollectionFactory()
+        self.bookmark_collection = find_bookmark_collection(self.user_one)
 
         self.registration = RegistrationFactory(project=self.public_project_user_one,
                                                       creator=self.user_one, is_public=True)

--- a/api_tests/users/views/test_user_registrations_list.py
+++ b/api_tests/users/views/test_user_registrations_list.py
@@ -5,6 +5,7 @@ from tests.base import ApiTestCase
 from tests.factories import AuthUserFactory, BookmarkCollectionFactory, CollectionFactory, ProjectFactory, RegistrationFactory
 
 from api.base.settings.defaults import API_BASE
+from website.views import find_bookmark_collection
 
 
 class TestUserRegistrations(ApiTestCase):
@@ -37,7 +38,7 @@ class TestUserRegistrations(ApiTestCase):
                                                 is_public=False,
                                                 creator=self.user_one,
                                                 is_deleted=True)
-        self.bookmark_collection = BookmarkCollectionFactory()
+        self.bookmark_collection = find_bookmark_collection(self.user_one)
 
         self.reg_public_project_user_one = RegistrationFactory(project=self.public_project_user_one,
                                                       creator=self.user_one, is_public=True)

--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -1288,11 +1288,15 @@ class User(GuidStoredObject, AddonModelMixin):
     def save(self, *args, **kwargs):
         # TODO: Update mailchimp subscription on username change
         # Avoid circular import
+        first_save = not self._is_loaded
         self.username = self.username.lower().strip() if self.username else None
         ret = super(User, self).save(*args, **kwargs)
         if self.SEARCH_UPDATE_FIELDS.intersection(ret) and self.is_confirmed:
             self.update_search()
             self.update_search_nodes_contributors()
+        if first_save:
+            from website.project import new_bookmark_collection  # Avoid circular import
+            new_bookmark_collection(self)
         return ret
 
     def update_search(self):

--- a/scripts/migration/ensure_bookmark_uniqueness.py
+++ b/scripts/migration/ensure_bookmark_uniqueness.py
@@ -1,0 +1,62 @@
+import argparse
+import logging
+
+from modularodm import Q
+
+from framework.auth.core import User
+from framework.transactions.context import TokuTransaction
+from scripts import utils as script_utils
+from website.app import init_app
+from website.project import Node
+
+
+logger = logging.getLogger(__name__)
+
+def get_targets():
+    logger.info('Acquiring targets...')
+    targets = [u for u in User.find() if Node.find(Q('is_bookmark_collection', 'eq', True) & Q('is_deleted', 'eq', False) & Q('contributors', 'eq', u._id)).count() > 1]
+    logger.info('Found {} target users.'.format(len(targets)))
+    return targets
+
+def migrate():
+    targets = get_targets()
+    total = len(targets)
+    for i, user in enumerate(targets):
+        logger.info('({}/{}) Preparing to migrate User {}'.format(i + 1, total, user._id))
+        bookmarks = Node.find(Q('is_bookmark_collection', 'eq', True) & Q('contributors', 'eq', user._id))
+        if sum([bool(n.nodes) for n in bookmarks]) > 1:
+            raise Exception('Expected no users to have more than one bookmark with .nodes, {} violated'.format(user._id))
+        bookmark_to_keep = None
+        for n in bookmarks:
+            if n.nodes:
+                bookmark_to_keep = n
+        bookmark_to_keep = bookmark_to_keep or bookmarks[0]
+        logger.info('Marking Node {} as primary Bookmark Collection for User {}, preparing to delete others'.format(bookmark_to_keep._id, user._id))
+        for n in bookmarks:
+            if n._id != bookmark_to_keep._id:
+                n.is_deleted = True
+                n.save()
+        logger.info('Successfully migrated User {}'.format(user._id))
+    logger.info('Successfully migrated {} users'.format(total))
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Ensures every confirmed user has only one bookmark collection.'
+    )
+    parser.add_argument(
+        '--dry',
+        action='store_true',
+        dest='dry_run',
+        help='Run migration and roll back changes to db',
+    )
+    pargs = parser.parse_args()
+    if not pargs.dry_run:
+        script_utils.add_file_logger(logger, __file__)
+    init_app(set_backends=True, routes=False)
+    with TokuTransaction():
+        migrate()
+        if pargs.dry_run:
+            raise Exception('Dry Run -- Transaction aborted.')
+
+if __name__ == '__main__':
+    main()

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -56,9 +56,8 @@ from website.identifiers.model import Identifier
 from website.archiver import ARCHIVER_SUCCESS
 from website.project.licenses import NodeLicense, NodeLicenseRecord, ensure_licenses
 from website.util import permissions
-from website.files.models.osfstorage import OsfStorageFile, FileVersion
+from website.files.models.osfstorage import OsfStorageFile
 from website.exceptions import InvalidSanctionApprovalToken
-
 
 ensure_licenses = functools.partial(ensure_licenses, warn=False)
 

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -12,6 +12,7 @@ from tests import base
 from tests.base import fake
 from tests import factories
 from framework.celery_tasks import handlers
+from website.views import find_bookmark_collection
 
 
 class TestUser(base.OsfTestCase):
@@ -136,7 +137,7 @@ class TestUser(base.OsfTestCase):
         normal_contributed_node.add_contributor(self.user)
         normal_contributed_node.save()
         deleted_node = factories.ProjectFactory(creator=self.user, is_deleted=True)
-        bookmark_collection_node = factories.BookmarkCollectionFactory(creator=self.user)
+        bookmark_collection_node = find_bookmark_collection(self.user)
         collection_node = factories.CollectionFactory(creator=self.user)
         project_to_be_invisible_on = factories.ProjectFactory()
         project_to_be_invisible_on.add_contributor(self.user, visible=False)
@@ -154,7 +155,7 @@ class TestUser(base.OsfTestCase):
         invisible_contributor = factories.UserFactory()
         normal_node = factories.ProjectFactory(creator=invisible_contributor)
         deleted_node = factories.ProjectFactory(creator=invisible_contributor, is_deleted=True)
-        bookmark_collection_node = factories.BookmarkCollectionFactory(creator=invisible_contributor)
+        bookmark_collection_node = find_bookmark_collection(invisible_contributor)
         collection_node = factories.CollectionFactory(creator=invisible_contributor)
         project_to_be_invisible_on = factories.ProjectFactory()
         project_to_be_invisible_on.add_contributor(invisible_contributor, visible=False)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -36,7 +36,7 @@ from website.project.decorators import (
 )
 from website.util import api_url_for
 
-from tests.test_cas_authentication import make_external_response, generate_external_user_with_resp
+from tests.test_cas_authentication import generate_external_user_with_resp
 
 
 class TestAuthUtils(OsfTestCase):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -59,9 +59,8 @@ from website.addons.wiki.exceptions import (
     PageConflictError,
     PageNotFoundError,
 )
-from website.project.model import ensure_schemas
 from website.project.sanctions import Sanction, DraftRegistrationApproval
-from website.prereg.utils import get_prereg_schema
+from website.views import find_bookmark_collection
 
 from tests.base import OsfTestCase, Guid, fake, capture_signals, get_default_metaschema
 from tests.factories import (
@@ -777,6 +776,7 @@ class TestUser(OsfTestCase):
             if node.category == 'project'
             and not node.is_registration
             and not node.is_deleted
+            and not node.is_collection
         ]
         public_projects = [p for p in projects if p.is_public]
         assert_equal(d['number_projects'], len(projects))
@@ -1035,7 +1035,7 @@ class TestMergingUsers(OsfTestCase):
         self.master.save()
 
     def test_bookmark_collection_nodes_arent_merged(self):
-        dashnode = ProjectFactory(creator=self.dupe, is_bookmark_collection=True)
+        dashnode = find_bookmark_collection(self.dupe)
 
         self._merge_dupe()
 
@@ -2473,7 +2473,7 @@ class TestBookmarkCollection(OsfTestCase):
         # Create project with component
         self.user = UserFactory()
         self.auth = Auth(user=self.user)
-        self.project = BookmarkCollectionFactory(creator=self.user)
+        self.project = find_bookmark_collection(self.user)
 
     def test_bookmark_collection_is_bookmark_collection(self):
         assert_equal(self.project.is_bookmark_collection, True)

--- a/tests/test_search/test_views.py
+++ b/tests/test_search/test_views.py
@@ -6,6 +6,7 @@ from nose.tools import *  # noqa PEP8 asserts
 from tests import factories
 from tests.test_search import SearchTestCase
 from website.util import api_url_for
+from website.views import find_bookmark_collection
 
 
 class TestSearchViews(SearchTestCase):
@@ -118,7 +119,7 @@ class TestODMTitleSearch(SearchTestCase):
         self.public_project = factories.ProjectFactory(creator=self.user_two, is_public=True, title="baz")
         self.registration_project = factories.RegistrationFactory(creator=self.user, title="qux")
         self.folder = factories.CollectionFactory(creator=self.user, title="quux")
-        self.dashboard = factories.BookmarkCollectionFactory(creator=self.user, title="Dashboard")
+        self.dashboard = find_bookmark_collection(self.user)
         self.url = api_url_for('search_projects_by_title')
 
     def test_search_projects_by_title(self):

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -4,8 +4,9 @@ from urlparse import urlparse
 from nose.tools import *  # flake8: noqa
 import unittest
 
-from framework.auth import Auth
+from modularodm import Q
 
+from framework.auth import Auth
 from website.models import Node, NodeLog
 
 from tests.base import DbIsolationMixin, OsfTestCase
@@ -22,14 +23,14 @@ class TestUtilsTests(OsfTestCase):
         self.auth = Auth(self.user)
 
     def test_assert_logs(self):
-        
+
         def add_log(self):
             self.node.add_log(NodeLog.UPDATED_FIELDS, {}, auth=self.auth)
         wrapped = test_utils.assert_logs(NodeLog.UPDATED_FIELDS, 'node')(add_log)
         wrapped(self)
 
     def test_assert_logs_fail(self):
-        
+
         def dont_add_log(self):
             pass
         wrapped = test_utils.assert_logs(NodeLog.UPDATED_FIELDS, 'node')(dont_add_log)
@@ -43,7 +44,7 @@ class TestUtilsTests(OsfTestCase):
         def add_two_logs(self):
             add_log(self)
             self.node.add_log(NodeLog.CONTRIB_ADDED, {}, auth=self.auth)
-            
+
         wrapped = test_utils.assert_logs(NodeLog.UPDATED_FIELDS, 'node', -2)(
             test_utils.assert_logs(NodeLog.CONTRIB_ADDED, 'node')(add_two_logs)
         )
@@ -78,7 +79,7 @@ class DbIsolationMixinTests(object):
         ProjectFactory()
         self.__class__.ntest_calls += 1  # a little goofy, yes; each test gets its own instance
         nexpected = self.__class__.ntest_calls if self.nexpected == 'ntest_calls' else 1
-        assert_equal(nexpected, len(Node.find()))
+        assert_equal(nexpected, len(Node.find(Q('is_bookmark_collection', 'eq', False))))
 
     def test_1(self): self.check()
     def test_2(self): self.check()

--- a/tests/test_websitefiles.py
+++ b/tests/test_websitefiles.py
@@ -9,6 +9,7 @@ from website.files import utils
 from website.files import models
 from website.files import exceptions
 from website.models import Guid
+from website.views import find_bookmark_collection
 
 from tests.base import OsfTestCase
 from tests.factories import AuthUserFactory, ProjectFactory
@@ -181,6 +182,7 @@ class TestFileNodeObj(FilesTestCase):
         )
 
     def test_find(self):
+        models.StoredFileNode.remove_one(find_bookmark_collection(self.user).get_addon('osfstorage').root_node)
         models.StoredFileNode.remove_one(self.node.get_addon('osfstorage').root_node)
         models.StoredFileNode(
             path='afile',

--- a/website/notifications/listeners.py
+++ b/website/notifications/listeners.py
@@ -8,6 +8,8 @@ logger = logging.getLogger(__name__)
 
 @project_created.connect
 def subscribe_creator(node):
+    if node.institution_id or node.is_collection or node.is_deleted:
+        return None
     try:
         subscribe_user_to_notifications(node, node.creator)
     except InvalidSubscriptionError as err:

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -1664,7 +1664,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable, Spam
 
         if first_save and self.is_bookmark_collection:
             existing_bookmark_collections = Node.find(
-                Q('is_bookmark_collection', 'eq', True) & Q('contributors', 'eq', self.creator._id)
+                Q('is_bookmark_collection', 'eq', True) & Q('contributors', 'eq', self.creator._id) & Q('is_deleted', 'eq', False)
             )
             if existing_bookmark_collections.count() > 0:
                 raise NodeStateError('Only one bookmark collection allowed per user.')

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -762,6 +762,8 @@ def validate_doi(value):
     return True
 
 
+# TODO: uncomment after migrating
+# @unique_on(['creator', 'is_bookmark_collection', 'is_deleted'])
 class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable, SpamMixin):
 
     #: Whether this is a pointer or not
@@ -2611,7 +2613,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable, Spam
 
         if save:
             self.save()
-        if user:
+        if user and not self.is_collection:
             increment_user_activity_counters(user._primary_key, action, log.date.isoformat())
         return log
 

--- a/website/views.py
+++ b/website/views.py
@@ -21,7 +21,6 @@ from website.institutions.views import view_institution
 
 from website.models import Guid
 from website.models import Node, Institution, PreprintService
-from website.project import new_bookmark_collection
 from website.settings import EXTERNAL_EMBER_APPS
 from website.util import permissions
 
@@ -101,11 +100,7 @@ def index():
 
 
 def find_bookmark_collection(user):
-    bookmark_collection = Node.find(Q('is_bookmark_collection', 'eq', True) & Q('contributors', 'eq', user._id))
-    if bookmark_collection.count() == 0:
-        new_bookmark_collection(user)
-    return bookmark_collection[0]
-
+    return Node.find_one(Q('is_bookmark_collection', 'eq', True) & Q('contributors', 'eq', user._id) & Q('is_deleted', 'eq', False))
 
 @must_be_logged_in
 def dashboard(auth):


### PR DESCRIPTION
## Purpose
Ensure/Enforce a 1-1 relationship between Users and bookmark collection Nodes

## Changes
* Add migration to fix data
* Create users bookmark collection only when user is created
* Add commented-out uniqueness constraint

## Side effects
Uniqueness won't be enforced until #6905 is merged.

## Ticket
[[OSF-7551]](https://openscience.atlassian.net/browse/OSF-7551)