### PR TITLE
[RFR] [SVCS-336] Add env variable required for some file types to render in docker

### DIFF
--- a/.docker-compose.mfr.env
+++ b/.docker-compose.mfr.env
@@ -9,4 +9,14 @@ SERVER_CONFIG_ALLOWED_PROVIDER_DOMAINS='http://192.168.168.167:5000/ http://192.
 
 UNOCONV_PORT_2002_TCP_ADDR=192.168.168.167
 
+# Related settings from MFR  mfr/extensions/settings.py
+# These settings are used for changing URI in templates for renderers that download from 
+# waterbutler in template. e.g. 192.168.168.167 -> localhost
+# LOCAL_DEVELOPMENT = config.get_bool('LOCAL_DEVELOPMENT', 0)
+# DOCKER_LOCAL_HOST = config.get('DOCKER_LOCAL_HOST', '192.168.168.167')
+# LOCAL_HOST = config.get('LOCAL_HOST', 'localhost')
+
+# Indicates use of local docker development setup
+EXTENSION_CONFIG_LOCAL_DEVELOPMENT=1
+
 #PYTHONUNBUFFERED=0 # This when set to 0 will allow print statements to be visible in the Docker logs


### PR DESCRIPTION
[#SVCS-336] B

## Purpose

SVCS-336 adds functionality to override DOCKER_LOCAL_HOST in certain
situations required for some file types(pdf, pdb, and video) to render.
This addendum PR makes that behavior the default in our docker development
setup.

## Side effects

None


## Ticket

[SVCS-336](https://openscience.atlassian.net/browse/SVCS-336)
