### PR TITLE
Revert "Revert "[OSF-7636] Add ability to inherit tags from parent node""

### DIFF
--- a/website/static/js/addProjectPlugin.js
+++ b/website/static/js/addProjectPlugin.js
@@ -41,6 +41,7 @@ var AddProject = {
         self.newProjectCategory = m.prop(self.defaultCat);
         self.newProjectTemplate = m.prop('');
         self.newProjectInheritContribs = m.prop(false);
+        self.newProjectInheritTags = m.prop(false);
         self.institutions = options.institutions || window.contextVars.currentUser.institutions || [];
         self.checkedInstitutions = {};
         self.institutions.map(
@@ -101,6 +102,10 @@ var AddProject = {
                         }
                     }
                 };
+
+            if(self.newProjectInheritTags()){
+                data.data.attributes.tags = window.contextVars.node.tags;
+            }
 
             if (self.newProjectTemplate()) {
                 data.data.attributes.template_from = self.newProjectTemplate();
@@ -233,6 +238,17 @@ var AddProject = {
                                 }), ' Add contributors from ', m('b', options.parentTitle),
                                 m('br'),
                                 m('i', ' Admins of ', m('b', options.parentTitle), ' will have read access to this component.')
+                            ),
+                            m('br'),
+                            m('label.f-w-md',
+
+                                m('input', {
+                                    type: 'checkbox',
+                                    name: 'inherit_tags',
+                                    onchange : function() {
+                                        ctrl.newProjectInheritTags(this.checked);
+                                    }
+                                }), ' Add tags from ', m('b', options.parentTitle)
                             )
                         ]) : '',
                         ctrl.options.parentID !== null ? m('.span', [


### PR DESCRIPTION
In response to this this ticket: https://openscience.atlassian.net/browse/OSF-7636, the changes to fix this problem have already been merged here: https://github.com/CenterForOpenScience/osf.io/pull/7353, so we just have to revert the revert and will be at 100%.