### PR TITLE
[wip][hotfix] Use custom domains for providers in sitemap [OSF-8282]

### DIFF
--- a/osf/models/preprint_service.py
+++ b/osf/models/preprint_service.py
@@ -84,7 +84,7 @@ class PreprintService(DirtyFieldsMixin, GuidMixin, IdentifierMixin, BaseModel):
 
     @property
     def url(self):
-        if self.provider.domain_redirect_enabled or self.provider._id == 'osf':
+        if (self.provider.domain_redirect_enabled and self.provider.domain) or self.provider._id == 'osf':
             return '/{}/'.format(self._id)
 
         return '/preprints/{}/{}/'.format(self.provider._id, self._id)

--- a/scripts/generate_sitemap.py
+++ b/scripts/generate_sitemap.py
@@ -218,7 +218,7 @@ class Sitemap(object):
                 config = settings.SITEMAP_PREPRINT_CONFIG
                 preprint_url = obj.url
                 provider = obj.provider
-                domain = provider.domain if (provider.enable_redirect and provider.domain) else settings.DOMAIN
+                domain = provider.domain if (provider.domain_redirect_enabled and provider.domain) else settings.DOMAIN
                 if provider == osf:
                     preprint_url = '/preprints/{}/'.format(obj._id)
                 config['loc'] = urlparse.urljoin(domain, preprint_url)

--- a/scripts/generate_sitemap.py
+++ b/scripts/generate_sitemap.py
@@ -217,9 +217,11 @@ class Sitemap(object):
                 preprint_date = obj.date_modified.strftime('%Y-%m-%d')
                 config = settings.SITEMAP_PREPRINT_CONFIG
                 preprint_url = obj.url
-                if obj.provider == osf:
+                provider = obj.provider
+                domain = provider.domain if (provider.enable_redirect and provider.domain) else settings.DOMAIN
+                if provider == osf:
                     preprint_url = '/preprints/{}/'.format(obj._id)
-                config['loc'] = urlparse.urljoin(settings.DOMAIN, preprint_url)
+                config['loc'] = urlparse.urljoin(domain, preprint_url)
                 config['lastmod'] = preprint_date
                 self.add_url(config)
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
sitemap urls point to non-redirected routes
<!-- Describe the purpose of your changes -->

## Changes
Users custom domains for preprint providers that redirect
OLD:
<img width="509" alt="screen shot 2017-07-14 at 3 14 48 pm" src="https://user-images.githubusercontent.com/1322421/28227350-8cd35380-68a7-11e7-982b-7520fab02569.png">
NEW:
<img width="480" alt="screen shot 2017-07-14 at 3 15 47 pm" src="https://user-images.githubusercontent.com/1322421/28227352-8f946b90-68a7-11e7-96c2-2785f4a2d144.png">

<!-- Briefly describe or list your changes  -->

## Side effects
N/A
<!--Any possible side effects? -->


## Ticket

https://openscience.atlassian.net/browse/OSF-8282

## QA 
Will be checked when MattC runs it, no QA needed

## Tests
No tests; sitemap dun have any tests yet.
