### PR TITLE
Send updated preprints to SHARE be default

### DIFF
--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -6,6 +6,7 @@ import urlparse
 from framework.celery_tasks import handlers
 from addons.osfstorage.models import OsfStorageFile
 from website.preprints.tasks import format_preprint
+from website.preprints.tasks import on_preprint_updated
 from website.util import permissions
 
 from framework.auth import Auth
@@ -601,3 +602,12 @@ class TestPreprintSaveShareHook(OsfTestCase):
     def test_save_unpublished_subject_change_not_called(self, mock_on_preprint_updated):
         self.preprint.set_subjects([[self.subject_two._id]], auth=self.auth, save=True)
         assert not mock_on_preprint_updated.called
+
+    @mock.patch('website.preprints.tasks.requests')
+    @mock.patch('website.project.tasks.settings.SHARE_URL', 'ima_real_website')
+    def test_send_to_share_is_true(self, mock_requests):
+        self.preprint.provider.access_token = 'Snowmobiling'
+        self.preprint.provider.save()
+        on_preprint_updated(self.preprint._id)
+
+        assert mock_requests.post.called

--- a/website/preprints/tasks.py
+++ b/website/preprints/tasks.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 @celery_app.task(ignore_results=True)
-def on_preprint_updated(preprint_id, update_share=False):
+def on_preprint_updated(preprint_id, update_share=True):
     # WARNING: Only perform Read-Only operations in an asynchronous task, until Repeatable Read/Serializable
     # transactions are implemented in View and Task application layers.
     from osf.models import PreprintService


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Defaulting to `False` for share updates causes other calls to this method to fail.

e.g. https://github.com/CenterForOpenScience/osf.io/blob/master/osf/models/preprint_service.py#L232

## Changes

<!-- Briefly describe or list your changes  -->
TODO: **Once released, manually resend all preprints starting June 10th.**

```python
from website.preprints.tasks import on_preprint_updated
preprint_ids = PreprintService.objects.filter(date_modified__gte=datetime.datetime(2017, 6, 9)).values_list('guids___id', flat=True)
for pid in preprint_ids:
    print(pid)
    on_preprint_updated(pid, update_share=True)
```

## Side effects

<!--Any possible side effects? -->


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
