### PR TITLE
[feature] Collapse Info Panel on My Projects Page by Default [OSF-6777]

### DIFF
--- a/website/static/js/myProjects.js
+++ b/website/static/js/myProjects.js
@@ -333,7 +333,7 @@ var MyProjects = {
         self.logUrlCache = {}; // dictionary of load urls to avoid multiple calls with little refactor
         self.nodeUrlCache = {}; // Cached returns of the project related urls
         // VIEW STATES
-        self.showInfo = m.prop(true); // Show the info panel
+        self.showInfo = m.prop(false); // Show the info panel
         self.showSidebar = m.prop(false); // Show the links with collections etc. used in narrow views
         self.allProjectsLoaded = m.prop(false);
         self.categoryList = [];


### PR DESCRIPTION
#### Purpose
- Collapses the info panel/preview pane on the my projects page by default.

#### Changes
- Change the initialization value of the `showInfo` m.prop() from true to false.

#### Side Effects
- IMO, it's not obvious that the info panel even exists anymore, but ¯\\\_(ツ)_/¯ 

#### Ticket
- [OSF-6777](https://openscience.atlassian.net/browse/OSF-6777)

#### GIFs
- Before (expanded by default)
![myprojects-before](https://cloud.githubusercontent.com/assets/7913604/24115562/1f0d773c-0d7a-11e7-8764-3bb779a5d6e7.gif)


- After (collapsed by default)
![myprojects-after](https://cloud.githubusercontent.com/assets/7913604/24115565/21babe22-0d7a-11e7-91ed-468bbf7edfc5.gif)
