### PR TITLE
Update README with Preprint Provider Management Command [No Ticket]

### DIFF
--- a/README-docker-compose.md
+++ b/README-docker-compose.md
@@ -171,7 +171,7 @@ Ubuntu: Skip install of docker-sync, fswatch, and unison. instead...
 - Populate preprint providers:
   - After resetting your database or with a new install you will need to populate the table of preprint providers. **You must have run migrations first.**
     - `docker-compose run --rm web python -m scripts.update_taxonomies`
-    - `docker-compose run --rm web python -m scripts.populate_preprint_providers`
+    - `docker-compose run --rm web python manage.py populate_fake_preprint_providers`
 - Populate citation styles
   - Needed for api v2 citation style rendering.
     - `docker-compose run --rm web python -m scripts.parse_citation_styles`


### PR DESCRIPTION
#### Purpose
- The `populate_fake_preprint_providers` management command has replaced the `populate_preprint_providers` script for local development. This PR updates the README to reflect that change.

