### PR TITLE
Include OSF Urls for all contributors to preprints with EZID metadata [OSF-8131]

### DIFF
--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -124,15 +124,24 @@ class TestMetadataGeneration(OsfTestCase):
         formatted_creators = metadata.format_creators(preprint)
 
         contributors_with_orcids = 0
+        guid_identifiers = []
         for creator_xml in formatted_creators:
             assert creator_xml.find('creatorName').text != u'{}, {}'.format(self.invisible_contrib.family_name, self.invisible_contrib.given_name)
-            if creator_xml.find('nameIdentifier') is not None:
-                assert creator_xml.find('nameIdentifier').attrib['nameIdentifierScheme'] == 'ORCID'
-                assert creator_xml.find('nameIdentifier').attrib['schemeURI'] == 'http://orcid.org/'
-                contributors_with_orcids += 1
+
+            name_identifiers = creator_xml.findall('nameIdentifier')
+
+            for name_identifier in name_identifiers:
+                if name_identifier.attrib['nameIdentifierScheme'] == 'ORCID':
+                    assert name_identifier.attrib['schemeURI'] == 'http://orcid.org/'
+                    contributors_with_orcids += 1
+                else:
+                    guid_identifiers.append(name_identifier.text)
+                    assert name_identifier.attrib['nameIdentifierScheme'] == 'OSF'
+                    assert name_identifier.attrib['schemeURI'] == 'https://osf.io'
 
         assert contributors_with_orcids >= 1
         assert len(formatted_creators) == len(self.node.visible_contributors)
+        assert sorted(guid_identifiers) == sorted(['https://osf.io/{}'.format(contrib._id) for contrib in self.node.visible_contributors])
 
     def test_format_subjects_for_preprint(self):
         subject = SubjectFactory()

--- a/website/identifiers/metadata.py
+++ b/website/identifiers/metadata.py
@@ -76,6 +76,7 @@ def format_creators(preprint):
         creator = CREATOR(E.creatorName(format_contributor(contributor)))
         creator.append(E.givenName(remove_control_characters(contributor.given_name)))
         creator.append(E.familyName(remove_control_characters(contributor.family_name)))
+        creator.append(E.nameIdentifier('https://osf.io/{}'.format(contributor._id), nameIdentifierScheme='OSF', schemeURI='https://osf.io'))
 
         # contributor.external_identity = {'ORCID': {'1234-1234-1234-1234': 'VERIFIED'}}
         if contributor.external_identity.get('ORCID'):


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

We are now minting DOIs for Preprints. We're sending extra metadata to EZID for them to pass to DataCite. We are including ORCIDs for contributors in this metadata.

For proper disambiguation in SHARE, let's also include the OSF user's GUID in the EZID metadata

## Changes

- Also include a user's OSF profile as a persistent identifier when sending preprint metadata to SHARE
- update preprint metadata format test

## Side effects
Older preprints will have inconsistent metadata, which shouldn't be a problem other than continuity. If they're updated at all, however, their EZID metadata should also be updated to include contributor's OSF urls. 


## Ticket
https://openscience.atlassian.net/browse/OSF-8131