### PR TITLE
Admin - Update metrics permission required name

### DIFF
--- a/admin/metrics/views.py
+++ b/admin/metrics/views.py
@@ -6,7 +6,7 @@ from admin.base.settings import KEEN_CREDENTIALS
 
 class MetricsView(PermissionRequiredMixin, TemplateView):
     template_name = 'metrics/osf_metrics.html'
-    permission_required = 'common_auth.view_metrics'
+    permission_required = 'osf.view_metrics'
     raise_exception = True
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION

## Purpose

Permissions were changed to be under the OSF namespace in a previous PR, but this change slipped by by accident. This is to allow metrics only users to actually be able to view metrics

## Changes
- Update permission required name

## Side effects

None anticipated

