### PR TITLE
[hotfix] Remove AbstractNode to Node Aliasing in Institution View [OSF-8300]

### DIFF
--- a/api/institutions/views.py
+++ b/api/institutions/views.py
@@ -9,7 +9,7 @@ from modularodm import Q
 
 from framework.auth.oauth_scopes import CoreScopes
 
-from osf.models import OSFUser as User, AbstractNode as Node, Institution
+from osf.models import OSFUser as User, Node, Institution
 from website.util import permissions as osf_permissions
 
 from api.base import permissions as base_permissions

--- a/api_tests/institutions/views/test_institution_nodes_list.py
+++ b/api_tests/institutions/views/test_institution_nodes_list.py
@@ -7,6 +7,7 @@ from osf_tests.factories import (
     AuthUserFactory,
     ProjectFactory,
     NodeFactory,
+    RegistrationFactory,
 )
 
 
@@ -65,6 +66,16 @@ class TestInstitutionNodeList:
         assert public_node._id in ids
         assert user_private_node._id not in ids
         assert private_node._id not in ids
+
+    def test_registration_not_returned(self, app, institution, public_node, institution_node_url):
+        registration = RegistrationFactory(project=public_node, is_public=True)
+        res = app.get(institution_node_url)
+
+        assert res.status_code == 200
+        ids = [each['id'] for each in res.json['data']]
+
+        assert public_node._id in ids
+        assert registration._id not in ids
 
     def test_affiliated_component_with_affiliated_parent_not_returned(self, app, user, institution, public_node, institution_node_url):
         # version < 2.2


### PR DESCRIPTION
#### Purpose
- Prevents registrations from being returned from /v2/institutions/<inst_id>/nodes/

#### Changes
- Remove aliasing of AbstractNode to Node.
- Add test.

#### Ticket
- [OSF-8300](https://openscience.atlassian.net/browse/OSF-8300)
