### PR TITLE
[feature-fix] Render HTML in Dataverse Custom Publish Text [OSF-7211]

### DIFF
--- a/addons/dataverse/client.py
+++ b/addons/dataverse/client.py
@@ -6,6 +6,7 @@ from dataverse.exceptions import ConnectionError, UnauthorizedError, OperationFa
 from framework.exceptions import HTTPError
 
 from addons.dataverse import settings
+from website.util.sanitize import strip_html
 
 def _connect(host, token):
     try:
@@ -117,4 +118,4 @@ def get_dataverse(connection, alias):
 def get_custom_publish_text(connection):
     if connection is None:
         return ''
-    return connection.get_custom_publish_text()
+    return strip_html(connection.get_custom_publish_text(), tags=['strong', 'li', 'ul'])

--- a/addons/dataverse/static/dataverseFangornConfig.js
+++ b/addons/dataverse/static/dataverseFangornConfig.js
@@ -38,7 +38,7 @@ var _dataverseItemButtons = {
             // Set the modal content to reflect the file's external host
             var modalContent = [
                 // for now, only display custom publish text for UVA's dataverse
-                m('p.m-md', item.data.host == 'dataverse.lib.virginia.edu' ? item.data.hostCustomPublishText : ''),
+                m('p.m-md', item.data.host == 'dataverse.lib.virginia.edu' ? m.trust(item.data.hostCustomPublishText) : ''),
                 m('p.m-md', both ? 'This dataset cannot be published until the ' + item.data.dataverse + ' Dataverse is published. ' : ''),
                 m('p.m-md', 'By publishing this ' + toPublish + ', all content will be made available through ' + host + ' using their internal privacy settings, regardless of your OSF project settings. '),
                 m('p.font-thick.m-md', both ? 'Do you want to publish this Dataverse AND this dataset?' : 'Are you sure you want to publish this dataset?')

--- a/website/util/sanitize.py
+++ b/website/util/sanitize.py
@@ -5,7 +5,7 @@ import json
 import bleach
 
 
-def strip_html(unclean):
+def strip_html(unclean, tags=[]):
     """Sanitize a string, removing (as opposed to escaping) HTML tags
 
     :param unclean: A string to be stripped of HTML tags
@@ -17,7 +17,7 @@ def strip_html(unclean):
     # functions, such as rapply (recursively applies a function to collections)
     if not isinstance(unclean, basestring) and not is_iterable(unclean) and unclean is not None:
         return unclean
-    return bleach.clean(unclean, strip=True, tags=[], attributes=[], styles=[])
+    return bleach.clean(unclean, strip=True, tags=tags, attributes=[], styles=[])
 
 
 # TODO: Not used anywhere except unit tests? Review for deletion


### PR DESCRIPTION
#### Purpose
- Fixes the display of custom dataverse publish text which may contain HTML.

#### Changes
- Strips the HTML received from dataverse (with the exception of `strong`, `li`, and `ul` tags)
- Use `m.trust()` to render the un-stripped tags.

#### Screenshots
- Before:
![screen shot 2017-04-17 at 10 03 44 am](https://cloud.githubusercontent.com/assets/7913604/25091997/ca46d112-2359-11e7-9a79-a8576bfcf3ed.png)

- After:
![screen shot 2017-04-17 at 10 17 57 am](https://cloud.githubusercontent.com/assets/7913604/25092001/ccd9b7be-2359-11e7-8738-83abb3199218.png)


#### Ticket
- [OSF-7211](https://openscience.atlassian.net/browse/OSF-7211)
