### PR TITLE
Move jquery and jquery-ui back to regular bower dependencies so that …

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,8 @@
     "bootstrap": "^3.3.7",
     "ace-builds": "1.1.8",
     "bootstrap.growl": "2.0.0",
+    "jquery": "^3.2.1",
+    "jquery-ui": "~1.12.1",
     "jquery.tagsinput": "1.3.2",
     "jquery-autosize": "1.18.15",
     "jquery-qrcode": "https://github.com/CenterForOpenScience/jquery-qrcode.git#5edbf81811b128a6df62bee4cff37892de3ac894",
@@ -22,8 +24,6 @@
     "jquery": "^3.2.1"
   },
   "devDependencies": {
-    "jquery": "^3.2.1",
-    "jquery-ui": "~1.12.1",
     "MathJax": "2.7.2"
   }
 }


### PR DESCRIPTION
…they get bundled

Fixes issue introduced in #7784 