### PR TITLE
[RFR][OSF-8522] Special characters do not render on registration forms

### DIFF
--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -210,6 +210,9 @@ var Question = function(questionSchema, data) {
         value = self.data.value();
     } else {
         value = self.data.value || null;
+        if(value) {
+            value = $osf.decodeText(value);
+        }
     }
 
     if (self.type === 'choose' && self.format === 'multiselect') {


### PR DESCRIPTION
## Purpose
Decode HTML in project -> "View Registration Form"

## Changes

    Registration Form data is HTML encoded before storing in postgres.
    This PR HTML decodes data before presentation. Specifically &amp; , &gt; and, &lt;

## Side effects

Best effort has been made, but this PR should be reviewed with an eye towards javascript injection.


## Ticket

[OSF-8522](https://openscience.atlassian.net/browse/OSF-8522)
