### PR TITLE
[hotfix] Return Preprint Provider `email_support` [OSF-8173]

### DIFF
--- a/api/preprint_providers/serializers.py
+++ b/api/preprint_providers/serializers.py
@@ -24,6 +24,7 @@ class PreprintProviderSerializer(JSONAPISerializer):
     subjects_acceptable = ser.JSONField(required=False, allow_null=True)
     footer_links = ser.CharField(required=False)
     share_source = ser.CharField(read_only=True)
+    email_support = ser.CharField(required=False, allow_null=True)
     allow_submissions = DevOnly(ser.BooleanField(read_only=True))
     additional_providers = DevOnly(ser.ListField(child=ser.CharField(), read_only=True))
 
@@ -62,10 +63,6 @@ class PreprintProviderSerializer(JSONAPISerializer):
         min_version='2.0', max_version='2.3'
     )
     email_contact = ShowIfVersion(
-        ser.CharField(required=False, allow_null=True),
-        min_version='2.0', max_version='2.3'
-    )
-    email_support = ShowIfVersion(
         ser.CharField(required=False, allow_null=True),
         min_version='2.0', max_version='2.3'
     )

--- a/api_tests/preprint_providers/serializers/test_serializers.py
+++ b/api_tests/preprint_providers/serializers/test_serializers.py
@@ -49,7 +49,6 @@ class TestPreprintProviderSerializer(DbTestCase):
         assert_not_in('logo_path', attributes)
         assert_not_in('header_text', attributes)
         assert_not_in('email_contact', attributes)
-        assert_not_in('email_support', attributes)
         assert_not_in('social_facebook', attributes)
         assert_not_in('social_instagram', attributes)
         assert_not_in('social_twitter', attributes)


### PR DESCRIPTION
#### Purpose
- Un-versions preprint provider `email_support` field since ember-preprints displays this field on provider error pages.

#### Ticket
- [OSF-8173](https://openscience.atlassian.net/browse/OSF-8173)
