### PR TITLE
Re-add API v1 routes for adding pointers to nodes [OSF-8108]

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2734,6 +2734,106 @@ class TestPointerViews(OsfTestCase):
         assert_in(pointer_project._id, pointer_ids)
         assert_not_in(collection._id, pointer_ids)
 
+    def test_add_pointers(self):
+
+        url = self.project.api_url + 'pointer/'
+        node_ids = [
+            NodeFactory()._id
+            for _ in range(5)
+        ]
+        self.app.post_json(
+            url,
+            {'nodeIds': node_ids},
+            auth=self.user.auth,
+        ).maybe_follow()
+
+        self.project.reload()
+        assert_equal(
+            self.project.nodes_active.count(),
+            5
+        )
+
+    def test_add_the_same_pointer_more_than_once(self):
+        url = self.project.api_url + 'pointer/'
+        double_node = NodeFactory()
+
+        self.app.post_json(
+            url,
+            {'nodeIds': [double_node._id]},
+            auth=self.user.auth,
+        )
+        res = self.app.post_json(
+            url,
+            {'nodeIds': [double_node._id]},
+            auth=self.user.auth,
+            expect_errors=True
+        )
+        assert_equal(res.status_code, 400)
+
+    def test_add_pointers_no_user_logg_in(self):
+
+        url = self.project.api_url_for('add_pointers')
+        node_ids = [
+            NodeFactory()._id
+            for _ in range(5)
+        ]
+        res = self.app.post_json(
+            url,
+            {'nodeIds': node_ids},
+            auth=None,
+            expect_errors=True
+        )
+
+        assert_equal(res.status_code, 401)
+
+    def test_add_pointers_public_non_contributor(self):
+
+        project2 = ProjectFactory()
+        project2.set_privacy('public')
+        project2.save()
+
+        url = self.project.api_url_for('add_pointers')
+
+        self.app.post_json(
+            url,
+            {'nodeIds': [project2._id]},
+            auth=self.user.auth,
+        ).maybe_follow()
+
+        self.project.reload()
+        assert_equal(
+            self.project.nodes_active.count(),
+            1
+        )
+
+    def test_add_pointers_contributor(self):
+        user2 = AuthUserFactory()
+        self.project.add_contributor(user2)
+        self.project.save()
+
+        url = self.project.api_url_for('add_pointers')
+        node_ids = [
+            NodeFactory()._id
+            for _ in range(5)
+        ]
+        self.app.post_json(
+            url,
+            {'nodeIds': node_ids},
+            auth=user2.auth,
+        ).maybe_follow()
+
+        self.project.reload()
+        assert_equal(
+            self.project.linked_nodes.count(),
+            5
+        )
+
+    def test_add_pointers_not_provided(self):
+        url = self.project.api_url + 'pointer/'
+        res = self.app.post_json(url, {}, auth=self.user.auth, expect_errors=True)
+        assert_equal(res.status_code, 400)
+
+
     def test_remove_pointer(self):
         url = self.project.api_url + 'pointer/'
         node = NodeFactory()

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -1068,6 +1068,30 @@ def add_pointer(auth):
 
 @must_have_permission(WRITE)
 @must_not_be_registration
+def add_pointers(auth, node, **kwargs):
+    """Add pointers to a node.
+
+    """
+    node_ids = request.json.get('nodeIds')
+
+    if not node_ids:
+        raise HTTPError(http.BAD_REQUEST)
+
+    nodes = [
+        Node.load(node_id)
+        for node_id in node_ids
+    ]
+
+    try:
+        _add_pointers(node, nodes, auth)
+    except ValueError:
+        raise HTTPError(http.BAD_REQUEST)
+
+    return {}
+
+
+@must_have_permission(WRITE)
+@must_not_be_registration
 def remove_pointer(auth, node, **kwargs):
     """Remove a pointer from a node, raising a 400 if the pointer is not
     in `node.nodes`.

--- a/website/routes.py
+++ b/website/routes.py
@@ -1283,6 +1283,15 @@ def make_url_map(app):
         ),
         Rule(
             [
+                '/project/<pid>/pointer/',
+                '/project/<pid>/node/<nid>/pointer/',
+            ],
+            'post',
+            project_views.node.add_pointers,
+            json_renderer,
+        ),
+        Rule(
+            [
                 '/pointer/',
             ],
             'post',


### PR DESCRIPTION
[#OSF-8108]

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Got a little over-zealous removing old api v1 endpoints -- turns out `add_pointer` is still used by the frontend!

## Changes

- re-add `add_pointer` route, method, and tests

## Side effects

none anticipated


## Ticket
https://openscience.atlassian.net/browse/OSF-8108