### PR TITLE
[feature] Remove file revision anonymous contributors if no user [OSF-7292]

### DIFF
--- a/website/static/js/filepage/revisions.js
+++ b/website/static/js/filepage/revisions.js
@@ -129,11 +129,11 @@ var FileRevisionsTable = {
                   m('a', {href: parseInt(revision.displayVersion) === model.revisions.length ? self.baseUrl : revision.osfViewUrl}, revision.displayVersion)
                 ),
                 model.hasDate ? m('td', revision.displayDate) : false,
-                model.hasUser && !window.contextVars.node.anonymous ?
+                model.hasUser ? window.contextVars.node.anonymous ? m('td', 'Anonymous Contributor') :
                     m('td', revision.extra.user.url ?
                             m('a', {href: revision.extra.user.url}, revision.extra.user.name) :
                             revision.extra.user.name
-                    ) : m('td', 'Anonymous Contributor'),
+                    ) : false,
                 m('td', revision.extra.downloads > -1 ? m('.badge', revision.extra.downloads) : ''),
                 m('td',
                     m('a.btn.btn-primary.btn-sm.file-download', {


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Some addons do not have user data for revisions. Previously these were leaking information when viewed through anon vols, but this made it list anon user even if an addon did not have user data.

<!-- Describe the purpose of your changes -->

## Changes
Only show anonymized user if addon shows users and has a user.
<!-- Briefly describe or list your changes  -->

## Side effects
NA
<!--Any possible side effects? -->


## Ticket
https://openscience.atlassian.net/browse/OSF-7292
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->


## QA Notes
Test all addon revision pages both under normal conditions and through an anon VOL. "Anonymous User" should only show up for addons that show user info when viewed normally. The column width  weirdness (e.g., dataverse download header does not line up with the download button) matches how this was before things got broke'd. 

Note: Unpublished dataverses do not show up under VOLs, I made a ticket for this.