### PR TITLE
[feature] Prevent moving and copying quickfiles on the backend [OSF-8117]

### DIFF
--- a/addons/osfstorage/models.py
+++ b/addons/osfstorage/models.py
@@ -139,12 +139,19 @@ class OsfStorageFileNode(BaseFileNode):
         self._materialized_path = self.materialized_path
         return super(OsfStorageFileNode, self).delete(user=user, parent=parent) if self._check_delete_allowed() else None
 
+    def copy_under(self, destination_parent, name=None):
+        if self.node.is_quickfiles:
+            raise exceptions.FileNodeIsQuickFilesNode()
+        return super(OsfStorageFileNode, self).copy_under(destination_parent, name)
+
     def move_under(self, destination_parent, name=None):
         if self.is_preprint_primary:
             if self.node != destination_parent.node or self.provider != destination_parent.provider:
                 raise exceptions.FileNodeIsPrimaryFile()
         if self.is_checked_out:
             raise exceptions.FileNodeCheckedOutError()
+        if self.node.is_quickfiles:
+            raise exceptions.FileNodeIsQuickFilesNode()
         return super(OsfStorageFileNode, self).move_under(destination_parent, name)
 
     def check_in_or_out(self, user, checkout, save=False):

--- a/addons/osfstorage/views.py
+++ b/addons/osfstorage/views.py
@@ -85,7 +85,12 @@ def osfstorage_get_revisions(file_node, node_addon, payload, **kwargs):
 
 @decorators.waterbutler_opt_hook
 def osfstorage_copy_hook(source, destination, name=None, **kwargs):
-    return source.copy_under(destination, name=name).serialize(), httplib.CREATED
+    try:
+        return source.copy_under(destination, name=name).serialize(), httplib.CREATED
+    except exceptions.FileNodeIsQuickFilesNode:
+        raise HTTPError(httplib.BAD_REQUEST, data={
+            'message_long': 'Cannot copy file as it is in a quickfiles node'
+        })
 
 
 @decorators.waterbutler_opt_hook
@@ -99,6 +104,10 @@ def osfstorage_move_hook(source, destination, name=None, **kwargs):
     except exceptions.FileNodeIsPrimaryFile:
         raise HTTPError(httplib.FORBIDDEN, data={
             'message_long': 'Cannot move file as it is the primary file of preprint.'
+        })
+    except exceptions.FileNodeIsQuickFilesNode:
+        raise HTTPError(httplib.BAD_REQUEST, data={
+            'message_long': 'Cannot move file as it is in a quickfiles node'
         })
 
 

--- a/website/files/exceptions.py
+++ b/website/files/exceptions.py
@@ -20,3 +20,7 @@ class FileNodeCheckedOutError(FileException):
 
 class FileNodeIsPrimaryFile(FileException):
     pass
+
+
+class FileNodeIsQuickFilesNode(FileException):
+    pass


### PR DESCRIPTION
[#OSF-8117]

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
The backend should also prevent moving and copying files in a Quick Files Node, so you can't be sneaky and use the API instead of the frontend. 

## Changes
- Add quickfiles check to move and copy hooks
- add quickfiles exception to make things super clear (and to match checkout and preprint file handling)
- add tests to make sure they're caught properly 

## Side effects

None anticipated


## Ticket
https://openscience.atlassian.net/browse/OSF-8117