### PR TITLE
QuickFiles Improvements [OSF-8117]

### DIFF
--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -295,7 +295,7 @@ class BaseFileSerializer(JSONAPISerializer):
         return instance
 
     def is_valid(self, **kwargs):
-        return super(FileSerializer, self).is_valid(clean_html=False, **kwargs)
+        return super(BaseFileSerializer, self).is_valid(clean_html=False, **kwargs)
 
     def get_file_guid(self, obj):
         if obj:
@@ -306,6 +306,7 @@ class BaseFileSerializer(JSONAPISerializer):
 
     def get_absolute_url(self, obj):
         return api_v2_url('files/{}/'.format(obj._id))
+
 
 class FileSerializer(BaseFileSerializer):
     node = RelationshipField(related_view='nodes:node-detail',
@@ -339,13 +340,15 @@ class FileDetailSerializer(FileSerializer):
     id = IDField(source='_id', required=True)
 
 
-class QuickFilesFileDetailSerializer(BaseFileSerializer):
-    id = IDField(source='_id', required=True)
-
+class QuickFilesSerializer(BaseFileSerializer):
     user = RelationshipField(related_view='users:user-detail',
                              related_view_kwargs={'user_id': '<node.creator._id>'},
-                             help_text='The user who updloaded this file'
+                             help_text='The user who uploaded this file'
                              )
+
+
+class QuickFilesDetailSerializer(QuickFilesSerializer):
+    id = IDField(source='_id', required=True)
 
 
 class FileVersionSerializer(JSONAPISerializer):

--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -131,7 +131,7 @@ class FileTagField(ser.Field):
         return data
 
 
-class FileSerializer(JSONAPISerializer):
+class BaseFileSerializer(JSONAPISerializer):
     filterable_fields = frozenset([
         'id',
         'name',
@@ -181,10 +181,7 @@ class FileSerializer(JSONAPISerializer):
                                             related_meta={'unread': 'get_unread_comments_count'},
                                             filter={'target': 'get_file_guid'}
                                             )
-    node = RelationshipField(related_view='nodes:node-detail',
-                             related_view_kwargs={'node_id': '<node._id>'},
-                             help_text='The project that this file belongs to'
-                             )
+
     links = LinksField({
         'info': Link('files:file-detail', kwargs={'file_id': '<_id>'}),
         'move': WaterbutlerLink(),
@@ -310,6 +307,12 @@ class FileSerializer(JSONAPISerializer):
     def get_absolute_url(self, obj):
         return api_v2_url('files/{}/'.format(obj._id))
 
+class FileSerializer(BaseFileSerializer):
+    node = RelationshipField(related_view='nodes:node-detail',
+                             related_view_kwargs={'node_id': '<node._id>'},
+                             help_text='The project that this file belongs to'
+                             )
+
 
 class OsfStorageFileSerializer(FileSerializer):
     """ Overrides `filterable_fields` to make `last_touched` non-filterable
@@ -334,6 +337,15 @@ class FileDetailSerializer(FileSerializer):
     Overrides FileSerializer to make id required.
     """
     id = IDField(source='_id', required=True)
+
+
+class QuickFilesFileDetailSerializer(BaseFileSerializer):
+    id = IDField(source='_id', required=True)
+
+    user = RelationshipField(related_view='users:user-detail',
+                             related_view_kwargs={'user_id': '<node.creator._id>'},
+                             help_text='The user who updloaded this file'
+                             )
 
 
 class FileVersionSerializer(JSONAPISerializer):

--- a/api/files/views.py
+++ b/api/files/views.py
@@ -8,6 +8,7 @@ from osf.models import (
     Guid,
     BaseFileNode,
     FileVersion,
+    QuickFilesNode
 )
 
 from api.base.exceptions import Gone
@@ -21,7 +22,7 @@ from api.nodes.permissions import ReadOnlyIfRegistration
 from api.files.permissions import IsPreprintFile
 from api.files.permissions import CheckedOutOrAdmin
 from api.files.serializers import FileSerializer
-from api.files.serializers import FileDetailSerializer
+from api.files.serializers import FileDetailSerializer, QuickFilesFileDetailSerializer
 from api.files.serializers import FileVersionSerializer
 
 
@@ -323,6 +324,11 @@ class FileDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView, FileMixin):
     throttle_classes = (CreateGuidThrottle, NonCookieAuthThrottle, UserRateThrottle, )
     view_category = 'files'
     view_name = 'file-detail'
+
+    def get_serializer_class(self):
+        if isinstance(self.get_node(), QuickFilesNode):
+            return QuickFilesFileDetailSerializer
+        return FileDetailSerializer
 
     def get_node(self):
         return self.get_file().node

--- a/api/files/views.py
+++ b/api/files/views.py
@@ -22,7 +22,7 @@ from api.nodes.permissions import ReadOnlyIfRegistration
 from api.files.permissions import IsPreprintFile
 from api.files.permissions import CheckedOutOrAdmin
 from api.files.serializers import FileSerializer
-from api.files.serializers import FileDetailSerializer, QuickFilesFileDetailSerializer
+from api.files.serializers import FileDetailSerializer, QuickFilesDetailSerializer
 from api.files.serializers import FileVersionSerializer
 
 
@@ -327,7 +327,7 @@ class FileDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView, FileMixin):
 
     def get_serializer_class(self):
         if isinstance(self.get_node(), QuickFilesNode):
-            return QuickFilesFileDetailSerializer
+            return QuickFilesDetailSerializer
         return FileDetailSerializer
 
     def get_node(self):

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -4,7 +4,7 @@ from modularodm.exceptions import ValidationValueError, ValidationError
 
 from website import util as website_utils
 from api.base.exceptions import InvalidModelValueError
-from api.files.serializers import OsfStorageFileSerializer
+from api.files.serializers import QuickFilesSerializer
 from api.base.serializers import JSONAPIRelationshipSerializer, HideIfDisabled, BaseAPISerializer, WaterbutlerLink, Link
 from osf.models import OSFUser, QuickFilesNode
 
@@ -67,8 +67,8 @@ class UserSerializer(JSONAPISerializer):
         related_meta={'projects_in_common': 'get_projects_in_common'},
     ))
 
-    files = HideIfDisabled(QuickFilesRelationshipField(
-        related_view='users:user-files',
+    quickfiles = HideIfDisabled(QuickFilesRelationshipField(
+        related_view='users:user-quickfiles',
         related_view_kwargs={'user_id': '<_id>'},
     ))
 
@@ -182,16 +182,13 @@ class UserDetailSerializer(UserSerializer):
     id = IDField(source='_id', required=True)
 
 
-class UserQuickFilesSerializer(OsfStorageFileSerializer):
+class UserQuickFilesSerializer(QuickFilesSerializer):
     links = LinksField({
         'info': Link('files:file-detail', kwargs={'file_id': '<_id>'}),
         'upload': WaterbutlerLink(),
         'delete': WaterbutlerLink(),
         'download': WaterbutlerLink(must_be_file=True),
     })
-
-    # Don't serialize node relationship for QuickFiles as they don't have a detail view
-    node = None
 
 
 class ReadEmailUserDetailSerializer(UserDetailSerializer):

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -6,7 +6,7 @@ from website import util as website_utils
 from api.base.exceptions import InvalidModelValueError
 from api.files.serializers import OsfStorageFileSerializer
 from api.base.serializers import JSONAPIRelationshipSerializer, HideIfDisabled, BaseAPISerializer, WaterbutlerLink, Link
-from osf.models import OSFUser
+from osf.models import OSFUser, QuickFilesNode
 
 from api.base.serializers import (
     JSONAPISerializer, LinksField, RelationshipField, DevOnly, IDField, TypeField, ListDictField,
@@ -19,7 +19,7 @@ class QuickFilesRelationshipField(RelationshipField):
 
     def to_representation(self, value):
         relationship_links = super(QuickFilesRelationshipField, self).to_representation(value)
-        quickfiles_guid = value.created.filter(type='osf.quickfilesnode').values_list('guids___id', flat=True).get()
+        quickfiles_guid = value.created.filter(type=QuickFilesNode._typedmodels_type).values_list('guids___id', flat=True).get()
         upload_url = website_utils.waterbutler_api_url_for(quickfiles_guid, 'osfstorage')
         relationship_links['links']['upload'] = {
             'href': upload_url,

--- a/api/users/urls.py
+++ b/api/users/urls.py
@@ -13,6 +13,6 @@ urlpatterns = [
     url(r'^(?P<user_id>\w+)/nodes/$', views.UserNodes.as_view(), name=views.UserNodes.view_name),
     url(r'^(?P<user_id>\w+)/preprints/$', views.UserPreprints.as_view(), name=views.UserPreprints.view_name),
     url(r'^(?P<user_id>\w+)/registrations/$', views.UserRegistrations.as_view(), name=views.UserRegistrations.view_name),
-    url(r'^(?P<user_id>\w+)/files/$', views.UserQuickFiles.as_view(), name=views.UserQuickFiles.view_name),
+    url(r'^(?P<user_id>\w+)/quickfiles/$', views.UserQuickFiles.as_view(), name=views.UserQuickFiles.view_name),
     url(r'^(?P<user_id>\w+)/relationships/institutions/$', views.UserInstitutionsRelationship.as_view(), name=views.UserInstitutionsRelationship.view_name),
 ]

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -561,7 +561,7 @@ class UserQuickFiles(JSONAPIBaseView, generics.ListAPIView, WaterButlerMixin, Us
 
     serializer_class = UserQuickFilesSerializer
     view_category = 'users'
-    view_name = 'user-files'
+    view_name = 'user-quickfiles'
 
     def get_node(self, check_object_permissions):
         return QuickFilesNode.objects.get_for_user(self.get_user(check_permissions=False))

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -571,7 +571,7 @@ class UserQuickFiles(JSONAPIBaseView, generics.ListAPIView, WaterButlerMixin, Us
         self.kwargs[self.provider_lookup_url_kwarg] = 'osfstorage'
         files_list = self.fetch_from_waterbutler()
 
-        return files_list.children.all()
+        return files_list.children.all().prefetch_related('node')
 
     # overrides ListAPIView
     def get_queryset(self):

--- a/api_tests/users/views/test_user_detail.py
+++ b/api_tests/users/views/test_user_detail.py
@@ -87,7 +87,7 @@ class TestUserDetail(ApiTestCase):
         res = self.app.get(url, auth=self.user_one)
         quickfiles = QuickFilesNode.objects.get(creator=self.user_one)
         user_json = res.json['data']
-        upload_url = user_json['relationships']['files']['links']['upload']['href']
+        upload_url = user_json['relationships']['quickfiles']['links']['upload']['href']
         waterbutler_upload = website_utils.waterbutler_api_url_for(quickfiles._id, 'osfstorage')
 
         assert_equal(upload_url, waterbutler_upload)

--- a/api_tests/users/views/test_user_files_list.py
+++ b/api_tests/users/views/test_user_files_list.py
@@ -3,7 +3,8 @@ import pytest
 
 from osf_tests.factories import AuthUserFactory
 from api.base.settings.defaults import API_BASE
-from osf.models import QuickFilesNode, BaseFileNode
+from osf.models import QuickFilesNode
+from addons.osfstorage.models import OsfStorageFile
 
 
 @pytest.fixture()
@@ -47,7 +48,7 @@ class TestUserQuickFiles:
 
         ids = [each['id'] for each in node_json]
 
-        assert len(ids) == BaseFileNode.objects.filter(type='osf.osfstoragefile').count()
+        assert len(ids) == OsfStorageFile.objects.count()
 
     def test_get_files_not_logged_in(self, app, user):
         url = "/{}users/{}/files/".format(API_BASE, user._id)
@@ -55,7 +56,7 @@ class TestUserQuickFiles:
         node_json = res.json['data']
 
         ids = [each['id'] for each in node_json]
-        assert len(ids) == BaseFileNode.objects.filter(type='osf.osfstoragefile').count()
+        assert len(ids) == OsfStorageFile.objects.count()
 
     def test_get_files_logged_in_as_different_user(self, app, user):
         user_two = AuthUserFactory()
@@ -64,7 +65,7 @@ class TestUserQuickFiles:
         node_json = res.json['data']
 
         ids = [each['id'] for each in node_json]
-        assert len(ids) == BaseFileNode.objects.filter(type='osf.osfstoragefile').count()
+        assert len(ids) == OsfStorageFile.count()
 
     def test_get_files_me(self, app, user):
         user_two = AuthUserFactory()
@@ -81,9 +82,19 @@ class TestUserQuickFiles:
         node_json = res.json['data']
 
         ids_returned = [each['id'] for each in node_json]
-        ids_from_files = BaseFileNode.objects.filter(type='osf.osfstoragefile', node__creator=user).values_list('_id', flat=True)
-        user_two_file_ids = BaseFileNode.objects.filter(type='osf.osfstoragefile', node__creator=user_two).values_list('_id', flat=True)
+        ids_from_files = OsfStorageFile.objects.filter(node__creator=user).values_list('_id', flat=True)
+        user_two_file_ids = OsfStorageFile.objects.filter(node__creator=user_two).values_list('_id', flat=True)
 
         assert sorted(ids_returned) == sorted(ids_from_files)
         for ident in user_two_file_ids:
             assert ident not in ids_returned
+
+    def test_get_files_detail_has_user_relationship(self, app, user):
+        file_id = OsfStorageFile.objects.filter(node__creator=user).values_list('_id', flat=True).first()
+        url = "/{}files/{}/".format(API_BASE, file_id)
+        res = app.get(url, auth=user.auth)
+        file_detail_json = res.json['data']
+
+        assert 'user' in file_detail_json['relationships']
+        assert 'node' not in file_detail_json['relationships']
+        assert file_detail_json['relationships']['user']['links']['related']['href'].split('/')[-2] == user._id

--- a/api_tests/users/views/test_user_files_list.py
+++ b/api_tests/users/views/test_user_files_list.py
@@ -65,7 +65,7 @@ class TestUserQuickFiles:
         node_json = res.json['data']
 
         ids = [each['id'] for each in node_json]
-        assert len(ids) == OsfStorageFile.count()
+        assert len(ids) == OsfStorageFile.objects.count()
 
     def test_get_files_me(self, app, user):
         user_two = AuthUserFactory()

--- a/api_tests/users/views/test_user_files_list.py
+++ b/api_tests/users/views/test_user_files_list.py
@@ -29,20 +29,21 @@ class TestUserQuickFiles:
         root.append_file('The.txt')
         root.append_file('Buzzards.txt')
 
-    def test_authorized_gets_200(self, app, user):
-        url = "/{}users/{}/files/".format(API_BASE, user._id)
+    @pytest.fixture()
+    def url(self, user):
+        return "/{}users/{}/quickfiles/".format(API_BASE, user._id)
+
+    def test_authorized_gets_200(self, app, user, url):
         res = app.get(url, auth=user.auth)
         assert res.status_code == 200
         assert res.content_type == 'application/vnd.api+json'
 
-    def test_anonymous_gets_200(self, app, user):
-        url = "/{}users/{}/files/".format(API_BASE, user._id)
+    def test_anonymous_gets_200(self, app, url):
         res = app.get(url)
         assert res.status_code == 200
         assert res.content_type == 'application/vnd.api+json'
 
-    def test_get_files_logged_in(self, app, user):
-        url = "/{}users/{}/files/".format(API_BASE, user._id)
+    def test_get_files_logged_in(self, app, user, url):
         res = app.get(url, auth=user.auth)
         node_json = res.json['data']
 
@@ -50,17 +51,15 @@ class TestUserQuickFiles:
 
         assert len(ids) == OsfStorageFile.objects.count()
 
-    def test_get_files_not_logged_in(self, app, user):
-        url = "/{}users/{}/files/".format(API_BASE, user._id)
+    def test_get_files_not_logged_in(self, app, url):
         res = app.get(url)
         node_json = res.json['data']
 
         ids = [each['id'] for each in node_json]
         assert len(ids) == OsfStorageFile.objects.count()
 
-    def test_get_files_logged_in_as_different_user(self, app, user):
+    def test_get_files_logged_in_as_different_user(self, app, user, url):
         user_two = AuthUserFactory()
-        url = "/{}users/{}/files/".format(API_BASE, user._id)
         res = app.get(url, auth=user_two.auth)
         node_json = res.json['data']
 
@@ -77,7 +76,7 @@ class TestUserQuickFiles:
         root_two.append_file('Sister.txt')
         root_two.append_file('Abigail.txt')
 
-        url = "/{}users/me/files/".format(API_BASE)
+        url = "/{}users/me/quickfiles/".format(API_BASE)
         res = app.get(url, auth=user.auth)
         node_json = res.json['data']
 

--- a/osf/migrations/0053_add_quickfiles.py
+++ b/osf/migrations/0053_add_quickfiles.py
@@ -17,7 +17,7 @@ logging.basicConfig(level=logging.INFO)
 
 
 def add_quickfiles(*args, **kwargs):
-    ids_without_quickfiles = list(OSFUser.objects.exclude(created__type='osf.quickfilesnode').values_list('id', flat=True))
+    ids_without_quickfiles = list(OSFUser.objects.exclude(created__type=QuickFilesNode._typedmodels_type).values_list('id', flat=True))
 
     users_without_quickfiles = OSFUser.objects.filter(id__in=ids_without_quickfiles).order_by('id')
     total_quickfiles_to_create = users_without_quickfiles.count()

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -681,17 +681,18 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
 
             node.save()
 
+        from osf.models import QuickFilesNode
+        from osf.models import BaseFileNode
+
         # - projects where the user was the creator
-        user.created.filter(is_bookmark_collection=False).exclude(type='osf.quickfilesnode').update(creator=self)
+        user.created.filter(is_bookmark_collection=False).exclude(type=QuickFilesNode._typedmodels_type).update(creator=self)
 
         # - file that the user has checked_out, import done here to prevent import error
-        from osf.models import BaseFileNode
         for file_node in BaseFileNode.files_checked_out(user=user):
             file_node.checkout = self
             file_node.save()
 
         # - move files in the merged user's quickfiles node, checking for name conflicts
-        from osf.models import QuickFilesNode
         from addons.osfstorage.models import OsfStorageFileNode
         primary_quickfiles = QuickFilesNode.objects.get(creator=self)
         merging_user_quickfiles = QuickFilesNode.objects.get(creator=user)

--- a/osf_tests/test_quickfiles.py
+++ b/osf_tests/test_quickfiles.py
@@ -2,7 +2,8 @@ import mock
 import pytest
 
 from framework.auth.core import Auth
-from osf.models import QuickFilesNode, BaseFileNode
+from osf.models import QuickFilesNode
+from addons.osfstorage.models import OsfStorageFile
 from osf.exceptions import MaxRetriesError
 from api_tests.utils import create_test_file
 from tests.utils import assert_items_equal
@@ -109,7 +110,7 @@ class TestQuickFilesNode:
         user.merge_user(other_user)
         user.save()
 
-        stored_files = BaseFileNode.objects.filter(type='osf.osfstoragefile')
+        stored_files = OsfStorageFile.objects.all().prefetch_related('node')
         assert stored_files.count() == 2
         for stored_file in stored_files:
             assert stored_file.node == quickfiles
@@ -129,9 +130,8 @@ class TestQuickFilesNode:
         user.merge_user(third_user)
         user.save()
 
-        stored_files = BaseFileNode.objects.filter(type='osf.osfstoragefile')
+        actual_filenames = list(OsfStorageFile.objects.all().values_list('name', flat=True))
         expected_filenames = ['Woo.pdf', 'Woo (1).pdf', 'Woo (2).pdf']
-        actual_filenames = [stored_file.name for stored_file in stored_files]
 
         assert_items_equal(actual_filenames, expected_filenames)
 
@@ -150,9 +150,8 @@ class TestQuickFilesNode:
         user.merge_user(third_user)
         user.save()
 
-        stored_files = BaseFileNode.objects.filter(type='osf.osfstoragefile')
+        actual_filenames = list(OsfStorageFile.objects.all().values_list('name', flat=True))
         expected_filenames = ['Woo (1).pdf', 'Woo (2).pdf', 'Woo (3).pdf']
-        actual_filenames = [stored_file.name for stored_file in stored_files]
         assert_items_equal(actual_filenames, expected_filenames)
 
     def test_quickfiles_moves_destination_quickfiles_has_weird_numbers(self, user, quickfiles):
@@ -171,9 +170,8 @@ class TestQuickFilesNode:
         user.merge_user(third_user)
         user.save()
 
-        stored_files = BaseFileNode.objects.filter(type='osf.osfstoragefile', node=quickfiles)
+        actual_filenames = list(OsfStorageFile.objects.filter(node=quickfiles).values_list('name', flat=True))
         expected_filenames = ['Woo.pdf', 'Woo (1).pdf', 'Woo (2).pdf', 'Woo (3).pdf']
-        actual_filenames = [stored_file.name for stored_file in stored_files]
 
         assert_items_equal(actual_filenames, expected_filenames)
 

--- a/tests/test_quickfiles.py
+++ b/tests/test_quickfiles.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from osf.models import QuickFilesNode, BaseFileNode
+from osf.models import QuickFilesNode
 from osf_tests.factories import AuthUserFactory
 
 from tests.base import test_app
 from webtest_plus import TestApp
 from addons.osfstorage.tests.utils import make_payload
+from addons.osfstorage.models import OsfStorageFile
 
 from framework.auth import signing
 
@@ -51,7 +52,7 @@ class TestUserQuickFilesNodeFileCreation:
 
         assert res.status_code == 201
         assert res.json['status'] == 'success'
-        assert BaseFileNode.objects.filter(type='osf.osfstoragefile', node__creator=user, name=name).exists()
+        assert OsfStorageFile.objects.filter(node__creator=user, name=name).exists()
 
     def test_create_folder_throws_error(self, flask_app, user, quickfiles, post_to_quickfiles):
         name = 'new_illegal_folder'


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
QuickFiles needs a few improvements and a few additions to the file detail serializer when showing a detail page.


## Changes
- Change API routes from `v2/users/files/` to `v2/users/quickfiles/` per product request
- Change user file relationship to quickfiles
- add `BaseFileSerializer` and split into two subclasses:
    - normal `FileSerializer` for a standard file with the node relationship
    - `QuickFilesFileDetailSerializer` that instead has the user relationship
- use `OsfStorageFile` over `BaseFileNode` where appropriate
- use  `QuickFilesNode._typedmodels_type` over `osf.quickfilesnode` where appropriate

<!-- Briefly describe or list your changes  -->

## Side effects

none anticipated


## Ticket
https://openscience.atlassian.net/browse/OSF-8117