### PR TITLE
[hotfix] Name preprintservice permission correctly in base template

### DIFF
--- a/admin/templates/base.html
+++ b/admin/templates/base.html
@@ -107,7 +107,7 @@
               </ul>
             </li>
             {% endif %}
-            {% if perms.osf.view_preprint %}
+            {% if perms.osf.view_preprintservice %}
             <li><a href="{% url 'preprints:search' %}"><i class='fa fa-link'></i><span>Preprints</span> </a></li>
             {% endif %}
               {% if perms.osf.view_osfuser %}


### PR DESCRIPTION

## Purpose
View preprint permission named incorrectly in base template, so users can't see the sidebar for preprints

## Changes

- Rename permission check to `view_preprintservice` in sidebar

## Side effects

Admin app will need to be refreshed after merge!

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
