### PR TITLE
[feature fix] Fix institution user count in nightly metrics [OSF-8693]

### DIFF
--- a/scripts/analytics/institution_summary.py
+++ b/scripts/analytics/institution_summary.py
@@ -50,7 +50,7 @@ class InstitutionSummary(SummaryAnalytics):
                     'name': ensure_bytes(institution.name),
                 },
                 'users': {
-                    'total': institution.contributors.count(),
+                    'total': institution.osfuser_set.count(),
                 },
                 'nodes': {
                     'total': institution.nodes.filter(node_query).exclude(type='osf.registration').count(),


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Metrics is using the wrong contributors method so data is not being passed
<!-- Describe the purpose of your changes -->

## Changes
Use the correct user count
<!-- Briefly describe or list your changes  -->

## Side effects
NA
<!--Any possible side effects? -->

## Tests
There are no tests for institutions metrics (but there is a ticket to add them)


## Ticket

https://openscience.atlassian.net/browse/OSF-8693

## QA Notes

After this is run the plot on the institutions tab on metrics should pop back up to normal numbers:
![screen shot 2017-09-20 at 3 01 29 pm](https://user-images.githubusercontent.com/1322421/30662319-ac085ece-9e14-11e7-92d4-f9583a4ba02f.png)
