### PR TITLE
[Feature] Fix mithril redraws issues btn logs and tb filebrowser [OSF-8587]

### DIFF
--- a/website/static/js/components/logFeed.js
+++ b/website/static/js/components/logFeed.js
@@ -59,7 +59,7 @@ var LogFeed = {
                 m.redraw();
             }
             self.logRequestPending(true);
-            var promise = m.request({method : 'GET', url : url, config: mHelpers.apiV2Config({withCredentials: window.contextVars.isOnRootDomain})});
+            var promise = m.request({method : 'GET', background: true, url : url, config: mHelpers.apiV2Config({withCredentials: window.contextVars.isOnRootDomain})});
             promise.then(
                 function(result) {
                     _processResults(result);

--- a/website/static/js/pages/project-dashboard-page.js
+++ b/website/static/js/pages/project-dashboard-page.js
@@ -112,8 +112,6 @@ $(document).ready(function () {
     });
 
     if (!ctx.node.isRetracted) {
-        m.startComputation();
-
         if (ctx.node.institutions.length && !ctx.node.anonymous) {
             m.mount(document.getElementById('instLogo'), m.component(institutionLogos, {institutions: window.contextVars.node.institutions}));
         }
@@ -123,9 +121,9 @@ $(document).ready(function () {
         m.mount(document.getElementById('logFeed'), m.component(LogFeed.LogFeed, {node: node}));
 
         // Treebeard Files view
-        $.ajax({
-            url:  nodeApiUrl + 'files/grid/'
-        }).done(function (data) {
+        var urlFilesGrid = nodeApiUrl + 'files/grid/';
+        var promise = m.request({ method: 'GET', background: true, config: $osf.setXHRAuthorization, url: urlFilesGrid});
+        promise.then(function (data) {
             var fangornOpts = {
                 divID: 'treeGrid',
                 filesData: data.data,
@@ -201,8 +199,12 @@ $(document).ready(function () {
             if (newComponentElem) {
                 m.mount(newComponentElem, AddComponentButton);
             }
-            m.endComputation();
-        });
+            return promise;
+        }, function(xhr, textStatus, error) {
+            Raven.captureMessage('Error retrieving filebrowser', {extra: {url: urlFilesGrid, textStatus: textStatus, error: error}});
+        }
+
+      );
 
     }
 


### PR DESCRIPTION
## Purpose

To solve an issue described in https://github.com/CenterForOpenScience/osf.io/pull/7277,
logs and tb filebrowser mounts where put in same mithril redraw.

Use `m.request` with `background : true` to prevent mithril redraws upon promise return, while
keeping part of solution in https://github.com/CenterForOpenScience/osf.io/pull/7277

## Changes
- Have logFeed use with `m.request` with `background : true`
- Remove `m.startComputation/m.endComputation` pair

## Ticket
[OSF-8587](https://openscience.atlassian.net/browse/OSF-8587)