### PR TITLE
[hotfix] Other filtering ignored with filter[parent]=null [OSF-8744]

### DIFF
--- a/api/nodes/filters.py
+++ b/api/nodes/filters.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 from django.db.models import Q
 
 from api.base.exceptions import InvalidFilterOperator, InvalidFilterValue
@@ -18,8 +20,10 @@ class NodesFilterMixin(ListFilterMixin):
                 for field_name, operation in field_names.iteritems():
                     # filter[parent]=null
                     if field_name == 'parent' and operation['op'] == 'eq' and not operation['value']:
-                        return queryset.get_roots()
-        return super(NodesFilterMixin, self).param_queryset(query_params, default_queryset)
+                        queryset = queryset.get_roots()
+                        query_params = deepcopy(query_params)
+                        query_params.pop(key)
+        return super(NodesFilterMixin, self).param_queryset(query_params, queryset)
 
     def build_query_from_field(self, field_name, operation):
         if field_name == 'parent':

--- a/api_tests/nodes/views/test_node_list.py
+++ b/api_tests/nodes/views/test_node_list.py
@@ -322,6 +322,32 @@ class TestNodeFiltering:
         assert private_project._id not in ids
         assert public_project._id in ids
 
+    def test_filtering_by_public_toplevel(self, app, user_one):
+        public_project = ProjectFactory(creator=user_one, is_public=True)
+        private_project = ProjectFactory(creator=user_one, is_public=False)
+
+        url = '/{}nodes/?filter[public]=false&filter[parent]=null'.format(API_BASE)
+        res = app.get(url, auth=user_one.auth)
+        node_json = res.json['data']
+
+        # No public projects returned
+        assert not any([each['attributes']['public'] for each in node_json])
+
+        ids = [each['id'] for each in node_json]
+        assert public_project._id not in ids
+        assert private_project._id in ids
+
+        url = '/{}nodes/?filter[public]=true&filter[parent]=null'.format(API_BASE)
+        res = app.get(url, auth=user_one.auth)
+        node_json = res.json['data']
+
+        # No private projects returned
+        assert all([each['attributes']['public'] for each in node_json])
+
+        ids = [each['id'] for each in node_json]
+        assert private_project._id not in ids
+        assert public_project._id in ids
+
     def test_filtering_tags(self, app, public_project_one, public_project_two, tag_one, tag_two):
         url = '/{}nodes/?filter[tags]={}'.format(API_BASE, tag_one)
 


### PR DESCRIPTION


## Purpose

When making API calls with two or more filters including `parent=[null]`, filters after the parent null filter were being skipped

## Changes

- Add special case filter to queryset in `NodesFilterMixin` that can then be returned to Super

## Side effects

This might make filtering a lot slower cause of the copy -- *is there a better way?!?*


## Ticket
https://openscience.atlassian.net/browse/OSF-8744