### PR TITLE
[OSF-8490] Proxy Ember GUIDs

### DIFF
--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -82,6 +82,7 @@ PREPRINT_PROVIDER_DOMAINS = {
 }
 # External Ember App Local Development
 USE_EXTERNAL_EMBER = False
+PROXY_EMBER_APPS = False
 EXTERNAL_EMBER_APPS = {}
 
 LOG_PATH = os.path.join(APP_PATH, 'logs')

--- a/website/settings/local-dist.py
+++ b/website/settings/local-dist.py
@@ -29,15 +29,16 @@ PREPRINT_PROVIDER_DOMAINS = {
     'suffix': ':4200/'
 }
 USE_EXTERNAL_EMBER = True
+PROXY_EMBER_APPS = False
 EXTERNAL_EMBER_APPS = {
     'preprints': {
         'url': '/preprints/',
-        'server': 'http://localhost:4200',
+        'server': 'http://192.168.168.167:4200/',
         'path': '/preprints/'
     },
     'registries': {
         'url': '/registries/',
-        'server': 'http://localhost:4300',
+        'server': 'http://192.168.168.167:4300',
         'path': '/registries/'
     }
     # 'meetings': {


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Proxy ember guids to an external server

## Changes

If enabled with PROXY_EMBER_APPS in website/settings/local.py, it will proxy a request through to an external static server

## Side effects

Should be none


## Testing

You can test by this by updating local.py with the server url form local-dist and it should proxy the request through. I've tested it both with nginx and ember server.

## Ticket

https://openscience.atlassian.net/browse/OSF-8490
