### PR TITLE
[OSF-8307] Add tests for sitemap generation.

### DIFF
--- a/scripts/generate_sitemap.py
+++ b/scripts/generate_sitemap.py
@@ -161,7 +161,7 @@ class Sitemap(object):
         for obj in objs:
             try:
                 config = settings.SITEMAP_USER_CONFIG
-                config['loc'] = urlparse.urljoin(settings.DOMAIN, '/{}'.format(obj))
+                config['loc'] = urlparse.urljoin(settings.DOMAIN, '/{}/'.format(obj))
                 self.add_url(config)
             except Exception as e:
                 self.log_errors('USER', obj, e)
@@ -177,7 +177,7 @@ class Sitemap(object):
         for obj in objs:
             try:
                 config = settings.SITEMAP_NODE_CONFIG
-                config['loc'] = urlparse.urljoin(settings.DOMAIN, obj['guids___id'])
+                config['loc'] = urlparse.urljoin(settings.DOMAIN, '/{}/'.format(obj['guids___id']))
                 config['lastmod'] = obj['date_modified'].strftime('%Y-%m-%d')
                 self.add_url(config)
             except Exception as e:

--- a/scripts/generate_sitemap.py
+++ b/scripts/generate_sitemap.py
@@ -156,12 +156,12 @@ class Sitemap(object):
         progress.stop()
 
         # User urls
-        objs = OSFUser.objects.filter(is_active=True).values_list('guids___id', flat=True)
+        objs = OSFUser.objects.filter(is_active=True)
         progress.start(objs.count(), 'USER: ')
         for obj in objs:
             try:
                 config = settings.SITEMAP_USER_CONFIG
-                config['loc'] = urlparse.urljoin(settings.DOMAIN, '/{}/'.format(obj))
+                config['loc'] = urlparse.urljoin(settings.DOMAIN, obj.url)
                 self.add_url(config)
             except Exception as e:
                 self.log_errors('USER', obj, e)
@@ -171,14 +171,14 @@ class Sitemap(object):
         # AbstractNode urls (Nodes and Registrations, no Collections)
         objs = (AbstractNode.objects
             .filter(is_public=True, is_deleted=False, retraction_id__isnull=True)
-            .exclude(type="osf.collection")
-            .values('guids___id', 'date_modified'))
+            .exclude(type="osf.collection"))
+
         progress.start(objs.count(), 'NODE: ')
         for obj in objs:
             try:
                 config = settings.SITEMAP_NODE_CONFIG
-                config['loc'] = urlparse.urljoin(settings.DOMAIN, obj['guids___id'])
-                config['lastmod'] = obj['date_modified'].strftime('%Y-%m-%d')
+                config['loc'] = urlparse.urljoin(settings.DOMAIN, obj.url)
+                config['lastmod'] = obj.date_modified.strftime('%Y-%m-%d')
                 self.add_url(config)
             except Exception as e:
                 self.log_errors('NODE', obj['guids___id'], e)

--- a/scripts/generate_sitemap.py
+++ b/scripts/generate_sitemap.py
@@ -156,12 +156,12 @@ class Sitemap(object):
         progress.stop()
 
         # User urls
-        objs = OSFUser.objects.filter(is_active=True)
+        objs = OSFUser.objects.filter(is_active=True).values_list('guids___id', flat=True)
         progress.start(objs.count(), 'USER: ')
         for obj in objs:
             try:
                 config = settings.SITEMAP_USER_CONFIG
-                config['loc'] = urlparse.urljoin(settings.DOMAIN, obj.url)
+                config['loc'] = urlparse.urljoin(settings.DOMAIN, '/{}/'.format(obj))
                 self.add_url(config)
             except Exception as e:
                 self.log_errors('USER', obj, e)
@@ -171,14 +171,14 @@ class Sitemap(object):
         # AbstractNode urls (Nodes and Registrations, no Collections)
         objs = (AbstractNode.objects
             .filter(is_public=True, is_deleted=False, retraction_id__isnull=True)
-            .exclude(type="osf.collection"))
-
+            .exclude(type="osf.collection")
+            .values('guids___id', 'date_modified'))
         progress.start(objs.count(), 'NODE: ')
         for obj in objs:
             try:
                 config = settings.SITEMAP_NODE_CONFIG
-                config['loc'] = urlparse.urljoin(settings.DOMAIN, obj.url)
-                config['lastmod'] = obj.date_modified.strftime('%Y-%m-%d')
+                config['loc'] = urlparse.urljoin(settings.DOMAIN, obj['guids___id'])
+                config['lastmod'] = obj['date_modified'].strftime('%Y-%m-%d')
                 self.add_url(config)
             except Exception as e:
                 self.log_errors('NODE', obj['guids___id'], e)

--- a/scripts/generate_sitemap.py
+++ b/scripts/generate_sitemap.py
@@ -161,7 +161,7 @@ class Sitemap(object):
         for obj in objs:
             try:
                 config = settings.SITEMAP_USER_CONFIG
-                config['loc'] = urlparse.urljoin(settings.DOMAIN, '/{}/'.format(obj))
+                config['loc'] = urlparse.urljoin(settings.DOMAIN, '/{}'.format(obj))
                 self.add_url(config)
             except Exception as e:
                 self.log_errors('USER', obj, e)

--- a/scripts/tests/test_generate_sitemap.py
+++ b/scripts/tests/test_generate_sitemap.py
@@ -1,0 +1,86 @@
+import pytest
+
+import shutil, tempfile, xml, os
+from urlparse import urljoin
+from website import settings
+from scripts.generate_sitemap import main
+from osf_tests.factories import AuthUserFactory, PreprintProviderFactory, PreprintFactory, ProjectFactory, \
+    RegistrationFactory, CollectionFactory
+
+@pytest.mark.django_db
+class TestGenerateSitemap:
+
+    def test_all_links_are_included(self):
+        # Create temporary directory for the sitemaps to be generated
+        self.temp_dir = tempfile.mkdtemp()
+
+        # Set static folder to the path of temp_dir, so that the generator would store the sitemaps under
+        # <path_to_temp_dir>/sitemaps/
+        settings.STATIC_FOLDER = self.temp_dir
+
+        # Test setup
+        user_1 = AuthUserFactory()
+        user_2 = AuthUserFactory()
+        project_1 = ProjectFactory(creator=user_1)
+        project_2 = ProjectFactory(creator=user_2)
+        registration_1 = RegistrationFactory(project=project_1, creator=user_1, is_public=True)
+        registration_2 = RegistrationFactory(project=project_2, creator=user_2, is_public=True)
+        provider_1 = PreprintProviderFactory(_id='osf', name='osfprovider')
+        provider_2 = PreprintProviderFactory(_id='adl', name="anotherprovider")
+        preprint_1 = PreprintFactory(provider=provider_1, project=project_1, creator=user_1)
+        preprint_2 = PreprintFactory(provider=provider_2, project=project_2, creator=user_2)
+
+        # Constructed list of urls that should be included
+        list_of_urls = [urljoin(settings.DOMAIN, item['loc']) for item in settings.SITEMAP_STATIC_URLS]
+        list_of_urls.extend([urljoin(settings.DOMAIN, user_1._id), urljoin(settings.DOMAIN, user_2._id)])
+        list_of_urls.extend([urljoin(settings.DOMAIN, project_1._id),
+                               urljoin(settings.DOMAIN, project_2._id),
+                               urljoin(settings.DOMAIN, registration_1._id),
+                               urljoin(settings.DOMAIN, registration_2._id)])
+        list_of_urls.extend([settings.DOMAIN + 'preprints/' + preprint_1._id + '/',
+                             settings.DOMAIN + 'preprints/' + provider_2._id + '/' + preprint_2._id + '/'])
+
+        url_preprint_file_1 = os.path.join(
+                            settings.DOMAIN,
+                            'project',
+                            preprint_1.node._id,   # Parent node id
+                            'files',
+                            'osfstorage',
+                            preprint_1.primary_file._id,  # Preprint file deep_url
+                            '?action=download'
+                        )
+
+        url_preprint_file_2 = os.path.join(
+                            settings.DOMAIN,
+                            'project',
+                            preprint_2.node._id,   # Parent node id
+                            'files',
+                            'osfstorage',
+                            preprint_2.primary_file._id,  # Preprint file deep_url
+                            '?action=download'
+                        )
+
+        list_of_urls.extend([url_preprint_file_1, url_preprint_file_2])
+
+        # Run the script
+        main()
+
+        # Parse the generated XML sitemap file
+        with open(self.temp_dir + '/sitemaps' + '/sitemap_0.xml') as f:
+            tree = xml.etree.ElementTree.parse(f)
+
+        # Get all the urls in the sitemap
+        # Note: namespace was defined in the XML file, therefore necessary to include in tag
+        namespace = '{http://www.sitemaps.org/schemas/sitemap/0.9}'
+        urls = [element.text for element in tree.iter(namespace + 'loc')]
+
+        #assert list_of_static_links in urls
+        for items in list_of_urls:
+            print(items)
+
+        print("=========")
+
+        for items in urls:
+            print(items)
+
+        assert set(list_of_urls) == set(urls)

--- a/scripts/tests/test_generate_sitemap.py
+++ b/scripts/tests/test_generate_sitemap.py
@@ -74,13 +74,4 @@ class TestGenerateSitemap:
         namespace = '{http://www.sitemaps.org/schemas/sitemap/0.9}'
         urls = [element.text for element in tree.iter(namespace + 'loc')]
 
-        #assert list_of_static_links in urls
-        for items in list_of_urls:
-            print(items)
-
-        print("=========")
-
-        for items in urls:
-            print(items)
-
         assert set(list_of_urls) == set(urls)

--- a/scripts/tests/test_generate_sitemap.py
+++ b/scripts/tests/test_generate_sitemap.py
@@ -32,11 +32,11 @@ class TestGenerateSitemap:
 
         # Constructed list of urls that should be included
         list_of_urls = [urljoin(settings.DOMAIN, item['loc']) for item in settings.SITEMAP_STATIC_URLS]
-        list_of_urls.extend([urljoin(settings.DOMAIN, user_1._id), urljoin(settings.DOMAIN, user_2._id)])
-        list_of_urls.extend([urljoin(settings.DOMAIN, project_1._id),
-                               urljoin(settings.DOMAIN, project_2._id),
-                               urljoin(settings.DOMAIN, registration_1._id),
-                               urljoin(settings.DOMAIN, registration_2._id)])
+        list_of_urls.extend([urljoin(settings.DOMAIN, user_1.url), urljoin(settings.DOMAIN, user_2.url)])
+        list_of_urls.extend([urljoin(settings.DOMAIN, project_1.url),
+                             urljoin(settings.DOMAIN, project_2.url),
+                             urljoin(settings.DOMAIN, registration_1.url),
+                             urljoin(settings.DOMAIN, registration_2.url)])
         list_of_urls.extend([settings.DOMAIN + 'preprints/' + preprint_1._id + '/',
                              settings.DOMAIN + 'preprints/' + provider_2._id + '/' + preprint_2._id + '/'])
 

--- a/scripts/tests/test_generate_sitemap.py
+++ b/scripts/tests/test_generate_sitemap.py
@@ -32,11 +32,11 @@ class TestGenerateSitemap:
 
         # Constructed list of urls that should be included
         list_of_urls = [urljoin(settings.DOMAIN, item['loc']) for item in settings.SITEMAP_STATIC_URLS]
-        list_of_urls.extend([urljoin(settings.DOMAIN, user_1.url), urljoin(settings.DOMAIN, user_2.url)])
-        list_of_urls.extend([urljoin(settings.DOMAIN, project_1.url),
-                             urljoin(settings.DOMAIN, project_2.url),
-                             urljoin(settings.DOMAIN, registration_1.url),
-                             urljoin(settings.DOMAIN, registration_2.url)])
+        list_of_urls.extend([urljoin(settings.DOMAIN, user_1._id), urljoin(settings.DOMAIN, user_2._id)])
+        list_of_urls.extend([urljoin(settings.DOMAIN, project_1._id),
+                             urljoin(settings.DOMAIN, project_2._id),
+                             urljoin(settings.DOMAIN, registration_1._id),
+                             urljoin(settings.DOMAIN, registration_2._id)])
         list_of_urls.extend([settings.DOMAIN + 'preprints/' + preprint_1._id + '/',
                              settings.DOMAIN + 'preprints/' + provider_2._id + '/' + preprint_2._id + '/'])
 
@@ -93,7 +93,7 @@ class TestGenerateSitemap:
 
         # Create a collection, whose link should not be included in the sitemap
         collection = CollectionFactory()
-        collection_link = urljoin(settings.DOMAIN, collection.url)
+        collection_link = urljoin(settings.DOMAIN, collection._id)
 
         # Run the script
         main()


### PR DESCRIPTION
## Purpose

This PR aims to add unit tests to the sitemap generation script.

## Changes

scripts/generate_sitemap.py is changed so that the url method for nodes and users are used to generate links.

test_generate_sitemap.py is added as unit tests.

## Side effects



## Ticket

https://openscience.atlassian.net/browse/OSF-8307