### PR TITLE
[feature] Fix unregistered contributors registration records [OSF-8624]

### DIFF
--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -326,6 +326,15 @@ class Registration(AbstractNode):
             self.save()
         return retraction
 
+    def copy_unclaimed_records(self):
+        """Copies unclaimed_records to unregistered contributors from the registered_from node"""
+        registered_from_id = self.registered_from._id
+        for contributor in self.contributors.filter(is_registered=False):
+            record = contributor.unclaimed_records.get(registered_from_id)
+            if record:
+                contributor.unclaimed_records[self._id] = record
+                contributor.save()
+
     def delete_registration_tree(self, save=False):
         logger.debug('Marking registration {} as deleted'.format(self._id))
         self.is_deleted = True

--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -848,6 +848,7 @@ class TestContributorMethods:
             contributor=new_user
         )
         node.save()
+        new_user.refresh_from_db()
         assert node._primary_key not in new_user.unclaimed_records
 
     def test_is_contributor(self, node):

--- a/scripts/fix_registration_unclaimed_records.py
+++ b/scripts/fix_registration_unclaimed_records.py
@@ -1,0 +1,69 @@
+import logging
+import sys
+
+from django.db import transaction
+
+from framework.auth.core import generate_verification_key
+from website.app import setup_django
+setup_django()
+from osf.models import Registration, OSFUser
+from scripts import utils as script_utils
+
+
+logger = logging.getLogger(__name__)
+
+def main():
+    dry = '--dry' in sys.argv
+    if not dry:
+        # If we're not running in dry mode log everything to a file
+        script_utils.add_file_logger(logger, __file__)
+    with transaction.atomic():
+        qs = Registration.objects.filter(_contributors__is_registered=False)
+        logger.info('Found {} registrations with unregistered contributors'.format(qs.count()))
+        for registration in qs:
+            registration_id = registration._id
+            logger.info('Adding unclaimed_records for unregistered contributors on {}'.format(registration_id))
+            registered_from_id = registration.registered_from._id
+
+            # Update unclaimed records for all unregistered contributors in the registration
+            for contributor in registration.contributors.filter(is_registered=False):
+                contrib_id = contributor._id
+
+                # Most unregistered users will have a record for the registration's node
+                record = contributor.unclaimed_records.get(registered_from_id)
+
+                if not record:
+                    # Old unregistered contributors that have been removed from the original node will not have a record
+                    logger.info('No record for node {} for user {}, inferring from other data'.format(registered_from_id, contrib_id))
+
+                    # Get referrer id from logs
+                    for log in registration.logs.filter(action='contributor_added').order_by('date'):
+                        if contrib_id in log.params['contributors']:
+                            referrer_id = str(OSFUser.objects.get(id=log.user_id)._id)
+                            break
+                    else:
+                        # This should not get hit. Worst outcome is that resent claim emails will fail to send via admin for this record
+                        logger.info('No record of {} in {}\'s logs.'.format(contrib_id, registration_id))
+                        referrer_id = None
+
+                    verification_key = generate_verification_key(verification_type='claim')
+
+                    # name defaults back to name given in first unclaimed record
+                    record = {
+                        'name': contributor.given_name,
+                        'referrer_id': referrer_id,
+                        'token': verification_key['token'],
+                        'expires': verification_key['expires'],
+                        'email': None,
+                    }
+
+                logger.info('Writing new unclaimed_record entry for user {} for registration {}.'.format(contrib_id, registration_id))
+                contributor.unclaimed_records[registration_id] = record
+                contributor.save()
+
+        if dry:
+            raise Exception('Abort Transaction - Dry Run')
+    print('Done')
+
+if __name__ == '__main__':
+    main()

--- a/scripts/tests/test_fix_registration_unclaimed_records.py
+++ b/scripts/tests/test_fix_registration_unclaimed_records.py
@@ -1,0 +1,84 @@
+import pytest
+
+from framework.auth.core import Auth
+from osf_tests.factories import PreprintFactory, UserFactory, ProjectFactory
+from scripts.fix_registration_unclaimed_records import main as fix_records_script
+from osf_tests.utils import mock_archive
+
+pytestmark = pytest.mark.django_db
+
+class TestFixRegistrationUnclaimedRecords:
+
+    @pytest.fixture()
+    def user(self):
+        return UserFactory()
+
+    @pytest.fixture()
+    def project(self, user, auth, fake):
+        return ret
+
+    @pytest.fixture()
+    def auth(self, user):
+        return Auth(user)
+
+    @pytest.fixture()
+    def project(self, user, auth):
+        return ProjectFactory(creator=user)
+    
+    @pytest.fixture()
+    def contributor_unregistered(self, user, auth, project):
+        ret = project.add_unregistered_contributor(fullname='Johnny Git Gud', email='ford.prefect@hitchhikers.com', auth=auth)
+        project.save()
+        return ret
+
+    @pytest.fixture()
+    def contributor_unregistered_no_email(self, user, auth, project):
+        ret = project.add_unregistered_contributor(fullname='Johnny B. Bard', email='', auth=auth)
+        project.save()
+        return ret
+
+    @pytest.fixture()
+    def registration(self, project, contributor_unregistered, contributor_unregistered_no_email):
+        with mock_archive(project, autoapprove=True) as registration:
+            return registration
+
+    def test_migrate_bad_data(self, user, project, registration, contributor_unregistered, contributor_unregistered_no_email):
+        contributor_unregistered.refresh_from_db()
+        contributor_unregistered_no_email.refresh_from_db()
+ 
+        # confirm data exists
+        assert contributor_unregistered.unclaimed_records.get(registration._id, None)
+        assert contributor_unregistered_no_email.unclaimed_records.get(registration._id, None)
+
+        # clear registration data
+        del contributor_unregistered.unclaimed_records[registration._id]
+        contributor_unregistered.save()
+
+        # clear registration AND node data for second contributor
+        contributor_unregistered_no_email.unclaimed_records = {}
+
+        # change name to ensure given name passes on
+        contributor_unregistered_no_email.given_name = 'Shenanigans'
+        contributor_unregistered_no_email.save()
+
+        # Force refresh and confirm data gone
+        contributor_unregistered.refresh_from_db()
+        contributor_unregistered_no_email.refresh_from_db()
+        assert not contributor_unregistered.unclaimed_records.get(registration._id, False)
+        assert contributor_unregistered_no_email.unclaimed_records == {}
+
+        # Run script
+        fix_records_script()
+
+        # reload again
+        contributor_unregistered.refresh_from_db()
+        contributor_unregistered_no_email.refresh_from_db()
+
+        record_one = contributor_unregistered.unclaimed_records.get(registration._id)
+        assert record_one
+        assert record_one == contributor_unregistered.unclaimed_records.get(project._id)
+
+        record_two = contributor_unregistered_no_email.unclaimed_records.get(registration._id)
+        assert record_two 
+        assert record_two['name'] == 'Shenanigans'
+        assert record_two['email'] is None


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->
### MIGRATION MANUAL
## Purpose
Registrations don't get unclaimed records. Fix that. 
<!-- Describe the purpose of your changes -->

## Changes
1. When nodes are registered, copy over the unclaimed records
2. Script to fix old data

<!-- Briefly describe or list your changes  -->

## Side effects
Fix deletion of unclaimed records when contributors are removed. Currently they stick around because of a missing save. Test for that was passing because data wasn't being refreshed from the DB.  Humorously this missing deletion oversight makes the script much more efficient to run and with less data loss.

<!--Any possible side effects? -->


## Ticket

https://openscience.atlassian.net/browse/OSF-8624

## QA Notes
- Currently unclaimed users on registrations are not claimable via the registration. After the script is run these should work.
- Test creating a new registration with unclaimed contributors allows those contributors to be claimed via the registration.
- Test that creating a registration with unclaimed users, then deleting the originating node allows you to claim the user
- Test that unclaimed users on registration components are also claimable
- Test that unclaimed with and without email addresses work (this can be interspersed with the other tests, no reason it should be different)
- Confirm that citations work on registrations with unregistered contributors

## Deployment Actions
The `scripts/fix_registration_unclaimed_records.py` needs to be run to update the unclaimed records. It can be run in dry mode to confirm everything is working prior to running for real. No special instructions for staging vs prod.