### PR TITLE
[OSF-8339]API 502 - Continued

### DIFF
--- a/osf/models/files.py
+++ b/osf/models/files.py
@@ -443,11 +443,8 @@ class File(models.Model):
             self.versions.add(version)
         for entry in self.history:
             # Some entry might have an undefined modified field
-            try:
-                if data['modified'] is not None and data['modified'] < entry['modified']:
-                    sentry.log_message('update() receives metatdata older than the newest entry in file history.')
-            except TypeError:
-                pass
+            if data['modified'] is not None and entry['modified'] is not None and data['modified'] < entry['modified']:
+                sentry.log_message('update() receives metatdata older than the newest entry in file history.')
             if ('etag' in entry and 'etag' in data) and (entry['etag'] == data['etag']):
                 break
         else:

--- a/osf/models/files.py
+++ b/osf/models/files.py
@@ -442,8 +442,12 @@ class File(models.Model):
             version.save()
             self.versions.add(version)
         for entry in self.history:
-            if data['modified'] is not None and data['modified'] < entry['modified']:
-                sentry.log_message('update() receives metatdata older than the newest entry in file history.')
+            # Some entry might have an undefined modified field
+            try:
+                if data['modified'] is not None and data['modified'] < entry['modified']:
+                    sentry.log_message('update() receives metatdata older than the newest entry in file history.')
+            except TypeError:
+                pass
             if ('etag' in entry and 'etag' in data) and (entry['etag'] == data['etag']):
                 break
         else:

--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -927,14 +927,12 @@ class TestAddonFileViews(OsfTestCase):
                 ignoretz=True,
                 default=timezone.now()  # Just incase nothing can be parsed
             )})
-        print(file_node.history[0])
         data = {
             'name': 'a name',
             'materialized': 'materialized',
             'modified': '2016-08-22T13:54:32.100900'
         }
         file_node.update(revision=None, user=None, data=data)
-        print(file_node.history[1])
         mock_capture.assert_called_with(unicode('update() receives metatdata older than the newest entry in file history.'), extra={'session': {}})
 
 class TestLegacyViews(OsfTestCase):

--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -3,6 +3,7 @@
 import datetime
 import httplib as http
 import time
+import functools
 
 import furl
 import itsdangerous
@@ -30,7 +31,8 @@ from osf.models.files import BaseFileNode, TrashedFileNode
 from website.project import new_private_link
 from website.project.views.node import _view_project as serialize_node
 from website.util import api_url_for, rubeus
-
+from dateutil.parser import parse as parse_date
+from framework import sentry
 
 class SetEnvironMiddleware(object):
 
@@ -551,6 +553,20 @@ class TestAddonFileViews(OsfTestCase):
         self.user_addon.oauth_grants[self.project._id] = {self.oauth._id: []}
         self.user_addon.save()
 
+    def set_sentry(status):
+        def wrapper(func):
+            @functools.wraps(func)
+            def wrapped(*args, **kwargs):
+                enabled, sentry.enabled = sentry.enabled, status
+                func(*args, **kwargs)
+                sentry.enabled = enabled
+
+            return wrapped
+
+        return wrapper
+
+    with_sentry = set_sentry(True)
+
     def get_test_file(self):
         version = file_models.FileVersion(identifier='1')
         version.save()
@@ -898,9 +914,28 @@ class TestAddonFileViews(OsfTestCase):
             'modified': None
         }
         file_node.update(revision=None, data=file_data)
+        self.assertRaises(EOFError)
         assert_equal(len(file_node.history), 2)
         assert_equal(file_node.history[1], file_data)
 
+    @with_sentry
+    @mock.patch('framework.sentry.sentry.captureMessage')
+    def test_update_logs_to_sentry_when_called_with_disordered_metadata(self, mock_capture):
+        file_node = self.get_test_file()
+        file_node.history.append({'modified': parse_date(
+                '2017-08-22T13:54:32.100900',
+                ignoretz=True,
+                default=timezone.now()  # Just incase nothing can be parsed
+            )})
+        print(file_node.history[0])
+        data = {
+            'name': 'a name',
+            'materialized': 'materialized',
+            'modified': '2016-08-22T13:54:32.100900'
+        }
+        file_node.update(revision=None, user=None, data=data)
+        print(file_node.history[1])
+        mock_capture.assert_called_with(unicode('update() receives metatdata older than the newest entry in file history.'), extra={'session': {}})
 
 class TestLegacyViews(OsfTestCase):
 

--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -914,7 +914,6 @@ class TestAddonFileViews(OsfTestCase):
             'modified': None
         }
         file_node.update(revision=None, data=file_data)
-        self.assertRaises(EOFError)
         assert_equal(len(file_node.history), 2)
         assert_equal(file_node.history[1], file_data)
 


### PR DESCRIPTION
## Purpose

The [previous PR](https://github.com/CenterForOpenScience/osf.io/pull/7544) made a change to log to Sentry upon certain condition. However made the same mistake of failing to consider items with undefined 'modified' field. This PR fix this problem and adds a unit test checking for Sentry log.

## Changes

Changes to logging condition to ignore when 'entry['modified']' is None. Added a new unit test.

## Side effects

None


## Ticket

https://openscience.atlassian.net/browse/OSF-8339
