### PR TITLE
[hotfix] Fix Filtering by Date [OSF-8155]

### DIFF
--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -541,10 +541,12 @@ class ListFilterMixin(FilterMixin):
         if filters:
             for key, field_names in filters.iteritems():
                 for field_name, data in field_names.iteritems():
-                    if isinstance(queryset, list):
-                        queryset = self.get_filtered_queryset(field_name, data, queryset)
-                    else:
-                        queryset = self.filter_by_field(queryset, field_name=field_name, operation=data)
+                    operations = data if isinstance(data, list) else [data]
+                    for operation in operations:
+                        if isinstance(queryset, list):
+                            queryset = self.get_filtered_queryset(field_name, operation, queryset)
+                        else:
+                            queryset = self.filter_by_field(queryset, field_name, operation)
         return queryset
 
     def filter_by_field(self, queryset, field_name, operation):
@@ -581,7 +583,7 @@ class ListFilterMixin(FilterMixin):
             if operation['value'] not in (list(), tuple()):
                 operation['source_field_name'] = '_contributors__guids___id'
                 operation['op'] = 'iexact'
-        if operation['source_field_name'] == 'kind':
+        if field_name == 'kind':
             operation['source_field_name'] = 'is_file'
             # The value should be boolean
             operation['value'] = operation['value'] == 'file'

--- a/api_tests/institutions/views/test_institution_nodes_list.py
+++ b/api_tests/institutions/views/test_institution_nodes_list.py
@@ -4,7 +4,7 @@ from tests.base import ApiTestCase
 from osf_tests.factories import InstitutionFactory, AuthUserFactory, ProjectFactory, NodeFactory
 
 from api.base.settings.defaults import API_BASE
-from api_tests.nodes.filters.test_filters import NodesListFilteringMixin
+from api_tests.nodes.filters.test_filters import NodesListFilteringMixin, NodesListDateFilteringMixin
 
 class TestInstitutionNodeList(ApiTestCase):
 
@@ -121,3 +121,24 @@ class TestNodeListFiltering(NodesListFilteringMixin, ApiTestCase):
         self.node_C1.save()
         self.node_C2.save()
         self.node_D2.save()
+
+
+class TestNodeListDateFiltering(NodesListDateFilteringMixin, ApiTestCase):
+
+    def setUp(self):
+        self.institution = InstitutionFactory()
+        self.url = '/{}institutions/{}/nodes/?'.format(API_BASE, self.institution._id)
+
+        super(TestNodeListDateFiltering, self).setUp()
+
+        self.node_may.is_public = True
+        self.node_june.is_public = True
+        self.node_july.is_public = True
+
+        self.node_may.affiliated_institutions.add(self.institution)
+        self.node_june.affiliated_institutions.add(self.institution)
+        self.node_july.affiliated_institutions.add(self.institution)
+
+        self.node_may.save()
+        self.node_june.save()
+        self.node_july.save()

--- a/api_tests/nodes/filters/test_filters.py
+++ b/api_tests/nodes/filters/test_filters.py
@@ -94,3 +94,103 @@ class NodesListFilteringMixin(object):
         res = self.app.get('{}{}'.format(self.contributors_url, self.user_two._id), auth=self.user.auth)
         actual = [node['id'] for node in res.json['data']]
         assert_equal(expected, actual)
+
+
+class NodesListDateFilteringMixin(object):
+
+    def setUp(self):
+        super(NodesListDateFilteringMixin, self).setUp()
+
+        assert self.url, 'Subclasses of NodesListDateFilteringMixin must define self.url'
+
+        self.user = AuthUserFactory()
+
+        self.node_may = ProjectFactory(creator=self.user)
+        self.node_june = ProjectFactory(creator=self.user)
+        self.node_july = ProjectFactory(creator=self.user)
+
+        self.node_may.date_created = '2016-05-01 00:00:00.000000+00:00'
+        self.node_june.date_created = '2016-06-01 00:00:00.000000+00:00'
+        self.node_july.date_created = '2016-07-01 00:00:00.000000+00:00'
+
+        self.node_may.save()
+        self.node_june.save()
+        self.node_july.save()
+
+        self.date_created_url = '{}filter[date_created]='.format(self.url)
+
+    def test_date_filter_equals(self):
+        expected = []
+        res = self.app.get('{}{}'.format(self.date_created_url, '2016-04-01'), auth=self.user.auth)
+        actual = [node['id'] for node in res.json['data']]
+        assert_equal(expected, actual)
+
+        expected = [self.node_may._id]
+        res = self.app.get('{}{}'.format(self.date_created_url, self.node_may.date_created), auth=self.user.auth)
+        actual = [node['id'] for node in res.json['data']]
+        assert_equal(expected, actual)
+
+    def test_date_filter_gt(self):
+        url = '{}filter[date_created][gt]='.format(self.url)
+
+        expected = []
+        res = self.app.get('{}{}'.format(url, '2016-08-01'), auth=self.user.auth)
+        actual = [node['id'] for node in res.json['data']]
+        assert_equal(expected, actual)
+
+        expected = [self.node_june._id, self.node_july._id]
+        res = self.app.get('{}{}'.format(url, '2016-05-01'), auth=self.user.auth)
+        actual = [node['id'] for node in res.json['data']]
+        assert_equal(set(expected), set(actual))
+
+    def test_date_filter_gte(self):
+        url = '{}filter[date_created][gte]='.format(self.url)
+
+        expected = []
+        res = self.app.get('{}{}'.format(url, '2016-08-01'), auth=self.user.auth)
+        actual = [node['id'] for node in res.json['data']]
+        assert_equal(expected, actual)
+
+        expected = [self.node_may._id, self.node_june._id, self.node_july._id]
+        res = self.app.get('{}{}'.format(url, '2016-05-01'), auth=self.user.auth)
+        actual = [node['id'] for node in res.json['data']]
+        assert_equal(set(expected), set(actual))
+
+    def test_date_fitler_lt(self):
+        url = '{}filter[date_created][lt]='.format(self.url)
+
+        expected = []
+        res = self.app.get('{}{}'.format(url, '2016-05-01'), auth=self.user.auth)
+        actual = [node['id'] for node in res.json['data']]
+        assert_equal(expected, actual)
+
+        expected = [self.node_may._id, self.node_june._id]
+        res = self.app.get('{}{}'.format(url, '2016-07-01'), auth=self.user.auth)
+        actual = [node['id'] for node in res.json['data']]
+        assert_equal(set(expected), set(actual))
+
+    def test_date_filter_lte(self):
+        url = '{}filter[date_created][lte]='.format(self.url)
+
+        expected = []
+        res = self.app.get('{}{}'.format(url, '2016-04-01'), auth=self.user.auth)
+        actual = [node['id'] for node in res.json['data']]
+        assert_equal(expected, actual)
+
+        expected = [self.node_may._id, self.node_june._id, self.node_july._id]
+        res = self.app.get('{}{}'.format(url, '2016-07-01'), auth=self.user.auth)
+        actual = [node['id'] for node in res.json['data']]
+        assert_equal(set(expected), set(actual))
+
+    def test_date_filter_eq(self):
+        url = '{}filter[date_created][eq]='.format(self.url)
+
+        expected = []
+        res = self.app.get('{}{}'.format(url, '2016-04-01'), auth=self.user.auth)
+        actual = [node['id'] for node in res.json['data']]
+        assert_equal(expected, actual)
+
+        expected = [self.node_may._id]
+        res = self.app.get('{}{}'.format(url, self.node_may.date_created), auth=self.user.auth)
+        actual = [node['id'] for node in res.json['data']]
+        assert_equal(expected, actual)

--- a/api_tests/nodes/views/test_node_list.py
+++ b/api_tests/nodes/views/test_node_list.py
@@ -12,7 +12,7 @@ from website.util.sanitize import strip_html
 from website.views import find_bookmark_collection
 
 from api.base.settings.defaults import API_BASE, MAX_PAGE_SIZE
-from api_tests.nodes.filters.test_filters import NodesListFilteringMixin
+from api_tests.nodes.filters.test_filters import NodesListFilteringMixin, NodesListDateFilteringMixin
 
 from tests.base import ApiTestCase
 from osf_tests.factories import (
@@ -2124,5 +2124,10 @@ class TestNodeListPagination(ApiTestCase):
 
 
 class TestNodeListFiltering(NodesListFilteringMixin, ApiTestCase):
+
+    url = '/{}nodes/?'.format(API_BASE)
+
+
+class TestNodeListDateFiltering(NodesListDateFilteringMixin, ApiTestCase):
 
     url = '/{}nodes/?'.format(API_BASE)

--- a/api_tests/users/views/test_user_nodes_list.py
+++ b/api_tests/users/views/test_user_nodes_list.py
@@ -13,7 +13,7 @@ from osf_tests.factories import (
 )
 
 from api.base.settings.defaults import API_BASE
-from api_tests.nodes.filters.test_filters import NodesListFilteringMixin
+from api_tests.nodes.filters.test_filters import NodesListFilteringMixin, NodesListDateFilteringMixin
 
 from website.views import find_bookmark_collection
 
@@ -145,5 +145,10 @@ class TestUserNodesPreprintsFiltering(ApiTestCase):
 
 
 class TestNodeListFiltering(NodesListFilteringMixin, ApiTestCase):
+
+    url = '/{}users/me/nodes/?'.format(API_BASE)
+
+
+class TestNodeListDateFiltering(NodesListDateFilteringMixin, ApiTestCase):
 
     url = '/{}users/me/nodes/?'.format(API_BASE)


### PR DESCRIPTION
#### Purpose
- Fix filtering nodes by date in the API.

#### Changes
- Add tests to check filtering nodes by dates.
- Handle lists of operations in `ListFilterMixin` as `filter[date][eq]=day` becomes `[filter[date][gt]=day-1, filter[date][lt]=day+1]`.

#### Side Effects
- None expected.

#### Ticket
- [OSF-8155](https://openscience.atlassian.net/browse/OSF-8155)
