### PR TITLE
Hotfix/update share preprint date modified[OSF-8388]

### DIFF
--- a/osf/management/commands/update_preprint_share_dates.py
+++ b/osf/management/commands/update_preprint_share_dates.py
@@ -1,0 +1,43 @@
+from __future__ import unicode_literals
+import logging
+
+from django.core.management.base import BaseCommand
+
+from scripts import utils as script_utils
+from osf.models import PreprintService
+from website.preprints.tasks import on_preprint_updated
+
+logger = logging.getLogger(__name__)
+
+def update_share_preprint_modified_dates(dry_run=False):
+    dates_updated = 0
+    for preprint in PreprintService.objects.filter():
+        if preprint.node.date_modified > preprint.date_modified:
+            if not dry_run:
+                on_preprint_updated(preprint._id)
+            dates_updated += 1
+    return dates_updated
+
+class Command(BaseCommand):
+    """
+    Send more accurate preprint modified dates to Share (max of node.date_modified and preprint.date_modified)
+    """
+    def add_arguments(self, parser):
+        super(Command, self).add_arguments(parser)
+        parser.add_argument(
+            '--dry',
+            action='store_true',
+            dest='dry_run',
+            help='Say how many preprint updates would be sent to share',
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options.get('dry_run', False)
+        if not dry_run:
+            script_utils.add_file_logger(logger, __file__)
+            dates_updated = update_share_preprint_modified_dates()
+            logger.info('Sent %d new preprint modified dates to Share' % dates_updated)
+
+        else:
+            dates_updated = update_share_preprint_modified_dates(dry_run=True)
+            logger.info('Would have sent %d new preprint modified dates to Share' % dates_updated)

--- a/osf/management/commands/update_preprint_share_dates.py
+++ b/osf/management/commands/update_preprint_share_dates.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 import logging
 
 from django.core.management.base import BaseCommand
+from django.db.models import F
 
 from scripts import utils as script_utils
 from osf.models import PreprintService
@@ -10,17 +11,16 @@ from website.preprints.tasks import on_preprint_updated
 logger = logging.getLogger(__name__)
 
 def update_share_preprint_modified_dates(dry_run=False):
-    dates_updated = 0
-    for preprint in PreprintService.objects.filter():
-        if preprint.node.date_modified > preprint.date_modified:
-            if not dry_run:
-                on_preprint_updated(preprint._id)
-            dates_updated += 1
-    return dates_updated
+    for preprint in PreprintService.objects.filter(date_modified__lt=F('node__date_modified')):
+        if dry_run:
+            logger.info('Would have sent ' + preprint._id + ' data to SHARE')
+        else:
+            on_preprint_updated(preprint._id)
+            logger.info(preprint._id + ' data sent to SHARE')
 
 class Command(BaseCommand):
     """
-    Send more accurate preprint modified dates to Share (max of node.date_modified and preprint.date_modified)
+    Send more accurate preprint modified dates to SHARE (sends updates if preprint.date_modified < node.date_modified)
     """
     def add_arguments(self, parser):
         super(Command, self).add_arguments(parser)
@@ -28,16 +28,11 @@ class Command(BaseCommand):
             '--dry',
             action='store_true',
             dest='dry_run',
-            help='Say how many preprint updates would be sent to share',
+            help='Say how many preprint updates would be sent to SHARE',
         )
 
     def handle(self, *args, **options):
         dry_run = options.get('dry_run', False)
         if not dry_run:
             script_utils.add_file_logger(logger, __file__)
-            dates_updated = update_share_preprint_modified_dates()
-            logger.info('Sent %d new preprint modified dates to Share' % dates_updated)
-
-        else:
-            dates_updated = update_share_preprint_modified_dates(dry_run=True)
-            logger.info('Would have sent %d new preprint modified dates to Share' % dates_updated)
+        update_share_preprint_modified_dates(dry_run)

--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -2314,10 +2314,9 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             # avoid circular imports
             from website.preprints.tasks import on_preprint_updated
             PreprintService = apps.get_model('osf.PreprintService')
-            update_share = bool(self.SEARCH_UPDATE_FIELDS.intersection(saved_fields))
             # .preprints wouldn't return a single deleted preprint
             for preprint in PreprintService.objects.filter(node_id=self.id, is_published=True):
-                enqueue_task(on_preprint_updated.s(preprint._id, update_share=update_share))
+                enqueue_task(on_preprint_updated.s(preprint._id))
 
         user = User.load(user_id)
         if user and self.check_spam(user, saved_fields, request_headers):

--- a/tests/test_preprints.py
+++ b/tests/test_preprints.py
@@ -465,6 +465,13 @@ class TestOnPreprintUpdatedTask(OsfTestCase):
 
         assert nodes == {}
 
+    def test_format_preprint_date_modified_node_updated(self):
+        self.preprint.node.save()
+        res = format_preprint(self.preprint)
+        nodes = dict(enumerate(res))
+        preprint = nodes.pop(next(k for k, v in nodes.items() if v['@type'] == 'preprint'))
+        assert preprint['date_updated'] == self.preprint.node.date_modified.isoformat()
+
     def test_format_preprint_nones(self):
         self.preprint.node.tags = []
         self.preprint.date_published = None

--- a/website/preprints/tasks.py
+++ b/website/preprints/tasks.py
@@ -62,7 +62,13 @@ def format_preprint(preprint, old_subjects=None):
             preprint.node.tags.filter(name='qatest').exists() or
             preprint.node.is_deleted
         ),
-        'date_updated': preprint.date_modified.isoformat(),
+        # Note: Changing any preprint attribute that is pulled from the node, like title, will NOT bump
+        # the preprint's date modified but will bump the node's date_modified.
+        # We have to send the latest date to SHARE to actually get the result to be updated.
+        # If we send a date_updated that is <= the one we previously sent, SHARE will ignore any changes
+        # because it looks like a race condition that arose from preprints being resent to SHARE on
+        # every step of preprint creation.
+        'date_updated': max(preprint.date_modified, preprint.node.date_modified).isoformat(),
         'date_published': preprint.date_published.isoformat() if preprint.date_published else None
     })
 


### PR DESCRIPTION
## Purpose

SHARE is not actually updated when most preprint fields change. This is because it relies on the `date_modified` attribute of preprints, which currently only updates on preprint exclusive fields (those not on the node). When preprints are separated from nodes, this problem will disappear, but until then, we want to send SHARE a more realistic`date_modified` for preprints. 

## Changes

This sends the greater of the node `date_modified` or the preprint `date_modified` to SHARE whenever a node associated with a preprint is updated.

There is also a management command that resends SHARE data for any node modified later than its associated preprint for all other preprints - this sends SHARE the later node `date_modified`.

Also, because it is hard to check when a primary file is updated, SHARE is updated whenever a preprint node is updated.

## Side effects
SHARE data is now sent any time a preprint node it updated.

The `date_modified` of a node does not link up exactly with what we would want the `date_modified` of a preprint to be, so SHARE might have modified dates that are slightly newer than the preprint data actually is.

## Ticket

https://openscience.atlassian.net/browse/OSF-8388