### PR TITLE
[OSF-8323] Incorrect error message is shown for Dataverse 500 error

### DIFF
--- a/addons/dataverse/static/dataverseNodeConfig.js
+++ b/addons/dataverse/static/dataverseNodeConfig.js
@@ -297,7 +297,7 @@ ViewModel.prototype.setInfo = function() {
     }).fail(function(xhr, textStatus, error) {
         self.submitting(false);
         var errorMessage = (xhr.status === 410) ? self.messages.datasetDeaccessioned :
-            (xhr.status = 406) ? self.messages.forbiddenCharacters : self.messages.setDatasetError;
+            (xhr.status === 406) ? self.messages.forbiddenCharacters : self.messages.setDatasetError;
         self.changeMessage(errorMessage, 'text-danger');
         Raven.captureMessage('Could not authenticate with Dataverse', {
             extra: {


### PR DESCRIPTION
## Purpose

When attempting to connect to a Dataset in Dataverse, when you receive a 500 it's always displayed as an "illegal character error". This fix makes sure the error is properly displayed.

## Changes

One line fix of simple code typo

## Side effects

None that I know of.

## Tests

Can't think of any relevant tests.

## Ticket

https://openscience.atlassian.net/browse/OSF-8323