### PR TITLE
[Hotfix] Load logs [OSF-8713]

### DIFF
--- a/website/static/js/components/logFeed.js
+++ b/website/static/js/components/logFeed.js
@@ -58,7 +58,7 @@ var LogFeed = {
                 self.totalPages(Math.ceil(result.links.meta.total / result.links.meta.per_page));
             }
             self.logRequestPending(true);
-            var promise = m.request({method : 'GET', background: true, url : url, config: mHelpers.apiV2Config({withCredentials: window.contextVars.isOnRootDomain})});
+            var promise = m.request({method : 'GET', url : url, config: mHelpers.apiV2Config({withCredentials: window.contextVars.isOnRootDomain})});
             promise.then(
                 function(result) {
                     _processResults(result);

--- a/website/static/js/pages/project-dashboard-page.js
+++ b/website/static/js/pages/project-dashboard-page.js
@@ -129,7 +129,7 @@ $(document).ready(function () {
 
         // Treebeard Files view
         var urlFilesGrid = nodeApiUrl + 'files/grid/';
-        var promise = m.request({ method: 'GET', background: true, config: $osf.setXHRAuthorization, url: urlFilesGrid});
+        var promise = m.request({ method: 'GET', config: $osf.setXHRAuthorization, url: urlFilesGrid});
         promise.then(function (data) {
             var fangornOpts = {
                 divID: 'treeGrid',


### PR DESCRIPTION
## Purpose
Fix bug introduced in #7721

## Changes
* Ensure UI redraws after log request completes

<img width="491" alt="redraw" src="https://user-images.githubusercontent.com/5659262/31090569-08c7ec64-a776-11e7-8220-1ea7f3eabbad.png">

## Side effects
None expected. Tested to verify logs and files still load independently.

## Ticket
[[OSF-8713]](https://openscience.atlassian.net/browse/OSF-8713)
