### PR TITLE
[Hotfix] Start OSF without 'preprint path'

### DIFF
--- a/website/views.py
+++ b/website/views.py
@@ -27,7 +27,8 @@ from website.project.model import has_anonymous_link
 from website.util import permissions
 
 logger = logging.getLogger(__name__)
-preprints_dir = os.path.abspath(os.path.join(os.getcwd(), EXTERNAL_EMBER_APPS['preprints']['path']))
+if EXTERNAL_EMBER_APPS:
+    preprints_dir = os.path.abspath(os.path.join(os.getcwd(), EXTERNAL_EMBER_APPS['preprints']['path']))
 
 def serialize_contributors_for_summary(node, max_count=3):
     # # TODO: Use .filter(visible=True) when chaining is fixed in django-include


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
If you don't have any '_path_' in _EXTERNAL_EMBER_APPS['preprints']_ OSF crash on start.
<!-- Describe the purpose of your changes -->

## Changes
Request if _EXTERNAL_EMBER_APPS_ is defined.
<!-- Briefly describe or list your changes  -->

## Side effects

<!--Any possible side effects? -->


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
