### PR TITLE
[Hotfix] Handle archival edge case [OSF-8185]

### DIFF
--- a/osf/management/commands/force_archive.py
+++ b/osf/management/commands/force_archive.py
@@ -129,6 +129,7 @@ def perform_wb_copy(reg, node_settings):
             archive_folder = dst.files.get(name=node_settings.archive_folder_name.replace('/', '-'))
             archive_folder.delete()
         if SKIP_COLLISIONS:
+            complete_archive_target(reg, node_settings.short_name)
             return
     params = {'cookie': user.get_or_create_cookie()}
     data = {
@@ -288,9 +289,10 @@ def archive(registration):
             if short_name == 'osfstorage':
                 file_tree = build_file_tree(reg, node_settings)
                 manually_archive(file_tree, reg, node_settings)
+                complete_archive_target(reg, short_name)
             else:
+                assert reg.archiving, '{}: Must be `archiving` for WB to copy'.format(reg._id)
                 perform_wb_copy(reg, node_settings)
-            complete_archive_target(reg, short_name)
 
 def archive_registrations():
     for reg in deepcopy(VERIFIED):


### PR DESCRIPTION
## Purpose
Extends #7351 and #7377 

## Changes
* Don't mark registration as finished archiving until WB finishes copying

## Side effects
For non-OSFS addons, must be ran twice -- the second time after WB finishes copying, and with the `--skip-collisions` flag.

## Ticket
[[OSF-8185}}(https://openscience.atlassian.net/browse/OSF-8185)
