### PR TITLE
[Hotfix] Allow nus users [OSF-8198]

### DIFF
--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -1336,7 +1336,6 @@ BLACKLISTED_DOMAINS = [
     'nowhere.org',
     'nowmymail.com',
     'nurfuerspam.de',
-    'nus.edu.sg',
     'nwldx.com',
     'objectmail.com',
     'obobbo.com',


### PR DESCRIPTION
## Purpose

Allow adding NUS users as contributors

## Changes

Remove nus.edu.sg from blacklisted domains

## Ticket

[OSF-8198](https://openscience.atlassian.net/browse/OSF-8198)
