### PR TITLE
Admin Name search now case insensitive [#OSF-6841]

### DIFF
--- a/admin/users/views.py
+++ b/admin/users/views.py
@@ -301,7 +301,7 @@ class UserSearchList(PermissionRequiredMixin, ListView):
     paginate_by = 25
 
     def get_queryset(self):
-        query = OSFUser.objects.filter(fullname__contains=self.kwargs['name']).only(
+        query = OSFUser.objects.filter(fullname__icontains=self.kwargs['name']).only(
             'guids', 'fullname', 'username', 'date_confirmed', 'date_disabled'
         )
         return query

--- a/admin_tests/users/test_views.py
+++ b/admin_tests/users/test_views.py
@@ -466,6 +466,17 @@ class TestUserSearchView(AdminTestCase):
         for user in results:
             nt.assert_in('Hardy', user.fullname)
 
+    def test_search_user_list_case_insensitive(self):
+        view = views.UserSearchList()
+        view = setup_view(view, self.request)
+        view.kwargs = {'name': 'hardy'}
+
+        results = view.get_queryset()
+
+        nt.assert_equal(len(results), 3)
+        for user in results:
+            nt.assert_in('Hardy', user.fullname)
+
 
 class TestGetLinkView(AdminTestCase):
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Addendum to #7070  -- now with more name search case insensitivity!

## Changes
Search by name is now case insensitive!

Searching by "User name" or "USER NAME" or "UsEr NAmE" should yield the same results.

## Side effects
None antipated


## Ticket
https://openscience.atlassian.net/browse/OSF-6841