### PR TITLE
[hotfix] Add temporary scripts directory and second email to ERPC participants [OSF-8726]

### DIFF
--- a/scripts/remove_after_use/send_2nd_erpc_email.py
+++ b/scripts/remove_after_use/send_2nd_erpc_email.py
@@ -1,0 +1,104 @@
+import sys
+import logging
+
+from website.app import setup_django
+setup_django()
+
+from website import settings
+from scripts import utils as script_utils
+from osf.models import MetaSchema, Contributor, Registration
+from framework.email.tasks import send_email
+
+logger = logging.getLogger(__name__)
+
+
+EMAIL_TEXT = """
+
+Hi -
+
+We are writing to you to briefly inquire about the status of your entry in the 2016 Election Research Preacceptance Competition (ERPC).
+
+Please take this brief survey now: https://dartmouth.co1.qualtrics.com/jfe/form/SV_892z7o3XngHhuYJ . It will take approximately five minutes and would be immensely helpful to us in learning both about the status of your entry and what about the ERPC did or did not work well. Thank you!
+
+Sincerely,
+
+Skip and Brendan
+
+
+*Arthur Lupia*
+
+Institute for Social Research and Department of Political Science, University of Michigan
+
+Chair, The National Academies Roundtable on the Communication and Use of Behavioral and Social Sciences
+
+Chairman of the Board, Center for Open Science
+
+http://www.arthurlupia.com
+
+lupia@umich.edu
+
+Twitter: @ArthurLupia
+
+
+*Brendan Nyhan*
+
+Professor of Government
+
+Dartmouth College
+
+nyhan@dartmouth.edu
+
+http://www.dartmouth.edu/~nyhan
+
+"""
+
+
+def get_erpc_participants(dry=True):
+    """
+        :param dry: Also include the email addresses for the ERPC Administrators.
+
+        :return: A list of emails for anyone who has admin + read/write to a registration created
+        with the ERPC registration schema
+    """
+    erpc_metaschema = MetaSchema.objects.get(name='Election Research Preacceptance Competition', active=False)
+    registrations = Registration.objects.filter(registered_schema=erpc_metaschema)
+
+    participants_to_email = []
+    for registration in registrations:
+        contributors = Contributor.objects.filter(node=registration).only('user')
+        for contributor in contributors:
+            if contributor.write or contributor.admin:
+                participants_to_email.append(contributor.user.username)
+
+    if not dry:
+        participants_to_email += ['lupia@umich.edu', 'brendan.j.nyhan@dartmouth.edu']
+
+    return participants_to_email
+
+
+def send_email_to_erpc_participants(participants, dry=True):
+    from_addr = settings.FROM_EMAIL
+    subject = 'ERPC user survey - help us learn how to improve preacceptance!'
+
+    participants = set(participants)
+
+    logger.info('About to send an email to {} ERPC participants'.format(len(participants)))
+
+    for participant in participants:
+        if not dry:
+            logger.info('Sending to {}'.format(participant))
+            send_email(from_addr=from_addr, to_addr=participant, subject=subject, mimetype='text', message=EMAIL_TEXT, username=settings.MAIL_USERNAME, password=settings.MAIL_PASSWORD)
+        else:
+            logger.info('Would have sent an email to {}'.format(participant))
+
+def main(dry):
+    participants = get_erpc_participants(dry)
+    send_email_to_erpc_participants(participants, dry)
+
+
+if __name__ == '__main__':
+    dry = '--dry' in sys.argv
+    if not dry:
+        # If we're not running in dry mode log everything to a file
+        script_utils.add_file_logger(logger, __file__)
+    main(dry=dry)

--- a/scripts/remove_after_use/test_send_2nd_erpc_email.py
+++ b/scripts/remove_after_use/test_send_2nd_erpc_email.py
@@ -1,0 +1,34 @@
+import pytest
+
+from osf.models import MetaSchema
+from scripts.remove_after_use.send_2nd_erpc_email import get_erpc_participants
+from framework.auth.core import Auth
+from osf_tests.factories import AuthUserFactory, ProjectFactory
+
+from tests.utils import assert_items_equal
+
+
+@pytest.mark.django_db
+class TestERPCParticipantEmail:
+
+    def test_get_erpc_participants(self):
+        creator = AuthUserFactory()
+        admin_contributor = AuthUserFactory()
+        write_contributor = AuthUserFactory()
+        read_contributor = AuthUserFactory()
+
+        project = ProjectFactory(creator=creator)
+        project.add_contributor(admin_contributor, permissions=['admin'], auth=Auth(creator))
+        project.add_contributor(write_contributor, permissions=['write'], auth=Auth(creator))
+        project.add_contributor(read_contributor, permissions=['read'], auth=Auth(creator))
+        project.save()
+        schema = MetaSchema.objects.get(name='Election Research Preacceptance Competition', active=False)
+
+        registration = project.register_node(schema=schema, auth=Auth(creator), data='')
+        registration.save()
+
+        gathered_participant_emails = get_erpc_participants()
+        expected_participant_emails = [admin_contributor.username, creator.username, write_contributor.username]
+
+        assert_items_equal(gathered_participant_emails, expected_participant_emails)
+        assert read_contributor not in gathered_participant_emails


### PR DESCRIPTION

## Purpose
Send a second email to ERPC participants with a survey!

After the removal of all old/temporary scripts, figured it'd be best to add a new place in the OSF scripts directory for these temporary scripts and tests so that they're easier to identify and remove after they have been executed.

Here's a preview of the sent email as received by gmail:

![screen shot 2017-10-03 at 4 12 22 pm](https://user-images.githubusercontent.com/801594/31148159-e0969666-a859-11e7-945c-ec83b18e84f1.png)


## Changes

- add a new `remove_after_use` directory inside the scripts directory
- Add a script to send email to ERPC participants with survey
- Add a test to ensure it is send to the right people

## Side effects
None anticipated


## Ticket
https://openscience.atlassian.net/browse/OSF-8726