### PR TITLE
[OSF-8760] Pin keen-tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "jstimezonedetect": "^1.0.6",
     "keen-analysis": "^1.1.0",
     "keen-dataviz": "^1.0.2",
-    "keen-tracking": "^1.0.3",
+    "keen-tracking": "1.0.3",
     "knockout": "~3.4.2",
     "knockout.validation": "^2.0.2",
     "less": "^2.5.3",


### PR DESCRIPTION
## Purpose

keen/keen-tracking.js@9bbc71e8b2a0e301aab51ab677877172e8cc0dd2 causes the site to break

![image](https://user-images.githubusercontent.com/3374510/31210376-b3d72e22-a95f-11e7-80e2-d8cdb3f3c6d1.png)

## Changes

Pins the version of keen-tracking in package.json

We should switch to yarn and use `--frozen-lockfile` or `--pure-lockfile` flags to solve this problem.

## Side effects

N/A

## QA

Fixes the staging3 navbar problem

## Ticket

https://openscience.atlassian.net/browse/OSF-8760

cc @CenterForOpenScience/reviews 

