### PR TITLE
[OSF-7720] Move serialization logic into SQL

### DIFF
--- a/addons/osfstorage/models.py
+++ b/addons/osfstorage/models.py
@@ -238,12 +238,12 @@ class OsfStorageFile(OsfStorageFileNode, File):
             ret['fullPath'] = self.materialized_path
 
         version = self.get_version(version)
-        return dict(
-            ret,
-            version=self.versions.count(),
-            md5=version.metadata.get('md5') if version else None,
-            sha256=version.metadata.get('sha256') if version else None,
-        )
+        ret.update({
+            'version': self.versions.count(),
+            'md5': version.metadata.get('md5') if version else None,
+            'sha256': version.metadata.get('sha256') if version else None,
+        })
+        return ret
 
     def create_version(self, creator, location, metadata=None):
         latest_version = self.get_version()

--- a/addons/osfstorage/utils.py
+++ b/addons/osfstorage/utils.py
@@ -56,7 +56,7 @@ def serialize_revision(node, record, version, index, anon=False):
         'user': user,
         'index': index + 1,
         'date': version.date_created.isoformat(),
-        'downloads': record.get_download_count(version=index),
+        'downloads': version._download_count if hasattr(version, '_download_count') else record.get_download_count(version=index),
         'md5': version.metadata.get('md5'),
         'sha256': version.metadata.get('sha256'),
     }

--- a/osf/models/files.py
+++ b/osf/models/files.py
@@ -24,6 +24,7 @@ from website.files import utils
 from website.files.exceptions import VersionNotFoundError
 from website.util import api_v2_url, waterbutler_api_url_for
 from osf.utils.datetime_aware_jsonfield import coerce_nonnaive_datetimes
+from osf.utils.manager import IncludeQuerySet
 import pytz
 
 # TODO DELETE ME POST MIGRATION
@@ -677,6 +678,8 @@ class FileVersion(ObjectIDMixin, BaseModel):
 
     metadata = DateTimeAwareJSONField(blank=True, default=dict)
     location = DateTimeAwareJSONField(default=None, blank=True, null=True, validators=[validate_location])
+
+    includable_objects = IncludeQuerySet.as_manager()
 
     @property
     def location_hash(self):

--- a/osf/models/files.py
+++ b/osf/models/files.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import logging
 import os
 
@@ -499,27 +501,25 @@ class File(models.Model):
         newest_version = self.versions.all().last()
 
         if not newest_version:
-            return dict(
-                self._serialize(),
-                size=None,
-                version=None,
-                modified=None,
-                created=None,
-                contentType=None,
-                downloads=self.get_download_count(),
-                checkout=self.checkout._id if self.checkout else None,
-            )
+            return dict(self._serialize(), **{
+                'size': None,
+                'version': None,
+                'modified': None,
+                'created': None,
+                'contentType': None,
+                'downloads': self.get_download_count(),
+                'checkout': self.checkout._id if self.checkout else None,
+            })
 
-        return dict(
-            self._serialize(),
-            size=newest_version.size,
-            downloads=self.get_download_count(),
-            checkout=self.checkout._id if self.checkout else None,
-            version=newest_version.identifier if newest_version else None,
-            contentType=newest_version.content_type if newest_version else None,
-            modified=newest_version.date_modified.isoformat() if newest_version.date_modified else None,
-            created=self.versions.all().first().date_modified.isoformat() if self.versions.all().first().date_modified else None,
-        )
+        return dict(self._serialize(), **{
+            'size': newest_version.size,
+            'downloads': self.get_download_count(),
+            'checkout': self.checkout._id if self.checkout else None,
+            'version': newest_version.identifier if newest_version else None,
+            'contentType': newest_version.content_type if newest_version else None,
+            'modified': newest_version.date_modified.isoformat() if newest_version.date_modified else None,
+            'created': self.versions.all().first().date_modified.isoformat() if self.versions.all().first().date_modified else None,
+        })
 
     def restore(self, recursive=True, parent=None, save=True, deleted_on=None):
         raise UnableToRestore('You cannot restore something that is not deleted.')


### PR DESCRIPTION
```python
In [38]: prod = requests.get('https://files.osf.io/v1/resources/ktehs/providers/osfstorage/?meta').json()['data']

In [39]: local = requests.get('http://localhost:7777/v1/resources/ktehs/providers/osfstorage/?meta').json()['data']

In [40]: local = [x['attributes'] for x in sorted(local, key=lambda y: y['id'])]

In [41]: prod = [x['attributes'] for x in sorted(prod, key=lambda y: y['id'])]

In [42]: _ = [x.pop('modified', None) for x in prod]

In [43]: _ = [x.pop('modified', None) for x in local]

In [44]: prod == local
Out[44]: True
```

Even better:

```python
In [47]:  prod = requests.get('https://files.osf.io/v1/resources/ktehs/providers/osfstorage/58b85106594d9001fbfeb37f/?meta').json()['data']

In [48]: %time  prod = requests.get('https://files.osf.io/v1/resources/ktehs/providers/osfstorage/58b85106594d9001fbfeb37f/?meta').json()['data']
CPU times: user 144 ms, sys: 36 ms, total: 180 ms
Wall time: 17.4 s

In [49]: %time local = requests.get('http://localhost:7777/v1/resources/ktehs/providers/osfstorage/58b85106594d9001fbfeb37f/?meta').json()['data']
CPU times: user 66.8 ms, sys: 8.95 ms, total: 75.7 ms
Wall time: 3.56 s

In [50]: local = [x['attributes'] for x in sorted(local, key=lambda y: y['id'])]

In [51]: prod = [x['attributes'] for x in sorted(prod, key=lambda y: y['id'])]

In [52]: _ = [x.pop('modified', None) for x in prod]

In [53]: _ = [x.pop('modified', None) for x in local]

In [54]: prod == local
Out[54]: True

```
