### PR TITLE
[Feature] Fix forking a pointer [OSF-8062]

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2880,7 +2880,7 @@ class TestPointerViews(OsfTestCase):
         self.project.add_pointer(node, auth=self.consolidate_auth)
         self.app.post_json(
             url,
-            {'pointerId': node._id},
+            {'nodeId': node._id},
             auth=self.user.auth
         )
 
@@ -2894,7 +2894,7 @@ class TestPointerViews(OsfTestCase):
         url = self.project.api_url + 'pointer/fork/'
         res = self.app.post_json(
             url,
-            {'pointerId': None},
+            {'nodeId': None},
             auth=self.user.auth,
             expect_errors=True
         )
@@ -2904,7 +2904,7 @@ class TestPointerViews(OsfTestCase):
         url = self.project.api_url + 'pointer/fork/'
         res = self.app.post_json(
             url,
-            {'pointerId': 'somefakeid'},
+            {'nodeId': 'somefakeid'},
             auth=self.user.auth,
             expect_errors=True
         )

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2877,10 +2877,10 @@ class TestPointerViews(OsfTestCase):
     def test_fork_pointer(self):
         url = self.project.api_url + 'pointer/fork/'
         node = NodeFactory(creator=self.user)
-        pointer = self.project.add_pointer(node, auth=self.consolidate_auth)
+        self.project.add_pointer(node, auth=self.consolidate_auth)
         self.app.post_json(
             url,
-            {'pointerId': pointer._id},
+            {'pointerId': node._id},
             auth=self.user.auth
         )
 

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -1124,8 +1124,9 @@ def fork_pointer(auth, node, **kwargs):
     """
     NodeRelation = apps.get_model('osf.NodeRelation')
 
-    pointer_id = request.json.get('pointerId')
-    pointer = NodeRelation.load(pointer_id)
+    linked_node_id = request.json.get('pointerId')
+    linked_node = Node.load(linked_node_id)
+    pointer = NodeRelation.objects.filter(child=linked_node, is_node_link=True, parent=node).first()
 
     if pointer is None:
         # TODO: Change this to 404?

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -1124,7 +1124,7 @@ def fork_pointer(auth, node, **kwargs):
     """
     NodeRelation = apps.get_model('osf.NodeRelation')
 
-    linked_node_id = request.json.get('pointerId')
+    linked_node_id = request.json.get('nodeId')
     linked_node = Node.load(linked_node_id)
     pointer = NodeRelation.objects.filter(child=linked_node, is_node_link=True, parent=node).first()
 

--- a/website/static/js/project.js
+++ b/website/static/js/project.js
@@ -96,7 +96,7 @@ NodeActions.forkNode = function() {
     });
 };
 
-NodeActions.forkPointer = function(pointerId) {
+NodeActions.forkPointer = function(nodeId) {
     bootbox.confirm({
         title: 'Fork this project?',
         message: 'Are you sure you want to fork this project?',
@@ -108,7 +108,7 @@ NodeActions.forkPointer = function(pointerId) {
                 // Fork pointer
                 $osf.postJSON(
                     ctx.node.urls.api + 'pointer/fork/',
-                    {pointerId: pointerId}
+                    {nodeId: nodeId}
                 ).done(function() {
                     window.location.reload();
                 }).fail(function() {


### PR DESCRIPTION
## Purpose

Fix issues with forking a pointer (node link) on the project
overview page, component list widget.

## Changes

- Use json parameter, pointerId, as linked node id as opposed to a pointer/node-link id
- Rename parameter to avoid future confusion
- Update forkPointer tests

## Side effects

N/A

## Ticket

https://openscience.atlassian.net/browse/OSF-8062
