### PR TITLE
[EOSF-339] Subject Filtering

### DIFF
--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -21,7 +21,7 @@ from api.base.exceptions import (
     RelationshipPostMakesNoChanges,
     EndpointNotImplementedError,
 )
-from api.base.filters import ODMFilterMixin, ListFilterMixin, DjangoFilterMixin
+from api.base.filters import ODMFilterMixin, ListFilterMixin, PreprintFilterMixin
 from api.base.pagination import CommentPagination, NodeContributorPagination, MaxSizePagination
 from api.base.parsers import (
     JSONAPIRelationshipParser,
@@ -103,7 +103,6 @@ from osf.models import (Node, PrivateLink, NodeLog, Institution, Comment, DraftR
 from osf.models import OSFUser as User
 from osf.models import NodeRelation, AlternativeCitation, Guid
 from osf.models import BaseFileNode
-from osf.models import Subject
 from osf.models.files import File, Folder
 from addons.wiki.models import NodeWikiPage
 from website.exceptions import NodeStateError
@@ -3497,7 +3496,7 @@ class NodeIdentifierList(NodeMixin, IdentifierList):
     serializer_class = NodeIdentifierSerializer
 
 
-class NodePreprintsList(JSONAPIBaseView, generics.ListAPIView, NodeMixin, DjangoFilterMixin):
+class NodePreprintsList(JSONAPIBaseView, generics.ListAPIView, NodeMixin, PreprintFilterMixin):
     """List of preprints for a node. *Read-only*.
 
     ##Note
@@ -3560,20 +3559,6 @@ class NodePreprintsList(JSONAPIBaseView, generics.ListAPIView, NodeMixin, Django
 
     view_category = 'nodes'
     view_name = 'node-preprints'
-
-    def postprocess_query_param(self, key, field_name, operation):
-        if field_name == 'provider':
-            operation['source_field_name'] = 'provider___id'
-
-        if field_name == 'id':
-            operation['source_field_name'] = 'guids___id'
-
-        if field_name == 'subjects':
-            try:
-                Subject.objects.get(_id=operation['value'])
-                operation['source_field_name'] = 'subjects___id'
-            except Subject.DoesNotExist:
-                operation['source_field_name'] = 'subjects__text'
 
     # overrides DjangoFilterMixin
     def get_default_django_query(self):

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -103,6 +103,7 @@ from osf.models import (Node, PrivateLink, NodeLog, Institution, Comment, DraftR
 from osf.models import OSFUser as User
 from osf.models import NodeRelation, AlternativeCitation, Guid
 from osf.models import BaseFileNode
+from osf.models import Subject
 from osf.models.files import File, Folder
 from addons.wiki.models import NodeWikiPage
 from website.exceptions import NodeStateError
@@ -3566,6 +3567,13 @@ class NodePreprintsList(JSONAPIBaseView, generics.ListAPIView, NodeMixin, Django
 
         if field_name == 'id':
             operation['source_field_name'] = 'guids___id'
+
+        if field_name == 'subjects':
+            try:
+                Subject.objects.get(_id=operation['value'])
+                operation['source_field_name'] = 'subjects___id'
+            except Subject.DoesNotExist:
+                operation['source_field_name'] = 'subjects__text'
 
     # overrides DjangoFilterMixin
     def get_default_django_query(self):

--- a/api/preprint_providers/views.py
+++ b/api/preprint_providers/views.py
@@ -206,6 +206,13 @@ class PreprintProviderPreprintList(JSONAPIBaseView, generics.ListAPIView, Django
         if field_name == 'id':
             operation['source_field_name'] = 'guids___id'
 
+        if field_name == 'subjects':
+            try:
+                Subject.objects.get(_id=operation['value'])
+                operation['source_field_name'] = 'subjects___id'
+            except Subject.DoesNotExist:
+                operation['source_field_name'] = 'subjects__text'
+
     # overrides DjangoFilterMixin
     def get_default_django_query(self):
         auth = get_user_auth(self.request)

--- a/api/preprint_providers/views.py
+++ b/api/preprint_providers/views.py
@@ -9,7 +9,7 @@ from framework.auth.oauth_scopes import CoreScopes
 from website.models import Node, Subject, PreprintService, PreprintProvider
 
 from api.base import permissions as base_permissions
-from api.base.filters import DjangoFilterMixin, ODMFilterMixin
+from api.base.filters import PreprintFilterMixin, ODMFilterMixin
 from api.base.views import JSONAPIBaseView
 from api.base.pagination import MaxSizePagination
 from api.base.utils import get_object_or_error, get_user_auth
@@ -142,7 +142,7 @@ class PreprintProviderDetail(JSONAPIBaseView, generics.RetrieveAPIView):
         return get_object_or_error(PreprintProvider, self.kwargs['provider_id'], display_name='PreprintProvider')
 
 
-class PreprintProviderPreprintList(JSONAPIBaseView, generics.ListAPIView, DjangoFilterMixin):
+class PreprintProviderPreprintList(JSONAPIBaseView, generics.ListAPIView, PreprintFilterMixin):
     """Preprints from a given preprint_provider. *Read Only*
 
     To update preprints with a given preprint_provider, see the `<node_id>/relationships/preprint_provider` endpoint
@@ -198,20 +198,6 @@ class PreprintProviderPreprintList(JSONAPIBaseView, generics.ListAPIView, Django
 
     view_category = 'preprint_providers'
     view_name = 'preprints-list'
-
-    def postprocess_query_param(self, key, field_name, operation):
-        if field_name == 'provider':
-            operation['source_field_name'] = 'provider___id'
-
-        if field_name == 'id':
-            operation['source_field_name'] = 'guids___id'
-
-        if field_name == 'subjects':
-            try:
-                Subject.objects.get(_id=operation['value'])
-                operation['source_field_name'] = 'subjects___id'
-            except Subject.DoesNotExist:
-                operation['source_field_name'] = 'subjects__text'
 
     # overrides DjangoFilterMixin
     def get_default_django_query(self):

--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -63,7 +63,7 @@ class PreprintSerializer(JSONAPISerializer):
         'date_published',
         'provider',
         'is_published',
-        'subjects'
+        'subjects',
     ])
 
     id = IDField(source='_id', read_only=True)

--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -63,6 +63,7 @@ class PreprintSerializer(JSONAPISerializer):
         'date_published',
         'provider',
         'is_published',
+        'subjects'
     ])
 
     id = IDField(source='_id', read_only=True)

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -164,6 +164,8 @@ class PreprintList(JSONAPIBaseView, generics.ListCreateAPIView, DjangoFilterMixi
             operation['source_field_name'] = 'provider___id'
         if field_name == 'id':
             operation['source_field_name'] = 'guids___id'
+        if field_name == 'subjects':
+            operation['source_field_name'] = 'subjects__text'
 
     def get_serializer_class(self):
         if self.request.method == 'POST':

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -170,7 +170,6 @@ class PreprintList(JSONAPIBaseView, generics.ListCreateAPIView, DjangoFilterMixi
                 operation['source_field_name'] = 'subjects___id'
             except Subject.DoesNotExist:
                 operation['source_field_name'] = 'subjects__text'
-                operation['op'] = 'contains'
 
     def get_serializer_class(self):
         if self.request.method == 'POST':

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -6,7 +6,7 @@ from rest_framework import generics
 from rest_framework.exceptions import NotFound, PermissionDenied, NotAuthenticated
 from rest_framework import permissions as drf_permissions
 
-from website.models import PreprintService
+from website.models import PreprintService, Subject
 from framework.auth.oauth_scopes import CoreScopes
 
 from api.base.exceptions import Conflict
@@ -165,7 +165,12 @@ class PreprintList(JSONAPIBaseView, generics.ListCreateAPIView, DjangoFilterMixi
         if field_name == 'id':
             operation['source_field_name'] = 'guids___id'
         if field_name == 'subjects':
-            operation['source_field_name'] = 'subjects__text'
+            try:
+                Subject.objects.get(_id=operation['value'])
+                operation['source_field_name'] = 'subjects___id'
+            except Subject.DoesNotExist:
+                operation['source_field_name'] = 'subjects__text'
+                operation['op'] = 'contains'
 
     def get_serializer_class(self):
         if self.request.method == 'POST':

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -6,12 +6,12 @@ from rest_framework import generics
 from rest_framework.exceptions import NotFound, PermissionDenied, NotAuthenticated
 from rest_framework import permissions as drf_permissions
 
-from website.models import PreprintService, Subject
+from website.models import PreprintService
 from framework.auth.oauth_scopes import CoreScopes
 
 from api.base.exceptions import Conflict
 from api.base.views import JSONAPIBaseView
-from api.base.filters import DjangoFilterMixin
+from api.base.filters import PreprintFilterMixin
 from api.base.parsers import (
     JSONAPIMultipleRelationshipsParser,
     JSONAPIMultipleRelationshipsParserForRegularJSON,
@@ -51,7 +51,7 @@ class PreprintMixin(NodeMixin):
         return preprint
 
 
-class PreprintList(JSONAPIBaseView, generics.ListCreateAPIView, DjangoFilterMixin):
+class PreprintList(JSONAPIBaseView, generics.ListCreateAPIView, PreprintFilterMixin):
     """Preprints that represent a special kind of preprint node. *Writeable*.
 
     Paginated list of preprints ordered by their `date_created`.  Each resource contains a representation of the
@@ -157,19 +157,6 @@ class PreprintList(JSONAPIBaseView, generics.ListCreateAPIView, DjangoFilterMixi
     ordering = ('-date_created')
     view_category = 'preprints'
     view_name = 'preprint-list'
-
-    # overrides FilterMixin
-    def postprocess_query_param(self, key, field_name, operation):
-        if field_name == 'provider':
-            operation['source_field_name'] = 'provider___id'
-        if field_name == 'id':
-            operation['source_field_name'] = 'guids___id'
-        if field_name == 'subjects':
-            try:
-                Subject.objects.get(_id=operation['value'])
-                operation['source_field_name'] = 'subjects___id'
-            except Subject.DoesNotExist:
-                operation['source_field_name'] = 'subjects__text'
 
     def get_serializer_class(self):
         if self.request.method == 'POST':

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -29,7 +29,7 @@ from django.db.models import Q
 from rest_framework import permissions as drf_permissions
 from rest_framework import generics
 from rest_framework.exceptions import NotAuthenticated, NotFound
-from website.models import ExternalAccount, Node, User
+from website.models import ExternalAccount, Node, User, Subject
 from osf.models import PreprintService
 
 
@@ -537,6 +537,13 @@ class UserPreprints(JSONAPIBaseView, generics.ListAPIView, UserMixin, DjangoFilt
 
         if field_name == 'id':
             operation['source_field_name'] = 'guids___id'
+
+        if field_name == 'subjects':
+            try:
+                Subject.objects.get(_id=operation['value'])
+                operation['source_field_name'] = 'subjects___id'
+            except Subject.DoesNotExist:
+                operation['source_field_name'] = 'subjects__text'
 
     # overrides DjangoFilterMixin
     def get_default_django_query(self):

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -2,7 +2,7 @@
 from api.addons.views import AddonSettingsMixin
 from api.base import permissions as base_permissions
 from api.base.exceptions import Conflict
-from api.base.filters import ListFilterMixin, ODMFilterMixin, DjangoFilterMixin
+from api.base.filters import ListFilterMixin, ODMFilterMixin, PreprintFilterMixin
 from api.base.parsers import (JSONAPIRelationshipParser,
                               JSONAPIRelationshipParserForRegularJSON)
 from api.base.serializers import AddonAccountSerializer
@@ -29,7 +29,7 @@ from django.db.models import Q
 from rest_framework import permissions as drf_permissions
 from rest_framework import generics
 from rest_framework.exceptions import NotAuthenticated, NotFound
-from website.models import ExternalAccount, Node, User, Subject
+from website.models import ExternalAccount, Node, User
 from osf.models import PreprintService
 
 
@@ -515,7 +515,7 @@ class UserNodes(JSONAPIBaseView, generics.ListAPIView, UserMixin, NodeODMFilterM
         return Node.find(self.get_query_from_request()).select_related('node_license').include('guids', 'contributor__user__guids', 'root__guids', limit_includes=10)
 
 
-class UserPreprints(JSONAPIBaseView, generics.ListAPIView, UserMixin, DjangoFilterMixin):
+class UserPreprints(JSONAPIBaseView, generics.ListAPIView, UserMixin, PreprintFilterMixin):
     permission_classes = (
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,
@@ -530,20 +530,6 @@ class UserPreprints(JSONAPIBaseView, generics.ListAPIView, UserMixin, DjangoFilt
     serializer_class = PreprintSerializer
     view_category = 'users'
     view_name = 'user-preprints'
-
-    def postprocess_query_param(self, key, field_name, operation):
-        if field_name == 'provider':
-            operation['source_field_name'] = 'provider___id'
-
-        if field_name == 'id':
-            operation['source_field_name'] = 'guids___id'
-
-        if field_name == 'subjects':
-            try:
-                Subject.objects.get(_id=operation['value'])
-                operation['source_field_name'] = 'subjects___id'
-            except Subject.DoesNotExist:
-                operation['source_field_name'] = 'subjects__text'
 
     # overrides DjangoFilterMixin
     def get_default_django_query(self):

--- a/api_tests/preprints/filters/test_filters.py
+++ b/api_tests/preprints/filters/test_filters.py
@@ -50,6 +50,8 @@ class PreprintsListFilteringMixin(object):
 
         self.is_published_and_modified_url = '{}filter[is_published]=true&filter[date_created]=2013-12-11'.format(self.url)
 
+        self.has_subject = '{}filter[subjects]='.format(self.url)
+
     def test_provider_filter_null(self):
         expected = []
         res = self.app.get('{}null'.format(self.provider_url), auth=self.user.auth)
@@ -133,6 +135,22 @@ class PreprintsListFilteringMixin(object):
     def test_multiple_filters_returns_one(self):
         expected = set([self.preprint_two._id])
         res = self.app.get(self.is_published_and_modified_url,
+            auth=self.user.auth
+        )
+        actual = set([preprint['id'] for preprint in res.json['data']])
+        assert_equal(expected, actual)
+
+    def test_subject_filter_using_id(self):
+        expected = set([self.preprint._id, self.preprint_three._id])
+        res = self.app.get('{}{}'.format(self.has_subject, self.subject._id),
+            auth=self.user.auth
+        )
+        actual = set([preprint['id'] for preprint in res.json['data']])
+        assert_equal(expected, actual)
+
+    def test_subject_filter_using_text(self):
+        expected = set([self.preprint._id, self.preprint_three._id])
+        res = self.app.get('{}{}'.format(self.has_subject, self.subject.text),
             auth=self.user.auth
         )
         actual = set([preprint['id'] for preprint in res.json['data']])

--- a/api_tests/preprints/filters/test_filters.py
+++ b/api_tests/preprints/filters/test_filters.py
@@ -155,3 +155,9 @@ class PreprintsListFilteringMixin(object):
         )
         actual = set([preprint['id'] for preprint in res.json['data']])
         assert_equal(expected, actual)
+
+    def test_unknows_subject_filter(self):
+        res = self.app.get('{}notActuallyASubjectIdOrTestMostLikely'.format(self.has_subject),
+            auth=self.user.auth
+        )
+        assert_equal(len(res.json['data']), 0)

--- a/api_tests/preprints/filters/test_filters.py
+++ b/api_tests/preprints/filters/test_filters.py
@@ -23,10 +23,10 @@ class PreprintsListFilteringMixin(object):
         assert self.project, 'Subclasses of PreprintsListFilteringMixin must define self.project'
         assert self.project_two, 'Subclasses of PreprintsListFilteringMixin must define self.projec_two'
         assert self.project_three, 'Subclasses of PreprintsListFilteringMixin must define self.project_three'
-        assert self.url, 'Subclasses of PreprintsListFilteringMixin must define self.url' 
+        assert self.url, 'Subclasses of PreprintsListFilteringMixin must define self.url'
 
-        self.subject = SubjectFactory()
-        self.subject_two = SubjectFactory()
+        self.subject = SubjectFactory(text='First Subject')
+        self.subject_two = SubjectFactory(text='Second Subject')
 
         self.preprint = PreprintFactory(creator=self.user, project=self.project, provider=self.provider, subjects=[[self.subject._id]])
         self.preprint_two = PreprintFactory(creator=self.user, project=self.project_two, filename='tough.txt', provider=self.provider_two, subjects=[[self.subject_two._id]])


### PR DESCRIPTION
## Purpose
To allow api filtering of preprints by the id of their subjects again. Additionally, allow filtering by text in the subject.
 
## Changes
Make subjects a filterable field on preprints.

## Ticket

https://openscience.atlassian.net/browse/EOSF-339

## QA Considerations:
Should be able to do two things:
`/v2/preprints/?filter[subjects]=<subject_id>`
`/v2/preprints/?filter[subjects]=<subject_text>`
and it should return all matching preprints.