### PR TITLE
[feature] fix comment notification dupes [OSF-6528]

### DIFF
--- a/osf/models/comment.py
+++ b/osf/models/comment.py
@@ -162,6 +162,7 @@ class Comment(GuidMixin, SpamMixin, CommentableMixin, BaseModel):
 
         log_dict.update(comment.root_target.referent.get_extra_log_params(comment))
 
+        new_mentions = []
         if comment.content:
             new_mentions = get_valid_mentioned_users_guids(comment, comment.node.contributors)
             if new_mentions:
@@ -178,7 +179,7 @@ class Comment(GuidMixin, SpamMixin, CommentableMixin, BaseModel):
         )
 
         comment.node.save()
-        project_signals.comment_added.send(comment, auth=auth)
+        project_signals.comment_added.send(comment, auth=auth, new_mentions=new_mentions)
 
         return comment
 

--- a/website/notifications/emails.py
+++ b/website/notifications/emails.py
@@ -15,7 +15,6 @@ def notify(event, user, node, timestamp, **context):
     :param user: user who triggered notification
     :param node: instance of Node
     :param timestamp: time event happened
-    :param exclude: list of guids to exclude or None
     :param context: optional variables specific to templates
         target_user: used with comment_replies
     :return: List of user ids notifications were sent to

--- a/website/project/views/comment.py
+++ b/website/project/views/comment.py
@@ -120,7 +120,7 @@ def send_comment_added_notification(comment, auth, new_mentions):
         target_user=target.referent.user if is_reply(target) else None,
         parent_comment=target.referent.content if is_reply(target) else '',
         url=comment.get_comment_page_url(),
-        exclude=new_mentions
+        exclude=new_mentions,
     )
     time_now = timezone.now()
     sent_subscribers = notify(

--- a/website/project/views/comment.py
+++ b/website/project/views/comment.py
@@ -107,7 +107,7 @@ def render_email_markdown(content):
 
 
 @comment_added.connect
-def send_comment_added_notification(comment, auth):
+def send_comment_added_notification(comment, auth, new_mentions):
     node = comment.node
     target = comment.target
 
@@ -119,7 +119,8 @@ def send_comment_added_notification(comment, auth):
         provider=PROVIDERS[comment.root_target.referent.provider] if comment.page == Comment.FILES else '',
         target_user=target.referent.user if is_reply(target) else None,
         parent_comment=target.referent.content if is_reply(target) else '',
-        url=comment.get_comment_page_url()
+        url=comment.get_comment_page_url(),
+        exclude=new_mentions
     )
     time_now = timezone.now()
     sent_subscribers = notify(

--- a/website/project/views/comment.py
+++ b/website/project/views/comment.py
@@ -131,7 +131,7 @@ def send_comment_added_notification(comment, auth):
     )
 
     if is_reply(target):
-        if target.referent.user and target.referent.user not in sent_subscribers:
+        if target.referent.user and target.referent.user._id not in sent_subscribers:
             notify(
                 event='global_comment_replies',
                 user=auth.user,


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Comments send dupe emails if they are replies or at mentions. This fixes that.
<!-- Describe the purpose of your changes -->

## Changes
1. Fix bug where user object was being checked against a list of string guids.
2. Add an exclude context variable to stop dupes.
<!-- Briefly describe or list your changes  -->

## Side effects
1. Greatly refactored/tidied code (no more 3 nested deep if statements in a for loop)
2. Added line comments.


## Code Notes
Exclude includes the user._id, which means checks for target_user._id and checks if user._id are no longer necessary as they are filtered in the list comprehension.

## Ticket
[#OSF-6528]
https://openscience.atlassian.net/browse/OSF-6528
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->