### PR TITLE
Remove unused APIv1 profile endpoints [OSF-8107]

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1048,12 +1048,6 @@ class TestUserProfile(OsfTestCase):
         super(TestUserProfile, self).setUp()
         self.user = AuthUserFactory()
 
-    def test_sanitization_of_edit_profile(self):
-        url = api_url_for('edit_profile', uid=self.user._id)
-        post_data = {'name': 'fullname', 'value': 'new<b> name</b>     '}
-        request = self.app.post(url, post_data, auth=self.user.auth)
-        assert_equal('new name', request.json['name'])
-
     def test_fmt_date_or_none(self):
         with assert_raises(HTTPError) as cm:
             #enter a date before 1900

--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -35,7 +35,6 @@ from website.profile import utils as profile_utils
 from website.util.time import throttle_period_expired
 from website.util import api_v2_url, web_url_for, paths
 from website.util.sanitize import escape_html
-from website.util.sanitize import strip_html
 from website.views import serialize_node_summary
 from addons.base import utils as addon_utils
 
@@ -319,28 +318,6 @@ def profile_view_id(uid, auth):
     is_profile = auth and auth.user == user
     # Embed node data, so profile node lists can be rendered
     return _profile_view(user, is_profile, embed_nodes=False, include_node_counts=True)
-
-
-@must_be_logged_in
-def edit_profile(**kwargs):
-    # NOTE: This method is deprecated. Use update_user instead.
-    # TODO: Remove this view
-    user = kwargs['auth'].user
-
-    form = request.form
-
-    ret = {'response': 'success'}
-    if form.get('name') == 'fullname' and form.get('value', '').strip():
-        user.fullname = strip_html(form['value']).strip()
-        user.save()
-        ret['name'] = user.fullname
-    return ret
-
-
-def get_profile_summary(user_id, formatter='long'):
-
-    user = User.load(user_id)
-    return user.get_summary(formatter)
 
 
 @must_be_logged_in

--- a/website/routes.py
+++ b/website/routes.py
@@ -821,9 +821,6 @@ def make_url_map(app):
         Rule('/profile/<uid>/', 'get', profile_views.profile_view_id_json, json_renderer),
 
         # Used by profile.html
-        Rule('/profile/<uid>/edit/', 'post', profile_views.edit_profile, json_renderer),
-        Rule('/profile/<user_id>/summary/', 'get',
-             profile_views.get_profile_summary, json_renderer),
         Rule('/user/<uid>/<pid>/claim/email/', 'post',
              project_views.contributor.claim_user_post, json_renderer),
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

It appears that the following endpoints are unused by the frontend and can therefore be removed:
PUT /api/v1/profile/<uid>/edit/
GET /api/v1/profile/<user_id>/summary/

So let's get rid of them!

## Changes

- Remove `edit_profile` and `get_profile_summary` routes
- Remove those views as well
- Remove test that references `edit_profile`

## Side effects

None anticipated


## Ticket

https://openscience.atlassian.net/browse/OSF-8107