### PR TITLE
Return correct subjects_acceptable [EOSF-668]

### DIFF
--- a/osf/models/preprint_provider.py
+++ b/osf/models/preprint_provider.py
@@ -5,6 +5,7 @@ from modularodm import Q
 
 from osf.models.base import BaseModel, ObjectIDMixin
 from osf.models.licenses import NodeLicense
+from osf.models.subject import Subject
 from osf.utils.datetime_aware_jsonfield import DateTimeAwareJSONField
 from osf.utils.fields import EncryptedTextField
 
@@ -48,9 +49,8 @@ class PreprintProvider(ObjectIDMixin, BaseModel):
             return self.subjects.filter(parent__isnull=True)
         else:
             # TODO: Delet this when all PreprintProviders have a mapping
-            from osf.models.subject import Subject
             if len(self.subjects_acceptable) == 0:
-                return Subject.find(Q('parent', 'isnull', True))
+                return Subject.objects.filter(parent__isnull=True, provider___id='osf')
             tops = set([sub[0][0] for sub in self.subjects_acceptable])
             return [Subject.load(sub) for sub in tops]
 
@@ -86,7 +86,8 @@ class PreprintProvider(ObjectIDMixin, BaseModel):
 
 
 def rules_to_subjects(rules):
-    from osf.models.subject import Subject
+    if not rules:
+        return Subject.objects.filter(provider___id='osf')
     q = []
     for rule in rules:
         if rule[1]:

--- a/osf/models/subject.py
+++ b/osf/models/subject.py
@@ -9,7 +9,6 @@ from include import IncludeQuerySet
 from website.util import api_v2_url
 
 from osf.models.base import BaseModel, MODMCompatibilityQuerySet, ObjectIDMixin
-from osf.models.preprint_provider import PreprintProvider
 from osf.models.validators import validate_subject_hierarchy_length, validate_subject_provider_mapping
 
 class SubjectQuerySet(MODMCompatibilityQuerySet, IncludeQuerySet):
@@ -24,7 +23,7 @@ class Subject(ObjectIDMixin, BaseModel, DirtyFieldsMixin):
     text = models.CharField(null=False, max_length=256)  # max length on prod: 73
     parent = models.ForeignKey('self', related_name='children', null=True, blank=True, on_delete=models.SET_NULL, validators=[validate_subject_hierarchy_length])
     bepress_subject = models.ForeignKey('self', related_name='aliases', null=True, blank=True, on_delete=models.deletion.CASCADE)
-    provider = models.ForeignKey(PreprintProvider, related_name='subjects', on_delete=models.deletion.CASCADE)
+    provider = models.ForeignKey('PreprintProvider', related_name='subjects', on_delete=models.deletion.CASCADE)
 
     objects = SubjectQuerySet.as_manager()
 


### PR DESCRIPTION
## Purpose
Handle edge case when `subjects_acceptable` is `[]` and `self.subjects.exists()` is `False`

## Changes
* Include only BePress Subjects

## Side effects
Could lead to weird behavior if there are no Subjects with `.provider` `'osf'`, but that should be handled by either a [migration](https://github.com/CenterForOpenScience/osf.io/blob/develop/osf/migrations/0024_migrate_subject_parents_to_parent.py#L57-L61) or the [`update_taxonomies` script](https://github.com/CenterForOpenScience/osf.io/blob/develop/scripts/update_taxonomies.py#L70)

## Ticket
[EOSF-668](https://openscience.atlassian.net/browse/EOSF-668)