### PR TITLE
[feature] Fix NodeProviderDetail 502 [OSF-7904]

### DIFF
--- a/api/nodes/permissions.py
+++ b/api/nodes/permissions.py
@@ -22,11 +22,12 @@ from api.base.utils import get_user_auth, is_deprecated
 class ContributorOrPublic(permissions.BasePermission):
 
     def has_object_permission(self, request, view, obj):
+        from api.nodes.views import NodeProvider
         if isinstance(obj, BaseAddonSettings):
             obj = obj.owner
-        if isinstance(obj, PreprintService):
+        if isinstance(obj, (NodeProvider, PreprintService)):
             obj = obj.node
-        assert isinstance(obj, (AbstractNode, NodeRelation)), 'obj must be an Node, NodeRelation, PreprintService, or AddonSettings; got {}'.format(obj)
+        assert isinstance(obj, (AbstractNode, NodeRelation)), 'obj must be an Node, NodeProvider, NodeRelation, PreprintService, or AddonSettings; got {}'.format(obj)
         auth = get_user_auth(request)
         if request.method in permissions.SAFE_METHODS:
             return obj.is_public or obj.can_view(auth)

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -2428,7 +2428,7 @@ class NodeProviderDetail(JSONAPIBaseView, generics.RetrieveAPIView, NodeMixin):
     view_name = 'node-provider-detail'
 
     def get_object(self):
-        return NodeProvider(self.kwargs['provider'], Node.load(self.kwargs['node_id']))
+        return NodeProvider(self.kwargs['provider'], self.get_node())
 
 
 class NodeAlternativeCitationsList(JSONAPIBaseView, generics.ListCreateAPIView, NodeMixin):

--- a/api_tests/nodes/views/test_node_files_list.py
+++ b/api_tests/nodes/views/test_node_files_list.py
@@ -490,4 +490,26 @@ class TestNodeFilesListPagination(ApiTestCase):
         res = self.app.get(url, auth=self.user.auth)
         self.check_file_order(res)
 
+class TestNodeProviderDetail(ApiTestCase):
 
+    def setUp(self):
+        super(TestNodeProviderDetail, self).setUp()
+        self.user = AuthUserFactory()
+        self.public_project = ProjectFactory(is_public=True)
+        self.private_project = ProjectFactory(creator=self.user)
+        self.public_url = '/{}nodes/{}/files/providers/osfstorage/'.format(API_BASE, self.public_project._id)
+        self.private_url = '/{}nodes/{}/files/providers/osfstorage/'.format(API_BASE, self.private_project._id)
+
+    def test_can_view_if_contributor(self):
+        res = self.app.get(self.private_url, auth=self.user.auth)
+        assert_equal(res.status_code, 200)
+        assert_equal(res.json['data']['id'], '{}:osfstorage'.format(self.private_project._id))
+
+    def test_can_view_if_public(self):
+        res = self.app.get(self.public_url)
+        assert_equal(res.status_code, 200)
+        assert_equal(res.json['data']['id'], '{}:osfstorage'.format(self.public_project._id))
+
+    def test_cannot_view_if_private(self):
+        res = self.app.get(self.private_url, expect_errors=True)
+        assert_equal(res.status_code, 401)


### PR DESCRIPTION
#### Purpose
- Fix 502 when accessing NodeProviderDetail endpoints (`/v2/nodes/<node_id>/files/providers/<provider>/`)

#### Changes
- Handle `NodeProvider` object in `ContributorOrPublic` permissions class.

#### Ticket
- [OSF-7904](https://openscience.atlassian.net/browse/OSF-7904)
