### PR TITLE
[hotfix] Remove unnecessary count queries when sending PUT to /api/v1/profile

### DIFF
--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -57,7 +57,7 @@ class TestUserSerializers(OsfTestCase):
         NodeFactory(creator=user)
         ProjectFactory(creator=user, is_public=True)
         CollectionFactory(creator=user)
-        d = utils.serialize_user(user, full=True)
+        d = utils.serialize_user(user, full=True, include_node_counts=True)
         gravatar = filters.gravatar(
             user,
             use_ssl=True,

--- a/website/profile/utils.py
+++ b/website/profile/utils.py
@@ -16,7 +16,7 @@ def get_gravatar(user, size=None):
     )
 
 
-def serialize_user(user, node=None, admin=False, full=False, is_profile=False):
+def serialize_user(user, node=None, admin=False, full=False, is_profile=False, include_node_counts=False):
     """
     Return a dictionary representation of a registered user.
 
@@ -91,8 +91,6 @@ def serialize_user(user, node=None, admin=False, full=False, is_profile=False):
 
         projects = Node.find_for_user(user, PROJECT_QUERY).get_roots()
         ret.update({
-            'number_projects': projects.count(),
-            'number_public_projects': projects.filter(is_public=True).count(),
             'activity_points': user.get_activity_points(),
             'gravatar_url': gravatar(
                 user, use_ssl=True,
@@ -101,6 +99,11 @@ def serialize_user(user, node=None, admin=False, full=False, is_profile=False):
             'is_merged': user.is_merged,
             'merged_by': merged_by,
         })
+        if include_node_counts:
+            ret.update({
+                'number_projects': projects.count(),
+                'number_public_projects': projects.filter(is_public=True).count(),
+            })
 
     return ret
 

--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -276,7 +276,7 @@ def _profile_view(profile, is_profile=False, embed_nodes=False):
     badges = []
 
     if profile:
-        profile_user_data = profile_utils.serialize_user(profile, full=True, is_profile=is_profile)
+        profile_user_data = profile_utils.serialize_user(profile, full=True, is_profile=is_profile, include_node_counts=embed_nodes)
         ret = {
             'profile': profile_user_data,
             'assertions': badge_assertions,


### PR DESCRIPTION


## Purpose

Unnecessary count queries were being made on the `PUT /api/v1/profile/` endpoint, which gets called often (every time a user visits the dashboard).

## Changes

Don't include the user's number of public projects and components.

## Side effects

<!--Any possible side effects? -->


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
