### PR TITLE
[Hotfix] Redirect `/download` [OSF-7835]

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -3,6 +3,7 @@ import httplib
 import os
 import uuid
 import markupsafe
+import urllib
 from django.utils import timezone
 
 from flask import make_response
@@ -37,6 +38,7 @@ from website.project import decorators
 from website.project.decorators import must_be_contributor_or_public, must_be_valid_project
 from website.project.model import DraftRegistration, MetaSchema
 from website.project.utils import serialize_node
+from website.settings import MFR_SERVER_URL
 from website.util import rubeus
 
 # import so that associated listener is instantiated and gets emails
@@ -660,6 +662,10 @@ def addon_view_or_download_file(auth, path, provider, **kwargs):
 
     if action == 'download':
         return redirect(file_node.generate_waterbutler_url(**dict(extras, direct=None, version=version.identifier, _internal=extras.get('mode') == 'render')))
+
+    if action == 'export':
+        extras['action'] = 'download'
+        return redirect('{}/export?format={}&url={}'.format(MFR_SERVER_URL, request.args['format'], urllib.quote(file.generate_waterbutler_url(**dict(extras, direct=None, version=version.identifier, _internal=extras.get('mode') == 'render')))))
 
     if action == 'get_guid':
         draft_id = extras.get('draft')

--- a/osf_tests/test_guid.py
+++ b/osf_tests/test_guid.py
@@ -3,11 +3,13 @@ import pytest
 import urllib
 from django.core.exceptions import MultipleObjectsReturned
 
+from framework.auth import Auth
 from osf.models import Guid, NodeLicenseRecord, OSFUser
 from osf.modm_compat import Q
-from osf_tests.factories import UserFactory, NodeFactory, NodeLicenseRecordFactory, RegistrationFactory, PreprintFactory
+from osf_tests.factories import AuthUserFactory, UserFactory, NodeFactory, NodeLicenseRecordFactory, RegistrationFactory, PreprintFactory
 from tests.base import OsfTestCase
-from website.settings import MFR_SERVER_URL
+from tests.test_websitefiles import TestFile
+from website.settings import MFR_SERVER_URL, WATERBUTLER_URL
 
 @pytest.mark.django_db
 class TestGuid:
@@ -172,31 +174,118 @@ class TestResolveGuid(OsfTestCase):
 
         res = self.app.get(pp.url + 'download/')
         assert res.status_code == 302
-        assert '/v1/resources/{}/providers/{}{}?action=download&version=1&direct'.format(pp.node._id, pp.primary_file.provider, pp.primary_file.path) in res.location
+        assert '{}/v1/resources/{}/providers/{}{}?action=download&version=1&direct'.format(WATERBUTLER_URL, pp.node._id, pp.primary_file.provider, pp.primary_file.path) in res.location
 
         res = self.app.get('/{}/download'.format(pp.primary_file.get_guid(create=True)._id))
         assert res.status_code == 302
-        assert '/v1/resources/{}/providers/{}{}?action=download&version=1&direct'.format(pp.node._id, pp.primary_file.provider, pp.primary_file.path) in res.location
+        assert '{}/v1/resources/{}/providers/{}{}?action=download&version=1&direct'.format(WATERBUTLER_URL, pp.node._id, pp.primary_file.provider, pp.primary_file.path) in res.location
+
+        pp.primary_file.create_version(
+            creator=pp.node.creator,
+            location={u'folder': u'osf', u'object': u'deadbe', u'service': u'cloud'},
+            metadata={u'contentType': u'img/png', u'size': 9001}
+        )
+        pp.primary_file.save()
+
+        res = self.app.get(pp.url + 'download/')
+        assert res.status_code == 302
+        assert '{}/v1/resources/{}/providers/{}{}?action=download&version=2&direct'.format(WATERBUTLER_URL, pp.node._id, pp.primary_file.provider, pp.primary_file.path) in res.location
+
+        res = self.app.get(pp.url + 'download/?version=1')
+        assert res.status_code == 302
+        assert '{}/v1/resources/{}/providers/{}{}?action=download&version=1&direct'.format(WATERBUTLER_URL, pp.node._id, pp.primary_file.provider, pp.primary_file.path) in res.location
+
+        unpub_pp = PreprintFactory(project=self.node, is_published=False)
+        res = self.app.get(unpub_pp.url + 'download/?version=1', auth=self.node.creator.auth)
+        assert res.status_code == 302
+        assert '{}/v1/resources/{}/providers/{}{}?action=download&version=1&direct'.format(WATERBUTLER_URL, unpub_pp.node._id, unpub_pp.primary_file.provider, unpub_pp.primary_file.path) in res.location
 
     def test_resolve_guid_download_file_export(self):
         pp = PreprintFactory(finish=True)
 
         res = self.app.get(pp.url + 'download?format=asdf')
         assert res.status_code == 302
-        assert '/export?format=asdf&url=' in res.location
-        assert '/v1/resources/{}/providers/{}{}%3Faction%3Ddownload'.format(pp.node._id, pp.primary_file.provider, pp.primary_file.path) in res.location
+        assert '{}/export?format=asdf&url='.format(MFR_SERVER_URL) in res.location
+        assert '{}/v1/resources/{}/providers/{}{}%3Faction%3Ddownload'.format(urllib.quote(WATERBUTLER_URL), pp.node._id, pp.primary_file.provider, pp.primary_file.path) in res.location
 
         res = self.app.get(pp.url + 'download/?format=asdf')
         assert res.status_code == 302
-        assert '/export?format=asdf&url=' in res.location
-        assert '/v1/resources/{}/providers/{}{}%3Faction%3Ddownload'.format(pp.node._id, pp.primary_file.provider, pp.primary_file.path) in res.location
+        assert '{}/export?format=asdf&url='.format(MFR_SERVER_URL) in res.location
+        assert '{}/v1/resources/{}/providers/{}{}%3Faction%3Ddownload'.format(urllib.quote(WATERBUTLER_URL), pp.node._id, pp.primary_file.provider, pp.primary_file.path) in res.location
 
         res = self.app.get('/{}/download?format=asdf'.format(pp.primary_file.get_guid(create=True)._id))
         assert res.status_code == 302
-        assert '/export?format=asdf&url=' in res.location
-        assert '/v1/resources/{}/providers/{}{}%3Faction%3Ddownload'.format(pp.node._id, pp.primary_file.provider, pp.primary_file.path) in res.location
+        assert '{}/export?format=asdf&url='.format(MFR_SERVER_URL) in res.location
+        assert '{}/v1/resources/{}/providers/{}{}%3Faction%3Ddownload'.format(urllib.quote(WATERBUTLER_URL), pp.node._id, pp.primary_file.provider, pp.primary_file.path) in res.location
 
         res = self.app.get('/{}/download/?format=asdf'.format(pp.primary_file.get_guid(create=True)._id))
         assert res.status_code == 302
-        assert '/export?format=asdf&url=' in res.location
-        assert '/v1/resources/{}/providers/{}{}%3Faction%3Ddownload'.format(pp.node._id, pp.primary_file.provider, pp.primary_file.path) in res.location
+        assert '{}/export?format=asdf&url='.format(MFR_SERVER_URL) in res.location
+        assert '{}/v1/resources/{}/providers/{}{}%3Faction%3Ddownload'.format(urllib.quote(WATERBUTLER_URL), pp.node._id, pp.primary_file.provider, pp.primary_file.path) in res.location
+
+        pp.primary_file.create_version(
+            creator=pp.node.creator,
+            location={u'folder': u'osf', u'object': u'deadbe', u'service': u'cloud'},
+            metadata={u'contentType': u'img/png', u'size': 9001}
+        )
+        pp.primary_file.save()
+
+        res = self.app.get(pp.url + 'download/?format=asdf')
+        assert res.status_code == 302
+        assert '{}/export?format=asdf&url='.format(MFR_SERVER_URL) in res.location
+        assert '{}/v1/resources/{}/providers/{}{}%3F'.format(urllib.quote(WATERBUTLER_URL), pp.node._id, pp.primary_file.provider, pp.primary_file.path) in res.location
+        quarams = res.location.split('%3F')[1].split('%26')
+        assert 'action%3Ddownload' in quarams
+        assert 'version%3D2' in quarams
+        assert 'direct' in quarams
+
+        res = self.app.get(pp.url + 'download/?format=asdf&version=1')
+        assert res.status_code == 302
+        assert '{}/export?format=asdf&url='.format(MFR_SERVER_URL) in res.location
+        assert '{}/v1/resources/{}/providers/{}{}%3F'.format(urllib.quote(WATERBUTLER_URL), pp.node._id, pp.primary_file.provider, pp.primary_file.path) in res.location
+        quarams = res.location.split('%3F')[1].split('%26')
+        assert 'action%3Ddownload' in quarams
+        assert 'version%3D1' in quarams
+        assert 'direct' in quarams
+
+        unpub_pp = PreprintFactory(project=self.node, is_published=False)
+        res = self.app.get(unpub_pp.url + 'download?format=asdf', auth=unpub_pp.node.creator.auth)
+        assert res.status_code == 302
+        assert res.status_code == 302
+        assert '{}/export?format=asdf&url='.format(MFR_SERVER_URL) in res.location
+        assert '{}/v1/resources/{}/providers/{}{}%3F'.format(urllib.quote(WATERBUTLER_URL), unpub_pp.node._id, unpub_pp.primary_file.provider, unpub_pp.primary_file.path) in res.location
+        quarams = res.location.split('%3F')[1].split('%26')
+        assert 'action%3Ddownload' in quarams
+        assert 'version%3D1' in quarams
+        assert 'direct' in quarams
+
+    def test_resolve_guid_download_errors(self):
+        testfile = TestFile.get_or_create(self.node, 'folder/path')
+        testfile.name = 'asdf'
+        testfile.materialized_path = '/folder/path'
+        guid = testfile.get_guid(create=True)
+        testfile.save()
+        testfile.delete()
+        res = self.app.get('/{}/download'.format(guid), expect_errors=True)
+        assert res.status_code == 404
+
+        pp = PreprintFactory(is_published=False)
+
+        res = self.app.get(pp.url + 'download', expect_errors=True)
+        assert res.status_code == 404
+
+        pp.is_published = True
+        pp.save()
+        pp.node.is_public = False
+        pp.node.save()
+
+        non_contrib = AuthUserFactory()
+
+        res = self.app.get(pp.url + 'download', auth=non_contrib.auth, expect_errors=True)
+        assert res.status_code == 403
+
+        pp.node.is_deleted = True
+        pp.node.save()
+
+        res = self.app.get(pp.url + 'download', auth=non_contrib.auth, expect_errors=True)
+        assert res.status_code == 410

--- a/website/views.py
+++ b/website/views.py
@@ -248,6 +248,10 @@ def resolve_guid(guid, suffix=None):
             file_referent = None
             if isinstance(referent, PreprintService) and referent.primary_file:
                 if not referent.is_published:
+                    # TODO: Ideally, permissions wouldn't be checked here.
+                    # This is necessary to prevent a logical inconsistency with
+                    # the routing scheme - if a preprint is not published, only
+                    # admins should be able to know it exists.
                     auth = Auth.from_kwargs(request.args.to_dict(), {})
                     if not referent.node.has_permission(auth.user, permissions.ADMIN):
                         raise HTTPError(http.NOT_FOUND)


### PR DESCRIPTION
## Purpose
Redirect `/download` for files and preprints

## Changes
Add special cases in `resolve_guid`

## Side effects
None expected

## Ticket
[[OSF-7835]](https://openscience.atlassian.net/browse/OSF-7835)