### PR TITLE
Add title and contributors to preprint serialzier [OSF-8499]

### DIFF
--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -75,6 +75,13 @@ class PreprintSerializer(JSONAPISerializer):
     is_published = ser.BooleanField(required=False)
     is_preprint_orphan = ser.BooleanField(read_only=True)
     license_record = NodeLicenseSerializer(required=False, source='license')
+    title = ser.CharField(source='node.title', read_only=True)
+
+    contributors = RelationshipField(
+        related_view='nodes:node-contributors',
+        related_view_kwargs={'node_id': '<node._id>'},
+        read_only=True
+    )
 
     citation = RelationshipField(
         related_view='preprints:preprint-citation',

--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -63,6 +63,12 @@ class TestPreprintDetail:
         assert data['type'] == 'preprints'
         assert data['id'] == preprint._id
 
+    #   test title in preprint data
+        assert data['attributes']['title'] == preprint.node.title
+
+    #   test contributors in preprint data
+        assert data['relationships'].get('contributors', None)
+
     #   test_preprint_node_deleted_detail_failure
         deleted_node = ProjectFactory(creator=user, is_deleted=True)
         deleted_preprint = PreprintFactory(project=deleted_node, creator=user)
@@ -71,6 +77,17 @@ class TestPreprintDetail:
         deleted_preprint_res = app.get(deleted_preprint_url, expect_errors=True)
         assert deleted_preprint_res.status_code == 404
         assert res.content_type == 'application/vnd.api+json'
+
+    def test_embed_contributors(self, app, user, preprint):
+        url = '/{}preprints/{}/?embed=contributors'.format(API_BASE, preprint._id)
+
+        res = app.get(url, auth=user.auth)
+        embeds = res.json['data']['embeds']
+        ids = preprint.node.contributors.all().values_list('guids___id', flat=True)
+        ids = ['{}-{}'.format(preprint.node._id, id_) for id_ in ids]
+        for contrib in embeds['contributors']['data']:
+            assert contrib['id'] in ids
+
 
 @pytest.mark.django_db
 class TestPreprintDelete:


### PR DESCRIPTION

## Purpose

This is a starting step in the process of separating preprints and nodes -- starting out with the node's title and contributors on the preprint serializer (and making sure the contributor's relationship is embeddable) will make Moderation easier!

## Changes
- add node title and node contributors fields as read only
- add tests to make sure they're there
- add test to make sure node contributors are embeddable on the preprint API view

## Side effects

none anticipated


## Ticket
https://openscience.atlassian.net/browse/OSF-8499