### PR TITLE
[OSF-7619] Add Download-as-zip button to GitHub Fangorn interface

### DIFF
--- a/addons/github/static/githubFangornConfig.js
+++ b/addons/github/static/githubFangornConfig.js
@@ -220,6 +220,13 @@ var _githubItemButtons = {
                             icon: 'fa fa-trash',
                             className: 'text-danger'
                         }, 'Delete Folder'));
+                        buttons.push(
+                            m.component(Fangorn.Components.button, {
+                                onclick: function (event) { Fangorn.ButtonEvents._downloadZipEvent.call(tb, event, item); },
+                                icon: 'fa fa-download',
+                                className: 'text-primary'
+                            }, 'Download as zip')
+                        );
                     }
                 }
                 if (item.data.addonFullname) {


### PR DESCRIPTION
## Purpose

We flat out forgot to put a "Download As Zip" button in the GitHub Fangorn interface... Until now.

## Changes

The Download as zip is put in the GitHub Fangorn interface.

## Side effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/OSF-7619

## Before
<img width="1436" alt="screen shot 2017-08-07 at 4 58 37 pm" src="https://user-images.githubusercontent.com/9688518/29045495-c59379b4-7b91-11e7-8978-5b4d56f5ddc9.png">
<img width="1440" alt="screen shot 2017-08-07 at 4 58 16 pm" src="https://user-images.githubusercontent.com/9688518/29045496-c5964cd4-7b91-11e7-8bcc-12b302387145.png">


## After
<img width="1440" alt="screen shot 2017-08-07 at 4 49 08 pm" src="https://user-images.githubusercontent.com/9688518/29045524-dcfde0e4-7b91-11e7-8b77-e3eed4af637f.png">
<img width="1439" alt="screen shot 2017-08-07 at 5 06 29 pm" src="https://user-images.githubusercontent.com/9688518/29045781-cba9a52a-7b92-11e7-92e0-0eb411dff421.png">

