### PR TITLE
[RFR] [OSF-7990] Add attribute share_publish_type to PreprintProviderSerializer.

### DIFF
--- a/api/preprint_providers/serializers.py
+++ b/api/preprint_providers/serializers.py
@@ -23,6 +23,7 @@ class PreprintProviderSerializer(JSONAPISerializer):
     domain_redirect_enabled = ser.BooleanField(required=True)
     footer_links = ser.CharField(required=False)
     share_source = ser.CharField(read_only=True)
+    share_publish_type = ser.CharField(read_only=True)
     email_support = ser.CharField(required=False, allow_null=True)
     preprint_word = ser.CharField(required=False, allow_null=True)
     allow_submissions = ser.BooleanField(read_only=True)

--- a/api_tests/preprint_providers/serializers/test_serializers.py
+++ b/api_tests/preprint_providers/serializers/test_serializers.py
@@ -34,6 +34,7 @@ class TestPreprintProviderSerializer(DbTestCase):
         assert_in('social_facebook', attributes)
         assert_in('social_instagram', attributes)
         assert_in('social_twitter', attributes)
+        assert_in('subjects_acceptable', attributes)
 
     def test_preprint_provider_serialization_v24(self):
         req = make_drf_request_with_version(version='2.4')
@@ -52,3 +53,36 @@ class TestPreprintProviderSerializer(DbTestCase):
         assert_not_in('social_facebook', attributes)
         assert_not_in('social_instagram', attributes)
         assert_not_in('social_twitter', attributes)
+
+    def test_preprint_provider_serialization_v25(self):
+        req = make_drf_request_with_version(version='2.5')
+        result = PreprintProviderSerializer(self.preprint_provider, context={'request': req}).data
+
+        data = result['data']
+        attributes = data['attributes']
+
+        assert_equal(data['id'], self.preprint_provider._id)
+        assert_equal(data['type'], 'preprint_providers')
+
+        assert_not_in('banner_path', attributes)
+        assert_not_in('logo_path', attributes)
+        assert_not_in('header_text', attributes)
+        assert_not_in('email_contact', attributes)
+        assert_not_in('social_facebook', attributes)
+        assert_not_in('social_instagram', attributes)
+        assert_not_in('social_twitter', attributes)
+        assert_not_in('subjects_acceptable', attributes)
+
+        assert_in('name', attributes)
+        assert_in('description', attributes)
+        assert_in('advisory_board', attributes)
+        assert_in('example', attributes)
+        assert_in('domain', attributes)
+        assert_in('domain_redirect_enabled', attributes)
+        assert_in('footer_links', attributes)
+        assert_in('share_source', attributes)
+        assert_in('share_publish_type', attributes)
+        assert_in('email_support', attributes)
+        assert_in('preprint_word', attributes)
+        assert_in('allow_submissions', attributes)
+        assert_in('additional_providers', attributes)


### PR DESCRIPTION
[#OSF-7990]

## Purpose

Add attribute share_publish_type to PreprintProviderSerializer.

## Changes

Add attribute share_publish_type to PreprintProviderSerializer.
Add test.

## Side effects

None


## Ticket

[OSF-7990](https://openscience.atlassian.net/browse/OSF-7990)
