### PR TITLE
[Feature] Show loaders when authorizing dataverse [OSF-8602]

### DIFF
--- a/addons/dataverse/static/dataverseNodeConfig.js
+++ b/addons/dataverse/static/dataverseNodeConfig.js
@@ -29,6 +29,7 @@ function ViewModel(url) {
     self.loadedSettings = ko.observable(false);
     self.loadedDatasets = ko.observable(false);
     self.submitting = ko.observable(false);
+    self.authorizing = ko.observable(false);
 
     self.dataverses = ko.observableArray([]);
     self.datasets = ko.observableArray([]);
@@ -267,6 +268,7 @@ ViewModel.prototype.updateFromData = function(data) {
 ViewModel.prototype.clearModal = function() {
     var self = this;
     self.message('');
+    self.authorizing(false);
     self.messageClass('text-info');
     self.apiToken(null);
     self.selectedHost(null);
@@ -358,9 +360,10 @@ ViewModel.prototype.sendAuth = function() {
 
     // Selection should not be empty
     if( !self.selectedHost() ){
-        self.changeMessage("Please select a Dataverse repository.", 'text-danger');
+        self.changeMessage('Please select a Dataverse repository.', 'text-danger');
         return;
     }
+    self.authorizing(true);
     var url = self.urls().create;
     return $osf.postJSON(
         url,
@@ -369,11 +372,13 @@ ViewModel.prototype.sendAuth = function() {
             api_token: self.apiToken
         })
     ).done(function() {
+        self.authorizing(false);
         self.clearModal();
         $modal.modal('hide');
         self.userHasAuth(true);
         self.importAuth();
     }).fail(function(xhr, textStatus, error) {
+        self.authorizing(false);
         var errorMessage = (xhr.status === 401) ? self.messages.authInvalid : self.messages.authError;
         self.changeMessage(errorMessage, 'text-danger');
         Raven.captureMessage('Could not authenticate with Dataverse', {
@@ -588,10 +593,13 @@ ViewModel.prototype.changeMessage = function(text, css, timeout) {
 function DataverseNodeConfig(selector, url) {
     // Initialization code
     var self = this;
-    self.selector = selector;
+    self.selector = $(selector);
     self.url = url;
     // On success, instantiate and bind the ViewModel
     self.viewModel = new ViewModel(url);
     $osf.applyBindings(self.viewModel, '#dataverseScope');
+    self.selector.on('hidden.bs.modal', function(){
+        self.viewModel.clearModal();
+    });
 }
 module.exports = DataverseNodeConfig;

--- a/addons/dataverse/static/dataverseNodeConfig.js
+++ b/addons/dataverse/static/dataverseNodeConfig.js
@@ -363,8 +363,10 @@ ViewModel.prototype.sendAuth = function() {
         self.changeMessage('Please select a Dataverse repository.', 'text-danger');
         return;
     }
-    self.authorizing(true);
+
     var url = self.urls().create;
+
+    self.authorizing(true);
     return $osf.postJSON(
         url,
         ko.toJS({
@@ -593,13 +595,10 @@ ViewModel.prototype.changeMessage = function(text, css, timeout) {
 function DataverseNodeConfig(selector, url) {
     // Initialization code
     var self = this;
-    self.selector = $(selector);
+    self.selector = selector;
     self.url = url;
     // On success, instantiate and bind the ViewModel
     self.viewModel = new ViewModel(url);
     $osf.applyBindings(self.viewModel, '#dataverseScope');
-    self.selector.on('hidden.bs.modal', function(){
-        self.viewModel.clearModal();
-    });
 }
 module.exports = DataverseNodeConfig;

--- a/addons/dataverse/templates/dataverse_credentials_modal.mako
+++ b/addons/dataverse/templates/dataverse_credentials_modal.mako
@@ -66,10 +66,16 @@
 
                 <div class="modal-footer">
 
+                    <div data-bind="visible: authorizing" class="ball-pulse ball-scale-blue text-center">
+                      <div></div>
+                      <div></div>
+                      <div></div>
+                    </div>
+
                     <a href="#" class="btn btn-default" data-bind="click: clearModal" data-dismiss="modal">Cancel</a>
 
                     <!-- Save Button -->
-                    <button data-bind="click: sendAuth" class="btn btn-success">Save</button>
+                    <button data-bind="click: sendAuth, css: {'disabled': authorizing}" class="btn btn-success">Save</button>
 
                 </div><!-- end modal-footer -->
 


### PR DESCRIPTION
## Purpose

Show loader when user sends post request to authorize Dataverse.

## Changes

- Add loaders to modal view
- Add loader state to modal controller
- Loaders disappear upon request return (failure/success)
- Disable save button while authorizing

## Side effects
N/A
## Ticket

[OSF-8602](https://openscience.atlassian.net/browse/OSF-8602)

## Before
## After
**user settings**
![after-dv-loader](https://user-images.githubusercontent.com/4511563/30653712-d49ab5fa-9df9-11e7-8b47-9e10e66bba54.gif)
**node settings**
![after-dv-loader-nodesettings](https://user-images.githubusercontent.com/4511563/30653866-44fa98d8-9dfa-11e7-82a5-741213acc878.gif)


