### PR TITLE
[OSF-8237] citation preview available even if individual fields are not filled

### DIFF
--- a/website/static/js/profile.js
+++ b/website/static/js/profile.js
@@ -478,7 +478,7 @@ var NameViewModel = function(urls, modes, preventUnsaved, fetchCallback) {
     };
 
     self.hasDetail = ko.computed(function() {
-        return !! self.given();
+        return !! (self.given() && self.family());
     });
 
     self.citeApa = ko.computed(function() {

--- a/website/static/js/profile.js
+++ b/website/static/js/profile.js
@@ -394,7 +394,6 @@ BaseViewModel.prototype.submit = function() {
 var NameViewModel = function(urls, modes, preventUnsaved, fetchCallback) {
     var self = this;
     BaseViewModel.call(self, urls, modes, preventUnsaved);
-    fetchCallback = fetchCallback || noop;
     TrackedMixin.call(self);
 
     self.full = koHelpers.sanitizedObservable().extend({
@@ -406,6 +405,11 @@ var NameViewModel = function(urls, modes, preventUnsaved, fetchCallback) {
     self.middle = koHelpers.sanitizedObservable().extend({trimmed: true});
     self.family = koHelpers.sanitizedObservable().extend({trimmed: true});
     self.suffix = koHelpers.sanitizedObservable().extend({trimmed: true});
+
+    self.imputedGiven = ko.observable();
+    self.imputedMiddle = ko.observable();
+    self.imputedFamily = ko.observable();
+    self.imputedSuffix = ko.observable();
 
     self.trackedProperties = [
         self.full,
@@ -427,11 +431,14 @@ var NameViewModel = function(urls, modes, preventUnsaved, fetchCallback) {
         return !! self.full();
     });
 
-    self.impute = function(callback) {
-        var cb = callback || noop;
-        if (! self.hasFirst()) {
-            return;
-        }
+    self.autoFill = function() {
+        self.given(self.imputedGiven());
+        self.middle(self.imputedMiddle());
+        self.family(self.imputedFamily());
+        self.suffix(self.imputedSuffix());
+    };
+
+    self.impute = function () {
         return $.ajax({
             type: 'GET',
             url: urls.impute,
@@ -439,8 +446,11 @@ var NameViewModel = function(urls, modes, preventUnsaved, fetchCallback) {
                 name: self.full()
             },
             dataType: 'json',
-            success: [self.unserialize.bind(self), cb],
-            error: self.handleError.bind(self, 'Could not fetch names')
+        }).success(function (response) {
+            self.imputedGiven(response.given);
+            self.imputedMiddle(response.middle);
+            self.imputedFamily(response.family);
+            self.imputedSuffix(response.suffix);
         });
     };
 
@@ -467,34 +477,48 @@ var NameViewModel = function(urls, modes, preventUnsaved, fetchCallback) {
         return suffix;
     };
 
+    self.hasDetail = ko.computed(function() {
+        return !! self.given();
+    });
+
     self.citeApa = ko.computed(function() {
-        var cite = self.family();
-        var given = $.trim(self.given() + ' ' + self.middle());
+        var cite = self.hasDetail() ? self.family() : self.imputedFamily();
+        var given = self.hasDetail() ? $.trim(self.given() + ' ' + self.middle()) : $.trim(self.imputedGiven() + ' ' + self.imputedMiddle());
 
         if (given) {
             cite = cite + ', ' + self.initials(given);
         }
-        if (self.suffix()) {
+        if (self.hasDetail() && self.suffix()) {
             cite = cite + ', ' + suffix(self.suffix());
+        } else if (self.imputedSuffix()){
+            cite = cite + ', ' + suffix(self.imputedSuffix());
         }
         return cite;
     });
 
     self.citeMla = ko.computed(function() {
-        var cite = self.family();
-        if (self.given()) {
+        var cite = self.hasDetail() ? self.family() : self.imputedFamily();
+        if (self.hasDetail()) {
             cite = cite + ', ' + self.given();
             if (self.middle()) {
                 cite = cite + ' ' + self.initials(self.middle());
             }
+        } else if (self.full()) {
+            cite = cite + ', ' + self.imputedGiven();
+            if (self.imputedMiddle()) {
+                cite = cite + ' ' + self.initials(self.imputedMiddle());
+            }
         }
-        if (self.suffix()) {
+        if (self.hasDetail() && self.suffix()) {
             cite = cite + ', ' + suffix(self.suffix());
+        } else if (self.imputedSuffix()) {
+            cite = cite + ', ' + suffix(self.imputedSuffix());
         }
         return cite;
     });
 
-    self.fetch(fetchCallback);
+    self.fetch(self.impute);
+    self.full.subscribe(self.impute);
 };
 NameViewModel.prototype = Object.create(BaseViewModel.prototype);
 $.extend(NameViewModel.prototype, SerializeMixin.prototype, TrackedMixin.prototype);

--- a/website/templates/include/profile/names.mako
+++ b/website/templates/include/profile/names.mako
@@ -18,7 +18,7 @@
         </span>
 
         <div style="margin-bottom: 10px;">
-            <a class="btn btn-primary" data-bind="enabled: hasFirst(), click: impute">Auto-fill</a>
+            <a class="btn btn-primary" data-bind="enabled: hasFirst(), click: autoFill">Auto-fill</a>
         </div>
 
         <div class="form-group">


### PR DESCRIPTION
## Purpose

Enable citation preview on user profile setting page when only full name is specified.

## Changes

Originally, the "impute" api v1 endpoint would only be called whenever the user hits "Auto-fill" button to auto-fill the specific names. However, if we want to show citation preview using only the full name information, we have to impute the full name upon page load and on changes and then get the corresponding MLA/APA citation previews.

Therefore, in `profile.js`, four more knockout observables are added. The `impute` function is changed to be invoked on page load and subsequent changes and store the imputed names to the added observables. An `autoFill` function is added to set the specific name fields from imputed name observables when user click the button. `citeMla` and `citeApa` is changed to user imputed names when specific name fields are not filled.

## QA Notes

The citation preview would always show that of the full name unless both Family name and Given Name are specified. This is to match the actual citation as shown in project page. Additional tests should be taken to make sure under all circumstances the preview would always match the actual citation of the project page.

## Ticket

https://openscience.atlassian.net/browse/OSF-8237