### PR TITLE
[feature] Custom admin style when dev_mode off [OSF-8140]

### DIFF
--- a/admin/templates/base.html
+++ b/admin/templates/base.html
@@ -209,3 +209,10 @@
 
   </body>
 </html>
+
+{% if not osf_settings.DEV_MODE %}
+  <style>
+    .navbar { background-color: #bc493c !important;}
+    .logo { background-color: #a53e35 !important;}
+  </style>
+{% endif %}


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Staging and Prod admin app have the same style and may be difficult to tell the difference.
<!-- Describe the purpose of your changes -->

## Changes
Add custom style if dev_mode if off to make the style big and red for prod. Staging should stay the same.
<!-- Briefly describe or list your changes  -->
BEFORE: 
<img width="1440" alt="screen shot 2017-07-05 at 1 02 50 pm" src="https://user-images.githubusercontent.com/1322421/27875912-ff76a0a8-6182-11e7-8c36-d8ef1874653d.png">
AFTER:
<img width="1440" alt="screen shot 2017-07-05 at 1 02 18 pm" src="https://user-images.githubusercontent.com/1322421/27875915-0227b49a-6183-11e7-8218-1a728aa092c8.png">


## Side effects
N/A
<!--Any possible side effects? -->


## Ticket
https://openscience.atlassian.net/browse/OSF-8140
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->


## QA Notes

Confirm that admin looks the same on staging. Have someone confirm new color of admin on prod.