### PR TITLE
[hotfix][OSF-8176] Figshare errors locks user out of project 

### DIFF
--- a/addons/figshare/messages.py
+++ b/addons/figshare/messages.py
@@ -32,4 +32,8 @@ FIGSHARE_VIEW_FILE_OVERSIZED = 'This figshare file is too large to render; <u><a
 
 OAUTH_INVALID = 'Your OAuth key for figshare is no longer valid. Please re-authenticate. '
 
+FIGSHARE_INTERNAL_SERVER_ERROR = 'Figshare is experiencing technical problems when connecting to the OSF. Please wait while they resolve the problem or contact them at https://support.figshare.com.'
+
+FIGSHARE_UNSPECIFIED_ERROR = 'Figshare was contacted and returned with the following error message: {error_message}.'
+
 # END MFR MESSAGES

--- a/addons/figshare/models.py
+++ b/addons/figshare/models.py
@@ -235,7 +235,10 @@ class NodeSettings(BaseStorageAddon, BaseOAuthNodeSettings):
         except HTTPError as e:
             if e.code == 403:
                 return [messages.OAUTH_INVALID]
-            raise
+            elif e.code == 500:
+                return [messages.FIGSHARE_INTERNAL_SERVER_ERROR]
+            else:
+                return [messages.FIGSHARE_UNSPECIFIED_ERROR.format(error_message=e.message)]
 
         article_permissions = 'public' if project_is_public else 'private'
 


### PR DESCRIPTION
## Purpose

Display correct error message for internal Figshare errors, or other unexpected errors originating on their end.

## Changes

Now when we catch errors from Figshare we always attribute them to Figshare.

## Side effects

Figshare errors can't be rethrown to as OSF errors.

## Ticket
https://openscience.atlassian.net/browse/OSF-8176