### PR TITLE
[hotfix] Fix Duplicate File Logs on Project Overview Page [OSF-7585]

### DIFF
--- a/website/static/js/logTextParser.js
+++ b/website/static/js/logTextParser.js
@@ -439,7 +439,7 @@ var LogPieces = {
     path: {
         controller: function(logObject){
             var self = this;
-            self.returnLinkForPath = function() {
+            self.returnLinkForPath = function(logObject) {
                 if (logObject) {
                     var action = logObject.attributes.action;
                     var acceptableLinkedItems = ['osf_storage_file_added', 'osf_storage_file_updated', 'file_tag_added', 'file_tag_removed',
@@ -453,7 +453,7 @@ var LogPieces = {
             };
         },
         view: function (ctrl, logObject) {
-            var url = ctrl.returnLinkForPath();
+            var url = ctrl.returnLinkForPath(logObject);
             return returnTextParams('path', 'a file', logObject, url);
         }
     },
@@ -461,7 +461,7 @@ var LogPieces = {
     filename: {
         controller: function(logObject) {
             var self = this;
-            self.returnLinkForPath = function(){
+            self.returnLinkForPath = function(logObject){
                 if (logObject){
                     var action = logObject.attributes.action;
                     var acceptableLinkedItems = ['dataverse_file_added'];
@@ -473,7 +473,7 @@ var LogPieces = {
             };
         },
         view: function (ctrl, logObject) {
-            var url = ctrl.returnLinkForPath();
+            var url = ctrl.returnLinkForPath(logObject);
             return returnTextParams('filename', 'a title', logObject, url);
         }
     },
@@ -557,7 +557,7 @@ var LogPieces = {
     googledrive_path: {
         controller: function(logObject){
             var self = this;
-            self.returnLinkForPath = function() {
+            self.returnLinkForPath = function(logObject) {
                 if (logObject) {
                     var action = logObject.attributes.action;
                     var acceptableLinkedItems = ['googledrive_file_added', 'googledrive_file_updated'];
@@ -569,7 +569,7 @@ var LogPieces = {
             };
         },
         view: function (ctrl, logObject) {
-            var url = ctrl.returnLinkForPath();
+            var url = ctrl.returnLinkForPath(logObject);
             var path = logObject.attributes.params.path;
             if(paramIsReturned(path, logObject)){
                 path = stripBackslash(decodeURIComponent(path));


### PR DESCRIPTION
#### Purpose
- See ticket (especially Sara's comment) for better explanation. 
- TL;DR: file-related logs aren't being updated correctly when paginating through the log feed, resulting in linked file names leading to the wrong file. 

#### Changes
- Passes the correct logObject to the `returnLinkForPath` controller function. 
- From the Mithril docs:
> The controller function is called once when the component is rendered. Subsequently, the view function is called and will be called again anytime a redraw is required. 
  - The logs widget on the project overview page redraws when a new page of logs is requested, so only the view function (with the logObject from the first page when the controller was called) was being called when viewing any logs page other than the first. 
  - The logs widget on the My Projects page adds to an existing list as opposed to redrawing, therefore the controller was called for every new log and this problem didn't exist in that widget.

#### QA Notes
- While this was only broken in the Recent Activity widget on the project overview page (and not in the Activity widget of the My Projects page) the code that was changed is shared between the two. I wouldn't expect to see any issues on the My Projects page from this change, but QA might want to check anyways. 
- In order to be checked correctly, several logs of the same type (across more than one page of the logs widget) need to exist (i.e. upload >6 OSFS files and then check that the file mentioned in the top log on the second page links to itself and not to the file in the top log on the first page). 
  - In addition to basically all OSFS logs being broken, I'm fairly confident dataverse and googledrive logs are also broken (again **if and only if** the logs in the same position of the widget between pages are of the same type). 
  - Affected GoogleDrive log types are: `googledrive_file_added`, `googledrive_file_removed`, `googledrive_file_updated`, `googledrive_file_created`. 
  - Affected dataverse log types are: `dataverse_file_added`, `dataverse_file_removed`. 
- It's a weird issue, lemme know if you need me to demo or if I can explain it better in person when testing time comes.

#### Ticket
- [OSF-7585](https://openscience.atlassian.net/browse/OSF-7585)

