### PR TITLE
Use preprint edit route [OSF-7761]

### DIFF
--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -243,7 +243,7 @@
             This project represents a preprint. <a href="http://help.osf.io/m/preprints">Learn more</a> about how to work with preprint files.
             <a href="${node['preprint_url']}" class="btn btn-default btn-sm m-r-xs pull-right">View preprint</a>
             % if user['is_admin']:
-                <a href="${node['preprint_url']}?edit" class="btn btn-default btn-sm m-r-xs pull-right">Edit preprint</a>
+                <a href="${node['preprint_url']}/edit" class="btn btn-default btn-sm m-r-xs pull-right">Edit preprint</a>
             % endif
         </div>
     </div>

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -243,7 +243,7 @@
             This project represents a preprint. <a href="http://help.osf.io/m/preprints">Learn more</a> about how to work with preprint files.
             <a href="${node['preprint_url']}" class="btn btn-default btn-sm m-r-xs pull-right">View preprint</a>
             % if user['is_admin']:
-                <a href="${node['preprint_url']}/edit" class="btn btn-default btn-sm m-r-xs pull-right">Edit preprint</a>
+                <a href="${node['preprint_url']}edit" class="btn btn-default btn-sm m-r-xs pull-right">Edit preprint</a>
             % endif
         </div>
     </div>


### PR DESCRIPTION
## Purpose

Editing preprints is changing from a query parameter to a route, but the OSF links to the query parameter version. We meed to link using the route.

## Changes

Changed the Project template to do `/edit` instead of `?edit`

## Side effects

No.

## Ticket

https://openscience.atlassian.net/browse/OSF-7761