### PR TITLE
[OSF-8195] Stop admins from redirecting to blank domain

### DIFF
--- a/admin/static/js/preprint_providers/preprintProviders.js
+++ b/admin/static/js/preprint_providers/preprintProviders.js
@@ -125,6 +125,19 @@ $(document).ready(function() {
         });
     };
 
+    if($('#id_domain_redirect_enabled').checked){
+        $('#id_domain').attr('required', "");
+    }
+
+    $('#id_domain_redirect_enabled').click(function() {
+        if(this.checked) {
+            $('#id_domain').attr('required', "");
+        }else {
+            $('#id_domain').removeAttr('required');
+
+        }
+    });
+
     $("#import-form").submit(function(event) {
         tinymceFields = ['description', 'advisory_board', 'footer_links'];
         checkedBooleanFields = ['domain_redirect_enabled', 'allow_submissions'];


### PR DESCRIPTION
## Purpose

Currently admins adding or modifying preprint provider information can submit a preprint form with a blank domain, this causes bad redirects which the admins don't intend. This fix beefs up the validation to require the domain when the preprint provider has domain redirect enabled.

## Changes

Smallish Jquery fix, I tried many different implementations (probably too many) using server side changes, but this Jquery fix was the best I came up with.

## Side effects

Know that I know of.

## Tests

I couldn't think of any relevant tests. 

## Ticket

https://openscience.atlassian.net/browse/OSF-8195