### PR TITLE
[Hotfix] Skip attempts to archive empty addons [OSF-7922]

### DIFF
--- a/website/archiver/tasks.py
+++ b/website/archiver/tasks.py
@@ -126,6 +126,9 @@ def stat_addon(addon_short_name, job_pk):
     job = ArchiveJob.load(job_pk)
     src, dst, user = job.info()
     src_addon = src.get_addon(addon_name)
+    if hasattr(src_addon, 'configured') and not src_addon.configured:
+        # Addon enabled but not configured - no file trees, nothing to archive.
+        return AggregateStatResult(src_addon._id, addon_short_name)
     try:
         file_tree = src_addon._get_file_tree(user=user, version=version)
     except HTTPError as e:


### PR DESCRIPTION
## Purpose
Don't attempt to collect files that can't be accessed.

## Changes
* LBYL

## Side effects
It's possible that registrations which would otherwise not archive will have an empty root folder for an addon that is enabled but not configured.

## Ticket
[[OSF-7922]](https://openscience.atlassian.net/browse/OSF-7922)
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
