### PR TITLE
feature/fix admin preprint provider logos [OSF-8704]

### DIFF
--- a/admin/preprint_providers/views.py
+++ b/admin/preprint_providers/views.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import json
+import urlparse
 
 from django.core import serializers
 from django.core.urlresolvers import reverse_lazy
@@ -10,6 +11,7 @@ from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.forms.models import model_to_dict
 from django.shortcuts import redirect
 
+from website import settings as web_settings
 from admin.base import settings
 from admin.base.forms import ImportFileForm
 from admin.preprint_providers.forms import PreprintProviderForm
@@ -41,7 +43,6 @@ class PreprintProviderList(PermissionRequiredMixin, ListView):
         return {
             'preprint_providers': query_set,
             'page': page,
-            'logohost': settings.OSF_URL
         }
 
 
@@ -114,10 +115,11 @@ class PreprintProviderDisplay(PermissionRequiredMixin, DetailView):
 
         subject_html += '</ul>'
         preprint_provider_attributes['subjects_acceptable'] = subject_html
+        preprint_provider_attributes['lower_name'] = preprint_provider._id
 
         kwargs['preprint_provider'] = preprint_provider_attributes
         kwargs['subject_ids'] = list(subject_ids)
-        kwargs['logohost'] = settings.OSF_URL
+        kwargs['logohost'] = urlparse.urljoin(web_settings.DOMAIN, web_settings.PREPRINTS_ASSETS)
         fields = model_to_dict(preprint_provider)
         fields['toplevel_subjects'] = list(subject_ids)
         fields['subjects_chosen'] = ', '.join(str(i) for i in subject_ids)

--- a/admin/templates/preprint_providers/detail.html
+++ b/admin/templates/preprint_providers/detail.html
@@ -22,7 +22,7 @@
         </div>
         <div class="row">
             <div class="col-md-12 text-center">
-                <img class="institution-logo" src="{{ logohost }}/static/img/preprint_providers/{{ preprint_provider.logo_name }}">
+                <img class="institution-logo" src="{{logohost}}{{preprint_provider.lower_name}}/square_color_no_transparent.png">
                 <h2>{{ preprint_provider.name }}</h2>
             </div>
         </div>

--- a/admin/templates/preprint_providers/list.html
+++ b/admin/templates/preprint_providers/list.html
@@ -16,7 +16,6 @@
     <table class="table table-striped table-hover table-responsive">
     <thead>
         <tr>
-            <th>Logo</th>
             <th>Name</th>
             <th>Description</th>
         </tr>
@@ -24,11 +23,6 @@
     <tbody>
     {% for preprint_provider in preprint_providers %}
     <tr>
-        <td>
-            <a href="{% url 'preprint_providers:detail' preprint_provider_id=preprint_provider.id %}">
-                <img class="institution-logo" src="{{ logohost }}/static/img/preprint_providers/{{preprint_provider.logo_name }}">
-            </a>
-        </td>
         <td><a href="{% url 'preprint_providers:detail' preprint_provider_id=preprint_provider.id %}">{{ preprint_provider.name }}</a></td>
         <td>{{ preprint_provider.description | safe}}</td>
     </tr>


### PR DESCRIPTION
## Purpose
The logo links for preprint providers were broken in the admin app.

## Changes
Removed the provider logos from the preprint provider list view.
Fixed the link for the preprint provider detail view.

## Side effects

None

## Tests
None needed, purely frontend.

## Ticket

https://openscience.atlassian.net/browse/OSF-8704


<img width="1166" alt="screen shot 2017-10-10 at 3 47 08 pm" src="https://user-images.githubusercontent.com/7839433/31407268-51a0252a-add2-11e7-9e8d-c3c8af8caefd.png">
<img width="961" alt="screen shot 2017-10-10 at 3 46 51 pm" src="https://user-images.githubusercontent.com/7839433/31407275-58d67b64-add2-11e7-8069-9bff1dd8f6b5.png">
