### PR TITLE
Remove usages of StoredFileNode and FileNode [OSF-7854]

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -31,7 +31,7 @@ from website import mails
 from website import settings
 from addons.base import exceptions
 from addons.base import signals as file_signals
-from osf.models import FileNode, StoredFileNode, TrashedFileNode
+from osf.models import BaseFileNode, TrashedFileNode
 from website.models import Node, NodeLog, User
 from website.profile.utils import get_gravatar
 from website.project import decorators
@@ -439,7 +439,7 @@ def create_waterbutler_log(payload, **kwargs):
 
 @file_signals.file_updated.connect
 def addon_delete_file_node(self, node, user, event_type, payload):
-    """ Get addon StoredFileNode(s), move it into the TrashedFileNode collection
+    """ Get addon BaseFileNode(s), move it into the TrashedFileNode collection
     and remove it from StoredFileNode.
 
     Required so that the guids of deleted addon files are not re-pointed when an
@@ -450,7 +450,7 @@ def addon_delete_file_node(self, node, user, event_type, payload):
         path = payload['metadata']['path']
         materialized_path = payload['metadata']['materialized']
         if path.endswith('/'):
-            folder_children = FileNode.resolve_class(provider, FileNode.ANY).find(
+            folder_children = BaseFileNode.resolve_class(provider, BaseFileNode.ANY).find(
                 Q('provider', 'eq', provider) &
                 Q('node', 'eq', node) &
                 Q('_materialized_path', 'startswith', materialized_path)
@@ -459,10 +459,10 @@ def addon_delete_file_node(self, node, user, event_type, payload):
                 if item.kind == 'file' and not TrashedFileNode.load(item._id):
                     item.delete(user=user)
                 elif item.kind == 'folder':
-                    StoredFileNode.remove_one(item)
+                    BaseFileNode.remove_one(item)
         else:
             try:
-                file_node = FileNode.resolve_class(provider, FileNode.FILE).find_one(
+                file_node = BaseFileNode.resolve_class(provider, BaseFileNode.FILE).find_one(
                     Q('node', 'eq', node) &
                     Q('_materialized_path', 'eq', materialized_path)
                 )
@@ -628,7 +628,7 @@ def addon_view_or_download_file(auth, path, provider, **kwargs):
         })
 
     savepoint_id = transaction.savepoint()
-    file_node = FileNode.resolve_class(provider, FileNode.FILE).get_or_create(node, path)
+    file_node = BaseFileNode.resolve_class(provider, BaseFileNode.FILE).get_or_create(node, path)
 
     # Note: Cookie is provided for authentication to waterbutler
     # it is overriden to force authentication as the current user

--- a/addons/osfstorage/tests/test_views.py
+++ b/addons/osfstorage/tests/test_views.py
@@ -571,7 +571,6 @@ class TestDeleteHook(HookTestCase):
         assert_equal(resp.json, {'status': 'success'})
         fid = file._id
         del file
-        # models.StoredFileNode._clear_object_cache()
         assert_is(models.OsfStorageFileNode.load(fid), None)
         assert_true(models.TrashedFileNode.load(fid))
 

--- a/api/files/permissions.py
+++ b/api/files/permissions.py
@@ -1,11 +1,11 @@
 from rest_framework import permissions
 
 from api.base.utils import get_user_auth
-from osf.models import FileNode
+from osf.models import BaseFileNode
 
 class CheckedOutOrAdmin(permissions.BasePermission):
     def has_object_permission(self, request, view, obj):
-        assert isinstance(obj, FileNode), 'obj must be a FileNode, got {}'.format(obj)
+        assert isinstance(obj, BaseFileNode), 'obj must be a BaseFileNode, got {}'.format(obj)
 
         if request.method in permissions.SAFE_METHODS:
             return True
@@ -21,7 +21,7 @@ class CheckedOutOrAdmin(permissions.BasePermission):
 
 class IsPreprintFile(permissions.BasePermission):
     def has_object_permission(self, request, view, obj):
-        assert isinstance(obj, FileNode), 'obj must be a FileNode, got {}'.format(obj)
+        assert isinstance(obj, BaseFileNode), 'obj must be a BaseFileNode, got {}'.format(obj)
 
         if request.method == 'DELETE' and obj.node.preprint_file == obj and not obj.node._has_abandoned_preprint:
             return False

--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -6,7 +6,7 @@ import furl
 import pytz
 
 from framework.auth.core import Auth, User
-from osf.models import FileNode
+from osf.models import BaseFileNode
 from rest_framework import serializers as ser
 from website import settings
 from website.project.model import Comment
@@ -251,7 +251,7 @@ class FileSerializer(JSONAPISerializer):
         return None
 
     def update(self, instance, validated_data):
-        assert isinstance(instance, FileNode), 'Instance must be a FileNode'
+        assert isinstance(instance, BaseFileNode), 'Instance must be a BaseFileNode'
         if instance.provider != 'osfstorage' and 'tags' in validated_data:
             raise Conflict('File service provider {} does not support tags on the OSF.'.format(instance.provider))
         auth = get_user_auth(self.context['request'])

--- a/api/files/views.py
+++ b/api/files/views.py
@@ -6,9 +6,8 @@ from framework.auth.oauth_scopes import CoreScopes
 
 from osf.models import (
     Guid,
-    FileNode,
+    BaseFileNode,
     FileVersion,
-    StoredFileNode
 )
 
 from api.base.exceptions import Gone
@@ -36,10 +35,10 @@ class FileMixin(object):
 
     def get_file(self, check_permissions=True):
         try:
-            obj = utils.get_object_or_error(FileNode, self.kwargs[self.file_lookup_url_kwarg])
+            obj = utils.get_object_or_error(BaseFileNode, self.kwargs[self.file_lookup_url_kwarg])
         except (NotFound, Gone):
             obj = utils.get_object_or_error(Guid, self.kwargs[self.file_lookup_url_kwarg]).referent
-            if not isinstance(obj, StoredFileNode):
+            if not isinstance(obj, BaseFileNode):
                 raise NotFound
 
         if check_permissions:

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -99,7 +99,7 @@ from api.wikis.serializers import NodeWikiSerializer
 from framework.auth.oauth_scopes import CoreScopes
 from framework.postcommit_tasks.handlers import enqueue_postcommit_task
 from osf.models import AbstractNode
-from osf.models import (Node, PrivateLink, NodeLog, Institution, Comment, DraftRegistration, PreprintService, FileNode)
+from osf.models import (Node, PrivateLink, NodeLog, Institution, Comment, DraftRegistration, PreprintService)
 from osf.models import OSFUser as User
 from osf.models import NodeRelation, AlternativeCitation, Guid
 from osf.models import BaseFileNode
@@ -177,10 +177,10 @@ class WaterButlerMixin(object):
 
     def get_file_item(self, item):
         attrs = item['attributes']
-        file_node = FileNode.resolve_class(
+        file_node = BaseFileNode.resolve_class(
             attrs['provider'],
-            FileNode.FOLDER if attrs['kind'] == 'folder'
-            else FileNode.FILE
+            BaseFileNode.FOLDER if attrs['kind'] == 'folder'
+            else BaseFileNode.FILE
         ).get_or_create(self.get_node(check_object_permissions=False), attrs['path'])
 
         file_node.update(None, attrs, user=self.request.user)
@@ -1981,7 +1981,7 @@ class NodeFilesList(JSONAPIBaseView, generics.ListAPIView, WaterButlerMixin, Lis
             provider = self.kwargs[self.provider_lookup_url_kwarg]
             # Resolve to a provider-specific subclass, so that
             # trashed file nodes are filtered out automatically
-            ConcreteFileNode = BaseFileNode.resolve_class(provider, FileNode.ANY)
+            ConcreteFileNode = BaseFileNode.resolve_class(provider, BaseFileNode.ANY)
             return ConcreteFileNode.objects.filter(
                 id__in=[self.get_file_item(file).id for file in files_list],
             )

--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -19,12 +19,12 @@ from framework.exceptions import PermissionsError
 from website.util import permissions
 from website.exceptions import NodeStateError
 from website.project import signals as project_signals
-from osf.models import StoredFileNode, PreprintService, PreprintProvider, Node, NodeLicense
+from osf.models import BaseFileNode, PreprintService, PreprintProvider, Node, NodeLicense
 
 
 class PrimaryFileRelationshipField(RelationshipField):
     def get_object(self, file_id):
-        return StoredFileNode.load(file_id)
+        return BaseFileNode.load(file_id)
 
     def to_internal_value(self, data):
         file = self.get_object(data)

--- a/api/search/serializers.py
+++ b/api/search/serializers.py
@@ -11,7 +11,7 @@ from osf.models import AbstractNode
 
 from osf.models import OSFUser as User
 
-from osf.models import FileNode
+from osf.models import BaseFileNode
 
 from osf.models import Institution
 
@@ -31,7 +31,7 @@ class SearchSerializer(JSONAPISerializer):
             serializer = UserSerializer(data, context=self.context)
             return UserSerializer.to_representation(serializer, data)
 
-        if isinstance(data, FileNode):
+        if isinstance(data, BaseFileNode):
             serializer = FileSerializer(data, context=self.context)
             return FileSerializer.to_representation(serializer, data)
 

--- a/api/search/views.py
+++ b/api/search/views.py
@@ -16,7 +16,7 @@ from api.institutions.serializers import InstitutionSerializer
 
 from framework.auth.oauth_scopes import CoreScopes
 
-from osf.models import Institution, FileNode, AbstractNode as Node, OSFUser as User
+from osf.models import Institution, BaseFileNode, AbstractNode as Node, OSFUser as User
 from website.search import search
 from website.search.exceptions import MalformedQueryError
 from website.search.util import build_query
@@ -306,7 +306,7 @@ class SearchFiles(BaseSearchView):
 
     """
 
-    model_class = FileNode
+    model_class = BaseFileNode
     serializer_class = FileSerializer
 
     doc_type = 'file'

--- a/api_tests/wikis/views/test_wiki_content.py
+++ b/api_tests/wikis/views/test_wiki_content.py
@@ -70,9 +70,7 @@ class TestWikiContentView(ApiWikiTestCase):
         self._set_up_public_registration_with_wiki_page()
         withdrawal = self.public_registration.retract_registration(user=self.user, save=True)
         token = withdrawal.approval_state.values()[0]['approval_token']
-        # TODO: Remove mocking when StoredFileNode is implemented
-        with mock.patch('osf.models.AbstractNode.update_search'):
-            withdrawal.approve_retraction(self.user, token)
-            withdrawal.save()
+        withdrawal.approve_retraction(self.user, token)
+        withdrawal.save()
         res = self.app.get(self.public_registration_url, auth=self.user.auth, expect_errors=True)
         assert_equal(res.status_code, 403)

--- a/osf/models/__init__.py
+++ b/osf/models/__init__.py
@@ -25,8 +25,8 @@ from osf.models.preprint_service import PreprintService  # noqa
 from osf.models.identifiers import Identifier  # noqa
 from osf.models.files import (  # noqa
     BaseFileNode,
-    File, Folder, FileNode,  # noqa
-    FileVersion, StoredFileNode, TrashedFile, TrashedFileNode, TrashedFolder,  # noqa
+    File, Folder,  # noqa
+    FileVersion, TrashedFile, TrashedFileNode, TrashedFolder,  # noqa
 )  # noqa
 from osf.models.node_relation import NodeRelation  # noqa
 from osf.models.analytics import UserActivityCounter, PageCounter  # noqa

--- a/osf/models/files.py
+++ b/osf/models/files.py
@@ -29,7 +29,6 @@ __all__ = (
     'File',
     'Folder',
     'FileVersion',
-    'StoredFileNode',
     'BaseFileNode',
     'TrashedFileNode',
 )
@@ -401,11 +400,6 @@ class BaseFileNode(TypedModel, CommentableMixin, OptionalGuidMixin, Taggable, Ob
             self.name,
             self.node
         )
-
-
-# TODO Refactor code pointing at FileNode to point to StoredFileNode
-FileNode = StoredFileNode = BaseFileNode
-
 
 class UnableToRestore(Exception):
     pass

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -659,8 +659,8 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
         user.created.filter(is_bookmark_collection=False).update(creator=self)
 
         # - file that the user has checked_out, import done here to prevent import error
-        from osf.models import FileNode
-        for file_node in FileNode.files_checked_out(user=user):
+        from osf.models import BaseFileNode
+        for file_node in BaseFileNode.files_checked_out(user=user):
             file_node.checkout = self
             file_node.save()
 

--- a/osf_tests/test_comment.py
+++ b/osf_tests/test_comment.py
@@ -17,7 +17,7 @@ from website.project.views.comment import update_file_guid_referent
 from website.project.signals import comment_added, mention_added, contributor_added
 from framework.exceptions import PermissionsError
 from tests.base import capture_signals
-from osf.models import Comment, NodeLog, Guid, FileNode
+from osf.models import Comment, NodeLog, Guid, BaseFileNode
 from osf.modm_compat import Q
 from osf.utils.auth import Auth
 from .factories import (
@@ -492,7 +492,7 @@ class FileCommentMoveRenameTestMixin(object):
         payload = self._create_payload('move', user, source, destination, self.file._id)
         update_file_guid_referent(self=None, node=destination['node'], event_type='addon_file_renamed', payload=payload)
         self.guid.reload()
-        file_node = FileNode.resolve_class(self.provider, FileNode.FILE).get_or_create(destination['node'], self._format_path(destination['path'], file_id=self.file._id))
+        file_node = BaseFileNode.resolve_class(self.provider, BaseFileNode.FILE).get_or_create(destination['node'], self._format_path(destination['path'], file_id=self.file._id))
         assert self.guid._id == file_node.get_guid()._id
         file_comments = Comment.find(Q('root_target', 'eq', self.guid.pk))
         assert file_comments.count() == 1
@@ -514,7 +514,7 @@ class FileCommentMoveRenameTestMixin(object):
         update_file_guid_referent(self=None, node=destination['node'], event_type='addon_file_renamed', payload=payload)
         self.guid.reload()
 
-        file_node = FileNode.resolve_class(self.provider, FileNode.FILE).get_or_create(destination['node'], self._format_path('{}{}'.format(destination['path'], file_name), file_id=self.file._id))
+        file_node = BaseFileNode.resolve_class(self.provider, BaseFileNode.FILE).get_or_create(destination['node'], self._format_path('{}{}'.format(destination['path'], file_name), file_id=self.file._id))
         assert self.guid._id == file_node.get_guid()._id
         file_comments = Comment.find(Q('root_target', 'eq', self.guid.pk))
         assert file_comments.count() == 1
@@ -536,7 +536,7 @@ class FileCommentMoveRenameTestMixin(object):
         update_file_guid_referent(self=None, node=destination['node'], event_type='addon_file_renamed', payload=payload)
         self.guid.reload()
 
-        file_node = FileNode.resolve_class(self.provider, FileNode.FILE).get_or_create(destination['node'], self._format_path('{}{}'.format(destination['path'], file_path), file_id=self.file._id))
+        file_node = BaseFileNode.resolve_class(self.provider, BaseFileNode.FILE).get_or_create(destination['node'], self._format_path('{}{}'.format(destination['path'], file_path), file_id=self.file._id))
         assert self.guid._id == file_node.get_guid()._id
         file_comments = Comment.find(Q('root_target', 'eq', self.guid.pk))
         assert file_comments.count() == 1
@@ -557,7 +557,7 @@ class FileCommentMoveRenameTestMixin(object):
         update_file_guid_referent(self=None, node=destination['node'], event_type='addon_file_moved', payload=payload)
         self.guid.reload()
 
-        file_node = FileNode.resolve_class(self.provider, FileNode.FILE).get_or_create(destination['node'], self._format_path(destination['path'], file_id=self.file._id))
+        file_node = BaseFileNode.resolve_class(self.provider, BaseFileNode.FILE).get_or_create(destination['node'], self._format_path(destination['path'], file_id=self.file._id))
         assert self.guid._id == file_node.get_guid()._id
         file_comments = Comment.find(Q('root_target', 'eq', self.guid.pk))
         assert file_comments.count() == 1
@@ -578,7 +578,7 @@ class FileCommentMoveRenameTestMixin(object):
         update_file_guid_referent(self=None, node=destination['node'], event_type='addon_file_moved', payload=payload)
         self.guid.reload()
 
-        file_node = FileNode.resolve_class(self.provider, FileNode.FILE).get_or_create(destination['node'], self._format_path(destination['path'], file_id=self.file._id))
+        file_node = BaseFileNode.resolve_class(self.provider, BaseFileNode.FILE).get_or_create(destination['node'], self._format_path(destination['path'], file_id=self.file._id))
         assert self.guid._id == file_node.get_guid()._id
         file_comments = Comment.find(Q('root_target', 'eq', self.guid.pk))
         assert file_comments.count() == 1
@@ -599,7 +599,7 @@ class FileCommentMoveRenameTestMixin(object):
         update_file_guid_referent(self=None, node=destination['node'], event_type='addon_file_moved', payload=payload)
         self.guid.reload()
 
-        file_node = FileNode.resolve_class(self.provider, FileNode.FILE).get_or_create(destination['node'], self._format_path(destination['path'], file_id=self.file._id))
+        file_node = BaseFileNode.resolve_class(self.provider, BaseFileNode.FILE).get_or_create(destination['node'], self._format_path(destination['path'], file_id=self.file._id))
         assert self.guid._id == file_node.get_guid()._id
         assert self.guid.referent.node._id == destination['node']._id
         file_comments = Comment.find(Q('root_target', 'eq', self.guid.pk))
@@ -621,7 +621,7 @@ class FileCommentMoveRenameTestMixin(object):
         update_file_guid_referent(self=None, node=destination['node'], event_type='addon_file_moved', payload=payload)
         self.guid.reload()
 
-        file_node = FileNode.resolve_class(self.provider, FileNode.FILE).get_or_create(destination['node'], self._format_path(destination['path'], file_id=self.file._id))
+        file_node = BaseFileNode.resolve_class(self.provider, BaseFileNode.FILE).get_or_create(destination['node'], self._format_path(destination['path'], file_id=self.file._id))
         assert self.guid._id == file_node.get_guid()._id
         assert self.guid.referent.node._id == destination['node']._id
         file_comments = Comment.find(Q('root_target', 'eq', self.guid.pk))
@@ -644,7 +644,7 @@ class FileCommentMoveRenameTestMixin(object):
         update_file_guid_referent(self=None, node=destination['node'], event_type='addon_file_moved', payload=payload)
         self.guid.reload()
 
-        file_node = FileNode.resolve_class(self.provider, FileNode.FILE).get_or_create(destination['node'], self._format_path('{}{}'.format(destination['path'], file_name), file_id=self.file._id))
+        file_node = BaseFileNode.resolve_class(self.provider, BaseFileNode.FILE).get_or_create(destination['node'], self._format_path('{}{}'.format(destination['path'], file_name), file_id=self.file._id))
         assert self.guid._id == file_node.get_guid()._id
         file_comments = Comment.find(Q('root_target', 'eq', self.guid.pk))
         assert file_comments.count() == 1
@@ -666,7 +666,7 @@ class FileCommentMoveRenameTestMixin(object):
         update_file_guid_referent(self=None, node=destination['node'], event_type='addon_file_moved', payload=payload)
         self.guid.reload()
 
-        file_node = FileNode.resolve_class(self.provider, FileNode.FILE).get_or_create(destination['node'], self._format_path('{}{}'.format(destination['path'], file_name), file_id=self.file._id))
+        file_node = BaseFileNode.resolve_class(self.provider, BaseFileNode.FILE).get_or_create(destination['node'], self._format_path('{}{}'.format(destination['path'], file_name), file_id=self.file._id))
         assert self.guid._id == file_node.get_guid()._id
         file_comments = Comment.find(Q('root_target', 'eq', self.guid.pk))
         assert file_comments.count() == 1
@@ -688,7 +688,7 @@ class FileCommentMoveRenameTestMixin(object):
         update_file_guid_referent(self=None, node=destination['node'], event_type='addon_file_moved', payload=payload)
         self.guid.reload()
 
-        file_node = FileNode.resolve_class(self.provider, FileNode.FILE).get_or_create(destination['node'], self._format_path('{}{}'.format(destination['path'], file_name), file_id=self.file._id))
+        file_node = BaseFileNode.resolve_class(self.provider, BaseFileNode.FILE).get_or_create(destination['node'], self._format_path('{}{}'.format(destination['path'], file_name), file_id=self.file._id))
         assert self.guid._id == file_node.get_guid()._id
         file_comments = Comment.find(Q('root_target', 'eq', self.guid.pk))
         assert file_comments.count() == 1
@@ -710,7 +710,7 @@ class FileCommentMoveRenameTestMixin(object):
         update_file_guid_referent(self=None, node=destination['node'], event_type='addon_file_moved', payload=payload)
         self.guid.reload()
 
-        file_node = FileNode.resolve_class(self.provider, FileNode.FILE).get_or_create(destination['node'], self._format_path('{}{}'.format(destination['path'], file_name), file_id=self.file._id))
+        file_node = BaseFileNode.resolve_class(self.provider, BaseFileNode.FILE).get_or_create(destination['node'], self._format_path('{}{}'.format(destination['path'], file_name), file_id=self.file._id))
         assert self.guid._id == file_node.get_guid()._id
         file_comments = Comment.find(Q('root_target', 'eq', self.guid.pk))
         assert file_comments.count() == 1
@@ -744,7 +744,7 @@ class FileCommentMoveRenameTestMixin(object):
         update_file_guid_referent(self=None, node=destination['node'], event_type='addon_file_moved', payload=payload)
         self.guid.reload()
 
-        file_node = FileNode.resolve_class('osfstorage', FileNode.FILE).get_or_create(destination['node'], destination['path'])
+        file_node = BaseFileNode.resolve_class('osfstorage', BaseFileNode.FILE).get_or_create(destination['node'], destination['path'])
         assert self.guid._id == file_node.get_guid()._id
         file_comments = Comment.find(Q('root_target', 'eq', self.guid.pk))
         assert file_comments.count() == 1
@@ -785,7 +785,7 @@ class FileCommentMoveRenameTestMixin(object):
         update_file_guid_referent(self=None, node=destination['node'], event_type='addon_file_moved', payload=payload)
         self.guid.reload()
 
-        file_node = FileNode.resolve_class('osfstorage', FileNode.FILE).get_or_create(destination['node'], osf_file._id)
+        file_node = BaseFileNode.resolve_class('osfstorage', BaseFileNode.FILE).get_or_create(destination['node'], osf_file._id)
         assert self.guid._id == file_node.get_guid()._id
         file_comments = Comment.find(Q('root_target', 'eq', self.guid.pk))
         assert file_comments.count() == 1
@@ -819,7 +819,7 @@ class FileCommentMoveRenameTestMixin(object):
         update_file_guid_referent(self=None, node=destination['node'], event_type='addon_file_moved', payload=payload)
         self.guid.reload()
 
-        file_node = FileNode.resolve_class(destination_provider, FileNode.FILE).get_or_create(destination['node'], destination['path'])
+        file_node = BaseFileNode.resolve_class(destination_provider, BaseFileNode.FILE).get_or_create(destination['node'], destination['path'])
         assert self.guid._id == file_node.get_guid()._id
         file_comments = Comment.find(Q('root_target', 'eq', self.guid.pk))
         assert file_comments.count() == 1
@@ -859,7 +859,7 @@ class FileCommentMoveRenameTestMixin(object):
         update_file_guid_referent(self=None, node=destination['node'], event_type='addon_file_moved', payload=payload)
         self.guid.reload()
 
-        file_node = FileNode.resolve_class(destination_provider, FileNode.FILE).get_or_create(destination['node'], destination_path)
+        file_node = BaseFileNode.resolve_class(destination_provider, BaseFileNode.FILE).get_or_create(destination['node'], destination_path)
         assert self.guid._id == file_node.get_guid()._id
         file_comments = Comment.find(Q('root_target', 'eq', self.guid.pk))
         assert file_comments.count() == 1
@@ -910,7 +910,7 @@ class TestOsfstorageFileCommentMoveRename(FileCommentMoveRenameTestMixin):
         update_file_guid_referent(self=None, node=destination['node'], event_type='addon_file_moved', payload=payload)
         self.guid.reload()
 
-        file_node = FileNode.resolve_class(self.provider, FileNode.FILE).get_or_create(destination['node'], self._format_path(destination['path'], file_id=self.file._id))
+        file_node = BaseFileNode.resolve_class(self.provider, BaseFileNode.FILE).get_or_create(destination['node'], self._format_path(destination['path'], file_id=self.file._id))
         assert self.guid._id == file_node.get_guid()._id
         assert self.guid.referent.node._id == destination['node']._id
         file_comments = Comment.find(Q('root_target', 'eq', self.guid.pk))
@@ -933,7 +933,7 @@ class TestOsfstorageFileCommentMoveRename(FileCommentMoveRenameTestMixin):
         update_file_guid_referent(self=None, node=destination['node'], event_type='addon_file_moved', payload=payload)
         self.guid.reload()
 
-        file_node = FileNode.resolve_class(self.provider, FileNode.FILE).get_or_create(destination['node'], self._format_path(destination['path'], file_id=self.file._id))
+        file_node = BaseFileNode.resolve_class(self.provider, BaseFileNode.FILE).get_or_create(destination['node'], self._format_path(destination['path'], file_id=self.file._id))
         assert self.guid._id == file_node.get_guid()._id
         assert self.guid.referent.node._id == destination['node']._id
         file_comments = Comment.find(Q('root_target', 'eq', self.guid.pk))
@@ -957,7 +957,7 @@ class TestOsfstorageFileCommentMoveRename(FileCommentMoveRenameTestMixin):
         update_file_guid_referent(self=None, node=destination['node'], event_type='addon_file_moved', payload=payload)
         self.guid.reload()
 
-        file_node = FileNode.resolve_class(self.provider, FileNode.FILE).get_or_create(destination['node'], self._format_path('{}{}'.format(destination['path'], file_name), file_id=self.file._id))
+        file_node = BaseFileNode.resolve_class(self.provider, BaseFileNode.FILE).get_or_create(destination['node'], self._format_path('{}{}'.format(destination['path'], file_name), file_id=self.file._id))
         assert self.guid._id == file_node.get_guid()._id
         file_comments = Comment.find(Q('root_target', 'eq', self.guid.pk))
         assert file_comments.count() == 1
@@ -980,7 +980,7 @@ class TestOsfstorageFileCommentMoveRename(FileCommentMoveRenameTestMixin):
         update_file_guid_referent(self=None, node=destination['node'], event_type='addon_file_moved', payload=payload)
         self.guid.reload()
 
-        file_node = FileNode.resolve_class(self.provider, FileNode.FILE).get_or_create(destination['node'], self._format_path('{}{}'.format(destination['path'], file_name), file_id=self.file._id))
+        file_node = BaseFileNode.resolve_class(self.provider, BaseFileNode.FILE).get_or_create(destination['node'], self._format_path('{}{}'.format(destination['path'], file_name), file_id=self.file._id))
         assert self.guid._id == file_node.get_guid()._id
         file_comments = Comment.find(Q('root_target', 'eq', self.guid.pk))
         assert file_comments.count() == 1

--- a/scripts/osfstorage/usage_audit.py
+++ b/scripts/osfstorage/usage_audit.py
@@ -29,7 +29,7 @@ from scripts import utils as scripts_utils
 # App must be init'd before django models are imported
 init_app(set_backends=True, routes=False)
 
-from osf.models import StoredFileNode, TrashedFileNode, FileVersion
+from osf.models import BaseFileNode, FileVersion
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
@@ -60,7 +60,7 @@ def add_to_white_list(gtg):
 
 
 def get_usage(node):
-    vids = [each for each in StoredFileNode.active.filter(provider='osfstorage', node=node).values_list('versions', flat=True) if each]
+    vids = [each for each in BaseFileNode.active.filter(provider='osfstorage', node=node).values_list('versions', flat=True) if each]
 
     t_vids = [each for eac in TrashedFile.objects.filter(provider='osfstorage', node=node).values_list('versions', flat=True) if each]
 

--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -26,7 +26,7 @@ from addons.github.exceptions import ApiError
 from addons.github.models import GithubFolder, GithubFile, GithubFileNode
 from addons.github.tests.factories import GitHubAccountFactory
 from osf.models import files as file_models
-from osf.models.files import StoredFileNode, TrashedFileNode
+from osf.models.files import BaseFileNode, TrashedFileNode
 from website.project import new_private_link
 from website.project.model import MetaSchema, ensure_schemas
 from website.project.views.node import _view_project as serialize_node
@@ -713,7 +713,7 @@ class TestAddonFileViews(OsfTestCase):
 
             self.app.get(url + '?version=invalid', auth=self.user.auth, expect_errors=True)
 
-            assert_is_not_none(StoredFileNode.load(file_node._id))
+            assert_is_not_none(BaseFileNode.load(file_node._id))
             assert_is_none(TrashedFileNode.load(file_node._id))
 
     def test_unauthorized_addons_raise(self):

--- a/tests/test_websitefiles.py
+++ b/tests/test_websitefiles.py
@@ -9,7 +9,6 @@ from nose.tools import *  # noqa
 from addons.osfstorage.models import OsfStorageFile, OsfStorageFolder, OsfStorageFileNode
 from addons.s3.models import S3File
 from osf.models import File
-from osf.models import FileNode
 from osf.models import Folder
 from osf.models.files import BaseFileNode
 from tests.base import OsfTestCase
@@ -189,9 +188,9 @@ class TestFileNodeObj(FilesTestCase):
         )
         item.save()
 
-        assert_is(models.FileNode.load('notanid'), None)
+        assert_is(models.BaseFileNode.load('notanid'), None)
         assert_true(isinstance(TestFolder.load(item._id), TestFolder))
-        assert_true(isinstance(models.FileNode.load(item._id), TestFolder))
+        assert_true(isinstance(models.BaseFileNode.load(item._id), TestFolder))
 
     def test_parent(self):
         parent = TestFolder(

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -22,7 +22,7 @@ from framework.mongo.utils import paginated
 from modularodm import Q
 from osf.models import AbstractNode as Node
 from osf.models import OSFUser as User
-from osf.models import FileNode
+from osf.models import BaseFileNode
 from osf.models import Institution
 from website import settings
 from website.filters import gravatar
@@ -51,7 +51,7 @@ DOC_TYPE_TO_MODEL = {
     'project': Node,
     'registration': Node,
     'user': User,
-    'file': FileNode,
+    'file': BaseFileNode,
     'institution': Institution
 }
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Currently, StoredFileNode and FileNode are aliases of BaseFileNode, and they only exist for backwards compatibility.

## Changes

- Remove aliases of `StoredFileNode` and `FileNode` from new OSF models
- Switch usages in tests, views, serializers, etc to use `BaseFileNode`

## Side effects

none anticipated


## Ticket
https://openscience.atlassian.net/browse/OSF-7854