### PR TITLE
[Hotfix] Display correct error message for invalid Figshare credentials [OSF-8004]

### DIFF
--- a/addons/figshare/models.py
+++ b/addons/figshare/models.py
@@ -230,7 +230,12 @@ class NodeSettings(BaseStorageAddon, BaseOAuthNodeSettings):
                 message = messages.BEFORE_PAGE_LOAD_PUBLIC_NODE_MIXED_FS.format(category=node.project_or_component, project_id=figshare.folder_id)
 
         connect = FigshareClient(self.external_account.oauth_key)
-        project_is_public = connect.container_is_public(self.folder_id, self.folder_path)
+        try:
+            project_is_public = connect.container_is_public(self.folder_id, self.folder_path)
+        except HTTPError as e:
+            if e.code == 403:
+                return [messages.OAUTH_INVALID]
+            raise
 
         article_permissions = 'public' if project_is_public else 'private'
 


### PR DESCRIPTION
## Purpose
Display correct error message for invalid Figshare credentials

## Changes
* Except a `403` in `before_page_load`

## Side effects
None expected

## Ticket
[[OSF-8004]](https://openscience.atlassian.net/browse/OSF-8004)