### PR TITLE
[Feature] Do not show menu on regs at all [OSF-7442]

### DIFF
--- a/website/templates/util/render_node.mako
+++ b/website/templates/util/render_node.mako
@@ -57,22 +57,20 @@
                     <i class="fa fa-times remove-pointer" data-id="${summary['id']}" data-toggle="tooltip" title="Remove link"></i>
                     <i class="fa fa-code-fork" onclick="NodeActions.forkPointer('${summary['id']}', '${summary['primary_id']}');" data-toggle="tooltip" title="Fork this ${summary['node_type']} into ${node['node_type']} ${node['title']}"></i>
                 % endif
-                % if summary['primary'] and summary['logged_in'] and summary['is_contributor']:
+                % if summary['primary'] and summary['logged_in'] and summary['is_contributor'] and not summary['is_registration']:
                     <div class="dropdown pull-right" id="componentQuickActions">
                         <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">
                             <span class="glyphicon glyphicon-option-horizontal"></span>
                         </button>
                         <ul class="dropdown-menu dropdown-menu-right">
                             <li><a tabindex="-1" href="${domain}${summary['id']}/contributors/">Manage Contributors</a></li>
-                            % if not node['is_registration']:
-                                <li><a tabindex="-1" href="${domain}${summary['id']}/settings/">Settings</a></li>
-                                % if summary['is_admin']:
-                                <li>
-                                    <a tabindex="-1" onclick="ComponentActions.deleteNode(${summary['childExists'] | sjson, n}, '${summary['node_type']}', ${summary['isPreprint'] | sjson, n},'${summary['api_url']}')" type="button">
-                                        Delete
-                                    </a>
-                                </li>
-                                % endif
+                            <li><a tabindex="-1" href="${domain}${summary['id']}/settings/">Settings</a></li>
+                            % if summary['is_admin']:
+                            <li>
+                                <a tabindex="-1" onclick="ComponentActions.deleteNode(${summary['childExists'] | sjson, n}, '${summary['node_type']}', ${summary['isPreprint'] | sjson, n},'${summary['api_url']}')" type="button">
+                                    Delete
+                                </a>
+                            </li>
                             % endif
                         </ul>
                   </div>


### PR DESCRIPTION
## Purpose

Remove quick actions menu on registration (per product demo).

## Changes

Use `summary['is_registration']` registration check 

## Ticket

[OSF-7442 ](https://openscience.atlassian.net/browse/OSF-7442)
