### PR TITLE
[hotfix] Order prereg submissions by datetime_updated [OSF-8740]

### DIFF
--- a/admin/pre_reg/views.py
+++ b/admin/pre_reg/views.py
@@ -32,8 +32,8 @@ SORT_BY = {
     'n_initiator': '-initiator__fullname',
     'title': 'branched_from__title',
     'n_title': '-branched_from__title',
-    'date': 'datetime_initiated',
-    'n_date': '-datetime_initiated',
+    'date': 'datetime_updated',
+    'n_date': '-datetime_updated',
     'state': 'approval__state',
     'n_state': '-approval__state',
 }
@@ -41,7 +41,7 @@ SORT_BY = {
 
 class DraftListView(PermissionRequiredMixin, ListView):
     template_name = 'pre_reg/draft_list.html'
-    ordering = '-datetime_initiated'
+    ordering = '-datetime_updated'
     context_object_name = 'draft'
     permission_required = 'osf.view_prereg'
     raise_exception = True


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Draft registrations were showing up in the order that the draft was initiated, not the order in which they were submitted for approval. Fix that!

## Changes

- change ordering to `datetime_updated` over `datetime_initated`
- add a test to make sure this stays fixed

## Side effects

none anticipated!


## Ticket
https://openscience.atlassian.net/browse/OSF-8740