### PR TITLE
feature/shorten contrib logs: Remove extra 'and' [OSF-8346]

### DIFF
--- a/website/static/js/logTextParser.js
+++ b/website/static/js/logTextParser.js
@@ -114,12 +114,15 @@ var getContributorList = function (contributors, maxShown){
            if(i !== contributors.length -1 && ((i !== maxShown -1) || justOneMore)){
                comma = ', ';
            }
-           if(i === contributors.length -2 || ((i === maxShown -1) && !justOneMore)){
-               comma = ', and ';
+           if(i === contributors.length -2 || ((i === maxShown -1) && !justOneMore) && (i !== contributors.length -1)) {
+               if (contributors.length === 2)
+                   comma = ' and ';
+               else
+                   comma = ', and ';
            }
 
            if (i === maxShown && !justOneMore){
-               contribList.push([((contributors.length - i).toString() + ' others'), '']);
+               contribList.push([((contributors.length - i).toString() + ' others'), ' ']);
                return contribList;
            }
 

--- a/website/static/js/tests/logTextParser.test.js
+++ b/website/static/js/tests/logTextParser.test.js
@@ -24,16 +24,37 @@ describe('logTextParser', () => {
         it('displays all contributors if under maxShown limit', () => {
             var logText = LogText.getContributorList(contributors, 11);
             assert.equal(logText.length, 10);
+            assert.equal(logText[9][1], ' ');
+            assert.equal(logText[8][1], ', and ');
+
+        });
+        it('contribs equals maxShown limit', () => {
+            var logText = LogText.getContributorList(contributors, 10);
+            assert.equal(logText.length, 10);
+            assert.equal(logText[9][1], ' ');
+            assert.equal(logText[8][1], ', and ');
+
         });
         it('displays all contributors if only one over maxShown limit', () => {
             var logText = LogText.getContributorList(contributors, 9);
             assert.equal(logText.length, 10);
+            assert.equal(logText[9][1], ' ');
+            assert.equal(logText[8][1], ', and ');
 
         });
         it('displays only up to maxShown limit', () => {
             var logText = LogText.getContributorList(contributors, 3);
             assert.equal(logText.length, 4);
             assert.equal(logText[3][0], '7 others');
+            assert.equal(logText[3][1], ' ');
+            assert.equal(logText[2][1], ', and ');
+
+        });
+        it('displays no comma if only two contribs added', () => {
+            var logText = LogText.getContributorList([makeFakeContributor(), makeFakeContributor()], 3);
+            assert.equal(logText.length, 2);
+            assert.equal(logText[1][1], ' ');
+            assert.equal(logText[0][1], ' and ');
 
         });
     });


### PR DESCRIPTION
## Purpose

In shortening contrib logs, I ended up with an extra ', and' if maxShown == number of contributors.
Shown [here](https://openscience.atlassian.net/browse/OSF-8346?focusedCommentId=57030&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-57030).

I also realized that after adding the oxford comma, two contributors were added you would have an extra comma.

## Changes

Remove this extra 'and'.
Remove the comma if there are only two contributors.
I also added/updated tests for these cases.

## Ticket

https://openscience.atlassian.net/browse/OSF-8346
