### PR TITLE
Add .docker-sync to sync_excludes and watch_excludes for osf.io

### DIFF
--- a/docker-sync.yml
+++ b/docker-sync.yml
@@ -59,5 +59,5 @@ syncs:
     sync_strategy: 'unison'
     sync_args: [ '-prefer newer' ]
     sync_excludes_type: 'Name'
-    sync_excludes: ['.DS_Store', '*.map', '*.pyc', '*.tmp', 'etree.py', '.git', '.idea', 'bower_components', 'node_modules']
-    watch_excludes: ['.*\.DS_Store', '.*\.map', '.*\.pyc', '.*\.tmp', '.*/etree\.py', '.*/\.git', '.*/\.idea', '.*/bower_components', '.*/node_modules']
+    sync_excludes: ['.DS_Store', '*.map', '*.pyc', '*.tmp', 'etree.py', '.git', '.idea', 'bower_components', 'node_modules', '.docker-sync']
+    watch_excludes: ['.*\.DS_Store', '.*\.map', '.*\.pyc', '.*\.tmp', '.*/etree\.py', '.*/\.git', '.*/\.idea', '.*/bower_components', '.*/node_modules', '.*/.docker-sync']


### PR DESCRIPTION
## Purpose

When running docker-sync in daemon mode, it writes a pid file and log file to .docker-sync, which it then tries to sync. This results in writing to the log, syncing the log, ad infinitum.

## Changes

Added .docker-sync to sync_excludes and watch_excludes for osf.io

## Side effects

N/A

## Ticket

N/A
