### PR TITLE
[hotfix] Optimize Sitemap Generator [OSF-8168]

### DIFF
--- a/osf/models/preprint_service.py
+++ b/osf/models/preprint_service.py
@@ -6,6 +6,7 @@ from django.db import models
 from django.utils import timezone
 from django.utils.functional import cached_property
 from django.contrib.contenttypes.fields import GenericRelation
+from include import IncludeManager
 
 from framework.celery_tasks.handlers import enqueue_task
 from framework.exceptions import PermissionsError
@@ -39,6 +40,8 @@ class PreprintService(DirtyFieldsMixin, GuidMixin, IdentifierMixin, BaseModel):
     subjects = models.ManyToManyField(blank=True, to='osf.Subject', related_name='preprint_services')
 
     identifiers = GenericRelation(Identifier, related_query_name='preprintservices')
+
+    objects = IncludeManager()
 
     class Meta:
         unique_together = ('node', 'provider')


### PR DESCRIPTION
#### Purpose
- Make the sitemap generator more fast. 

#### Changes
- Use more Django magic (values, values_list, select_related, include).
- Remove `.iterator()` from loops.
- `preprint.primary_file.node._id` --> `preprint.node._id`

#### Side Effects
- Unsure if adding `IncludeManager` to `PreprintService` will have side effects... @sloria? 

#### Ticket
- [OSF-8168](https://openscience.atlassian.net/browse/OSF-8168)

#### More Fast
```
LOCAL
USERS=783; NODES=1021; PREP=352; TOTAL_URL_COUNT=2516;
  OLD
    time = [13.60890507698059, 13.498132944107056, 13.477915048599243, 13.3643319606781, 13.486894130706787]
    queries (user) = 784
    queries (node) = 1023
    queries (prep) = 2113
  NEW
    time = [2.0950450897216797, 2.0373950004577637, 2.051614999771118, 1.997941017150879, 1.9991240501403809]
    queries (user) = 1 
    queries (node) = 1 
    queries (prep) = 1 
```

```
STAGING
USERS=672; NODES=7569; PREP=180; TOTAL_URL_COUNT=8608;
  OLD
    time = [79.34490895271301, 77.33839106559753]
  NEW
    time = [3.8284010887145996, 3.492077112197876, 3.4077110290527344, 3.2731480598449707, 3.325674057006836]
```