### PR TITLE
[OSF-8007] Cancel changes button on admin preprint config

### DIFF
--- a/admin/static/js/preprint_providers/preprintProviders.js
+++ b/admin/static/js/preprint_providers/preprintProviders.js
@@ -100,6 +100,12 @@ $(document).ready(function() {
             });
         }
     });
+    $("#discard").click(function(e) {
+        e.preventDefault();
+        if (window.confirm('Are you sure want to discard all your changes?')) {
+            location.reload(true);
+        }
+    });
 
     $("#show-modify-form").click(function() {
 

--- a/admin/templates/preprint_providers/update_preprint_provider_form.html
+++ b/admin/templates/preprint_providers/update_preprint_provider_form.html
@@ -90,6 +90,7 @@
             </div>
             {% endif %}
             <input class="form-button" type="submit" value="Save" />
+            <a id="discard" class="btn btn-danger form-button">Discard</a>
         </form>
     </div>
     <div class="col-md-3">


### PR DESCRIPTION
## Purpose

When modifying preprint info on the admin page there's no way of discarding your changes, even if you restart the page everything is cached and your likely to forget your initial configuration. This fix gives the user a hard refresh in the form of a Discard button.

## Changes

Add a new discard buttom with a js prompt that restarts the page without a cache.

## Side effects

None that I know of.

## Before

<img width="1440" alt="screen shot 2017-08-08 at 11 36 52 am" src="https://user-images.githubusercontent.com/9688518/29080506-ed9794d0-7c2d-11e7-8b49-d30488bdf089.png">

## After 

![admin_page_cancel_btn](https://user-images.githubusercontent.com/9688518/29080546-062995ca-7c2e-11e7-893b-91973e7ae7b9.gif)



## Ticket

https://openscience.atlassian.net/browse/OSF-8007