### PR TITLE
[Hotfix] Fix TCI build

### DIFF
--- a/admin_tests/users/test_views.py
+++ b/admin_tests/users/test_views.py
@@ -452,7 +452,7 @@ class TestUserWorkshopFormView(AdminTestCase):
         nt.assert_equal(user_nodes_created_since_workshop, 0)
 
     def test_user_activity_after_workshop_only(self):
-        activity_date = timezone.now() + timedelta(days=1)
+        activity_date = timezone.now() + timedelta(hours=25)
         self._create_nodes_and_add_logs(first_activity_date=activity_date)
 
         result_csv = self._create_and_parse_test_file(self.data)
@@ -477,7 +477,7 @@ class TestUserWorkshopFormView(AdminTestCase):
         nt.assert_equal(user_nodes_created_since_workshop, 0)
 
     def test_user_activity_day_of_workshop_and_after(self):
-        activity_date = timezone.now() + timedelta(days=1)
+        activity_date = timezone.now() + timedelta(hours=25)
         self._create_nodes_and_add_logs(
             first_activity_date=self.workshop_date,
             second_activity_date=activity_date
@@ -492,7 +492,7 @@ class TestUserWorkshopFormView(AdminTestCase):
 
     def test_user_activity_before_workshop_and_after(self):
         before_activity_date = timezone.now() - timedelta(days=1)
-        after_activity_date = timezone.now() + timedelta(days=1)
+        after_activity_date = timezone.now() + timedelta(hours=25)
         self._create_nodes_and_add_logs(
             first_activity_date=before_activity_date,
             second_activity_date=after_activity_date


### PR DESCRIPTION
## Purpose
Fix TCI build

## Changes
* Edit tests to conform with expected behavior based on [code](https://github.com/CenterForOpenScience/osf.io/blob/581683795ab27dff21b8e9f025214a15919757bd/admin/users/views.py#L373-L381)

## Alternate solutions
Because I'm not certain "expected behavior based on code" equates to "expected behavior", two possible alternatives were considered:
```
diff --git a/admin/users/views.py b/admin/users/views.py
index 0d2dde4..b68d40a 100644
--- a/admin/users/views.py
+++ b/admin/users/views.py
@@ -372,13 +372,11 @@ class UserWorkshopFormView(PermissionRequiredMixin, FormView):

     @staticmethod
     def get_user_logs_since_workshop(user, workshop_date):
-        query_date = workshop_date + timedelta(days=1)
-        return NodeLog.objects.filter(user=user, date__gt=query_date)
+        return NodeLog.objects.filter(user=user, date__gt=workshop_date)

     @staticmethod
     def get_user_nodes_since_workshop(user, workshop_date):
-        query_date = workshop_date + timedelta(days=1)
-        return Node.objects.filter(creator=user, date_created__gt=query_date)
+        return Node.objects.filter(creator=user, date_created__gt=workshop_date)

     def parse(self, csv_file):
         """ Parse and add to csv file.
```
and
```
diff --git a/admin/users/views.py b/admin/users/views.py
index 0d2dde4..3682397 100644
--- a/admin/users/views.py
+++ b/admin/users/views.py
@@ -372,12 +372,12 @@ class UserWorkshopFormView(PermissionRequiredMixin, FormView):

     @staticmethod
     def get_user_logs_since_workshop(user, workshop_date):
-        query_date = workshop_date + timedelta(days=1)
+        query_date = workshop_date + timedelta(days=1) - timedelta(hours=workshop_date.hour, minutes=workshop_date.minute, seconds=workshop_date.second, microseconds=workshop_date.microsecond)
         return NodeLog.objects.filter(user=user, date__gt=query_date)

     @staticmethod
     def get_user_nodes_since_workshop(user, workshop_date):
-        query_date = workshop_date + timedelta(days=1)
+        query_date = workshop_date + timedelta(days=1) - timedelta(hours=workshop_date.hour, minutes=workshop_date.minute, seconds=workshop_date.second, microseconds=workshop_date.microsecond)
         return Node.objects.filter(creator=user, date_created__gt=query_date)

     def parse(self, csv_file):
```
The former assumes that any logs/nodes created immediately after the workshop date are desired, even if only by seconds.
The latter assumes that any logs/nodes created anytime on a day following the workshop date are desired, and is convoluted (rather than just calling `.date()`) to avoid issues with `date`/`datetime` type conversion and timezone naïveté. 

## Side effects
None expected

## Ticket
None