### PR TITLE
[hotfix] Update prereg draft approval/rejection email [OSF-7759]

### DIFF
--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -450,7 +450,7 @@ class DraftRegistration(ObjectIDMixin, BaseModel):
     @property
     def url(self):
         return self.URL_TEMPLATE.format(
-            node_id=self.branched_from,
+            node_id=self.branched_from._id,
             draft_id=self._id
         )
 

--- a/osf_tests/test_registrations.py
+++ b/osf_tests/test_registrations.py
@@ -566,3 +566,9 @@ class TestDraftRegistrations:
         draft.update_metadata(new_data)
         draft.save()
         assert draft.registration_metadata['foo']['comments'] == comments
+
+    def test_draft_registration_url(self):
+        project = factories.ProjectFactory()
+        draft = factories.DraftRegistrationFactory(branched_from=project)
+
+        assert draft.url == settings.DOMAIN + 'project/{}/drafts/{}'.format(project._id, draft._id)


### PR DESCRIPTION
## Purpose

DraftRegistration approval emails were sending emails with the full parent Node representation instead of just the GUID -- fix that!

## Changes

- Construct the url for the draft registration with the _id instead
- Add test for proper URL formation

## Side effects

None anticipated

## Ticket
https://openscience.atlassian.net/browse/OSF-7759