### PR TITLE
[OSF-8228] OSF side Nav bar cleanup (firefox username alignment, long username fixes)

### DIFF
--- a/website/static/css/style.css
+++ b/website/static/css/style.css
@@ -230,6 +230,46 @@ a {
     }
 }
 
+
+@media (max-width: 991px) {
+    .navbar-header {
+        float: none;
+    }
+    .navbar-toggle {
+        display: block;
+    }
+    .navbar-collapse {
+        border-top: 1px solid transparent;
+        box-shadow: inset 0 1px 0 rgba(255,255,255,0.1);
+    }
+    .navbar-collapse.collapse {
+        display: none!important;
+    }
+    .navbar-nav {
+        float: none!important;
+        margin: 7.5px -15px;
+    }
+    .navbar-nav>li {
+        float: none;
+    }
+    .navbar-nav>li>a {
+        padding-top: 10px;
+        padding-bottom: 10px;
+    }
+    .navbar-text {
+        float: none;
+        margin: 15px 0;
+    }
+    /* since 3.1.0 */
+    .navbar-collapse.collapse.in {
+        display: block!important;
+    }
+    .collapsing {
+        overflow: hidden!important;
+    }
+}
+
+
 @media (min-width: 768px) {
     .osf-navbar .navbar-nav>li>a {
         padding-left: 7px;

--- a/website/templates/nav.mako
+++ b/website/templates/nav.mako
@@ -48,9 +48,9 @@
 
             % if user_name and display_name:
             <li class="dropdown">
-            <button class="dropdown-toggle nav-user-dropdown btn-link" data-toggle="dropdown" role="button" aria-expanded="false" aria-label="Toggle auth dropdown">
+            <button class="dropdown-toggle nav-user-dropdown btn-link" data-toggle="dropdown" role="button" aria-expanded="false" aria-label="Toggle auth dropdown" style="margin-top: 12px;">
                 <span class="osf-gravatar">
-                    <img src="${user_gravatar}" alt="User gravatar">
+                    <img src="${user_gravatar}" style="top: -2px;position: relative;" alt="User gravatar">
                 </span> ${display_name}
                 <span class="caret"></span>
             </button>


### PR DESCRIPTION
## Purpose

Current there are two problems with the OSF navbar:

1. The username name text and gravtar are silghtly out of vertical alignment
2. Very long usernames (even though they are wrapped properly) can break the navbar into two unsightly rows.
Alignment problem:
![screen shot 2017-07-05 at 3 19 15 pm](https://user-images.githubusercontent.com/9688518/28123568-4a7bd2f0-66ef-11e7-8c54-65f0da0e42f3.png)
Row problem:
![screen shot 2017-07-05 at 3 24 23 pm](https://user-images.githubusercontent.com/9688518/28123569-4a8ad4b2-66ef-11e7-944b-09e3f27dc731.png)

## Changes

Simple CSS and HTML changes, now the navbar will collapse into a dropdown sooner and the alignment is fixed with style tags.

## Side effects

Should be limited to aesthetics. I used style tags where possible to avoid any unforeseeable interaction.

## Tests

For aesthetics changes I can't think of any meaningful tests.

## Ticket

https://openscience.atlassian.net/browse/OSF-8228