### PR TITLE
[Improvement][MOD-132] Update email html templates

### DIFF
--- a/reviews/models/mixins.py
+++ b/reviews/models/mixins.py
@@ -230,7 +230,7 @@ class ReviewsMachine(Machine):
             'email_recipients': [contributor._id for contributor in self.reviewable.node.contributors],
             'reviewable': self.reviewable,
             'workflow': self.reviewable.provider.reviews_workflow,
-            'provider_url': self.reviewable.provider.external_url if self.reviewable.provider.external_url is not None else settings.DOMAIN + '/preprints' + self.reviewable.provider._id,
+            'provider_url': self.reviewable.provider.domain if self.reviewable.provider.domain is not None else settings.DOMAIN + 'preprints/' + self.reviewable.provider._id,
             'provider_contact_email': self.reviewable.provider.email_contact if self.reviewable.provider.email_contact is not None else 'contact@osf.io',
             'provider_support_email': self.reviewable.provider.email_support if self.reviewable.provider.email_support is not None else 'support@osf.io',
         }

--- a/website/templates/emails/reviews_submission_confirmation.html.mako
+++ b/website/templates/emails/reviews_submission_confirmation.html.mako
@@ -21,10 +21,10 @@
         Sincerely,
         <br>
         Your ${reviewable.provider.name} and OSF teams
-        <br><br>
+        <p>
         Center for Open Science<br>
         210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-        <br><br>
+        </p>
         <a href="https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md">Privacy Policy</a>
     </div>
 </%def>

--- a/website/templates/emails/reviews_submission_confirmation.html.mako
+++ b/website/templates/emails/reviews_submission_confirmation.html.mako
@@ -2,30 +2,24 @@
 <%inherit file="notify_base.mako"/>
 <%def name="content()">
     <div style="margin: 40px;">
-        Hello ${user.fullname},
-        <br><br>
+        <p>Hello ${user.fullname},</p>
         % if is_creator:
-        Your ${reviewable.provider.preprint_word} <a href="${reviewable.absolute_url}">${reviewable.node.title}</a> has been successfully submitted to ${reviewable.provider.name}.
+            <p>Your ${reviewable.provider.preprint_word} <a href="${reviewable.absolute_url}">${reviewable.node.title}</a> has been successfully submitted to ${reviewable.provider.name}.</p>
         % else:
-        ${referrer.fullname} has added you as a contributor to the ${reviewable.provider.preprint_word} <a href="${reviewable.absolute_url}">${reviewable.node.title}</a> on ${reviewable.provider.name}, which is hosted on the Open Science Framework.
+            <p>${referrer.fullname} has added you as a contributor to the ${reviewable.provider.preprint_word} <a href="${reviewable.absolute_url}">${reviewable.node.title}</a> on ${reviewable.provider.name}, which is hosted on the Open Science Framework.</p>
         % endif
-        <br><br>
         % if workflow == 'pre-moderation':
-        ${reviewable.provider.name} has chosen to moderate their submissions using a pre-moderation workflow, which means your submission is pending until accepted by a moderator. You will receive a separate notification informing you of any status changes.
+            <p>${reviewable.provider.name} has chosen to moderate their submissions using a pre-moderation workflow, which means your submission is pending until accepted by a moderator. You will receive a separate notification informing you of any status changes.</p>
         % elif workflow == 'post-moderation':
-        ${reviewable.provider.name} has chosen to moderate their submissions using a post-moderation workflow, which means your submission is public and discoverable, while still pending acceptance by a moderator. You will receive a separate notification informing you of any status changes.
+            <p>${reviewable.provider.name} has chosen to moderate their submissions using a post-moderation workflow, which means your submission is public and discoverable, while still pending acceptance by a moderator. You will receive a separate notification informing you of any status changes.</p>
         % endif
-        <br><br>
-        You will ${'not receive ' if no_future_emails else 'be automatically subscribed to '}future notification emails for this ${reviewable.provider.preprint_word}. Each ${reviewable.provider.preprint_word} is associated with a project on the Open Science Framework for managing the ${reviewable.provider.preprint_word}. To change your email notification preferences, visit your <a href="${domain + 'settings/notifications/'}">project user settings</a>.
-        <br><br>
-        If you have been erroneously associated with "${reviewable.node.title}", then you may visit the project's "Contributors" page and remove yourself as a contributor.
-        <br><br>
-        For more information about ${reviewable.provider.name}, visit <a href="${provider_url}">${provider_url}</a> to learn more. To learn about the Open Science Framework, visit <a href="https://osf.io/">https://osf.io/</a>.
-        <br><br>
-        For questions regarding submission criteria, please email ${provider_contact_email}
-        <br><br>
+        <p>You will ${'not receive ' if no_future_emails else 'be automatically subscribed to '}future notification emails for this ${reviewable.provider.preprint_word}. Each ${reviewable.provider.preprint_word} is associated with a project on the Open Science Framework for managing the ${reviewable.provider.preprint_word}. To change your email notification preferences, visit your <a href="${domain + 'settings/notifications/'}">project user settings</a>.</p>
+        <p>If you have been erroneously associated with "${reviewable.node.title}", then you may visit the project's "Contributors" page and remove yourself as a contributor.</p>
+        <p>For more information about ${reviewable.provider.name}, visit <a href="${provider_url}">${provider_url}</a> to learn more. To learn about the Open Science Framework, visit <a href="https://osf.io/">https://osf.io/</a>.</p>
+        <p>For questions regarding submission criteria, please email ${provider_contact_email}</p>
         <br>
-        Sincerely,<br>
+        Sincerely,
+        <br>
         Your ${reviewable.provider.name} and OSF teams
         <br><br>
         Center for Open Science<br>

--- a/website/templates/emails/reviews_submission_status.html.mako
+++ b/website/templates/emails/reviews_submission_status.html.mako
@@ -1,22 +1,16 @@
 ## -*- coding: utf-8 -*-
 <div style="margin: 40px;">
-    <br>
-    Hello ${user.fullname},
-    <br><br>
+    <p>Hello ${user.fullname},</p>
     % if workflow == 'pre-moderation':
-    Your submission "${reviewable.node.title}", submitted to ${reviewable.provider.name} has ${'not been accepted. You may edit the '+ reviewable.provider.preprint_word+ ' and resubmit, at which time it will becoming pending moderation.' if is_rejected else 'been accepted by the moderator and is now discoverable to others.'}
+        <p>Your submission "${reviewable.node.title}", submitted to ${reviewable.provider.name} has ${'not been accepted. You may edit the '+ reviewable.provider.preprint_word+ ' and resubmit, at which time it will becoming pending moderation.' if is_rejected else 'been accepted by the moderator and is now discoverable to others.'}</p>
     % elif workflow == 'post-moderation':
-    Your submission "${reviewable.node.title}", submitted to ${reviewable.provider.name} has ${'not been accepted and will be made private and not discoverable by others. You may edit the '+ reviewable.provider.preprint_word+ ' and contact the moderator at '+ provider_support_email +' to resubmit.' if is_rejected else 'been accepted by the moderator and remains discoverable to others. '} ${'The moderator has also provided a comment that is only visible to contributors of the '+ reviewable.provider.preprint_word+ ', and not to others. ' if notify_comment else ''}
+        <p>Your submission "${reviewable.node.title}", submitted to ${reviewable.provider.name} has ${'not been accepted and will be made private and not discoverable by others. You may edit the '+ reviewable.provider.preprint_word+ ' and contact the moderator at '+ provider_support_email +' to resubmit.' if is_rejected else 'been accepted by the moderator and remains discoverable to others. '} ${'The moderator has also provided a comment that is only visible to contributors of the '+ reviewable.provider.preprint_word+ ', and not to others. ' if notify_comment else ''}</p>
     % endif
-    <br><br>
-    You will ${'not receive ' if no_future_emails else 'be automatically subscribed to '}future notification emails for this ${reviewable.provider.preprint_word}. Each ${reviewable.provider.preprint_word} is associated with a project on the Open Science Framework for managing the ${reviewable.provider.preprint_word}. To change your email notification preferences, visit your <a href="${domain + 'settings/notifications/'}">project user settings</a>.
-    <br><br>
-    If you have been erroneously associated with "${reviewable.node.title}", then you may visit the project's "Contributors" page and remove yourself as a contributor.
-    <br><br>
-    For more information about ${reviewable.provider.name}, visit <a href="${provider_url}">${provider_url}</a> to learn more. To learn about the Open Science Framework, visit <a href="https://osf.io/">https://osf.io/</a>.
-    <br><br>
-    For questions regarding submission criteria, please email ${provider_contact_email}
-    <br><br><br>
+    <p>You will ${'not receive ' if no_future_emails else 'be automatically subscribed to '}future notification emails for this ${reviewable.provider.preprint_word}. Each ${reviewable.provider.preprint_word} is associated with a project on the Open Science Framework for managing the ${reviewable.provider.preprint_word}. To change your email notification preferences, visit your <a href="${domain + 'settings/notifications/'}">project user settings</a>.</p>
+    <p>If you have been erroneously associated with "${reviewable.node.title}", then you may visit the project's "Contributors" page and remove yourself as a contributor.</p>
+    <p>For more information about ${reviewable.provider.name}, visit <a href="${provider_url}">${provider_url}</a> to learn more. To learn about the Open Science Framework, visit <a href="https://osf.io/">https://osf.io/</a>.</p>
+    <p>For questions regarding submission criteria, please email ${provider_contact_email}</p>
+    <br>
     Sincerely,
     <br>
     Your ${reviewable.provider.name} and OSF teams

--- a/website/templates/emails/reviews_submission_status.html.mako
+++ b/website/templates/emails/reviews_submission_status.html.mako
@@ -14,9 +14,9 @@
     Sincerely,
     <br>
     Your ${reviewable.provider.name} and OSF teams
-    <br><br>
+    <p>
     Center for Open Science<br>
     210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-    <br><br>
+    </p>
     <a href="https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md">Privacy Policy</a>
 </div>

--- a/website/templates/emails/reviews_submission_status.html.mako
+++ b/website/templates/emails/reviews_submission_status.html.mako
@@ -1,31 +1,28 @@
 ## -*- coding: utf-8 -*-
-<%inherit file="notify_base.mako"/>
-<%def name="content()">
-    <div style="margin: 40px;">
-        <br>
-        Hello ${user.fullname},
-        <br><br>
-        % if workflow == 'pre-moderation':
-        Your submission "${reviewable.node.title}", submitted to ${reviewable.provider.name} has ${'not been accepted. You may edit the '+ reviewable.provider.preprint_word+ ' and resubmit, at which time it will becoming pending moderation.' if is_rejected else 'been accepted by the moderator and is now discoverable to others.'}
-        % elif workflow == 'post-moderation':
-        Your submission "${reviewable.node.title}", submitted to ${reviewable.provider.name} has ${'not been accepted and will be made private and not discoverable by others. You may edit the '+ reviewable.provider.preprint_word+ ' and contact the moderator at '+ provider_support_email +' to resubmit.' if is_rejected else 'been accepted by the moderator and remains discoverable to others. '} ${'The moderator has also provided a comment that is only visible to contributors of the '+ reviewable.provider.preprint_word+ ', and not to others. ' if notify_comment else ''}
-        % endif
-        <br><br>
-        You will ${'not receive ' if no_future_emails else 'be automatically subscribed to '}future notification emails for this ${reviewable.provider.preprint_word}. Each ${reviewable.provider.preprint_word} is associated with a project on the Open Science Framework for managing the ${reviewable.provider.preprint_word}. To change your email notification preferences, visit your <a href="${domain + 'settings/notifications/'}">project user settings</a>.
-        <br><br>
-        If you have been erroneously associated with "${reviewable.node.title}", then you may visit the project's "Contributors" page and remove yourself as a contributor.
-        <br><br>
-        For more information about ${reviewable.provider.name}, visit <a href="${provider_url}">${provider_url}</a> to learn more. To learn about the Open Science Framework, visit <a href="https://osf.io/">https://osf.io/</a>.
-        <br><br>
-        For questions regarding submission criteria, please email ${provider_contact_email}
-        <br><br><br>
-        Sincerely,
-        <br>
-        Your ${reviewable.provider.name} and OSF teams
-        <br><br>
-        Center for Open Science<br>
-        210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-        <br><br>
-        <a href="https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md">Privacy Policy</a>
-    </div>
-</%def>
+<div style="margin: 40px;">
+    <br>
+    Hello ${user.fullname},
+    <br><br>
+    % if workflow == 'pre-moderation':
+    Your submission "${reviewable.node.title}", submitted to ${reviewable.provider.name} has ${'not been accepted. You may edit the '+ reviewable.provider.preprint_word+ ' and resubmit, at which time it will becoming pending moderation.' if is_rejected else 'been accepted by the moderator and is now discoverable to others.'}
+    % elif workflow == 'post-moderation':
+    Your submission "${reviewable.node.title}", submitted to ${reviewable.provider.name} has ${'not been accepted and will be made private and not discoverable by others. You may edit the '+ reviewable.provider.preprint_word+ ' and contact the moderator at '+ provider_support_email +' to resubmit.' if is_rejected else 'been accepted by the moderator and remains discoverable to others. '} ${'The moderator has also provided a comment that is only visible to contributors of the '+ reviewable.provider.preprint_word+ ', and not to others. ' if notify_comment else ''}
+    % endif
+    <br><br>
+    You will ${'not receive ' if no_future_emails else 'be automatically subscribed to '}future notification emails for this ${reviewable.provider.preprint_word}. Each ${reviewable.provider.preprint_word} is associated with a project on the Open Science Framework for managing the ${reviewable.provider.preprint_word}. To change your email notification preferences, visit your <a href="${domain + 'settings/notifications/'}">project user settings</a>.
+    <br><br>
+    If you have been erroneously associated with "${reviewable.node.title}", then you may visit the project's "Contributors" page and remove yourself as a contributor.
+    <br><br>
+    For more information about ${reviewable.provider.name}, visit <a href="${provider_url}">${provider_url}</a> to learn more. To learn about the Open Science Framework, visit <a href="https://osf.io/">https://osf.io/</a>.
+    <br><br>
+    For questions regarding submission criteria, please email ${provider_contact_email}
+    <br><br><br>
+    Sincerely,
+    <br>
+    Your ${reviewable.provider.name} and OSF teams
+    <br><br>
+    Center for Open Science<br>
+    210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
+    <br><br>
+    <a href="https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md">Privacy Policy</a>
+</div>

--- a/website/templates/emails/reviews_update_comment.html.mako
+++ b/website/templates/emails/reviews_update_comment.html.mako
@@ -1,26 +1,23 @@
 ## -*- coding: utf-8 -*-
-<%inherit file="notify_base.mako"/>
-<%def name="content()">
-    <div style="margin: 40px;">
-        Hello ${user.fullname},
-        <br><br>
-        Your ${reviewable.provider.preprint_word} "${reviewable.node.title}" has an updated comment by the moderator. To view the comment, go to your <a href="${reviewable.absolute_url}">${reviewable.provider.preprint_word}</a>.
-        <br><br>
-        You will ${'not receive ' if no_future_emails else 'be automatically subscribed to '}future notification emails for this ${reviewable.provider.preprint_word}. Each ${reviewable.provider.preprint_word} is associated with a project on the Open Science Framework for managing the ${reviewable.provider.preprint_word}. To change your email notification preferences, visit your <a href="${domain + 'settings/notifications/'}">project user settings</a>.
-        <br><br>
-        If you have been erroneously associated with "${reviewable.node.title}", then you may visit the project's "Contributors" page and remove yourself as a contributor.
-        <br><br>
-        For more information about ${reviewable.provider.name}, visit <a href="${provider_url}">${provider_url}</a> to learn more. To learn about the Open Science Framework, visit <a href="https://osf.io/">https://osf.io/</a>.
-        <br><br>
-        For questions regarding submission criteria, please email ${provider_contact_email}
-        <br><br><br>
-        Sincerely,
-        <br>
-        Your ${reviewable.provider.name} and OSF teams
-        <br><br>
-        Center for Open Science<br>
-        210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-        <br><br>
-        <a href="https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md">Privacy Policy</a>
-    </div>
-</%def>
+<div style="margin: 40px;">
+    Hello ${user.fullname},
+    <br><br>
+    Your ${reviewable.provider.preprint_word} "${reviewable.node.title}" has an updated comment by the moderator. To view the comment, go to your <a href="${reviewable.absolute_url}">${reviewable.provider.preprint_word}</a>.
+    <br><br>
+    You will ${'not receive ' if no_future_emails else 'be automatically subscribed to '}future notification emails for this ${reviewable.provider.preprint_word}. Each ${reviewable.provider.preprint_word} is associated with a project on the Open Science Framework for managing the ${reviewable.provider.preprint_word}. To change your email notification preferences, visit your <a href="${domain + 'settings/notifications/'}">project user settings</a>.
+    <br><br>
+    If you have been erroneously associated with "${reviewable.node.title}", then you may visit the project's "Contributors" page and remove yourself as a contributor.
+    <br><br>
+    For more information about ${reviewable.provider.name}, visit <a href="${provider_url}">${provider_url}</a> to learn more. To learn about the Open Science Framework, visit <a href="https://osf.io/">https://osf.io/</a>.
+    <br><br>
+    For questions regarding submission criteria, please email ${provider_contact_email}
+    <br><br><br>
+    Sincerely,
+    <br>
+    Your ${reviewable.provider.name} and OSF teams
+    <br><br>
+    Center for Open Science<br>
+    210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
+    <br><br>
+    <a href="https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md">Privacy Policy</a>
+</div>

--- a/website/templates/emails/reviews_update_comment.html.mako
+++ b/website/templates/emails/reviews_update_comment.html.mako
@@ -1,17 +1,12 @@
 ## -*- coding: utf-8 -*-
 <div style="margin: 40px;">
-    Hello ${user.fullname},
-    <br><br>
-    Your ${reviewable.provider.preprint_word} "${reviewable.node.title}" has an updated comment by the moderator. To view the comment, go to your <a href="${reviewable.absolute_url}">${reviewable.provider.preprint_word}</a>.
-    <br><br>
-    You will ${'not receive ' if no_future_emails else 'be automatically subscribed to '}future notification emails for this ${reviewable.provider.preprint_word}. Each ${reviewable.provider.preprint_word} is associated with a project on the Open Science Framework for managing the ${reviewable.provider.preprint_word}. To change your email notification preferences, visit your <a href="${domain + 'settings/notifications/'}">project user settings</a>.
-    <br><br>
-    If you have been erroneously associated with "${reviewable.node.title}", then you may visit the project's "Contributors" page and remove yourself as a contributor.
-    <br><br>
-    For more information about ${reviewable.provider.name}, visit <a href="${provider_url}">${provider_url}</a> to learn more. To learn about the Open Science Framework, visit <a href="https://osf.io/">https://osf.io/</a>.
-    <br><br>
-    For questions regarding submission criteria, please email ${provider_contact_email}
-    <br><br><br>
+    <p>Hello ${user.fullname},</p>
+    <p>Your ${reviewable.provider.preprint_word} "${reviewable.node.title}" has an updated comment by the moderator. To view the comment, go to your <a href="${reviewable.absolute_url}">${reviewable.provider.preprint_word}</a>.</p>
+    <p>You will ${'not receive ' if no_future_emails else 'be automatically subscribed to '}future notification emails for this ${reviewable.provider.preprint_word}. Each ${reviewable.provider.preprint_word} is associated with a project on the Open Science Framework for managing the ${reviewable.provider.preprint_word}. To change your email notification preferences, visit your <a href="${domain + 'settings/notifications/'}">project user settings</a>.</p>
+    <p>If you have been erroneously associated with "${reviewable.node.title}", then you may visit the project's "Contributors" page and remove yourself as a contributor.</p>
+    <p>For more information about ${reviewable.provider.name}, visit <a href="${provider_url}">${provider_url}</a> to learn more. To learn about the Open Science Framework, visit <a href="https://osf.io/">https://osf.io/</a>.</p>
+    <p>For questions regarding submission criteria, please email ${provider_contact_email}</p>
+    <br>
     Sincerely,
     <br>
     Your ${reviewable.provider.name} and OSF teams

--- a/website/templates/emails/reviews_update_comment.html.mako
+++ b/website/templates/emails/reviews_update_comment.html.mako
@@ -10,9 +10,9 @@
     Sincerely,
     <br>
     Your ${reviewable.provider.name} and OSF teams
-    <br><br>
+    <p>
     Center for Open Science<br>
     210 Ridge McIntire Road, Suite 500, Charlottesville, VA 22903-5083
-    <br><br>
+    </p>
     <a href="https://github.com/CenterForOpenScience/cos.io/blob/master/PRIVACY_POLICY.md">Privacy Policy</a>
 </div>


### PR DESCRIPTION
## Purpose

Update HTML templates for update comments and status change notifications. 
## Changes

Remove inheritance from notify_base.mako which has the base template (contains header and footer).  

### Reason 
Those two types of notifications are stored into the notification digest and later use the digest.html.mako, which already has both the header and footer, causing duplication in content. 
New submission notification is not stored in the notification digest (not using the digest.html.mako) template, therefore the inheritance from notify_base.mako is kept.

## Demo
https://jsfiddle.net/sherifvt/yvhpx9d3/
https://jsfiddle.net/sherifvt/3b4rap7y/

## Side effects

<!--Any possible side effects? -->


## Ticket
https://openscience.atlassian.net/browse/MOD-132
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
