### PR TITLE
Update default ordering for NodeAddonList and UserAddonList [OSF-8359] [OSF-8347]

### DIFF
--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -2237,8 +2237,6 @@ class NodeAddonFolderList(JSONAPIBaseView, generics.ListAPIView, NodeMixin, Addo
     view_category = 'nodes'
     view_name = 'node-addon-folders'
 
-    ordering = ('-date_modified',)
-
     def get_queryset(self):
         # TODO: [OSF-6120] refactor this/NS models to be generalizable
         node_addon = self.get_addon_settings()

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -2058,7 +2058,7 @@ class NodeAddonList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin, Node
     view_category = 'nodes'
     view_name = 'node-addons'
 
-    ordering = ('-date_modified',)
+    ordering = ('-id',)
 
     def get_default_queryset(self):
         qs = []

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -314,7 +314,7 @@ class UserAddonList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin, User
     view_category = 'users'
     view_name = 'user-addons'
 
-    ordering = ('-date_last_refreshed',)
+    ordering = ('-id',)
 
     def get_queryset(self):
         qs = [addon for addon in self.get_user().get_addons() if 'accounts' in addon.config.configs]


### PR DESCRIPTION

## Purpose

`NodeAddonList` and `UserAddonList` don't currently have dates to be ordered by by default, switch those to `id` . 

Remove default ordering from addon folder list, as wasn't working with ODM filtering.

Worked on in conjuction with @TomBaxter !

## Changes

- update ordering on `NodeAddonList`
- update ordering on `UserAddonList`
- remove default ordering from `NodeAddonFolderList`

## Side effects

None anticipated

## Ticket
https://openscience.atlassian.net/browse/OSF-8359
https://openscience.atlassian.net/browse/OSF-8347
