### PR TITLE
Except bad GH creds [OSF-7892][OSF-7895]

### DIFF
--- a/addons/github/apps.py
+++ b/addons/github/apps.py
@@ -32,6 +32,8 @@ def github_hgrid_data(node_settings, auth, **kwargs):
         except NotFoundError:
             logger.error('Could not access GitHub repo')
             return None
+        except GitHubError:
+            return
         if repo.private:
             return None
 

--- a/addons/github/models.py
+++ b/addons/github/models.py
@@ -180,7 +180,10 @@ class NodeSettings(BaseStorageAddon, BaseOAuthNodeSettings):
     @property
     def is_private(self):
         connection = GitHubClient(external_account=self.external_account)
-        return connection.repo(user=self.user, repo=self.repo).private
+        try:
+            return connection.repo(user=self.user, repo=self.repo).private
+        except GitHubError:
+            return
 
     # TODO: Delete me and replace with serialize_settings / Knockout
     def to_json(self, user):


### PR DESCRIPTION
## Purpose
Don't needlessly send errors to sentry

## Changes
* `except GitHubError`s in two places

## Side effects
None expected

## Ticket
[[OSF-7892]](https://openscience.atlassian.net/browse/OSF-7892)
[[OSF-7895]](https://openscience.atlassian.net/browse/OSF-7895)