### PR TITLE
Feature/use linked nodes

### DIFF
--- a/api/collections/views.py
+++ b/api/collections/views.py
@@ -512,7 +512,7 @@ class NodeLinksList(JSONAPIBaseView, bulk_views.BulkDestroyJSONAPIView, bulk_vie
     model_class = NodeRelation
 
     def get_queryset(self):
-        return self.get_node().node_relations.filter(child__is_deleted=False).exclude(child__type='osf.collection')
+        return self.get_node().node_relations.select_related('child').filter(child__is_deleted=False).exclude(child__type='osf.collection')
 
     # Overrides BulkDestroyJSONAPIView
     def perform_destroy(self, instance):

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -3084,9 +3084,8 @@ class LinkedNodesList(BaseLinkedList, NodeMixin):
     view_name = 'linked-nodes'
 
     def get_queryset(self):
-        return [node for node in
-            super(LinkedNodesList, self).get_queryset()
-            if not node.is_registration]
+        queryset = super(LinkedNodesList, self).get_queryset()
+        return queryset.exclude(type='osf.registration')
 
     # overrides APIView
     def get_parser_context(self, http_request):

--- a/website/static/js/home-page/newAndNoteworthyPlugin.js
+++ b/website/static/js/home-page/newAndNoteworthyPlugin.js
@@ -40,16 +40,16 @@ var NewAndNoteworthy = {
         };
 
         // Load new and noteworthy nodes
-        var newAndNoteworthyUrl = $osf.apiV2Url('nodes/' + window.contextVars.newAndNoteworthy + '/node_links/', {});
+        var newAndNoteworthyUrl = $osf.apiV2Url('nodes/' + window.contextVars.newAndNoteworthy + '/linked_nodes/', {});
         var newAndNoteworthyPromise = m.request({method: 'GET', url: newAndNoteworthyUrl, config: xhrconfig, background: true});
         newAndNoteworthyPromise.then(function(result){
             var numNew = result.data.length;
             for (var l = 0; l < numNew; l++) {
                 var data = result.data[l];
-                if (lodashGet(data, 'embeds.target_node.data', null)) {
-                    if (data.embeds.target_node.data.attributes.public === true) {
-                        self.newAndNoteworthyNodes().push(result.data[l]);
-                        self.fetchContributors(result.data[l]);
+                if (data) {
+                    if (data.attributes.public === true) {
+                        self.newAndNoteworthyNodes().push(data);
+                        self.fetchContributors(data);
                     }
                 }
                 if (self.newAndNoteworthyNodes().length === self.SHOW_TOTAL){
@@ -63,16 +63,16 @@ var NewAndNoteworthy = {
         });
 
         // Load popular nodes
-        var popularUrl = $osf.apiV2Url('nodes/' + window.contextVars.popular + '/node_links/', {});
+        var popularUrl = $osf.apiV2Url('nodes/' + window.contextVars.popular + '/linked_nodes/', {});
         var popularPromise = m.request({method: 'GET', url: popularUrl, config: xhrconfig, background: true});
         popularPromise.then(function(result){
             var numPopular = result.data.length;
             for (var l = 0; l < numPopular; l++) {
                 var data = result.data[l];
-                if (lodashGet(data, 'embeds.target_node.data', null)) {
-                    if (data.embeds.target_node.data.attributes.public === true) {
-                        self.popularNodes().push(result.data[l]);
-                        self.fetchContributors(result.data[l]);
+                if (data) {
+                    if (data.attributes.public === true) {
+                        self.popularNodes().push(data);
+                        self.fetchContributors(data);
                     }
                 }
                 if (self.popularNodes().length === self.SHOW_TOTAL){
@@ -87,7 +87,7 @@ var NewAndNoteworthy = {
 
         // Additional API call to fetch node link contributors
         self.fetchContributors = function(nodeLink) {
-            var url = lodashGet(nodeLink, 'embeds.target_node.data.relationships.contributors.links.related.href', null);
+            var url = lodashGet(nodeLink, 'relationships.contributors.links.related.href', null);
             var promise = m.request({method: 'GET', url : url, config: xhrconfig});
             promise.then(function(result){
                 var contribNames = [];
@@ -160,7 +160,7 @@ var NewAndNoteworthy = {
             return m('',[
                 m('.row',[
                     m('.col-xs-12.col-md-6', m('.public-projects-box.', m('h4.m-b-md','New and Noteworthy'), newAndNoteworthyProjectsTemplate())),
-                    m('.col-xs-12.col-md-6', m('.public-projects-box.', m('h4.m-b-md','Most Popular'), popularProjectsTemplate ()))
+                    m('.col-xs-12.col-md-6', m('.public-projects-box.', m('h4.m-b-md','Most Popular'), popularProjectsTemplate()))
                 ]),
                 m('.row', m('.text-center.col-sm-12', findMoreProjectsButton()))
         ]);
@@ -182,12 +182,12 @@ var NoteworthyNodeDisplay = {
         };
     },
     view: function(ctrl, args) {
-        var description = args.node.embeds.target_node.data.attributes.description;
+        var description = args.node.attributes.description;
         var tooltipDescription = description ? description.split(' ').splice(0,30).join(' ') + '...' : '';
-        var title = args.node.embeds.target_node.data.attributes.title;
+        var title = args.node.attributes.title;
         var numContrib = args.contributorsMapping[args.node.id] ? args.contributorsMapping[args.node.id].total : 0;
         var contributors = $osf.contribNameFormat(args.node, numContrib, args.getFamilyName);
-        var destination = '/' + args.node.embeds.target_node.data.id;
+        var destination = '/' + args.node.id;
 
         return m('a', {href: destination, onclick: function() {
             $osf.trackClick('discoverPublicProjects', 'navigate', 'navigate-to-specific-project');


### PR DESCRIPTION

## Purpose

Remove usage of the deprecated `/node_links/` endpoint and use faster `/linked_nodes/` for the "Popular" and "New and Noteworthy" widgets.

## Changes

- The "Popular projects" and "New and Noteworthy" widgets request from `/api/v2/<nid>/linked_nodes/
- The /node_links/ endpoint filters out registrations in the db and returns a queryset, rather than a list

## Side effects

<!--Any possible side effects? -->


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
