### PR TITLE
[feature] Fix Preprint Contributor Added Emails [OSF-8037]

### DIFF
--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -252,7 +252,7 @@ class TestPreprintProvider(OsfTestCase):
         self.preprint.save()
         self.preprint.reload()
 
-        assert ('branded', 'WWEArxiv') == find_preprint_provider(self.preprint.node)
+        assert ('branded', self.provider) == find_preprint_provider(self.preprint.node)
 
     def test_top_level_subjects(self):
         subj_a = SubjectFactory(provider=self.provider, text='A')

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1963,7 +1963,7 @@ class TestAddingContributorViews(OsfTestCase):
             node=project,
             referrer_name=self.auth.user.fullname,
             all_global_subscriptions_none=False,
-            branded_service_name=None,
+            branded_service=None,
         )
         assert_almost_equal(contributor.contributor_added_email_records[project._id]['last_sent'], int(time.time()), delta=1)
 
@@ -2188,7 +2188,7 @@ class TestUserInviteViews(OsfTestCase):
             email=real_email.lower().strip(),
             fullname=unreg_user.get_unclaimed_record(project._id)['name'],
             node=project,
-            branded_service_name=None
+            branded_service=None
         )
 
     @mock.patch('website.project.views.contributor.mails.send_mail')

--- a/website/templates/emails/contributor_added_preprints_branded.txt.mako
+++ b/website/templates/emails/contributor_added_preprints_branded.txt.mako
@@ -4,7 +4,7 @@
 
 Hello ${user.fullname},
 
-${referrer_name + ' has added you' if referrer_name else 'You have been added'} as a contributor to the preprint "${node.title}" on ${branded_service_name}, which is hosted on the Open Science Framework: ${node.absolute_url}
+${referrer_name + ' has added you' if referrer_name else 'You have been added'} as a contributor to the preprint "${node.title}" on ${branded_service.name}, which is hosted on the Open Science Framework: ${node.absolute_url}
 
 You will ${'not receive ' if all_global_subscriptions_none else 'be automatically subscribed to '}notification emails for this preprint. Each preprint is associated with a project on the Open Science Framework for managing the preprint. To change your email notification preferences, visit your project user settings: ${settings.DOMAIN + "settings/notifications/"}
 
@@ -13,9 +13,9 @@ If you have been erroneously associated with "${node.title}", then you may visit
 
 Sincerely,
 
-Your ${branded_service_name} and OSF teams
+Your ${branded_service.name} and OSF teams
 
 
-Want more information? Visit https://osf.io/preprints/${branded_service_name.lower()} to learn about ${branded_service_name} or https://osf.io/ to learn about the Open Science Framework, or https://cos.io/ for information about its supporting organization, the Center for Open Science.
+Want more information? Visit https://osf.io/preprints/${branded_service._id} to learn about ${branded_service.name} or https://osf.io/ to learn about the Open Science Framework, or https://cos.io/ for information about its supporting organization, the Center for Open Science.
 
-Questions? Email support+${branded_service_name.lower()}@osf.io
+Questions? Email support+${branded_service._id}@osf.io

--- a/website/templates/emails/invite_preprints_branded.txt.mako
+++ b/website/templates/emails/invite_preprints_branded.txt.mako
@@ -4,7 +4,7 @@
 
 Hello ${fullname},
 
-You have been added by ${referrer.fullname} as a contributor to the preprint "${node.title}" on ${branded_service_name}, powered by the Open Science Framework. To set a password for your account, visit:
+You have been added by ${referrer.fullname} as a contributor to the preprint "${node.title}" on ${branded_service.name}, powered by the Open Science Framework. To set a password for your account, visit:
 
 ${claim_url}
 
@@ -14,14 +14,14 @@ To preview "${node.title}" click the following link: ${node.absolute_url}
 
 (NOTE: if this project is private, you will not be able to view it until you have confirmed your account)
 
-If you are not ${fullname} or you have been erroneously associated with "${node.title}", then email contact+${branded_service_name.lower()}@osf.io with the subject line "Claiming Error" to report the problem.
+If you are not ${fullname} or you have been erroneously associated with "${node.title}", then email contact+${branded_service._id}@osf.io with the subject line "Claiming Error" to report the problem.
 
 
 Sincerely,
 
-Your ${branded_service_name} and OSF teams
+Your ${branded_service.name} and OSF teams
 
 
-Want more information? Visit https://osf.io/preprints/${branded_service_name.lower()} to learn about ${branded_service_name} or https://osf.io/ to learn about the Open Science Framework, or https://cos.io/ for information about its supporting organization, the Center for Open Science.
+Want more information? Visit https://osf.io/preprints/${branded_service._id} to learn about ${branded_service.name} or https://osf.io/ to learn about the Open Science Framework, or https://cos.io/ for information about its supporting organization, the Center for Open Science.
 
-Questions? Email support+${branded_service_name.lower()}@osf.io
+Questions? Email support+${branded_service._id}@osf.io


### PR DESCRIPTION
#### Purpose
- Fixes malformed links and emails in preprint contributor added emails.

#### Changes
- Use preprint provider `_id` (instead of `name`) to format links and emails.

#### Ticket
- [OSF-8037](https://openscience.atlassian.net/browse/OSF-8037)