### PR TITLE
Add Permission tests for admin views

### DIFF
--- a/admin/pre_reg/views.py
+++ b/admin/pre_reg/views.py
@@ -201,6 +201,9 @@ class CommentUpdateView(PermissionRequiredMixin, UpdateView):
     permission_required = ('osf.view_prereg', 'osf.administer_prereg')
     raise_exception = True
 
+    def get_object(self, *args, **kwargs):
+        return DraftRegistration.load(self.kwargs.get('draft_pk'))
+
     def post(self, request, *args, **kwargs):
         try:
             data = json.loads(request.body).get('schema_data', {})

--- a/admin/preprints/views.py
+++ b/admin/preprints/views.py
@@ -20,7 +20,7 @@ class PreprintFormView(PermissionRequiredMixin, GuidFormView):
     """
     template_name = 'preprints/search.html'
     object_type = 'preprint'
-    permission_required = 'osf.view_node'
+    permission_required = 'osf.view_preprintservice'
     raise_exception = True
 
     @property

--- a/admin_tests/common_auth/test_logs.py
+++ b/admin_tests/common_auth/test_logs.py
@@ -2,12 +2,14 @@ from nose import tools as nt
 
 from tests.base import AdminTestCase
 
+from osf_tests.factories import UserFactory
 from osf.models.admin_log_entry import AdminLogEntry, update_admin_log
 
 
 class TestUpdateAdminLog(AdminTestCase):
     def test_add_log(self):
-        update_admin_log('123', 'dfqc2', 'This', 'log_added')
+        user = UserFactory()
+        update_admin_log(user.id, 'dfqc2', 'This', 'log_added')
         nt.assert_equal(AdminLogEntry.objects.count(), 1)
         log = AdminLogEntry.objects.latest('action_time')
-        nt.assert_equal(log.user_id, 123)
+        nt.assert_equal(log.user_id, user.id)

--- a/admin_tests/meetings/test_views.py
+++ b/admin_tests/meetings/test_views.py
@@ -2,6 +2,10 @@ from nose import tools as nt
 
 from django.test import RequestFactory
 from django.http import Http404
+from django.core.urlresolvers import reverse
+from django.contrib.auth.models import Permission
+from django.core.exceptions import PermissionDenied
+
 from tests.base import AdminTestCase
 from tests.factories import AuthUserFactory
 from tests.test_conferences import ConferenceFactory
@@ -31,6 +35,27 @@ class TestMeetingListView(AdminTestCase):
         view = MeetingListView()
         nt.assert_equal(len(view.get_queryset()), 3)
 
+    def test_no_user_permissions_raises_error(self):
+        user = AuthUserFactory()
+        request = RequestFactory().get(reverse('meetings:list'))
+        request.user = user
+
+        with self.assertRaises(PermissionDenied):
+            MeetingListView.as_view()(request)
+
+    def test_correct_view_permissions(self):
+        user = AuthUserFactory()
+
+        view_permission = Permission.objects.get(codename='view_conference')
+        user.user_permissions.add(view_permission)
+        user.save()
+
+        request = RequestFactory().get(reverse('meetings:list'))
+        request.user = user
+
+        response = MeetingListView.as_view()(request)
+        self.assertEqual(response.status_code, 200)
+
 
 class TestMeetingFormView(AdminTestCase):
     def setUp(self):
@@ -38,7 +63,7 @@ class TestMeetingFormView(AdminTestCase):
         self.conf = ConferenceFactory()
         self.user = AuthUserFactory()
         self.request = RequestFactory().post('/fake_path')
-        self.view = MeetingFormView()
+        self.view = MeetingFormView
         mod_data = dict(data)
         mod_data.update({
             'edit': 'True',
@@ -51,14 +76,16 @@ class TestMeetingFormView(AdminTestCase):
         self.form = MeetingForm(data=mod_data)
         self.form.is_valid()
 
+        self.url = reverse('meetings:detail', kwargs={'endpoint': self.conf.endpoint})
+
     def test_dispatch_raise_404(self):
-        view = setup_form_view(self.view, self.request, self.form,
+        view = setup_form_view(self.view(), self.request, self.form,
                                endpoint='meh')
         with nt.assert_raises(Http404):
             view.dispatch(self.request, endpoint='meh')
 
     def test_get_context(self):
-        view = setup_form_view(self.view, self.request, self.form,
+        view = setup_form_view(self.view(), self.request, self.form,
                                endpoint=self.conf.endpoint)
         view.conf = self.conf
         res = view.get_context_data()
@@ -67,7 +94,7 @@ class TestMeetingFormView(AdminTestCase):
         nt.assert_equal(res['endpoint'], self.conf.endpoint)
 
     def test_get_initial(self):
-        view = setup_form_view(self.view, self.request, self.form,
+        view = setup_form_view(self.view(), self.request, self.form,
                                endpoint=self.conf.endpoint)
         view.conf = self.conf
         res = view.get_initial()
@@ -76,7 +103,7 @@ class TestMeetingFormView(AdminTestCase):
         nt.assert_in('submission2_plural', res)
 
     def test_form_valid(self):
-        view = setup_form_view(self.view, self.request, self.form,
+        view = setup_form_view(self.view(), self.request, self.form,
                                endpoint=self.conf.endpoint)
         view.conf = self.conf
         view.form_valid(self.form)
@@ -85,6 +112,25 @@ class TestMeetingFormView(AdminTestCase):
         nt.assert_equal(self.conf.location, self.form.cleaned_data['location'])
         nt.assert_equal(self.conf.start_date, self.form.cleaned_data['start_date'])
 
+    def test_no_user_permissions_raises_error(self):
+        request = RequestFactory().get(self.url)
+        request.user = self.user
+
+        with self.assertRaises(PermissionDenied):
+            self.view.as_view()(request, endpoint=self.conf.endpoint)
+
+    def test_correct_view_permissions(self):
+
+        view_permission = Permission.objects.get(codename='change_conference')
+        self.user.user_permissions.add(view_permission)
+        self.user.save()
+
+        request = RequestFactory().get(self.url)
+        request.user = self.user
+
+        response = self.view.as_view()(request, endpoint=self.conf.endpoint)
+        self.assertEqual(response.status_code, 200)
+
 
 class TestMeetingCreateFormView(AdminTestCase):
     def setUp(self):
@@ -92,22 +138,44 @@ class TestMeetingCreateFormView(AdminTestCase):
         Conference.remove()
         self.user = AuthUserFactory()
         self.request = RequestFactory().post('/fake_path')
-        self.view = MeetingCreateFormView()
+        self.view = MeetingCreateFormView
         mod_data = dict(data)
         mod_data.update({'admins': self.user.emails[0]})
         self.form = MeetingForm(data=mod_data)
         self.form.is_valid()
 
+        self.url = reverse('meetings:create')
+
     def test_get_initial(self):
-        self.view.get_initial()
-        nt.assert_equal(self.view.initial['edit'], False)
+        self.view().get_initial()
+        nt.assert_equal(self.view().initial['edit'], False)
         nt.assert_equal(self.view.initial['submission1'],
                         DEFAULT_FIELD_NAMES['submission1'])
 
     def test_form_valid(self):
-        view = setup_form_view(self.view, self.request, self.form)
+        view = setup_form_view(self.view(), self.request, self.form)
         view.form_valid(self.form)
         nt.assert_equal(Conference.objects.filter(endpoint=data['endpoint']).count(), 1)
+
+    def test_no_user_permissions_raises_error(self):
+        request = RequestFactory().get(self.url)
+        request.user = self.user
+
+        with self.assertRaises(PermissionDenied):
+            self.view.as_view()(request)
+
+    def test_correct_view_permissions(self):
+        change_permission = Permission.objects.get(codename='view_conference')
+        view_permission = Permission.objects.get(codename='change_conference')
+        self.user.user_permissions.add(view_permission)
+        self.user.user_permissions.add(change_permission)
+        self.user.save()
+
+        request = RequestFactory().get(self.url)
+        request.user = self.user
+
+        response = self.view.as_view()(request)
+        self.assertEqual(response.status_code, 200)
 
 
 class TestMeetingMisc(AdminTestCase):

--- a/admin_tests/meetings/test_views.py
+++ b/admin_tests/meetings/test_views.py
@@ -40,7 +40,7 @@ class TestMeetingListView(AdminTestCase):
         request = RequestFactory().get(reverse('meetings:list'))
         request.user = user
 
-        with self.assertRaises(PermissionDenied):
+        with nt.assert_raises(PermissionDenied):
             MeetingListView.as_view()(request)
 
     def test_correct_view_permissions(self):
@@ -54,7 +54,7 @@ class TestMeetingListView(AdminTestCase):
         request.user = user
 
         response = MeetingListView.as_view()(request)
-        self.assertEqual(response.status_code, 200)
+        nt.assert_equal(response.status_code, 200)
 
 
 class TestMeetingFormView(AdminTestCase):
@@ -116,7 +116,7 @@ class TestMeetingFormView(AdminTestCase):
         request = RequestFactory().get(self.url)
         request.user = self.user
 
-        with self.assertRaises(PermissionDenied):
+        with nt.assert_raises(PermissionDenied):
             self.view.as_view()(request, endpoint=self.conf.endpoint)
 
     def test_correct_view_permissions(self):
@@ -129,7 +129,7 @@ class TestMeetingFormView(AdminTestCase):
         request.user = self.user
 
         response = self.view.as_view()(request, endpoint=self.conf.endpoint)
-        self.assertEqual(response.status_code, 200)
+        nt.assert_equal(response.status_code, 200)
 
 
 class TestMeetingCreateFormView(AdminTestCase):
@@ -161,7 +161,7 @@ class TestMeetingCreateFormView(AdminTestCase):
         request = RequestFactory().get(self.url)
         request.user = self.user
 
-        with self.assertRaises(PermissionDenied):
+        with nt.assert_raises(PermissionDenied):
             self.view.as_view()(request)
 
     def test_correct_view_permissions(self):
@@ -175,7 +175,7 @@ class TestMeetingCreateFormView(AdminTestCase):
         request.user = self.user
 
         response = self.view.as_view()(request)
-        self.assertEqual(response.status_code, 200)
+        nt.assert_equal(response.status_code, 200)
 
 
 class TestMeetingMisc(AdminTestCase):

--- a/admin_tests/nodes/test_views.py
+++ b/admin_tests/nodes/test_views.py
@@ -48,7 +48,7 @@ class TestNodeView(AdminTestCase):
         request = RequestFactory().get(reverse('nodes:node', kwargs={'guid': guid}))
         request.user = user
 
-        with self.assertRaises(PermissionDenied):
+        with nt.assert_raises(PermissionDenied):
             NodeView.as_view()(request, guid=guid)
 
     def test_correct_view_permissions(self):
@@ -64,7 +64,7 @@ class TestNodeView(AdminTestCase):
         request.user = user
 
         response = NodeView.as_view()(request, guid=guid)
-        self.assertEqual(response.status_code, 200)
+        nt.assert_equal(response.status_code, 200)
 
 
 class TestNodeDeleteView(AdminTestCase):
@@ -110,7 +110,7 @@ class TestNodeDeleteView(AdminTestCase):
         request = RequestFactory().get(self.url)
         request.user = user
 
-        with self.assertRaises(PermissionDenied):
+        with nt.assert_raises(PermissionDenied):
             self.plain_view.as_view()(request, guid=guid)
 
     def test_correct_view_permissions(self):
@@ -127,7 +127,7 @@ class TestNodeDeleteView(AdminTestCase):
         request.user = user
 
         response = self.plain_view.as_view()(request, guid=guid)
-        self.assertEqual(response.status_code, 200)
+        nt.assert_equal(response.status_code, 200)
 
 
 class TestRemoveContributor(AdminTestCase):
@@ -195,7 +195,7 @@ class TestRemoveContributor(AdminTestCase):
         request = RequestFactory().get(self.url)
         request.user = self.user
 
-        with self.assertRaises(PermissionDenied):
+        with nt.assert_raises(PermissionDenied):
             self.view.as_view()(request, node_id=guid, user_id=self.user)
 
     def test_correct_view_permissions(self):
@@ -209,4 +209,4 @@ class TestRemoveContributor(AdminTestCase):
         request.user = self.user
 
         response = self.view.as_view()(request, node_id=self.node._id, user_id=self.user._id)
-        self.assertEqual(response.status_code, 200)
+        nt.assert_equal(response.status_code, 200)

--- a/admin_tests/nodes/test_views.py
+++ b/admin_tests/nodes/test_views.py
@@ -1,14 +1,15 @@
 import mock
-from osf.models.admin_log_entry import AdminLogEntry
-from admin.nodes.views import (NodeDeleteView, NodeRemoveContributorView,
-                               NodeView)
-from admin_tests.utilities import setup_log_view, setup_view
-from django.test import RequestFactory
-from framework.auth import User
 from nose import tools as nt
+from django.test import RequestFactory
+from django.core.urlresolvers import reverse
+from django.core.exceptions import PermissionDenied
+from django.contrib.auth.models import Permission
+
 from tests.base import AdminTestCase
 from tests.factories import AuthUserFactory, ProjectFactory
-from website.project.model import Node, NodeLog
+from osf.models import AdminLogEntry, OSFUser, Node, NodeLog
+from admin_tests.utilities import setup_log_view, setup_view
+from admin.nodes.views import (NodeDeleteView, NodeRemoveContributorView, NodeView)
 
 
 class TestNodeView(AdminTestCase):
@@ -40,15 +41,42 @@ class TestNodeView(AdminTestCase):
         res = view.get_context_data()
         nt.assert_equal(res[NodeView.context_object_name], temp_object)
 
+    def test_no_user_permissions_raises_error(self):
+        user = AuthUserFactory()
+        node = ProjectFactory()
+        guid = node._id
+        request = RequestFactory().get(reverse('nodes:node', kwargs={'guid': guid}))
+        request.user = user
+
+        with self.assertRaises(PermissionDenied):
+            NodeView.as_view()(request, guid=guid)
+
+    def test_correct_view_permissions(self):
+        user = AuthUserFactory()
+        node = ProjectFactory()
+        guid = node._id
+
+        change_permission = Permission.objects.get(codename='view_node')
+        user.user_permissions.add(change_permission)
+        user.save()
+
+        request = RequestFactory().get(reverse('nodes:node', kwargs={'guid': guid}))
+        request.user = user
+
+        response = NodeView.as_view()(request, guid=guid)
+        self.assertEqual(response.status_code, 200)
+
 
 class TestNodeDeleteView(AdminTestCase):
     def setUp(self):
         super(TestNodeDeleteView, self).setUp()
         self.node = ProjectFactory()
         self.request = RequestFactory().post('/fake_path')
-        self.view = NodeDeleteView()
-        self.view = setup_log_view(self.view, self.request,
+        self.plain_view = NodeDeleteView
+        self.view = setup_log_view(self.plain_view(), self.request,
                                    guid=self.node._id)
+
+        self.url = reverse('nodes:remove', kwargs={'guid': self.node._id})
 
     def test_get_object(self):
         obj = self.view.get_object()
@@ -76,6 +104,31 @@ class TestNodeDeleteView(AdminTestCase):
         nt.assert_false(self.node.is_deleted)
         nt.assert_equal(AdminLogEntry.objects.count(), count + 1)
 
+    def test_no_user_permissions_raises_error(self):
+        user = AuthUserFactory()
+        guid = self.node._id
+        request = RequestFactory().get(self.url)
+        request.user = user
+
+        with self.assertRaises(PermissionDenied):
+            self.plain_view.as_view()(request, guid=guid)
+
+    def test_correct_view_permissions(self):
+        user = AuthUserFactory()
+        guid = self.node._id
+
+        change_permission = Permission.objects.get(codename='delete_node')
+        view_permission = Permission.objects.get(codename='view_node')
+        user.user_permissions.add(change_permission)
+        user.user_permissions.add(view_permission)
+        user.save()
+
+        request = RequestFactory().get(self.url)
+        request.user = user
+
+        response = self.plain_view.as_view()(request, guid=guid)
+        self.assertEqual(response.status_code, 200)
+
 
 class TestRemoveContributor(AdminTestCase):
     def setUp(self):
@@ -85,28 +138,29 @@ class TestRemoveContributor(AdminTestCase):
         self.user_2 = AuthUserFactory()
         self.node.add_contributor(self.user_2)
         self.node.save()
-        self.view = NodeRemoveContributorView()
+        self.view = NodeRemoveContributorView
         self.request = RequestFactory().post('/fake_path')
+        self.url = reverse('nodes:remove_user', kwargs={'node_id': self.node._id, 'user_id': self.user._id})
 
     def test_get_object(self):
-        view = setup_log_view(self.view, self.request, node_id=self.node._id,
+        view = setup_log_view(self.view(), self.request, node_id=self.node._id,
                               user_id=self.user._id)
         node, user = view.get_object()
         nt.assert_is_instance(node, Node)
-        nt.assert_is_instance(user, User)
+        nt.assert_is_instance(user, OSFUser)
 
     @mock.patch('admin.nodes.views.Node.remove_contributor')
     def test_remove_contributor(self, mock_remove_contributor):
         user_id = self.user_2._id
         node_id = self.node._id
-        view = setup_log_view(self.view, self.request, node_id=node_id,
+        view = setup_log_view(self.view(), self.request, node_id=node_id,
                               user_id=user_id)
         view.delete(self.request)
         mock_remove_contributor.assert_called_with(self.user_2, None, log=False)
 
     def test_integration_remove_contributor(self):
         nt.assert_in(self.user_2, self.node.contributors)
-        view = setup_log_view(self.view, self.request, node_id=self.node._id,
+        view = setup_log_view(self.view(), self.request, node_id=self.node._id,
                               user_id=self.user_2._id)
         count = AdminLogEntry.objects.count()
         view.delete(self.request)
@@ -118,7 +172,7 @@ class TestRemoveContributor(AdminTestCase):
             len(list(self.node.get_admin_contributors(self.node.contributors))),
             1
         )
-        view = setup_log_view(self.view, self.request, node_id=self.node._id,
+        view = setup_log_view(self.view(), self.request, node_id=self.node._id,
                               user_id=self.user._id)
         count = AdminLogEntry.objects.count()
         view.delete(self.request)
@@ -131,7 +185,28 @@ class TestRemoveContributor(AdminTestCase):
         nt.assert_equal(AdminLogEntry.objects.count(), count)
 
     def test_no_log(self):
-        view = setup_log_view(self.view, self.request, node_id=self.node._id,
+        view = setup_log_view(self.view(), self.request, node_id=self.node._id,
                               user_id=self.user_2._id)
         view.delete(self.request)
         nt.assert_not_equal(self.node.logs.latest().action, NodeLog.CONTRIB_REMOVED)
+
+    def test_no_user_permissions_raises_error(self):
+        guid = self.node._id
+        request = RequestFactory().get(self.url)
+        request.user = self.user
+
+        with self.assertRaises(PermissionDenied):
+            self.view.as_view()(request, node_id=guid, user_id=self.user)
+
+    def test_correct_view_permissions(self):
+        change_permission = Permission.objects.get(codename='change_node')
+        view_permission = Permission.objects.get(codename='view_node')
+        self.user.user_permissions.add(change_permission)
+        self.user.user_permissions.add(view_permission)
+        self.user.save()
+
+        request = RequestFactory().get(self.url)
+        request.user = self.user
+
+        response = self.view.as_view()(request, node_id=self.node._id, user_id=self.user._id)
+        self.assertEqual(response.status_code, 200)

--- a/admin_tests/pre_reg/test_views.py
+++ b/admin_tests/pre_reg/test_views.py
@@ -3,6 +3,9 @@ from nose import tools as nt
 from django.test import RequestFactory
 from django.db import transaction
 from django.http import Http404
+from django.core.urlresolvers import reverse
+from django.contrib.auth.models import Permission
+from django.core.exceptions import PermissionDenied
 
 from tests.base import AdminTestCase
 from osf_tests.factories import (
@@ -12,7 +15,6 @@ from osf_tests.factories import (
     UserFactory
 )
 from osf.models.registrations import DraftRegistration
-from website.files.models import StoredFileNode
 from addons.osfstorage.models import OsfStorageFile, OsfStorageFileNode
 
 from website.project.model import ensure_schemas
@@ -51,8 +53,10 @@ class TestDraftListView(AdminTestCase):
         )
         self.dr2.submit_for_review(self.user, {}, save=True)
         self.request = RequestFactory().get('/fake_path')
-        self.view = DraftListView()
-        self.view = setup_view(self.view, self.request)
+        self.plain_view = DraftListView
+        self.view = setup_view(self.plain_view(), self.request)
+
+        self.url = reverse('pre_reg:prereg')
 
     def test_get_queryset(self):
         res = list(self.view.get_queryset())
@@ -65,6 +69,24 @@ class TestDraftListView(AdminTestCase):
         nt.assert_is_instance(res, dict)
         nt.assert_is_instance(res['drafts'], list)
         nt.assert_equal(len(res['drafts']), 2)
+
+    def test_no_user_permissions_raises_error(self):
+        request = RequestFactory().get(self.url)
+        request.user = self.user
+
+        with self.assertRaises(PermissionDenied):
+            self.plain_view.as_view()(request)
+
+    def test_correct_view_permissions(self):
+        view_permission = Permission.objects.get(codename='view_prereg')
+        self.user.user_permissions.add(view_permission)
+        self.user.save()
+
+        request = RequestFactory().get(self.url)
+        request.user = self.user
+
+        response = self.plain_view.as_view()(request)
+        self.assertEqual(response.status_code, 200)
 
 
 class TestDraftDetailView(AdminTestCase):
@@ -79,14 +101,35 @@ class TestDraftDetailView(AdminTestCase):
         )
         self.dr1.submit_for_review(self.user, {}, save=True)
         self.request = RequestFactory().get('/fake_path')
-        self.view = DraftDetailView()
-        self.view = setup_view(self.view, self.request, draft_pk=self.dr1._id)
+        self.plain_view = DraftDetailView
+        self.view = setup_view(self.plain_view(), self.request, draft_pk=self.dr1._id)
+
+        self.url = reverse('pre_reg:view_draft', kwargs={'draft_pk': self.dr1._id})
 
     @mock.patch('admin.pre_reg.views.DraftDetailView.checkout_files')
     def test_get_object(self, mock_files):
         res = self.view.get_object()
         nt.assert_is_instance(res, dict)
         nt.assert_equal(res['pk'], self.dr1._id)
+
+    def test_no_user_permissions_raises_error(self):
+        request = RequestFactory().get(self.url)
+        request.user = self.user
+
+        with self.assertRaises(PermissionDenied):
+            self.plain_view.as_view()(request, draft_pk=self.dr1._id)
+
+    @mock.patch('admin.pre_reg.views.DraftDetailView.checkout_files')
+    def test_correct_view_permissions(self, mock_files):
+        view_permission = Permission.objects.get(codename='view_prereg')
+        self.user.user_permissions.add(view_permission)
+        self.user.save()
+
+        request = RequestFactory().get(self.url)
+        request.user = self.user
+
+        response = self.plain_view.as_view()(request, draft_pk=self.dr1._id)
+        self.assertEqual(response.status_code, 200)
 
 
 class TestDraftFormView(AdminTestCase):
@@ -101,8 +144,8 @@ class TestDraftFormView(AdminTestCase):
         self.dr1.submit_for_review(self.user, {}, save=True)
         self.dr1.flags  # sets flags if there aren't any yet.
         self.request = RequestFactory().get('/fake_path')
-        self.view = DraftFormView()
-        self.view = setup_view(self.view, self.request, draft_pk=self.dr1._id)
+        self.plain_view = DraftFormView
+        self.view = setup_view(self.plain_view(), self.request, draft_pk=self.dr1._id)
 
         self.post = RequestFactory().post('/fake_path')
         self.post.user = UserFactory()
@@ -111,6 +154,7 @@ class TestDraftFormView(AdminTestCase):
             'notes': 'Far between',
             'proof_of_publication': 'approved',
         }
+        self.url = reverse('pre_reg:view_draft', kwargs={'draft_pk': self.dr1._id})
 
     def test_dispatch_raise_404(self):
         view = setup_view(DraftFormView(), self.request, draft_pk='wrong')
@@ -179,6 +223,35 @@ class TestDraftFormView(AdminTestCase):
         nt.assert_true(mock_reject.called)
         nt.assert_equal(count + 1, AdminLogEntry.objects.count())
 
+    def test_no_user_permissions_raises_error(self):
+        request = RequestFactory().get(self.url)
+        request.user = self.user
+
+        with self.assertRaises(PermissionDenied):
+            self.plain_view.as_view()(request, draft_pk=self.dr1._id)
+
+    def test_get_correct_view_permissions(self):
+        view_permission = Permission.objects.get(codename='view_prereg')
+        self.user.user_permissions.add(view_permission)
+        self.user.save()
+
+        request = RequestFactory().get(self.url)
+        request.user = self.user
+
+        response = self.plain_view.as_view()(request, draft_pk=self.dr1._id)
+        self.assertEqual(response.status_code, 200)
+
+    def test_post_correct_view_permissions(self):
+        view_permission = Permission.objects.get(codename='view_prereg')
+        self.user.user_permissions.add(view_permission)
+        self.user.save()
+
+        request = RequestFactory().get(self.url)
+        request.user = self.user
+
+        response = self.plain_view.as_view()(request, draft_pk=self.dr1._id)
+        self.assertEqual(response.status_code, 200)
+
 
 class TestCommentUpdateView(AdminTestCase):
     def setUp(self):
@@ -192,8 +265,10 @@ class TestCommentUpdateView(AdminTestCase):
         self.dr1.submit_for_review(self.user, {}, save=True)
         self.request = RequestFactory().post('/fake_path', data={'blah': 'arg'})
         self.request.user = UserFactory()
-        self.view = CommentUpdateView()
-        self.view = setup_view(self.view, self.request, draft_pk=self.dr1._id)
+        self.plain_view = CommentUpdateView
+        self.view = setup_view(self.plain_view(), self.request, draft_pk=self.dr1._id)
+
+        self.url = reverse('pre_reg:comment', kwargs={'draft_pk': self.dr1._id})
 
     @mock.patch('admin.pre_reg.views.json.loads')
     @mock.patch('admin.pre_reg.views.DraftRegistration.update_metadata')
@@ -201,6 +276,13 @@ class TestCommentUpdateView(AdminTestCase):
         count = AdminLogEntry.objects.count()
         self.view.post(self.request)
         nt.assert_equal(AdminLogEntry.objects.count(), count + 1)
+
+    def test_no_user_permissions_raises_error(self):
+        request = RequestFactory().get(self.url)
+        request.user = self.user
+
+        with self.assertRaises(PermissionDenied):
+            self.plain_view.as_view()(request, draft_pk=self.dr1._id)
 
 
 class TestPreregFiles(AdminTestCase):
@@ -291,7 +373,7 @@ class TestPreregFiles(AdminTestCase):
 
     def test_get_meta_data_files(self):
         for item in get_metadata_files(self.draft):
-            nt.assert_in(type(item), [OsfStorageFile, StoredFileNode])
+            nt.assert_in(type(item), [OsfStorageFile, OsfStorageFileNode])
 
     def test_get_file_questions(self):
         questions = get_file_questions('prereg-prize.json')
@@ -314,14 +396,14 @@ class TestPreregFiles(AdminTestCase):
         data['q7']['value']['uploader']['extra'][0].pop('fileId')
         self.draft.update_metadata(data)
         for item in get_metadata_files(self.draft):
-            nt.assert_in(type(item), [OsfStorageFile, StoredFileNode])
+            nt.assert_in(type(item), [OsfStorageFile, OsfStorageFileNode])
 
     def test_file_id_missing_odd(self):
         data = self.draft.registration_metadata
         data['q26']['extra'][0].pop('fileId')
         self.draft.update_metadata(data)
         for item in get_metadata_files(self.draft):
-            nt.assert_in(type(item), [OsfStorageFile, StoredFileNode])
+            nt.assert_in(type(item), [OsfStorageFile, OsfStorageFileNode])
 
     def test_wrong_provider(self):
         data = self.draft.registration_metadata

--- a/admin_tests/pre_reg/test_views.py
+++ b/admin_tests/pre_reg/test_views.py
@@ -74,7 +74,7 @@ class TestDraftListView(AdminTestCase):
         request = RequestFactory().get(self.url)
         request.user = self.user
 
-        with self.assertRaises(PermissionDenied):
+        with nt.assert_raises(PermissionDenied):
             self.plain_view.as_view()(request)
 
     def test_correct_view_permissions(self):
@@ -86,7 +86,7 @@ class TestDraftListView(AdminTestCase):
         request.user = self.user
 
         response = self.plain_view.as_view()(request)
-        self.assertEqual(response.status_code, 200)
+        nt.assert_equal(response.status_code, 200)
 
 
 class TestDraftDetailView(AdminTestCase):
@@ -116,7 +116,7 @@ class TestDraftDetailView(AdminTestCase):
         request = RequestFactory().get(self.url)
         request.user = self.user
 
-        with self.assertRaises(PermissionDenied):
+        with nt.assert_raises(PermissionDenied):
             self.plain_view.as_view()(request, draft_pk=self.dr1._id)
 
     @mock.patch('admin.pre_reg.views.DraftDetailView.checkout_files')
@@ -129,7 +129,7 @@ class TestDraftDetailView(AdminTestCase):
         request.user = self.user
 
         response = self.plain_view.as_view()(request, draft_pk=self.dr1._id)
-        self.assertEqual(response.status_code, 200)
+        nt.assert_equal(response.status_code, 200)
 
 
 class TestDraftFormView(AdminTestCase):
@@ -227,7 +227,7 @@ class TestDraftFormView(AdminTestCase):
         request = RequestFactory().get(self.url)
         request.user = self.user
 
-        with self.assertRaises(PermissionDenied):
+        with nt.assert_raises(PermissionDenied):
             self.plain_view.as_view()(request, draft_pk=self.dr1._id)
 
     def test_get_correct_view_permissions(self):
@@ -239,7 +239,7 @@ class TestDraftFormView(AdminTestCase):
         request.user = self.user
 
         response = self.plain_view.as_view()(request, draft_pk=self.dr1._id)
-        self.assertEqual(response.status_code, 200)
+        nt.assert_equal(response.status_code, 200)
 
     def test_post_correct_view_permissions(self):
         view_permission = Permission.objects.get(codename='view_prereg')
@@ -250,7 +250,7 @@ class TestDraftFormView(AdminTestCase):
         request.user = self.user
 
         response = self.plain_view.as_view()(request, draft_pk=self.dr1._id)
-        self.assertEqual(response.status_code, 200)
+        nt.assert_equal(response.status_code, 200)
 
 
 class TestCommentUpdateView(AdminTestCase):
@@ -281,7 +281,7 @@ class TestCommentUpdateView(AdminTestCase):
         request = RequestFactory().get(self.url)
         request.user = self.user
 
-        with self.assertRaises(PermissionDenied):
+        with nt.assert_raises(PermissionDenied):
             self.plain_view.as_view()(request, draft_pk=self.dr1._id)
 
 

--- a/admin_tests/preprints/test_views.py
+++ b/admin_tests/preprints/test_views.py
@@ -16,6 +16,7 @@ from admin.preprints.forms import ChangeProviderForm
 class TestPreprintView(AdminTestCase):
 
     def setUp(self):
+        super(TestPreprintView, self).setUp()
         self.preprint = PreprintFactory()
         self.view = views.PreprintView
 
@@ -90,6 +91,7 @@ class TestPreprintView(AdminTestCase):
 class TestPreprintFormView(AdminTestCase):
 
     def setUp(self):
+        super(TestPreprintFormView, self).setUp()
         self.preprint = PreprintFactory()
         self.view = views.PreprintFormView
         self.user = AuthUserFactory()
@@ -112,4 +114,4 @@ class TestPreprintFormView(AdminTestCase):
         request.user = self.user
 
         response = self.view.as_view()(request)
-        self.assertEqual(response.status_code, 200)
+        nt.assert_equal(response.status_code, 200)

--- a/admin_tests/preprints/test_views.py
+++ b/admin_tests/preprints/test_views.py
@@ -1,0 +1,115 @@
+from nose import tools as nt
+from django.test import RequestFactory
+from django.core.urlresolvers import reverse
+from django.core.exceptions import PermissionDenied
+from django.contrib.auth.models import Permission
+
+from tests.base import AdminTestCase
+from osf.models import PreprintService
+from osf_tests.factories import AuthUserFactory, PreprintFactory, PreprintProviderFactory
+from admin_tests.utilities import setup_view
+
+from admin.preprints import views
+from admin.preprints.forms import ChangeProviderForm
+
+
+class TestPreprintView(AdminTestCase):
+
+    def setUp(self):
+        self.preprint = PreprintFactory()
+        self.view = views.PreprintView
+
+    def test_no_guid(self):
+        request = RequestFactory().get('/fake_path')
+        view = setup_view(self.view(), request)
+        preprint = view.get_object()
+        nt.assert_is_none(preprint)
+
+    def test_get_object(self):
+        request = RequestFactory().get('/fake_path')
+        view = setup_view(self.view(), request, guid=self.preprint._id)
+        res = view.get_object()
+        nt.assert_is_instance(res, PreprintService)
+
+    def test_no_user_permissions_raises_error(self):
+        user = AuthUserFactory()
+        request = RequestFactory().get(reverse('preprints:preprint', kwargs={'guid': self.preprint._id}))
+        request.user = user
+
+        with self.assertRaises(PermissionDenied):
+            self.view.as_view()(request, guid=self.preprint._id)
+
+    def test_correct_view_permissions(self):
+        user = AuthUserFactory()
+
+        view_permission = Permission.objects.get(codename='view_preprintservice')
+        user.user_permissions.add(view_permission)
+        user.save()
+
+        request = RequestFactory().get(reverse('preprints:preprint', kwargs={'guid': self.preprint._id}))
+        request.user = user
+
+        response = self.view.as_view()(request, guid=self.preprint._id)
+        self.assertEqual(response.status_code, 200)
+
+    def test_change_preprint_provider_no_permission(self):
+        user = AuthUserFactory()
+        request = RequestFactory().post(reverse('preprints:preprint', kwargs={'guid': self.preprint._id}))
+        request.user = user
+
+        with self.assertRaises(PermissionDenied):
+            self.view.as_view()(request, guid=self.preprint._id)
+
+    def test_change_preprint_provider_correct_permission(self):
+        user = AuthUserFactory()
+
+        change_permission = Permission.objects.get(codename='change_preprintservice')
+        view_permission = Permission.objects.get(codename='view_preprintservice')
+        user.user_permissions.add(change_permission)
+        user.user_permissions.add(view_permission)
+        user.save()
+
+        request = RequestFactory().post(reverse('preprints:preprint', kwargs={'guid': self.preprint._id}))
+        request.user = user
+
+        response = self.view.as_view()(request, guid=self.preprint._id)
+        self.assertEqual(response.status_code, 302)
+
+    def test_change_preprint_provider_form(self):
+        new_provider = PreprintProviderFactory()
+        self.view.kwargs = {'guid': self.preprint._id}
+        form_data = {
+            'provider': new_provider.id
+        }
+        form = ChangeProviderForm(data=form_data, instance=self.preprint)
+        self.view().form_valid(form)
+
+        nt.assert_equal(self.preprint.provider, new_provider)
+
+
+class TestPreprintFormView(AdminTestCase):
+
+    def setUp(self):
+        self.preprint = PreprintFactory()
+        self.view = views.PreprintFormView
+        self.user = AuthUserFactory()
+        self.url = reverse('preprints:search')
+
+    def test_no_user_permissions_raises_error(self):
+        request = RequestFactory().get(self.url)
+        request.user = self.user
+
+        with self.assertRaises(PermissionDenied):
+            self.view.as_view()(request)
+
+    def test_correct_view_permissions(self):
+
+        view_permission = Permission.objects.get(codename='view_preprintservice')
+        self.user.user_permissions.add(view_permission)
+        self.user.save()
+
+        request = RequestFactory().get(self.url)
+        request.user = self.user
+
+        response = self.view.as_view()(request)
+        self.assertEqual(response.status_code, 200)

--- a/admin_tests/preprints/test_views.py
+++ b/admin_tests/preprints/test_views.py
@@ -37,7 +37,7 @@ class TestPreprintView(AdminTestCase):
         request = RequestFactory().get(reverse('preprints:preprint', kwargs={'guid': self.preprint._id}))
         request.user = user
 
-        with self.assertRaises(PermissionDenied):
+        with nt.assert_raises(PermissionDenied):
             self.view.as_view()(request, guid=self.preprint._id)
 
     def test_correct_view_permissions(self):
@@ -51,14 +51,14 @@ class TestPreprintView(AdminTestCase):
         request.user = user
 
         response = self.view.as_view()(request, guid=self.preprint._id)
-        self.assertEqual(response.status_code, 200)
+        nt.assert_equal(response.status_code, 200)
 
     def test_change_preprint_provider_no_permission(self):
         user = AuthUserFactory()
         request = RequestFactory().post(reverse('preprints:preprint', kwargs={'guid': self.preprint._id}))
         request.user = user
 
-        with self.assertRaises(PermissionDenied):
+        with nt.assert_raises(PermissionDenied):
             self.view.as_view()(request, guid=self.preprint._id)
 
     def test_change_preprint_provider_correct_permission(self):
@@ -74,7 +74,7 @@ class TestPreprintView(AdminTestCase):
         request.user = user
 
         response = self.view.as_view()(request, guid=self.preprint._id)
-        self.assertEqual(response.status_code, 302)
+        nt.assert_equal(response.status_code, 302)
 
     def test_change_preprint_provider_form(self):
         new_provider = PreprintProviderFactory()
@@ -100,8 +100,7 @@ class TestPreprintFormView(AdminTestCase):
     def test_no_user_permissions_raises_error(self):
         request = RequestFactory().get(self.url)
         request.user = self.user
-
-        with self.assertRaises(PermissionDenied):
+        with nt.assert_raises(PermissionDenied):
             self.view.as_view()(request)
 
     def test_correct_view_permissions(self):

--- a/admin_tests/spam/test_extras.py
+++ b/admin_tests/spam/test_extras.py
@@ -1,9 +1,11 @@
 from nose import tools as nt
 from django.test import SimpleTestCase
+from django.test.utils import override_settings
 
 from admin.spam.templatetags import spam_extras
 
 
+@override_settings(ROOT_URLCONF='admin.base.urls')
 class TestReverseTags(SimpleTestCase):
     def test_reverse_spam_detail(self):
         res = spam_extras.reverse_spam_detail('123ab', page='2', status='4')

--- a/admin_tests/users/test_views.py
+++ b/admin_tests/users/test_views.py
@@ -3,7 +3,7 @@ import csv
 import os
 import furl
 import pytz
-from datetime import timedelta, datetime
+from datetime import datetime, timedelta
 
 from nose import tools as nt
 from django.test import RequestFactory
@@ -13,11 +13,6 @@ from django.utils import timezone
 from django.core.urlresolvers import reverse
 from django.core.exceptions import PermissionDenied
 from django.contrib.auth.models import Permission
-from nose import tools as nt
-import mock
-import csv
-import os
-from datetime import timedelta
 
 from tests.base import AdminTestCase
 from website import settings

--- a/admin_tests/users/test_views.py
+++ b/admin_tests/users/test_views.py
@@ -1,14 +1,19 @@
-from django.test import RequestFactory
-from django.http import Http404
-from django.core.files.uploadedfile import SimpleUploadedFile
-from django.utils import timezone
-from nose import tools as nt
 import mock
 import csv
 import os
 import furl
 import pytz
 from datetime import timedelta, datetime
+
+from nose import tools as nt
+from django.test import RequestFactory
+from django.http import Http404
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.utils import timezone
+from django.core.urlresolvers import reverse
+from django.core.exceptions import PermissionDenied
+from django.contrib.auth.models import Permission
+
 
 from tests.base import AdminTestCase
 from website import settings
@@ -56,48 +61,95 @@ class TestUserView(AdminTestCase):
         res = view.get_context_data()
         nt.assert_equal(res[views.UserView.context_object_name], temp_object)
 
+    def test_no_user_permissions_raises_error(self):
+        user = UserFactory()
+        guid = user._id
+        request = RequestFactory().get(reverse('users:user', kwargs={'guid': guid}))
+        request.user = user
+
+        with self.assertRaises(PermissionDenied):
+            views.UserView.as_view()(request, guid=guid)
+
+    def test_correct_view_permissions(self):
+        user = UserFactory()
+        guid = user._id
+
+        view_permission = Permission.objects.get(codename='view_osfuser')
+        user.user_permissions.add(view_permission)
+        user.save()
+
+        request = RequestFactory().get(reverse('users:user', kwargs={'guid': guid}))
+        request.user = user
+
+        response = views.UserView.as_view()(request, guid=guid)
+        self.assertEqual(response.status_code, 200)
+
 
 class TestResetPasswordView(AdminTestCase):
     def test_reset_password_context(self):
         user = UserFactory()
         guid = user._id
         request = RequestFactory().get('/fake_path')
-        view = views.ResetPasswordView()
+        view = views.ResetPasswordView(initial={})
         view = setup_view(view, request, guid=guid)
         res = view.get_context_data()
         nt.assert_is_instance(res, dict)
         nt.assert_in((user.emails[0], user.emails[0]), view.initial['emails'])
+
+    def test_no_user_permissions_raises_error(self):
+        user = UserFactory()
+
+        guid = user._id
+        request = RequestFactory().get(reverse('users:reset_password', kwargs={'guid': guid}))
+        request.user = user
+
+        with self.assertRaises(PermissionDenied):
+            views.ResetPasswordView.as_view()(request, guid=guid)
+
+    def test_correct_view_permissions(self):
+        user = UserFactory()
+        guid = user._id
+
+        change_permission = Permission.objects.get(codename='change_osfuser')
+        user.user_permissions.add(change_permission)
+        user.save()
+
+        request = RequestFactory().get(reverse('users:reset_password', kwargs={'guid': guid}))
+        request.user = user
+
+        response = views.ResetPasswordView.as_view()(request, guid=guid)
+        self.assertEqual(response.status_code, 200)
 
 
 class TestDisableUser(AdminTestCase):
     def setUp(self):
         self.user = UserFactory()
         self.request = RequestFactory().post('/fake_path')
-        self.view = views.UserDeleteView()
+        self.view = views.UserDeleteView
         self.view = setup_log_view(self.view, self.request, guid=self.user._id)
 
     def test_get_object(self):
-        obj = self.view.get_object()
+        obj = self.view().get_object()
         nt.assert_is_instance(obj, OSFUser)
 
     def test_get_context(self):
-        res = self.view.get_context_data(object=self.user)
+        res = self.view().get_context_data(object=self.user)
         nt.assert_in('guid', res)
         nt.assert_equal(res.get('guid'), self.user._id)
 
     def test_disable_user(self):
         settings.ENABLE_EMAIL_SUBSCRIPTIONS = False
         count = AdminLogEntry.objects.count()
-        self.view.delete(self.request)
+        self.view().delete(self.request)
         self.user.reload()
         nt.assert_true(self.user.is_disabled)
         nt.assert_equal(AdminLogEntry.objects.count(), count + 1)
 
     def test_reactivate_user(self):
         settings.ENABLE_EMAIL_SUBSCRIPTIONS = False
-        self.view.delete(self.request)
+        self.view().delete(self.request)
         count = AdminLogEntry.objects.count()
-        self.view.delete(self.request)
+        self.view().delete(self.request)
         self.user.reload()
         nt.assert_false(self.user.is_disabled)
         nt.assert_equal(AdminLogEntry.objects.count(), count + 1)
@@ -107,6 +159,28 @@ class TestDisableUser(AdminTestCase):
         with nt.assert_raises(Http404):
             view.delete(self.request)
 
+    def test_no_user_permissions_raises_error(self):
+        user = UserFactory()
+        guid = user._id
+        request = RequestFactory().get(reverse('users:disable', kwargs={'guid': guid}))
+        request.user = user
+
+        with self.assertRaises(PermissionDenied):
+            self.view.as_view()(request, guid=guid)
+
+    def test_correct_view_permissions(self):
+        user = UserFactory()
+        guid = user._id
+
+        change_permission = Permission.objects.get(codename='change_osfuser')
+        user.user_permissions.add(change_permission)
+        user.save()
+
+        request = RequestFactory().get(reverse('users:disable', kwargs={'guid': guid}))
+        request.user = user
+
+        response = self.view.as_view()(request, guid=guid)
+        self.assertEqual(response.status_code, 200)
 
 class TestDisableSpamUser(AdminTestCase):
     def setUp(self):
@@ -114,22 +188,22 @@ class TestDisableSpamUser(AdminTestCase):
         self.public_node = ProjectFactory(creator=self.user, is_public=True)
         self.public_node = ProjectFactory(creator=self.user, is_public=False)
         self.request = RequestFactory().post('/fake_path')
-        self.view = views.SpamUserDeleteView()
+        self.view = views.SpamUserDeleteView
         self.view = setup_log_view(self.view, self.request, guid=self.user._id)
 
     def test_get_object(self):
-        obj = self.view.get_object()
+        obj = self.view().get_object()
         nt.assert_is_instance(obj, OSFUser)
 
     def test_get_context(self):
-        res = self.view.get_context_data(object=self.user)
+        res = self.view().get_context_data(object=self.user)
         nt.assert_in('guid', res)
         nt.assert_equal(res.get('guid'), self.user._id)
 
     def test_disable_spam_user(self):
         settings.ENABLE_EMAIL_SUBSCRIPTIONS = False
         count = AdminLogEntry.objects.count()
-        self.view.delete(self.request)
+        self.view().delete(self.request)
         self.user.reload()
         self.public_node.reload()
         nt.assert_true(self.user.is_disabled)
@@ -137,12 +211,35 @@ class TestDisableSpamUser(AdminTestCase):
         nt.assert_equal(AdminLogEntry.objects.count(), count + 3)
 
     def test_no_user(self):
-        view = setup_view(views.UserDeleteView(), self.request, guid='meh')
+        view = setup_view(self.view(), self.request, guid='meh')
         with nt.assert_raises(Http404):
             view.delete(self.request)
 
+    def test_no_user_permissions_raises_error(self):
+        user = UserFactory()
+        guid = user._id
+        request = RequestFactory().get(reverse('users:spam_disable', kwargs={'guid': guid}))
+        request.user = user
 
-class SpamUserListMixin(AdminTestCase):
+        with self.assertRaises(PermissionDenied):
+            self.view.as_view()(request, guid=guid)
+
+    def test_correct_view_permissions(self):
+        user = UserFactory()
+        guid = user._id
+
+        change_permission = Permission.objects.get(codename='change_osfuser')
+        user.user_permissions.add(change_permission)
+        user.save()
+
+        request = RequestFactory().get(reverse('users:spam_disable', kwargs={'guid': guid}))
+        request.user = user
+
+        response = self.view.as_view()(request, guid=guid)
+        self.assertEqual(response.status_code, 200)
+
+
+class SpamUserListMixin(object):
     def setUp(self):
 
         spam_flagged = TagFactory(name='spam_flagged')
@@ -163,15 +260,39 @@ class SpamUserListMixin(AdminTestCase):
 
         self.request = RequestFactory().post('/fake_path')
 
+    def test_no_user_permissions_raises_error(self):
+        user = UserFactory()
+        guid = user._id
+        request = RequestFactory().get(self.url)
+        request.user = user
+
+        with self.assertRaises(PermissionDenied):
+            self.view.as_view()(request, guid=guid)
+
+    def test_correct_view_permissions(self):
+        user = UserFactory()
+        guid = user._id
+
+        change_permission = Permission.objects.get(codename='view_osfuser')
+        user.user_permissions.add(change_permission)
+        user.save()
+
+        request = RequestFactory().get(self.url)
+        request.user = user
+
+        response = self.view.as_view()(request, guid=guid)
+        self.assertEqual(response.status_code, 200)
+
 
 class TestFlaggedSpamUserList(SpamUserListMixin):
     def setUp(self):
         super(TestFlaggedSpamUserList, self).setUp()
-        self.view = views.UserFlaggedSpamList()
-        self.view = setup_log_view(self.view, self.request)
+        self.view = views.UserFlaggedSpamList
+        self.view = setup_log_view(self.view(), self.request)
+        self.url = reverse('users:flagged-spam')
 
     def test_get_queryset(self):
-        qs = self.view.get_queryset()
+        qs = self.view().get_queryset()
         nt.assert_equal(qs.count(), 1)
         nt.assert_equal(qs[0]._id, self.flagged_user._id)
 
@@ -179,11 +300,13 @@ class TestFlaggedSpamUserList(SpamUserListMixin):
 class TestConfirmedSpamUserList(SpamUserListMixin):
     def setUp(self):
         super(TestConfirmedSpamUserList, self).setUp()
-        self.view = views.UserKnownSpamList()
-        self.view = setup_log_view(self.view, self.request)
+        self.view = views.UserKnownSpamList
+        self.view = setup_log_view(self.view(), self.request)
+
+        self.url = reverse('users:known-spam')
 
     def test_get_queryset(self):
-        qs = self.view.get_queryset()
+        qs = self.view().get_queryset()
         nt.assert_equal(qs.count(), 1)
         nt.assert_equal(qs[0]._id, self.spam_user._id)
 
@@ -191,11 +314,13 @@ class TestConfirmedSpamUserList(SpamUserListMixin):
 class TestConfirmedHamUserList(SpamUserListMixin):
     def setUp(self):
         super(TestConfirmedHamUserList, self).setUp()
-        self.view = views.UserKnownHamList()
-        self.view = setup_log_view(self.view, self.request)
+        self.view = views.UserKnownHamList
+        self.view = setup_log_view(self.view(), self.request)
+
+        self.url = reverse('users:known-ham')
 
     def test_get_queryset(self):
-        qs = self.view.get_queryset()
+        qs = self.view().get_queryset()
         nt.assert_equal(qs.count(), 1)
         nt.assert_equal(qs[0]._id, self.ham_user._id)
 
@@ -205,12 +330,14 @@ class TestRemove2Factor(AdminTestCase):
         super(TestRemove2Factor, self).setUp()
         self.user = AuthUserFactory()
         self.request = RequestFactory().post('/fake_path')
-        self.view = views.User2FactorDeleteView()
-        self.view = setup_log_view(self.view, self.request, guid=self.user._id)
+        self.view = views.User2FactorDeleteView
+        self.setup_view = setup_log_view(self.view(), self.request, guid=self.user._id)
+
+        self.url = reverse('users:remove2factor', kwargs={'guid': self.user._id})
 
     @mock.patch('osf.models.user.OSFUser.delete_addon')
     def test_remove_two_factor_get(self, mock_delete_addon):
-        self.view.delete(self.request)
+        self.setup_view.delete(self.request)
         mock_delete_addon.assert_called_with('twofactor')
 
     def test_integration_delete_two_factor(self):
@@ -219,10 +346,31 @@ class TestRemove2Factor(AdminTestCase):
         user_settings = self.user.get_addon('twofactor')
         nt.assert_not_equal(user_settings, None)
         count = AdminLogEntry.objects.count()
-        self.view.delete(self.request)
+        self.setup_view.delete(self.request)
         post_addon = self.user.get_addon('twofactor')
         nt.assert_equal(post_addon, None)
         nt.assert_equal(AdminLogEntry.objects.count(), count + 1)
+
+    def test_no_user_permissions_raises_error(self):
+        guid = self.user._id
+        request = RequestFactory().get(self.url)
+        request.user = self.user
+
+        with self.assertRaises(PermissionDenied):
+            self.view.as_view()(request, guid=guid)
+
+    def test_correct_view_permissions(self):
+        guid = self.user._id
+
+        change_permission = Permission.objects.get(codename='change_osfuser')
+        self.user.user_permissions.add(change_permission)
+        self.user.save()
+
+        request = RequestFactory().get(self.url)
+        request.user = self.user
+
+        response = self.view.as_view()(request, guid=guid)
+        self.assertEqual(response.status_code, 200)
 
 
 class TestUserWorkshopFormView(AdminTestCase):

--- a/admin_tests/users/test_views.py
+++ b/admin_tests/users/test_views.py
@@ -412,13 +412,15 @@ class TestUserWorkshopFormView(AdminTestCase):
         return result_csv
 
     def _create_nodes_and_add_logs(self, first_activity_date, second_activity_date=None):
-        node_one = ProjectFactory(creator=self.user_1, date_created=first_activity_date)
+        node_one = ProjectFactory(creator=self.user_1)
+        node_one.date_created = first_activity_date
         node_one.add_log(
             'log_added', params={'project': node_one._id}, auth=self.auth_1, log_date=first_activity_date, save=True
         )
 
         if second_activity_date:
-            node_two = ProjectFactory(creator=self.user_1, date_created=second_activity_date)
+            node_two = ProjectFactory(creator=self.user_1)
+            node_two.date_created = second_activity_date
             node_two.add_log(
                 'log_added', params={'project': node_two._id}, auth=self.auth_1, log_date=second_activity_date, save=True
             )
@@ -457,7 +459,7 @@ class TestUserWorkshopFormView(AdminTestCase):
         user_logs_since_workshop = result_csv[1][-3]
         user_nodes_created_since_workshop = result_csv[1][-2]
 
-        nt.assert_equal(user_logs_since_workshop, 2)
+        nt.assert_equal(user_logs_since_workshop, 1)
         nt.assert_equal(user_nodes_created_since_workshop, 1)
 
     def test_user_activity_day_of_workshop_and_before(self):
@@ -485,7 +487,7 @@ class TestUserWorkshopFormView(AdminTestCase):
         user_logs_since_workshop = result_csv[1][-3]
         user_nodes_created_since_workshop = result_csv[1][-2]
 
-        nt.assert_equal(user_logs_since_workshop, 2)
+        nt.assert_equal(user_logs_since_workshop, 1)
         nt.assert_equal(user_nodes_created_since_workshop, 1)
 
     def test_user_activity_before_workshop_and_after(self):
@@ -500,7 +502,8 @@ class TestUserWorkshopFormView(AdminTestCase):
         user_logs_since_workshop = result_csv[1][-3]
         user_nodes_created_since_workshop = result_csv[1][-2]
 
-        nt.assert_equal(user_logs_since_workshop, 2)
+        # One log before workshop, one after, only should show the one after
+        nt.assert_equal(user_logs_since_workshop, 1)
         nt.assert_equal(user_nodes_created_since_workshop, 1)
 
     def test_user_osf_account_not_found(self):

--- a/tests/base.py
+++ b/tests/base.py
@@ -17,6 +17,7 @@ import mock
 import pytest
 
 from addons.wiki.models import NodeWikiPage
+from django.test.utils import override_settings
 from django.test import TestCase as DjangoTestCase
 from faker import Factory
 from framework.auth import User
@@ -347,9 +348,9 @@ class ApiAddonTestCase(ApiTestCase):
             self.account.remove()
 
 
+@override_settings(ROOT_URLCONF='admin.base.urls')
 class AdminTestCase(DbTestCase, DjangoTestCase, SearchTestCase, MockRequestTestCase):
-    urls = 'admin.base.urls'
-
+    pass
 
 class NotificationTestCase(OsfTestCase):
     """An `OsfTestCase` to use when testing specific subscription behavior.


### PR DESCRIPTION

## Purpose

Add tests that check permissions for user, node, meeting, preprnt, and prereg views
Also update all admin tests to actually pass when run locally

## Changes

- node view tests
- user view tests
- prereg view tests
- meeting view tests
- Preprint view tests
- updates to other tests to run properly locally

## Side effects

None anticipated


## Ticket
https://openscience.atlassian.net/browse/OSF-7427