### PR TITLE
Add Date Registration Initiated to Admin App [OSF-7230]

### DIFF
--- a/admin/nodes/serializers.py
+++ b/admin/nodes/serializers.py
@@ -24,6 +24,7 @@ def serialize_node(node):
         'children': map(serialize_simple_node, node.nodes),
         'deleted': node.is_deleted,
         'pending_registration': node.is_pending_registration,
+        'registered_date': node.registered_date,
         'creator': node.creator._id,
         'spam_status': node.spam_status,
         'spam_pro_tip': node.spam_pro_tip,

--- a/admin/templates/nodes/node.html
+++ b/admin/templates/nodes/node.html
@@ -247,6 +247,10 @@
                                 <td>{{ node.date_created | date }}</td>
                             </tr>
                             <tr>
+                                <td>Datetime Registered (UTC)</td>
+                                <td>{{ node.registered_date | date:"F j, Y P" }}</td>
+                            </tr>
+                            <tr>
                                 <td>Pending</td>
                                 <td>{{ node.pending_registration }}</td>
                             </tr>


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Currently, admin app displays "Date Created" for Registrations. However, this date refers to the date the Project was created. This is a bit confusing and doesn't give enough information about the registration to Support staff (e.g., user emails about a registration that's pending, but Support doesn't know if the registration should be "out" of pending by now or not).

It would be helpful to see the date/time the registration was initiated in the admin app, so we can do better troubleshooting of private projects/registrations.

![screen shot 2017-04-07 at 2 50 08 pm](https://cloud.githubusercontent.com/assets/801594/24815150/3eb4ce38-1ba2-11e7-818b-45d1148199f6.png)


## Changes

- Add registered_date to admin's node serializer
- Display the registered date in the node's Registration detail section

## Side effects

None anticipated


## Ticket
https://openscience.atlassian.net/browse/OSF-7230