### PR TITLE
[WIP] Iterate api GUID route behavior to support ember apps

### DIFF
--- a/api/guids/views.py
+++ b/api/guids/views.py
@@ -1,11 +1,13 @@
 import furl
 from django import http
+from django.core.urlresolvers import resolve
 from rest_framework.exceptions import NotFound
 from rest_framework import permissions as drf_permissions
 from rest_framework import generics
 
 from framework.guid.model import Guid
 from framework.auth.oauth_scopes import CoreScopes
+
 from api.base.exceptions import EndpointNotImplementedError
 from api.base import permissions as base_permissions
 from api.base.views import JSONAPIBaseView
@@ -39,9 +41,27 @@ class GuidDetail(JSONAPIBaseView, generics.RetrieveAPIView):
 
     @staticmethod
     def should_resolve(request):
+        """
+        If the ?resolve query param is present, this view will return a simple payload containing a relationship link
+        to the final endpoint, instead of redirecting to the final destination API URL for that resource type.
+        """
         query_params = getattr(request, 'query_params', request.GET)
-        resolve = query_params.get('resolve')
-        return resolve is None or is_truthy(resolve)
+        flag = query_params.get('resolve')
+        return flag is None or is_truthy(resolve)
+
+    @staticmethod
+    def should_resolve_payload(request):
+        """
+        If the ?payload query param is present (at all, with any value), this view will return the full payload
+            expected for that resource type
+
+        In order to use this endpoint, a user must have appropriate permissions (access to the resource, and, if using
+        OAuth, a token with the appropriate scopes)
+        """
+        query_params = getattr(request, 'query_params', request.GET)
+        # Just check that any value is present. If the query param is present w/o value, this will be an empty string.
+        flag = query_params.get('payload', None)
+        return flag is not None
 
     def get_serializer_class(self):
         if not self.should_resolve(self.request):
@@ -57,10 +77,20 @@ class GuidDetail(JSONAPIBaseView, generics.RetrieveAPIView):
         )
 
     def get(self, request, **kwargs):
+        # Three behaviors (old /?resolve may be deprecated/legacy behavior)
+        if self.should_resolve_payload(request):
+            # URL ?payload: return the payload of the final response for this single resource
+            url = self.get_redirect_url(absolute=False, **kwargs)
+            dest = resolve(url)
+            view = dest.func
+            return view(request._request, *dest.args, **dest.kwargs)
+
         if not self.should_resolve(self.request):
+            # URL ?resolve: return a simple payload linking to the authoritative url
             return super(GuidDetail, self).get(request, **kwargs)
 
-        url = self.get_redirect_url(**kwargs)
+        # Else return a 301 that redirects the client to the final authoritative URL
+        url = self.get_redirect_url(absolute=True, **kwargs)
         if url:
             query_params = getattr(request, 'query_params', request.GET)
             if query_params:
@@ -68,12 +98,14 @@ class GuidDetail(JSONAPIBaseView, generics.RetrieveAPIView):
             return http.HttpResponseRedirect(url)
         raise NotFound
 
-    def get_redirect_url(self, **kwargs):
+    def get_redirect_url(self, absolute=True, **kwargs):
         guid = Guid.load(kwargs['guids'])
+        url_property = 'absolute_api_v2_url' if absolute else 'deep_api_v2_url'
         if guid:
             referent = guid.referent
-            if getattr(referent, 'absolute_api_v2_url', None):
-                return referent.absolute_api_v2_url
+            url = getattr(referent, url_property, None)
+            if url:
+                return url
             else:
-                raise EndpointNotImplementedError()
+                raise EndpointNotImplementedError
         return None

--- a/framework/auth/core.py
+++ b/framework/auth/core.py
@@ -1155,6 +1155,10 @@ class User(GuidStoredObject, AddonModelMixin):
         return '/profile/{}/'.format(self._primary_key)
 
     @property
+    def deep_api_v2_url(self):
+        return '/v2/users/{}/'.format(self._primary_key)
+
+    @property
     def unconfirmed_email_info(self):
         """Return a list of dictionaries containing information about each of this
         user's unconfirmed emails.

--- a/framework/guid/model.py
+++ b/framework/guid/model.py
@@ -61,6 +61,12 @@ class GuidStoredObject(StoredObject):
 
     @property
     def deep_url(self):
+        """The canonical web page URL for the GUID resource"""
+        return None
+
+    @property
+    def deep_api_v2_url(self):
+        """The canonical APIv2 URL for the GUID resource"""
         return None
 
     def _ensure_guid(self):

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -374,6 +374,11 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
         return api_v2_url(path)
 
     @property
+    def deep_api_v2_url(self):
+        # TODO: Make more generic for different types and consolidate with absolute url generation
+        return '/v2/nodes/{}/'.format(self._id)
+
+    @property
     def absolute_url(self):
         if not self.url:
             return None

--- a/osf/models/preprint_service.py
+++ b/osf/models/preprint_service.py
@@ -74,6 +74,10 @@ class PreprintService(GuidMixin, BaseModel):
         return '/preprints/{}/'.format(self._primary_key)
 
     @property
+    def deep_api_v2_url(self):
+        return '/v2/preprints/{}/'.format(self._primary_key)
+
+    @property
     def url(self):
         return '/{}/'.format(self._id)
 

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -374,6 +374,11 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
         return '/profile/{}/'.format(self._primary_key)
 
     @property
+    def deep_api_v2_url(self):
+        # TODO: Make more generic for different types and consolidate with absolute url generation
+        return '/v2/users/{}/'.format(self._id)
+
+    @property
     def url(self):
         return '/{}/'.format(self._id)
 

--- a/website/preprints/model.py
+++ b/website/preprints/model.py
@@ -62,6 +62,10 @@ class PreprintService(GuidStoredObject):
         return '/preprints/{}/'.format(self._primary_key)
 
     @property
+    def deep_api_v2_url(self):
+        return '/v2/preprints/{}/'.format(self._primary_key)
+
+    @property
     def url(self):
         if self.provider._id != 'osf':
             # Note that this will change with Phase 2 of branded preprints.

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2671,6 +2671,11 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable, Spam
         return '/project/{}/'.format(self._primary_key)
 
     @property
+    def deep_api_v2_url(self):
+        # TODO: Make more generic for different types and consolidate with absolute url generation
+        return '/v2/nodes/{}/'.format(self._id)
+
+    @property
     def linked_nodes_self_url(self):
         return self.absolute_api_v2_url + 'relationships/linked_nodes/'
 


### PR DESCRIPTION
## Companion to
https://openscience.atlassian.net/browse/EOSF-522
https://github.com/CenterForOpenScience/ember-osf/pull/186

## Purpose
The ember-osf front end will need a way to get information about a resource based on a GUID. We should not need to make multiple API request roundtrips just to decide what template to render. This PR modifies the APIv2 GUID endpoint to *directly return a payload describing the resulting resource*.

Previously, it either returned a 301 redirect or else a custom payload that just linked to the final destination. Both of those behaviors require an additional request-response roundtrip cycle, slowing the user experience + increasing time to first (and every) pageload.

Ember data is smart enough to load the right model based on API payload, regardless of endpoint. See [proof of concept](https://github.com/CenterForOpenScience/ember-osf/pull/186) intended to work with this PR.

## Changes

Add a new `deep_api_v2_url` method to all GUID-type models.

### TODO
- [ ] Refactor to DRY logic and handle more node types.
- [ ] Add lots of tests
- [ ] Verify that the new behavior respects auth (and oauth!) settings as specified when proxying the original request
- [ ] Add guid handling on files models, and other guid resources per requirements.

### Models affected
This endpoint will be able to proxy to payloads for the following resource types:
- Users
- Nodes
- Files

(others TBD based on requirements)

## Side effects
Will need to be verified thoroughly to ensure it respects both cookie and OAuth permissions rules when proxying to the new route.

(user should only be allowed to see the payload for a resource they would be allowed to see for an equivalent resource made directly to the same endpoint)

Goal is to preserve existing GUID route behavior. The new one would only occur if the user passed a specific type of URL (with query param `/v2/guids/<guid>?payload`).

## Ticket
https://openscience.atlassian.net/browse/OSF-7539
