### PR TITLE
[Feature] Prevent component create with empty title [OSF-8162]

### DIFF
--- a/website/static/js/addProjectPlugin.js
+++ b/website/static/js/addProjectPlugin.js
@@ -178,8 +178,8 @@ var AddProject = {
                                 onkeyup: function(ev){
                                     var val = ev.target.value;
                                     var validTitle = val.trim().length > 0;
-                                    if (ev.which === 13) {
-                                         validTitle && ctrl.add();
+                                    if (ev.which === 13 && validTitle) {
+                                        ctrl.add();
                                     }
                                     ctrl.newProjectName(val);
                                     ctrl.isValid(validTitle);

--- a/website/static/js/addProjectPlugin.js
+++ b/website/static/js/addProjectPlugin.js
@@ -79,6 +79,10 @@ var AddProject = {
 
 
         self.add = function _add () {
+            var validTitle = self.newProjectName().trim().length > 0;
+            if (! validTitle) {
+              return;
+            }
             if (self.isAdding()) {
                 return;
             }
@@ -177,12 +181,11 @@ var AddProject = {
                             m('input[type="text"].form-control.project-name', {
                                 onkeyup: function(ev){
                                     var val = ev.target.value;
-                                    var validTitle = val.trim().length > 0;
-                                    if (ev.which === 13 && validTitle) {
+                                    if (ev.which === 13) {
                                         ctrl.add();
                                     }
                                     ctrl.newProjectName(val);
-                                    ctrl.isValid(validTitle);
+                                    ctrl.isValid(val.trim().length > 0);
                                 },
                                 onchange: function(ev) {
                                     //  This will not be reliably running!

--- a/website/static/js/addProjectPlugin.js
+++ b/website/static/js/addProjectPlugin.js
@@ -180,10 +180,10 @@ var AddProject = {
                             m('label[for="projectName].f-w-lg.text-bigger', 'Title'),
                             m('input[type="text"].form-control.project-name', {
                                 onkeyup: function(ev){
-                                    var val = ev.target.value;
                                     if (ev.which === 13) {
                                         ctrl.add();
                                     }
+                                    var val = ev.target.value;
                                     ctrl.newProjectName(val);
                                     ctrl.isValid(val.trim().length > 0);
                                 },

--- a/website/static/js/addProjectPlugin.js
+++ b/website/static/js/addProjectPlugin.js
@@ -82,9 +82,6 @@ var AddProject = {
             if (self.isAdding()) {
                 return;
             }
-            if (self.newProjectName().length === 0) {
-                return;
-            }
             self.isAdding(true);
             var url;
             var data;
@@ -179,12 +176,13 @@ var AddProject = {
                             m('label[for="projectName].f-w-lg.text-bigger', 'Title'),
                             m('input[type="text"].form-control.project-name', {
                                 onkeyup: function(ev){
-                                    if (ev.which === 13) {
-                                         ctrl.add();
-                                    }
                                     var val = ev.target.value;
+                                    var validTitle = val.trim().length > 0;
+                                    if (ev.which === 13) {
+                                         validTitle && ctrl.add();
+                                    }
                                     ctrl.newProjectName(val);
-                                    ctrl.isValid(val.trim().length > 0);
+                                    ctrl.isValid(validTitle);
                                 },
                                 onchange: function(ev) {
                                     //  This will not be reliably running!

--- a/website/static/js/addProjectPlugin.js
+++ b/website/static/js/addProjectPlugin.js
@@ -79,9 +79,8 @@ var AddProject = {
 
 
         self.add = function _add () {
-            var validTitle = self.newProjectName().trim().length > 0;
-            if (! validTitle) {
-              return;
+            if (! self.isValid()) {
+                return;
             }
             if (self.isAdding()) {
                 return;
@@ -180,12 +179,12 @@ var AddProject = {
                             m('label[for="projectName].f-w-lg.text-bigger', 'Title'),
                             m('input[type="text"].form-control.project-name', {
                                 onkeyup: function(ev){
+                                    var val = ev.target.value;
+                                    ctrl.isValid(val.trim().length > 0);
                                     if (ev.which === 13) {
                                         ctrl.add();
                                     }
-                                    var val = ev.target.value;
                                     ctrl.newProjectName(val);
-                                    ctrl.isValid(val.trim().length > 0);
                                 },
                                 onchange: function(ev) {
                                     //  This will not be reliably running!

--- a/website/static/js/addProjectPlugin.js
+++ b/website/static/js/addProjectPlugin.js
@@ -82,6 +82,9 @@ var AddProject = {
             if (self.isAdding()) {
                 return;
             }
+            if (self.newProjectName().length === 0) {
+                return;
+            }
             self.isAdding(true);
             var url;
             var data;


### PR DESCRIPTION
## Purpose

Fix issue where a user submits empty (create component) 
form through enter key press.

## Changes

- Prevent addProjectPlugin controller from sending request if project/component
title is not provided.

## Side effects

N/A

## Ticket

https://openscience.atlassian.net/browse/OSF-8162

##QA Considerations
- In add component form, try submitting empty form by pressing enter. The form should not submit, check the network tab in console to make sure no request is made.
- Type spaces in the component title and submit form with enter key press. The form should not submit
- Type spaces followed by letters say "      awesome title", should save and submit just fine. The spaces in the title will be trimmed, the title "awesome title".
