### PR TITLE
Update user.date_last_login every 8 hours [OSF-7660]

### DIFF
--- a/api/institutions/authentication.py
+++ b/api/institutions/authentication.py
@@ -3,7 +3,6 @@ import json
 import jwe
 import jwt
 
-from django.utils import timezone
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.authentication import BaseAuthentication
 
@@ -58,8 +57,7 @@ class InstitutionAuthentication(BaseAuthentication):
             user.middle_names = provider['user'].get('middleNames') or user.middle_names
             user.family_name = provider['user'].get('familyName') or user.family_name
             user.suffix = provider['user'].get('suffix') or user.suffix
-            user.date_last_login = timezone.now()
-            user.save()
+            user.update_date_last_login(save=True)
 
             # User must be saved in order to have a valid _id
             user.register(username)

--- a/framework/auth/__init__.py
+++ b/framework/auth/__init__.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 import uuid
 
-from django.utils import timezone
-
 from framework import bcrypt
 from framework.auth import signals
 from framework.auth.core import User, Auth
@@ -44,7 +42,7 @@ def authenticate(user, access_token, response):
         'auth_user_fullname': user.fullname,
         'auth_user_access_token': access_token,
     })
-    user.date_last_login = timezone.now()
+    user.update_date_last_login()
     user.clean_email_verifications()
     user.update_affiliated_institutions_by_email_domain()
     user.save()

--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -581,8 +581,7 @@ def confirm_email_get(token, auth=None, **kwargs):
         })
 
     if is_initial_confirmation:
-        user.date_last_login = timezone.now()
-        user.save()
+        user.update_date_last_login(save=True)
 
         # send out our welcome message
         mails.send_mail(

--- a/framework/sessions/__init__.py
+++ b/framework/sessions/__init__.py
@@ -3,7 +3,6 @@ import httplib as http
 import urllib
 import urlparse
 
-from django.utils import timezone
 from django.apps import apps
 import bson.objectid
 import itsdangerous
@@ -160,7 +159,7 @@ def before_request():
         if not util_time.throttle_period_expired(user_session.date_created, settings.OSF_SESSION_TIMEOUT):
             if user_session.data.get('auth_user_id') and 'api' not in request.url:
                 OSFUser = apps.get_model('osf.OSFUser')
-                OSFUser.objects.filter(guids___id=user_session.data['auth_user_id']).invalidated_update(date_last_login=timezone.now())
+                OSFUser.objects.get(guids___id=user_session.data['auth_user_id']).update_date_last_login(save=True)
             set_session(user_session)
         else:
             remove_session(user_session)

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -1134,6 +1134,13 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
         for node in self.contributed:
             node.update_search()
 
+    def update_date_last_login(self, save=False):
+        if (not self.date_last_login or
+                timezone.now() - self.date_last_login > website_settings.LAST_LOGIN_THRESHOLD):
+            self.date_last_login = timezone.now()
+            if save:
+                self.save()
+
     def get_summary(self, formatter='long'):
         return {
             'user_fullname': self.fullname,

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -48,6 +48,7 @@ from osf.utils.names import impute_names
 from website import settings as website_settings
 from website import filters, mails
 from website.project import new_bookmark_collection
+from website.util.time import throttle_period_expired
 
 logger = logging.getLogger(__name__)
 
@@ -1135,8 +1136,7 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
             node.update_search()
 
     def update_date_last_login(self, save=False):
-        if (not self.date_last_login or
-                timezone.now() - self.date_last_login > website_settings.LAST_LOGIN_THRESHOLD):
+        if not self.date_last_login or throttle_period_expired(self.date_last_login, website_settings.LAST_LOGIN_THRESHOLD):
             self.date_last_login = timezone.now()
             if save:
                 self.save()

--- a/website/conferences/views.py
+++ b/website/conferences/views.py
@@ -4,7 +4,6 @@ import httplib
 import logging
 
 from django.db import transaction
-from django.utils import timezone
 from modularodm import Q
 from modularodm.exceptions import ModularOdmException
 
@@ -84,8 +83,7 @@ def add_poster_by_email(conference, message):
             user.save()  # need to save in order to access m2m fields (e.g. tags)
             users_created.append(user)
             user.add_system_tag('osf4m')
-            user.date_last_login = timezone.now()
-            user.save()
+            user.update_date_last_login(save=True)
             # must save the user first before accessing user._id
             set_password_url = web_url_for(
                 'reset_password_get',

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -43,6 +43,9 @@ CITATION_STYLES_PATH = os.path.join(BASE_PATH, 'static', 'vendor', 'bower_compon
 # Minimum seconds between forgot password email attempts
 SEND_EMAIL_THROTTLE = 30
 
+# Hours before updating user.date_last_login
+LAST_LOGIN_THRESHOLD = timedelta(hours=8)
+
 # Hours before pending embargo/retraction/registration automatically becomes active
 RETRACTION_PENDING_TIME = datetime.timedelta(days=2)
 EMBARGO_PENDING_TIME = datetime.timedelta(days=2)


### PR DESCRIPTION
## Purpose
Update `user.date_last_login` less frequently than every request to invalidate cache less frequently

## Changes
* Fatten model, update after 8 hour threshold

## Side effects
None expected. `NO_LOGIN_WAIT_TIME` and `NO_LOGIN_OSF4M_WAIT_TIME` are compared against `date_last_login`, but are `4` and `6` weeks, respectively.

## Ticket
[[OSF-7660]](https://openscience.atlassian.net/browse/OSF-7660)