### PR TITLE
[hotfix] populate fangorn renaming folder fix [OSF-7151]

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1952,7 +1952,7 @@ var FGToolbar = {
 
         if (ctrl.tb.toolbarMode() === toolbarModes.DEFAULT) {
             ctrl.nameData('');
-            ctrl.renameId('')
+            ctrl.renameId('');
         }
         if(typeof item !== 'undefined' && item.id !== ctrl.renameId()){
             ctrl.renameData(item.data.name);

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -1701,13 +1701,15 @@ var FGInput = {
         var placeholder = args.placeholder || '';
         var id = args.id || '';
         var helpTextId = args.helpTextId || '';
+        var oninput = args.oninput || noop;
         var onkeypress = args.onkeypress || noop;
-        var value = args.value ? '[value="' + args.value + '"]' : '';
         return m('span', [
-            m('input' + value, {
+            m('input', {
                 'id' : id,
                 className: 'pull-right form-control' + extraCSS,
+                oninput: oninput,
                 onkeypress: onkeypress,
+                'value': args.value || '',
                 'data-toggle': tooltipText ? 'tooltip' : '',
                 'title': tooltipText,
                 'data-placement' : 'bottom',
@@ -1922,6 +1924,9 @@ var FGToolbar = {
         self.createFolder = function(event){
             _createFolder.call(self.tb, event, self.dismissToolbar, self.helpText);
         };
+        self.nameData = m.prop('');
+        self.renameId = m.prop('');
+        self.renameData = m.prop('');
     },
     view : function(ctrl) {
         var templates = {};
@@ -1944,16 +1949,28 @@ var FGToolbar = {
         $('.tb-row').click(function(){
             ctrl.helpText('');
         });
+
+        if (ctrl.tb.toolbarMode() === toolbarModes.DEFAULT) {
+            ctrl.nameData('');
+            ctrl.renameId('')
+        }
+        if(typeof item !== 'undefined' && item.id !== ctrl.renameId()){
+            ctrl.renameData(item.data.name);
+            ctrl.renameId(item.id);
+        }
+
         if (ctrl.tb.options.placement !== 'fileview') {
             templates[toolbarModes.ADDFOLDER] = [
                 m('.col-xs-9', [
                     m.component(FGInput, {
+                        oninput: m.withAttr('value', ctrl.nameData),
                         onkeypress: function (event) {
                             if (ctrl.tb.pressedKey === ENTER_KEY) {
                                 ctrl.createFolder.call(ctrl.tb, event, ctrl.dismissToolbar);
                             }
                         },
                         id: 'createFolderInput',
+                        value: ctrl.nameData(),
                         helpTextId: 'createFolderHelp',
                         placeholder: 'New folder name',
                     }, ctrl.helpText())
@@ -1974,12 +1991,14 @@ var FGToolbar = {
             templates[toolbarModes.RENAME] = [
                 m('.col-xs-9',
                     m.component(FGInput, {
+                        oninput: m.withAttr('value', ctrl.renameData),
                         onkeypress: function (event) {
                             if (ctrl.tb.pressedKey === ENTER_KEY) {
                                 _renameEvent.call(ctrl.tb);
                             }
                         },
                         id: 'renameInput',
+                        value: ctrl.renameData(),
                         helpTextId: 'renameHelpText',
                         placeholder: 'Enter name',
                     }, ctrl.helpText())


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Fangorn doesn't auto populate rename text due to an earlier bug. 
<!-- Describe the purpose of your changes -->

## Changes
This fixes that and how folder creation naming works, since the previous version broke that.
<!-- Briefly describe or list your changes  -->

## Side effects
None known
<!--Any possible side effects? -->

## Ticket
[#OSF-7151]
https://openscience.atlassian.net/browse/OSF-7151
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->

## QA Notes
Check that all fangorn inputs work properly (filter, rename, folder create)
Check that renaming works
Check that there were no regressions (] and " ' all work, etc)
Also check for regressions of the last letter disappearing bug on mouse out