### PR TITLE
[feature] Hide deleted preprint detail [OSF-8076]

### DIFF
--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -45,7 +45,7 @@ class PreprintMixin(NodeMixin):
             self.kwargs[self.preprint_lookup_url_kwarg],
             display_name='preprint'
         )
-        if not preprint:
+        if not preprint or preprint.node.is_deleted:
             raise NotFound
         # May raise a permission denied
         if check_object_permissions:

--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -44,6 +44,16 @@ class TestPreprintDetail(ApiTestCase):
         assert_equal(self.data['type'], 'preprints')
         assert_equal(self.data['id'], self.preprint._id)
 
+    def test_preprint_node_deleted_detail_failure(self):
+        deleted_node = ProjectFactory(creator=self.user, is_deleted=True)
+        deleted_preprint = PreprintFactory(project=deleted_node, creator=self.user)
+
+        url = '/{}preprints/{}/'.format(API_BASE, deleted_preprint._id)
+        res = self.app.get(url, expect_errors=True)
+        assert_equal(res.status_code, 404)
+        assert_equal(self.res.content_type, 'application/vnd.api+json')
+
+
 class TestPreprintDelete(ApiTestCase):
     def setUp(self):
         super(TestPreprintDelete, self).setUp()


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Deleted preprints can be seen through the api if you have the guid.
<!-- Describe the purpose of your changes -->

## Changes
Preprints with deleted nodes 404 now; added a test of this
<!-- Briefly describe or list your changes  -->

## Side effects
NA
<!--Any possible side effects? -->


## Ticket
https://openscience.atlassian.net/browse/OSF-8076
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->


## QA Considerations
Test a preprint with a deleted node 404's and one that is not deleted does not 404.