### PR TITLE
Remove MODM from osf models and osf_tests [OSF-8314]

### DIFF
--- a/api/institutions/serializers.py
+++ b/api/institutions/serializers.py
@@ -1,8 +1,5 @@
-from django.apps import apps
 from rest_framework import serializers as ser
 from rest_framework import exceptions
-
-from modularodm import Q
 
 from osf.models import AbstractNode
 from website.util import permissions as osf_permissions
@@ -90,8 +87,7 @@ class InstitutionNodesRelationshipSerializer(BaseAPISerializer):
         if not changes_flag:
             raise RelationshipPostMakesNoChanges
 
-        ConcreteNode = apps.get_model('osf.Node')
         return {
-            'data': list(ConcreteNode.find_by_institutions(inst, Q('is_deleted', 'ne', True))),
+            'data': list(inst.nodes.filter(is_deleted=False, type='osf.node')),
             'self': inst
         }

--- a/api/institutions/views.py
+++ b/api/institutions/views.py
@@ -1,4 +1,3 @@
-from django.apps import apps
 from rest_framework import generics
 from rest_framework import permissions as drf_permissions
 from rest_framework import exceptions
@@ -295,10 +294,9 @@ class InstitutionNodesRelationship(JSONAPIBaseView, generics.RetrieveDestroyAPIV
     view_name = 'institution-relationships-nodes'
 
     def get_object(self):
-        ConcreteNode = apps.get_model('osf.Node')
         inst = self.get_institution()
         auth = get_user_auth(self.request)
-        nodes = ConcreteNode.find_by_institutions(inst, Q('is_deleted', 'ne', True)).can_view(user=auth.user, private_link=auth.private_link)
+        nodes = inst.nodes.filter(is_deleted=False, type='osf.node').can_view(user=auth.user, private_link=auth.private_link)
         ret = {
             'data': nodes,
             'self': inst

--- a/osf/management/commands/populate_fake_preprint_providers.py
+++ b/osf/management/commands/populate_fake_preprint_providers.py
@@ -95,13 +95,10 @@ PREPRINT_PROVIDERS = [
 
 def get_subject_id(name):
     if name not in SUBJECTS_CACHE:
-        subject = None
         try:
-            subject = Subject.objects.get(text=name)
+            SUBJECTS_CACHE[name] = Subject.objects.filter(text=name).values_list('_id', flat=True).get()
         except Subject.DoesNotExist:
             raise Exception('Subject: "{}" not found'.format(name))
-        else:
-            SUBJECTS_CACHE[name] = subject._id
 
     return SUBJECTS_CACHE[name]
 

--- a/osf/management/commands/populate_fake_preprint_providers.py
+++ b/osf/management/commands/populate_fake_preprint_providers.py
@@ -28,9 +28,6 @@ from django.core.management import call_command
 from django.core.management.base import BaseCommand
 from django.db import transaction
 
-from modularodm import Q
-from modularodm.exceptions import NoResultsFound
-
 from osf.models import NodeLicense, Subject, PreprintProvider
 from scripts import utils as script_utils
 from website.settings import PREPRINT_PROVIDER_DOMAINS
@@ -100,8 +97,8 @@ def get_subject_id(name):
     if name not in SUBJECTS_CACHE:
         subject = None
         try:
-            subject = Subject.find_one(Q('text', 'eq', name))
-        except NoResultsFound:
+            subject = Subject.objects.get(text=name)
+        except Subject.DoesNotExist:
             raise Exception('Subject: "{}" not found'.format(name))
         else:
             SUBJECTS_CACHE[name] = subject._id
@@ -110,8 +107,8 @@ def get_subject_id(name):
 
 def get_license(name):
     try:
-        license = NodeLicense.find_one(Q('name', 'eq', name))
-    except NoResultsFound:
+        license = NodeLicense.objects.get(name=name)
+    except NodeLicense.DoesNotExist:
         raise Exception('License: "{}" not found'.format(name))
     return license
 

--- a/osf/models/external.py
+++ b/osf/models/external.py
@@ -5,7 +5,6 @@ import httplib as http
 import logging
 
 from django.contrib.postgres.fields import ArrayField
-from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils import timezone
 from flask import request
@@ -17,7 +16,6 @@ from requests_oauthlib import OAuth1Session, OAuth2Session
 from framework.exceptions import HTTPError, PermissionsError
 from framework.sessions import session
 from osf.models import base
-from osf.modm_compat import Q
 from osf.utils.fields import EncryptedTextField, NonNaiveDateTimeField
 from website.oauth.utils import PROVIDER_LOOKUP
 from website.security import random_string
@@ -274,21 +272,11 @@ class ExternalProvider(object):
         return self._set_external_account(user, info)
 
     def _set_external_account(self, user, info):
-        try:
-            # create a new ``ExternalAccount`` ...
-            self.account = ExternalAccount(
-                provider=self.short_name,
-                provider_id=info['provider_id'],
-                provider_name=self.name,
-            )
-            self.account.save()
-        except ValidationError:
-            # ... or get the old one
-            self.account = ExternalAccount.find_one(
-                Q('provider', 'eq', self.short_name) &
-                Q('provider_id', 'eq', info['provider_id'])
-            )
-            assert self.account is not None
+
+        self.account, created = ExternalAccount.objects.get_or_create(
+            provider=self.short_name,
+            provider_id=info['provider_id'],
+        )
 
         # ensure that provider_name is correct
         self.account.provider_name = self.name

--- a/osf/models/files.py
+++ b/osf/models/files.py
@@ -5,11 +5,10 @@ import os
 
 import requests
 from dateutil.parser import parse as parse_date
-from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 from django.db.models import Manager
+from django.core.exceptions import ObjectDoesNotExist
 from django.utils import timezone
-from modularodm.exceptions import NoResultsFound
 from typedmodels.models import TypedModel, TypedModelManager
 from include import IncludeManager
 
@@ -18,7 +17,6 @@ from osf.models.base import BaseModel, OptionalGuidMixin, ObjectIDMixin
 from osf.models.comment import CommentableMixin
 from osf.models.mixins import Taggable
 from osf.models.validators import validate_location
-from osf.modm_compat import Q
 from osf.utils.datetime_aware_jsonfield import DateTimeAwareJSONField
 from osf.utils.fields import NonNaiveDateTimeField
 from website.files import utils
@@ -184,9 +182,7 @@ class BaseFileNode(TypedModel, CommentableMixin, OptionalGuidMixin, Taggable, Ob
         materialized_path = '/' + materialized_path.lstrip('/')
         if materialized_path.endswith('/'):
             # it's a folder
-            folder_children = cls.find(Q('provider', 'eq', provider) &
-                                       Q('node', 'eq', node) &
-                                       Q('_materialized_path', 'startswith', materialized_path))
+            folder_children = cls.objects.filter(provider=provider, node=node, _materialized_path__startswith=materialized_path)
             for item in folder_children:
                 if item.kind == 'file':
                     guid = item.get_guid()
@@ -195,9 +191,10 @@ class BaseFileNode(TypedModel, CommentableMixin, OptionalGuidMixin, Taggable, Ob
         else:
             # it's a file
             try:
-                file_obj = cls.find_one(
-                    Q('node', 'eq', node) & Q('_materialized_path', 'eq', materialized_path))
-            except NoResultsFound:
+                file_obj = cls.objects.get(
+                    node=node, _materialized_path=materialized_path
+                )
+            except cls.DoesNotExist:
                 return guids
             guid = file_obj.get_guid()
             if guid:
@@ -219,7 +216,7 @@ class BaseFileNode(TypedModel, CommentableMixin, OptionalGuidMixin, Taggable, Ob
         :param user: The user with checked out files
         :return: A queryset of all FileNodes checked out by user
         """
-        return cls.find(Q('checkout', 'eq', user))
+        return cls.objects.filter(checkout=user)
 
     @classmethod
     def resolve_class(cls, provider, type_integer):
@@ -532,10 +529,7 @@ class Folder(models.Model):
         return child
 
     def find_child_by_name(self, name, kind=2):
-        return self.resolve_class(self.provider, kind).find_one(
-            Q('name', 'eq', name) &
-            Q('parent', 'eq', self)
-        )
+        return self.resolve_class(self.provider, kind).objects.get(name=name, parent=self)
 
     def serialize(self):
         return self._serialize()
@@ -673,15 +667,15 @@ class FileVersion(ObjectIDMixin, BaseModel):
             # Shouldn't ever happen, but we already have an archive
             return True  # We've found ourself
 
-        other = self.__class__.find(
-            Q('_id', 'ne', self._id) &
-            Q('metadata.sha256', 'eq', self.metadata['sha256']) &
-            Q('metadata.archive', 'ne', None) &
-            Q('metadata.vault', 'ne', None)
-        ).first()
-        if not other:
+        other = self.__class__.objects.filter(
+            metadata__sha256=self.metadata['sha256']
+        ).exclude(
+            _id=self._id, metadata__archive__is_null=True, metadata__vault__is_null=True
+        )
+        if not other.exists():
             return False
         try:
+            other = other.first()
             self.metadata['vault'] = other.metadata['vault']
             self.metadata['archive'] = other.metadata['archive']
         except KeyError:

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -42,7 +42,6 @@ from osf.models.spam import SpamMixin
 from osf.models.tag import Tag
 from osf.models.user import OSFUser
 from osf.models.validators import validate_doi, validate_title
-from osf.modm_compat import Q as MODMQ
 from osf.utils.auth import Auth, get_user
 from osf.utils.datetime_aware_jsonfield import DateTimeAwareJSONField
 from osf.utils.fields import NonNaiveDateTimeField
@@ -686,12 +685,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
 
     @classmethod
     def find_by_institutions(cls, inst, query=None):
-        base_query = MODMQ('affiliated_institutions', 'eq', inst)
-        if query:
-            final_query = base_query & query
-        else:
-            final_query = base_query
-        return cls.find(final_query)
+        return inst.nodes.filter(query) if query else inst.nodes.all()
 
     def _is_embargo_date_valid(self, end_date):
         now = timezone.now()
@@ -1420,10 +1414,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
 
     @classmethod
     def find_for_user(cls, user, subquery=None):
-        combined_query = MODMQ('contributors', 'eq', user)
-        if subquery is not None:
-            combined_query = combined_query & subquery
-        return cls.find(combined_query)
+        return user.nodes.filter(subquery) if subquery else user.nodes.all()
 
     def can_comment(self, auth):
         if self.comment_level == 'public':

--- a/osf/models/queued_mail.py
+++ b/osf/models/queued_mail.py
@@ -7,7 +7,6 @@ from website.mails import presends
 from website import settings as osf_settings
 
 from osf.models.base import BaseModel, ObjectIDMixin
-from osf.modm_compat import Q
 from osf.utils.datetime_aware_jsonfield import DateTimeAwareJSONField
 
 
@@ -68,11 +67,7 @@ class QueuedMail(ObjectIDMixin, BaseModel):
         Does not look for queue-up emails.
         :return: a list of those emails
         """
-        return self.__class__.find(
-            Q('email_type', 'eq', self.email_type) &
-            Q('user', 'eq', self.user) &
-            Q('sent_at', 'ne', None)
-        )
+        return self.__class__.objects.filter(email_type=self.email_type, user=self.user).exclude(sent_at=None)
 
 
 def queue_mail(to_addr, mail, send_at, user, **context):

--- a/osf/models/sanctions.py
+++ b/osf/models/sanctions.py
@@ -23,7 +23,6 @@ from website.project import tasks as project_tasks
 
 from osf.models import MetaSchema
 from osf.models.base import BaseModel, ObjectIDMixin
-from osf.modm_compat import Q
 from osf.utils.datetime_aware_jsonfield import DateTimeAwareJSONField
 
 VIEW_PROJECT_URL_TEMPLATE = osf_settings.DOMAIN + '{node_id}/'
@@ -584,10 +583,13 @@ class Retraction(EmailApprovableSanction):
         rejection_token = user_approval_state.get('rejection_token')
         if rejection_token:
             Registration = apps.get_model('osf.Registration')
+            node_id = user_approval_state.get('node_id', None)
+            registration = Registration.objects.select_related(
+                'registered_from'
+            ).get(
+                guids___id=node_id
+            ) if node_id else self.registrations.first()
 
-            root_registration = Registration.find_one(Q('retraction', 'eq', self))
-            node_id = user_approval_state.get('node_id', root_registration._id)
-            registration = Registration.load(node_id)
             return {
                 'node_id': registration.registered_from._id,
                 'token': rejection_token,
@@ -597,18 +599,14 @@ class Retraction(EmailApprovableSanction):
         urls = urls or self.stashed_urls.get(user._id, {})
         registration_link = urls.get('view', self._view_url(user._id, node))
         if is_authorizer:
-            Registration = apps.get_model('osf.Registration')
-
             approval_link = urls.get('approve', '')
             disapproval_link = urls.get('reject', '')
             approval_time_span = osf_settings.RETRACTION_PENDING_TIME.days * 24
 
-            registration = Registration.find_one(Q('retraction', 'eq', self))
-
             return {
                 'is_initiator': self.initiated_by == user,
                 'initiated_by': self.initiated_by.fullname,
-                'project_name': registration.title,
+                'project_name': self.registrations.filter().values_list('title', flat=True).get(),
                 'registration_link': registration_link,
                 'approval_link': approval_link,
                 'disapproval_link': disapproval_link,
@@ -624,7 +622,7 @@ class Retraction(EmailApprovableSanction):
         Registration = apps.get_model('osf.Registration')
         NodeLog = apps.get_model('osf.NodeLog')
 
-        parent_registration = Registration.find_one(Q('retraction', 'eq', self))
+        parent_registration = Registration.objects.get(retraction=self)
         parent_registration.registered_from.add_log(
             action=NodeLog.RETRACTION_CANCELLED,
             params={
@@ -643,7 +641,7 @@ class Retraction(EmailApprovableSanction):
         self.date_retracted = timezone.now()
         self.save()
 
-        parent_registration = Registration.find_one(Q('retraction', 'eq', self))
+        parent_registration = Registration.objects.get(retraction=self)
         parent_registration.registered_from.add_log(
             action=NodeLog.RETRACTION_APPROVED,
             params={
@@ -865,9 +863,7 @@ class DraftRegistrationApproval(Sanction):
     def _on_complete(self, user):
         DraftRegistration = apps.get_model('osf.DraftRegistration')
 
-        draft = DraftRegistration.find_one(
-            Q('approval', 'eq', self)
-        )
+        draft = DraftRegistration.objects.get(approval=self)
 
         initiator = draft.initiator.merged_by or draft.initiator
         auth = Auth(initiator)
@@ -899,9 +895,7 @@ class DraftRegistrationApproval(Sanction):
         self.meta = {}
         self.save()
 
-        draft = DraftRegistration.find_one(
-            Q('approval', 'eq', self)
-        )
+        draft = DraftRegistration.objects.get(approval=self)
         initiator = draft.initiator.merged_by or draft.initiator
         self._send_rejection_email(initiator, draft)
 

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -32,7 +32,6 @@ from framework.auth.exceptions import (ChangePasswordError, ExpiredTokenError,
 from framework.exceptions import PermissionsError
 from framework.sessions.utils import remove_sessions_for_user
 from osf.utils.requests import get_current_request
-from modularodm.exceptions import NoResultsFound
 from osf.exceptions import reraise_django_validation_errors
 from osf.models.base import BaseModel, GuidMixin, GuidMixinQuerySet
 from osf.models.contributor import RecentlyAddedContributor
@@ -41,7 +40,6 @@ from osf.models.mixins import AddonModelMixin
 from osf.models.session import Session
 from osf.models.tag import Tag
 from osf.models.validators import validate_email, validate_social, validate_history_item
-from osf.modm_compat import Q
 from osf.utils.datetime_aware_jsonfield import DateTimeAwareJSONField
 from osf.utils.fields import NonNaiveDateTimeField, LowercaseEmailField
 from osf.utils.names import impute_names
@@ -872,10 +870,8 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
         for token in email_verifications:
             if self.email_verifications[token].get('confirmed', False):
                 try:
-                    user_merge = OSFUser.find_one(
-                        Q('emails__address', 'eq', self.email_verifications[token]['email'].lower())
-                    )
-                except NoResultsFound:
+                    user_merge = OSFUser.objects.get(emails__address__iexact=self.email_verifications[token]['email'])
+                except OSFUser.DoesNotExist:
                     user_merge = False
 
                 unconfirmed_emails.append({'address': self.email_verifications[token]['email'],
@@ -1088,8 +1084,8 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
 
         # If this email is confirmed on another account, abort
         try:
-            user_to_merge = OSFUser.find_one(Q('emails__address', 'eq', email))
-        except NoResultsFound:
+            user_to_merge = OSFUser.objects.get(emails__address=email)
+        except OSFUser.DoesNotExist:
             user_to_merge = None
 
         if user_to_merge and merge:
@@ -1103,9 +1099,8 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
 
         # If another user has this email as its username, get it
         try:
-            unregistered_user = OSFUser.find_one(Q('username', 'eq', email) &
-                                              Q('_id', 'ne', self._id))
-        except NoResultsFound:
+            unregistered_user = OSFUser.objects.exclude(guids___id=self._id).get(username=email)
+        except OSFUser.DoesNotExist:
             unregistered_user = None
 
         if unregistered_user:
@@ -1373,8 +1368,8 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
         :returns: The signed cookie
         """
         secret = secret or settings.SECRET_KEY
-        user_session = Session.find(
-            Q('data.auth_user_id', 'eq', self._id)
+        user_session = Session.objects.filter(
+            data__auth_user_id=self._id
         ).order_by(
             '-date_modified'
         ).first()

--- a/osf/modm_compat.py
+++ b/osf/modm_compat.py
@@ -168,4 +168,7 @@ def _get_internal_type(field):
 def to_django_query(query, model_cls=None):
     """Translate a modular-odm Q or QueryGroup to a Django query.
     """
+    # temporary measure as queries are converted away from modm
+    if isinstance(query, DjangoQ):
+        return query
     return Q.from_modm_query(query, model_cls=model_cls).to_django_query()

--- a/osf/utils/auth.py
+++ b/osf/utils/auth.py
@@ -47,10 +47,7 @@ def get_user(email=None, password=None, verification_key=None):
     if verification_key:
         query_list.append(Q(verification_key=verification_key))
     try:
-        query = query_list[0]
-        for query_part in query_list[1:]:
-            query = query & query_part
-        user = User.objects.get(query)
+        user = User.objects.get(query_list[0])
         return user
     except Exception as err:
         logger.error(err)

--- a/osf/utils/auth.py
+++ b/osf/utils/auth.py
@@ -1,8 +1,8 @@
 import logging
 
 from django.apps import apps
-from modularodm.exceptions import QueryException
-from modularodm import Q
+from django.db.models import Q
+from django.core.exceptions import ObjectDoesNotExist
 
 from framework.sessions import session
 
@@ -30,14 +30,14 @@ def get_user(email=None, password=None, verification_key=None):
     query_list = []
     if email:
         email = email.strip().lower()
-        query_list.append(Q('emails__address', 'eq', email) | Q('username', 'eq', email))
+        query_list.append(Q(emails__address=email) | Q(username=email))
     if password:
         password = password.strip()
         try:
             query = query_list[0]
             for query_part in query_list[1:]:
                 query = query & query_part
-            user = User.find_one(query)
+            user = User.objects.get(query)
         except Exception as err:
             logger.error(err)
             user = None
@@ -45,12 +45,12 @@ def get_user(email=None, password=None, verification_key=None):
             return False
         return user
     if verification_key:
-        query_list.append(Q('verification_key', 'eq', verification_key))
+        query_list.append(Q(verification_key=verification_key))
     try:
         query = query_list[0]
         for query_part in query_list[1:]:
             query = query & query_part
-        user = User.find_one(query)
+        user = User.objects.get(query)
         return user
     except Exception as err:
         logger.error(err)
@@ -84,7 +84,7 @@ class Auth(object):
             if private_link.is_deleted:
                 return None
 
-        except QueryException:
+        except ObjectDoesNotExist:
             return None
 
         return private_link

--- a/osf_tests/factories.py
+++ b/osf_tests/factories.py
@@ -13,7 +13,6 @@ from factory.django import DjangoModelFactory
 from django.utils import timezone
 from django.db.utils import IntegrityError
 from faker import Factory
-from modularodm.exceptions import NoResultsFound
 
 from website import settings
 from website.notifications.constants import NOTIFICATION_TYPES

--- a/osf_tests/test_archive_target.py
+++ b/osf_tests/test_archive_target.py
@@ -1,4 +1,3 @@
-from modularodm import Q
 import pytest
 
 from osf.models import ArchiveTarget
@@ -9,4 +8,4 @@ def test_querying_on_id():
     # translated properly
     archive_target = ArchiveTarget(name='s3', stat_result={}, errors=[])
     archive_target.save()
-    assert archive_target in ArchiveTarget.find(Q('_id', 'eq', archive_target._id))
+    assert archive_target in ArchiveTarget.objects.filter(_id=archive_target._id)

--- a/osf_tests/test_archiver.py
+++ b/osf_tests/test_archiver.py
@@ -12,9 +12,8 @@ import celery
 import httpretty
 import mock  # noqa
 from django.utils import timezone
+from django.db import IntegrityError
 from mock import call
-from modularodm import Q
-from modularodm.exceptions import KeyExistsException
 import pytest
 from nose.tools import *  # flake8: noqa
 
@@ -282,7 +281,7 @@ def generate_schema_from_data(data):
     )
     try:
         schema.save()
-    except KeyExistsException:
+    except IntegrityError:
 
         # Unfortunately, we don't have db isolation between test cases for some
         # reason. Update the doc currently in the db rather than saving a new

--- a/osf_tests/test_comment.py
+++ b/osf_tests/test_comment.py
@@ -1,7 +1,7 @@
 import pytest
 from collections import OrderedDict
 
-from modularodm.exceptions import ValidationError
+from django.core.exceptions import ValidationError
 
 
 from addons.box.models import BoxFile
@@ -18,7 +18,6 @@ from website.project.signals import comment_added, mention_added, contributor_ad
 from framework.exceptions import PermissionsError
 from tests.base import capture_signals
 from osf.models import Comment, NodeLog, Guid, BaseFileNode
-from osf.modm_compat import Q
 from osf.utils.auth import Auth
 from .factories import (
     CommentFactory,
@@ -60,7 +59,7 @@ def test_comments_have_longer_guid():
 def test_comments_are_queryable_by_root_target():
     root_target = ProjectFactory()
     comment = CommentFactory(node=root_target)
-    assert Comment.find(Q('root_target', 'eq', root_target.guids.first()))[0] == comment
+    assert Comment.objects.filter(root_target=root_target.guids.first()).first() == comment
 
 
 # copied from tests/test_comments.py
@@ -494,7 +493,7 @@ class FileCommentMoveRenameTestMixin(object):
         self.guid.reload()
         file_node = BaseFileNode.resolve_class(self.provider, BaseFileNode.FILE).get_or_create(destination['node'], self._format_path(destination['path'], file_id=self.file._id))
         assert self.guid._id == file_node.get_guid()._id
-        file_comments = Comment.find(Q('root_target', 'eq', self.guid.pk))
+        file_comments = Comment.objects.filter(root_target=self.guid.pk)
         assert file_comments.count() == 1
 
     def test_comments_move_on_folder_rename(self, project, user):
@@ -516,7 +515,7 @@ class FileCommentMoveRenameTestMixin(object):
 
         file_node = BaseFileNode.resolve_class(self.provider, BaseFileNode.FILE).get_or_create(destination['node'], self._format_path('{}{}'.format(destination['path'], file_name), file_id=self.file._id))
         assert self.guid._id == file_node.get_guid()._id
-        file_comments = Comment.find(Q('root_target', 'eq', self.guid.pk))
+        file_comments = Comment.objects.filter(root_target=self.guid.pk)
         assert file_comments.count() == 1
 
     def test_comments_move_on_subfolder_file_when_parent_folder_is_renamed(self, project, user):
@@ -538,7 +537,7 @@ class FileCommentMoveRenameTestMixin(object):
 
         file_node = BaseFileNode.resolve_class(self.provider, BaseFileNode.FILE).get_or_create(destination['node'], self._format_path('{}{}'.format(destination['path'], file_path), file_id=self.file._id))
         assert self.guid._id == file_node.get_guid()._id
-        file_comments = Comment.find(Q('root_target', 'eq', self.guid.pk))
+        file_comments = Comment.objects.filter(root_target=self.guid.pk)
         assert file_comments.count() == 1
 
     def test_comments_move_when_file_moved_to_subfolder(self, project, user):
@@ -559,7 +558,7 @@ class FileCommentMoveRenameTestMixin(object):
 
         file_node = BaseFileNode.resolve_class(self.provider, BaseFileNode.FILE).get_or_create(destination['node'], self._format_path(destination['path'], file_id=self.file._id))
         assert self.guid._id == file_node.get_guid()._id
-        file_comments = Comment.find(Q('root_target', 'eq', self.guid.pk))
+        file_comments = Comment.objects.filter(root_target=self.guid.pk)
         assert file_comments.count() == 1
 
     def test_comments_move_when_file_moved_from_subfolder_to_root(self, project, user):
@@ -580,7 +579,7 @@ class FileCommentMoveRenameTestMixin(object):
 
         file_node = BaseFileNode.resolve_class(self.provider, BaseFileNode.FILE).get_or_create(destination['node'], self._format_path(destination['path'], file_id=self.file._id))
         assert self.guid._id == file_node.get_guid()._id
-        file_comments = Comment.find(Q('root_target', 'eq', self.guid.pk))
+        file_comments = Comment.objects.filter(root_target=self.guid.pk)
         assert file_comments.count() == 1
 
     def test_comments_move_when_file_moved_from_project_to_component(self, project, component, user):
@@ -602,7 +601,7 @@ class FileCommentMoveRenameTestMixin(object):
         file_node = BaseFileNode.resolve_class(self.provider, BaseFileNode.FILE).get_or_create(destination['node'], self._format_path(destination['path'], file_id=self.file._id))
         assert self.guid._id == file_node.get_guid()._id
         assert self.guid.referent.node._id == destination['node']._id
-        file_comments = Comment.find(Q('root_target', 'eq', self.guid.pk))
+        file_comments = Comment.objects.filter(root_target=self.guid.pk)
         assert file_comments.count() == 1
 
     def test_comments_move_when_file_moved_from_component_to_project(self, project, component, user):
@@ -624,7 +623,7 @@ class FileCommentMoveRenameTestMixin(object):
         file_node = BaseFileNode.resolve_class(self.provider, BaseFileNode.FILE).get_or_create(destination['node'], self._format_path(destination['path'], file_id=self.file._id))
         assert self.guid._id == file_node.get_guid()._id
         assert self.guid.referent.node._id == destination['node']._id
-        file_comments = Comment.find(Q('root_target', 'eq', self.guid.pk))
+        file_comments = Comment.objects.filter(root_target=self.guid.pk)
         assert file_comments.count() == 1
 
     def test_comments_move_when_folder_moved_to_subfolder(self, user, project):
@@ -646,7 +645,7 @@ class FileCommentMoveRenameTestMixin(object):
 
         file_node = BaseFileNode.resolve_class(self.provider, BaseFileNode.FILE).get_or_create(destination['node'], self._format_path('{}{}'.format(destination['path'], file_name), file_id=self.file._id))
         assert self.guid._id == file_node.get_guid()._id
-        file_comments = Comment.find(Q('root_target', 'eq', self.guid.pk))
+        file_comments = Comment.objects.filter(root_target=self.guid.pk)
         assert file_comments.count() == 1
 
     def test_comments_move_when_folder_moved_from_subfolder_to_root(self, project, user):
@@ -668,7 +667,7 @@ class FileCommentMoveRenameTestMixin(object):
 
         file_node = BaseFileNode.resolve_class(self.provider, BaseFileNode.FILE).get_or_create(destination['node'], self._format_path('{}{}'.format(destination['path'], file_name), file_id=self.file._id))
         assert self.guid._id == file_node.get_guid()._id
-        file_comments = Comment.find(Q('root_target', 'eq', self.guid.pk))
+        file_comments = Comment.objects.filter(root_target=self.guid.pk)
         assert file_comments.count() == 1
 
     def test_comments_move_when_folder_moved_from_project_to_component(self, project, component, user):
@@ -690,7 +689,7 @@ class FileCommentMoveRenameTestMixin(object):
 
         file_node = BaseFileNode.resolve_class(self.provider, BaseFileNode.FILE).get_or_create(destination['node'], self._format_path('{}{}'.format(destination['path'], file_name), file_id=self.file._id))
         assert self.guid._id == file_node.get_guid()._id
-        file_comments = Comment.find(Q('root_target', 'eq', self.guid.pk))
+        file_comments = Comment.objects.filter(root_target=self.guid.pk)
         assert file_comments.count() == 1
 
     def test_comments_move_when_folder_moved_from_component_to_project(self, project, component, user):
@@ -712,7 +711,7 @@ class FileCommentMoveRenameTestMixin(object):
 
         file_node = BaseFileNode.resolve_class(self.provider, BaseFileNode.FILE).get_or_create(destination['node'], self._format_path('{}{}'.format(destination['path'], file_name), file_id=self.file._id))
         assert self.guid._id == file_node.get_guid()._id
-        file_comments = Comment.find(Q('root_target', 'eq', self.guid.pk))
+        file_comments = Comment.objects.filter(root_target=self.guid.pk)
         assert file_comments.count() == 1
 
     def test_comments_move_when_file_moved_to_osfstorage(self, project, user):
@@ -746,7 +745,7 @@ class FileCommentMoveRenameTestMixin(object):
 
         file_node = BaseFileNode.resolve_class('osfstorage', BaseFileNode.FILE).get_or_create(destination['node'], destination['path'])
         assert self.guid._id == file_node.get_guid()._id
-        file_comments = Comment.find(Q('root_target', 'eq', self.guid.pk))
+        file_comments = Comment.objects.filter(root_target=self.guid.pk)
         assert file_comments.count() == 1
 
     def test_comments_move_when_folder_moved_to_osfstorage(self, project, user):
@@ -787,7 +786,7 @@ class FileCommentMoveRenameTestMixin(object):
 
         file_node = BaseFileNode.resolve_class('osfstorage', BaseFileNode.FILE).get_or_create(destination['node'], osf_file._id)
         assert self.guid._id == file_node.get_guid()._id
-        file_comments = Comment.find(Q('root_target', 'eq', self.guid.pk))
+        file_comments = Comment.objects.filter(root_target=self.guid.pk)
         assert file_comments.count() == 1
 
     @pytest.mark.parametrize(
@@ -821,7 +820,7 @@ class FileCommentMoveRenameTestMixin(object):
 
         file_node = BaseFileNode.resolve_class(destination_provider, BaseFileNode.FILE).get_or_create(destination['node'], destination['path'])
         assert self.guid._id == file_node.get_guid()._id
-        file_comments = Comment.find(Q('root_target', 'eq', self.guid.pk))
+        file_comments = Comment.objects.filter(root_target=self.guid.pk)
         assert file_comments.count() == 1
 
     @pytest.mark.parametrize(
@@ -861,7 +860,7 @@ class FileCommentMoveRenameTestMixin(object):
 
         file_node = BaseFileNode.resolve_class(destination_provider, BaseFileNode.FILE).get_or_create(destination['node'], destination_path)
         assert self.guid._id == file_node.get_guid()._id
-        file_comments = Comment.find(Q('root_target', 'eq', self.guid.pk))
+        file_comments = Comment.objects.filter(root_target=self.guid.pk)
         assert file_comments.count() == 1
 
 
@@ -913,7 +912,7 @@ class TestOsfstorageFileCommentMoveRename(FileCommentMoveRenameTestMixin):
         file_node = BaseFileNode.resolve_class(self.provider, BaseFileNode.FILE).get_or_create(destination['node'], self._format_path(destination['path'], file_id=self.file._id))
         assert self.guid._id == file_node.get_guid()._id
         assert self.guid.referent.node._id == destination['node']._id
-        file_comments = Comment.find(Q('root_target', 'eq', self.guid.pk))
+        file_comments = Comment.objects.filter(root_target=self.guid.pk)
         assert file_comments.count() == 1
 
     def test_comments_move_when_file_moved_from_component_to_project(self, project, component, user):
@@ -936,7 +935,7 @@ class TestOsfstorageFileCommentMoveRename(FileCommentMoveRenameTestMixin):
         file_node = BaseFileNode.resolve_class(self.provider, BaseFileNode.FILE).get_or_create(destination['node'], self._format_path(destination['path'], file_id=self.file._id))
         assert self.guid._id == file_node.get_guid()._id
         assert self.guid.referent.node._id == destination['node']._id
-        file_comments = Comment.find(Q('root_target', 'eq', self.guid.pk))
+        file_comments = Comment.objects.filter(root_target=self.guid.pk)
         assert file_comments.count() == 1
 
     def test_comments_move_when_folder_moved_from_project_to_component(self, project, component, user):
@@ -959,7 +958,7 @@ class TestOsfstorageFileCommentMoveRename(FileCommentMoveRenameTestMixin):
 
         file_node = BaseFileNode.resolve_class(self.provider, BaseFileNode.FILE).get_or_create(destination['node'], self._format_path('{}{}'.format(destination['path'], file_name), file_id=self.file._id))
         assert self.guid._id == file_node.get_guid()._id
-        file_comments = Comment.find(Q('root_target', 'eq', self.guid.pk))
+        file_comments = Comment.objects.filter(root_target=self.guid.pk)
         assert file_comments.count() == 1
 
     def test_comments_move_when_folder_moved_from_component_to_project(self, project, component, user):
@@ -982,7 +981,7 @@ class TestOsfstorageFileCommentMoveRename(FileCommentMoveRenameTestMixin):
 
         file_node = BaseFileNode.resolve_class(self.provider, BaseFileNode.FILE).get_or_create(destination['node'], self._format_path('{}{}'.format(destination['path'], file_name), file_id=self.file._id))
         assert self.guid._id == file_node.get_guid()._id
-        file_comments = Comment.find(Q('root_target', 'eq', self.guid.pk))
+        file_comments = Comment.objects.filter(root_target=self.guid.pk)
         assert file_comments.count() == 1
 
     def test_comments_move_when_file_moved_to_osfstorage(self):

--- a/osf_tests/test_elastic_search.py
+++ b/osf_tests/test_elastic_search.py
@@ -8,7 +8,6 @@ import functools
 
 from nose.tools import *  # flake8: noqa (PEP8 asserts)
 import mock
-from modularodm import Q
 
 from framework.auth.core import Auth
 
@@ -234,9 +233,7 @@ class TestNodeSearch(OsfTestCase):
     @unittest.skip("Elasticsearch latency seems to be causing theses tests to fail randomly.")
     @retry_assertion(retries=10)
     def test_node_license_updates_correctly(self):
-        other_license = NodeLicense.find_one(
-            Q('name', 'eq', 'MIT License')
-        )
+        other_license = NodeLicense.objects.get(name='MIT License')
         new_license = factories.NodeLicenseRecordFactory(node_license=other_license)
         self.node.node_license = new_license
         self.node.save()
@@ -965,7 +962,7 @@ class TestSearchFiles(OsfTestCase):
 
     def test_file_download_url_no_guid(self):
         file_ = self.root.append_file('Timber.mp3')
-        path = OsfStorageFile.find_one( Q('node', 'eq', file_.node_id)).path
+        path = OsfStorageFile.objects.get(node=file_.node).path
         deep_url = '/' + file_.node._id + '/files/osfstorage' + path + '/'
         find = query_file('Timber.mp3')['results']
         assert_not_equal(file_.path, '')

--- a/osf_tests/test_institution.py
+++ b/osf_tests/test_institution.py
@@ -1,7 +1,5 @@
 from osf.models import Institution
 
-from modularodm import Q
-
 from .factories import InstitutionFactory
 import pytest
 
@@ -17,7 +15,7 @@ def test_factory():
 @pytest.mark.django_db
 def test_querying_on_domains():
     inst = InstitutionFactory(domains=['foo.test'])
-    result = Institution.find(Q('domains', 'eq', 'foo.test'))
+    result = Institution.objects.filter(domains__contains=['foo.test'])
     assert inst in result
 
 

--- a/osf_tests/test_prereg.py
+++ b/osf_tests/test_prereg.py
@@ -1,7 +1,5 @@
 from nose.tools import *  # noqa
 
-from modularodm import Q
-
 from osf.models import MetaSchema
 from website.prereg import prereg_landing_page as landing_page
 from website.prereg.utils import drafts_for_user, get_prereg_schema
@@ -40,9 +38,7 @@ class TestPreregLandingPage(OsfTestCase):
         )
 
     def test_has_project_and_draft_registration(self):
-        prereg_schema = MetaSchema.find_one(
-            Q('name', 'eq', 'Prereg Challenge')
-        )
+        prereg_schema = MetaSchema.objects.get(name='Prereg Challenge')
         factories.DraftRegistrationFactory(
             initiator=self.user,
             registration_schema=prereg_schema
@@ -59,10 +55,7 @@ class TestPreregLandingPage(OsfTestCase):
         )
 
     def test_drafts_for_user_omits_registered(self):
-        prereg_schema = MetaSchema.find_one(
-            Q('name', 'eq', 'Prereg Challenge') &
-            Q('schema_version', 'eq', 2)
-        )
+        prereg_schema = MetaSchema.objects.get(name='Prereg Challenge', schema_version=2)
 
         d1 = factories.DraftRegistrationFactory(
             initiator=self.user,

--- a/osf_tests/utils.py
+++ b/osf_tests/utils.py
@@ -3,7 +3,6 @@ import datetime as dt
 import functools
 import mock
 
-from modularodm.storage import EphemeralStorage
 from framework.auth import Auth
 from django.utils import timezone
 
@@ -15,11 +14,6 @@ from website.archiver import listeners as archiver_listeners
 from osf.models import Sanction
 
 from .factories import get_default_metaschema
-
-
-def set_up_ephemeral_storage(schemas):
-    for schema in schemas:
-        schema.set_storage(EphemeralStorage(collection_name=schema._name))
 
 
 # From Flask-Security: https://github.com/mattupstate/flask-security/blob/develop/flask_security/utils.py

--- a/website/project/model.py
+++ b/website/project/model.py
@@ -3,6 +3,7 @@ import logging
 import re
 
 from django.apps import apps
+from django.core.exceptions import ValidationError
 
 from modularodm import Q
 from modularodm.exceptions import ValidationValueError
@@ -29,9 +30,9 @@ def validate_contributor(guid, contributors):
     OSFUser = apps.get_model('osf.OSFUser')
     user = OSFUser.load(guid)
     if not user or not user.is_claimed:
-        raise ValidationValueError('User does not exist or is not active.')
+        raise ValidationError('User does not exist or is not active.')
     elif user not in contributors:
-        raise ValidationValueError('Mentioned user is not a contributor.')
+        raise ValidationError('Mentioned user is not a contributor.')
     return True
 
 def get_valid_mentioned_users_guids(comment, contributors):

--- a/website/project/utils.py
+++ b/website/project/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Various node-related utilities."""
 from django.apps import apps
-from modularodm import Q
+from django.db.models import Q
 
 from website import settings
 
@@ -15,22 +15,18 @@ def serialize_node(*args, **kwargs):
     return _view_project(*args, **kwargs)  # Not recommended practice
 
 PROJECT_QUERY = (
-    # Can encompass accessible projects, registrations, or forks
-    # Note: is_bookmark collection(s) are implicitly assumed to also be collections; that flag intentionally omitted
-    Q('is_deleted', 'eq', False) &
-    Q('type', 'ne', 'osf.collection')
+    Q(is_deleted=False) & ~Q(type='osf.collection')
 )
 
 def recent_public_registrations(n=10):
-    from django.db.models import Q as DQ
     Registration = apps.get_model('osf.Registration')
 
     return Registration.objects.filter(
         is_public=True,
         is_deleted=False,
     ).filter(
-        DQ(DQ(embargo__isnull=True) | ~DQ(embargo__state='unapproved')) &
-        DQ(DQ(retraction__isnull=True) | ~DQ(retraction__state='approved'))
+        Q(Q(embargo__isnull=True) | ~Q(embargo__state='unapproved')) &
+        Q(Q(retraction__isnull=True) | ~Q(retraction__state='approved'))
     ).get_roots().order_by('-registered_date')[:n]
 
 
@@ -102,7 +98,7 @@ def activity():
                 break
 
     # New and Noteworthy projects are updated manually
-    new_and_noteworthy_projects = list(Node.find_one(Q('_id', 'eq', settings.NEW_AND_NOTEWORTHY_LINKS_NODE)).nodes_pointer)
+    new_and_noteworthy_projects = list(Node.objects.get(guid___id=settings.NEW_AND_NOTEWORTHY_LINKS_NODE).nodes_pointer)
 
     return {
         'new_and_noteworthy_projects': new_and_noteworthy_projects,

--- a/website/routes.py
+++ b/website/routes.py
@@ -5,6 +5,7 @@ import httplib as http
 
 from flask import request
 from flask import send_from_directory
+from django.core.exceptions import ObjectDoesNotExist
 
 from geoip import geolite2
 
@@ -21,9 +22,6 @@ from framework.routing import process_rules
 from framework.auth import views as auth_views
 from framework.routing import render_mako_string
 from framework.auth.core import _get_current_user
-
-from modularodm import Q
-from modularodm.exceptions import QueryException, NoResultsFound
 
 from osf.models import Institution
 from website import util
@@ -60,9 +58,9 @@ def get_globals():
     location = geolite2.lookup(request.remote_addr) if request.remote_addr else None
     if request.host_url != settings.DOMAIN:
         try:
-            inst_id = (Institution.find_one(Q('domains', 'eq', request.host.lower())))._id
+            inst_id = Institution.objects.get(domains__icontains=[request.host])._id
             request_login_url = '{}institutions/{}'.format(settings.DOMAIN, inst_id)
-        except NoResultsFound:
+        except ObjectDoesNotExist:
             request_login_url = request.url.replace(request.host_url, settings.DOMAIN)
     else:
         request_login_url = request.url
@@ -126,13 +124,11 @@ def get_globals():
 
 
 def is_private_link_anonymous_view():
+    # Avoid circular import
+    from osf.models import PrivateLink
     try:
-        # Avoid circular import
-        from osf.models import PrivateLink
-        return PrivateLink.find_one(
-            Q('key', 'eq', request.args.get('view_only'))
-        ).anonymous
-    except QueryException:
+        return PrivateLink.objects.filter(key=request.args.get('view_only')).values_list('anonymous', flat=True).get()
+    except PrivateLink.DoesNotExist:
         return False
 
 


### PR DESCRIPTION
## Purpose
Since we've officially moved away from using modular ODM, let's take steps to also remove the backwards-compatible modm-like queries.

## Changes

- Default to using Django queries from OSF models in `osf/`
- Default to using Django from osf models tests in `osf_tests/`
- Residual updates in API views and serializers that were necessary to go along with these backend models changes

## Side effects
None anticipated, but when merged has the potential for many merge conflicts as this touches a lot of files

## Ticket

https://openscience.atlassian.net/browse/OSF-8314