### PR TITLE
[feature] Fix create_fakes [No Ticket]

### DIFF
--- a/scripts/create_fakes.py
+++ b/scripts/create_fakes.py
@@ -329,7 +329,7 @@ def create_fake_project(creator, n_users, privacy, n_components, name, n_tags, p
         node.add_contributor(contrib, auth=auth)
     if isinstance(n_components, int):
         for _ in range(n_components):
-            NodeFactory(project=node, title=fake.science_sentence(), description=fake.science_paragraph(),
+            NodeFactory(parent=node, title=fake.science_sentence(), description=fake.science_paragraph(),
                         creator=creator)
     elif isinstance(n_components, list):
         render_generations_from_node_structure_list(node, creator, n_components)


### PR DESCRIPTION
#### Purpose
- Fix the create_fakes script.

#### Changes
- `NodeFactory` kwarg changed from `project` to `parent`.
- Avoids this error when creating a fake project with components:
```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/local/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/code/scripts/create_fakes.py", line 384, in <module>
    main()
  File "/code/scripts/create_fakes.py", line 377, in main
    args.presentation_name, args.is_registration, args.is_preprint, args.preprint_provider)
  File "/code/scripts/create_fakes.py", line 333, in create_fake_project
    creator=creator)
  File "/usr/local/lib/python2.7/site-packages/factory/base.py", line 67, in __call__
    return cls.create(**kwargs)
  File "/usr/local/lib/python2.7/site-packages/factory/base.py", line 594, in create
    return cls._generate(True, attrs)
  File "/usr/local/lib/python2.7/site-packages/factory/base.py", line 519, in _generate
    obj = cls._prepare(create, **attrs)
  File "/usr/local/lib/python2.7/site-packages/factory/base.py", line 494, in _prepare
    return cls._create(model_class, *args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/factory/django.py", line 181, in _create
    return manager.create(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/django/db/models/manager.py", line 122, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/django/db/models/query.py", line 399, in create
    obj = self.model(**kwargs)
  File "osf/models/node.py", line 402, in __init__
    super(AbstractNode, self).__init__(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/dirtyfields/dirtyfields.py", line 22, in __init__
    super(DirtyFieldsMixin, self).__init__(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/typedmodels/models.py", line 370, in __init__
    super(TypedModel, self).__init__(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/django/db/models/base.py", line 443, in __init__
    raise TypeError("'%s' is an invalid keyword argument for this function" % list(kwargs)[0])
TypeError: 'project' is an invalid keyword argument for this function
```