### PR TITLE
Add link between projects and registrations in admin [OSF-6842]

### DIFF
--- a/admin/nodes/serializers.py
+++ b/admin/nodes/serializers.py
@@ -30,6 +30,7 @@ def serialize_node(node):
         'spam_pro_tip': node.spam_pro_tip,
         'spam_data': json.dumps(node.spam_data, indent=4),
         'is_public': node.is_public,
+        'registrations': [serialize_node(registration) for registration in node.registrations.all()]
     }
 
 

--- a/admin/nodes/serializers.py
+++ b/admin/nodes/serializers.py
@@ -30,7 +30,8 @@ def serialize_node(node):
         'spam_pro_tip': node.spam_pro_tip,
         'spam_data': json.dumps(node.spam_data, indent=4),
         'is_public': node.is_public,
-        'registrations': [serialize_node(registration) for registration in node.registrations.all()]
+        'registrations': [serialize_node(registration) for registration in node.registrations.all()],
+        'registered_from': node.registered_from._id if node.registered_from else None
     }
 
 

--- a/admin/templates/nodes/node.html
+++ b/admin/templates/nodes/node.html
@@ -232,7 +232,28 @@
                 <td>Registration</td>
                 <td>
                     {% if not node.is_registration %}
-                        {{ node.is_registration }}
+                        <table class="table table-bordered table-hover">
+                                <thead>
+                                <tr>
+                                    <td>Registration</td>
+                                    <td>Date Created</td>
+                                    <td>Pending</td>
+                                    <td>Withdrawn</td>
+                                    <td>Embargo</td>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                {% for registration in node.registrations %}
+                                <tr>
+                                    <td><a href="{{ registration.id | reverse_node }}">{{ registration.id }}</a></td>
+                                    <td>{{ registration.date_created | date }}</td>
+                                    <td>{{ registration.pending_registration }}</td>
+                                    <td>{{ registration.withdrawn }}</td>
+                                    <td>{{ registration.embargo }}</td>
+                                </tr>
+                        {% endfor %}
+                                </tbody>
+                            </table>
                     {% else %}
                         <table class="table table-bordered table-hover">
                         <thead>

--- a/admin/templates/nodes/node.html
+++ b/admin/templates/nodes/node.html
@@ -283,6 +283,10 @@
                                 <td>Embargo</td>
                                 <td>{{ node.embargo }}</td>
                             </tr>
+                            <tr>
+                                <td>Registered From</td>
+                                <td><a href="{% url 'nodes:node' node.registered_from %}">{{ node.registered_from }}</a></td>
+                            </tr>
                         </tbody>
                         </table>
                     {% endif %}


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Add link on project detail to registrations, add link on registration to `registered_from` node

### Node View
![screen shot 2017-04-03 at 5 04 15 pm](https://cloud.githubusercontent.com/assets/801594/24631852/ef869cca-188f-11e7-8696-5d380d6634bc.png)

### Registration View
![screen shot 2017-04-03 at 5 04 25 pm](https://cloud.githubusercontent.com/assets/801594/24631856/f4dc9044-188f-11e7-90ae-00d38ff205ce.png)


## Changes

- Updates to node seralizer to include registration and registered_from
- Update to node template view

## Side effects

None anticipated


## Ticket
https://openscience.atlassian.net/browse/OSF-6842