### PR TITLE
[hotfix] Add Preprint provider filters [OSF-8579]

### DIFF
--- a/api/preprint_providers/serializers.py
+++ b/api/preprint_providers/serializers.py
@@ -7,11 +7,13 @@ from api.base.serializers import JSONAPISerializer, LinksField, RelationshipFiel
 class PreprintProviderSerializer(JSONAPISerializer):
 
     filterable_fields = frozenset([
-        'name',
+        'allow_submissions',
         'description',
-        'id',
         'domain',
-        'domain_redirect_enabled'
+        'domain_redirect_enabled',
+        'id',
+        'name',
+        'share_publish_type',
     ])
 
     name = ser.CharField(required=True)

--- a/api_tests/preprint_providers/views/test_preprint_provider_list.py
+++ b/api_tests/preprint_providers/views/test_preprint_provider_list.py
@@ -1,0 +1,61 @@
+import pytest
+
+from api.base.settings.defaults import API_BASE
+from osf_tests.factories import (
+    AuthUserFactory,
+    PreprintProviderFactory,
+)
+
+
+@pytest.mark.django_db
+class TestPreprintProviderList:
+
+    @pytest.fixture()
+    def url(self):
+        return '/{}preprint_providers/?version=2.2&'.format(API_BASE)
+
+    @pytest.fixture()
+    def user(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def provider_one(self):
+        return PreprintProviderFactory(name='Sockarxiv')
+
+    @pytest.fixture()
+    def provider_two(self):
+        provider = PreprintProviderFactory(name='Spotarxiv')
+        provider.allow_submissions = False
+        provider.domain = 'https://www.spotarxiv.com'
+        provider.description = 'spots not dots'
+        provider.domain_redirect_enabled = True
+        provider._id = 'spot'
+        provider.share_publish_type = 'Thesis'
+        provider.save()
+        return provider
+
+
+    def test_preprint_provider_list(self, app, url, user, provider_one, provider_two):
+        # Test length and not auth
+        res = app.get(url)
+        assert res.status_code == 200
+        assert len(res.json['data']) == 2
+
+        # Test length and auth
+        res = app.get(url, auth=user.auth)
+        assert res.status_code == 200
+        assert len(res.json['data']) == 2
+
+    @pytest.mark.parametrize('filter_type,filter_value', [
+        ('allow_submissions', True),
+        ('description', 'spots%20not%20dots'),
+        ('domain', 'https://www.spotarxiv.com'),
+        ('domain_redirect_enabled', True),
+        ('id', 'spot'),
+        ('name', 'Spotarxiv'),
+        ('share_publish_type', 'Thesis'),
+    ])
+    def test_preprint_provider_list_filtering(self, filter_type, filter_value, app, url, provider_one, provider_two):
+        res = app.get('{}filter[{}]={}'.format(url, filter_type, filter_value))
+        assert res.status_code == 200
+        assert len(res.json['data']) == 1


### PR DESCRIPTION

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
EOSF needs `allow_submissions` and `share_publish_type` filterable fields on preprint providers.
<!-- Describe the purpose of your changes -->

## Changes
Add `allow_submissions` and `share_publish_type` filterable fields. 

I explored adding indices to the DB for the filters, but the table is small enough that it doesn't matter.
<!-- Briefly describe or list your changes  -->

## Side effects
We now have preprint provider list view tests. Hooray.
<!--Any possible side effects? -->


## Ticket

https://openscience.atlassian.net/browse/OSF-8579

## QA
Test filtering on allow_submissions and share_publish type on preprint_providers:

api.osf.io/v2/preprint_providers/?filter[share_publish_type]=thesis
api.osf.io/v2/preprint_providers/?filter[allow_submissions]=preprints

api.osf.io/v2/preprint_providers/?filter[allow_submissions]=True
api.osf.io/v2/preprint_providers/?filter[allow_submissions]=False

