### PR TITLE
[HOLD][Hotfix] Show only published preprints [OSF-7433]

### DIFF
--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -435,7 +435,9 @@ class ListFilterMixin(FilterMixin):
         field = self.serializer_class._declared_fields[field_name]
         source_field_name = params['source_field_name']
 
-        if isinstance(field, ser.SerializerMethodField):
+        if self.should_filter_special_param(source_field_name):
+            return_val = self.filter_special_param(params, default_queryset)
+        elif isinstance(field, ser.SerializerMethodField):
             return_val = [
                 item for item in default_queryset
                 if self.FILTERS[params['op']](self.get_serializer_method(field_name)(item), params['value'])
@@ -481,3 +483,13 @@ class ListFilterMixin(FilterMixin):
         serializer = self.get_serializer()
         serializer_method_name = 'get_' + field_name
         return getattr(serializer, serializer_method_name)
+
+    def should_filter_special_param(self, field_name):
+        """ This should be overridden in subclasses for custom filtering behavior
+        """
+        return False
+
+    def filter_special_param(self, params, filter_set):
+        """ This should be overridden in subclasses for custom filtering behavior
+        """
+        pass

--- a/api/preprints/filters.py
+++ b/api/preprints/filters.py
@@ -1,0 +1,17 @@
+from api.base.filters import ListFilterMixin
+
+
+class PreprintsListFilterMixin(ListFilterMixin):
+
+    def should_filter_special_param(self, field_name):
+        """ This should be overridden in subclasses for custom filtering behavior
+        """
+        return field_name == 'provider'
+
+    def filter_special_param(self, params, filter_list):
+        """ This should be overridden in subclasses for custom filtering behavior
+        """
+        return [
+            preprint for preprint in filter_list
+            if preprint.provider._id == params['value']
+        ]

--- a/api/preprints/permissions.py
+++ b/api/preprints/permissions.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from rest_framework import permissions
+from rest_framework import exceptions
 
 from api.base.utils import get_user_auth
 from website.models import PreprintService
@@ -15,4 +16,6 @@ class PreprintPublishedOrAdmin(permissions.BasePermission):
         if request.method in permissions.SAFE_METHODS:
             return obj.is_published or node.has_permission(auth.user, osf_permissions.ADMIN)
         else:
-            return node.has_permission(auth.user, osf_permissions.ADMIN)
+            if not node.has_permission(auth.user, osf_permissions.ADMIN):
+                raise exceptions.PermissionDenied(detail='User must be an admin to update a preprint.')
+            return True

--- a/api/preprints/permissions.py
+++ b/api/preprints/permissions.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from rest_framework import permissions
+
+from api.base.utils import get_user_auth
+from website.models import PreprintService
+from website.util import permissions as osf_permissions
+
+
+class PreprintPublishedOrAdmin(permissions.BasePermission):
+
+    def has_object_permission(self, request, view, obj):
+        assert isinstance(obj, PreprintService), 'obj must be a PreprintService'
+        node = obj.node
+        auth = get_user_auth(request)
+        if request.method in permissions.SAFE_METHODS:
+            return obj.is_published or node.has_permission(auth.user, osf_permissions.ADMIN)
+        else:
+            return node.has_permission(auth.user, osf_permissions.ADMIN)

--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -130,9 +130,6 @@ class PreprintSerializer(JSONAPISerializer):
         assert isinstance(preprint.node, Node), 'You must specify a preprint with a valid node to be updated.'
 
         auth = get_user_auth(self.context['request'])
-        if not preprint.node.has_permission(auth.user, 'admin'):
-            raise exceptions.PermissionDenied(detail='User must be an admin to update a preprint.')
-
         save_node = False
         save_preprint = False
         recently_published = False

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -143,7 +143,7 @@ class PreprintList(JSONAPIBaseView, generics.ListCreateAPIView, ODMFilterMixin):
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
         ContributorOrPublic,
-        PreprintPublishedOrAdmin,
+        PreprintPublishedOrAdmin,  # TODO: tests fail because this isn't applied. Use ListFilterMixin
     )
 
     parser_classes = (JSONAPIMultipleRelationshipsParser, JSONAPIMultipleRelationshipsParserForRegularJSON,)

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -10,7 +10,6 @@ from framework.auth.oauth_scopes import CoreScopes
 
 from api.base.exceptions import Conflict
 from api.base.views import JSONAPIBaseView
-from api.base.filters import ListFilterMixin
 from api.base.parsers import (
     JSONAPIMultipleRelationshipsParser,
     JSONAPIMultipleRelationshipsParserForRegularJSON,
@@ -28,6 +27,7 @@ from api.nodes.serializers import (
 )
 from api.nodes.views import NodeMixin, WaterButlerMixin
 from api.nodes.permissions import ContributorOrPublic
+from api.preprints.filters import PreprintsListFilterMixin
 from api.preprints.permissions import PreprintPublishedOrAdmin
 
 
@@ -50,7 +50,7 @@ class PreprintMixin(NodeMixin):
         return preprint
 
 
-class PreprintList(JSONAPIBaseView, generics.ListCreateAPIView, ListFilterMixin):
+class PreprintList(JSONAPIBaseView, generics.ListCreateAPIView, PreprintsListFilterMixin):
     """Preprints that represent a special kind of preprint node. *Writeable*.
 
     Paginated list of preprints ordered by their `date_created`.  Each resource contains a representation of the

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -28,6 +28,7 @@ from api.nodes.serializers import (
 )
 from api.nodes.views import NodeMixin, WaterButlerMixin
 from api.nodes.permissions import ContributorOrPublic
+from api.preprints.permissions import PreprintPublishedOrAdmin
 
 
 class PreprintMixin(NodeMixin):
@@ -142,6 +143,7 @@ class PreprintList(JSONAPIBaseView, generics.ListCreateAPIView, ODMFilterMixin):
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
         ContributorOrPublic,
+        PreprintPublishedOrAdmin,
     )
 
     parser_classes = (JSONAPIMultipleRelationshipsParser, JSONAPIMultipleRelationshipsParserForRegularJSON,)
@@ -237,6 +239,7 @@ class PreprintDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, Pre
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
         ContributorOrPublic,
+        PreprintPublishedOrAdmin,
     )
     parser_classes = (JSONAPIMultipleRelationshipsParser, JSONAPIMultipleRelationshipsParserForRegularJSON,)
 

--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -645,3 +645,37 @@ class TestPreprintUpdateLicense(ApiTestCase):
         assert_equal(res.status_code, 200)
         assert_equal(before_num_logs, after_num_logs)
         assert_equal(before_update_log._id, after_update_log._id)
+
+
+class TestPreprintIsPublishedDetail(ApiTestCase):
+    def setUp(self):
+        super(TestPreprintIsPublishedDetail, self).setUp()
+        self.admin= AuthUserFactory()
+        self.write_contrib = AuthUserFactory()
+        self.non_contrib = AuthUserFactory()
+
+        self.public_project = ProjectFactory(creator=self.admin, public=True)
+        self.public_project.add_contributor(self.write_contrib, permissions=['read', 'write'], save=True)
+        self.subject = SubjectFactory()
+        self.provider = PreprintProviderFactory()
+        self.file_one_public_project = test_utils.create_test_file(self.public_project, self.admin, 'mgla.pdf')
+
+        self.unpublished_preprint = PreprintFactory(creator=self.admin, filename='mgla.pdf', provider=self.provider, subjects=[[self.subject._id]], project=self.public_project, is_published=False)
+
+        self.url = '/{}preprints/{}/'.format(API_BASE, self.unpublished_preprint._id)
+
+    def test_unpublished_visible_to_admins(self):
+        res = self.app.get(self.url, auth=self.admin.auth)
+        assert res.json['data']['id'] == self.unpublished_preprint._id
+
+    def test_unpublished_invisible_to_write_contribs(self):
+        res = self.app.get(self.url, auth=self.write_contrib.auth, expect_errors=True)
+        assert res.status_code == 403
+
+    def test_unpublished_invisible_to_non_contribs(self):
+        res = self.app.get(self.url, auth=self.non_contrib.auth, expect_errors=True)
+        assert res.status_code == 403
+
+    def test_unpublished_invisible_to_public(self):
+        res = self.app.get(self.url, expect_errors=True)
+        assert res.status_code == 401

--- a/api_tests/preprints/views/test_preprint_list.py
+++ b/api_tests/preprints/views/test_preprint_list.py
@@ -268,3 +268,66 @@ class TestPreprintCreate(ApiTestCase):
         log = preprint.node.logs[-2]
         assert_equal(log.action, 'preprint_initiated')
         assert_equal(log.params.get('preprint'), preprint_id)
+
+class TestPreprintIsPublishedList(ApiTestCase):
+    def setUp(self):
+        super(TestPreprintIsPublishedList, self).setUp()
+        self.admin= AuthUserFactory()
+        self.write_contrib = AuthUserFactory()
+        self.non_contrib = AuthUserFactory()
+
+        self.published_project = ProjectFactory(creator=self.admin, public=True)
+        self.public_project = ProjectFactory(creator=self.admin, public=True)
+        self.public_project.add_contributor(self.write_contrib, permissions=[permissions.DEFAULT_CONTRIBUTOR_PERMISSIONS], save=True)
+        self.subject = SubjectFactory()
+        self.provider = PreprintProviderFactory()
+
+        self.file_one_public_project = test_utils.create_test_file(self.public_project, self.admin, 'mgla.pdf')
+        self.file_one_published_project = test_utils.create_test_file(self.published_project, self.admin, 'saor.pdf')
+
+        self.unpublished_preprint = PreprintFactory(creator=self.admin, filename='mgla.pdf', provider=self.provider, subjects=[[self.subject._id]], project=self.public_project, is_published=False)
+        self.published_preprint = PreprintFactory(creator=self.admin, filename='saor.pdf', provider=self.provider, subjects=[[self.subject._id]], project=self.published_project, is_published=True)
+
+        self.url = '/{}preprints/'.format(API_BASE)
+
+    def tearDown(self):
+        super(TestPreprintIsPublishedList, self).tearDown()
+        PreprintService.remove()
+        Node.remove()
+
+    def test_unpublished_visible_to_admins(self):
+        res = self.app.get(self.url, auth=self.admin.auth)
+        assert len(res.json['data']) == 2
+        assert self.unpublished_preprint._id in [d['id'] for d in res.json['data']]
+
+    def test_unpublished_invisible_to_write_contribs(self):
+        res = self.app.get(self.url, auth=self.write_contrib.auth)
+        assert len(res.json['data']) == 1
+        assert self.unpublished_preprint._id not in [d['id'] for d in res.json['data']]
+
+    def test_unpublished_invisible_to_non_contribs(self):
+        res = self.app.get(self.url, auth=self.non_contrib.auth)
+        assert len(res.json['data']) == 1
+        assert self.unpublished_preprint._id not in [d['id'] for d in res.json['data']]
+
+    def test_unpublished_invisible_to_public(self):
+        res = self.app.get(self.url)
+        assert len(res.json['data']) == 1
+        assert self.unpublished_preprint._id not in [d['id'] for d in res.json['data']]
+
+    def test_filter_published_false_admin(self):
+        res = self.app.get('{}?filter[is_published]=false'.format(self.url), auth=self.admin.auth)
+        assert len(res.json['data']) == 1
+        assert self.unpublished_preprint._id in [d['id'] for d in res.json['data']]
+
+    def test_filter_published_false_write_contrib(self):
+        res = self.app.get('{}?filter[is_published]=false'.format(self.url), auth=self.write_contrib.auth)
+        assert len(res.json['data']) == 0
+
+    def test_filter_published_false_non_contrib(self):
+        res = self.app.get('{}?filter[is_published]=false'.format(self.url), auth=self.non_contrib.auth)
+        assert len(res.json['data']) == 0
+
+    def test_filter_published_false_public(self):
+        res = self.app.get('{}?filter[is_published]=false'.format(self.url))
+        assert len(res.json['data']) == 0

--- a/website/preprints/model.py
+++ b/website/preprints/model.py
@@ -196,7 +196,7 @@ class PreprintService(GuidStoredObject):
 
     def save(self, *args, **kwargs):
         saved_fields = super(PreprintService, self).save(*args, **kwargs)
-        if saved_fields:
+        if 'is_published' in saved_fields or self.is_published:
             enqueue_task(on_preprint_updated.s(self._id))
 
 

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -2172,7 +2172,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable, Spam
             from website.preprints.tasks import on_preprint_updated
             from website.preprints.model import PreprintService
             # .preprints wouldn't return a single deleted preprint
-            for preprint in PreprintService.find(Q('node', 'eq', self)):
+            for preprint in PreprintService.find(Q('node', 'eq', self) & Q('is_published', 'eq', True)):
                 enqueue_task(on_preprint_updated.s(preprint._id))
 
         user = User.load(user_id)

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -1179,7 +1179,7 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable, Spam
             return False
         if self.preprint_file.node == self:
             self._is_preprint_orphan = False
-            return True
+            return self.has_published_preprint
         else:
             self._is_preprint_orphan = True
             return False
@@ -1196,6 +1196,11 @@ class Node(GuidStoredObject, AddonModelMixin, IdentifierMixin, Commentable, Spam
         if not self.is_preprint:
             return []
         return PreprintService.find(Q('node', 'eq', self))
+
+    @property
+    def has_published_preprint(self):
+        from website.preprints.model import PreprintService
+        return bool(PreprintService.find(Q('node', 'eq', self) & Q('is_published', 'eq', True)).count())
 
     @property
     def preprint_url(self):

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -741,7 +741,7 @@ def _view_project(node, auth, primary=False):
             'alternative_citations': [citation.to_json() for citation in node.alternative_citations],
             'has_draft_registrations': node.has_active_draft_registrations,
             'contributors': [contributor._id for contributor in node.contributors],
-            'is_preprint': node.is_preprint,
+            'is_preprint': node.has_published_preprint,
             'is_preprint_orphan': node.is_preprint_orphan,
             'preprint_file_id': node.preprint_file._id if node.preprint_file else None,
             'preprint_url': node.preprint_url


### PR DESCRIPTION
## Purpose
Don't expose preprints with `is_published==False`

## Changes
* Permissions class
* Limit number of tasks sent to SHARE

## Side effects
Possible confusion for users who have seen unpublished preprints and expect them to remain public. Product is aware and has mitigated.

## TODO
Duplicate model-property changes in Django models.

## Ticket
[[OSF-7433]](https://openscience.atlassian.net/browse/OSF-7433)