### PR TITLE
Change build to quay image for sharejs in docker-compose settings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -289,7 +289,7 @@ services:
     stdin_open: true
 
   sharejs:
-    build: ./addons/wiki/
+    image: quay.io/centerforopenscience/sharejs:develop
     restart: unless-stopped
     ports:
       - 7007:7007


### PR DESCRIPTION

## Purpose

Use pre-built quay image for docker-compose (like other services)

## Changes

build → image in docker-compose.yaml

## Side effects

N/A

## Ticket

N/A, QA not required
