### PR TITLE
feature/remove folder urls from logs [OSF-8121]

### DIFF
--- a/addons/osfstorage/models.py
+++ b/addons/osfstorage/models.py
@@ -447,24 +447,23 @@ class NodeSettings(BaseStorageAddon, BaseNodeSettings):
         return settings.WATERBUTLER_CREDENTIALS
 
     def create_waterbutler_log(self, auth, action, metadata):
-        url = self.owner.web_url_for(
-            'addon_view_or_download_file',
-            path=metadata['path'],
-            provider='osfstorage'
-        )
+        params = {
+            'node': self.owner._id,
+            'project': self.owner.parent_id,
+
+            'path': metadata['materialized'],
+        }
+
+        if (metadata['kind'] != 'folder'):
+            url = self.owner.web_url_for(
+                'addon_view_or_download_file',
+                path=metadata['path'],
+                provider='osfstorage'
+            )
+            params['urls'] = {'view': url, 'download': url + '?action=download'}
 
         self.owner.add_log(
             'osf_storage_{0}'.format(action),
             auth=auth,
-            params={
-                'node': self.owner._id,
-                'project': self.owner.parent_id,
-
-                'path': metadata['materialized'],
-
-                'urls': {
-                    'view': url,
-                    'download': url + '?action=download'
-                },
-            },
+            params=params
         )

--- a/api/logs/serializers.py
+++ b/api/logs/serializers.py
@@ -167,7 +167,7 @@ class NodeLogSerializer(JSONAPISerializer):
     id = ser.CharField(read_only=True, source='_id')
     date = DateByVersion(read_only=True)
     action = ser.CharField(read_only=True)
-    params = NodeLogParamsSerializer(read_only=True)
+    params = ser.SerializerMethodField(read_only=True)
     links = LinksField({'self': 'get_absolute_url'})
 
     class Meta:
@@ -200,3 +200,8 @@ class NodeLogSerializer(JSONAPISerializer):
 
     def get_absolute_url(self, obj):
         return obj.absolute_url
+
+    def get_params(self, obj):
+        if obj.action == 'osf_storage_folder_created' and obj.params.get('urls'):
+            obj.params.pop('urls')
+        return NodeLogParamsSerializer(obj.params, context=self.context, read_only=True).data

--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -159,6 +159,11 @@ class TestAddonLogs(OsfTestCase):
         self.user_addon.oauth_grants[self.node._id] = {self.oauth_settings._id: []}
         self.user_addon.save()
 
+    def configure_osf_addon(self):
+        self.project = ProjectFactory(creator=self.user)
+        self.node_addon = self.project.get_addon('osfstorage')
+        self.node_addon.save()
+
     def build_payload(self, metadata, **kwargs):
         options = dict(
             auth={'id': self.user._id},
@@ -287,6 +292,28 @@ class TestAddonLogs(OsfTestCase):
             self.node.logs.latest().action,
             'github_addon_file_renamed',
         )
+
+    def test_add_file_osfstorage_log(self):
+        self.configure_osf_addon()
+        path = 'pizza'
+        url = self.node.api_url_for('create_waterbutler_log')
+        payload = self.build_payload(metadata={'materialized': path, 'kind': 'file', 'path': path})
+        nlogs = self.node.logs.count()
+        self.app.put_json(url, payload, headers={'Content-Type': 'application/json'})
+        self.node.reload()
+        assert_equal(self.node.logs.count(), nlogs + 1)
+        assert('urls' in self.node.logs.filter(action='osf_storage_file_added')[0].params)
+
+    def test_add_folder_osfstorage_log(self):
+        self.configure_osf_addon()
+        path = 'pizza'
+        url = self.node.api_url_for('create_waterbutler_log')
+        payload = self.build_payload(metadata={'materialized': path, 'kind': 'folder', 'path': path})
+        nlogs = self.node.logs.count()
+        self.app.put_json(url, payload, headers={'Content-Type': 'application/json'})
+        self.node.reload()
+        assert_equal(self.node.logs.count(), nlogs + 1)
+        assert('urls' not in self.node.logs.filter(action='osf_storage_file_added')[0].params)
 
 
 class TestCheckAuth(OsfTestCase):


### PR DESCRIPTION
## Purpose

Currently when you create a folder in osfstorage, and go to the `logs` view of its node in the api you will see urls ('view' and 'download') for the folder. These folder links are incorrect and should be removed.

## Changes

1. Stop new osf_storage folder links from being added to logs when new logs are created. 
2. Remove osf_storage folder links from api serialization (this stops the api from showing the old urls that already exist in the database).

## Side effects
There will be an inconsistency in the information osf_storage_folder_created `nodelog`s have. Newer osf_storage_folder_created logs will have no urls, while older logs will still have the incorrect urls (we just won't show them).

## Ticket

https://openscience.atlassian.net/browse/OSF-8121

## Testing notes
If you find a node with existing folders and go to <api_url>/nodes/<nid>/logs/ you should no 'urls' section under params. The same should happen if you create a new osfstorage folder. No other urls should be removed - files and folders in places other than osfstorage should still have urls.

<img width="744" alt="screen shot 2017-08-18 at 10 32 58 am" src="https://user-images.githubusercontent.com/7839433/29464194-2167fb7e-8403-11e7-955c-ab2b82d07f97.png">
<img width="439" alt="screen shot 2017-08-18 at 10 33 23 am" src="https://user-images.githubusercontent.com/7839433/29464199-2507ba26-8403-11e7-9812-3c0eaa2d0bbb.png">
