### PR TITLE
[OSF-7636] Fix bug in auto populating tags

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -443,7 +443,8 @@ class NodeSerializer(JSONAPISerializer):
         except ValidationError as e:
             raise InvalidModelValueError(detail=e.messages[0])
         if len(tag_instances):
-            node.tags.add(*tag_instances)
+            for tag in tag_instances:
+                node.tags.add(tag)
         if is_truthy(request.GET.get('inherit_contributors')) and validated_data['parent'].has_permission(user, 'write'):
             auth = get_user_auth(request)
             parent = validated_data['parent']

--- a/api_tests/nodes/views/test_node_list.py
+++ b/api_tests/nodes/views/test_node_list.py
@@ -881,6 +881,31 @@ class TestNodeCreate(ApiTestCase):
         assert_equal(len(new_component.contributors), 2)
         assert_equal(len(new_component.contributors), len(parent_project.contributors))
 
+    def test_create_component_with_tags(self):
+        parent_project = ProjectFactory(creator=self.user_one)
+        url = '/{}nodes/{}/children/'.format(API_BASE, parent_project._id)
+        component_data = {
+            'data': {
+                'type': 'nodes',
+                'attributes': {
+                    'title': self.title,
+                    'category': self.category,
+                    'tags': ['test tag 1', 'test tag 2']
+                }
+            }
+        }
+        res = self.app.post_json_api(url, component_data, auth=self.user_one.auth)
+        assert_equal(res.status_code, 201)
+        json_data = res.json['data']
+
+        new_component_id = json_data['id']
+        new_component = Node.load(new_component_id)
+
+        assert_equal(len(new_component.tags.all()), 2)
+        tag1, tag2 = new_component.tags.all()
+        assert_equal(tag1.name, 'test tag 1')
+        assert_equal(tag2.name, 'test tag 2')
+
     def test_create_component_inherit_contributors_with_unregistered_contributor(self):
         parent_project = ProjectFactory(creator=self.user_one)
         parent_project.add_unregistered_contributor(

--- a/website/static/js/pages/project-dashboard-page.js
+++ b/website/static/js/pages/project-dashboard-page.js
@@ -218,6 +218,9 @@ $(document).ready(function () {
             var url = nodeApiUrl + 'tags/';
             var data = {tag: tag};
             var request = $osf.postJSON(url, data);
+            request.success(function() {
+                window.contextVars.node.tags.push(tag);
+            });
             request.fail(function(xhr, textStatus, error) {
                 Raven.captureMessage('Failed to add tag', {
                     extra: {
@@ -233,6 +236,9 @@ $(document).ready(function () {
                 return false;
             }
             var request = $osf.ajaxJSON('DELETE', url, {'data': {'tag': tag}});
+            request.success(function() {
+                window.contextVars.node.tags.splice(window.contextVars.node.tags.indexOf(tag), 1);
+            });
             request.fail(function(xhr, textStatus, error) {
                 // Suppress "tag not found" errors, as the end result is what the user wanted (tag is gone)- eg could be because two people were working at same time
                 if (xhr.status !== 409) {


### PR DESCRIPTION
## Purpose

The feature to inherit tags from the parent node didn't account for tags that had just been added (tags which added on the backend, but not yet loaded in the frontend contextVars), this changes makes sure the contextVars always reflect reality.

## Changes

On a successful Ajax request adding or removing tags, the contextVars are changed to reflect this.

## Side effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/OSF-7636