### PR TITLE
Remove usages of current_user_gravatar and get_gravitar route [OSF-7996]

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,8 +10,8 @@ from flask import Flask
 from nose.tools import *  # noqa (PEP8 asserts)
 import blinker
 
-from tests.base import OsfTestCase
-from osf_tests.factories import RegistrationFactory
+from tests.base import OsfTestCase, DbTestCase
+from osf_tests.factories import RegistrationFactory, UserFactory
 
 from framework.routing import Rule, json_renderer
 from framework.utils import secure_filename
@@ -22,6 +22,7 @@ from website.util import paths
 from website.util.mimetype import get_mimetype
 from website.util import web_url_for, api_url_for, is_json_request, waterbutler_url_for, conjunct, api_v2_url
 from website.project import utils as project_utils
+from website.profile import utils as profile_utils
 from website.util.time import throttle_period_expired
 
 try:
@@ -424,6 +425,20 @@ class TestProjectUtils(OsfTestCase):
             self.set_registered_date(reg, tdiff)
         regs = [r for r in project_utils.recent_public_registrations(7)]
         assert_equal(len(regs), 7)
+
+
+class TestProfileUtils(DbTestCase):
+
+    def setUp(self):
+        self.user = UserFactory()
+
+    def test_get_other_user_gravatar_default_size(self):
+        gravitar = profile_utils.get_gravatar(self.user)
+        assert_true(gravitar)
+
+    def test_get_other_user_gravatar_specific_size(self):
+        gravitar = profile_utils.get_gravatar(self.user, size=25)
+        assert_true(gravitar)
 
 
 class TestSignalUtils(unittest.TestCase):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1316,48 +1316,6 @@ class TestUserProfile(OsfTestCase):
         res = self.app.put_json(url, payload, auth=self.user.auth)
         assert_equal(res.status_code, 200)
 
-    def test_get_current_user_gravatar_default_size(self):
-        url = api_url_for('current_user_gravatar')
-        res = self.app.get(url, auth=self.user.auth)
-        current_user_gravatar = res.json['gravatar_url']
-        assert_true(current_user_gravatar is not None)
-        url = api_url_for('get_gravatar', uid=self.user._id)
-        res = self.app.get(url, auth=self.user.auth)
-        my_user_gravatar = res.json['gravatar_url']
-        assert_equal(current_user_gravatar, my_user_gravatar)
-
-    def test_get_other_user_gravatar_default_size(self):
-        user2 = AuthUserFactory()
-        url = api_url_for('current_user_gravatar')
-        res = self.app.get(url, auth=self.user.auth)
-        current_user_gravatar = res.json['gravatar_url']
-        url = api_url_for('get_gravatar', uid=user2._id)
-        res = self.app.get(url, auth=self.user.auth)
-        user2_gravatar = res.json['gravatar_url']
-        assert_true(user2_gravatar is not None)
-        assert_not_equal(current_user_gravatar, user2_gravatar)
-
-    def test_get_current_user_gravatar_specific_size(self):
-        url = api_url_for('current_user_gravatar')
-        res = self.app.get(url, auth=self.user.auth)
-        current_user_default_gravatar = res.json['gravatar_url']
-        url = api_url_for('current_user_gravatar', size=11)
-        res = self.app.get(url, auth=self.user.auth)
-        current_user_small_gravatar = res.json['gravatar_url']
-        assert_true(current_user_small_gravatar is not None)
-        assert_not_equal(current_user_default_gravatar, current_user_small_gravatar)
-
-    def test_get_other_user_gravatar_specific_size(self):
-        user2 = AuthUserFactory()
-        url = api_url_for('get_gravatar', uid=user2._id)
-        res = self.app.get(url, auth=self.user.auth)
-        gravatar_default_size = res.json['gravatar_url']
-        url = api_url_for('get_gravatar', uid=user2._id, size=11)
-        res = self.app.get(url, auth=self.user.auth)
-        gravatar_small = res.json['gravatar_url']
-        assert_true(gravatar_small is not None)
-        assert_not_equal(gravatar_default_size, gravatar_small)
-
     def test_update_user_timezone(self):
         assert_equal(self.user.timezone, 'Etc/UTC')
         payload = {'timezone': 'America/New_York', 'id': self.user._id}

--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -92,15 +92,6 @@ def get_public_components(uid=None, user=None):
         for node in nodes
     ]
 
-@must_be_logged_in
-def current_user_gravatar(size=None, **kwargs):
-    user_id = kwargs['auth'].user._id
-    return get_gravatar(user_id, size=size)
-
-
-def get_gravatar(uid, size=None):
-    return {'gravatar_url': profile_utils.get_gravatar(User.load(uid), size=size)}
-
 
 def date_or_none(date):
     try:

--- a/website/routes.py
+++ b/website/routes.py
@@ -39,6 +39,7 @@ from website import views as website_views
 from website.citations import views as citation_views
 from website.search import views as search_views
 from website.oauth import views as oauth_views
+from website.profile.utils import get_gravatar
 from website.profile import views as profile_views
 from website.project import views as project_views
 from addons.base import views as addon_views
@@ -73,7 +74,7 @@ def get_globals():
         'user_locale': user.locale if user and user.locale else '',
         'user_timezone': user.timezone if user and user.timezone else '',
         'user_url': user.url if user else '',
-        'user_gravatar': profile_views.current_user_gravatar(size=25)['gravatar_url'] if user else '',
+        'user_gravatar': get_gravatar(user=user, size=25) if user else '',
         'user_email_verifications': user.unconfirmed_email_info if user else [],
         'user_api_url': user.api_url if user else '',
         'user_entry_point': metrics.get_entry_point(user) if user else '',
@@ -846,31 +847,6 @@ def make_url_map(app):
             profile_views.delete_external_identity,
             json_renderer,
         ),
-
-        Rule(
-            [
-                '/profile/gravatar/',
-                '/users/gravatar/',
-                '/profile/gravatar/<size>',
-                '/users/gravatar/<size>',
-            ],
-            'get',
-            profile_views.current_user_gravatar,
-            json_renderer,
-        ),
-
-        Rule(
-            [
-                '/profile/<uid>/gravatar/',
-                '/users/<uid>/gravatar/',
-                '/profile/<uid>/gravatar/<size>',
-                '/users/<uid>/gravatar/<size>',
-            ],
-            'get',
-            profile_views.get_gravatar,
-            json_renderer,
-        ),
-
 
         # Rules for user profile configuration
         Rule('/settings/names/', 'get', profile_views.serialize_names, json_renderer),


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

The `current_user_gravatar` endpoint is unnecessary. It is used in website.routes.get_globals, but we can just use `website.profile.utils.get_gravatar` for that. Removing that call should also remove unnecessary queries for the currently logged-in user (made in the must_be_logged_in decorator).

## Changes

- Remove routes that use methods
- Remove tests that called those routes
- Use `get_gravitar` method located in `website/profile/utils.py` for globals
- Add tests for profile util get_gravitar


## Side effects
None anticipated


## Ticket
https://openscience.atlassian.net/browse/OSF-7996