### PR TITLE
feature/fixes to preprint provider import export[OSF-8236]

### DIFF
--- a/admin/preprint_providers/views.py
+++ b/admin/preprint_providers/views.py
@@ -18,7 +18,8 @@ from osf.models.preprint_provider import rules_to_subjects
 
 # When preprint_providers exclusively use Subject relations for creation, set this to False
 SHOW_TAXONOMIES_IN_PREPRINT_PROVIDER_CREATE = True
-FIELDS_TO_NOT_IMPORT_EXPORT = ['access_token', 'share_source', 'subjects_acceptable']
+#TODO: Add subjects back in when custom taxonomies are fully integrated
+FIELDS_TO_NOT_IMPORT_EXPORT = ['access_token', 'share_source', 'subjects_acceptable', 'subjects']
 
 
 class PreprintProviderList(PermissionRequiredMixin, ListView):

--- a/admin/preprint_providers/views.py
+++ b/admin/preprint_providers/views.py
@@ -18,7 +18,7 @@ from osf.models.preprint_provider import rules_to_subjects
 
 # When preprint_providers exclusively use Subject relations for creation, set this to False
 SHOW_TAXONOMIES_IN_PREPRINT_PROVIDER_CREATE = True
-FIELDS_TO_NOT_IMPORT_EXPORT = ['access_token', 'share_source']
+FIELDS_TO_NOT_IMPORT_EXPORT = ['access_token', 'share_source', 'subjects_acceptable']
 
 
 class PreprintProviderList(PermissionRequiredMixin, ListView):
@@ -168,6 +168,7 @@ class ExportPreprintProvider(PermissionRequiredMixin, View):
         cleaned_data = json.loads(data)[0]
         cleaned_fields = {key: value for key, value in cleaned_data['fields'].iteritems() if key not in FIELDS_TO_NOT_IMPORT_EXPORT}
         cleaned_fields['licenses_acceptable'] = [node_license.license_id for node_license in preprint_provider.licenses_acceptable.all()]
+        cleaned_fields['default_license'] = preprint_provider.default_license.license_id if preprint_provider.default_license else ''
         cleaned_fields['subjects'] = self.serialize_subjects(preprint_provider)
         cleaned_data['fields'] = cleaned_fields
         filename = '{}_export.json'.format(preprint_provider.name)
@@ -237,7 +238,7 @@ class ImportPreprintProvider(PermissionRequiredMixin, View):
     def parse_file(self, f):
         parsed_file = ''
         for chunk in f.chunks():
-            parsed_file += str(chunk)
+            parsed_file += chunk.decode('utf-8')
         return parsed_file
 
     def get_page_provider(self):

--- a/admin_tests/preprint_providers/test_views.py
+++ b/admin_tests/preprint_providers/test_views.py
@@ -246,9 +246,9 @@ class TestPreprintProviderExportImport(AdminTestCase):
 
         nt.assert_equal(res.status_code, 302)
         nt.assert_equal(new_provider._id, 'new_id')
-        nt.assert_equal(new_provider.subjects.all().count(), 1)
+        # nt.assert_equal(new_provider.subjects.all().count(), 1)
         nt.assert_equal(new_provider.licenses_acceptable.all().count(), 1)
-        nt.assert_equal(new_provider.subjects.all()[0].text, self.subject.text)
+        # nt.assert_equal(new_provider.subjects.all()[0].text, self.subject.text)
         nt.assert_equal(new_provider.licenses_acceptable.all()[0].license_id, 'NONE')
 
     def test_update_provider_existing_subjects(self):
@@ -277,9 +277,9 @@ class TestPreprintProviderExportImport(AdminTestCase):
 
         nt.assert_equal(res.status_code, 302)
         nt.assert_equal(new_provider_id, self.preprint_provider.id)
-        nt.assert_equal(self.preprint_provider.subjects.all().count(), 1)
+        # nt.assert_equal(self.preprint_provider.subjects.all().count(), 1)
         nt.assert_equal(self.preprint_provider.licenses_acceptable.all().count(), 1)
-        nt.assert_equal(self.preprint_provider.subjects.all()[0].text, self.subject.text)
+        # nt.assert_equal(self.preprint_provider.subjects.all()[0].text, self.subject.text)
         nt.assert_equal(self.preprint_provider.licenses_acceptable.all()[0].license_id, 'CCBY')
 
 


### PR DESCRIPTION
## Purpose

My [PR](https://github.com/CenterForOpenScience/osf.io/pull/7521/) for fixing preprint provider import export did not work correctly on staging. 

## Changes

This PR removes taxonomy import/export and fixes some unicode and licenses problems. 

## Side effects

Importing/Exporting taxonomies will continue to not work.

## Testing Nodes
Subjects should not change on import. A future ticket will fix this. If you are creating a new preprint provider it will assume the default - which is the full bepress taxonomy.

## Ticket
https://openscience.atlassian.net/browse/OSF-8236
