### PR TITLE
Add docs for debugging services

### DIFF
--- a/.docker-compose.env
+++ b/.docker-compose.env
@@ -16,3 +16,5 @@ MFR_SERVER_URL=http://localhost:7778
 BROKER_URL=amqp://guest:guest@192.168.168.167:5672/
 LIVE_RELOAD_DOMAIN=http://192.168.168.167:4200
 REDIS_URL=redis://192.168.168.167:6379/1
+
+#PYTHONUNBUFFERED=0 # This when set to 0 will allow print statements to be visible in the Docker logs

--- a/.docker-compose.mfr.env
+++ b/.docker-compose.mfr.env
@@ -6,3 +6,5 @@ SERVER_CONFIG_HMAC_SECRET=changeme
 
 SERVER_CONFIG_ADDRESS=0.0.0.0
 SERVER_CONFIG_ALLOWED_PROVIDER_DOMAINS='http://192.168.168.167:5000/ http://192.168.168.167:7777/'
+
+#PYTHONUNBUFFERED=0 # This when set to 0 will allow print statements to be visible in the Docker logs

--- a/.docker-compose.wb.env
+++ b/.docker-compose.wb.env
@@ -12,3 +12,5 @@ SERVER_CONFIG_ADDRESS=0.0.0.0
 OSF_AUTH_CONFIG_API_URL=http://192.168.168.167:5000/api/v1/files/auth/
 
 TASKS_CONFIG_BROKER_URL=amqp://guest:guest@192.168.168.167:5672//
+
+#PYTHONUNBUFFERED=0 # This when set to 0 will allow print statements to be visible in the Docker logs

--- a/README-docker-compose.md
+++ b/README-docker-compose.md
@@ -233,7 +233,7 @@ The OSF is supported by several services which function independently from the m
   git update-index --no-skip-worktree docker-compose.override.yml docker-sync.yml
   ```
 
-  This will allow local changes to be reflected in your Docker environment, but you'll have to run `docker-compose up --force-recreate <container name>` every time you modify code in order to see your changes reflected in the application. But fear not! Setting `DEBUG=1` and `SERVER_CONFIG_DEBUG=1` in `docker-compose.wb.env` or `docker-compose.mfr.env` will enable live reload for those services, so your changes will take effect automatically in a few seconds.
+  The first time that sync settings are changed, you will need to run docker-compose up --force-recreate <container name>. To see the effect of code changes as you work (without needing to restart the container), you will need to separately turn on debug mode for the service by setting `DEBUG=1` and `SERVER_CONFIG_DEBUG=1` in `docker-compose.wb.env` or `docker-compose.mfr.env` this will enable live reload for those services, so your changes will take effect automatically in a few seconds.
 
 ### Catching Print Statements
 

--- a/README-docker-compose.md
+++ b/README-docker-compose.md
@@ -239,21 +239,8 @@ The OSF is supported by several services which function independently from the m
 
 If you want to debug your changes by using print statements, you'll have to have to set your container's environment variable PYTHONUNBUFFERED to 0. You can do this two ways:
   
-  1. Edit your container configuration in docker-compose.override.yml to include the new enviroment varible. For example to get print statements from Waterbutler:
-  ```yml
-    wb:
-    volumes_from:
-      - container:wb-sync
-  ```
-  becomes
-  ```yml
-    wb:
-    volumes_from:
-      - container:wb-sync
-    environment:
-      - PYTHONUNBUFFERED=0
-   ```
-   2. If you're using a container running Python 3 you can insert the following code prior to a print statement:
+  1. Edit your container configuration in docker-compose.mfr.env or docker-compose.mfr.env to include the new environment variable by uncommenting PYTHONUNBUFFERED=0 
+  2. If you're using a container running Python 3 you can insert the following code prior to a print statement:
    ```
     import functools
     print = functools.partial(print, flush=True)


### PR DESCRIPTION
## Purpose

Some of the documentation surrounding debugging services in a docker environment were unclear or incomplete. This adds some notes about how to best debug with docker-sync.

## Changes

Adds and reorganizes to README-docker-compose.md

## Side effects

None