### PR TITLE
Feature/Remove 'preprints' from register pages [OSF-8549]

### DIFF
--- a/website/templates/public/register.mako
+++ b/website/templates/public/register.mako
@@ -34,7 +34,7 @@
     %for provider in preprint_campaigns.keys():
         %if campaign == provider:
             <div class="text-center m-t-lg">
-                <h3>${preprint_campaigns[provider]['name'] | n} Preprints</h3><hr>
+                <h3>${preprint_campaigns[provider]['name'] | n}</h3><hr>
             </div>
         %endif
     %endfor


### PR DESCRIPTION
## Purpose

Now that we've added Thesis Commons, adding preprints to the names of all the preprint providers for the register pages no longer works.

## Changes

The word preprints has been completely removed from the headings on the preprint register pages.

## Notes
While the ticket said to simply remove the word 'preprints' from the Thesis Commons register page, after discussing this with @brianjgeiger he suggested removing the word 'preprints' from all of the preprint register pages as it is not necessary for understanding (a similar change was recently made to emails). 

## Tests
None: Word change

## Ticket

https://openscience.atlassian.net/browse/OSF-8549

<img width="823" alt="screen shot 2017-08-31 at 2 59 30 pm" src="https://user-images.githubusercontent.com/7839433/29940725-1fd8334a-8e5e-11e7-914c-d8aaf2fa913b.png">
<img width="809" alt="screen shot 2017-08-31 at 3 00 04 pm" src="https://user-images.githubusercontent.com/7839433/29940726-1fd8eefc-8e5e-11e7-95bb-4c124863e890.png">
