### PR TITLE
[OSF-7439] File page - Change default text prompt for tags for users with no tags 

### DIFF
--- a/website/static/js/pages/file-page.js
+++ b/website/static/js/pages/file-page.js
@@ -16,6 +16,7 @@ $(function() {
         width: '100%',
         interactive: window.contextVars.currentUser.canEdit,
         maxChars: 128,
+        defaultText: 'add a tag to enhance discoverability',
         onAddTag: function (tag) {
             var url = tagUrl;
             var request = $osf.postJSON(url, {'tag': tag });
@@ -43,6 +44,12 @@ $(function() {
             });
         }
     });
+
+    // allows inital default message to fit on empty tag
+    if(!$('.tag').length){
+        $('#fileTags_tag').css('width', '250px');
+    }
+
     $('#fileTags_tag').attr('maxlength', '128');
     if (!window.contextVars.currentUser.canEdit || window.contextVars.node.isRegistration) {
         $('a[title="Removing tag"]').remove();


### PR DESCRIPTION
## Purpose

This points out to the user they have no tags for their project by changing the text prompt for uses with no tags for the files page.

## Changes

Changes to over override taginput.js's default text behavior for the file page tags.

## Side effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/OSF-7439

## Figure
<img width="343" alt="screen shot 2017-05-04 at 2 25 38 pm" src="https://cloud.githubusercontent.com/assets/9688518/25718887/a58cddf6-30d5-11e7-9203-112c3805812f.png">
