### PR TITLE
Remove system tags from user in admin when changing spam status [OSF-7760]

### DIFF
--- a/admin/users/views.py
+++ b/admin/users/views.py
@@ -17,7 +17,6 @@ from django.shortcuts import redirect
 from osf.models.user import OSFUser
 from osf.models.node import Node, NodeLog
 from osf.models.spam import SpamStatus
-from osf.models.tag import Tag
 from framework.auth import get_user
 from framework.auth.utils import impute_names
 from framework.auth.core import generate_verification_key
@@ -59,14 +58,10 @@ class UserDeleteView(PermissionRequiredMixin, DeleteView):
             if user.date_disabled is None or kwargs.get('is_spam'):
                 user.disable_account()
                 user.is_registered = False
-                if 'spam_flagged' in user.system_tags or 'ham_confirmed' in user.system_tags:
-                    if 'spam_flagged' in user.system_tags:
-                        t = Tag.all_tags.get(name='spam_flagged', system=True)
-                        # TODO: removing system tags this way does not currently work -- https://openscience.atlassian.net/browse/OSF-7760
-                        user.tags.remove(t)
-                    if 'ham_confirmed' in user.system_tags:
-                        t = Tag.all_tags.get(name='ham_confirmed', system=True)
-                        user.tags.remove(t)
+                if 'spam_flagged' in user.system_tags:
+                    user.tags.through.objects.filter(tag__name='spam_flagged').delete()
+                if 'ham_confirmed' in user.system_tags:
+                    user.tags.through.objects.filter(tag__name='ham_confirmed').delete()
 
                 if kwargs.get('is_spam') and 'spam_confirmed' not in user.system_tags:
                     user.add_system_tag('spam_confirmed')
@@ -76,15 +71,9 @@ class UserDeleteView(PermissionRequiredMixin, DeleteView):
                 user.date_disabled = None
                 subscribe_on_confirm(user)
                 user.is_registered = True
-                if 'spam_flagged' in user.system_tags or 'spam_confirmed' in user.system_tags:
-                    if 'spam_flagged' in user.system_tags:
-                        t = Tag.all_tags.get(name='spam_flagged', system=True)
-                        user.tags.remove(t)
-                    if 'spam_confirmed' in user.system_tags:
-                        t = Tag.all_tags.get(name='spam_confirmed', system=True)
-                        user.tags.remove(t)
-                    if 'ham_confirmed' not in user.system_tags:
-                        user.add_system_tag('ham_confirmed')
+                user.tags.through.objects.filter(tag__name__in=['spam_flagged', 'spam_confirmed'], tag__system=True).delete()
+                if 'ham_confirmed' not in user.system_tags:
+                    user.add_system_tag('ham_confirmed')
                 flag = USER_RESTORED
                 message = 'User account {} reenabled'.format(user.pk)
             user.save()

--- a/admin_tests/users/test_views.py
+++ b/admin_tests/users/test_views.py
@@ -218,8 +218,8 @@ class TestHamUserRestore(AdminTestCase):
 
     def test_enable_user(self):
         self.user.disable_account()
+        self.user.save()
         nt.assert_true(self.user.is_disabled)
-
         self.view().delete(self.request)
         self.user.reload()
 

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -180,7 +180,7 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
     #   the result of a bug, as they were all created over a small time span.
     is_claimed = models.BooleanField(default=False, db_index=True)
 
-    # a list of strings - for internal use
+    # for internal use
     tags = models.ManyToManyField('Tag', blank=True)
 
     # security emails that have been sent

--- a/osf_tests/test_tag.py
+++ b/osf_tests/test_tag.py
@@ -5,7 +5,7 @@ from django.db import DataError
 from framework.auth import Auth
 from osf.models import Tag
 from osf.exceptions import ValidationError
-from osf_tests.factories import ProjectFactory
+from osf_tests.factories import ProjectFactory, UserFactory
 from website.exceptions import TagNotFoundError
 
 pytestmark = pytest.mark.django_db
@@ -73,3 +73,12 @@ class TestTags:
     def test_remove_tag_not_present(self, project, auth):
         with pytest.raises(TagNotFoundError):
             project.remove_tag('scientific', auth=auth)
+
+    def test_remove_system_tag_from_user(self):
+        user = UserFactory()
+        system_tag = Tag.objects.create(name='test_system_tag', system=True)
+        user.tags.add(system_tag)
+        assert user.all_tags.first() == system_tag
+
+        user.tags.through.objects.filter(tag=system_tag).delete()
+        assert user.all_tags.count() == 0


### PR DESCRIPTION

## Purpose
The syntax in the admin app for removing old system tags for users to indicate their spam status has been broken since Tag became a many-to-many relationship, and system tags were filtered out by default. Use the correct syntax to remove the relationship from the spam tags when appropriate

## Changes

- Simplify `UserDeleteView` used by both `HamUserRestoreView` and `SpamUserDeleteView` for users
- Add tests for the admin "HamUserRestoreView"
- Add test for removing a system tag
- Remove old comment from user model

## Side effects

None anticipated


## Ticket
https://openscience.atlassian.net/browse/OSF-7760

## For Testing
To test this ticket, check the behavior of the "Disable Spam Account" and the "Re-enable Ham Account" buttons on a User's detail in the admin.

After clicking "Disable Spam Account":
- the system tag "spam_confirmed" should appear in the users detail table
- the user should appear in the "Known Spam" list under "OSF Users" in the admin sidebar

After clicking "Re-enable Ham Account":
- the system tag "ham_confirmed" should appear in the users detail table (with no other tags)
- the user should appear in the "Known Ham" list under "OSF Users" in the admin sidebar
