### PR TITLE
Feature/add affiliation to registration [OSF-8514]

### DIFF
--- a/api/institutions/serializers.py
+++ b/api/institutions/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers as ser
 from rest_framework import exceptions
 
-from osf.models import AbstractNode
+from osf.models import Node, Registration
 from website.util import permissions as osf_permissions
 
 from api.base.serializers import JSONAPISerializer, RelationshipField, LinksField, JSONAPIRelationshipSerializer, \
@@ -75,9 +75,9 @@ class InstitutionNodesRelationshipSerializer(BaseAPISerializer):
 
         changes_flag = False
         for node_dict in node_dicts:
-            node = AbstractNode.load(node_dict['_id'])
+            node = Node.load(node_dict['_id'])
             if not node:
-                raise exceptions.NotFound(detail='AbstractNode with id "{}" was not found'.format(node_dict['_id']))
+                raise exceptions.NotFound(detail='Node with id "{}" was not found'.format(node_dict['_id']))
             if not node.has_permission(user, osf_permissions.WRITE):
                 raise exceptions.PermissionDenied(detail='Write permission on node {} required'.format(node_dict['_id']))
             if not node.is_affiliated_with_institution(inst):
@@ -89,5 +89,48 @@ class InstitutionNodesRelationshipSerializer(BaseAPISerializer):
 
         return {
             'data': list(inst.nodes.filter(is_deleted=False, type='osf.node')),
+            'self': inst
+        }
+
+class RegistrationRelated(JSONAPIRelationshipSerializer):
+    id = ser.CharField(source='_id', required=False, allow_null=True)
+    class Meta:
+        type_ = 'registrations'
+
+class InstitutionRegistrationsRelationshipSerializer(BaseAPISerializer):
+    data = ser.ListField(child=RegistrationRelated())
+    links = LinksField({'self': 'get_self_url',
+                        'html': 'get_related_url'})
+
+    def get_self_url(self, obj):
+        return obj['self'].registrations_relationship_url
+
+    def get_related_url(self, obj):
+        return obj['self'].registrations_url
+
+    class Meta:
+        type_ = 'registrations'
+
+    def create(self, validated_data):
+        inst = self.context['view'].get_object()['self']
+        user = self.context['request'].user
+        registration_dicts = validated_data['data']
+
+        changes_flag = False
+        for registration_dict in registration_dicts:
+            registration = Registration.load(registration_dict['_id'])
+            if not registration:
+                raise exceptions.NotFound(detail='Registration with id "{}" was not found'.format(registration_dict['_id']))
+            if not registration.has_permission(user, osf_permissions.WRITE):
+                raise exceptions.PermissionDenied(detail='Write permission on registration {} required'.format(registration_dict['_id']))
+            if not registration.is_affiliated_with_institution(inst):
+                registration.add_affiliated_institution(inst, user, save=True)
+                changes_flag = True
+
+        if not changes_flag:
+            raise RelationshipPostMakesNoChanges
+
+        return {
+            'data': list(inst.nodes.filter(is_deleted=False, type='osf.registration')),
             'self': inst
         }

--- a/api/institutions/urls.py
+++ b/api/institutions/urls.py
@@ -8,6 +8,7 @@ urlpatterns = [
     url(r'^(?P<institution_id>\w+)/$', views.InstitutionDetail.as_view(), name=views.InstitutionDetail.view_name),
     url(r'^(?P<institution_id>\w+)/nodes/$', views.InstitutionNodeList.as_view(), name=views.InstitutionNodeList.view_name),
     url(r'^(?P<institution_id>\w+)/registrations/$', views.InstitutionRegistrationList.as_view(), name=views.InstitutionRegistrationList.view_name),
+    url(r'^(?P<institution_id>\w+)/relationships/registrations/$', views.InstitutionRegistrationsRelationship.as_view(), name=views.InstitutionRegistrationsRelationship.view_name),
     url(r'^(?P<institution_id>\w+)/relationships/nodes/$', views.InstitutionNodesRelationship.as_view(), name=views.InstitutionNodesRelationship.view_name),
     url(r'^(?P<institution_id>\w+)/users/$', views.InstitutionUserList.as_view(), name=views.InstitutionUserList.view_name),
 ]

--- a/api/institutions/views.py
+++ b/api/institutions/views.py
@@ -6,7 +6,7 @@ from rest_framework.response import Response
 
 from framework.auth.oauth_scopes import CoreScopes
 
-from osf.models import OSFUser, Node, Institution
+from osf.models import OSFUser, Node, Institution, Registration
 from website.util import permissions as osf_permissions
 
 from api.base import permissions as base_permissions
@@ -26,7 +26,7 @@ from api.users.serializers import UserSerializer
 from api.registrations.serializers import RegistrationSerializer
 
 from api.institutions.authentication import InstitutionAuthentication
-from api.institutions.serializers import InstitutionSerializer, InstitutionNodesRelationshipSerializer
+from api.institutions.serializers import InstitutionSerializer, InstitutionNodesRelationshipSerializer, InstitutionRegistrationsRelationshipSerializer
 from api.institutions.permissions import UserIsAffiliated
 
 class InstitutionMixin(object):
@@ -225,6 +225,90 @@ class InstitutionRegistrationList(InstitutionNodeList):
 
     def get_queryset(self):
         return self.get_queryset_from_request()
+
+class InstitutionRegistrationsRelationship(JSONAPIBaseView, generics.RetrieveDestroyAPIView, generics.CreateAPIView, InstitutionMixin):
+    """ Relationship Endpoint for Institution -> Registrations Relationship
+
+    Used to set, remove, update and retrieve the affiliated_institution of registrations with this institution
+
+    ##Actions
+
+    ###Create
+
+        Method:        POST
+        URL:           /links/self
+        Query Params:  <none>
+        Body (JSON):   {
+                         "data": [{
+                           "type": "registrations",   # required
+                           "id": <registration_id>   # required
+                         }]
+                       }
+        Success:       201
+
+    This requires write permissions on the registrations requested and for the user making the request to
+    have the institution affiliated in their account.
+
+    ###Destroy
+
+        Method:        DELETE
+        URL:           /links/self
+        Query Params:  <none>
+        Body (JSON):   {
+                         "data": [{
+                           "type": "registrations",   # required
+                           "id": <registration_id>   # required
+                         }]
+                       }
+        Success:       204
+
+    This requires write permissions in the registrations requested.
+    """
+    permission_classes = (
+        drf_permissions.IsAuthenticatedOrReadOnly,
+        base_permissions.TokenHasScope,
+        UserIsAffiliated
+    )
+    required_read_scopes = [CoreScopes.NULL]
+    required_write_scopes = [CoreScopes.NULL]
+    serializer_class = InstitutionRegistrationsRelationshipSerializer
+    parser_classes = (JSONAPIRelationshipParser, JSONAPIRelationshipParserForRegularJSON, )
+
+    view_category = 'institutions'
+    view_name = 'institution-relationships-registrations'
+
+    def get_object(self):
+        inst = self.get_institution()
+        auth = get_user_auth(self.request)
+        registrations = inst.nodes.filter(is_deleted=False, type='osf.registration').can_view(user=auth.user, private_link=auth.private_link)
+        ret = {
+            'data': registrations,
+            'self': inst
+        }
+        self.check_object_permissions(self.request, ret)
+        return ret
+
+    def perform_destroy(self, instance):
+        data = self.request.data['data']
+        user = self.request.user
+        ids = [datum['id'] for datum in data]
+        registrations = []
+        for id_ in ids:
+            registration = Registration.load(id_)
+            if not registration.has_permission(user, osf_permissions.WRITE):
+                raise exceptions.PermissionDenied(detail='Write permission on registration {} required'.format(id_))
+            registrations.append(registration)
+
+        for registration in registrations:
+            registration.remove_affiliated_institution(inst=instance['self'], user=user)
+            registration.save()
+
+    def create(self, *args, **kwargs):
+        try:
+            ret = super(InstitutionRegistrationsRelationship, self).create(*args, **kwargs)
+        except RelationshipPostMakesNoChanges:
+            return Response(status=status.HTTP_204_NO_CONTENT)
+        return ret
 
 class InstitutionNodesRelationship(JSONAPIBaseView, generics.RetrieveDestroyAPIView, generics.CreateAPIView, InstitutionMixin):
     """ Relationship Endpoint for Institution -> Nodes Relationship

--- a/api/institutions/views.py
+++ b/api/institutions/views.py
@@ -269,8 +269,8 @@ class InstitutionRegistrationsRelationship(JSONAPIBaseView, generics.RetrieveDes
         base_permissions.TokenHasScope,
         UserIsAffiliated
     )
-    required_read_scopes = [CoreScopes.NULL]
-    required_write_scopes = [CoreScopes.NULL]
+    required_read_scopes = [CoreScopes.NODE_REGISTRATIONS_READ, CoreScopes.INSTITUTION_READ]
+    required_write_scopes = [CoreScopes.NODE_REGISTRATIONS_WRITE]
     serializer_class = InstitutionRegistrationsRelationshipSerializer
     parser_classes = (JSONAPIRelationshipParser, JSONAPIRelationshipParserForRegularJSON, )
 
@@ -353,8 +353,8 @@ class InstitutionNodesRelationship(JSONAPIBaseView, generics.RetrieveDestroyAPIV
         base_permissions.TokenHasScope,
         UserIsAffiliated
     )
-    required_read_scopes = [CoreScopes.NULL]
-    required_write_scopes = [CoreScopes.NULL]
+    required_read_scopes = [CoreScopes.NODE_BASE_READ, CoreScopes.INSTITUTION_READ]
+    required_write_scopes = [CoreScopes.NODE_BASE_WRITE]
     serializer_class = InstitutionNodesRelationshipSerializer
     parser_classes = (JSONAPIRelationshipParser, JSONAPIRelationshipParserForRegularJSON, )
 

--- a/api_tests/institutions/views/test_institution_relationship_nodes.py
+++ b/api_tests/institutions/views/test_institution_relationship_nodes.py
@@ -361,6 +361,10 @@ class TestInstitutionRelationshipRegistrations:
         return user
 
     @pytest.fixture()
+    def user(self, institution):
+        return AuthUserFactory()
+
+    @pytest.fixture()
     def registration_no_owner(self):
         return RegistrationFactory(is_public=True)
 
@@ -466,8 +470,7 @@ class TestInstitutionRelationshipRegistrations:
         registration_no_affiliation.reload()
         assert institution in registration_no_affiliation.affiliated_institutions.all()
 
-    def test_add_user_is_read_write(self, app, registration_no_affiliation, url_institution_registrations, institution):
-        user = AuthUserFactory()
+    def test_add_user_is_read_write(self, app, user, registration_no_affiliation, url_institution_registrations, institution):
         user.affiliated_institutions.add(institution)
         registration_no_affiliation.add_contributor(user)
         registration_no_affiliation.save()
@@ -492,8 +495,7 @@ class TestInstitutionRelationshipRegistrations:
         registration_pending.reload()
         assert institution in registration_pending.affiliated_institutions.all()
 
-    def test_add_user_is_read_only(self, app, registration_no_affiliation, url_institution_registrations, institution):
-        user = AuthUserFactory()
+    def test_add_user_is_read_only(self, app, user, registration_no_affiliation, url_institution_registrations, institution):
         user.affiliated_institutions.add(institution)
         registration_no_affiliation.add_contributor(user, permissions=[permissions.READ])
         registration_no_affiliation.save()
@@ -509,8 +511,7 @@ class TestInstitutionRelationshipRegistrations:
         registration_no_affiliation.reload()
         assert institution not in registration_no_affiliation.affiliated_institutions.all()
 
-    def test_add_user_is_admin_but_not_affiliated(self, app, url_institution_registrations, institution):
-        user = AuthUserFactory()
+    def test_add_user_is_admin_but_not_affiliated(self, user, app, url_institution_registrations, institution):
         registration = RegistrationFactory(creator=user)
         res = app.post_json_api(
             url_institution_registrations,
@@ -547,8 +548,7 @@ class TestInstitutionRelationshipRegistrations:
         assert res.status_code == 204
         assert institution not in registration_pending.affiliated_institutions.all()
 
-    def test_delete_user_is_read_write(self, app, registration_pending, url_institution_registrations, institution):
-        user = AuthUserFactory()
+    def test_delete_user_is_read_write(self, app, user, registration_pending, url_institution_registrations, institution):
         registration_pending.add_contributor(user)
         registration_pending.save()
 
@@ -562,8 +562,7 @@ class TestInstitutionRelationshipRegistrations:
         assert res.status_code == 204
         assert institution not in registration_pending.affiliated_institutions.all()
 
-    def test_delete_user_is_read_only(self, registration_pending, app, url_institution_registrations, institution):
-        user = AuthUserFactory()
+    def test_delete_user_is_read_only(self, user, registration_pending, app, url_institution_registrations, institution):
         registration_pending.add_contributor(user, permissions='read')
         registration_pending.save()
 
@@ -578,8 +577,7 @@ class TestInstitutionRelationshipRegistrations:
         assert res.status_code == 403
         assert institution in registration_pending.affiliated_institutions.all()
 
-    def test_delete_user_is_admin_but_not_affiliated_with_inst(self, institution, app, url_institution_registrations):
-        user = AuthUserFactory()
+    def test_delete_user_is_admin_but_not_affiliated_with_inst(self, user, institution, app, url_institution_registrations):
         registration = RegistrationFactory(creator=user)
         registration.affiliated_institutions.add(institution)
         registration.save()
@@ -594,3 +592,4 @@ class TestInstitutionRelationshipRegistrations:
         assert res.status_code == 204
         registration.reload()
         assert institution not in registration.affiliated_institutions.all()
+        

--- a/api_tests/institutions/views/test_institution_relationship_nodes.py
+++ b/api_tests/institutions/views/test_institution_relationship_nodes.py
@@ -592,4 +592,3 @@ class TestInstitutionRelationshipRegistrations:
         assert res.status_code == 204
         registration.reload()
         assert institution not in registration.affiliated_institutions.all()
-        

--- a/api_tests/institutions/views/test_institution_relationship_nodes.py
+++ b/api_tests/institutions/views/test_institution_relationship_nodes.py
@@ -1,8 +1,9 @@
 import pytest
 
 from api.base.settings.defaults import API_BASE
-from framework.auth import Auth
 from osf_tests.factories import (
+    WithdrawnRegistrationFactory,
+    RegistrationFactory,
     InstitutionFactory,
     AuthUserFactory,
     NodeFactory,
@@ -12,6 +13,12 @@ from website.util import permissions
 def make_payload(*node_ids):
     data = [
         {'type': 'nodes', 'id': id_} for id_ in node_ids
+    ]
+    return {'data': data}
+
+def make_registration_payload(*node_ids):
+    data = [
+        {'type': 'registrations', 'id': id_} for id_ in node_ids
     ]
     return {'data': data}
 
@@ -323,3 +330,267 @@ class TestInstitutionRelationshipNodes:
         )
 
         assert res.status_code == 403
+
+    def test_add_non_node(self, app, user, institution, url_institution_nodes):
+        registration = RegistrationFactory(creator=user, is_public=True)
+        registration.affiliated_institutions.add(institution)
+        registration.save()
+
+        res = app.post_json_api(
+            url_institution_nodes,
+            make_payload(registration._id),
+            expect_errors=True,
+            auth=user.auth
+        )
+
+        assert res.status_code == 404
+
+
+@pytest.mark.django_db
+class TestInstitutionRelationshipRegistrations:
+
+    @pytest.fixture()
+    def institution(self):
+        return InstitutionFactory()
+
+    @pytest.fixture()
+    def admin(self, institution):
+        user = AuthUserFactory()
+        user.affiliated_institutions.add(institution)
+        user.save()
+        return user
+
+    @pytest.fixture()
+    def registration_no_owner(self):
+        return RegistrationFactory(is_public=True)
+
+    @pytest.fixture()
+    def registration_no_affiliation(self, admin):
+        return RegistrationFactory(creator=admin)
+
+    @pytest.fixture()
+    def registration_pending(self, admin, institution):
+        registration = RegistrationFactory(creator=admin)
+        registration.affiliated_institutions.add(institution)
+        registration.save()
+        return registration
+
+    @pytest.fixture()
+    def registration_public(self, admin, institution):
+        registration = RegistrationFactory(creator=admin, is_public=True)
+        registration.affiliated_institutions.add(institution)
+        registration.save()
+        return registration
+
+    @pytest.fixture()
+    def url_institution_registrations(self, institution):
+        return '/{}institutions/{}/relationships/registrations/'.format(API_BASE, institution._id)
+
+
+    def test_auth_get_registrations(self, app, admin, registration_no_owner, registration_no_affiliation, registration_pending, registration_public, url_institution_registrations):
+
+        #test getting registrations without auth (for complete registrations)
+        res = app.get(url_institution_registrations)
+        assert res.status_code == 200
+        registration_ids = [reg['id'] for reg in res.json['data']]
+        assert registration_no_affiliation._id not in registration_ids
+        assert registration_pending._id not in registration_ids
+        assert registration_no_owner._id not in registration_ids
+        assert registration_public._id in registration_ids
+
+        #Withdraw a registration, make sure it still shows up
+        WithdrawnRegistrationFactory(registration=registration_public, user=admin)
+
+        #test getting registrations with auth (for embargoed and pending)
+        res = app.get(url_institution_registrations, auth=admin.auth)
+        assert res.status_code == 200
+        registration_ids = [reg['id'] for reg in res.json['data']]
+        assert registration_no_affiliation._id not in registration_ids
+        assert registration_pending._id in registration_ids
+        assert registration_public._id in registration_ids
+        assert registration_no_owner._id not in registration_ids
+
+    def test_add_on_nonexistent_registration(self, app, admin, registration_no_affiliation, url_institution_registrations):
+        #test registration does not exist
+        res = app.post_json_api(
+            url_institution_registrations,
+            make_registration_payload('notIdatAll'),
+            expect_errors=True,
+            auth=admin.auth
+        )
+
+        assert res.status_code == 404
+
+        res = app.post_json_api(
+            url_institution_registrations,
+            {'data': [{'type': 'nodes', 'id': registration_no_affiliation._id}]},
+            expect_errors=True,
+            auth=admin.auth
+        )
+
+        assert res.status_code == 409
+
+    def test_add_no_permissions(self, app, registration_no_affiliation, url_institution_registrations, institution):
+        res = app.post_json_api(
+            url_institution_registrations,
+            make_registration_payload(registration_no_affiliation._id),
+            expect_errors=True,
+            auth = AuthUserFactory().auth
+        )
+
+        assert res.status_code == 403
+        registration_no_affiliation.reload()
+        assert institution not in registration_no_affiliation.affiliated_institutions.all()
+
+    def test_add_user_is_admin(self, admin, app, registration_no_affiliation, url_institution_registrations, institution):
+        res = app.post_json_api(
+            url_institution_registrations,
+            make_registration_payload(registration_no_affiliation._id),
+            auth=admin.auth
+        )
+
+        assert res.status_code == 201
+        registration_no_affiliation.reload()
+        assert institution in registration_no_affiliation.affiliated_institutions.all()
+
+    def test_add_withdrawn_registration(self, app, url_institution_registrations, admin, registration_no_affiliation, institution):
+        WithdrawnRegistrationFactory(registration=registration_no_affiliation, user=admin)
+
+        res = app.post_json_api(
+            url_institution_registrations,
+            make_registration_payload(registration_no_affiliation._id),
+            auth=admin.auth
+        )
+
+        assert res.status_code == 201
+        registration_no_affiliation.reload()
+        assert institution in registration_no_affiliation.affiliated_institutions.all()
+
+    def test_add_user_is_read_write(self, app, registration_no_affiliation, url_institution_registrations, institution):
+        user = AuthUserFactory()
+        user.affiliated_institutions.add(institution)
+        registration_no_affiliation.add_contributor(user)
+        registration_no_affiliation.save()
+        res = app.post_json_api(
+            url_institution_registrations,
+            make_registration_payload(registration_no_affiliation._id),
+            auth=user.auth
+        )
+
+        assert res.status_code == 201
+        registration_no_affiliation.reload()
+        assert institution in registration_no_affiliation.affiliated_institutions.all()
+
+    def test_add_already_added(self, admin, app, registration_pending, url_institution_registrations, institution):
+        res = app.post_json_api(
+            url_institution_registrations,
+            make_registration_payload(registration_pending._id),
+            auth=admin.auth
+        )
+
+        assert res.status_code == 204
+        registration_pending.reload()
+        assert institution in registration_pending.affiliated_institutions.all()
+
+    def test_add_user_is_read_only(self, app, registration_no_affiliation, url_institution_registrations, institution):
+        user = AuthUserFactory()
+        user.affiliated_institutions.add(institution)
+        registration_no_affiliation.add_contributor(user, permissions=[permissions.READ])
+        registration_no_affiliation.save()
+
+        res = app.post_json_api(
+            url_institution_registrations,
+            make_registration_payload(registration_no_affiliation._id),
+            auth=user.auth,
+            expect_errors=True
+        )
+
+        assert res.status_code == 403
+        registration_no_affiliation.reload()
+        assert institution not in registration_no_affiliation.affiliated_institutions.all()
+
+    def test_add_user_is_admin_but_not_affiliated(self, app, url_institution_registrations, institution):
+        user = AuthUserFactory()
+        registration = RegistrationFactory(creator=user)
+        res = app.post_json_api(
+            url_institution_registrations,
+            make_registration_payload(registration._id),
+            expect_errors=True,
+            auth=user.auth
+        )
+
+        assert res.status_code == 403
+        registration.reload()
+        assert institution not in registration.affiliated_institutions.all()
+
+    def test_add_some_with_permissions_others_without(self, admin, registration_no_affiliation, registration_no_owner, app, url_institution_registrations, institution):
+        res = app.post_json_api(
+            url_institution_registrations,
+            make_registration_payload(registration_no_owner._id, registration_no_affiliation._id),
+            expect_errors=True,
+            auth=admin.auth
+        )
+
+        assert res.status_code == 403
+        registration_no_owner.reload()
+        registration_no_affiliation.reload()
+        assert institution not in registration_no_owner.affiliated_institutions.all()
+        assert institution not in registration_no_affiliation.affiliated_institutions.all()
+
+    def test_delete_user_is_admin(self, app, url_institution_registrations, registration_pending, admin, institution):
+        res = app.delete_json_api(
+            url_institution_registrations,
+            make_registration_payload(registration_pending._id),
+            auth=admin.auth
+        )
+        registration_pending.reload()
+        assert res.status_code == 204
+        assert institution not in registration_pending.affiliated_institutions.all()
+
+    def test_delete_user_is_read_write(self, app, registration_pending, url_institution_registrations, institution):
+        user = AuthUserFactory()
+        registration_pending.add_contributor(user)
+        registration_pending.save()
+
+        res = app.delete_json_api(
+            url_institution_registrations,
+            make_registration_payload(registration_pending._id),
+            auth=user.auth
+        )
+        registration_pending.reload()
+
+        assert res.status_code == 204
+        assert institution not in registration_pending.affiliated_institutions.all()
+
+    def test_delete_user_is_read_only(self, registration_pending, app, url_institution_registrations, institution):
+        user = AuthUserFactory()
+        registration_pending.add_contributor(user, permissions='read')
+        registration_pending.save()
+
+        res = app.delete_json_api(
+            url_institution_registrations,
+            make_registration_payload(registration_pending._id),
+            auth=user.auth,
+            expect_errors=True
+        )
+        registration_pending.reload()
+
+        assert res.status_code == 403
+        assert institution in registration_pending.affiliated_institutions.all()
+
+    def test_delete_user_is_admin_but_not_affiliated_with_inst(self, institution, app, url_institution_registrations):
+        user = AuthUserFactory()
+        registration = RegistrationFactory(creator=user)
+        registration.affiliated_institutions.add(institution)
+        registration.save()
+        assert institution in registration.affiliated_institutions.all()
+
+        res = app.delete_json_api(
+            url_institution_registrations,
+            make_registration_payload(registration._id),
+            auth=user.auth
+        )
+
+        assert res.status_code == 204
+        registration.reload()
+        assert institution not in registration.affiliated_institutions.all()

--- a/osf/models/institution.py
+++ b/osf/models/institution.py
@@ -84,6 +84,14 @@ class Institution(DirtyFieldsMixin, Loggable, base.ObjectIDMixin, base.BaseModel
         return self.absolute_api_v2_url + 'relationships/nodes/'
 
     @property
+    def registrations_url(self):
+        return self.absolute_api_v2_url + 'registrations/'
+
+    @property
+    def registrations_relationship_url(self):
+        return self.absolute_api_v2_url + 'relationships/registrations/'
+
+    @property
     def logo_path(self):
         if self.logo_name:
             return '/static/img/institutions/shields/{}'.format(self.logo_name)

--- a/website/static/js/institutionProjectSettings.js
+++ b/website/static/js/institutionProjectSettings.js
@@ -32,6 +32,7 @@ var ViewModel = function(data) {
     self.nodeId = ko.observable(data.node.id);
     self.rootId = ko.observable(data.node.rootId);
     self.childExists = ko.observable(data.node.childExists);
+    self.isRegistration = ko.observable(data.node.isRegistration);
 
     //user chooses to delete all nodes
     self.modifyChildren = ko.observable(false);
@@ -155,9 +156,9 @@ var ViewModel = function(data) {
             message: '<div class="spinner-loading-wrapper"><div class="ball-scale ball-scale-blue"><div></div></div><p class="m-t-sm fg-load-message"> Updating affiliation... this may take a minute.</p></div>',
         });
         var index;
-        var url = data.apiV2Prefix + 'institutions/' + item.id + '/relationships/nodes/';
+        var url = data.apiV2Prefix + 'institutions/' + item.id + '/relationships/' + (self.isRegistration() ? 'registrations/' :  'nodes/');
         var ajaxJSONType = self.isAddInstitution() ? 'POST': 'DELETE';
-        var nodesToModify = [{'type': 'nodes', 'id': self.nodeId()}];
+        var nodesToModify = [{'type': (self.isRegistration() ? 'registrations' :  'nodes'), 'id': self.nodeId()}];
         self.loading(true);
         if (self.modifyChildren()) {
             for (var node in self.childNodes()) {

--- a/website/static/js/institutionProjectSettings.js
+++ b/website/static/js/institutionProjectSettings.js
@@ -155,18 +155,23 @@ var ViewModel = function(data) {
             closeButton: false,
             message: '<div class="spinner-loading-wrapper"><div class="ball-scale ball-scale-blue"><div></div></div><p class="m-t-sm fg-load-message"> Updating affiliation... this may take a minute.</p></div>',
         });
-        var index;
-        var url = data.apiV2Prefix + 'institutions/' + item.id + '/relationships/' + (self.isRegistration() ? 'registrations/' :  'nodes/');
-        var ajaxJSONType = self.isAddInstitution() ? 'POST': 'DELETE';
-        var nodesToModify = [{'type': (self.isRegistration() ? 'registrations' :  'nodes'), 'id': self.nodeId()}];
-        self.loading(true);
-        if (self.modifyChildren()) {
-            for (var node in self.childNodes()) {
-                if (self.childNodes()[node].hasPermissions) {
-                    nodesToModify.push({'type': 'nodes', 'id': node});
+        var index, url, nodesToModify;
+        if (self.isRegistration()) {
+            url = data.apiV2Prefix + 'institutions/' + item.id + '/relationships/registrations/';
+            nodesToModify = [{'type': 'registrations', 'id': self.nodeId()}];
+        } else {
+            url = data.apiV2Prefix + 'institutions/' + item.id + '/relationships/nodes/';
+            nodesToModify = [{'type': 'nodes', 'id': self.nodeId()}];
+            if (self.modifyChildren()) {
+                for (var node in self.childNodes()) {
+                    if (self.childNodes()[node].hasPermissions) {
+                        nodesToModify.push({'type': 'nodes', 'id': node});
+                    }
                 }
             }
         }
+        self.loading(true);
+        var ajaxJSONType = self.isAddInstitution() ? 'POST': 'DELETE';
         return $osf.ajaxJSON(
             ajaxJSONType,
             url,

--- a/website/static/js/institutionProjectSettings.js
+++ b/website/static/js/institutionProjectSettings.js
@@ -155,7 +155,8 @@ var ViewModel = function(data) {
             closeButton: false,
             message: '<div class="spinner-loading-wrapper"><div class="ball-scale ball-scale-blue"><div></div></div><p class="m-t-sm fg-load-message"> Updating affiliation... this may take a minute.</p></div>',
         });
-        var index, url, nodesToModify;
+        var url = '';
+        var nodesToModify = [];
         if (self.isRegistration()) {
             url = data.apiV2Prefix + 'institutions/' + item.id + '/relationships/registrations/';
             nodesToModify = [{'type': 'registrations', 'id': self.nodeId()}];
@@ -183,6 +184,7 @@ var ViewModel = function(data) {
                 fields: {xhrFields: {withCredentials: true}}
             }
         ).done(function () {
+            var index;
             if (self.isAddInstitution()) {
                 index = self.availableInstitutionsIds().indexOf(item.id);
                 var added = self.availableInstitutions.splice(index, 1)[0];

--- a/website/templates/project/project_header.mako
+++ b/website/templates/project/project_header.mako
@@ -72,7 +72,7 @@
                             <li><a href="${node['url']}contributors/">Contributors</a></li>
                         % endif
 
-                        % if user['has_read_permissions'] and not node['is_registration'] or (node['is_registration'] and 'admin' in user['permissions']):
+                        % if user['has_read_permissions'] and not node['is_registration'] or (node['is_registration'] and 'write' in user['permissions']):
                             <li><a href="${node['url']}settings/">Settings</a></li>
                         % endif
                     % endif

--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -32,10 +32,6 @@
                             <li><a href="#configureCommentingAnchor">Commenting</a></li>
                         % endif
 
-                        % if enable_institutions:
-                            <li><a href="#configureInstitutionAnchor">Project Affiliation / Branding</a></li>
-                        % endif
-
                         <li><a href="#configureNotificationsAnchor">Email Notifications</a></li>
 
                         <li><a href="#redirectLink">Redirect Link</a></li>
@@ -48,6 +44,10 @@
                             <li><a href="#withdrawRegistrationAnchor">Withdraw Public Registration</a></li>
                         % endif
 
+                    % endif
+
+                    % if enable_institutions:
+                        <li><a href="#configureInstitutionAnchor">Project Affiliation / Branding</a></li>
                     % endif
 
                 </ul>
@@ -313,75 +313,6 @@
                 %endif
             % endif  ## End Configure Commenting
 
-        % if not node['is_registration']:
-                % if enable_institutions:
-                    <div class="panel panel-default scripted" id="institutionSettings">
-                    <span id="configureInstitutionAnchor" class="anchor"></span>
-                    <div class="panel-heading clearfix">
-                        <h3 class="panel-title">Project Affiliation / Branding</h3>
-                    </div>
-                    <div class="panel-body">
-                        <div class="help-block">
-                            % if 'write' not in user['permissions']:
-                                <p class="text-muted">Contributors with read-only permissions to this project cannot add or remove institutional affiliations.</p>
-                            % endif:
-                            <!-- ko if: affiliatedInstitutions().length == 0 -->
-                            Projects can be affiliated with institutions that have created OSF for Institutions accounts.
-                            This allows:
-                            <ul>
-                               <li>institutional logos to be displayed on public projects</li>
-                               <li>public projects to be discoverable on specific institutional landing pages</li>
-                               <li>single sign-on to the OSF with institutional credentials</li>
-                               <li><a href="http://help.osf.io/m/os4i">FAQ</a></li>
-                            </ul>
-                            <!-- /ko -->
-                        </div>
-                        <!-- ko if: affiliatedInstitutions().length > 0 -->
-                        <label>Affiliated Institutions: </label>
-                        <!-- /ko -->
-                        <table class="table">
-                            <tbody>
-                                <!-- ko foreach: {data: affiliatedInstitutions, as: 'item'} -->
-                                <tr>
-                                    <td><img class="img-circle" width="50px" height="50px" data-bind="attr: {src: item.logo_path}"></td>
-                                    <td><span data-bind="text: item.name"></span></td>
-                                    <td>
-                                        % if 'admin' in user['permissions']:
-                                            <button data-bind="disable: $parent.loading(), click: $parent.clearInst" class="pull-right btn btn-danger">Remove</button>
-                                        % elif 'write' in user['permissions']:
-                                            <!-- ko if: $parent.userInstitutionsIds.indexOf(item.id) !== -1 -->
-                                               <button data-bind="disable: $parent.loading(), click: $parent.clearInst" class="pull-right btn btn-danger">Remove</button>
-                                            <!-- /ko -->
-                                        % endif
-                                    </td>
-                                </tr>
-                                <!-- /ko -->
-                            </tbody>
-                        </table>
-                            </br>
-                        <!-- ko if: availableInstitutions().length > 0 -->
-                        <label>Available Institutions: </label>
-                        <table class="table">
-                            <tbody>
-                                <!-- ko foreach: {data: availableInstitutions, as: 'item'} -->
-                                <tr>
-                                    <td><img class="img-circle" width="50px" height="50px" data-bind="attr: {src: item.logo_path}"></td>
-                                    <td><span data-bind="text: item.name"></span></td>
-                                    % if 'write' in user['permissions']:
-                                        <td><button
-                                                data-bind="disable: $parent.loading(),
-                                                click: $parent.submitInst"
-                                                class="pull-right btn btn-success">Add</button></td>
-                                    % endif
-                                </tr>
-                                <!-- /ko -->
-                            </tbody>
-                        </table>
-                        <!-- /ko -->
-                    </div>
-                </div>
-                % endif
-        % endif
         % if user['has_read_permissions']:  ## Begin Configure Email Notifications
 
             % if not node['is_registration']:
@@ -530,6 +461,74 @@
             % endif
 
         % endif  ## End Retract Registration
+
+        % if enable_institutions:
+             <div class="panel panel-default scripted" id="institutionSettings">
+                 <span id="configureInstitutionAnchor" class="anchor"></span>
+                 <div class="panel-heading clearfix">
+                     <h3 class="panel-title">Project Affiliation / Branding</h3>
+                 </div>
+                 <div class="panel-body">
+                     <div class="help-block">
+                         % if 'write' not in user['permissions']:
+                             <p class="text-muted">Contributors with read-only permissions to this project cannot add or remove institutional affiliations.</p>
+                         % endif:
+                         <!-- ko if: affiliatedInstitutions().length == 0 -->
+                         Projects can be affiliated with institutions that have created OSF for Institutions accounts.
+                         This allows:
+                         <ul>
+                            <li>institutional logos to be displayed on public projects</li>
+                            <li>public projects to be discoverable on specific institutional landing pages</li>
+                            <li>single sign-on to the OSF with institutional credentials</li>
+                            <li><a href="http://help.osf.io/m/os4i">FAQ</a></li>
+                         </ul>
+                         <!-- /ko -->
+                     </div>
+                     <!-- ko if: affiliatedInstitutions().length > 0 -->
+                     <label>Affiliated Institutions: </label>
+                     <!-- /ko -->
+                     <table class="table">
+                         <tbody>
+                             <!-- ko foreach: {data: affiliatedInstitutions, as: 'item'} -->
+                             <tr>
+                                 <td><img class="img-circle" width="50px" height="50px" data-bind="attr: {src: item.logo_path}"></td>
+                                 <td><span data-bind="text: item.name"></span></td>
+                                 <td>
+                                     % if 'admin' in user['permissions']:
+                                         <button data-bind="disable: $parent.loading(), click: $parent.clearInst" class="pull-right btn btn-danger">Remove</button>
+                                     % elif 'write' in user['permissions']:
+                                         <!-- ko if: $parent.userInstitutionsIds.indexOf(item.id) !== -1 -->
+                                            <button data-bind="disable: $parent.loading(), click: $parent.clearInst" class="pull-right btn btn-danger">Remove</button>
+                                         <!-- /ko -->
+                                     % endif
+                                 </td>
+                             </tr>
+                             <!-- /ko -->
+                         </tbody>
+                     </table>
+                         </br>
+                     <!-- ko if: availableInstitutions().length > 0 -->
+                     <label>Available Institutions: </label>
+                     <table class="table">
+                         <tbody>
+                             <!-- ko foreach: {data: availableInstitutions, as: 'item'} -->
+                             <tr>
+                                 <td><img class="img-circle" width="50px" height="50px" data-bind="attr: {src: item.logo_path}"></td>
+                                 <td><span data-bind="text: item.name"></span></td>
+                                 % if 'write' in user['permissions']:
+                                     <td><button
+                                             data-bind="disable: $parent.loading(),
+                                             click: $parent.submitInst"
+                                             class="pull-right btn btn-success">Add</button></td>
+                                 % endif
+                             </tr>
+                             <!-- /ko -->
+                         </tbody>
+                     </table>
+                     <!-- /ko -->
+                 </div>
+            </div>
+        % endif
 
     </div>
     <!-- End right column -->


### PR DESCRIPTION
## Purpose

Users should be able to update institutional affiliations on registrations.

## Changes

This PR adds the ability to update institutional affiliations for registrations in two ways:
1. It adds the 'Project Affiliation / Branding' section to the settings page of a registration.
2. It adds an API endpoint at `/v2/institutions/<institution>/relationships/registrations/` that allows one to add/delete/view institutional registration relationships (this also supports the section added to settings).
3. Settings are now visible for all write contributors of a registration.

Also, `/v2/institutions/<institution>/relationships/nodes/` previously could add relationships for any AbstractNodes. This was a bug and was removed.

## Side effects
This PR also moves the 'Project Affiliation / Branding' section to the bottom of the settings page.

## Ticket

https://openscience.atlassian.net/browse/OSF-8514

![registration_affiliations](https://user-images.githubusercontent.com/7839433/30328399-39cd932e-979d-11e7-824c-f1cb8379992c.gif)

<img width="1110" alt="screen shot 2017-09-11 at 3 42 22 pm" src="https://user-images.githubusercontent.com/7839433/30328436-58fffa3e-979d-11e7-9efc-a43fc8442dd0.png">
