### PR TITLE
[OSF-8385] Sentry log first 10 sitemap generation errors.

### DIFF
--- a/scripts/generate_sitemap.py
+++ b/scripts/generate_sitemap.py
@@ -137,6 +137,10 @@ class Sitemap(object):
         self.errors += 1
         logger.info('Error on {}, {}:'.format(obj, obj_id))
         logger.exception(error)
+
+        if self.errors <= 10:
+            sentry.log_message(error)
+
         if self.errors == 1000:
             sentry.log_message('ERROR: generate_sitemap stopped execution after reaching 1000 errors. See logs for details.')
             raise Exception('Too many errors generating sitemap.')


### PR DESCRIPTION
## Purpose

Right now the logs for the sitemap are only stored in the osf logs, which requires prod access to get into. The sitemap should send the first 10 errors it receives to sentry in addition to logging.

## Changes

Simple python change logs the first 10 errors.

## Side effects

None that I know of.

## Testing

Tested it in the shell.

## Ticket

https://openscience.atlassian.net/browse/OSF-8385