### PR TITLE
[OSF-8319] Add logs to admin app on node detail page

### DIFF
--- a/admin/nodes/serializers.py
+++ b/admin/nodes/serializers.py
@@ -32,8 +32,11 @@ def serialize_node(node):
         'is_public': node.is_public,
         'registrations': [serialize_node(registration) for registration in node.registrations.all()],
         'registered_from': node.registered_from._id if node.registered_from else None,
-        'logs': reversed([(log, log.params.iteritems()) for log in node.logs.all()])
     }
+
+def serialize_log(log):
+
+    return log, log.params.iteritems()
 
 
 def serialize_simple_user_and_node_permissions(node, user):

--- a/admin/nodes/serializers.py
+++ b/admin/nodes/serializers.py
@@ -31,11 +31,10 @@ def serialize_node(node):
         'spam_data': json.dumps(node.spam_data, indent=4),
         'is_public': node.is_public,
         'registrations': [serialize_node(registration) for registration in node.registrations.all()],
-        'registered_from': node.registered_from._id if node.registered_from else None,
+        'registered_from': node.registered_from._id if node.registered_from else None
     }
 
 def serialize_log(log):
-
     return log, log.params.iteritems()
 
 

--- a/admin/nodes/serializers.py
+++ b/admin/nodes/serializers.py
@@ -31,7 +31,8 @@ def serialize_node(node):
         'spam_data': json.dumps(node.spam_data, indent=4),
         'is_public': node.is_public,
         'registrations': [serialize_node(registration) for registration in node.registrations.all()],
-        'registered_from': node.registered_from._id if node.registered_from else None
+        'registered_from': node.registered_from._id if node.registered_from else None,
+        'logs': reversed([(log, log.params.iteritems()) for log in node.logs.all()])
     }
 
 

--- a/admin/nodes/urls.py
+++ b/admin/nodes/urls.py
@@ -13,6 +13,8 @@ urlpatterns = [
         name='known-ham'),
     url(r'^(?P<guid>[a-z0-9]+)/$', views.NodeView.as_view(),
         name='node'),
+    url(r'^(?P<guid>[a-z0-9]+)/logs/$', views.AdminNodeLogView.as_view(),
+        name='node-logs'),
     url(r'^registration_list/$', views.RegistrationListView.as_view(),
         name='registrations'),
     url(r'^(?P<guid>[a-z0-9]+)/remove/$', views.NodeDeleteView.as_view(),

--- a/admin/nodes/views.py
+++ b/admin/nodes/views.py
@@ -25,7 +25,7 @@ from osf.models.admin_log_entry import (
     REINDEX_ELASTIC,
 )
 from admin.nodes.templatetags.node_extras import reverse_node
-from admin.nodes.serializers import serialize_node, serialize_simple_user_and_node_permissions
+from admin.nodes.serializers import serialize_node, serialize_simple_user_and_node_permissions, serialize_log
 from website.project.tasks import update_node_share
 from website.project.views.register import osf_admin_change_status_identifier
 
@@ -200,6 +200,35 @@ class NodeView(PermissionRequiredMixin, GuidView):
         guid = self.kwargs.get('guid')
         node = Node.load(guid) or Registration.load(guid)
         return serialize_node(node)
+
+
+class AdminNodeLogView(PermissionRequiredMixin, ListView):
+    """ Allow admins to see logs"""
+
+    template_name = 'nodes/node_logs.html'
+    context_object_name = 'node'
+    paginate_by = 10
+    paginate_orphans = 1
+    ordering = 'date'
+    permission_required = 'osf.view_node'
+    raise_exception = True
+
+    def get_object(self, queryset=None):
+        return Node.load(self.kwargs.get('guid')) or Registration.load(self.kwargs.get('guid'))
+
+    def get_queryset(self):
+        return self.get_object().logs.all().order_by(self.ordering)
+
+    def get_context_data(self, **kwargs):
+        query_set = self.get_queryset()
+        print query_set
+        page_size = self.get_paginate_by(query_set)
+        paginator, page, query_set, is_paginated = self.paginate_queryset(
+            query_set, page_size)
+        return {
+            'logs': map(serialize_log, query_set),
+            'page': page,
+        }
 
 
 class RegistrationListView(PermissionRequiredMixin, ListView):

--- a/admin/nodes/views.py
+++ b/admin/nodes/views.py
@@ -221,7 +221,6 @@ class AdminNodeLogView(PermissionRequiredMixin, ListView):
 
     def get_context_data(self, **kwargs):
         query_set = self.get_queryset()
-        print query_set
         page_size = self.get_paginate_by(query_set)
         paginator, page, query_set, is_paginated = self.paginate_queryset(
             query_set, page_size)

--- a/admin/templates/nodes/node.html
+++ b/admin/templates/nodes/node.html
@@ -343,6 +343,24 @@
                     <pre>{{ node.spam_data }}</pre>
                 </td>
             </tr>
+            <tr>
+                <td>Logs</td>
+
+                <td>
+                    <ul>
+                    {% for log, params in node.logs %}
+                        <li>
+                            <b>{{ log.action }}</b> by {{log.user}} at {{ log.date }} with the following parameters:
+
+                            {% for key, value in params %}
+                            <div>{{key}} : {{ value }}</div>
+                            {% endfor %}
+
+                        </li>
+                    {% endfor %}
+                    </ul>
+                </td>
+            </tr>
         </tbody>
         </table>
         </div>

--- a/admin/templates/nodes/node.html
+++ b/admin/templates/nodes/node.html
@@ -16,10 +16,13 @@
                class="btn btn-primary col-md-1">
                 <i class="fa fa-search"></i>
             </a>
+            <a href="{% url 'nodes:node-logs' node.id %}" class="btn btn-primary col-md-1 padded">
+                View Logs
+            </a>
             {%  if perms.osf.delete_node %}
                 {% if not node.is_registration %}
                     {% if not node.deleted %}
-                        <span class="col-md-2">
+                        <span class="col-md-1">
                         <a href="{% url 'nodes:remove' guid=node.id %}"
                            data-toggle="modal" data-target="#deleteModal"
                            class="btn btn-danger">
@@ -85,7 +88,7 @@
                     {# Data from above link #}
                 </div>
             </div>
-            <span class="col-md-2">
+            <span class="col-md-1">
                 <a href="{% url 'nodes:reindex-elastic-node' guid=node.id %}"
                    data-toggle="modal" data-target="#confirmReindexElasticNode"
                    class="btn btn-default">
@@ -104,6 +107,7 @@
                 <h3>Registration Details</h3>
             {% else %}
                 <h3>Node Details</h3>
+            </tr>
             {% endif %}
         </div>
         <div class="row">
@@ -341,24 +345,6 @@
                 <td>SPAM Data</td>
                 <td>
                     <pre>{{ node.spam_data }}</pre>
-                </td>
-            </tr>
-            <tr>
-                <td>Logs</td>
-
-                <td>
-                    <ul>
-                    {% for log, params in node.logs %}
-                        <li>
-                            <b>{{ log.action }}</b> by {{log.user}} at {{ log.date }} with the following parameters:
-
-                            {% for key, value in params %}
-                            <div>{{key}} : {{ value }}</div>
-                            {% endfor %}
-
-                        </li>
-                    {% endfor %}
-                    </ul>
                 </td>
             </tr>
         </tbody>

--- a/admin/templates/nodes/node_logs.html
+++ b/admin/templates/nodes/node_logs.html
@@ -1,0 +1,49 @@
+{% extends 'base.html' %}
+{% load static %}
+{% block title %}
+    <title>Node Logs</title>
+{% endblock title %}
+{% block content %}
+    <div class="container-fluid">
+        <table class="table table-striped table-hover table-responsive">
+            <thead>
+                <th>
+                    Date
+                </th>
+                <th>
+                    Action
+                </th>
+                <th>
+                    User
+                </th>
+                <th>
+                    Parameters
+                </th>
+            </thead>
+            <tbody>
+            {% for log, params in logs %}
+                <tr>
+                    <td>
+                        {{ log.date }}
+                    </td>
+                    <td>
+                        {{ log.action }}
+                    </td>
+                    <td>
+                        {{ log.user }}
+                    </td>
+                    <td>
+                        {% for key, value in params %}
+                            <div>
+                                <span><b>{{ key }}</b></span> : <span>{{ value }}</span>
+                            </div>
+                        {% endfor %}
+                    </td>
+                </tr>
+            {% endfor %}
+            </tbody>
+            {% csrf_token %}
+        </table>
+    </div>
+    {% include "util/pagination.html" with items=page status=status %}
+{% endblock content %}


### PR DESCRIPTION
## Purpose

Allows admins to view the logs of private projects.

## Changes

Simple changes to the admin node.html page and and serializers.py to expose log info.

## Side effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/OSF-8319

## Screenshot
![new_admin_log](https://user-images.githubusercontent.com/9688518/30120629-66a3fdac-92f7-11e7-9481-6215847cc3ed.gif)

