### PR TITLE
[RFR] [OSF-8498] API: Add id and type to relationships

### DIFF
--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -68,6 +68,11 @@ class TestPreprintDetail:
 
     #   test contributors in preprint data
         assert data['relationships'].get('contributors', None)
+        assert data['relationships']['contributors'].get('data', None) == None
+
+    #   test node type and id in preprint data
+        assert data['relationships']['node']['data'].get('id', None) == preprint.node._id
+        assert data['relationships']['node']['data'].get('type', None) == 'nodes'
 
     #   test_preprint_node_deleted_detail_failure
         deleted_node = ProjectFactory(creator=user, is_deleted=True)
@@ -519,6 +524,11 @@ class TestPreprintUpdateLicense:
         res = make_request(url, data, auth=admin_contrib.auth)
         assert res.status_code == 200
         preprint.reload()
+
+        res_data = res.json['data']
+        pp_license_id = preprint.license.node_license._id
+        assert res_data['relationships']['license']['data'].get('id', None) == pp_license_id
+        assert res_data['relationships']['license']['data'].get('type', None) == 'licenses'
 
         assert preprint.license.node_license == cc0_license
         assert preprint.license.year == None


### PR DESCRIPTION
[#OSF-8498]

## Purpose
Return relationship data for those relations of the form...
proto://host:port/v2/<namespace>/<namespace_id>/

## Changes

Update api/base/serializers.py::RelationshipField::to_representation to add "data" to "relationships"

## Side effects

This PR makes assumptions about the form of endpoint URLs and the naming standard of kwargs passed to views. I don't believe that failures to live up to my assumptions will result in returning bad data, it should result in no passed data, but bad data is a possibility.

## Ticket

[OSF-8498](https://openscience.atlassian.net/browse/OSF-8498)
