### PR TITLE
Allow unregistered contribs to be imported across components [OSF-7697]

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -439,7 +439,7 @@ class NodeSerializer(JSONAPISerializer):
                 if not contributor.user.is_registered:
                     node.add_unregistered_contributor(
                         fullname=contributor.user.fullname, email=contributor.user.email, auth=auth,
-                        permissions=parent.get_permissions(contributor.user)
+                        permissions=parent.get_permissions(contributor.user), existing_user=contributor.user
                     )
             node.add_contributors(contributors, auth=auth, log=True, save=True)
         return node

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -1145,17 +1145,18 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             self.save()
 
     def add_unregistered_contributor(self, fullname, email, auth, send_email='default',
-                                     visible=True, permissions=None, save=False):
+                                     visible=True, permissions=None, save=False, existing_user=None):
         """Add a non-registered contributor to the project.
 
         :param str fullname: The full name of the person.
         :param str email: The email address of the person.
         :param Auth auth: Auth object for the user adding the contributor.
+        :param User existing_user: the unregister_contributor if it is already created, otherwise None
         :returns: The added contributor
         :raises: DuplicateEmailError if user with given email is already in the database.
         """
-        # Create a new user record
-        contributor = OSFUser.create_unregistered(fullname=fullname, email=email)
+        # Create a new user record if you weren't passed an existing user
+        contributor = existing_user if existing_user else OSFUser.create_unregistered(fullname=fullname, email=email)
 
         contributor.add_unclaimed_record(node=self, referrer=auth.user,
                                          given_name=fullname, email=email)

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -184,7 +184,7 @@ def project_new_node(auth, node, **kwargs):
                 if contributor._id == user._id and not contributor.is_registered:
                     new_component.add_unregistered_contributor(
                         fullname=contributor.fullname, email=contributor.email,
-                        permissions=perm, auth=auth
+                        permissions=perm, auth=auth, existing_user=contributor
                     )
                 else:
                     new_component.add_contributor(contributor, permissions=perm, auth=auth)


### PR DESCRIPTION
## Purpose
The `Contributor` model was added in the rewrite, and a small edge case was missed. This fixes

## Changes
* Fix bad merge from ~October

## Side effects
None expected

## Ticket
[[OSF-7697]](https://openscience.atlassian.net/browse/OSF-7697)