### PR TITLE
[RFR] Add custom caching decorator and implement on various properties

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -303,3 +303,35 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+
+cached_property decorator
+========================
+
+Copyright (c) 2009, David Hall.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, 
+       this list of conditions and the following disclaimer.
+    
+    2. Redistributions in binary form must reproduce the above copyright 
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+
+    3. Neither the name of David Hall nor the names of its contributors may be
+       used to endorse or promote products derived from this software without
+       specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -551,7 +551,6 @@ class RelationshipField(ser.HyperlinkedIdentityField):
         """
         if callable(kwargs_dict):
             kwargs_dict = kwargs_dict(obj)
-
         kwargs_retrieval = {}
         for lookup_url_kwarg, lookup_field in kwargs_dict.items():
             try:

--- a/osf/models/base.py
+++ b/osf/models/base.py
@@ -19,6 +19,7 @@ from django.db.models import Q
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.utils import timezone
+from osf.utils.caching import cached_property
 
 from osf.exceptions import ValidationError
 from osf.modm_compat import to_django_query
@@ -628,7 +629,7 @@ class GuidMixin(BaseIDMixin):
     def _natural_key(self):
         return self.guid_string
 
-    @property
+    @cached_property
     def _id(self):
         try:
             guid = self.guids.all()[0]

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -18,7 +18,7 @@ from django.db import models, transaction, connection
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.utils import timezone
-from django.utils.functional import cached_property
+from osf.utils.caching import cached_property
 from keen import scoped_keys
 from modularodm import Q as MQ
 from psycopg2._psycopg import AsIs

--- a/osf/utils/caching.py
+++ b/osf/utils/caching.py
@@ -17,7 +17,7 @@ class _CachedProperty(property):
 
     def __init__(self, fget, fset=None, fdel=None, doc=None):
         """Initializes the cached property."""
-        self._cache_name = "_{name}_cache".format(
+        self._cache_name = '_{name}_cache'.format(
             name=fget.__name__,
         )
         # Wrap the accessors.
@@ -58,5 +58,5 @@ class _CachedProperty(property):
         return do_fdel
 
 
-# Public name for the cached property decorator. Using a class as a decorator just looks plain ugly. :P            
+# Public name for the cached property decorator. Using a class as a decorator just looks plain ugly. :P
 cached_property = _CachedProperty

--- a/osf/utils/caching.py
+++ b/osf/utils/caching.py
@@ -36,7 +36,8 @@ class _CachedProperty(property):
                 return getattr(obj, self._cache_name)
             # Generate the value to cache.
             value = fget(obj)
-            setattr(obj, self._cache_name, value)
+            if value:
+                setattr(obj, self._cache_name, value)
             return value
 
         return do_fget

--- a/osf/utils/caching.py
+++ b/osf/utils/caching.py
@@ -1,0 +1,62 @@
+"""
+A property cache mechanism.
+The cache is stored on the model as a protected attribute. Expensive
+property lookups, such as database access, can therefore be sped up
+when accessed multiple times in the same request.
+The property can also be safely set and deleted without interference.
+"""
+from __future__ import unicode_literals
+
+from functools import wraps
+
+# from https://github.com/etianen/django-optimizations/blob/master/src/optimizations/propertycache.py
+
+
+class _CachedProperty(property):
+    """A property who's value is cached on the object."""
+
+    def __init__(self, fget, fset=None, fdel=None, doc=None):
+        """Initializes the cached property."""
+        self._cache_name = "_{name}_cache".format(
+            name=fget.__name__,
+        )
+        # Wrap the accessors.
+        fget = self._wrap_fget(fget)
+        if callable(fset):
+            fset = self._wrap_fset(fset)
+        if callable(fdel):
+            fdel = self._wrap_fdel(fdel)
+        # Create the property.
+        super(_CachedProperty, self).__init__(fget, fset, fdel, doc)
+
+    def _wrap_fget(self, fget):
+        @wraps(fget)
+        def do_fget(obj):
+            if hasattr(obj, self._cache_name):
+                return getattr(obj, self._cache_name)
+            # Generate the value to cache.
+            value = fget(obj)
+            setattr(obj, self._cache_name, value)
+            return value
+
+        return do_fget
+
+    def _wrap_fset(self, fset):
+        @wraps(fset)
+        def do_fset(obj, value):
+            fset(obj, value)
+            setattr(obj, self._cache_name, value)
+
+        return do_fset
+
+    def _wrap_fdel(self, fdel):
+        @wraps(fdel)
+        def do_fdel(obj):
+            fdel(obj)
+            delattr(obj, self._cache_name)
+
+        return do_fdel
+
+
+# Public name for the cached property decorator. Using a class as a decorator just looks plain ugly. :P            
+cached_property = _CachedProperty


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Make less guid queries

## Changes

Add custom cached_property decorator that supports setters. Implement on GuidMixin._id and Node.parent_node and Node.root.

## Side effects

Could cause setting guids on existing objects to not work good.


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->