### PR TITLE
[OSF-8493] Admin import for preprints should be fault tolerant for new fields

### DIFF
--- a/admin/preprint_providers/views.py
+++ b/admin/preprint_providers/views.py
@@ -231,8 +231,9 @@ class ImportPreprintProvider(PermissionRequiredMixin, View):
         if form.is_valid():
             file_str = self.parse_file(request.FILES['file'])
             file_json = json.loads(file_str)
+            current_fields = [f.name for f in PreprintProvider._meta.get_fields()]
             # make sure not to import an exported access token for SHARE
-            cleaned_result = {key: value for key, value in file_json['fields'].iteritems() if key not in FIELDS_TO_NOT_IMPORT_EXPORT}
+            cleaned_result = {key: value for key, value in file_json['fields'].iteritems() if key not in FIELDS_TO_NOT_IMPORT_EXPORT and key in current_fields}
             preprint_provider = self.create_or_update_provider(cleaned_result)
             return redirect('preprint_providers:detail', preprint_provider_id=preprint_provider.id)
 

--- a/admin_tests/preprint_providers/test_views.py
+++ b/admin_tests/preprint_providers/test_views.py
@@ -262,8 +262,8 @@ class TestPreprintProviderExportImport(AdminTestCase):
         content_dict = json.loads(res.content)
 
         content_dict['fields']['_id'] = 'new_id'
-        content_dict['fields']['new_field'] = "this is a new field, not in the model"
-        del content_dict['fields']['description'] # this is a old field, removed from the model JSON
+        content_dict['fields']['new_field'] = 'this is a new field, not in the model'
+        del content_dict['fields']['description']  # this is a old field, removed from the model JSON
 
         data = StringIO(unicode(json.dumps(content_dict), 'utf-8'))
         self.import_request.FILES['file'] = InMemoryUploadedFile(data, None, 'data', 'application/json', 500, None, {})

--- a/admin_tests/preprint_providers/test_views.py
+++ b/admin_tests/preprint_providers/test_views.py
@@ -255,6 +255,27 @@ class TestPreprintProviderExportImport(AdminTestCase):
         # nt.assert_equal(new_provider.subjects.all()[0].text, self.subject.text)
         nt.assert_equal(new_provider.licenses_acceptable.all()[0].license_id, 'NONE')
 
+    def test_export_to_import_new_provider_with_models_out_of_sync(self):
+        update_taxonomies('test_bepress_taxonomy.json')
+
+        res = self.view.get(self.request)
+        content_dict = json.loads(res.content)
+
+        content_dict['fields']['_id'] = 'new_id'
+        content_dict['fields']['new_field'] = "this is a new field, not in the model"
+        del content_dict['fields']['description'] # this is a old field, removed from the model JSON
+
+        data = StringIO(unicode(json.dumps(content_dict), 'utf-8'))
+        self.import_request.FILES['file'] = InMemoryUploadedFile(data, None, 'data', 'application/json', 500, None, {})
+
+        res = self.import_view.post(self.import_request)
+
+        provider_id = ''.join([i for i in res.url if i.isdigit()])
+        new_provider = PreprintProvider.objects.get(id=provider_id)
+
+        nt.assert_equal(res.status_code, 302)
+        nt.assert_equal(new_provider._id, 'new_id')
+
     def test_update_provider_existing_subjects(self):
         # If there are existing subjects for a provider, imported subjects are ignored
         self.import_view.kwargs = {'preprint_provider_id': self.preprint_provider.id}


### PR DESCRIPTION
## Purpose

Currently if an admin tries to import JSON from an old preprint provider to create a new preprint with different fields they will be treated to an 502. This PR fixes that.

## Changes

Single line python fix makes sure only fields in the current PreprintProvider model are included.

## Side effects

Any new fields added are automatically set to there default settings in the Preprint create detail.

## Tests

Includes unit test.

## Ticket

https://openscience.atlassian.net/browse/OSF-8493