### PR TITLE
[OSF-8099] API citations show wrong names

### DIFF
--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -638,7 +638,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             'id': self._id,
             'title': sanitize.unescape_entities(self.title),
             'author': [
-                contributor.csl_name  # method in auth/model.py which parses the names of authors
+                contributor.csl_name(self._id)  # method in auth/model.py which parses the names of authors
                 for contributor in self.visible_contributors
             ],
             'publisher': 'Open Science Framework',

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -470,15 +470,16 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
     def csl_given_name(self):
         return utils.generate_csl_given_name(self.given_name, self.middle_names, self.suffix)
 
-    @property
-    def csl_name(self):
-        if self.family_name and self.given_name:
+    def csl_name(self, node_id):
+        if self.is_registered:
+            """If the user is registered, use the family/given names """
             return {
                 'family': self.family_name,
                 'given': self.csl_given_name,
             }
         else:
-            parsed = utils.impute_names(self.fullname)
+            """ If the user isn't registered, use the unregistered contributor name instead """
+            parsed = utils.impute_names(self.get_unclaimed_record(node_id)['name'])
             given_name = parsed['given']
             middle_names = parsed['middle']
             family_name = parsed['family']

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -472,14 +472,19 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
 
     def csl_name(self, node_id):
         if self.is_registered:
-            """If the user is registered, use the family/given names """
+            name = self.fullname
+        else:
+            name = self.get_unclaimed_record(node_id)['name']
+
+        if self.is_registered and self.family_name and self.given_name:
+            """If the user is registered and has a family and given name, use those"""
             return {
                 'family': self.family_name,
                 'given': self.csl_given_name,
             }
         else:
             """ If the user isn't registered, use the unregistered contributor name instead """
-            parsed = utils.impute_names(self.get_unclaimed_record(node_id)['name'])
+            parsed = utils.impute_names(name)
             given_name = parsed['given']
             middle_names = parsed['middle']
             family_name = parsed['family']

--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -3173,7 +3173,7 @@ class TestCitationsProperties:
         node.save()
         assert len(node.csl['author']) == 2
         expected_authors = [
-            contrib.csl_name for contrib in [node.creator, visible]
+            contrib.csl_name(node._id) for contrib in [node.creator, visible]
         ]
 
         assert node.csl['author'] == expected_authors

--- a/osf_tests/test_user.py
+++ b/osf_tests/test_user.py
@@ -980,16 +980,51 @@ class TestTagging:
 
 class TestCitationProperties:
 
-    def test_user_csl(self, user):
-        # Convert a User instance to csl's name-variable schema
+    @pytest.fixture()
+    def referrer(self):
+        return UserFactory()
+
+    @pytest.fixture()
+    def email(self):
+        return fake.email()
+
+    @pytest.fixture()
+    def unreg_user(self, referrer, project, email):
+        user = UnregUserFactory()
+        given_name = 'Fredd Merkury'
+        user.add_unclaimed_record(node=project,
+            given_name=given_name, referrer=referrer,
+            email=email)
+        user.save()
+        return user
+
+    @pytest.fixture()
+    def project(self, referrer):
+        return NodeFactory(creator=referrer)
+
+    def test_registered_user_csl(self, user):
+        # Tests the csl name for a registered user
+        if user.is_registered:
+            assert bool(
+                user.csl_name(user._id) ==
+                {
+                    'given': user.given_name,
+                    'family': user.family_name,
+                }
+            )
+
+    def test_unregistered_user_csl(self, unreg_user, project):
+        # Tests the csl name for an unregistered user
+        name = unreg_user.unclaimed_records[project._primary_key]['name'].split(' ')
+        family_name = name[-1]
+        given_name = ' '.join(name[:-1])
         assert bool(
-            user.csl_name ==
+            unreg_user.csl_name(project._id) ==
             {
-                'given': user.given_name,
-                'family': user.family_name,
+                'given': given_name,
+                'family': family_name,
             }
         )
-
 
 # copied from tests/test_models.py
 class TestMergingUsers:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -49,7 +49,7 @@ class TestAuthUtils(OsfTestCase):
         user.middle_names = ''
         user.suffix = ''
         user.save()
-        resp = user.csl_name
+        resp = user.csl_name(user._id)
         family_name = resp['family']
         given_name = resp['given']
         assert_equal(family_name, 'King')

--- a/tests/test_citations.py
+++ b/tests/test_citations.py
@@ -4,7 +4,7 @@ from django.utils import timezone
 from nose.tools import *  # noqa
 
 from framework.auth.core import Auth
-from osf_tests.factories import AuthUserFactory, ProjectFactory, UserFactory
+from osf_tests.factories import AuthUserFactory, ProjectFactory, UserFactory, NodeFactory, fake, UnregUserFactory
 from scripts import parse_citation_styles
 from tests.base import OsfTestCase
 from osf.models import OSFUser as User, AbstractNode as Node
@@ -89,28 +89,46 @@ class CitationsNodeTestCase(OsfTestCase):
         node.save()
         assert_equal(len(node.csl['author']), 2)
         expected_authors = [
-            contrib.csl_name for contrib in [node.creator, visible]
+            contrib.csl_name(node._id) for contrib in [node.creator, visible]
         ]
 
         assert_equal(node.csl['author'], expected_authors)
 
 class CitationsUserTestCase(OsfTestCase):
-    def setUp(self):
-        super(CitationsUserTestCase, self).setUp()
-        self.user = UserFactory()
 
-    def tearDown(self):
-        super(CitationsUserTestCase, self).tearDown()
-        User.remove()
+    def test_registered_user_csl(self):
+        # Tests the csl name for a registered user
+        user = User.create_confirmed(
+            username=fake.email(), password='foobar', fullname=fake.name()
+        )
+        if user.is_registered:
+            assert bool(
+                user.csl_name(user._id) ==
+                {
+                    'given': user.given_name,
+                    'family': user.family_name,
+                }
+            )
 
-    def test_user_csl(self):
-        # Convert a User instance to csl's name-variable schema
-        assert_equal(
-            self.user.csl_name,
+    def test_unregistered_user_csl(self):
+        # Tests the csl name for an unregistered user
+        referrer = UserFactory()
+        project = NodeFactory(creator=referrer)
+        user = UnregUserFactory()
+        given_name = 'Fredd Merkury'
+        user.add_unclaimed_record(node=project,
+            given_name=given_name, referrer=referrer,
+            email=fake.email())
+        user.save()
+        name = user.unclaimed_records[project._primary_key]['name'].split(' ')
+        family_name = name[-1]
+        given_name = ' '.join(name[:-1])
+        assert bool(
+            user.csl_name(project._id) ==
             {
-                'given': self.user.given_name,
-                'family': self.user.family_name,
-            },
+                'given': given_name,
+                'family': family_name,
+            }
         )
 
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

For some unregistered contributors, the API was showing the wrong name.  When there is a new unregistered contributor being added to a project, the API will automatically check if the email being used is already in use by another contributor.  If it is, it'll add the new unregistered contributor's name to a new field under the contributor that already exists.  

For citations it will get the first and last name fields of the contributor.  If the contributor is an unregistered contributor with an email that already exists, this can be an issue if the names aren't exactly the same.  

## Changes

The changes include adding a conditional to the API's logic when making citations.  If the user isn't registered, it will get the unregistered_contributor field instead of the first/last name fields.  

For example, the name 'Pasquale Anselmi' in the contributor list shows up correctly.
<img width="980" alt="screen shot 2017-05-16 at 6 24 41 pm" src="https://cloud.githubusercontent.com/assets/19379783/26783715/ad641e9e-49c7-11e7-9c55-ab1bbabff769.png">

But in the citation it only shows up as 'P.'
<img width="484" alt="screen shot 2017-05-16 at 6 29 18 pm" src="https://cloud.githubusercontent.com/assets/19379783/26783719/af2897a0-49c7-11e7-8ab8-bc59aa04152a.png">

The reason why it wasn't showing up correctly is because it was using the name of the previously entered in contributor name. 

In the test example after the changes, the unregistered user 'Pasquale Anselmi' was created using an email that's also being used by another test user:
<img width="824" alt="screen shot 2017-06-05 at 8 09 06 am" src="https://cloud.githubusercontent.com/assets/19379783/26783584/f90979d0-49c6-11e7-9223-98e8ca1b9184.png">
And the citations show up correctly:
<img width="648" alt="screen shot 2017-06-05 at 8 09 20 am" src="https://cloud.githubusercontent.com/assets/19379783/26783585/fada23b8-49c6-11e7-8356-cdee0f415649.png">


## Ticket

https://openscience.atlassian.net/browse/OSF-8099

## Notes to QA

The process for testing will be pretty much the same for https://github.com/CenterForOpenScience/ember-preprints/pull/373, but instead of checking the meta tags you'll just be checking the citations:

1.) Create a new preprint
2.) Add an unregistered contributor
3.) Save the preprint and view it.  Make sure that the meta tags are showing the right information for the contributors currently added
4.) Edit the preprint, this time removing the old unregistered contributor and adding a new unregistered contributor with the same email
5.) Save the changes and view the preprint.  Check the contributor list and the names inside the citations to make sure they reflect the current contributors