### PR TITLE
[hotfix] migrate specific preprints script [OSF-7649]

### DIFF
--- a/scripts/migration/migrate_specific_share_preprint_data.py
+++ b/scripts/migration/migrate_specific_share_preprint_data.py
@@ -1,0 +1,68 @@
+import argparse
+import json
+import logging
+import sys
+
+from framework.mongo import database
+from framework.transactions.context import TokuTransaction
+from scripts import utils as script_utils
+from website.app import init_app
+from website.models import PreprintService
+from website.preprints.tasks import on_preprint_updated
+from website import settings
+
+logger = logging.getLogger(__name__)
+
+
+def migrate(targets):
+    assert settings.SHARE_URL, 'SHARE_URL must be set to migrate.'
+    assert settings.SHARE_API_TOKEN, 'SHARE_API_TOKEN must be set to migrate.'
+    target_count = len(targets)
+    successes = []
+    failures = []
+    count = 0
+
+    logger.info('Preparing to migrate {} preprints.'.format(target_count))
+    for preprint_id in targets:
+        count += 1
+        logger.info('{}/{} - {}'.format(count, target_count, preprint_id))
+        try:
+            on_preprint_updated(preprint_id)
+        except Exception as e:
+            # TODO: This reliably fails for certain nodes with
+            # IncompleteRead(0 bytes read)
+            failures.append(preprint_id)
+            logger.warn('Encountered exception {} while posting to SHARE for preprint {}'.format(e, preprint_id))
+        else:
+            successes.append(preprint_id)
+
+    logger.info('Successes: {}'.format(successes))
+    logger.info('Failures: {}'.format(failures))
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Changes the provider of specified PreprintService objects'
+    )
+    parser.add_argument(
+        '--dry',
+        action='store_true',
+        dest='dry_run',
+        help='Run migration and roll back changes to db',
+    )
+    parser.add_argument(
+        '--targets',
+        action='store',
+        dest='targets',
+        help='List of targets, of form {"data": ["preprint_id", ...]}',
+    )
+    pargs = parser.parse_args()
+    if not pargs.dry_run:
+        script_utils.add_file_logger(logger, __file__)
+    init_app(set_backends=True, routes=False)
+    with TokuTransaction():
+        migrate(targets=json.loads(pargs.targets)['data'])
+        if pargs.dry_run:
+            raise RuntimeError('Dry run, transaction rolled back.')
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
There is no easy way to add individual (or a list) of preprints to share. 
<!-- Describe the purpose of your changes -->

## Changes
This script allows a list to be passed to the migrate specific preprints instead of all preprints
e.g., for a dry run: `scripts.migration.migrate_specific_share_preprint_data --dry --targets '{"data":["rnizy"]}'`
<!-- Briefly describe or list your changes  -->

## Side effects
N/A, though the script will need to be modified for django
<!--Any possible side effects? -->


## Ticket
https://openscience.atlassian.net/browse/OSF-7649
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->

## QA Considerations
Can be tested by whoever runs the script, no standard QA