### PR TITLE
[Feature] Add extra check for newly private projects [OSF-7647]

### DIFF
--- a/website/templates/public/pages/active_nodes.mako
+++ b/website/templates/public/pages/active_nodes.mako
@@ -58,6 +58,8 @@
             <%
                 #import locale
                 #locale.setlocale(locale.LC_ALL, 'en_US')
+                if not node.is_public:
+                    continue
                 if node.is_registration:
                     explicit_date = '{month} {dt.day} {dt.year}'.format(
                         dt=node.registered_date.date(),


### PR DESCRIPTION
## Purpose

Prevent newly private projects from showing in activity tabs. 
As the data for activity tabs (popular public, new and noteworthy)  are generated
by script (not on per-request basis), newly private may show with permissions errors.

## Changes

Add extra frontend check to make sure newly private projects do not show in activity
tabs.

## Before

## After

## Ticket

[OSF-7647](https://openscience.atlassian.net/browse/OSF-7647)
