### PR TITLE
[feature] Optimize Contributors Page for Large Projects [OSF-8536]

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -962,13 +962,12 @@ class TestGetNodeTree(OsfTestCase):
         res = self.app.get(url, auth=self.user.auth)
         tree = res.json[0]
         parent_node_id = tree['node']['id']
-        child1_id = tree['children'][0]['node']['id']
-        child2_id = tree['children'][1]['node']['id']
-        child3_id = tree['children'][2]['node']['id']
+        child_ids = [child['node']['id'] for child in tree['children']]
+
         assert_equal(parent_node_id, project._primary_key)
-        assert_equal(child1_id, child1._primary_key)
-        assert_equal(child2_id, child2._primary_key)
-        assert_equal(child3_id, child3._primary_key)
+        assert_in(child1._primary_key, child_ids)
+        assert_in(child2._primary_key, child_ids)
+        assert_in(child3._primary_key, child_ids)
 
     def test_get_node_with_child_linked_to_parent(self):
         project = ProjectFactory(creator=self.user)

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -2,13 +2,14 @@
 import logging
 import httplib as http
 import math
+from collections import defaultdict
 from itertools import islice
 
 from bs4 import BeautifulSoup
 from flask import request
 from django.apps import apps
 from django.core.exceptions import ValidationError
-from django.db.models import Count, Q
+from django.db.models import Count, Q, OuterRef, Exists, Subquery
 
 from framework import status
 from framework.utils import iso8601format
@@ -35,7 +36,7 @@ from website.util.rubeus import collect_addon_js
 from website.project.model import has_anonymous_link, NodeUpdateError, validate_title
 from website.project.forms import NewNodeForm
 from website.project.metadata.utils import serialize_meta_schemas
-from osf.models import AbstractNode, PrivateLink, Contributor
+from osf.models import AbstractNode, PrivateLink, Contributor, Node, NodeRelation
 from osf.models.contributor import get_contributor_permissions
 from osf.models.licenses import serialize_node_license_record
 from website import settings
@@ -812,22 +813,34 @@ def get_affiliated_institutions(obj):
         })
     return ret
 
-def _get_children(node, auth, indent=0):
+def serialize_children(child_list, nested, indent=0):
+    results = []
+    for child in child_list:
+        results.append({
+            'id': child._id,
+            'title': child.title,
+            'is_public': child.is_public,
+            'parent_id': child.parentnode_id,
+            'indent': indent
+        })
+        if child._id in nested.keys():
+            results.extend(serialize_children(nested.get(child._id), nested, indent + 1))
+    return results
 
-    children = []
+def _get_children(node, auth):
+    is_admin = Contributor.objects.filter(node=OuterRef('pk'), admin=True, user=auth.user)
+    parent_node_sqs = NodeRelation.objects.filter(child=OuterRef('pk'), is_node_link=False).values('parent__guids___id')
+    children = (Node.objects.get_children(node)
+                .filter(is_deleted=False)
+                .annotate(parentnode_id=Subquery(parent_node_sqs[:1]))
+                .annotate(has_admin_perm=Exists(is_admin))
+                .filter(has_admin_perm=True))
 
-    for child in node.nodes_primary:
-        if not child.is_deleted and child.has_permission(auth.user, ADMIN):
-            children.append({
-                'id': child._primary_key,
-                'title': child.title,
-                'indent': indent,
-                'is_public': child.is_public,
-                'parent_id': child.parent_id,
-            })
-            children.extend(_get_children(child, auth, indent + 1))
+    nested = defaultdict(list)
+    for child in children:
+        nested[child.parentnode_id].append(child)
 
-    return children
+    return serialize_children(nested[node._id], nested)
 
 
 @must_be_valid_project
@@ -885,73 +898,101 @@ def _get_readable_descendants(auth, node, permission=None):
                 descendants.append(descendant)
     return descendants, all_readable
 
-def node_child_tree(user, nodes):
-    """ Format data to test for node privacy settings for use in treebeard.
-    :param user: modular odm User object
-    :param nodes: list of parent project node objects
-    :return: treebeard-formatted data
-    """
-    items = []
+def serialize_child_tree(child_list, user, nested):
+    serialized_children = []
+    for child in child_list:
+        if child.has_read_perm or child.has_permission_on_children(user, READ):
+            contributors = [{
+                'id': contributor.user._id,
+                'is_admin': contributor.admin,
+                'is_confirmed': contributor.user.is_confirmed,
+                'visible': contributor.visible
+            } for contributor in child.contributor_set.all()]
 
-    for node in nodes:
-        assert node, '{} is not a valid Node.'.format(node._id)
-
-        can_read = node.has_permission(user, READ)
-        can_read_children = node.has_permission_on_children(user, 'read')
-        if not can_read and not can_read_children:
-            continue
-
-        contributors = []
-        for contributor in node.contributors:
-            contributors.append({
-                'id': contributor._id,
-                'is_admin': node.has_permission(contributor, ADMIN),
-                'is_confirmed': contributor.is_confirmed
+            serialized_children.append({
+                'node': {
+                    'id': child._id,
+                    'url': child.url if child.has_read_perm else '',
+                    'title': child.title if child.has_read_perm else 'Private Project',
+                    'is_public': child.is_public,
+                    'contributors': contributors,
+                    'is_admin': child.has_admin_perm,
+                },
+                'user_id': user._id,
+                'children': serialize_child_tree(nested.get(child._id), user, nested) if child._id in nested.keys() else [],
+                'nodeType': 'project' if not child.parentnode_id else 'component',
+                'category': child.category,
+                'permissions': {
+                    'view': child.has_read_perm,
+                    'is_admin': child.has_admin_perm
+                }
             })
 
-        affiliated_institutions = [{
-            'id': affiliated_institution.pk,
-            'name': affiliated_institution.name
-        } for affiliated_institution in node.affiliated_institutions.all()]
+    return sorted(serialized_children, key=lambda k: len(k['children']), reverse=True)
 
-        children = node.get_nodes(**{'is_deleted': False, 'is_node_link': False})
-        children_tree = []
-        # List project/node if user has at least 'read' permissions (contributor or admin viewer) or if
-        # user is contributor on a component of the project/node
-        children_tree.extend(node_child_tree(user, children))
+def node_child_tree(user, node):
+    """ Format data to test for node privacy settings for use in treebeard.
+    :param user: user object
+    :param node: parent project node object
+    :return: treebeard-formatted data
+    """
+    serialized_nodes = []
 
-        item = {
+    assert node, '{} is not a valid Node.'.format(node._id)
+
+    is_admin_sqs = Contributor.objects.filter(node=OuterRef('pk'), admin=True, user=user)
+    can_read_sqs = Contributor.objects.filter(node=OuterRef('pk'), read=True, user=user)
+    parent_node_sqs = NodeRelation.objects.filter(child=OuterRef('pk'), is_node_link=False).values('parent__guids___id')
+    children = (Node.objects.get_children(node)
+                .filter(is_deleted=False)
+                .annotate(parentnode_id=Subquery(parent_node_sqs[:1]))
+                .annotate(has_admin_perm=Exists(is_admin_sqs))
+                .annotate(has_read_perm=Exists(can_read_sqs))
+                .include('contributor__user__guids')
+                )
+
+    nested = defaultdict(list)
+    for child in children:
+        nested[child.parentnode_id].append(child)
+
+    contributors = [{
+        'id': contributor.user._id,
+        'is_admin': node.has_permission(contributor.user, ADMIN),
+        'is_confirmed': contributor.user.is_confirmed,
+        'visible': contributor.visible
+    } for contributor in node.contributor_set.all().include('user__guids')]
+
+    can_read = node.has_permission(user, READ)
+    is_admin = node.has_permission(user, ADMIN)
+
+    if can_read or node.has_permission_on_children(user, READ):
+        serialized_nodes.append({
             'node': {
                 'id': node._id,
                 'url': node.url if can_read else '',
                 'title': node.title if can_read else 'Private Project',
                 'is_public': node.is_public,
                 'contributors': contributors,
-                'visible_contributors': list(node.visible_contributor_ids),
-                'is_admin': node.has_permission(user, ADMIN),
-                'affiliated_institutions': affiliated_institutions
+                'is_admin': is_admin
             },
             'user_id': user._id,
-            'children': children_tree,
+            'children': serialize_child_tree(nested.get(node._id), user, nested) if node._id in nested.keys() else [],
             'kind': 'folder' if not node.parent_node or not node.parent_node.has_permission(user, 'read') else 'node',
             'nodeType': node.project_or_component,
             'category': node.category,
             'permissions': {
                 'view': can_read,
-                'is_admin': node.has_permission(user, 'read')
+                'is_admin': is_admin
             }
-        }
+        })
 
-        items.append(item)
-
-    return items
-
+    return serialized_nodes
 
 @must_be_logged_in
 @must_be_valid_project
 def get_node_tree(auth, **kwargs):
     node = kwargs.get('node') or kwargs['project']
-    tree = node_child_tree(auth.user, [node])
+    tree = node_child_tree(auth.user, node)
     return tree
 
 @must_be_valid_project

--- a/website/static/js/projectSettingsTreebeardBase.js
+++ b/website/static/js/projectSettingsTreebeardBase.js
@@ -7,6 +7,7 @@
 
 var m = require('mithril');
 var Fangorn = require('js/fangorn').Fangorn;
+var lodashGet = require('lodash.get');
 
 
 function resolveToggle(item) {
@@ -32,6 +33,7 @@ function getNodesOriginal(nodeTree, nodesOriginal) {
     var j;
     var adminContributors = [];
     var registeredContributors = [];
+    var visibleContributors = [];
     var nodeId = nodeTree.node.id;
     for (i=0; i < nodeTree.node.contributors.length; i++) {
         if (nodeTree.node.contributors[i].is_admin) {
@@ -40,10 +42,13 @@ function getNodesOriginal(nodeTree, nodesOriginal) {
         if (nodeTree.node.contributors[i].is_confirmed) {
             registeredContributors.push(nodeTree.node.contributors[i].id);
         }
+        if (nodeTree.node.contributors[i].visible) {
+            visibleContributors.push(nodeTree.node.contributors[i].id);
+        }
     }
-    var nodeInstitutions = [];
+    var nodeInstitutions = lodashGet(nodeTree.node, 'affiliated_institutions', []);
 
-    nodeInstitutions = nodeTree.node.affiliated_institutions.map(function(item) {
+    nodeInstitutions = nodeInstitutions.map(function(item) {
         return item.id;
     });
 
@@ -53,7 +58,7 @@ function getNodesOriginal(nodeTree, nodesOriginal) {
         title: nodeTree.node.title,
         contributors: nodeTree.node.contributors,
         isAdmin: nodeTree.node.is_admin,
-        visibleContributors: nodeTree.node.visible_contributors,
+        visibleContributors: visibleContributors,
         adminContributors: adminContributors,
         registeredContributors: registeredContributors,
         institutions: nodeInstitutions,

--- a/website/static/js/projectSettingsTreebeardBase.js
+++ b/website/static/js/projectSettingsTreebeardBase.js
@@ -7,7 +7,6 @@
 
 var m = require('mithril');
 var Fangorn = require('js/fangorn').Fangorn;
-var lodashGet = require('lodash.get');
 
 
 function resolveToggle(item) {
@@ -46,7 +45,7 @@ function getNodesOriginal(nodeTree, nodesOriginal) {
             visibleContributors.push(nodeTree.node.contributors[i].id);
         }
     }
-    var nodeInstitutions = lodashGet(nodeTree.node, 'affiliated_institutions', []);
+    var nodeInstitutions = nodeTree.node.affiliated_institutions || [];
 
     nodeInstitutions = nodeInstitutions.map(function(item) {
         return item.id;


### PR DESCRIPTION
#### Purpose
- Speeds up the contributors page for large and deeply nested projects. 

#### Changes
- Greatly reduces the number of queries made by the `_get_children` and `node_child_tree` v1 views by using subqueries, annotations, and django-include. 
- Consolidates some serialization logic so that expensive permissions checks are executed once instead of 3-4 times per node.

#### Side Effects
- Faster! Otherwise, none expected.

#### Stats 🐱 
- Local response times and num queries when testing against a QA project (23rez) with ~100 children:
```
BEFORE
/api/v1/project/<guid>/_get_editable_children/:
    response time: 
        ~3s (admin on root, r+w on children)
        ~23s (admin on root, admin on children)
    num queries:
        43 (admin on root, r+w on children)
        373 (admin on root, admin on children)
/api/v1/project/<guid>/_tree response time:
    response time: 
        ~38s (admin on root, admin on children)
        ~52s (admin on root, r+w on children) 
    num queries:
        1267 -- not a typo, it's really 1267 (admin on root, admin on children) 
        2170 -- I *reallly* wish I was kidding (admin on root, r+w on children)

AFTER
/api/v1/project/<guid>/_get_editable_children/:
    response time:
        ~1s (admin on root, r+w on children)
        ~3s (admin on root, admin on children)
    num queries:
        1 (admin on root, admin on children) 
        1 (admin on root, r+w on children) 

/api/v1/project/<guid>/_tree response time:
    response time:
        ~3s (admin on root, admin on children)
        ~3s (admin on root, r+w on children) 
    num queries:
        12 (admin on root, admin on children) 
        12 (admin on root, r+w on children)
```

#### QA Notes
- The add VOL modal (specifically the "which components would you like to associate with this link?" bit) and the add contributor modal (specifically the "select components" page) should be tested, especially with complicated parent-child permission combinations. 
- Note that the VOL modal will no longer have ordering (if it did before?), but children will still appear nested (indented) below their parents. 
- Note that the components in the "select components" modal will now be ordered by number of children.

#### Ticket
- [OSF-8536](https://openscience.atlassian.net/browse/OSF-8536)
