### PR TITLE
[hotfix] Fix inactive user password reset [OSF-8652]

### DIFF
--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -165,34 +165,25 @@ def forgot_password_post():
                 status_message = 'You have recently requested to change your password. Please wait a few minutes ' \
                                  'before trying again.'
                 kind = 'error'
-            else:
-                # TODO [OSF-6673]: Use the feature in [OSF-6998] for user to resend claim email.
-                # if the user account is not claimed yet
-                if (user_obj.is_invited and
-                        user_obj.unclaimed_records and
-                        not user_obj.date_last_login and
-                        not user_obj.is_claimed and
-                        not user_obj.is_registered):
-                    status_message = 'You cannot reset password on this account. Please contact OSF Support.'
-                    kind = 'error'
-                else:
-                    # new random verification key (v2)
-                    user_obj.verification_key_v2 = generate_verification_key(verification_type='password')
-                    user_obj.email_last_sent = timezone.now()
-                    user_obj.save()
-                    reset_link = furl.urljoin(
-                        settings.DOMAIN,
-                        web_url_for(
-                            'reset_password_get',
-                            uid=user_obj._id,
-                            token=user_obj.verification_key_v2['token']
-                        )
+            # TODO [OSF-6673]: Use the feature in [OSF-6998] for user to resend claim email.
+            elif user_obj.is_active:
+                # new random verification key (v2)
+                user_obj.verification_key_v2 = generate_verification_key(verification_type='password')
+                user_obj.email_last_sent = timezone.now()
+                user_obj.save()
+                reset_link = furl.urljoin(
+                    settings.DOMAIN,
+                    web_url_for(
+                        'reset_password_get',
+                        uid=user_obj._id,
+                        token=user_obj.verification_key_v2['token']
                     )
-                    mails.send_mail(
-                        to_addr=email,
-                        mail=mails.FORGOT_PASSWORD,
-                        reset_link=reset_link
-                    )
+                )
+                mails.send_mail(
+                    to_addr=email,
+                    mail=mails.FORGOT_PASSWORD,
+                    reset_link=reset_link
+                )
 
         status.push_status_message(status_message, kind=kind, trust=False)
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
inactive users can reset passwords. They shouldn't be able to get in but it ain't great. 
<!-- Describe the purpose of your changes -->

## Changes
Use is_active to determine if a user can receive emails for password resets instead. Do not show error message if attempting to reset passwords for an unconfirmed user. 
<!-- Briefly describe or list your changes  -->

## Side effects
N/A
<!--Any possible side effects? -->


## Ticket

https://openscience.atlassian.net/browse/OSF-8652

## QA Notes
1. confirm disabled users, unconfirmed users, spam users, don't get emails (and don't show the error message when trying to reset passwords). 
2. Confirm that normal password resets work. 