### PR TITLE
[Feature] Convert api_tests/comments into pytest [OSF-8082]

### DIFF
--- a/api_tests/comments/views/test_comment_detail.py
+++ b/api_tests/comments/views/test_comment_detail.py
@@ -2,6 +2,7 @@ import pytest
 
 import mock
 from urlparse import urlparse
+
 from framework.auth import core
 from osf.models import Guid
 from api.base.settings.defaults import API_BASE

--- a/api_tests/comments/views/test_comment_detail.py
+++ b/api_tests/comments/views/test_comment_detail.py
@@ -34,7 +34,7 @@ class CommentDetailMixin(object):
     def non_contributor(self):
         return AuthUserFactory()
 
-    # private_project_with_comments
+    # check if all necessary fixtures are setup by subclass
     @pytest.fixture()
     def private_project(self):
         raise NotImplementedError

--- a/api_tests/comments/views/test_comment_detail.py
+++ b/api_tests/comments/views/test_comment_detail.py
@@ -4,8 +4,7 @@ import mock
 from urlparse import urlparse
 
 from framework.auth import core
-from framework.guid.model import Guid
-
+from osf.models import Guid
 from api.base.settings.defaults import API_BASE
 from api.base.settings import osf_settings
 from api_tests import utils as test_utils

--- a/api_tests/comments/views/test_comment_detail.py
+++ b/api_tests/comments/views/test_comment_detail.py
@@ -1,8 +1,7 @@
+import pytest
+
 import mock
 from urlparse import urlparse
-
-import pytest
-from nose.tools import *  # flake8: noqa
 
 from framework.auth import core
 from framework.guid.model import Guid
@@ -11,6 +10,7 @@ from api.base.settings.defaults import API_BASE
 from api.base.settings import osf_settings
 from api_tests import utils as test_utils
 from tests.base import ApiTestCase
+from addons.wiki.tests.factories import NodeWikiFactory
 from osf_tests.factories import (
     ProjectFactory,
     AuthUserFactory,
@@ -18,16 +18,85 @@ from osf_tests.factories import (
     RegistrationFactory,
     PrivateLinkFactory,
 )
-from addons.wiki.tests.factories import NodeWikiFactory
 
-
+@pytest.mark.django_db
 class CommentDetailMixin(object):
 
-    def setUp(self):
-        super(CommentDetailMixin, self).setUp()
-        self.user = AuthUserFactory()
-        self.contributor = AuthUserFactory()
-        self.non_contributor = AuthUserFactory()
+    @pytest.fixture()
+    def user(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def contributor(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def non_contributor(self):
+        return AuthUserFactory()
+
+    # private_project_with_comments
+    @pytest.fixture()
+    def private_project(self):
+        raise NotImplementedError
+
+    @pytest.fixture()
+    def comment(self):
+        raise NotImplementedError
+
+    @pytest.fixture()
+    def private_url(self):
+        raise NotImplementedError
+
+    @pytest.fixture()
+    def payload(self):
+        raise NotImplementedError
+
+    # public_project_with_comments
+    @pytest.fixture()
+    def public_project(self):
+        raise NotImplementedError
+
+    @pytest.fixture()
+    def public_comment(self):
+        raise NotImplementedError
+
+    @pytest.fixture()
+    def public_comment_reply(self):
+        raise NotImplementedError
+
+    @pytest.fixture()
+    def public_url(self):
+        raise NotImplementedError
+
+    @pytest.fixture()
+    def public_comment_payload(self):
+        raise NotImplementedError
+
+    # registration_with_comments
+    @pytest.fixture()
+    def registration(self):
+        raise NotImplementedError
+
+    @pytest.fixture()
+    def registration_url(self):
+        raise NotImplementedError
+
+    @pytest.fixture()
+    def registration_comment(self):
+        raise NotImplementedError
+
+    @pytest.fixture()
+    def comment_url(self):
+        raise NotImplementedError
+
+    @pytest.fixture()
+    def registration_comment_reply(self):
+        raise NotImplementedError
+
+    @pytest.fixture()
+    def replies_url(self):
+        raise NotImplementedError
+
 
     def _set_up_payload(self, target_id, content='test', has_content=True):
         payload = {
@@ -44,675 +113,722 @@ class CommentDetailMixin(object):
             payload['data']['attributes']['content'] = content
         return payload
 
-    def _set_up_private_project_with_comment(self):
-        raise NotImplementedError
+    def test_private_node_comments_related_auth(self, app, user, contributor, non_contributor, comment, private_url):
+        # test_private_node_logged_in_contributor_can_view_comment
+        res = app.get(private_url, auth=user.auth)
+        assert res.status_code == 200
+        assert comment._id == res.json['data']['id']
+        assert comment.content == res.json['data']['attributes']['content']
 
-    def _set_up_public_project_with_comment(self):
-        raise NotImplementedError
+        # def test_private_node_logged_in_non_contributor_cannot_view_comment
+        res = app.get(private_url, auth=non_contributor.auth, expect_errors=True)
+        assert res.status_code == 403
+        assert res.json['errors'][0]['detail'] == 'You do not have permission to perform this action.'
 
-    def _set_up_registration_with_comment(self):
-        raise NotImplementedError
+        # def test_private_node_logged_out_user_cannot_view_comment
+        res = app.get(private_url, expect_errors=True)
+        assert res.status_code == 401
+        assert res.json['errors'][0]['detail'] == 'Authentication credentials were not provided.'
 
-    def test_private_node_logged_in_contributor_can_view_comment(self):
-        self._set_up_private_project_with_comment()
-        res = self.app.get(self.private_url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(self.comment._id, res.json['data']['id'])
-        assert_equal(self.comment.content, res.json['data']['attributes']['content'])
-
-    def test_private_node_logged_in_non_contributor_cannot_view_comment(self):
-        self._set_up_private_project_with_comment()
-        res = self.app.get(self.private_url, auth=self.non_contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
-        assert_equal(res.json['errors'][0]['detail'], 'You do not have permission to perform this action.')
-
-    def test_private_node_logged_out_user_cannot_view_comment(self):
-        self._set_up_private_project_with_comment()
-        res = self.app.get(self.private_url, expect_errors=True)
-        assert_equal(res.status_code, 401)
-        assert_equal(res.json['errors'][0]['detail'], 'Authentication credentials were not provided.')
-
-    def test_private_node_user_with_private_link_can_see_comment(self):
-        self._set_up_private_project_with_comment()
+    def test_private_node_user_with_private_and_anonymous_link_misc(self, app, private_project, comment):
+        # def test_private_node_user_with_private_link_can_see_comment
         private_link = PrivateLinkFactory(anonymous=False)
-        private_link.nodes.add(self.private_project)
+        private_link.nodes.add(private_project)
         private_link.save()
-        res = self.app.get('/{}comments/{}/'.format(API_BASE, self.comment._id), {'view_only': private_link.key}, expect_errors=True)
-        assert_equal(res.status_code, 200)
-        assert_equal(self.comment._id, res.json['data']['id'])
-        assert_equal(self.comment.content, res.json['data']['attributes']['content'])
+        res = app.get('/{}comments/{}/'.format(API_BASE, comment._id), {'view_only': private_link.key}, expect_errors=True)
+        assert res.status_code == 200
+        assert comment._id == res.json['data']['id']
+        assert comment.content == res.json['data']['attributes']['content']
 
-    def test_private_node_user_with_anonymous_link_cannot_see_commenter_info(self):
-        self._set_up_private_project_with_comment()
+        # test_private_node_user_with_anonymous_link_cannot_see_commenter_info
         private_link = PrivateLinkFactory(anonymous=True)
-        private_link.nodes.add(self.private_project)
+        private_link.nodes.add(private_project)
         private_link.save()
-        res = self.app.get('/{}comments/{}/'.format(API_BASE, self.comment._id), {'view_only': private_link.key})
-        assert_equal(res.status_code, 200)
-        assert_equal(self.comment._id, res.json['data']['id'])
-        assert_equal(self.comment.content, res.json['data']['attributes']['content'])
-        assert_not_in('user', res.json['data']['relationships'])
+        res = app.get('/{}comments/{}/'.format(API_BASE, comment._id), {'view_only': private_link.key})
+        assert res.status_code == 200
+        assert comment._id == res.json['data']['id']
+        assert comment.content == res.json['data']['attributes']['content']
+        assert 'user' not in res.json['data']['relationships']
 
-    def test_private_node_user_with_anonymous_link_cannot_see_mention_info(self):
-        self._set_up_private_project_with_comment()
-        self.comment.content = 'test with [@username](userlink) and @mention'
-        self.comment.save()
-        private_link = PrivateLinkFactory(anonymous=True)
-        private_link.nodes.add(self.private_project)
-        private_link.save()
-        res = self.app.get('/{}comments/{}/'.format(API_BASE, self.comment._id), {'view_only': private_link.key})
-        assert_equal(res.status_code, 200)
-        assert_equal(self.comment._id, res.json['data']['id'])
-        assert_equal( 'test with @A User and @mention', res.json['data']['attributes']['content'])
+        # test_private_node_user_with_anonymous_link_cannot_see_mention_info
+        comment.content = 'test with [@username](userlink) and @mention'
+        comment.save()
+        res = app.get('/{}comments/{}/'.format(API_BASE, comment._id), {'view_only': private_link.key})
+        assert res.status_code == 200
+        assert comment._id == res.json['data']['id']
+        assert 'test with @A User and @mention' == res.json['data']['attributes']['content']
 
-    def test_public_node_logged_in_contributor_can_view_comment(self):
-        self._set_up_public_project_with_comment()
-        res = self.app.get(self.public_url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(self.public_comment._id, res.json['data']['id'])
-        assert_equal(self.public_comment.content, res.json['data']['attributes']['content'])
+    def test_public_node_comment_auth_misc(self, app, user, non_contributor, public_project, public_url, public_comment, registration_comment, comment_url):
+        # test_public_node_logged_in_contributor_can_view_comment
+        res = app.get(public_url, auth=user.auth)
+        assert res.status_code == 200
+        assert public_comment._id == res.json['data']['id']
+        assert public_comment.content == res.json['data']['attributes']['content']
 
-    def test_public_node_logged_in_non_contributor_can_view_comment(self):
-        self._set_up_public_project_with_comment()
-        res = self.app.get(self.public_url, auth=self.non_contributor.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(self.public_comment._id, res.json['data']['id'])
-        assert_equal(self.public_comment.content, res.json['data']['attributes']['content'])
+        # test_public_node_logged_in_non_contributor_can_view_comment
+        res = app.get(public_url, auth=non_contributor.auth)
+        assert res.status_code == 200
+        assert public_comment._id == res.json['data']['id']
+        assert public_comment.content == res.json['data']['attributes']['content']
 
-    def test_public_node_logged_out_user_can_view_comment(self):
-        self._set_up_public_project_with_comment()
-        res = self.app.get(self.public_url)
-        assert_equal(res.status_code, 200)
-        assert_equal(self.public_comment._id, res.json['data']['id'])
-        assert_equal(self.public_comment.content, res.json['data']['attributes']['content'])
+        # test_public_node_logged_out_user_can_view_comment
+        res = app.get(public_url)
+        assert res.status_code == 200
+        assert public_comment._id == res.json['data']['id']
+        assert public_comment.content == res.json['data']['attributes']['content']
 
-    def test_public_node_user_with_private_link_can_view_comment(self):
-        self._set_up_public_project_with_comment()
+        # test_registration_logged_in_contributor_can_view_comment
+        res = app.get(comment_url, auth=user.auth)
+        assert res.status_code == 200
+        assert registration_comment._id == res.json['data']['id']
+        assert registration_comment.content == res.json['data']['attributes']['content']
+
+        # test_public_node_user_with_private_link_can_view_comment
         private_link = PrivateLinkFactory(anonymous=False)
-        private_link.nodes.add(self.public_project)
+        private_link.nodes.add(public_project)
         private_link.save()
-        res = self.app.get('/{}comments/{}/'.format(API_BASE, self.public_comment._id), {'view_only': private_link.key}, expect_errors=True)
-        assert_equal(self.public_comment._id, res.json['data']['id'])
-        assert_equal(self.public_comment.content, res.json['data']['attributes']['content'])
+        res = app.get('/{}comments/{}/'.format(API_BASE, public_comment._id), {'view_only': private_link.key}, expect_errors=True)
+        assert public_comment._id == res.json['data']['id']
+        assert public_comment.content == res.json['data']['attributes']['content']
 
-    def test_registration_logged_in_contributor_can_view_comment(self):
-        self._set_up_registration_with_comment()
-        res = self.app.get(self.comment_url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(self.registration_comment._id, res.json['data']['id'])
-        assert_equal(self.registration_comment.content, res.json['data']['attributes']['content'])
+    def test_comment_has_multiple_links(self, app, user, public_url, public_project, public_comment, public_comment_reply, comment_url, registration):
+        res = app.get(public_url)
+        assert res.status_code == 200
+        # test_comment_has_user_link
+        url_user = res.json['data']['relationships']['user']['links']['related']['href']
+        expected_url = '/{}users/{}/'.format(API_BASE, user._id)
+        assert urlparse(url_user).path == expected_url
 
-    def test_comment_has_user_link(self):
-        self._set_up_public_project_with_comment()
-        res = self.app.get(self.public_url)
-        url = res.json['data']['relationships']['user']['links']['related']['href']
-        expected_url = '/{}users/{}/'.format(API_BASE, self.user._id)
-        assert_equal(res.status_code, 200)
-        assert_equal(urlparse(url).path, expected_url)
+        # test_comment_has_node_link
+        url_node = res.json['data']['relationships']['node']['links']['related']['href']
+        expected_url = '/{}nodes/{}/'.format(API_BASE, public_project._id)
+        assert urlparse(url_node).path == expected_url
 
-    def test_comment_has_node_link(self):
-        self._set_up_public_project_with_comment()
-        res = self.app.get(self.public_url)
+        # test_comment_has_replies_link
+        url_replies = res.json['data']['relationships']['replies']['links']['related']['href']
+        uri = test_utils.urlparse_drop_netloc(url_replies)
+        res_uri = app.get(uri)
+        assert res_uri.status_code == 200
+        assert res_uri.json['data'][0]['type'] == 'comments'
+
+        # test_comment_has_reports_link
+        url_reports = res.json['data']['relationships']['reports']['links']['related']['href']
+        expected_url = '/{}comments/{}/reports/'.format(API_BASE, public_comment._id)
+        assert urlparse(url_reports).path == expected_url
+
+        # test_registration_comment_has_node_link
+        res = app.get(comment_url, auth=user.auth)
         url = res.json['data']['relationships']['node']['links']['related']['href']
-        expected_url = '/{}nodes/{}/'.format(API_BASE, self.public_project._id)
-        assert_equal(res.status_code, 200)
-        assert_equal(urlparse(url).path, expected_url)
+        expected_url = '/{}registrations/{}/'.format(API_BASE, registration._id)
+        assert res.status_code == 200
+        assert urlparse(url).path == expected_url
 
-    def test_registration_comment_has_node_link(self):
-        self._set_up_registration_with_comment()
-        res = self.app.get(self.comment_url, auth=self.user.auth)
-        url = res.json['data']['relationships']['node']['links']['related']['href']
-        expected_url = '/{}registrations/{}/'.format(API_BASE, self.registration._id)
-        assert_equal(res.status_code, 200)
-        assert_equal(urlparse(url).path, expected_url)
+    def test_private_node_comment_auth_misc(self, app, user, non_contributor, private_url, payload):
+        # test_private_node_only_logged_in_contributor_commenter_can_update_comment
+        res = app.put_json_api(private_url, payload, auth=user.auth)
+        assert res.status_code == 200
+        assert payload['data']['attributes']['content'] == res.json['data']['attributes']['content']
 
-    def test_comment_has_replies_link(self):
-        self._set_up_public_project_with_comment()
-        res = self.app.get(self.public_url)
-        assert_equal(res.status_code, 200)
-        url = res.json['data']['relationships']['replies']['links']['related']['href']
-        uri = test_utils.urlparse_drop_netloc(url)
-        res = self.app.get(uri)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.json['data'][0]['type'], 'comments')
+        # test_private_node_logged_in_non_contributor_cannot_update_comment
+        res = app.put_json_api(private_url, payload, auth=non_contributor.auth, expect_errors=True)
+        assert res.status_code == 403
+        assert res.json['errors'][0]['detail'] == 'You do not have permission to perform this action.'
 
-    def test_comment_has_reports_link(self):
-        self._set_up_public_project_with_comment()
-        res = self.app.get(self.public_url)
-        url = res.json['data']['relationships']['reports']['links']['related']['href']
-        expected_url = '/{}comments/{}/reports/'.format(API_BASE, self.public_comment._id)
-        assert_equal(res.status_code, 200)
-        assert_equal(urlparse(url).path, expected_url)
+        # test_private_node_logged_out_user_cannot_update_comment
+        res = app.put_json_api(private_url, payload, expect_errors=True)
+        assert res.status_code == 401
+        assert res.json['errors'][0]['detail'] == 'Authentication credentials were not provided.'
 
-    def test_private_node_only_logged_in_contributor_commenter_can_update_comment(self):
-        self._set_up_private_project_with_comment()
-        res = self.app.put_json_api(self.private_url, self.payload, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(self.payload['data']['attributes']['content'], res.json['data']['attributes']['content'])
+    def test_public_node_comment_auth_misc(self, app, user, contributor, non_contributor, public_url, public_comment, public_comment_payload):
+        # test_public_node_only_contributor_commenter_can_update_comment
+        res = app.put_json_api(public_url, public_comment_payload, auth=user.auth)
+        assert res.status_code == 200
+        assert public_comment_payload['data']['attributes']['content'] == res.json['data']['attributes']['content']
 
-    def test_private_node_logged_in_non_contributor_cannot_update_comment(self):
-        self._set_up_private_project_with_comment()
-        res = self.app.put_json_api(self.private_url, self.payload, auth=self.non_contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
-        assert_equal(res.json['errors'][0]['detail'], 'You do not have permission to perform this action.')
+        # test_public_node_contributor_cannot_update_other_users_comment
+        res = app.put_json_api(public_url, public_comment_payload, auth=contributor.auth, expect_errors=True)
+        assert res.status_code == 403
+        assert res.json['errors'][0]['detail'] == 'You do not have permission to perform this action.'
 
-    def test_private_node_logged_out_user_cannot_update_comment(self):
-        self._set_up_private_project_with_comment()
-        res = self.app.put_json_api(self.private_url, self.payload, expect_errors=True)
-        assert_equal(res.status_code, 401)
-        assert_equal(res.json['errors'][0]['detail'], 'Authentication credentials were not provided.')
+        # test_public_node_non_contributor_cannot_update_other_users_comment
+        res = app.put_json_api(public_url, public_comment_payload, auth=non_contributor.auth, expect_errors=True)
+        assert res.status_code == 403
+        assert res.json['errors'][0]['detail'] == 'You do not have permission to perform this action.'
 
-    def test_public_node_only_contributor_commenter_can_update_comment(self):
-        self._set_up_public_project_with_comment()
-        res = self.app.put_json_api(self.public_url, self.public_comment_payload, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(self.public_comment_payload['data']['attributes']['content'], res.json['data']['attributes']['content'])
+        # test_public_node_logged_out_user_cannot_update_comment
+        res = app.put_json_api(public_url, public_comment_payload, expect_errors=True)
+        assert res.status_code == 401
+        assert res.json['errors'][0]['detail'] == 'Authentication credentials were not provided.'
 
-    def test_public_node_contributor_cannot_update_other_users_comment(self):
-        self._set_up_public_project_with_comment()
-        res = self.app.put_json_api(self.public_url, self.public_comment_payload, auth=self.contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
-        assert_equal(res.json['errors'][0]['detail'], 'You do not have permission to perform this action.')
-
-    def test_public_node_non_contributor_cannot_update_other_users_comment(self):
-        self._set_up_public_project_with_comment()
-        res = self.app.put_json_api(self.public_url, self.public_comment_payload, auth=self.non_contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
-        assert_equal(res.json['errors'][0]['detail'], 'You do not have permission to perform this action.')
-
-    def test_public_node_logged_out_user_cannot_update_comment(self):
-        self._set_up_public_project_with_comment()
-        res = self.app.put_json_api(self.public_url, self.public_comment_payload, expect_errors=True)
-        assert_equal(res.status_code, 401)
-        assert_equal(res.json['errors'][0]['detail'], 'Authentication credentials were not provided.')
-
-    def test_update_comment_cannot_exceed_max_length(self):
-        self._set_up_private_project_with_comment()
+    def test_update_comment_misc(self, app, user, private_url, comment):
+        # test_update_comment_cannot_exceed_max_length
         content = ('c' * (osf_settings.COMMENT_MAXLENGTH + 3))
-        payload = self._set_up_payload(self.comment._id, content=content)
-        res = self.app.put_json_api(self.private_url, payload, auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, 400)
-        assert_equal(res.json['errors'][0]['detail'],
+        payload = self._set_up_payload(comment._id, content=content)
+        res = app.put_json_api(private_url, payload, auth=user.auth, expect_errors=True)
+        assert res.status_code == 400
+        assert (res.json['errors'][0]['detail'] ==
                      'Ensure this field has no more than {} characters.'.format(str(osf_settings.COMMENT_MAXLENGTH)))
 
-    def test_update_comment_cannot_be_empty(self):
-        self._set_up_private_project_with_comment()
-        payload = self._set_up_payload(self.comment._id, content='')
-        res = self.app.put_json_api(self.private_url, payload, auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, 400)
-        assert_equal(res.json['errors'][0]['detail'], 'This field may not be blank.')
+        # test_update_comment_cannot_be_empty
+        payload = self._set_up_payload(comment._id, content='')
+        res = app.put_json_api(private_url, payload, auth=user.auth, expect_errors=True)
+        assert res.status_code == 400
+        assert res.json['errors'][0]['detail'] == 'This field may not be blank.'
 
-    def test_private_node_only_logged_in_contributor_commenter_can_delete_comment(self):
-        self._set_up_private_project_with_comment()
-        res = self.app.delete_json_api(self.private_url, auth=self.user.auth)
-        assert_equal(res.status_code, 204)
+    def test_private_node_only_logged_in_contributor_commenter_can_delete_comment(self, app, user, private_url):
+        res = app.delete_json_api(private_url, auth=user.auth)
+        assert res.status_code == 204
 
-    def test_private_node_only_logged_in_contributor_commenter_can_delete_own_reply(self):
-        self._set_up_private_project_with_comment()
-        reply_target = Guid.load(self.comment._id)
-        reply = CommentFactory(node=self.private_project, target=reply_target, user=self.user)
+    def test_private_node_only_logged_in_contributor_commenter_can_delete_own_reply(self, app, user, private_project, comment):
+        reply_target = Guid.load(comment._id)
+        reply = CommentFactory(node=private_project, target=reply_target, user=user)
         reply_url = '/{}comments/{}/'.format(API_BASE, reply._id)
-        res = self.app.delete_json_api(reply_url, auth=self.user.auth)
-        assert_equal(res.status_code, 204)
+        res = app.delete_json_api(reply_url, auth=user.auth)
+        assert res.status_code == 204
 
-    def test_private_node_only_logged_in_contributor_commenter_can_undelete_own_reply(self):
-        self._set_up_private_project_with_comment()
-        reply_target = Guid.load(self.comment._id)
-        reply = CommentFactory(node=self.private_project, target=reply_target, user=self.user)
+    def test_private_node_only_logged_in_contributor_commenter_can_undelete_own_reply(self, app, user, private_project, comment):
+        reply_target = Guid.load(comment._id)
+        reply = CommentFactory(node=private_project, target=reply_target, user=user)
         reply_url = '/{}comments/{}/'.format(API_BASE, reply._id)
         reply.is_deleted = True
         reply.save()
         payload = self._set_up_payload(reply._id, has_content=False)
-        res = self.app.patch_json_api(reply_url, payload, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_false(res.json['data']['attributes']['deleted'])
-        assert_equal(res.json['data']['attributes']['content'], reply.content)
+        res = app.patch_json_api(reply_url, payload, auth=user.auth)
+        assert res.status_code == 200
+        assert not res.json['data']['attributes']['deleted']
+        assert res.json['data']['attributes']['content'] == reply.content
 
-    def test_private_node_contributor_cannot_delete_other_users_comment(self):
-        self._set_up_private_project_with_comment()
-        res = self.app.delete_json_api(self.private_url, auth=self.contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
-        assert_equal(res.json['errors'][0]['detail'], 'You do not have permission to perform this action.')
+    def test_private_node_cannot_delete_comment_situation(self, app, user, contributor, non_contributor, private_url, comment):
+    # def test_private_node_contributor_cannot_delete_other_users_comment(self):
+        res = app.delete_json_api(private_url, auth=contributor.auth, expect_errors=True)
+        assert res.status_code == 403
+        assert res.json['errors'][0]['detail'] == 'You do not have permission to perform this action.'
 
-    def test_private_node_non_contributor_cannot_delete_comment(self):
-        self._set_up_private_project_with_comment()
-        res = self.app.delete_json_api(self.private_url, auth=self.non_contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
-        assert_equal(res.json['errors'][0]['detail'], 'You do not have permission to perform this action.')
+    # def test_private_node_non_contributor_cannot_delete_comment(self):
+        res = app.delete_json_api(private_url, auth=non_contributor.auth, expect_errors=True)
+        assert res.status_code == 403
+        assert res.json['errors'][0]['detail'] == 'You do not have permission to perform this action.'
 
-    def test_private_node_logged_out_user_cannot_delete_comment(self):
-        self._set_up_private_project_with_comment()
-        res = self.app.delete_json_api(self.private_url, expect_errors=True)
-        assert_equal(res.status_code, 401)
+    # def test_private_node_logged_out_user_cannot_delete_comment(self):
+        res = app.delete_json_api(private_url, expect_errors=True)
+        assert res.status_code == 401
 
-    def test_private_node_user_cannot_delete_already_deleted_comment(self):
-        self._set_up_private_project_with_comment()
-        self.comment.is_deleted = True
-        self.comment.save()
-        res = self.app.delete_json_api(self.private_url, auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, 400)
-        assert_equal(res.json['errors'][0]['detail'], 'Comment already deleted.')
+    # def test_private_node_user_cannot_delete_already_deleted_comment(self):
+        comment.is_deleted = True
+        comment.save()
+        res = app.delete_json_api(private_url, auth=user.auth, expect_errors=True)
+        assert res.status_code == 400
+        assert res.json['errors'][0]['detail'] == 'Comment already deleted.'
 
-    def test_private_node_only_logged_in_contributor_commenter_can_undelete_comment(self):
-        self._set_up_private_project_with_comment()
-        self.comment.is_deleted = True
-        self.comment.save()
-        url = '/{}comments/{}/'.format(API_BASE, self.comment._id)
-        payload = self._set_up_payload(self.comment._id, has_content=False)
-        res = self.app.patch_json_api(url, payload, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_false(res.json['data']['attributes']['deleted'])
-        assert_equal(res.json['data']['attributes']['content'], self.comment.content)
+    def test_private_node_only_logged_in_contributor_commenter_can_undelete_comment(self, app, user, comment):
+        comment.is_deleted = True
+        comment.save()
+        url = '/{}comments/{}/'.format(API_BASE, comment._id)
+        payload = self._set_up_payload(comment._id, has_content=False)
+        res = app.patch_json_api(url, payload, auth=user.auth)
+        assert res.status_code == 200
+        assert not res.json['data']['attributes']['deleted']
+        assert res.json['data']['attributes']['content'] == comment.content
 
-    def test_private_node_contributor_cannot_undelete_other_users_comment(self):
-        self._set_up_private_project_with_comment()
-        self.comment.is_deleted = True
-        self.comment.save()
-        url = '/{}comments/{}/'.format(API_BASE, self.comment._id)
-        payload = self._set_up_payload(self.comment._id, has_content=False)
-        res = self.app.patch_json_api(url, payload, auth=self.contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
+    def test_private_node_cannot_undelete_comment_situation(self, app, user, contributor, non_contributor, comment):
+        comment.is_deleted = True
+        comment.save()
+        url = '/{}comments/{}/'.format(API_BASE, comment._id)
+        payload = self._set_up_payload(comment._id, has_content=False)
 
-    def test_private_node_non_contributor_cannot_undelete_comment(self):
-        self._set_up_private_project_with_comment()
-        self.comment.is_deleted = True
-        self.comment.save()
-        url = '/{}comments/{}/'.format(API_BASE, self.comment._id)
-        payload = self._set_up_payload(self.comment._id, has_content=False)
-        res = self.app.patch_json_api(url, payload, auth=self.non_contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
+        # test_private_node_contributor_cannot_undelete_other_users_comment
+        res = app.patch_json_api(url, payload, auth=contributor.auth, expect_errors=True)
+        assert res.status_code == 403
 
-    def test_private_node_logged_out_user_cannot_undelete_comment(self):
-        self._set_up_private_project_with_comment()
-        self.comment.is_deleted = True
-        self.comment.save()
-        url = '/{}comments/{}/'.format(API_BASE, self.comment._id)
-        payload = self._set_up_payload(self.comment._id, has_content=False)
-        res = self.app.patch_json_api(url, payload, expect_errors=True)
-        assert_equal(res.status_code, 401)
+        # test_private_node_non_contributor_cannot_undelete_comment
+        res = app.patch_json_api(url, payload, auth=non_contributor.auth, expect_errors=True)
+        assert res.status_code == 403
 
-    def test_public_node_only_logged_in_contributor_commenter_can_delete_comment(self):
-        self._set_up_public_project_with_comment()
-        res = self.app.delete_json_api(self.public_url, auth=self.user.auth)
-        assert_equal(res.status_code, 204)
+        # test_private_node_logged_out_user_cannot_undelete_comment
+        res = app.patch_json_api(url, payload, expect_errors=True)
+        assert res.status_code == 401
 
-    def test_public_node_contributor_cannot_delete_other_users_comment(self):
-        self._set_up_public_project_with_comment()
-        res = self.app.delete_json_api(self.public_url, auth=self.contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
-        assert_equal(res.json['errors'][0]['detail'], 'You do not have permission to perform this action.')
+    def test_public_node_only_logged_in_contributor_commenter_can_delete_comment(self, app, user, public_url):
+        res = app.delete_json_api(public_url, auth=user.auth)
+        assert res.status_code == 204
 
-    def test_public_node_non_contributor_cannot_delete_other_users_comment(self):
-        self._set_up_public_project_with_comment()
-        res = self.app.delete_json_api(self.public_url, auth=self.non_contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
-        assert_equal(res.json['errors'][0]['detail'], 'You do not have permission to perform this action.')
+    def test_public_node_cannot_delete_comment_situations(self, app, user, contributor, non_contributor, public_url, public_comment):
+        # test_public_node_contributor_cannot_delete_other_users_comment
+        res = app.delete_json_api(public_url, auth=contributor.auth, expect_errors=True)
+        assert res.status_code == 403
+        assert res.json['errors'][0]['detail'] == 'You do not have permission to perform this action.'
 
-    def test_public_node_logged_out_user_cannot_delete_comment(self):
-        self._set_up_public_project_with_comment()
-        res = self.app.delete_json_api(self.public_url, expect_errors=True)
-        assert_equal(res.status_code, 401)
-        assert_equal(res.json['errors'][0]['detail'], 'Authentication credentials were not provided.')
+        # test_public_node_non_contributor_cannot_delete_other_users_comment
+        res = app.delete_json_api(public_url, auth=non_contributor.auth, expect_errors=True)
+        assert res.status_code == 403
+        assert res.json['errors'][0]['detail'] == 'You do not have permission to perform this action.'
 
-    def test_public_node_user_cannot_delete_already_deleted_comment(self):
-        self._set_up_public_project_with_comment()
-        self.public_comment.is_deleted = True
-        self.public_comment.save()
-        res = self.app.delete_json_api(self.public_url, auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, 400)
-        assert_equal(res.json['errors'][0]['detail'], 'Comment already deleted.')
+        # test_public_node_logged_out_user_cannot_delete_comment
+        res = app.delete_json_api(public_url, expect_errors=True)
+        assert res.status_code == 401
+        assert res.json['errors'][0]['detail'] == 'Authentication credentials were not provided.'
 
-    def test_private_node_only_logged_in_commenter_can_view_deleted_comment(self):
-        self._set_up_private_project_with_comment()
-        self.comment.is_deleted = True
-        self.comment.save()
-        url = '/{}comments/{}/'.format(API_BASE, self.comment._id)
-        res = self.app.get(url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['attributes']['content'], self.comment.content)
+        # test_public_node_user_cannot_delete_already_deleted_comment
+        public_comment.is_deleted = True
+        public_comment.save()
+        res = app.delete_json_api(public_url, auth=user.auth, expect_errors=True)
+        assert res.status_code == 400
+        assert res.json['errors'][0]['detail'] == 'Comment already deleted.'
 
-    def test_private_node_contributor_cannot_see_other_users_deleted_comment(self):
-        self._set_up_private_project_with_comment()
-        self.comment.is_deleted = True
-        self.comment.save()
-        url = '/{}comments/{}/'.format(API_BASE, self.comment._id)
-        res = self.app.get(url, auth=self.contributor.auth)
-        assert_equal(res.status_code, 200)
-        assert_is_none(res.json['data']['attributes']['content'])
+    def test_private_node_deleted_comment_auth_misc(self, app, user, contributor, comment, private_project):
+        comment.is_deleted = True
+        comment.save()
 
-    def test_private_node_logged_out_user_cannot_see_deleted_comment(self):
-        self._set_up_private_project_with_comment()
-        self.comment.is_deleted = True
-        self.comment.save()
-        url = '/{}comments/{}/'.format(API_BASE, self.comment._id)
-        res = self.app.get(url, expect_errors=True)
-        assert_equal(res.status_code, 401)
-        assert_equal(res.json['errors'][0]['detail'], 'Authentication credentials were not provided.')
+        # test_private_node_only_logged_in_commenter_can_view_deleted_comment
+        url = '/{}comments/{}/'.format(API_BASE, comment._id)
+        res = app.get(url, auth=user.auth)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['content'] == comment.content
 
-    def test_private_node_view_only_link_user_cannot_see_deleted_comment(self):
-        self._set_up_private_project_with_comment()
-        self.comment.is_deleted = True
-        self.comment.save()
+        # test_private_node_contributor_cannot_see_other_users_deleted_comment
+        url = '/{}comments/{}/'.format(API_BASE, comment._id)
+        res = app.get(url, auth=contributor.auth)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['content'] is None
 
+        # test_private_node_logged_out_user_cannot_see_deleted_comment
+        url = '/{}comments/{}/'.format(API_BASE, comment._id)
+        res = app.get(url, expect_errors=True)
+        assert res.status_code == 401
+        assert res.json['errors'][0]['detail'] == 'Authentication credentials were not provided.'
+
+        # test_private_node_view_only_link_user_cannot_see_deleted_comment
         private_link = PrivateLinkFactory(anonymous=False)
-        private_link.nodes.add(self.private_project)
+        private_link.nodes.add(private_project)
         private_link.save()
 
-        res = self.app.get('/{}comments/{}/'.format(API_BASE, self.comment._id), {'view_only': private_link.key}, expect_errors=True)
-        assert_equal(res.status_code, 200)
-        assert_is_none(res.json['data']['attributes']['content'])
+        res = app.get('/{}comments/{}/'.format(API_BASE, comment._id), {'view_only': private_link.key}, expect_errors=True)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['content'] is None
 
-    def test_private_node_anonymous_view_only_link_user_cannot_see_deleted_comment(self):
-        self._set_up_private_project_with_comment()
-        self.comment.is_deleted = True
-        self.comment.save()
-
+        # test_private_node_anonymous_view_only_link_user_cannot_see_deleted_comment
         anonymous_link = PrivateLinkFactory(anonymous=True)
-        anonymous_link.nodes.add(self.private_project)
+        anonymous_link.nodes.add(private_project)
         anonymous_link.save()
 
-        res = self.app.get('/{}comments/{}/'.format(API_BASE, self.comment._id), {'view_only': anonymous_link.key}, expect_errors=True)
-        assert_equal(res.status_code, 200)
-        assert_is_none(res.json['data']['attributes']['content'])
+        res = app.get('/{}comments/{}/'.format(API_BASE, comment._id), {'view_only': anonymous_link.key}, expect_errors=True)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['content'] is None
 
-    def test_public_node_only_logged_in_commenter_can_view_deleted_comment(self):
-        self._set_up_public_project_with_comment()
-        self.public_comment.is_deleted = True
-        self.public_comment.save()
-        url = '/{}comments/{}/'.format(API_BASE, self.public_comment._id)
-        res = self.app.get(url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['attributes']['content'], self.public_comment.content)
+    def test_public_node_deleted_comments_auth_misc(self, app, user, contributor, non_contributor, public_project, public_comment):
+        public_comment.is_deleted = True
+        public_comment.save()
+        url = '/{}comments/{}/'.format(API_BASE, public_comment._id)
 
-    def test_public_node_contributor_cannot_view_other_users_deleted_comment(self):
-        self._set_up_public_project_with_comment()
-        self.public_comment.is_deleted = True
-        self.public_comment.save()
-        url = '/{}comments/{}/'.format(API_BASE, self.public_comment._id)
-        res = self.app.get(url, auth=self.contributor.auth)
-        assert_equal(res.status_code, 200)
-        assert_is_none(res.json['data']['attributes']['content'])
+        # test_public_node_only_logged_in_commenter_can_view_deleted_comment
+        res = app.get(url, auth=user.auth)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['content'] == public_comment.content
 
-    def test_public_node_non_contributor_cannot_view_other_users_deleted_comment(self):
-        self._set_up_public_project_with_comment()
-        self.public_comment.is_deleted = True
-        self.public_comment.save()
-        url = '/{}comments/{}/'.format(API_BASE, self.public_comment._id)
-        res = self.app.get(url, auth=self.non_contributor.auth)
-        assert_equal(res.status_code, 200)
-        assert_is_none(res.json['data']['attributes']['content'])
+        # test_public_node_contributor_cannot_view_other_users_deleted_comment
 
-    def test_public_node_logged_out_user_cannot_view_deleted_comments(self):
-        self._set_up_public_project_with_comment()
-        self.public_comment.is_deleted = True
-        self.public_comment.save()
-        url = '/{}comments/{}/'.format(API_BASE, self.public_comment._id)
-        res = self.app.get(url)
-        assert_equal(res.status_code, 200)
-        assert_is_none(res.json['data']['attributes']['content'])
+        res = app.get(url, auth=contributor.auth)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['content'] is None
 
-    def test_public_node_view_only_link_user_cannot_see_deleted_comment(self):
-        self._set_up_public_project_with_comment()
-        self.public_comment.is_deleted = True
-        self.public_comment.save()
+        # test_public_node_non_contributor_cannot_view_other_users_deleted_comment
+        res = app.get(url, auth=non_contributor.auth)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['content'] is None
 
+        # test_public_node_logged_out_user_cannot_view_deleted_comments
+        res = app.get(url)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['content'] is None
+
+        # test_public_node_view_only_link_user_cannot_see_deleted_comment
         private_link = PrivateLinkFactory(anonymous=False)
-        private_link.nodes.add(self.public_project)
+        private_link.nodes.add(public_project)
         private_link.save()
 
-        res = self.app.get('/{}comments/{}/'.format(API_BASE, self.public_comment._id), {'view_only': private_link.key}, expect_errors=True)
-        assert_equal(res.status_code, 200)
-        assert_is_none(res.json['data']['attributes']['content'])
+        res = app.get('/{}comments/{}/'.format(API_BASE, public_comment._id), {'view_only': private_link.key}, expect_errors=True)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['content'] is None
 
 
-class TestCommentDetailView(CommentDetailMixin, ApiTestCase):
+class TestCommentDetailView(CommentDetailMixin):
 
-    def _set_up_private_project_with_comment(self):
-        self.private_project = ProjectFactory.create(is_public=False, creator=self.user)
-        self.private_project.add_contributor(self.contributor, save=True)
-        self.comment = CommentFactory(node=self.private_project, user=self.user)
-        self.private_url = '/{}comments/{}/'.format(API_BASE, self.comment._id)
-        self.payload = self._set_up_payload(self.comment._id)
+    # private_project_with_comments
+    @pytest.fixture()
+    def private_project(self, user, contributor):
+        private_project = ProjectFactory.create(is_public=False, creator=user)
+        private_project.add_contributor(contributor, save=True)
+        return private_project
 
-    def _set_up_public_project_with_comment(self):
-        self.public_project = ProjectFactory.create(is_public=True, creator=self.user)
-        self.public_project.add_contributor(self.contributor, save=True)
-        self.public_comment = CommentFactory(node=self.public_project, user=self.user)
-        reply_target = Guid.load(self.public_comment._id)
-        self.public_comment_reply = CommentFactory(node=self.public_project, target=reply_target, user=self.user)
-        self.public_url = '/{}comments/{}/'.format(API_BASE, self.public_comment._id)
-        self.public_comment_payload = self._set_up_payload(self.public_comment._id)
+    @pytest.fixture()
+    def comment(self, user, private_project):
+        return CommentFactory(node=private_project, user=user)
 
-    def _set_up_registration_with_comment(self):
-        self.registration = RegistrationFactory(creator=self.user)
-        self.registration_url = '/{}registrations/{}/'.format(API_BASE, self.registration._id)
-        self.registration_comment = CommentFactory(node=self.registration, user=self.user)
-        self.comment_url = '/{}comments/{}/'.format(API_BASE, self.registration_comment._id)
-        reply_target = Guid.load(self.registration_comment._id)
-        self.registration_comment_reply = CommentFactory(node=self.registration, target=reply_target, user=self.user)
-        self.replies_url = '/{}registrations/{}/comments/?filter[target]={}'.format(API_BASE, self.registration._id, self.registration_comment._id)
+    @pytest.fixture()
+    def private_url(self, comment):
+        return '/{}comments/{}/'.format(API_BASE, comment._id)
 
-    def test_comment_has_target_link_with_correct_type(self):
-        self._set_up_public_project_with_comment()
-        res = self.app.get(self.public_url)
+    @pytest.fixture()
+    def payload(self, comment):
+        return self._set_up_payload(comment._id)
+
+    # public_project_with_comments
+    @pytest.fixture()
+    def public_project(self, user, contributor):
+        public_project = ProjectFactory.create(is_public=True, creator=user)
+        public_project.add_contributor(contributor, save=True)
+        return public_project
+
+    @pytest.fixture()
+    def public_comment(self, user, public_project):
+        return CommentFactory(node=public_project, user=user)
+
+    @pytest.fixture()
+    def public_comment_reply(self, user, public_comment, public_project):
+        reply_target = Guid.load(public_comment._id)
+        return CommentFactory(node=public_project, target=reply_target, user=user)
+
+    @pytest.fixture()
+    def public_url(self, public_comment):
+        return '/{}comments/{}/'.format(API_BASE, public_comment._id)
+
+    @pytest.fixture()
+    def public_comment_payload(self, public_comment):
+        return self._set_up_payload(public_comment._id)
+
+    # registration_with_comments
+    @pytest.fixture()
+    def registration(self, user):
+        return RegistrationFactory(creator=user)
+
+    @pytest.fixture()
+    def registration_url(self, registration):
+        return '/{}registrations/{}/'.format(API_BASE, registration._id)
+
+    @pytest.fixture()
+    def registration_comment(self, user, registration):
+        return CommentFactory(node=registration, user=user)
+
+    @pytest.fixture()
+    def comment_url(self, registration_comment):
+        return '/{}comments/{}/'.format(API_BASE, registration_comment._id)
+
+    @pytest.fixture()
+    def registration_comment_reply(self, user, registration, registration_comment):
+        reply_target = Guid.load(registration_comment._id)
+        return CommentFactory(node=registration, target=reply_target, user=user)
+
+    @pytest.fixture()
+    def replies_url(self, registration, registration_comment):
+        return '/{}registrations/{}/comments/?filter[target]={}'.format(API_BASE, registration._id, registration_comment._id)
+
+
+    def test_comment_has_target_link_with_correct_type(self, app, public_url, public_project):
+        res = app.get(public_url)
         url = res.json['data']['relationships']['target']['links']['related']['href']
-        expected_url = '/{}nodes/{}/'.format(API_BASE, self.public_project._id)
+        expected_url = '/{}nodes/{}/'.format(API_BASE, public_project._id)
         target_type = res.json['data']['relationships']['target']['links']['related']['meta']['type']
         expected_type = 'nodes'
-        assert_equal(res.status_code, 200)
-        assert_equal(urlparse(url).path, expected_url)
-        assert_equal(target_type, expected_type)
+        assert res.status_code == 200
+        assert urlparse(url).path == expected_url
+        assert target_type == expected_type
 
-    def test_public_node_non_contributor_commenter_can_update_comment(self):
+    def test_public_node_non_contributor_commenter_can_update_comment(self, app, non_contributor):
         project = ProjectFactory(is_public=True, comment_level='public')
-        comment = CommentFactory(node=project, user=self.non_contributor)
+        comment = CommentFactory(node=project, user=non_contributor)
         url = '/{}comments/{}/'.format(API_BASE, comment._id)
         payload = self._set_up_payload(comment._id)
-        res = self.app.put_json_api(url, payload, auth=self.non_contributor.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(payload['data']['attributes']['content'], res.json['data']['attributes']['content'])
+        res = app.put_json_api(url, payload, auth=non_contributor.auth)
+        assert res.status_code == 200
+        assert payload['data']['attributes']['content'] == res.json['data']['attributes']['content']
 
-    def test_public_node_non_contributor_commenter_cannot_update_own_comment_if_comment_level_private(self):
+    def test_public_node_non_contributor_commenter_cannot_update_own_comment_if_comment_level_private(self, app, non_contributor):
         project = ProjectFactory(is_public=True, comment_level='public')
-        comment = CommentFactory(node=project, user=self.non_contributor)
+        comment = CommentFactory(node=project, user=non_contributor)
         project.comment_level = 'private'
         project.save()
         url = '/{}comments/{}/'.format(API_BASE, comment._id)
         payload = self._set_up_payload(comment._id)
-        res = self.app.put_json_api(url, payload, auth=self.non_contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
-        assert_equal(res.json['errors'][0]['detail'], 'You do not have permission to perform this action.')
+        res = app.put_json_api(url, payload, auth=non_contributor.auth, expect_errors=True)
+        assert res.status_code == 403
+        assert res.json['errors'][0]['detail'] == 'You do not have permission to perform this action.'
 
-    def test_public_node_non_contributor_commenter_can_delete_comment(self):
+    def test_public_node_non_contributor_commenter_can_delete_comment(self, app, non_contributor):
         project = ProjectFactory(is_public=True)
-        comment = CommentFactory(node=project, user=self.non_contributor)
+        comment = CommentFactory(node=project, user=non_contributor)
         url = '/{}comments/{}/'.format(API_BASE, comment._id)
-        res = self.app.delete_json_api(url, auth=self.non_contributor.auth)
-        assert_equal(res.status_code, 204)
+        res = app.delete_json_api(url, auth=non_contributor.auth)
+        assert res.status_code == 204
 
-    def test_registration_comment_has_usable_replies_relationship_link(self):
-        self._set_up_registration_with_comment()
-        res = self.app.get(self.registration_url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
+    def test_registration_comment_has_usable_replies_relationship_link(self, app, user, registration_url, registration_comment_reply):
+        res = app.get(registration_url, auth=user.auth)
+        assert res.status_code == 200
         comments_url = res.json['data']['relationships']['comments']['links']['related']['href']
         comments_uri = test_utils.urlparse_drop_netloc(comments_url)
-        comments_res = self.app.get(comments_uri, auth=self.user.auth)
-        assert_equal(comments_res.status_code, 200)
+        comments_res = app.get(comments_uri, auth=user.auth)
+        assert comments_res.status_code == 200
         replies_url = comments_res.json['data'][0]['relationships']['replies']['links']['related']['href']
         replies_uri = test_utils.urlparse_drop_netloc(replies_url)
-        replies_res = self.app.get(replies_uri, auth=self.user.auth)
+        replies_res = app.get(replies_uri, auth=user.auth)
         node_url = comments_res.json['data'][0]['relationships']['node']['links']['related']['href']
         node_uri = test_utils.urlparse_drop_netloc(node_url)
-        assert_equal(node_uri, self.registration_url)
+        assert node_uri == registration_url
 
-    def test_registration_comment_has_usable_node_relationship_link(self):
-        self._set_up_registration_with_comment()
-        res = self.app.get(self.registration_url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
+    def test_registration_comment_has_usable_node_relationship_link(self, app, user, registration, registration_url, registration_comment_reply):
+        res = app.get(registration_url, auth=user.auth)
+        assert res.status_code == 200
         comments_url = res.json['data']['relationships']['comments']['links']['related']['href']
         comments_uri = test_utils.urlparse_drop_netloc(comments_url)
-        comments_res = self.app.get(comments_uri, auth=self.user.auth)
-        assert_equal(comments_res.status_code, 200)
+        comments_res = app.get(comments_uri, auth=user.auth)
+        assert comments_res.status_code == 200
         node_url = comments_res.json['data'][0]['relationships']['node']['links']['related']['href']
         node_uri = test_utils.urlparse_drop_netloc(node_url)
-        node_res = self.app.get(node_uri, auth=self.user.auth)
-        assert_in(self.registration._id, node_res.json['data']['id'])
+        node_res = app.get(node_uri, auth=user.auth)
+        assert registration._id in node_res.json['data']['id']
+
+class TestFileCommentDetailView(CommentDetailMixin):
+    # private_project_with_comments
+    @pytest.fixture()
+    def private_project(self, user, contributor):
+        private_project = ProjectFactory.create(is_public=False, creator=user)
+        private_project.add_contributor(contributor, save=True)
+        return private_project
+
+    @pytest.fixture()
+    def file(self, user, private_project):
+        return test_utils.create_test_file(private_project, user)
+
+    @pytest.fixture()
+    def comment(self, user, private_project, file):
+        return CommentFactory(node=private_project, target=file.get_guid(), user=user)
+
+    @pytest.fixture()
+    def private_url(self, comment):
+        return '/{}comments/{}/'.format(API_BASE, comment._id)
+
+    @pytest.fixture()
+    def payload(self, comment):
+        return self._set_up_payload(comment._id)
+
+    # public_project_with_comments
+    @pytest.fixture()
+    def public_project(self, user, contributor):
+        public_project = ProjectFactory.create(is_public=True, creator=user, comment_level='private')
+        public_project.add_contributor(contributor, save=True)
+        return public_project
+
+    @pytest.fixture()
+    def public_file(self, user, public_project):
+        return test_utils.create_test_file(public_project, user)
+
+    @pytest.fixture()
+    def public_comment(self, user, public_project, public_file):
+        return CommentFactory(node=public_project, target=public_file.get_guid(), user=user)
+
+    @pytest.fixture()
+    def public_comment_reply(self, user, public_comment, public_project):
+        reply_target = Guid.load(public_comment._id)
+        return CommentFactory(node=public_project, target=reply_target, user=user)
+
+    @pytest.fixture()
+    def public_url(self, public_comment):
+        return '/{}comments/{}/'.format(API_BASE, public_comment._id)
+
+    @pytest.fixture()
+    def public_comment_payload(self, public_comment):
+        return self._set_up_payload(public_comment._id)
+
+    # registration_with_comments
+    @pytest.fixture()
+    def registration(self, user):
+        return RegistrationFactory(creator=user, comment_level='private')
+
+    @pytest.fixture()
+    def registration_file(self, user, registration):
+        return test_utils.create_test_file(registration, user)
+
+    @pytest.fixture()
+    def registration_comment(self, user, registration, registration_file):
+        return CommentFactory(node=registration, target=registration_file.get_guid(), user=user)
+
+    @pytest.fixture()
+    def comment_url(self, registration_comment):
+        return '/{}comments/{}/'.format(API_BASE, registration_comment._id)
+
+    @pytest.fixture()
+    def registration_comment_reply(self, user, registration, registration_comment):
+        reply_target = Guid.load(registration_comment._id)
+        return CommentFactory(node=registration, target=reply_target, user=user)
 
 
-class TestFileCommentDetailView(CommentDetailMixin, ApiTestCase):
-
-    def _set_up_private_project_with_comment(self):
-        self.private_project = ProjectFactory.create(is_public=False, creator=self.user, comment_level='private')
-        self.private_project.add_contributor(self.contributor, save=True)
-        self.file = test_utils.create_test_file(self.private_project, self.user)
-        self.comment = CommentFactory(node=self.private_project, target=self.file.get_guid(), user=self.user)
-        self.private_url = '/{}comments/{}/'.format(API_BASE, self.comment._id)
-        self.payload = self._set_up_payload(self.comment._id)
-
-    def _set_up_public_project_with_comment(self):
-        self.public_project = ProjectFactory.create(is_public=True, creator=self.user, comment_level='private')
-        self.public_project.add_contributor(self.contributor, save=True)
-        self.public_file = test_utils.create_test_file(self.public_project, self.user)
-        self.public_comment = CommentFactory(node=self.public_project, target=self.public_file.get_guid(), user=self.user)
-        reply_target = Guid.load(self.public_comment._id)
-        self.public_comment_reply = CommentFactory(node=self.public_project, target=reply_target, user=self.user)
-        self.public_url = '/{}comments/{}/'.format(API_BASE, self.public_comment._id)
-        self.public_comment_payload = self._set_up_payload(self.public_comment._id)
-
-    def _set_up_registration_with_comment(self):
-        self.registration = RegistrationFactory(creator=self.user, comment_level='private')
-        self.registration_file = test_utils.create_test_file(self.registration, self.user)
-        self.registration_comment = CommentFactory(node=self.registration, target=self.registration_file.get_guid(), user=self.user)
-        self.comment_url = '/{}comments/{}/'.format(API_BASE, self.registration_comment._id)
-        reply_target = Guid.load(self.registration_comment._id)
-        self.registration_comment_reply = CommentFactory(node=self.registration, target=reply_target, user=self.user)
-
-    def test_file_comment_has_target_link_with_correct_type(self):
-        self._set_up_public_project_with_comment()
-        res = self.app.get(self.public_url)
+    def test_file_comment_has_target_link_with_correct_type(self, app, public_url, public_file):
+        res = app.get(public_url)
         url = res.json['data']['relationships']['target']['links']['related']['href']
-        expected_url = '/{}files/{}/'.format(API_BASE, self.public_file._id)
+        expected_url = '/{}files/{}/'.format(API_BASE, public_file._id)
         target_type = res.json['data']['relationships']['target']['links']['related']['meta']['type']
         expected_type = 'files'
-        assert_equal(res.status_code, 200)
-        assert_equal(urlparse(url).path, expected_url)
-        assert_equal(target_type, expected_type)
+        assert res.status_code == 200
+        assert urlparse(url).path == expected_url
+        assert target_type == expected_type
 
-    def test_public_node_non_contributor_commenter_can_update_file_comment(self):
+    def test_public_node_non_contributor_commenter_can_update_file_comment(self, app, non_contributor):
         project = ProjectFactory(is_public=True)
         test_file = test_utils.create_test_file(project, project.creator)
-        comment = CommentFactory(node=project, target=test_file.get_guid(), user=self.non_contributor)
+        comment = CommentFactory(node=project, target=test_file.get_guid(), user=non_contributor)
         url = '/{}comments/{}/'.format(API_BASE, comment._id)
         payload = self._set_up_payload(comment._id)
-        res = self.app.put_json_api(url, payload, auth=self.non_contributor.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(payload['data']['attributes']['content'], res.json['data']['attributes']['content'])
+        res = app.put_json_api(url, payload, auth=non_contributor.auth)
+        assert res.status_code == 200
+        assert payload['data']['attributes']['content'] == res.json['data']['attributes']['content']
 
-    def test_public_node_non_contributor_commenter_cannot_update_own_file_comment_if_comment_level_private(self):
+    def test_public_node_non_contributor_commenter_cannot_update_own_file_comment_if_comment_level_private(self, app, non_contributor):
         project = ProjectFactory(is_public=True)
         test_file = test_utils.create_test_file(project, project.creator)
-        comment = CommentFactory(node=project, target=test_file.get_guid(), user=self.non_contributor)
+        comment = CommentFactory(node=project, target=test_file.get_guid(), user=non_contributor)
         project.comment_level = 'private'
         project.save()
         url = '/{}comments/{}/'.format(API_BASE, comment._id)
         payload = self._set_up_payload(comment._id)
-        res = self.app.put_json_api(url, payload, auth=self.non_contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
-        assert_equal(res.json['errors'][0]['detail'], 'You do not have permission to perform this action.')
+        res = app.put_json_api(url, payload, auth=non_contributor.auth, expect_errors=True)
+        assert res.status_code == 403
+        assert res.json['errors'][0]['detail'] == 'You do not have permission to perform this action.'
 
-    def test_public_node_non_contributor_commenter_can_delete_file_comment(self):
+    def test_public_node_non_contributor_commenter_can_delete_file_comment(self, app, non_contributor):
         project = ProjectFactory(is_public=True, comment_level='public')
         test_file = test_utils.create_test_file(project, project.creator)
-        comment = CommentFactory(node=project, target=test_file.get_guid(), user=self.non_contributor)
+        comment = CommentFactory(node=project, target=test_file.get_guid(), user=non_contributor)
         url = '/{}comments/{}/'.format(API_BASE, comment._id)
-        res = self.app.delete_json_api(url, auth=self.non_contributor.auth)
-        assert_equal(res.status_code, 204)
+        res = app.delete_json_api(url, auth=non_contributor.auth)
+        assert res.status_code == 204
 
-    def test_comment_detail_for_deleted_file_is_not_returned(self):
-        self._set_up_private_project_with_comment()
+    def test_comment_detail_for_deleted_file_is_not_returned(self, app, user, private_project, file, private_url):
         # Delete commented file
-        osfstorage = self.private_project.get_addon('osfstorage')
+        osfstorage = private_project.get_addon('osfstorage')
         root_node = osfstorage.get_root()
-        self.file.delete()
-        res = self.app.get(self.private_url, auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, 404)
+        file.delete()
+        res = app.get(private_url, auth=user.auth, expect_errors=True)
+        assert res.status_code == 404
 
 
-class TestWikiCommentDetailView(CommentDetailMixin, ApiTestCase):
+class TestWikiCommentDetailView(CommentDetailMixin):
+    # private_project_with_comments
+    @pytest.fixture()
+    def private_project(self, user, contributor):
+        private_project = ProjectFactory.create(is_public=False, creator=user, comment_level='private')
+        private_project.add_contributor(contributor, save=True)
+        return private_project
 
-    def _set_up_private_project_with_comment(self):
-        self.private_project = ProjectFactory.create(is_public=False, creator=self.user, comment_level='private')
-        self.private_project.add_contributor(self.contributor, save=True)
+    @pytest.fixture()
+    def wiki(self, user, private_project):
         with mock.patch('osf.models.AbstractNode.update_search'):
-            self.wiki = NodeWikiFactory(node=self.private_project, user=self.user)
-        self.comment = CommentFactory(node=self.private_project, target=Guid.load(self.wiki._id), user=self.user)
-        self.private_url = '/{}comments/{}/'.format(API_BASE, self.comment._id)
-        self.payload = self._set_up_payload(self.comment._id)
+            return NodeWikiFactory(node=private_project, user=user)
 
-    def _set_up_public_project_with_comment(self):
-        self.public_project = ProjectFactory.create(is_public=True, creator=self.user, comment_level='private')
-        self.public_project.add_contributor(self.contributor, save=True)
+    @pytest.fixture()
+    def comment(self, user, private_project, wiki):
+        return CommentFactory(node=private_project, target=Guid.load(wiki._id), user=user)
+
+    @pytest.fixture()
+    def private_url(self, comment):
+        return '/{}comments/{}/'.format(API_BASE, comment._id)
+
+    @pytest.fixture()
+    def payload(self, comment):
+        return self._set_up_payload(comment._id)
+
+    # public_project_with_comments
+    @pytest.fixture()
+    def public_project(self, user, contributor):
+        public_project = ProjectFactory.create(is_public=True, creator=user, comment_level='private')
+        public_project.add_contributor(contributor, save=True)
+        return public_project
+
+    @pytest.fixture()
+    def public_wiki(self, user, public_project):
         with mock.patch('osf.models.AbstractNode.update_search'):
-            self.public_wiki = NodeWikiFactory(node=self.public_project, user=self.user)
-        self.public_comment = CommentFactory(node=self.public_project, target=Guid.load(self.public_wiki._id), user=self.user)
-        reply_target = Guid.load(self.public_comment._id)
-        self.public_comment_reply = CommentFactory(node=self.public_project, target=reply_target, user=self.user)
-        self.public_url = '/{}comments/{}/'.format(API_BASE, self.public_comment._id)
-        self.public_comment_payload = self._set_up_payload(self.public_comment._id)
+            return NodeWikiFactory(node=public_project, user=user)
 
-    def _set_up_registration_with_comment(self):
-        self.registration = RegistrationFactory(creator=self.user, comment_level='private')
+    @pytest.fixture()
+    def public_comment(self, user, public_project, public_wiki):
+        return CommentFactory(node=public_project, target=Guid.load(public_wiki._id), user=user)
+
+    @pytest.fixture()
+    def public_comment_reply(self, user, public_comment, public_project):
+        reply_target = Guid.load(public_comment._id)
+        return CommentFactory(node=public_project, target=reply_target, user=user)
+
+    @pytest.fixture()
+    def public_url(self, public_comment):
+        return '/{}comments/{}/'.format(API_BASE, public_comment._id)
+
+    @pytest.fixture()
+    def public_comment_payload(self, public_comment):
+        return self._set_up_payload(public_comment._id)
+
+    # registration_with_comments
+    @pytest.fixture()
+    def registration(self, user):
+        return RegistrationFactory(creator=user, comment_level='private')
+
+    @pytest.fixture()
+    def registration_wiki(self, registration, user):
         with mock.patch('osf.models.AbstractNode.update_search'):
-            self.registration_wiki = NodeWikiFactory(node=self.registration, user=self.user)
-        self.registration_comment = CommentFactory(node=self.registration, target=Guid.load(self.registration_wiki._id), user=self.user)
-        self.comment_url = '/{}comments/{}/'.format(API_BASE, self.registration_comment._id)
-        reply_target = Guid.load(self.registration_comment._id)
-        self.registration_comment_reply = CommentFactory(node=self.registration, target=reply_target, user=self.user)
+            return NodeWikiFactory(node=registration, user=user)
 
-    def test_wiki_comment_has_target_link_with_correct_type(self):
-        self._set_up_public_project_with_comment()
-        res = self.app.get(self.public_url)
+    @pytest.fixture()
+    def registration_comment(self, user, registration, registration_wiki):
+        return CommentFactory(node=registration, target=Guid.load(registration_wiki._id), user=user)
+
+    @pytest.fixture()
+    def comment_url(self, registration_comment):
+        return '/{}comments/{}/'.format(API_BASE, registration_comment._id)
+
+    @pytest.fixture()
+    def registration_comment_reply(self, user, registration, registration_comment):
+        reply_target = Guid.load(registration_comment._id)
+        return CommentFactory(node=registration, target=reply_target, user=user)
+
+    def test_wiki_comment_has_target_link_with_correct_type(self, app, public_url, public_wiki):
+        res = app.get(public_url)
         url = res.json['data']['relationships']['target']['links']['related']['href']
-        expected_url = self.public_wiki.get_absolute_url()
+        expected_url = public_wiki.get_absolute_url()
         target_type = res.json['data']['relationships']['target']['links']['related']['meta']['type']
         expected_type = 'wiki'
-        assert_equal(res.status_code, 200)
-        assert_equal(url, expected_url)
-        assert_equal(target_type, expected_type)
+        assert res.status_code == 200
+        assert url == expected_url
+        assert target_type == expected_type
 
-    def test_public_node_non_contributor_commenter_can_update_wiki_comment(self):
+    def test_public_node_non_contributor_commenter_can_update_wiki_comment(self, app, user, non_contributor, ):
         project = ProjectFactory(is_public=True)
-        test_wiki = NodeWikiFactory(node=project, user=self.user)
-        comment = CommentFactory(node=project, target=Guid.load(test_wiki._id), user=self.non_contributor)
+        test_wiki = NodeWikiFactory(node=project, user=user)
+        comment = CommentFactory(node=project, target=Guid.load(test_wiki._id), user=non_contributor)
         url = '/{}comments/{}/'.format(API_BASE, comment._id)
         payload = self._set_up_payload(comment._id)
-        res = self.app.put_json_api(url, payload, auth=self.non_contributor.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(payload['data']['attributes']['content'], res.json['data']['attributes']['content'])
+        res = app.put_json_api(url, payload, auth=non_contributor.auth)
+        assert res.status_code == 200
+        assert payload['data']['attributes']['content'] == res.json['data']['attributes']['content']
 
-    def test_public_node_non_contributor_commenter_cannot_update_own_wiki_comment_if_comment_level_private(self):
+    def test_public_node_non_contributor_commenter_cannot_update_own_wiki_comment_if_comment_level_private(self, app, user, non_contributor):
         project = ProjectFactory(is_public=True)
-        test_wiki = NodeWikiFactory(node=project, user=self.user)
-        comment = CommentFactory(node=project, target=Guid.load(test_wiki._id), user=self.non_contributor)
+        test_wiki = NodeWikiFactory(node=project, user=user)
+        comment = CommentFactory(node=project, target=Guid.load(test_wiki._id), user=non_contributor)
         project.comment_level = 'private'
         project.save()
         url = '/{}comments/{}/'.format(API_BASE, comment._id)
         payload = self._set_up_payload(comment._id)
-        res = self.app.put_json_api(url, payload, auth=self.non_contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
-        assert_equal(res.json['errors'][0]['detail'], 'You do not have permission to perform this action.')
+        res = app.put_json_api(url, payload, auth=non_contributor.auth, expect_errors=True)
+        assert res.status_code == 403
+        assert res.json['errors'][0]['detail'] == 'You do not have permission to perform this action.'
 
-    def test_public_node_non_contributor_commenter_can_delete_wiki_comment(self):
+    def test_public_node_non_contributor_commenter_can_delete_wiki_comment(self, app, user, non_contributor):
         project = ProjectFactory(is_public=True, comment_level='public')
-        test_wiki = NodeWikiFactory(node=project, user=self.user)
-        comment = CommentFactory(node=project, target=Guid.load(test_wiki._id), user=self.non_contributor)
+        test_wiki = NodeWikiFactory(node=project, user=user)
+        comment = CommentFactory(node=project, target=Guid.load(test_wiki._id), user=non_contributor)
         url = '/{}comments/{}/'.format(API_BASE, comment._id)
-        res = self.app.delete_json_api(url, auth=self.non_contributor.auth)
-        assert_equal(res.status_code, 204)
+        res = app.delete_json_api(url, auth=non_contributor.auth)
+        assert res.status_code == 204
 
-    def test_comment_detail_for_deleted_wiki_is_not_returned(self):
-        self._set_up_private_project_with_comment()
+    def test_comment_detail_for_deleted_wiki_is_not_returned(self, app, user, wiki, private_url, private_project):
         # Delete commented wiki page
-        self.private_project.delete_node_wiki(self.wiki.page_name, core.Auth(self.user))
-        res = self.app.get(self.private_url, auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, 404)
+        private_project.delete_node_wiki(wiki.page_name, core.Auth(user))
+        res = app.get(private_url, auth=user.auth, expect_errors=True)
+        assert res.status_code == 404

--- a/api_tests/comments/views/test_comment_report_detail.py
+++ b/api_tests/comments/views/test_comment_report_detail.py
@@ -5,6 +5,7 @@ from django.utils import timezone
 from datetime import datetime
 
 from osf.models import Guid
+
 from api.base.settings.defaults import API_BASE
 from api_tests import utils as test_utils
 from tests.base import ApiTestCase

--- a/api_tests/comments/views/test_comment_report_detail.py
+++ b/api_tests/comments/views/test_comment_report_detail.py
@@ -4,7 +4,7 @@ import mock
 from django.utils import timezone
 from datetime import datetime
 
-from osf.model import Guid
+from osf.models import Guid
 from api.base.settings.defaults import API_BASE
 from api_tests import utils as test_utils
 from tests.base import ApiTestCase

--- a/api_tests/comments/views/test_comment_report_detail.py
+++ b/api_tests/comments/views/test_comment_report_detail.py
@@ -1,154 +1,36 @@
-import mock
 import pytest
+
+import mock
 from django.utils import timezone
-from nose.tools import *  # flake8: noqa
 from datetime import datetime
 
 from framework.guid.model import Guid
-
 from api.base.settings.defaults import API_BASE
 from api_tests import utils as test_utils
 from tests.base import ApiTestCase
 from osf_tests.factories import ProjectFactory, AuthUserFactory, CommentFactory
 from addons.wiki.tests.factories import NodeWikiFactory
 
-
+@pytest.mark.django_db
 class ReportDetailViewMixin(object):
 
-    def setUp(self):
-        super(ReportDetailViewMixin, self).setUp()
-        self.user = AuthUserFactory()
-        self.contributor = AuthUserFactory()
-        self.non_contributor = AuthUserFactory()
-        self.payload = {
-            'data': {
-                'id': self.user._id,
-                'type': 'comment_reports',
-                'attributes': {
-                    'category': 'spam',
-                    'message': 'Spam is delicious.'
-                }
-            }
-        }
+    @pytest.fixture()
+    def user(self):
+        return AuthUserFactory()
 
-    def _set_up_private_project_comment_reports(self):
-        raise NotImplementedError
+    @pytest.fixture()
+    def contributor(self):
+        return AuthUserFactory()
 
-    def _set_up_public_project_comment_reports(self):
-        raise NotImplementedError
+    @pytest.fixture()
+    def non_contributor(self):
+        return AuthUserFactory()
 
-    def test_private_node_reporting_contributor_can_view_report_detail(self):
-        self._set_up_private_project_comment_reports()
-        res = self.app.get(self.private_url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['id'], self.user._id)
-
-    def test_private_node_reported_contributor_cannot_view_report_detail(self):
-        self._set_up_private_project_comment_reports()
-        res = self.app.get(self.private_url, auth=self.contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
-
-    def test_private_node_logged_in_non_contributor_cannot_view_report_detail(self):
-        self._set_up_private_project_comment_reports()
-        res = self.app.get(self.private_url, auth=self.non_contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
-
-    def test_private_node_logged_out_contributor_cannot_view_report_detail(self):
-        self._set_up_private_project_comment_reports()
-        res = self.app.get(self.private_url, expect_errors=True)
-        assert_equal(res.status_code, 401)
-
-    def test_public_node_reporting_contributor_can_view_report_detail(self):
-        self._set_up_public_project_comment_reports()
-        res = self.app.get(self.public_url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['id'], self.user._id)
-
-    def test_public_node_reported_contributor_cannot_view_report_detail(self):
-        self._set_up_public_project_comment_reports()
-        res = self.app.get(self.public_url, auth=self.contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
-
-    def test_public_node_logged_in_non_contributor_cannot_view_other_users_report_detail(self):
-        self._set_up_public_project_comment_reports()
-        res = self.app.get(self.public_url, auth=self.non_contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
-
-    def test_public_node_logged_out_contributor_cannot_view_report_detail(self):
-        self._set_up_public_project_comment_reports()
-        res = self.app.get(self.public_url, expect_errors=True)
-        assert_equal(res.status_code, 401)
-
-    def test_public_node_logged_in_non_contributor_reporter_can_view_own_report_detail(self):
-        self._set_up_public_project_comment_reports()
-        self.public_comment.reports[self.non_contributor._id] = {
-            'category': 'spam',
-            'text': 'This is spam',
-            'date': timezone.now(),
-            'retracted': False,
-        }
-        self.public_comment.save()
-        url = '/{}comments/{}/reports/{}/'.format(API_BASE, self.public_comment._id, self.non_contributor._id)
-        res = self.app.get(url, auth=self.non_contributor.auth)
-        assert_equal(res.status_code, 200)
-
-    def test_private_node_reporting_contributor_can_update_report_detail(self):
-        self._set_up_private_project_comment_reports()
-        res = self.app.put_json_api(self.private_url, self.payload, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['id'], self.user._id)
-        assert_equal(res.json['data']['attributes']['message'], self.payload['data']['attributes']['message'])
-
-    def test_private_node_reported_contributor_cannot_update_report_detail(self):
-        self._set_up_private_project_comment_reports()
-        res = self.app.put_json_api(self.private_url, self.payload, auth=self.contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
-
-    def test_private_node_logged_in_non_contributor_cannot_update_report_detail(self):
-        self._set_up_private_project_comment_reports()
-        res = self.app.put_json_api(self.private_url, self.payload, auth=self.non_contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
-
-    def test_private_node_logged_out_contributor_cannot_update_detail(self):
-        self._set_up_private_project_comment_reports()
-        res = self.app.put_json_api(self.private_url, self.payload, expect_errors=True)
-        assert_equal(res.status_code, 401)
-
-    def test_public_node_reporting_contributor_can_update_detail(self):
-        self._set_up_public_project_comment_reports()
-        res = self.app.put_json_api(self.public_url, self.payload, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['id'], self.user._id)
-        assert_equal(res.json['data']['attributes']['message'], self.payload['data']['attributes']['message'])
-
-    def test_public_node_reported_contributor_cannot_update_detail(self):
-        self._set_up_public_project_comment_reports()
-        res = self.app.put_json_api(self.public_url, self.payload, auth=self.contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
-
-    def test_public_node_logged_in_non_contributor_cannot_update_other_users_report_detail(self):
-        self._set_up_public_project_comment_reports()
-        res = self.app.put_json_api(self.public_url, self.payload, auth=self.non_contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
-
-    def test_public_node_logged_out_contributor_cannot_update_report_detail(self):
-        self._set_up_public_project_comment_reports()
-        res = self.app.put_json_api(self.public_url, self.payload, expect_errors=True)
-        assert_equal(res.status_code, 401)
-
-    def test_public_node_logged_in_non_contributor_reporter_can_update_own_report_detail(self):
-        self._set_up_public_project_comment_reports()
-        self.public_comment.reports[self.non_contributor._id] = {
-            'category': 'spam',
-            'text': 'This is spam',
-            'date': timezone.now(),
-            'retracted': False,
-        }
-        self.public_comment.save()
-        url = '/{}comments/{}/reports/{}/'.format(API_BASE, self.public_comment._id, self.non_contributor._id)
+    @pytest.fixture()
+    def payload(self, user):
         payload = {
             'data': {
-                'id': self.non_contributor._id,
+                'id': user._id,
                 'type': 'comment_reports',
                 'attributes': {
                     'category': 'spam',
@@ -156,161 +38,357 @@ class ReportDetailViewMixin(object):
                 }
             }
         }
-        res = self.app.put_json_api(url, payload, auth=self.non_contributor.auth)
-        assert_equal(res.status_code, 200)
-        assert_equal(res.json['data']['attributes']['message'], payload['data']['attributes']['message'])
+        return payload
 
-    def test_private_node_reporting_contributor_can_delete_report_detail(self):
-        self._set_up_private_project_comment_reports()
-        comment = CommentFactory.build(node=self.private_project, user=self.contributor, target=self.comment.target)
-        comment.reports = {self.user._id: {
+    # check if all necessary features are setup in subclass
+    @pytest.fixture()
+    def private_project(self):
+        raise NotImplementedError
+
+    @pytest.fixture()
+    def comment(self):
+        raise NotImplementedError
+
+    @pytest.fixture()
+    def private_url(self):
+        raise NotImplementedError
+
+    @pytest.fixture()
+    def public_project(self):
+        raise NotImplementedError
+
+    @pytest.fixture()
+    def public_comment(self):
+        raise NotImplementedError
+
+    @pytest.fixture()
+    def public_url(self):
+        raise NotImplementedError
+
+    def test_private_node_view_report_detail_auth_misc(self, app, user, contributor, non_contributor, private_url):
+        # test_private_node_reporting_contributor_can_view_report_detail
+        res = app.get(private_url, auth=user.auth)
+        assert res.status_code == 200
+        assert res.json['data']['id'] == user._id
+
+        # test_private_node_reported_contributor_cannot_view_report_detail
+        res = app.get(private_url, auth=contributor.auth, expect_errors=True)
+        assert res.status_code == 403
+
+        # test_private_node_logged_in_non_contributor_cannot_view_report_detail
+        res = app.get(private_url, auth=non_contributor.auth, expect_errors=True)
+        assert res.status_code == 403
+
+        # test_private_node_logged_out_contributor_cannot_view_report_detail
+        res = app.get(private_url, expect_errors=True)
+        assert res.status_code == 401
+
+    def test_public_node_view_report_detail_auth_misc(self, app, user, contributor, non_contributor, public_url):
+        # test_public_node_reporting_contributor_can_view_report_detail
+        res = app.get(public_url, auth=user.auth)
+        assert res.status_code == 200
+        assert res.json['data']['id'] == user._id
+
+        # test_public_node_reported_contributor_cannot_view_report_detail
+        res = app.get(public_url, auth=contributor.auth, expect_errors=True)
+        assert res.status_code == 403
+
+        # test_public_node_logged_in_non_contributor_cannot_view_other_users_report_detail
+        res = app.get(public_url, auth=non_contributor.auth, expect_errors=True)
+        assert res.status_code == 403
+
+        # test_public_node_logged_out_contributor_cannot_view_report_detail
+        res = app.get(public_url, expect_errors=True)
+        assert res.status_code == 401
+
+    def test_public_node_logged_in_non_contributor_reporter_can_view_own_report_detail(self, app, non_contributor, public_comment):
+        public_comment.reports[non_contributor._id] = {
+            'category': 'spam',
+            'text': 'This is spam',
+            'date': timezone.now(),
+            'retracted': False,
+        }
+        public_comment.save()
+        url = '/{}comments/{}/reports/{}/'.format(API_BASE, public_comment._id, non_contributor._id)
+        res = app.get(url, auth=non_contributor.auth)
+        assert res.status_code == 200
+
+    def test_private_node_update_report_detail_auth_misc(self, app, user, contributor, non_contributor, payload, private_url):
+        # test_private_node_reported_contributor_cannot_update_report_detail
+        res = app.put_json_api(private_url, payload, auth=contributor.auth, expect_errors=True)
+        assert res.status_code == 403
+
+        # test_private_node_logged_in_non_contributor_cannot_update_report_detail
+        res = app.put_json_api(private_url, payload, auth=non_contributor.auth, expect_errors=True)
+        assert res.status_code == 403
+
+        # test_private_node_logged_out_contributor_cannot_update_detail
+        res = app.put_json_api(private_url, payload, expect_errors=True)
+        assert res.status_code == 401
+
+        # test_private_node_reporting_contributor_can_update_report_detail
+        res = app.put_json_api(private_url, payload, auth=user.auth)
+        assert res.status_code == 200
+        assert res.json['data']['id'] == user._id
+        assert res.json['data']['attributes']['message'] == payload['data']['attributes']['message']
+
+    def test_public_node_update_report_detail_auth_misc(self, app, user, contributor, non_contributor, payload, public_url):
+        # test_public_node_reported_contributor_cannot_update_detail
+        res = app.put_json_api(public_url, payload, auth=contributor.auth, expect_errors=True)
+        assert res.status_code == 403
+
+        # test_public_node_logged_in_non_contributor_cannot_update_other_users_report_detail
+        res = app.put_json_api(public_url, payload, auth=non_contributor.auth, expect_errors=True)
+        assert res.status_code == 403
+
+        # test_public_node_logged_out_contributor_cannot_update_report_detail
+        res = app.put_json_api(public_url, payload, expect_errors=True)
+        assert res.status_code == 401
+
+        # test_public_node_reporting_contributor_can_update_detail
+        res = app.put_json_api(public_url, payload, auth=user.auth)
+        assert res.status_code == 200
+        assert res.json['data']['id'] == user._id
+        assert res.json['data']['attributes']['message'] == payload['data']['attributes']['message']
+
+    def test_public_node_logged_in_non_contributor_reporter_can_update_own_report_detail(self, app, non_contributor, public_comment):
+        public_comment.reports[non_contributor._id] = {
+            'category': 'spam',
+            'text': 'This is spam',
+            'date': timezone.now(),
+            'retracted': False,
+        }
+        public_comment.save()
+        url = '/{}comments/{}/reports/{}/'.format(API_BASE, public_comment._id, non_contributor._id)
+        payload = {
+            'data': {
+                'id': non_contributor._id,
+                'type': 'comment_reports',
+                'attributes': {
+                    'category': 'spam',
+                    'message': 'Spam is delicious.'
+                }
+            }
+        }
+        res = app.put_json_api(url, payload, auth=non_contributor.auth)
+        assert res.status_code == 200
+        assert res.json['data']['attributes']['message'] == payload['data']['attributes']['message']
+
+    def test_private_node_delete_report_detail_auth_misc(self, app, user, contributor, non_contributor, private_project, payload, private_url, comment):
+        # test_private_node_reported_contributor_cannot_delete_report_detail
+        res = app.delete_json_api(private_url, auth=contributor.auth, expect_errors=True)
+        assert res.status_code == 403
+
+        # test_private_node_logged_in_non_contributor_cannot_delete_report_detail
+        res = app.delete_json_api(private_url, auth=non_contributor.auth, expect_errors=True)
+        assert res.status_code == 403
+
+        # test_private_node_logged_out_contributor_cannot_delete_detail
+        res = app.delete_json_api(private_url, expect_errors=True)
+        assert res.status_code == 401
+
+        # test_private_node_reporting_contributor_can_delete_report_detail
+        comment_new = CommentFactory.build(node=private_project, user=contributor, target=comment.target)
+        comment_new.reports = {user._id: {
+            'category': 'spam',
+            'text': 'This is spam',
+            'date': timezone.now(),
+            'retracted': False,
+        }}
+        comment_new.save()
+        url = '/{}comments/{}/reports/{}/'.format(API_BASE, comment_new._id, user._id)
+        res = app.delete_json_api(url, auth=user.auth)
+        assert res.status_code == 204
+
+    def test_public_node_delete_report_detail_auth_misc(self, app, user, contributor, non_contributor, public_url):
+
+        # test_public_node_reported_contributor_cannot_delete_detail
+        res = app.delete_json_api(public_url, auth=contributor.auth, expect_errors=True)
+        assert res.status_code == 403
+
+        # test_public_node_logged_in_non_contributor_cannot_delete_other_users_report_detail
+        res = app.delete_json_api(public_url, auth=non_contributor.auth, expect_errors=True)
+        assert res.status_code == 403
+
+        # test_public_node_logged_out_contributor_cannot_delete_report_detail
+        res = app.delete_json_api(public_url, expect_errors=True)
+        assert res.status_code == 401
+
+        # test_public_node_reporting_contributor_can_delete_detail
+        res = app.delete_json_api(public_url, auth=user.auth)
+        assert res.status_code == 204
+
+    def test_public_node_logged_in_non_contributor_reporter_can_delete_own_report_detail(self, app, non_contributor, public_comment):
+        public_comment.reports[non_contributor._id] = {
+            'category': 'spam',
+            'text': 'This is spam',
+            'date': timezone.now(),
+            'retracted': False,
+        }
+        public_comment.save()
+        url = '/{}comments/{}/reports/{}/'.format(API_BASE, public_comment._id, non_contributor._id)
+        res = app.delete_json_api(url, auth=non_contributor.auth)
+        assert res.status_code == 204
+
+
+class TestReportDetailView(ReportDetailViewMixin):
+
+    # private_project_comment_reports
+    @pytest.fixture()
+    def private_project(self, user, contributor):
+        private_project = ProjectFactory.create(is_public=False, creator=user)
+        private_project.add_contributor(contributor = contributor, save=True)
+        return private_project
+
+    @pytest.fixture()
+    def comment(self, user, contributor, private_project):
+        comment = CommentFactory(node=private_project, user=contributor)
+        comment.reports = {user._id: {
             'category': 'spam',
             'text': 'This is spam',
             'date': timezone.now(),
             'retracted': False,
         }}
         comment.save()
-        url = '/{}comments/{}/reports/{}/'.format(API_BASE, comment._id, self.user._id)
-        res = self.app.delete_json_api(url, auth=self.user.auth)
-        assert_equal(res.status_code, 204)
+        return comment
 
-    def test_private_node_reported_contributor_cannot_delete_report_detail(self):
-        self._set_up_private_project_comment_reports()
-        res = self.app.delete_json_api(self.private_url, auth=self.contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
+    @pytest.fixture()
+    def private_url(self, user, comment):
+        return '/{}comments/{}/reports/{}/'.format(API_BASE, comment._id, user._id)
 
-    def test_private_node_logged_in_non_contributor_cannot_delete_report_detail(self):
-        self._set_up_private_project_comment_reports()
-        res = self.app.delete_json_api(self.private_url, auth=self.non_contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
+    # public_project_comment_reports
+    @pytest.fixture()
+    def public_project(self, user, contributor):
+        public_project = ProjectFactory.create(is_public=True, creator=user)
+        public_project.add_contributor(contributor = contributor, save=True)
+        return public_project
 
-    def test_private_node_logged_out_contributor_cannot_delete_detail(self):
-        self._set_up_private_project_comment_reports()
-        res = self.app.delete_json_api(self.private_url, expect_errors=True)
-        assert_equal(res.status_code, 401)
-
-    def test_public_node_reporting_contributor_can_delete_detail(self):
-        self._set_up_public_project_comment_reports()
-        res = self.app.delete_json_api(self.public_url, auth=self.user.auth)
-        assert_equal(res.status_code, 204)
-
-    def test_public_node_reported_contributor_cannot_delete_detail(self):
-        self._set_up_public_project_comment_reports()
-        res = self.app.delete_json_api(self.public_url, auth=self.contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
-
-    def test_public_node_logged_in_non_contributor_cannot_delete_other_users_report_detail(self):
-        self._set_up_public_project_comment_reports()
-        res = self.app.delete_json_api(self.public_url, auth=self.non_contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
-
-    def test_public_node_logged_out_contributor_cannot_delete_report_detail(self):
-        self._set_up_public_project_comment_reports()
-        res = self.app.delete_json_api(self.public_url, expect_errors=True)
-        assert_equal(res.status_code, 401)
-
-    def test_public_node_logged_in_non_contributor_reporter_can_delete_own_report_detail(self):
-        self._set_up_public_project_comment_reports()
-        self.public_comment.reports[self.non_contributor._id] = {
-            'category': 'spam',
-            'text': 'This is spam',
-            'date': timezone.now(),
-            'retracted': False,
-        }
-        self.public_comment.save()
-        url = '/{}comments/{}/reports/{}/'.format(API_BASE, self.public_comment._id, self.non_contributor._id)
-        res = self.app.delete_json_api(url, auth=self.non_contributor.auth)
-        assert_equal(res.status_code, 204)
-
-
-class TestReportDetailView(ReportDetailViewMixin, ApiTestCase):
-
-    def _set_up_private_project_comment_reports(self):
-        self.private_project = ProjectFactory.create(is_public=False, creator=self.user)
-        self.private_project.add_contributor(contributor=self.contributor, save=True)
-        self.comment = CommentFactory.build(node=self.private_project, user=self.contributor)
-        self.comment.reports = {self.user._id: {
+    @pytest.fixture()
+    def public_comment(self, user, contributor, public_project):
+        public_comment = CommentFactory(node=public_project, user=contributor)
+        public_comment.reports = {user._id: {
             'category': 'spam',
             'text': 'This is spam',
             'date': timezone.now(),
             'retracted': False,
         }}
-        self.comment.save()
-        self.private_url = '/{}comments/{}/reports/{}/'.format(API_BASE, self.comment._id, self.user._id)
+        public_comment.save()
+        return public_comment
 
-    def _set_up_public_project_comment_reports(self):
-        self.public_project = ProjectFactory.create(is_public=True, creator=self.user)
-        self.public_project.add_contributor(contributor=self.contributor, save=True)
-        self.public_comment = CommentFactory.build(node=self.public_project, user=self.contributor)
-        self.public_comment.reports = {self.user._id: {
+    @pytest.fixture()
+    def public_url(self, user, public_comment):
+        return '/{}comments/{}/reports/{}/'.format(API_BASE, public_comment._id, user._id)
+
+class TestFileCommentReportDetailView(ReportDetailViewMixin):
+
+    # private_project_comment_reports
+    @pytest.fixture()
+    def private_project(self, user, contributor):
+        private_project = ProjectFactory.create(is_public=False, creator=user)
+        private_project.add_contributor(contributor=contributor, save=True)
+        return private_project
+
+    @pytest.fixture()
+    def file(self, user, private_project):
+        return test_utils.create_test_file(private_project, user)
+
+    @pytest.fixture()
+    def comment(self, user, contributor, private_project, file):
+        comment = CommentFactory(node=private_project, target=file.get_guid(), user=contributor)
+        comment.reports = {user._id: {
             'category': 'spam',
             'text': 'This is spam',
             'date': timezone.now(),
             'retracted': False,
         }}
-        self.public_comment.save()
-        self.public_url = '/{}comments/{}/reports/{}/'.format(API_BASE, self.public_comment._id, self.user._id)
+        comment.save()
+        return comment
 
+    @pytest.fixture()
+    def private_url(self, user, comment):
+        return '/{}comments/{}/reports/{}/'.format(API_BASE, comment._id, user._id)
 
-class TestFileCommentReportDetailView(ReportDetailViewMixin, ApiTestCase):
+    # public_project_comment_reports
+    @pytest.fixture()
+    def public_project(self, user, contributor):
+        public_project = ProjectFactory.create(is_public=True, creator=user)
+        public_project.add_contributor(contributor = contributor, save=True)
+        return public_project
 
-    def _set_up_private_project_comment_reports(self):
-        self.private_project = ProjectFactory.create(is_public=False, creator=self.user)
-        self.private_project.add_contributor(contributor=self.contributor, save=True)
-        self.file = test_utils.create_test_file(self.private_project, self.user)
-        self.comment = CommentFactory.build(node=self.private_project, target=self.file.get_guid(), user=self.contributor)
-        self.comment.reports = {self.user._id: {
+    @pytest.fixture()
+    def public_file(self, user, public_project):
+        return test_utils.create_test_file(public_project, user)
+
+    @pytest.fixture()
+    def public_comment(self, user, contributor, public_project, public_file):
+        public_comment = CommentFactory(node=public_project, target=public_file.get_guid(), user=contributor)
+        public_comment.reports = {user._id: {
             'category': 'spam',
             'text': 'This is spam',
             'date': timezone.now(),
             'retracted': False,
         }}
-        self.comment.save()
-        self.private_url = '/{}comments/{}/reports/{}/'.format(API_BASE, self.comment._id, self.user._id)
+        public_comment.save()
+        return public_comment
 
-    def _set_up_public_project_comment_reports(self):
-        self.public_project = ProjectFactory.create(is_public=True, creator=self.user)
-        self.public_project.add_contributor(contributor=self.contributor, save=True)
-        self.public_file = test_utils.create_test_file(self.public_project, self.user)
-        self.public_comment = CommentFactory.build(node=self.public_project, target=self.public_file.get_guid(), user=self.contributor)
-        self.public_comment.reports = {self.user._id: {
-            'category': 'spam',
-            'text': 'This is spam',
-            'date': timezone.now(),
-            'retracted': False,
-        }}
-        self.public_comment.save()
-        self.public_url = '/{}comments/{}/reports/{}/'.format(API_BASE, self.public_comment._id, self.user._id)
+    @pytest.fixture()
+    def public_url(self, user, public_comment):
+        return '/{}comments/{}/reports/{}/'.format(API_BASE, public_comment._id, user._id)
 
+class TestWikiCommentReportDetailView(ReportDetailViewMixin):
 
-class TestWikiCommentReportDetailView(ReportDetailViewMixin, ApiTestCase):
+    # private_project_comment_reports
+    @pytest.fixture()
+    def private_project(self, user, contributor):
+        private_project = ProjectFactory.create(is_public=False, creator=user)
+        private_project.add_contributor(contributor=contributor, save=True)
+        return private_project
 
-    def _set_up_private_project_comment_reports(self):
-        self.private_project = ProjectFactory.create(is_public=False, creator=self.user)
-        self.private_project.add_contributor(contributor=self.contributor, save=True)
+    @pytest.fixture()
+    def wiki(self, user, private_project):
         with mock.patch('osf.models.AbstractNode.update_search'):
-            self.wiki = NodeWikiFactory(node=self.private_project, user=self.user)
-        self.comment = CommentFactory.build(node=self.private_project, target=Guid.load(self.wiki._id), user=self.contributor)
-        self.comment.reports = {self.user._id: {
-            'category': 'spam',
-            'text': 'This is spam',
-            'date': timezone.now(),
-            'retracted': False,
-        }}
-        self.comment.save()
-        self.private_url = '/{}comments/{}/reports/{}/'.format(API_BASE, self.comment._id, self.user._id)
+            return NodeWikiFactory(node=private_project, user=user)
 
-    def _set_up_public_project_comment_reports(self):
-        self.public_project = ProjectFactory.create(is_public=True, creator=self.user)
-        self.public_project.add_contributor(contributor=self.contributor, save=True)
-        with mock.patch('osf.models.AbstractNode.update_search'):
-            self.public_wiki = NodeWikiFactory(node=self.public_project, user=self.user)
-        self.public_comment = CommentFactory.build(node=self.public_project, target=Guid.load(self.public_wiki._id), user=self.contributor)
-        self.public_comment.reports = {self.user._id: {
+    @pytest.fixture()
+    def comment(self, user, contributor, private_project, wiki):
+        comment = CommentFactory(node=private_project, target=Guid.load(wiki._id), user=contributor)
+        comment.reports = {user._id: {
             'category': 'spam',
             'text': 'This is spam',
             'date': timezone.now(),
             'retracted': False,
         }}
-        self.public_comment.save()
-        self.public_url = '/{}comments/{}/reports/{}/'.format(API_BASE, self.public_comment._id, self.user._id)
+        comment.save()
+        return comment
+
+    @pytest.fixture()
+    def private_url(self, user, comment):
+        return '/{}comments/{}/reports/{}/'.format(API_BASE, comment._id, user._id)
+
+    # public_project_comment_reports
+    @pytest.fixture()
+    def public_project(self, user, contributor):
+        public_project = ProjectFactory.create(is_public=True, creator=user)
+        public_project.add_contributor(contributor = contributor, save=True)
+        return public_project
+
+    @pytest.fixture()
+    def public_wiki(self, user, public_project):
+        with mock.patch('osf.models.AbstractNode.update_search'):
+            return NodeWikiFactory(node=public_project, user=user)
+
+    @pytest.fixture()
+    def public_comment(self, user, contributor, public_project, public_wiki):
+        public_comment = CommentFactory(node=public_project, target=Guid.load(public_wiki._id), user=contributor)
+        public_comment.reports = {user._id: {
+            'category': 'spam',
+            'text': 'This is spam',
+            'date': timezone.now(),
+            'retracted': False,
+        }}
+        public_comment.save()
+        return public_comment
+
+    @pytest.fixture()
+    def public_url(self, user, public_comment):
+        return '/{}comments/{}/reports/{}/'.format(API_BASE, public_comment._id, user._id)

--- a/api_tests/comments/views/test_comment_report_detail.py
+++ b/api_tests/comments/views/test_comment_report_detail.py
@@ -5,7 +5,6 @@ from django.utils import timezone
 from datetime import datetime
 
 from osf.models import Guid
-
 from api.base.settings.defaults import API_BASE
 from api_tests import utils as test_utils
 from tests.base import ApiTestCase

--- a/api_tests/comments/views/test_comment_report_detail.py
+++ b/api_tests/comments/views/test_comment_report_detail.py
@@ -4,7 +4,7 @@ import mock
 from django.utils import timezone
 from datetime import datetime
 
-from framework.guid.model import Guid
+from osf.model import Guid
 from api.base.settings.defaults import API_BASE
 from api_tests import utils as test_utils
 from tests.base import ApiTestCase

--- a/api_tests/comments/views/test_comment_report_list.py
+++ b/api_tests/comments/views/test_comment_report_list.py
@@ -5,6 +5,7 @@ from django.utils import timezone
 from datetime import datetime
 
 from osf.models import Guid
+
 from api.base.settings.defaults import API_BASE
 from api_tests import utils as test_utils
 from tests.base import ApiTestCase

--- a/api_tests/comments/views/test_comment_report_list.py
+++ b/api_tests/comments/views/test_comment_report_list.py
@@ -4,7 +4,7 @@ import mock
 from django.utils import timezone
 from datetime import datetime
 
-from osf.model import Guid
+from osf.models import Guid
 from api.base.settings.defaults import API_BASE
 from api_tests import utils as test_utils
 from tests.base import ApiTestCase

--- a/api_tests/comments/views/test_comment_report_list.py
+++ b/api_tests/comments/views/test_comment_report_list.py
@@ -1,27 +1,36 @@
-import mock
 import pytest
+
+import mock
 from django.utils import timezone
-from nose.tools import *  # flake8: noqa
 from datetime import datetime
 
 from framework.guid.model import Guid
-
 from api.base.settings.defaults import API_BASE
 from api_tests import utils as test_utils
 from tests.base import ApiTestCase
 from osf_tests.factories import ProjectFactory, AuthUserFactory, CommentFactory
 from addons.wiki.tests.factories import NodeWikiFactory
 
-
+@pytest.mark.django_db
 class CommentReportsMixin(object):
 
-    def setUp(self):
-        super(CommentReportsMixin, self).setUp()
-        self.user = AuthUserFactory()
-        self.contributor = AuthUserFactory()
-        self.non_contributor = AuthUserFactory()
-        self.payload = {
+    @pytest.fixture()
+    def user(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def contributor(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def non_contributor(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def payload(self, user):
+        payload = {
             'data': {
+                'id': user._id,
                 'type': 'comment_reports',
                 'attributes': {
                     'category': 'spam',
@@ -29,97 +38,85 @@ class CommentReportsMixin(object):
                 }
             }
         }
+        return payload
 
-    def _set_up_private_project_comment_reports(self):
-        raise NotImplementedError
+    def test_private_node_view_reports_auth_misc(self, app, user, contributor, non_contributor, private_url):
+        # test_private_node_logged_out_user_cannot_view_reports
+        res = app.get(private_url, expect_errors=True)
+        assert res.status_code == 401
 
-    def _set_up_public_project_comment_reports(self, comment_level='public'):
-        raise NotImplementedError
+        # test_private_node_logged_in_non_contributor_cannot_view_reports
+        res = app.get(private_url, auth=non_contributor.auth, expect_errors=True)
+        assert res.status_code == 403
 
-    def test_private_node_logged_out_user_cannot_view_reports(self):
-        self._set_up_private_project_comment_reports()
-        res = self.app.get(self.private_url, expect_errors=True)
-        assert_equal(res.status_code, 401)
-
-    def test_private_node_logged_in_non_contributor_cannot_view_reports(self):
-        self._set_up_private_project_comment_reports()
-        res = self.app.get(self.private_url, auth=self.non_contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
-
-    def test_private_node_only_reporting_user_can_view_reports(self):
-        self._set_up_private_project_comment_reports()
-        res = self.app.get(self.private_url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
+        # test_private_node_only_reporting_user_can_view_reports
+        res = app.get(private_url, auth=user.auth)
+        assert res.status_code == 200
         report_json = res.json['data']
         report_ids = [report['id'] for report in report_json]
-        assert_equal(len(report_json), 1)
-        assert_in(self.user._id, report_ids)
+        assert len(report_json) == 1
+        assert user._id in report_ids
 
-    def test_private_node_reported_user_does_not_see_report(self):
-        self._set_up_private_project_comment_reports()
-        res = self.app.get(self.private_url, auth=self.contributor.auth)
-        assert_equal(res.status_code, 200)
+        # test_private_node_reported_user_does_not_see_report
+        res = app.get(private_url, auth=contributor.auth)
+        assert res.status_code == 200
         report_json = res.json['data']
         report_ids = [report['id'] for report in report_json]
-        assert_equal(len(report_json), 0)
-        assert_not_in(self.contributor._id, report_ids)
+        assert len(report_json) == 0
+        assert contributor._id not in report_ids
 
-    def test_public_node_only_reporting_contributor_can_view_report(self):
-        self._set_up_public_project_comment_reports()
-        res = self.app.get(self.public_url, auth=self.user.auth)
-        assert_equal(res.status_code, 200)
+    def test_public_node_view_report_auth_misc(self, app, user, contributor, non_contributor, public_url):
+        # test_public_node_logged_out_user_cannot_view_reports
+        res = app.get(public_url, expect_errors=True)
+        assert res.status_code == 401
+
+        # test_public_node_only_reporting_contributor_can_view_report
+        res = app.get(public_url, auth=user.auth)
+        assert res.status_code == 200
         report_json = res.json['data']
         report_ids = [report['id'] for report in report_json]
-        assert_equal(len(report_json), 1)
-        assert_in(self.user._id, report_ids)
+        assert len(report_json) == 1
+        assert user._id in report_ids
 
-    def test_public_node_reported_user_does_not_see_report(self):
-        self._set_up_public_project_comment_reports()
-        res = self.app.get(self.public_url, auth=self.contributor.auth)
-        assert_equal(res.status_code, 200)
+        # test_public_node_reported_user_does_not_see_report
+        res = app.get(public_url, auth=contributor.auth)
+        assert res.status_code == 200
         report_json = res.json['data']
         report_ids = [report['id'] for report in report_json]
-        assert_equal(len(report_json), 0)
-        assert_not_in(self.contributor._id, report_ids)
+        assert len(report_json) == 0
+        assert contributor._id not in report_ids
 
-    def test_public_node_non_contributor_does_not_see_other_user_reports(self):
-        self._set_up_public_project_comment_reports()
-        res = self.app.get(self.public_url, auth=self.non_contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 200)
+        # test_public_node_non_contributor_does_not_see_other_user_reports
+        res = app.get(public_url, auth=non_contributor.auth, expect_errors=True)
+        assert res.status_code == 200
         report_json = res.json['data']
         report_ids = [report['id'] for report in report_json]
-        assert_equal(len(report_json), 0)
-        assert_not_in(self.non_contributor._id, report_ids)
+        assert len(report_json) == 0
+        assert non_contributor._id not in report_ids
 
-    def test_public_node_non_contributor_reporter_can_view_own_report(self):
-        self._set_up_public_project_comment_reports()
-        self.public_comment.reports[self.non_contributor._id] = {
+    def test_public_node_non_contributor_reporter_can_view_own_report(self, app, non_contributor, public_comment, public_url):
+        public_comment.reports[non_contributor._id] = {
             'category': 'spam',
             'text': 'This is spam',
             'date': timezone.now(),
             'retracted': False,
         }
-        self.public_comment.save()
-        res = self.app.get(self.public_url, auth=self.non_contributor.auth)
-        assert_equal(res.status_code, 200)
+        public_comment.save()
+        res = app.get(public_url, auth=non_contributor.auth)
+        assert res.status_code == 200
         report_json = res.json['data']
         report_ids = [report['id'] for report in report_json]
-        assert_equal(len(report_json), 1)
-        assert_in(self.non_contributor._id, report_ids)
+        assert len(report_json) == 1
+        assert non_contributor._id in report_ids
 
-    def test_public_node_logged_out_user_cannot_view_reports(self):
-        self._set_up_public_project_comment_reports()
-        res = self.app.get(self.public_url, expect_errors=True)
-        assert_equal(res.status_code, 401)
+    @pytest.mark.parametrize('comment_level', ['private'])
+    def test_public_node_private_comment_level_non_contributor_cannot_see_reports(self, app, non_contributor, public_url, comment_level):
+        res = app.get(public_url, auth=non_contributor.auth, expect_errors=True)
+        assert res.status_code == 403
+        assert res.json['errors'][0]['detail'] == 'You do not have permission to perform this action.'
 
-    def test_public_node_private_comment_level_non_contributor_cannot_see_reports(self):
-        self._set_up_public_project_comment_reports(comment_level='private')
-        res = self.app.get(self.public_url, auth=self.non_contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
-        assert_equal(res.json['errors'][0]['detail'], 'You do not have permission to perform this action.')
-
-    def test_report_comment_invalid_type(self):
-        self._set_up_private_project_comment_reports()
+    def test_invalid_report_comment(self, app, user, private_url):
+        # test_report_comment_invalid_type
         payload = {
             'data': {
                 'type': 'Not a valid type.',
@@ -129,11 +126,10 @@ class CommentReportsMixin(object):
                 }
             }
         }
-        res = self.app.post_json_api(self.private_url, payload, auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, 409)
+        res = app.post_json_api(private_url, payload, auth=user.auth, expect_errors=True)
+        assert res.status_code == 409
 
-    def test_report_comment_no_type(self):
-        self._set_up_private_project_comment_reports()
+        # test_report_comment_no_type
         payload = {
             'data': {
                 'type': '',
@@ -143,13 +139,12 @@ class CommentReportsMixin(object):
                 }
             }
         }
-        res = self.app.post_json_api(self.private_url, payload, auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, 400)
-        assert_equal(res.json['errors'][0]['detail'], 'This field may not be blank.')
-        assert_equal(res.json['errors'][0]['source']['pointer'], '/data/type')
+        res = app.post_json_api(private_url, payload, auth=user.auth, expect_errors=True)
+        assert res.status_code == 400
+        assert res.json['errors'][0]['detail'] == 'This field may not be blank.'
+        assert res.json['errors'][0]['source']['pointer'] == '/data/type'
 
-    def test_report_comment_invalid_spam_category(self):
-        self._set_up_private_project_comment_reports()
+        # test_report_comment_invalid_spam_category
         category = 'Not a valid category'
         payload = {
             'data': {
@@ -160,14 +155,14 @@ class CommentReportsMixin(object):
                 }
             }
         }
-        res = self.app.post_json_api(self.private_url, payload, auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, 400)
-        assert_equal(res.json['errors'][0]['detail'], '\"' + category + '\"' + ' is not a valid choice.')
+        res = app.post_json_api(private_url, payload, auth=user.auth, expect_errors=True)
+        assert res.status_code == 400
+        assert res.json['errors'][0]['detail'] == '\"' + category + '\"' + ' is not a valid choice.'
 
-    def test_report_comment_allow_blank_message(self):
-        self._set_up_private_project_comment_reports()
-        comment = CommentFactory(node=self.private_project, user=self.contributor, target=self.comment.target)
-        url = '/{}comments/{}/reports/'.format(API_BASE, comment._id)
+    def test_report_comment_allow_blank_message(self, app, user, contributor, private_project, comment):
+
+        comment_new = CommentFactory(node=private_project, user=contributor, target=comment.target)
+        url = '/{}comments/{}/reports/'.format(API_BASE, comment_new._id)
         payload = {
             'data': {
                 'type': 'comment_reports',
@@ -177,168 +172,242 @@ class CommentReportsMixin(object):
                 }
             }
         }
-        res = self.app.post_json_api(url, payload, auth=self.user.auth)
-        assert_equal(res.status_code, 201)
-        assert_equal(res.json['data']['id'], self.user._id)
-        assert_equal(res.json['data']['attributes']['message'], payload['data']['attributes']['message'])
+        res = app.post_json_api(url, payload, auth=user.auth)
+        assert res.status_code == 201
+        assert res.json['data']['id'] == user._id
+        assert res.json['data']['attributes']['message'] == payload['data']['attributes']['message']
 
-    def test_private_node_logged_out_user_cannot_report_comment(self):
-        self._set_up_private_project_comment_reports()
-        res = self.app.post_json_api(self.private_url, self.payload, expect_errors=True)
-        assert_equal(res.status_code, 401)
+    def test_private_node_report_comment_auth_misc(self, app, user, contributor, non_contributor, private_project, private_url, comment, payload):
 
-    def test_private_node_logged_in_non_contributor_cannot_report_comment(self):
-        self._set_up_private_project_comment_reports()
-        res = self.app.post_json_api(self.private_url, self.payload, auth=self.non_contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
+        # test_private_node_logged_out_user_cannot_report_comment
+        res = app.post_json_api(private_url, payload, expect_errors=True)
+        assert res.status_code == 401
 
-    def test_private_node_logged_in_contributor_can_report_comment(self):
-        self._set_up_private_project_comment_reports()
-        comment = CommentFactory(node=self.private_project, user=self.contributor, target=self.comment.target)
-        url = '/{}comments/{}/reports/'.format(API_BASE, comment._id)
-        res = self.app.post_json_api(url, self.payload, auth=self.user.auth)
-        assert_equal(res.status_code, 201)
-        assert_equal(res.json['data']['id'], self.user._id)
+        # test_private_node_logged_in_non_contributor_cannot_report_comment
+        res = app.post_json_api(private_url, payload, auth=non_contributor.auth, expect_errors=True)
+        assert res.status_code == 403
 
-    def test_user_cannot_report_own_comment(self):
-        self._set_up_private_project_comment_reports()
-        res = self.app.post_json_api(self.private_url, self.payload, auth=self.contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 400)
-        assert_equal(res.json['errors'][0]['detail'], 'You cannot report your own comment.')
+        # test_private_node_logged_in_contributor_can_report_comment
+        comment_new = CommentFactory(node=private_project, user=contributor, target=comment.target)
+        url = '/{}comments/{}/reports/'.format(API_BASE, comment_new._id)
+        res = app.post_json_api(url, payload, auth=user.auth)
+        assert res.status_code == 201
+        assert res.json['data']['id'] == user._id
 
-    def test_user_cannot_report_comment_twice(self):
-        self._set_up_private_project_comment_reports()
+    def test_user_cannot_report_comment_condition(self, app, user, contributor, private_url, payload):
+        # test_user_cannot_report_own_comment
+        res = app.post_json_api(private_url, payload, auth=contributor.auth, expect_errors=True)
+        assert res.status_code == 400
+        assert res.json['errors'][0]['detail'] == 'You cannot report your own comment.'
+
+        # test_user_cannot_report_comment_twice
         # User cannot report the comment again
-        res = self.app.post_json_api(self.private_url, self.payload, auth=self.user.auth, expect_errors=True)
-        assert_equal(res.status_code, 400)
-        assert_equal(res.json['errors'][0]['detail'], 'Comment already reported.')
+        res = app.post_json_api(private_url, payload, auth=user.auth, expect_errors=True)
+        assert res.status_code == 400
+        assert res.json['errors'][0]['detail'] == 'Comment already reported.'
 
-    def test_public_node_logged_out_user_cannot_report_comment(self):
-        self._set_up_public_project_comment_reports()
-        res = self.app.post_json_api(self.public_url, self.payload, expect_errors=True)
-        assert_equal(res.status_code, 401)
+    def test_public_node_report_comment_auth_misc(self, app, user, contributor, non_contributor, public_project, public_url, public_comment, payload):
+    # def test_public_node_logged_out_user_cannot_report_comment(self):
+        res = app.post_json_api(public_url, payload, expect_errors=True)
+        assert res.status_code == 401
 
-    def test_public_node_contributor_can_report_comment(self):
-        self._set_up_public_project_comment_reports()
-        comment = CommentFactory(node=self.public_project, user=self.contributor, target=self.public_comment.target)
+    # def test_public_node_contributor_can_report_comment(self):
+        comment = CommentFactory(node=public_project, user=contributor, target=public_comment.target)
         url = '/{}comments/{}/reports/'.format(API_BASE, comment._id)
+        res = app.post_json_api(url, payload, auth=user.auth)
+        assert res.status_code == 201
+        assert res.json['data']['id'] == user._id
 
-        res = self.app.post_json_api(url, self.payload, auth=self.user.auth)
-        assert_equal(res.status_code, 201)
-        assert_equal(res.json['data']['id'], self.user._id)
-
-    def test_public_node_non_contributor_can_report_comment(self):
+    # def test_public_node_non_contributor_can_report_comment(self):
         """ Test that when a public project allows any osf user to
             comment (comment_level == 'public), non-contributors
             can also report comments.
         """
-        self._set_up_public_project_comment_reports()
-        res = self.app.post_json_api(self.public_url, self.payload, auth=self.non_contributor.auth)
-        assert_equal(res.status_code, 201)
-        assert_equal(res.json['data']['id'], self.non_contributor._id)
+        res = app.post_json_api(public_url, payload, auth=non_contributor.auth)
+        assert res.status_code == 201
+        assert res.json['data']['id'] == non_contributor._id
 
-    def test_public_node_private_comment_level_non_contributor_cannot_report_comment(self):
-        self._set_up_public_project_comment_reports(comment_level='private')
-        res = self.app.get(self.public_url, auth=self.non_contributor.auth, expect_errors=True)
-        assert_equal(res.status_code, 403)
-        assert_equal(res.json['errors'][0]['detail'], 'You do not have permission to perform this action.')
+    @pytest.mark.parametrize('comment_level', ['private'])
+    def test_public_node_private_comment_level_non_contributor_cannot_report_comment(self, app, non_contributor, comment_level, public_url):
+        res = app.get(public_url, auth=non_contributor.auth, expect_errors=True)
+        assert res.status_code == 403
+        assert res.json['errors'][0]['detail'] == 'You do not have permission to perform this action.'
 
+class TestCommentReportsView(CommentReportsMixin):
+    # private_project_comment_reports
+    @pytest.fixture()
+    def private_project(self, user, contributor):
+        private_project = ProjectFactory.create(is_public=False, creator=user)
+        private_project.add_contributor(contributor=contributor, save=True)
+        return private_project
 
-class TestCommentReportsView(CommentReportsMixin, ApiTestCase):
-
-    def _set_up_private_project_comment_reports(self):
-        self.private_project = ProjectFactory.create(is_public=False, creator=self.user)
-        self.private_project.add_contributor(contributor=self.contributor, save=True)
-        self.comment = CommentFactory.build(node=self.private_project, user=self.contributor)
-        self.comment.reports = self.comment.reports or {}
-        self.comment.reports[self.user._id] = {
+    @pytest.fixture()
+    def comment(self, user, contributor, private_project):
+        comment = CommentFactory(node=private_project, user=contributor)
+        comment.reports = comment.reports or {}
+        comment.reports[user._id] = {
             'category': 'spam',
             'text': 'This is spam',
             'date': timezone.now(),
             'retracted': False,
         }
-        self.comment.save()
-        self.private_url = '/{}comments/{}/reports/'.format(API_BASE, self.comment._id)
+        comment.save()
+        return comment
 
-    def _set_up_public_project_comment_reports(self, comment_level='public'):
-        self.public_project = ProjectFactory.create(is_public=True, creator=self.user, comment_level=comment_level)
-        self.public_project.add_contributor(contributor=self.contributor, save=True)
-        self.public_comment = CommentFactory.build(node=self.public_project, user=self.contributor)
-        self.public_comment.reports = self.public_comment.reports or {}
-        self.public_comment.reports[self.user._id] = {
+    @pytest.fixture()
+    def private_url(self, user, comment):
+        return '/{}comments/{}/reports/'.format(API_BASE, comment._id)
+
+    # public_project_comment_reports
+    @pytest.fixture()
+    def public_project(self, user, contributor, comment_level):
+        public_project = ProjectFactory.create(is_public=True, creator=user, comment_level=comment_level)
+        public_project.add_contributor(contributor=contributor, save=True)
+        return public_project
+
+    @pytest.fixture()
+    def public_comment(self, user, contributor, public_project):
+        public_comment = CommentFactory(node=public_project, user=contributor)
+        public_comment.reports = public_comment.reports or {}
+        public_comment.reports[user._id] = {
             'category': 'spam',
             'text': 'This is spam',
             'date': timezone.now(),
             'retracted': False,
         }
-        self.public_comment.save()
-        self.public_url = '/{}comments/{}/reports/'.format(API_BASE, self.public_comment._id)
+        public_comment.save()
+        return public_comment
 
+    @pytest.fixture()
+    def public_url(self, user, public_comment):
+        return '/{}comments/{}/reports/'.format(API_BASE, public_comment._id)
 
-class TestWikiCommentReportsView(CommentReportsMixin, ApiTestCase):
+    @pytest.fixture()
+    def comment_level(self):
+        return 'public'
 
-    def _set_up_private_project_comment_reports(self):
-        self.private_project = ProjectFactory.create(is_public=False, creator=self.user)
-        self.private_project.add_contributor(contributor=self.contributor, save=True)
+class TestWikiCommentReportsView(CommentReportsMixin):
+
+    # private_project_comment_reports
+    @pytest.fixture()
+    def private_project(self, user, contributor):
+        private_project = ProjectFactory.create(is_public=False, creator=user)
+        private_project.add_contributor(contributor=contributor, save=True)
+        return private_project
+
+    @pytest.fixture()
+    def wiki(self, user, private_project):
         with mock.patch('osf.models.AbstractNode.update_search'):
-            self.wiki = NodeWikiFactory(node=self.private_project, user=self.user)
-        self.comment = CommentFactory.build(node=self.private_project, target=Guid.load(self.wiki._id), user=self.contributor)
-        self.comment.reports = self.comment.reports or {}
-        self.comment.reports[self.user._id] = {
+            return NodeWikiFactory(node=private_project, user=user)
+
+    @pytest.fixture()
+    def comment(self, user, contributor, private_project, wiki):
+        comment = CommentFactory(node=private_project, target=Guid.load(wiki._id), user=contributor)
+        comment.reports = comment.reports or {}
+        comment.reports[user._id] = {
             'category': 'spam',
             'text': 'This is spam',
             'date': timezone.now(),
             'retracted': False,
         }
-        self.comment.save()
-        self.private_url = '/{}comments/{}/reports/'.format(API_BASE, self.comment._id)
+        comment.save()
+        return comment
 
-    def _set_up_public_project_comment_reports(self, comment_level='public'):
-        self.public_project = ProjectFactory.create(is_public=True, creator=self.user, comment_level=comment_level)
-        self.public_project.add_contributor(contributor=self.contributor, save=True)
+    @pytest.fixture()
+    def private_url(self, user, comment):
+        return '/{}comments/{}/reports/'.format(API_BASE, comment._id)
+
+    # public_project_comment_reports
+    @pytest.fixture()
+    def public_project(self, user, contributor, comment_level):
+        public_project = ProjectFactory.create(is_public=True, creator=user, comment_level=comment_level)
+        public_project.add_contributor(contributor=contributor, save=True)
+        return public_project
+
+    @pytest.fixture()
+    def public_wiki(self, user, public_project):
         with mock.patch('osf.models.AbstractNode.update_search'):
-            self.public_wiki = NodeWikiFactory(node=self.public_project, user=self.user)
-        self.public_comment = CommentFactory.build(node=self.public_project, target=Guid.load(self.public_wiki._id), user=self.contributor)
-        self.public_comment.reports = self.public_comment.reports or {}
-        self.public_comment.reports[self.user._id] = {
+            return NodeWikiFactory(node=public_project, user=user)
+
+    @pytest.fixture()
+    def public_comment(self, user, contributor, public_project, public_wiki):
+        public_comment = CommentFactory(node=public_project, target=Guid.load(public_wiki._id), user=contributor)
+        public_comment.reports = public_comment.reports or {}
+        public_comment.reports[user._id] = {
             'category': 'spam',
             'text': 'This is spam',
             'date': timezone.now(),
             'retracted': False,
         }
-        self.public_comment.save()
-        self.public_url = '/{}comments/{}/reports/'.format(API_BASE, self.public_comment._id)
+        public_comment.save()
+        return public_comment
 
-class TestFileCommentReportsView(CommentReportsMixin, ApiTestCase):
+    @pytest.fixture()
+    def public_url(self, user, public_comment):
+        return '/{}comments/{}/reports/'.format(API_BASE, public_comment._id)
 
-    def _set_up_private_project_comment_reports(self):
-        self.private_project = ProjectFactory.create(is_public=False, creator=self.user)
-        self.private_project.add_contributor(contributor=self.contributor, save=True)
-        self.file = test_utils.create_test_file(self.private_project, self.user)
-        self.comment = CommentFactory.build(node=self.private_project, target=self.file.get_guid(), user=self.contributor)
-        self.comment.reports = self.comment.reports or {}
-        self.comment.reports[self.user._id] = {
+    @pytest.fixture()
+    def comment_level(self):
+        return 'public'
+
+class TestFileCommentReportsView(CommentReportsMixin):
+
+    # private_project_comment_reports
+    @pytest.fixture()
+    def private_project(self, user, contributor):
+        private_project = ProjectFactory.create(is_public=False, creator=user)
+        private_project.add_contributor(contributor=contributor, save=True)
+        return private_project
+
+    @pytest.fixture()
+    def file(self, user, private_project):
+        return test_utils.create_test_file(private_project, user)
+
+    @pytest.fixture()
+    def comment(self, user, contributor, private_project, file):
+        comment = CommentFactory(node=private_project, target=file.get_guid(), user=contributor)
+        comment.reports = comment.reports or {}
+        comment.reports[user._id] = {
             'category': 'spam',
             'text': 'This is spam',
             'date': timezone.now(),
             'retracted': False,
         }
-        self.comment.save()
-        self.private_url = '/{}comments/{}/reports/'.format(API_BASE, self.comment._id)
+        comment.save()
+        return comment
 
-    def _set_up_public_project_comment_reports(self, comment_level='public'):
-        self.public_project = ProjectFactory.create(is_public=True, creator=self.user, comment_level=comment_level)
-        self.public_project.add_contributor(contributor=self.contributor, save=True)
-        self.public_file = test_utils.create_test_file(self.public_project, self.user)
-        self.public_comment = CommentFactory.build(node=self.public_project, target=self.public_file.get_guid(), user=self.contributor)
-        self.public_comment.reports = self.public_comment.reports or {}
-        self.public_comment.reports[self.user._id] = {
+    @pytest.fixture()
+    def private_url(self, user, comment):
+        return '/{}comments/{}/reports/'.format(API_BASE, comment._id)
+
+    # public_project_comment_reports
+    @pytest.fixture()
+    def public_project(self, user, contributor, comment_level):
+        public_project = ProjectFactory.create(is_public=True, creator=user, comment_level=comment_level)
+        public_project.add_contributor(contributor=contributor, save=True)
+        return public_project
+
+    @pytest.fixture()
+    def public_file(self, user, public_project):
+        return test_utils.create_test_file(public_project, user)
+
+    @pytest.fixture()
+    def public_comment(self, user, contributor, public_project, public_file):
+        public_comment = CommentFactory(node=public_project, target=public_file.get_guid(), user=contributor)
+        public_comment.reports = public_comment.reports or {}
+        public_comment.reports[user._id] = {
             'category': 'spam',
             'text': 'This is spam',
             'date': timezone.now(),
             'retracted': False,
         }
-        self.public_comment.save()
-        self.public_url = '/{}comments/{}/reports/'.format(API_BASE, self.public_comment._id)
+        public_comment.save()
+        return public_comment
 
+    @pytest.fixture()
+    def public_url(self, user, public_comment):
+        return '/{}comments/{}/reports/'.format(API_BASE, public_comment._id)
 
+    @pytest.fixture()
+    def comment_level(self):
+        return 'public'

--- a/api_tests/comments/views/test_comment_report_list.py
+++ b/api_tests/comments/views/test_comment_report_list.py
@@ -40,6 +40,35 @@ class CommentReportsMixin(object):
         }
         return payload
 
+    # check if all necessary features are setup in subclass
+    @pytest.fixture()
+    def private_project(self):
+        raise NotImplementedError
+
+    @pytest.fixture()
+    def comment(self):
+        raise NotImplementedError
+
+    @pytest.fixture()
+    def private_url(self):
+        raise NotImplementedError
+
+    @pytest.fixture()
+    def public_project(self):
+        raise NotImplementedError
+
+    @pytest.fixture()
+    def public_comment(self):
+        raise NotImplementedError
+
+    @pytest.fixture()
+    def public_url(self):
+        raise NotImplementedError
+
+    @pytest.fixture()
+    def comment_level(self):
+        raise NotImplementedError
+
     def test_private_node_view_reports_auth_misc(self, app, user, contributor, non_contributor, private_url):
         # test_private_node_logged_out_user_cannot_view_reports
         res = app.get(private_url, expect_errors=True)

--- a/api_tests/comments/views/test_comment_report_list.py
+++ b/api_tests/comments/views/test_comment_report_list.py
@@ -5,7 +5,6 @@ from django.utils import timezone
 from datetime import datetime
 
 from osf.models import Guid
-
 from api.base.settings.defaults import API_BASE
 from api_tests import utils as test_utils
 from tests.base import ApiTestCase

--- a/api_tests/comments/views/test_comment_report_list.py
+++ b/api_tests/comments/views/test_comment_report_list.py
@@ -4,7 +4,7 @@ import mock
 from django.utils import timezone
 from datetime import datetime
 
-from framework.guid.model import Guid
+from osf.model import Guid
 from api.base.settings.defaults import API_BASE
 from api_tests import utils as test_utils
 from tests.base import ApiTestCase


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Conversion of tests from Nose to Pytest
Increase in performance

## Changes

Pytest conversion for all test files in api_tests/comments folder
Grouping of tests for all test files in api_tests/comments folder

## Side effects

Not Known

## Ticket

https://openscience.atlassian.net/browse/OSF-8082