### PR TITLE
[OSF-6477] Allow the user to cancel the deactivation request for their account.

### DIFF
--- a/admin/static/css/base.css
+++ b/admin/static/css/base.css
@@ -24,3 +24,9 @@ form p label {
     position:relative;
     margin-left: 30px;
 }
+
+.padded {
+    padding-top: 20px;
+    padding-bottom: 20px;
+}
+

--- a/admin/templates/users/user.html
+++ b/admin/templates/users/user.html
@@ -7,7 +7,7 @@
 {% block content %}
 <div class="container-fluid">
     <div class="row">
-        <div class="col-md-8">
+        <div class="col-md-12">
             <div class="btn-group" role="group">
                 <a href="{% url 'users:search' %}" class="btn btn-default"><i class="fa fa-search"></i></a>
                 {%  if perms.osf.view_spam %}
@@ -32,23 +32,39 @@
                 <a href="{% url 'desk:customer' user.id %}" data-toggle="modal" data-target="#deskModal" class="btn btn-default">Desk profile</a>
                 <a href="{% url 'desk:user_cases' user.id %}" data-toggle="modal" data-target="#caseModal" class="btn btn-default">Desk cases</a>
                 {% endif %}
+                <a href="{% url 'users:reset_password' user.id %}"
+                   data-toggle="modal" data-target="#resetModal"
+                   class="btn btn-primary">
+                    Send reset
+                </a>
+                <a href="{% url 'users:reindex-elastic-user' guid=user.id %}" data-toggle="modal" data-target="#confirmReindexElasticUser" class="btn btn-success">Elastic Reindex</a>
+
+
             </div>
         </div>
-        <div class="col-md-4 form-group">
-            {% if not user.disabled %}
-                <a href="{% url 'users:disable' user.id %}" data-toggle="modal" data-target="#disableModal" class="btn btn-danger">Disable account</a>
-            {% elif 'spam_confirmed' not in user.system_tags %}
-                <form method="post" action="{% url 'users:reactivate' user.id %}">
-                    {% csrf_token %}
-                    <input class="btn btn-success" type="submit" value="Reactivate account"/>
-                </form>
-            {% endif %}
-            {% if not user.disabled or 'spam_flagged' in user.system_tags %}
-                <a href="{% url 'users:spam_disable' user.id %}" data-toggle="modal" data-target="#disableSpamModal" class="btn btn-danger">Disable Spam account</a>
-            {% elif 'spam_confirmed' in user.system_tags %}
-                <a href="{% url 'users:ham_enable' user.id %}" data-toggle="modal" data-target="#enableHamModal" class="btn btn-success">Re-enable Ham account</a>
-            {% endif %}
-            <a href="{% url 'users:reindex-elastic-user' guid=user.id %}" data-toggle="modal" data-target="#confirmReindexElasticUser" class="btn btn-success">Elastic Reindex</a>
+    </div>
+    <div class="row">
+        <div class="col-md-12">
+            <div class="btn-group padded" role="group">
+                {% if not user.disabled %}
+                    {% if user.requested_deactivation %}
+                        <a href="{% url 'users:disable' user.id %}" data-toggle="modal" data-target="#disableModal" class="btn btn-danger">Requested account deactivation</a>
+                    {% else %}
+                        <a href="{% url 'users:disable' user.id %}" data-toggle="modal" data-target="#disableModal" class="btn btn-danger disabled">Requested account deactivation</a>
+                    {% endif %}
+                    <a href="{% url 'users:disable' user.id %}" data-toggle="modal" data-target="#disableModal" class="btn btn-danger">Force disable account</a>
+                {% elif 'deac_confirmed' not in user.system_tags %}
+                    <form method="post" action="{% url 'users:reactivate' user.id %}">
+                        {% csrf_token %}
+                        <input class="btn btn-success" type="submit" value="Reactivate account"/>
+                    </form>
+                {% endif %}
+                {% if not user.disabled or 'spam_flagged' in user.system_tags %}
+                    <a href="{% url 'users:spam_disable' user.id %}" data-toggle="modal" data-target="#disableSpamModal" class="btn btn-danger">Disable Spam account</a>
+                {% elif 'spam_confirmed' in user.system_tags %}
+                    <a href="{% url 'users:ham_enable' user.id %}" data-toggle="modal" data-target="#enableHamModal" class="btn btn-success">Re-enable Ham account</a>
+                {% endif %}
+            </div>
         </div>
     </div>
 
@@ -67,11 +83,6 @@
 
             {%  if perms.osf.change_osfuser %}
                 <span class="col-md-2">
-                <a href="{% url 'users:reset_password' user.id %}"
-                   data-toggle="modal" data-target="#resetModal"
-                   class="btn btn-primary">
-                    Send reset
-                </a>
                 </span>
             {% endif %}
             <div class="modal" id="resetModal" style="display: none">

--- a/admin/users/serializers.py
+++ b/admin/users/serializers.py
@@ -17,7 +17,8 @@ def serialize_user(user):
         'two_factor': user.has_addon('twofactor'),
         'osf_link': user.absolute_url,
         'system_tags': user.system_tags,
-        'unclaimed': bool(user.unclaimed_records)
+        'unclaimed': bool(user.unclaimed_records),
+        'requested_deactivation': bool(user.requested_deactivation)
     }
 
 

--- a/website/profile/views.py
+++ b/website/profile/views.py
@@ -764,3 +764,10 @@ def request_deactivation(auth):
     user.requested_deactivation = True
     user.save()
     return {'message': 'Sent account deactivation request'}
+
+@must_be_logged_in
+def cancel_request_deactivation(auth):
+    user = auth.user
+    user.requested_deactivation = False
+    user.save()
+    return {'message': 'You have canceled your deactivation request'}

--- a/website/routes.py
+++ b/website/routes.py
@@ -830,6 +830,12 @@ def make_url_map(app):
             profile_views.request_deactivation,
             json_renderer,
         ),
+        Rule(
+            '/profile/cancel_request_deactivation/',
+            'post',
+            profile_views.cancel_request_deactivation,
+            json_renderer,
+        ),
 
         Rule(
             '/profile/logins/',

--- a/website/templates/profile/account.mako
+++ b/website/templates/profile/account.mako
@@ -216,15 +216,11 @@
                 <div id="deactivateAccount" class="panel panel-default">
                     <div class="panel-heading clearfix"><h3 class="panel-title">Deactivate Account</h3></div>
                     <div class="panel-body">
-                        %if not requested_deactivation:
-                            <p class="alert alert-warning"><strong>Warning:</strong> This action is irreversible.</p>
-                        %endif
+                        <p class="alert alert-warning"><strong>Warning:</strong> Once your deactivation has been approved the effects are irreversible.</p>
                         <p>Deactivating your account will remove you from all public projects to which you are a contributor. Your account will no longer be associated with OSF projects, and your work on the OSF will be inaccessible.</p>
-                        %if not requested_deactivation:
-                             <a class="btn btn-danger" data-bind="click: submit, css: success() === true ? 'disabled' : ''">Request deactivation</a>
-                        %else:
-                             <p><b>Your account is currently pending deactivation.</b></p>
-                        %endif
+                        <p data-bind="click: cancel, visible: requestPending()"><b>Your account is currently pending deactivation.</b></p>
+                        <a class="btn btn-danger" data-bind="click: submit, visible: !requestPending()">Request deactivation</a>
+                        <a class="btn btn-success" data-bind="click: cancel, visible: requestPending()">Cancel deactivation request</a>
                     </div>
                 </div>
             </div>
@@ -251,7 +247,8 @@
 <%def name="javascript_bottom()">
     <script type="text/javascript">
         window.contextVars = $.extend(true, {}, window.contextVars, {
-            username: ${user_name | sjson, n}
+            username: ${user_name | sjson, n},
+            requestedDeactivation: ${requested_deactivation | sjson, n}
         });
     </script>
     ${parent.javascript_bottom()}


### PR DESCRIPTION
## Purpose

Currently if a user tries to deactivate your account they send a deactivation request to an admin who will review it and get back to them, so if they click it (and confirm it with a confirmation modal) by accident they can't rescind their request. This PR allows them to cancel their deactivation request.

## Changes

Adds route for canceling request and minor front-end changes to call that route and display reinvent info about account status. 

## Side effects

None that I know of.

## Testing 

I checked for pre-existing relevant tests and there weren't any. It would be beneficial to write some simple tests, but it should probably be done as a separate ticket. It just seems illogical to include tests for canceling a deactivation request when there are none for making a deactivation request.

## Ticket

https://openscience.atlassian.net/browse/OSF-6477