### PR TITLE
Use Preprint object itself when initially requesting identifiers [OSF-8321]

### DIFF
--- a/osf/models/preprint_service.py
+++ b/osf/models/preprint_service.py
@@ -193,7 +193,7 @@ class PreprintService(DirtyFieldsMixin, GuidMixin, IdentifierMixin, BaseModel):
                 )
 
             # This should be called after all fields for EZID metadta have been set
-            enqueue_task(get_and_set_preprint_identifiers.s(self._id))
+            enqueue_task(get_and_set_preprint_identifiers.s(self))
 
         if save:
             self.node.save()

--- a/website/preprints/tasks.py
+++ b/website/preprints/tasks.py
@@ -108,10 +108,7 @@ def format_preprint(preprint):
 
 
 @celery_app.task(ignore_results=True)
-def get_and_set_preprint_identifiers(preprint_id):
-    from osf.models import PreprintService
-
-    preprint = PreprintService.load(preprint_id)
+def get_and_set_preprint_identifiers(preprint):
     ezid_response = request_identifiers_from_ezid(preprint)
     id_dict = parse_identifiers(ezid_response)
     preprint.set_identifier_values(doi=id_dict['doi'], ark=id_dict['ark'])


### PR DESCRIPTION

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Previously, when the Preprint was loaded from the database, since it was
unsaved the first time around the incorrect information was being passed
along to SHARE on first pass didn't include the new identifier
information.


## Changes

Use `preprint` in  `get_and_set_preprint_identifiers` instead of `preprint_id`

## Side effects

DOIs should get sent to SHARE the first time around now hopefully?


## Ticket
https://openscience.atlassian.net/browse/OSF-8321