### PR TITLE
Load profile logs lazily [OSF-7676]

### DIFF
--- a/website/static/js/components/logFeed.js
+++ b/website/static/js/components/logFeed.js
@@ -59,6 +59,7 @@ var LogFeed = {
                 var page = params.page || 1;
                 self.currentPage(parseInt(page));
                 self.totalPages(Math.ceil(result.links.meta.total / result.links.meta.per_page));
+                m.redraw();
             }
             self.logRequestPending(true);
             var promise = m.request({method : 'GET', url : url, config: mHelpers.apiV2Config({withCredentials: window.contextVars.isOnRootDomain})});

--- a/website/static/js/pages/render-nodes.js
+++ b/website/static/js/pages/render-nodes.js
@@ -2,8 +2,6 @@
 
 var $osf = require('js/osfHelpers');
 var $ = require('jquery');
-var m = require('mithril');
-var LogFeed = require('js/components/logFeed.js');
 
 // model for components, due to simplicity did not create a new file
 var ComponentControl = {};

--- a/website/static/js/pages/render-nodes.js
+++ b/website/static/js/pages/render-nodes.js
@@ -12,17 +12,3 @@ var ComponentControl = {};
 $('.render-nodes-list').each(function() {
     $osf.applyBindings(ComponentControl, this);
 });
-
-$(document).ready(function() {
-    var nodes = window.contextVars.nodes;
-    if (nodes) {
-        for (var i = 0; i < nodes.length; ++i) {
-            var node = nodes[i].node;
-            node.id = nodes[i].id;
-            if (node.can_view && !node.archiving && !node.is_retracted) {
-                var nodeLogFeed = 'logFeed-' + node.id;
-                m.mount(document.getElementById(nodeLogFeed), m.component(LogFeed.LogFeed, {node: node, limitLogs: true}));
-            }
-        }
-    }
-});

--- a/website/static/js/project.js
+++ b/website/static/js/project.js
@@ -6,7 +6,10 @@
 var $ = require('jquery');
 var bootbox = require('bootbox');
 var Raven = require('raven-js');
+var m = require('mithril');
 var ko = require('knockout');
+var LogFeed = require('js/components/logFeed.js');
+
 
 var $osf = require('js/osfHelpers');
 
@@ -145,11 +148,24 @@ NodeActions.openCloseNode = function(nodeId) {
     var body = $('#body-' + nodeId);
 
     body.toggleClass('hide');
+    var node = null;
+
+    if (document.getElementById('logFeed-' + nodeId).children[0].classList.item(0) === 'spinner-loading-wrapper') {
+        for (var i = 0; i < window.contextVars.nodes.length; ++i){
+            if (window.contextVars.nodes[i].id === nodeId) {
+                node = window.contextVars.nodes[i].node;
+            }
+        }
+    }
 
     if (body.hasClass('hide')) {
         icon.removeClass('fa fa-angle-up');
         icon.addClass('fa fa-angle-down');
     } else {
+        if (node && node.can_view && !node.archiving && !node.is_retracted) {
+            var nodeLogFeed = 'logFeed-' + node.primary_id;
+            m.mount(document.getElementById(nodeLogFeed), m.component(LogFeed.LogFeed, {node: node, limitLogs: true}));
+        }
         icon.removeClass('fa fa-angle-down');
         icon.addClass('fa fa-angle-up');
     }


### PR DESCRIPTION
## Purpose
Reduce load time of user profile

## Changes
* Mount LogFeeds on first toggle, not pageload
* Allow individual log panes to draw independently of all the panes on the page

## Side effects
None expected

## Ticket
[[OSF-7676]](https://openscience.atlassian.net/browse/OSF-7676)