### PR TITLE
[feature] Fix populate_preprint_providers Script [No Ticket]

### DIFF
--- a/scripts/populate_preprint_providers.py
+++ b/scripts/populate_preprint_providers.py
@@ -48,6 +48,7 @@ def get_license(name):
 def update_or_create(provider_data):
     provider = PreprintProvider.load(provider_data['_id'])
     licenses = [get_license(name) for name in provider_data.pop('licenses_acceptable', [])]
+    default_license = provider_data.pop('default_license', False)
     if provider:
         provider_data['subjects_acceptable'] = map(
             lambda rule: (map(get_subject_id, rule[0]), rule[1]),
@@ -55,7 +56,6 @@ def update_or_create(provider_data):
         )
         if licenses:
             provider.licenses_acceptable.add(*licenses)
-        default_license = provider_data.pop('default_license', False)
         if default_license:
             provider.default_license = get_license(default_license)
         for key, val in provider_data.iteritems():
@@ -69,6 +69,9 @@ def update_or_create(provider_data):
         new_provider.save()
         if licenses:
             new_provider.licenses_acceptable.add(*licenses)
+        if default_license:
+            new_provider.default_license = get_license(default_license)
+            new_provider.save()
         provider = PreprintProvider.load(new_provider._id)
         print('Added new preprint provider: {}'.format(provider._id))
         return new_provider, True


### PR DESCRIPTION
#### Purpose
- Script currently fails when attempting to set the `default_license` for a new preprint provider:
```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/local/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/code/scripts/populate_preprint_providers.py", line 1392, in <module>
    main(env)
  File "/code/scripts/populate_preprint_providers.py", line 1381, in main
    update_or_create(PREPRINT_PROVIDERS[provider_id])
  File "/code/scripts/populate_preprint_providers.py", line 68, in update_or_create
    new_provider = PreprintProvider(**provider_data)
  File "/usr/local/lib/python2.7/site-packages/django/db/models/base.py", line 553, in __init__
    _setattr(self, field.name, rel_obj)
  File "/usr/local/lib/python2.7/site-packages/django/db/models/fields/related_descriptors.py", line 216, in __set__
    self.field.remote_field.model._meta.object_name,
ValueError: Cannot assign "'CC0 1.0 Universal'": "PreprintProvider.default_license" must be a "NodeLicense" instance.
```

#### Changes
- Set `default_license` for providers that are being created in the script.  