### PR TITLE
[Hotfix] Use `creator` to distinguish valid bookmarks [OSF-7696]

### DIFF
--- a/scripts/migration/ensure_bookmark_existence.py
+++ b/scripts/migration/ensure_bookmark_existence.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 def get_targets():
     logger.info('Acquiring targets...')
-    targets = [u for u in User.find() if Node.find(Q('is_bookmark_collection', 'eq', True) & Q('is_deleted', 'eq', False) & Q('contributors', 'eq', u._id)).count() == 0]
+    targets = [u for u in User.find(Q('merged_by', 'eq', None)) if Node.find(Q('is_bookmark_collection', 'eq', True) & Q('is_deleted', 'eq', False) & Q('creator', 'eq', u._id)).count() == 0]
     logger.info('Found {} target users.'.format(len(targets)))
     return targets
 
@@ -30,7 +30,7 @@ def migrate():
 
 def main():
     parser = argparse.ArgumentParser(
-        description='Ensures every confirmed user has a bookmark collection.'
+        description='Ensures every user has a bookmark collection.'
     )
     parser.add_argument(
         '--dry',

--- a/website/project/__init__.py
+++ b/website/project/__init__.py
@@ -69,7 +69,7 @@ def new_bookmark_collection(user):
 
     """
     existing_bookmark_collection = Node.find(
-        Q('is_bookmark_collection', 'eq', True) & Q('contributors', 'eq', user._id) & Q('is_deleted', 'eq', False)
+        Q('is_bookmark_collection', 'eq', True) & Q('creator', 'eq', user._id) & Q('is_deleted', 'eq', False)
     )
 
     if existing_bookmark_collection.count() > 0:

--- a/website/views.py
+++ b/website/views.py
@@ -100,7 +100,7 @@ def index():
 
 
 def find_bookmark_collection(user):
-    return Node.find_one(Q('is_bookmark_collection', 'eq', True) & Q('contributors', 'eq', user._id) & Q('is_deleted', 'eq', False))
+    return Node.find_one(Q('is_bookmark_collection', 'eq', True) & Q('creator', 'eq', user._id) & Q('is_deleted', 'eq', False))
 
 @must_be_logged_in
 def dashboard(auth):


### PR DESCRIPTION
## Purpose
Fix bad data

## Changes
* Use `creator` to distinguish valid bookmarks

## Side effects
~~It might be possible for this to break existing valid bookmark collections with links.~~

~~TODO: investigate if there are any~~

Update: not a problem. See ticket for details

## Deployment Notes
```
python -m scripts.migration.ensure_bookmark_existence --dry
python -m scripts.migration.ensure_bookmark_uniqueness --dry 
```

## Ticket
[[OSF-7696]](https://openscience.atlassian.net/browse/OSF-7696)