### PR TITLE
[feature] Make deleted primary file orphan a preprint [OSF-7939]

### DIFF
--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -455,6 +455,8 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
         """For v1 compat"""
         if (not self.is_preprint) and self._is_preprint_orphan:
             return True
+        if self.preprint_file:
+            return self.preprint_file.is_deleted
         return False
 
     @property

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -123,6 +123,12 @@ class TestSetPreprintFile(OsfTestCase):
         with assert_raises(AttributeError):
             self.preprint.set_primary_file('inatlanta', auth=self.auth, save=True)
 
+    def test_deleted_file_creates_orphan(self):
+        self.preprint.set_primary_file(self.file, auth=self.auth, save=True)
+        self.file.is_deleted = True
+        self.file.save()
+        assert_true(self.project.is_preprint_orphan)
+
     def test_preprint_created_date(self):
         self.preprint.set_primary_file(self.file, auth=self.auth, save=True)
         assert_equal(self.project.preprint_file._id, self.file._id)


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
It is possible for a preprint to have a deleted primary file but not show it is an orphan.
<!-- Describe the purpose of your changes -->

## Changes
Add check to is_preprint_orphan for deleted file and return true if true
<!-- Briefly describe or list your changes  -->

## Side effects
na
<!--Any possible side effects? -->


## Ticket
https://openscience.atlassian.net/browse/OSF-7939
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
