### PR TITLE
Update engrXiv Steering Committee list [OSF-7376]

### DIFF
--- a/scripts/populate_preprint_providers.py
+++ b/scripts/populate_preprint_providers.py
@@ -109,7 +109,7 @@ def main(env):
                         <li><a href="http://directory.uark.edu/people/dcjensen">David Jensen</a>, mechanical engineer, University of Arkansas</li>
                         <li><a href="http://biomech.media.mit.edu/people/">Kevin Moerman</a>, biomechanical engineer, Massachusetts Institute of Technology</li>
                         <li><a href="http://kyleniemeyer.com/">Kyle Niemeyer</a>, mechanical engineer, Oregon State University</li>
-                        <li><a href="http://www.douglasvanbossuyt.com/">Douglas Van Bossuyt</a>, mechanical engineer, Colorado School of Mines</li>
+                        <li><a href="http://www.douglasvanbossuyt.com/">Douglas Van Bossuyt</a>, mechanical engineer, KTM Research</li>
                     </ul>
                 </div>
             ''',


### PR DESCRIPTION
## Purpose

engrXiv needs a quick update to their Steering Committee section
Update the affiliation for Douglas Van Bossuyt from “Colorado School of Mines” to “KTM Research”

## Changes
Update populate_preprint_providers.py script file with the new affiliation.

## Side effects

## Ticket

Ticket Link: 
https://openscience.atlassian.net/browse/OSF-7376 
https://openscience.atlassian.net/browse/EOSF-464
