### PR TITLE
[hotfix] registration files id [OSF-8015]

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -956,7 +956,7 @@ class NodeProviderSerializer(JSONAPISerializer):
     provider = ser.CharField(read_only=True)
     files = NodeFileHyperLinkField(
         related_view='nodes:node-files',
-        related_view_kwargs={'node_id': '<node_id>', 'path': '<path>', 'provider': '<provider>'},
+        related_view_kwargs={'node_id': '<node._id>', 'path': '<path>', 'provider': '<provider>'},
         kind='folder',
         never_embed=True
     )

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -336,7 +336,7 @@ class RegistrationFileSerializer(OsfStorageFileSerializer):
 
     files = NodeFileHyperLinkField(
         related_view='registrations:registration-files',
-        related_view_kwargs={'node_id': '<node_id>', 'path': '<path>', 'provider': '<provider>'},
+        related_view_kwargs={'node_id': '<node._id>', 'path': '<path>', 'provider': '<provider>'},
         kind='folder'
     )
 
@@ -357,7 +357,7 @@ class RegistrationProviderSerializer(NodeProviderSerializer):
     """
     files = NodeFileHyperLinkField(
         related_view='registrations:registration-files',
-        related_view_kwargs={'node_id': '<node_id>', 'path': '<path>', 'provider': '<provider>'},
+        related_view_kwargs={'node_id': '<node._id>', 'path': '<path>', 'provider': '<provider>'},
         kind='folder',
         never_embed=True
     )

--- a/api_tests/registrations/views/test_registration_files_list.py
+++ b/api_tests/registrations/views/test_registration_files_list.py
@@ -1,0 +1,35 @@
+import pytest
+
+from tests.json_api_test_app import JSONAPITestApp
+from api.base.settings.defaults import API_BASE
+from api_tests import utils as api_utils
+from tests.base import ApiTestCase
+from osf_tests.factories import (
+    AuthUserFactory,
+    ProjectFactory,
+    RegistrationFactory
+)
+
+@pytest.mark.django_db
+class TestRegistrationFilesList(object):
+
+    @pytest.fixture(autouse=True)
+    def setUp(self):
+        self.app = JSONAPITestApp()
+        self.user = AuthUserFactory()
+        self.node = ProjectFactory(creator=self.user)
+        self.registration = RegistrationFactory(project=self.node, creator=self.user)
+        # Note: folders/files added to node do not seem to get picked up by the Registration factory so they are added after
+        self.folder = self.registration.get_addon('osfstorage').get_root().append_folder('Archive of OSF Storage')
+        self.folder.save()
+        self.file = self.folder.append_file('So, on average, it has been super comfortable this week')
+        self.file.save()
+
+
+    def test_registration_relationships_contains_guid_not_id(self):
+        url = '/{}registrations/{}/files/{}/'.format(API_BASE, self.registration._id, self.file.provider)
+        res = self.app.get(url, auth=self.user.auth)
+
+        split_href = res.json['data'][0]['relationships']['files']['links']['related']['href'].split('/')
+        assert self.registration._id in split_href
+        assert self.registration.id not in split_href


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
the id for a registration is wrong in certain places


<!-- Describe the purpose of your changes -->

## Changes
Uses _id instead of id; add a test, h/t @Nesiehr

<!-- Briefly describe or list your changes  -->

## Side effects
Swapped two other places to _id (that currently worked) for consistency
<!--Any possible side effects? -->


## Ticket
https://openscience.atlassian.net/browse/OSF-8015
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->

## QA Considerations
Test a registrations `https://api.osf.io/v2/registrations/b6psa/files/osfstorage/` route and make sure the guid is populated in the href (see ticket for an example)