### PR TITLE
[feature] Admin App Allow Styling in Preprint Provider HTML Fields [OSF-8206]

### DIFF
--- a/admin/preprint_providers/forms.py
+++ b/admin/preprint_providers/forms.py
@@ -37,7 +37,8 @@ class PreprintProviderForm(ModelForm):
         return bleach.clean(
             self.data.get('advisory_board'),
             tags=['a', 'b', 'br', 'div', 'em', 'h2', 'h3', 'li', 'p', 'strong', 'ul'],
-            attributes=['class', 'href', 'title', 'target'],
+            attributes=['class', 'style', 'href', 'title', 'target'],
+            styles=['text-align', 'vertical-align'],
             strip=True
         )
 
@@ -45,7 +46,8 @@ class PreprintProviderForm(ModelForm):
         return bleach.clean(
             self.data.get('description'),
             tags=['a', 'br', 'em', 'p', 'span', 'strong'],
-            attributes=['class', 'href', 'title', 'target'],
+            attributes=['class', 'style', 'href', 'title', 'target'],
+            styles=['text-align', 'vertical-align'],
             strip=True
         )
 
@@ -54,6 +56,6 @@ class PreprintProviderForm(ModelForm):
             self.data.get('footer_links'),
             tags=['a', 'br', 'div', 'em', 'p', 'span', 'strong'],
             attributes=['class', 'style', 'href', 'title', 'target'],
-            styles=['vertical-align'],
+            styles=['text-align', 'vertical-align'],
             strip=True
         )


### PR DESCRIPTION
#### Companion PR 
- https://github.com/CenterForOpenScience/ember-preprints/pull/406

#### Purpose
- Allows (minimal) styling of preprint provider HTML fields in the admin app.

#### Changes
- Adds `style` to the list of allowed attributes and `text-align` to the list of allowed styles for preprint provider HTML fields.

#### Side Effects
- None expected.

#### Ticket
- [OSF-8206](https://openscience.atlassian.net/browse/OSF-8206)
