### PR TITLE
[OSF-8083] Read-only contributors should be able to unauthorize addons connected to their external accounts

### DIFF
--- a/addons/base/generic_views.py
+++ b/addons/base/generic_views.py
@@ -113,7 +113,7 @@ def set_config(addon_short_name, addon_full_name, Serializer, set_folder):
 def deauthorize_node(addon_short_name):
     @must_not_be_registration
     @must_have_addon(addon_short_name, 'node')
-    @must_have_permission(permissions.WRITE)
+    @must_be_addon_authorizer(addon_short_name)
     def _deauthorize_node(auth, node_addon, **kwargs):
         node_addon.deauthorize(auth=auth)
         node_addon.save()

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -260,8 +260,8 @@ def node_setting(auth, node, **kwargs):
 
     addons_enabled = []
     addon_enabled_settings = []
-
     addons = list(node.get_addons())
+
     for addon in addons:
         addons_enabled.append(addon.config.short_name)
         if 'node' in addon.config.configs:
@@ -270,6 +270,10 @@ def node_setting(auth, node, **kwargs):
             # TODO inject only short_name and render fully client side
             config['template_lookup'] = addon.config.template_lookup
             config['addon_icon_url'] = addon.config.icon_url
+            if addon.user_settings is not None and config.get('is_owner', None) is None:
+                config.update({
+                    'is_owner': auth.user == addon.user_settings.owner
+                })
             addon_enabled_settings.append(config)
 
     addon_enabled_settings = sorted(addon_enabled_settings, key=lambda addon: addon['addon_full_name'].lower())
@@ -302,6 +306,7 @@ def node_setting(auth, node, **kwargs):
     ret['categories'].update({
         'project': 'Project'
     })
+
 
     return ret
 def collect_node_config_js(addons):

--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -159,59 +159,60 @@
 
                     </div>
                 </div>
+            % endif  ## End Select Addons
+        % endif
 
-                % if addon_enabled_settings:
-                    <span id="configureAddonsAnchor" class="anchor"></span>
+% if addon_enabled_settings:
+    <span id="configureAddonsAnchor" class="anchor"></span>
 
-                    <div id="configureAddons" class="panel panel-default">
+    <div id="configureAddons" class="panel panel-default">
 
-                        <div class="panel-heading clearfix">
-                            <h3 class="panel-title">Configure Add-ons</h3>
-                        </div>
-                        <div class="panel-body">
+        <div class="panel-heading clearfix">
+            <h3 class="panel-title">Configure Add-ons</h3>
+        </div>
+        <div class="panel-body">
 
-                        % for node_settings_dict in addon_enabled_settings or []:
-                            ${render_node_settings(node_settings_dict)}
+            % for node_settings_dict in addon_enabled_settings or []:
+                %if 'write' in user['permissions'] or (node_settings_dict.get('is_owner', None) is not None and node_settings_dict['is_owner']):
+                    ${render_node_settings(node_settings_dict)}
+                    % if not loop.last:
+                        <hr />
+                    % endif
+                %endif
+            % endfor
 
-                                % if not loop.last:
-                                    <hr />
-                                % endif
+        </div>
+    </div>
 
-                        % endfor
+% endif
 
-                        </div>
-                    </div>
 
-                % endif
 
-            % endif
 
-        % endif  ## End Select Addons
-
-        % if 'write' in user['permissions']:  ## Begin Wiki Config
+% if 'write' in user['permissions']:  ## Begin Wiki Config
             % if not node['is_registration']:
-                <div class="panel panel-default">
-                    <span id="configureWikiAnchor" class="anchor"></span>
-                    <div class="panel-heading clearfix">
-                        <h3 class="panel-title">Wiki</h3>
-                    </div>
+    <div class="panel panel-default">
+        <span id="configureWikiAnchor" class="anchor"></span>
+        <div class="panel-heading clearfix">
+            <h3 class="panel-title">Wiki</h3>
+        </div>
 
-                <div class="panel-body">
-                    %if wiki:
-                        <form id="selectWikiForm">
-                            <div>
-                                <label>
-                                    <input
-                                            type="checkbox"
-                                            name="${wiki.short_name}"
-                                            class="wiki-select"
-                                            data-bind="checked: enabled"
-                                    />
-                                    Enable the wiki in <b>${node['title']}</b>.
-                                </label>
+        <div class="panel-body">
+            %if wiki:
+                <form id="selectWikiForm">
+                    <div>
+                        <label>
+                            <input
+                                    type="checkbox"
+                                    name="${wiki.short_name}"
+                                    class="wiki-select"
+                                    data-bind="checked: enabled"
+                            />
+                            Enable the wiki in <b>${node['title']}</b>.
+                        </label>
 
-                                <div data-bind="visible: enabled()" class="text-success" style="padding-left: 15px">
-                                    <p data-bind="text: wikiMessage"></p>
+                        <div data-bind="visible: enabled()" class="text-success" style="padding-left: 15px">
+                            <p data-bind="text: wikiMessage"></p>
                                 </div>
                                 <div data-bind="visible: !enabled()" class="text-danger" style="padding-left: 15px">
                                     <p data-bind="text: wikiMessage"></p>


### PR DESCRIPTION
## Purpose

If a contributor authorized their external accounts for project addons, it cannot disconnect its external accounts from the project. Currently, if such a contributor wants to disconnect through user settings page, a 403 is returned. The configuration section is also not available on the project settings page for such contributors.

## Changes

To make sure a read-only contributor can disconnect its external account on user settings page, the decorator `@must_have_permission(permissions.WRITE)` is changed to `@must_be_addon_authorizer(addon_short_name)` for the `_deauthorize_node()` method.

For the project settings page, an `is_owner` field is added to the context in `node.py` for every enabled addon. Changes were make to `settings.mako` to make use of the field.

## Side effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/OSF-8083