### PR TITLE
[RFR] [OSF-7948] Delete subjects_acceptable list from PreprintProviderSerializer

### DIFF
--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -152,6 +152,7 @@ REST_FRAMEWORK = {
         '2.2',
         '2.3',
         '2.4',
+        '2.5',
     ),
     'DEFAULT_FILTER_BACKENDS': ('api.base.filters.ODMOrderingFilter',),
     'DEFAULT_PAGINATION_CLASS': 'api.base.pagination.JSONAPIPagination',

--- a/api/base/settings/local-dist.py
+++ b/api/base/settings/local-dist.py
@@ -26,6 +26,7 @@ REST_FRAMEWORK['ALLOWED_VERSIONS'] = (
     '2.2',
     '2.3',
     '2.4',
+    '2.5',
     '3.0',
     '3.0.1',
 )

--- a/api/preprint_providers/serializers.py
+++ b/api/preprint_providers/serializers.py
@@ -21,7 +21,6 @@ class PreprintProviderSerializer(JSONAPISerializer):
     example = ser.CharField(required=False, allow_null=True)
     domain = ser.CharField(required=False, allow_null=False)
     domain_redirect_enabled = ser.BooleanField(required=True)
-    subjects_acceptable = ser.JSONField(required=False, allow_null=True)
     footer_links = ser.CharField(required=False)
     share_source = ser.CharField(read_only=True)
     email_support = ser.CharField(required=False, allow_null=True)
@@ -77,6 +76,10 @@ class PreprintProviderSerializer(JSONAPISerializer):
     social_instagram = ShowIfVersion(
         ser.CharField(required=False, allow_null=True),
         min_version='2.0', max_version='2.3'
+    )
+    subjects_acceptable = ShowIfVersion(
+        ser.ListField(required=False, default=[]),
+        min_version='2.0', max_version='2.4'
     )
 
     class Meta:

--- a/api/preprint_providers/urls.py
+++ b/api/preprint_providers/urls.py
@@ -8,5 +8,5 @@ urlpatterns = [
     url(r'^(?P<provider_id>\w+)/$', views.PreprintProviderDetail.as_view(), name=views.PreprintProviderDetail.view_name),
     url(r'^(?P<provider_id>\w+)/licenses/$', views.PreprintProviderLicenseList.as_view(), name=views.PreprintProviderLicenseList.view_name),
     url(r'^(?P<provider_id>\w+)/preprints/$', views.PreprintProviderPreprintList.as_view(), name=views.PreprintProviderPreprintList.view_name),
-    url(r'^(?P<provider_id>\w+)/taxonomies/$', views.PreprintProviderSubjectList.as_view(), name=views.PreprintProviderSubjectList.view_name),
+    url(r'^(?P<provider_id>\w+)/taxonomies/$', views.PreprintProviderTaxonomies.as_view(), name=views.PreprintProviderTaxonomies.view_name),
 ]

--- a/api/preprint_providers/views.py
+++ b/api/preprint_providers/views.py
@@ -39,7 +39,6 @@ class PreprintProviderList(JSONAPIBaseView, generics.ListAPIView, ODMFilterMixin
         advisory_board           string              HTML for the advisory board/steering committee section
         email_contact            string              the contact email for the preprint provider
         email_support            string              the support email for the preprint provider
-        subjects_acceptable      [[string],boolean]  the list of acceptable subjects for the preprint provider
         social_facebook          string              the preprint provider's Facebook account
         social_instagram         string              the preprint provider's Instagram account
         social_twitter           string              the preprint provider's Twitter account
@@ -103,7 +102,6 @@ class PreprintProviderDetail(JSONAPIBaseView, generics.RetrieveAPIView):
         advisory_board           string              HTML for the advisory board/steering committee section
         email_contact            string              the contact email for the preprint provider
         email_support            string              the support email for the preprint provider
-        subjects_acceptable      [[string],boolean]  the list of acceptable subjects for the preprint provider
         social_facebook          string              the preprint provider's Facebook account
         social_instagram         string              the preprint provider's Instagram account
         social_twitter           string              the preprint provider's Twitter account
@@ -220,7 +218,7 @@ class PreprintProviderPreprintList(JSONAPIBaseView, generics.ListAPIView, Prepri
         return PreprintService.objects.filter(self.get_query_from_request()).distinct()
 
 
-class PreprintProviderSubjectList(JSONAPIBaseView, generics.ListAPIView):
+class PreprintProviderTaxonomies(JSONAPIBaseView, generics.ListAPIView):
     permission_classes = (
         drf_permissions.IsAuthenticatedOrReadOnly,
         base_permissions.TokenHasScope,


### PR DESCRIPTION
## Purpose
[#OSF-7948]
Preprint providers should not have subjects_acceptable in API response

## Changes
Deprecated subjects_acceptable
New API version 2.5
Renamed PreprintProviderSubjectList to PreprintProviderTaxonomies as it is now only used by the taxonomies endpoint.

### v2 API 
```
curl -s http://localhost:8000/v2/preprint_providers/agrixiv/ | jq '.data.attributes
' | jq keys
[
  "additional_providers",
  "advisory_board",
  "allow_submissions",
  "banner_path",
  "description",
  "domain",
  "domain_redirect_enabled",
  "email_contact",
  "email_support",
  "example",
  "footer_links",
  "header_text",
  "logo_path",
  "name",
  "share_source",
  "social_facebook",
  "social_instagram",
  "social_twitter",
  "subjects_acceptable"
]
```
### v2.4 API 
```
curl -s http://localhost:8000/v2/preprint_providers/agrixiv/?version=2.4 | jq '.data.attributes
' | jq keys
[
  "additional_providers",
  "advisory_board",
  "allow_submissions",
  "description",
  "domain",
  "domain_redirect_enabled",
  "email_support",
  "example",
  "footer_links",
  "name",
  "share_source",
  "subjects_acceptable"
]
```
### v2.5 API 
```
curl -s http://localhost:8000/v2/preprint_providers/agrixiv/?version=2.5 | jq '.data.attributes
' | jq keys
[
  "additional_providers",
  "advisory_board",
  "allow_submissions",
  "description",
  "domain",
  "domain_redirect_enabled",
  "email_support",
  "example",
  "footer_links",
  "name",
  "share_source"
]
```

## Side effects
None

## Ticket
[OSF-7948](https://openscience.atlassian.net/browse/OSF-7948)
