### PR TITLE
[SVCS-259] Files with conflicting hash maps return oldest modified date

### DIFF
--- a/osf/models/files.py
+++ b/osf/models/files.py
@@ -896,8 +896,8 @@ class FileVersion(ObjectIDMixin, BaseModel):
         self.size = self.metadata.get('size', self.size)
         self.content_type = self.metadata.get('contentType', self.content_type)
         if self.metadata.get('modified'):
-            self.metadata['modified'] = str(timezone.now())
-            self.date_modified = parse_date(str(timezone.now()), ignoretz=False)
+            self.metadata['modified'] = timezone.now().isoformat()
+            self.date_modified = parse_date(timezone.now().isoformat(), ignoretz=False)
 
         if save:
             self.save()

--- a/osf/models/files.py
+++ b/osf/models/files.py
@@ -896,7 +896,8 @@ class FileVersion(ObjectIDMixin, BaseModel):
         self.size = self.metadata.get('size', self.size)
         self.content_type = self.metadata.get('contentType', self.content_type)
         if self.metadata.get('modified'):
-            self.date_modified = parse_date(self.metadata['modified'], ignoretz=False)
+            self.metadata['modified'] = str(timezone.now())
+            self.date_modified = parse_date(str(timezone.now()), ignoretz=False)
 
         if save:
             self.save()


### PR DESCRIPTION
## Purpose

Files with the same hashes all have the same dates. They have the date of the first that was uploaded.

## Changes

This problem was apparently caused by the fact that files with the same hash inherit a lot of the metadata for there twin, much of the metadata is over-written with new metadata, but date modified is left out.

## Side Effects
This requires another PR in waterbutler to be fully effective. 
https://github.com/CenterForOpenScience/waterbutler/pull/200

## Ticket
https://openscience.atlassian.net/browse/SVCS-259