### PR TITLE
[Feature] Add django_celery_beat [OSF-8605]

### DIFF
--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -84,6 +84,7 @@ INSTALLED_APPS = (
     'django.contrib.admin',
 
     # 3rd party
+    'django_celery_beat',
     'rest_framework',
     'corsheaders',
     'raven.contrib.django.raven_compat',
@@ -270,3 +271,5 @@ SELECT_FOR_UPDATE_ENABLED = True
 
 # Disable anonymous user permissions in django-guardian
 ANONYMOUS_USER_NAME = None
+
+CELERY_BEAT_SCHEDULER = 'django_celery_beat.schedulers:DatabaseScheduler'

--- a/framework/celery_tasks/__init__.py
+++ b/framework/celery_tasks/__init__.py
@@ -17,7 +17,7 @@ if settings.SENTRY_DSN:
     client = Client(settings.SENTRY_DSN, release=settings.VERSION, tags={'App': 'celery'})
     register_signal(client)
 
-if settings.BROKER_USE_SSL:
+if settings.CELERY_BROKER_USE_SSL:
     app.setup_security()
 
 @app.task

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,9 @@ Markdown==2.4.1
 Pygments==1.6
 WTForms==1.0.4
 beautifulsoup4==4.3.2
-celery==3.1.25
+celery==4.1.0
+kombu==4.1.0
+vine==1.1.4
 httplib2==0.9
 hurry.filesize==0.9
 itsdangerous==0.24
@@ -41,10 +43,6 @@ git+https://github.com/CenterForOpenScience/modular-odm.git@0.4.0
 # Python markdown extensions for comment emails
 git+git://github.com/CenterForOpenScience/mdx_del_ins.git
 
-# Kombu with the ability to specify queue priority
-# TODO: Remove this when Kombu has a stable release including commit c20f854
-git+git://github.com/CenterForOpenScience/kombu.git@v3.0.36
-
 # Issue: certifi-2015.9.6.1 and 2015.9.6.2 fail verification (https://github.com/certifi/python-certifi/issues/26)
 # MailChimp Ticket: LTK1218902287135X, Domain: https://us9.api.mailchimp.com
 certifi==2015.4.28
@@ -65,6 +63,10 @@ Django==1.11.4
 djangorestframework==3.6.3
 django-cors-headers==1.3.1
 djangorestframework-bulk==0.2.1
+# django-celery-beat==1.0.1  # BSD 3 Clause
+# Contains a fix for handling disabled tasks that still has not been release
+git+git://github.com/celery/django-celery-beat@f014edcb954c707cb7628f4416257b6a58689523# BSD 3 Clause
+
 pyjwt==1.4.0
 # Issue: sorry, but this version only supports 100 named groups (https://github.com/eliben/pycparser/issues/147)
 pycparser==2.13

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -397,7 +397,7 @@ try:
 except ImportError:
     pass
 else:
-    CELERY_QUEUES = (
+    CELERY_TASK_QUEUES = (
         Queue(LOW_QUEUE, Exchange(LOW_QUEUE), routing_key=LOW_QUEUE,
               consumer_arguments={'x-priority': -1}),
         Queue(DEFAULT_QUEUE, Exchange(DEFAULT_QUEUE), routing_key=DEFAULT_QUEUE,
@@ -408,10 +408,10 @@ else:
               consumer_arguments={'x-priority': 10}),
     )
 
-    CELERY_DEFAULT_EXCHANGE_TYPE = 'direct'
-    CELERY_ROUTES = ('framework.celery_tasks.routers.CeleryRouter', )
-    CELERY_IGNORE_RESULT = True
-    CELERY_STORE_ERRORS_EVEN_IF_IGNORED = True
+    CELERY_TASK_DEFAULT_EXCHANGE_TYPE = 'direct'
+    CELERY_TASK_ROUTES = ('framework.celery_tasks.routers.CeleryRouter', )
+    CELERY_TASK_IGNORE_RESULT = True
+    CELERY_TASK_STORE_ERRORS_EVEN_IF_IGNORED = True
 
 # Default RabbitMQ broker
 RABBITMQ_USERNAME = os.environ.get('RABBITMQ_USERNAME', 'guest')
@@ -420,11 +420,11 @@ RABBITMQ_HOST = os.environ.get('RABBITMQ_HOST', 'localhost')
 RABBITMQ_PORT = os.environ.get('RABBITMQ_PORT', '5672')
 RABBITMQ_VHOST = os.environ.get('RABBITMQ_VHOST', '/')
 
-BROKER_URL = os.environ.get('BROKER_URL', 'amqp://{}:{}@{}:{}/{}'.format(RABBITMQ_USERNAME, RABBITMQ_PASSWORD, RABBITMQ_HOST, RABBITMQ_PORT, RABBITMQ_VHOST))
-BROKER_USE_SSL = False
+CELERY_BROKER_URL = os.environ.get('CELERY_BROKER_URL', 'amqp://{}:{}@{}:{}/{}'.format(RABBITMQ_USERNAME, RABBITMQ_PASSWORD, RABBITMQ_HOST, RABBITMQ_PORT, RABBITMQ_VHOST))
+CELERY_BROKER_USE_SSL = False
 
 # Default RabbitMQ backend
-CELERY_RESULT_BACKEND = os.environ.get('CELERY_RESULT_BACKEND', BROKER_URL)
+CELERY_RESULT_BACKEND = os.environ.get('CELERY_RESULT_BACKEND', CELERY_BROKER_URL)
 
 # Modules to import when celery launches
 CELERY_IMPORTS = (
@@ -468,7 +468,7 @@ except ImportError:
     pass
 else:
     #  Setting up a scheduler, essentially replaces an independent cron job
-    CELERYBEAT_SCHEDULE = {
+    CELERY_BEAT_SCHEDULE = {
         '5-minute-emails': {
             'task': 'website.notifications.tasks.send_users_email',
             'schedule': crontab(minute='*/5'),
@@ -549,7 +549,7 @@ else:
     }
 
     # Tasks that need metrics and release requirements
-    # CELERYBEAT_SCHEDULE.update({
+    # CELERY_BEAT_SCHEDULE.update({
     #     'usage_audit': {
     #         'task': 'scripts.osfstorage.usage_audit',
     #         'schedule': crontab(minute=0, hour=0),  # Daily 12 a.m

--- a/website/settings/local-dist.py
+++ b/website/settings/local-dist.py
@@ -78,12 +78,12 @@ OSF_SERVER_CERT = None
 
 ##### Celery #####
 ## Default RabbitMQ broker
-BROKER_URL = 'amqp://'
+CELERY_BROKER_URL = 'amqp://'
 
 # Celery with SSL
 # import ssl
 #
-# BROKER_USE_SSL = {
+# CELERY_BROKER_USE_SSL = {
 #     'keyfile': '/etc/ssl/private/worker.key',
 #     'certfile': '/etc/ssl/certs/worker.pem',
 #     'ca_certs': '/etc/ssl/certs/ca-chain.cert.pem',

--- a/website/settings/local-travis.py
+++ b/website/settings/local-travis.py
@@ -5,6 +5,7 @@ These settings override what's in website/settings/defaults.py
 NOTE: local.py will not be added to source control.
 '''
 import inspect
+import logging
 
 from . import defaults
 import os
@@ -53,7 +54,7 @@ OSF_SERVER_CERT = None
 
 ##### Celery #####
 ## Default RabbitMQ broker
-BROKER_URL = 'amqp://'
+CELERY_BROKER_URL = 'amqp://'
 
 # In-memory result backend
 CELERY_RESULT_BACKEND = 'cache'
@@ -90,3 +91,5 @@ POPULAR_LINKS_REGISTRATIONS = 'woooo'
 
 EZID_USERNAME = 'testfortravisnotreal'
 EZID_PASSWORD = 'testfortravisnotreal'
+
+logging.getLogger('celery.app.trace').setLevel(logging.FATAL)


### PR DESCRIPTION
## Purpose
Store beat schedule on database

## Changes
* Use `django-celery-beat`
* Update default settings
* Update requirements
* Verified schedule mechanism works:
```
beat_1              | [2017-09-06 17:17:24,488: DEBUG/MainProcess] Current schedule:
beat_1              | <ScheduleEntry: embargo_registrations scripts.embargo_registrations(dry_run=False) <crontab: 0 0 * * * (m/h/d/dM/MY)>
beat_1              | <ScheduleEntry: retract_registrations scripts.retract_registrations(dry_run=False) <crontab: 0 0 * * * (m/h/d/dM/MY)>
beat_1              | <ScheduleEntry: daily-emails website.notifications.tasks.send_users_email('email_digest') <crontab: 0 0 * * * (m/h/d/dM/MY)>
beat_1              | <ScheduleEntry: new-and-noteworthy scripts.populate_new_and_noteworthy_projects(dry_run=False) <crontab: 0 2 6 * * (m/h/d/dM/MY)>
beat_1              | <ScheduleEntry: triggered_mails scripts.triggered_mails(dry_run=False) <crontab: 0 0 * * * (m/h/d/dM/MY)>
beat_1              | <ScheduleEntry: run_keen_snapshots scripts.analytics.run_keen_snapshots() <crontab: 0 3 * * * (m/h/d/dM/MY)>
beat_1              | <ScheduleEntry: approve_embargo_terminations scripts.approve_embargo_terminations(dry_run=False) <crontab: 0 0 * * * (m/h/d/dM/MY)>
beat_1              | <ScheduleEntry: update_popular_nodes scripts.populate_popular_projects_and_registrations(dry_run=False) <crontab: 0 2 * * * (m/h/d/dM/MY)>
beat_1              | <ScheduleEntry: send_queued_mails scripts.send_queued_mails(dry_run=False) <crontab: 0 12 * * * (m/h/d/dM/MY)>
beat_1              | <ScheduleEntry: 5-minute-emails website.notifications.tasks.send_users_email('email_transactional') <crontab: */5 * * * * (m/h/d/dM/MY)>
beat_1              | <ScheduleEntry: run_keen_summaries scripts.analytics.run_keen_summaries(yesterday=True) <crontab: 0 1 * * * (m/h/d/dM/MY)>
beat_1              | <ScheduleEntry: approve_registrations scripts.approve_registrations(dry_run=False) <crontab: 0 0 * * * (m/h/d/dM/MY)>
beat_1              | <ScheduleEntry: generate_sitemap scripts.generate_sitemap() <crontab: 0 0 * * * (m/h/d/dM/MY)>
beat_1              | <ScheduleEntry: run_keen_events scripts.analytics.run_keen_events(yesterday=True) <crontab: 0 4 * * * (m/h/d/dM/MY)>
beat_1              | <ScheduleEntry: refresh_addons scripts.refresh_addon_tokens(addons={'box': 60, 'mendeley': 14, 'googledrive': 14}, dry_run=False) <crontab: 0 2 * * * (m/h/d/dM/MY)>
```

## Side effects
Settings will need to be modified when deployed. Also, as a follow up ticket: `The AMQP result backend is scheduled for deprecation in version 4.0 and removal in version v5.0. Please use RPC backend or a persistent backend.`
#### Requires #7676 to be deployed **several days** in advance

## Ticket
[[OSF-8605]](https://openscience.atlassian.net/browse/OSF-8605)
