### PR TITLE
[OSF-7828] Replace '.' with ' ' when indexing wiki page names

### DIFF
--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -367,7 +367,8 @@ def serialize_node(node, category):
     }
     if not node.is_retracted:
         for wiki in NodeWikiPage.objects.filter(guids___id__in=node.wiki_pages_current.values()):
-            elastic_document['wikis'][wiki.page_name] = wiki.raw_text(node)
+            # '.' is not allowed in field names in ES2
+            elastic_document['wikis'][wiki.page_name.replace('.', ' ')] = wiki.raw_text(node)
 
     return elastic_document
 


### PR DESCRIPTION


## Purpose

Updating nodes that have a wiki name with a dot in them fails.

## Changes

Replace '.' with ' ' when indexing wiki page names.

## Side effects

<!--Any possible side effects? -->

Must be merged before running `populate_instititions` on prod. Therefore, this should be merged before #7120


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->

https://openscience.atlassian.net/browse/OSF-7828
