### PR TITLE
[hold] [Hotfix][SHARE-674][Fix] Don't use DOIs as preprint identifiers

### DIFF
--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -279,7 +279,7 @@ class TestOnPreprintUpdatedTask(OsfTestCase):
     def test_format_preprint(self):
         res = format_preprint(self.preprint)
 
-        assert set(gn['@type'] for gn in res) == {'creator', 'contributor', 'throughsubjects', 'subject', 'throughtags', 'tag', 'workidentifier', 'agentidentifier', 'person', 'preprint'}
+        assert set(gn['@type'] for gn in res) == {'creator', 'contributor', 'throughsubjects', 'subject', 'throughtags', 'tag', 'workidentifier', 'agentidentifier', 'person', 'preprint', 'workrelation', 'creativework'}
 
         nodes = dict(enumerate(res))
         preprint = nodes.pop(next(k for k, v in nodes.items() if v['@type'] == 'preprint'))
@@ -351,17 +351,24 @@ class TestOnPreprintUpdatedTask(OsfTestCase):
             self.preprint.node.creator.profile_image_url(),
         ]) | set(urlparse.urljoin(settings.DOMAIN, user.profile_url) for user in self.preprint.node.contributors if user.is_registered)
 
-        workidentifiers = {nodes.pop(k)['uri'] for k, v in nodes.items() if v['@type'] == 'workidentifier'}
-        assert workidentifiers == set([
-            'http://dx.doi.org/{}'.format(self.preprint.article_doi),
-            urlparse.urljoin(settings.DOMAIN, self.preprint.url)
-        ])
+        related_work = next(nodes.pop(k) for k, v in nodes.items() if v['@type'] == 'creativework')
+        assert set(related_work.keys()) == {'@id', '@type'}  # Empty except @id and @type
+
+        doi = next(nodes.pop(k) for k, v in nodes.items() if v['@type'] == 'workidentifier' and 'doi' in v['uri'])
+        assert doi['creative_work'] == related_work
+
+        workidentifiers = [nodes.pop(k)['uri'] for k, v in nodes.items() if v['@type'] == 'workidentifier']
+        assert workidentifiers == [urlparse.urljoin(settings.DOMAIN, self.preprint.url)]
+
+        relation = nodes.pop(nodes.keys()[0])
+        assert relation == {'@id': relation['@id'], '@type': 'workrelation', 'related': {'@id': related_work['@id'], '@type': related_work['@type']}, 'subject': {'@id': preprint['@id'], '@type': preprint['@type']}}
 
         assert nodes == {}
 
     def test_format_preprint_nones(self):
         self.preprint.node.tags = None
         self.preprint.date_published = None
+        self.preprint.node.preprint_article_doi = None
         self.preprint.set_subjects([], auth=Auth(self.preprint.node.creator), save=False)
 
         res = format_preprint(self.preprint)
@@ -429,10 +436,7 @@ class TestOnPreprintUpdatedTask(OsfTestCase):
         ]) | set(urlparse.urljoin(settings.DOMAIN, user.profile_url) for user in self.preprint.node.contributors if user.is_registered)
 
         workidentifiers = {nodes.pop(k)['uri'] for k, v in nodes.items() if v['@type'] == 'workidentifier'}
-        assert workidentifiers == set([
-            'http://dx.doi.org/{}'.format(self.preprint.article_doi),
-            urlparse.urljoin(settings.DOMAIN, self.preprint.url)
-        ])
+        assert workidentifiers == set([urlparse.urljoin(settings.DOMAIN, self.preprint.url)])
 
         assert nodes == {}
 

--- a/website/preprints/tasks.py
+++ b/website/preprints/tasks.py
@@ -50,7 +50,10 @@ def format_preprint(preprint):
     ]
 
     if preprint.article_doi:
-        to_visit.append(GraphNode('workidentifier', creative_work=preprint_graph, uri='http://dx.doi.org/{}'.format(preprint.article_doi)))
+        # Article DOI refers to a clone of this preprint on another system and therefore does not qualify as an identifier for this preprint
+        related_work = GraphNode('creativework')
+        to_visit.append(GraphNode('workrelation', subject=preprint_graph, related=related_work))
+        to_visit.append(GraphNode('workidentifier', creative_work=related_work, uri='http://dx.doi.org/{}'.format(preprint.article_doi)))
 
     preprint_graph.attrs['tags'] = [
         GraphNode('throughtags', creative_work=preprint_graph, tag=GraphNode('tag', name=tag._id))


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

DOIs have been incorrectly processed as the DOI of the preprint it is attached to. `article_doi` is actually a descriptor of a related article/preprint.

## Changes

DOIs are now used to describe a related object.

## Ticket

https://openscience.atlassian.net/browse/SHARE-674
