### PR TITLE
Remove unused APIv1 project endpoints and views [OSF-8109]

### DIFF
--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -200,13 +200,6 @@ class TestIdentifierViews(OsfTestCase):
         self.user = AuthUserFactory()
         self.node = RegistrationFactory(creator=self.user, is_public=True)
 
-    def test_get_identifiers(self):
-        self.node.set_identifier_value('doi', 'FK424601')
-        self.node.set_identifier_value('ark', 'fk224601')
-        res = self.app.get(self.node.api_url_for('node_identifiers_get'))
-        assert_equal(res.json['doi'], 'FK424601')
-        assert_equal(res.json['ark'], 'fk224601')
-
     @httpretty.activate
     def test_create_identifiers_not_exists(self):
         identifier = self.node._id

--- a/tests/test_registrations/test_embargoes.py
+++ b/tests/test_registrations/test_embargoes.py
@@ -1002,11 +1002,7 @@ class RegistrationEmbargoViewsTestCase(OsfTestCase):
             self.registration.embargo.approve_embargo(User.load(user_id), approval_token)
         self.registration.save()
 
-        res = self.app.post(
-            self.registration.api_url_for('project_set_privacy', permissions='public'),
-            auth=self.user.auth,
-        )
-        assert_equal(res.status_code, 200)
+        self.registration.set_privacy('public', Auth(self.registration.creator))
         for reg in self.registration.node_and_primary_descendants():
             reg.reload()
             assert_false(reg.is_public)
@@ -1040,11 +1036,7 @@ class RegistrationEmbargoViewsTestCase(OsfTestCase):
             self.registration.embargo.approve_embargo(User.load(user_id), approval_token)
         self.registration.save()
 
-        res = self.app.post(
-            self.registration.api_url_for('project_set_privacy', permissions='public'),
-            auth=self.user.auth,
-        )
-        assert_equal(res.status_code, 200)
+        self.registration.set_privacy('public', Auth(self.registration.creator))
         for admin in self.registration.admin_contributors:
             assert_true(any([each[0][0] == admin.username for each in mock_send_mail.call_args_list]))
 
@@ -1067,11 +1059,7 @@ class RegistrationEmbargoViewsTestCase(OsfTestCase):
             registration.embargo.approve_embargo(User.load(user_id), approval_token)
         self.registration.save()
 
-        res = self.app.post(
-            registration.api_url_for('project_set_privacy', permissions='public'),
-            auth=self.user.auth
-        )
-        assert_equal(res.status_code, 200)
+        registration.set_privacy('public', Auth(self.registration.creator))
         asked_admins = [(admin._id, n._id) for admin, n in mock_ask.call_args[0][0]]
         for admin, node in registration.get_admin_contributors_recursive():
             assert_in((admin._id, node._id), asked_admins)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -689,50 +689,6 @@ class TestProjectViews(OsfTestCase):
         # A log event was saved
         assert_equal(self.project.logs.latest().action, 'edit_title')
 
-    def test_make_public(self):
-        self.project.is_public = False
-        self.project.save()
-        url = "/api/v1/project/{0}/permissions/public/".format(self.project._id)
-        res = self.app.post_json(url, {}, auth=self.auth)
-        self.project.reload()
-        assert_true(self.project.is_public)
-        assert_equal(res.json['status'], 'success')
-
-    def test_make_private(self):
-        self.project.is_public = True
-        self.project.save()
-        url = "/api/v1/project/{0}/permissions/private/".format(self.project._id)
-        res = self.app.post_json(url, {}, auth=self.auth)
-        self.project.reload()
-        assert_false(self.project.is_public)
-        assert_equal(res.json['status'], 'success')
-
-    def test_cant_make_public_if_not_admin(self):
-        non_admin = AuthUserFactory()
-        self.project.add_contributor(non_admin, permissions=['read', 'write'])
-        self.project.is_public = False
-        self.project.save()
-        url = "/api/v1/project/{0}/permissions/public/".format(self.project._id)
-        res = self.app.post_json(
-            url, {}, auth=non_admin.auth,
-            expect_errors=True,
-        )
-        assert_equal(res.status_code, http.FORBIDDEN)
-        assert_false(self.project.is_public)
-
-    def test_cant_make_private_if_not_admin(self):
-        non_admin = AuthUserFactory()
-        self.project.add_contributor(non_admin, permissions=['read', 'write'])
-        self.project.is_public = True
-        self.project.save()
-        url = "/api/v1/project/{0}/permissions/private/".format(self.project._id)
-        res = self.app.post_json(
-            url, {}, auth=non_admin.auth,
-            expect_errors=True,
-        )
-        assert_equal(res.status_code, http.FORBIDDEN)
-        assert_true(self.project.is_public)
-
     def test_add_tag(self):
         url = self.project.api_url_for('project_add_tag')
         self.app.post_json(url, {'tag': "foo'ta#@%#%^&g?"}, auth=self.auth)
@@ -763,14 +719,6 @@ class TestProjectViews(OsfTestCase):
         url = self.project.api_url_for('project_remove_tag')
         res = self.app.delete_json(url, {'tag': 'troz'}, auth=self.auth, expect_errors=True)
         assert_equal(res.status_code, http.CONFLICT)
-
-    def test_remove_project(self):
-        url = self.project.api_url
-        res = self.app.delete_json(url, {}, auth=self.auth).maybe_follow()
-        self.project.reload()
-        assert_equal(self.project.is_deleted, True)
-        assert_in('url', res.json)
-        assert_equal(res.json['url'], '/dashboard/')
 
     def test_suspended_project(self):
         node = NodeFactory(parent=self.project, creator=self.user1)
@@ -840,33 +788,6 @@ class TestProjectViews(OsfTestCase):
         assert last_log.action == NodeLog.VIEW_ONLY_LINK_REMOVED
         assert last_log.params.get('anonymous_link')
 
-    def test_remove_component(self):
-        node = NodeFactory(parent=self.project, creator=self.user1)
-        url = node.api_url
-        res = self.app.delete_json(url, {}, auth=self.auth).maybe_follow()
-        node.reload()
-        assert_equal(node.is_deleted, True)
-        assert_in('url', res.json)
-        assert_equal(res.json['url'], self.project.url)
-
-    def test_cant_remove_component_if_not_admin(self):
-        node = NodeFactory(parent=self.project, creator=self.user1)
-        non_admin = AuthUserFactory()
-        node.add_contributor(
-            non_admin,
-            permissions=['read', 'write'],
-            save=True,
-        )
-
-        url = node.api_url
-        res = self.app.delete_json(
-            url, {}, auth=non_admin.auth,
-            expect_errors=True,
-        ).maybe_follow()
-
-        assert_equal(res.status_code, http.FORBIDDEN)
-        assert_false(node.is_deleted)
-
     def test_view_project_returns_whether_to_show_wiki_widget(self):
         user = AuthUserFactory()
         project = ProjectFactory(creator=user, is_public=True)
@@ -891,12 +812,6 @@ class TestProjectViews(OsfTestCase):
         res = self.app.get(url, auth=user.auth)
         assert_in('fork_count', res.json['node'])
         assert_equal(0, res.json['node']['fork_count'])
-
-    def test_statistic_page_redirect(self):
-        url = self.project.web_url_for('project_statistics_redirect')
-        res = self.app.get(url, auth=self.auth)
-        assert_equal(res.status_code, 302)
-        assert_in(self.project.web_url_for('project_statistics', _guid=True), res.location)
 
     def test_registration_retraction_redirect(self):
         url = self.project.web_url_for('node_registration_retraction_redirect')
@@ -3999,17 +3914,6 @@ class TestFileViews(OsfTestCase):
         self.project = ProjectFactory(creator=self.user, is_public=True)
         self.project.add_contributor(self.user)
         self.project.save()
-
-    def test_files_get(self):
-
-        url = self.project.api_url_for('collect_file_trees')
-        res = self.app.get(url, auth=self.user.auth)
-        expected = _view_project(self.project, auth=Auth(user=self.user))
-
-        assert_equal(res.status_code, http.OK)
-        assert_equal(res.json['node'], expected['node'])
-        assert_in('tree_js', res.json)
-        assert_in('tree_css', res.json)
 
     def test_grid_data(self):
         url = self.project.api_url_for('grid_data')

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -12,7 +12,6 @@ from django.db.models import Count
 
 from framework import status
 from framework.utils import iso8601format
-from framework.flask import redirect
 from framework.auth.decorators import must_be_logged_in, collect_auth
 from framework.exceptions import HTTPError
 from osf.models.nodelog import NodeLog
@@ -419,25 +418,9 @@ def project_statistics(auth, node, **kwargs):
     return ret
 
 
-@must_be_valid_project
-@must_be_contributor_or_public
-def project_statistics_redirect(auth, node, **kwargs):
-    return redirect(node.web_url_for('project_statistics', _guid=True))
-
 ###############################################################################
 # Make Private/Public
 ###############################################################################
-
-
-@must_be_valid_project
-@must_have_permission(ADMIN)
-def project_before_set_public(node, **kwargs):
-    prompt = node.callback('before_make_public')
-
-    return {
-        'prompts': prompt
-    }
-
 
 @must_be_valid_project
 @must_have_permission(ADMIN)
@@ -459,6 +442,7 @@ def project_set_privacy(auth, node, **kwargs):
         'status': 'success',
         'permissions': permissions,
     }
+
 
 @must_be_valid_project
 @must_not_be_registration
@@ -482,41 +466,6 @@ def update_node(auth, node, **kwargs):
     }
     node.save()
     return {'updated_fields': updated_fields_dict}
-
-
-@must_be_valid_project
-@must_have_permission(ADMIN)
-@must_not_be_registration
-def component_remove(auth, node, **kwargs):
-    """Remove component, and recursively remove its children. If node has a
-    parent, add log and redirect to parent; else redirect to user dashboard.
-
-    """
-    try:
-        node.remove_node(auth)
-    except NodeStateError as e:
-        raise HTTPError(
-            http.BAD_REQUEST,
-            data={
-                'message_short': 'Error',
-                'message_long': 'Could not delete component: ' + e.message
-            },
-        )
-    node.save()
-
-    message = '{} has been successfully deleted.'.format(
-        node.project_or_component.capitalize()
-    )
-    status.push_status_message(message, kind='success', trust=False)
-    parent = node.parent_node
-    if parent and parent.can_view(auth):
-        redirect_url = node.parent_node.url
-    else:
-        redirect_url = '/dashboard/'
-
-    return {
-        'url': redirect_url,
-    }
 
 
 @must_be_valid_project

--- a/website/project/views/register.py
+++ b/website/project/views/register.py
@@ -222,19 +222,6 @@ def osf_admin_change_status_identifier(node, status):
 
 
 @must_be_valid_project
-@must_be_contributor_or_public
-def node_identifiers_get(node, **kwargs):
-    """Retrieve identifiers for a node. Node must be a public registration.
-    """
-    if not node.is_public:
-        raise HTTPError(http.BAD_REQUEST)
-    return {
-        'doi': node.get_identifier_value('doi'),
-        'ark': node.get_identifier_value('ark'),
-    }
-
-
-@must_be_valid_project
 @must_have_permission(ADMIN)
 def node_identifiers_post(auth, node, **kwargs):
     """Create identifier pair for a node. Node must be a public registration.

--- a/website/routes.py
+++ b/website/routes.py
@@ -1117,17 +1117,6 @@ def make_url_map(app):
             notemplate,
         ),
 
-        # Statistics
-        Rule(
-            [
-                '/project/<pid>/statistics/',
-                '/project/<pid>/node/<nid>/statistics/',
-            ],
-            'get',
-            project_views.node.project_statistics_redirect,
-            notemplate,
-        ),
-
         Rule(
             [
                 '/project/<pid>/analytics/',
@@ -1395,17 +1384,6 @@ def make_url_map(app):
             json_renderer,
         ),
 
-        # Remove
-        Rule(
-            [
-                '/project/<pid>/',
-                '/project/<pid>/node/<nid>/',
-            ],
-            'delete',
-            project_views.node.component_remove,
-            json_renderer,
-        ),
-
         # Reorder components
         Rule('/project/<pid>/reorder_components/', 'post',
              project_views.node.project_reorder_components, json_renderer),
@@ -1448,11 +1426,6 @@ def make_url_map(app):
                 '/project/<pid>/node/<nid>/pointer/fork/',
             ], 'post', project_views.node.fork_pointer, json_renderer,
         ),
-        # View forks
-        Rule([
-            '/project/<pid>/forks/',
-            '/project/<pid>/node/<nid>/forks/',
-        ], 'get', project_views.node.node_forks, json_renderer),
 
         # Registrations
         Rule([
@@ -1464,10 +1437,6 @@ def make_url_map(app):
             '/project/<pid>/node/<nid>/drafts/<draft_id>/register/',
         ], 'post', project_views.drafts.register_draft_registration, json_renderer),
         Rule([
-            '/project/<pid>/register/<template>/',
-            '/project/<pid>/node/<nid>/register/<template>/',
-        ], 'get', project_views.register.node_register_template_page, json_renderer),
-        Rule([
             '/project/<pid>/withdraw/',
             '/project/<pid>/node/<nid>/withdraw/'
         ], 'post', project_views.register.node_registration_retraction_post, json_renderer),
@@ -1477,46 +1446,8 @@ def make_url_map(app):
                 '/project/<pid>/identifiers/',
                 '/project/<pid>/node/<nid>/identifiers/',
             ],
-            'get',
-            project_views.register.node_identifiers_get,
-            json_renderer,
-        ),
-
-        Rule(
-            [
-                '/project/<pid>/identifiers/',
-                '/project/<pid>/node/<nid>/identifiers/',
-            ],
             'post',
             project_views.register.node_identifiers_post,
-            json_renderer,
-        ),
-
-        # Statistics
-        Rule([
-            '/project/<pid>/statistics/',
-            '/project/<pid>/node/<nid>/statistics/',
-        ], 'get', project_views.node.project_statistics, json_renderer),
-
-        # Permissions
-        Rule([
-            '/project/<pid>/permissions/<permissions>/',
-            '/project/<pid>/node/<nid>/permissions/<permissions>/',
-        ], 'post', project_views.node.project_set_privacy, json_renderer),
-
-        Rule([
-            '/project/<pid>/permissions/beforepublic/',
-            '/project/<pid>/node/<nid>/permissions/beforepublic/',
-        ], 'get', project_views.node.project_before_set_public, json_renderer),
-
-        # Combined files
-        Rule(
-            [
-                '/project/<pid>/files/',
-                '/project/<pid>/node/<nid>/files/'
-            ],
-            'get',
-            project_views.file.collect_file_trees,
             json_renderer,
         ),
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

It appears that the following endpoints are unused by the frontend and can therefore be removed:
- GET /api/v1/project/<<pid>>/forks/ (view is still used for mako endpoint, but API endpoint is unused)
- GET /api/v1/project/<<pid>>/register/<template>/ (view is still used for mako endpoint, but API endpoint is unused)
- PUT /api/v1/project/<<pid>>/
- DELETE /api/v/1/project/<<pid>>/
- GET /api/v1/project/<<pid>>/identifiers/
- GET /api/v1/project/<<pid>>/statistics/ (view is still used for mako endpoint, but API endpoint is unused)
- GET /api/v1/project/<<pid>>/files/
- GET /api/v1/project/<<pid>>/permissions/beforepublic/
- POST /api/v1/project/<<pid>>/permissions/<permissions>/

## Changes

- Remove the specified API v1 routes and views where appropriate
- Remove references to the routes and views in tests

## Side effects

None anticipated, code should be unused so everything should work as normal!


## Ticket
https://openscience.atlassian.net/browse/OSF-8109