### PR TITLE
[feature] Fix Multiple Field Filtering [OSF-8310]

### DIFF
--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -348,9 +348,10 @@ class ListFilterMixin(FilterMixin):
         filters = self.parse_query_params(query_params)
         queryset = default_queryset
         query_parts = []
-        sub_query_parts = []
+
         if filters:
             for key, field_names in filters.iteritems():
+                sub_query_parts = []
                 for field_name, data in field_names.iteritems():
                     operations = data if isinstance(data, list) else [data]
                     if isinstance(queryset, list):


### PR DESCRIPTION
#### Purpose
- Fixes a bug that resulted in incorrect results being returned when filtering on multiple fields, if any of the filter fields were also used in creating the default queryset (i.e. filtering nodes by both `public` and `title`). 

#### Changes
- Slight modification to `ListFilterMixin`
- Mega test added.

#### Side Effects
- None expected.

#### Ticket
- [OSF-8310](https://openscience.atlassian.net/browse/OSF-8310)
