### PR TITLE
[Feature] Prevent redraw grey screen when add component is clicked quickly [OSF-8053]

### DIFF
--- a/website/static/js/pages/project-dashboard-page.js
+++ b/website/static/js/pages/project-dashboard-page.js
@@ -121,16 +121,15 @@ $(document).ready(function () {
         contributors: window.contextVars.node.contributors,
         currentUserCanEdit: window.contextVars.currentUser.canEdit
     });
-    var newComponentElem = document.getElementById('newComponent');
-
-    m.startComputation();
-
-    if (ctx.node.institutions.length && !ctx.node.anonymous && !ctx.node.isRetracted) {
-        m.mount(document.getElementById('instLogo'), m.component(institutionLogos, {institutions: window.contextVars.node.institutions}));
-    }
-    $('#contributorsList').osfToggleHeight();
 
     if (!ctx.node.isRetracted) {
+        m.startComputation();
+
+        if (ctx.node.institutions.length && !ctx.node.anonymous) {
+            m.mount(document.getElementById('instLogo'), m.component(institutionLogos, {institutions: window.contextVars.node.institutions}));
+        }
+        $('#contributorsList').osfToggleHeight();
+
         // Recent Activity widget
         m.mount(document.getElementById('logFeed'), m.component(LogFeed.LogFeed, {node: node}));
 
@@ -200,16 +199,18 @@ $(document).ready(function () {
                 }
             };
             var filebrowser = new Fangorn(fangornOpts);
+            var newComponentElem = document.getElementById('newComponent');
+            if (window.contextVars.node.isPublic) {
+                m.mount(document.getElementById('shareButtonsPopover'),
+                        m.component(SocialShare.ShareButtonsPopover,
+                            {title: window.contextVars.node.title, url: window.location.href}));
+            }
             if (newComponentElem) {
                 m.mount(newComponentElem, AddComponentButton);
             };
             m.endComputation();
         });
-    } else {
-        if (newComponentElem) {
-            m.mount(newComponentElem, AddComponentButton);
-        };
-        m.endComputation();
+
     }
 
     // Tooltips
@@ -295,11 +296,5 @@ $(document).ready(function () {
         $('span.tag span').each(function(idx, elm) {
             $(elm).text($(elm).text().replace(/\s*$/, ''));
         });
-    }
-
-    if (window.contextVars.node.isPublic && !window.contextVars.node.isRetracted) {
-        m.mount(document.getElementById('shareButtonsPopover'),
-                m.component(SocialShare.ShareButtonsPopover,
-                    {title: window.contextVars.node.title, url: window.location.href}));
     }
 });

--- a/website/static/js/pages/project-dashboard-page.js
+++ b/website/static/js/pages/project-dashboard-page.js
@@ -201,13 +201,17 @@ $(document).ready(function () {
             var filebrowser = new Fangorn(fangornOpts);
             var newComponentElem = document.getElementById('newComponent');
             if (window.contextVars.node.isPublic) {
-                m.mount(document.getElementById('shareButtonsPopover'),
-                        m.component(SocialShare.ShareButtonsPopover,
-                            {title: window.contextVars.node.title, url: window.location.href}));
+                m.mount(
+                    document.getElementById('shareButtonsPopover'),
+                    m.component(
+                        SocialShare.ShareButtonsPopover,
+                        {title: window.contextVars.node.title, url: window.location.href}
+                    )
+                );
             }
             if (newComponentElem) {
                 m.mount(newComponentElem, AddComponentButton);
-            };
+            }
             m.endComputation();
         });
 

--- a/website/static/js/pages/project-dashboard-page.js
+++ b/website/static/js/pages/project-dashboard-page.js
@@ -122,9 +122,8 @@ $(document).ready(function () {
         currentUserCanEdit: window.contextVars.currentUser.canEdit
     });
     var newComponentElem = document.getElementById('newComponent');
-    if (newComponentElem) {
-        m.mount(newComponentElem, AddComponentButton);
-    }
+
+    m.startComputation();
 
     if (ctx.node.institutions.length && !ctx.node.anonymous && !ctx.node.isRetracted) {
         m.mount(document.getElementById('instLogo'), m.component(institutionLogos, {institutions: window.contextVars.node.institutions}));
@@ -201,7 +200,16 @@ $(document).ready(function () {
                 }
             };
             var filebrowser = new Fangorn(fangornOpts);
+            if (newComponentElem) {
+                m.mount(newComponentElem, AddComponentButton);
+            };
+            m.endComputation();
         });
+    } else {
+        if (newComponentElem) {
+            m.mount(newComponentElem, AddComponentButton);
+        };
+        m.endComputation();
     }
 
     // Tooltips


### PR DESCRIPTION
## Purpose
Prevent grey screen (modal backdrop) which occurs when the addComponent is clicked before the 
treebeard/fangorn filebrowser is fully added to the DOM.

## Changes

Modifies the order in which Mithril draws mounted components by using
m.startComputation/m.endComputation to only allow one redraw. As a result,
the addCompnent button is not clickable till filebrowser is fully drawn.

## Ticket

https://openscience.atlassian.net/browse/OSF-8053