### PR TITLE
Feature/Make getContributorList handle unregistered contributors correctly [OSF-8346]

### DIFF
--- a/website/static/js/logTextParser.js
+++ b/website/static/js/logTextParser.js
@@ -129,8 +129,9 @@ var getContributorList = function (contributors, maxShown){
            else {
                if (item.unregistered_name) {
                    contribList.push([item.unregistered_name, comma]);
+               } else {
+                   contribList.push([item.full_name, comma]);
                }
-               contribList.push([item.full_name, comma]);
        }}
        return contribList;
 };

--- a/website/static/js/tests/logTextParser.test.js
+++ b/website/static/js/tests/logTextParser.test.js
@@ -9,15 +9,17 @@ var makeFakeContributor = function(active=true){
     return {
         name: faker.name.findName(),
         id: 'a1234',
-        active: active
+        active: active,
+        unregistered_name: faker.name.findName()
     };
 };
 
 describe('logTextParser', () => {
     describe('getContributorList', () => {
         var contributors = [];
-        for (var i = 0; i<10; i++) {
+        for (var i = 0; i<5; i++) {
             contributors.push(makeFakeContributor());
+            contributors.push(makeFakeContributor(false));
         }
         it('displays all contributors if under maxShown limit', () => {
             var logText = LogText.getContributorList(contributors, 11);


### PR DESCRIPTION
## Purpose
When I shortened contributor logs (OSF-8346), I made a new function, getContributor list, which returned a list of contributors for the log to display. I forgot an `else` statement on one of the lines and unregistered contributors were being listed twice.

## Changes
This fixes that mistake and adds unregistered contributors to my test.

## Side effects
None

## Ticket
https://openscience.atlassian.net/browse/OSF-8346



