### PR TITLE
Preprint identifier list only return identifiers for that preprint [OSF-8640]

### DIFF
--- a/api/identifiers/views.py
+++ b/api/identifiers/views.py
@@ -71,8 +71,6 @@ class IdentifierList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin):
 
     def get_default_queryset(self):
         obj = self.get_object()
-        if isinstance(obj, PreprintService):
-            return obj.node.identifiers.all()
         return obj.identifiers.all()
 
     # overrides ListCreateAPIView

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -7,7 +7,7 @@ from rest_framework.exceptions import NotFound, PermissionDenied, NotAuthenticat
 from rest_framework import permissions as drf_permissions
 
 from framework.auth.oauth_scopes import CoreScopes
-from osf.models import PreprintService, Identifier
+from osf.models import PreprintService
 
 from api.base.exceptions import Conflict
 from api.base.views import JSONAPIBaseView, WaterButlerMixin
@@ -397,7 +397,3 @@ class PreprintIdentifierList(IdentifierList, PreprintMixin):
     # overrides IdentifierList
     def get_object(self, check_object_permissions=True):
         return self.get_preprint(check_object_permissions=check_object_permissions)
-
-    # overrides ListCreateAPIView
-    def get_queryset(self):
-        return Identifier.find(self.get_queryset_from_request())

--- a/api_tests/identifiers/views/test_identifier_list.py
+++ b/api_tests/identifiers/views/test_identifier_list.py
@@ -220,10 +220,13 @@ class TestPreprintIdentifierList:
         assert res_preprint_identifier.status_code == 200
         assert res_preprint_identifier.content_type == 'application/vnd.api+json'
 
-    def test_identifier_list_returns_correct_number_and_referent(self, preprint, res_preprint_identifier, data_preprint_identifier, all_identifiers):
+    def test_identifier_list_returns_correct_number_and_referent(self, preprint, res_preprint_identifier, data_preprint_identifier, all_identifiers, user):
+        # add another preprint so there are more identifiers
+        PreprintFactory(creator=user)
+
         # test_identifier_list_returns_correct_number
         total = res_preprint_identifier.json['links']['meta']['total']
-        assert total == all_identifiers.count()
+        assert total == Identifier.objects.filter(object_id=preprint.id).count()
 
         # test_identifier_list_returns_correct_referent
         paths = [


### PR DESCRIPTION


## Purpose
After the modm removal, the identifiers endpoint for preprints was returning too many identifiers!

## Changes
-Update preprint identifier list, remove old override
- change default queryset for IdentifierList to return identifiers for that object
- make preprint identifier list test a bit more robust

## Side effects
none anticipated


## Ticket
https://openscience.atlassian.net/browse/OSF-8640