### PR TITLE
[OSF-7662] Filter out system tags when accessing Node.tags

### DIFF
--- a/admin/users/views.py
+++ b/admin/users/views.py
@@ -54,10 +54,10 @@ class UserDeleteView(PermissionRequiredMixin, DeleteView):
                 user.is_registered = False
                 if 'spam_flagged' in user.system_tags or 'ham_confirmed' in user.system_tags:
                     if 'spam_flagged' in user.system_tags:
-                        t = Tag.objects.get(name='spam_flagged', system=True)
+                        t = Tag.all_tags.get(name='spam_flagged', system=True)
                         user.tags.remove(t)
                     if 'ham_confirmed' in user.system_tags:
-                        t = Tag.objects.get(name='ham_confirmed', system=True)
+                        t = Tag.all_tags.get(name='ham_confirmed', system=True)
                         user.tags.remove(t)
                     if 'spam_confirmed' not in user.system_tags:
                         user.add_system_tag('spam_confirmed')
@@ -69,10 +69,10 @@ class UserDeleteView(PermissionRequiredMixin, DeleteView):
                 user.is_registered = True
                 if 'spam_flagged' in user.system_tags or 'spam_confirmed' in user.system_tags:
                     if 'spam_flagged' in user.system_tags:
-                        t = Tag.objects.get(name='spam_flagged', system=True)
+                        t = Tag.all_tags.get(name='spam_flagged', system=True)
                         user.tags.remove(t)
                     if 'spam_confirmed' in user.system_tags:
-                        t = Tag.objects.get(name='spam_confirmed', system=True)
+                        t = Tag.all_tags.get(name='spam_confirmed', system=True)
                         user.tags.remove('spam_confirmed')
                     if 'ham_confirmed' not in user.system_tags:
                         user.add_system_tag('ham_confirmed')

--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -940,6 +940,12 @@ class TestNodeTags(ApiTestCase):
         assert_equal(res.status_code, 200)
         assert_equal(len(res.json['data']['attributes']['tags']), 0)
 
+    def test_node_detail_does_not_expose_system_tags(self):
+        self.public_project.add_system_tag('systag', save=True)
+        res = self.app.get(self.public_url)
+        assert_equal(res.status_code, 200)
+        assert_equal(len(res.json['data']['attributes']['tags']), 0)
+
     @assert_logs(NodeLog.TAG_ADDED, 'public_project')
     def test_contributor_can_add_tag_to_public_project(self):
         res = self.app.patch_json_api(self.public_url, self.one_new_tag_json, auth=self.user.auth, expect_errors=True)

--- a/osf/management/commands/migratedata.py
+++ b/osf/management/commands/migratedata.py
@@ -640,7 +640,7 @@ def save_bare_system_tags(page_size=10000):
     Tag.objects.bulk_create(system_tags)
 
     logger.info('MODM System Tags: {}'.format(total))
-    logger.info('django system tags: {}'.format(Tag.objects.filter(system=True).count()))
+    logger.info('django system tags: {}'.format(Tag.all_tags.filter(system=True).count()))
     logger.info('Done with {} in {} seconds...'.format(
         sys._getframe().f_code.co_name,
         (timezone.now() - start).total_seconds()))

--- a/osf/management/commands/migraterelations.py
+++ b/osf/management/commands/migraterelations.py
@@ -75,10 +75,10 @@ def build_toku_django_lookup_table_cache():
     # add the "special" ones
     lookups.update(
         {format_lookup_key(x['name'], ContentType.objects.get_for_model(Tag).pk, template='{}:not_system'): x['pk'] for x in
-         Tag.objects.filter(system=False).values('name', 'pk')})
+         Tag.all_tags.filter(system=False).values('name', 'pk')})
     lookups.update(
         {format_lookup_key(x['name'], ContentType.objects.get_for_model(Tag).pk, template='{}:system'): x['pk'] for x in
-         Tag.objects.filter(system=True).values('name', 'pk')})
+         Tag.all_tags.filter(system=True).values('name', 'pk')})
 
     lookups.update({format_lookup_key(x['_id'], ContentType.objects.get_for_model(CitationStyle).pk): x['pk']
                     for x in CitationStyle.objects.all().values('_id', 'pk')})

--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -97,7 +97,7 @@ class Taggable(models.Model):
             raise ValueError('Must provide auth if adding a non-system tag')
 
         if not isinstance(tag, Tag):
-            tag_instance, created = Tag.objects.get_or_create(name=tag, system=system)
+            tag_instance, created = Tag.all_tags.get_or_create(name=tag, system=system)
         else:
             tag_instance = tag
 

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -917,12 +917,18 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             .values_list('user__guids___id', flat=True)
 
     @property
+    def all_tags(self):
+        """Return a queryset containing all of this node's tags (incl. system tags)."""
+        # Tag's default manager only returns non-system tags, so we can't use self.tags
+        return Tag.all_tags.filter(abstractnode_tagged=self)
+
+    @property
     def system_tags(self):
         """The system tags associated with this node. This currently returns a list of string
         names for the tags, for compatibility with v1. Eventually, we can just return the
         QuerySet.
         """
-        return self.tags.filter(system=True).values_list('name', flat=True)
+        return self.all_tags.filter(system=True).values_list('name', flat=True)
 
     # Override Taggable
     def add_tag_log(self, tag, auth):
@@ -1544,7 +1550,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
 
         registered.registered_schema.add(schema)
         registered.copy_contributors_from(self)
-        registered.tags.add(*self.tags.values_list('pk', flat=True))
+        registered.tags.add(*self.all_tags.values_list('pk', flat=True))
         registered.affiliated_institutions.add(*self.affiliated_institutions.values_list('pk', flat=True))
         registered.alternative_citations.add(*self.alternative_citations.values_list('pk', flat=True))
 
@@ -1796,7 +1802,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
         # Need to save here in order to access m2m fields
         forked.save()
 
-        forked.tags.add(*self.tags.all())
+        forked.tags.add(*self.all_tags.values_list('pk', flat=True))
         for node_relation in original.node_relations.filter(child__is_deleted=False):
             node_contained = node_relation.child
             # Fork child nodes

--- a/osf/models/tag.py
+++ b/osf/models/tag.py
@@ -2,6 +2,14 @@ from django.db import models
 
 from .base import BaseModel
 
+
+class TagManager(models.Manager):
+    """Manager that filters out system tags by default.
+    """
+
+    def get_queryset(self):
+        return super(TagManager, self).get_queryset().filter(system=False)
+
 class Tag(BaseModel):
     # TODO DELETE ME POST MIGRATION
     primary_identifier_name = 'name'
@@ -10,6 +18,9 @@ class Tag(BaseModel):
     # /TODO DELETE ME POST MIGRATION
     name = models.CharField(db_index=True, max_length=1024)
     system = models.BooleanField(default=False)
+
+    objects = TagManager()
+    all_tags = models.Manager()
 
     def __unicode__(self):
         if self.system:
@@ -29,7 +40,7 @@ class Tag(BaseModel):
         so we make Tag.load('tagname') work as if `name` were the primary key.
         """
         try:
-            return cls.objects.get(system=system, name=data)
+            return cls.all_tags.get(system=system, name=data)
         except cls.DoesNotExist:
             return None
 

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -455,12 +455,18 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
             return None
 
     @property
+    def all_tags(self):
+        """Return a queryset containing all of this user's tags (incl. system tags)."""
+        # Tag's default manager only returns non-system tags, so we can't use self.tags
+        return Tag.all_tags.filter(osfuser=self)
+
+    @property
     def system_tags(self):
-        """The system tags associated with this user. This currently returns a list of string
+        """The system tags associated with this node. This currently returns a list of string
         names for the tags, for compatibility with v1. Eventually, we can just return the
         QuerySet.
         """
-        return self.tags.filter(system=True).values_list('name', flat=True)
+        return self.all_tags.filter(system=True).values_list('name', flat=True)
 
     @property
     def csl_given_name(self):
@@ -1221,10 +1227,10 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
 
     def add_system_tag(self, tag):
         if not isinstance(tag, Tag):
-            tag_instance, created = Tag.objects.get_or_create(name=tag.lower(), system=True)
+            tag_instance, created = Tag.all_tags.get_or_create(name=tag.lower(), system=True)
         else:
             tag_instance = tag
-        if not self.tags.filter(id=tag_instance.id).exists():
+        if not self.all_tags.filter(id=tag_instance.id).exists():
             self.tags.add(tag_instance)
         return tag_instance
 

--- a/osf_tests/conftest.py
+++ b/osf_tests/conftest.py
@@ -24,6 +24,8 @@ SILENT_LOGGERS = [
     'website.search.elastic_search',
     'website.search_migration.migrate',
     'website.util.paths',
+    'requests_oauthlib.oauth2_session',
+    'raven.contrib.django.client.DjangoClient',
 ]
 for logger_name in SILENT_LOGGERS:
     logging.getLogger(logger_name).setLevel(logging.CRITICAL)

--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -685,9 +685,9 @@ class TestTagging:
         node.add_system_tag('FoO')
         node.save()
 
-        tag = Tag.objects.get(name='FoO')
-        assert node.tags.count() == 1
-        assert tag in node.tags.all()
+        tag = Tag.all_tags.get(name='FoO', system=True)
+        assert node.all_tags.count() == 1
+        assert tag in node.all_tags.all()
 
         assert tag.system is True
 
@@ -696,11 +696,30 @@ class TestTagging:
         assert original_log_count == new_log_count
 
     def test_system_tags_property(self, node, auth):
+        other_node = ProjectFactory()
+        other_node.add_system_tag('bAr')
+
         node.add_system_tag('FoO')
         node.add_tag('bAr', auth=auth)
 
         assert 'FoO' in node.system_tags
         assert 'bAr' not in node.system_tags
+
+    def test_system_tags_property_on_registration(self):
+        project = ProjectFactory()
+        project.add_system_tag('from-project')
+        registration = RegistrationFactory(project=project)
+
+        registration.add_system_tag('registration-only')
+
+        # Registration gets project's system tags
+        assert 'from-project' in registration.system_tags
+        assert 'registration-only' not in project.system_tags
+        assert 'registration-only' in registration.system_tags
+
+    def test_tags_does_not_return_system_tags(self, node):
+        node.add_system_tag('systag')
+        assert 'systag' not in node.tags.values_list('name', flat=True)
 
 class TestSearch:
 

--- a/osf_tests/test_user.py
+++ b/osf_tests/test_user.py
@@ -944,16 +944,16 @@ class TestTagging:
 
         assert len(user.system_tags) == 1
 
-        tag = Tag.objects.get(name=tag_name, system=True)
-        assert tag in user.tags.all()
+        tag = Tag.all_tags.get(name=tag_name, system=True)
+        assert tag in user.all_tags.all()
 
     def test_tags_get_lowercased(self, user):
         tag_name = 'NeOn'
         user.add_system_tag(tag_name)
         user.save()
 
-        tag = Tag.objects.get(name=tag_name.lower(), system=True)
-        assert tag in user.tags.all()
+        tag = Tag.all_tags.get(name=tag_name.lower(), system=True)
+        assert tag in user.all_tags.all()
 
     def test_system_tags_property(self, user):
         tag_name = fake.word()
@@ -1485,7 +1485,6 @@ class TestUserMerging(OsfTestCase):
                 'other': today,
                 'shared': today,
             },
-            'tags': [Tag.load('user', system=True).id, Tag.load('shared', system=True).id, Tag.load('other', system=True).id],
             'unclaimed_records': {},
         }
 
@@ -1519,6 +1518,9 @@ class TestUserMerging(OsfTestCase):
                 assert list(getattr(self.user, k).all().values_list('id', flat=True)) == v, '{} doesn\'t match expectations'.format(k)
             else:
                 assert getattr(self.user, k) == v, '{} doesn\'t match expectation'.format(k)
+
+
+        assert sorted(self.user.system_tags) == ['other', 'shared', 'user']
 
         # check fields set on merged user
         assert other_user.merged_by == self.user


### PR DESCRIPTION
## Purpose

System tags were being exposed through the v2 node detail endpoint.

## Changes

- Override the default Manager for Tag, so that `node.tags` filters out system tags
- Add the `all_tags` manager for Tag. Usage: `Tag.all_tags.filter(osfuser=user, system=False)`
- Add the `all_tags` property to OSFUser and AbstractNode. 

## Side effects

When filtering tags, you must call `all_tags` if you want to include system tags, e.g. `node.all_tags.filter(name=name, system=True)`.

## Ticket

https://openscience.atlassian.net/browse/OSF-7662

## Other notes

In an attempt to address [OSF-7606](https://openscience.atlassian.net/browse/OSF-7606), I tried a couple optimizations on this branch, but neither of them improved performance or reduced the number of queries.

1. Making `tags` a SerializerMethodField in NodeSerializer

```python
# Before
    tags = JSONAPIListField(child=NodeTagField(), required=False)

# After
    tags = ser.SerializerMethodField()
    def get_tags(self, node):
        return node.tags.values_list('name', flat=True)
```

This did not reduce the number of queries or the load time.

2. Eager-loading _contributors in the UserNodes endpoint

```python
# Before
    def get_queryset(self):
        return Node.find(self.get_query_from_request()).select_related('root')


# After
    def get_queryset(self):
        return Node.find(self.get_query_from_request()).select_related('root').eager('_contributors')
```

This actually increased the number of queries and increased load time.
