### PR TITLE
Fix number of subject children if not allowed by preprint provider [OSF-7615]

### DIFF
--- a/api/preprint_providers/views.py
+++ b/api/preprint_providers/views.py
@@ -206,6 +206,19 @@ class PreprintProviderSubjectList(JSONAPIBaseView, generics.ListAPIView):
 
     serializer_class = TaxonomySerializer
 
+    def preprare_subjects(self, provider):
+        final_subjects = set()
+        for i in provider.all_subjects:
+            final_subjects.add(i._id)
+        return final_subjects
+
+    def check_child_count(self, sub, final_form):
+        num_children = 0
+        for child in sub.children.all():
+            if  child._id in final_form:
+                num_children += 1
+        setattr(sub, 'child_count_provider', num_children)
+
     def is_valid_subject(self, allows_children, allowed_parents, sub):
         if sub._id in allowed_parents:
             return True
@@ -226,8 +239,12 @@ class PreprintProviderSubjectList(JSONAPIBaseView, generics.ListAPIView):
             #  Calculate this here to only have to do it once.
             allowed_parents = [id_ for sublist in provider.subjects_acceptable for id_ in sublist[0]]
             allows_children = [subs[0][-1] for subs in provider.subjects_acceptable if subs[1]]
-            return [sub for sub in Subject.find(Q('parents___id', 'eq', parent)) if provider.subjects_acceptable == [] or self.is_valid_subject(allows_children=allows_children, allowed_parents=allowed_parents, sub=sub)]
+            subjects = [sub for sub in Subject.find(Q('parents___id', 'eq', parent)) if provider.subjects_acceptable == [] or self.is_valid_subject(allows_children=allows_children, allowed_parents=allowed_parents, sub=sub)]
+            final_form = self.preprare_subjects(provider=provider)
+            [self.check_child_count(sub=sub, final_form=final_form) for sub in subjects]
+            return subjects
         return provider.all_subjects
+
 
 
 class PreprintProviderLicenseList(LicenseList):

--- a/api/taxonomies/serializers.py
+++ b/api/taxonomies/serializers.py
@@ -24,7 +24,13 @@ class TaxonomySerializer(JSONAPISerializer):
     id = ser.CharField(source='_id', required=True)
     text = ser.CharField(max_length=200)
     parents = JSONAPIListField(child=TaxonomyField())
-    child_count = ser.IntegerField()
+    child_count = ser.SerializerMethodField('get_child_num')
+
+    def get_child_num(self, obj):
+        if hasattr(obj, 'child_count_provider'):
+            return getattr(obj,'child_count_provider')
+        else:
+            return len(obj.children.all())
 
     links = LinksField({
         'parents': 'get_parent_urls',


### PR DESCRIPTION
## Purpose
Subjects might have children that the provider does not allow. There is an API response for any single subject listing its children. There is a need to fix the API side so that the serializer show the real children count based on the current provider.

## Changes

- Update preprint_provider view. 
   - Count number of children for each subject, if only allowed by the current preprint provider.
   - Store the count into a subject attribute **'child_count_provider'**.
- Update serializer.
   - Use a new method that checks if the subject has the **'child_count_provider'** and returns its value. Otherwise, returns all the children.

## Side effects
The response time for the API has been recorded. The extra step needed for searching and counting the children added an extra time to the API response (approx. 3-4x times slower at worst case scenario). This effect is noted with large lists (e.g. Arts and Humanities subject under SocArXiv)

## Ticket

https://openscience.atlassian.net/browse/OSF-7615 
