### PR TITLE
[feature] Use Subqueries to Prevent Duplicate Records [OSF-8310]

### DIFF
--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -34,7 +34,7 @@ from api.base.throttling import (
     NonCookieAuthThrottle,
     AddContributorThrottle,
 )
-from api.base.utils import default_node_list_queryset, default_node_permission_queryset
+from api.base.utils import default_node_list_queryset, default_node_list_permission_queryset
 from api.base.utils import get_object_or_error, is_bulk_request, get_user_auth, is_truthy
 from api.base.views import JSONAPIBaseView
 from api.base.views import (
@@ -275,8 +275,7 @@ class NodeList(JSONAPIBaseView, bulk_views.BulkUpdateJSONAPIView, bulk_views.Bul
 
     # overrides NodesFilterMixin
     def get_default_queryset(self):
-        user = self.request.user
-        return default_node_list_queryset() & default_node_permission_queryset(user)
+        return default_node_list_permission_queryset(user=self.request.user, model_cls=Node)
 
     # overrides ListBulkCreateJSONAPIView, BulkUpdateJSONAPIView
     def get_queryset(self):
@@ -1239,7 +1238,7 @@ class NodeChildrenList(JSONAPIBaseView, bulk_views.ListBulkCreateJSONAPIView, No
     ordering = ('-date_modified',)
 
     def get_default_queryset(self):
-        return default_node_list_queryset()
+        return default_node_list_queryset(model_cls=Node)
 
     # overrides ListBulkCreateJSONAPIView
     def get_queryset(self):

--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -2,7 +2,7 @@ from rest_framework import generics, permissions as drf_permissions
 from rest_framework.exceptions import ValidationError, NotFound
 from framework.auth.oauth_scopes import CoreScopes
 
-from osf.models import AbstractNode
+from osf.models import AbstractNode, Registration
 from api.base import permissions as base_permissions
 from api.base.filters import ListFilterMixin
 from api.base.views import JSONAPIBaseView, BaseContributorDetail, BaseContributorList, BaseNodeLinksDetail, BaseNodeLinksList, WaterButlerMixin
@@ -12,7 +12,7 @@ from api.base.serializers import LinkedNodesRelationshipSerializer
 from api.base.pagination import NodeContributorPagination
 from api.base.parsers import JSONAPIRelationshipParser
 from api.base.parsers import JSONAPIRelationshipParserForRegularJSON
-from api.base.utils import get_user_auth, default_registration_list_queryset, default_registration_permission_queryset
+from api.base.utils import get_user_auth, default_node_list_permission_queryset
 from api.comments.serializers import RegistrationCommentSerializer, CommentCreateSerializer
 from api.identifiers.serializers import RegistrationIdentifierSerializer
 from api.nodes.views import NodeIdentifierList
@@ -155,7 +155,7 @@ class RegistrationList(JSONAPIBaseView, generics.ListAPIView, NodesFilterMixin):
 
     # overrides NodesFilterMixin
     def get_default_queryset(self):
-        return default_registration_list_queryset() & default_registration_permission_queryset(self.request.user)
+        return default_node_list_permission_queryset(user=self.request.user, model_cls=Registration)
 
     def is_blacklisted(self):
         query_params = self.parse_query_params(self.request.query_params)
@@ -509,7 +509,7 @@ class RegistrationChildrenList(JSONAPIBaseView, generics.ListAPIView, ListFilter
     ordering = ('-date_modified',)
 
     def get_default_queryset(self):
-        return default_registration_list_queryset() & default_registration_permission_queryset(self.request.user)
+        return default_node_list_permission_queryset(user=self.request.user, model_cls=Registration)
 
     def get_queryset(self):
         registration = self.get_node()

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -8,9 +8,7 @@ from api.base.parsers import (JSONAPIRelationshipParser,
                               JSONAPIRelationshipParserForRegularJSON)
 from api.base.serializers import AddonAccountSerializer
 from api.base.utils import (default_node_list_queryset,
-                            default_node_permission_queryset,
-                            default_registration_list_queryset,
-                            default_registration_permission_queryset,
+                            default_node_list_permission_queryset,
                             get_object_or_error,
                             get_user_auth)
 from api.base.views import JSONAPIBaseView, WaterButlerMixin
@@ -33,7 +31,7 @@ from django.db.models import Q
 from rest_framework import permissions as drf_permissions
 from rest_framework import generics
 from rest_framework.exceptions import NotAuthenticated, NotFound
-from osf.models import Contributor, ExternalAccount, QuickFilesNode, AbstractNode, PreprintService, OSFUser
+from osf.models import Contributor, ExternalAccount, QuickFilesNode, AbstractNode, PreprintService, OSFUser, Registration, Node
 
 
 class UserMixin(object):
@@ -528,10 +526,9 @@ class UserNodes(JSONAPIBaseView, generics.ListAPIView, UserMixin, NodesFilterMix
     # overrides NodesFilterMixin
     def get_default_queryset(self):
         user = self.get_user()
-        qs = default_node_list_queryset().filter(contributor__user__id=user.id)
         if user != self.request.user:
-            return qs & default_node_permission_queryset(self.request.user)
-        return qs
+            return default_node_list_permission_queryset(user=self.request.user, model_cls=Node).filter(contributor__user__id=user.id)
+        return default_node_list_queryset(model_cls=Node).filter(contributor__user__id=user.id)
 
     # overrides ListAPIView
     def get_queryset(self):
@@ -738,7 +735,7 @@ class UserRegistrations(JSONAPIBaseView, generics.ListAPIView, UserMixin, NodesF
     def get_default_queryset(self):
         user = self.get_user()
         current_user = self.request.user
-        qs = default_registration_list_queryset() & default_registration_permission_queryset(current_user)
+        qs = default_node_list_permission_queryset(user=current_user, model_cls=Registration)
         return qs.filter(contributor__user__id=user.id)
 
     # overrides ListAPIView

--- a/requirements.txt
+++ b/requirements.txt
@@ -85,7 +85,7 @@ python-geoip-geolite2==2015.0303
 django-typed-models==0.7.0
 git+https://github.com/cos-forks/django-dirtyfields@develop
 git+https://github.com/cos-forks/django-extensions@master
-django-include==0.1.0
+django-include==0.2.3
 psycopg2==2.6.2
 ujson==1.35
 sqlparse==0.2.2


### PR DESCRIPTION
#### Purpose
- #7493 introduced a bug where the API returned duplicate registrations (and likely duplicate nodes as well). This PR fixes that. 

#### Changes
- Use subqueries in `default_node_permissions_queryset()` util to prevent duplicate nodes from being returned without having to use `.distinct()` everywhere. 
- Make `default_node_list_queryset` and `default_node_permissions_queryset` generalizable to nodes and registrations.

```
In [33]: qs = Registration.objects.filter(is_deleted=False) & Registration.objects.filter(Q(is_public=True) | Q(_contributors=me))

In [34]: qs.count()
Out[34]: 10454
```

vs.

```
In [3]: me = OSFUser.objects.get(username='casey@cos.io')

In [4]: sqs = Contributor.objects.filter(node=OuterRef('pk'), user__id=me.id, read=True)

In [5]: contrib_qs = Registration.objects.annotate(contrib=Exists(sqs)).filter(contrib=True)

In [6]: qs = Registration.objects.filter(is_deleted=False) & (Registration.objects.filter(is_public=True) | contrib_qs)

In [7]: qs.count()
Out[7]: 4843
```


#### Side effects
- None expected.

#### Ticket
- [OSF-8310](https://openscience.atlassian.net/browse/OSF-8310)
