### PR TITLE
[feature] Change stickiness to use previous 30 days; add more stickiness metrics [OSF-7687]

### DIFF
--- a/admin/static/js/metrics/metrics.es6.js
+++ b/admin/static/js/metrics/metrics.es6.js
@@ -64,7 +64,31 @@ var getOneDayTimeframe = function(daysBack, monthsBack) {
     };
 };
 
+/**
+ * Configure a time frame for a day x days ago (end) and y days prior to x (start)
+ *
+ * @method getVariableDayTimeframe
+ * @param {Integer} endDaysBack - the number of days back to set as the end day
+ * @param {Integer} totalDays - the number of days back to reach the start day
+ * @return {Object} the keen-formatted timeframe
+ */
+var getVariableDayTimeframe = function(endDaysBack, totalDays) {
+    var start = null;
+    var end = null;
+    var date = new Date();
 
+    date.setUTCDate(date.getDate() - endDaysBack);
+    date.setUTCHours(0, 0, 0, 0, 0);
+
+    end = date.toISOString();
+
+    date.setDate(date.getDate() - totalDays);
+    start = date.toISOString();
+    return {
+        "start": start,
+        "end": end
+    };
+};
 
 /**
  * Configure a Title for a chart dealing with the past month or day
@@ -322,6 +346,14 @@ var monthlyActiveUsersQuery = new keenAnalysis.Query("count_unique", {
     timezone: "UTC"
 });
 
+// Previous 30 Days Active Users
+var thirtyDaysActiveUsersQuery = new keenAnalysis.Query("count_unique", {
+    eventCollection: "pageviews",
+    targetProperty: "user.id",
+    timeframe: "previous_30_days",
+    timezone: "UTC"
+});
+
 var dailyActiveUsersQuery = new keenAnalysis.Query("count_unique", {
     event_collection: "pageviews",
     target_property: "user.id",
@@ -334,6 +366,48 @@ var totalProjectsQuery = new keenAnalysis.Query("sum", {
     targetProperty: "projects.total",
     timezone: "UTC",
     timeframe: "previous_1_days",
+});
+
+// 7 Days back Active Users
+var weekBackThirtyDaysActiveUsersQuery = new keenAnalysis.Query("count_unique", {
+    eventCollection: "pageviews",
+    targetProperty: "user.id",
+    timeframe: getVariableDayTimeframe(7, 30),
+});
+
+// 7 Days back Active Users
+var weekBackDailyActiveUsersQuery = new keenAnalysis.Query("count_unique", {
+    eventCollection: "pageviews",
+    targetProperty: "user.id",
+    timeframe: getVariableDayTimeframe(7, 1),
+});
+
+// 28 Days back Active Users
+var monthBackThirtyDaysActiveUsersQuery = new keenAnalysis.Query("count_unique", {
+    eventCollection: "pageviews",
+    targetProperty: "user.id",
+    timeframe: getVariableDayTimeframe(28, 30),
+});
+
+// 28 Days back Active Users
+var monthBackDailyActiveUsersQuery = new keenAnalysis.Query("count_unique", {
+    eventCollection: "pageviews",
+    targetProperty: "user.id",
+    timeframe: getVariableDayTimeframe(28, 1),
+});
+
+// 364 Days back Active Users
+var yearBackThirtyDaysActiveUsersQuery = new keenAnalysis.Query("count_unique", {
+    eventCollection: "pageviews",
+    targetProperty: "user.id",
+    timeframe: getVariableDayTimeframe(364, 30),
+});
+
+// 364 Days back Active Users
+var yearBackDailyActiveUsersQuery = new keenAnalysis.Query("count_unique", {
+    eventCollection: "pageviews",
+    targetProperty: "user.id",
+    timeframe: getVariableDayTimeframe(364, 1),
 });
 
 // <+><+><+><+><+><+
@@ -808,7 +882,13 @@ var ActiveUserMetrics = function() {
 var HealthyUserMetrics = function() {
 
     // stickiness ratio - DAU/MAU
-    renderCalculationBetweenTwoQueries(dailyActiveUsersQuery, monthlyActiveUsersQuery, "#stickiness-ratio", null, "percentage");
+    renderCalculationBetweenTwoQueries(dailyActiveUsersQuery, thirtyDaysActiveUsersQuery, "#stickiness-ratio-1-day-ago", null, "percentage");
+     // stickiness ratio - DAU/MAU for 1 week ago
+    renderCalculationBetweenTwoQueries(weekBackDailyActiveUsersQuery, weekBackThirtyDaysActiveUsersQuery , "#stickiness-ratio-1-week-ago", null, "percentage");
+    // stickiness ratio - DAU/MAU for 4 weeks ago
+    renderCalculationBetweenTwoQueries(monthBackDailyActiveUsersQuery, monthBackThirtyDaysActiveUsersQuery , "#stickiness-ratio-4-weeks-ago", null, "percentage");
+    // stickiness ratio - DAU/MAU for 52 weeks ago
+    renderCalculationBetweenTwoQueries(yearBackDailyActiveUsersQuery, yearBackThirtyDaysActiveUsersQuery , "#stickiness-ratio-52-weeks-ago", null, "percentage");
 };
 
 

--- a/admin/templates/metrics/osf_metrics.html
+++ b/admin/templates/metrics/osf_metrics.html
@@ -577,10 +577,50 @@
                                 Stickiness Ratio
                             </div>
                             <div class="chart-stage">
-                                <div id="stickiness-ratio"></div>
+                                <div id="stickiness-ratio-1-day-ago"></div>
                             </div>
                             <div class="chart-notes">
-                                Of those that are active in the last month, how many are active daily? Daily Active Users / Monthly Active Users.
+                                Of those that are active in the last 30 days, how many are active daily? 
+                                Formula: Daily Active Users (yesterday) / Daily Active Users previous 30 days
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-sm-4">
+                        <div class="chart-wrapper">
+                            <div class="chart-title">
+                                Stickiness Ratio 1 week ago
+                            </div>
+                            <div class="chart-stage">
+                                <div id="stickiness-ratio-1-week-ago"></div>
+                            </div>
+                            <div class="chart-notes">
+                                Stickiness Ratio for the same day of the week 1 week ago.
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-sm-4">
+                        <div class="chart-wrapper">
+                            <div class="chart-title">
+                                Stickiness Ratio 4 weeks ago
+                            </div>
+                            <div class="chart-stage">
+                                <div id="stickiness-ratio-4-weeks-ago"></div>
+                            </div>
+                            <div class="chart-notes">
+                                Stickiness Ratio for the same day of the week 4 weeks ago.
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-sm-4">
+                        <div class="chart-wrapper">
+                            <div class="chart-title">
+                                Stickiness Ratio 52 weeks ago
+                            </div>
+                            <div class="chart-stage">
+                                <div id="stickiness-ratio-52-weeks-ago"></div>
+                            </div>
+                            <div class="chart-notes">
+                                Stickiness Ratio for the same day of the week 52 weeks ago.
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Stickiness did not have needed context to be useful. Used previous month instead of last 30 days.
<!-- Describe the purpose of your changes -->

## Changes
1. Use yesterday/previous 30 days now
2. Add stickiness for same day last week, month, year

Old:
<img width="1199" alt="screen shot 2017-08-18 at 12 06 20 pm" src="https://user-images.githubusercontent.com/1322421/29467240-bce5b122-840d-11e7-9bd9-f979a6b085e3.png">
New:
<img width="1194" alt="screen shot 2017-08-18 at 11 59 44 am" src="https://user-images.githubusercontent.com/1322421/29467201-92c442e6-840d-11e7-9ca5-39b141c6304a.png">

<!-- Briefly describe or list your changes  -->

## Side effects
Note the change in % in the screenshots. Previously it was grabbing the previous month and comparing it to yesterday. So  yesterday's DAU / July Users  versus yesterdays DAU / yesterday + 29 more days DAU
<!--Any possible side effects? -->


## Ticket

https://openscience.atlassian.net/browse/OSF-7687

## Tests
No tests, all front end JS changes that don't have tests.

## QA Notes
Make sure everything renders, not much to it. Hard to verify the numbers exactly.
