### PR TITLE
[hotfix] Remove DevOnly from Preprint Provider fields in API [No Ticket]

### DIFF
--- a/api/preprint_providers/serializers.py
+++ b/api/preprint_providers/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers as ser
 
 from api.base.utils import absolute_reverse
-from api.base.serializers import JSONAPISerializer, LinksField, RelationshipField, ShowIfVersion, DevOnly
+from api.base.serializers import JSONAPISerializer, LinksField, RelationshipField, ShowIfVersion
 
 
 class PreprintProviderSerializer(JSONAPISerializer):
@@ -25,8 +25,8 @@ class PreprintProviderSerializer(JSONAPISerializer):
     footer_links = ser.CharField(required=False)
     share_source = ser.CharField(read_only=True)
     email_support = ser.CharField(required=False, allow_null=True)
-    allow_submissions = DevOnly(ser.BooleanField(read_only=True))
-    additional_providers = DevOnly(ser.ListField(child=ser.CharField(), read_only=True))
+    allow_submissions = ser.BooleanField(read_only=True)
+    additional_providers = ser.ListField(child=ser.CharField(), read_only=True)
 
     preprints = RelationshipField(
         related_view='preprint_providers:preprints-list',


### PR DESCRIPTION
#### Purpose
-  Fixes submit button not displaying on OSF Preprints landing page.
- Fixes https://osf.io/preprints/submit `404`ing.

#### Changes
- Remove `DevOnly` from preprint provider fields. Preprints app needs these fields from the API so everything isn't broken.

#### Side effects
- None expected.
