### PR TITLE
[feature] Check saved_fields before updating institution in search [No ticket]

### DIFF
--- a/osf/models/institution.py
+++ b/osf/models/institution.py
@@ -109,13 +109,13 @@ class Institution(DirtyFieldsMixin, Loggable, base.ObjectIDMixin, base.BaseModel
         from website.search.search import update_institution, update_node
         from website.search.exceptions import SearchUnavailableError
 
-        try:
-            update_institution(self)
-        except SearchUnavailableError as e:
-            logger.exception(e)
-
         saved_fields = self.get_dirty_fields()
         if saved_fields and bool(self.pk):
+            try:
+                update_institution(self)
+            except SearchUnavailableError as e:
+                logger.exception(e)
+
             for node in self.nodes.filter(is_deleted=False):
                 try:
                     update_node(node, async=False)


### PR DESCRIPTION
#### Purpose
- From [discussion with @sloria](https://github.com/CenterForOpenScience/osf.io/pull/7477#pullrequestreview-53857522): only update an institution in search if it has changed (i.e. check `saved_fields` first).
