### PR TITLE
[feature] Prevent Unconfirmed User Contributor Additions (API) [OSF-7975]

### DIFF
--- a/api_tests/nodes/views/test_node_contributors_list.py
+++ b/api_tests/nodes/views/test_node_contributors_list.py
@@ -1110,7 +1110,8 @@ class TestNodeContributorAdd(NodeCRUDTestCase):
         assert_equal(res.status_code, 404)
         assert_equal(
             res.json['errors'][0]['detail'],
-            'Cannot add unconfirmed user {} to node {}'.format(unconfirmed_user._id, self.public_project._id)
+            'Cannot add unconfirmed user {} to node {} by guid. Add an unregistered contributor with fullname and email.'
+            .format(unconfirmed_user._id, self.public_project._id)
         )
 
 

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -1240,6 +1240,11 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             contributor = OSFUser.load(user_id)
             if not contributor:
                 raise ValueError('User with id {} was not found.'.format(user_id))
+            if not contributor.is_registered:
+                raise ValueError(
+                    'Cannot add unconfirmed user {} to node {} by guid. Add an unregistered contributor with fullname and email.'
+                    .format(user_id, self._id)
+                )
             if self.contributor_set.filter(user=contributor).exists():
                 raise ValidationValueError('{} is already a contributor.'.format(contributor.fullname))
             contributor, _ = self.add_contributor(contributor=contributor, auth=auth, visible=bibliographic,


### PR DESCRIPTION
#### Purpose
- Prevent unconfirmed users from being added as contributors via the API.

#### Changes
- Check `user.is_registered` in `node.add_contributors_registered_or_not`

#### Side Effects
- None expected

#### Ticket
- [OSF-7975](https://openscience.atlassian.net/browse/OSF-7975)
