### PR TITLE
ensure pagination includes default pk order by [#OSF-7607]

### DIFF
--- a/api/base/pagination.py
+++ b/api/base/pagination.py
@@ -2,6 +2,7 @@ from django.utils import six
 from collections import OrderedDict
 from django.core.urlresolvers import reverse
 from django.core.paginator import InvalidPage, Paginator as DjangoPaginator
+from django.db.models import QuerySet
 
 from rest_framework import pagination
 from rest_framework.exceptions import NotFound
@@ -136,7 +137,7 @@ class JSONAPIPagination(pagination.PageNumberPagination):
         if request.parser_context['kwargs'].get('is_embedded'):
             # Pagination requires an order by clause, especially when using Postgres.
             # see: https://docs.djangoproject.com/en/1.10/topics/pagination/#required-arguments
-            if not queryset.ordered:
+            if isinstance(queryset, QuerySet) and not queryset.ordered:
                 queryset = queryset.order_by(queryset.model._meta.pk.name)
 
             paginator = DjangoPaginator(queryset, self.page_size)
@@ -268,7 +269,7 @@ class SearchPagination(JSONAPIPagination):
 
         # Pagination requires an order by clause, especially when using Postgres.
         # see: https://docs.djangoproject.com/en/1.10/topics/pagination/#required-arguments
-        if not queryset.ordered:
+        if isinstance(queryset, QuerySet) and not queryset.ordered:
             queryset = queryset.order_by(queryset.model._meta.pk.name)
 
         self.paginator = SearchPaginator(queryset, page_size)

--- a/api/base/pagination.py
+++ b/api/base/pagination.py
@@ -134,6 +134,11 @@ class JSONAPIPagination(pagination.PageNumberPagination):
         If this is an embedded resource, returns first page, ignoring query params.
         """
         if request.parser_context['kwargs'].get('is_embedded'):
+            # Pagination requires an order by clause, especially when using Postgres.
+            # see: https://docs.djangoproject.com/en/1.10/topics/pagination/#required-arguments
+            if not queryset.ordered:
+                queryset = queryset.order_by(queryset.model._meta.pk.name)
+
             paginator = DjangoPaginator(queryset, self.page_size)
             page_number = 1
             try:
@@ -260,6 +265,11 @@ class SearchPagination(JSONAPIPagination):
         page_size = self.get_page_size(request)
         if not page_size:
             return None
+
+        # Pagination requires an order by clause, especially when using Postgres.
+        # see: https://docs.djangoproject.com/en/1.10/topics/pagination/#required-arguments
+        if not queryset.ordered:
+            queryset = queryset.order_by(queryset.model._meta.pk.name)
 
         self.paginator = SearchPaginator(queryset, page_size)
         model = getattr(request.parser_context['view'], 'model_class', None)

--- a/framework/mongo/utils.py
+++ b/framework/mongo/utils.py
@@ -3,6 +3,7 @@ import functools
 import httplib as http
 
 from django.core.paginator import Paginator
+from django.db.models import QuerySet
 
 import markupsafe
 import pymongo
@@ -153,7 +154,7 @@ def paginated(model, query=None, increment=200, each=True):
 
     # Pagination requires an order by clause, especially when using Postgres.
     # see: https://docs.djangoproject.com/en/1.10/topics/pagination/#required-arguments
-    if not queryset.ordered:
+    if isinstance(queryset, QuerySet) and not queryset.ordered:
         queryset = queryset.order_by(queryset.model._meta.pk.name)
 
     paginator = Paginator(queryset.all(), increment)

--- a/framework/mongo/utils.py
+++ b/framework/mongo/utils.py
@@ -150,8 +150,12 @@ def paginated(model, query=None, increment=200, each=True):
         are yielded.
     """
     queryset = model.find(query)
+
+    # Pagination requires an order by clause, especially when using Postgres.
+    # see: https://docs.djangoproject.com/en/1.10/topics/pagination/#required-arguments
     if not queryset.ordered:
-        queryset = queryset.order_by('id')
+        queryset = queryset.order_by(queryset.model._meta.pk.name)
+
     paginator = Paginator(queryset.all(), increment)
     for page_num in paginator.page_range:
         page = paginator.page(page_num)


### PR DESCRIPTION
Default Django Pagination usages to `ORDER BY 'id'` if when an `order_by` has not been specified.

Avoids the case where paginated rows are returned more than once during a paginated request.

[Postgres does not order rows](https://www.postgresql.org/docs/9.1/static/queries-order.html)

#### 7.5. Sorting Rows
> After a query has produced an output table (after the select list has been processed) it can optionally be sorted. **If sorting is not chosen, the rows will be returned in an unspecified order.** The actual order in that case will depend on the scan and join plan types and the order on disk, but it must not be relied on. A particular output ordering can only be guaranteed if the sort step is explicitly chosen.

#### Django Pagination Recommends Order By

https://docs.djangoproject.com/en/1.10/topics/pagination/#required-arguments

>A list, tuple, QuerySet, or other sliceable object with a count() or __len__() method. For consistent pagination, **QuerySets should be ordered, e.g. with an order_by() clause or with a default ordering on the model.**

fixes #6966 
