### PR TITLE
[hotfix] OSF Meetings Submission Tags [OSF-7848]

### DIFF
--- a/website/conferences/views.py
+++ b/website/conferences/views.py
@@ -164,7 +164,7 @@ def _render_conference_node(node, idx, conf):
         'nodeUrl': node.url,
         'author': author.family_name if author.family_name else author.fullname,
         'authorUrl': author.url,
-        'category': conf.field_names['submission1'] if conf.field_names['submission1'] in node.system_tags else conf.field_names['submission2'],
+        'category': conf.field_names['submission1'] if conf.field_names['submission1'] in tags else conf.field_names['submission2'],
         'download': download_count,
         'downloadUrl': download_url,
         'dateCreated': node.date_created.isoformat(),


### PR DESCRIPTION
#### Purpose
- Display the correct category for meetings submissions. 

#### Changes
- Display the category of a meeting submission based on project tags, not system tags. The list of submissions for a meeting is already determined by project tags, not system tags.

#### Side Effects
- I *think* `system_tags` for OSF Meetings will be obsolete after this change, and we could consider removing them / not adding them when submission emails are processed.

#### Ticket
- [OSF-7848](https://openscience.atlassian.net/browse/OSF-7848)
