### PR TITLE
Allow postgres data volume to be overridden with an envvar

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,5 +1,5 @@
 
-version: '2'
+version: '2.1'
 
 services:
 

--- a/docker-compose.ubuntu.yml
+++ b/docker-compose.ubuntu.yml
@@ -1,5 +1,5 @@
 
-version: '2'
+version: '2.1'
 
 services:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 # Reference README-docker-compose.md for instructions.
 
-version: '2'
+version: '2.1'
 
 volumes:
   postgres_data_vol:
@@ -63,7 +63,7 @@ services:
         sed -i -e 's/max_connections.*/max_connections = 5000/' /var/lib/postgresql/data/postgresql.conf
         sed -i -e 's/#log_min_duration_statement = .*/log_min_duration_statement = 0/' /var/lib/postgresql/data/postgresql.conf
     volumes:
-      - postgres_data_vol:/var/lib/postgresql/data/
+      - "${POSTGRES_DATA_VOL:-postgres_data_vol}:/var/lib/postgresql/data/"
     stdin_open: true
 
   tokumx:


### PR DESCRIPTION
This makes it easier to use local database dumps

The compose file version was bumped to 2.1 in order to add support
for ${VARIABLE:-default}

https://docs.docker.com/compose/compose-file/#variable-substitution
