### PR TITLE
[hotfix] redirect file head req

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -656,7 +656,7 @@ def addon_view_or_download_file(auth, path, provider, **kwargs):
 
     # TODO clean up these urls and unify what is used as a version identifier
     if request.method == 'HEAD':
-        return make_response(('', 200, {
+        return make_response(('', httplib.FOUND, {
             'Location': file_node.generate_waterbutler_url(**dict(extras, direct=None, version=version.identifier, _internal=extras.get('mode') == 'render'))
         }))
 

--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -746,21 +746,23 @@ class TestAddonFileViews(OsfTestCase):
 
         assert_equals(resp.status_code, 400)
 
-    def test_head_returns_url(self):
+    def test_head_returns_url_and_redriect(self):
         file_node = self.get_test_file()
         guid = file_node.get_guid(create=True)
 
         resp = self.app.head('/{}/'.format(guid._id), auth=self.user.auth)
         location = furl.furl(resp.location)
+        assert_equals(resp.status_code, 302)
         assert_urls_equal(location.url, file_node.generate_waterbutler_url(direct=None, version=''))
 
-    def test_head_returns_url_with_version(self):
+    def test_head_returns_url_with_version_and_redirect(self):
         file_node = self.get_test_file()
         guid = file_node.get_guid(create=True)
 
         resp = self.app.head('/{}/?revision=1&foo=bar'.format(guid._id), auth=self.user.auth)
         location = furl.furl(resp.location)
         # Note: version is added but us but all other url params are added as well
+        assert_equals(resp.status_code, 302)
         assert_urls_equal(location.url, file_node.generate_waterbutler_url(direct=None, revision=1, version='', foo='bar'))
 
     def test_nonexistent_addons_raise(self):


### PR DESCRIPTION
## Purpose

Send back a proper `302` response when a `HEAD` request is made to the file download endpoint.

e.g. `curl -O -v https://osf.io/87trm/download` is returning `HTTP 1/1 200 OK` w/ a `Location` header.

```
> HEAD /87trm/download HTTP/1.1
> Host: osf.io
> User-Agent: curl/7.54.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Date: Fri, 07 Jul 2017 19:48:48 GMT
< Content-Type: text/html; charset=utf-8
< Content-Length: 0
< Location: https://files.osf.io/v1/resources/pyvfg/providers/osfstorage/595e8a0f9ad5a1022c00ceb5?action=download&version=1&direct
< X-Frame-Options: SAMEORIGIN
< Cache-Control: no-cache, no-store, max-age=0, must-revalidate
< Expires: Mon, 01 Jan 1990 00:00:00 GMT
< Pragma: no-cache
< Strict-Transport-Security: max-age=16000000; preload;
```

This workaround was put in place during a period of time we used `token` parameters with WaterButler in order to workaround IE9 limitations and is no longer necessary and is also non-standard.

## Changes

HTTP `HEAD` requests made to `/<guid>/download` will now redirect to WB for metadata lookup.

## Side effects

N/A

## Ticket
