### PR TITLE
Add line to preprint filter to not add ids to preprints with deleted nodes [OSF-7772]

### DIFF
--- a/scripts/add_identifiers_to_existing_preprints.py
+++ b/scripts/add_identifiers_to_existing_preprints.py
@@ -2,7 +2,6 @@ import sys
 import time
 import logging
 from scripts import utils as script_utils
-from django.db import transaction
 
 from website.app import setup_django
 from website.identifiers.utils import request_identifiers_from_ezid, parse_identifiers
@@ -14,7 +13,7 @@ logger = logging.getLogger(__name__)
 def main(dry=True):
     from osf.models import PreprintService
 
-    preprints_without_identifiers = PreprintService.objects.filter(identifiers__isnull=True, is_published=True)
+    preprints_without_identifiers = PreprintService.objects.filter(identifiers__isnull=True, is_published=True, node__is_deleted=False)
     logger.info('About to add identifiers to {} preprints.'.format(preprints_without_identifiers.count()))
 
     for preprint in preprints_without_identifiers:


### PR DESCRIPTION

## Purpose
If an old preprint has a deleted node, don't request an identifier for it.

## Changes

- add check to see if a preprint has a deleted node before requesting an identifier
- remove unused import

## Side effects
none anticipated


## Ticket
https://openscience.atlassian.net/browse/OSF-7772