### PR TITLE
[OSF-7614] Fix collapse problem by check if item is already open

### DIFF
--- a/website/static/js/project-organizer.js
+++ b/website/static/js/project-organizer.js
@@ -345,7 +345,7 @@ var tbOptions = {
     },
     resolveToggle : _poResolveToggle,
     resolveLazyloadUrl : function(item) {
-    if (item.data.relationships.children.links.related.meta.count === item.children.length)
+    if (item.open || item.data.relationships.children.links.related.meta.count === item.children.length)
         return null;
       var tb = this;
       var deferred = $.Deferred();


### PR DESCRIPTION
## Purpose

Fixes collapse bug on my projects page with a project that has components. Seems to only surface in Django, possibly due to a race condition/promise resolution and latency.

## Changes

Checks if item is open already and returns early instead of firing a network request

## Side effects

N/A

## Ticket

https://openscience.atlassian.net/browse/OSF-7614
