### PR TITLE
Remove unnecessary Session save [#OSF-8373]

### DIFF
--- a/addons/osfstorage/views.py
+++ b/addons/osfstorage/views.py
@@ -296,6 +296,7 @@ def osfstorage_download(file_node, payload, node_addon, **kwargs):
     if user_id:
         current_session = get_session()
         current_session.data['auth_user_id'] = user_id
+        current_session.save()
 
     if not request.args.get('version'):
         version_id = None

--- a/framework/sessions/__init__.py
+++ b/framework/sessions/__init__.py
@@ -147,8 +147,10 @@ def before_request():
                     user_session.data['auth_error_code'] = http.UNAUTHORIZED
                     return
             user_session.data['auth_user_username'] = user.username
-            user_session.data['auth_user_id'] = user._primary_key
             user_session.data['auth_user_fullname'] = user.fullname
+            if user_session.data.get('auth_user_id', None) != user._primary_key:
+                user_session.data['auth_user_id'] = user._primary_key
+                user_session.save()
         else:
             # Invalid key: Not found in database
             user_session.data['auth_error_code'] = http.UNAUTHORIZED
@@ -177,8 +179,6 @@ def before_request():
 
 
 def after_request(response):
-    if session.data.get('auth_user_id'):
-        session.save()
     # Disallow embedding in frames
     response.headers['X-Frame-Options'] = 'SAMEORIGIN'
     return response


### PR DESCRIPTION

## Purpose
Prevent doing a db write every request unless necessary

## Changes
* Remove unnecessary `Session` save in `after_request`
* Ensure session is saved when actually updating `auth_user_id`

## Side effects
None expected

## Ticket
[[OSF-8373]](https://openscience.atlassian.net/browse/OSF-8373)
