### PR TITLE
[feature] Fix update_taxonomies and populate_fake_preprint_providers [No Ticket]

### DIFF
--- a/osf/management/commands/populate_fake_preprint_providers.py
+++ b/osf/management/commands/populate_fake_preprint_providers.py
@@ -12,7 +12,8 @@ In order to make additional changes to a preprint provider
 you should run the admin app which will allow you to edit a preprint provider.
 
 Before running this command, you should run the update_taxonomies script
-to populate subjects (if you haven't already).
+to populate subjects (if you haven't already). The update_taxonomies script
+will create the OSF preprint provider.
 '''
 
 from __future__ import unicode_literals
@@ -33,7 +34,7 @@ from modularodm.exceptions import NoResultsFound
 
 from osf.models import NodeLicense, Subject, PreprintProvider
 from scripts import utils as script_utils
-from website.settings import PREPRINT_PROVIDER_DOMAINS, DOMAIN
+from website.settings import PREPRINT_PROVIDER_DOMAINS
 
 logger = logging.getLogger(__name__)
 
@@ -44,14 +45,6 @@ def format_domain_url(domain):
 
 SUBJECTS_CACHE = {}
 PREPRINT_PROVIDERS = [
-    {
-        '_id': 'osf',
-        'name': 'Open Science Framework',
-        'domain': DOMAIN,
-        'domain_redirect_enabled': False,
-        'default_license': 'CC0 1.0 Universal',
-        'licenses_acceptable': ['CC0 1.0 Universal', 'CC-By Attribution 4.0 International', 'No license'],
-    },
     {
         '_id': 'lawarxiv',
         'name': '[TEST] LawArXiv',

--- a/scripts/update_taxonomies.py
+++ b/scripts/update_taxonomies.py
@@ -15,10 +15,14 @@ from website import settings
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
-# Stolen from scripts.populate_preprint_providers for initial subject creation
+# OSF preprint provider used for initial subject creation
 OSF_PROVIDER_DATA = {
     '_id': 'osf',
     'name': 'Open Science Framework',
+    'domain': settings.DOMAIN,
+    'domain_redirect_enabled': False,
+    'default_license': 'CC0 1.0 Universal',
+    'licenses_acceptable': ['CC0 1.0 Universal', 'CC-By Attribution 4.0 International', 'No license'],
 }
 
 def update_taxonomies(filename):


### PR DESCRIPTION
#### Purpose
- Fixes error when running `update_taxonomies`:
```
  File "/usr/local/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/local/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/code/scripts/update_taxonomies.py", line 74, in <module>
    main()
  File "/code/scripts/update_taxonomies.py", line 69, in main
    update_taxonomies('bepress_taxonomy.json')
  File "/code/scripts/update_taxonomies.py", line 30, in update_taxonomies
    bepress_provider, _ = update_or_create(OSF_PROVIDER_DATA)
  File "scripts/populate_preprint_providers.py", line 50, in update_or_create
    provider_data['domain_redirect_enabled'] &= PREPRINT_PROVIDER_DOMAINS['enabled'] and bool(provider_data['domain'])
KeyError: 'domain_redirect_enabled'
```

#### Changes
- Add data necessary for OSF preprint provider to be created in `update_taxonomies` script. 
- Remove creation of OSF preprint provider from `populate_fake_preprint_providers` as it will always be created when `update_taxonomies` is run.
