### PR TITLE
[feature] Use NodesFilterMixin in Nodes List Views [OSF-8085]

### DIFF
--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -557,7 +557,9 @@ class ListFilterMixin(FilterMixin):
             }
         """
         query_field_name = operation['source_field_name']
-        if operation['op'] != 'eq':
+        if operation['op'] == 'ne':
+            return queryset.exclude(**{query_field_name: operation['value']})
+        elif operation['op'] != 'eq':
             query_field_name = '{}__{}'.format(query_field_name, operation['op'])
         return queryset.filter(**{query_field_name: operation['value']})
 
@@ -571,6 +573,9 @@ class ListFilterMixin(FilterMixin):
             if operation['value'] not in (list(), tuple()):
                 operation['source_field_name'] = 'tags__name'
                 operation['op'] = 'iexact'
+            elif operation['value'] == []:
+                operation['source_field_name'] = 'tags__isnull'
+                operation['value'] = True
         # contributors iexact because guid matching
         if field_name == 'contributors':
             if operation['value'] not in (list(), tuple()):
@@ -584,6 +589,9 @@ class ListFilterMixin(FilterMixin):
             operation['op'] = 'exact'
         if field_name == 'permission':
             operation['op'] = 'exact'
+        if field_name == 'id':
+            operation['source_field_name'] = 'guids___id'
+            operation['op'] = 'in'
 
     def get_filtered_queryset(self, field_name, params, default_queryset):
         """filters default queryset based on the serializer field type"""

--- a/api/institutions/views.py
+++ b/api/institutions/views.py
@@ -24,12 +24,14 @@ from api.base.parsers import (
 )
 from api.base.exceptions import RelationshipPostMakesNoChanges
 from api.nodes.serializers import NodeSerializer
-from api.nodes.filters import NodesListFilterMixin
+from api.nodes.filters import NodesFilterMixin
 from api.users.serializers import UserSerializer
 
 from api.institutions.authentication import InstitutionAuthentication
 from api.institutions.serializers import InstitutionSerializer, InstitutionNodesRelationshipSerializer
 from api.institutions.permissions import UserIsAffiliated
+
+from osf.models import Registration
 
 class InstitutionMixin(object):
     """Mixin with convenience method get_institution
@@ -134,7 +136,7 @@ class InstitutionDetail(JSONAPIBaseView, generics.RetrieveAPIView, InstitutionMi
         return self.get_institution()
 
 
-class InstitutionNodeList(JSONAPIBaseView, NodesListFilterMixin, generics.ListAPIView, InstitutionMixin):
+class InstitutionNodeList(JSONAPIBaseView, generics.ListAPIView, InstitutionMixin, NodesFilterMixin):
     """Nodes that have selected an institution as their primary institution.
 
     ##Permissions
@@ -155,22 +157,20 @@ class InstitutionNodeList(JSONAPIBaseView, NodesListFilterMixin, generics.ListAP
 
     ordering = ('-date_modified', )
 
-    # overrides ODMFilterMixin
-    def get_default_odm_query(self):
-        return (
+    # overrides NodesFilterMixin
+    def get_default_queryset(self):
+        return Node.find((
             Q('is_deleted', 'ne', True) &
             Q('is_public', 'eq', True)
-        )
+        ))
 
     # overrides RetrieveAPIView
     def get_queryset(self):
-        ConcreteNode = apps.get_model('osf.Node')
         inst = self.get_institution()
-        query = self.get_query_from_request()
+        nodes = inst.nodes.filter(id__in=set(self.get_queryset_from_request().values_list('id', flat=True)))
         if self.request.version < '2.2':
-            return ConcreteNode.find_by_institutions(inst, query).get_roots()
-        else:
-            return ConcreteNode.find_by_institutions(inst, query)
+            return nodes.get_roots()
+        return nodes
 
 
 class InstitutionUserList(JSONAPIBaseView, ODMFilterMixin, generics.ListAPIView, InstitutionMixin):
@@ -232,14 +232,12 @@ class InstitutionRegistrationList(InstitutionNodeList):
 
     ordering = ('-date_modified', )
 
-    def get_default_odm_query(self):
-        return self.base_node_query
+    def get_default_queryset(self):
+        return Registration.find(self.base_node_query)
 
     def get_queryset(self):
-        Registration = apps.get_model('osf.Registration')
         inst = self.get_institution()
-        query = self.get_query_from_request()
-        nodes = Registration.find_by_institutions(inst, query)
+        nodes = inst.nodes.filter(id__in=set(self.get_queryset_from_request().values_list('id', flat=True)))
         return [node for node in nodes if not node.is_retracted]
 
 class InstitutionNodesRelationship(JSONAPIBaseView, generics.RetrieveDestroyAPIView, generics.CreateAPIView, InstitutionMixin):

--- a/api/nodes/filters.py
+++ b/api/nodes/filters.py
@@ -11,24 +11,6 @@ from api.base import utils
 from osf.models import NodeRelation, AbstractNode as Node
 
 
-class NodesListFilterMixin(ODMFilterMixin):
-
-    # TODO: This mixin should be replaced with NodesFilterMixin on all views.
-
-    def _operation_to_query(self, operation):
-        if operation['source_field_name'] == 'root':
-            if None in operation['value']:
-                raise InvalidFilterValue()
-            return MQ('root__guids___id', 'in', operation['value'])
-        if operation['source_field_name'] == 'parent_node':
-            if operation['value']:
-                parent = utils.get_object_or_error(Node, operation['value'], display_name='parent')
-                return MQ('_id', 'in', [node._id for node in parent.get_nodes(is_node_link=False)])
-            else:
-                return MQ('parent_nodes__guids___id', 'eq', None)
-        return super(NodesListFilterMixin, self)._operation_to_query(operation)
-
-
 class NodeODMFilterMixin(ODMFilterMixin):
 
     def should_parse_special_query_params(self, field_name):
@@ -75,9 +57,6 @@ class NodeODMFilterMixin(ODMFilterMixin):
 
 
 class NodesFilterMixin(ListFilterMixin):
-
-    def postprocess_query_param(self, key, field_name, operation):
-        pass
 
     def filter_by_field(self, queryset, field_name, operation):
         if field_name == 'parent':

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -57,7 +57,7 @@ from api.identifiers.serializers import NodeIdentifierSerializer
 from api.identifiers.views import IdentifierList
 from api.institutions.serializers import InstitutionSerializer
 from api.logs.serializers import NodeLogSerializer
-from api.nodes.filters import NodeODMFilterMixin, NodesListFilterMixin
+from api.nodes.filters import NodeODMFilterMixin, NodesFilterMixin
 from api.nodes.permissions import (
     IsAdmin,
     IsPublic,
@@ -203,7 +203,7 @@ class WaterButlerMixin(object):
         return obj
 
 
-class NodeList(JSONAPIBaseView, bulk_views.BulkUpdateJSONAPIView, bulk_views.BulkDestroyJSONAPIView, bulk_views.ListBulkCreateJSONAPIView, NodeODMFilterMixin, NodesListFilterMixin, WaterButlerMixin):
+class NodeList(JSONAPIBaseView, bulk_views.BulkUpdateJSONAPIView, bulk_views.BulkDestroyJSONAPIView, bulk_views.ListBulkCreateJSONAPIView, NodesFilterMixin, WaterButlerMixin):
     """Nodes that represent projects and components. *Writeable*.
 
     Paginated list of nodes ordered by their `date_modified`.  Each resource contains the full representation of the
@@ -308,29 +308,12 @@ class NodeList(JSONAPIBaseView, bulk_views.BulkUpdateJSONAPIView, bulk_views.Bul
 
     ordering = ('-date_modified', )  # default ordering
 
-    # overrides FilterMixin
-    def postprocess_query_param(self, key, field_name, operation):
-        # tag queries will usually be on Tag.name,
-        # ?filter[tags]=foo should be translated to MQ('tags__name', 'eq', 'foo')
-        # But queries on lists should be tags, e.g.
-        # ?filter[tags]=foo,bar should be translated to MQ('tags', 'isnull', True)
-        # ?filter[tags]=[] should be translated to MQ('tags', 'isnull', True)
-        if field_name == 'tags':
-            if operation['value'] not in (list(), tuple()):
-                operation['source_field_name'] = 'tags__name'
-                operation['op'] = 'iexact'
-        # contributors iexact because guid matching
-        if field_name == 'contributors':
-            if operation['value'] not in (list(), tuple()):
-                operation['source_field_name'] = '_contributors__guids___id'
-                operation['op'] = 'iexact'
-
-    # overrides ODMFilterMixin
-    def get_default_odm_query(self):
+    # overrides NodesFilterMixin
+    def get_default_queryset(self):
         user = self.request.user
         base_query = default_node_list_query()
         permissions_query = default_node_permission_query(user)
-        return base_query & permissions_query
+        return Node.find(base_query & permissions_query)
 
     # overrides ListBulkCreateJSONAPIView, BulkUpdateJSONAPIView
     def get_queryset(self):
@@ -357,8 +340,7 @@ class NodeList(JSONAPIBaseView, bulk_views.BulkUpdateJSONAPIView, bulk_views.Bul
                     raise PermissionDenied
             return nodes
         else:
-            query = self.get_query_from_request()
-            return AbstractNode.find(query).distinct()
+            return self.get_queryset_from_request().distinct()
 
     # overrides ListBulkCreateJSONAPIView, BulkUpdateJSONAPIView, BulkDestroyJSONAPIView
     def get_serializer_class(self):

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -12,7 +12,7 @@ from api.base.utils import (default_node_list_query,
                             get_user_auth)
 from api.base.views import JSONAPIBaseView
 from api.institutions.serializers import InstitutionSerializer
-from api.nodes.filters import NodesFilterMixin, NodesListFilterMixin, NodeODMFilterMixin
+from api.nodes.filters import NodesFilterMixin
 from api.nodes.serializers import NodeSerializer
 from api.preprints.serializers import PreprintSerializer
 from api.registrations.serializers import RegistrationSerializer
@@ -593,7 +593,7 @@ class UserInstitutions(JSONAPIBaseView, generics.ListAPIView, UserMixin):
 
 
 # TODO: This view should be a subclass of UserNodes (i.e. NodeODMFilterMixin and NodesListFilterMixin replaced with NodesFilterMixin)
-class UserRegistrations(JSONAPIBaseView, generics.ListAPIView, UserMixin, NodeODMFilterMixin, NodesListFilterMixin):
+class UserRegistrations(JSONAPIBaseView, generics.ListAPIView, UserMixin, NodesFilterMixin):
     """List of registrations that the user contributes to. *Read-only*.
 
     Paginated list of registrations that the user contributes to.  Each resource contains the full representation of the
@@ -688,8 +688,8 @@ class UserRegistrations(JSONAPIBaseView, generics.ListAPIView, UserMixin, NodeOD
     view_category = 'users'
     view_name = 'user-registrations'
 
-    # overrides ODMFilterMixin
-    def get_default_odm_query(self):
+    # overrides NodesFilterMixin
+    def get_default_queryset(self):
         user = self.get_user()
         current_user = self.request.user
 
@@ -702,11 +702,11 @@ class UserRegistrations(JSONAPIBaseView, generics.ListAPIView, UserMixin, NodeOD
         if not current_user.is_anonymous:
             permission_query = (permission_query | MQ('contributors', 'eq', current_user))
         query = query & permission_query
-        return query
+        return Node.find(query)
 
     # overrides ListAPIView
     def get_queryset(self):
-        return Node.find(self.get_query_from_request()).select_related('node_license').include('guids', 'contributor__user__guids', 'root__guids', limit_includes=10)
+        return self.get_queryset_from_request().select_related('node_license').include('guids', 'contributor__user__guids', 'root__guids', limit_includes=10)
 
 
 class UserInstitutionsRelationship(JSONAPIBaseView, generics.RetrieveDestroyAPIView, UserMixin):

--- a/api_tests/registrations/filters/test_filters.py
+++ b/api_tests/registrations/filters/test_filters.py
@@ -3,7 +3,7 @@ from nose.tools import *  # flake8: noqa
 import pytest
 
 from osf.models import Node
-
+from osf.utils.auth import Auth
 from osf_tests.factories import (
     AuthUserFactory,
     NodeFactory,
@@ -20,6 +20,7 @@ class RegistrationListFilteringMixin(object):
         assert self.url, 'Subclasses of RegistrationListFilteringMixin must define self.url'
 
         self.user = AuthUserFactory()
+        self.user_two = AuthUserFactory()
 
         self.A = ProjectFactory(creator=self.user)
         self.B1 = NodeFactory(parent=self.A, creator=self.user)
@@ -28,11 +29,15 @@ class RegistrationListFilteringMixin(object):
         self.C2 = NodeFactory(parent=self.B2, creator=self.user)
         self.D2 = NodeFactory(parent=self.C2, creator=self.user)
 
+        self.A.add_contributor(self.user_two, save=True)
+
         self.node_A = RegistrationFactory(project=self.A, creator=self.user)
         self.node_B2 = RegistrationFactory(project=self.B2, creator=self.user)
 
         self.parent_url = '{}filter[parent]='.format(self.url)
         self.root_url ='{}filter[root]='.format(self.url)
+        self.tags_url ='{}filter[tags]='.format(self.url)
+        self.contributors_url ='{}filter[contributors]='.format(self.url)
 
     def test_parent_filter_null(self):
         expected = [self.node_A._id, self.node_B2._id]
@@ -73,3 +78,20 @@ class RegistrationListFilteringMixin(object):
         actual = [node['id'] for node in res.json['data']]
         assert_equal(len(actual), 6)
         assert_equal(set(expected), set(actual))
+
+    def test_tag_filter(self):
+        self.node_A.add_tag('nerd', auth=Auth(self.node_A.creator), save=True)
+        expected = [self.node_A._id]
+        res = self.app.get('{}nerd'.format(self.tags_url), auth=self.user.auth)
+        actual = [node['id'] for node in res.json['data']]
+        assert_equal(expected, actual)
+
+        res = self.app.get('{}bird'.format(self.tags_url), auth=self.user.auth)
+        actual = [node['id'] for node in res.json['data']]
+        assert_equal([], actual)
+
+    def test_contributor_filter(self):
+        expected = [self.node_A._id]
+        res = self.app.get('{}{}'.format(self.contributors_url, self.user_two._id), auth=self.user.auth)
+        actual = [node['id'] for node in res.json['data']]
+        assert_equal(expected, actual)


### PR DESCRIPTION
#### Purpose
- Fixes filtering by tags and contributors on user and institution node list views. 

#### Changes
- Replaces `NodeODMFilterMixin` and `NodesListFilterMixin` with `NodesFilterMixin` on all nodes list views.
  - /v2/users/<user_id>/nodes/ 
  - /v2/users/<user_id>/registrations/
  - /v2/institutions/<inst_id>/nodes/
  - /v2/institutions/<inst_id>/registrations/
  - /v2/nodes/
  - /v2/registrations/

#### Side Effects
- None expected.

#### Ticket
- [OSF-8085](https://openscience.atlassian.net/browse/OSF-8085)
