### PR TITLE
[OSF-7620] In Fangorn, Github's [Open] button only points to the default branch

### DIFF
--- a/addons/github/static/githubFangornConfig.js
+++ b/addons/github/static/githubFangornConfig.js
@@ -300,7 +300,9 @@ var _githubItemButtons = {
 
 function changeBranch(item, ref){
     item.data.branch = ref;
-    item.data.urls.repo = item.data.urls.repo.substring(0, item.data.urls.repo.lastIndexOf('/tree/') + 1) + 'tree/' + ref;
+    var index = item.data.urls.repo.lastIndexOf('/tree/');
+    var branch_url = item.data.urls.repo.substring(0, index + 1);
+    item.data.urls.repo = branch_url + 'tree/' + ref;
     this.updateFolder(null, item);
 }
 

--- a/addons/github/static/githubFangornConfig.js
+++ b/addons/github/static/githubFangornConfig.js
@@ -300,6 +300,7 @@ var _githubItemButtons = {
 
 function changeBranch(item, ref){
     item.data.branch = ref;
+    item.data.urls.repo = item.data.urls.repo.substring(0, item.data.urls.repo.lastIndexOf('/tree/') + 1) + 'tree/' + ref;
     this.updateFolder(null, item);
 }
 


### PR DESCRIPTION
## Purpose

The "Open" button in for GitHub in fangorn always takes you to to the page for the default branch regardless of what branch you've selected in the dropdown menu. This PR sends you to the right page.

## Changes

Simple js one-line change updates repo url.

## Side effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/OSF-7620