### PR TITLE
[feature] Fix API Sorting [OSF-8656]

### DIFF
--- a/api_tests/nodes/views/test_node_list.py
+++ b/api_tests/nodes/views/test_node_list.py
@@ -119,6 +119,13 @@ class TestNodeList:
             project = AbstractNode.load(project_json['id'])
             assert project_json['embeds']['root']['data']['id'] == project.root._id
 
+    def test_node_list_sorting(self, app, url):
+        res = app.get('{}?sort=-date_created'.format(url))
+        assert res.status_code == 200
+
+        res = app.get('{}?sort=title'.format(url))
+        assert res.status_code == 200
+
 
 @pytest.mark.django_db
 class TestNodeFiltering:


### PR DESCRIPTION
#### Purpose
- #7682 broke the ability to sort API endpoints that use `DISTINCT` by any non-default-ordering field, i.e. https://staging-api.osf.io/v2/nodes/?sort=-date_created 502'd.

#### Changes
- If a request contains ordering fields and the existing queryset contains distinct fields, add the ordering fields to the queryset's distinct fields.

#### Side Effects
- None expected.

#### Ticket
- [OSF-8656](https://openscience.atlassian.net/browse/OSF-8656)
