### PR TITLE
[hotfix] Add files and tags to preprint serializer for node-preprint divorce [OSF-8734]

### DIFF
--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -5,14 +5,15 @@ from rest_framework import serializers as ser
 from api.base.exceptions import Conflict
 from api.base.serializers import (
     JSONAPISerializer, IDField,
-    LinksField, RelationshipField, DateByVersion,
+    LinksField, RelationshipField, DateByVersion, JSONAPIListField
 )
 from api.base.utils import absolute_reverse, get_user_auth
 from api.taxonomies.serializers import TaxonomyField
 from api.nodes.serializers import (
     NodeCitationSerializer,
     NodeLicenseSerializer,
-    get_license_details
+    get_license_details,
+    NodeTagField
 )
 from framework.exceptions import PermissionsError
 from website.util import permissions
@@ -76,6 +77,7 @@ class PreprintSerializer(JSONAPISerializer):
     license_record = NodeLicenseSerializer(required=False, source='license')
     title = ser.CharField(source='node.title', required=False)
     description = ser.CharField(required=False, allow_blank=True, allow_null=True, source='node.description')
+    tags = JSONAPIListField(child=NodeTagField(), required=False, source='node.tags')
 
     contributors = RelationshipField(
         related_view='nodes:node-contributors',
@@ -108,6 +110,11 @@ class PreprintSerializer(JSONAPISerializer):
         related_view='preprint_providers:preprint_provider-detail',
         related_view_kwargs={'provider_id': '<provider._id>'},
         read_only=False
+    )
+
+    files = RelationshipField(
+        related_view='nodes:node-providers',
+        related_view_kwargs={'node_id': '<_id>'}
     )
 
     primary_file = PrimaryFileRelationshipField(

--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -257,6 +257,27 @@ class TestPreprintUpdate:
         assert mock_preprint_updated.called
 
     @mock.patch('website.preprints.tasks.on_preprint_updated.s')
+    def test_update_tags(self, mock_preprint_updated, app, user, preprint, url):
+        new_tags = ['hey', 'sup']
+
+        for tag in new_tags:
+            assert tag not in preprint.node.tags.all().values_list('name', flat=True)
+
+        update_tags_payload = build_preprint_update_payload(
+            preprint._id,
+            attributes={
+                'tags': new_tags
+            }
+        )
+        res = app.patch_json_api(url, update_tags_payload, auth=user.auth)
+
+        assert res.status_code == 200
+        preprint.node.reload()
+
+        assert sorted(list(preprint.node.tags.all().values_list('name', flat=True))) == new_tags
+        assert mock_preprint_updated.called
+
+    @mock.patch('website.preprints.tasks.on_preprint_updated.s')
     def test_update_contributors(self, mock_preprint_updated, app, user, preprint, url):
         new_user = AuthUserFactory()
         contributor_payload = {


### PR DESCRIPTION
[#OSF-8734]

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

As another step in the node preprint divorce, add a few more fields to the Preprint serializer so that the frontend can pretend that Preprint is its own thing!

## Changes

- add files to the preprint serializer
- add tags to the preprint serialzier
- add special case to update tags in preprint serializer since same is done in node serializer
- tests for updating tags

## Side effects

none anticipated


## Ticket
https://openscience.atlassian.net/browse/OSF-8734