### PR TITLE
[HAUTFIX] [RFR] Fix IntegrityError on duplicate file upload [OSF-7741]

### DIFF
--- a/addons/osfstorage/views.py
+++ b/addons/osfstorage/views.py
@@ -228,7 +228,6 @@ def osfstorage_create_child(file_node, payload, node_addon, **kwargs):
 
     # Create a save point so that we can rollback and unlock
     # the parent record
-    import ipdb; ipdb.set_trace()
     with transaction.atomic():
         try:
             created, file_node = False, parent.find_child_by_name(name, kind=int(not is_folder))

--- a/addons/osfstorage/views.py
+++ b/addons/osfstorage/views.py
@@ -11,6 +11,7 @@ from django.db.models.expressions import RawSQL
 from modularodm import Q
 
 from flask import request
+from modularodm.exceptions import NoResultsFound
 
 from framework.auth import Auth
 from framework.sessions import get_session
@@ -225,16 +226,17 @@ def osfstorage_create_child(file_node, payload, node_addon, **kwargs):
     if not (name or user) or '/' in name:
         raise HTTPError(httplib.BAD_REQUEST)
 
-    try:
-        # Create a save point so that we can rollback and unlock
-        # the parent record
-        with transaction.atomic():
+    # Create a save point so that we can rollback and unlock
+    # the parent record
+    import ipdb; ipdb.set_trace()
+    with transaction.atomic():
+        try:
+            created, file_node = False, parent.find_child_by_name(name, kind=int(not is_folder))
+        except NoResultsFound:
             if is_folder:
                 created, file_node = True, parent.append_folder(name)
             else:
                 created, file_node = True, parent.append_file(name)
-    except (ValidationError, IntegrityError):
-        created, file_node = False, parent.find_child_by_name(name, kind=int(not is_folder))
 
     if not created and is_folder:
         raise HTTPError(httplib.CONFLICT, data={


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Stop IntegrityErrors from being logged in postgres logs for duplicate file uploads.

## Changes

Reversed the logic to try and find a file before creating one.

## Side effects

Small possibility the file could change in between it being found and it being updated but that existed before and could not be mitigated without a fairly large refactor.


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
