### PR TITLE
[feature] Replace '&amp;' with '&' in Profile Tabs [OSF-3945]

### DIFF
--- a/website/static/js/profile.js
+++ b/website/static/js/profile.js
@@ -731,6 +731,11 @@ SocialViewModel.prototype.unserialize = function(data) {
     var self = this;
     var websiteValue = [];
     $.each(data || {}, function(key, value) {
+        if (key === 'profileWebsites') {
+            value = value.map(function(website) {
+                return website.replace(/&amp;/gi, '&');
+            });
+        }
         if (ko.isObservable(self[key]) && key === 'profileWebsites') {
             if (value && value.length === 0) {
                 value.push(ko.observable('').extend({
@@ -924,6 +929,11 @@ ListViewModel.prototype.unserialize = function(data) {
         self.editable(false);
     }
     self.contents(ko.utils.arrayMap(data.contents || [], function (each) {
+        for (var attr in each) {
+            if (typeof each[attr] === 'string') {
+                each[attr] = each[attr].replace(/&amp;/gi, '&');
+            }
+        }
         return new self.ContentModel(self).unserialize(each);
     }));
 

--- a/website/static/js/profile.js
+++ b/website/static/js/profile.js
@@ -731,6 +731,9 @@ SocialViewModel.prototype.unserialize = function(data) {
     var self = this;
     var websiteValue = [];
     $.each(data || {}, function(key, value) {
+        if (key === 'scholar') {
+            value = value.replace(/&amp;/gi, '&');
+        }
         if (key === 'profileWebsites') {
             value = value.map(function(website) {
                 return website.replace(/&amp;/gi, '&');

--- a/website/static/js/profile.js
+++ b/website/static/js/profile.js
@@ -934,7 +934,7 @@ ListViewModel.prototype.unserialize = function(data) {
     self.contents(ko.utils.arrayMap(data.contents || [], function (each) {
         for (var attr in each) {
             each[attr] = $osf.decodeText(each[attr]);
-        };
+        }
         return new self.ContentModel(self).unserialize(each);
     }));
 

--- a/website/static/js/profile.js
+++ b/website/static/js/profile.js
@@ -731,13 +731,13 @@ SocialViewModel.prototype.unserialize = function(data) {
     var self = this;
     var websiteValue = [];
     $.each(data || {}, function(key, value) {
-        if (key === 'scholar') {
-            value = $osf.decodeText(value);
-        }
+        console.log(key, value);
         if (key === 'profileWebsites') {
             value = value.map(function(website) {
                 return $osf.decodeText(website);
             });
+        } else {
+            value = $osf.decodeText(value);
         }
         if (ko.isObservable(self[key]) && key === 'profileWebsites') {
             if (value && value.length === 0) {
@@ -934,7 +934,7 @@ ListViewModel.prototype.unserialize = function(data) {
     self.contents(ko.utils.arrayMap(data.contents || [], function (each) {
         for (var attr in each) {
             if (typeof each[attr] === 'string') {
-                each[attr] = $osf.decodeText(each[attr])
+                each[attr] = $osf.decodeText(each[attr]);
             }
         }
         return new self.ContentModel(self).unserialize(each);

--- a/website/static/js/profile.js
+++ b/website/static/js/profile.js
@@ -735,7 +735,7 @@ SocialViewModel.prototype.unserialize = function(data) {
             value = value.map(function(website) {
                 return $osf.decodeText(website);
             });
-        } else if (typeof value === 'string') {
+        } else {
             value = $osf.decodeText(value);
         }
 
@@ -933,9 +933,7 @@ ListViewModel.prototype.unserialize = function(data) {
     }
     self.contents(ko.utils.arrayMap(data.contents || [], function (each) {
         for (var attr in each) {
-            if (typeof each[attr] === 'string') {
-                each[attr] = $osf.decodeText(each[attr]);
-            }
+            each[attr] = $osf.decodeText(each[attr]);
         }
         return new self.ContentModel(self).unserialize(each);
     }));

--- a/website/static/js/profile.js
+++ b/website/static/js/profile.js
@@ -732,11 +732,11 @@ SocialViewModel.prototype.unserialize = function(data) {
     var websiteValue = [];
     $.each(data || {}, function(key, value) {
         if (key === 'scholar') {
-            value = value.replace(/&amp;/gi, '&');
+            value = $osf.decodeText(value);
         }
         if (key === 'profileWebsites') {
             value = value.map(function(website) {
-                return website.replace(/&amp;/gi, '&');
+                return $osf.decodeText(website);
             });
         }
         if (ko.isObservable(self[key]) && key === 'profileWebsites') {
@@ -934,7 +934,7 @@ ListViewModel.prototype.unserialize = function(data) {
     self.contents(ko.utils.arrayMap(data.contents || [], function (each) {
         for (var attr in each) {
             if (typeof each[attr] === 'string') {
-                each[attr] = each[attr].replace(/&amp;/gi, '&');
+                each[attr] = $osf.decodeText(each[attr])
             }
         }
         return new self.ContentModel(self).unserialize(each);

--- a/website/static/js/profile.js
+++ b/website/static/js/profile.js
@@ -934,7 +934,7 @@ ListViewModel.prototype.unserialize = function(data) {
     self.contents(ko.utils.arrayMap(data.contents || [], function (each) {
         for (var attr in each) {
             each[attr] = $osf.decodeText(each[attr]);
-        }
+        };
         return new self.ContentModel(self).unserialize(each);
     }));
 

--- a/website/static/js/profile.js
+++ b/website/static/js/profile.js
@@ -731,14 +731,14 @@ SocialViewModel.prototype.unserialize = function(data) {
     var self = this;
     var websiteValue = [];
     $.each(data || {}, function(key, value) {
-        console.log(key, value);
         if (key === 'profileWebsites') {
             value = value.map(function(website) {
                 return $osf.decodeText(website);
             });
-        } else {
+        } else if (typeof value === 'string') {
             value = $osf.decodeText(value);
         }
+
         if (ko.isObservable(self[key]) && key === 'profileWebsites') {
             if (value && value.length === 0) {
                 value.push(ko.observable('').extend({


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

<!-- Describe the purpose of your changes -->
When users added '&' to their employment / education / social personal website link it resulted in being displayed as '&amp;'.
This replaces any '&amp;' with '&' in the personal website links and employment and education tabs on the profile page.

## Changes

<!-- Briefly describe or list your changes  -->
Modified profile.js to pick up on where '&amp;' was being displayed on the employment, education, and social tabs where applicable.

## Side effects

<!--Any possible side effects? -->
If a user were to have '&amp;' in their personal website social link it would likely break the link by replacing that with '&'

## QA Considerations

There may be other links under social where a user could put  an ampersand, so if that is the case this will need to be updated.

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
https://openscience.atlassian.net/browse/OSF-3945