### PR TITLE
[OSF-8353] Registrations Settings Page is throwing 404 errors - Prod and Staging

### DIFF
--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -578,7 +578,10 @@
 
     <script type="text/javascript" src=${"/static/public/js/project-settings-page.js" | webpack_asset}></script>
     <script src=${"/static/public/js/sharing-page.js" | webpack_asset}></script>
-    <script type="text/javascript" src=${"/static/public/js/forward/node-cfg.js" | webpack_asset}></script>
+
+    % if not node['is_registration']:
+        <script type="text/javascript" src=${"/static/public/js/forward/node-cfg.js" | webpack_asset}></script>
+    % endif
     
     % for js_asset in addon_js:
         <script src="${js_asset | webpack_asset}"></script>


### PR DESCRIPTION
[#OSF-8353]
## Purpose
Skip <script ... node-cfg.js> in project/settings.mako if registration

## Changes
Updated website/templates/project/settings.mako

project/settings view growling about 404 for addon settings asregistrations have no addon settings. Surrounded offending call with "if not node.is_registration.

## Side effects

None


## Ticket

[OSF-8353](https://openscience.atlassian.net/browse/OSF-8353)
