### PR TITLE
[OSF-8339] Fix API 502s when refreshing github metadata

### DIFF
--- a/osf/models/files.py
+++ b/osf/models/files.py
@@ -445,7 +445,7 @@ class File(models.Model):
                 break
         else:
             # Insert into history if there is no matching etag
-            if data.get('modified'):
+            if data.get('modified') and None not in [ item['modified'] for item in self.history ]:
                 utils.insort(self.history, data, lambda x: x['modified'])
             # If modified not included in the metadata, insert at the end of the history
             else:

--- a/osf/models/files.py
+++ b/osf/models/files.py
@@ -14,6 +14,7 @@ from typedmodels.models import TypedModel, TypedModelManager
 from include import IncludeManager
 
 from framework.analytics import get_basic_counters
+from framework import sentry
 from osf.models.base import BaseModel, OptionalGuidMixin, ObjectIDMixin
 from osf.models.comment import CommentableMixin
 from osf.models.mixins import Taggable
@@ -441,15 +442,12 @@ class File(models.Model):
             version.save()
             self.versions.add(version)
         for entry in self.history:
+            if data['modified'] is not None and data['modified'] < entry['modified']:
+                sentry.log_message('update() receives metatdata older than the newest entry in file history.')
             if ('etag' in entry and 'etag' in data) and (entry['etag'] == data['etag']):
                 break
         else:
-            # Insert into history if there is no matching etag
-            if data.get('modified') and None not in [item['modified'] for item in self.history]:
-                utils.insort(self.history, data, lambda x: x['modified'])
-            # If modified not included in the metadata, insert at the end of the history
-            else:
-                self.history.append(data)
+            self.history.append(data)
 
         # Finally update last touched
         self.last_touched = timezone.now()

--- a/osf/models/files.py
+++ b/osf/models/files.py
@@ -445,7 +445,7 @@ class File(models.Model):
                 break
         else:
             # Insert into history if there is no matching etag
-            if data.get('modified') and None not in [ item['modified'] for item in self.history ]:
+            if data.get('modified') and None not in [item['modified'] for item in self.history]:
                 utils.insort(self.history, data, lambda x: x['modified'])
             # If modified not included in the metadata, insert at the end of the history
             else:

--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -888,6 +888,19 @@ class TestAddonFileViews(OsfTestCase):
         assert_equal(len(file_node.history), 1)
         assert_equal(file_node.history[0], file_data)
 
+    @mock.patch('website.archiver.tasks.archive')
+    def test_missing_modified_date_in_file_history(self, mock_archive):
+        file_node = self.get_test_file()
+        file_node.history.append({'modified': None})
+        file_data = {
+            'name': 'Test File Update',
+            'materialized': file_node.materialized_path,
+            'modified': None
+        }
+        file_node.update(revision=None, data=file_data)
+        assert_equal(len(file_node.history), 2)
+        assert_equal(file_node.history[1], file_data)
+
 
 class TestLegacyViews(OsfTestCase):
 


### PR DESCRIPTION
## Purpose

This PR complements [this PR](https://github.com/CenterForOpenScience/osf.io/pull/6835) as a fix for #6062 .

## Changes
Suppose a github file name `README.md` exists for a repo connected to an OSF project, the `update()` method for this GithubFile would be called to update the file history when the following api v2 endpoints are called:
1. /nodes/<project_guid>/files/github
2. /nodes/<project_guid>/files/github/README.md

For the first endpoint, waterbutler would update the file history by passing a new entry (a dict whose value for key `modified` is `None`) to the `update()` method. For the second endpoint, however, waterbutler would do so with a dict whose value for `modified` is the actual time of modification.
Therefore, when `insort()` is called to insert the new data from waterbutler as a history entry, comparisons between existing entries and the data would be made to determine where the order of the new entry in the list. If the first api v2 endpoint is called, because the value for `modified` is `None`, a TypeError would be thrown. The [previous PR](https://github.com/CenterForOpenScience/osf.io/pull/6835) fix this problem by only sort in a new entry with `modified` is not None, otherwise, it simply append the new entry to the end of file history. It does not fix the situation when an entry with `modified==None` is already in the file history.

To fix this problem thoroughly, a change is implemented to check for value of `modified` for all file history entires. If one of the entry has an undefined `modified` value, it would also append the new entry to the end of the file history.

Notes for reproducing this bug:
1. Commit a file on a Github Repo linked to a project.
2. Visit the api at `/nodes/<project-guid>/files/github`
3. Commit to the same file again.
4. Visit the api at `/nodes/<project_guid>/files/github/<filename>`

## Side effects

Similar side effects to https://github.com/CenterForOpenScience/osf.io/pull/6835.


## Ticket

https://openscience.atlassian.net/browse/OSF-8339