### PR TITLE
[feature] Bug Fix: Fix Broken Admin Routes (Flagged Spam, Known Spam, Known Ham) [OSF-8249]

### DIFF
--- a/admin/nodes/views.py
+++ b/admin/nodes/views.py
@@ -244,7 +244,7 @@ class NodeSpamList(PermissionRequiredMixin, ListView):
         query = (
             Q('spam_status', 'eq', self.SPAM_STATE)
         )
-        return Node.find(query).sort(self.ordering)
+        return Node.find(query).order_by(self.ordering)
 
     def get_context_data(self, **kwargs):
         query_set = kwargs.pop('object_list', self.object_list)

--- a/admin_tests/nodes/test_views.py
+++ b/admin_tests/nodes/test_views.py
@@ -7,6 +7,9 @@ from admin.nodes.views import (
     NodeView,
     NodeReindexShare,
     NodeReindexElastic,
+    NodeFlaggedSpamList,
+    NodeKnownSpamList,
+    NodeKnownHamList,
 )
 from admin_tests.utilities import setup_log_view, setup_view
 
@@ -21,6 +24,33 @@ from osf_tests.factories import AuthUserFactory, ProjectFactory, RegistrationFac
 
 
 class TestNodeView(AdminTestCase):
+
+    def test_get_flagged_spam(self):
+        user = AuthUserFactory()
+        user.is_superuser = True
+        user.save()
+        request = RequestFactory().get(reverse('nodes:flagged-spam'))
+        request.user = user
+        response = NodeFlaggedSpamList.as_view()(request)
+        nt.assert_equal(response.status_code, 200)
+
+    def test_get_known_spam(self):
+        user = AuthUserFactory()
+        user.is_superuser = True
+        user.save()
+        request = RequestFactory().get(reverse('nodes:known-spam'))
+        request.user = user
+        response = NodeKnownSpamList.as_view()(request)
+        nt.assert_equal(response.status_code, 200)
+
+    def test_get_known_ham(self):
+        user = AuthUserFactory()
+        user.is_superuser = True
+        user.save()
+        request = RequestFactory().get(reverse('nodes:known-ham'))
+        request.user = user
+        response = NodeKnownHamList.as_view()(request)
+        nt.assert_equal(response.status_code, 200)
 
     def test_no_guid(self):
         request = RequestFactory().get('/fake_path')


### PR DESCRIPTION
…dd test cases

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

<!-- Describe the purpose of your changes -->
Fix broken admin app routes (node/ flagged_spam, known_spam, known_ham)

## Changes

<!-- Briefly describe or list your changes  -->
One line fix to use order-by instead of sort in admin/nodes/views.py
Added response status code tests to make sure those routes don't break silently in the future

Before:
<img width="1280" alt="before" src="https://user-images.githubusercontent.com/7832815/28072873-34ec49d8-6622-11e7-91f5-199bcaaddaeb.png">
After:
<img width="1280" alt="after" src="https://user-images.githubusercontent.com/7832815/28072874-34ef3e90-6622-11e7-89f3-fc79d6bf865a.png">

## Side effects

<!--Any possible side effects? -->
None known.

## QA Considerations

Affected Admin Routes:
/nodes/flagged_spam
/nodes/known_spam
/nodes/known_ham

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
https://openscience.atlassian.net/browse/OSF-8249