### PR TITLE
Use resolve_guid route after confirming unregistered contrib [OSF-8714]

### DIFF
--- a/website/project/views/contributor.py
+++ b/website/project/views/contributor.py
@@ -746,7 +746,7 @@ def claim_user_form(auth, **kwargs):
             status.push_status_message(language.CLAIMED_CONTRIBUTOR, kind='success', trust=True)
             # Redirect to CAS and authenticate the user with a verification key.
             return redirect(cas.get_login_url(
-                web_url_for('view_project', pid=pid, _absolute=True),
+                web_url_for('resolve_guid', guid=pid, _absolute=True),
                 username=user.username,
                 verification_key=user.verification_key
             ))


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

CAS login tokens expect a certain URL when logging in, and the
redirected url (/project/guid) does not match the URL that CAS is
expecting (/guid/).

Thanks @cslzchen for helping figure this one out!


## Changes
- redirect directly to guid resolve project URL so that CAS can match the URL that the token was generated for

## Side effects

None anticipated


## Ticket
https://openscience.atlassian.net/browse/OSF-8714