### PR TITLE
Feature/fix add system tag

### DIFF
--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -103,6 +103,7 @@ class Taggable(models.Model):
 
         if not self.tags.filter(id=tag_instance.id).exists():
             self.tags.add(tag_instance)
+            # TODO: Logging belongs in on_tag_added hook
             if log:
                 self.add_tag_log(tag_instance, auth)
             if save:
@@ -111,6 +112,8 @@ class Taggable(models.Model):
         return tag_instance
 
     def add_system_tag(self, tag, save=True):
+        if isinstance(tag, Tag) and not tag.system:
+            raise ValueError('Non-system tag passed to add_system_tag')
         return self.add_tag(tag=tag, auth=None, save=save, log=False, system=True)
 
     def add_tag_log(self, *args, **kwargs):

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -1233,6 +1233,8 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
             tag_instance, created = Tag.all_tags.get_or_create(name=tag.lower(), system=True)
         else:
             tag_instance = tag
+        if not tag_instance.system:
+            raise ValueError('Non-system tag passed to add_system_tag')
         if not self.all_tags.filter(id=tag_instance.id).exists():
             self.tags.add(tag_instance)
         return tag_instance

--- a/osf_tests/conftest.py
+++ b/osf_tests/conftest.py
@@ -19,12 +19,14 @@ SILENT_LOGGERS = [
     'framework.auth.core',
     'framework.celery_tasks.signals',
     'website.app',
+    'website.archiver.tasks',
     'website.mails',
     'website.notifications.listeners',
     'website.search.elastic_search',
     'website.search_migration.migrate',
     'website.util.paths',
     'requests_oauthlib.oauth2_session',
+    'raven.base.Client',
     'raven.contrib.django.client.DjangoClient',
 ]
 for logger_name in SILENT_LOGGERS:

--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -54,6 +54,7 @@ from osf_tests.factories import (
     NodeRelationFactory,
     InstitutionFactory,
     SessionFactory,
+    TagFactory,
 )
 from .factories import get_default_metaschema
 from addons.wiki.tests.factories import NodeWikiFactory
@@ -694,6 +695,19 @@ class TestTagging:
         # No log added
         new_log_count = node.logs.count()
         assert original_log_count == new_log_count
+
+    def test_add_system_tag_instance(self, node):
+        tag = TagFactory(system=True)
+        node.add_system_tag(tag)
+
+        assert tag in node.all_tags.all()
+
+    def test_add_system_tag_non_system_instance(self, node):
+        tag = TagFactory(system=False)
+        with pytest.raises(ValueError):
+            node.add_system_tag(tag)
+
+        assert tag not in node.all_tags.all()
 
     def test_system_tags_property(self, node, auth):
         other_node = ProjectFactory()

--- a/osf_tests/test_user.py
+++ b/osf_tests/test_user.py
@@ -39,6 +39,7 @@ from .factories import (
     NodeFactory,
     InstitutionFactory,
     SessionFactory,
+    TagFactory,
     UserFactory,
     UnregUserFactory,
     UnconfirmedUserFactory
@@ -946,6 +947,17 @@ class TestTagging:
 
         tag = Tag.all_tags.get(name=tag_name, system=True)
         assert tag in user.all_tags.all()
+
+    def test_add_system_tag_instance(self, user):
+        tag = TagFactory(system=True)
+        user.add_system_tag(tag)
+        assert tag in user.all_tags.all()
+
+    def test_add_system_tag_with_non_system_instance(self, user):
+        tag = TagFactory(system=False)
+        with pytest.raises(ValueError):
+            user.add_system_tag(tag)
+        assert tag not in user.all_tags.all()
 
     def test_tags_get_lowercased(self, user):
         tag_name = 'NeOn'

--- a/tests/base.py
+++ b/tests/base.py
@@ -76,11 +76,15 @@ SILENT_LOGGERS = [
     'framework.auth.core',
     'framework.celery_tasks.signals',
     'website.app',
+    'website.archiver.tasks',
     'website.mails',
     'website.notifications.listeners',
     'website.search.elastic_search',
     'website.search_migration.migrate',
     'website.util.paths',
+    'requests_oauthlib.oauth2_session',
+    'raven.base.Client',
+    'raven.contrib.django.client.DjangoClient',
 ]
 for logger_name in SILENT_LOGGERS:
     logging.getLogger(logger_name).setLevel(logging.CRITICAL)


### PR DESCRIPTION
## Purpose

`add_system_tag` would allow adding non-system tags if passing a Tag instance.

## Changes

- Raise an error if passing a non-system Tag instance to add_system_tag.
- Silence a few loud logs during tests.

## Side effects

<!--Any possible side effects? -->


## Ticket

