### PR TITLE
Add subject children to subjects in preprint provider taxonomies [EOSF-491]

### DIFF
--- a/api/taxonomies/serializers.py
+++ b/api/taxonomies/serializers.py
@@ -25,6 +25,13 @@ class TaxonomySerializer(JSONAPISerializer):
     text = ser.CharField(max_length=200)
     parents = JSONAPIListField(child=TaxonomyField())
     child_count = ser.IntegerField()
+    children = ser.SerializerMethodField('get_child_num')
+
+    def get_child_num(self, obj):
+        if hasattr(obj, 'child_list_provider'):
+            return getattr(obj, 'child_list_provider')
+        else:
+            return []
 
     links = LinksField({
         'parents': 'get_parent_urls',


### PR DESCRIPTION
## Purpose
There are some cases where there is a need to retrieve subjects' children in the same request to save additional server calls from the front end. An example here is the need to show a tooltip of example subdisciplines for each top level subject in the preprint taxonomy. Currently, the subdisciplines are hard-coded in the preprint front-end, causing the display of one or more subjects that are not used (allowed) by the provider. This PR is related to PRs [326](https://github.com/CenterForOpenScience/ember-preprints/pull/326) in preprints and [202](https://github.com/CenterForOpenScience/ember-osf/pull/202) in ember-osf. The three PRs present solution 1. Another solution is presented in PR [312](https://github.com/CenterForOpenScience/ember-preprints/pull/312)

## Changes
- Update the preprint view
- Update the taxonomy serializer

## Side effects

In Figure 1, The average response time of API has been recorded using soapUI tool for both the old and new version.

**Figure 1**
![image](https://cloud.githubusercontent.com/assets/11130339/25281834/a46625f8-267c-11e7-9a57-d93fe13cbefa.png)


In Figure 2, The average (finish) time to fulfill the API requests by the chrome browser based on the developer tools has been recorded

**Figure 2**
![image](https://cloud.githubusercontent.com/assets/11130339/25281842/a99ac038-267c-11e7-82ab-3bc9f3826b8b.png)

**JSON output of the API after including the children**
![image](https://cloud.githubusercontent.com/assets/11130339/25282627/0b932922-267f-11e7-99d0-314e70c9b08a.png)


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
