### PR TITLE
[OSF-8516] Add a modal for deleting projects with components.

### DIFF
--- a/api/base/generic_bulk_views.py
+++ b/api/base/generic_bulk_views.py
@@ -76,10 +76,14 @@ class BulkDestroyJSONAPIView(bulk_generics.BulkDestroyAPIView):
         Retrieves resources in request body
         """
         model_cls = request.parser_context['view'].model_class
+
         requested_ids = [data['id'] for data in request_data]
         column_name = 'guids___id' if issubclass(model_cls, GuidMixin) else '_id'
         resource_object_list = model_cls.find(Q(column_name, 'in', requested_ids))
-
+        if column_name == 'guids___id':
+            resource_object_list = [resource_object_list.get(guids___id=id) for id in requested_ids]
+        else:
+            resource_object_list = [resource_object_list.get(_id=id) for id in requested_ids]
         for resource in resource_object_list:
             if getattr(resource, 'is_deleted', None):
                 raise Gone

--- a/api/base/generic_bulk_views.py
+++ b/api/base/generic_bulk_views.py
@@ -80,16 +80,18 @@ class BulkDestroyJSONAPIView(bulk_generics.BulkDestroyAPIView):
         requested_ids = [data['id'] for data in request_data]
         column_name = 'guids___id' if issubclass(model_cls, GuidMixin) else '_id'
         resource_object_list = model_cls.find(Q(column_name, 'in', requested_ids))
-        if column_name == 'guids___id':
-            resource_object_list = [resource_object_list.get(guids___id=id) for id in requested_ids]
-        else:
-            resource_object_list = [resource_object_list.get(_id=id) for id in requested_ids]
+
         for resource in resource_object_list:
             if getattr(resource, 'is_deleted', None):
                 raise Gone
 
         if len(resource_object_list) != len(request_data):
             raise ValidationError({'non_field_errors': 'Could not find all objects to delete.'})
+
+        if column_name == 'guids___id':
+            resource_object_list = [resource_object_list.get(guids___id=id) for id in requested_ids]
+        else:
+            resource_object_list = [resource_object_list.get(_id=id) for id in requested_ids]
 
         return resource_object_list
 

--- a/api_tests/nodes/views/test_node_list.py
+++ b/api_tests/nodes/views/test_node_list.py
@@ -2259,7 +2259,7 @@ class TestNodeBulkDelete:
         assert res.status_code == 400
 
         new_payload = {'data': [{'id': public_component._id, 'type': 'nodes'}, {'id': public_project_parent._id, 'type': 'nodes'}]}
-        res = app.delete_json_api(url, new_payload, auth=user_one.auth, expect_errors=True, bulk=True)
+        res = app.delete_json_api(url, new_payload, auth=user_one.auth, bulk=True)
         assert res.status_code == 204
 
 

--- a/website/static/js/nodesDelete.js
+++ b/website/static/js/nodesDelete.js
@@ -1,0 +1,296 @@
+/**
+ * Controller for deleting a node and it childs (if they exists)
+ */
+'use strict';
+
+var $ = require('jquery');
+var $3 = window.$3;
+var ko = require('knockout');
+var Raven = require('raven-js');
+var $osf = require('./osfHelpers');
+var osfHelpers = require('js/osfHelpers');
+var m = require('mithril');
+var NodesDeleteTreebeard = require('js/nodesDeleteTreebeard');
+
+function _flattenNodeTree(nodeTree) {
+    var ret = [];
+    var stack = [nodeTree];
+    while (stack.length) {
+        var node = stack.pop();
+        ret.push(node);
+        stack = stack.concat(node.children);
+    }
+    return ret;
+}
+
+/**
+ * take treebeard tree structure of nodes and get a dictionary of parent node and all its
+ * children
+ */
+function getNodesOriginal(nodeTree, nodesOriginal) {
+    var flatNodes = _flattenNodeTree(nodeTree);
+    $.each(flatNodes, function(_, nodeMeta) {
+        nodesOriginal[nodeMeta.node.id] = {
+            public: nodeMeta.node.is_public,
+            id: nodeMeta.node.id,
+            title: nodeMeta.node.title,
+            isAdmin: nodeMeta.node.is_admin,
+            changed: false
+        };
+    });
+    nodesOriginal[nodeTree.node.id].isRoot = true;
+    return nodesOriginal;
+}
+
+/**
+ * patches all the nodes in a changed state
+ * uses API v2 bulk requests
+ */
+function patchNodesDelete(nodes) {
+    var nodesV2Url = window.contextVars.apiV2Prefix + 'nodes/';
+    var nodesPatch = $.map(nodes, function (node) {
+        return {
+            'type': 'nodes',
+            'id': node.id,
+            'attributes': {
+                'public': node.public
+            }
+        };
+    });
+    //s3 is a very recent version of jQuery that fixes a known bug when used in internet explorer
+    return $3.ajax({
+        url: nodesV2Url,
+        type: 'DELETE',
+        dataType: 'json',
+        contentType: 'application/vnd.api+json; ext=bulk',
+        crossOrigin: true,
+        xhrFields: {withCredentials: true},
+        processData: false,
+        data: JSON.stringify({
+            data: nodesPatch.reverse()
+        })
+    });
+}
+
+/**
+ * view model which corresponds to nodes_delete.mako (#nodesDelete)
+ *
+ * @type {NodesPrivacyViewModel}
+ */
+var NodesDeleteViewModel = function(node, onSetDelete) {
+    var self = this;
+    self.WARNING = 'warning';
+    self.SELECT = 'select';
+    self.CONFIRM = 'confirm';
+
+    self.onSetDelete = onSetDelete;
+
+    self.parentIsEmbargoed = node.is_embargoed;
+    self.parentIsPublic = node.is_public;
+    self.parentNodeType = node.node_type;
+    self.isPreprint = node.is_preprint;
+    self.treebeardUrl = window.contextVars.node.urls.api  + 'tree/';
+    self.nodesOriginal = {};
+    self.nodesChanged = ko.observable();
+    //state of current nodes
+    self.nodesState = ko.observableArray();
+    self.nodesState.subscribe(function(newValue) {
+        var nodesChanged = 0;
+        for (var key in newValue) {
+            if (newValue[key].public !== self.nodesOriginal[key].public) {
+                newValue[key].changed = true;
+                nodesChanged++;
+            }
+            else {
+                newValue[key].changed = false;
+            }
+        }
+        self.nodesChanged(nodesChanged > 0);
+        m.redraw(true);
+    });
+    //original node state on page load
+    self.nodesChangedPublic = ko.observableArray([]);
+    self.nodesChangedPrivate = ko.observableArray([]);
+    self.hasChildren = ko.observable(false);
+    $('#nodesDelete').on('hidden.bs.modal', function () {
+        self.clear();
+    });
+
+    self.page = ko.observable(self.WARNING);
+
+    self.pageTitle = ko.computed(function() {
+        if (self.page() === self.WARNING &&  self.parentIsEmbargoed) {
+            return "This is a message";
+        }
+
+        return {
+            warning: self.parentIsPublic ?
+                'Make ' + self.parentNodeType + ' private' :
+                'Warning',
+            select: 'Change privacy settings',
+            confirm: 'Projects and components affected'
+        }[self.page()];
+    });
+
+    self.message = ko.computed(function() {
+        if (self.page() === self.WARNING &&  self.parentIsEmbargoed) {
+            return "This is a message"
+        }
+
+        if (self.page() === self.WARNING &&  self.isPreprint) {
+            return "messages"
+        }
+
+        return {
+            warning: "messages",
+            select: "messages",
+            confirm: "messages"
+        }[self.page()];
+    });
+};
+
+/**
+ * get node tree for treebeard from API V1
+ */
+NodesDeleteViewModel.prototype.fetchNodeTree = function() {
+    var self = this;
+
+    return $.ajax({
+        url: self.treebeardUrl,
+        type: 'GET',
+        dataType: 'json'
+    }).done(function(response) {
+        self.nodesOriginal = getNodesOriginal(response[0], self.nodesOriginal);
+        var size = 0;
+        $.each(Object.keys(self.nodesOriginal), function(_, key) {
+            if (self.nodesOriginal.hasOwnProperty(key)) {
+                size++;
+            }
+        });
+        self.hasChildren(size > 1);
+        var nodesState = $.extend(true, {}, self.nodesOriginal);
+        var nodeParent = response[0].node.id;
+        //change node state and response to reflect button push by user on project page (make public | make private)
+        nodesState[nodeParent].public = response[0].node.is_public = !self.parentIsPublic;
+        nodesState[nodeParent].changed = true;
+        self.nodesState(nodesState);
+    }).fail(function(xhr, status, error) {
+        $osf.growl('Error', 'Unable to retrieve project settings');
+        Raven.captureMessage('Could not GET project settings.', {
+            extra: {
+                url: self.treebeardUrl, status: status, error: error
+            }
+        });
+    });
+};
+
+NodesDeleteViewModel.prototype.selectProjects = function() {
+    this.page(this.SELECT);
+};
+
+NodesDeleteViewModel.prototype.confirmWarning =  function() {
+    var nodesState = ko.toJS(this.nodesState);
+    for (var node in nodesState) {
+        if (nodesState[node].changed) {
+            if (nodesState[node].public) {
+                this.nodesChangedPublic().push(nodesState[node].title);
+            }
+            else {
+                this.nodesChangedPrivate().push(nodesState[node].title);
+            }
+        }
+    }
+    this.page(this.CONFIRM);
+};
+
+NodesDeleteViewModel.prototype.confirmChanges =  function() {
+    var self = this;
+
+    var nodesState = ko.toJS(this.nodesState());
+    nodesState = Object.keys(nodesState).map(function(key) {
+        return nodesState[key];
+    });
+    var nodesChanged = nodesState.filter(function(node) {
+        return node.changed;
+    });
+    //The API's bulk limit is 100 nodes.  We catch the exception in nodes_privacy.mako.
+    if (nodesChanged.length <= 100) {
+        $osf.block('Deleting Project');
+        patchNodesDelete(nodesChanged).then(function () {
+            self.onSetDelete(nodesChanged);
+            self.nodesChangedPublic([]);
+            self.nodesChangedPrivate([]);
+            self.page(self.WARNING);
+            window.location.reload();
+        }).fail(function (xhr) {
+            $osf.unblock();
+            var errorMessage = 'Unable to update project privacy';
+            if (xhr.responseJSON && xhr.responseJSON.errors) {
+                errorMessage = xhr.responseJSON.errors[0].detail;
+            }
+            $osf.growl('Problem changing privacy', errorMessage);
+            Raven.captureMessage('Could not PATCH project settings.');
+            self.clear();
+            $('#nodesDelete').modal('hide');
+        }).always(function() {
+            $osf.unblock();
+        });
+    }
+};
+
+NodesDeleteViewModel.prototype.clear = function() {
+    this.nodesChangedPublic([]);
+    this.nodesChangedPrivate([]);
+    this.page(this.WARNING);
+};
+
+NodesDeleteViewModel.prototype.back = function() {
+    this.nodesChangedPublic([]);
+    this.nodesChangedPrivate([]);
+    this.page(this.SELECT);
+};
+
+NodesDeleteViewModel.prototype.makeEmbargoPublic = function() {
+    var self = this;
+
+    var nodesChanged = $.map(self.nodesOriginal, function(node) {
+	if (node.isRoot) {
+            node.public = true;
+	    return node;
+	}
+	return null;
+    }).filter(Boolean);
+    $osf.block('Submitting request to end embargo early ...');
+    patchNodesDelete(nodesChanged).then(function (res) {
+        $osf.unblock();
+        $('.modal').modal('hide');
+        self.onSetPrivacy(nodesChanged, true);
+        $osf.growl(
+            'Email sent',
+            'The administrator(s) can approve or cancel the action within 48 hours. If 48 hours pass without any action taken, then the registration will become public.',
+            'success'
+        );
+    });
+};
+
+function NodesDelete(selector, node, onSetDelete) {
+    var self = this;
+
+    self.selector = selector;
+    self.$element = $(self.selector);
+    self.viewModel = new NodesDeleteViewModel(node, onSetDelete);
+    self.viewModel.fetchNodeTree().done(function(response) {
+        new NodesDeleteTreebeard('nodesDeleteTreebeard', response, self.viewModel.nodesState, self.viewModel.nodesOriginal);
+    });
+    self.init();
+}
+
+NodesDelete.prototype.init = function() {
+    osfHelpers.applyBindings(this.viewModel, this.selector);
+};
+
+module.exports = {
+    _NodesDeleteViewModel: NodesDeleteViewModel,
+    NodesDelete: NodesDelete
+};
+

--- a/website/static/js/nodesDelete.js
+++ b/website/static/js/nodesDelete.js
@@ -57,6 +57,7 @@ function patchNodesDelete(nodes) {
             }
         };
     });
+
     //s3 is a very recent version of jQuery that fixes a known bug when used in internet explorer
     return $3.ajax({
         url: nodesV2Url,
@@ -67,7 +68,7 @@ function patchNodesDelete(nodes) {
         xhrFields: {withCredentials: true},
         processData: false,
         data: JSON.stringify({
-            data: nodesPatch.reverse()
+            data: nodesPatch
         })
     });
 }
@@ -216,7 +217,7 @@ NodesDeleteViewModel.prototype.confirmChanges =  function() {
     //The API's bulk limit is 100 nodes.  We catch the exception in nodes_privacy.mako.
     if (nodesChanged.length <= 100) {
         $osf.block('Deleting Project');
-        patchNodesDelete(nodesChanged).then(function () {
+        patchNodesDelete(nodesChanged.reverse()).then(function () {
             self.onSetDelete(nodesChanged);
             self.nodesChangedPublic([]);
             self.nodesChangedPrivate([]);

--- a/website/static/js/nodesDelete.js
+++ b/website/static/js/nodesDelete.js
@@ -9,6 +9,7 @@ var Raven = require('raven-js');
 var $osf = require('./osfHelpers');
 var osfHelpers = require('js/osfHelpers');
 var m = require('mithril');
+var bootbox = require('bootbox');
 var NodesDeleteTreebeard = require('js/nodesDeleteTreebeard');
 
 function _flattenNodeTree(nodeTree) {
@@ -66,7 +67,12 @@ function batchNodesDelete(nodes) {
             data: nodesBatch
         }),
         success: function(){
-            window.location.href = '/dashboard/';
+            bootbox.alert({
+            message: 'Project has been successfully deleted.',
+                callback: function(confirmed) {
+                    window.location.href = '/dashboard/';
+                }
+            });
         }
     });
 }
@@ -82,8 +88,6 @@ var NodesDeleteViewModel = function(node) {
     self.CONFIRM = 'confirm';
 
     self.confirmationString = '';
-    self.parentIsEmbargoed = node.is_embargoed;
-    self.parentIsPublic = node.is_public;
     self.treebeardUrl = window.contextVars.node.urls.api  + 'tree/';
     self.nodesOriginal = {};
     self.nodesDeleted = ko.observable();

--- a/website/static/js/nodesDelete.js
+++ b/website/static/js/nodesDelete.js
@@ -201,7 +201,7 @@ NodesDeleteViewModel.prototype.confirmChanges =  function() {
         return node.changed;
     });
 
-    if ($('#bbConfirmText').val() === this.confirmationString) {
+    if ($('#bbConfirmTextDelete').val() === this.confirmationString) {
         if (nodesChanged.length <= 100) {
             $osf.block('Deleting Project');
             batchNodesDelete(nodesChanged.reverse()).then(function () {

--- a/website/static/js/nodesDelete.js
+++ b/website/static/js/nodesDelete.js
@@ -4,7 +4,6 @@
 'use strict';
 
 var $ = require('jquery');
-var $3 = window.$3;
 var ko = require('knockout');
 var Raven = require('raven-js');
 var $osf = require('./osfHelpers');
@@ -55,7 +54,7 @@ function batchNodesDelete(nodes) {
     });
 
     //s3 is a very recent version of jQuery that fixes a known bug when used in internet explorer
-    return $3.ajax({
+    return $.ajax({
         url: nodesV2Url,
         type: 'DELETE',
         dataType: 'json',
@@ -65,7 +64,10 @@ function batchNodesDelete(nodes) {
         processData: false,
         data: JSON.stringify({
             data: nodesBatch
-        })
+        }),
+        success: function(){
+            window.location.href = '/dashboard/';
+        }
     });
 }
 
@@ -82,8 +84,6 @@ var NodesDeleteViewModel = function(node) {
     self.confirmationString = '';
     self.parentIsEmbargoed = node.is_embargoed;
     self.parentIsPublic = node.is_public;
-    self.parentNodeType = node.node_type;
-    self.isPreprint = node.is_preprint;
     self.treebeardUrl = window.contextVars.node.urls.api  + 'tree/';
     self.nodesOriginal = {};
     self.nodesDeleted = ko.observable();
@@ -206,7 +206,6 @@ NodesDeleteViewModel.prototype.confirmChanges =  function() {
             $osf.block('Deleting Project');
             batchNodesDelete(nodesChanged.reverse()).then(function () {
                 self.page(self.WARNING);
-                window.location.reload();
             }).fail(function (xhr) {
                 $osf.unblock();
                 var errorMessage = 'Unable to delete project';

--- a/website/static/js/nodesDeleteTreebeard.js
+++ b/website/static/js/nodesDeleteTreebeard.js
@@ -74,7 +74,7 @@ function NodesDeleteTreebeard(divID, data, nodesState, nodesOriginal) {
             var id = item.data.node.id;
             var nodesStateLocal = ko.toJS(nodesState());
             //this lets treebeard know when changes come from the knockout side (select all or select none)
-            item.data.node.is_public = nodesStateLocal[id].public;
+            item.data.node.changed = nodesStateLocal[id].changed;
             columns.push(
                 {
                     data : 'action',
@@ -84,19 +84,12 @@ function NodesDeleteTreebeard(divID, data, nodesState, nodesOriginal) {
                         return m('input[type=checkbox]', {
                             disabled : !item.data.node.is_admin,
                             onclick : function() {
-                                item.data.node.is_public = !item.data.node.is_public;
                                 item.open = true;
-                                nodesStateLocal[id].public = item.data.node.is_public;
-                                if (nodesStateLocal[id].public !== nodesOriginal[id].local) {
-                                    nodesStateLocal[id].changed = true;
-                                }
-                                else {
-                                    nodesStateLocal[id].changed = false;
-                                }
+                                nodesStateLocal[id].changed = !nodesStateLocal[id].changed;
                                 nodesState(nodesStateLocal);
                                 tb.updateFolder(null, item);
                             },
-                            checked: nodesState()[id].public
+                            checked: nodesState()[id].changed
                         });
                     }
                 },

--- a/website/static/js/nodesDeleteTreebeard.js
+++ b/website/static/js/nodesDeleteTreebeard.js
@@ -1,0 +1,119 @@
+'use strict';
+
+var $ = require('jquery');
+var m = require('mithril');
+var ko = require('knockout');
+var Treebeard = require('treebeard');
+var projectSettingsTreebeardBase = require('js/projectSettingsTreebeardBase');
+
+function expandOnLoad() {
+    var tb = this;  // jshint ignore: line
+    for (var i = 0; i < tb.treeData.children.length; i++) {
+        var parent = tb.treeData.children[i];
+        tb.updateFolder(null, parent);
+        expandChildren(tb, parent.children);
+    }
+}
+
+function expandChildren(tb, children) {
+    var openParent = false;
+    for (var i = 0; i < children.length; i++) {
+        var child = children[i];
+        var parent = children[i].parent();
+        if (child.children.length > 0) {
+            expandChildren(tb, child.children);
+        }
+    }
+    if (openParent) {
+        openAncestors(tb, children[0]);
+    }
+}
+
+function openAncestors (tb, item) {
+    var parent = item.parent();
+    if(parent && parent.id > 0) {
+        tb.updateFolder(null, parent);
+        openAncestors(tb, parent);
+    }
+}
+
+function NodesDeleteTreebeard(divID, data, nodesState, nodesOriginal) {
+    /**
+     * nodesChanged and nodesState are knockout variables.  nodesChanged will keep track of the nodes that have
+     *  changed state.  nodeState is all the nodes in their current state.
+     * */
+    var tbOptions = $.extend({}, projectSettingsTreebeardBase.defaults, {
+        divID: divID,
+        filesData: data,
+        naturalScrollLimit : 0,
+        rowHeight : 35,
+        hScroll : 0,
+        columnTitles : function() {
+            return [
+                {
+                    title: 'checkBox',
+                    width: '4%',
+                    sortType : 'text',
+                    sort : true
+                },
+                {
+                    title: 'project',
+                    width : '96%',
+                    sortType : 'text',
+                    sort: true
+                }
+            ];
+        },
+        onload : function () {
+            var tb = this;
+            expandOnLoad.call(tb);
+        },
+        resolveRows: function nodesDeleteResolveRows(item){
+            var tb = this;
+            var columns = [];
+            var id = item.data.node.id;
+            var nodesStateLocal = ko.toJS(nodesState());
+            //this lets treebeard know when changes come from the knockout side (select all or select none)
+            item.data.node.is_public = nodesStateLocal[id].public;
+            columns.push(
+                {
+                    data : 'action',
+                    sortInclude : false,
+                    filter : false,
+                    custom : function () {
+                        return m('input[type=checkbox]', {
+                            disabled : !item.data.node.is_admin,
+                            onclick : function() {
+                                item.data.node.is_public = !item.data.node.is_public;
+                                item.open = true;
+                                nodesStateLocal[id].public = item.data.node.is_public;
+                                if (nodesStateLocal[id].public !== nodesOriginal[id].local) {
+                                    nodesStateLocal[id].changed = true;
+                                }
+                                else {
+                                    nodesStateLocal[id].changed = false;
+                                }
+                                nodesState(nodesStateLocal);
+                                tb.updateFolder(null, item);
+                            },
+                            checked: nodesState()[id].public
+                        });
+                    }
+                },
+                {
+                    data: 'project',  // Data field name
+                    folderIcons: true,
+                    filter: true,
+                    sortInclude: false,
+                    hideColumnTitles: false,
+                    custom: function () {
+                        return m('span', item.data.node.title);
+                    }
+                }
+            );
+            return columns;
+        }
+    });
+    var grid = new Treebeard(tbOptions);
+}
+module.exports = NodesDeleteTreebeard;

--- a/website/static/js/nodesDeleteTreebeard.js
+++ b/website/static/js/nodesDeleteTreebeard.js
@@ -69,28 +69,37 @@ function NodesDeleteTreebeard(divID, data, nodesState, nodesOriginal) {
             expandOnLoad.call(tb);
         },
         resolveRows: function nodesDeleteResolveRows(item){
+            var tooltips = function(){
+                $('[data-toggle="tooltip"]').tooltip();
+            };
             var tb = this;
             var columns = [];
             var id = item.data.node.id;
             var nodesStateLocal = ko.toJS(nodesState());
             //this lets treebeard know when changes come from the knockout side (select all or select none)
             item.data.node.changed = nodesStateLocal[id].changed;
+            //A wrapper div for tooltips must exist because tooltips does not work on a disabled element
+            var tooltipWrapper = item.data.node.is_admin ? 'div' : 'div[data-toggle="tooltip"][title="You must have admin permissions on this component to be able to delete it."][data-placement="right"]';
             columns.push(
                 {
                     data : 'action',
                     sortInclude : false,
                     filter : false,
                     custom : function () {
-                        return m('input[type=checkbox]', {
-                            disabled : !item.data.node.is_admin,
-                            onclick : function() {
-                                item.open = true;
-                                nodesStateLocal[id].changed = !nodesStateLocal[id].changed;
-                                nodesState(nodesStateLocal);
-                                tb.updateFolder(null, item);
-                            },
-                            checked: nodesState()[id].changed
-                        });
+                        return m(tooltipWrapper, {config: tooltips()},
+                            [
+                                m('input[type=checkbox]', {
+                                    disabled : !item.data.node.is_admin,
+                                    onclick : function() {
+                                        item.open = true;
+                                        nodesStateLocal[id].changed = !nodesStateLocal[id].changed;
+                                        nodesState(nodesStateLocal);
+                                        tb.updateFolder(null, item);
+                                    },
+                                    checked: nodesState()[id].changed,
+                                })
+                            ]
+                        );
                     }
                 },
                 {

--- a/website/static/js/pages/project-settings-page.js
+++ b/website/static/js/pages/project-settings-page.js
@@ -86,7 +86,7 @@ $(document).ready(function() {
     }
 
     if(ctx.node.childExists){
-        new NodesDelete.NodesDelete('#nodesDelete', ctx.node)
+        new NodesDelete.NodesDelete('#nodesDelete', ctx.node);
     }else{
         $('#deleteNode').on('click', function() {
             ProjectSettings.getConfirmationCode(ctx.node.nodeType, ctx.node.isPreprint);

--- a/website/static/js/pages/project-settings-page.js
+++ b/website/static/js/pages/project-settings-page.js
@@ -85,13 +85,13 @@ $(document).ready(function() {
         ko.applyBindings(projectSettingsVM, $('#projectSettings')[0]);
     }
 
-    $('#deleteNode').on('click', function() {
-        if(ctx.node.childExists){
-            new NodesDelete.NodesDelete('#nodesDelete', ctx.node)
-        }else{
+    if(ctx.node.childExists){
+        new NodesDelete.NodesDelete('#nodesDelete', ctx.node)
+    }else{
+        $('#deleteNode').on('click', function() {
             ProjectSettings.getConfirmationCode(ctx.node.nodeType, ctx.node.isPreprint);
-        }
-    });
+        });
+    }
 
     // TODO: Knockout-ify me
     $('#commentSettings').on('submit', function() {

--- a/website/static/js/pages/project-settings-page.js
+++ b/website/static/js/pages/project-settings-page.js
@@ -6,10 +6,13 @@ var Raven = require('raven-js');
 var ko = require('knockout');
 
 var ProjectSettings = require('js/projectSettings.js');
+var NodesDelete = require('js/nodesDelete.js');
 var InstitutionProjectSettings = require('js/institutionProjectSettings.js');
 
 var $osf = require('js/osfHelpers');
 require('css/addonsettings.css');
+
+var template = require('raw!templates/registration-modal.html');
 
 var ctx = window.contextVars;
 
@@ -84,7 +87,7 @@ $(document).ready(function() {
 
     $('#deleteNode').on('click', function() {
         if(ctx.node.childExists){
-            $osf.growl('Error', 'Any child components must be deleted prior to deleting this project.','danger', 30000);
+            new NodesDelete.NodesDelete('#nodesDelete', ctx.node)
         }else{
             ProjectSettings.getConfirmationCode(ctx.node.nodeType, ctx.node.isPreprint);
         }

--- a/website/static/js/pages/project-settings-page.js
+++ b/website/static/js/pages/project-settings-page.js
@@ -12,8 +12,6 @@ var InstitutionProjectSettings = require('js/institutionProjectSettings.js');
 var $osf = require('js/osfHelpers');
 require('css/addonsettings.css');
 
-var template = require('raw!templates/registration-modal.html');
-
 var ctx = window.contextVars;
 
 

--- a/website/static/js/projectSettings.js
+++ b/website/static/js/projectSettings.js
@@ -7,6 +7,7 @@ var $osf = require('js/osfHelpers');
 var oop = require('js/oop');
 var ChangeMessageMixin = require('js/changeMessage');
 var language = require('js/osfLanguage').projectSettings;
+var NodesDelete = require('js/nodesDelete').NodesDelete;
 
 var ProjectSettings = oop.extend(
     ChangeMessageMixin,

--- a/website/templates/project/nodes_delete.mako
+++ b/website/templates/project/nodes_delete.mako
@@ -63,7 +63,7 @@
                                 <p>
                                     Type the following to continue: <strong data-bind="text: confirmationString"></strong>
                                 </p>
-                                <input id="bbConfirmText" class="form-control">
+                                <input id="bbConfirmTextDelete" class="form-control">
                             </div>
                         </div>
                     </div><!-- end projects changed warning page -->

--- a/website/templates/project/nodes_delete.mako
+++ b/website/templates/project/nodes_delete.mako
@@ -6,14 +6,7 @@
                     <button type="button" class="close" data-dismiss="modal" data-bind="click: clear" aria-label="Close"><span aria-hidden="true">&times;</span></button>
                     <h3 class="modal-title" data-bind="text:pageTitle"></h3>
                 </div>
-
                 <div class="modal-body">
-                    <!-- warning page -->
-                    <div data-bind="if: page() == WARNING">
-                      <span data-bind="html:message"></span>
-                    </div>
-                    <!-- end warning page -->
-
                     <!-- select projects page -->
                     <div data-bind="visible:page() === SELECT">
                         <div class="row">
@@ -22,6 +15,10 @@
                                     <span data-bind="html:message"></span>
                                 </div>
                             </div>
+                        </div>
+                        <div>
+                            Select:&nbsp;
+                            <a class="text-bigger" data-bind="click:selectAll">All components</a>
                         </div>
                         <div class="tb-row-titles">
                             <div style="width: 100%" data-tb-th-col="0" class="tb-th">
@@ -44,16 +41,15 @@
 
                     <!-- projects changed warning page -->
                     <div data-bind="if: page() === CONFIRM">
-                        <div data-bind="if: nodesChangedPublic().length + nodesChangedPrivate().length <= 100">
-
-                            <div data-bind="if: nodesChanged()">
-                                <div data-bind="visible: nodesChangedPublic().length > 0">
+                        <div data-bind="if: nodesChanged().length <= 100">
+                            <div data-bind="if: nodesDeleted()">
+                                <div data-bind="visible: nodesChanged().length > 0">
                                     <div class="panel panel-default">
                                         <div class="panel-heading clearfix">
-                                            <h3 class="panel-title" data-bind="html:message()['nodesPublic']"></h3>
+                                            <h3 class="panel-title" data-bind="html:message"></h3>
                                         </div>
                                         <div class="panel-body">
-                                            <ul data-bind="foreach: { data: nodesChangedPublic, as: 'item' }">
+                                            <ul data-bind="foreach: { data: nodesChanged, as: 'item' }">
                                                 <li>
                                                     <h4 class="f-w-lg" data-bind="text: item"></h4>
                                                 </li>
@@ -61,28 +57,14 @@
                                         </div>
                                     </div>
                                 </div>
-                                <div data-bind="visible: nodesChangedPrivate().length > 0">
-                                    <div class="panel panel-default">
-                                        <div class="panel-heading clearfix">
-                                            <h3 class="panel-title" data-bind="html:message()['nodesPrivate']"></h3>
-                                        </div>
-                                        <div class="panel-body">
-                                            <ul data-bind="foreach: { data: nodesChangedPrivate, as: 'item' }">
-                                                <li>
-                                                    <h4 class="f-w-lg" data-bind="text: item"></h4>
-                                                </li>
-                                            </ul>
-                                        </div>
-                                    </div>
-                                </div>
+                                <p>
+                                    Please note that deleting your project will erase all your project data and this process is IRREVERSIBLE.
+                                </p>
+                                <p>
+                                    Type the following to continue: <strong data-bind="text: confirmationString"></strong>
+                                </p>
+                                <input id="bbConfirmText" class="form-control">
                             </div>
-                        </div>
-
-                        <div data-bind="ifnot: nodesChanged()">
-                            <span data-bind="html:message()['nodesNotChangedWarning']"></span>
-                        </div>
-                        <div data-bind="if: nodesChangedPublic().length + nodesChangedPrivate().length > 100">
-                            <span data-bind="html:message()['tooManyNodesWarning']"></span>
                         </div>
                     </div><!-- end projects changed warning page -->
                 </div><!-- end modal-body -->
@@ -95,22 +77,12 @@
 
                     <a href="#" class="btn btn-default" data-bind="click: clear" data-dismiss="modal">Cancel</a>
 
-                    <span data-bind="if: page() == WARNING">
-                      <span data-bind="if: parentIsEmbargoed">
-                        <a class="btn btn-primary" data-bind="click: makeEmbargoPublic">Confirm</a>
-                      </span>
-                      <span data-bind="ifnot: parentIsEmbargoed">
-                        <a class="btn btn-primary" data-bind="visible: hasChildren(), click:selectProjects">Continue</a>
-                        <a class="btn btn-primary" data-bind="visible: !hasChildren(), click:confirmChanges">Confirm</a>
-                      </span>
-                    </span>
-
                     <span data-bind="if: page() == SELECT">
-                      <a class="btn btn-primary" data-bind="click:confirmWarning">Continue</a>
+                      <a class="btn btn-primary" data-bind="css: { disabled: !nodesDeleted() }, click:confirmWarning" >Continue</a>
                     </span>
 
-                    <span data-bind="if: page() == CONFIRM && (nodesChangedPublic().length + nodesChangedPrivate().length <= 100)">
-                      <a href="#" class="btn btn-primary" data-bind="click: confirmChanges, visible: nodesChanged()" data-dismiss="modal">Confirm</a>
+                    <span data-bind="if: page() == CONFIRM && (nodesChanged().length <= 100)">
+                      <a href="#" class="btn btn-danger" data-bind="click: confirmChanges, visible: nodesDeleted()" data-dismiss="modal">Delete</a>
                     </span>
                 </div><!-- end modal-footer -->
             </div><!-- end modal-content -->

--- a/website/templates/project/nodes_delete.mako
+++ b/website/templates/project/nodes_delete.mako
@@ -1,0 +1,120 @@
+<div id="nodesDelete" class="modal fade">
+    <div class="modal-dialog modal-md">
+        <div style="display: none;" data-bind="visible: true">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" data-bind="click: clear" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    <h3 class="modal-title" data-bind="text:pageTitle"></h3>
+                </div>
+
+                <div class="modal-body">
+                    <!-- warning page -->
+                    <div data-bind="if: page() == WARNING">
+                      <span data-bind="html:message"></span>
+                    </div>
+                    <!-- end warning page -->
+
+                    <!-- select projects page -->
+                    <div data-bind="visible:page() === SELECT">
+                        <div class="row">
+                            <div class="col-md-10">
+                                <div class="m-b-md box p-sm">
+                                    <span data-bind="html:message"></span>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="tb-row-titles">
+                            <div style="width: 100%" data-tb-th-col="0" class="tb-th">
+                                <span class="m-r-sm"></span>
+                            </div>
+                        </div>
+                        <div class="osf-treebeard">
+                            <div id="nodesDeleteTreebeard">
+                                <div class="spinner-loading-wrapper">
+                                    <div class="logo-spin logo-md"></div>
+                                    <p class="m-t-sm fg-load-message"> Loading projects and components...  </p>
+                                </div>
+                            </div>
+                            <div class="help-block" style="padding-left: 15px">
+                                <p id="configureNotificationsMessage"></p>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- end select projects page -->
+
+                    <!-- projects changed warning page -->
+                    <div data-bind="if: page() === CONFIRM">
+                        <div data-bind="if: nodesChangedPublic().length + nodesChangedPrivate().length <= 100">
+
+                            <div data-bind="if: nodesChanged()">
+                                <div data-bind="visible: nodesChangedPublic().length > 0">
+                                    <div class="panel panel-default">
+                                        <div class="panel-heading clearfix">
+                                            <h3 class="panel-title" data-bind="html:message()['nodesPublic']"></h3>
+                                        </div>
+                                        <div class="panel-body">
+                                            <ul data-bind="foreach: { data: nodesChangedPublic, as: 'item' }">
+                                                <li>
+                                                    <h4 class="f-w-lg" data-bind="text: item"></h4>
+                                                </li>
+                                            </ul>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div data-bind="visible: nodesChangedPrivate().length > 0">
+                                    <div class="panel panel-default">
+                                        <div class="panel-heading clearfix">
+                                            <h3 class="panel-title" data-bind="html:message()['nodesPrivate']"></h3>
+                                        </div>
+                                        <div class="panel-body">
+                                            <ul data-bind="foreach: { data: nodesChangedPrivate, as: 'item' }">
+                                                <li>
+                                                    <h4 class="f-w-lg" data-bind="text: item"></h4>
+                                                </li>
+                                            </ul>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div data-bind="ifnot: nodesChanged()">
+                            <span data-bind="html:message()['nodesNotChangedWarning']"></span>
+                        </div>
+                        <div data-bind="if: nodesChangedPublic().length + nodesChangedPrivate().length > 100">
+                            <span data-bind="html:message()['tooManyNodesWarning']"></span>
+                        </div>
+                    </div><!-- end projects changed warning page -->
+                </div><!-- end modal-body -->
+
+                <div class="modal-footer">
+                    <!--ordering puts back button before cancel -->
+                <span data-bind="if: page() == CONFIRM">
+                    <a href="#" class="btn btn-default" data-bind="click: back" data-dismiss="modal">Back</a>
+                </span>
+
+                    <a href="#" class="btn btn-default" data-bind="click: clear" data-dismiss="modal">Cancel</a>
+
+                    <span data-bind="if: page() == WARNING">
+                      <span data-bind="if: parentIsEmbargoed">
+                        <a class="btn btn-primary" data-bind="click: makeEmbargoPublic">Confirm</a>
+                      </span>
+                      <span data-bind="ifnot: parentIsEmbargoed">
+                        <a class="btn btn-primary" data-bind="visible: hasChildren(), click:selectProjects">Continue</a>
+                        <a class="btn btn-primary" data-bind="visible: !hasChildren(), click:confirmChanges">Confirm</a>
+                      </span>
+                    </span>
+
+                    <span data-bind="if: page() == SELECT">
+                      <a class="btn btn-primary" data-bind="click:confirmWarning">Continue</a>
+                    </span>
+
+                    <span data-bind="if: page() == CONFIRM && (nodesChangedPublic().length + nodesChangedPrivate().length <= 100)">
+                      <a href="#" class="btn btn-primary" data-bind="click: confirmChanges, visible: nodesChanged()" data-dismiss="modal">Confirm</a>
+                    </span>
+                </div><!-- end modal-footer -->
+            </div><!-- end modal-content -->
+        </div>
+
+    </div><!-- end modal-dialog -->
+</div><!-- end modal -->

--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -1,4 +1,5 @@
 <%inherit file="project/project_base.mako"/>
+<%include file="project/nodes_delete.mako"/>
 <%def name="title()">${node['title']} Settings</%def>
 
 <div class="page-header visible-xs">
@@ -101,7 +102,7 @@
                                 To delete a parent project, you must first delete all child components
                                 by visiting their settings pages.
                             </div>
-                            <button id="deleteNode" class="btn btn-danger btn-delete-node">Delete ${node['node_type']}</button>
+                            <button id="deleteNode" class="btn btn-danger btn-delete-node" data-toggle="modal" data-target="#nodesDelete">Delete ${node['node_type']}</button>
                     % endif
                     </div>
                 </div>

--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -97,11 +97,6 @@
                         </div>
                     % if 'admin' in user['permissions']:
                         <hr />
-                            <div class="help-block">
-                                A project cannot be deleted if it has any components within it.
-                                To delete a parent project, you must first delete all child components
-                                by visiting their settings pages.
-                            </div>
                             <button id="deleteNode" class="btn btn-danger btn-delete-node" data-toggle="modal" data-target="#nodesDelete">Delete ${node['node_type']}</button>
                     % endif
                     </div>


### PR DESCRIPTION
## Purpose

This PR aims to improve the deletion process of projects with components by adding a helper modal to the front-end, enabling site users to choose delete all the components when deleting a project.

## Changes

There are two parts to this PR. 

The first part is a fix for the bulk deletion API. As of now, bulk deletion of a project and its components would fail even if all the components of the project are specified in postorder in the XHR request. The reason is that a database query to get all node instances does not preserve such order, resulting in error upon deleting nodes with undeleted child nodes.

Changes made:
1. In `api/base/generic_bulk_views.py`, `resource_object_list` is sorted according to the order specified in the request before returning.

The second part is a series of front end assets addition/modification for implementing the helper modal.

1. Added `nodesDelete.js` as a controller for the modal. The KO viewmodel is also defined in this file.
2. Added `nodes_delete.mako` as the template for the modal.
3. Added `NodesDeleteTreebeard.js`, subclassing Treebeard to show the project hierarchy and handles user selection.
4. `project-settings-page.js` is modified to initialize the modal when the current node has a child.
5. `projectSettings.js` is modified to import `nodesDelete.js`.

## Side effects

For the first part, sorting the list after the query may affect performance of the bulk deletion API. However the there seems to be no way to make the query preserve the order. Some thoughts on this are very much welcomed.


## Ticket

https://openscience.atlassian.net/browse/OSF-8516