### PR TITLE
[feature] Add context manager for disabling auto_now updates [OSF-8222]

### DIFF
--- a/osf/utils/migrations.py
+++ b/osf/utils/migrations.py
@@ -2,11 +2,30 @@ import os
 import json
 import logging
 
+from contextlib import contextmanager
+
 from website import settings
 from osf.models import NodeLicense, MetaSchema
 from website.project.metadata.schemas import OSF_META_SCHEMAS
 
 logger = logging.getLogger(__file__)
+
+
+@contextmanager
+def disable_auto_now_fields(model):
+    """
+    Context manager to disable updates of all auto_now fields for a given model.
+
+    """
+    for field in model._meta.get_fields():
+        if hasattr(field, 'auto_now') and field.auto_now:
+            field.auto_now = False
+    try:
+        yield
+    finally:
+        for field in model._meta.get_fields():
+            if hasattr(field, 'auto_now') and not field.auto_now:
+                field.auto_now = True
 
 
 def ensure_licenses(*args, **kwargs):

--- a/osf_tests/test_utils.py
+++ b/osf_tests/test_utils.py
@@ -1,0 +1,33 @@
+import pytest
+
+from osf.models import Node
+from osf.utils.migrations import disable_auto_now_fields
+from osf_tests.factories import NodeFactory
+
+pytestmark = pytest.mark.django_db
+
+@pytest.fixture()
+def node():
+    return NodeFactory()
+
+
+class TestDisableAutoNowContextManager:
+
+    def test_auto_now_not_updated(self, node):
+        # update, save, confirm date changes
+        original_date_modified = node.date_modified
+        node.title = 'A'
+        node.save()
+        assert node.date_modified != original_date_modified
+
+        # update and save within context manager, confirm date doesn't change (i.e. auto_now was set to False)
+        new_date_modified = node.date_modified
+        with disable_auto_now_fields(Node):
+            node.title = 'AB'
+            node.save()
+        assert node.date_modified == new_date_modified
+
+        # update, save, confirm date changes (i.e. that auto_now was set back to True)
+        node.title = 'ABC'
+        node.save()
+        assert node.date_modified != new_date_modified


### PR DESCRIPTION
#### Purpose
- Adds a context manager to prevent `auto_now` fields from being updated during migrations and scripts.

#### Changes
- Adds `disable_auto_now_fields` context manager and test in `test_utils.py`. 

#### Side Effects
- None expected.

#### Ticket
- [OSF-8222](https://openscience.atlassian.net/browse/OSF-8222)
