### PR TITLE
[feature] Fix Author Link on Meetings Submission [OSF-7589]

### DIFF
--- a/website/conferences/views.py
+++ b/website/conferences/views.py
@@ -164,7 +164,7 @@ def _render_conference_node(node, idx, conf):
         'title': node.title,
         'nodeUrl': node.url,
         'author': author.family_name if author.family_name else author.fullname,
-        'authorUrl': node.creator.url,
+        'authorUrl': author.url,
         'category': conf.field_names['submission1'] if conf.field_names['submission1'] in node.system_tags else conf.field_names['submission2'],
         'download': download_count,
         'downloadUrl': download_url,


### PR DESCRIPTION
#### Purpose
- Updates the link to an author's profile page on a meetings submission to be correct in the case that the project creator removes themselves as a contributor (or makes someone else the project administrator).

#### Ticket
- [OSF-7589](https://openscience.atlassian.net/browse/OSF-7589)

#### Before GIF
![casey](https://cloud.githubusercontent.com/assets/7913604/25722448/4a3fb56a-30e2-11e7-910e-b00d360a6f2d.gif)


#### After GIF
![karen](https://cloud.githubusercontent.com/assets/7913604/25722437/3b92c14c-30e2-11e7-811d-b3d66b55f8f7.gif)

