### PR TITLE
Fix typo in Subject sidebar view [OSF-8284]

### DIFF
--- a/admin/templates/base.html
+++ b/admin/templates/base.html
@@ -171,7 +171,7 @@
           {% if perms.osf.view_metrics %}
             <li><a href="{% url 'metrics:metrics' %}"><i class='fa fa-link'></i> <span>OSF Metrics</span></a></li>
           {% endif %}
-          {% if perms.osf.view_subjects%}
+          {% if perms.osf.view_subject%}
             <li><a href="{% url 'subjects:list' %}"><i class='fa fa-link'></i> <span>OSF Subjects</span></a></li>
           {% endif %}
           </ul><!-- /.sidebar-menu -->


### PR DESCRIPTION
[#OSF-8284]

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Users with the view subject permission were still unable to see the subjects link in the sidebar because of a misspelled subject permission check -- it should not be plural.

## Changes
- actually add correct permission in sidebar

## Side effects
I really really really need better proofreading skills


## Ticket
https://openscience.atlassian.net/browse/OSF-8284