### PR TITLE
[hotfix] Handle amps in PO and dashboard [OSF-6853]

### DIFF
--- a/website/static/js/home-page/quickProjectSearchPlugin.js
+++ b/website/static/js/home-page/quickProjectSearchPlugin.js
@@ -52,6 +52,7 @@ var QuickSearchProject = {
         promise.then(function(result) {
             self.countDisplayed(result.data.length);
             result.data.forEach(function (node) {
+                node.attributes.title = $osf.decodeText(node.attributes.title);
                 self.nodes().push(node);
                 self.retrieveContributors(node);
             });
@@ -87,6 +88,7 @@ var QuickSearchProject = {
                     // This redraw allows the "load more" button to be displayed
                     m.redraw();
                     result.data.forEach(function(node){
+                        node.attributes.title = $osf.decodeText(node.attributes.title);
                         self.nodes().push(node);
                         self.retrieveContributors(node);
                     });
@@ -576,7 +578,7 @@ function getAncestorDescriptor(node, nodeID, ancestor, ancestorID) {
         default:
             ancestorDescriptor = 'Name Unavailable / ';
     }
-    return ancestorDescriptor;
+    return $osf.decodeText(ancestorDescriptor);
 }
 
 var QuickSearchNodeDisplay = {

--- a/website/static/js/myProjects.js
+++ b/website/static/js/myProjects.js
@@ -264,7 +264,7 @@ function getUID() {
 function _formatDataforPO(item) {
     item.kind = 'folder';
     item.uid = item.id;
-    item.name = item.attributes.title;
+    item.name = $osf.decodeText(item.attributes.title);
     item.tags = item.attributes.tags.toString();
     item.contributors = '';
     var contributorsData = lodashGet(item, 'embeds.contributors.data', null);
@@ -825,7 +825,7 @@ var MyProjects = {
             promise.then(function(result){
                 result.data.forEach(function(node){
                     var count = node.relationships.linked_registrations.links.related.meta.count + node.relationships.linked_nodes.links.related.meta.count;
-                    self.collections().push(new LinkObject('collection', {nodeType : 'collection', node : node, count : m.prop(count), loaded: 1 }, node.attributes.title));
+                    self.collections().push(new LinkObject('collection', {nodeType : 'collection', node : node, count : m.prop(count), loaded: 1 }, $osf.decodeText(node.attributes.title)));
 
                     var regLink = $osf.apiV2Url('collections/' + node.id + '/linked_registrations/', { query : { 'related_counts' : 'children', 'embed' : 'contributors', 'version': '2.2' }});
                     var link = $osf.apiV2Url('collections/' + node.id + '/linked_nodes/', { query : { 'related_counts' : 'children', 'embed' : 'contributors' }});
@@ -1118,7 +1118,7 @@ var Collections = {
             promise.then(function(result){
                 var node = result.data;
                 var count = node.relationships.linked_nodes.links.related.meta.count || 0;
-                self.collections().push(new LinkObject('collection', { path : 'collections/' + node.id + '/linked_nodes/', query : { 'related_counts' : 'children' }, node : node, count : m.prop(count), nodeType : 'collection' }, node.attributes.title));
+                self.collections().push(new LinkObject('collection', { path : 'collections/' + node.id + '/linked_nodes/', query : { 'related_counts' : 'children' }, node : node, count : m.prop(count), nodeType : 'collection' }, $osf.decodeText(node.attributes.title)));
                 var link = $osf.apiV2Url('collections/' + node.id + '/linked_nodes/', { query : { 'related_counts' : 'children', 'embed' : 'contributors'}});
                 args.fetchers[self.collections()[self.collections().length-1].id] = new NodeFetcher('nodes', link);
                 args.fetchers[self.collections()[self.collections().length-1].id].on(['page', 'done'], args.onPageLoad);
@@ -1639,7 +1639,7 @@ var Breadcrumbs = {
                                     $osf.trackClick('myProjects', 'add-component', 'open-add-component-modal');
                                 }}, [m('i.fa.fa-plus.m-r-xs', {style: 'font-size: 10px;'}), 'Create component']),
                                 parentID: linkObject.data.id,
-                                parentTitle: linkObject.data.name,
+                                parentTitle: $osf.decodeText(linkObject.data.name),
                                 modalID: 'addSubComponent',
                                 title: 'Create new component',
                                 categoryList: args.categoryList,
@@ -1670,7 +1670,7 @@ var Breadcrumbs = {
                         }
                         return [
                             m('li', [
-                                m('span.btn', item.label),
+                                m('span.btn', $osf.decodeText(item.label)),
                                 contributorsTemplate,
                                 tagsTemplate,
                                 m('i.fa.fa-angle-right')
@@ -1682,7 +1682,7 @@ var Breadcrumbs = {
                 item.index = index; // Add index to update breadcrumbs
                 item.placement = 'breadcrumb'; // differentiate location for proper breadcrumb actions
                 return m('li',[
-                    m('span.btn.btn-link', {onclick : updateFilesOnClick.bind(null, item)},  item.label),
+                    m('span.btn.btn-link', {onclick : updateFilesOnClick.bind(null, item)},  $osf.decodeText(item.label)),
                     index === 0 && arr.length === 1 ? [contributorsTemplate, tagsTemplate] : '',
                     m('i.fa.fa-angle-right'),
                     ]
@@ -1828,7 +1828,7 @@ var Information = {
                 } }, 'Remove from collection')) : '',
                     m('h3', m('a', { href : item.links.html, onclick: function(){
                         $osf.trackClick('myProjects', 'information-panel', 'navigate-to-project');
-                    }}, item.attributes.title)),
+                    }}, $osf.decodeText(item.attributes.title))),
                 m('[role="tabpanel"]', [
                     m('ul.nav.nav-tabs.m-b-md[role="tablist"]', [
                         m('li[role="presentation"].active', m('a[href="#tab-information"][aria-controls="information"][role="tab"][data-toggle="tab"]', {onclick: function(){
@@ -1879,7 +1879,7 @@ var Information = {
                     return m('.db-info-multi', [
                         m('h4', m('a', { href : item.data.links.html, onclick: function(){
                             $osf.trackClick('myProjects', 'information-panel', 'navigate-to-project-multiple-selected');
-                        }}, item.data.attributes.title)),
+                        }}, $osf.decodeText(item.data.attributes.title))),
                         m('p.db-info-meta.text-muted', [
                             m('span', item.data.attributes.public ? 'Public' : 'Private' + ' ' + item.data.attributes.category),
                             m('span', ', Last Modified on ' + item.data.date.local)

--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -362,6 +362,12 @@ var mapByProperty = function(list, attr) {
 };
 
 
+/** 
+ * Replaces encoded & with decoded values
+ */
+var decodeText = function(text){
+    return text.replace(/&amp;/g, '&');
+};
 
 /**
   * Return whether or not a value is an email address.
@@ -1068,5 +1074,6 @@ module.exports = window.$.osf = {
     getDomain: getDomain,
     toRelativeUrl: toRelativeUrl,
     linkifyText: linkifyText,
-    getConfirmationString: getConfirmationString
+    getConfirmationString: getConfirmationString,
+    decodeText: decodeText,
 };

--- a/website/static/js/project-organizer.js
+++ b/website/static/js/project-organizer.js
@@ -35,22 +35,23 @@ function _poTitleColumn(item) {
         e.stopImmediatePropagation();
     };
     var node = item.data; // Where actual data of the node is
+    var title = $osf.decodeText(node.attributes.title);
     var css = ''; // Keep for future expandability -- Remove: item.data.isSmartFolder ? 'project-smart-folder smart-folder' : '';
     var isMypreprintsCollection = tb.options.currentView().collection.data.nodeType === 'preprints';
     if (item.data.archiving) { // TODO check if this variable will be available
-        return  m('span', {'class': 'registration-archiving'}, node.attributes.title + ' [Archiving]');
+        return m('span', {'class': 'registration-archiving'}, title + ' [Archiving]');
     } else if (node.attributes.preprint && isMypreprintsCollection){
-        return [ m('a.fg-file-links', { 'class' : css, href : node.embeds.preprints.data[0].links.html, 'data-nodeID' : node.id, 'data-nodeTitle': node.attributes.title,'data-nodeType': node.type, onclick : function(event) {
+        return [ m('a.fg-file-links', { 'class' : css, href : preprintLinkPre + node.id, 'data-nodeID' : node.id, 'data-nodeTitle': title,'data-nodeType': node.type, onclick : function(event) {
             preventSelect.call(this, event);
             $osf.trackClick('myProjects', 'projectOrganizer', 'navigate-to-preprint');
-        }}, node.attributes.title) ];
+        }}, title) ];
     } else if(node.links.html){
-        return [ m('a.fg-file-links', { 'class' : css, href : node.links.html, 'data-nodeID' : node.id, 'data-nodeTitle': node.attributes.title, 'data-nodeType': node.type, onclick : function(event) {
+        return [ m('a.fg-file-links', { 'class' : css, href : node.links.html, 'data-nodeID' : node.id, 'data-nodeTitle': title, 'data-nodeType': node.type, onclick : function(event) {
             preventSelect.call(this, event);
             $osf.trackClick('myProjects', 'projectOrganizer', 'navigate-to-specific-project');
-        }}, node.attributes.title) ];
+        }}, title) ];
     } else {
-        return  m('span', { 'class' : css, 'data-nodeID' : node.id, 'data-nodeTitle': node.attributes.title, 'data-nodeType': node.type}, node.attributes.title);
+        return m('span', { 'class' : css, 'data-nodeID' : node.id, 'data-nodeTitle': title, 'data-nodeType': node.type}, title);
     }
 }
 

--- a/website/static/js/project-organizer.js
+++ b/website/static/js/project-organizer.js
@@ -41,7 +41,7 @@ function _poTitleColumn(item) {
     if (item.data.archiving) { // TODO check if this variable will be available
         return m('span', {'class': 'registration-archiving'}, title + ' [Archiving]');
     } else if (node.attributes.preprint && isMypreprintsCollection){
-        return [ m('a.fg-file-links', { 'class' : css, href : preprintLinkPre + node.id, 'data-nodeID' : node.id, 'data-nodeTitle': title,'data-nodeType': node.type, onclick : function(event) {
+        return [ m('a.fg-file-links', { 'class' : css, href : node.embeds.preprints.data[0].links.html, 'data-nodeID' : node.id, 'data-nodeTitle': title,'data-nodeType': node.type, onclick : function(event) {
             preventSelect.call(this, event);
             $osf.trackClick('myProjects', 'projectOrganizer', 'navigate-to-preprint');
         }}, title) ];

--- a/website/static/js/tests/osfHelpers.test.js
+++ b/website/static/js/tests/osfHelpers.test.js
@@ -178,6 +178,14 @@ describe('osfHelpers', () => {
         });
     });
 
+    describe('decodeText', () => {
+        it('returns properly decoded text', () => {
+            var text = '&amp;';
+            var ret = $osf.decodeText(text);
+            assert.equal(ret, '&');
+        });
+    });
+
     describe('isEmail', () => {
         it('returns true for valid emails', () => {
             var emails = [


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
& become &amp; on the Dashboard and Project Organizer.
The ideal solution to this would handle amps better on the backend. This is a cosmetic front end hack/fix to make amps show up properly. Where possible I caught the titles early, but a lot of the time.

This also now handles < and >

<!-- Describe the purpose of your changes -->

## Changes
Replace &amp; with & on PO and Dashboard

## Side effects

This is a hack, so manually making the name contain &amp; will convert it to & in these displays.

## Ticket
[#OSF-6853]
https://openscience.atlassian.net/browse/OSF-6853

## QA Considerations
Test a project name that contains &
On the Dashboard project widget:
1. Make sure titles in the dashboard handle amps
2. Make sure each level of parent-grandparent handles amps (picture)
![screen shot 2016-11-01 at 10 26 54 am](https://cloud.githubusercontent.com/assets/1322421/19892963/bca238b8-a01d-11e6-9f8a-4caae4ab3263.png)
3. Make sure searching matches amp properly (e.g., title = cat&dog, quick search cat&d matches; cat&amp;dog will still match as well iirc)
4. Make sure projects loaded by pressing the 'more' down arrow handle amps

Project Organizer:
1. Make sure titles handle amps
2. Make sure child nodes handle amps
3. Make sure the side bar (information/activity area) handles amps (NOTE: Node logs in Activity do not handle amps)
4. Make sure newly created collections handle amps
5. Make sure collections handle amps on refresh (e.g., previously created ones, not new ones)
6. Make sure renaming collections properly populates the amp
7. Make sure renamed collections handle the amp
8. Check that dragging a project into a collection, the text being dragged handles the amps
9. Check that filtering filters on & not &amp;
10. Make sure breadcrumbs (both parent and child) handle amps

I think that is all of the places this changed.
