### PR TITLE
[OSF-7439] Change default text prompt for tags for users with no tags

### DIFF
--- a/website/static/js/pages/project-dashboard-page.js
+++ b/website/static/js/pages/project-dashboard-page.js
@@ -212,7 +212,9 @@ $(document).ready(function () {
         width: '100%',
         interactive: window.contextVars.currentUser.canEdit,
         maxChars: 128,
+        defaultText: 'add a tag to enhance discoverability',
         onAddTag: function(tag) {
+            $('#node-tags_tag').attr('data-default', 'add a tag');
             var url = nodeApiUrl + 'tags/';
             var data = {tag: tag};
             var request = $osf.postJSON(url, data);
@@ -244,6 +246,11 @@ $(document).ready(function () {
             });
         }
     });
+
+    // allows inital default message to fit on empty tag
+    if(!$('.tag').length){
+        $('#node-tags_tag').css('width', '250px');
+    }
 
     $('#addPointer').on('shown.bs.modal', function(){
         if(!$osf.isIE()){


### PR DESCRIPTION
## Purpose

This points out to the user they have no tags for their project by changing the text prompt for uses with no tags.

## Changes

Changes to over override taginput.js's default text behavior.

## Side effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/OSF-7439

## Figure
<img width="1227" alt="screen shot 2017-03-01 at 9 22 22 am" src="https://cloud.githubusercontent.com/assets/9688518/23463841/fc2d085e-fe60-11e6-81e8-b6ab5710519a.png">
