### PR TITLE
Fix alternative citation tests

### DIFF
--- a/api_tests/nodes/views/test_node_alternative_citations.py
+++ b/api_tests/nodes/views/test_node_alternative_citations.py
@@ -1696,7 +1696,7 @@ class TestManualCitationCorrections(ApiTestCase):
         csl = self.project.csl
         citation = citation_utils.render_citation(self.project, 'modern-language-association')
         expected_citation = csl['author'][0]['family'] + ', ' + csl['author'][0]['given'] + '. ' + u"\u201c" + csl['title'] + u"\u201d" + '. ' +\
-                            csl['publisher'] + ', ' + self.project.date_created.strftime("%-d %b. %Y. Web.")
+                            csl['publisher'] + ', ' + (self.project.date_created.strftime("%-d %b. %Y. Web.") if self.project.date_created.month != 5 else self.project.date_created.strftime("%-d %b %Y. Web."))
         assert_equal(citation, expected_citation)
 
     def test_chicago_citation(self):


### PR DESCRIPTION
## Purpose
Prevent the alternative citation test from breaking (every May).

## Changes
Citeprocpy's MLA citation produces the month in an abbreviated format, with a `.` if the month actually gets abbreviated. Our test adds it at the end of the month as well, except it doesn't account for May, which doesn't get abbreviated and so doesn't get a `.`. This adds that exception for the unit test to work every month.

## Side effects
Tests will pass every month, instead of only passing 11 out of 12 times a year 🉑 :fire:

