### PR TITLE
API log list optimizations and .root fix

### DIFF
--- a/api/logs/serializers.py
+++ b/api/logs/serializers.py
@@ -99,15 +99,15 @@ class NodeLogParamsSerializer(RestrictedDictSerializer):
     def get_params_node(self, obj):
         node_id = obj.get('node', None)
         if node_id:
-            node = Node.load(node_id)
-            return {'id': node_id, 'title': node.title}
+            node = Node.objects.filter(guids___id=node_id).values('title').get()
+            return {'id': node_id, 'title': node['title']}
         return None
 
     def get_params_project(self, obj):
         project_id = obj.get('project', None)
         if project_id:
-            node = Node.load(project_id)
-            return {'id': project_id, 'title': node.title}
+            node = Node.objects.filter(guids___id=project_id).values('title').get()
+            return {'id': project_id, 'title': node['title']}
         return None
 
     def get_contributors(self, obj):

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -2601,7 +2601,7 @@ class NodeLogList(JSONAPIBaseView, generics.ListAPIView, NodeMixin, ODMFilterMix
         return query
 
     def get_queryset(self):
-        queryset = NodeLog.find(self.get_query_from_request())
+        queryset = NodeLog.find(self.get_query_from_request()).select_related('node', 'original_node', 'user')
         return queryset
 
 

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -505,7 +505,7 @@ class UserNodes(JSONAPIBaseView, generics.ListAPIView, UserMixin, NodePreprintsF
 
     # overrides ListAPIView
     def get_queryset(self):
-        return Node.find(self.get_query_from_request())
+        return Node.find(self.get_query_from_request()).select_related('root')
 
 
 class UserPreprints(UserNodes):

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -1762,6 +1762,8 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
                         parent=forked,
                         child=forked_node
                     )
+                    forked_node.root = None
+                    forked_node.save()  # Recompute root on save()
             else:
                 # Copy linked nodes
                 NodeRelation.objects.get_or_create(

--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -148,15 +148,20 @@ def test_get_children():
     greatgrandchild1 = NodeFactory(parent=grandchild1)
     greatgrandchild2 = NodeFactory(parent=grandchild2)
     greatgrandchild3 = NodeFactory(parent=grandchild3)
-    greatgrandchild_1 = NodeFactory(parent=grandchild_1)
+    greatgrandchild_1 = NodeFactory(parent=grandchild_1, is_deleted=True)
 
-    assert 20 == len(Node.objects.get_children(root))
+    assert 20 == Node.objects.get_children(root).count()
+    pks = Node.objects.get_children(root, primary_keys=True)
+    assert 20 == len(pks)
+    assert set(pks) == set(Node.objects.exclude(id=root.id).values_list('id', flat=True))
+
+    assert greatgrandchild_1 in Node.objects.get_children(root).all()
+    assert greatgrandchild_1 not in Node.objects.get_children(root, active=True).all()
 
 def test_get_children_with_barren_parent():
     root = ProjectFactory()
 
     assert 0 == len(Node.objects.get_children(root))
-
 
 def test_get_children_with_links():
     root = ProjectFactory()


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Make APIv2 logs/ endpoints faster.

## Changes

* Fixes bug where forked nodes' `root` would be incorrect
* Simplify and optimize `AbstractNodeQuerySet.get_children` by using the the `descendants` related name rather than a recursive query
* Use `.values` in NodeLogParamsSerializer to avoid instantiation and select overhead
* Use `select_related` to eagerly select NodeLogSerializer's relationship fields

## Side effects

<!--Any possible side effects? -->

~2 second speedup for the `/v2/nodes/<nid>/logs/` endpoint

Before

![node_log_list_ _django_rest_framework](https://cloud.githubusercontent.com/assets/2379650/23559260/5e60ab26-0004-11e7-872e-931e47559ec1.png)

After

![node_log_list_ _django_rest_framework](https://cloud.githubusercontent.com/assets/2379650/23559243/53b0ba68-0004-11e7-91e6-d9040a264206.png)



## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
