### PR TITLE
[feature] Fix Failing Registrations with &, <, > in File Names [OSF-7613]

### DIFF
--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -73,6 +73,48 @@ class TestSanitize(unittest.TestCase):
             '&lt;&gt;&'
         )
 
+    def test_unescape_html_additional_safe_characters(self):
+        assert_equal(
+            sanitize.unescape_entities(
+                '&lt;&gt; diamonds &amp; diamonds &lt;&gt;',
+                {
+                    '&lt;': '<',
+                    '&gt;': '>'
+                }
+            ),
+            '<> diamonds & diamonds <>'
+        )
+        assert_equal(
+            sanitize.unescape_entities(
+                ['&lt;&gt;&amp;'],
+                {
+                    '&lt;': '<',
+                    '&gt;': '>'
+                }
+            )[0],
+            '<>&'
+        )
+        assert_equal(
+            sanitize.unescape_entities(
+                ('&lt;&gt;&amp;', ),
+                {
+                    '&lt;': '<',
+                    '&gt;': '>'
+                }
+            )[0],
+            '<>&'
+        )
+        assert_equal(
+            sanitize.unescape_entities(
+                {'key': '&lt;&gt;&amp;'},
+                {
+                    '&lt;': '<',
+                    '&gt;': '>'
+                }
+            )['key'],
+            '<>&'
+        )
+
     def test_safe_json(self):
         """Add escaping of forward slashes, but only where string literal contains closing markup"""
         assert_equal(

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -77,7 +77,7 @@ class TestSanitize(unittest.TestCase):
         assert_equal(
             sanitize.unescape_entities(
                 '&lt;&gt; diamonds &amp; diamonds &lt;&gt;',
-                {
+                safe={
                     '&lt;': '<',
                     '&gt;': '>'
                 }
@@ -87,7 +87,7 @@ class TestSanitize(unittest.TestCase):
         assert_equal(
             sanitize.unescape_entities(
                 ['&lt;&gt;&amp;'],
-                {
+                safe={
                     '&lt;': '<',
                     '&gt;': '>'
                 }
@@ -97,7 +97,7 @@ class TestSanitize(unittest.TestCase):
         assert_equal(
             sanitize.unescape_entities(
                 ('&lt;&gt;&amp;', ),
-                {
+                safe={
                     '&lt;': '<',
                     '&gt;': '>'
                 }
@@ -107,7 +107,7 @@ class TestSanitize(unittest.TestCase):
         assert_equal(
             sanitize.unescape_entities(
                 {'key': '&lt;&gt;&amp;'},
-                {
+                safe={
                     '&lt;': '<',
                     '&gt;': '>'
                 }

--- a/website/archiver/utils.py
+++ b/website/archiver/utils.py
@@ -14,6 +14,7 @@ from website import (
     mails,
     settings
 )
+from website.util import sanitize
 
 def send_archiver_size_exceeded_mails(src, user, stat_result):
     mails.send_mail(
@@ -205,9 +206,14 @@ def get_file_map(node, file_map):
 
 def find_registration_file(value, node):
     from osf.models import AbstractNode as Node
-
     orig_sha256 = value['sha256']
-    orig_name = value['selectedFileName']
+    orig_name = sanitize.unescape_entities(
+        value['selectedFileName'],
+        {
+            '&lt;': '<',
+            '&gt;': '>'
+        }
+    )
     orig_node = value['nodeId']
     file_map = get_file_map(node)
     for sha256, value, node_id in file_map:

--- a/website/archiver/utils.py
+++ b/website/archiver/utils.py
@@ -209,7 +209,7 @@ def find_registration_file(value, node):
     orig_sha256 = value['sha256']
     orig_name = sanitize.unescape_entities(
         value['selectedFileName'],
-        {
+        safe={
             '&lt;': '<',
             '&gt;': '>'
         }

--- a/website/util/sanitize.py
+++ b/website/util/sanitize.py
@@ -78,7 +78,7 @@ def assert_clean(data):
 
 
 # TODO: Remove unescape_entities when mako html safe comes in
-def unescape_entities(value):
+def unescape_entities(value, safe=None):
     """
     Convert HTML-encoded data (stored in the database) to literal characters.
 
@@ -91,15 +91,18 @@ def unescape_entities(value):
         '&amp;': '&',
     }
 
+    if safe and isinstance(safe, dict):
+        safe_characters.update(safe)
+
     if isinstance(value, dict):
         return {
-            key: unescape_entities(value)
+            key: unescape_entities(value, safe=safe_characters)
             for (key, value) in value.iteritems()
         }
 
     if is_iterable_but_not_string(value):
         return [
-            unescape_entities(each)
+            unescape_entities(each, safe=safe_characters)
             for each in value
         ]
     if isinstance(value, basestring):

--- a/website/util/sanitize.py
+++ b/website/util/sanitize.py
@@ -85,6 +85,9 @@ def unescape_entities(value, safe=None):
     Intended primarily for endpoints consumed by frameworks that handle their own escaping (eg Knockout)
 
     :param value: A string, dict, or list
+    :param safe: A dict of escape sequences and characters that can be used to extend the set of
+        characters that this function will unescape. Use with caution as there are few cases in which
+        there will be reason to unescape characters beyond '&'.
     :return: A string or list or dict without html escape characters
     """
     safe_characters = {


### PR DESCRIPTION
#### Purpose
- Fixes `ArchivedFileNotFound` error being incorrectly raised for files with <, >, and & characters in their name that have been attached to a registration schema.

#### Changes
- Unescape selected file names for comparison to file map in archival process.
- Adds regression test for file names with special characters.
- Adds failing test case for `different_file_names_same_shas` (mostly unrelated, just seemed like a good test to add).
- Allows additional safe characters to be passed to `unescape_entities()`.
- Adds test for `unescape_entities()` with additional characters.

#### Side effects
- None expected.

#### Ticket
- [OSF-7613](https://openscience.atlassian.net/browse/OSF-7613)
