### PR TITLE
[hotfix] Sort pre-reg submission by the date the approval was created

### DIFF
--- a/admin/pre_reg/views.py
+++ b/admin/pre_reg/views.py
@@ -32,8 +32,8 @@ SORT_BY = {
     'n_initiator': '-initiator__fullname',
     'title': 'branched_from__title',
     'n_title': '-branched_from__title',
-    'date': 'datetime_updated',
-    'n_date': '-datetime_updated',
+    'date': 'approval__initiation_date',
+    'n_date': '-approval__initiation_date',
     'state': 'approval__state',
     'n_state': '-approval__state',
 }
@@ -41,7 +41,7 @@ SORT_BY = {
 
 class DraftListView(PermissionRequiredMixin, ListView):
     template_name = 'pre_reg/draft_list.html'
-    ordering = '-datetime_updated'
+    ordering = '-approval__initiation_date'
     context_object_name = 'draft'
     permission_required = 'osf.view_prereg'
     raise_exception = True

--- a/admin_tests/pre_reg/test_views.py
+++ b/admin_tests/pre_reg/test_views.py
@@ -1,3 +1,5 @@
+import datetime
+
 import mock
 from nose import tools as nt
 from django.test import RequestFactory
@@ -62,7 +64,7 @@ class TestDraftListView(AdminTestCase):
         nt.assert_equal(len(res), 2)
         nt.assert_is_instance(res[0], DraftRegistration)
 
-    def test_queryset_returns_in_order_date_updated(self):
+    def test_queryset_returns_in_order_date_submitted(self):
         created_first_submitted_second = DraftRegistrationFactory(
             initiator=self.user,
             registration_schema=self.schema,
@@ -79,7 +81,9 @@ class TestDraftListView(AdminTestCase):
 
         created_second_submitted_first.submit_for_review(self.user, {}, save=True)
         created_first_submitted_second.submit_for_review(self.user, {}, save=True)
+        created_second_submitted_first.datetime_updated = created_first_submitted_second.datetime_updated + datetime.timedelta(1)
 
+        assert created_second_submitted_first.datetime_updated > created_first_submitted_second.datetime_updated
         res = list(self.view.get_queryset())
         nt.assert_true(res[0] == created_first_submitted_second)
 


### PR DESCRIPTION
[#OSF-8740]

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

In the admin, actually sort by the datetime that the approval was created, not the last time the draft registration was last updated.

## Changes

- sort by approval creation date
- modify test

## Side effects

none anticipated


## Ticket
https://openscience.atlassian.net/browse/OSF-8740