### PR TITLE
[Feature] Use newer prereg eligible journals url [OSF-7906]

### DIFF
--- a/website/templates/prereg_landing_info.mako
+++ b/website/templates/prereg_landing_info.mako
@@ -11,7 +11,7 @@
 <%def name="steps()">
   <ol>
     <li>Specify all your study and analysis decisions prior to investigating your data</li>
-    <li>Publish your study in an <a target='_blank' href='https://cos.io/preregjournals'>eligible journal</a></li>
+    <li>Publish your study in an <a target='_blank' href='https://cos.io/our-services/prereg-more-information/'>eligible journal</a></li>
     <li>Receive $1,000</li>
   </ol>
 </%def>


### PR DESCRIPTION
## Purpose

Use newer prereg eligible journals cos url

## Changes

Use newer url `https://cos.io/our-services/prereg-more-information/` instead of ` https://cos.io/preregjournals` to prevent unnecessary redirect.

## Ticket

[OSF-7906](https://openscience.atlassian.net/browse/OSF-7906)
