### PR TITLE
Feature/Add email template for adding contributors to a preprint OSF node [EOSF-412]

### DIFF
--- a/website/mails/mails.py
+++ b/website/mails/mails.py
@@ -207,6 +207,10 @@ CONTRIBUTOR_ADDED_PREPRINT = lambda template, provider: Mail(
     'contributor_added_preprints_{}'.format(template),
     subject='You have been added as a contributor to {} {} preprint.'.format(get_english_article(provider), provider)
 )
+CONTRIBUTOR_ADDED_PREPRINT_NODE_FROM_OSF = Mail(
+    'contributor_added_preprint_node_from_osf',
+    subject='You have been added as a contributor to an OSF project.'
+)
 FORWARD_INVITE = Mail('forward_invite', subject='Please forward to ${fullname}')
 FORWARD_INVITE_REGISTERED = Mail('forward_invite_registered', subject='Please forward to ${fullname}')
 

--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -531,6 +531,8 @@ def notify_added_contributor(node, contributor, auth=None, throttle=None, email_
             if not email_template or not preprint_provider:
                 return
             email_template = getattr(mails, 'CONTRIBUTOR_ADDED_PREPRINT')(email_template, preprint_provider.name)
+        elif node.is_preprint:
+            email_template = getattr(mails, 'CONTRIBUTOR_ADDED_PREPRINT_NODE_FROM_OSF'.format(email_template.upper()))
         else:
             email_template = getattr(mails, 'CONTRIBUTOR_ADDED_DEFAULT'.format(email_template.upper()))
 

--- a/website/templates/emails/contributor_added_preprint_node_from_osf.txt.mako
+++ b/website/templates/emails/contributor_added_preprint_node_from_osf.txt.mako
@@ -1,0 +1,23 @@
+<%!
+    from website import settings
+%>
+
+Hello ${user.fullname},
+
+${referrer_name + ' has added you' if referrer_name else 'You have been added'} as a contributor to the project "${node.title}" on the Open Science Framework: ${node.absolute_url}
+
+This project also has a public preprint, discoverable at: ${node.preprints.get_queryset()[0].absolute_url}
+
+You will ${'not receive ' if all_global_subscriptions_none else 'be automatically subscribed to '} notification emails for this project. To change your email notification preferences, visit your project or your user settings: ${settings.DOMAIN + "settings/notifications/"}
+
+If you are erroneously being associated with "${node.title}," then you may visit the project's "Contributors" page and remove yourself as a contributor.
+
+
+Sincerely,
+
+Open Science Framework Robot
+
+
+Want more information? Visit https://osf.io/ to learn about the Open Science Framework, or https://cos.io/ for information about its supporting organization, the Center for Open Science.
+
+Questions? Email contact@osf.io


### PR DESCRIPTION
## Purpose

Currently, when there is a preprint associated with a node and someone is added to that node as a contributor, there is no indication in the email that the node also contains a preprint. 

## Changes

Added an email template to send when adding contributors to a node that contains a preprint.

## Side effects

All nodes with preprints will now receive this email instead of the default email when contributors are added. Both templates will need to be changed if the default template needs to be changed.

## Ticket

https://openscience.atlassian.net/browse/EOSF-412
