### PR TITLE
[Hotfix] Fix folder relationship id [OSF-7758]

### DIFF
--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -146,7 +146,7 @@ class FileSerializer(JSONAPISerializer):
 
     files = NodeFileHyperLinkField(
         related_view='nodes:node-files',
-        related_view_kwargs={'node_id': '<node_id>', 'path': '<path>', 'provider': '<provider>'},
+        related_view_kwargs={'node_id': '<node._id>', 'path': '<path>', 'provider': '<provider>'},
         kind='folder'
     )
     versions = NodeFileHyperLinkField(

--- a/api_tests/files/views/test_file_detail.py
+++ b/api_tests/files/views/test_file_detail.py
@@ -438,6 +438,15 @@ class TestFileView(ApiTestCase):
             res = self.app.get(self.file_url, auth=self.user.auth)
             assert_equal(res.json['data']['attributes']['current_version'], version)
 
+    # Regression test for OSF-7758
+    def test_folder_files_relationships_contains_guid_not_id(self):
+        self.folder = self.node.get_addon('osfstorage').get_root().append_folder('I\'d be a teacher!!')
+        self.folder.save()
+        self.folder_url = '/{}files/{}/'.format(API_BASE, self.folder._id)
+        res = self.app.get(self.folder_url, auth=self.user.auth)
+        split_href = res.json['data']['relationships']['files']['links']['related']['href'].split('/')
+        assert_in(self.node._id, split_href)
+        assert_not_in(self.node.id, split_href)
 
 class TestFileVersionView(ApiTestCase):
     def setUp(self):


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Files relationships were using node_id instead of node_.id, and thus gave the postgres table val instead of the guid.
<!-- Describe the purpose of your changes -->

## Changes
Fix id; add test.
<!-- Briefly describe or list your changes  -->

## Side effects
N/A
<!--Any possible side effects? -->


## Ticket
https://openscience.atlassian.net/browse/OSF-7758
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->


## QA Notes
Create a folder in a project. Navigate to the folder's file page (e.g., https://api.osf.io/v2/files/58e655786c613b0252fec572/ )
and confirm that the guid appears correctly in the relationships->files->links->related->href