### PR TITLE
Periodic test failure of TestUserWorkshopFormView tests [OSF-8081]

### DIFF
--- a/admin_tests/users/test_views.py
+++ b/admin_tests/users/test_views.py
@@ -1,6 +1,5 @@
 import mock
 import csv
-import os
 import furl
 import pytz
 import pytest
@@ -400,14 +399,19 @@ class TestUserWorkshopFormView(AdminTestCase):
             [None, self.workshop_date.strftime('%m/%d/%y'), None, None, None, 'fake@example.com', None],
         ]
 
-    def _create_and_parse_test_file(self, data):
-        with open('test.csv', 'w') as fp:
-            writer = csv.writer(fp)
-            for row in data:
-                writer.writerow(row)
+        self.mock_data = mock.patch.object(
+            csv,
+            'reader',
+            # parse data into the proper format handling None values as csv reader would
+            side_effect=(lambda values: [[item or '' for item in value] for value in values])
+        )
+        self.mock_data.start()
 
-        with file('test.csv') as fp:
-            result_csv = self.view.parse(fp)
+    def tearDown(self):
+        self.mock_data.stop()
+
+    def _create_and_parse_test_file(self, data):
+        result_csv = self.view.parse(data)
 
         return result_csv
 
@@ -537,22 +541,12 @@ class TestUserWorkshopFormView(AdminTestCase):
             [None, '9/1/16', None, None, None, self.user_1.username, None],
         ]
 
-        with open('test.csv', 'w') as fp:
-            writer = csv.writer(fp)
-            for row in data:
-                writer.writerow(row)
-
-        with file('test.csv', mode='rb') as fp:
-            uploaded = SimpleUploadedFile(fp.name, fp.read(), content_type='text/csv')
+        uploaded = SimpleUploadedFile('test_name', bytes(csv.reader(data)), content_type='text/csv')
 
         form = WorkshopForm(data={'document': uploaded})
         form.is_valid()
         form.cleaned_data['document'] = uploaded
         setup_form_view(self.view, request, form)
-
-    def tearDown(self):
-        if os.path.isfile('test.csv'):
-            os.remove('test.csv')
 
 
 class TestUserSearchView(AdminTestCase):


### PR DESCRIPTION

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Admin test that creates and destroys a CSV file would occasionally fail on travis, causing the whole build to fail

## Changes

- Use mocking for `csv.read` instead of actually creating and parsing a test file

## Side effects

none anticipated


## Ticket
https://openscience.atlassian.net/browse/OSF-8081