### PR TITLE
[feature] Add DirtyFieldsMixin to Institution Model [OSF-8244]

### DIFF
--- a/osf/models/institution.py
+++ b/osf/models/institution.py
@@ -1,4 +1,7 @@
 import logging
+
+from dirtyfields import DirtyFieldsMixin
+
 from django.conf import settings
 from django.contrib.postgres import fields
 from django.core.urlresolvers import reverse
@@ -10,7 +13,7 @@ from osf.models.mixins import Loggable
 logger = logging.getLogger(__name__)
 
 
-class Institution(Loggable, base.ObjectIDMixin, base.BaseModel):
+class Institution(DirtyFieldsMixin, Loggable, base.ObjectIDMixin, base.BaseModel):
 
     # TODO Remove null=True for things that shouldn't be nullable
     # e.g. CharFields should never be null=True
@@ -103,12 +106,21 @@ class Institution(Loggable, base.ObjectIDMixin, base.BaseModel):
             return None
 
     def update_search(self):
-        from website.search.search import update_institution
+        from website.search.search import update_institution, update_node
         from website.search.exceptions import SearchUnavailableError
+
         try:
             update_institution(self)
         except SearchUnavailableError as e:
             logger.exception(e)
+
+        saved_fields = self.get_dirty_fields()
+        if saved_fields and bool(self.pk):
+            for node in self.nodes.filter(is_deleted=False):
+                try:
+                    update_node(node, async=False)
+                except SearchUnavailableError as e:
+                    logger.exception(e)
 
     def save(self, *args, **kwargs):
         self.update_search()

--- a/scripts/populate_institutions.py
+++ b/scripts/populate_institutions.py
@@ -795,13 +795,7 @@ def main(env):
     init_app(routes=False)
     with transaction.atomic():
         for inst_data in INSTITUTIONS:
-            new_inst, inst_created = update_or_create(inst_data)
-            # update the nodes elastic docs, to have current names of institutions. This will
-            # only work properly if this file is the only thing changing institution attributes
-            if not inst_created:
-                nodes = Node.find_by_institutions(new_inst, query=Q('is_deleted', 'ne', True))
-                for node in nodes:
-                    update_node(node, async=False)
+            update_or_create(inst_data)
         for extra_inst in Institution.objects.exclude(_id__in=[x['_id'] for x in INSTITUTIONS]):
             logger.warn('Extra Institution : {} - {}'.format(extra_inst._id, extra_inst.name))
 


### PR DESCRIPTION
#### Purpose
- Optimizes `scripts.populate_institutions` 
- Removes the call to `update_node` for every affiliated node of every institution updated/created in the script. Instead, nodes will be updated in search if the institution is actually changed on save, i.e. if the name of an institution is changed in the populate script.

#### Changes
- Add `DirtyFieldsMixin` to `Institution` model. 
- Update `Insitution.save()` to check for changed fields before calling `update_node` for all affiliated nodes. 

#### Side Effects
- Whenever an Institution is saved (with a changed field, such as `name`), `update_node` will be called for every node affiliated with that institution. In theory, this shouldn't be a problem because `scripts.populate_institutions` is the only place where institutions are updated.

#### Ticket
- [OSF-8244](https://openscience.atlassian.net/browse/OSF-8244)
