### PR TITLE
[Feature] Add Guide for Docker Compose Runtime Privilege [No Ticket]

### DIFF
--- a/README-docker-compose.md
+++ b/README-docker-compose.md
@@ -369,3 +369,37 @@ $ docker-compose up requirements mfr_requirements wb_requirements
 # Run db migrations
 $ docker-compose run --rm web python manage.py migrate
 ```
+
+## Miscellaneous
+
+### Runtime Privilege
+
+When running privileged commands such as `strace` inside a docker container, you may encounter the following error.
+
+```bash
+strace: test_ptrace_setoptions_followfork: PTRACE_TRACEME doesn't work: Operation not permitted
+```
+
+The issue is that docker containers run in unprivileged mode by default.
+
+For `docker run`, you can use `--privilege=true` to give the container extended privileges. You can also add or drop capabilities by using `cap-add` and `cap-drop`. Since Docker 1.12, there is no need to add `--security-opt seccomp=unconfined` because the seccomp profile will adjust to selected capabilities. ([Reference](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities))
+
+When using `docker-compose`, set `privileged: true` for individual containers in the `docker-compose.yml`. ([Reference](https://docs.docker.com/compose/compose-file/#domainname-hostname-ipc-mac_address-privileged-read_only-shm_size-stdin_open-tty-user-working_dir)) Here is an example for WaterButler:
+
+```yml
+wb:
+  image: quay.io/centerforopenscience/waterbutler:develop
+  command: invoke server
+  privileged: true
+  restart: unless-stopped
+  ports:
+    - 7777:7777
+  env_file:
+    - .docker-compose.wb.env
+  volumes:
+    - wb_requirements_vol:/usr/local/lib/python3.5
+    - wb_requirements_local_bin_vol:/usr/local/bin
+    - osfstoragecache_vol:/code/website/osfstoragecache
+    - wb_tmp_vol:/tmp
+  stdin_open: true
+```


### PR DESCRIPTION
## Purpose

Add `docker` and `docker-compose` guide for runtime privilege configuration.

## Changes

Update the file `README-docker-compose.md` .

![docker-compose-readme](https://user-images.githubusercontent.com/3750414/31024124-18890096-a50c-11e7-8c7d-dd5c9e3a72a2.png)

## Side effects

No

## Ticket

No Ticket