### PR TITLE
[feature] Redirect bad osfstorage file urls [OSF-7684]

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -646,6 +646,12 @@ def addon_view_or_download_file(auth, path, provider, **kwargs):
         # Rollback the insertion of the file_node
         transaction.savepoint_rollback(savepoint_id)
         if not file_node.pk:
+            redirect_file_node = BaseFileNode.load(path)
+            # Allow osfstorage to redirect if the deep url can be used to find a valid file_node
+            if redirect_file_node and redirect_file_node.provider == 'osfstorage' and not redirect_file_node.is_deleted:
+                return redirect(
+                    redirect_file_node.node.web_url_for('addon_view_or_download_file', path=redirect_file_node._id, provider=redirect_file_node.provider)
+                )
             raise HTTPError(httplib.NOT_FOUND, data={
                 'message_short': 'File Not Found',
                 'message_long': 'The requested file could not be found.'

--- a/addons/osfstorage/tests/test_views.py
+++ b/addons/osfstorage/tests/test_views.py
@@ -25,6 +25,7 @@ from addons.osfstorage.apps import osf_storage_root
 from addons.osfstorage import utils
 from addons.base.views import make_auth
 from addons.osfstorage import settings as storage_settings
+from api_tests.utils import create_test_file
 
 from tests.factories import ProjectFactory
 
@@ -958,3 +959,26 @@ class TestFileTags(StorageTestCase):
 
         assert_equal(res.status_code, 400)
         mock_log.assert_not_called()
+
+
+@pytest.mark.django_db
+class TestFileViews(StorageTestCase):
+
+    def test_file_views(self):
+        file = create_test_file(node=self.node, user=self.user)
+        url = self.node.web_url_for('addon_view_or_download_file', path=file._id, provider=file.provider)
+        # Test valid url file 200 on redirect
+        redirect = self.app.get(url, auth=self.user.auth)
+        assert redirect.status_code == 302
+        res = redirect.follow(auth=self.user.auth)
+        assert res.status_code == 200
+
+        # Test invalid node but valid deep_url redirects (moved log urls)
+        project_two = ProjectFactory(creator=self.user)
+        url = project_two.web_url_for('addon_view_or_download_file', path=file._id, provider=file.provider)
+        redirect = self.app.get(url, auth=self.user.auth)
+        assert redirect.status_code == 302
+        redirect_two = redirect.follow(auth=self.user.auth)
+        assert redirect_two.status_code == 302
+        res = redirect_two.follow(auth=self.user.auth)
+        assert res.status_code == 200


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
When files are moved between providers the links in logs get broken. Instead of attempting to fix the links themselves, this PR redirects the url to the final destination by loading the deep url and constructing the proper link.
<!-- Describe the purpose of your changes -->

## Changes
Redirect osfstorage links to new locations. Add tests.
<!-- Briefly describe or list your changes  -->

## Side effects
NA
<!--Any possible side effects? -->


## Ticket
https://openscience.atlassian.net/browse/OSF-7684<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->

## QA Notes
For OSFStorage:
1. Test that links from logs in moved files redirect to the correct location
2. Test that moved and then deleted files do not redirect infinitely (note: they are not throwing a 410 resource deleted error, I'll make a ticket for that).
3. Test that valid log links work properly too.
4. Test that guid file links still work as intended.

Other providers:
Make sure unmoved links still work and broken links are still broken. This is important as one change could throw new errors. For example, while developing locally I managed to break a github file completely. A good way to ensure this isn't possible is to view a valid addon file, then view a moved link for an addon file, and then viewing the valid addon file again. 
