### PR TITLE
Also generate links for Unclaimed users in admin [OSF-7123]

### DIFF
--- a/admin/templates/users/get_link.html
+++ b/admin/templates/users/get_link.html
@@ -3,7 +3,16 @@
     <h3>{{ title }} for user {{ username }}</h3>
 </div>
 <div class="modal-body">
+    {% if user_link %}
     <p>{{ user_link }}</p>
+    {% endif %}
+    {% if node_claim_links %}
+    <ul>
+        {% for link in node_claim_links %}
+        <li>{{ link }}</li>
+        {% endfor %}
+    </ul>
+    {% endif %}
 </div>
 <div class="modal-footer">
     <button type="button" class="btn btn-default"

--- a/admin/templates/users/user.html
+++ b/admin/templates/users/user.html
@@ -14,12 +14,18 @@
                 <a href="{% url 'spam:user_spam' user.id %}" class="btn btn-default">Related spam</a>
                 {% endif %}
                 {%  if perms.osf.change_osfuser %}
+                    {% if  user.is_claimed %}
                 <a href="{% url 'users:reset_password' user.id %}" data-toggle="modal" data-target="#resetModal" class="btn btn-default">Send reset password email</a>
-                <a href="{% url 'users:get_reset_password' user.id %}" data-toggle="modal" data-target="#getResetModal" class="btn btn-default">Get password reset link</a>
+                {% endif %}
+                        <a href="{% url 'users:get_reset_password' user.id %}" data-toggle="modal" data-target="#getResetModal" class="btn btn-default">Get password reset link</a>
                 {% if user.confirmed %}
                     <button class="btn btn-default disabled" data-toggle="tooltip" title="User already confirmed">Get confirmation link</button>
-                    {% else %}
-                    <a href="{% url 'users:get_confirmation' user.id %}" data-toggle="modal" data-target="#getConfirmationModal" class="btn btn-default">Get confirmation link</a>
+                {% else %}
+                    {% if user.is_claimed %}
+                        <a href="{% url 'users:get_confirmation' user.id %}" data-toggle="modal" data-target="#getConfirmationModal" class="btn btn-default">Get confirmation link</a>
+                    {%  else %}
+                        <a href="{% url 'users:get_claim_urls' user.id %}" data-toggle="modal" data-target="#getUserClaimModal" class="btn btn-default">Get claim links</a>
+                    {% endif %}
                 {% endif %}
                 {% endif %}
                 {%  if perms.osf.view_desk %}
@@ -78,6 +84,11 @@
                 </div>
             </div>
             <div class="modal" id="getConfirmationModal" style="display: none">
+                <div class="modal-dialog">
+                    <div class="modal-content"></div>
+                </div>
+            </div>
+            <div class="modal" id="getUserClaimModal" style="display: none">
                 <div class="modal-dialog">
                     <div class="modal-content"></div>
                 </div>

--- a/admin/users/serializers.py
+++ b/admin/users/serializers.py
@@ -17,6 +17,7 @@ def serialize_user(user):
         'two_factor': user.has_addon('twofactor'),
         'osf_link': user.absolute_url,
         'system_tags': user.system_tags,
+        'is_claimed': user.is_claimed,
     }
 
 

--- a/admin/users/urls.py
+++ b/admin/users/urls.py
@@ -15,6 +15,7 @@ urlpatterns = [
     url(r'^(?P<guid>[a-z0-9]+)/disable_spam/$', views.SpamUserDeleteView.as_view(), name='spam_disable'),
     url(r'^(?P<guid>[a-z0-9]+)/enable_ham/$', views.HamUserRestoreView.as_view(), name='ham_enable'),
     url(r'^(?P<guid>[a-z0-9]+)/reactivate/$', views.UserDeleteView.as_view(), name='reactivate'),
+    url(r'^(?P<guid>[a-z0-9]+)/get_claim_urls/$', views.GetUserClaimLinks.as_view(), name='get_claim_url'),
     url(r'^(?P<guid>[a-z0-9]+)/two-factor/disable/$', views.User2FactorDeleteView.as_view(), name='remove2factor'),
     url(r'^(?P<guid>[a-z0-9]+)/get_confirmation/$', views.GetUserConfirmationLink.as_view(), name='get_confirmation'),
     url(r'^(?P<guid>[a-z0-9]+)/get_reset_password/$', views.GetPasswordResetLink.as_view(), name='get_reset_password'),

--- a/admin/users/views.py
+++ b/admin/users/views.py
@@ -498,7 +498,7 @@ class GetUserClaimLinks(GetUserLink):
             )
             links.append('Claim URL for node {}: {}'.format(node._id, url))
 
-        return links or 'User currently has no active unclaimed records for any nodes.'
+        return links or ['User currently has no active unclaimed records for any nodes.']
 
     def get_link(self, user):
         return None

--- a/admin/users/views.py
+++ b/admin/users/views.py
@@ -445,7 +445,11 @@ class GetUserLink(PermissionRequiredMixin, TemplateView):
         raise NotImplementedError()
 
     def get_link_type(self):
+        # Used in the title of the link modal
         raise NotImplementedError()
+
+    def get_claim_links(self, user):
+        return None
 
     def get_context_data(self, **kwargs):
         user = OSFUser.load(self.kwargs.get('guid'))
@@ -453,6 +457,7 @@ class GetUserLink(PermissionRequiredMixin, TemplateView):
         kwargs['user_link'] = self.get_link(user)
         kwargs['username'] = user.username
         kwargs['title'] = self.get_link_type()
+        kwargs['node_claim_links'] = self.get_claim_links(user)
 
         return super(GetUserLink, self).get_context_data(**kwargs)
 
@@ -477,6 +482,29 @@ class GetPasswordResetLink(GetUserLink):
 
     def get_link_type(self):
         return 'Password Reset'
+
+
+class GetUserClaimLinks(GetUserLink):
+    def get_claim_links(self, user):
+        links = []
+
+        for guid, value in user.unclaimed_records.iteritems():
+            node = Node.load(guid)
+            url = '{base_url}user/{uid}/{project_id}/claim/?token={token}'.format(
+                base_url=DOMAIN,
+                uid=user._id,
+                project_id=guid,
+                token=value['token']
+            )
+            links.append('Claim URL for node {}: {}'.format(node._id, url))
+
+        return links or 'User currently has no active unclaimed records for any nodes.'
+
+    def get_link(self, user):
+        return None
+
+    def get_link_type(self):
+        return 'Claim User'
 
 
 class ResetPasswordView(PermissionRequiredMixin, FormView):

--- a/admin_tests/users/test_views.py
+++ b/admin_tests/users/test_views.py
@@ -515,3 +515,22 @@ class TestGetLinkView(AdminTestCase):
         link_path = str(furl.furl(link).path)
 
         nt.assert_equal(link_path, ideal_link_path)
+
+    def test_get_unclaimed_node_links(self):
+        project = ProjectFactory()
+        unregistered_contributor = project.add_unregistered_contributor(fullname='Brother Nero', email='matt@hardyboyz.biz', auth=Auth(project.creator))
+        project.save()
+
+        request = RequestFactory().get('/fake_path')
+        view = views.GetUserClaimLinks()
+        view = setup_view(view, request, guid=unregistered_contributor._id)
+
+        links = view.get_claim_links(unregistered_contributor)
+        unclaimed_records = unregistered_contributor.unclaimed_records
+
+        nt.assert_equal(len(links), 1)
+        nt.assert_equal(len(links), len(unclaimed_records.keys()))
+        link = links[0]
+
+        nt.assert_in(project._id, link)
+        nt.assert_in(unregistered_contributor.unclaimed_records[project._id]['token'], link)


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Addendum to https://github.com/CenterForOpenScience/osf.io/pull/7088

If a user is unclaimed, generate claim links for every node that they've been added as an unregistered contributor on

![screen shot 2017-05-04 at 2 43 34 pm](https://cloud.githubusercontent.com/assets/801594/25721178/864a1848-30dd-11e7-9c83-9c246ac6fda8.png)


## Changes

- urls for unclaimed user route
- view that parses unclaimed records and turns to links
- changes to structure of modal to show list of links if necesary
- add is_claimed to user serializer
- test for link generation from unclaimed user record

## Side effects

None anticipated


## Ticket
https://openscience.atlassian.net/browse/OSF-7123