### PR TITLE
[#OSF-7742]Dashboard "Search for more projects" button url shows zero search results in elastic search

### DIFF
--- a/website/static/js/home-page/newAndNoteworthyPlugin.js
+++ b/website/static/js/home-page/newAndNoteworthyPlugin.js
@@ -151,7 +151,7 @@ var NewAndNoteworthy = {
         }
 
         function findMoreProjectsButton () {
-            return m('a.btn.btn-default.m-v-lg', {type:'button', href:'/search', onclick: function() {
+            return m('a.btn.btn-default.m-v-lg', {type:'button', href:'/search/?q=* ', onclick: function() {
                 $osf.trackClick('discoverPublicProjects', 'navigate', 'navigate-to-search-for-more-projects');
             }}, 'Search for more projects');
         }


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Dashboard "Search for more projects" button url shows zero search results in elastic search
<!-- Describe the purpose of your changes -->

## Changes
1.Login to OSF, go to your dashboard
2.Scroll down, just past New & Noteworthy and Popular
3.Click the "Search for more projects" button

Before change:
<img width="1378" alt="screen shot 2017-04-27 at 2 54 18 pm" src="https://cloud.githubusercontent.com/assets/4974056/25499439/6acebc88-2b59-11e7-92aa-b8958689ba5d.png">
After change:

<!-- Briefly describe or list your changes  -->

## Side effects
There is a short delay when you try to search for everything in the elastic search and return the result. And it creates unnecessary weights on the search since everytime someone click that button. He is trying to search everything in the elastic search.
<!--Any possible side effects? -->


## Ticket
https://openscience.atlassian.net/browse/OSF-7742
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
