### PR TITLE
Remove subjects_acceptable from the preprint_provider serializer (unu…

### DIFF
--- a/api/preprint_providers/serializers.py
+++ b/api/preprint_providers/serializers.py
@@ -86,10 +86,6 @@ class PreprintProviderSerializer(JSONAPISerializer):
         ser.CharField(required=False, allow_null=True),
         min_version='2.0', max_version='2.3'
     )
-    subjects_acceptable = ShowIfVersion(
-        ser.ListField(required=False, default=[]),
-        min_version='2.0', max_version='2.4'
-    )
 
     class Meta:
         type_ = 'preprint_providers'

--- a/api_tests/preprint_providers/serializers/test_serializers.py
+++ b/api_tests/preprint_providers/serializers/test_serializers.py
@@ -34,7 +34,6 @@ class TestPreprintProviderSerializer(DbTestCase):
         assert_in('social_facebook', attributes)
         assert_in('social_instagram', attributes)
         assert_in('social_twitter', attributes)
-        assert_in('subjects_acceptable', attributes)
 
     def test_preprint_provider_serialization_v24(self):
         req = make_drf_request_with_version(version='2.4')
@@ -71,7 +70,6 @@ class TestPreprintProviderSerializer(DbTestCase):
         assert_not_in('social_facebook', attributes)
         assert_not_in('social_instagram', attributes)
         assert_not_in('social_twitter', attributes)
-        assert_not_in('subjects_acceptable', attributes)
 
         assert_in('name', attributes)
         assert_in('description', attributes)


### PR DESCRIPTION
…sed)

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Removes unused `subjects_acceptable` field in preprint_provider serializer to make the API responses smaller and faster. This field is used under /v2/preprint_providers/<provider_id>/taxonomies/ endpoint.

## Changes

Deletes the `subjects_acceptable` field from the serializer and its tests

## Side effects

Faster and smaller API responses from the preprint_providers endpoint


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
