### PR TITLE
[Feature] Fix issues with forking pointer [OSF-8062]

### DIFF
--- a/osf/models/mixins.py
+++ b/osf/models/mixins.py
@@ -399,18 +399,10 @@ class NodeLinkMixin(models.Model):
         except NodeRelation.DoesNotExist:
             raise ValueError('Node link {0} not in list'.format(node_relation._id))
 
-        # Fork into current node and replace pointer with forked component
+        # Fork node to which current nodelink points
         forked = node.fork_node(auth)
         if forked is None:
             raise ValueError('Could not fork node')
-
-        relation = NodeRelation.objects.get(
-            parent=self,
-            child=node,
-            is_node_link=True
-        )
-        relation.child = forked
-        relation.save()
 
         if hasattr(self, 'add_log'):
             # Add log

--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -2578,11 +2578,9 @@ class TestPointerMethods:
         assert forked.is_fork is True
         assert forked.forked_from == content
         assert forked.primary is True
-        assert node._nodes.first() == forked
         assert(
             node.logs.latest().action == NodeLog.POINTER_FORKED
         )
-        assert content not in node._nodes.all()
         assert(
             node.logs.latest().params == {
                 'parent_node': node.parent_id,

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2753,15 +2753,16 @@ class TestPointerViews(OsfTestCase):
         )
         assert_equal(res.status_code, 400)
 
-    def test_fork_pointer(self):
+    def test_forking_pointer_works(self):
         url = self.project.api_url + 'pointer/fork/'
-        node = NodeFactory(creator=self.user)
-        self.project.add_pointer(node, auth=self.consolidate_auth)
-        self.app.post_json(
-            url,
-            {'nodeId': node._id},
-            auth=self.user.auth
-        )
+        linked_node = NodeFactory(creator=self.user)
+        pointer = self.project.add_pointer(linked_node, auth=self.consolidate_auth)
+        assert_true(linked_node.id, pointer.child.id)
+        res = self.app.post_json(url, {'nodeId': pointer.child._id}, auth=self.user.auth)
+        assert_equal(res.status_code, 201)
+        assert_in('node', res.json['data'])
+        fork = res.json['data']['node']
+        assert_equal(fork['title'], 'Fork of {}'.format(linked_node.title))
 
     def test_fork_pointer_not_provided(self):
         url = self.project.api_url + 'pointer/fork/'

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -1173,6 +1173,9 @@ def fork_pointer(auth, node, **kwargs):
     """Fork a pointer. Raises BAD_REQUEST if pointer not provided, not found,
     or not present in `nodes`.
 
+    :param Auth auth: Consolidated authorization
+    :param Node node: root from which pointer is child
+    :return: Fork of node to which nodelink(pointer) points
     """
     NodeRelation = apps.get_model('osf.NodeRelation')
 
@@ -1185,10 +1188,15 @@ def fork_pointer(auth, node, **kwargs):
         raise HTTPError(http.BAD_REQUEST)
 
     try:
-        node.fork_pointer(pointer, auth=auth, save=True)
+        fork = node.fork_pointer(pointer, auth=auth, save=True)
     except ValueError:
         raise HTTPError(http.BAD_REQUEST)
 
+    return {
+        'data': {
+            'node': serialize_node_summary(node=fork, auth=auth, show_path=False)
+        }
+    }, http.CREATED
 
 def abbrev_authors(node):
     lead_author = node.visible_contributors[0]

--- a/website/static/js/project.js
+++ b/website/static/js/project.js
@@ -62,7 +62,7 @@ function afterForkGoto(url) {
       },
       closeButton: false
   });
-};
+}
 
 NodeActions.forkNode = function() {
     NodeActions.beforeForkNode(ctx.node.urls.api + 'fork/before/', function() {
@@ -84,7 +84,7 @@ NodeActions.forkNode = function() {
             }
         ).done(function(response) {
             $osf.unblock();
-            afterForkGoto(response.data.links.html)
+            afterForkGoto(response.data.links.html);
         }).fail(function(response) {
             $osf.unblock();
             if (response.status === 403) {

--- a/website/static/js/project.js
+++ b/website/static/js/project.js
@@ -43,6 +43,27 @@ NodeActions.beforeForkNode = function(url, done) {
     );
 };
 
+function afterForkGoto(url) {
+  bootbox.confirm({
+      message: '<h4 class="add-project-success text-success">Fork created successfully!</h4>',
+      callback: function(result) {
+          if(result) {
+              window.location = url;
+          }
+      },
+      buttons: {
+          confirm: {
+              label: 'Go to new fork',
+              className: 'btn-success'
+          },
+          cancel: {
+              label: 'Keep working here'
+          }
+      },
+      closeButton: false
+  });
+};
+
 NodeActions.forkNode = function() {
     NodeActions.beforeForkNode(ctx.node.urls.api + 'fork/before/', function() {
         // Block page
@@ -63,24 +84,7 @@ NodeActions.forkNode = function() {
             }
         ).done(function(response) {
             $osf.unblock();
-            bootbox.confirm({
-                message: '<h4 class="add-project-success text-success">Fork created successfully!</h4>',
-                callback: function(result) {
-                    if(result) {
-                        window.location = response.data.links.html;
-                    }
-                },
-                buttons: {
-                    confirm: {
-                        label: 'Go to new fork',
-                        className: 'btn-success'
-                    },
-                    cancel: {
-                        label: 'Keep working here'
-                    }
-                },
-                closeButton: false
-            });
+            afterForkGoto(response.data.links.html)
         }).fail(function(response) {
             $osf.unblock();
             if (response.status === 403) {
@@ -109,8 +113,9 @@ NodeActions.forkPointer = function(nodeId) {
                 $osf.postJSON(
                     ctx.node.urls.api + 'pointer/fork/',
                     {nodeId: nodeId}
-                ).done(function() {
-                    window.location.reload();
+                ).done(function(response) {
+                    $osf.unblock();
+                    afterForkGoto(response.data.node.url);
                 }).fail(function() {
                     $osf.unblock();
                     $osf.growl('Error','Could not fork link.');

--- a/website/templates/util/render_node.mako
+++ b/website/templates/util/render_node.mako
@@ -55,7 +55,7 @@
             <div class="pull-right">
                 % if not summary['primary'] and 'write' in user['permissions'] and not node['is_registration']:
                     <i class="fa fa-times remove-pointer" data-id="${summary['id']}" data-toggle="tooltip" title="Remove link"></i>
-                    <i class="fa fa-code-fork" onclick="NodeActions.forkPointer('${summary['id']}', '${summary['primary_id']}');" data-toggle="tooltip" title="Fork this ${summary['node_type']} into ${node['node_type']} ${node['title']}"></i>
+                    <i class="fa fa-code-fork" onclick="NodeActions.forkPointer('${summary['id']}', '${summary['primary_id']}');" data-toggle="tooltip" title="Create a fork of ${summary['title']}"></i>
                 % endif
                 % if summary['primary'] and summary['logged_in'] and summary['is_contributor'] and not summary['is_registration']:
                     <div class="dropdown pull-right" id="componentQuickActions">


### PR DESCRIPTION
## Purpose
**Addl. dev. for https://github.com/CenterForOpenScience/osf.io/pull/7368**

Forking a pointer should create a fork of the node the pointer/nodelink points to, leave the pointer
unchanged.

- Intended: forking a pointer should results in the pointer getting replaced by the fork of the node it points to. The fork should becomes a component of the parent node. 
- What's happening is that the pointer gets replaced by renamed pointer to the a fork of the project it points to.
- What's going to happen, we leave the pointer alone in its place as (non-primary) component, create and return a fork, prompt user to go to the (new) fork or keep working on current page.

## Changes
- Prevent replacing pointer with renamed pointer to fork
- Fix fork-pointer tooltip
- Return fork and status code 
- Update tests

## Before

![before-fork-pointer-fix](https://user-images.githubusercontent.com/4511563/29585148-1f6a672c-8754-11e7-8b4e-eeca6ccc783a.gif)

## After
![after-fork-pointer-fix](https://user-images.githubusercontent.com/4511563/29585149-1f6ac104-8754-11e7-9061-feea2279b4a9.gif)

## Ticket

[OSF-8062](https://openscience.atlassian.net/browse/OSF-8062)
