### PR TITLE
[feature] Allow cancelling of draft reg with deleted node [OSF-7768]

### DIFF
--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -347,9 +347,9 @@ def configure_comments(node, **kwargs):
 # View Project
 ##############################################################################
 
+@process_token_or_pass
 @must_be_valid_project(retractions_valid=True)
 @must_be_contributor_or_public
-@process_token_or_pass
 def view_project(auth, node, **kwargs):
     primary = '/api/v1' not in request.path
     ret = _view_project(node, auth,


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Deleting a node before a registration is approved/canceled makes it so that the registration cannot be cancelled. 
<!-- Describe the purpose of your changes -->

## Changes
Changes the order of the decorators to allow the token to execute.
<!-- Briefly describe or list your changes  -->

## Side effects
None known, permissions are checked via the token as well, so shouldn't cause any problems.
<!--Any possible side effects? -->


## Ticket
https://openscience.atlassian.net/browse/OSF-7768
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->

## QA Notes
Steps to reproduce:
1. Create Node
2. Create Draft Registration (but do not approve)
3. Open draft in a new tab for easy access (to not lose the link)
4. Delete Node
5. Go to draft and click note at top to delete draft
6. Draft should now delete (although it will send you to a resource not found page with a drop down saying draft registration was deleted).

Test:
1. Approving and Rejecting a registration with a deleted and intact node
2. Test the above with embargoes as well.
3. Because permissions checking orders changed, also test using the approve/reject registration email link with a non-contributor user to ensure it fails.