### PR TITLE
Add checkboxselectmultiple widget for admin form

### DIFF
--- a/admin/common_auth/forms.py
+++ b/admin/common_auth/forms.py
@@ -23,7 +23,8 @@ class UserRegistrationForm(forms.Form):
 
     group_perms = forms.ModelMultipleChoiceField(
         queryset=Group.objects.all(),
-        required=False
+        required=False,
+        widget=forms.CheckboxSelectMultiple
     )
 
 


### PR DESCRIPTION
## Purpose

A small update that makes the superuer's form for adding admin users a little nicer

#### Before
![screen shot 2017-03-29 at 1 15 47 pm](https://cloud.githubusercontent.com/assets/801594/24467324/08a832a2-1482-11e7-9e7f-f17a71e55fbf.png)


#### After
![screen shot 2017-03-29 at 1 15 27 pm](https://cloud.githubusercontent.com/assets/801594/24467329/0d561c42-1482-11e7-812d-a75b1698754a.png)


## Changes
- Specify a form widget on admin permissions update page

## Side effects

None anticipated
