### PR TITLE
[feature] Search Fixes [OSF-7763]

### DIFF
--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -221,18 +221,13 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
         'title',
         'category',
         'description',
-        'visible_contributor_ids',
-        'tags',
         'is_fork',
-        'is_registration',
         'retraction',
         'embargo',
         'is_public',
         'is_deleted',
         'wiki_pages_current',
-        'is_retracted',
         'node_license',
-        'affiliated_institutions',
         'preprint_file',
     }
 
@@ -720,6 +715,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             raise UserNotAffiliatedError('User is not affiliated with {}'.format(inst.name))
         if not self.is_affiliated_with_institution(inst):
             self.affiliated_institutions.add(inst)
+            self.update_search()
         if log:
             NodeLog = apps.get_model('osf.NodeLog')
 
@@ -752,6 +748,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
                 )
             if save:
                 self.save()
+            self.update_search()
             return True
         return False
 
@@ -1148,7 +1145,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
                 project_signals.contributor_added.send(self,
                                                        contributor=contributor,
                                                        auth=auth, email_template=send_email)
-
+            self.update_search()
             return contrib_to_add, True
 
         # Permissions must be overridden if changed when contributor is
@@ -1363,7 +1360,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             )
 
         self.save()
-
+        self.update_search()
         # send signal to remove this user from project subscriptions
         project_signals.contributor_removed.send(self, user=contributor)
 


### PR DESCRIPTION
#### Purpose
- Update search when contributors are added and removed.
- Update search when an affiliated institution is added or removed.

#### Changes
- Add a few `update_search()` calls.
- For contributors, I considered adding `@contributor_added.connect` to `update_contributors_async` in search.py, but it seemed to overcomplicate things as that signal is already used to trigger a handful of other events (with different method signatures). See the [closed PR](https://github.com/CenterForOpenScience/osf.io/pull/7196) if you're curious. I could've added a new signal just for search, but that seemed a bit overkill as it would require adding signals for updating tags and institutions as well (if we were being consistent). 

#### Ticket
- [OSF-7763](https://openscience.atlassian.net/browse/OSF-7763)
