### PR TITLE
Update permissions checks to look in osf instead of admin [OSF-7563]

### DIFF
--- a/admin/common_auth/views.py
+++ b/admin/common_auth/views.py
@@ -98,7 +98,7 @@ class DeskUserCreateFormView(PermissionRequiredMixin, CreateView):
     form_class = DeskUserForm
     template_name = 'desk/settings.html'
     success_url = reverse_lazy('auth:desk')
-    permissions_required = 'admin.view_desk'
+    permission_required = 'osf.view_desk'
     raise_exception = True
 
     def form_valid(self, form):
@@ -110,7 +110,7 @@ class DeskUserUpdateFormView(PermissionRequiredMixin, UpdateView):
     form_class = DeskUserForm
     template_name = 'desk/settings.html'
     success_url = reverse_lazy('auth:desk')
-    permissions_required = 'admin.view_desk'
+    permission_required = 'osf.view_desk'
     raise_exception = True
 
     def get_object(self, queryset=None):

--- a/admin/desk/views.py
+++ b/admin/desk/views.py
@@ -13,7 +13,7 @@ class DeskCaseList(PermissionRequiredMixin, ListView):
     context_object_name = 'cases'
     paginate_by = 100
     paginate_orphans = 5
-    permission_required = 'common_auth.view_desk'
+    permission_required = 'osf.view_desk'
     raise_exception = True
 
     def dispatch(self, request, *args, **kwargs):
@@ -50,7 +50,7 @@ class DeskCaseList(PermissionRequiredMixin, ListView):
 class DeskCustomer(PermissionRequiredMixin, DetailView):
     template_name = 'desk/customer.html'
     context_object_name = 'customer'
-    permission_required = 'common_auth.view_desk'
+    permission_required = 'osf.view_desk'
     raise_exception = True
 
     def dispatch(self, request, *args, **kwargs):

--- a/admin/nodes/views.py
+++ b/admin/nodes/views.py
@@ -228,7 +228,7 @@ class NodeSpamList(PermissionRequiredMixin, ListView):
     paginate_orphans = 1
     ordering = 'date_created'
     context_object_name = '-node'
-    permission_required = 'common_auth.view_spam'
+    permission_required = 'osf.view_spam'
     raise_exception = True
 
     def get_queryset(self):
@@ -281,7 +281,7 @@ class NodeKnownHamList(NodeSpamList):
 
 class NodeConfirmSpamView(PermissionRequiredMixin, NodeDeleteBase):
     template_name = 'nodes/confirm_spam.html'
-    permission_required = 'common_auth.mark_spam'
+    permission_required = 'osf.mark_spam'
     raise_exception = True
 
     def delete(self, request, *args, **kwargs):
@@ -298,7 +298,7 @@ class NodeConfirmSpamView(PermissionRequiredMixin, NodeDeleteBase):
 
 class NodeConfirmHamView(PermissionRequiredMixin, NodeDeleteBase):
     template_name = 'nodes/confirm_ham.html'
-    permission_required = 'common_auth.mark_spam'
+    permission_required = 'osf.mark_spam'
     raise_exception = True
 
     def delete(self, request, *args, **kwargs):

--- a/admin/pre_reg/views.py
+++ b/admin/pre_reg/views.py
@@ -33,7 +33,7 @@ class DraftListView(PermissionRequiredMixin, ListView):
     template_name = 'pre_reg/draft_list.html'
     ordering = '-date'
     context_object_name = 'draft'
-    permission_required = 'common_auth.view_prereg'
+    permission_required = 'osf.view_prereg'
     raise_exception = True
 
     def get_queryset(self):
@@ -106,7 +106,7 @@ class DraftDownloadListView(DraftListView):
 class DraftDetailView(PermissionRequiredMixin, DetailView):
     template_name = 'pre_reg/draft_detail.html'
     context_object_name = 'draft'
-    permission_required = 'common_auth.view_prereg'
+    permission_required = 'osf.view_prereg'
     raise_exception = True
 
     def get_object(self, queryset=None):
@@ -131,7 +131,7 @@ class DraftFormView(PermissionRequiredMixin, FormView):
     template_name = 'pre_reg/draft_form.html'
     form_class = DraftRegistrationForm
     context_object_name = 'draft'
-    permission_required = 'common_auth.view_prereg'
+    permission_required = 'osf.view_prereg'
     raise_exception = True
 
     def dispatch(self, request, *args, **kwargs):
@@ -198,7 +198,7 @@ class DraftFormView(PermissionRequiredMixin, FormView):
 
 class CommentUpdateView(PermissionRequiredMixin, UpdateView):
     context_object_name = 'draft'
-    permission_required = ('common_auth.view_prereg', 'common_auth.administer_prereg')
+    permission_required = ('osf.view_prereg', 'osf.administer_prereg')
     raise_exception = True
 
     def post(self, request, *args, **kwargs):

--- a/admin/spam/views.py
+++ b/admin/spam/views.py
@@ -21,7 +21,7 @@ from admin.spam.templatetags.spam_extras import reverse_spam_detail
 class EmailView(PermissionRequiredMixin, DetailView):
     template_name = 'spam/email.html'
     context_object_name = 'spam'
-    permission_required = 'common_auth.view_spam'
+    permission_required = 'osf.view_spam'
 
     def get_object(self, queryset=None):
         spam_id = self.kwargs.get('spam_id')
@@ -41,7 +41,7 @@ class SpamList(PermissionRequiredMixin, ListView):
     paginate_orphans = 1
     ordering = '-date_last_reported'
     context_object_name = 'spam'
-    permission_required = 'common_auth.view_spam'
+    permission_required = 'osf.view_spam'
     raise_exception = True
 
     def get_queryset(self):
@@ -89,7 +89,7 @@ class SpamDetail(PermissionRequiredMixin, FormView):
     """
     form_class = ConfirmForm
     template_name = 'spam/detail.html'
-    permission_required = 'common_auth.view_spam'
+    permission_required = 'osf.view_spam'
     raise_exception = True
 
     def get_context_data(self, **kwargs):

--- a/admin/templates/base.html
+++ b/admin/templates/base.html
@@ -117,15 +117,15 @@
               </ul>
             </li>
               {% endif %}
-          {% if perms.common_auth.view_spam %}
+          {% if perms.osf.view_spam %}
             <li><a href="{% url 'spam:spam' %}"><i class='fa fa-link'></i> <span>OSF Spam</span></a></li>
             <li><a href="{% url 'nodes:registrations' %}"><i class='fa fa-link'></i> <span>OSF Registrations</span></a></li>
             <li><a href="{% url 'meetings:list' %}"><i class='fa fa-link'></i> <span>OSF Meetings</span></a></li>
           {% endif %}
-          {% if perms.common_auth.view_prereg %}
+          {% if perms.osf.view_prereg %}
             <li><a href="{% url 'pre_reg:prereg' %}"><i class='fa fa-link'></i> <span>OSF Prereg</span></a></li>
             {% endif %}
-          {% if perms.common_auth.view_metrics %}
+          {% if perms.osf.view_metrics %}
             <li><a href="{% url 'metrics:metrics' %}"><i class='fa fa-link'></i> <span>OSF Metrics</span></a></li>
           {% endif %}
           </ul><!-- /.sidebar-menu -->

--- a/admin/templates/nodes/node.html
+++ b/admin/templates/nodes/node.html
@@ -44,7 +44,7 @@
                     {% endif %}
                 {% endif %}
                 {% endif %}
-            {% if perms.common_auth.mark_spam %}
+            {% if perms.osf.mark_spam %}
             <span class="col-md-2">
                 <a href="{% url 'nodes:confirm-spam' guid=node.id %}"
                    data-toggle="modal" data-target="#confirmSpamModal"

--- a/admin/templates/nodes/node_list.html
+++ b/admin/templates/nodes/node_list.html
@@ -92,7 +92,7 @@
         {% endfor %}
     </tbody>
 </table>
-{% if form_action and perms.common_auth.mark_spam %}
+{% if form_action and perms.osf.mark_spam %}
 <button class="btn btn-warning" type="button" data-toggle="modal" data-target="#confirmSpamListModal">
     Confirm Spam
 </button>

--- a/admin/templates/pre_reg/draft_detail.html
+++ b/admin/templates/pre_reg/draft_detail.html
@@ -99,7 +99,7 @@
         <a data-bind="click: nextPage" class="btn btn-primary">Next Page</a>
     </div>
 </div>
-    {% if perms.common_auth.administer_prereg %}
+    {% if perms.osf.administer_prereg %}
         {% include "pre_reg/comment_editor.html" %}
     {% endif %}
 {% endblock %}

--- a/admin/templates/pre_reg/draft_list.html
+++ b/admin/templates/pre_reg/draft_list.html
@@ -9,7 +9,7 @@
 
 {% block content %}
     <h2>List of Preregistration Drafts</h2>
-    {% if perms.common_auth.view_prereg %}
+    {% if perms.osf.view_prereg %}
     <div>
         {# Add types here #}
         <a href="{% url 'pre_reg:download' %}" class="btn btn-primary">
@@ -89,7 +89,7 @@
             {{ draft.submitted | date:"N dS Y g:i a"}}
         </td>
         <td>
-            {% if perms.common_auth.administer_prereg %}
+            {% if perms.osf.administer_prereg %}
             <a href="{% url 'pre_reg:update_draft' draft.pk %}"
                class="btn btn-success" data-toggle="modal"
                data-target="#form{{ draft.pk }}">

--- a/admin/templates/spam/detail.html
+++ b/admin/templates/spam/detail.html
@@ -16,7 +16,7 @@
                class="btn btn-primary">
                 Back to user's list
             </a>
-            {%  if perms.common_auth.mark_spam %}
+            {%  if perms.osf.mark_spam %}
             <a href="{% url 'spam:email' comment.id %}"
                data-toggle="modal" data-target="#email"
                class="btn btn-default">
@@ -33,7 +33,7 @@
 
         <br>
 
-        {%  if perms.common_auth.mark_spam %}
+        {%  if perms.osf.mark_spam %}
         <div class="row">
         <div class="panel col-md-6">
         <form action="{% reverse_spam_detail comment.id page=page_number status=status %}"

--- a/admin/templates/users/user.html
+++ b/admin/templates/users/user.html
@@ -13,7 +13,7 @@
                 <i class="fa fa-search"></i>
             </a>
             </span>
-            {%  if perms.common_auth.view_spam %}
+            {%  if perms.osf.view_spam %}
             <span class="col-md-2">
             <a href="{% url 'spam:user_spam' user.id %}"
                class="btn btn-primary">
@@ -21,7 +21,7 @@
             </a>
             </span>
             {% endif %}
-            {%  if perms.common_auth.view_desk %}
+            {%  if perms.osf.view_desk %}
             <div class="btn-group" role="group">
                 <a href="{% url 'desk:customer' user.id %}"
                    data-toggle="modal" data-target="#deskModal"

--- a/admin/templates/users/user_list.html
+++ b/admin/templates/users/user_list.html
@@ -56,7 +56,7 @@
         {% endfor %}
     </tbody>
 </table>
-{% if form_action and perms.common_auth.mark_spam %}
+{% if form_action and perms.osf.mark_spam %}
 <button class="btn btn-warning" type="button" data-toggle="modal" data-target="#confirmSpamListModal">
     Confirm Spam
 </button>

--- a/admin/users/views.py
+++ b/admin/users/views.py
@@ -175,7 +175,7 @@ class UserSpamList(PermissionRequiredMixin, ListView):
     paginate_orphans = 1
     ordering = ('date_disabled')
     context_object_name = '-user'
-    permission_required = ('common_auth.view_spam', 'osf.view_user')
+    permission_required = ('osf.view_spam', 'osf.view_user')
     raise_exception = True
 
     def get_queryset(self):
@@ -197,7 +197,7 @@ class UserFlaggedSpamList(UserSpamList, DeleteView):
     template_name = 'users/flagged_spam_list.html'
 
     def delete(self, request, *args, **kwargs):
-        if not request.user.get_perms('admin.mark_spam'):
+        if not request.user.get_perms('osf.mark_spam'):
             raise PermissionDenied("You don't have permission to update this user's spam status.")
         user_ids = [
             uid for uid in request.POST.keys()


### PR DESCRIPTION


<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

The `AdminProfile` model was moved from the admin app to the OSF app, so
the permissions checks throughout the admin app needed to be adjusted to
account for the move. Basically replace 'common_auth' with 'osf' and
'admin' with 'osf' in some cases.

## Changes

- update permissions checks throughout to look for permissions under `osf` instead of `common_auth` or `admin`

## Side effects

None anticipated


## Ticket
https://openscience.atlassian.net/browse/OSF-7563