### PR TITLE
[OSF-6247] Admin cannot see preregs that are approved but canceled by users.

### DIFF
--- a/admin/pre_reg/serializers.py
+++ b/admin/pre_reg/serializers.py
@@ -33,7 +33,7 @@ def serialize_draft_registration(draft, json_safe=True):
         'registration_schema': serialize_meta_schema(draft.registration_schema),
         'initiated': iso8601format(draft.datetime_initiated) if json_safe else draft.datetime_initiated,
         'updated': iso8601format(draft.datetime_updated) if json_safe else draft.datetime_updated,
-        'submitted': iso8601format(draft.approval.initiation_date) if json_safe else draft.approval.initiation_date,
+        'submitted': (iso8601format(draft.approval.initiation_date) if json_safe else draft.approval.initiation_date) if draft.approval else None,
         'requires_approval': draft.requires_approval,
         'is_pending_approval': draft.is_pending_review,
         'is_approved': draft.is_approved,
@@ -66,7 +66,9 @@ def get_url(draft):
 
 
 def get_embargo(draft, json_safe):
-    registration_choice = draft.approval.meta.get('registration_choice', None)
+    registration_choice = None
+    if draft.approval is not None:
+        registration_choice = draft.approval.meta.get('registration_choice', None)
     if registration_choice == EMBARGO:
         time = parser.parse(draft.approval.meta['embargo_end_date'])
         return iso8601format(time) if json_safe else time

--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -329,11 +329,7 @@ class Registration(AbstractNode):
     def delete_registration_tree(self, save=False):
         logger.debug('Marking registration {} as deleted'.format(self._id))
         self.is_deleted = True
-        for draft_registration in DraftRegistration.objects.filter(registered_node=self):
-            # Allow draft registration to be submitted
-            if draft_registration.approval:
-                draft_registration.approval = None
-                draft_registration.save()
+
         if not getattr(self.embargo, 'for_existing_registration', False):
             self.registered_from = None
         if save:
@@ -468,10 +464,10 @@ class DraftRegistration(ObjectIDMixin, BaseModel):
     @property
     def is_approved(self):
         if self.requires_approval:
-            if not self.approval:
-                return False
-            else:
+            try:
                 return self.approval.is_approved
+            except AttributeError:
+                return None
         else:
             return False
 

--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -2302,7 +2302,7 @@ class TestNodeTraversals:
         assert Node.find(Q('_id', 'in', reg_ids) & Q('is_deleted', 'eq', False)).count() == 0
         assert mock_update_search.call_count == orig_call_count + len(reg_ids)
 
-    def test_delete_registration_tree_sets_draft_registration_approvals_to_none(self, user):
+    def test_delete_registration_tree_does_not_set_draft_registration_approvals_to_none(self, user):
         reg = RegistrationFactory()
 
         dr = DraftRegistrationFactory(initiator=user)
@@ -2315,7 +2315,7 @@ class TestNodeTraversals:
         reg.delete_registration_tree(save=True)
 
         dr.reload()
-        assert dr.approval is None
+        assert dr.approval is not None
 
     @mock.patch('osf.models.node.AbstractNode.update_search')
     def test_delete_registration_tree_deletes_backrefs(self, mock_update_search):

--- a/website/project/views/drafts.py
+++ b/website/project/views/drafts.py
@@ -129,8 +129,8 @@ def submit_draft_for_review(auth, node, draft, *args, **kwargs):
         meta['embargo_end_date'] = end_date_string
     meta['registration_choice'] = registration_choice
 
-    # Don't allow resubmission unless submission was rejected
-    if draft.approval and draft.approval.state != Sanction.REJECTED:
+    # Don't allow resubmission unless submission was rejected by both the admin and the user
+    if draft.approval and draft.approval.state != Sanction.REJECTED and draft.registered_node.registration_approval.state != Sanction.REJECTED:
         raise HTTPError(http.CONFLICT, data=dict(message_long='Cannot resubmit previously submitted draft.'))
 
     draft.submit_for_review(
@@ -186,8 +186,8 @@ def register_draft_registration(auth, node, draft, *args, **kwargs):
     registration_choice = data.get('registrationChoice', 'immediate')
     validate_registration_choice(registration_choice)
 
-    # Don't allow resubmission unless submission was rejected
-    if draft.approval and draft.approval.state != Sanction.REJECTED:
+    # Don't allow resubmission unless submission was rejected by user
+    if draft.registered_node and draft.registered_node.registration_approval.state != Sanction.REJECTED:
         raise HTTPError(http.CONFLICT, data=dict(message_long='Cannot resubmit previously submitted draft.'))
 
     register = draft.register(auth)


### PR DESCRIPTION
## Purpose
Site admins cannot see list of preregs that have been approved (by the site admin) but later canceled by users. This PR fix this problem by slightly changing the registration workflow. 

## Changes
To better understand the underlying problem, it is worth to note that there are four models closely related to the entire registration workflow: `DraftRegistration`, `DraftRegistrationApproval`, `Registration` and `RegistrationApproval`.

When a user starts drafting a registration, a `DraftRegistration` instance is created. However, before the user submits the `DraftRegistration` for approval,`DraftRegistration.approval == None`. After the submission, `DraftRegistration.approval` is set to be a new `DraftRegistrationApproval` instance, whose state indicates whether this DraftRegistration has been approved by **the Admin**. 

After **the Admin** approves the`DraftRegistration`, a new `Registration` instance, which is the actual node representing the registration, is created. It has a `Registration.registration_approval` field, which is a `RegistrationApproval` instance, whose state reflects whether **the user(s)** approve of the release of this registration (by clicking on the links included in the email sent).

Therefore, in short, the state of `DraftRegistrationApproval` determines whether **the Admin** approves the `DraftRegistration`, while the state of `RegistrationApproval` determines whether **the user(s)** approve. This also means that, if a registration does not need Admin approval, its corresponding `DraftRegistration.approval` is `None`, instead of a `DraftRegistrationApproval` instance.

According to these lines in `views.py`, 
https://github.com/CenterForOpenScience/osf.io/blob/3e0a506e9311c9bb7f1a6aa74f4bebbc384dd244/admin/pre_reg/views.py#L40-L43
the Admin prereg page should show all `DraftRegistration` that has been submitted. In reality, it does not because when **the user** cancels a registration through email, `DraftRegistration.approval` is set to `None`. Judging from the code comment, 
https://github.com/CenterForOpenScience/osf.io/blob/08a604c550c68c53653bf751ccd0571acc50cab4/osf/models/registrations.py#L333
this is done [in a hotfix PR](https://github.com/CenterForOpenScience/osf.io/pull/6875) to allow draft registrations to be (re)submitted, because these lines 
https://github.com/CenterForOpenScience/osf.io/blob/930c225fdcb1f8d78452628e12eb8dbc73facdb6/website/project/views/drafts.py#L134-L135 
would only allow resubmission if `DraftRegistration` is disapproved by **the Admin**, failing to consider the situation when it is disapproved by the **user(s)**.

As a result, following changes are made:
1. In `registrations.py`, the `delete_registration_tree()` method is modified so that it would not set `DraftRegistration.approval` to `None` upon user disapproval. `is_approved` of `DraftRegistration` model is also modified to return the state of `DraftRegistrationApproval`.

2. In `drafts.py`, conditions for allowing resubmission is changed so that it no longer blocks `DraftRegistration` instances that are canceled by users. Conditions for allowing re-registering  (without submission for review) are also changed accordingly.

3. Because of the new behavior of the registration workflow, one unit test is change to make sure deletion of registration trees does not result in `DraftRegistration.approval == None`.

4. Several other changes so that it doesn't break.

## Side effects

For this PR to work perfectly, a migration script is needed to reestablish the link between `DraftRegistrationApproval` and the `DraftRegistration` for those that were disapprove by users. I decided to put this to CR and get some feedback first. I'll try to write a migration once reviewers think this is the right way to go.


## Ticket

https://openscience.atlassian.net/browse/OSF-6247