### PR TITLE
[Fix] Return the correct dates for OSFstorage files at get_children

### DIFF
--- a/addons/osfstorage/views.py
+++ b/addons/osfstorage/views.py
@@ -135,6 +135,7 @@ def osfstorage_get_metadata(file_node, **kwargs):
 def osfstorage_get_children(file_node, **kwargs):
     from django.contrib.contenttypes.models import ContentType
     with connection.cursor() as cursor:
+        # Read the documentation on FileVersion's fields before reading this code
         cursor.execute('''
             SELECT json_agg(CASE
                 WHEN F.type = 'osf.osfstoragefile' THEN
@@ -147,8 +148,8 @@ def osfstorage_get_children(file_node, **kwargs):
                         , 'downloads',  COALESCE(DOWNLOAD_COUNT, 0)
                         , 'version', (SELECT COUNT(*) FROM osf_basefilenode_versions WHERE osf_basefilenode_versions.basefilenode_id = F.id)
                         , 'contentType', LATEST_VERSION.content_type
-                        , 'modified', LATEST_VERSION.date_modified
-                        , 'created', EARLIEST_VERSION.date_modified
+                        , 'modified', LATEST_VERSION.date_created
+                        , 'created', EARLIEST_VERSION.date_created
                         , 'checkout', CHECKOUT_GUID
                         , 'md5', LATEST_VERSION.metadata ->> 'md5'
                         , 'sha256', LATEST_VERSION.metadata ->> 'sha256'


### PR DESCRIPTION
  As documented on the FileVersion model, date_modified is meant for
  internal use and/or debugging only. date_created represents when the
  version was created or the date_modified of the FILE supposing it is
  the newest version.

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

<!-- Describe the purpose of your changes -->

## Changes

<!-- Briefly describe or list your changes  -->

## Side effects

<!--Any possible side effects? -->


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
