### PR TITLE
Feature/fix name to emberosf-sync [No Ticket]

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -83,7 +83,7 @@ services:
 #    build: ../ember-osf
 #    command: /bin/bash -c "yarn --pure-lockfile && ./node_modules/bower/bin/bower install --allow-root --config.interactive=false"
 #    volumes:
-#      - ember-osf-sync:/code:nocopy
+#      - emberosf-sync:/code:nocopy
 
 volumes:
   osf-sync:


### PR DESCRIPTION
## Purpose

Allow linking to emberosf-sync.

## Changes

Emberosf-sync volume accidentally named ember-osf-sync  the docker-compose.override.yml. Fixing this.

## Side effects

None

## Ticket

None
