### PR TITLE
[hotfix] Fix Prereg Banner on Mobile [OSF-7644]

### DIFF
--- a/website/static/js/home-page/quickProjectSearchPlugin.js
+++ b/website/static/js/home-page/quickProjectSearchPlugin.js
@@ -497,13 +497,13 @@ var QuickSearchProject = {
             return m ('.prereg.banner',
                 m('.row',
                     [
-                        m('.col-xs-9.m-v-sm',
+                        m('.col-md-9.m-v-sm',
                             m('div.conference-centering',
                                 m('p', 'Improve your next study. Enter the Prereg Challenge and you could win $1,000.')
                             )
                         ),
-                        m('.col-xs-3.text-center.m-v-sm',
-                            m('div.pull-right',  m('a.btn.btn-success.btn-success-high-contrast.f-w-xl', { type:'button',  href:'/prereg/', onclick: function() {
+                        m('.col-md-3.text-center.m-v-sm',
+                            m('div',  m('a.btn.btn-success.btn-success-high-contrast.f-w-xl', { type:'button',  href:'/prereg/', onclick: function() {
                                 $osf.trackClick('prereg', 'navigate', 'navigate-to-begin-prereg');
                             }}, 'Start Prereg Challenge'))
                         )

--- a/website/templates/home.mako
+++ b/website/templates/home.mako
@@ -33,6 +33,7 @@
 
 <%def name="stylesheets()">
   <link rel="stylesheet" href="/static/css/pages/home-page.css">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1, minimum-scale=1">
 </%def>
 
 <%def name="javascript_bottom()">


### PR DESCRIPTION
#### Purpose
- The button on the new prereg banner overlapped with the banner text on mobile screens, and also made the mobile dropdown menu disappear. Oops.

#### Screenshots 
- Still good on large screens:
![screen shot 2017-03-31 at 10 40 46 am](https://cloud.githubusercontent.com/assets/7913604/24555535/82ef0904-15ff-11e7-913e-e6f3b69a5786.png)

- Better on mobile screens:
![screen shot 2017-03-31 at 10 40 30 am](https://cloud.githubusercontent.com/assets/7913604/24555539/85f87590-15ff-11e7-874d-a158e102a9c1.png)


#### Ticket
- [OSF-7644](https://openscience.atlassian.net/browse/OSF-7644)
