### PR TITLE
Add log when user adds or removes a private link [OSF-7309]

### DIFF
--- a/api/logs/serializers.py
+++ b/api/logs/serializers.py
@@ -87,6 +87,7 @@ class NodeLogParamsSerializer(RestrictedDictSerializer):
     wiki = ser.DictField(read_only=True)
     citation_name = ser.CharField(read_only=True, source='citation.name')
     institution = NodeLogInstitutionSerializer(read_only=True)
+    anonymous_link = ser.BooleanField(read_only=True)
 
     def get_view_url(self, obj):
         urls = obj.get('urls', None)

--- a/osf/models/nodelog.py
+++ b/osf/models/nodelog.py
@@ -112,6 +112,9 @@ class NodeLog(ObjectIDMixin, BaseModel):
     PREPRINT_FILE_UPDATED = 'preprint_file_updated'
     PREPRINT_LICENSE_UPDATED = 'preprint_license_updated'
 
+    VIEW_ONLY_LINK_ADDED = 'view_only_link_added'
+    VIEW_ONLY_LINK_REMOVED = 'view_only_link_removed'
+
     actions = ([CHECKED_IN, CHECKED_OUT, FILE_TAG_REMOVED, FILE_TAG_ADDED, CREATED_FROM, PROJECT_CREATED,
                 PROJECT_REGISTERED, PROJECT_DELETED, NODE_CREATED, NODE_FORKED, NODE_REMOVED,
                 NODE_LINK_CREATED, NODE_LINK_FORKED, NODE_LINK_REMOVED, WIKI_UPDATED,
@@ -128,7 +131,8 @@ class NodeLog(ObjectIDMixin, BaseModel):
                 REGISTRATION_APPROVAL_INITIATED, REGISTRATION_APPROVAL_APPROVED,
                 PREREG_REGISTRATION_INITIATED,
                 CITATION_ADDED, CITATION_EDITED, CITATION_REMOVED,
-                AFFILIATED_INSTITUTION_ADDED, AFFILIATED_INSTITUTION_REMOVED, PREPRINT_INITIATED, PREPRINT_FILE_UPDATED, PREPRINT_LICENSE_UPDATED] + list(sum([
+                AFFILIATED_INSTITUTION_ADDED, AFFILIATED_INSTITUTION_REMOVED, PREPRINT_INITIATED,
+                PREPRINT_FILE_UPDATED, PREPRINT_LICENSE_UPDATED, VIEW_ONLY_LINK_ADDED, VIEW_ONLY_LINK_REMOVED] + list(sum([
                     config.actions for config in apps.get_app_configs() if config.name.startswith('addons.')
                 ], tuple())))
     action_choices = [(action, action.upper()) for action in actions]

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -14,7 +14,7 @@ from framework import status
 from framework.utils import iso8601format
 from framework.flask import redirect
 from framework.auth.decorators import must_be_logged_in, collect_auth
-from framework.exceptions import HTTPError, PermissionsError
+from framework.exceptions import HTTPError
 from osf.models.nodelog import NodeLog
 
 from website import language

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -14,7 +14,8 @@ from framework import status
 from framework.utils import iso8601format
 from framework.flask import redirect
 from framework.auth.decorators import must_be_logged_in, collect_auth
-from framework.exceptions import HTTPError
+from framework.exceptions import HTTPError, PermissionsError
+from osf.models.nodelog import NodeLog
 
 from website import language
 
@@ -596,6 +597,21 @@ def remove_private_link(*args, **kwargs):
         link = PrivateLink.load(link_id)
         link.is_deleted = True
         link.save()
+
+        for node in link.nodes.all():
+            log_dict = {
+                'project': node.parent_id,
+                'node': node._id,
+                'user': kwargs.get('auth').user._id,
+                'anonymous_link': link.anonymous,
+            }
+
+            node.add_log(
+                NodeLog.VIEW_ONLY_LINK_REMOVED,
+                log_dict,
+                auth=kwargs.get('auth', None)
+            )
+
     except ModularOdmException:
         raise HTTPError(http.NOT_FOUND)
 

--- a/website/static/js/anonymousLogActionsList.json
+++ b/website/static/js/anonymousLogActionsList.json
@@ -76,5 +76,7 @@
     "affiliated_institution_removed": "A user removed an affiliation from a project",
     "preprint_initiated": "A user made a project a preprint",
     "preprint_file_updated": "A user updated the primary file of a preprint",
-    "preprint_license_updated": "A user updated the license of a preprint"
+    "preprint_license_updated": "A user updated the license of a preprint",
+    "view_only_link_added": "A user created a view-only link to a project",
+    "view_only_link_removed": "A user removed a view-only link to a project"
 }

--- a/website/static/js/logActionsList.json
+++ b/website/static/js/logActionsList.json
@@ -76,5 +76,7 @@
     "affiliated_institution_removed": "${user} removed ${institution} affiliation from ${node}",
     "preprint_initiated": "${user} made ${node} a ${preprint} on ${preprint_provider} Preprints",
     "preprint_file_updated": "${user} updated the primary file of this ${preprint} on ${preprint_provider} Preprints",
-    "preprint_license_updated": "${user} updated the license of this ${preprint} on ${preprint_provider} Preprints ${license}"
+    "preprint_license_updated": "${user} updated the license of this ${preprint} on ${preprint_provider} Preprints ${license}",
+    "view_only_link_added": "${user} created ${anonymous_link} view-only link to ${node}",
+    "view_only_link_removed": "${user} removed ${anonymous_link} view-only link to ${node}"
 }

--- a/website/static/js/logTextParser.js
+++ b/website/static/js/logTextParser.js
@@ -671,6 +671,15 @@ var LogPieces = {
             return m('span', '');
         }
     },
+    
+    anonymous_link: {
+        view: function(ctrl, logObject) {
+            if (logObject.attributes.params.anonymous_link) {
+                return m('span', 'an anonymous');
+            }
+            return m('span', 'a');
+        }
+    }
 };
 
 module.exports = LogText;


### PR DESCRIPTION
## Purpose
Add logs whenever a view-only link is created on a project or component. Currently, a user could create a view-only link, share that with others, allowing them to access the project. The user could then remove the VOL and his collaborators would never know that the project's contents had been shared. 

Create new logs that say when a normal or an anonymous view only link is added or removed.

![screen shot 2017-02-27 at 12 06 32 pm](https://cloud.githubusercontent.com/assets/801594/23371172/375ec43a-fce5-11e6-87ac-4ac647a291bc.png)

## Changes

- Add `VIEW_ONLY_LINK_ADDED` and `VIEW_ONLY_LINK_REMOVED` to the `NodeLog` model
- Add `anonymous_link` to the NodeLog serializer
- Add log when node link is added or removed
- Tests to make sure logs are added
- Log text added to log actions list
- Log kwarg `anonymous_link` parsed in `LogTextParser.js`

## Side effects

None anticipated


## Ticket
https://openscience.atlassian.net/browse/OSF-7309