### PR TITLE
[hotfix] - NodeLog query performance improvements [OSF-8288]

### DIFF
--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -99,7 +99,7 @@ from api.wikis.serializers import NodeWikiSerializer
 from framework.auth.oauth_scopes import CoreScopes
 from framework.postcommit_tasks.handlers import enqueue_postcommit_task
 from osf.models import AbstractNode
-from osf.models import (Node, PrivateLink, NodeLog, Institution, Comment, DraftRegistration, PreprintService)
+from osf.models import (Node, PrivateLink, Institution, Comment, DraftRegistration, PreprintService)
 from osf.models import OSFUser as User
 from osf.models import NodeRelation, AlternativeCitation, Guid
 from osf.models import BaseFileNode
@@ -2501,7 +2501,7 @@ class NodeAlternativeCitationDetail(JSONAPIBaseView, generics.RetrieveUpdateDest
         self.get_node().remove_citation(get_user_auth(self.request), instance, save=True)
 
 
-class NodeLogList(JSONAPIBaseView, generics.ListAPIView, NodeMixin, ODMFilterMixin):
+class NodeLogList(JSONAPIBaseView, generics.ListAPIView, NodeMixin, ListFilterMixin):
     """List of Logs associated with a given Node. *Read-only*.
 
     <!--- Copied Description from NodeLogDetail -->
@@ -2629,13 +2629,15 @@ class NodeLogList(JSONAPIBaseView, generics.ListAPIView, NodeMixin, ODMFilterMix
         ExcludeWithdrawals
     )
 
-    def get_default_odm_query(self):
+    def get_default_queryset(self):
         auth = get_user_auth(self.request)
-        query = self.get_node().get_aggregate_logs_query(auth)
-        return query
+        queryset = self.get_node().get_aggregate_logs_queryset(auth)
+        return queryset
 
     def get_queryset(self):
-        queryset = NodeLog.find(self.get_query_from_request()).select_related('node', 'original_node', 'user')
+        queryset = self.get_queryset_from_request().include(
+            'node__guids', 'user__guids', 'original_node__guids', limit_includes=10
+        )
         return queryset
 
 

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -5,6 +5,7 @@ import re
 import urlparse
 import warnings
 
+from django.db.models import Q
 from dirtyfields import DirtyFieldsMixin
 from django.apps import apps
 from django.contrib.contenttypes.fields import GenericRelation
@@ -42,7 +43,7 @@ from osf.models.spam import SpamMixin
 from osf.models.tag import Tag
 from osf.models.user import OSFUser
 from osf.models.validators import validate_doi, validate_title
-from osf.modm_compat import Q
+from osf.modm_compat import Q as MODMQ
 from osf.utils.auth import Auth, get_user
 from osf.utils.datetime_aware_jsonfield import DateTimeAwareJSONField
 from osf.utils.fields import NonNaiveDateTimeField
@@ -687,7 +688,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
 
     @classmethod
     def find_by_institutions(cls, inst, query=None):
-        base_query = Q('affiliated_institutions', 'eq', inst)
+        base_query = MODMQ('affiliated_institutions', 'eq', inst)
         if query:
             final_query = base_query & query
         else:
@@ -778,15 +779,17 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
 
     def get_aggregate_logs_query(self, auth):
         return (
-            (   # TODO: remove `list` call during phase 2
-                Q('node_id', 'in', list(Node.objects.get_children(self).can_view(user=auth.user, private_link=auth.private_link).values_list('id', flat=True))) |
-                Q('node_id', 'eq', self.id)
-            ) & Q('should_hide', 'eq', False)
+            (
+                Q(node_id__in=list(Node.objects.get_children(self).can_view(user=auth.user, private_link=auth.private_link).values_list('id', flat=True))) |
+                Q(node_id=self.id)
+            ) & Q(should_hide=False)
         )
 
     def get_aggregate_logs_queryset(self, auth):
         query = self.get_aggregate_logs_query(auth)
-        return NodeLog.find(query).order_by('-date')
+        return NodeLog.objects.filter(query).order_by('-date').include(
+            'node__guids', 'user__guids', 'original_node__guids', limit_includes=10
+        )
 
     def get_absolute_url(self):
         return self.absolute_api_v2_url
@@ -1419,7 +1422,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
 
     @classmethod
     def find_for_user(cls, user, subquery=None):
-        combined_query = Q('contributors', 'eq', user)
+        combined_query = MODMQ('contributors', 'eq', user)
         if subquery is not None:
             combined_query = combined_query & subquery
         return cls.find(combined_query)

--- a/osf/models/nodelog.py
+++ b/osf/models/nodelog.py
@@ -1,3 +1,5 @@
+from include import IncludeManager
+
 from django.apps import apps
 from django.db import models
 from django.utils import timezone
@@ -14,6 +16,8 @@ class NodeLog(ObjectIDMixin, BaseModel):
         'user': 'user__guids___id',
         'original_node': 'original_node__guids___id'
     }
+
+    objects = IncludeManager()
 
     DATE_FORMAT = '%m/%d/%Y %H:%M UTC'
 


### PR DESCRIPTION

## Purpose

The query for NodeLogs is a little slow - let's make that a little faster!

## Changes

- Update the NodeLog view to use django queries
- Use the `IncludeManager` for `NodeLog` objects and on API queries

## Side effects
None anticipated


## Ticket
https://openscience.atlassian.net/browse/OSF-8288