### PR TITLE
Update local figshare instructions to reflect model changes [#OSF-7755]

### DIFF
--- a/addons/figshare/README.md
+++ b/addons/figshare/README.md
@@ -33,7 +33,7 @@ has instructions for use with ngrok, but there are other methods.
 from addons.figshare.client import FigshareClient
 from website.oauth.models import ExternalAccount
 
-me = User.find_one(Q('username', 'eq', '<your username>'))
+me = OSFUser.load('<osf_guid>')
 token = '<personal token id from figshare>'
 client = FigshareClient(token)
 
@@ -47,7 +47,7 @@ ea = ExternalAccount(
 )
 ea.save()
 fu = me.get_or_add_addon('figshare')
-me.external_accounts.append(ea)
+me.external_accounts.add(ea)
 me.save()
 
 commit()

--- a/addons/figshare/README.md
+++ b/addons/figshare/README.md
@@ -29,8 +29,9 @@ has instructions for use with ngrok, but there are other methods.
 1. Go to [figshare](http://figshare.com), create an account, and login
 2. Click the dropdown with your name and select **Applications** and click **Create Personal Token**
 3. `invoke shell`, then run:
-```
+```python
 from addons.figshare.client import FigshareClient
+from osf.models.user import OSFUser
 from website.oauth.models import ExternalAccount
 
 me = OSFUser.load('<osf_guid>')


### PR DESCRIPTION
## Purpose
There are special instructions required to use the Figshare addon locally. These instructions should be brought up to date with recent model changes, and we should confirm that the instructions work as written.

## Changes
This is a developer facing change to docs, and should not affect user or site functionality.

## Side effects
None expected. This is my first PR with the new models, so worth verifying for accuracy. Worked when I ran locally in `shell_plus`.

## Ticket
https://openscience.atlassian.net/browse/OSF-7755
