### PR TITLE
Add throttle for date_last_login

### DIFF
--- a/api/institutions/authentication.py
+++ b/api/institutions/authentication.py
@@ -3,7 +3,6 @@ import json
 import jwe
 import jwt
 
-from django.utils import timezone
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.authentication import BaseAuthentication
 
@@ -58,8 +57,7 @@ class InstitutionAuthentication(BaseAuthentication):
             user.middle_names = provider['user'].get('middleNames') or user.middle_names
             user.family_name = provider['user'].get('familyName') or user.family_name
             user.suffix = provider['user'].get('suffix') or user.suffix
-            user.date_last_login = timezone.now()
-            user.save()
+            user.update_date_last_login(save=True)
 
             # User must be saved in order to have a valid _id
             user.register(username)

--- a/framework/auth/__init__.py
+++ b/framework/auth/__init__.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 import uuid
 
-from django.utils import timezone
-
 from framework import bcrypt
 from framework.auth import signals
 from framework.auth.core import User, Auth
@@ -44,7 +42,7 @@ def authenticate(user, access_token, response):
         'auth_user_fullname': user.fullname,
         'auth_user_access_token': access_token,
     })
-    user.date_last_login = timezone.now()
+    user.update_date_last_login()
     user.clean_email_verifications()
     user.update_affiliated_institutions_by_email_domain()
     user.save()

--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -581,8 +581,7 @@ def confirm_email_get(token, auth=None, **kwargs):
         })
 
     if is_initial_confirmation:
-        user.date_last_login = timezone.now()
-        user.save()
+        user.update_date_last_login(save=True)
 
         # send out our welcome message
         mails.send_mail(

--- a/framework/sessions/__init__.py
+++ b/framework/sessions/__init__.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
+import datetime as dt
 import httplib as http
 import urllib
 import urlparse
 
 from django.utils import timezone
+from django.db.models import Q
 from django.apps import apps
 import bson.objectid
 import itsdangerous
@@ -161,11 +163,11 @@ def before_request():
             # Update date last login when making non-api requests
             if user_session.data.get('auth_user_id') and 'api' not in request.url:
                 OSFUser = apps.get_model('osf.OSFUser')
-                query = OSFUser.objects.filter(guids___id=user_session.data['auth_user_id']).only('date_last_login')
-                user = query.get()
-                # Throttle updates to date_last_login
-                if util_time.throttle_period_expired(user.date_last_login, settings.DATE_LAST_LOGIN_THROTTLE):
-                    query.invalidated_update(date_last_login=timezone.now())
+                (
+                    OSFUser.objects
+                    .filter(guids___id=user_session.data['auth_user_id'])
+                    .filter(Q(date_last_login__isnull=True) | Q(date_last_login__lt=timezone.now() - dt.timedelta(seconds=settings.DATE_LAST_LOGIN_THROTTLE)))
+                ).update(date_last_login=timezone.now())
             set_session(user_session)
         else:
             remove_session(user_session)

--- a/framework/sessions/__init__.py
+++ b/framework/sessions/__init__.py
@@ -166,6 +166,7 @@ def before_request():
                 (
                     OSFUser.objects
                     .filter(guids___id=user_session.data['auth_user_id'])
+                    # Throttle updates
                     .filter(Q(date_last_login__isnull=True) | Q(date_last_login__lt=timezone.now() - dt.timedelta(seconds=settings.DATE_LAST_LOGIN_THROTTLE)))
                 ).update(date_last_login=timezone.now())
             set_session(user_session)

--- a/osf/migrations/0040_ensure_root_field.py
+++ b/osf/migrations/0040_ensure_root_field.py
@@ -17,7 +17,7 @@ def ensure_root(*args):
         node.save()
 
 def reset_root(*args):
-    AbstractNode.objects.all().invalidated_update(root=None)
+    AbstractNode.objects.all().update(root=None)
 
 
 class Migration(migrations.Migration):

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -972,11 +972,11 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
         if not self.is_contributor(user):
             raise ValueError(u'User {0} not in contributors'.format(user))
         if visible and not Contributor.objects.filter(node=self, user=user, visible=True).exists():
-            Contributor.objects.filter(node=self, user=user, visible=False).invalidated_update(visible=True)
+            Contributor.objects.filter(node=self, user=user, visible=False).update(visible=True)
         elif not visible and Contributor.objects.filter(node=self, user=user, visible=True).exists():
             if Contributor.objects.filter(node=self, visible=True).count() == 1:
                 raise ValueError('Must have at least one visible contributor')
-            Contributor.objects.filter(node=self, user=user, visible=True).invalidated_update(visible=False)
+            Contributor.objects.filter(node=self, user=user, visible=True).update(visible=False)
         else:
             return
         message = (
@@ -2614,8 +2614,8 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
         new_page.save()
 
         if has_comments:
-            Comment.objects.filter(root_target=current.guids.all()[0]).invalidated_update(root_target=Guid.load(new_page._id))
-            Comment.objects.filter(target=current.guids.all()[0]).invalidated_update(target=Guid.load(new_page._id))
+            Comment.objects.filter(root_target=current.guids.all()[0]).update(root_target=Guid.load(new_page._id))
+            Comment.objects.filter(target=current.guids.all()[0]).update(target=Guid.load(new_page._id))
 
         if current:
             for contrib in self.contributors:

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -48,6 +48,7 @@ from osf.utils.names import impute_names
 from website import settings as website_settings
 from website import filters, mails
 from website.project import new_bookmark_collection
+from website.util.time import throttle_period_expired
 
 logger = logging.getLogger(__name__)
 
@@ -1133,6 +1134,12 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
         """
         for node in self.contributed:
             node.update_search()
+
+    def update_date_last_login(self, save=False):
+        if not self.date_last_login or throttle_period_expired(self.date_last_login, website_settings.DATE_LAST_LOGIN_THROTTLE):
+            self.date_last_login = timezone.now()
+            if save:
+                self.save()
 
     def get_summary(self, formatter='long'):
         return {

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -669,12 +669,12 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
 
                 node.contributor_set.filter(user=user).delete()
             else:
-                node.contributor_set.filter(user=user).invalidated_update(user=self)
+                node.contributor_set.filter(user=user).update(user=self)
 
             node.save()
 
         # - projects where the user was the creator
-        user.created.filter(is_bookmark_collection=False).invalidated_update(creator=self)
+        user.created.filter(is_bookmark_collection=False).update(creator=self)
 
         # - file that the user has checked_out, import done here to prevent import error
         from osf.models import FileNode

--- a/website/conferences/views.py
+++ b/website/conferences/views.py
@@ -4,7 +4,6 @@ import httplib
 import logging
 
 from django.db import transaction
-from django.utils import timezone
 from modularodm import Q
 from modularodm.exceptions import ModularOdmException
 
@@ -84,8 +83,7 @@ def add_poster_by_email(conference, message):
             user.save()  # need to save in order to access m2m fields (e.g. tags)
             users_created.append(user)
             user.add_system_tag('osf4m')
-            user.date_last_login = timezone.now()
-            user.save()
+            user.update_date_last_login(save=True)
             # must save the user first before accessing user._id
             set_password_url = web_url_for(
                 'reset_password_get',

--- a/website/project/views/comment.py
+++ b/website/project/views/comment.py
@@ -97,7 +97,7 @@ def find_and_create_file_from_metadata(children, source, destination, destinatio
 
 
 def update_comment_node(root_target_id, source_node, destination_node):
-    Comment.objects.filter(root_target___id=root_target_id).invalidated_update(node=destination_node)
+    Comment.objects.filter(root_target___id=root_target_id).update(node=destination_node)
     source_node.save()
     destination_node.save()
 

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -43,6 +43,9 @@ CITATION_STYLES_PATH = os.path.join(BASE_PATH, 'static', 'vendor', 'bower_compon
 # Minimum seconds between forgot password email attempts
 SEND_EMAIL_THROTTLE = 30
 
+# Minimum seconds that must elapse before updating a user's date_last_login field
+DATE_LAST_LOGIN_THROTTLE = 60
+
 # Hours before pending embargo/retraction/registration automatically becomes active
 RETRACTION_PENDING_TIME = datetime.timedelta(days=2)
 EMBARGO_PENDING_TIME = datetime.timedelta(days=2)

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -43,7 +43,7 @@ CITATION_STYLES_PATH = os.path.join(BASE_PATH, 'static', 'vendor', 'bower_compon
 # Minimum seconds between forgot password email attempts
 SEND_EMAIL_THROTTLE = 30
 
-# Minimum seconds that must elapse before updating a user's date_last_login field
+# Seconds that must elapse before updating a user's date_last_login field
 DATE_LAST_LOGIN_THROTTLE = 60
 
 # Hours before pending embargo/retraction/registration automatically becomes active


### PR DESCRIPTION
Includes #6994

## Purpose

Prevents potential locking errors and unnecessary updates to User records.

## Changes

Only update `date_last_login` after 60 seconds have elapsed after last update.

## Side effects

We used to do this for requests that used basic auth: https://github.com/CenterForOpenScience/osf.io/commit/c35b12f9de9cb209eb649234708adfb3199f997f , but we must have forgotten to add the throttle for cookie auth.
