### PR TITLE
[feature] Update Language on Registrations Tab [OSF-7577]

### DIFF
--- a/website/templates/project/registrations.mako
+++ b/website/templates/project/registrations.mako
@@ -26,12 +26,14 @@
     ##          There have been no registrations of the parent project (<a href="${parent_node['url']}">${parent_node['title']}</a>).
     ##      %endif
         % else:
-        <p>
-          There have been no completed registrations of this project. For a list of the most viewed and most recent public registrations on the Open Science Framework, click <a href="/explore/activity/#newPublicRegistrations">here</a>.
           % if 'admin' in user['permissions']:
-          You can start a new registration by clicking the “New registration” button, and you have the option of saving as a draft registration before submission.
+            <p>There have been no completed registrations of this project.
+            You can start a new registration by clicking the “New registration” button, and you have the option of saving as a draft registration before submission.</p>
+          % else:
+            <p>There have been no completed registrations of this project.
+            Only project administrators can initiate registrations.</p>
           % endif
-        </p>
+          <p>For a list of the most viewed and most recent public registrations on the Open Science Framework, click <a href="/explore/activity/#newPublicRegistrations">here</a>.</p>
         % endif
         %if parent_node['exists'] and user['is_admin_parent']:
         <br />


### PR DESCRIPTION
#### Purpose
- Updates the language displayed on the registrations tab when there are no registrations. 
- Adds language to make it clear that non-admins don't have permission to create a registration.

#### Side effects
- None expected.

#### Ticket
- [OSF-7577](https://openscience.atlassian.net/browse/OSF-7577)

#### Screenshots 
- Before (same view for admins and non-admins)
![screen shot 2017-03-03 at 10 55 35 am](https://cloud.githubusercontent.com/assets/7913604/24112164/05dd09ae-0d6f-11e7-900c-f3797957247d.png)


- After (admin view)
![screen shot 2017-03-20 at 1 04 19 pm](https://cloud.githubusercontent.com/assets/7913604/24112173/0b8fe2c2-0d6f-11e7-9d9c-645206f11b83.png)


- After (non-admin view)
![screen shot 2017-03-20 at 1 04 00 pm](https://cloud.githubusercontent.com/assets/7913604/24112168/08dd5550-0d6f-11e7-8068-190387745e9b.png)

