### PR TITLE
[feature] File View Page Short Download URLs [OSF-7834]

### DIFF
--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -309,11 +309,6 @@ var FileViewPage = {
 
             });
         });
-        $(document).on('fileviewpage:download', function() {
-            //replace mode=render with action=download for download count incrementation
-            window.location = self.file.urls.content.replace('mode=render', 'action=download');
-            return false;
-        });
 
         self.shareJSObservables = {
             activeUsers: m.prop([]),
@@ -532,7 +527,7 @@ var FileViewPage = {
                 m.component(SharePopover, {link: link, height: height})
             ]) : '',
             m('.btn-group.m-t-xs', [
-                ctrl.isLatestVersion ? m('button.btn.btn-sm.btn-primary.file-download', {onclick: $(document).trigger.bind($(document), 'fileviewpage:download')}, 'Download') : null
+                ctrl.isLatestVersion ? m('a.btn.btn-sm.btn-primary.file-download', {href: 'download'}, 'Download') : null
             ]),
             m('.btn-group.btn-group-sm.m-t-xs', [
                ctrl.editor ? m( '.btn.btn-default.disabled', 'Toggle view: ') : null

--- a/website/static/js/filepage/revisions.js
+++ b/website/static/js/filepage/revisions.js
@@ -139,7 +139,7 @@ var FileRevisionsTable = {
                     m('a.btn.btn-primary.btn-sm.file-download', {
                         href: revision.osfDownloadUrl,
                         onclick: function() {
-                            window.location = revision.waterbutlerDownloadUrl;
+                            window.location = revision.osfDownloadUrl;
                             return false;
                         }
                     }, m('i.fa.fa-download'))
@@ -228,8 +228,7 @@ var FileRevisionsTable = {
         }
 
         revision.osfViewUrl = '?' + $.param(options);
-        revision.osfDownloadUrl = '?' + $.param($.extend({action: 'download'}, options));
-        revision.waterbutlerDownloadUrl = waterbutler.buildDownloadUrl(file.path, file.provider, node.id, options);
+        revision.osfDownloadUrl = 'download?' + $.param(options);
 
         return revision;
     }


### PR DESCRIPTION
#### Purpose
- Use short download URLs on the file view page. The download button in the toolbar and the download buttons in the revisions table have been changed.

#### Changes
- Use the new 'osf.io/<file_guid>/download` short URL instead of WaterButler download URLs on the file view page.

#### Side Effects
- None expected.

#### QA Notes
- Ensure that download counts aren't affected.
- Ensure the download URL can be copied by right clicking the buttons (as noted in the ticket). 

#### Ticket
- [OSF-7834](https://openscience.atlassian.net/browse/OSF-7834)
