### PR TITLE
[#OSF-8584]Trigger for wiki widget "Read More" does not match display field length

### DIFF
--- a/addons/wiki/tests/test_views.py
+++ b/addons/wiki/tests/test_views.py
@@ -170,7 +170,7 @@ class TestUpdateNodeWiki(OsfTestCase):
         project.update_node_wiki('home', wiki_content, self.auth)
         url = project.web_url_for('view_project')
         res = self.app.get(url, auth=self.user.auth)
-        assert 'Read More' not in res.json
+        assert 'Read More' not in res.body
 
 
 class TestRenameNodeWiki(OsfTestCase):

--- a/addons/wiki/tests/test_views.py
+++ b/addons/wiki/tests/test_views.py
@@ -160,6 +160,18 @@ class TestUpdateNodeWiki(OsfTestCase):
         assert wiki._id not in contributor.comments_viewed_timestamp
         assert comment.target.referent._id == new_version_id
 
+    # Regression test for https://openscience.atlassian.net/browse/OSF-8584
+    def test_no_read_more_when_less_than_400_character(self):
+        wiki_content = '1234567'
+        for x in range(39):
+            wiki_content += '1234567890'
+        assert len(wiki_content) == 397
+        project = ProjectFactory(creator=self.user)
+        project.update_node_wiki('home', wiki_content, self.auth)
+        url = project.web_url_for('view_project')
+        res = self.app.get(url, auth=self.user.auth)
+        assert 'Read More' not in res.json
+
 
 class TestRenameNodeWiki(OsfTestCase):
 

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -387,12 +387,11 @@ def view_project(auth, node, **kwargs):
         MAX_DISPLAY_LENGTH = 400
         rendered_before_update = False
         if wiki_page and wiki_page.html(node):
-            wiki_html = wiki_page.html(node)
+            wiki_html = BeautifulSoup(wiki_page.html(node))
             if len(wiki_html) > MAX_DISPLAY_LENGTH:
                 wiki_html = BeautifulSoup(wiki_html[:MAX_DISPLAY_LENGTH] + '...', 'html.parser')
                 more = True
-            else:
-                wiki_html = BeautifulSoup(wiki_html)
+
             rendered_before_update = wiki_page.rendered_before_update
         else:
             wiki_html = None


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Fix the problem that trigger for wiki widget "Read More" does not match display field length
<!-- Describe the purpose of your changes -->

## Changes
before change:
<img width="1338" alt="screen shot 2017-09-27 at 2 36 52 pm" src="https://user-images.githubusercontent.com/4974056/30931017-751517ae-a391-11e7-8281-225f90386e87.png">
after change:
<img width="1304" alt="screen shot 2017-09-27 at 2 36 57 pm" src="https://user-images.githubusercontent.com/4974056/30931033-7f1b18e8-a391-11e7-9b23-e0dd4860f6e1.png">


<!-- Briefly describe or list your changes  -->

## Side effects

<!--Any possible side effects? -->


## Ticket
https://openscience.atlassian.net/browse/OSF-8584
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
