### PR TITLE
[hotfix] Distinct preprints fix [OSF-7903]

### DIFF
--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -3583,4 +3583,4 @@ class NodePreprintsList(JSONAPIBaseView, generics.ListAPIView, NodeMixin, Django
 
     # overrides ListAPIView
     def get_queryset(self):
-        return PreprintService.objects.filter(self.get_query_from_request())
+        return PreprintService.objects.filter(self.get_query_from_request()).distinct()

--- a/api/preprint_providers/views.py
+++ b/api/preprint_providers/views.py
@@ -204,7 +204,7 @@ class PreprintProviderPreprintList(JSONAPIBaseView, generics.ListAPIView, Django
 
     # overrides ListAPIView
     def get_queryset(self):
-        return PreprintService.objects.filter(self.get_query_from_request())
+        return PreprintService.objects.filter(self.get_query_from_request()).distinct()
 
 
 class PreprintProviderSubjectList(JSONAPIBaseView, generics.ListAPIView):

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -187,7 +187,7 @@ class PreprintList(JSONAPIBaseView, generics.ListCreateAPIView, DjangoFilterMixi
 
     # overrides ListAPIView
     def get_queryset(self):
-        return PreprintService.objects.filter(self.get_query_from_request())
+        return PreprintService.objects.filter(self.get_query_from_request()).distinct()
 
 class PreprintDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, PreprintMixin, WaterButlerMixin):
     """Preprint Detail  *Writeable*.

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -553,7 +553,7 @@ class UserPreprints(JSONAPIBaseView, generics.ListAPIView, UserMixin, DjangoFilt
         return (default_query & no_user_query)
 
     def get_queryset(self):
-        return PreprintService.objects.filter(self.get_query_from_request())
+        return PreprintService.objects.filter(self.get_query_from_request()).distinct()
 
 
 class UserInstitutions(JSONAPIBaseView, generics.ListAPIView, UserMixin):


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Api is duplicating returned values.
<!-- Describe the purpose of your changes -->

## Changes
Adds distinct() to the queryset for the 4 api routes
<!-- Briefly describe or list your changes  -->

## Side effects
None known

<!--Any possible side effects? -->


## Ticket
https://openscience.atlassian.net/browse/OSF-7903
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->

## QA Notes
!!!! Make sure you test both logged in and non logged in users!!!!

See https://staging-api.osf.io/v2/preprints/?filter[provider]=osf
If you look at the id values, note that some of them duplicate. There should not be duplicated preprint data.

This changes the 4 preprint api routes: users, preprints, preprint_providers, and nodes
Easiest way to find the issue is to filter by a specific preprint provider