### PR TITLE
Move listener for identifier update when node deleted [OSF-7772]

### DIFF
--- a/website/app.py
+++ b/website/app.py
@@ -30,6 +30,7 @@ from website.archiver import listeners  # noqa
 from website.files.models import FileNode
 from website.mails import listeners  # noqa
 from website.notifications import listeners  # noqa
+from website.identifiers import listeners  # noqa
 from website.project.licenses import ensure_licenses
 from website.project.model import ensure_schemas
 from werkzeug.contrib.fixers import ProxyFix

--- a/website/identifiers/listeners.py
+++ b/website/identifiers/listeners.py
@@ -1,0 +1,10 @@
+from website.project import signals
+from framework.celery_tasks.handlers import enqueue_task
+
+
+@signals.node_deleted.connect
+def update_status_on_delete(node):
+    from website.preprints.tasks import update_ezid_metadata_on_change
+
+    for preprint in node.preprints.all():
+        enqueue_task(update_ezid_metadata_on_change.s(preprint, status='unavailable'))

--- a/website/identifiers/utils.py
+++ b/website/identifiers/utils.py
@@ -5,9 +5,7 @@ import logging
 
 from framework.exceptions import HTTPError
 from website import settings
-from website.project import signals
 from website.identifiers.metadata import datacite_metadata_for_node, datacite_metadata_for_preprint
-from framework.celery_tasks.handlers import enqueue_task
 
 logger = logging.getLogger(__name__)
 
@@ -157,10 +155,3 @@ def get_or_create_identifiers(target_object):
                 [each.strip('/') for each in pair.strip().split(':')]
                 for pair in resp['success'].split('|')
             )
-
-@signals.node_deleted.connect
-def update_status_on_delete(node):
-    from website.preprints.tasks import update_ezid_metadata_on_change
-
-    for preprint in node.preprints.all():
-        enqueue_task(update_ezid_metadata_on_change.s(preprint, status='unavailable'))


### PR DESCRIPTION
[#OSF-7772]



## Purpose
When a node was deleted, the listener for updating metadat on EZID was not functioning properly, as the listener was not imported when the app was initiated. 

Move the function for listening for when a preprint's node is deleted to a separate listeners file, which can then be imported in `app.py`. This way, when the app starts up on staging, the listener to update EZID metadata when a node is deleted is properly imported along with other listeners!

## Changes

- Move listener from `identifiers/utils.py` to new `identifiers/listeners.py` and import them in `website/app.py`

## Side effects

None anticipated


## Ticket
https://openscience.atlassian.net/browse/OSF-7772