### PR TITLE
[OSF-7927] View-only link returns 403 for add-on files

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -623,7 +623,9 @@ class RelationshipField(ser.HyperlinkedIdentityField):
                         else:
                             url = None
 
-                    url = extend_querystring_if_key_exists(url, self.context['request'], 'view_only')
+                    if url:
+                        url = extend_querystring_if_key_exists(url, self.context['request'],
+                                                               'view_only')
                     urls[view_name] = url
 
         if not urls['self'] and not urls['related']:

--- a/api/nodes/utils.py
+++ b/api/nodes/utils.py
@@ -28,7 +28,10 @@ def get_file_object(node, path, provider, request):
     if not node.get_addon(provider) or not node.get_addon(provider).configured:
         raise NotFound('The {} provider is not configured for this project.'.format(provider))
 
-    url = waterbutler_api_url_for(node._id, provider, path, _internal=True, meta=True)
+    view_only = request.query_params.get('view_only', default=None)
+    url = waterbutler_api_url_for(node._id, provider, path, _internal=True,
+                                  meta=True, view_only=view_only)
+
     waterbutler_request = requests.get(
         url,
         cookies=request.COOKIES,


### PR DESCRIPTION
[#OSF-7927]

## Purpose

View only link API requests to api.nodes.views.NodeFilesList are failing because 'view_only' kwarg s not being passed.

Add 'view_only' kwarg to WB request, if present in OSF request.

## Changes

Update api/nodes/views.py class NodeFilesList

Check for 'view_only' in request.query_params and pass to waterbutler_api_url_for if found.

Added test api_tests/nodes/views/test_node_files_list.py::TestNodeFilesList::test_vol_node_files_list

## Side effects

None


## Ticket

[OSF-7927](https://openscience.atlassian.net/browse/OSF-7927)
