### PR TITLE
[HOLD] SHARE subject serialization [OSF-7788]

### DIFF
--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -209,7 +209,7 @@ class PreprintSerializer(JSONAPISerializer):
 
     def set_field(self, func, val, auth, save=False):
         try:
-            func(val, auth, save=save)
+            func(val, auth)
         except PermissionsError as e:
             raise exceptions.PermissionDenied(detail=e.message)
         except ValueError as e:
@@ -246,7 +246,8 @@ class PreprintCreateSerializer(PreprintSerializer):
             raise Conflict('Only one preprint per provider can be submitted for a node. Check `meta[existing_resource_id]`.', meta={'existing_resource_id': conflict._id})
 
         preprint = PreprintService(node=node, provider=provider)
-        self.set_field(preprint.set_primary_file, primary_file, auth, save=True)
+        self.set_field(preprint.set_primary_file, primary_file, auth)
+        preprint.save()
         preprint.node._has_abandoned_preprint = True
         preprint.node.save()
 

--- a/osf/models/subject.py
+++ b/osf/models/subject.py
@@ -43,6 +43,10 @@ class Subject(ObjectIDMixin, BaseModel, DirtyFieldsMixin):
         """For v1 compat."""
         return self.children.count()
 
+    @property
+    def central_alias(self):
+        return self.bepress_subject or self
+
     def get_absolute_url(self):
         return self.absolute_api_v2_url
 

--- a/osf/models/subject.py
+++ b/osf/models/subject.py
@@ -43,10 +43,6 @@ class Subject(ObjectIDMixin, BaseModel, DirtyFieldsMixin):
         """For v1 compat."""
         return self.children.count()
 
-    @property
-    def central_alias(self):
-        return self.bepress_subject or self
-
     def get_absolute_url(self):
         return self.absolute_api_v2_url
 

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -85,7 +85,7 @@ class TestSetPreprintFile(OsfTestCase):
         with assert_raises(ValueError):
             self.preprint.set_published(True, auth=self.auth, save=True)
         self.preprint.provider = PreprintProviderFactory()
-        self.preprint.set_subjects([[SubjectFactory()._id]], auth=self.auth, save=True)
+        self.preprint.set_subjects([[SubjectFactory()._id]], auth=self.auth)
         self.project.reload()
         assert_false(self.project.is_preprint)
         self.preprint.set_published(True, auth=self.auth, save=True)
@@ -100,7 +100,7 @@ class TestSetPreprintFile(OsfTestCase):
         with assert_raises(ValueError):
             self.preprint.set_published(True, auth=self.auth, save=True)
         self.preprint.provider = PreprintProviderFactory()
-        self.preprint.set_subjects([[SubjectFactory()._id]], auth=self.auth, save=True)
+        self.preprint.set_subjects([[SubjectFactory()._id]], auth=self.auth)
         self.project.reload()
         assert_false(self.project.is_public)
         self.preprint.set_published(True, auth=self.auth, save=True)
@@ -160,7 +160,7 @@ class TestPreprintServicePermissions(OsfTestCase):
     def test_nonadmin_cannot_set_subjects(self):
         initial_subjects = list(self.preprint.subjects.all())
         with assert_raises(PermissionsError):
-            self.preprint.set_subjects([[SubjectFactory()._id]], auth=Auth(self.write_contrib), save=True)
+            self.preprint.set_subjects([[SubjectFactory()._id]], auth=Auth(self.write_contrib))
 
         self.preprint.reload()
         assert_equal(initial_subjects, list(self.preprint.subjects.all()))
@@ -191,7 +191,7 @@ class TestPreprintServicePermissions(OsfTestCase):
 
     def test_admin_can_set_subjects(self):
         initial_subjects = list(self.preprint.subjects.all())
-        self.preprint.set_subjects([[SubjectFactory()._id]], auth=Auth(self.user), save=True)
+        self.preprint.set_subjects([[SubjectFactory()._id]], auth=Auth(self.user))
 
         self.preprint.reload()
         assert_not_equal(initial_subjects, list(self.preprint.subjects.all()))
@@ -341,7 +341,7 @@ class TestOnPreprintUpdatedTask(OsfTestCase):
             self.preprint.node.creator.suffix = ''
         self.preprint.node.creator.save()
 
-        self.preprint.set_subjects([[SubjectFactory()._id]], auth=Auth(self.preprint.node.creator), save=False)
+        self.preprint.set_subjects([[SubjectFactory()._id]], auth=Auth(self.preprint.node.creator))
 
     def tearDown(self):
         handlers.celery_before_request()
@@ -444,7 +444,7 @@ class TestOnPreprintUpdatedTask(OsfTestCase):
         self.preprint.node.tags = []
         self.preprint.date_published = None
         self.preprint.node.preprint_article_doi = None
-        self.preprint.set_subjects([], auth=Auth(self.preprint.node.creator), save=False)
+        self.preprint.set_subjects([], auth=Auth(self.preprint.node.creator))
 
         res = format_preprint(self.preprint)
 
@@ -595,12 +595,12 @@ class TestPreprintSaveShareHook(OsfTestCase):
     @mock.patch('website.preprints.tasks.on_preprint_updated.s')
     def test_save_published_subject_change_called(self, mock_on_preprint_updated):
         self.preprint.is_published = True
-        self.preprint.set_subjects([[self.subject_two._id]], auth=self.auth, save=True)
+        self.preprint.set_subjects([[self.subject_two._id]], auth=self.auth)
         assert mock_on_preprint_updated.called
 
     @mock.patch('website.preprints.tasks.on_preprint_updated.s')
     def test_save_unpublished_subject_change_not_called(self, mock_on_preprint_updated):
-        self.preprint.set_subjects([[self.subject_two._id]], auth=self.auth, save=True)
+        self.preprint.set_subjects([[self.subject_two._id]], auth=self.auth)
         assert not mock_on_preprint_updated.called
 
     @mock.patch('website.preprints.tasks.requests')

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -369,14 +369,14 @@ class TestOnPreprintUpdatedTask(OsfTestCase):
         through_subjects = [nodes.pop(k) for k, v in nodes.items() if v['@type'] == 'throughsubjects']
         s_ids = [s['@id'] for s in subjects]
         ts_ids = [ts['subject']['@id'] for ts in through_subjects]
-        cs_ids = list(set(s['central_synonym']['@id'] for s in subjects))
+        cs_ids = [i for i in set(s.get('central_synonym', {}).get('@id') for s in subjects) if i]
         for ts in ts_ids:
             assert ts in s_ids
             assert ts not in cs_ids  # Only aliased subjects are connected to self.preprint
         for s in subjects:
             subject = Subject.objects.get(text=s['name'])
             assert s['uri'].endswith('v2/taxonomies/{}/'.format(subject._id))  # This cannot change
-        assert set(subject['name'] for subject in subjects) == set([s.text for s in self.preprint.subjects.all()] + [s.central_alias.text for s in self.preprint.subjects.all()])
+        assert set(subject['name'] for subject in subjects) == set([s.text for s in self.preprint.subjects.all()] + [s.bepress_subject.text for s in self.preprint.subjects.filter(bepress_subject__isnull=False)])
 
         people = sorted([nodes.pop(k) for k, v in nodes.items() if v['@type'] == 'person'], key=lambda x: x['given_name'])
         expected_people = sorted([{

--- a/website/preprints/tasks.py
+++ b/website/preprints/tasks.py
@@ -8,7 +8,7 @@ from framework.celery_tasks import app as celery_app
 from framework import sentry
 
 from website import settings
-from website.util.share import GraphNode, format_contributor
+from website.util.share import GraphNode, format_contributor, format_subject
 
 from website.identifiers.utils import request_identifiers_from_ezid, get_ezid_client, build_ezid_metadata, parse_identifiers
 
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 @celery_app.task(ignore_results=True)
-def on_preprint_updated(preprint_id, update_share=True):
+def on_preprint_updated(preprint_id, update_share=True, old_subjects=[]):
     # WARNING: Only perform Read-Only operations in an asynchronous task, until Repeatable Read/Serializable
     # transactions are implemented in View and Task application layers.
     from osf.models import PreprintService
@@ -39,14 +39,16 @@ def on_preprint_updated(preprint_id, update_share=True):
                 'attributes': {
                     'tasks': [],
                     'raw': None,
-                    'data': {'@graph': format_preprint(preprint)}
+                    'data': {'@graph': format_preprint(preprint, old_subjects)}
                 }
             }
         }, headers={'Authorization': 'Bearer {}'.format(preprint.provider.access_token), 'Content-Type': 'application/vnd.api+json'})
         logger.debug(resp.content)
         resp.raise_for_status()
 
-def format_preprint(preprint):
+def format_preprint(preprint, old_subjects=[]):
+    from osf.models import Subject
+    old_subjects = [Subject.objects.get(id=s) for s in old_subjects]
     preprint_graph = GraphNode('preprint', **{
         'title': preprint.node.title,
         'description': preprint.node.description or '',
@@ -83,10 +85,15 @@ def format_preprint(preprint):
         for tag in preprint.node.tags.values_list('name', flat=True) if tag
     ]
 
-    preprint_graph.attrs['subjects'] = [
-        GraphNode('throughsubjects', creative_work=preprint_graph, subject=GraphNode('subject', name=subject))
-        for subject in set(s.bepress_text for s in preprint.subjects.all())
+    current_subjects = [
+        GraphNode('throughsubjects', creative_work=preprint_graph, subject=format_subject(s))
+        for s in preprint.subjects.all()
     ]
+    deleted_subjects = [
+        GraphNode('throughsubjects', creative_work=preprint_graph, is_deleted=True, subject=format_subject(s))
+        for s in old_subjects if not preprint.subjects.filter(id=s.id).exists()
+    ]
+    preprint_graph.attrs['subjects'] = current_subjects + deleted_subjects
 
     to_visit.extend(format_contributor(preprint_graph, user, preprint.node.get_visible(user), i) for i, user in enumerate(preprint.node.contributors))
     to_visit.extend(GraphNode('AgentWorkRelation', creative_work=preprint_graph, agent=GraphNode('institution', name=institution))

--- a/website/util/share.py
+++ b/website/util/share.py
@@ -80,5 +80,5 @@ def format_subject(subject, context={}):
         uri=subject.absolute_api_v2_url,
     )
     context[subject.id].attrs['parent'] = format_subject(subject.parent, context)
-    context[subject.id].attrs['central_synonym'] = format_subject(subject.central_alias, context)
+    context[subject.id].attrs['central_synonym'] = format_subject(subject.bepress_subject, context)
     return context[subject.id]

--- a/website/util/share.py
+++ b/website/util/share.py
@@ -68,7 +68,9 @@ def format_contributor(preprint, user, bibliographic, index):
         cited_as=user.fullname,
     )
 
-def format_subject(subject, context={}):
+def format_subject(subject, context=None):
+    if context is None:
+        context = {}
     if subject is None:
         return None
     if subject.id in context:

--- a/website/util/share.py
+++ b/website/util/share.py
@@ -67,3 +67,18 @@ def format_contributor(preprint, user, bibliographic, index):
         creative_work=preprint,
         cited_as=user.fullname,
     )
+
+def format_subject(subject, context={}):
+    if subject is None:
+        return None
+    if subject.id in context:
+        return context[subject.id]
+    context[subject.id] = GraphNode(
+        'subject',
+        name=subject.text,
+        is_deleted=False,
+        uri=subject.absolute_api_v2_url,
+    )
+    context[subject.id].attrs['parent'] = format_subject(subject.parent, context)
+    context[subject.id].attrs['central_synonym'] = format_subject(subject.central_alias, context)
+    return context[subject.id]


### PR DESCRIPTION
## Purpose
OSF-side of https://github.com/CenterForOpenScience/SHARE/pull/653

## Changes
* Update `Subject` serialization process
* Include information about deleted subjects when a `preprint.subjects` M2M relation changes

## Side effects
None expected. 

## Note
Tagged `[HOLD]` because this shouldn't go in until SHARE's ready for it.

## Ticket
Extension of [OSF-7788](https://openscience.atlassian.net/browse/OSF-7788)