### PR TITLE
[feature-fix] Prevent Deactivated User Contributor Additions [OSF-7122]

### DIFF
--- a/api_tests/nodes/views/test_node_contributors_list.py
+++ b/api_tests/nodes/views/test_node_contributors_list.py
@@ -935,7 +935,7 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
         assert_equal(res.status_code, 400)
         assert_equal(res.json['errors'][0]['detail'], '{} is already a contributor.'.format(name))
 
-    def test_add_contributor_user_is_deactivated(self):
+    def test_add_contributor_user_is_deactivated_registered_payload(self):
         user = UserFactory()
         user.date_disabled = datetime.utcnow()
         user.save()
@@ -951,6 +951,23 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
                         }
                     }
                 }
+            }
+        }
+        res = self.app.post_json_api(self.public_url, payload, auth=self.user.auth, expect_errors=True)
+        assert_equal(res.status_code, 400)
+        assert_equal(res.json['errors'][0]['detail'], 'Deactivated users cannot be added as contributors.')
+
+    def test_add_contributor_user_is_deactivated_unregistered_payload(self):
+        user = UserFactory()
+        user.date_disabled = datetime.utcnow()
+        user.save()
+        payload =  {
+            'data': {
+                'type': 'contributors',
+                'attributes': {
+                    'full_name': user.fullname,
+                    'email': user.username
+                },
             }
         }
         res = self.app.post_json_api(self.public_url, payload, auth=self.user.auth, expect_errors=True)

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -1102,6 +1102,9 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
 
         # If user is merged into another account, use master account
         contrib_to_add = contributor.merged_by if contributor.is_merged else contributor
+        if contrib_to_add.is_disabled:
+            raise ValidationValueError('Deactivated users cannot be added as contributors.')
+
         if not self.is_contributor(contrib_to_add):
 
             contributor_obj, created = Contributor.objects.get_or_create(user=contrib_to_add, node=self)
@@ -1237,8 +1240,6 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             contributor = OSFUser.load(user_id)
             if not contributor:
                 raise ValueError('User with id {} was not found.'.format(user_id))
-            if contributor.is_disabled:
-                raise ValidationValueError('Deactivated users cannot be added as contributors.')
             if self.contributor_set.filter(user=contributor).exists():
                 raise ValidationValueError('{} is already a contributor.'.format(contributor.fullname))
             contributor, _ = self.add_contributor(contributor=contributor, auth=auth, visible=bibliographic,


### PR DESCRIPTION
#### Purpose
- Prevent deactivated users from being added as unregistered contributors through the API.

#### Changes
- Check if contributor is a deactivated user in `add_contributor()` 

#### Ticket
- [OSF-7122](https://openscience.atlassian.net/browse/OSF-7122)
