### PR TITLE
[EOSF-824] Allow quickfiles to create guids, and reroute based on fid without no…

### DIFF
--- a/api/files/views.py
+++ b/api/files/views.py
@@ -336,13 +336,12 @@ class FileDetail(JSONAPIBaseView, generics.RetrieveUpdateAPIView, FileMixin):
     # overrides RetrieveAPIView
     def get_object(self):
         user = utils.get_user_auth(self.request).user
-
-        if (self.request.GET.get('create_guid', False) and
-                self.get_node().has_permission(user, 'admin') and
-                utils.has_admin_scope(self.request)):
-            self.get_file(check_permissions=True).get_guid(create=True)
-
-        return self.get_file()
+        file = self.get_file()
+        if self.request.GET.get('create_guid', False):
+            # allows quickfiles to be given guids when another user wants a permanent link to it
+            if (self.get_node().has_permission(user, 'admin') and utils.has_admin_scope(self.request)) or file.node.is_quickfiles:
+                file.get_guid(create=True)
+        return file
 
 class FileVersionsList(JSONAPIBaseView, generics.ListAPIView, FileMixin):
     """List of versions for the requested file. *Read-only*.

--- a/website/project/decorators.py
+++ b/website/project/decorators.py
@@ -75,7 +75,7 @@ def must_not_be_rejected(func):
 
     return wrapped
 
-def must_be_valid_project(func=None, retractions_valid=False):
+def must_be_valid_project(func=None, retractions_valid=False, quickfiles_valid=False):
     """ Ensures permissions to retractions are never implicitly granted. """
 
     # TODO: Check private link
@@ -86,7 +86,7 @@ def must_be_valid_project(func=None, retractions_valid=False):
 
             _inject_nodes(kwargs)
 
-            if getattr(kwargs['node'], 'is_collection', True) or getattr(kwargs['node'], 'is_quickfiles', True):
+            if getattr(kwargs['node'], 'is_collection', True) or (getattr(kwargs['node'], 'is_quickfiles', True) and not quickfiles_valid):
                 raise HTTPError(
                     http.NOT_FOUND
                 )

--- a/website/routes.py
+++ b/website/routes.py
@@ -1230,6 +1230,14 @@ def make_url_map(app):
             addon_views.addon_view_or_download_file_legacy,
             json_renderer
         ),
+        Rule(
+            [
+                '/quickfiles/<fid>/'
+            ],
+            'get',
+            addon_views.addon_view_or_download_quickfile,
+            json_renderer
+        )
     ])
 
     # API


### PR DESCRIPTION
## Ticket:
https://openscience.atlassian.net/browse/EOSF-824

## Purpose
For viewing quickfiles: Add new route, like /quickfiles/<path:path>/ that proxies to /project/<quickfiles-guid>/files/osfstorage/<path:path>/
For generating share links: Bypass admin permission check when creating GUIDs for quickfiles when using ?create_guid=1