### PR TITLE
[#OSF-8154]Institutions pages: registrations missing contrib names

### DIFF
--- a/api/institutions/views.py
+++ b/api/institutions/views.py
@@ -26,6 +26,7 @@ from api.base.exceptions import RelationshipPostMakesNoChanges
 from api.nodes.serializers import NodeSerializer
 from api.nodes.filters import NodesFilterMixin
 from api.users.serializers import UserSerializer
+from api.registrations.serializers import RegistrationSerializer
 
 from api.institutions.authentication import InstitutionAuthentication
 from api.institutions.serializers import InstitutionSerializer, InstitutionNodesRelationshipSerializer
@@ -224,7 +225,7 @@ class InstitutionAuth(JSONAPIBaseView, generics.CreateAPIView):
 class InstitutionRegistrationList(InstitutionNodeList):
     """Registrations have selected an institution as their primary institution.
     """
-
+    serializer_class = RegistrationSerializer
     view_name = 'institution-registrations'
 
     base_node_query = (


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Fix the problem registrations of institutions missing contrib names
<!-- Describe the purpose of your changes -->

## Changes
Before change:
when you go to any institution page and click on all registration, you will see no contributors for registrations
After change:
Contributors will show up for all institution registrations.
<!-- Briefly describe or list your changes  -->

## Side effects

<!--Any possible side effects? -->


## Ticket
https://openscience.atlassian.net/browse/OSF-8154
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
