### PR TITLE
Added commented out docker-sync and docker-compose config for static …

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -98,3 +98,11 @@ services:
   api:
     volumes_from:
       - container:osf-sync
+
+######### Use this to get a local CDN for static assets: #############
+#  static-assets:
+#    build: ../osf-assets
+#    ports:
+#      - 10000:80
+#    volumes_from:
+#      - container:static-assets-sync

--- a/docker-sync.yml
+++ b/docker-sync.yml
@@ -53,6 +53,15 @@ syncs:
 #    sync_excludes: ['.DS_Store', '*.map', '*.pyc', '*.tmp', '.git', '.idea', 'bower_components', 'node_modules', 'tmp', 'dist']
 #    watch_excludes: ['.*\.DS_Store', '.*\.map', '.*\.pyc', '.*\.tmp', '.*/\.git', '.*/\.idea', '.*/bower_components', '.*/node_modules', '.*/tmp', '.*/dist']
 
+#  static-assets-sync:
+#    src: '../osf-assets'
+#    dest: '/assets'
+#    sync_strategy: 'unison'
+#    sync_args: [ '-prefer newer' ]
+#    sync_excludes_type: 'Name'
+#    sync_excludes: ['.DS_Store', '*.map', '*.pyc', '*.tmp', '.git', '.idea', 'bower_components', 'node_modules', 'tmp', 'dist']
+#    watch_excludes: ['.*\.DS_Store', '.*\.map', '.*\.pyc', '.*\.tmp', '.*/\.git', '.*/\.idea', '.*/bower_components', '.*/node_modules', '.*/tmp', '.*/dist']
+
   osf-sync:
     src: './'
     dest: '/code'


### PR DESCRIPTION
## Purpose

This adds commented out configuration for docker-sync and docker-compose to stand up a synced local CDN to serve static assets for development.

Related PR: https://github.com/brianjgeiger/osf-assets/pull/1

## Changes

Added commented out config to docker-sync.yml and docker-compose.override.yml

## Side effects

None as all config is commented out.

## Ticket

N/A
