### PR TITLE
Remove usages of and old methods for BaseFileNode.stored_object [OSF-7853]

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -459,7 +459,7 @@ def addon_delete_file_node(self, node, user, event_type, payload):
                 if item.kind == 'file' and not TrashedFileNode.load(item._id):
                     item.delete(user=user)
                 elif item.kind == 'folder':
-                    StoredFileNode.remove_one(item.stored_object)
+                    StoredFileNode.remove_one(item)
         else:
             try:
                 file_node = FileNode.resolve_class(provider, FileNode.FILE).find_one(

--- a/addons/osfstorage/tests/test_views.py
+++ b/addons/osfstorage/tests/test_views.py
@@ -599,7 +599,7 @@ class TestDeleteHook(HookTestCase):
 
     def test_attempt_delete_while_preprint(self):
         file = self.root_node.append_file('Nights')
-        self.node.preprint_file = file.stored_object
+        self.node.preprint_file = file
         self.node.save()
         res = self.delete(file, expect_errors=True)
 
@@ -608,7 +608,7 @@ class TestDeleteHook(HookTestCase):
     def test_attempt_delete_folder_with_preprint(self):
         folder = self.root_node.append_folder('Fishes')
         file = folder.append_file('Fish')
-        self.node.preprint_file = file.stored_object
+        self.node.preprint_file = file
         self.node.save()
         res = self.delete(folder, expect_errors=True)
 
@@ -668,7 +668,7 @@ class TestMoveHook(HookTestCase):
     def test_within_node_move_while_preprint(self):
 
         file = self.root_node.append_file('Self Control')
-        self.node.preprint_file = file.stored_object
+        self.node.preprint_file = file
         self.node.save()
         folder = self.root_node.append_folder('Frank Ocean')
         res = self.send_hook(

--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -48,11 +48,11 @@ class CheckoutField(ser.HyperlinkedRelatedField):
 
         super(CheckoutField, self).__init__('users:user-detail', **kwargs)
 
-    def resolve(self, resource, request):
+    def resolve(self, resource, field_name, request):
         """
         Resolves the view when embedding.
         """
-        embed_value = resource.stored_object.checkout._id
+        embed_value = resource.checkout._id
         return resolve(
             reverse(
                 self.view_name,

--- a/osf/models/files.py
+++ b/osf/models/files.py
@@ -340,7 +340,7 @@ class BaseFileNode(TypedModel, CommentableMixin, OptionalGuidMixin, Taggable, Ob
 
     def move_under(self, destination_parent, name=None):
         self.name = name or self.name
-        self.parent = destination_parent.stored_object
+        self.parent = destination_parent
         self._update_node(save=True)  # Trust _update_node to save us
 
         return self

--- a/osf/models/files.py
+++ b/osf/models/files.py
@@ -164,19 +164,6 @@ class BaseFileNode(TypedModel, CommentableMixin, OptionalGuidMixin, Taggable, Ob
         """The comment page type associated with StoredFileNodes."""
         return 'files'
 
-    @property
-    def stored_object(self):
-        """
-        DEPRECATED: Returns self after logging.
-        :return:
-        """
-        logger.warn('BaseFileNode.stored_object is deprecated.')
-        return self
-
-    @stored_object.setter
-    def stored_object(self, value):
-        raise DeprecatedException('BaseFileNode.stored_object is deprecated.')
-
     @classmethod
     def create(cls, **kwargs):
         kwargs.update(provider=cls._provider)

--- a/osf/models/preprint_service.py
+++ b/osf/models/preprint_service.py
@@ -10,7 +10,6 @@ from framework.celery_tasks.handlers import enqueue_task
 from framework.exceptions import PermissionsError
 from osf.models.subject import Subject
 from osf.utils.fields import NonNaiveDateTimeField
-from website.files.models import StoredFileNode
 from website.preprints.tasks import on_preprint_updated
 from website.project.model import NodeLog
 from website.project.licenses import set_license
@@ -129,9 +128,6 @@ class PreprintService(DirtyFieldsMixin, GuidMixin, BaseModel):
     def set_primary_file(self, preprint_file, auth, save=False):
         if not self.node.has_permission(auth.user, ADMIN):
             raise PermissionsError('Only admins can change a preprint\'s primary file.')
-
-        if not isinstance(preprint_file, StoredFileNode):
-            preprint_file = preprint_file.stored_object
 
         if preprint_file.node != self.node or preprint_file.provider != 'osfstorage':
             raise ValueError('This file is not a valid primary file for this preprint.')

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -2,11 +2,8 @@
 from nose.tools import *  # flake8: noqa (PEP8 asserts)
 import mock
 import urlparse
-from modularodm import Q
-from modularodm.exceptions import NoResultsFound, ValidationValueError
 
 from framework.celery_tasks import handlers
-from addons.osfstorage import settings as osfstorage_settings
 from website.files.models.osfstorage import OsfStorageFile
 from website.preprints.tasks import format_preprint
 from website.util import permissions
@@ -16,7 +13,6 @@ from framework.exceptions import PermissionsError
 
 from website import settings
 from osf.models import NodeLog, Subject
-from osf.exceptions import NodeStateError
 
 from tests.base import OsfTestCase
 from osf_tests.factories import (
@@ -26,7 +22,7 @@ from osf_tests.factories import (
     PreprintProviderFactory,
     SubjectFactory
 )
-from tests.utils import assert_logs, assert_not_logs
+from tests.utils import assert_logs
 from api_tests import utils as api_test_utils
 from website.project.views.contributor import find_preprint_provider
 
@@ -112,7 +108,7 @@ class TestSetPreprintFile(OsfTestCase):
     def test_add_primary_file(self):
         self.preprint.set_primary_file(self.file, auth=self.auth, save=True)
         assert_equal(self.project.preprint_file, self.file)
-        assert_equal(type(self.project.preprint_file), type(self.file.stored_object))
+        assert_equal(type(self.project.preprint_file), type(self.file))
 
     @assert_logs(NodeLog.PREPRINT_FILE_UPDATED, 'project')
     def test_change_primary_file(self):

--- a/website/preprints/model.py
+++ b/website/preprints/model.py
@@ -115,9 +115,6 @@ class PreprintService(GuidStoredObject):
         if not self.node.has_permission(auth.user, ADMIN):
             raise PermissionsError('Only admins can change a preprint\'s primary file.')
 
-        if not isinstance(preprint_file, StoredFileNode):
-            preprint_file = preprint_file.stored_object
-
         if preprint_file.node != self.node or preprint_file.provider != 'osfstorage':
             raise ValueError('This file is not a valid primary file for this preprint.')
 

--- a/website/preprints/model.py
+++ b/website/preprints/model.py
@@ -9,7 +9,6 @@ from framework.exceptions import PermissionsError
 from framework.guid.model import GuidStoredObject
 from framework.mongo import ObjectId, StoredObject
 from framework.mongo.utils import unique_on
-from website.files.models import StoredFileNode
 from website.preprints.tasks import on_preprint_updated
 from website.project.model import NodeLog
 from website.project.licenses import set_license


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

`BaseFileNode.stored_object` is deprecated, and before was still in use via a property that just returned itself. So, get rid of references to `stored_object` for `BaseFileNode` objects, and remove the warning messages and placeholder methods as well.

## Changes

- Remove references to `stored_object` for `BaseFileNode` objects
- Remove the helper method and warnings
- Fix  call to render wen embeding file checkout in the API - discovered while removing `stored_object` call

## Side effects
- The old `BaseFileNode` model was not updated, so will still be able to use `stored_object`


## Ticket
https://openscience.atlassian.net/browse/OSF-7853