### PR TITLE
 Prevent "HTTP took to long to complete" when running 'docker-compose logs'

### DIFF
--- a/README-docker-compose.md
+++ b/README-docker-compose.md
@@ -214,25 +214,38 @@ Ubuntu: Skip install of docker-sync, fswatch, and unison. instead...
     - `docker-compose run --rm web python manage.py reset_db --noinput`
 
 ## Application Debugging
-- Console Debugging with IPDB
-  - `$ docker attach [projectname]_web_1`
 
-    _NOTE: You can detach from a container and leave it running using the CTRL-p CTRL-q key sequence._
+### Console Debugging with IPDB
 
-  - `$ docker-compose up web`
+If you use the following to add a breakpoint
 
-    _NOTE: Lacks detachment key sequence, see: https://github.com/docker/compose/issues/3311_
+```python
+import ipdb; ipdb.set_trace()
+```
 
-- Remote Debugging with PyCharm
-  - Add a Python Remote Debugger per container
-    - Name: `Remote Debug (web)`
-    - Local host name: `192.168.168.167`
-    - Port: `11000`
-    - Path mappings: (It is recommended to use absolute path. `~/` may not work.)
-      - `/Users/<your username>/Projects/cos/osf : /code`
-      - (Optional) `/Users/<your username>/.virtualenvs/osf/lib/python2.7/site-packages : /usr/local/lib/python2.7/site-packages`
-    - `Single Instance only`
-  - Configure `.docker-compose.env` `<APP>_REMOTE_DEBUG` environment variables to match these settings.
+You should run the `web` and/or `api` container (depending on which codebase the breakpoint is in) using:
+
+```
+# Kill the already-running web container
+docker-compose kill web
+
+# Run a web container. App logs and breakpoints will show up here.
+docker-compose run --service-ports web
+```
+
+**IMPORTANT: While attached to the running app, CTRL-c will stop the container.** To detach from the container and leave it running, **use CTRL-p CTRL-q**. Use `docker attach` to re-attach to the container, passing the *container-name* (which you can get from `docker-compose ps`), e.g. `docker attach osf_web_run_1`.
+
+### Remote Debugging with PyCharm
+
+- Add a Python Remote Debugger per container
+  - Name: `Remote Debug (web)`
+  - Local host name: `192.168.168.167`
+  - Port: `11000`
+  - Path mappings: (It is recommended to use absolute path. `~/` may not work.)
+    - `/Users/<your username>/Projects/cos/osf : /code`
+    - (Optional) `/Users/<your username>/.virtualenvs/osf/lib/python2.7/site-packages : /usr/local/lib/python2.7/site-packages`
+  - `Single Instance only`
+- Configure `.docker-compose.env` `<APP>_REMOTE_DEBUG` environment variables to match these settings.
 
 ## Application Tests
 - Run All Tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,6 @@ services:
     volumes:
       - elasticsearch_data_vol:/usr/share/elasticsearch/data
     stdin_open: true
-    tty: true
 
   postgres:
     image: postgres:9.6
@@ -66,7 +65,6 @@ services:
     volumes:
       - postgres_data_vol:/var/lib/postgresql/data/
     stdin_open: true
-    tty: true
 
   tokumx:
     image: quay.io/centerforopenscience/tokumx:latest
@@ -78,7 +76,6 @@ services:
     volumes:
       - tokumx_data_vol:/data/db
     stdin_open: true
-    tty: true
 
   rabbitmq:
     image: rabbitmq:3-management
@@ -88,7 +85,6 @@ services:
     volumes:
       - rabbitmq_vol:/var/lib/rabbitmq
     stdin_open: true
-    tty: true
 
   redis:
     image: redis
@@ -103,7 +99,6 @@ services:
     ports:
       - 6379:6379
     stdin_open: true
-    tty: true
 
 #  flower:
 #    image: quay.io/centerforopenscience/osf:develop
@@ -144,7 +139,6 @@ services:
     volumes:
       - mfr_requirements_vol:/usr/local/lib/python3.5
     stdin_open: true
-    tty: true
 
   ###############
   # WaterButler #
@@ -175,7 +169,6 @@ services:
       - wb_requirements_vol:/usr/local/lib/python3.5
       - wb_osfstoragecache_vol:/code/website/osfstoragecache
     stdin_open: true
-    tty: true
 
   ##################################
   # Central Authentication Service #
@@ -190,7 +183,6 @@ services:
     depends_on:
       - postgres
     stdin_open: true
-    tty: true
 
 
   #############
@@ -210,7 +202,6 @@ services:
     volumes:
       - preprints_dist_vol:/code/dist
     stdin_open: true
-    tty: true
 
   ##############
   # Registries #
@@ -230,7 +221,6 @@ services:
   #   volumes:
   #     - registries_dist_vol:/code/dist
   #   stdin_open: true
-  #   tty: true
 
 
   #######
@@ -263,7 +253,6 @@ services:
       - osf_bower_components_vol:/code/website/static/vendor/bower_components
       - osf_node_modules_vol:/code/node_modules
     stdin_open: true
-    tty: true
 
   admin_assets:
     image: quay.io/centerforopenscience/osf:develop
@@ -278,7 +267,6 @@ services:
       - osf_admin_bower_components_vol:/code/admin/static/vendor/bower_components
       - osf_admin_node_modules_vol:/code/admin/node_modules
     stdin_open: true
-    tty: true
 
   sharejs:
     image: quay.io/centerforopenscience/osf:develop
@@ -294,7 +282,6 @@ services:
       - osf_requirements_vol:/usr/local/lib/python2.7
       - osf_node_modules_vol:/code/node_modules
     stdin_open: true
-    tty: true
 
 #  beat:
 #    image: quay.io/centerforopenscience/osf:develop
@@ -331,7 +318,6 @@ services:
       - osf_bower_components_vol:/code/website/static/vendor/bower_components
       - osf_node_modules_vol:/code/node_modules
     stdin_open: true
-    tty: true
 
   admin:
     image: quay.io/centerforopenscience/osf:develop
@@ -350,7 +336,6 @@ services:
     env_file:
       - .docker-compose.env
     stdin_open: true
-    tty: true
     volumes:
       - osf_requirements_vol:/usr/local/lib/python2.7
       - osf_bower_components_vol:/code/website/static/vendor/bower_components
@@ -379,7 +364,6 @@ services:
       - osf_bower_components_vol:/code/website/static/vendor/bower_components
       - osf_node_modules_vol:/code/node_modules
     stdin_open: true
-    tty: true
 
   web:
     image: quay.io/centerforopenscience/osf:develop
@@ -404,4 +388,3 @@ services:
       - preprints_dist_vol:/preprints
       # - registries_dist_vol:/registries
     stdin_open: true
-    tty: true


### PR DESCRIPTION


## Purpose

The `docker-compose logs` command crashes locally after 60 seconds with the following error:

```
HTTP request took too long to complete
```

This prevents this from happening by removing `tty: true` from docker-compose.yml. (see https://github.com/docker/compose/issues/3106).

## Changes

- Remove `tty: true`
- Update docs re: ipdb breakpoints

## Side effects

This changes how devs will access ipdb breakpoints. They will need to run apps using `docker-compose run --service-ports web` ([source](https://github.com/pydanny/cookiecutter-django/blob/master/docs/developing-locally-docker.rst#debugging)). See the updated docs for details.
