### PR TITLE
Revert "[#OSF-7628]Add Physical COS Address to Transactional\Notification Emails"

### DIFF
--- a/admin/templates/base.html
+++ b/admin/templates/base.html
@@ -197,7 +197,7 @@
       <!-- Main Footer -->
       <footer class="main-footer">
         <!-- Default to the left -->
-        <strong>Copyright &copy; 2015-2017 <a href="http://www.osf.io">osf.io</a>.</strong> All rights reserved.
+        <strong>Copyright &copy; 2015-2016 <a href="http://www.osf.io">osf.io</a>.</strong> All rights reserved.
       </footer>
 
     </div><!-- ./wrapper -->

--- a/website/templates/emails/archive_copy_error_user.html.mako
+++ b/website/templates/emails/archive_copy_error_user.html.mako
@@ -13,13 +13,4 @@
     We cannot archive ${src.title} at this time because there were errors copying files from some of the linked third-party services. It's possible that this is due to temporary unavailability of one or more of these services and that retrying the registration may resolve this issue. Our development team is investigating this failure. We're sorry for any inconvenience this may have caused.
   </td>
 </tr>
-<tr >
-    <td style="border-collapse: collapse;" align="left">
-        <br>
-        Center for Open Science<br>
-        210 Ridge McIntire Road<br>
-        Suite 500<br>
-        Charlottesville, VA 22903-5083<br>
-    </td>
-</tr>
 </%def>

--- a/website/templates/emails/archive_file_not_found_user.html.mako
+++ b/website/templates/emails/archive_file_not_found_user.html.mako
@@ -21,13 +21,4 @@
     </ul>
   </td>
 </tr>
-<tr >
-    <td style="border-collapse: collapse;" align="left">
-        <br>
-        Center for Open Science<br>
-        210 Ridge McIntire Road<br>
-        Suite 500<br>
-        Charlottesville, VA 22903-5083<br>
-    </td>
-</tr>
 </%def>

--- a/website/templates/emails/archive_size_exceeded_user.html.mako
+++ b/website/templates/emails/archive_size_exceeded_user.html.mako
@@ -12,13 +12,4 @@
     We cannot archive ${src.title} at this time because the projected size of the registration exceeds our usage limits. You should receive a followup email from our support team shortly. We're sorry for any inconvenience this may have caused.
   </td>
 </tr>
-<tr >
-    <td style="border-collapse: collapse;" align="left">
-        <br>
-        Center for Open Science<br>
-        210 Ridge McIntire Road<br>
-        Suite 500<br>
-        Charlottesville, VA 22903-5083<br>
-    </td>
-</tr>
 </%def>

--- a/website/templates/emails/archive_success.html.mako
+++ b/website/templates/emails/archive_success.html.mako
@@ -14,13 +14,4 @@
     You can view the registration <a href="${settings.DOMAIN.rstrip('/') + src.url}">here.</a>
   </td>
 </tr>
-<tr >
-    <td style="border-collapse: collapse;" align="left">
-        <br>
-        Center for Open Science<br>
-        210 Ridge McIntire Road<br>
-        Suite 500<br>
-        Charlottesville, VA 22903-5083<br>
-    </td>
-</tr>
 </%def>

--- a/website/templates/emails/archive_uncaught_error_user.html.mako
+++ b/website/templates/emails/archive_uncaught_error_user.html.mako
@@ -13,13 +13,4 @@
     We cannot archive ${src.title} at this time because there were errors copying files to the registration. Our development team is investigating this failure. We're sorry for any inconvenience this may have caused.
   </td>
 </tr>
-<tr >
-    <td style="border-collapse: collapse;" align="left">
-        <br>
-        Center for Open Science<br>
-        210 Ridge McIntire Road<br>
-        Suite 500<br>
-        Charlottesville, VA 22903-5083<br>
-    </td>
-</tr>
 </%def>

--- a/website/templates/emails/comment_replies.html.mako
+++ b/website/templates/emails/comment_replies.html.mako
@@ -14,13 +14,11 @@
             <a href="${url}" style="padding: 0;margin: 0;border: none;list-style: none;color: #008de5;text-decoration: none;">&#10095;</a>
         </td>
     </tr>
-    <tr >
-        <td style="border-collapse: collapse;" align="left">
-            <br>
-            Center for Open Science<br>
-            210 Ridge McIntire Road<br>
-            Suite 500<br>
-            Charlottesville, VA 22903-5083<br>
-        </td>
+    <tr style="border-collapse: collapse;" align="left">
+        <br>
+        Center for Open Science<br>
+        210 Ridge McIntire Road<br>
+        Suite 500<br>
+        Charlottesville, VA 22903-5083<br>
     </tr>
 </table>

--- a/website/templates/emails/comment_replies.txt.mako
+++ b/website/templates/emails/comment_replies.txt.mako
@@ -4,7 +4,7 @@ ${'\t'}To view this on the Open Science Framework, please visit: ${url}.
 
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md

--- a/website/templates/emails/comments.txt.mako
+++ b/website/templates/emails/comments.txt.mako
@@ -1,10 +1,3 @@
 ${user} at ${localized_timestamp}: ${content}.
 
 ${'\t'}To view this on the Open Science Framework, please visit: ${url}.
-
-
-Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
-Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md

--- a/website/templates/emails/conference_failed.txt.mako
+++ b/website/templates/emails/conference_failed.txt.mako
@@ -7,7 +7,7 @@ Sincerely yours,
 The OSF Robot
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md

--- a/website/templates/emails/conference_inactive.txt.mako
+++ b/website/templates/emails/conference_inactive.txt.mako
@@ -7,7 +7,7 @@ Sincerely yours,
 The OSF Robot
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md

--- a/website/templates/emails/conference_submitted.txt.mako
+++ b/website/templates/emails/conference_submitted.txt.mako
@@ -31,7 +31,7 @@ Sincerely yours,
 The OSF Robot
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md

--- a/website/templates/emails/confirm.txt.mako
+++ b/website/templates/emails/confirm.txt.mako
@@ -9,7 +9,7 @@ ${confirmation_url}
 The OSF Team
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md

--- a/website/templates/emails/confirm_erpc.txt.mako
+++ b/website/templates/emails/confirm_erpc.txt.mako
@@ -7,7 +7,7 @@ ${confirmation_url}
 From the team at the Center for Open Science
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md

--- a/website/templates/emails/confirm_merge.txt.mako
+++ b/website/templates/emails/confirm_merge.txt.mako
@@ -10,7 +10,7 @@ If you do not wish to merge these accounts, no action is required on your part. 
 
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md

--- a/website/templates/emails/confirm_preprints_branded.txt.mako
+++ b/website/templates/emails/confirm_preprints_branded.txt.mako
@@ -9,7 +9,7 @@ Sincerely,
 Your ${branded_preprints_provider} and OSF teams
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md

--- a/website/templates/emails/confirm_preprints_osf.txt.mako
+++ b/website/templates/emails/confirm_preprints_osf.txt.mako
@@ -9,7 +9,7 @@ Sincerely,
 Open Science Framework Robot
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md

--- a/website/templates/emails/confirm_prereg.txt.mako
+++ b/website/templates/emails/confirm_prereg.txt.mako
@@ -7,7 +7,7 @@ ${confirmation_url}
 From the team at the Center for Open Science
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md

--- a/website/templates/emails/confirm_registries_osf.txt.mako
+++ b/website/templates/emails/confirm_registries_osf.txt.mako
@@ -7,9 +7,3 @@ ${confirmation_url}
 
 Sincerely,
 Open Science Framework Robot
-
-Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
-Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md

--- a/website/templates/emails/contributor_added_default.txt.mako
+++ b/website/templates/emails/contributor_added_default.txt.mako
@@ -16,9 +16,9 @@ Sincerely,
 Open Science Framework Robot
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md
 
 Want more information? Visit https://osf.io/ to learn about the Open Science Framework, or https://cos.io/ for information about its supporting organization, the Center for Open Science.

--- a/website/templates/emails/contributor_added_preprint_node_from_osf.txt.mako
+++ b/website/templates/emails/contributor_added_preprint_node_from_osf.txt.mako
@@ -17,11 +17,6 @@ Sincerely,
 
 Open Science Framework Robot
 
-Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
-Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md
 
 Want more information? Visit https://osf.io/ to learn about the Open Science Framework, or https://cos.io/ for information about its supporting organization, the Center for Open Science.
 

--- a/website/templates/emails/contributor_added_preprints_branded.txt.mako
+++ b/website/templates/emails/contributor_added_preprints_branded.txt.mako
@@ -16,9 +16,9 @@ Sincerely,
 Your ${branded_service.name} and OSF teams
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md
 
 Want more information? Visit https://osf.io/preprints/${branded_service._id} to learn about ${branded_service.name} or https://osf.io/ to learn about the Open Science Framework, or https://cos.io/ for information about its supporting organization, the Center for Open Science.

--- a/website/templates/emails/contributor_added_preprints_osf.txt.mako
+++ b/website/templates/emails/contributor_added_preprints_osf.txt.mako
@@ -16,9 +16,9 @@ Sincerely,
 Open Science Framework Robot
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md
 
 Want more information? Visit https://osf.io/ to learn about the Open Science Framework, or https://cos.io/ for information about its supporting organization, the Center for Open Science.

--- a/website/templates/emails/digest.txt.mako
+++ b/website/templates/emails/digest.txt.mako
@@ -21,9 +21,9 @@ ${build_message(message)}
 From the Open Science Framework
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md
 
 <%def name="build_message(d, indent=0)">

--- a/website/templates/emails/email_contributors_of_registrations.txt.mako
+++ b/website/templates/emails/email_contributors_of_registrations.txt.mako
@@ -17,9 +17,9 @@ Regards,
 The OSF Team
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md
 
 We may send you occasional Service-related emails that you may not opt-out of (e.g. changes or updates to features of our Services that have security or privacy implications, technical and security notices, account verification); this is one of those emails.

--- a/website/templates/emails/email_removed.txt.mako
+++ b/website/templates/emails/email_removed.txt.mako
@@ -10,7 +10,7 @@ Sincerely yours,
 The OSF Robot
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md

--- a/website/templates/emails/external_confirm_create.txt.mako
+++ b/website/templates/emails/external_confirm_create.txt.mako
@@ -9,7 +9,7 @@ ${confirmation_url}
 The OSF Team
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md

--- a/website/templates/emails/external_confirm_link.txt.mako
+++ b/website/templates/emails/external_confirm_link.txt.mako
@@ -9,7 +9,7 @@ ${confirmation_url}
 The OSF Team
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md

--- a/website/templates/emails/external_confirm_success.txt.mako
+++ b/website/templates/emails/external_confirm_success.txt.mako
@@ -5,7 +5,7 @@ Congratulations! You have successfully linked your ${external_id_provider} accou
 The OSF Team
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md

--- a/website/templates/emails/file_operation_failed.html.mako
+++ b/website/templates/emails/file_operation_failed.html.mako
@@ -63,14 +63,12 @@
             </table>
         </td>
     </tr>
-    <tr >
-        <td style="border-collapse: collapse;" align="left">
-            <br>
-            Center for Open Science<br>
-            210 Ridge McIntire Road<br>
-            Suite 500<br>
-            Charlottesville, VA 22903-5083<br>
-        </td>
+    <tr style="border-collapse: collapse;" align="left">
+        <br>
+        Center for Open Science<br>
+        210 Ridge McIntire Road<br>
+        Suite 500<br>
+        Charlottesville, VA 22903-5083<br>
     </tr>
     <tr>
         <td style="border-collapse: collapse; padding-top: 15px;">
@@ -78,7 +76,7 @@
                 <tbody>
                     <tr>
                         <td style="border-collapse: collapse;">
-                            <p class="small text-center" style="text-align: center;font-size: 12px;">Copyright &copy; 2017 Center For Open Science, All rights reserved. |
+                            <p class="small text-center" style="text-align: center;font-size: 12px;">Copyright &copy; 2015 Center For Open Science, All rights reserved. |
                                     <a href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/PRIVACY_POLICY.md">Privacy Policy</a></p>
                             <p class="small text-center" style="text-align: center;font-size: 12px; line-height: 20px;">You received this email because you are subscribed to email notifications. <br><a href="${url}" style="padding: 0;margin: 0;border: none;list-style: none;color: #008de5;text-decoration: none;font-weight: bold;">Update Subscription Preferences</a></p>
                         </td>

--- a/website/templates/emails/file_operation_failed.txt.mako
+++ b/website/templates/emails/file_operation_failed.txt.mako
@@ -5,7 +5,7 @@ An error has occurred, and the ${'folder' if source_path.endswith('/') else 'fil
 The Open Science Framework Robot
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md

--- a/website/templates/emails/file_operation_success.html.mako
+++ b/website/templates/emails/file_operation_success.html.mako
@@ -58,14 +58,12 @@
                           The ${'folder' if source_path.endswith('/') else 'file'} "${source_path.strip('/')}" has been successfully ${'moved' if action == 'move' else 'copied'} from ${source_addon} in ${source_node.title} to ${destination_addon}.
                         </td>
                     </tr>
-                    <<tr >
-                        <td style="border-collapse: collapse;" align="left">
-                            <br>
-                            Center for Open Science<br>
-                            210 Ridge McIntire Road<br>
-                            Suite 500<br>
-                            Charlottesville, VA 22903-5083<br>
-                        </td>
+                    <tr style="border-collapse: collapse;" align="left">
+                        <br>
+                        Center for Open Science<br>
+                        210 Ridge McIntire Road<br>
+                        Suite 500<br>
+                        Charlottesville, VA 22903-5083<br>
                     </tr>
                 </tbody>
             </table>
@@ -77,7 +75,7 @@
                 <tbody>
                     <tr>
                         <td style="border-collapse: collapse;">
-                            <p class="small text-center" style="text-align: center;font-size: 12px;">Copyright &copy; 2017 Center For Open Science, All rights reserved. |
+                            <p class="small text-center" style="text-align: center;font-size: 12px;">Copyright &copy; 2015 Center For Open Science, All rights reserved. |
                                     <a href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/PRIVACY_POLICY.md">Privacy Policy</a></p>
                             <p class="small text-center" style="text-align: center;font-size: 12px; line-height: 20px;">You received this email because you are subscribed to email notifications. <br><a href="${url}" style="padding: 0;margin: 0;border: none;list-style: none;color: #008de5;text-decoration: none;font-weight: bold;">Update Subscription Preferences</a></p>
                         </td>

--- a/website/templates/emails/file_operation_success.txt.mako
+++ b/website/templates/emails/file_operation_success.txt.mako
@@ -5,7 +5,7 @@ The ${'folder' if source_path.endswith('/') else 'file'} "${source_path.strip('/
 The Open Science Framework Robot
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md

--- a/website/templates/emails/file_updated.html.mako
+++ b/website/templates/emails/file_updated.html.mako
@@ -7,20 +7,18 @@
                 <span class="person" style="font-weight: bold;">${user.fullname} </span>
                 ${message}
             </span>
+            <tr style="border-collapse: collapse;" align="left">
+                <br>
+                Center for Open Science<br>
+                210 Ridge McIntire Road<br>
+                Suite 500<br>
+                Charlottesville, VA 22903-5083<br>
+            </tr>
         </td>
         <td width="25" style="text-align:center;border-collapse: collapse;font-size: 24px;border-left: 1px solid #ddd;">
             <a href="${url}" style="margin: 0;border: none;list-style: none;color: #008de5;text-decoration: none;">
                 &#10095;
             </a>
-        </td>
-    </tr>
-    <tr >
-        <td style="border-collapse: collapse;" align="left">
-            <br>
-            Center for Open Science<br>
-            210 Ridge McIntire Road<br>
-            Suite 500<br>
-            Charlottesville, VA 22903-5083<br>
         </td>
     </tr>
 </table>

--- a/website/templates/emails/forgot_password.txt.mako
+++ b/website/templates/emails/forgot_password.txt.mako
@@ -4,7 +4,7 @@ ${reset_link}
 
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md

--- a/website/templates/emails/forward_invite.txt.mako
+++ b/website/templates/emails/forward_invite.txt.mako
@@ -25,9 +25,9 @@ Sincerely,
 The OSF Team
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md
 
 Want more information? Visit https://osf.io/ or https://cos.io/ for information about the Open Science Framework and its supporting organization, the Center for Open Science. Questions? Email contact@osf.io.

--- a/website/templates/emails/forward_invite_registered.txt.mako
+++ b/website/templates/emails/forward_invite_registered.txt.mako
@@ -21,9 +21,9 @@ Sincerely,
 The OSF Team
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md
 
 Want more information? Visit https://osf.io/ or https://cos.io/ for information about the Open Science Framework and its supporting organization, the Center for Open Science. Questions? Email contact@osf.io

--- a/website/templates/emails/initial_confirm.txt.mako
+++ b/website/templates/emails/initial_confirm.txt.mako
@@ -9,7 +9,7 @@ ${confirmation_url}
 The OSF Team
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md

--- a/website/templates/emails/invite_default.txt.mako
+++ b/website/templates/emails/invite_default.txt.mako
@@ -22,9 +22,9 @@ Sincerely,
 Open Science Framework Robot
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md
 
 Want more information? Visit https://osf.io/ to learn about the Open Science Framework, or https://cos.io/ for information about its supporting organization, the Center for Open Science.

--- a/website/templates/emails/invite_preprints_branded.txt.mako
+++ b/website/templates/emails/invite_preprints_branded.txt.mako
@@ -22,9 +22,9 @@ Sincerely,
 Your ${branded_service.name} and OSF teams
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md
 
 Want more information? Visit https://osf.io/preprints/${branded_service._id} to learn about ${branded_service.name} or https://osf.io/ to learn about the Open Science Framework, or https://cos.io/ for information about its supporting organization, the Center for Open Science.

--- a/website/templates/emails/invite_preprints_osf.txt.mako
+++ b/website/templates/emails/invite_preprints_osf.txt.mako
@@ -22,9 +22,9 @@ Sincerely,
 Open Science Framework Robot
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md
 
 Want more information? Visit https://osf.io/ to learn about the Open Science Framework, or https://cos.io/ for information about its supporting organization, the Center for Open Science.

--- a/website/templates/emails/mentions.html.mako
+++ b/website/templates/emails/mentions.html.mako
@@ -10,17 +10,15 @@
             <span class="timestamp" style="color: grey;"> at ${localized_timestamp}: </span>
             <span class="content" style="display: block;padding: 6px 5px 0px 8px;font-size: 14px;">${content}</span>
         </td>
-        <td class="link text-center" width="25" style="border-collapse: collapse;text-align: center;font-size: 18px;border-left: 1px solid #ddd;">
-            <a href="${url}" style="padding: 0;margin: 0;border: none;list-style: none;color: #008de5;text-decoration: none;">&#10095;</a>
-        </td>
-    </tr>
-    <tr >
-        <td style="border-collapse: collapse;" align="left">
+        <tr style="border-collapse: collapse;" align="left">
             <br>
             Center for Open Science<br>
             210 Ridge McIntire Road<br>
             Suite 500<br>
             Charlottesville, VA 22903-5083<br>
+        </tr>
+        <td class="link text-center" width="25" style="border-collapse: collapse;text-align: center;font-size: 18px;border-left: 1px solid #ddd;">
+            <a href="${url}" style="padding: 0;margin: 0;border: none;list-style: none;color: #008de5;text-decoration: none;">&#10095;</a>
         </td>
     </tr>
 </table>

--- a/website/templates/emails/mentions.txt.mako
+++ b/website/templates/emails/mentions.txt.mako
@@ -4,7 +4,7 @@ ${'\t'}To view this on the Open Science Framework, please visit: ${url}.
 
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md

--- a/website/templates/emails/new_public_project.html.mako
+++ b/website/templates/emails/new_public_project.html.mako
@@ -22,13 +22,6 @@
         Best wishes,
         <br>
         COS Support Team
-
-        <br>
-        Center for Open Science<br>
-        210 Ridge McIntire Road<br>
-        Suite 500<br>
-        Charlottesville, VA 22903-5083<br>
-
     </div>
 </%def>
 <%def name="footer()">

--- a/website/templates/emails/no_addon.html.mako
+++ b/website/templates/emails/no_addon.html.mako
@@ -15,13 +15,6 @@
         <br><br>
         Best wishes,<br>
         COS Support Team
-
-        <br>
-        Center for Open Science<br>
-        210 Ridge McIntire Road<br>
-        Suite 500<br>
-        Charlottesville, VA 22903-5083<br>
-
     </div>
 </%def>
 <%def name="footer()">

--- a/website/templates/emails/no_login.html.mako
+++ b/website/templates/emails/no_login.html.mako
@@ -19,13 +19,6 @@
         Best,
         <br>
         COS Support Team
-
-        <br>
-        Center for Open Science<br>
-        210 Ridge McIntire Road<br>
-        Suite 500<br>
-        Charlottesville, VA 22903-5083<br>
-
     </div>
 </%def>
 <%def name="footer()">

--- a/website/templates/emails/notify_base.mako
+++ b/website/templates/emails/notify_base.mako
@@ -39,6 +39,13 @@
             <table id="content" width="600" border="0" cellpadding="25" cellspacing="0" align="center" style="margin: 30px auto 0 auto;background: white;box-shadow: 0 0 2px #ccc;">
               <tbody>
                 ${self.content()}
+                <tr style="border-collapse: collapse;" align="left">
+                    <br>
+                    Center for Open Science<br>
+                    210 Ridge McIntire Road<br>
+                    Suite 500<br>
+                    Charlottesville, VA 22903-5083<br>
+                </tr>
               </tbody>
             </table>
 
@@ -61,7 +68,7 @@
                     <tbody>
                         <tr>
                             <td style="border-collapse: collapse;">
-                                <p class="text-smaller text-center" style="text-align: center;font-size: 12px;">Copyright &copy; 2017 Center For Open Science, All rights reserved. |
+                                <p class="text-smaller text-center" style="text-align: center;font-size: 12px;">Copyright &copy; 2016 Center For Open Science, All rights reserved. |
                                     <a href="https://github.com/CenterForOpenScience/centerforopenscience.org/blob/master/PRIVACY_POLICY.md">Privacy Policy</a>
                                 ${self.footer()}
                                 </p>

--- a/website/templates/emails/password_reset.txt.mako
+++ b/website/templates/emails/password_reset.txt.mako
@@ -13,7 +13,7 @@ Sincerely yours,
 The OSF Robot
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md

--- a/website/templates/emails/pending_embargo_admin.txt.mako
+++ b/website/templates/emails/pending_embargo_admin.txt.mako
@@ -23,7 +23,7 @@ Sincerely yours,
 The OSF Robots
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md

--- a/website/templates/emails/pending_embargo_non_admin.txt.mako
+++ b/website/templates/emails/pending_embargo_non_admin.txt.mako
@@ -10,7 +10,7 @@ Sincerely yours,
 The OSF Robots
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md

--- a/website/templates/emails/pending_embargo_termination_admin.txt.mako
+++ b/website/templates/emails/pending_embargo_termination_admin.txt.mako
@@ -15,7 +15,7 @@ Sincerely yours,
 The OSF Robots
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md

--- a/website/templates/emails/pending_embargo_termination_non_admin.txt.mako
+++ b/website/templates/emails/pending_embargo_termination_non_admin.txt.mako
@@ -9,7 +9,7 @@ Sincerely yours,
 The OSF Robots
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md

--- a/website/templates/emails/pending_invite.txt.mako
+++ b/website/templates/emails/pending_invite.txt.mako
@@ -13,9 +13,9 @@ Sincerely,
 The OSF Team
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md
 
 More information? Visit https://osf.io/ and https://cos.io/ for information about the Open Science Framework and its supporting organization, the Center for Open Science.

--- a/website/templates/emails/pending_registered.txt.mako
+++ b/website/templates/emails/pending_registered.txt.mako
@@ -13,9 +13,9 @@ Sincerely,
 The OSF Team
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md
 
 More information? Visit https://osf.io/ and https://cos.io/ for information about the Open Science Framework and its supporting organization, the Center for Open Science.

--- a/website/templates/emails/pending_registration_admin.txt.mako
+++ b/website/templates/emails/pending_registration_admin.txt.mako
@@ -22,7 +22,7 @@ Sincerely yours,
 The OSF Robots
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md

--- a/website/templates/emails/pending_registration_non_admin.txt.mako
+++ b/website/templates/emails/pending_registration_non_admin.txt.mako
@@ -10,7 +10,7 @@ Sincerely yours,
 The OSF Robots
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md

--- a/website/templates/emails/pending_retraction_admin.txt.mako
+++ b/website/templates/emails/pending_retraction_admin.txt.mako
@@ -18,7 +18,7 @@ Sincerely yours,
 The OSF Robots
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md

--- a/website/templates/emails/pending_retraction_non_admin.txt.mako
+++ b/website/templates/emails/pending_retraction_non_admin.txt.mako
@@ -9,7 +9,7 @@ Sincerely yours,
 The OSF Robots
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md

--- a/website/templates/emails/prereg_challenge_rejected.txt.mako
+++ b/website/templates/emails/prereg_challenge_rejected.txt.mako
@@ -13,7 +13,7 @@ Sincerely,
 The team at the Center for Open Science
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md

--- a/website/templates/emails/primary_email_changed.txt.mako
+++ b/website/templates/emails/primary_email_changed.txt.mako
@@ -9,7 +9,7 @@ Sincerely yours,
 The OSF Robot
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md

--- a/website/templates/emails/security_permissions_change.txt.mako
+++ b/website/templates/emails/security_permissions_change.txt.mako
@@ -19,9 +19,9 @@ Regards,
 The OSF Team
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md
 
 Note: In system-wide security messages, we will not ask you to click on links or ask you for information - passwords or otherwise.

--- a/website/templates/emails/spam_user_banned.txt.mako
+++ b/website/templates/emails/spam_user_banned.txt.mako
@@ -7,7 +7,7 @@ Regards,
 The OSF Team
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md

--- a/website/templates/emails/transactional.html.mako
+++ b/website/templates/emails/transactional.html.mako
@@ -27,15 +27,6 @@
                 </td>
             </tr>
         </tbody>
-        <tr >
-            <td style="border-collapse: collapse;" align="left">
-                <br>
-                Center for Open Science<br>
-                210 Ridge McIntire Road<br>
-                Suite 500<br>
-                Charlottesville, VA 22903-5083<br>
-            </td>
-        </tr>
     </table>
 </%def>
 

--- a/website/templates/emails/transactional.txt.mako
+++ b/website/templates/emails/transactional.txt.mako
@@ -5,7 +5,7 @@ Recent Activity:
 From the Open Science Framework
 
 Center for Open Science
-
-210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-
+210 Ridge McIntire Road
+Suite 500
+Charlottesville, VA 22903-5083
 Privacy Policy: https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md

--- a/website/templates/emails/welcome.html.mako
+++ b/website/templates/emails/welcome.html.mako
@@ -40,13 +40,6 @@ Learn more about the OSF by reading the <a href="http://help.osf.io/">Guides</a>
 Sincerely,<br>
 <br>
 The Center for Open Science Team<br>
-
-<br>
-Center for Open Science<br>
-210 Ridge McIntire Road<br>
-Suite 500<br>
-Charlottesville, VA 22903-5083<br>
-
   </td>
 </tr>
 </%def>

--- a/website/templates/emails/welcome_osf4i.html.mako
+++ b/website/templates/emails/welcome_osf4i.html.mako
@@ -42,13 +42,6 @@ Learn more about the OSF at our <a href="http://help.osf.io">Guides page</a>, or
 Sincerely,<br>
 <br>
 The Center for Open Science Team<br>
-
-<br>
-Center for Open Science<br>
-210 Ridge McIntire Road<br>
-Suite 500<br>
-Charlottesville, VA 22903-5083<br>
-
   </td>
 </tr>
 </%def>

--- a/website/templates/emails/welcome_osf4m.html.mako
+++ b/website/templates/emails/welcome_osf4m.html.mako
@@ -23,13 +23,6 @@
         Best wishes,
         <br>
         COS Support Team
-
-        <br>
-        Center for Open Science<br>
-        210 Ridge McIntire Road<br>
-        Suite 500<br>
-        Charlottesville, VA 22903-5083<br>
-
         <br><br>
         P.S. Got questions? <a href="mailto:support@osf.io">Just send us an email!</a>
     </div>


### PR DESCRIPTION
Reverts CenterForOpenScience/osf.io#7605