### PR TITLE
[hotfix] Chain tasks for preprint DOI minting and sending to SHARE [OSF-8321]

### DIFF
--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -292,7 +292,8 @@ class TestPreprintUpdate:
 
         assert not preprint.subjects.filter(_id=subject._id).exists()
 
-    def test_update_published(self, app, user):
+    @mock.patch('website.preprints.tasks.get_and_set_preprint_identifiers.si')
+    def test_update_published(self, mock_get_identifiers, app, user):
         unpublished = PreprintFactory(creator=user, is_published=False)
         url = '/{}preprints/{}/'.format(API_BASE, unpublished._id)
         payload = build_preprint_update_payload(unpublished._id, attributes={'is_published': True})

--- a/api_tests/preprints/views/test_preprint_list.py
+++ b/api_tests/preprints/views/test_preprint_list.py
@@ -141,7 +141,8 @@ class TestPreprintCreate(ApiTestCase):
 
         assert_equal(res.status_code, 201)
 
-    def test_create_preprint_from_private_project(self):
+    @mock.patch('website.preprints.tasks.get_and_set_preprint_identifiers.si')
+    def test_create_preprint_from_private_project(self, mock_create_identifiers):
         private_project_payload = build_preprint_create_payload(self.private_project._id, self.provider._id, self.file_one_private_project._id, attrs={
                 'subjects': [[SubjectFactory()._id]],
                 'is_published': True
@@ -259,7 +260,8 @@ class TestPreprintCreate(ApiTestCase):
         assert_equal(res.status_code, 400)
         assert_equal(res.json['errors'][0]['detail'], 'Cannot create a preprint from a deleted node.')
 
-    def test_create_preprint_adds_log_if_published(self):
+    @mock.patch('website.preprints.tasks.get_and_set_preprint_identifiers.si')
+    def test_create_preprint_adds_log_if_published(self, mock_get_identifiers):
         public_project_payload = build_preprint_create_payload(
             self.public_project._id,
             self.provider._id,
@@ -277,8 +279,9 @@ class TestPreprintCreate(ApiTestCase):
         assert_equal(log.action, 'preprint_initiated')
         assert_equal(log.params.get('preprint'), preprint_id)
 
-    @mock.patch('website.preprints.tasks.on_preprint_updated.s')
-    def test_create_preprint_from_project_published_hits_update(self, mock_on_preprint_updated):
+    @mock.patch('website.preprints.tasks.get_and_set_preprint_identifiers.si')
+    @mock.patch('website.preprints.tasks.on_preprint_updated.si')
+    def test_create_preprint_from_project_published_hits_update(self, mock_on_preprint_updated, mock_get_identifiers):
         private_project_payload = build_preprint_create_payload(self.private_project._id, self.provider._id, self.file_one_private_project._id, attrs={
                 'subjects': [[SubjectFactory()._id]],
                 'is_published': True
@@ -286,7 +289,7 @@ class TestPreprintCreate(ApiTestCase):
         res = self.app.post_json_api(self.url, private_project_payload, auth=self.user.auth)
         assert mock_on_preprint_updated.called
 
-    @mock.patch('website.preprints.tasks.on_preprint_updated.s')
+    @mock.patch('website.preprints.tasks.on_preprint_updated.si')
     def test_create_preprint_from_project_unpublished_does_not_hit_update(self, mock_on_preprint_updated):
         private_project_payload = build_preprint_create_payload(self.private_project._id, self.provider._id, self.file_one_private_project._id, attrs={
                 'subjects': [[SubjectFactory()._id]],

--- a/api_tests/preprints/views/test_preprint_list_mixin.py
+++ b/api_tests/preprints/views/test_preprint_list_mixin.py
@@ -138,7 +138,7 @@ class PreprintIsValidListMixin(object):
         res = self.app.get(self.url, auth=self.admin.auth)
         assert len(res.json['data']) == 0
 
-    @mock.patch('website.preprints.tasks.on_preprint_updated.s')
+    @mock.patch('website.preprints.tasks.on_preprint_updated.si')
     def test_preprint_node_null_invisible(self, mock_preprint_updated):
         self.preprint.node = None
         self.preprint.save()

--- a/osf/models/preprint_service.py
+++ b/osf/models/preprint_service.py
@@ -7,7 +7,7 @@ from django.utils import timezone
 from django.utils.functional import cached_property
 from django.contrib.contenttypes.fields import GenericRelation
 
-from framework.celery_tasks.handlers import enqueue_task
+from framework.postcommit_tasks.handlers import enqueue_postcommit_task
 from framework.exceptions import PermissionsError
 from osf.models import NodeLog, Subject
 from osf.models.validators import validate_subject_hierarchy
@@ -193,7 +193,7 @@ class PreprintService(DirtyFieldsMixin, GuidMixin, IdentifierMixin, BaseModel):
                 )
 
             # This should be called after all fields for EZID metadta have been set
-            enqueue_task(get_and_set_preprint_identifiers.s(self))
+            enqueue_postcommit_task(get_and_set_preprint_identifiers, (), {'preprint': self}, celery=True)
 
         if save:
             self.node.save()
@@ -229,5 +229,5 @@ class PreprintService(DirtyFieldsMixin, GuidMixin, IdentifierMixin, BaseModel):
         ret = super(PreprintService, self).save(*args, **kwargs)
 
         if (not first_save and 'is_published' in saved_fields) or self.is_published:
-            enqueue_task(on_preprint_updated.s(self._id))
+            enqueue_postcommit_task(on_preprint_updated, (self._id,), {}, celery=True)
         return ret

--- a/osf_tests/factories.py
+++ b/osf_tests/factories.py
@@ -556,7 +556,7 @@ class PreprintFactory(DjangoModelFactory):
 
     @classmethod
     def _create(cls, target_class, *args, **kwargs):
-        update_task_patcher = mock.patch('website.preprints.tasks.on_preprint_updated.s')
+        update_task_patcher = mock.patch('website.preprints.tasks.on_preprint_updated.si')
         update_task_patcher.start()
 
         finish = kwargs.pop('finish', True)
@@ -604,7 +604,7 @@ class PreprintFactory(DjangoModelFactory):
             if license_details:
                 instance.set_preprint_license(license_details, auth=auth)
 
-            create_task_patcher = mock.patch('website.preprints.tasks.get_and_set_preprint_identifiers.s')
+            create_task_patcher = mock.patch('website.preprints.tasks.get_and_set_preprint_identifiers.si')
             mock_create_identifier = create_task_patcher.start()
             if is_published:
                 mock_create_identifier.side_effect = sync_set_identifiers(instance)

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -311,7 +311,7 @@ class TestPreprintIdentifiers(OsfTestCase):
         self.auth = Auth(user=self.user)
         self.preprint = PreprintFactory(is_published=False, creator=self.user)
 
-    @mock.patch('website.preprints.tasks.get_and_set_preprint_identifiers.s')
+    @mock.patch('website.preprints.tasks.get_and_set_preprint_identifiers.si')
     def test_identifiers_task_called_on_publish(self, mock_get_and_set_identifiers):
         assert self.preprint.identifiers.count() == 0
         self.preprint.set_published(True, auth=self.auth, save=True)
@@ -582,37 +582,37 @@ class TestPreprintSaveShareHook(OsfTestCase):
         self.file = api_test_utils.create_test_file(self.project, self.admin, 'second_place.pdf')
         self.preprint = PreprintFactory(creator=self.admin, filename='second_place.pdf', provider=self.provider, subjects=[[self.subject._id]], project=self.project, is_published=False)
 
-    @mock.patch('website.preprints.tasks.on_preprint_updated.s')
+    @mock.patch('website.preprints.tasks.on_preprint_updated.si')
     def test_save_unpublished_not_called(self, mock_on_preprint_updated):
         self.preprint.save()
         assert not mock_on_preprint_updated.called
 
-    @mock.patch('website.preprints.tasks.on_preprint_updated.s')
+    @mock.patch('website.preprints.tasks.on_preprint_updated.si')
     def test_save_published_called(self, mock_on_preprint_updated):
         self.preprint.set_published(True, auth=self.auth, save=True)
         assert mock_on_preprint_updated.called
 
     # This covers an edge case where a preprint is forced back to unpublished
     # that it sends the information back to share
-    @mock.patch('website.preprints.tasks.on_preprint_updated.s')
+    @mock.patch('website.preprints.tasks.on_preprint_updated.si')
     def test_save_unpublished_called_forced(self, mock_on_preprint_updated):
         self.preprint.set_published(True, auth=self.auth, save=True)
         self.preprint.published = False
         self.preprint.save(**{'force_update': True})
         assert_equal(mock_on_preprint_updated.call_count, 2)
 
-    @mock.patch('website.preprints.tasks.on_preprint_updated.s')
+    @mock.patch('website.preprints.tasks.on_preprint_updated.si')
     def test_save_published_called(self, mock_on_preprint_updated):
         self.preprint.set_published(True, auth=self.auth, save=True)
         assert mock_on_preprint_updated.called
 
-    @mock.patch('website.preprints.tasks.on_preprint_updated.s')
+    @mock.patch('website.preprints.tasks.on_preprint_updated.si')
     def test_save_published_subject_change_called(self, mock_on_preprint_updated):
         self.preprint.is_published = True
         self.preprint.set_subjects([[self.subject_two._id]], auth=self.auth, save=True)
         assert mock_on_preprint_updated.called
 
-    @mock.patch('website.preprints.tasks.on_preprint_updated.s')
+    @mock.patch('website.preprints.tasks.on_preprint_updated.si')
     def test_save_unpublished_subject_change_not_called(self, mock_on_preprint_updated):
         self.preprint.set_subjects([[self.subject_two._id]], auth=self.auth, save=True)
         assert not mock_on_preprint_updated.called


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Celery tasks for minting a new DOI and then sending to SHARE were grouped so one was happening before the other was ready. 

## Changes

- Chain the two tasks together so that one executes after the other!

## Side effects

None anticipated


## Ticket
https://openscience.atlassian.net/browse/OSF-8321