### PR TITLE
Optimize checkout and is_preprint_primary checks for folders [OSF-7958]

### DIFF
--- a/addons/osfstorage/models.py
+++ b/addons/osfstorage/models.py
@@ -342,21 +342,15 @@ class OsfStorageFolder(OsfStorageFileNode, Folder):
                 return True
         except AttributeError:
             return False
-        # TODO this should be one query
-        for child in self.children.all():
-            try:
-                if child.is_checked_out:
-                    return True
-            except AttributeError:
-                pass
+        if self.children.filter(checkout=True).exists():
+            return True
         return False
 
     @property
     def is_preprint_primary(self):
         if self.node.preprint_file:
-            for child in self.children.all().select_related('node'):
-                if child.is_preprint_primary:
-                    return True
+            if self.children.filter(node__preprint_file__isnull=False).filter(node___has_abandoned_preprint=False).exists():
+                return True
         return False
 
     def serialize(self, include_full=False, version=None):

--- a/addons/osfstorage/models.py
+++ b/addons/osfstorage/models.py
@@ -337,20 +337,14 @@ class OsfStorageFolder(OsfStorageFileNode, Folder):
 
     @property
     def is_checked_out(self):
-        try:
-            if self.checkout:
-                return True
-        except AttributeError:
-            return False
-        if self.children.filter(checkout=True).exists():
-            return True
-        return False
+        return self.children.filter(checkout__isnull=False).exists()
 
     @property
     def is_preprint_primary(self):
         if self.node.preprint_file:
-            if self.children.filter(node__preprint_file__isnull=False).filter(node___has_abandoned_preprint=False).exists():
-                return True
+            for child in self.children.filter(node__preprint_file=self.node.preprint_file).select_related('node'):
+                if child.is_preprint_primary:
+                    return True
         return False
 
     def serialize(self, include_full=False, version=None):

--- a/addons/osfstorage/models.py
+++ b/addons/osfstorage/models.py
@@ -337,7 +337,36 @@ class OsfStorageFolder(OsfStorageFileNode, Folder):
 
     @property
     def is_checked_out(self):
-        return self.children.filter(checkout__isnull=False).exists()
+        sql = """
+            WITH RECURSIVE is_checked_out_cte(id, parent_id, checkout_id) AS (
+              SELECT
+                T.id,
+                T.parent_id,
+                T.checkout_id
+              FROM %s AS T
+              WHERE T.id = %s
+              UNION ALL
+              SELECT
+                T.id,
+                T.parent_id,
+                T.checkout_id
+              FROM is_checked_out_cte AS R
+                JOIN %s AS T ON T.parent_id = R.id
+            )
+            SELECT N.checkout_id
+            FROM is_checked_out_cte as N
+            WHERE N.checkout_id IS NOT NULL
+            LIMIT 1;
+        """
+
+        with connection.cursor() as cursor:
+            cursor.execute(sql, [AsIs(self._meta.db_table), self.pk, AsIs(self._meta.db_table)])
+            row = cursor.fetchone()
+
+            if row and row[0]:
+                return True
+
+        return False
 
     @property
     def is_preprint_primary(self):


### PR DESCRIPTION
[#OSF-7958]

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

On `OsfStorageFolder`, the properties `is_preprint_primary` and `is_checked_out` have a few recursive calls to see if a folder contains a preprint or checked out file. This can be optimized!

## Changes

- optimize check for `is_preprint_primary`
- optimize check for `is_checked_out`

## Side effects

None anticipated

## Ticket
https://openscience.atlassian.net/browse/OSF-7958