### PR TITLE
Fix call to find popular projects and registrations [OSF-8675]

### DIFF
--- a/scripts/tests/test_populate_new_and_noteworthy.py
+++ b/scripts/tests/test_populate_new_and_noteworthy.py
@@ -1,11 +1,9 @@
 from nose.tools import *  # noqa
 
-import mock
-
 from tests.base import OsfTestCase
-from tests.factories import ProjectFactory
+from osf_tests.factories import ProjectFactory
 
-from website.project.model import Node
+from osf.models import Node
 from website.settings import NEW_AND_NOTEWORTHY_LINKS_NODE
 
 from scripts import populate_new_and_noteworthy_projects as script
@@ -16,37 +14,39 @@ class TestPopulateNewAndNoteworthy(OsfTestCase):
     def setUp(self):
         super(TestPopulateNewAndNoteworthy, self).setUp()
 
+        self.new_and_noteworthy_links_node = ProjectFactory()
+        self.new_and_noteworthy_links_node._id = NEW_AND_NOTEWORTHY_LINKS_NODE
+        self.new_and_noteworthy_links_node.save()
+
         self.nn1 = ProjectFactory(is_public=True)
         self.nn2 = ProjectFactory(is_public=True)
         self.nn3 = ProjectFactory(is_public=True)
         self.nn4 = ProjectFactory(is_public=True)
         self.nn5 = ProjectFactory(is_public=True)
 
+        self.all_ids = {self.nn1._id, self.nn2._id, self.nn3._id, self.nn4._id, self.nn5._id}
+
     def tearDown(self):
         super(TestPopulateNewAndNoteworthy, self).tearDown()
-        Node.remove()
+        Node.objects.all().delete()
 
     def test_get_new_and_noteworthy_nodes(self):
-        new_noteworthy = script.get_new_and_noteworthy_nodes()
-        assert_equal(set(new_noteworthy), {self.nn1._id, self.nn2._id, self.nn3._id, self.nn4._id, self.nn5._id})
+        new_noteworthy = script.get_new_and_noteworthy_nodes(self.new_and_noteworthy_links_node)
+        assert_equal(set(new_noteworthy), self.all_ids)
 
     def test_populate_new_and_noteworthy(self):
-
-        self.new_and_noteworthy_links_node = ProjectFactory()
-        self.new_and_noteworthy_links_node._id = NEW_AND_NOTEWORTHY_LINKS_NODE
-        self.new_and_noteworthy_links_node.save()
-
-        assert_equal(len(self.new_and_noteworthy_links_node.nodes), 0)
+        assert_equal(self.new_and_noteworthy_links_node._nodes.count(), 0)
 
         script.main(dry_run=False)
         self.new_and_noteworthy_links_node.reload()
 
-        assert_equal(len(self.new_and_noteworthy_links_node.nodes), 5)
+        assert_equal(self.new_and_noteworthy_links_node._nodes.count(), 5)
 
         script.main(dry_run=False)
 
         self.new_and_noteworthy_links_node.reload()
 
-        new_and_noteworthy_node_links = {pointer.node._id for pointer in self.new_and_noteworthy_links_node.nodes}
+        # new_and_noteworthy_node_links = {pointer.node._id for pointer in self.new_and_noteworthy_links_node.nodes}
+        new_and_noteworthy_node_links = self.new_and_noteworthy_links_node._nodes.all().values_list('guids___id', flat=True)
 
-        assert_equal(set(new_and_noteworthy_node_links), {self.nn1._id, self.nn2._id, self.nn3._id, self.nn4._id, self.nn5._id})
+        assert_equal(set(new_and_noteworthy_node_links), self.all_ids)

--- a/website/project/utils.py
+++ b/website/project/utils.py
@@ -100,7 +100,7 @@ def activity():
                 break
 
     # New and Noteworthy projects are updated manually
-    new_and_noteworthy_projects = list(Node.objects.get(guid___id=settings.NEW_AND_NOTEWORTHY_LINKS_NODE).nodes_pointer)
+    new_and_noteworthy_projects = list(Node.objects.get(guids___id=settings.NEW_AND_NOTEWORTHY_LINKS_NODE).nodes_pointer)
 
     return {
         'new_and_noteworthy_projects': new_and_noteworthy_projects,


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Fix django query in util for getting popular projects and registrations -- Also fix unrelated tests discovered in testing this ticket

## Changes

- update call in `website/project/utils.py` to filter by `guids___id` instead of `guid`
- fix tests in `test_populate_new_and_noteworthy.py`

## Side effects

None anticipated

## Ticket

https://openscience.atlassian.net/browse/OSF-8675
