### PR TITLE
Remove tokumx depend from all containers other then sharejs [#OSF-7765]

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -338,7 +338,6 @@ services:
       - 8001:8001
     depends_on:
       - postgres
-      - tokumx
       - rabbitmq
       - elasticsearch
     env_file:
@@ -359,7 +358,6 @@ services:
       - 8000:8000
     depends_on:
       - postgres
-      - tokumx
       - rabbitmq
       - elasticsearch
     environment:
@@ -380,7 +378,6 @@ services:
       - 5000:5000
     depends_on:
       - postgres
-      - tokumx
       - rabbitmq
       - elasticsearch
     environment:


### PR DESCRIPTION
## Purpose
Don't start tokumx container unless sharejs container is explicitly started

## Changes

Remove depend tokumx from admin, api, and web containers in docker-compose.yml.

## Assumptions

It is assumed that the sharejs container is the only container directly communicating with tokumx.


## Ticket

https://openscience.atlassian.net/browse/OSF-7765
