### PR TITLE
[hotfix] Fix preprints subjects in admin panel [OSF-7972]

### DIFF
--- a/admin/preprints/serializers.py
+++ b/admin/preprints/serializers.py
@@ -12,16 +12,9 @@ def serialize_preprint(preprint):
         'node': serialize_node(preprint.node),
         'is_published': preprint.is_published,
         'date_published': preprint.date_published,
-        'subjects': serialize_subjects(preprint.subjects),
+        'subjects': serialize_subjects(preprint.subject_hierarchy),
     }
 
 
-def serialize_subjects(subject_chains):
-    serialized_subjects = []
-    subject_ids = [_id for subject_chain in subject_chains for _id in subject_chain]
-    for subject in Subject.objects.filter(_id__in=subject_ids):
-        serialized_subjects.append({
-            'id': subject._id,
-            'text': subject.text
-        })
-    return serialized_subjects
+def serialize_subjects(subject_hierarchy):
+    return [{'id': subject._id, 'text': subject.text} for subjects in subject_hierarchy for subject in subjects]

--- a/admin/preprints/views.py
+++ b/admin/preprints/views.py
@@ -55,5 +55,5 @@ class PreprintView(PermissionRequiredMixin, UpdateView, GuidView):
         # TODO - we shouldn't need this serialized_preprint value -- https://openscience.atlassian.net/browse/OSF-7743
         kwargs['serialized_preprint'] = serialize_preprint(preprint)
         kwargs['change_provider_form'] = ChangeProviderForm(instance=preprint)
-        kwargs['subjects'] = serialize_subjects(preprint.subjects)
+        kwargs['subjects'] = serialize_subjects(preprint.subject_hierarchy)
         return super(PreprintView, self).get_context_data(**kwargs)


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Custom taxonomies broke preprints admin panel. 
Fairly convinced this would have been
<!-- Describe the purpose of your changes -->

## Changes
Fix taxonomies serialization. No tests because this would have been caught by travis admin tests if they were running (tested and confirmed it failed)
<!-- Briefly describe or list your changes  -->

## Side effects
NA
<!--Any possible side effects? -->


## Ticket
https://openscience.atlassian.net/browse/OSF-7972
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->

## QA Notes
1. Check that you can load up a preprint guid on the preprint view page.
2. Confirm that subjects appear accurately on the preprint detail page
3. Test this with a simple and complex hierarchy of subjects (single level of subject down to three-deep subjects)