### PR TITLE
[Feature] Add Export Wiki to PDF

### DIFF
--- a/addons/wiki/routes.py
+++ b/addons/wiki/routes.py
@@ -128,6 +128,18 @@ api_routes = {
             '/project/<pid>/node/<nid>/wiki/<wname>/validate/',
         ], 'get', views.project_wiki_validate_name, json_renderer),
 
+        # Export : GET
+        Rule([
+            '/project/<pid>/wiki/<wname>/pdf/',
+            '/project/<pid>/node/<nid>/wiki/<wname>/pdf/',
+        ], 'get', views.wiki_page_to_pdf, json_renderer),
+
+        # Export : GET
+        Rule([
+            '/project/<pid>/wiki/pdf/',
+            '/project/<pid>/node/<nid>/wiki/pdf/',
+        ], 'get', views.wiki_to_pdf, json_renderer),
+
         # Edit | POST
         Rule([
             '/project/<pid>/wiki/<wname>/edit/',

--- a/addons/wiki/templates/edit.mako
+++ b/addons/wiki/templates/edit.mako
@@ -41,6 +41,11 @@
                     % else:
                         <h3 class="panel-title"> <i class="fa fa-list"></i>  Menu </h3>
                     % endif
+                    % if wiki_content:
+                        <div class="wiki-toolbar-icon text-primary" data-toggle="modal" data-target="#exportWiki">
+                            <i class="fa fa-file-pdf-o text-primary"></i><span>PDF</span>
+                        </div>
+                    % endif
                     <div id="toggleIcon" class="pull-right hidden-xs">
                         <div class="panel-collapse pointer"><i class="fa fa-angle-left"></i></div>
                     </div>
@@ -239,6 +244,7 @@
 <!-- Wiki modals should also be placed here! -->
   <%include file="wiki/templates/add_wiki_page.mako"/>
   <%include file="wiki/templates/wiki-bar-modal-help.mako"/>
+  <%include file="wiki/templates/export.mako"/>
 % if wiki_id and wiki_name != 'home':
   <%include file="wiki/templates/delete_wiki_page.mako"/>
 % endif

--- a/addons/wiki/templates/export.mako
+++ b/addons/wiki/templates/export.mako
@@ -1,0 +1,49 @@
+<!-- Export Wiki Page Modal -->
+<div class="modal fade" id="exportWiki">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                <h3 class="modal-title">Export wiki page</h3>
+            </div><!-- end modal-header -->
+            <div class="modal-body">
+                <div style="padding-bottom:10px">Please select your PDF export option.
+                    <div class="radio">
+                        <label>
+                            <input type="radio" id="exportCurrent" name="exportLevel" value="current" checked>
+                            Current Page
+                        </label>
+                    </div>
+                    <div class="radio">
+                        <label>
+                            <input type="radio" id="exportProject" name="exportLevel" value="project">
+                            Project Pages
+                        </label>
+                    </div>
+                </div>
+            </div><!-- end modal-body -->
+            <div class="modal-footer">
+                % if wiki_content:
+                    <a id="export-wiki" class="btn btn-success" data-dismiss="modal" style="margin-left: 200px;">Export</a>
+                % else:
+                    <a disabled id="export-wiki" class="btn btn-success" data-dismiss="modal" style="margin-left: 200px;">Export</a>
+                % endif
+                <a id="close" href="#" class="btn btn-default" data-dismiss="modal">Cancel</a>
+            </div><!-- end modal-footer -->
+        </div><!-- end modal- content -->
+    </div><!-- end modal-dialog -->
+</div><!-- end modal -->
+
+<script type="text/javascript">
+
+    $(document).ready(function() {
+        var $WikiForm = $('#pageName');
+
+        $('#export-wiki').on('click', function () {
+            if (document.getElementById('exportCurrent').checked)
+                window.open(${ urls['api']['base'] | sjson, n } + encodeURIComponent($WikiForm.text()) + '/pdf/');
+            else if (document.getElementById('exportProject').checked)
+                window.open(${ urls['api']['base'] | sjson, n } + 'pdf/');
+        });
+    });
+</script>

--- a/addons/wiki/templates/nav.mako
+++ b/addons/wiki/templates/nav.mako
@@ -17,6 +17,14 @@
                 </li>
                 % endif
             % endif
+            % if wiki_content:
+                <li data-toggle="tooltip" title="Export" data-placement="right" data-container="body">
+                    <a href="#" data-toggle="modal" data-target="#exportWiki">
+                        <span class="wiki-nav-closed"><i class="fa fa-file-pdf-o text-primary"> </i></span>
+                    </a>
+                </li>
+            % endif
+
         </ul>
     </div>
 </nav>

--- a/addons/wiki/utils.py
+++ b/addons/wiki/utils.py
@@ -205,3 +205,22 @@ def serialize_wiki_settings(user, nodes):
         items.append(item)
 
     return items
+
+
+def export_wiki_to_pdf(all_pages):
+    """ Generate a PDF document from a list of prerendered PDF files
+
+    :param all_pages: list of prerendered PDF files
+    :return: joined data as PDF file
+    """
+    val = []
+
+    for doc in all_pages:
+        if not doc:
+            continue
+        for p in doc.pages:
+            val.append(p)
+
+    pdf = all_pages[0].copy(val).write_pdf()
+
+    return pdf

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,8 @@ python-dateutil==2.5.0
 python-gnupg==0.3.6
 pytz==2014.9
 bleach==1.4.1
-html5lib==0.999
+WeasyPrint==0.36
+html5lib==0.9999999
 blinker==1.3
 furl==0.4.92
 elasticsearch==1.3.0


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Users might like:
( Uploading project data, enhancing it with additional information, finish a project, end of the story? )

Sometimes it's nice to offer the option to download an overview of all surrounding wiki information, just by one klick.
With this dialog it's possible to export current wiki page or all wiki project pages via PDF. To save, to share, to print and add handwritten notes or annotations ...

<!-- Describe the purpose of your changes -->

## Changes
Add WeasyPrint==0.36 to requirements.txt and set html5lib==0.9999999. 

<!-- Briefly describe or list your changes  -->

## Side effects
WeasyPrint uses html5lib==0.999999999 but it OSF has some problems with it. So I chose 0.9999999 and it work.
<!--Any possible side effects? -->


## Ticket
[Ticket 479](https://github.com/CenterForOpenScience/osf.io/issues/479)
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
