### PR TITLE
[Feature] Show licenses acceptable as formatted list [OSF-8009]

### DIFF
--- a/admin/preprint_providers/views.py
+++ b/admin/preprint_providers/views.py
@@ -86,7 +86,12 @@ class PreprintProviderDisplay(PermissionRequiredMixin, DetailView):
         preprint_provider_attributes = model_to_dict(preprint_provider)
         kwargs.setdefault('page_number', self.request.GET.get('page', '1'))
 
-        preprint_provider_attributes['licenses_acceptable'] = preprint_provider.licenses_acceptable.values_list('name', flat=True)
+        licenses_acceptable = list(preprint_provider.licenses_acceptable.values_list('name', flat=True))
+        licenses_html = '<ul>'
+        for license in licenses_acceptable:
+            licenses_html += '<li>{}</li>'.format(license)
+        licenses_html += '</ul>'
+        preprint_provider_attributes['licenses_acceptable'] = licenses_html
 
         subject_html = '<ul class="three-cols">'
         for parent in preprint_provider.top_level_subjects:


### PR DESCRIPTION
## Purpose

Show acceptable licenses as formatted list

## Changes

Modify admin preprintProviderDisplay view to show formatted list
of acceptable licenses.

<img width="354" alt="edit-config" src="https://user-images.githubusercontent.com/6599111/27841664-57426784-60d1-11e7-893b-ba36efcc1723.png">
<img width="975" alt="saved-config" src="https://user-images.githubusercontent.com/6599111/27841674-6af01754-60d1-11e7-96c0-645efe7045e5.png">


## Ticket

https://openscience.atlassian.net/browse/OSF-8009
