### PR TITLE
[hotfix] Prereg Banner [OSF-7644]

### DIFF
--- a/website/static/css/pages/home-page.css
+++ b/website/static/css/pages/home-page.css
@@ -1,3 +1,7 @@
+body {
+    overflow-x: hidden;
+}
+
 h3, h4 {
     font-weight: 400;
 }
@@ -27,7 +31,7 @@ h3, h4 {
 }
 
 .prereg {
-    background: #C5D6E6 url("/static/img/bg6.jpg") no-repeat center top;
+    background: #337AB7;
     background-size: cover;
 }
 

--- a/website/static/css/quick-project-search-plugin.css
+++ b/website/static/css/quick-project-search-plugin.css
@@ -110,3 +110,16 @@
     margin-top: 20px;
     margin-bottom: 50px;
 }
+
+.prereg.banner {
+    margin: -45px -999px 10px -999px;
+    padding: 0px 999px 0px 999px;
+}
+
+.prereg p {
+    margin: 0;
+    padding-top: 6px;
+    padding-bottom: 6px;
+    color: white;
+    font-weight: bold;
+}

--- a/website/static/js/home-page/quickProjectSearchPlugin.js
+++ b/website/static/js/home-page/quickProjectSearchPlugin.js
@@ -493,9 +493,29 @@ var QuickSearchProject = {
             })))];
         }
 
+        function preregBanner() {
+            return m ('.prereg.banner',
+                m('.row',
+                    [
+                        m('.col-xs-9.m-v-sm',
+                            m('div.conference-centering',
+                                m('p', 'Improve your next study. Enter the Prereg Challenge and you could win $1,000.')
+                            )
+                        ),
+                        m('.col-xs-3.text-center.m-v-sm',
+                            m('div.pull-right',  m('a.btn.btn-success.btn-success-high-contrast.f-w-xl', { type:'button',  href:'/prereg/', onclick: function() {
+                                $osf.trackClick('prereg', 'navigate', 'navigate-to-begin-prereg');
+                            }}, 'Start Prereg Challenge'))
+                        )
+                    ]
+                )
+            );
+        }
+
         if (ctrl.eligibleNodes().length === 0 && ctrl.filter() == null) {
             return m('.row',
                 m('.col-xs-12',[
+                    preregBanner(),
                     headerTemplate(),
                     m('.row.quick-project',
                         m('.col-sm-12.text-center', [
@@ -509,7 +529,10 @@ var QuickSearchProject = {
         }
         else {
             return m('.row',
-                m('.col-xs-12', headerTemplate()),
+                m('.col-xs-12', [
+                    preregBanner(),
+                    headerTemplate()
+                ]),
                 m('.col-xs-12',[
                     m('.row.quick-project', m('.col-xs-12',
                     m('.m-b-sm.text-center', [

--- a/website/static/js/pages/home-page.js
+++ b/website/static/js/pages/home-page.js
@@ -60,14 +60,6 @@ $(document).ready(function(){
 
                     ]
                 )),
-                m('.prereg', m('.container',
-                    [
-                        m('.row', [
-                            m(columnSizeClass,  m.component(Prereg, {}))
-                        ])
-
-                    ]
-                )),
                 m('.meetings', m('.container',
                     [
                         m('.row', [


### PR DESCRIPTION
#### Purpose
- Adds a Prereg promo banner to the top of the dashboard page.
- Removes the exisiting Prereg section from the page.

#### Changes
- Prereg banner added to `quickProjectSearchPlugin.js`
- `preregPlugin.js` purposely not removed so that the old banner can be added back easily, if desired.

#### Screenshots
![screen shot 2017-03-27 at 1 19 13 pm](https://cloud.githubusercontent.com/assets/7913604/24368884/31cacd68-12f0-11e7-997c-9ad79ab6fac1.png)


![screen shot 2017-03-27 at 1 19 36 pm](https://cloud.githubusercontent.com/assets/7913604/24368887/341bd990-12f0-11e7-8d05-ca471f91f30b.png)


#### Ticket
- [OSF-7644](https://openscience.atlassian.net/browse/OSF-7644)

