### PR TITLE
[RFR]Update line that was pointing to the erstwhile ./website/addons now .…

### DIFF
--- a/website/static/js/tests/tests.webpack.js
+++ b/website/static/js/tests/tests.webpack.js
@@ -10,5 +10,5 @@ var context = require.context('.', true, /.*test\.js$/); //make sure you have yo
 context.keys().forEach(context);
 
 // Include all files in the addons directory that end with .test.js
-var addonContext = require.context('../../../addons/', true, /.*test\.js$/); //make sure you have your directory and regex test set correctly!
+var addonContext = require.context('../../../../addons/', true, /.*test\.js$/); //make sure you have your directory and regex test set correctly!
 addonContext.keys().forEach(addonContext);


### PR DESCRIPTION
No ticket. Found issue while debugging another issue.

## Purpose

Fix Karma tests

## Changes

One line in website/static/js/tests/tests.webpack.js was pointing to ./website/addons which is now no more. However, many/most developers may still have ./website/addons/*/*/*.local.py s in their environments. Which has masked this issue.

## Side effects

None


## Ticket
No ticket. Found issue while debugging another issue.
