### PR TITLE
[feature] Fix `id` Filtering

### DIFF
--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -18,6 +18,7 @@ from modularodm.query import queryset as modularodm_queryset
 from rest_framework import serializers as ser
 from rest_framework.filters import OrderingFilter
 from osf.models import Subject
+from osf.models.base import GuidMixin
 
 
 def lowercase(lower):
@@ -408,7 +409,11 @@ class ListFilterMixin(FilterMixin):
         if field_name == 'permission':
             operation['op'] = 'exact'
         if field_name == 'id':
-            operation['source_field_name'] = 'guids___id'
+            operation['source_field_name'] = (
+                'guids___id'
+                if issubclass(self.model_class, GuidMixin)
+                else self.model_class.primary_identifier_name
+            )
             operation['op'] = 'in'
 
     def get_filtered_queryset(self, field_name, params, default_queryset):

--- a/api/licenses/views.py
+++ b/api/licenses/views.py
@@ -1,3 +1,4 @@
+from django.apps import apps
 from rest_framework import generics, permissions as drf_permissions
 from framework.auth.oauth_scopes import CoreScopes
 
@@ -72,6 +73,7 @@ class LicenseList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin):
 
     required_read_scopes = [CoreScopes.LICENSE_READ]
     required_write_scopes = [CoreScopes.NULL]
+    model_class = apps.get_model('osf.NodeLicense')
 
     serializer_class = LicenseSerializer
     view_category = 'licenses'
@@ -84,8 +86,3 @@ class LicenseList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin):
 
     def get_queryset(self):
         return self.get_queryset_from_request()
-
-    def postprocess_query_param(self, key, field_name, operation):
-        if field_name == 'id':
-            operation['source_field_name'] = '_id'
-            operation['op'] = 'in'

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -1,3 +1,4 @@
+from django.apps import apps
 
 from api.addons.views import AddonSettingsMixin
 from api.base import permissions as base_permissions
@@ -136,6 +137,7 @@ class UserList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin):
 
     required_read_scopes = [CoreScopes.USERS_READ]
     required_write_scopes = [CoreScopes.NULL]
+    model_class = apps.get_model('osf.OSFUser')
 
     serializer_class = UserSerializer
 


### PR DESCRIPTION
#### Purpose
- Fix filtering by `id` on non-Guid objects.

#### Changes
- Determine filter `source_field_name` based on either `self.model_class.primary_identifier_name` or `issubclass(self.model_class, GuidMixin)`.

#### Side effects
- None expected.

#### Ticket
- None
