### PR TITLE
[Feature] Add link to cos prereg journals [OSF-7906]

### DIFF
--- a/website/templates/prereg_landing_info.mako
+++ b/website/templates/prereg_landing_info.mako
@@ -11,7 +11,7 @@
 <%def name="steps()">
   <ol>
     <li>Specify all your study and analysis decisions prior to investigating your data</li>
-    <li>Publish your study in an eligible journal</li>
+    <li>Publish your study in an <a target='_blank' href='https://cos.io/preregjournals'>eligible journal</a></li>
     <li>Receive $1,000</li>
   </ol>
 </%def>


### PR DESCRIPTION
## Purpose

Add COS eligible journal list link in the OSF preregistration challenge workflow steps

## Changes

- Make 'eligible journals' a link pointing to COS eligible journals

## Ticket

https://openscience.atlassian.net/browse/OSF-7906