### PR TITLE
[feature] Fix Redirect Link Serializer [OSF-8058]

### DIFF
--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -514,8 +514,8 @@ class NodeAddonSettingsSerializerBase(JSONAPISerializer):
     folder_path = ser.CharField(required=False, allow_null=True)
 
     # Forward-specific
-    label = ser.CharField(required=False, allow_null=True)
-    url = ser.CharField(required=False, allow_null=True)
+    label = ser.CharField(required=False, allow_blank=True)
+    url = ser.CharField(required=False, allow_blank=True)
 
     links = LinksField({
         'self': 'get_absolute_url',

--- a/api_tests/nodes/views/test_node_addons.py
+++ b/api_tests/nodes/views/test_node_addons.py
@@ -1020,8 +1020,8 @@ class TestNodeForwardAddon(NodeUnmanageableAddonTestSuiteMixin, ApiAddonTestCase
                 'id': self.short_name,
                 'type': 'node_addons',
                 'attributes': {
-                    'url': None,
-                    'label': None
+                    'url': '',
+                    'label': ''
                     }
                 }
             }, auth=self.user.auth)
@@ -1037,14 +1037,14 @@ class TestNodeForwardAddon(NodeUnmanageableAddonTestSuiteMixin, ApiAddonTestCase
                 'id': self.short_name,
                 'type': 'node_addons',
                 'attributes': {
-                    'url': None,
+                    'url': '',
                     'label': 'A Link'
                     }
                 }
             }, auth=self.user.auth,
             expect_errors=True)
-
         assert_equal(res.status_code, 400)
+        assert_equal(res.json['errors'][0]['detail'], 'Cannot set label without url')
 
     def test_settings_detail_PUT_only_url_sets_settings(self):
         self.node_settings.reset()


### PR DESCRIPTION
#### Purpose
- Fixes bug discovered while testing OSF-8058 (getting an error when saving redirect link with an empty label field).

#### Changes
- `allow_null` --> `allow_blank` in the forward settings serializer.
- From the DRF docs: http://www.django-rest-framework.org/api-guide/fields/#charfield
  > The `allow_null` option is also available for string fields, although its usage is discouraged in favor of `allow_blank`. It is valid to set both `allow_blank=True` and `allow_null=True`, but doing so means that there will be two differing types of empty value permissible for string representations, which can lead to data inconsistencies and subtle application bugs.

#### Side Effects
- Sending `url=None` or `label=None` in a request payload used to be succesful, but will now fail with an appropriate error message.

#### Ticket
- [OSF-8058](https://openscience.atlassian.net/browse/OSF-8058)
