### PR TITLE
[OSF-8421] Change "preprint" text to "thesis," etc in emails

### DIFF
--- a/website/mails/mails.py
+++ b/website/mails/mails.py
@@ -177,7 +177,7 @@ CONFIRM_EMAIL_ERPC = Mail(
 )
 CONFIRM_EMAIL_PREPRINTS = lambda name, provider: Mail(
     'confirm_preprints_{}'.format(name),
-    subject='Open Science Framework Account Verification, {} Preprints Service'.format(provider)
+    subject='Open Science Framework Account Verification, {}'.format(provider)
 )
 CONFIRM_EMAIL_REGISTRIES_OSF = Mail(
     'confirm_registries_osf',
@@ -197,7 +197,7 @@ INVITE_DEFAULT = Mail(
 )
 INVITE_PREPRINT = lambda template, provider: Mail(
     'invite_preprints_{}'.format(template),
-    subject='You have been added as a contributor to {} {} preprint.'.format(get_english_article(provider), provider)
+    subject='You have been added as a contributor to {} {} {}.'.format(get_english_article(provider.name), provider.name, provider.preprint_word)
 )
 CONTRIBUTOR_ADDED_DEFAULT = Mail(
     'contributor_added_default',
@@ -205,7 +205,7 @@ CONTRIBUTOR_ADDED_DEFAULT = Mail(
 )
 CONTRIBUTOR_ADDED_PREPRINT = lambda template, provider: Mail(
     'contributor_added_preprints_{}'.format(template),
-    subject='You have been added as a contributor to {} {} preprint.'.format(get_english_article(provider), provider)
+    subject='You have been added as a contributor to {} {} {}.'.format(get_english_article(provider.name), provider.name, provider.preprint_word)
 )
 CONTRIBUTOR_ADDED_PREPRINT_NODE_FROM_OSF = Mail(
     'contributor_added_preprint_node_from_osf',

--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -454,7 +454,7 @@ def send_claim_email(email, unclaimed_user, node, notify=True, throttle=24 * 360
             email_template, preprint_provider = find_preprint_provider(node)
             if not email_template or not preprint_provider:
                 return
-            mail_tpl = getattr(mails, 'INVITE_PREPRINT')(email_template, preprint_provider.name)
+            mail_tpl = getattr(mails, 'INVITE_PREPRINT')(email_template, preprint_provider)
         else:
             mail_tpl = getattr(mails, 'INVITE_DEFAULT'.format(email_template.upper()))
 
@@ -529,7 +529,7 @@ def notify_added_contributor(node, contributor, auth=None, throttle=None, email_
             email_template, preprint_provider = find_preprint_provider(node)
             if not email_template or not preprint_provider:
                 return
-            email_template = getattr(mails, 'CONTRIBUTOR_ADDED_PREPRINT')(email_template, preprint_provider.name)
+            email_template = getattr(mails, 'CONTRIBUTOR_ADDED_PREPRINT')(email_template, preprint_provider)
         elif node.is_preprint:
             email_template = getattr(mails, 'CONTRIBUTOR_ADDED_PREPRINT_NODE_FROM_OSF'.format(email_template.upper()))
         else:

--- a/website/templates/emails/confirm_preprints_branded.txt.mako
+++ b/website/templates/emails/confirm_preprints_branded.txt.mako
@@ -1,6 +1,6 @@
 Hello ${user.fullname},
 
-Welcome to ${branded_preprints_provider} Preprints, powered by the Open Science Framework. To continue, please verify your email address by visiting this link:
+Welcome to ${branded_preprints_provider}, powered by the Open Science Framework. To continue, please verify your email address by visiting this link:
 
 ${confirmation_url}
 

--- a/website/templates/emails/contributor_added_preprints_branded.txt.mako
+++ b/website/templates/emails/contributor_added_preprints_branded.txt.mako
@@ -4,9 +4,9 @@
 
 Hello ${user.fullname},
 
-${referrer_name + ' has added you' if referrer_name else 'You have been added'} as a contributor to the preprint "${node.title}" on ${branded_service.name}, which is hosted on the Open Science Framework: ${node.absolute_url}
+${referrer_name + ' has added you' if referrer_name else 'You have been added'} as a contributor to the ${branded_service.preprint_word} "${node.title}" on ${branded_service.name}, which is hosted on the Open Science Framework: ${node.absolute_url}
 
-You will ${'not receive ' if all_global_subscriptions_none else 'be automatically subscribed to '}notification emails for this preprint. Each preprint is associated with a project on the Open Science Framework for managing the preprint. To change your email notification preferences, visit your project user settings: ${settings.DOMAIN + "settings/notifications/"}
+You will ${'not receive ' if all_global_subscriptions_none else 'be automatically subscribed to '}notification emails for this ${branded_service.preprint_word}. Each ${branded_service.preprint_word} is associated with a project on the Open Science Framework for managing the ${branded_service.preprint_word}. To change your email notification preferences, visit your project user settings: ${settings.DOMAIN + "settings/notifications/"}
 
 If you have been erroneously associated with "${node.title}", then you may visit the project's "Contributors" page and remove yourself as a contributor.
 

--- a/website/templates/emails/invite_preprints_branded.txt.mako
+++ b/website/templates/emails/invite_preprints_branded.txt.mako
@@ -4,11 +4,11 @@
 
 Hello ${fullname},
 
-You have been added by ${referrer.fullname} as a contributor to the preprint "${node.title}" on ${branded_service.name}, powered by the Open Science Framework. To set a password for your account, visit:
+You have been added by ${referrer.fullname} as a contributor to the ${branded_service.preprint_word} "${node.title}" on ${branded_service.name}, powered by the Open Science Framework. To set a password for your account, visit:
 
 ${claim_url}
 
-Once you have set a password, you will be able to make contributions to "${node.title}" and create your own preprints. You will automatically be subscribed to notification emails for this preprint. Each preprint is associated with a project on the Open Science Framework for managing the preprint.  To change your email notification preferences, visit your project or your user settings: ${settings.DOMAIN + "settings/notifications/"}
+Once you have set a password, you will be able to make contributions to "${node.title}" and create your own ${branded_service.preprint_word}. You will automatically be subscribed to notification emails for this ${branded_service.preprint_word}. Each ${branded_service.preprint_word} is associated with a project on the Open Science Framework for managing the ${branded_service.preprint_word}.  To change your email notification preferences, visit your project or your user settings: ${settings.DOMAIN + "settings/notifications/"}
 
 To preview "${node.title}" click the following link: ${node.absolute_url}
 


### PR DESCRIPTION
## Purpose

To change the wording in emails sent by branded preprint sites.

## Changes

Change three email templates to make use of `preprint_word_singular` and `preprint_word_plural` fields. Add a migration file.

## Side effects

The change only works if the `preprint_word_singular` and `preprint_word_plural` fields for each PreprintProvider instances are set on prod/staging.

## Ticket

https://openscience.atlassian.net/browse/OSF-8421