### PR TITLE
Feature/fix wrapping[OSF-6788]

### DIFF
--- a/website/static/css/log-feed.css
+++ b/website/static/css/log-feed.css
@@ -15,6 +15,7 @@
 
 .db-log-avatar {
     display: inline-block;
+    position: absolute;
 }
 
 #poFilter {

--- a/website/static/css/new-and-noteworthy-plugin.css
+++ b/website/static/css/new-and-noteworthy-plugin.css
@@ -2,6 +2,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    display:block;
 }
 
 .public-projects-box {

--- a/website/static/css/pages/profile-page.css
+++ b/website/static/css/pages/profile-page.css
@@ -93,10 +93,6 @@ table.table.table-plain th, table.table.table-plain td {
     margin-right: .5em;
 }
 
-#social td:first-child {
-    word-break: break-all;
-}
-
 .fa.toggle-icon {
     position: absolute;
     right: 0;

--- a/website/static/js/components/logFeed.js
+++ b/website/static/js/components/logFeed.js
@@ -217,7 +217,7 @@ var LogFeed = {
                     image = m('img', { src : item.embeds.user.errors[0].meta.profile_image});
                 }
                 return m('.db-activity-item', [
-                    m('', [m('.db-log-avatar.m-r-xs', image), m.component(LogText.LogText, item)]),
+                    m('', [m('.db-log-avatar.m-r-xs', image), m('span.p-l-sm.p-r-sm', ''), m.component(LogText.LogText, item)]),
                     m('.text-right', m('span.text-muted.m-r-xs', item.attributes.formattableDate.local))
                 ]);
             }) : '',

--- a/website/templates/include/profile/jobs.mako
+++ b/website/templates/include/profile/jobs.mako
@@ -138,7 +138,7 @@
                     <!-- ko if: expandable() -->
                         <div class="panel panel-default">
                             <div class="panel-heading card-heading" data-bind="click: toggle(), attr: {id: 'jobHeading' + $index(), href: '#jobCard' + $index()}" role="button" data-toggle="collapse" aria-controls="card" aria-expanded="false">
-                                <div class="header-content">
+                                <div class="header-content break-word">
                                     <h5 class="institution" data-bind="text: institution"></h5>
                                     <span data-bind="if: startYear()" class="subheading">
                                         <span data-bind="text: startMonth"></span> <span data-bind="text: startYear"></span> - <span data-bind="text: endView"></span>

--- a/website/templates/include/profile/schools.mako
+++ b/website/templates/include/profile/schools.mako
@@ -137,7 +137,7 @@
                     <!-- ko if: expandable() -->
                         <div class="panel panel-default">
                             <div class="panel-heading card-heading" data-bind="click: toggle(), attr: {id: 'schoolHeading' + $index(), href: '#schoolCard' + $index()}" role="button" data-toggle="collapse" aria-controls="card" aria-expanded="false">
-                                <div class="header-content">
+                                <div class="header-content break-word">
                                     <h5 class="institution" data-bind="text: institution"></h5>
                                     <span data-bind="if: startYear()" class="subheading">
                                         <span data-bind="text: startMonth"></span> <span data-bind="text: startYear"></span> - <span data-bind="text: endView"></span>

--- a/website/templates/include/profile/social.mako
+++ b/website/templates/include/profile/social.mako
@@ -160,9 +160,10 @@
         <table class="table social-links" data-bind="if: hasValues()">
             <tbody>
                 <tr data-bind="if: hasProfileWebsites()">
+                    <td><span><i class='fa fa-globe fa-2x'/></span></td>
                     <td data-bind="visible: profileWebsites().length > 1">Personal websites</td>
                     <td data-bind="visible: profileWebsites().length === 1">Personal website</td>
-                    <td colspan="2" data-bind="foreach: profileWebsites"><a data-bind="attr: {href: $data}, text: $data"></a><br></td>
+                    <td data-bind="foreach: profileWebsites"><a data-bind="attr: {href: $data}, text: $data"></a><br></td>
                 </tr>
             </tbody>
 

--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -223,7 +223,7 @@
                     %if wiki:
                         <form id="selectWikiForm">
                             <div>
-                                <label>
+                                <label class="break-word">
                                     <input
                                             type="checkbox"
                                             name="${wiki.short_name}"


### PR DESCRIPTION
## Purpose
There are various places on the OSF that have strange wrapping. 

## Changes

- Make authors with long names wrap instead of overflowing box in 'New and Noteworthy'.
   https://openscience.atlassian.net/browse/OSF-7358
- Stop job titles and institutions from overflowing box on employment section of profile page.
- Fix overflow of 'enable wiki' section of project settings page.
- Fix overflow of 'personal websites' in the social section of the profile page.
   (Also add icon to the personal websites section to balance out table.)
   https://openscience.atlassian.net/browse/OSF-7477
   https://openscience.atlassian.net/browse/OSF-7608
- Stop long usernames from being out of line with their gravitar.
   (Even if a username is long enough to warrant its own line, keep it in line with gravitar.)

## Side effects

None

## Tests
None: HTML/CSS

## Ticket

https://openscience.atlassian.net/browse/OSF-6788

Before:
<img width="396" alt="newandnoteworthybroken" src="https://user-images.githubusercontent.com/7839433/29936517-8703f21a-8e50-11e7-9c3d-7da9cb909b4d.png">
After:
<img width="375" alt="newandnoteworthyfixed" src="https://user-images.githubusercontent.com/7839433/29936528-93fa421c-8e50-11e7-957d-a00be3cc9199.png">
Before:
<img width="720" alt="educationoverflowbroken" src="https://user-images.githubusercontent.com/7839433/29936557-ac9da17e-8e50-11e7-9435-d42d7a2686db.png">
After:
<img width="568" alt="educationoverflowfixed" src="https://user-images.githubusercontent.com/7839433/29936563-b548964e-8e50-11e7-832d-409996d1f7df.png">
Before:
<img width="914" alt="enablewikibroken" src="https://user-images.githubusercontent.com/7839433/29936590-cf4a1d9c-8e50-11e7-9df0-703924ea6b6d.png">
After:
<img width="857" alt="enablewikifixed" src="https://user-images.githubusercontent.com/7839433/29936857-a65ff1a8-8e51-11e7-8a81-7bacb82a2ca7.png">
Before:
<img width="359" alt="personalwebsitesquishedbroken" src="https://user-images.githubusercontent.com/7839433/29936646-f56dc50a-8e50-11e7-91dd-be1b360824ca.png">
After:
<img width="360" alt="personalwebsitefixedsquished" src="https://user-images.githubusercontent.com/7839433/29936656-fb867176-8e50-11e7-8ddd-1c4e6e222e24.png">
Before:
<img width="571" alt="createdgravitarbroken" src="https://user-images.githubusercontent.com/7839433/29936671-084e728c-8e51-11e7-82ed-2b6d591fbdf5.png">
After:
<img width="444" alt="sameloggravitarfixed" src="https://user-images.githubusercontent.com/7839433/29936681-0e12fde6-8e51-11e7-98f1-f60c866fbeb8.png">




