### PR TITLE
Feature/add maintenance alerts to all pages [OSF-7841]

### DIFF
--- a/website/static/css/pages/project-page.css
+++ b/website/static/css/pages/project-page.css
@@ -243,3 +243,8 @@ li.addon-categories a{
     vertical-align: baseline;
     width:30%;
 }
+/*Moves maintenence alert under project header*/
+#maintenance.alert {
+    position: relative;
+    top: 45px;
+}

--- a/website/static/css/search-bar.css
+++ b/website/static/css/search-bar.css
@@ -65,3 +65,9 @@
 #searchControls>.row {
     padding-top: 60px;
 }
+
+/*Moves maintenance alert under search bar*/
+#maintenance.alert {
+    position: relative;
+    top: 55px;
+}

--- a/website/static/js/pages/base-page.js
+++ b/website/static/js/pages/base-page.js
@@ -8,7 +8,6 @@ require('../../vendor/bootstrap-editable-custom/css/bootstrap-editable.css');
 require('../../vendor/bower_components/jquery-ui/themes/base/resizable.css');
 require('../../css/bootstrap-xl.css');
 require('../../css/animate.css');
-require('../../css/search-bar.css');
 require('font-awesome-webpack');
 
 var $ = require('jquery');

--- a/website/static/js/pages/project-base-page.js
+++ b/website/static/js/pages/project-base-page.js
@@ -8,6 +8,7 @@ var AccountClaimer = require('js/accountClaimer');
 // pages
 require('js/project');
 require('js/licensePicker');
+require('css/pages/project-page.css');
 
 var node = window.contextVars.node;
 var OFFSET = 49;

--- a/website/static/js/pages/search-page.js
+++ b/website/static/js/pages/search-page.js
@@ -2,4 +2,5 @@ var $ = require('jquery');
 $('input[name=q]').remove();
 
 var Search = require('../search.js');
+require('../../css/search-bar.css');
 new Search('#searchControls', '/api/v1/search/', '');

--- a/website/templates/base.mako
+++ b/website/templates/base.mako
@@ -351,21 +351,6 @@
 <%def name="content_wrap()">
     <div class="watermarked">
         <div class="container ${self.container_class()}">
-            ## Maintenance alert
-            % if maintenance:
-                <div id="maintenance" class="scripted alert alert-dismissible" role="alert">
-                <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                    <span aria-hidden="true">&times;</span></button>
-                <strong>Notice:</strong>
-                % if maintenance['message']:
-                    ${maintenance['message']}
-                % else:
-                    The site will undergo maintenance between <span id="maintenanceTime"></span>.
-                    Thank you for your patience.
-                % endif
-            </div>
-            % endif
-            ## End Maintenance alert
 
             % if status:
                 ${self.alert()}

--- a/website/templates/nav.mako
+++ b/website/templates/nav.mako
@@ -87,5 +87,26 @@
     </div>
 </div>
 </nav>
+    <div class="container-fluid">
+        <div class="row">
+            <div class="col">
+                ## Maintenance alert
+                % if maintenance:
+                    <div id="maintenance" class="scripted alert alert-dismissible" role="alert">
+                    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                        <span aria-hidden="true">&times;</span></button>
+                    <strong>Notice:</strong>
+                    % if maintenance['message']:
+                        ${maintenance['message']}
+                    % else:
+                        The site will undergo maintenance between <span id="maintenanceTime"></span>.
+                        Thank you for your patience.
+                    % endif
+                </div>
+                % endif
+                ## End Maintenance alert
+            </div>
+        </div>
+    </div>
 </div>
 </%def>

--- a/website/templates/project/project_header.mako
+++ b/website/templates/project/project_header.mako
@@ -99,6 +99,17 @@
         }
     </style>
 
+    %if maintenance:
+        <style type="text/css">
+            @media (max-width: 767px) {
+                #projectBanner .osf-project-navbar {
+                    position: absolute;
+                    top: 100px;
+                }
+            }
+        </style>
+    %endif
+
     % if node['is_registration']:  ## Begin registration undismissable labels
 
         % if not node['is_retracted']:


### PR DESCRIPTION
## Purpose

Currently, the maintenance banner does not show up on all of the OSF pages. It also shows up slightly differently on the pages that it does show up on.

## Changes

The maintenance banner functionality was added to the navbar instead of being added to individual pages. This makes it easy for the maintenance banner to work well on most OSF pages (as it can be a normal bootstrap row). 

Unfortunately, the maintenance banner does not work as seamlessly on pages that have elements  fixed directly below the navbar (such as the project navbar). On the search page and the project pages, the maintenance banner was moved to be below those elements instead of directly below the navbar.

## Side effects

The maintenance banner will now appear nicely on any page with normally placed elements, but if anything is placed in a `fixed` or `absolute` position directly below the navbar, it will likely cover the banner. On these pages, the navbar will need to be positioned relatively.


## Ticket

https://openscience.atlassian.net/browse/OSF-7841

## QA Notes
Maintenance banner should appear directly below navbar on all pages except search page and project pages. 

## Tests
None because this is purely html/css.

![banner](https://user-images.githubusercontent.com/7839433/29792039-1dab2b3e-8c0d-11e7-8d2f-66a082444873.gif)

<img width="1440" alt="screen shot 2017-08-28 at 4 01 55 pm" src="https://user-images.githubusercontent.com/7839433/29791747-0e098262-8c0c-11e7-9756-37a21ba0655d.png">
<img width="1440" alt="screen shot 2017-08-28 at 4 09 13 pm" src="https://user-images.githubusercontent.com/7839433/29791751-127d9446-8c0c-11e7-99fb-56cf8d1d2dd7.png">
<img width="335" alt="screen shot 2017-08-28 at 4 08 53 pm" src="https://user-images.githubusercontent.com/7839433/29791758-161777a2-8c0c-11e7-878b-11b3d9b92bed.png">



