### PR TITLE
[OSF-8710] File title is made editable in file detail page

### DIFF
--- a/website/static/js/pages/file-page.js
+++ b/website/static/js/pages/file-page.js
@@ -58,4 +58,42 @@ $(function() {
         });
     }
 
+    if(window.contextVars.currentUser.canEdit && !window.contextVars.node.isRegistration) {
+        $('#fileTitleEditable').editable({
+            type: 'text',
+            mode: 'inline',
+            send: 'always',
+            url: window.contextVars.file.urls.delete,
+            ajaxOptions: {
+                type: 'post',
+                contentType: 'application/json',
+                dataType: 'json',
+                beforeSend: $osf.setXHRAuthorization
+            },
+            validate: function(value) {
+                if($.trim(value) === ''){
+                    return 'The file title cannot be empty.';
+                } else if(value.length > 100){
+                    return 'The file title cannot be more than 100 characters.';
+                }
+            },
+            params: function(params) {
+                var payload = {
+                    action: 'rename',
+                    rename: params.value,
+                };
+                return JSON.stringify(payload);
+            },
+            success: function(response) {
+                window.location.reload();
+            },
+            error: function (response) {
+                if (response.status === 409){
+                    $osf.growl('Cannot rename file.', 'An item with the same name already exists in this location.')
+                } else {
+                    return $osf.handleEditableError
+                }
+            }
+        });
+    }
 });

--- a/website/static/js/pages/file-page.js
+++ b/website/static/js/pages/file-page.js
@@ -58,7 +58,16 @@ $(function() {
         });
     }
 
-    if(window.contextVars.currentUser.canEdit && !window.contextVars.node.isRegistration) {
+    var titleEditable = function () {
+        var readOnlyProviders = ['bitbucket', 'figshare', 'dataverse'];
+        var ctx = window.contextVars;
+        if (readOnlyProviders.includes(ctx.file.provider) || ctx.file.checkoutUser || !ctx.currentUser.canEdit || ctx.node.isRegistration)
+            return false;
+        else
+            return true;
+    };
+
+    if(titleEditable()) {
         $('#fileTitleEditable').editable({
             type: 'text',
             mode: 'inline',
@@ -88,10 +97,11 @@ $(function() {
                 window.location.reload();
             },
             error: function (response) {
-                if (response.status === 409){
-                    $osf.growl('Cannot rename file.', 'An item with the same name already exists in this location.');
-                } else {
-                    return $osf.handleEditableError;
+                var msg = response.responseJSON.message;
+                if (msg) {
+                    // This is done to override inherited css style and prevent error message lines from overlapping with each other
+                    $('.editable-error-block').css('line-height', '35px');
+                    return msg;
                 }
             }
         });

--- a/website/static/js/pages/file-page.js
+++ b/website/static/js/pages/file-page.js
@@ -89,9 +89,9 @@ $(function() {
             },
             error: function (response) {
                 if (response.status === 409){
-                    $osf.growl('Cannot rename file.', 'An item with the same name already exists in this location.')
+                    $osf.growl('Cannot rename file.', 'An item with the same name already exists in this location.');
                 } else {
-                    return $osf.handleEditableError
+                    return $osf.handleEditableError;
                 }
             }
         });

--- a/website/templates/project/view_file.mako
+++ b/website/templates/project/view_file.mako
@@ -15,7 +15,7 @@
   <div class="col-sm-5">
     <h2 class="break-word">
       ## Split file name into two parts: with and without extension
-      ${file_name_title | h}<span id="file-ext">${file_name_ext | h}</span>
+      <span id="fileTitleEditable">${file_name | h}</span>
       <a id='versionLink' class='scripted'>(Version: ${ version_id | h})</a>
       % if file_revision:
         <small>&nbsp;${file_revision | h}</small>


### PR DESCRIPTION
## Purpose

This PR makes file title editable in file detail page.

## Changes

In `file-page.js`, the file title element is made editable by using the bootstrap-editable library. 

## Side effects

None

## Ticket

https://openscience.atlassian.net/browse/OSF-8710