### PR TITLE
Keep a cached version of parent_node on the class instance

### DIFF
--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -18,6 +18,7 @@ from django.db import models, transaction, connection
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.utils import timezone
+from django.utils.functional import cached_property
 from keen import scoped_keys
 from modularodm import Q as MQ
 from psycopg2._psycopg import AsIs
@@ -237,7 +238,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
 
     objects = AbstractNodeQuerySet.as_manager()
 
-    @property
+    @cached_property
     def parent_node(self):
         node_rel = NodeRelation.objects.filter(
             child=self,


### PR DESCRIPTION
… embedded children

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Registration endpoints with embedded children were slow because they were getting `parent_node` over and over again for no reason. This uses a django decorator to cache a version of the `parent_node` on the class instance.

## Changes

I imported cached_property from django.utils.functional and then put `cached_` in front of property.

## Side effects

Assuming transactions are working this shouldn't have any side-effects.


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->