### PR TITLE
[Hotfix] Replace incorrect _guids lookup.

### DIFF
--- a/scripts/populate_new_and_noteworthy_projects.py
+++ b/scripts/populate_new_and_noteworthy_projects.py
@@ -105,7 +105,7 @@ def update_node_links(designated_node, target_node_ids, description):
 def main(dry_run=True):
     init_app(routes=False)
 
-    new_and_noteworthy_links_node = Node.objects.get(_guids___id=NEW_AND_NOTEWORTHY_LINKS_NODE)
+    new_and_noteworthy_links_node = Node.objects.get(guids___id=NEW_AND_NOTEWORTHY_LINKS_NODE)
     new_and_noteworthy_node_ids = get_new_and_noteworthy_nodes(new_and_noteworthy_links_node)
 
     update_node_links(new_and_noteworthy_links_node, new_and_noteworthy_node_ids, 'new and noteworthy')


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

_guids isn't a real field. It's a byproduct of the guid annotations. It's the name of the field that's being added to the queryset. The underscore was supposed to show that it was private and people shouldn't use it. People used it.

## Changes

Remove the _ and use the public guids___id field for filtering.

## Side effects

I checked to make sure there were no other occurrences of _guids filtering in the code base. People could still use it if they don't understand how it works.


## Ticket


Here's the sentry error: https://sentry.cos.io/sentry/osf/issues/277605/

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->