### PR TITLE
[OSF-8051] Prevent submitting an already registered draft for review.

### DIFF
--- a/tests/test_registrations/test_views.py
+++ b/tests/test_registrations/test_views.py
@@ -20,7 +20,7 @@ from website.util import permissions, api_url_for
 from website.project.views import drafts as draft_views
 
 from osf_tests.factories import (
-    NodeFactory, AuthUserFactory, DraftRegistrationFactory, RegistrationFactory
+    NodeFactory, AuthUserFactory, DraftRegistrationFactory, RegistrationFactory, Auth
 )
 from tests.test_registrations.base import RegistrationsTestBase
 
@@ -120,14 +120,17 @@ class TestDraftRegistrationViews(RegistrationsTestBase):
         assert_equal(res.status_code, http.BAD_REQUEST)
 
     def test_submit_draft_for_review_already_registered(self):
-        reg = RegistrationFactory(user=self.user)
+        self.draft.register(Auth(self.user), save=True)
+
         res = self.app.post_json(
-            reg.api_url_for('submit_draft_for_review', draft_id=self.draft._id),
-            self.invalid_payload,
+            self.draft_api_url('submit_draft_for_review'),
+            self.immediate_payload,
             auth=self.user.auth,
             expect_errors=True
         )
         assert_equal(res.status_code, http.BAD_REQUEST)
+        assert_equal(res.json['message_long'], 'This draft has already been registered, if you wish to register it '
+                                               'again or submit it for review please create a new draft.')
 
     def test_draft_before_register_page(self):
         url = self.draft_url('draft_before_register_page')

--- a/website/project/views/drafts.py
+++ b/website/project/views/drafts.py
@@ -129,6 +129,11 @@ def submit_draft_for_review(auth, node, draft, *args, **kwargs):
         meta['embargo_end_date'] = end_date_string
     meta['registration_choice'] = registration_choice
 
+    if draft.registered_node:
+        raise HTTPError(http.CONFLICT, data=dict(message_long='This draft has already been registered, if you wish to '
+                                                              'register it again or submit it for review please create '
+                                                              'a new draft.'))
+
     # Don't allow resubmission unless submission was rejected
     if draft.approval and draft.approval.state != Sanction.REJECTED:
         raise HTTPError(http.CONFLICT, data=dict(message_long='Cannot resubmit previously submitted draft.'))

--- a/website/project/views/drafts.py
+++ b/website/project/views/drafts.py
@@ -129,8 +129,8 @@ def submit_draft_for_review(auth, node, draft, *args, **kwargs):
         meta['embargo_end_date'] = end_date_string
     meta['registration_choice'] = registration_choice
 
-    if draft.registered_node:
-        raise HTTPError(http.CONFLICT, data=dict(message_long='This draft has already been registered, if you wish to '
+    if draft.registered_node and not draft.registered_node.is_deleted:
+        raise HTTPError(http.BAD_REQUEST, data=dict(message_long='This draft has already been registered, if you wish to '
                                                               'register it again or submit it for review please create '
                                                               'a new draft.'))
 


### PR DESCRIPTION
## Purpose

Currently if a user has two versions of a draft open (like in two tabs) they can submit one for review and submit the other without review and this leads to some confusing behavior. This fix stops the user from being able to do this.

## Changes

Add line for submit_for_review function which rejects already registered nodes.

## Side effects

None that I know of.

## Tests

There was a test associated with this behavior, but it was bad and would produce a false positive every time. I fixed it, possibly there are other false positives in that test class.

## Ticket

https://openscience.atlassian.net/browse/OSF-8051