### PR TITLE
[Hotfix] Optimize view project

### DIFF
--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -654,6 +654,7 @@ def _view_project(node, auth, primary=False,
     """Build a JSON object containing everything needed to render
     project.view.mako.
     """
+    node = Node.objects.filter(pk=node.pk).include('contributor__user__guids').get()
     user = auth.user
 
     parent = node.find_readable_antecedent(auth)
@@ -791,7 +792,7 @@ def _view_project(node, auth, primary=False,
         ]
     }
     if embed_contributors and not anonymous:
-        data['node']['contributors'] = utils.serialize_contributors(node.visible_contributors, node=node)
+        data['node']['contributors'] = utils.serialize_visible_contributors(node)
     if embed_descendants:
         descendants, all_readable = _get_readable_descendants(auth=auth, node=node)
         data['user']['can_sort'] = all_readable


### PR DESCRIPTION
## Purpose
Reduce number of queries required to view a project with lots of contributors

New:
```
In [7]: %timeit -n 10 utils.serialize_visible_contributors(included_n)
10 loops, best of 3: 25.6 ms per loop
```
Old:
```
In [8]: %timeit -n 10 utils.serialize_contributors(n.visible_contributors, node=n)
10 loops, best of 3: 14.9 s per loop
```

## Changes
* `.include` related models
* Create new utils for this case

## Side effects
None expected

## Ticket
None known