### PR TITLE
[feature] Switch sitemap datemod to lastmod [OSF-7682]

### DIFF
--- a/scripts/generate_sitemap.py
+++ b/scripts/generate_sitemap.py
@@ -114,7 +114,7 @@ class Sitemap(object):
             loc_text = self.doc.createTextNode(urlparse.urljoin(settings.DOMAIN, 'sitemaps/sitemap_{}.xml.gz'.format(str(f))))
             loc.appendChild(loc_text)
 
-            datemod = doc.createElement('datemod')
+            datemod = doc.createElement('lastmod')
             sitemap.appendChild(datemod)
             datemod_text = self.doc.createTextNode(datetime.datetime.now().isoformat())
             datemod.appendChild(datemod_text)

--- a/scripts/generate_sitemap.py
+++ b/scripts/generate_sitemap.py
@@ -116,7 +116,7 @@ class Sitemap(object):
 
             datemod = doc.createElement('lastmod')
             sitemap.appendChild(datemod)
-            datemod_text = self.doc.createTextNode(datetime.datetime.now().isoformat())
+            datemod_text = self.doc.createTextNode(datetime.datetime.now().strftime('%Y-%m-%d'))
             datemod.appendChild(datemod_text)
 
         print('Writing `sitemap_index.xml`')
@@ -168,7 +168,7 @@ class Sitemap(object):
             try:
                 config = settings.SITEMAP_NODE_CONFIG
                 config['loc'] = urlparse.urljoin(settings.DOMAIN, obj.url)
-                config['lastmod'] = obj.date_modified.isoformat()
+                config['lastmod'] = obj.date_modified.strftime('%Y-%m-%d')
                 self.add_url(config)
             except Exception as e:
                 self.log_errors(obj, obj._id, e)
@@ -180,7 +180,7 @@ class Sitemap(object):
         progress.start(objs.count() * 2, 'PREP: ')
         for obj in objs.iterator():
             try:
-                preprint_date = obj.date_modified.isoformat()
+                preprint_date = obj.date_modified.strftime('%Y-%m-%d')
                 config = settings.SITEMAP_PREPRINT_CONFIG
                 config['loc'] = urlparse.urljoin(settings.DOMAIN, obj.url)
                 config['lastmod'] = preprint_date


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Sitemap index file incorrectly used 'datemod' instead of 'lastmod'
<!-- Describe the purpose of your changes -->

## Changes
Change the tag to be 'lastmod'
<!-- Briefly describe or list your changes  -->

## Side effects
Also changing dates to be YYYY-MM-DD instead of full ISO8601
<!--Any possible side effects? -->


## Ticket
https://openscience.atlassian.net/browse/OSF-7682
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
