### PR TITLE
[feature fix] admin provider import export [OSF-8236]

### DIFF
--- a/admin/preprint_providers/urls.py
+++ b/admin/preprint_providers/urls.py
@@ -6,6 +6,7 @@ urlpatterns = [
     url(r'^$', views.PreprintProviderList.as_view(), name='list'),
     url(r'^create/$', views.CreatePreprintProvider.as_view(), name='create'),
     url(r'^import/$', views.ImportPreprintProvider.as_view(), name='import'),
+    url(r'^(?P<preprint_provider_id>[a-z0-9]+)/import/$', views.ImportPreprintProvider.as_view(), name='import'),
     url(r'^get_subjects/$', views.SubjectDynamicUpdateView.as_view(), name='get_subjects'),
     url(r'^get_descendants/$', views.GetSubjectDescendants.as_view(), name='get_descendants'),
     url(r'^rules_to_subjects/$', views.RulesToSubjects.as_view(), name='rules_to_subjects'),

--- a/admin/preprint_providers/views.py
+++ b/admin/preprint_providers/views.py
@@ -179,7 +179,7 @@ class ExportPreprintProvider(PermissionRequiredMixin, View):
         return response
 
     def serialize_subjects(self, provider):
-        if provider._id != "osf":
+        if provider._id != 'osf':
             result = {}
             result['include'] = []
             result['exclude'] = []
@@ -235,7 +235,7 @@ class ImportPreprintProvider(PermissionRequiredMixin, View):
             # make sure not to import an exported access token for SHARE
             cleaned_result = {key: value for key, value in file_json['fields'].iteritems() if key not in FIELDS_TO_NOT_IMPORT_EXPORT}
             preprint_provider = self.create_or_update_provider(cleaned_result)
-            return redirect('preprint_providers:detail', preprint_provider_id = preprint_provider.id)
+            return redirect('preprint_providers:detail', preprint_provider_id=preprint_provider.id)
 
     def parse_file(self, f):
         parsed_file = ''

--- a/admin/preprint_providers/views.py
+++ b/admin/preprint_providers/views.py
@@ -4,11 +4,12 @@ import json
 
 from django.core import serializers
 from django.core.urlresolvers import reverse_lazy
-from django.http import HttpResponse, JsonResponse, HttpResponseRedirect
+from django.http import HttpResponse, JsonResponse
 from django.views.generic import ListView, DetailView, View, CreateView, DeleteView, TemplateView, UpdateView
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.forms.models import model_to_dict
 from django.shortcuts import redirect
+
 from modularodm import Q
 from modularodm.exceptions import NoResultsFound
 
@@ -21,7 +22,6 @@ from osf.models.preprint_provider import rules_to_subjects
 # When preprint_providers exclusively use Subject relations for creation, set this to False
 SHOW_TAXONOMIES_IN_PREPRINT_PROVIDER_CREATE = True
 FIELDS_TO_NOT_IMPORT_EXPORT = ['access_token', 'share_source']
-MANY_TO_MANY_FIELDS = ['subjects_acceptable', 'licenses_acceptable', 'default_license']
 
 
 class PreprintProviderList(PermissionRequiredMixin, ListView):
@@ -170,15 +170,27 @@ class ExportPreprintProvider(PermissionRequiredMixin, View):
         data = serializers.serialize('json', [preprint_provider])
         cleaned_data = json.loads(data)[0]
         cleaned_fields = {key: value for key, value in cleaned_data['fields'].iteritems() if key not in FIELDS_TO_NOT_IMPORT_EXPORT}
-        # Change licenses from ID to name
         cleaned_fields['licenses_acceptable'] = [license.license_id for license in preprint_provider.licenses_acceptable.all()]
-        #TODO: Update subject serialization????
+        cleaned_fields['subjects'] = self.serialize_subjects(preprint_provider)
         cleaned_data['fields'] = cleaned_fields
         filename = '{}_export.json'.format(preprint_provider.name)
         response = HttpResponse(json.dumps(cleaned_data), content_type='text/json')
         response['Content-Disposition'] = 'attachment; filename={}'.format(filename)
         return response
 
+    def serialize_subjects(self, provider):
+        if provider._id != "osf":
+            result = {}
+            result['include'] = []
+            result['exclude'] = []
+            result['custom'] = {
+                subject.text: {
+                    'parent': subject.parent.text if subject.parent else '',
+                    'bepress': subject.bepress_subject.text
+                }
+                for subject in provider.subjects.all()
+            }
+            return result
 
 class DeletePreprintProvider(PermissionRequiredMixin, DeleteView):
     permission_required = 'osf.delete_preprintprovider'
@@ -223,7 +235,7 @@ class ImportPreprintProvider(PermissionRequiredMixin, View):
             # make sure not to import an exported access token for SHARE
             cleaned_result = {key: value for key, value in file_json['fields'].iteritems() if key not in FIELDS_TO_NOT_IMPORT_EXPORT}
             preprint_provider = self.create_or_update_provider(cleaned_result)
-            return HttpResponseRedirect("/preprint_providers/" + str(preprint_provider.id))
+            return redirect('preprint_providers:detail', preprint_provider_id = preprint_provider.id)
 
     def parse_file(self, f):
         parsed_file = ''
@@ -231,7 +243,6 @@ class ImportPreprintProvider(PermissionRequiredMixin, View):
             parsed_file += str(chunk)
         return parsed_file
 
-    # I thought license ids worked nicely here, but we can use names instead if desired
     def get_license(self, license_id):
         try:
             license = NodeLicense.find_one(Q('license_id', 'eq', license_id))
@@ -239,26 +250,36 @@ class ImportPreprintProvider(PermissionRequiredMixin, View):
             raise Exception('License: "{}" not found'.format(license_id))
         return license
 
+    def get_page_provider(self):
+        page_provider_id = self.kwargs.get('preprint_provider_id', '')
+        if page_provider_id:
+            return PreprintProvider.objects.get(id=page_provider_id)
+
+    def add_subjects(self, provider, subject_data):
+        from osf.management.commands.populate_custom_taxonomies import migrate
+        migrate(provider._id, subject_data)
+
     def create_or_update_provider(self, provider_data):
-        provider = PreprintProvider.load(provider_data['_id'])
+        provider = self.get_page_provider()
         licenses = [self.get_license(license_id) for license_id in provider_data.pop('licenses_acceptable', [])]
         default_license = provider_data.pop('default_license', False)
-        #TODO: Deal with stubjects here
-        # If I do something about subjects here I won't have to use simple_provider_data
-        simple_provider_data = {key: value for key, value in provider_data.iteritems() if key not in MANY_TO_MANY_FIELDS}
+        subject_data = provider_data.pop('subjects', False)
 
         if provider:
-            for key, val in simple_provider_data.iteritems():
+            for key, val in provider_data.iteritems():
                 setattr(provider, key, val)
         else:
-            provider = PreprintProvider(**simple_provider_data)
+            provider = PreprintProvider(**provider_data)
 
         provider.save()
 
         if licenses:
-            provider.licenses_acceptable.add(*licenses)
+            provider.licenses_acceptable = licenses
         if default_license:
             provider.default_license = self.get_license(default_license)
+        # Only adds the JSON taxonomy if there is no existing taxonomy data
+        if subject_data and not provider.subjects.count():
+            self.add_subjects(provider, subject_data)
         return provider
 
 

--- a/admin/templates/preprint_providers/update_preprint_provider_form.html
+++ b/admin/templates/preprint_providers/update_preprint_provider_form.html
@@ -97,7 +97,7 @@
             <h4>Import from JSON</h4>
             <p>Choose a JSON file that has been previously exported from another Preprint Provider detail page. This will
                 pre-populate the Preprint Provider change form with those details.</p>
-            <form id="import-form" action = {% url 'preprint_providers:import' %} method="post" enctype="multipart/form-data">
+            <form action = {% url 'preprint_providers:import' %} method="post" enctype="multipart/form-data">
                 {% csrf_token %}
                 {{ import_form.as_p }}
                 <input class="form-button" type="submit" value="Import" />

--- a/admin/templates/preprint_providers/update_preprint_provider_form.html
+++ b/admin/templates/preprint_providers/update_preprint_provider_form.html
@@ -97,7 +97,11 @@
             <h4>Import from JSON</h4>
             <p>Choose a JSON file that has been previously exported from another Preprint Provider detail page. This will
                 pre-populate the Preprint Provider change form with those details.</p>
-            <form action = {% url 'preprint_providers:import' %} method="post" enctype="multipart/form-data">
+            {% if preprint_provider %}
+                <form action = {% url 'preprint_providers:import' preprint_provider_id=preprint_provider.id %} method="post" enctype="multipart/form-data" >
+            {% else %}
+                <form action = {% url 'preprint_providers:import' %} method="post" enctype="multipart/form-data" >
+            {% endif %}
                 {% csrf_token %}
                 {{ import_form.as_p }}
                 <input class="form-button" type="submit" value="Import" />

--- a/admin_tests/preprint_providers/test_views.py
+++ b/admin_tests/preprint_providers/test_views.py
@@ -13,7 +13,7 @@ from osf_tests.factories import (
     PreprintFactory,
     SubjectFactory,
 )
-from osf.models import PreprintProvider
+from osf.models import PreprintProvider, NodeLicense
 from admin_tests.utilities import setup_form_view, setup_user_view
 from admin.preprint_providers import views
 from admin.preprint_providers.forms import PreprintProviderForm
@@ -213,7 +213,7 @@ class TestPreprintProviderExportImport(AdminTestCase):
         self.import_view = views.ImportPreprintProvider()
         self.import_view = setup_user_view(self.import_view, self.import_request, user=self.user)
 
-        self.preprint_provider.licenses_acceptable = [self.import_view.get_license('NONE')]
+        self.preprint_provider.licenses_acceptable = [NodeLicense.objects.get(license_id='NONE')]
         self.subject = SubjectFactory(provider=self.preprint_provider)
 
     def test_post(self):
@@ -230,14 +230,14 @@ class TestPreprintProviderExportImport(AdminTestCase):
             nt.assert_not_in(field, content_dict['fields'].keys())
 
     def test_export_to_import_new_provider(self):
-        update_taxonomies('bepress_taxonomy.json')
+        update_taxonomies('test_bepress_taxonomy.json')
 
         res = self.view.get(self.request)
         content_dict = json.loads(res.content)
 
         content_dict['fields']['_id'] = 'new_id'
-        file = StringIO(u'' + json.dumps(content_dict))
-        self.import_request.FILES['file'] = InMemoryUploadedFile(file, None, 'data', 'application/json', 500, None, {})
+        data = StringIO(unicode(json.dumps(content_dict), 'utf-8'))
+        self.import_request.FILES['file'] = InMemoryUploadedFile(data, None, 'data', 'application/json', 500, None, {})
 
         res = self.import_view.post(self.import_request)
 
@@ -262,14 +262,14 @@ class TestPreprintProviderExportImport(AdminTestCase):
         new_subject_data['custom'] = {
             'TestSubject1': {
                 'parent': '',
-                'bepress': 'Kinesiology'
+                'bepress': 'Law'
             }
         }
 
         content_dict['fields']['subjects'] = json.dumps(new_subject_data)
         content_dict['fields']['licenses_acceptable'] = ['CCBY']
-        file = StringIO(u'' + json.dumps(content_dict))
-        self.import_request.FILES['file'] = InMemoryUploadedFile(file, None, 'data', 'application/json', 500, None, {})
+        data = StringIO(unicode(json.dumps(content_dict), 'utf-8'))
+        self.import_request.FILES['file'] = InMemoryUploadedFile(data, None, 'data', 'application/json', 500, None, {})
 
         res = self.import_view.post(self.import_request)
 

--- a/admin_tests/preprint_providers/test_views.py
+++ b/admin_tests/preprint_providers/test_views.py
@@ -1,7 +1,10 @@
 import json
+from io import StringIO
 
 from nose import tools as nt
 from django.test import RequestFactory
+from django.core.files.uploadedfile import InMemoryUploadedFile
+from scripts.update_taxonomies import update_taxonomies
 
 from tests.base import AdminTestCase
 from osf_tests.factories import (
@@ -193,9 +196,9 @@ class TestPreprintProviderChangeForm(AdminTestCase):
         nt.assert_equal(new_provider.advisory_board, stripped_advisory_board)
 
 
-class TestPreprintProviderExport(AdminTestCase):
+class TestPreprintProviderExportImport(AdminTestCase):
     def setUp(self):
-        super(TestPreprintProviderExport, self).setUp()
+        super(TestPreprintProviderExportImport, self).setUp()
 
         self.user = AuthUserFactory()
         self.preprint_provider = PreprintProviderFactory()
@@ -205,6 +208,13 @@ class TestPreprintProviderExport(AdminTestCase):
         self.view = setup_user_view(self.view, self.request, user=self.user)
 
         self.view.kwargs = {'preprint_provider_id': self.preprint_provider.id}
+
+        self.import_request = RequestFactory().get('/fake_path')
+        self.import_view = views.ImportPreprintProvider()
+        self.import_view = setup_user_view(self.import_view, self.import_request, user=self.user)
+
+        self.preprint_provider.licenses_acceptable = [self.import_view.get_license('NONE')]
+        self.subject = SubjectFactory(provider=self.preprint_provider)
 
     def test_post(self):
         res = self.view.get(self.request)
@@ -218,6 +228,59 @@ class TestPreprintProviderExport(AdminTestCase):
         content_dict = json.loads(res.content)
         for field in views.FIELDS_TO_NOT_IMPORT_EXPORT:
             nt.assert_not_in(field, content_dict['fields'].keys())
+
+    def test_export_to_import_new_provider(self):
+        update_taxonomies('bepress_taxonomy.json')
+
+        res = self.view.get(self.request)
+        content_dict = json.loads(res.content)
+
+        content_dict['fields']['_id'] = 'new_id'
+        file = StringIO(u'' + json.dumps(content_dict))
+        self.import_request.FILES['file'] = InMemoryUploadedFile(file, None, 'data', 'application/json', 500, None, {})
+
+        res = self.import_view.post(self.import_request)
+
+        provider_id = ''.join([i for i in res.url if i.isdigit()])
+        new_provider = PreprintProvider.objects.get(id=provider_id)
+
+        nt.assert_equal(res.status_code, 302)
+        nt.assert_equal(new_provider._id, 'new_id')
+        nt.assert_equal(new_provider.subjects.all().count(), 1)
+        nt.assert_equal(new_provider.licenses_acceptable.all().count(), 1)
+        nt.assert_equal(new_provider.subjects.all()[0].text, self.subject.text)
+        nt.assert_equal(new_provider.licenses_acceptable.all()[0].license_id, 'NONE')
+
+    def test_update_provider_existing_subjects(self):
+        # If there are existing subjects for a provider, imported subjects are ignored
+        self.import_view.kwargs = {'preprint_provider_id': self.preprint_provider.id}
+
+        res = self.view.get(self.request)
+        content_dict = json.loads(res.content)
+
+        new_subject_data = {'include': [], 'exclude': []}
+        new_subject_data['custom'] = {
+            'TestSubject1': {
+                'parent': '',
+                'bepress': 'Kinesiology'
+            }
+        }
+
+        content_dict['fields']['subjects'] = json.dumps(new_subject_data)
+        content_dict['fields']['licenses_acceptable'] = ['CCBY']
+        file = StringIO(u'' + json.dumps(content_dict))
+        self.import_request.FILES['file'] = InMemoryUploadedFile(file, None, 'data', 'application/json', 500, None, {})
+
+        res = self.import_view.post(self.import_request)
+
+        new_provider_id = int(''.join([i for i in res.url if i.isdigit()]))
+
+        nt.assert_equal(res.status_code, 302)
+        nt.assert_equal(new_provider_id, self.preprint_provider.id)
+        nt.assert_equal(self.preprint_provider.subjects.all().count(), 1)
+        nt.assert_equal(self.preprint_provider.licenses_acceptable.all().count(), 1)
+        nt.assert_equal(self.preprint_provider.subjects.all()[0].text, self.subject.text)
+        nt.assert_equal(self.preprint_provider.licenses_acceptable.all()[0].license_id, 'CCBY')
 
 
 class TestCreatePreprintProvider(AdminTestCase):

--- a/osf/management/commands/populate_custom_taxonomies.py
+++ b/osf/management/commands/populate_custom_taxonomies.py
@@ -1,8 +1,7 @@
 import json
 import logging
 
-import django
-django.setup()
+
 from django.core.management.base import BaseCommand
 from django.db import transaction
 

--- a/osf/management/commands/populate_custom_taxonomies.py
+++ b/osf/management/commands/populate_custom_taxonomies.py
@@ -1,7 +1,6 @@
 import json
 import logging
 
-
 from django.core.management.base import BaseCommand
 from django.db import transaction
 

--- a/website/static/test_bepress_taxonomy.json
+++ b/website/static/test_bepress_taxonomy.json
@@ -1,0 +1,1 @@
+{"data": ["Arts and Humanities_Philosophy_History of Philosophy", "Law_Animal Law", "Law_Consumer Protection Law", "Arts and Humanities_Religion_Missions and World Christianity"]}


### PR DESCRIPTION
## Purpose

Branded preprint provider taxonomies and licenses were not exporting/importing correctly between the staging and production admin app. 

## Changes

This changes subjects and licenses so they are looked up by name rather than by ID.

## Side effects

Due to custom taxonomies (and how hard it would be to update them), when attempting to update a preprint provider, if subjects for that provider already exist, the subjects from the import json will be ignored.

## Ticket

https://openscience.atlassian.net/browse/OSF-8236

