### PR TITLE
[Hotfix] Improve RCTE's [OSF-8616]

### DIFF
--- a/osf/models/node.py
+++ b/osf/models/node.py
@@ -86,19 +86,21 @@ class AbstractNodeQuerySet(GuidMixinQuerySet):
                 SELECT
                     parent_id,
                     child_id,
-                    1 AS LEVEL
+                    1 AS LEVEL,
+                    ARRAY[parent_id] as pids
                 FROM %s
                 %s
-                WHERE is_node_link IS FALSE %s
+                WHERE is_node_link IS FALSE AND parent_id = %s %s
                 UNION ALL
                 SELECT
-                    s.parent_id,
-                    d.child_id,
-                    d.level + 1
+                    d.parent_id,
+                    s.child_id,
+                    d.level + 1,
+                    d.pids || s.parent_id
                 FROM descendants AS d
                     JOIN %s AS s
-                    ON d.parent_id = s.child_id
-                WHERE s.is_node_link IS FALSE
+                    ON d.child_id = s.parent_id
+                WHERE s.is_node_link IS FALSE AND %s = ANY(pids)
                 ) SELECT array_agg(DISTINCT child_id)
                 FROM descendants
                 WHERE parent_id = %s;
@@ -108,8 +110,10 @@ class AbstractNodeQuerySet(GuidMixinQuerySet):
                 cursor.execute(sql, [
                     node_relation_table,
                     AsIs('LEFT JOIN osf_abstractnode ON {}.child_id = osf_abstractnode.id'.format(node_relation_table) if active else ''),
+                    root.pk,
                     AsIs('AND osf_abstractnode.is_deleted IS FALSE' if active else ''),
                     node_relation_table,
+                    root.pk,
                     root.pk])
                 row = cursor.fetchone()[0]
                 if not row:


### PR DESCRIPTION
## Purpose
`get_root` is called after node creation. When registering a node with multiple components, it's called once per created registration, and is slow.

`get_children` is called when listing logs, and is slow for non-root nodes.

## Changes
* Filter while recursing, reducing row count of built CTs
* Build CT for `get_children` in the logical direction (top-down)

## Side effects
None expected

## Ticket
[[OSF-8616]](https://openscience.atlassian.net/browse/OSF-8616)
