### PR TITLE
[feature] Add USER_EMAIL Scope [OSF-8148]

### DIFF
--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -8,7 +8,7 @@ from osf.models import OSFUser as User
 
 from api.base.serializers import (
     JSONAPISerializer, LinksField, RelationshipField, DevOnly, IDField, TypeField, ListDictField,
-    DateByVersion,
+    DateByVersion, EmailScopeRequired,
 )
 from api.base.utils import absolute_reverse, get_user_auth
 
@@ -34,6 +34,7 @@ class UserSerializer(JSONAPISerializer):
     timezone = HideIfDisabled(ser.CharField(required=False, help_text="User's timezone, e.g. 'Etc/UTC"))
     locale = HideIfDisabled(ser.CharField(required=False, help_text="User's locale, e.g.  'en_US'"))
     social = ListDictField(required=False)
+    email = EmailScopeRequired(ser.CharField(source='username', read_only=True))
 
     links = HideIfDisabled(LinksField(
         {

--- a/api_tests/base/test_auth.py
+++ b/api_tests/base/test_auth.py
@@ -245,3 +245,29 @@ class TestOAuthScopedAccess(ApiTestCase):
         assert_equal(res.location, redirect_url)
         redirect_res = res.follow(auth='some_valid_token', auth_type='jwt', expect_errors=True)
         assert_equal(redirect_res.status_code, 403)
+
+    @mock.patch('framework.auth.cas.CasClient.profile')
+    def test_user_email_scope_can_read_email(self, mock_user_info):
+        mock_user_info.return_value = self._scoped_response(['osf.users.user_email', 'osf.users.profile_read'])
+        url = api_v2_url('users/me/', base_route='/', base_prefix='v2/')
+        res = self.app.get(url, auth='some_valid_token', auth_type='jwt', expect_errors=True)
+        assert_equal(res.status_code, 200)
+        assert_equal(res.json['data']['attributes']['email'], self.user.username)
+
+    @mock.patch('framework.auth.cas.CasClient.profile')
+    def test_non_user_email_scope_cannot_read_email(self, mock_user_info):
+        mock_user_info.return_value = self._scoped_response(['osf.users.profile_read'])
+        url = api_v2_url('users/me/', base_route='/', base_prefix='v2/')
+        res = self.app.get(url, auth='some_valid_token', auth_type='jwt', expect_errors=True)
+        assert_equal(res.status_code, 200)
+        assert_not_in('email', res.json['data']['attributes'])
+        assert_not_in(self.user.username, res.json)
+
+    @mock.patch('framework.auth.cas.CasClient.profile')
+    def test_user_email_scope_cannot_read_other_email(self, mock_user_info):
+        mock_user_info.return_value = self._scoped_response(['osf.users.user_email', 'osf.users.profile_read'])
+        url = api_v2_url('users/{}/'.format(self.user2._id), base_route='/', base_prefix='v2/')
+        res = self.app.get(url, auth='some_valid_token', auth_type='jwt', expect_errors=True)
+        assert_equal(res.status_code, 200)
+        assert_not_in('email', res.json['data']['attributes'])
+        assert_not_in(self.user2.username, res.json)

--- a/framework/auth/oauth_scopes.py
+++ b/framework/auth/oauth_scopes.py
@@ -30,6 +30,7 @@ class CoreScopes(object):
     USERS_READ = 'users_read'
     USERS_WRITE = 'users_write'
     USERS_CREATE = 'users_create'
+    USERS_EMAIL = 'users_email'
 
     USER_ADDON_READ = 'users.addon_read'
 
@@ -123,6 +124,7 @@ class ComposedScopes(object):
     USERS_READ = (CoreScopes.USERS_READ, CoreScopes.ALWAYS_PUBLIC, )
     USERS_WRITE = USERS_READ + (CoreScopes.USERS_WRITE,)
     USERS_CREATE = USERS_READ + (CoreScopes.USERS_CREATE, )
+    USERS_EMAIL = (CoreScopes.USERS_EMAIL, )
 
     # Applications collection
     APPLICATIONS_READ = (CoreScopes.APPLICATIONS_READ, CoreScopes.ALWAYS_PUBLIC, )
@@ -204,6 +206,9 @@ public_scopes = {
     'osf.users.profile_read': scope(parts_=frozenset(ComposedScopes.USERS_READ),
                                 description='Read your profile data',
                                 is_public=True),
+    'osf.users.email_read': scope(parts_=frozenset(ComposedScopes.USERS_EMAIL),
+                                description='Read your primary email address.',
+                                is_public=False),
 }
 
 if settings.DEV_MODE:


### PR DESCRIPTION
#### Purpose
- Adds private `osf.users.user_email` scope.
- Adds restricted `email` field to user serializer.

#### Changes
- Skip `email` field if USER_EMAIL scope is not present.
- Skip `email` field if requesting user != serialized user.
- Add `osf.users.user_email` scope tests.

#### QA Notes
- Confirm that the `osf.users.user_email` scope is not listed when creating a personal access token (osf.io/settings/tokens). 
- Add a runscope test (or add an assertion to an existing runscope test) to confirm that the `email` field never appears in a user response.

#### Side Effects
- None expected.

#### Ticket
- [OSF-8148](https://openscience.atlassian.net/browse/OSF-8148)
