### PR TITLE
[feature] Improve Dashboard Wrapping [OSF-6539]

### DIFF
--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -909,7 +909,7 @@ var contribNameFormat = function(node, number, getFamilyName) {
     // handle charLimit overflow
     if (number === 1 && contribs.length > charLimit) {
         contribs.substring(0, charLimit - ellipses.length);
-    } else if (number == 2 && contribs.length > charLimit) {
+    } else if (number === 2 && contribs.length > charLimit) {
         contribs = contribs.substring(0, charLimit - (ellipses.length)).trim();
         contribs = contribs.concat(ellipses);
     } else if (number > 2 && (contribs.length + otherContribs.length) > charLimit) {
@@ -931,7 +931,7 @@ var contribNameFormat = function(node, number, getFamilyName) {
         contribs = contribs.concat(ellipses, otherContribs);
     }
 
-    return contribs
+    return contribs;
 };
 
 // Returns single name representing contributor, First match found of family name, given name, middle names, full name.

--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -891,7 +891,7 @@ var dialog = function(title, message, actionButtonLabel, options) {
 
 // Formats contributor family names for display.  Takes in project, number of contributors, and getFamilyName function
 var contribNameFormat = function(node, number, getFamilyName) {
-    const charLimit = 22;
+    const charLimit = 21;
     let contribs = '';
     let otherContribs = '';
     let ellipses = '...';

--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -891,11 +891,12 @@ var dialog = function(title, message, actionButtonLabel, options) {
 
 // Formats contributor family names for display.  Takes in project, number of contributors, and getFamilyName function
 var contribNameFormat = function(node, number, getFamilyName) {
-    const charLimit = 21;
-    let contribs = '';
-    let otherContribs = '';
-    let ellipses = '...';
+    var charLimit = 21;
+    var ellipses = '...';
+    var contribs = '';
+    var otherContribs = '';
 
+    // set base string to return
     if (number === 1) {
         contribs = getFamilyName(0, node);
     } else if (number === 2) {
@@ -905,6 +906,7 @@ var contribNameFormat = function(node, number, getFamilyName) {
         otherContribs = ` + ${number - 2}`;
     }
 
+    // handle charLimit overflow
     if (number === 1 && contribs.length > charLimit) {
         contribs.substring(0, charLimit - ellipses.length);
     } else if (number == 2 && contribs.length > charLimit) {
@@ -916,6 +918,17 @@ var contribNameFormat = function(node, number, getFamilyName) {
     } else if (number > 2 && contribs.length < charLimit) {
         contribs = contribs.substring(0, charLimit - (otherContribs.length)).trim();
         contribs = contribs.concat(otherContribs);
+    }
+
+    // handle long first name edge cases
+    if (number === 2 && getFamilyName(0, node).length > charLimit - 10) {
+        otherContribs = ` + ${number - 1}`;
+        contribs = getFamilyName(0, node).substring(0, charLimit - (ellipses.length + otherContribs.length));
+        contribs = contribs.concat(ellipses, otherContribs);
+    } else if (number === 3 && getFamilyName(0, node).length > charLimit - 10) {
+        otherContribs = ` + ${number - 1}`;
+        contribs = getFamilyName(0, node).substring(0, charLimit - (ellipses.length + otherContribs.length)).trim();
+        contribs = contribs.concat(ellipses, otherContribs);
     }
 
     return contribs

--- a/website/static/js/osfHelpers.js
+++ b/website/static/js/osfHelpers.js
@@ -891,23 +891,34 @@ var dialog = function(title, message, actionButtonLabel, options) {
 
 // Formats contributor family names for display.  Takes in project, number of contributors, and getFamilyName function
 var contribNameFormat = function(node, number, getFamilyName) {
+    const charLimit = 22;
+    let contribs = '';
+    let otherContribs = '';
+    let ellipses = '...';
+
     if (number === 1) {
-        return getFamilyName(0, node);
+        contribs = getFamilyName(0, node);
+    } else if (number === 2) {
+        contribs = `${getFamilyName(0, node)} and ${getFamilyName(1, node)}`;
+    } else {
+        contribs = `${getFamilyName(0, node)}, ${getFamilyName(1, node)}`;
+        otherContribs = ` + ${number - 2}`;
     }
-    else if (number === 2) {
-        return getFamilyName(0, node) + ' and ' +
-            getFamilyName(1, node);
+
+    if (number === 1 && contribs.length > charLimit) {
+        contribs.substring(0, charLimit - ellipses.length);
+    } else if (number == 2 && contribs.length > charLimit) {
+        contribs = contribs.substring(0, charLimit - (ellipses.length)).trim();
+        contribs = contribs.concat(ellipses);
+    } else if (number > 2 && (contribs.length + otherContribs.length) > charLimit) {
+        contribs = contribs.substring(0, charLimit - (ellipses.length + otherContribs.length)).trim();
+        contribs = contribs.concat(ellipses, otherContribs);
+    } else if (number > 2 && contribs.length < charLimit) {
+        contribs = contribs.substring(0, charLimit - (otherContribs.length)).trim();
+        contribs = contribs.concat(otherContribs);
     }
-    else if (number === 3) {
-        return getFamilyName(0, node) + ', ' +
-            getFamilyName(1, node) + ', and ' +
-            getFamilyName(2, node);
-    }
-    else {
-        return getFamilyName(0, node) + ', ' +
-            getFamilyName(1, node) + ', ' +
-            getFamilyName(2, node) + ' + ' + (number - 3);
-    }
+
+    return contribs
 };
 
 // Returns single name representing contributor, First match found of family name, given name, middle names, full name.


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

<!-- Describe the purpose of your changes -->
The dashboard contributor names would cause line breakages and weren't uniformly formatted, so this tries to improve the dashboard aesthetic by improving the contributor name formatting.

## Changes

<!-- Briefly describe or list your changes  -->
Improved how contributor names are listed to be more uniform and remain on a single line.

Before:
<img width="1280" alt="before" src="https://user-images.githubusercontent.com/7832815/28275269-618d1738-6ae1-11e7-8a6a-6b5d74c09d1b.png">

After:
<img width="1280" alt="after" src="https://user-images.githubusercontent.com/7832815/28275279-66d37886-6ae1-11e7-918e-38e354e85d7d.png">

## Side effects

<!--Any possible side effects? -->
Modifies contribNameFormat in osfHelpers, so other pages that use it will also get the improved formatting. (found in newAndNoteworthyPlugin.js, quickProjectSearchPlugin.js, home-page.js)

## QA considerations

General formatting style is different for single contribs, two contribs, and more than two contribs.
- Making sure this won't leave trailing spaces
- Making sure the second contrib name shows enough characters when being used
- Making sure the count is correct for the number of additional contribs not being displayed

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
https://openscience.atlassian.net/browse/OSF-6539