### PR TITLE
[#OSF-7310]Improve wording on move/replace file modal

### DIFF
--- a/website/static/css/fangorn.css
+++ b/website/static/css/fangorn.css
@@ -359,5 +359,4 @@ a.fangorn-toolbar-icon {
 /* file pop up modal text  */
 .replace-file {
     margin-left: 8px;
-    font-weight: bold;
 }

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -437,13 +437,13 @@ function checkConflicts(tb, item, folder, cb) {
         if (child.data.name === item.data.name && child.id !== item.id) {
            messageArray.push([
                 m('p', 'An item named "' + child.data.name + '" already exists in this location.'),
-                m('h5.text-danger.replace-file',
+                m('h5.replace-file',
                     '"Keep Both" will retain both files (and their version histories) in this location.'),
-                m('h5.text-danger.replace-file',
+                m('h5.replace-file',
                     '"Replace" will overwrite the existing file in this location. ' +
                     'You will lose previous versions of the overwritten file. ' +
                     'You will keep previous versions of the moved file.'),
-                m('h5.text-danger.replace-file', '"Cancel" will cancel the move.')
+                m('h5.replace-file', '"Cancel" will cancel the move.')
             ]);
             
             tb.modal.update(
@@ -468,13 +468,13 @@ function checkConflictsRename(tb, item, name, cb) {
         if (child.data.name === name && child.id !== item.id) {
             messageArray.push([
                 m('p', 'An item named "' + child.data.name + '" already exists in this location.'),
-                m('h5.text-danger.replace-file',
+                m('h5.replace-file',
                     '"Keep Both" will retain both files (and their version histories) in this location.'),
-                m('h5.text-danger.replace-file',
+                m('h5.replace-file',
                     '"Replace" will overwrite the existing file in this location. ' +
                     'You will lose previous versions of the overwritten file. ' +
                     'You will keep previous versions of the moved file.'),
-                m('h5.text-danger.replace-file', '"Cancel" will cancel the move.')
+                m('h5.replace-file', '"Cancel" will cancel the move.')
             ]);
 
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Make the text "unred" and "unbold"
<!-- Describe the purpose of your changes -->

## Changes
create a project and go to the file widget
create a folder
upload a file to the project both inside the folder and outside the folder
drag the file of the project from outside the folder to inside the folder

Before the ticket:
![image](https://cloud.githubusercontent.com/assets/4974056/25761713/d0443114-31a9-11e7-926d-1dc1b1763d64.png)

After https://github.com/CenterForOpenScience/osf.io/pull/6836's fix:
![image](https://cloud.githubusercontent.com/assets/4974056/25761742/e6a73064-31a9-11e7-8368-ce8e3b15d64d.png)

After this fix:
<img width="1298" alt="screen shot 2017-05-05 at 3 41 57 pm" src="https://cloud.githubusercontent.com/assets/4974056/25761753/f0ebd9a8-31a9-11e7-8d86-c9740bc0520c.png">


<!-- Briefly describe or list your changes  -->

## Side effects

<!--Any possible side effects? -->


## Ticket
https://openscience.atlassian.net/browse/OSF-7310
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
