### PR TITLE
[Feature] Fix MyProjects Page [OSF-8084]

### DIFF
--- a/website/static/js/myProjects.js
+++ b/website/static/js/myProjects.js
@@ -968,7 +968,7 @@ var MyProjects = {
                 // TODO Figure out why
                 setTimeout(m.redraw.bind(this, true), 250);
             }
-        }
+        };
 
         self.init = function _init_fileBrowser() {
             self.loadCategories().then(function(){
@@ -1032,7 +1032,7 @@ var MyProjects = {
                 multiselected : ctrl.multiselected,
                 highlightMultiselect : ctrl.highlightMultiselect,
                 _onload: function(tb) {
-                    ctrl.onLoadReset()
+                    ctrl.onLoadReset();
                 }
             },
             ctrl.projectOrganizerOptions

--- a/website/static/js/myProjects.js
+++ b/website/static/js/myProjects.js
@@ -25,6 +25,38 @@ if (!window.fileBrowserCounter) {
     window.fileBrowserCounter = 0;
 }
 
+var nodesFieldType = 'fields[nodes]';
+var registrationsFieldType = 'fields[registrations]';
+var usersFieldType = 'fields[users]';
+var contributorsFieldType = 'fields[contributors]';
+
+var sparseNodeFields = String([
+    'category',
+    'children',
+    'contributors',
+    'current_user_permissions',
+    'date_modified',
+    'parent',
+    'tags',
+    'title'
+]);
+
+var sparseRegistrationFields = String([
+    sparseNodeFields,
+    'registration',
+    'pending_registration_approval',
+    'withdrawn'
+]);
+
+var sparseUserFields = String([
+    'full_name',
+]);
+
+var sparseContributorFields = String([
+    'unregistered_contributor',
+    'users'
+]);
+
 //Backport of Set
 if (!window.Set) {
   window.Set = function Set(initial) {
@@ -52,33 +84,54 @@ if (!window.Set) {
 
 
 function NodeFetcher(type, link, handleOrphans, regType, regLink) {
-  this.type = type || 'nodes';
-  this.regType = regType || null;
-  this.regLink = regLink || null;
-  this.loaded = 0;
-  this._failed = 0;
-  this.total = 0;
-  this._flat = [];
-  this._orphans = [];
-  this._cache = {};
-  this._promise = null;
-  this._started = false;
-  this._continue = true;
-  this._handleOrphans = handleOrphans === undefined ? true : handleOrphans;
-  this._callbacks = {
-    done: [this._onFinish.bind(this)],
-    page: [],
-    children: [],
-    fetch : []
-  };
-  this.nextLink = link ?
-    link + '&version=2.2' :
-    $osf.apiV2Url('users/me/' + this.type + '/', { query: {'related_counts' : 'children', 'embed' : 'contributors', 'version': '2.2'}});
+    this.type = type || 'nodes';
+    this.regType = regType || null;
+    this.regLink = regLink || null;
+    this.loaded = 0;
+    this._failed = 0;
+    this.total = 0;
+    this._flat = [];
+    this._orphans = [];
+    this._cache = {};
+    this._promise = null;
+    this._started = false;
+    this._continue = true;
+    // hack to force a re-sort and cleanup when the fetcher is done
+    this.forceRedraw = false;
+    this._handleOrphans = handleOrphans === undefined ? true : handleOrphans;
+    this._callbacks = {
+        done: [this._onFinish.bind(this)],
+        page: [],
+        children: [],
+        fetch : []
+    };
+
+    var fieldsType = '';
+    var sparseFields = '';
+
+    if (this.type === 'nodes') {
+        fieldsType = nodesFieldType;
+        sparseFields = sparseNodeFields;
+    }
+
+    if (this.type === 'registrations') {
+        fieldsType = registrationsFieldType;
+        sparseFields = sparseRegistrationFields;
+    }
+
+    // TODO Use sparse fields on preprints, users/contributors already added
+    if (this.type === 'preprints') {
+        link = link ? link : $osf.apiV2Url('users/me/nodes/', { query : { 'filter[preprint]': true, 'related_counts' : 'children', 'embed' : ['contributors', 'preprints'], [usersFieldType] : sparseUserFields, [contributorsFieldType] : sparseContributorFields}});
+    }
+
+    this.nextLink = link ? 
+        link + '&version=2.2' :
+        $osf.apiV2Url('users/me/' + this.type + '/', { query: {'related_counts' : 'children', 'embed' : 'contributors', 'version': '2.2', [usersFieldType] : sparseUserFields, [contributorsFieldType] : sparseContributorFields, [fieldsType] : sparseFields}});
 }
 
 NodeFetcher.prototype = {
   isFinished: function() {
-    return this.loaded >= this.total && this._promise === null && this._orphans.length === 0;
+    return this.loaded >= this.total && this._promise === null && this._orphans.length === 0 && !this.nextLink;
   },
   isEmpty: function() {
     return this.loaded === 0 && this.isFinished();
@@ -108,6 +161,7 @@ NodeFetcher.prototype = {
   add: function(item) {
     if (!this._started ||this._flat.indexOf(item) !== - 1) return;
 
+    this.forceRedraw = true;
     this.total++;
     this.loaded++;
 
@@ -127,6 +181,11 @@ NodeFetcher.prototype = {
   },
   remove: function(item) {
     item = item.id || item;
+
+    this.forceRedraw = true;
+    this.total--;
+    this.loaded--;
+
     if (!this._cache[item]) return;
     delete this._cache[item];
     for(var i = 0; i < this._flat.length; i++)
@@ -153,7 +212,9 @@ NodeFetcher.prototype = {
   },
   fetch: function(id) {
     // TODO This method is currently untested
-    var url =  $osf.apiV2Url(this.type + '/' + id + '/', {query: {related_counts: 'children', embed: 'contributors', version: '2.2'}});
+    // this.type can be 'registrations' when it needs to be 'nodes' based on when this is called
+    // TODO assess sparse field usage (some already implemented)
+    var url =  $osf.apiV2Url(this.type + '/' + id + '/', {query: {related_counts: 'children', embed: 'contributors', version: '2.2', [usersFieldType] : sparseUserFields, [contributorsFieldType] : sparseContributorFields}});
     return m.request({method: 'GET', url: url, config: mHelpers.apiV2Config({withCredentials: window.contextVars.isOnRootDomain}), background: true})
       .then((function(result) {
         this.add(result.data);
@@ -173,8 +234,11 @@ NodeFetcher.prototype = {
     this.nextLink = results.links.next;
     this.loaded += results.data.length;
     for(var i = 0; i < results.data.length; i++) {
-      if (this.type === 'registrations' && (results.data[i].attributes.withdrawn === true || results.data[i].attributes.pending_registration_approval === true))
+      if (this.type === 'registrations' && (results.data[i].attributes.withdrawn === true || results.data[i].attributes.pending_registration_approval === true)){
+          this.total--;
+          this.loaded--;
           continue; // Exclude retracted and pending registrations
+      }
       else if (results.data[i].relationships.parent && this._handleOrphans)
           this._orphans.push(results.data[i]);
       else
@@ -236,6 +300,7 @@ NodeFetcher.prototype = {
     $osf.growl('We\'re having some trouble contacting our servers. Try reloading the page.', 'Something went wrong!', 'danger', 5000);
   },
   _onFinish: function() {
+    this.forceRedraw = true;
     this._flat = this._orphans.concat(this._flat).sort(function(a,b) {
       a = new Date(a.attributes.date_modified);
       b = new Date(b.attributes.date_modified);
@@ -359,7 +424,7 @@ var MyProjects = {
         self.systemCollections = options.systemCollections || [
             new LinkObject('collection', { nodeType : 'projects'}, 'All my projects'),
             new LinkObject('collection', { nodeType : 'registrations'}, 'All my registrations'),
-            new LinkObject('collection', { nodeType : 'preprints', link: $osf.apiV2Url('users/me/nodes/', { query : { 'filter[preprint]': true, 'related_counts' : 'children', 'embed' : ['contributors', 'preprints']}})}, 'All my preprints')
+            new LinkObject('collection', { nodeType : 'preprints'}, 'All my preprints')
         ];
 
         self.fetchers = {};
@@ -442,7 +507,8 @@ var MyProjects = {
                 var id = item.data.id;
                 if(!item.data.attributes.retracted){
                     var urlPrefix = item.data.attributes.registration ? 'registrations' : 'nodes';
-                    var url = $osf.apiV2Url(urlPrefix + '/' + id + '/logs/', { query : { 'page[size]' : 6, 'embed' : ['original_node', 'user', 'linked_node', 'template_node'], 'profile_image_size': PROFILE_IMAGE_SIZE}});
+                    // TODO assess sparse field usage (some already implemented)
+                    var url = $osf.apiV2Url(urlPrefix + '/' + id + '/logs/', { query : { 'page[size]' : 6, 'embed' : ['original_node', 'user', 'linked_node', 'template_node'], 'profile_image_size': PROFILE_IMAGE_SIZE, [usersFieldType] : sparseUserFields}});
                     var promise = self.getLogs(url);
                     return promise;
                 }
@@ -616,7 +682,7 @@ var MyProjects = {
             }
             self.updateFolder()(null, self.treeData());
             // Manually select first item without triggering a click
-            if(self.multiselected()().length === 0 && self.treeData().children[0]){
+            if (self.treeData().children[0] && ((self.multiselected()().length === 0 && self.currentView().fetcher.isFinished()) || self.currentView().fetcher.forceRedraw === true)) {
               self.updateTbMultiselect([self.treeData().children[0]]);
             }
             m.redraw(true);
@@ -826,10 +892,10 @@ var MyProjects = {
                 result.data.forEach(function(node){
                     var count = node.relationships.linked_registrations.links.related.meta.count + node.relationships.linked_nodes.links.related.meta.count;
                     self.collections().push(new LinkObject('collection', {nodeType : 'collection', node : node, count : m.prop(count), loaded: 1 }, $osf.decodeText(node.attributes.title)));
-
-                    var regLink = $osf.apiV2Url('collections/' + node.id + '/linked_registrations/', { query : { 'related_counts' : 'children', 'embed' : 'contributors', 'version': '2.2' }});
-                    var link = $osf.apiV2Url('collections/' + node.id + '/linked_nodes/', { query : { 'related_counts' : 'children', 'embed' : 'contributors' }});
-                    self.fetchers[self.collections()[self.collections().length-1].id] = new NodeFetcher('nodes', link, false, 'registraions', regLink);
+                    // TODO assess whether more sparse fields can be used
+                    var regLink = $osf.apiV2Url('collections/' + node.id + '/linked_registrations/', { query : { 'related_counts' : 'children', 'embed' : 'contributors', 'version': '2.2', [registrationsFieldType]: sparseRegistrationFields}});
+                    var link = $osf.apiV2Url('collections/' + node.id + '/linked_nodes/', { query : { 'related_counts' : 'children', 'embed' : 'contributors', [nodesFieldType]: sparseNodeFields }});
+                    self.fetchers[self.collections()[self.collections().length-1].id] = new NodeFetcher('nodes', link, false, 'registrations', regLink);
                     self.fetchers[self.collections()[self.collections().length-1].id].on(['page'], self.onPageLoad);
                 });
                 if(result.links.next){
@@ -884,6 +950,26 @@ var MyProjects = {
           }
         };
 
+        self.onLoadReset = function() {
+            var current = self.currentView().fetcher;
+            if (current.isFinished() && current.forceRedraw && !current.isEmpty()) {
+
+                // If data loads before treebeard force redrawing
+                self.loadValue(100);
+                self.generateFiltersList();
+                self.updateList();
+
+                // Hack to force redraws when things get out of sync due to race condition
+                // If the believed number of rows is different from the actual number, force another redraw
+                if (!(self.currentView().totalRows === 0 && current._flat.length !== 0)) {
+                    current.forceRedraw = false;
+                }
+                // TB/Mithril interaction requires the redraw to be called a bit later
+                // TODO Figure out why
+                setTimeout(m.redraw.bind(this, true), 250);
+            }
+        }
+
         self.init = function _init_fileBrowser() {
             self.loadCategories().then(function(){
                 self.fetchers[self.systemCollections[0].id].on(['page', 'done'], self.onPageLoad);
@@ -893,6 +979,7 @@ var MyProjects = {
                 }
             });
             if (!self.viewOnly){
+                // TODO use sparse fields
                 var collectionsUrl = $osf.apiV2Url('collections/', { query : {'related_counts' : 'linked_registrations,linked_nodes', 'page[size]' : self.collectionsPageSize(), 'sort' : 'date_created', 'embed' : 'linked_nodes'}});
                 self.loadCollections(collectionsUrl);
             }
@@ -945,18 +1032,12 @@ var MyProjects = {
                 multiselected : ctrl.multiselected,
                 highlightMultiselect : ctrl.highlightMultiselect,
                 _onload: function(tb) {
-                  if (!ctrl.currentView().fetcher.isFinished()) return;
-                  // If data loads before treebeard force redrawing
-                  ctrl.loadValue(100);
-                  ctrl.generateFiltersList();
-                  ctrl.updateList();
-                  // TB/Mithril interaction requires the redraw to be called a bit later
-                  // TODO Figure out why
-                  setTimeout(m.redraw.bind(this, true), 250);
+                    ctrl.onLoadReset()
                 }
             },
             ctrl.projectOrganizerOptions
         );
+        ctrl.onLoadReset();
         return [
             !ctrl.institutionId ? m('.dashboard-header', m('.row', [
                 m('.col-xs-8', m('h3', [


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
There were many, many issues on the my projects page. This fixes a bunch of them. There are still more. 
<!-- Describe the purpose of your changes -->

## Changes

Fixed issues:
1. Withdrawn Registrations and Pending Registrations no longer break Bookmarks, Collections, and All my Registrations
2. If a collection only has withdrawn/pending registrations in it, the empty banner will show up now.
3. Use Sparse fields to speed up some of the api calls (there is room for more of these still)
4. Fix typo that caused certain registrations related api requests to fail (I had this happen a few times but I couldn't isolate when it happened exactly, sorry).
5. Force refreshes to stop registrations from duplicating under certain circumstances (Todd had this happen and I had it occur locally). 
6. Stop the empty collection message from flashing when a collection only contains registrations
7. Properly resort collections that contain projects and registrations when everything is loaded
8. Properly show empty collection messages if all items are removed from a collection (will still break if the collection contains children and if those children have been expanded; I think...)

Not fixed issues:
1. Item counts for collections do not take into account subtracting withdrawn registrations and pending registrations. This sounds like a simple fix but it really is not. The counts are generated from the initial collection meta information and not the actual serialized data about the nodes/registrations. An ideal solution would allow the meta counts to be updated when the collection is loaded. A less ideal solution could correct the counts when the withdrawn or pending nodes are removed.

2. Moving many files into a collection does not load all of the files when you click on the collection. Refreshing the page fixes this. Somewhere along the line fetchers lose track of everything they need to do and think they are done early. I think this is another race condition because the outcome is not predictable.

3. Uncached projects and registrations can be unfetchable under a few circumstances. If a fetcher for a particular collection has moved from fetching projects to fetching registrations, issues can occur when that collection needs to fetch projects again. I think what is happening is that the modifications to allow collections to contain registrations and projects (when they were split apart) was hacked on instead of rearchitected. The links to fetch new things are built via the current `type` of the fetcher, which can change as it switches from fetching projects to registrations. As a result, some nodes will fail when it tries to fetch them via the `/registrations/` api route and some registrations will fail when it tries to fetch them through the  `/nodes/` route. I did not see an easy way to rectify this problem as it is not obvious the type that needs to be fetched at time of fetching.

4. Some move actions fail inexplicably. Moving a lot of items at once will often throw an id error.

5. Collections with a single item in them do not allow that item to be dragged. Just found this one so no idea what is going on yet.

6. I noticed one case of duplications while moving 2 registrations to a collection during the demo, but I can't replicate it. Keep eyes peeled for dupes


<!-- Briefly describe or list your changes  -->

## Side effects
See changes list above, most of those are technically side effects :)
<!--Any possible side effects? -->


## Ticket
https://openscience.atlassian.net/browse/OSF-8084
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->

## QA Notes:
**Note from BrianG**: _This is definitely a "Better and not worse" type of ticket, and possibly a "Better and not much worse" situation. Lean towards making new tickets rather than bumping this back for addl development unless the new problems are bad enough that you would rather have the old problems on production than the new ones._

Try literally everything you can think of. There are so many little changes here that a full regression test of the my projects page is worth doing.

Also test the institutional dashboard pages (I did not consider those pages at all; I actually didn't know they existed....), I don't believe they should break, but worth taking a look to make sure.

Some edgy cases:
1. Test unregistered contributor filtering. 
2. Test tag things
3. Look for dates that are broken, data that is missing, links that don't work, logs that are broken etc. Sparse fields reduce the data the page has access to. This means I've removed access to data but it may not be easy to spot that something is broken because of it. For example, when I didn't include dates, all dates showed up as modified "A moment ago" or whatever the minimum one is.

4. Make sure sorting still works
5. Make sure the default sorting works properly, especially when registrations and projects are mixed.
6. Do some crazy stuff with withdrawn registrations and pending registrations. Can't hurt to mess with embargoes as well (they probably work like pending registrations, but I simply don't know).

I'll add more details if they come to me. 
