### PR TITLE
[OSF-7888] Disallow spam projects to register.

### DIFF
--- a/admin/templates/nodes/node.html
+++ b/admin/templates/nodes/node.html
@@ -45,13 +45,15 @@
                 {% endif %}
                 {% endif %}
             {% if perms.osf.mark_spam %}
-            <span class="col-md-2">
-                <a href="{% url 'nodes:confirm-spam' guid=node.id %}"
-                   data-toggle="modal" data-target="#confirmSpamModal"
-                   class="btn btn-warning">
-                    Confirm Spam
-                </a>
-            </span>
+                {% if not node.is_registration %}
+                    <span class="col-md-2">
+                        <a href="{% url 'nodes:confirm-spam' guid=node.id %}"
+                            data-toggle="modal" data-target="#confirmSpamModal"
+                            class="btn btn-warning">
+                            Confirm Spam
+                        </a>
+                    </span>
+                {% endif %}
             <div class="modal" id="confirmSpamModal">
                 <div class="modal-dialog">
                     <div class="modal-content"></div>

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -738,7 +738,8 @@ def _view_project(node, auth, primary=False,
             'is_preprint_orphan': node.is_preprint_orphan,
             'has_published_preprint': node.preprints.filter(is_published=True).exists() if node else False,
             'preprint_file_id': node.preprint_file._id if node.preprint_file else None,
-            'preprint_url': node.preprint_url
+            'preprint_url': node.preprint_url,
+            'is_spammy': node.is_spammy,
         },
         'parent_node': {
             'exists': parent is not None,

--- a/website/static/js/pages/project-registrations-page.js
+++ b/website/static/js/pages/project-registrations-page.js
@@ -27,13 +27,18 @@ $(document).ready(function() {
         }
     }
 
-    var draftManager = new RegistrationManager(node, '#draftRegistrationsScope', {
-        list: node.urls.api + 'drafts/',
-        submit: node.urls.api + 'draft/{draft_pk}/submit/',
-        delete: node.urls.api + 'drafts/{draft_pk}/',
-        schemas: '/api/v1/project/drafts/schemas/',
-        edit: node.urls.web + 'drafts/{draft_pk}/',
-        create: node.urls.web + 'registrations/'
-    }, $('#registerNode'));
-    draftManager.init();
+    var isSpammy = node.isSpammy;
+    if (!isSpammy) {
+        var draftManager = new RegistrationManager(node, '#draftRegistrationsScope', {
+            list: node.urls.api + 'drafts/',
+            submit: node.urls.api + 'draft/{draft_pk}/submit/',
+            delete: node.urls.api + 'drafts/{draft_pk}/',
+            schemas: '/api/v1/project/drafts/schemas/',
+            edit: node.urls.web + 'drafts/{draft_pk}/',
+            create: node.urls.web + 'registrations/'
+        }, $('#registerNode'));
+        draftManager.init();
+    } else{
+        $('#registerNode').text('New registration')
+    }
 });

--- a/website/static/js/pages/project-registrations-page.js
+++ b/website/static/js/pages/project-registrations-page.js
@@ -39,6 +39,7 @@ $(document).ready(function() {
         }, $('#registerNode'));
         draftManager.init();
     } else{
+        //To change the text from "Loading..." to "New registration" when RegistrationManager is not initialized
         $('#registerNode').text('New registration')
     }
 });

--- a/website/static/js/pages/project-registrations-page.js
+++ b/website/static/js/pages/project-registrations-page.js
@@ -40,6 +40,6 @@ $(document).ready(function() {
         draftManager.init();
     } else{
         //To change the text from "Loading..." to "New registration" when RegistrationManager is not initialized
-        $('#registerNode').text('New registration')
+        $('#registerNode').text('New registration');
     }
 });

--- a/website/templates/project/registrations.mako
+++ b/website/templates/project/registrations.mako
@@ -156,6 +156,7 @@
                 public: true,
             },
         });
+        window.contextVars.node = $.extend(true, {}, window.contextVars.node, {isSpammy: ${ node.get('is_spammy', False) | sjson, n }})
     </script>
 
     <script src=${"/static/public/js/project-registrations-page.js" | webpack_asset}> </script>


### PR DESCRIPTION
## Purpose

To disallow spam projects to be registered.

## Changes

Add `isSpammy` to `window.contextVars.node` . for project registration page. Change JS to disable register button for spam projects.

Removed "Confirm spam" button in admin app for registrations.

## Side effects

None

## Ticket

https://openscience.atlassian.net/browse/OSF-7888