### PR TITLE
[feature] Backwards-compatible API changes for preprint/node divorce [OSF-8488]

### DIFF
--- a/api/preprints/urls.py
+++ b/api/preprints/urls.py
@@ -8,4 +8,5 @@ urlpatterns = [
     url(r'^(?P<preprint_id>\w+)/citation/$', views.PreprintCitationDetail.as_view(), name=views.PreprintCitationDetail.view_name),
     url(r'^(?P<preprint_id>\w+)/citation/(?P<style_id>[-\w]+)/$', views.PreprintCitationStyleDetail.as_view(), name=views.PreprintCitationStyleDetail.view_name),
     url(r'^(?P<preprint_id>\w+)/identifiers/$', views.PreprintIdentifierList.as_view(), name=views.PreprintIdentifierList.view_name),
+    url(r'^(?P<preprint_id>\w+)/contributors/$', views.PreprintContributorsList.as_view(), name=views.PreprintContributorsList.view_name),
 ]

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -1,6 +1,7 @@
 import re
 
 from django.db.models import Q
+from django.shortcuts import get_object_or_404
 
 from rest_framework import generics
 from rest_framework.exceptions import NotFound, PermissionDenied, NotAuthenticated
@@ -16,7 +17,7 @@ from api.base.parsers import (
     JSONAPIMultipleRelationshipsParser,
     JSONAPIMultipleRelationshipsParserForRegularJSON,
 )
-from api.base.utils import get_object_or_error, get_user_auth
+from api.base.utils import get_user_auth
 from api.base import permissions as base_permissions
 from api.citations.utils import render_citation, preprint_csl
 from api.preprints.serializers import (
@@ -40,12 +41,10 @@ class PreprintMixin(NodeMixin):
     preprint_lookup_url_kwarg = 'preprint_id'
 
     def get_preprint(self, check_object_permissions=True):
-        preprint = get_object_or_error(
-            PreprintService,
-            self.kwargs[self.preprint_lookup_url_kwarg],
-            display_name='preprint'
+        preprint = get_object_or_404(
+            PreprintService.objects.select_related('node'), guids___id=self.kwargs[self.preprint_lookup_url_kwarg]
         )
-        if not preprint or preprint.node.is_deleted:
+        if preprint.node.is_deleted:
             raise NotFound
         # May raise a permission denied
         if check_object_permissions:

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -30,7 +30,7 @@ from api.nodes.serializers import (
 
 from api.identifiers.views import IdentifierList
 from api.identifiers.serializers import PreprintIdentifierSerializer
-from api.nodes.views import NodeMixin
+from api.nodes.views import NodeMixin, NodeContributorsList
 from api.nodes.permissions import ContributorOrPublic
 
 from api.preprints.permissions import PreprintPublishedOrAdmin
@@ -397,3 +397,10 @@ class PreprintIdentifierList(IdentifierList, PreprintMixin):
     # overrides IdentifierList
     def get_object(self, check_object_permissions=True):
         return self.get_preprint(check_object_permissions=check_object_permissions)
+
+
+class PreprintContributorsList(NodeContributorsList, PreprintMixin):
+
+    def create(self, request, *args, **kwargs):
+        self.kwargs['node_id'] = self.get_preprint(check_object_permissions=False).node._id
+        return super(PreprintContributorsList, self).create(request, *args, **kwargs)

--- a/api_tests/preprints/views/test_preprint_list.py
+++ b/api_tests/preprints/views/test_preprint_list.py
@@ -52,7 +52,8 @@ def build_preprint_create_payload(node_id=None, provider_id=None, file_id=None, 
     return payload
 
 
-def build_preprint_create_payload_without_node(provider_id=None, file_id=None, attrs={}):
+def build_preprint_create_payload_without_node(provider_id=None, file_id=None, attrs=None):
+    attrs = attrs or {}
     return build_preprint_create_payload(node_id=None, provider_id=provider_id, file_id=file_id, attrs=attrs)
 
 


### PR DESCRIPTION
## Purpose
We soon want to move away from the node - preprint entanglement, now that using django and postgres has made that possibility way more convenient. This is the first step in that process, that will "fake" the change first in the API, now making it possible to `POST`  to `/v2/preprints/` and `PATCH`es to `/v2/preprints/<preprint_id>/ `to create and update *all* formerly node related attributes including `title`, `description`, and `contributors`.

**Current workflow (assuming creating a new node)**
1. `POST` to `/v2/nodes/` to create the node
2. Upload the file to the node's wb upload link via `PUT`
3. `POST` to `/v2/preprints/` to create the preprint with provider and relationship to node
4. `PATCH` to `/v2/preprints/<prerprint_id>/` to add subjects to the preprint
5. `PATCH` to `/v2/nodes/<node_id>/` to add description and license to node
6. `PATCH` to `v2/preprints/<preprint_id>/` to also add license to preprint
7. `POST` to `/v2/nodes/<node_id>/contributors/` to add each contributor 
8. `PATCH` `/v2/preprints/<preprint_id>/` to publish the preprint
9. `PATCH` `/v2/nodes/<node_id>/` to make the node public

**New possible workflow**
1. `POST` to `/v2/preprints/` to create the preprint -- also creates a node if one isn't passed via id
2. Upload the file to the node's wb upload link via `PUT`
3. `PATCH` to `/v2/preprints/<preprint_id>/` to update the preprint with provider and primary file
4. `PATCH` to `/v2/preprints/<prerprint_id>/` to add subjects to the preprint
5. `PATCH` to `v2/preprints/<preprint_id>/` to also add license and description to preprint
6. `PATCH` to `/v2/nodes/<node_id>/` to add license to the node if checkbox is there (can't avoid this separate call to the node because of current frontend implementation)
7. `POST` to `/v2/preprints/<preprint_id>/contributors/` to add each contributor 
8. `PATCH` `/v2/preprints/<preprint_id>/` to publish the preprint (which makes the node public)

## Changes

- Update the preprint serializer to accommodate creating a preprint by `POST`
    - this will create a node if a node isn't passed
    - move setting of the primary file to the `update` method
        - now check for primary file on publish instead of in the preprint `create` method
    - update node properties in the preprint `update` method
    - set node privacy to `public` on publishing a preprint to avoid needing the extra API call
- Add preprint contributors view to handle updating contributors by `POST` to a preprints endpoint
- Add tests for creating a preprint by `POST` to `/v2/preprints/`
- Add tests for updating `title`, `description` and `contributors` by `PATCH` to `/v2/preprints/<preprint_id>/`

## Side effects
None anticipated, as this should be 100% backwards compatible with the way that the preprints ember app currently functions. It just opens the way for a new workflow!

## Ticket
https://openscience.atlassian.net/browse/OSF-8488