### PR TITLE
Allow renames for quickfile files [OSF-8117]

### DIFF
--- a/addons/osfstorage/models.py
+++ b/addons/osfstorage/models.py
@@ -150,7 +150,7 @@ class OsfStorageFileNode(BaseFileNode):
                 raise exceptions.FileNodeIsPrimaryFile()
         if self.is_checked_out:
             raise exceptions.FileNodeCheckedOutError()
-        if self.node.is_quickfiles:
+        if self.node.is_quickfiles and self.node != destination_parent.node:
             raise exceptions.FileNodeIsQuickFilesNode()
         return super(OsfStorageFileNode, self).move_under(destination_parent, name)
 


### PR DESCRIPTION


## Purpose

Allow a rename of a file via API - which turns out is the same as move!

## Changes

- Check for moving within the same node for a quickfiles file and allow if so!

## Side effects

None anticipated


## Ticket
https://openscience.atlassian.net/browse/OSF-8117