### PR TITLE
[OSF-8127] Download URLs 404 for Box file revisions

### DIFF
--- a/website/static/js/filepage/revisions.js
+++ b/website/static/js/filepage/revisions.js
@@ -227,7 +227,7 @@ var FileRevisionsTable = {
         }
 
         revision.osfViewUrl = '?' + $.param(options);
-        revision.osfDownloadUrl = 'download?' + $.param(options);
+        revision.osfDownloadUrl = !index ? 'download' : 'download?' + $.param(options);
 
         return revision;
     }


### PR DESCRIPTION
## Purpose

Currently clicking the download link for the most recent revision of a file using the box provider send you to the a file detail page which tells you the file can't be found. This fix cause that button to download the file.

## Changes

Simple one line js fix ensures current version is downloaded without revision parameter.

## Side effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/OSF-8127