### PR TITLE
[RFR] Bring Folder.update back from the dead [OSF-7783]

### DIFF
--- a/osf/models/files.py
+++ b/osf/models/files.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 import logging
 import os
 
+import datetime
 import requests
 from dateutil.parser import parse as parse_date
 from django.core.exceptions import ObjectDoesNotExist
@@ -321,44 +322,6 @@ class BaseFileNode(TypedModel, CommentableMixin, OptionalGuidMixin, Taggable, Ob
         # TODO Switch back to head requests
         # return self.update(revision, json.loads(resp.headers['x-waterbutler-metadata']))
 
-    def update(self, revision, data, user=None):
-        """Using revision and data update all data pretaining to self
-        :param str or None revision: The revision that data points to
-        :param dict data: Metadata recieved from waterbutler
-        :returns: FileVersion
-        """
-        self.name = data['name']
-        self.materialized_path = data['materialized']
-
-        version = FileVersion(identifier=revision)
-        version.update_metadata(data, save=False)
-
-        # Transform here so it can be sortted on later
-        if data['modified'] is not None and data['modified'] != '':
-            data['modified'] = parse_date(
-                data['modified'],
-                ignoretz=True,
-                default=timezone.now()  # Just incase nothing can be parsed
-            )
-
-        # if revision is none then version is the latest version
-        # Dont save the latest information
-        if revision is not None:
-            version.save()
-            self.versions.add(version)
-        for entry in self.history:
-            if ('etag' in entry and 'etag' in data) and (entry['etag'] == data['etag']):
-                break
-        else:
-            # Insert into history if there is no matching etag
-            utils.insort(self.history, data, lambda x: x['modified'])
-
-        # Finally update last touched
-        self.last_touched = timezone.now()
-
-        self.save()
-        return version
-
     def get_download_count(self, version=None):
         """Pull the download count from the pagecounter collection
         Limit to version if specified.
@@ -475,6 +438,44 @@ class File(models.Model):
     def kind(self):
         return 'file'
 
+    def update(self, revision, data, user=None):
+        """Using revision and data update all data pretaining to self
+        :param str or None revision: The revision that data points to
+        :param dict data: Metadata recieved from waterbutler
+        :returns: FileVersion
+        """
+        self.name = data['name']
+        self.materialized_path = data['materialized']
+
+        version = FileVersion(identifier=revision)
+        version.update_metadata(data, save=False)
+
+        # Transform here so it can be sortted on later
+        if data['modified'] is not None and data['modified'] != '':
+            data['modified'] = parse_date(
+                data['modified'],
+                ignoretz=True,
+                default=timezone.now()  # Just incase nothing can be parsed
+            )
+
+        # if revision is none then version is the latest version
+        # Dont save the latest information
+        if revision is not None:
+            version.save()
+            self.versions.add(version)
+        for entry in self.history:
+            if ('etag' in entry and 'etag' in data) and (entry['etag'] == data['etag']):
+                break
+        else:
+            # Insert into history if there is no matching etag
+            utils.insort(self.history, data, lambda x: x['modified'])
+
+        # Finally update last touched
+        self.last_touched = timezone.now()
+
+        self.save()
+        return version
+
     def serialize(self):
         newest_version = self.versions.all().last()
 
@@ -515,6 +516,17 @@ class Folder(models.Model):
     @property
     def children(self):
         return self._children.exclude(type__in=TrashedFileNode._typedmodels_subtypes)
+
+    def update(self, revision, data, save=True, user=None):
+        """Note: User is a kwargs here because of special requirements of
+        dataverse and django
+        See dataversefile.update
+        """
+        self.name = data['name']
+        self.materialized_path = data['materialized']
+        self.last_touched = datetime.datetime.utcnow()
+        if save:
+            self.save()
 
     def append_file(self, name, path=None, materialized_path=None, save=True):
         return self._create_child(name, File, path=path, materialized_path=materialized_path, save=save)

--- a/osf/models/files.py
+++ b/osf/models/files.py
@@ -3,7 +3,6 @@ from __future__ import unicode_literals
 import logging
 import os
 
-import datetime
 import requests
 from dateutil.parser import parse as parse_date
 from django.core.exceptions import ObjectDoesNotExist
@@ -524,7 +523,7 @@ class Folder(models.Model):
         """
         self.name = data['name']
         self.materialized_path = data['materialized']
-        self.last_touched = datetime.datetime.utcnow()
+        self.last_touched = timezone.now()
         if save:
             self.save()
 

--- a/osf_tests/test_files.py
+++ b/osf_tests/test_files.py
@@ -1,11 +1,12 @@
 import pytest
+from django.utils import timezone
 
 from addons.osfstorage import settings as osfstorage_settings
+from osf.models import BaseFileNode, Folder
 from osf_tests.factories import (
     UserFactory,
     ProjectFactory,
 )
-from osf.models import BaseFileNode
 
 pytestmark = pytest.mark.django_db
 
@@ -51,3 +52,16 @@ def test_active_manager_does_not_return_trashed_file_nodes(project, create_test_
     assert BaseFileNode.objects.filter(node=project).count() == 3
     # root folder + file = 2 BaseFileNodes
     assert BaseFileNode.active.filter(node=project).count() == 2
+
+def test_folder_update_calls_folder_update_method(project, create_test_file, monkeypatch):
+    file = create_test_file(node=project)
+    parent_folder = file.parent
+    def fake_update(*args, **kwargs):
+        return 'patched'
+
+    monkeypatch.setattr(Folder, 'update', fake_update)
+    folder_retval = parent_folder.update()
+    assert folder_retval == 'patched'
+
+    file_retval = file.update(revision='wot', data=dict(name='huh', materialized='/yes', modified=None))
+    assert file_retval != 'patched'


### PR DESCRIPTION

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Updating folders was failing because the File.update method was brought over from modm but the Folder.update method was not.

## Changes

Moved the BaseFileNode.update method to File. Added Folder.update method from modm. Added a test to make sure calling Folder.update calls Folder.update.

## Side effects

None expected.


## Ticket

https://openscience.atlassian.net/browse/OSF-7783?filter=17500