### PR TITLE
[OSF-7562] Render navbar server-side to avoid flashes of content

### DIFF
--- a/website/static/js/navbarControl.js
+++ b/website/static/js/navbarControl.js
@@ -1,4 +1,3 @@
-
 var $ = require('jquery');
 var ko = require('knockout');
 var bootbox = require('bootbox'); // TODO: Why is this import required? Is it? See [#OSF-6100]
@@ -11,7 +10,6 @@ var $osf = require('js/osfHelpers');
 var NavbarViewModel = function() {
     var self = this;
 
-    self.currentService = window.contextVars.meetings ? 'meetings' : 'home';
     $('#primary-navigation').on('click', function () {
         $('.navbar-collapse').collapse('hide');
     });

--- a/website/static/js/navbarControl.js
+++ b/website/static/js/navbarControl.js
@@ -12,20 +12,6 @@ var NavbarViewModel = function() {
     var self = this;
 
     self.currentService = window.contextVars.meetings ? 'meetings' : 'home';
-
-    self.osfServices = {
-        home: {
-            name: 'HOME ',
-            href: '/',
-            support: '/support/'
-        },
-        meetings: {
-            name: 'MEETINGS',
-            href: '/meetings/',
-            support: 'http://help.osf.io/m/meetings'
-        }
-    };
-
     $('#primary-navigation').on('click', function () {
         $('.navbar-collapse').collapse('hide');
     });

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -87,10 +87,7 @@
     </div>
     % endif
 
-    <%namespace name="nav_file" file="nav.mako"/>
-    <%block name="nav">
-        ${nav_file.nav(self.service_title, self.service_href, self.service_support)}
-    </%block>
+    ${self.nav()}
      ## TODO: shouldn't always have the watermark class
     ${self.content_wrap()}
 
@@ -206,6 +203,11 @@
 
 ###### Base template functions #####
 
+<%def name="nav()">
+    <%namespace name="nav_helper" file="nav.mako" />
+    ${nav_helper.nav(service_name='HOME', service_url='/', service_support_url='/support/')}
+</%def>
+
 <%def name="title()">
     ### The page title ###
 </%def>
@@ -245,12 +247,6 @@
 <%def name="alert()">
     <%include file="alert.mako"/>
 </%def>
-
-## Default nav bar service values
-<%def name="service_title()">HOME</%def>
-<%def name="service_href()">/</%def>
-<%def name="service_support()">/support/</%def>
-
 
 <%def name="content_wrap()">
     <div class="watermarked">

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -89,7 +89,7 @@
 
     <%namespace name="nav_file" file="nav.mako"/>
     <%block name="nav">
-        ${nav_file.nav()}
+        ${nav_file.nav(self.service_title, self.service_href, self.service_support)}
     </%block>
      ## TODO: shouldn't always have the watermark class
     ${self.content_wrap()}
@@ -245,6 +245,12 @@
 <%def name="alert()">
     <%include file="alert.mako"/>
 </%def>
+
+## Default nav bar service values
+<%def name="service_title()">HOME</%def>
+<%def name="service_href()">/</%def>
+<%def name="service_support()">/support/</%def>
+
 
 <%def name="content_wrap()">
     <div class="watermarked">

--- a/website/templates/nav.mako
+++ b/website/templates/nav.mako
@@ -1,4 +1,4 @@
-<%block name="nav">
+<%block name="nav", args="service_title,service_href,service_support">
 <link rel="stylesheet" href='/static/css/nav.css'>
 <div class="osf-nav-wrapper">
 
@@ -13,9 +13,9 @@
             </button>
         <a class="navbar-brand" href="/" aria-label="Go home"><span class="osf-navbar-logo"></span></a>
         <div class="service-name">
-            <a data-bind="attr: {href: osfServices[currentService].href}">
+            <a href="${service_href()}">
                 <span class="hidden-xs"> OSF </span>
-                <span><strong data-bind="text: osfServices[currentService].name"></strong></span>
+                <span><strong>${service_title()}</strong></span>
             </a>
         </div>
         <div class="dropdown primary-nav">
@@ -44,7 +44,7 @@
             <!-- /ko -->
 
             <li class="dropdown">
-            <a data-bind="attr: {href: osfServices[currentService].support}">Support</a>
+            <a href="${service_support()}">Support</a>
             </li>
 
             % if user_name and display_name:

--- a/website/templates/nav.mako
+++ b/website/templates/nav.mako
@@ -1,4 +1,4 @@
-<%block name="nav", args="service_title,service_href,service_support">
+<%def name="nav(service_name, service_url, service_support_url)">
 <link rel="stylesheet" href='/static/css/nav.css'>
 <div class="osf-nav-wrapper">
 
@@ -13,9 +13,9 @@
             </button>
         <a class="navbar-brand" href="/" aria-label="Go home"><span class="osf-navbar-logo"></span></a>
         <div class="service-name">
-            <a href="${service_href()}">
+            <a href="${service_url}">
                 <span class="hidden-xs"> OSF </span>
-                <span><strong>${service_title()}</strong></span>
+                <span><strong>${service_name}</strong></span>
             </a>
         </div>
         <div class="dropdown primary-nav">
@@ -36,15 +36,14 @@
 
     <div class="navbar-collapse collapse navbar-right" id="secondary-navigation">
         <ul class="nav navbar-nav">
-            <!-- ko if: currentService === 'home' -->
-            % if user_name:
-                <li><a href="${domain}myprojects/">My Projects</a></li>
+            % if service_name == 'HOME':
+                % if user_name:
+                    <li><a href="${domain}myprojects/">My Projects</a></li>
+                % endif
+                    <li><a href="${domain}search/">Search</a></li>
             % endif
-                <li><a href="${domain}search/">Search</a></li>
-            <!-- /ko -->
-
             <li class="dropdown">
-            <a href="${service_support()}">Support</a>
+            <a href="${service_support_url}">Support</a>
             </li>
 
             % if user_name and display_name:
@@ -87,8 +86,6 @@
         </ul>
     </div>
 </div>
-
-
 </nav>
 </div>
-</%block>
+</%def>

--- a/website/templates/public/pages/meeting.mako
+++ b/website/templates/public/pages/meeting.mako
@@ -1,5 +1,8 @@
 <%inherit file="base.mako"/>
 <%def name="title()">${ meeting['name'] }</%def>
+<%def name="service_title()">MEETINGS</%def>
+<%def name="service_href()">/meetings/</%def>
+<%def name="service_support()">http://help.osf.io/m/meetings/</%def>
 
 <%def name="content()">
     <%include file="public/pages/meeting_body.mako" />

--- a/website/templates/public/pages/meeting.mako
+++ b/website/templates/public/pages/meeting.mako
@@ -1,8 +1,10 @@
 <%inherit file="base.mako"/>
 <%def name="title()">${ meeting['name'] }</%def>
-<%def name="service_title()">MEETINGS</%def>
-<%def name="service_href()">/meetings/</%def>
-<%def name="service_support()">http://help.osf.io/m/meetings/</%def>
+
+<%def name="nav()">
+    <%namespace name="nav_helper" file="nav.mako" />
+    ${nav_helper.nav(service_name='MEETINGS', service_url='/meetings/', service_support_url='http://help.osf.io/m/meetings/')}
+</%def>
 
 <%def name="content()">
     <%include file="public/pages/meeting_body.mako" />

--- a/website/templates/public/pages/meeting_landing.mako
+++ b/website/templates/public/pages/meeting_landing.mako
@@ -1,9 +1,11 @@
 <%inherit file="base.mako"/>
 
 <%def name="title()">Meetings</%def>
-<%def name="service_title()">MEETINGS</%def>
-<%def name="service_href()">/meetings/</%def>
-<%def name="service_support()">http://help.osf.io/m/meetings/</%def>
+
+<%def name="nav()">
+    <%namespace name="nav_helper" file="nav.mako" />
+    ${nav_helper.nav(service_name='MEETINGS', service_url='/meetings/', service_support_url='http://help.osf.io/m/meetings/')}
+</%def>
 
 <%def name="stylesheets()">
     ${parent.stylesheets()}

--- a/website/templates/public/pages/meeting_landing.mako
+++ b/website/templates/public/pages/meeting_landing.mako
@@ -1,6 +1,10 @@
 <%inherit file="base.mako"/>
 
 <%def name="title()">Meetings</%def>
+<%def name="service_title()">MEETINGS</%def>
+<%def name="service_href()">/meetings/</%def>
+<%def name="service_support()">http://help.osf.io/m/meetings/</%def>
+
 <%def name="stylesheets()">
     ${parent.stylesheets()}
     <link rel="stylesheet" href="/static/css/pages/meeting-landing-page.css">


### PR DESCRIPTION
## Purpose

Carries on from #7393 . Changes the `nav` from a `block` to `def` to avoid having to pass around functions. 

## Changes

- Change nav from a `block` to a `def`
- Rename params
- Remove client-side logic (`currentService`)

## Ticket

https://openscience.atlassian.net/browse/OSF-7562
