### PR TITLE
Feature/Add custom taxonomy import/export [OSF-8392]

### DIFF
--- a/admin/preprint_providers/views.py
+++ b/admin/preprint_providers/views.py
@@ -18,8 +18,7 @@ from osf.models.preprint_provider import rules_to_subjects
 
 # When preprint_providers exclusively use Subject relations for creation, set this to False
 SHOW_TAXONOMIES_IN_PREPRINT_PROVIDER_CREATE = True
-#TODO: Add subjects back in when custom taxonomies are fully integrated
-FIELDS_TO_NOT_IMPORT_EXPORT = ['access_token', 'share_source', 'subjects_acceptable', 'subjects']
+FIELDS_TO_NOT_IMPORT_EXPORT = ['access_token', 'share_source']
 
 
 class PreprintProviderList(PermissionRequiredMixin, ListView):
@@ -170,7 +169,7 @@ class ExportPreprintProvider(PermissionRequiredMixin, View):
         cleaned_fields = {key: value for key, value in cleaned_data['fields'].iteritems() if key not in FIELDS_TO_NOT_IMPORT_EXPORT}
         cleaned_fields['licenses_acceptable'] = [node_license.license_id for node_license in preprint_provider.licenses_acceptable.all()]
         cleaned_fields['default_license'] = preprint_provider.default_license.license_id if preprint_provider.default_license else ''
-        # cleaned_fields['subjects'] = self.serialize_subjects(preprint_provider)
+        cleaned_fields['subjects'] = self.serialize_subjects(preprint_provider)
         cleaned_data['fields'] = cleaned_fields
         filename = '{}_export.json'.format(preprint_provider.name)
         response = HttpResponse(json.dumps(cleaned_data), content_type='text/json')
@@ -178,7 +177,7 @@ class ExportPreprintProvider(PermissionRequiredMixin, View):
         return response
 
     def serialize_subjects(self, provider):
-        if provider._id != 'osf':
+        if provider._id != 'osf' and provider.subjects.count():
             result = {}
             result['include'] = []
             result['exclude'] = []
@@ -249,7 +248,7 @@ class ImportPreprintProvider(PermissionRequiredMixin, View):
 
     def add_subjects(self, provider, subject_data):
         from osf.management.commands.populate_custom_taxonomies import migrate
-        migrate(provider._id, subject_data)
+        migrate(provider=provider._id, data=subject_data)
 
     def create_or_update_provider(self, provider_data):
         provider = self.get_page_provider()

--- a/admin_tests/preprint_providers/test_views.py
+++ b/admin_tests/preprint_providers/test_views.py
@@ -250,9 +250,9 @@ class TestPreprintProviderExportImport(AdminTestCase):
 
         nt.assert_equal(res.status_code, 302)
         nt.assert_equal(new_provider._id, 'new_id')
-        # nt.assert_equal(new_provider.subjects.all().count(), 1)
+        nt.assert_equal(new_provider.subjects.all().count(), 1)
         nt.assert_equal(new_provider.licenses_acceptable.all().count(), 1)
-        # nt.assert_equal(new_provider.subjects.all()[0].text, self.subject.text)
+        nt.assert_equal(new_provider.subjects.all()[0].text, self.subject.text)
         nt.assert_equal(new_provider.licenses_acceptable.all()[0].license_id, 'NONE')
 
     def test_update_provider_existing_subjects(self):
@@ -281,9 +281,9 @@ class TestPreprintProviderExportImport(AdminTestCase):
 
         nt.assert_equal(res.status_code, 302)
         nt.assert_equal(new_provider_id, self.preprint_provider.id)
-        # nt.assert_equal(self.preprint_provider.subjects.all().count(), 1)
+        nt.assert_equal(self.preprint_provider.subjects.all().count(), 1)
         nt.assert_equal(self.preprint_provider.licenses_acceptable.all().count(), 1)
-        # nt.assert_equal(self.preprint_provider.subjects.all()[0].text, self.subject.text)
+        nt.assert_equal(self.preprint_provider.subjects.all()[0].text, self.subject.text)
         nt.assert_equal(self.preprint_provider.licenses_acceptable.all()[0].license_id, 'CCBY')
 
 


### PR DESCRIPTION
## Purpose

Now that all taxonomies are custom taxonomies, we can easily import taxonomies from staging.

## Changes

I removed taxonomies from the excluded fields when importing a preprint provider.

## Side effects

None anticipated

## Ticket

https://openscience.atlassian.net/browse/OSF-8392