### PR TITLE
[#OSF-7232]Adding affiliations from components does not affiliate nested components (grandchildren)

### DIFF
--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -152,7 +152,7 @@ var mergePagesAjaxJSON = function(pages) {
 
 /**
  * Takes an array of response objects and returns just the children from the parent
- * @param {Array of Objects}, requires that api v2 call contained ``embed=parent``
+ * @param {Array of Objects}`
  * @return {Object data}
  */
 var getAllNodeChildrenFromNodeList = function(parent, nodeList) {
@@ -179,7 +179,7 @@ var getAllNodeChildrenFromNodeList = function(parent, nodeList) {
         var node = remaining.pop();
         for (var c in tree[node]){
             var child = tree[node][c];
-            remaining.push(tree[child]);
+            remaining.push([child]);
             children[child] = nodeList[child];    
         }
     }

--- a/website/static/js/tests/osfHelpers.test.js
+++ b/website/static/js/tests/osfHelpers.test.js
@@ -12,7 +12,85 @@ var $osf = require('../osfHelpers');
 sinon.assert.expose(assert, {prefix: ''});
 
 describe('osfHelpers', () => {
+    describe('getAllNodeChildrenFromNodeList', () => {
+         var getItem = function(parent, id){
+             if (parent) {
+                 return {
+                     'relationships': {
+                         'parent': {
+                             'links': {
+                                 'related': {
+                                     'href': '/v2/nodes/' + parent + '/',
+                                 }
+                             }
+                         }
+                     },
+                     'id': id,
+                 };
+             }
+             else {
+                 return {
+                     'relationships': {},
+                     'id': id,
+                 };
+             }
+         };
+         var nodeList = {};
+         var a0 = getItem(null, 'a0');
+         var a1 = getItem('a0', 'a1');
+         var a2 = getItem('a1', 'a2');
+         var a3 = getItem('a2', 'a3');
+         var b = getItem('a0', 'b');
+         nodeList.a0 = a0;
+         nodeList.a1 = a1;
+         nodeList.a2 = a2;
+         nodeList.a3 = a3;
+         nodeList.b = b;
 
+         it('returns no children when there are no children', () => {
+             var a3List = $osf.getAllNodeChildrenFromNodeList('a3', nodeList);
+             assert.equal(a3List.a0, undefined);
+             assert.equal(a3List.a1, undefined);
+             assert.equal(a3List.a2, undefined);
+             assert.equal(a3List.a3, undefined);
+             assert.equal(a3List.b, undefined);
+             var bList = $osf.getAllNodeChildrenFromNodeList('b', nodeList);
+             assert.equal(bList.a0, undefined);
+             assert.equal(bList.a1, undefined);
+             assert.equal(bList.a2, undefined);
+             assert.equal(bList.a3, undefined);
+             assert.equal(bList.b, undefined);
+         });
+
+         it('returns one child when there is only one child', () => {
+             var a2List = $osf.getAllNodeChildrenFromNodeList('a2', nodeList);
+             assert.equal(a2List.a0, undefined);
+             assert.equal(a2List.a1, undefined);
+             assert.equal(a2List.a2, undefined);
+             assert.equal(a2List.a3.id, 'a3');
+             assert.equal(a2List.b, undefined);
+         });
+
+         it('returns two children when child has a child', () => {
+             var a1List = $osf.getAllNodeChildrenFromNodeList('a1', nodeList);
+             assert.equal(a1List.a0, undefined);
+             assert.equal(a1List.a1, undefined);
+             assert.equal(a1List.a2.id, 'a2');
+             assert.equal(a1List.a3.id, 'a3');
+             assert.equal(a1List.b, undefined);
+         });
+
+         it('returns all children except the root', () => {
+             var a0List = $osf.getAllNodeChildrenFromNodeList('a0', nodeList);
+             assert.equal(a0List.a0, undefined);
+             assert.equal(a0List.a1.id, 'a1');
+             assert.equal(a0List.a2.id, 'a2');
+             assert.equal(a0List.a3.id, 'a3');
+             assert.equal(a0List.b.id, 'b');
+         });
+     });
+
+    
     describe('growl', () => {
         it('calls $.growl with correct arguments', () => {
             var stub = new sinon.stub($, 'growl');


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Fix the problem that adding affiliations from components does not affiliate nested components (grandchildren)
<!-- Describe the purpose of your changes -->

## QA notes:
What to test:

Create a project (1) and add a component (2)
Within the component, create a nested component (3)
Within 3, create another nested component (4), and then another within 4 (5), and another within 5 (6)
Go to Component 2 and go to Settings
Click to Add Affiliation and in the modal that appears, select to add the affiliation to 2 and every component within it
After affiliation has been added, check the components and nested components
Before change:
Only a few of components child nodes has the correct affiliation information. Usually it will be component 2, 3, 5 has but 4,6 doesn't
After change:
All child nodes of component 2 should have the correct affiliation information no matter it is add or remove affiliation.
<!-- Briefly describe or list your changes  -->

## Side effects

<!--Any possible side effects? -->


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
https://openscience.atlassian.net/browse/OSF-7232