### PR TITLE
[OSF-7831] Allow nodes AND registrations to be marked as Ham

### DIFF
--- a/admin/nodes/views.py
+++ b/admin/nodes/views.py
@@ -116,7 +116,7 @@ class NodeDeleteBase(DeleteView):
         return super(NodeDeleteBase, self).get_context_data(**context)
 
     def get_object(self, queryset=None):
-        return Node.load(self.kwargs.get('guid'))
+        return Node.load(self.kwargs.get('guid')) or Registration.load(self.kwargs.get('guid'))
 
 
 class NodeDeleteView(PermissionRequiredMixin, NodeDeleteBase):

--- a/admin_tests/nodes/test_views.py
+++ b/admin_tests/nodes/test_views.py
@@ -10,6 +10,7 @@ from admin.nodes.views import (
     NodeFlaggedSpamList,
     NodeKnownSpamList,
     NodeKnownHamList,
+    NodeConfirmHamView
 )
 from admin_tests.utilities import setup_log_view, setup_view
 
@@ -314,3 +315,31 @@ class TestNodeReindex(AdminTestCase):
         nt.assert_true(mock_update_search.called)
         nt.assert_true(mock_bulk_update_nodes.called)
         nt.assert_equal(AdminLogEntry.objects.count(), count + 1)
+
+class TestNodeConfirmHamView(AdminTestCase):
+    def setUp(self):
+        super(TestNodeConfirmHamView, self).setUp()
+
+        self.request = RequestFactory().post('/fake_path')
+        self.user = AuthUserFactory()
+
+        self.node = ProjectFactory(creator=self.user)
+        self.registration = RegistrationFactory(creator=self.user)
+
+    def test_confirm_node_as_ham(self):
+        view = NodeConfirmHamView()
+        view = setup_log_view(view, self.request, guid=self.node._id)
+        view.delete(self.request)
+
+        updated_node = view.get_object()
+        nt.assert_equal(updated_node, self.node)
+        nt.assert_true(updated_node.spam_status == 4)
+
+    def test_confirm_registration_as_ham(self):
+        view = NodeConfirmHamView()
+        view = setup_log_view(view, self.request, guid=self.registration._id)
+        view.delete(self.request)
+
+        updated_registration = view.get_object()
+        nt.assert_equal(updated_registration, self.registration)
+        nt.assert_true(updated_registration.spam_status == 4)

--- a/admin_tests/nodes/test_views.py
+++ b/admin_tests/nodes/test_views.py
@@ -331,15 +331,13 @@ class TestNodeConfirmHamView(AdminTestCase):
         view = setup_log_view(view, self.request, guid=self.node._id)
         view.delete(self.request)
 
-        updated_node = view.get_object()
-        nt.assert_equal(updated_node, self.node)
-        nt.assert_true(updated_node.spam_status == 4)
+        self.node.refresh_from_db()
+        nt.assert_true(self.node.spam_status == 4)
 
     def test_confirm_registration_as_ham(self):
         view = NodeConfirmHamView()
         view = setup_log_view(view, self.request, guid=self.registration._id)
         view.delete(self.request)
 
-        updated_registration = view.get_object()
-        nt.assert_equal(updated_registration, self.registration)
-        nt.assert_true(updated_registration.spam_status == 4)
+        self.registration.refresh_from_db()
+        nt.assert_true(self.registration.spam_status == 4)


### PR DESCRIPTION
## Purpose

Currently if a admin tries to mark a registration as Ham the process fails, this fix ensures the registration is marked correctly.

## Changes

Simple one line python change.

## Side effects

None that I know of.

## Testing

There are no existing unit tests for the existing group of "mark as Ham/Spam" views, I didn't think it was appropriate write a test to cover this single case without expanding the ticket to cover other methods and views.

## Ticket

https://openscience.atlassian.net/browse/OSF-7831