### PR TITLE
[feature] Fix UVA Dataverse API Token URL on User Settings Page [OSF-7215][OSF-7213]

### DIFF
--- a/addons/dataverse/static/dataverseUserConfig.js
+++ b/addons/dataverse/static/dataverseUserConfig.js
@@ -48,9 +48,9 @@ function ViewModel(url) {
         return Boolean(self.selectedHost());
     });
     self.tokenUrl = ko.pureComputed(function() {
-        var tokenPath = self.host() === 'dataverse.lib.virginia.edu'
-                ? '/account/apitoken' : '/dataverseuser.xhtml?selectTab=apiTokenTab';
-        return self.host() ? 'https://' + self.host() + tokenPath : null;
+        var tokenPath = 'dataverseuser.xhtml?selectTab=apiTokenTab';
+        var extraSlash = self.host() && self.host().substr(self.host().length - 1) === '/' ? '' : '/';
+        return self.host() ? 'https://' + self.host() + extraSlash + tokenPath : null;
     });
 
     // Flashed messages


### PR DESCRIPTION
#### Purpose / Changes
Same fix as #6565, but applied to the user settings page as well. 

#### Ticket
- [OSF-7213](https://openscience.atlassian.net/browse/OSF-7213)
- [OSF-7215](https://openscience.atlassian.net/browse/OSF-7215)