### PR TITLE
Feature/fix name of emberosf-sync volume [No Ticket]

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -95,7 +95,7 @@ volumes:
 #  mfr-sync:
 #    external: true
 
-#  ember-osf-sync:
+#  emberosf-sync:
 #    external: true
 
 #  preprints-sync:


### PR DESCRIPTION
## Purpose

Allow linking to emberosf-sync.

## Changes

Emberosf-sync volume accidentally named ember-osf-sync  the docker-compose.override.yml. Fixing this.

## Side effects

None

## Ticket

None
