### PR TITLE
[Feature] See only deleted comments you can restore [OSF-7290]

### DIFF
--- a/website/static/js/comment.js
+++ b/website/static/js/comment.js
@@ -397,7 +397,9 @@ var CommentModel = function(data, $parent, $root) {
     self.hasChildren = ko.observable(data.attributes.has_children);
     self.hasReport = ko.observable(data.attributes.has_report);
     self.isHam = ko.observable(data.attributes.is_ham);
-
+    self.canSeeDeleted = ko.pureComputed(function() {
+        return !self.isDeleted() || (self.isDeleted() && self.canEdit());
+    });
     self.isDeletedAbuse = ko.pureComputed(function() {
         return self.isDeleted() && self.isAbuse();
     });

--- a/website/templates/include/comment_template.mako
+++ b/website/templates/include/comment_template.mako
@@ -1,5 +1,5 @@
 <script type="text/html" id="commentTemplate">
-    <div class="comment-container" data-bind="attr:{id: id}">
+    <div class="comment-container" data-bind="if: canSeeDeleted, attr:{id: id}">
 
         <div class="comment-body m-b-sm p-sm osf-box">
              <div data-bind="visible: loading">


### PR DESCRIPTION
## Purpose

Hide deleted comment unless user edit permissions on that comment.

## Changes

Filter deleted comments and only display delete comments user
can restore (has edit permissions)

## Ticket

[OSF-7290](https://openscience.atlassian.net/browse/OSF-7290)

## Before

<img width="489" alt="before" src="https://user-images.githubusercontent.com/4511563/28576373-d04d6f9c-7121-11e7-8102-75d731736d40.png">

## After

<img width="482" alt="after" src="https://user-images.githubusercontent.com/4511563/28576452-dd02e118-7121-11e7-80fc-95881ec95391.png">