### PR TITLE
[MOD-110][Fix] Allow filtering preprints by the node's is_public

### DIFF
--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -65,6 +65,7 @@ class PreprintSerializer(JSONAPISerializer):
         'is_published',
         'subjects',
         'reviews_state',
+        'node_is_public',
     ])
 
     id = IDField(source='_id', read_only=True)
@@ -79,6 +80,7 @@ class PreprintSerializer(JSONAPISerializer):
     title = ser.CharField(source='node.title', required=False)
     description = ser.CharField(required=False, allow_blank=True, allow_null=True, source='node.description')
     tags = JSONAPIListField(child=NodeTagField(), required=False, source='node.tags')
+    node_is_public = ser.BooleanField(read_only=True, source='node__is_public')
 
     contributors = RelationshipField(
         related_view='nodes:node-contributors',

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -848,7 +848,7 @@ class UserActionList(JSONAPIBaseView, generics.ListAPIView, ListFilterMixin, Use
     # overrides ListFilterMixin
     def get_default_queryset(self):
         provider_queryset = get_objects_for_user(self.get_user(), 'view_actions', PreprintProvider)
-        return get_actions_queryset().filter(target__provider__in=provider_queryset)
+        return get_actions_queryset().filter(target__node__is_public=True, target__provider__in=provider_queryset)
 
     # overrides ListAPIView
     def get_queryset(self):

--- a/api_tests/preprints/filters/test_filters.py
+++ b/api_tests/preprints/filters/test_filters.py
@@ -229,13 +229,15 @@ class PreprintsListFilteringMixin(object):
         preprint_three.node.is_public = True
         preprint_three.node.save()
 
+        preprints = [preprint_one, preprint_two, preprint_three]
+
         res = app.get('{}{}'.format(node_is_public_url, 'false'), auth=user.auth)
-        expected = set([preprint_one._id])
+        expected = set([p._id for p in preprints if not p.node.is_public])
         actual = set([preprint['id'] for preprint in res.json['data']])
         assert expected == actual
 
         res = app.get('{}{}'.format(node_is_public_url, 'true'), auth=user.auth)
-        expected = set([preprint_two._id, preprint_three._id])
+        expected = set([p._id for p in preprints if p.node.is_public])
         actual = set([preprint['id'] for preprint in res.json['data']])
         assert expected == actual
 

--- a/api_tests/reviews/mixins/filter_mixins.py
+++ b/api_tests/reviews/mixins/filter_mixins.py
@@ -55,8 +55,8 @@ class ActionFilterMixin(object):
     @pytest.fixture()
     def all_actions(self, providers):
         actions = []
-        for p in providers:
-            preprint = PreprintFactory(provider=p, project=ProjectFactory(is_public=True))
+        for provider in providers:
+            preprint = PreprintFactory(provider=provider, project=ProjectFactory(is_public=True))
             for _ in range(5):
                 actions.append(ActionFactory(target=preprint))
         return actions

--- a/api_tests/reviews/mixins/filter_mixins.py
+++ b/api_tests/reviews/mixins/filter_mixins.py
@@ -8,6 +8,7 @@ from osf_tests.factories import (
     AuthUserFactory,
     PreprintFactory,
     PreprintProviderFactory,
+    ProjectFactory,
 )
 from reviews.permissions import GroupHelper
 
@@ -55,7 +56,7 @@ class ActionFilterMixin(object):
     def all_actions(self, providers):
         actions = []
         for p in providers:
-            preprint = PreprintFactory(provider=p)
+            preprint = PreprintFactory(provider=p, project=ProjectFactory(is_public=True))
             for _ in range(5):
                 actions.append(ActionFactory(target=preprint))
         return actions
@@ -67,7 +68,7 @@ class ActionFilterMixin(object):
     @pytest.fixture()
     def expected_actions(self, all_actions, allowed_providers):
         provider_ids = set([p.id for p in allowed_providers])
-        return [l for l in all_actions if l.target.provider_id in provider_ids]
+        return [a for a in all_actions if a.target.provider_id in provider_ids]
 
     @pytest.fixture()
     def user(self, allowed_providers):

--- a/api_tests/users/views/test_user_actions.py
+++ b/api_tests/users/views/test_user_actions.py
@@ -21,6 +21,14 @@ class TestActionFilters(ActionFilterMixin):
     def url(self):
         return '/{}users/me/actions/'.format(API_BASE)
 
+    @pytest.fixture()
+    def expected_actions(self, all_actions, allowed_providers):
+        expected = super(TestActionFilters, self).expected_actions(all_actions, allowed_providers)
+        node = expected[0].target.node
+        node.is_public = False
+        node.save()
+        return [a for a in expected if a.target.node.is_public]
+
     def test_no_permission(self, app, url, expected_actions):
         res = app.get(url, expect_errors=True)
         assert res.status_code == 401

--- a/api_tests/users/views/test_user_actions.py
+++ b/api_tests/users/views/test_user_actions.py
@@ -24,7 +24,7 @@ class TestActionFilters(ActionFilterMixin):
     @pytest.fixture()
     def expected_actions(self, all_actions, allowed_providers):
         actions = super(TestActionFilters, self).expected_actions(all_actions, allowed_providers)
-        node = expected[0].target.node
+        node = actions[0].target.node
         node.is_public = False
         node.save()
         return [a for a in actions if a.target.node.is_public]

--- a/api_tests/users/views/test_user_actions.py
+++ b/api_tests/users/views/test_user_actions.py
@@ -23,11 +23,11 @@ class TestActionFilters(ActionFilterMixin):
 
     @pytest.fixture()
     def expected_actions(self, all_actions, allowed_providers):
-        expected = super(TestActionFilters, self).expected_actions(all_actions, allowed_providers)
+        actions = super(TestActionFilters, self).expected_actions(all_actions, allowed_providers)
         node = expected[0].target.node
         node.is_public = False
         node.save()
-        return [a for a in expected if a.target.node.is_public]
+        return [a for a in actions if a.target.node.is_public]
 
     def test_no_permission(self, app, url, expected_actions):
         res = app.get(url, expect_errors=True)


### PR DESCRIPTION


<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Allow excluding preprints with private nodes from the reviews UI.
<!-- Describe the purpose of your changes -->

## Changes
Allow filtering with `filter[node_is_public]=true` on all preprint list endpoints.

Exclude actions on preprints with private nodes from `/users/me/actions/`

<!-- Briefly describe or list your changes  -->

## Side effects
None
<!--Any possible side effects? -->


## Ticket
https://openscience.atlassian.net/browse/MOD-110
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
