### PR TITLE
[Hotfix] fix mithril redraws [OSF-8587]

### DIFF
--- a/website/static/js/components/logFeed.js
+++ b/website/static/js/components/logFeed.js
@@ -62,7 +62,7 @@ var LogFeed = {
                 m.redraw();
             }
             self.logRequestPending(true);
-            var promise = m.request({method : 'GET', url : url, config: mHelpers.apiV2Config({withCredentials: window.contextVars.isOnRootDomain})});
+            var promise = m.request({method : 'GET', background: true, url : url, config: mHelpers.apiV2Config({withCredentials: window.contextVars.isOnRootDomain})});
             promise.then(
                 function(result) {
                     _processResults(result);

--- a/website/static/js/components/logFeed.js
+++ b/website/static/js/components/logFeed.js
@@ -59,7 +59,6 @@ var LogFeed = {
                 var page = params.page || 1;
                 self.currentPage(parseInt(page));
                 self.totalPages(Math.ceil(result.links.meta.total / result.links.meta.per_page));
-                m.redraw();
             }
             self.logRequestPending(true);
             var promise = m.request({method : 'GET', background: true, url : url, config: mHelpers.apiV2Config({withCredentials: window.contextVars.isOnRootDomain})});

--- a/website/static/js/pages/project-dashboard-page.js
+++ b/website/static/js/pages/project-dashboard-page.js
@@ -122,8 +122,6 @@ $(document).ready(function () {
     });
 
     if (!ctx.node.isRetracted) {
-        m.startComputation();
-
         if (ctx.node.institutions.length && !ctx.node.anonymous) {
             m.mount(document.getElementById('instLogo'), m.component(institutionLogos, {institutions: window.contextVars.node.institutions}));
         }
@@ -133,9 +131,9 @@ $(document).ready(function () {
         m.mount(document.getElementById('logFeed'), m.component(LogFeed.LogFeed, {node: node}));
 
         // Treebeard Files view
-        $.ajax({
-            url:  nodeApiUrl + 'files/grid/'
-        }).done(function (data) {
+        var urlFilesGrid = nodeApiUrl + 'files/grid/';
+        var promise = m.request({ method: 'GET', background: true, config: $osf.setXHRAuthorization, url: urlFilesGrid});
+        promise.then(function (data) {
             var fangornOpts = {
                 divID: 'treeGrid',
                 filesData: data.data,
@@ -211,8 +209,12 @@ $(document).ready(function () {
             if (newComponentElem) {
                 m.mount(newComponentElem, AddComponentButton);
             }
-            m.endComputation();
-        });
+            return promise;
+        }, function(xhr, textStatus, error) {
+            Raven.captureMessage('Error retrieving filebrowser', {extra: {url: urlFilesGrid, textStatus: textStatus, error: error}});
+        }
+
+      );
 
     }
 


### PR DESCRIPTION
## Purpose

To solve an issue described in https://github.com/CenterForOpenScience/osf.io/pull/7277,
logs and tb filebrowser mounts where put in same mithril redraw.

Use `m.request` with `background : true` to prevent mithril redraws upon promise return, while
keeping part of solution in https://github.com/CenterForOpenScience/osf.io/pull/7277

## Changes
- Have logFeed use with `m.request` with `background : true`
- Remove `m.startComputation/m.endComputation` pair

## QA Considerations
- Test this with a project that has lots of files, folders, and maybe several addons enabled. The point is to make the filebrowser take long to load. This fix should make it so the logs load independently and depending on the complexity/size of the files/folder/addons, logs may finish loading earlier.
- Check if the 'new component' button is only enabled when the filebrowser on the left is done rendering. 
- Check if you can create new component or link projects while logs are loading.

## Ticket
[OSF-8587](https://openscience.atlassian.net/browse/OSF-8587)