### PR TITLE
[OSF-8357] Remove dict as default args

### DIFF
--- a/api_tests/preprints/views/test_preprint_list.py
+++ b/api_tests/preprints/views/test_preprint_list.py
@@ -20,7 +20,11 @@ from tests.base import ApiTestCase, capture_signals
 from website.project import signals as project_signals
 from website.util import permissions
 
-def build_preprint_create_payload(node_id=None, provider_id=None, file_id=None, attrs={}):
+def build_preprint_create_payload(node_id=None, provider_id=None, file_id=None, attrs=None):
+
+    if not attrs:
+        attrs = {}
+
     payload = {
         "data": {
             "attributes": attrs,

--- a/osf/models/external.py
+++ b/osf/models/external.py
@@ -371,7 +371,7 @@ class ExternalProvider(object):
         """
         pass
 
-    def refresh_oauth_key(self, force=False, extra={}, resp_auth_token_key='access_token',
+    def refresh_oauth_key(self, force=False, extra=None, resp_auth_token_key='access_token',
                           resp_refresh_token_key='refresh_token', resp_expiry_fn=None):
         """Handles the refreshing of an oauth_key for account associated with this provider.
            Not all addons need to use this, as some do not have oauth_keys that expire.
@@ -388,6 +388,10 @@ class ExternalProvider(object):
         datetime-formatted oauth_key expiry key, given a successful refresh response from
         `auto_refresh_url`. A default using 'expires_at' as a key is provided.
         """
+
+        if not extra:
+            extra = {}
+
         # Ensure this is an authenticated Provider that uses token refreshing
         if not (self.account and self.auto_refresh_url):
             return False

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -18,6 +18,7 @@ HTTPretty==0.8.14
 # Syntax checking
 flake8==2.4.0
 flake8-quotes==0.3.0
+flake8-mutable==1.2.0
 
 # Avoid eating cpu with live reloading
 watchdog==0.8.3

--- a/website/util/sanitize.py
+++ b/website/util/sanitize.py
@@ -5,7 +5,7 @@ import json
 import bleach
 
 
-def strip_html(unclean, tags=[]):
+def strip_html(unclean, tags=None):
     """Sanitize a string, removing (as opposed to escaping) HTML tags
 
     :param unclean: A string to be stripped of HTML tags
@@ -13,6 +13,9 @@ def strip_html(unclean, tags=[]):
     :return: stripped string
     :rtype: str
     """
+    if not tags:
+        tags = []
+
     # We make this noop for non-string, non-collection inputs so this function can be used with higher-order
     # functions, such as rapply (recursively applies a function to collections)
     if not isinstance(unclean, basestring) and not is_iterable(unclean) and unclean is not None:


### PR DESCRIPTION
## Purpose

When it comes to Python using dicts as default args there's some weird behavior. The dict used as a default arg is used every time that method is called, potentially growing and retaining old information, here's an example.
```

In [1]: def dict_leaks(label, attrs={}):
    attrs[label] = "alive!"
    print('{}'.format(attrs))

In [2]:  dict_leaks("dog")
{'dog': 'alive!'}

In [3]: dict_leaks("cat")
{'dog': 'alive!', 'cat': 'alive!'}
```

So pretty sneaky and bad.

## Changes

I removed the instances of default dict arguments and changed the code so dicts are freshly instantiated. 

## Side effects

None that I know of.

## Test 

Would be nice if we could test for this but it would have to apply to all python code on the site to be meaningful.

## Ticket

https://openscience.atlassian.net/browse/OSF-8357