### PR TITLE
[#OSF-8154]Institutions pages: registrations missing contrib names

### DIFF
--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -9,6 +9,7 @@ from api.base.views import JSONAPIBaseView, BaseContributorDetail, BaseContribut
 
 from api.base.serializers import HideIfWithdrawal, LinkedRegistrationsRelationshipSerializer
 from api.base.serializers import LinkedNodesRelationshipSerializer
+from api.base.pagination import NodeContributorPagination
 from api.base.parsers import JSONAPIRelationshipParser
 from api.base.parsers import JSONAPIRelationshipParserForRegularJSON
 from api.base.utils import get_user_auth
@@ -380,6 +381,8 @@ class RegistrationContributorsList(BaseContributorList, RegistrationMixin, UserM
     """
     view_category = 'registrations'
     view_name = 'registration-contributors'
+
+    pagination_class = NodeContributorPagination
     serializer_class = RegistrationContributorsSerializer
 
     required_read_scopes = [CoreScopes.NODE_REGISTRATIONS_READ]

--- a/api_tests/institutions/views/test_institution_registrations_list.py
+++ b/api_tests/institutions/views/test_institution_registrations_list.py
@@ -4,8 +4,6 @@ from tests.base import ApiTestCase
 from osf_tests.factories import (
     AuthUserFactory,
     InstitutionFactory,
-    NodeFactory,
-    ProjectFactory,
     RegistrationFactory,
     WithdrawnRegistrationFactory
 )
@@ -85,6 +83,7 @@ class TestInstitutionRegistrationList(ApiTestCase):
         registration3.add_contributor(self.user2, auth=Auth(self.user1))
         registration3.save()
         registration3_url = '/{0}registrations/{1}/?embed=contributors'.format(API_BASE, registration3._id)
+
         res = self.app.get(registration3_url)
         assert_true(res.json['data']['embeds']['contributors']['meta']['total_bibliographic'])
         assert_equal(res.json['data']['embeds']['contributors']['meta']['total_bibliographic'], 2)

--- a/api_tests/institutions/views/test_institution_registrations_list.py
+++ b/api_tests/institutions/views/test_institution_registrations_list.py
@@ -85,8 +85,8 @@ class TestInstitutionRegistrationList(ApiTestCase):
         registration3_url = '/{0}registrations/{1}/?embed=contributors'.format(API_BASE, registration3._id)
 
         res = self.app.get(registration3_url)
-        assert_true(res.json['data']['embeds']['contributors']['link']['meta']['total_bibliographic'])
-        assert_equal(res.json['data']['embeds']['contributors']['link']['meta']['total_bibliographic'], 2)
+        assert_true(res.json['data']['embeds']['contributors']['links']['meta']['total_bibliographic'])
+        assert_equal(res.json['data']['embeds']['contributors']['links']['meta']['total_bibliographic'], 2)
 
 
 class TestRegistrationListFiltering(RegistrationListFilteringMixin, ApiTestCase):

--- a/api_tests/institutions/views/test_institution_registrations_list.py
+++ b/api_tests/institutions/views/test_institution_registrations_list.py
@@ -78,9 +78,11 @@ class TestInstitutionRegistrationList(ApiTestCase):
         assert_not_in(self.registration2._id, ids)
 
     def test_total_biographic_contributor_in_institution_registration(self):
+        user3 = AuthUserFactory()
         registration3 = RegistrationFactory(is_public=True, creator=self.user1)
         registration3.affiliated_institutions.add(self.institution)
         registration3.add_contributor(self.user2, auth=Auth(self.user1))
+        registration3.add_contributor(user3, auth=Auth(self.user1), visible=False)
         registration3.save()
         registration3_url = '/{0}registrations/{1}/?embed=contributors'.format(API_BASE, registration3._id)
 

--- a/api_tests/institutions/views/test_institution_registrations_list.py
+++ b/api_tests/institutions/views/test_institution_registrations_list.py
@@ -85,8 +85,8 @@ class TestInstitutionRegistrationList(ApiTestCase):
         registration3_url = '/{0}registrations/{1}/?embed=contributors'.format(API_BASE, registration3._id)
 
         res = self.app.get(registration3_url)
-        assert_true(res.json['data']['embeds']['contributors']['meta']['total_bibliographic'])
-        assert_equal(res.json['data']['embeds']['contributors']['meta']['total_bibliographic'], 2)
+        assert_true(res.json['data']['embeds']['contributors']['link']['meta']['total_bibliographic'])
+        assert_equal(res.json['data']['embeds']['contributors']['link']['meta']['total_bibliographic'], 2)
 
 
 class TestRegistrationListFiltering(RegistrationListFilteringMixin, ApiTestCase):

--- a/api_tests/institutions/views/test_institution_registrations_list.py
+++ b/api_tests/institutions/views/test_institution_registrations_list.py
@@ -79,6 +79,16 @@ class TestInstitutionRegistrationList(ApiTestCase):
 
         assert_not_in(self.registration2._id, ids)
 
+    def test_total_biographic_contributor_in_institution_registration(self):
+        registration3 = RegistrationFactory(is_public=True, creator=self.user1)
+        registration3.affiliated_institutions.add(self.institution)
+        registration3.add_contributor(self.user2, auth=Auth(self.user1))
+        registration3.save()
+        registration3_url = '/{0}registrations/{1}/?embed=contributors'.format(API_BASE, registration3._id)
+        res = self.app.get(registration3_url)
+        assert_true(res.json['data']['embeds']['contributors']['meta']['total_bibliographic'])
+        assert_equal(res.json['data']['embeds']['contributors']['meta']['total_bibliographic'], 2)
+
 
 class TestRegistrationListFiltering(RegistrationListFilteringMixin, ApiTestCase):
 

--- a/api_tests/registrations/views/test_registration_list.py
+++ b/api_tests/registrations/views/test_registration_list.py
@@ -72,11 +72,13 @@ class TestRegistrationList(ApiTestCase):
         assert_equal(registered_from, '/{}nodes/{}/'.format(API_BASE, self.public_project._id))
 
     def test_total_biographic_contributor_in_registration(self):
+        user3 = AuthUserFactory()
         registration = RegistrationFactory(is_public=True, creator=self.user)
         registration.add_contributor(self.user_two, auth=Auth(self.user))
+        registration.add_contributor(user3, auth=Auth(self.user), visible=False)
         registration.save()
         registration_url = '/{0}registrations/{1}/?embed=contributors'.format(API_BASE, registration._id)
-        
+
         res = self.app.get(registration_url)
         assert_true(res.json['data']['embeds']['contributors']['links']['meta']['total_bibliographic'])
         assert_equal(res.json['data']['embeds']['contributors']['links']['meta']['total_bibliographic'], 2)

--- a/api_tests/registrations/views/test_registration_list.py
+++ b/api_tests/registrations/views/test_registration_list.py
@@ -76,6 +76,7 @@ class TestRegistrationList(ApiTestCase):
         registration.add_contributor(self.user_two, auth=Auth(self.user))
         registration.save()
         registration_url = '/{0}registrations/{1}/?embed=contributors'.format(API_BASE, registration._id)
+        
         res = self.app.get(registration_url)
         assert_true(res.json['data']['embeds']['contributors']['links']['meta']['total_bibliographic'])
         assert_equal(res.json['data']['embeds']['contributors']['links']['meta']['total_bibliographic'], 2)

--- a/api_tests/registrations/views/test_registration_list.py
+++ b/api_tests/registrations/views/test_registration_list.py
@@ -77,8 +77,8 @@ class TestRegistrationList(ApiTestCase):
         registration.save()
         registration_url = '/{0}registrations/{1}/?embed=contributors'.format(API_BASE, registration._id)
         res = self.app.get(registration_url)
-        assert_true(res.json['data']['embeds']['contributors']['link']['meta']['total_bibliographic'])
-        assert_equal(res.json['data']['embeds']['contributors']['link']['meta']['total_bibliographic'], 2)
+        assert_true(res.json['data']['embeds']['contributors']['links']['meta']['total_bibliographic'])
+        assert_equal(res.json['data']['embeds']['contributors']['links']['meta']['total_bibliographic'], 2)
 
     def test_exclude_nodes_from_registrations_endpoint(self):
         res = self.app.get(self.url, auth=self.user.auth)

--- a/api_tests/registrations/views/test_registration_list.py
+++ b/api_tests/registrations/views/test_registration_list.py
@@ -76,7 +76,6 @@ class TestRegistrationList(ApiTestCase):
         registration.add_contributor(self.user_two, auth=Auth(self.user))
         registration.save()
         registration_url = '/{0}registrations/{1}/?embed=contributors'.format(API_BASE, registration._id)
-
         res = self.app.get(registration_url)
         assert_true(res.json['data']['embeds']['contributors']['link']['meta']['total_bibliographic'])
         assert_equal(res.json['data']['embeds']['contributors']['link']['meta']['total_bibliographic'], 2)

--- a/api_tests/registrations/views/test_registration_list.py
+++ b/api_tests/registrations/views/test_registration_list.py
@@ -78,8 +78,8 @@ class TestRegistrationList(ApiTestCase):
         registration_url = '/{0}registrations/{1}/?embed=contributors'.format(API_BASE, registration._id)
 
         res = self.app.get(registration_url)
-        assert_true(res.json['data']['embeds']['contributors']['meta']['total_bibliographic'])
-        assert_equal(res.json['data']['embeds']['contributors']['meta']['total_bibliographic'], 2)
+        assert_true(res.json['data']['embeds']['contributors']['link']['meta']['total_bibliographic'])
+        assert_equal(res.json['data']['embeds']['contributors']['link']['meta']['total_bibliographic'], 2)
 
     def test_exclude_nodes_from_registrations_endpoint(self):
         res = self.app.get(self.url, auth=self.user.auth)

--- a/api_tests/registrations/views/test_registration_list.py
+++ b/api_tests/registrations/views/test_registration_list.py
@@ -71,7 +71,7 @@ class TestRegistrationList(ApiTestCase):
 
         assert_equal(registered_from, '/{}nodes/{}/'.format(API_BASE, self.public_project._id))
 
-    def test_total_biographic_contributor_in_institution_registration(self):
+    def test_total_biographic_contributor_in_registration(self):
         registration = RegistrationFactory(is_public=True, creator=self.user)
         registration.add_contributor(self.user_two, auth=Auth(self.user))
         registration.save()

--- a/api_tests/registrations/views/test_registration_list.py
+++ b/api_tests/registrations/views/test_registration_list.py
@@ -71,6 +71,16 @@ class TestRegistrationList(ApiTestCase):
 
         assert_equal(registered_from, '/{}nodes/{}/'.format(API_BASE, self.public_project._id))
 
+    def test_total_biographic_contributor_in_institution_registration(self):
+        registration = RegistrationFactory(is_public=True, creator=self.user)
+        registration.add_contributor(self.user_two, auth=Auth(self.user))
+        registration.save()
+        registration_url = '/{0}registrations/{1}/?embed=contributors'.format(API_BASE, registration._id)
+
+        res = self.app.get(registration_url)
+        assert_true(res.json['data']['embeds']['contributors']['meta']['total_bibliographic'])
+        assert_equal(res.json['data']['embeds']['contributors']['meta']['total_bibliographic'], 2)
+
     def test_exclude_nodes_from_registrations_endpoint(self):
         res = self.app.get(self.url, auth=self.user.auth)
         ids = [each['id'] for each in res.json['data']]


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Fix the problem that if you have more than 2 contributors for an institution registration. The contributors will show as "+NaN" instead of the correct number.
<!-- Describe the purpose of your changes -->

## Changes
before change:

![image](https://user-images.githubusercontent.com/4974056/29787406-d2c44818-8bfc-11e7-80e7-c604538954b6.png)

After change:
The NaN should be replaced with the correct number.
<!-- Briefly describe or list your changes  -->

## Side effects

<!--Any possible side effects? -->


## Ticket
https://openscience.atlassian.net/browse/OSF-8154
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
