### PR TITLE
[feature] Fix Admin App Import Preprint Provider [OSF-8016]

### DIFF
--- a/admin/static/js/preprint_providers/preprintProviders.js
+++ b/admin/static/js/preprint_providers/preprintProviders.js
@@ -115,17 +115,19 @@ $(document).ready(function() {
         $.get(window.templateVars.rulesToSubjectsUrl, {"rules": JSON.stringify(rules)}, function (data) {
             var subjects = data["subjects"];
             for (var h=0; h<selected_subjects.length; h++) {
-                $("input[value=" + selected_subjects[h] + "]").prop("checked", false);
+                $("#subjects input[value=" + selected_subjects[h] + "]").prop("checked", false);
             }
             clearSubjects();
             for (var i=0; i<subjects.length; i++) {
                 addSubject(subjects[i]);
-                $("input[value=" + subjects[i] + "]").prop("checked", true);
+                $("#subjects input[value=" + subjects[i] + "]").prop("checked", true);
             }
         });
     };
 
     $("#import-form").submit(function(event) {
+        tinymceFields = ['description', 'advisory_board', 'footer_links'];
+        checkedBooleanFields = ['domain_redirect_enabled', 'allow_submissions'];
         event.preventDefault();
         $.ajax({
             url: window.templateVars.importUrl,
@@ -135,13 +137,22 @@ $(document).ready(function() {
             contentType: false,
             processData: false,
             success: function(response) {
-                for (var k in response){
-                    if (response.hasOwnProperty(k)) {
-                        if (k === "subjects_acceptable") {
-                            populateSubjects(response[k]);
+                for (var field_name in response){
+                    if (response.hasOwnProperty(field_name)) {
+                        field_value = response[field_name];
+                        if (field_name === "subjects_acceptable") {
+                            populateSubjects(field_value);
+                        } else if (checkedBooleanFields.includes(field_name)) {
+                            $("input[name=" + field_name + "]").prop("checked", field_value);
+                        } else if (tinymceFields.includes(field_name)) {
+                            tinymce.get("id_" + field_name).setContent(field_value);
+                        } else if (field_name === "licenses_acceptable") {
+                            field_value.forEach(function(element, index, array) {
+                                $("input[name=" + field_name + "][value=" + element + "]").prop("checked", true);
+                            });
                         } else {
-                            var field = $("#id_" + k);
-                            field.val(response[k]);
+                            var field = $("#id_" + field_name);
+                            field.val(field_value);
                         }
                     }
                 }


### PR DESCRIPTION
#### Purpose
- Fixes importing a preprint provider from JSON in the admin app.

#### Changes
- Add handling for all non-text fields when importing (boolean fields, tinymce fields, subjects, and licenses). Fix `subjects_acceptable` handling to only check subject checkboxes.

#### Side Effects
- Whenever a new field is added to the admin app for creating/updating a preprint provider, we need to make sure it imports and exports correctly. Especially if it's anything other than a simple text field.

#### QA / Admin Notes
- Broken fields included:
  - subjects_acceptable
  - licenses_acceptable
  - description
  - advisory_board
  - footer_links
  - domain_redirect_enabled
  - allow_submissions 
- Please check that all of the above fields import correctly now. 
- Please test **all** fields to ensure everything imports and exports correctly.
- Pay special attention to how subjects and licenses import -- previously, having certain subjects checked resulted in random licenses (that were *not* included in `licenses_acceptable`) also being checked. 

#### Ticket
- [OSF-8016](https://openscience.atlassian.net/browse/OSF-8016)
