### PR TITLE
[feature] select_for_update in merge_user [OSF-8297]

### DIFF
--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -262,3 +262,5 @@ OSF_SHELL_USER_IMPORTS = None
 
 # Settings for use in the admin
 OSF_URL = 'https://osf.io'
+
+SELECT_FOR_UPDATE_ENABLED = True

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -8,6 +8,7 @@ from rest_framework import permissions as drf_permissions
 
 from framework.auth.oauth_scopes import CoreScopes
 from osf.models import PreprintService
+from osf.utils.requests import check_select_for_update
 
 from api.base.exceptions import Conflict
 from api.base.views import JSONAPIBaseView, WaterButlerMixin
@@ -35,6 +36,7 @@ from api.nodes.permissions import ContributorOrPublic
 
 from api.preprints.permissions import PreprintPublishedOrAdmin
 
+
 class PreprintMixin(NodeMixin):
     serializer_class = PreprintSerializer
     preprint_lookup_url_kwarg = 'preprint_id'
@@ -42,7 +44,7 @@ class PreprintMixin(NodeMixin):
     def get_preprint(self, check_object_permissions=True):
         qs = PreprintService.objects.filter(guids___id=self.kwargs[self.preprint_lookup_url_kwarg])
         try:
-            preprint = qs.select_for_update().get() if self.request.method not in drf_permissions.SAFE_METHODS else qs.select_related('node').get()
+            preprint = qs.select_for_update().get() if check_select_for_update(self.request) else qs.select_related('node').get()
         except PreprintService.DoesNotExist:
             raise NotFound
 

--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -322,30 +322,6 @@ class NodeCRUDTestCase:
 @pytest.mark.django_db
 class TestNodeUpdate(NodeCRUDTestCase):
 
-    def test_select_for_update(self, app, user, title_new, description_new, category_new, project_public, url_public):
-        with transaction.atomic(), CaptureQueriesContext(connection) as ctx:
-            res = app.put_json_api(url_public, {
-                'data': {
-                    'id': project_public._id,
-                    'type': 'nodes',
-                    'attributes': {
-                        'title': title_new,
-                        'description': description_new,
-                        'category': category_new,
-                        'public': True
-                    }
-                }
-            }, auth=user.auth)
-
-        assert res.status_code == 200
-        assert res.content_type == 'application/vnd.api+json'
-        assert res.json['data']['attributes']['title'] == title_new
-        assert res.json['data']['attributes']['description'] == description_new
-        assert res.json['data']['attributes']['category'] == category_new
-
-        for_update_sql = connection.ops.for_update_sql()
-        assert any(for_update_sql in query['sql'] for query in ctx.captured_queries)
-
     def test_node_update_invalid_data(self, app, user, url_public):
         res = app.put_json_api(url_public, 'Incorrect data', auth=user.auth, expect_errors=True)
         assert res.status_code == 400

--- a/framework/auth/views.py
+++ b/framework/auth/views.py
@@ -33,6 +33,7 @@ from website.util import web_url_for
 from website.util.time import throttle_period_expired
 from website.util.sanitize import strip_html
 from osf.models.preprint_provider import PreprintProvider
+from osf.utils.requests import check_select_for_update
 
 @block_bing_preview
 @collect_auth
@@ -574,13 +575,18 @@ def confirm_email_get(token, auth=None, **kwargs):
     HTTP Method: GET
     """
 
-    user = OSFUser.load(kwargs['uid'])
     is_merge = 'confirm_merge' in request.args
+
+    try:
+        if not is_merge or not check_select_for_update():
+            user = OSFUser.objects.get(guids___id=kwargs['uid'])
+        else:
+            user = OSFUser.objects.filter(guids___id=kwargs['uid']).select_for_update().get()
+    except OSFUser.DoesNotExist:
+        raise HTTPError(http.NOT_FOUND)
+
     is_initial_confirmation = not user.date_confirmed
     log_out = request.args.get('logout', None)
-
-    if user is None:
-        raise HTTPError(http.NOT_FOUND)
 
     # if the user is merging or adding an email (they already are an osf user)
     if log_out:

--- a/osf/utils/requests.py
+++ b/osf/utils/requests.py
@@ -11,8 +11,11 @@ class DummyRequest(object):
 dummy_request = DummyRequest()
 
 
-def check_select_for_update(request):
-    return bool(request.method not in SAFE_METHODS and transaction.get_connection().in_atomic_block)
+def check_select_for_update(request=None):
+    atomic_transaction = transaction.get_connection().in_atomic_block
+    if request:
+        return request.method not in SAFE_METHODS and atomic_transaction
+    return atomic_transaction
 
 
 def get_current_request():

--- a/osf/utils/requests.py
+++ b/osf/utils/requests.py
@@ -4,6 +4,7 @@ from flask import Request as FlaskRequest
 from flask import request
 from rest_framework.permissions import SAFE_METHODS
 from api.base.api_globals import api_globals
+from api.base import settings
 
 
 class DummyRequest(object):
@@ -12,6 +13,8 @@ dummy_request = DummyRequest()
 
 
 def check_select_for_update(request=None):
+    if not settings.SELECT_FOR_UPDATE_ENABLED:
+        return False
     atomic_transaction = transaction.get_connection().in_atomic_block
     if request:
         return request.method not in SAFE_METHODS and atomic_transaction

--- a/osf_tests/test_user.py
+++ b/osf_tests/test_user.py
@@ -346,7 +346,7 @@ class TestOSFUser:
         assert 'foo@bar.com' not in user.unconfirmed_emails
         assert user.emails.filter(address='foo@bar.com').exists()
 
-    def test_confirm_email_merge_uses_select_for_update(self, user):
+    def test_confirm_email_merge_select_for_update(self, user):
         mergee = UserFactory(username='foo@bar.com')
         token = user.add_unconfirmed_email('foo@bar.com')
 
@@ -359,6 +359,21 @@ class TestOSFUser:
 
         for_update_sql = connection.ops.for_update_sql()
         assert any(for_update_sql in query['sql'] for query in ctx.captured_queries)
+
+    @mock.patch('osf.utils.requests.settings.SELECT_FOR_UPDATE_ENABLED', False)
+    def test_confirm_email_merge_select_for_update_disabled(self, user):
+        mergee = UserFactory(username='foo@bar.com')
+        token = user.add_unconfirmed_email('foo@bar.com')
+
+        with transaction.atomic(), CaptureQueriesContext(connection) as ctx:
+            user.confirm_email(token, merge=True)
+
+        mergee.reload()
+        assert mergee.is_merged
+        assert mergee.merged_by == user
+
+        for_update_sql = connection.ops.for_update_sql()
+        assert not any(for_update_sql in query['sql'] for query in ctx.captured_queries)
 
     def test_confirm_email_comparison_is_case_insensitive(self):
         u = UnconfirmedUserFactory.build(

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -323,18 +323,6 @@ class TestProjectViews(OsfTestCase):
         assert_equal(res.status_code, 200)
         assert not any(for_update_sql in query['sql'] for query in ctx.captured_queries)
 
-    def test_edit_node_uses_select_for_update(self):
-        node = ProjectFactory(creator=self.user1)
-        url = node.api_url_for('edit_node')
-
-        with transaction.atomic(), CaptureQueriesContext(connection) as ctx:
-            res = self.app.post_json(url, {'name': 'title', 'value': 'Seth Rollins'}, auth=self.user1.auth, expect_errors=False)
-
-        for_update_sql = connection.ops.for_update_sql()
-        assert_equal(res.status_code, 200)
-        assert_in('Seth Rollins', res.body)
-        assert any(for_update_sql in query['sql'] for query in ctx.captured_queries)
-
     def test_cannot_remove_only_visible_contributor(self):
         user1_contrib = self.project.contributor_set.get(user=self.user1)
         user1_contrib.visible = False


### PR DESCRIPTION
#### Purpose
- Confirm `select_for_update` is used when user accounts are merged.
- Allow `select_for_update` to be easily disabled.

#### Changes
- Update `check_select_for_update` helper.
- Update tests. 

#### Ticket
- [OSF-8297](https://openscience.atlassian.net/browse/OSF-8297)
