### PR TITLE
[hotfix] Add public to node sparse fields [OSF-8721]

### DIFF
--- a/website/static/js/myProjects.js
+++ b/website/static/js/myProjects.js
@@ -32,6 +32,7 @@ var sparseNodeFields = String([
     'current_user_permissions',
     'date_modified',
     'parent',
+    'public',
     'tags',
     'title'
 ]);


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Public was missing from the fields selected for the my projects page.
<!-- Describe the purpose of your changes -->

## Changes
Add public so things can be displayed as public again.
PUBLIC BEFORE:

<img width="298" alt="screen shot 2017-09-26 at 4 19 14 pm" src="https://user-images.githubusercontent.com/1322421/30882299-8774543e-a2d6-11e7-90d4-fb9a4c0d221b.png">

PUBLIC AFTER:
<img width="282" alt="screen shot 2017-09-26 at 4 19 32 pm" src="https://user-images.githubusercontent.com/1322421/30882319-901bdbc0-a2d6-11e7-87cc-a9ee6343e20b.png">

<!-- Briefly describe or list your changes  -->

## Side effects
More awesomeness.
<!--Any possible side effects? -->


## Ticket

https://openscience.atlassian.net/browse/OSF-8721
