### PR TITLE
[Feature] Remove non-existant js module from  webpack config [No ticket]

### DIFF
--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -31,7 +31,6 @@ var entry = {
     'project-dashboard': staticPath('js/pages/project-dashboard-page.js'),
     'project-base-page': staticPath('js/pages/project-base-page.js'),
     'project-settings-page': staticPath('js/pages/project-settings-page.js'),
-    'component-settings-page': staticPath('js/pages/component-settings-page.js'),
     'project-registrations-page': staticPath('js/pages/project-registrations-page.js'),
     'registration-retraction-page': staticPath('js/pages/registration-retraction-page.js'),
     'registration-edit-page': staticPath('js/pages/registration-edit-page.js'),


### PR DESCRIPTION
## Purpose
Remove non-existant js module from webpack.common.config.js
