### PR TITLE
[Feature] Correct github spelling on support page [OSF-7165]

### DIFF
--- a/website/templates/public/pages/support.mako
+++ b/website/templates/public/pages/support.mako
@@ -79,7 +79,7 @@
                 <a href="https://twitter.com/OSFramework" class="btn btn-link"><i class="fa fa-twitter"></i> Ask us a question on twitter </a>
                 <a href="https://groups.google.com/forum/#!forum/openscienceframework" class="btn btn-link"><i class="fa fa-users"></i> Join our mailing list </a>
                 <a href="https://www.facebook.com/CenterForOpenScience/" class="btn btn-link"><i class="fa fa-facebook"></i> Follow us on Facebook </a>
-                <a href="https://github.com/centerforopenscience" class="btn btn-link"><i class="fa fa-github"></i> Connect with COS on Github</a>
+                <a href="https://github.com/centerforopenscience" class="btn btn-link"><i class="fa fa-github"></i> Connect with COS on GitHub</a>
             </div>
         </div>
 


### PR DESCRIPTION
## Purpose

Spell github correctly on osf.io/support page

## Changes

Reapply changes made in https://github.com/CenterForOpenScience/osf.io/pull/7284
that got overwritten when fixing merge conflict.

## Ticket

https://openscience.atlassian.net/browse/OSF-7165
