### PR TITLE
[Hotfix] Optimize get_root [OSF-7779]

### DIFF
--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -71,9 +71,7 @@ logger = logging.getLogger(__name__)
 class AbstractNodeQuerySet(MODMCompatibilityQuerySet, IncludeQuerySet):
 
     def get_roots(self):
-        return self.extra(
-            where=['"osf_abstractnode".id in (SELECT id FROM osf_abstractnode WHERE id NOT IN (SELECT child_id FROM '
-                   'osf_noderelation WHERE is_node_link IS false))'])
+        return self.filter(id__in=self.exclude(type='osf.collection').values_list('root_id', flat=True))
 
     def get_children(self, root, active=False):
         # If `root` is a root node, we can use the 'descendants' related name

--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -287,6 +287,15 @@ class TestParentNode:
         assert child1 not in public_results2
         assert child2 not in public_results2
 
+    def test_get_roots_distinct(self):
+        top_level = ProjectFactory()
+        child1 = ProjectFactory(parent=top_level)
+        child2 = ProjectFactory(parent=top_level)
+        child3 = ProjectFactory(parent=top_level)
+
+        assert AbstractNode.objects.get_roots().count() == 1
+        assert top_level in AbstractNode.objects.get_roots()
+
     def test_license_searches_parent_nodes(self):
         license_record = NodeLicenseRecordFactory()
         project = ProjectFactory(node_license=license_record)


### PR DESCRIPTION
## Purpose
Optimize `get_root` to speed up profile, other pages.

Before:
```
In [4]: %timeit -n 3 get_public_projects(user=u)
3 loops, best of 3: 12.4 s per loop
```
After:
```
In [4]: %timeit -n 3 get_public_projects(user=u)
3 loops, best of 3: 8.51 s per loop
```
Note: most of the remaining 8.5s is contributor selects or nodelog counts. Also, `u` has ~250 projects, 149 public.

## Changes
* Utilize `root_id` field
* Add test

## Side effects
None expected

## Ticket
[[OSF-7779]](https://openscience.atlassian.net/browse/OSF-7779)
