### PR TITLE
Feature/shorten contributor logs [OSF-8346]

### DIFF
--- a/website/static/js/components/logFeed.js
+++ b/website/static/js/components/logFeed.js
@@ -220,7 +220,7 @@ var LogFeed = {
                     image = m('img', { src : item.embeds.user.errors[0].meta.profile_image});
                 }
                 return m('.db-activity-item', [
-                    m('', [m('.db-log-avatar.m-r-xs', image), m.component(LogText, item)]),
+                    m('', [m('.db-log-avatar.m-r-xs', image), m.component(LogText.LogText, item)]),
                     m('.text-right', m('span.text-muted.m-r-xs', item.attributes.formattableDate.local))
                 ]);
             }) : '',

--- a/website/static/js/logTextParser.js
+++ b/website/static/js/logTextParser.js
@@ -715,4 +715,7 @@ var LogPieces = {
     }
 };
 
-module.exports = LogText;
+module.exports = {
+    LogText:LogText,
+    getContributorList: getContributorList
+};

--- a/website/static/js/logTextParser.js
+++ b/website/static/js/logTextParser.js
@@ -220,25 +220,37 @@ var LogPieces = {
         view: function (ctrl, logObject) {
             var contributors = logObject.attributes.params.contributors;
             if(paramIsReturned(contributors, logObject)) {
-                return m('span', contributors.map(function(item, index, arr){
-                    var comma = ' ';
-                    if(index !== arr.length - 1){
-                        comma = ', ';
-                    }
-                    if(index === arr.length-2){
-                        comma = ' and ';
-                    }
+                return m('span', (function (){
+                    var contribList = [];
+                    var numContribShown = 15;
 
-                    if (item.active) {
-                        return [ m('a', {href: '/' + item.id + '/'}, item.full_name), comma];
-                    }
-                    else {
-                        if (item.unregistered_name) {
-                            return [item.unregistered_name, comma];
+                    var justOneMore = numContribShown === contributors.length -1;
+                    for(var i = 0; i < contributors.length; i++){
+                        var item = contributors[i];
+                        var comma = ' ';
+                        if(i !== contributors.length -1 && ((i !== numContribShown -1) || justOneMore)){
+                            comma = ', ';
                         }
-                        return [item.full_name, comma];
-                    }
-                }));
+                        if(i === contributors.length -2 || ((i === numContribShown -1) && !justOneMore)){
+                            comma = ' and ';
+                        }
+
+                        if (i === numContribShown && !justOneMore){
+                            contribList.push([((contributors.length - i).toString() + ' others'), '']);
+                            return contribList;
+                        }
+
+                        if (item.active) {
+                            contribList.push([ m('a', {href: '/' + item.id + '/'}, item.full_name), comma]);
+                        }
+                        else {
+                            if (item.unregistered_name) {
+                                contribList.push([item.unregistered_name, comma]);
+                            }
+                            contribList.push([item.full_name, comma]);
+                    }}
+                    return contribList;
+                }()));
             }
             return m('span', 'some users');
         }

--- a/website/static/js/logTextParser.js
+++ b/website/static/js/logTextParser.js
@@ -101,7 +101,9 @@ var returnTextParams = function (param, text, logObject, view_url) {
  * Returns a list of contributors to show in log as well as the trailing punctuation/text after each contributor.
  * If a contributor has a OSF profile, contributor is returned as a mithril link to user.
  * @param contributors {string} The list of contributors (OSF users or unregistered)
- * @returns [[]]
+ * @param maxShown {int} the number of contributors shown before saying "and # others"
+ * Note: if there is only 1 over maxShown, all contributors are shown
+ * @returns {array}
  */
 var getContributorList = function (contributors, maxShown){
        var contribList = [];

--- a/website/static/js/logTextParser.js
+++ b/website/static/js/logTextParser.js
@@ -13,6 +13,10 @@ var lodashGet = require('lodash.get');
 
 var ravenMessagesCache = []; // Cache messages to avoid sending multiple times in one page view
 var nodeCategories = require('json!built/nodeCategories.json');
+
+//Used when calling getContributorList to limit the number of contributors shown in a single log when many are mentioned
+var numContributorsShown = 3;
+
 /**
  * Utility function to not repeat logging errors to Sentry
  * @param message {String} Custom message for error
@@ -91,6 +95,42 @@ var returnTextParams = function (param, text, logObject, view_url) {
         return view_url ? m('a', {href: $osf.toRelativeUrl(view_url, window)}, source) : m('span', source);
     }
     return m('span', text);
+};
+
+/**
+ * Returns a list of contributors to show in log as well as the trailing punctuation/text after each contributor.
+ * If a contributor has a OSF profile, contributor is returned as a mithril link to user.
+ * @param contributors {string} The list of contributors (OSF users or unregistered)
+ * @returns [[]]
+ */
+var getContributorList = function (contributors, maxShown){
+       var contribList = [];
+       var justOneMore = numContributorsShown === contributors.length -1;
+       for(var i = 0; i < contributors.length; i++){
+           var item = contributors[i];
+           var comma = ' ';
+           if(i !== contributors.length -1 && ((i !== maxShown -1) || justOneMore)){
+               comma = ', ';
+           }
+           if(i === contributors.length -2 || ((i === maxShown -1) && !justOneMore)){
+               comma = ' and ';
+           }
+
+           if (i === maxShown && !justOneMore){
+               contribList.push([((contributors.length - i).toString() + ' others'), '']);
+               return contribList;
+           }
+
+           if (item.active) {
+               contribList.push([ m('a', {href: '/' + item.id + '/'}, item.full_name), comma]);
+           }
+           else {
+               if (item.unregistered_name) {
+                   contribList.push([item.unregistered_name, comma]);
+               }
+               contribList.push([item.full_name, comma]);
+       }}
+       return contribList;
 };
 
 var LogText = {
@@ -220,37 +260,7 @@ var LogPieces = {
         view: function (ctrl, logObject) {
             var contributors = logObject.attributes.params.contributors;
             if(paramIsReturned(contributors, logObject)) {
-                return m('span', (function (){
-                    var contribList = [];
-                    var numContribShown = 15;
-
-                    var justOneMore = numContribShown === contributors.length -1;
-                    for(var i = 0; i < contributors.length; i++){
-                        var item = contributors[i];
-                        var comma = ' ';
-                        if(i !== contributors.length -1 && ((i !== numContribShown -1) || justOneMore)){
-                            comma = ', ';
-                        }
-                        if(i === contributors.length -2 || ((i === numContribShown -1) && !justOneMore)){
-                            comma = ' and ';
-                        }
-
-                        if (i === numContribShown && !justOneMore){
-                            contribList.push([((contributors.length - i).toString() + ' others'), '']);
-                            return contribList;
-                        }
-
-                        if (item.active) {
-                            contribList.push([ m('a', {href: '/' + item.id + '/'}, item.full_name), comma]);
-                        }
-                        else {
-                            if (item.unregistered_name) {
-                                contribList.push([item.unregistered_name, comma]);
-                            }
-                            contribList.push([item.full_name, comma]);
-                    }}
-                    return contribList;
-                }()));
+                return m('span', getContributorList(contributors, numContributorsShown));
             }
             return m('span', 'some users');
         }

--- a/website/static/js/logTextParser.js
+++ b/website/static/js/logTextParser.js
@@ -115,7 +115,7 @@ var getContributorList = function (contributors, maxShown){
                comma = ', ';
            }
            if(i === contributors.length -2 || ((i === maxShown -1) && !justOneMore)){
-               comma = ' and ';
+               comma = ', and ';
            }
 
            if (i === maxShown && !justOneMore){

--- a/website/static/js/myProjects.js
+++ b/website/static/js/myProjects.js
@@ -1908,7 +1908,7 @@ var ActivityLogs = {
                 }
                 return m('.db-activity-item', [
                 m('', [ m('.db-log-avatar.m-r-xs', image),
-                    m.component(LogText, item)]),
+                    m.component(LogText.LogText, item)]),
                 m('.text-right', m('span.text-muted.m-r-xs', item.attributes.formattableDate.local))]);
 
             }) : '',

--- a/website/static/js/tests/logTextParser.test.js
+++ b/website/static/js/tests/logTextParser.test.js
@@ -1,0 +1,38 @@
+/*global describe, it, expect, example, before, after, beforeEach, afterEach, mocha, sinon*/
+'use strict';
+var assert = require('chai').assert;
+var LogText = require('js/logTextParser');
+var faker = require('faker');
+
+//In this case, we don't care if id's are all the same
+var makeFakeContributor = function(active=true){
+    return {
+        name: faker.name.findName(),
+        id: 'a1234',
+        active: active
+    };
+};
+
+describe('logTextParser', () => {
+    describe('getContributorList', () => {
+        var contributors = [];
+        for (var i = 0; i<10; i++) {
+            contributors.push(makeFakeContributor());
+        }
+        it('displays all contributors if under maxShown limit', () => {
+            var logText = LogText.getContributorList(contributors, 11);
+            assert.equal(logText.length, 10);
+        });
+        it('displays all contributors if only one over maxShown limit', () => {
+            var logText = LogText.getContributorList(contributors, 9);
+            assert.equal(logText.length, 10);
+
+        });
+        it('displays only up to maxShown limit', () => {
+            var logText = LogText.getContributorList(contributors, 3);
+            assert.equal(logText.length, 4);
+            assert.equal(logText[3][0], '7 others');
+
+        });
+    });
+});


### PR DESCRIPTION
## Purpose

If many contributors are added at one, they make the log entry very long.

## Changes
This changes the contributor added log text is created so that it only shows 3-4 contributors. If there are 4 it shows them all normally if there are 5 or more it shows 3 of the contributor names and then text that states "and 2 others."

## Side effects
I had to change the exports of `logTextParser` from a single export to a dictionary. This means that `LogText` will need to be grabbed by name any time it is used instead of just by importing `logTextParser`. The in most cases this change will look like this `LogText.LogText` instead of just `LogText` (depending on how the import is named).

## Notes
Could easily make it so it always just says "and <#> other(s) added" but this seemed cleaner.

## Ticket
https://openscience.atlassian.net/browse/OSF-8346

19 contributors added
<img width="561" alt="19 added" src="https://user-images.githubusercontent.com/7839433/28875932-62d13ed6-7765-11e7-9d05-6240003a5c46.png">

17 contributors added
<img width="561" alt="17 added" src="https://user-images.githubusercontent.com/7839433/28875933-62d7370a-7765-11e7-9e40-c0e915edfdfd.png">

16 contributors added
<img width="558" alt="16 added" src="https://user-images.githubusercontent.com/7839433/28875934-62f5ae38-7765-11e7-9de5-a21b7d3ab227.png">

6 contributors added (normal log stuff still works)
<img width="560" alt="6 added" src="https://user-images.githubusercontent.com/7839433/28878120-4ff5a750-776c-11e7-9f45-778c039c914b.png">



