### PR TITLE
[OSF-7423] Allow Figshare to work properly with unicode usernames

### DIFF
--- a/addons/figshare/models.py
+++ b/addons/figshare/models.py
@@ -80,7 +80,7 @@ class FigshareProvider(ExternalProvider):
 
         return {
             'provider_id': about['id'],
-            'display_name': '{} {}'.format(about['first_name'], about.get('last_name')),
+            'display_name': u'{} {}'.format(about['first_name'], about.get('last_name')),
         }
 
 


### PR DESCRIPTION
## Purpose

If you have unicode in your figshare username you currently can't connect to you account to osf, this fix stops the error and allows the accounts to be connected.

## Changes

Simple one line fix stops python from throwing Unicode error.

## Side effects

None that I know of.

## Ticket

## Tests

It would be pretty involved to mock up a test for this and the behavior is largely dependent on FIgshare's client.

https://openscience.atlassian.net/browse/OSF-7423