### PR TITLE
[hotfix] Fix error handling and mako template data [OSF-8570]

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -18,6 +18,8 @@ from modularodm import Q
 from modularodm.exceptions import NoResultsFound
 
 from addons.base.models import BaseStorageAddon
+from addons.osfstorage.models import OsfStorageFileNode
+
 from framework import sentry
 from framework.auth import Auth
 from framework.auth import cas
@@ -499,7 +501,7 @@ def addon_view_or_download_file_legacy(**kwargs):
 
         try:
             path = node_settings.get_root().find_child_by_name(path)._id
-        except NoResultsFound:
+        except OsfStorageFileNode.DoesNotExist:
             raise HTTPError(
                 404, data=dict(
                     message_short='File not found',

--- a/website/templates/project/view_file.mako
+++ b/website/templates/project/view_file.mako
@@ -203,8 +203,8 @@
             file_tags: ${file_tags if file_tags else False| sjson, n},
             guid: ${file_guid | sjson, n},
             id: ${file_id | sjson, n},
-            checkoutUser: ${checkout_user | sjson, n},
-            isPreregCheckout: ${pre_reg_checkout | sjson, n},
+            checkoutUser: ${checkout_user if checkout_user else None | sjson, n},
+            isPreregCheckout: ${pre_reg_checkout if pre_reg_checkout else False | sjson, n},
           urls: {
         %if error is None:
               render: ${ urls['render'] | sjson, n },


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Files that are not found lead to unable to resolve instead of nicely formatted not found pages (and are leading to a lot of sentry errors).
<!-- Describe the purpose of your changes -->

## Changes
1. Fix mako template data to handle data that was not being formatted properly.
2. Use correct exception catch for oststorage files

<!-- Briefly describe or list your changes  -->

## Side effects
NA
<!--Any possible side effects? -->


## Ticket

https://openscience.atlassian.net/browse/OSF-8570

## QA Notes
1. Test non existent files on various addons (e.g., osf.io/<guid>/files/github/imnotarealfile/)
2. Try deleted addon files via guid
3. Try osfstorage files that don't exist (e.g., osf.io/<guid>/files/imnotarealfile)

In all the above cases, you should get a properly formatted error message and not an "unable to resolve" error