### PR TITLE
[hotfix] Add Loading Indicator to Search Page [OSF-7961]

### DIFF
--- a/website/static/js/search.js
+++ b/website/static/js/search.js
@@ -280,6 +280,7 @@ var ViewModel = function(params) {
 
     self.filter = function(alias) {
         self.searchStarted(false);
+        self.results([]);
         self.currentPage(1);
         self.category(alias);
         if (alias.name === 'SHARE') {
@@ -340,6 +341,8 @@ var ViewModel = function(params) {
     };
 
     self.search = function(noPush, validate) {
+
+        self.searching(true);
 
         // Check for NOTs and ANDs put spaces before the ones that don't have spaces
         var query = self.query().replace(/\s?NOT tags:/g, ' NOT tags:');
@@ -462,6 +465,8 @@ var ViewModel = function(params) {
                 self.shareCategory(new Category('SHARE', data.count, 'SHARE'));
             });
 
+            self.searching(false);
+
         }).fail(function(response){
             self.totalResults(0);
             self.currentPage(0);
@@ -469,6 +474,7 @@ var ViewModel = function(params) {
             self.tags([]);
             self.categories([]);
             self.searchStarted(false);
+            self.searching(false);
             $osf.handleJSONError(response);
         });
 

--- a/website/templates/search.mako
+++ b/website/templates/search.mako
@@ -84,6 +84,11 @@
                     </div>
                     <!-- /ko -->
                     <div class="col-md-9">
+                        <!-- ko if: searching() -->
+                        <div class="panel-body clearfix" data-bind="css: {hidden: !searching()}">
+                            <div class="ball-scale ball-scale-blue text-center"><div></div></div>
+                        </div>
+                        <!-- /ko -->
                         <!-- ko if: searchStarted() && !totalCount() -->
                         <div class="search-results hidden" data-bind="css: {hidden: totalCount() }">No results found.</div>
                         <!-- /ko -->


### PR DESCRIPTION
#### Purpose
- Adds OSF style loading indicator to the search page.

#### Ticket
- [OSF-7961](https://openscience.atlassian.net/browse/OSF-7961)

### GIF
- You can only see the indicator flash for a brief moment here (since search isn't slow locally), but it should appear on initial search and when filtering between categories.
![may-09-2017 14-59-34](https://cloud.githubusercontent.com/assets/7913604/25867638/30422a78-34c8-11e7-8581-ed124b043fea.gif)
