### PR TITLE
[Feature] Prevent components reordering on a registration [OSF-7688]

### DIFF
--- a/website/templates/util/render_nodes.mako
+++ b/website/templates/util/render_nodes.mako
@@ -11,7 +11,7 @@
                 % endfor
             </span>
         </ul>
-        % if sortable and 'write' in user['permissions']:
+        % if sortable and 'write' in user['permissions'] and not node['is_registration']:
         <script>
             $(function(){
                 $('.sortable').sortable({


### PR DESCRIPTION
## Purpose

Prevent users with write access from reordering registration's components

## Changes

Add `is_registration` check to prevent users with write access to a registered node from
attempting to reorder components on a registration.

## Ticket

https://openscience.atlassian.net/browse/OSF-7688
