### PR TITLE
Add default API view ordering to get rid of UnorderedObjectListWarning [#OSF-8136]

### DIFF
--- a/api/addons/views.py
+++ b/api/addons/views.py
@@ -92,6 +92,8 @@ class AddonList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin):
     view_category = 'addons'
     view_name = 'addon-list'
 
+    ordering = ()
+
     def get_default_queryset(self):
         return [conf for conf in osf_settings.ADDONS_AVAILABLE_DICT.itervalues() if 'accounts' in conf.configs]
 

--- a/api/applications/views.py
+++ b/api/applications/views.py
@@ -55,6 +55,8 @@ class ApplicationList(JSONAPIBaseView, generics.ListCreateAPIView, ODMFilterMixi
     # solution for hiding this api endpoint
     renderer_classes = [JSONRendererWithESISupport, JSONAPIRenderer, ]  # Hide from web-browsable API tool
 
+    ordering = ('-date_created',)
+
     def get_default_odm_query(self):
         return (
             Q('owner', 'eq', self.request.user) &

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -798,6 +798,8 @@ class BaseContributorDetail(JSONAPIBaseView, generics.RetrieveAPIView):
 
 class BaseContributorList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin):
 
+    ordering = ('-date_modified',)
+
     def get_default_queryset(self):
         node = self.get_node()
 
@@ -824,6 +826,8 @@ class BaseNodeLinksDetail(JSONAPIBaseView, generics.RetrieveAPIView):
 
 
 class BaseNodeLinksList(JSONAPIBaseView, generics.ListAPIView):
+
+    ordering = ('-date_modified',)
 
     def get_queryset(self):
         auth = get_user_auth(self.request)
@@ -853,6 +857,8 @@ class BaseLinkedList(JSONAPIBaseView, generics.ListAPIView):
     serializer_class = None
     view_category = None
     view_name = None
+
+    ordering = ('-date_modified',)
 
     # TODO: This class no longer exists
     # model_class = Pointer

--- a/api/citations/views.py
+++ b/api/citations/views.py
@@ -40,6 +40,8 @@ class CitationStyleList(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin):
     view_category = 'citations'
     view_name = 'citation-list'
 
+    ordering = ('-date_modified',)
+
     # overrides ListAPIView
     def get_default_odm_query(self):
         return

--- a/api/collections/views.py
+++ b/api/collections/views.py
@@ -349,6 +349,8 @@ class LinkedNodesList(BaseLinkedList, CollectionMixin):
     view_category = 'collections'
     view_name = 'linked-nodes'
 
+    ordering = ('-date_modified',)
+
     def get_queryset(self):
         return super(LinkedNodesList, self).get_queryset().exclude(type='osf.registration')
 
@@ -430,6 +432,8 @@ class LinkedRegistrationsList(BaseLinkedList, CollectionMixin):
     view_category = 'collections'
     view_name = 'linked-registrations'
 
+    ordering = ('-date_modified',)
+
     def get_queryset(self):
         return super(LinkedRegistrationsList, self).get_queryset().filter(type='osf.registration')
 
@@ -508,6 +512,8 @@ class NodeLinksList(JSONAPIBaseView, bulk_views.BulkDestroyJSONAPIView, bulk_vie
     view_category = 'collections'
     view_name = 'node-pointers'
     model_class = NodeRelation
+
+    ordering = ('-date_modified',)
 
     def get_queryset(self):
         return self.get_node().node_relations.select_related('child').filter(child__is_deleted=False).exclude(child__type='osf.collection')

--- a/api/comments/views.py
+++ b/api/comments/views.py
@@ -259,6 +259,8 @@ class CommentReportsList(JSONAPIBaseView, generics.ListCreateAPIView, CommentMix
     view_category = 'comments'
     view_name = 'comment-reports'
 
+    ordering = ('-date_modified',)
+
     def get_queryset(self):
         user_id = self.request.user._id
         comment = self.get_comment()

--- a/api/files/views.py
+++ b/api/files/views.py
@@ -397,6 +397,8 @@ class FileVersionsList(JSONAPIBaseView, generics.ListAPIView, FileMixin):
     view_category = 'files'
     view_name = 'file-versions'
 
+    ordering = ('-modified',)
+
     def get_queryset(self):
         return self.get_file().versions.all()
 

--- a/api/identifiers/views.py
+++ b/api/identifiers/views.py
@@ -65,6 +65,8 @@ class IdentifierList(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin):
     view_category = 'identifiers'
     view_name = 'identifier-list'
 
+    ordering = ('-id',)
+
     def get_object(self, *args, **kwargs):
         raise NotImplementedError
 

--- a/api/institutions/views.py
+++ b/api/institutions/views.py
@@ -189,6 +189,8 @@ class InstitutionUserList(JSONAPIBaseView, ODMFilterMixin, generics.ListAPIView,
     view_category = 'institutions'
     view_name = 'institution-users'
 
+    ordering = ('-id',)
+
     # overrides ODMFilterMixin
     def get_default_odm_query(self):
         inst = self.get_institution()

--- a/api/metaschemas/views.py
+++ b/api/metaschemas/views.py
@@ -48,6 +48,8 @@ class MetaSchemasList(JSONAPIBaseView, generics.ListAPIView):
     view_category = 'metaschemas'
     view_name = 'metaschema-list'
 
+    ordering = ('-id',)
+
     # overrides ListCreateAPIView
     def get_queryset(self):
         return MetaSchema.objects.filter(schema_version=LATEST_SCHEMA_VERSION, active=True)

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -2265,6 +2265,7 @@ class NodeProvider(object):
         self.provider = provider
         self.node_id = node._id
         self.pk = node._id
+        self.id = node.id
 
 
 class NodeProvidersList(JSONAPIBaseView, generics.ListAPIView, NodeMixin):
@@ -2394,7 +2395,7 @@ class NodeProvidersList(JSONAPIBaseView, generics.ListAPIView, NodeMixin):
     view_category = 'nodes'
     view_name = 'node-providers'
 
-    ordering = ('-pk',)
+    ordering = ('-id',)
 
     def get_provider_item(self, provider):
         return NodeProvider(provider, self.get_node())

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -946,6 +946,8 @@ class NodeDraftRegistrationsList(JSONAPIBaseView, generics.ListCreateAPIView, No
     view_category = 'nodes'
     view_name = 'node-draft-registrations'
 
+    ordering = ('-date_modified',)
+
     # overrides ListCreateAPIView
     def get_queryset(self):
         node = self.get_node()
@@ -1166,6 +1168,8 @@ class NodeRegistrationsList(JSONAPIBaseView, generics.ListCreateAPIView, NodeMix
     view_category = 'nodes'
     view_name = 'node-registrations'
 
+    ordering = ('-date_modified',)
+
     # overrides ListCreateAPIView
     # TODO: Filter out withdrawals by default
     def get_queryset(self):
@@ -1273,6 +1277,8 @@ class NodeChildrenList(JSONAPIBaseView, bulk_views.ListBulkCreateJSONAPIView, No
     serializer_class = NodeSerializer
     view_category = 'nodes'
     view_name = 'node-children'
+
+    ordering = ('-date_modified',)
 
     # overrides NodeODMFilterMixin
     def get_default_odm_query(self):
@@ -1641,6 +1647,8 @@ class NodeForksList(JSONAPIBaseView, generics.ListCreateAPIView, NodeMixin, Node
     serializer_class = NodeForksSerializer
     view_category = 'nodes'
     view_name = 'node-forks'
+
+    ordering = ('-forked_date',)
 
     # overrides ListCreateAPIView
     def get_queryset(self):
@@ -2050,6 +2058,8 @@ class NodeAddonList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin, Node
     view_category = 'nodes'
     view_name = 'node-addons'
 
+    ordering = ('-date_modified',)
+
     def get_default_queryset(self):
         qs = []
         for addon in ADDONS_OAUTH:
@@ -2227,6 +2237,8 @@ class NodeAddonFolderList(JSONAPIBaseView, generics.ListAPIView, NodeMixin, Addo
     view_category = 'nodes'
     view_name = 'node-addon-folders'
 
+    ordering = ('-date_modified',)
+
     def get_queryset(self):
         # TODO: [OSF-6120] refactor this/NS models to be generalizable
         node_addon = self.get_addon_settings()
@@ -2382,6 +2394,8 @@ class NodeProvidersList(JSONAPIBaseView, generics.ListAPIView, NodeMixin):
     view_category = 'nodes'
     view_name = 'node-providers'
 
+    ordering = ('-pk',)
+
     def get_provider_item(self, provider):
         return NodeProvider(provider, self.get_node())
 
@@ -2446,6 +2460,8 @@ class NodeAlternativeCitationsList(JSONAPIBaseView, generics.ListCreateAPIView, 
     serializer_class = NodeAlternativeCitationSerializer
     view_category = 'nodes'
     view_name = 'alternative-citations'
+
+    ordering = ('-id',)
 
     def get_queryset(self):
         return self.get_node().alternative_citations.all()
@@ -2818,6 +2834,8 @@ class NodeInstitutionsList(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin
     model = Institution
     view_category = 'nodes'
     view_name = 'node-institutions'
+
+    ordering = ('-id',)
 
     def get_queryset(self):
         node = self.get_node()
@@ -3349,6 +3367,8 @@ class NodeViewOnlyLinksList(JSONAPIBaseView, generics.ListCreateAPIView, ListFil
     view_category = 'nodes'
     view_name = 'node-view-only-links'
 
+    ordering = ('-date_created',)
+
     def get_default_queryset(self):
         return self.get_node().private_links.filter(is_deleted=False)
 
@@ -3561,6 +3581,8 @@ class NodePreprintsList(JSONAPIBaseView, generics.ListAPIView, NodeMixin, Prepri
 
     view_category = 'nodes'
     view_name = 'node-preprints'
+
+    ordering = ('-date_modified',)
 
     # overrides DjangoFilterMixin
     def get_default_django_query(self):

--- a/api/preprint_providers/views.py
+++ b/api/preprint_providers/views.py
@@ -234,6 +234,8 @@ class PreprintProviderSubjectList(JSONAPIBaseView, generics.ListAPIView):
 
     serializer_class = TaxonomySerializer
 
+    ordering = ('-id',)
+
     def is_valid_subject(self, allows_children, allowed_parents, sub):
         # TODO: Delet this when all PreprintProviders have a mapping
         if sub._id in allowed_parents:
@@ -264,7 +266,7 @@ class PreprintProviderSubjectList(JSONAPIBaseView, generics.ListAPIView):
 
 
 class PreprintProviderLicenseList(LicenseList):
-    ordering = ()
+    ordering = ()  # TODO: should be ordered once the frontend for selecting default licenses no longer relies on order
     view_category = 'preprint_providers'
 
     def get_queryset(self):

--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -151,6 +151,8 @@ class RegistrationList(JSONAPIBaseView, generics.ListAPIView, NodesFilterMixin):
     view_category = 'registrations'
     view_name = 'registration-list'
 
+    ordering = ('-date_modified',)
+
     # overrides NodesFilterMixin
     def get_default_queryset(self):
         base_query = (
@@ -513,6 +515,8 @@ class RegistrationChildrenList(JSONAPIBaseView, generics.ListAPIView, ODMFilterM
 
     required_read_scopes = [CoreScopes.NODE_REGISTRATIONS_READ]
     required_write_scopes = [CoreScopes.NULL]
+
+    ordering = ('-date_modified',)
 
     def get_default_odm_query(self):
         base_query = (

--- a/api/taxonomies/views.py
+++ b/api/taxonomies/views.py
@@ -48,6 +48,8 @@ class TaxonomyList(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin):
     view_category = 'taxonomies'
     view_name = 'taxonomy-list'
 
+    ordering = ('-id',)
+
     # overrides ListAPIView
     def get_default_odm_query(self):
         return

--- a/api/tokens/views.py
+++ b/api/tokens/views.py
@@ -41,6 +41,8 @@ class TokenList(JSONAPIBaseView, generics.ListCreateAPIView, ODMFilterMixin):
     # solution for hiding this api endpoint
     renderer_classes = [JSONRendererWithESISupport, JSONAPIRenderer, ]  # Hide from web-browsable API tool
 
+    ordering = ('-id',)
+
     def get_default_odm_query(self):
 
         owner = self.request.user

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -306,6 +306,8 @@ class UserAddonList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin, User
     view_category = 'users'
     view_name = 'user-addons'
 
+    ordering = ('-date_last_refreshed',)
+
     def get_queryset(self):
         qs = [addon for addon in self.get_user().get_addons() if 'accounts' in addon.config.configs]
         qs.sort()
@@ -394,6 +396,8 @@ class UserAddonAccountList(JSONAPIBaseView, generics.ListAPIView, UserMixin, Add
     serializer_class = AddonAccountSerializer
     view_category = 'users'
     view_name = 'user-external_accounts'
+
+    ordering = ('-date_last_refreshed',)
 
     def get_queryset(self):
         return self.get_addon_settings(check_object_permissions=False).external_accounts
@@ -514,6 +518,8 @@ class UserNodes(JSONAPIBaseView, generics.ListAPIView, UserMixin, NodesFilterMix
     view_category = 'users'
     view_name = 'user-nodes'
 
+    ordering = ('-date_modified',)
+
     # overrides NodesFilterMixin
     def get_default_queryset(self):
         user = self.get_user()
@@ -583,6 +589,8 @@ class UserInstitutions(JSONAPIBaseView, generics.ListAPIView, UserMixin):
     serializer_class = InstitutionSerializer
     view_category = 'users'
     view_name = 'user-institutions'
+
+    ordering = ('-date_modified',)
 
     def get_default_odm_query(self):
         return None
@@ -687,6 +695,8 @@ class UserRegistrations(JSONAPIBaseView, generics.ListAPIView, UserMixin, NodesF
     serializer_class = RegistrationSerializer
     view_category = 'users'
     view_name = 'user-registrations'
+
+    ordering = ('-date_modified',)
 
     # overrides NodesFilterMixin
     def get_default_queryset(self):

--- a/api/view_only_links/views.py
+++ b/api/view_only_links/views.py
@@ -97,6 +97,8 @@ class ViewOnlyLinkNodes(JSONAPIBaseView, generics.ListAPIView):
     view_category = 'view-only-links'
     view_name = 'view-only-link-nodes'
 
+    ordering = ('-date_modified',)
+
     def get_serializer_class(self):
         if 'link_id' in self.kwargs:
             view_only_link = PrivateLink.load(self.kwargs['link_id'])

--- a/api_tests/taxonomies/views/test_taxonomy_list.py
+++ b/api_tests/taxonomies/views/test_taxonomy_list.py
@@ -1,6 +1,5 @@
 from nose.tools import *  # flake8: noqa
 
-from modularodm import Q
 from tests.base import ApiTestCase
 from osf_tests.factories import SubjectFactory
 from osf.models import Subject
@@ -16,7 +15,7 @@ class TestTaxonomy(ApiTestCase):
         self.subject1_child1 = SubjectFactory(parent=self.subject1)
         self.subject1_child2 = SubjectFactory(parent=self.subject1)
 
-        self.subjects = Subject.find()
+        self.subjects = Subject.objects.all().order_by('-id')
         self.url = '/{}taxonomies/'.format(API_BASE)
         self.res = self.app.get(self.url)
         self.data = self.res.json['data']


### PR DESCRIPTION
## Purpose

Travis logs for API tests (and local tests with the `-s` flag added) were throwing quite a few `UnorderedObjectListWarning` errors, which clued us in to the problem that many API views are indeed unordered, and so could return inconsistent results when paginating through them.

Let's add ordering to API views!

## Changes
- Add default `('-date_modified',)` ordering to many subclasses of`JSONAPIBaseView` 
- Add other orderings, mostly `('-id',)`, for other Views that aren't for a model with a `date_modified` field
- Update one taxonomies test to return results in the same way as the new view does for consistency

## Side effects
Pagination should now be consistent! So, none anticipated, but if anything was relying on inconsistent pagination (why would it?) this would go wonky.


## Ticket
https://openscience.atlassian.net/browse/OSF-8136