### PR TITLE
[Hotfix] Optimize BaseLinkedList [OSF-7738]

### DIFF
--- a/api/base/views.py
+++ b/api/base/views.py
@@ -851,11 +851,4 @@ class BaseLinkedList(JSONAPIBaseView, generics.ListAPIView):
     def get_queryset(self):
         auth = get_user_auth(self.request)
 
-        linked_node_ids = [
-            each.id for each in self.get_node().linked_nodes
-            .filter(is_deleted=False)
-            .exclude(type='osf.collection')
-            .order_by('-date_modified')
-            if each.can_view(auth)
-        ]
-        return self.get_node().linked_nodes.filter(id__in=linked_node_ids)
+        return self.get_node().linked_nodes.filter(is_deleted=False).exclude(type='osf.collection').can_view(user=auth.user, private_link=auth.private_link).order_by('-date_modified')

--- a/api/collections/views.py
+++ b/api/collections/views.py
@@ -350,9 +350,7 @@ class LinkedNodesList(BaseLinkedList, CollectionMixin):
     view_name = 'linked-nodes'
 
     def get_queryset(self):
-        return [node for node in
-            super(LinkedNodesList, self).get_queryset()
-            if not node.is_registration]
+        return super(LinkedNodesList, self).get_queryset().exclude(type='osf.registration')
 
     # overrides APIView
     def get_parser_context(self, http_request):

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -105,6 +105,7 @@ class AbstractNodeQuerySet(MODMCompatibilityQuerySet, IncludeQuerySet):
             if not isinstance(user, int):
                 raise TypeError('"user" must be either {} or {}. Got {!r}'.format(int, OSFUser, user))
 
+            qs |= self.filter(contributor__user_id=user, contributor__read=True)
             qs |= self.extra(where=['''
                 "osf_abstractnode".id in (
                     WITH RECURSIVE implicit_read AS (
@@ -121,7 +122,7 @@ class AbstractNodeQuerySet(MODMCompatibilityQuerySet, IncludeQuerySet):
                 )
             '''], params=(user, ))
 
-        return qs
+        return qs.distinct()
 
 
 class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixin,


### PR DESCRIPTION
## Purpose
Optimize. 

`c` is a collection with 15 links. Old way:
```
In [26]: %timeit -n 10 list(c.linked_nodes.filter(id__in=[e.id for e in c.linked_nodes.filter(is_deleted=False).exclude(type='osf.collection').order_by('-date_modified') if e.can_view(Auth(u))]))
[...]
10 loops, best of 3: 864 ms per loop
```
New way:
```
In [27]: %timeit -n 10 list(c.linked_nodes.filter(is_deleted=False).exclude(type='osf.collection').can_view(user=u, private_link=None).order_by('-date_modified'))
[...]
10 loops, best of 3: 261 ms per loop
```
## Changes
* Use `AbstractNodeQuerySet.can_view`
* Incidental fix: use `.exclude` instead of python filtering
* Incidental fix: explicitly check view permissions in `AbstractNodeQuerySet.can_view`

## Side Effects
None expected


## Ticket
[[OSF-7738]](https://openscience.atlassian.net/browse/OSF-7738)