### PR TITLE
[hotfix] stop preprint deletions [OSF-7938]

### DIFF
--- a/addons/osfstorage/models.py
+++ b/addons/osfstorage/models.py
@@ -128,17 +128,27 @@ class OsfStorageFileNode(BaseFileNode):
     def is_checked_out(self):
         return self.checkout is not None
 
-    def delete(self, user=None, parent=None, **kwargs):
-        if self.node.preprint_file and self.node.preprint_file.pk == self.pk:
-            self.node._is_preprint_orphan = True
-            self.node.save()
+    @property
+    def _delete_allowed(self):
+        if self.is_preprint_primary:
+            raise exceptions.FileNodeIsPrimaryFile()
         if self.is_checked_out:
             raise exceptions.FileNodeCheckedOutError()
+        return True
+
+    @property
+    def is_preprint_primary(self):
+        return self.node.preprint_file == self and not self.node._has_abandoned_preprint
+
+    def delete(self, user=None, parent=None, **kwargs):
         self._path = self.path
         self._materialized_path = self.materialized_path
-        return super(OsfStorageFileNode, self).delete(user=user, parent=parent, **kwargs)
+        return super(OsfStorageFileNode, self).delete(user=user, parent=parent) if self._delete_allowed else None
 
     def move_under(self, destination_parent, name=None):
+        if self.is_preprint_primary:
+            if self.node._id != destination_parent.node._id or self.provider != destination_parent.provider:
+                raise exceptions.FileNodeIsPrimaryFile()
         if self.is_checked_out:
             raise exceptions.FileNodeCheckedOutError()
         return super(OsfStorageFileNode, self).move_under(destination_parent, name)
@@ -340,6 +350,14 @@ class OsfStorageFolder(OsfStorageFileNode, Folder):
                     return True
             except AttributeError:
                 pass
+        return False
+
+    @property
+    def is_preprint_primary(self):
+        if self.node.is_preprint:
+            for child in self.children:
+                if child.is_preprint_primary:
+                    return True
         return False
 
     def serialize(self, include_full=False, version=None):

--- a/addons/osfstorage/models.py
+++ b/addons/osfstorage/models.py
@@ -353,8 +353,8 @@ class OsfStorageFolder(OsfStorageFileNode, Folder):
 
     @property
     def is_preprint_primary(self):
-        if self.node.is_preprint:
-            for child in self.children.all():
+        if self.node.preprint_file:
+            for child in self.children.all().select_related('node'):
                 if child.is_preprint_primary:
                     return True
         return False

--- a/addons/osfstorage/tests/test_views.py
+++ b/addons/osfstorage/tests/test_views.py
@@ -597,6 +597,22 @@ class TestDeleteHook(HookTestCase):
         res = self.delete(file_checked, expect_errors=True)
         assert_equal(res.status_code, 403)
 
+    def test_attempt_delete_while_preprint(self):
+        file = self.root_node.append_file('Nights')
+        self.node.preprint_file = file.stored_object
+        self.node.save()
+        res = self.delete(file, expect_errors=True)
+
+        assert_equal(res.status_code, 403)
+
+    def test_attempt_delete_folder_with_preprint(self):
+        folder = self.root_node.append_folder('Fishes')
+        file = folder.append_file('Fish')
+        self.node.preprint_file = file.stored_object
+        self.node.save()
+        res = self.delete(folder, expect_errors=True)
+
+        assert_equal(res.status_code, 403)
 
 @pytest.mark.django_db
 class TestMoveHook(HookTestCase):
@@ -648,6 +664,30 @@ class TestMoveHook(HookTestCase):
             expect_errors=True,
         )
         assert_equal(res.status_code, 405)
+
+    def test_within_node_move_while_preprint(self):
+
+        file = self.root_node.append_file('Self Control')
+        self.node.preprint_file = file.stored_object
+        self.node.save()
+        folder = self.root_node.append_folder('Frank Ocean')
+        res = self.send_hook(
+            'osfstorage_move_hook',
+            {'nid': self.root_node.node._id},
+            payload={
+                'source': file._id,
+                'node': self.root_node._id,
+                'user': self.user._id,
+                'destination': {
+                    'parent': folder._id,
+                    'node': folder.node._id,
+                    'name': folder.name,
+                }
+            },
+            method='post_json',
+            expect_errors=True,
+        )
+        assert_equal(res.status_code, 200)
 
 
 @pytest.mark.django_db

--- a/api_tests/nodes/views/test_node_list.py
+++ b/api_tests/nodes/views/test_node_list.py
@@ -637,9 +637,8 @@ class TestNodeFiltering(ApiTestCase):
         orphan = PreprintFactory(creator=self.preprint.node.creator)
 
         # orphan the preprint by deleting the file
-        orphan.primary_file.delete()
-        orphan.save()
-
+        orphan.node.preprint_file = None
+        orphan.node.save()
         url = '/{}nodes/?filter[preprint]=true'.format(API_BASE)
         res = self.app.get(url, auth=self.user_one.auth)
         assert_equal(res.status_code, 200)
@@ -654,8 +653,8 @@ class TestNodeFiltering(ApiTestCase):
         orphan = PreprintFactory(creator=self.preprint.node.creator)
 
         # orphan the preprint by deleting the file
-        orphan.primary_file.delete()
-        orphan.save()
+        orphan.node.preprint_file = None
+        orphan.node.save()
         orphan.refresh_from_db()
 
         url = '/{}nodes/?filter[preprint]=false'.format(API_BASE)

--- a/api_tests/users/views/test_user_nodes_list.py
+++ b/api_tests/users/views/test_user_nodes_list.py
@@ -125,8 +125,7 @@ class TestUserNodesPreprintsFiltering(ApiTestCase):
         self.valid_preprint = PreprintFactory(project=self.valid_preprint_node)
         self.abandoned_preprint = PreprintFactory(project=self.abandoned_preprint_node, is_published=False)
         self.orphaned_preprint = PreprintFactory(project=self.orphaned_preprint_node)
-        self.orphaned_preprint.node.preprint_file.delete()
-        self.orphaned_preprint.node.reload()  # preprint_file has been set to null
+        self.orphaned_preprint.node.preprint_file = None
         self.orphaned_preprint.node.save()
         self.url_base = '/{}users/me/nodes/?filter[preprint]='.format(API_BASE)
 

--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -511,7 +511,7 @@ var FileViewPage = {
             // Special case to not show delete for public figshare files
             (
                 ctrl.canEdit() &&
-                !(ctrl.node.isPreprint && ctrl.node.preprintFileId === ctrl.file.id) &&
+                !(ctrl.node.preprintFileId === ctrl.file.id) &&
                     !(ctrl.file.provider === 'figshare' && ctrl.file.extra.status === 'public') &&
                 (ctrl.file.provider !== 'osfstorage' || !ctrl.file.checkoutUser) &&
                 ctrl.requestDone &&

--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -511,7 +511,7 @@ var FileViewPage = {
             // Special case to not show delete for public figshare files
             (
                 ctrl.canEdit() &&
-                !(ctrl.node.preprintFileId === ctrl.file.id) &&
+                (ctrl.node.preprintFileId !== ctrl.file.id) &&
                     !(ctrl.file.provider === 'figshare' && ctrl.file.extra.status === 'public') &&
                 (ctrl.file.provider !== 'osfstorage' || !ctrl.file.checkoutUser) &&
                 ctrl.requestDone &&


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Code preventing preprints from being deleted did not get ported over when osfstorage was moved to addons. Currently only fangorn is preventing deletions of preprint files and bad moves, but fangorn has some known flaws (lazy loaded nested folders are supposed to be caught by the backend)
<!-- Describe the purpose of your changes -->

## Changes
Add back in the code blocking bad preprint actions
<!-- Briefly describe or list your changes  -->

## Side effects
None known; someone should check how many orphans were created.
<!--Any possible side effects? -->


## Ticket
https://openscience.atlassian.net/browse/OSF-7938
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->

## QA Notes
This is a regression of https://github.com/CenterForOpenScience/osf.io/pull/6525. However, all of the fangorn logic is still in place so the things that need thorough testing are the areas where fangorn is known to fail: when a preprint is inside a folder that has not been expanded. Test this situation thoroughly. A light regression of the fangorn blocking of bad actions (e.g., it copies instead of moves when it has a preprint; the button is grayed out when you click a preprint) would not be a bad idea.