### PR TITLE
[feature] Use mako def for navbar [OSF-7562]

### DIFF
--- a/website/static/js/navbarControl.js
+++ b/website/static/js/navbarControl.js
@@ -12,20 +12,6 @@ var NavbarViewModel = function() {
     var self = this;
 
     self.currentService = window.contextVars.meetings ? 'meetings' : 'home';
-
-    self.osfServices = {
-        home: {
-            name: 'HOME ',
-            href: '/',
-            support: '/support/'
-        },
-        meetings: {
-            name: 'MEETINGS',
-            href: '/meetings/',
-            support: 'http://help.osf.io/m/meetings'
-        }
-    };
-
     $('#primary-navigation').on('click', function () {
         $('.navbar-collapse').collapse('hide');
     });

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -89,7 +89,7 @@
 
     <%namespace name="nav_file" file="nav.mako"/>
     <%block name="nav">
-        ${nav_file.nav()}
+        ${nav_file.nav(self.service_title, self.service_href, self.service_support)}
     </%block>
      ## TODO: shouldn't always have the watermark class
     ${self.content_wrap()}
@@ -245,6 +245,12 @@
 <%def name="alert()">
     <%include file="alert.mako"/>
 </%def>
+
+## Default nav bar service values
+<%def name="service_title()">HOME</%def>
+<%def name="service_href()">/</%def>
+<%def name="service_support()">/support/</%def>
+
 
 <%def name="content_wrap()">
     <div class="watermarked">

--- a/website/templates/nav.mako
+++ b/website/templates/nav.mako
@@ -1,4 +1,4 @@
-<%block name="nav">
+<%block name="nav", args="service_title,service_href,service_support">
 <link rel="stylesheet" href='/static/css/nav.css'>
 <div class="osf-nav-wrapper">
 
@@ -13,9 +13,9 @@
             </button>
         <a class="navbar-brand" href="/" aria-label="Go home"><span class="osf-navbar-logo"></span></a>
         <div class="service-name">
-            <a data-bind="attr: {href: osfServices[currentService].href}">
+            <a href="${service_href()}">
                 <span class="hidden-xs"> OSF </span>
-                <span><strong data-bind="text: osfServices[currentService].name"></strong></span>
+                <span><strong>${service_title()}</strong></span>
             </a>
         </div>
         <div class="dropdown primary-nav">
@@ -44,7 +44,7 @@
             <!-- /ko -->
 
             <li class="dropdown">
-            <a data-bind="attr: {href: osfServices[currentService].support}">Support</a>
+            <a href="${service_support()}">Support</a>
             </li>
 
             % if user_name and display_name:

--- a/website/templates/public/pages/meeting.mako
+++ b/website/templates/public/pages/meeting.mako
@@ -1,5 +1,8 @@
 <%inherit file="base.mako"/>
 <%def name="title()">${ meeting['name'] }</%def>
+<%def name="service_title()">MEETINGS</%def>
+<%def name="service_href()">/meetings/</%def>
+<%def name="service_support()">http://help.osf.io/m/meetings/</%def>
 
 <%def name="content()">
     <%include file="public/pages/meeting_body.mako" />

--- a/website/templates/public/pages/meeting_landing.mako
+++ b/website/templates/public/pages/meeting_landing.mako
@@ -1,6 +1,10 @@
 <%inherit file="base.mako"/>
 
 <%def name="title()">Meetings</%def>
+<%def name="service_title()">MEETINGS</%def>
+<%def name="service_href()">/meetings/</%def>
+<%def name="service_support()">http://help.osf.io/m/meetings/</%def>
+
 <%def name="stylesheets()">
     ${parent.stylesheets()}
     <link rel="stylesheet" href="/static/css/pages/meeting-landing-page.css">


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
HOME and MEETINGS flash when loading. Also writes urls for HOME and MEETINGS backend side
<!-- Describe the purpose of your changes -->

## Changes
No more flashy home 🔦 📸 💥 
<!-- Briefly describe or list your changes  -->

## Side effects
na
<!--Any possible side effects? -->


## Ticket
https://openscience.atlassian.net/browse/OSF-7562
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->

## QA Notes
Check the home page, and various other pages to ensure the following data works properly
1. The text of title (HOME, MEETINGS)
2. Clicking HOME or MEETINGS goes to "/" or "/meetings/" respectively
3. The support button goes to the proper support location

Check both the base meetings page and a specific meeting page as these were modified separately