### PR TITLE
Bump invoke to 0.15.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@
 # To install dev requirements: inv requirements --dev
 # To install release requirements: inv requirements --release
 
-invoke==0.13.0
+invoke==0.15.0
 Werkzeug==0.10.4
 Flask==0.10.1
 gevent==1.2.1


### PR DESCRIPTION

## Purpose

The latest version resolves some issues with garbage characters being printed when running IPython with ctx.run (see Notes in #7062).

## Changes

Bump invoke

## Side effects

I reviewed invoke's changelog, and there should be no breaking changes that affect us.

Devs should update their requirements

```
docker-compose up requirements
```

and/or

```
pip install -r requirements.txt
```

