### PR TITLE
[MOD-138][Improvement] Allow contributors to see unpublished preprints

### DIFF
--- a/api/base/filters.py
+++ b/api/base/filters.py
@@ -505,10 +505,8 @@ class PreprintFilterMixin(ListFilterMixin):
             admin_user_query = Q(node__contributor__user_id=auth_user.id, node__contributor__admin=True)
             reviews_user_query = Q(node__is_public=True, provider__in=get_objects_for_user(auth_user, 'view_submissions', PreprintProvider))
             if allow_contribs:
-                contrib_query_base = Q(node__contributor__user_id=auth_user.id, node__contributor__read=True)
-                not_reviews_contrib_query = contrib_query_base & Q(is_published=True)
-                reviews_contrib_query = contrib_query_base & (Q(provider__reviews_workflow__isnull=False) & ~Q(reviews_state=States.INITIAL.value))
-                query = default_query & (no_user_query | not_reviews_contrib_query | reviews_contrib_query | admin_user_query | reviews_user_query)
+                contrib_user_query = ~Q(reviews_state=States.INITIAL.value) & Q(node__contributor__user_id=auth_user.id, node__contributor__read=True)
+                query = default_query & (no_user_query | contrib_user_query | admin_user_query | reviews_user_query)
             else:
                 query = default_query & (no_user_query | admin_user_query | reviews_user_query)
         else:

--- a/api/preprints/permissions.py
+++ b/api/preprints/permissions.py
@@ -17,9 +17,10 @@ class PreprintPublishedOrAdmin(permissions.BasePermission):
             if auth.user is None:
                 return obj.verified_publishable
             else:
+                user_has_permissions = obj.verified_publishable or (node.is_public and auth.user.has_perm('view_submissions', obj.provider)) or node.has_permission(auth.user, osf_permissions.ADMIN)
                 if obj.provider.reviews_workflow:
-                    return obj.verified_publishable or (node.is_public and auth.user.has_perm('view_submissions', obj.provider)) or node.has_permission(auth.user, osf_permissions.ADMIN) or (node.is_contributor(auth.user) and obj.reviews_state != 'initial')
-                return obj.verified_publishable or (node.is_public and auth.user.has_perm('view_submissions', obj.provider)) or node.has_permission(auth.user, osf_permissions.ADMIN)
+                    return user_has_permissions or (node.is_contributor(auth.user) and obj.reviews_state != 'initial')
+                return user_has_permissions
         else:
             if not node.has_permission(auth.user, osf_permissions.ADMIN):
                 raise exceptions.PermissionDenied(detail='User must be an admin to update a preprint.')

--- a/api/preprints/permissions.py
+++ b/api/preprints/permissions.py
@@ -5,6 +5,7 @@ from rest_framework import exceptions
 from api.base.utils import get_user_auth
 from osf.models import PreprintService
 from website.util import permissions as osf_permissions
+from reviews.workflow import States
 
 
 class PreprintPublishedOrAdmin(permissions.BasePermission):
@@ -19,7 +20,7 @@ class PreprintPublishedOrAdmin(permissions.BasePermission):
             else:
                 user_has_permissions = obj.verified_publishable or (node.is_public and auth.user.has_perm('view_submissions', obj.provider)) or node.has_permission(auth.user, osf_permissions.ADMIN)
                 if obj.provider.reviews_workflow:
-                    return user_has_permissions or (node.is_contributor(auth.user) and obj.reviews_state != 'initial')
+                    return user_has_permissions or (node.is_contributor(auth.user) and obj.reviews_state != States.INITIAL.value)
                 return user_has_permissions
         else:
             if not node.has_permission(auth.user, osf_permissions.ADMIN):

--- a/api/preprints/permissions.py
+++ b/api/preprints/permissions.py
@@ -17,7 +17,9 @@ class PreprintPublishedOrAdmin(permissions.BasePermission):
             if auth.user is None:
                 return obj.verified_publishable
             else:
-                return obj.verified_publishable or (node.is_public and auth.user.has_perm('view_submissions', obj.provider)) or node.is_contributor(auth.user)
+                if obj.provider.reviews_workflow:
+                    return obj.verified_publishable or (node.is_public and auth.user.has_perm('view_submissions', obj.provider)) or node.has_permission(auth.user, osf_permissions.ADMIN) or (node.is_contributor(auth.user) and obj.reviews_state != 'initial')
+                return obj.verified_publishable or (node.is_public and auth.user.has_perm('view_submissions', obj.provider)) or node.has_permission(auth.user, osf_permissions.ADMIN)
         else:
             if not node.has_permission(auth.user, osf_permissions.ADMIN):
                 raise exceptions.PermissionDenied(detail='User must be an admin to update a preprint.')

--- a/api/preprints/permissions.py
+++ b/api/preprints/permissions.py
@@ -17,7 +17,7 @@ class PreprintPublishedOrAdmin(permissions.BasePermission):
             if auth.user is None:
                 return obj.verified_publishable
             else:
-                return obj.verified_publishable or (node.is_public and auth.user.has_perm('view_submissions', obj.provider)) or node.has_permission(auth.user, osf_permissions.ADMIN)
+                return obj.verified_publishable or (node.is_public and auth.user.has_perm('view_submissions', obj.provider)) or node.is_contributor(auth.user)
         else:
             if not node.has_permission(auth.user, osf_permissions.ADMIN):
                 raise exceptions.PermissionDenied(detail='User must be an admin to update a preprint.')

--- a/api_tests/nodes/views/test_node_preprints.py
+++ b/api_tests/nodes/views/test_node_preprints.py
@@ -8,10 +8,10 @@ from api_tests.preprints.views.test_preprint_list_mixin import PreprintIsPublish
 from framework.auth.core import Auth
 from osf.models import PreprintService
 from osf_tests.factories import (
-    PreprintFactory, 
-    AuthUserFactory, 
-    ProjectFactory, 
-    SubjectFactory, 
+    PreprintFactory,
+    AuthUserFactory,
+    ProjectFactory,
+    SubjectFactory,
     PreprintProviderFactory,
 )
 from website.util import permissions
@@ -82,6 +82,24 @@ class TestNodePreprintIsPublishedList(PreprintIsPublishedListMixin):
     @pytest.fixture()
     def url(self, project_published):
         return '/{}nodes/{}/preprints/?version=2.2&'.format(API_BASE, project_published._id)
+
+    @pytest.fixture()
+    def preprint_unpublished(self, user_admin_contrib, provider_one, project_public, subject):
+        return PreprintFactory(creator=user_admin_contrib, filename='mgla.pdf', provider=provider_one, subjects=[[subject._id]], project=project_public, is_published=False)
+
+    def test_unpublished_visible_to_admins(self, app, user_admin_contrib, preprint_unpublished, preprint_published, url):
+        res = app.get(url, auth=user_admin_contrib.auth)
+        assert len(res.json['data']) == 2
+        assert preprint_unpublished._id in [d['id'] for d in res.json['data']]
+
+    def test_unpublished_invisible_to_write_contribs(self, app, user_write_contrib, preprint_unpublished, preprint_published, url):
+        res = app.get(url, auth=user_write_contrib.auth)
+        assert len(res.json['data']) == 1
+        assert preprint_unpublished._id not in [d['id'] for d in res.json['data']]
+
+    def test_filter_published_false_write_contrib(self, app, user_write_contrib, preprint_unpublished, url):
+        res = app.get('{}filter[is_published]=false'.format(url), auth=user_write_contrib.auth)
+        assert len(res.json['data']) == 0
 
 
 class TestNodePreprintIsValidList(PreprintIsValidListMixin):

--- a/api_tests/preprint_providers/views/test_preprint_provider_preprints_list.py
+++ b/api_tests/preprint_providers/views/test_preprint_provider_preprints_list.py
@@ -153,6 +153,24 @@ class TestPreprintProviderPreprintIsPublishedList(PreprintIsPublishedListMixin):
     def url(self, provider_one):
         return '/{}preprint_providers/{}/preprints/?version=2.2&'.format(API_BASE, provider_one._id)
 
+    @pytest.fixture()
+    def preprint_unpublished(self, user_admin_contrib, provider_one, project_public, subject):
+        return PreprintFactory(creator=user_admin_contrib, filename='mgla.pdf', provider=provider_one, subjects=[[subject._id]], project=project_public, is_published=False)
+
+    def test_unpublished_visible_to_admins(self, app, user_admin_contrib, preprint_unpublished, preprint_published, url):
+        res = app.get(url, auth=user_admin_contrib.auth)
+        assert len(res.json['data']) == 2
+        assert preprint_unpublished._id in [d['id'] for d in res.json['data']]
+
+    def test_unpublished_invisible_to_write_contribs(self, app, user_write_contrib, preprint_unpublished, preprint_published, url):
+        res = app.get(url, auth=user_write_contrib.auth)
+        assert len(res.json['data']) == 1
+        assert preprint_unpublished._id not in [d['id'] for d in res.json['data']]
+
+    def test_filter_published_false_write_contrib(self, app, user_write_contrib, preprint_unpublished, url):
+        res = app.get('{}filter[is_published]=false'.format(url), auth=user_write_contrib.auth)
+        assert len(res.json['data']) == 0
+
 class TestPreprintProviderPreprintIsValidList(PreprintIsValidListMixin):
 
     @pytest.fixture()

--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -18,6 +18,7 @@ from rest_framework import exceptions
 from tests.base import fake, capture_signals
 from website.project.signals import contributor_added
 from website.identifiers.utils import build_ezid_metadata
+from reviews.workflow import States
 
 
 def build_preprint_update_payload(node_id, attributes=None, relationships=None):
@@ -962,15 +963,15 @@ class TestReviewsPreprintDetailPermissions:
 
     @pytest.fixture()
     def unpublished_reviews_preprint(self, admin, reviews_provider, subject, public_project):
-        return PreprintFactory(creator=admin, filename='toe_socks_and_sunrises.pdf', provider=reviews_provider, subjects=[[subject._id]], project=public_project, is_published=False, reviews_state='pending')
+        return PreprintFactory(creator=admin, filename='toe_socks_and_sunrises.pdf', provider=reviews_provider, subjects=[[subject._id]], project=public_project, is_published=False, reviews_state=States.PENDING.value)
 
     @pytest.fixture()
     def unpublished_reviews_initial_preprint(self, admin, reviews_provider, subject, public_project):
-        return PreprintFactory(creator=admin, filename='toe_socks_and_sunrises.pdf', provider=reviews_provider, subjects=[[subject._id]], project=public_project, is_published=False, reviews_state='initial')
+        return PreprintFactory(creator=admin, filename='toe_socks_and_sunrises.pdf', provider=reviews_provider, subjects=[[subject._id]], project=public_project, is_published=False, reviews_state=States.INITIAL.value)
 
     @pytest.fixture()
     def private_reviews_preprint(self, admin, reviews_provider, subject, private_project):
-        return PreprintFactory(creator=admin, filename='toe_socks_and_sunsets.pdf', provider=reviews_provider, subjects=[[subject._id]], project=private_project, is_published=False, reviews_state='pending')
+        return PreprintFactory(creator=admin, filename='toe_socks_and_sunsets.pdf', provider=reviews_provider, subjects=[[subject._id]], project=private_project, is_published=False, reviews_state=States.PENDING.value)
 
     @pytest.fixture()
     def unpublished_url(self, unpublished_reviews_preprint):

--- a/api_tests/preprints/views/test_preprint_list.py
+++ b/api_tests/preprints/views/test_preprint_list.py
@@ -470,11 +470,6 @@ class TestPreprintIsPublishedList(PreprintIsPublishedListMixin):
         assert len(res.json['data']) == 1
         assert preprint_unpublished._id not in [d['id'] for d in res.json['data']]
 
-    def test_filter_published_false_admin(self, app, user_admin_contrib, preprint_unpublished, preprint_published, url):
-        res = app.get('{}filter[is_published]=false'.format(url), auth=user_admin_contrib.auth)
-        assert len(res.json['data']) == 1
-        assert preprint_unpublished._id in [d['id'] for d in res.json['data']]
-
     def test_filter_published_false_write_contrib(self, app, user_write_contrib, preprint_unpublished, url):
         res = app.get('{}filter[is_published]=false'.format(url), auth=user_write_contrib.auth)
         assert len(res.json['data']) == 0
@@ -520,11 +515,6 @@ class TestReviewsPendingPreprintIsPublishedList(PreprintIsPublishedListMixin):
     def test_unpublished_visible_to_write_contribs(self, app, user_write_contrib, preprint_unpublished, preprint_published, url):
         res = app.get(url, auth=user_write_contrib.auth)
         assert len(res.json['data']) == 2
-        assert preprint_unpublished._id in [d['id'] for d in res.json['data']]
-
-    def test_filter_published_false_admin(self, app, user_admin_contrib, preprint_unpublished, preprint_published, url):
-        res = app.get('{}filter[is_published]=false'.format(url), auth=user_admin_contrib.auth)
-        assert len(res.json['data']) == 1
         assert preprint_unpublished._id in [d['id'] for d in res.json['data']]
 
     def test_filter_published_false_write_contrib(self, app, user_write_contrib, preprint_unpublished, url):
@@ -573,11 +563,6 @@ class TestReviewsInitialPreprintIsPublishedList(PreprintIsPublishedListMixin):
         res = app.get(url, auth=user_write_contrib.auth)
         assert len(res.json['data']) == 1
         assert preprint_unpublished._id not in [d['id'] for d in res.json['data']]
-
-    def test_filter_published_false_admin(self, app, user_admin_contrib, preprint_unpublished, preprint_published, url):
-        res = app.get('{}filter[is_published]=false'.format(url), auth=user_admin_contrib.auth)
-        assert len(res.json['data']) == 1
-        assert preprint_unpublished._id in [d['id'] for d in res.json['data']]
 
     def test_filter_published_false_write_contrib(self, app, user_write_contrib, preprint_unpublished, url):
         res = app.get('{}filter[is_published]=false'.format(url), auth=user_write_contrib.auth)

--- a/api_tests/preprints/views/test_preprint_list.py
+++ b/api_tests/preprints/views/test_preprint_list.py
@@ -6,7 +6,11 @@ from addons.github.models import GithubFile
 from api.base.settings.defaults import API_BASE
 from api_tests import utils as test_utils
 from api_tests.preprints.filters.test_filters import PreprintsListFilteringMixin
-from api_tests.preprints.views.test_preprint_list_mixin import PreprintIsPublishedListMixin, PreprintIsValidListMixin
+from api_tests.preprints.views.test_preprint_list_mixin import (
+    PreprintIsPublishedListMixin,
+    PreprintListMatchesPreprintDetailMixin,
+    PreprintIsValidListMixin,
+)
 from api_tests.reviews.mixins.filter_mixins import ReviewableFilterMixin
 from framework.auth.core import Auth
 from osf.models import PreprintService, Node
@@ -20,6 +24,7 @@ from osf_tests.factories import (
 from tests.base import ApiTestCase, capture_signals
 from website.project import signals as project_signals
 from website.util import permissions
+from reviews.workflow import States
 
 def build_preprint_create_payload(node_id=None, provider_id=None, file_id=None, attrs={}):
     payload = {
@@ -450,6 +455,293 @@ class TestPreprintIsPublishedList(PreprintIsPublishedListMixin):
     @pytest.fixture()
     def url(self):
         return '/{}preprints/?version=2.2&'.format(API_BASE)
+
+    @pytest.fixture()
+    def preprint_unpublished(self, user_admin_contrib, provider_one, project_public, subject):
+        return PreprintFactory(creator=user_admin_contrib, filename='mgla.pdf', provider=provider_one, subjects=[[subject._id]], project=project_public, is_published=False)
+
+    def test_unpublished_visible_to_admins(self, app, user_admin_contrib, preprint_unpublished, preprint_published, url):
+        res = app.get(url, auth=user_admin_contrib.auth)
+        assert len(res.json['data']) == 2
+        assert preprint_unpublished._id in [d['id'] for d in res.json['data']]
+
+    def test_unpublished_invisible_to_write_contribs(self, app, user_write_contrib, preprint_unpublished, preprint_published, url):
+        res = app.get(url, auth=user_write_contrib.auth)
+        assert len(res.json['data']) == 1
+        assert preprint_unpublished._id not in [d['id'] for d in res.json['data']]
+
+    def test_filter_published_false_admin(self, app, user_admin_contrib, preprint_unpublished, preprint_published, url):
+        res = app.get('{}filter[is_published]=false'.format(url), auth=user_admin_contrib.auth)
+        assert len(res.json['data']) == 1
+        assert preprint_unpublished._id in [d['id'] for d in res.json['data']]
+
+    def test_filter_published_false_write_contrib(self, app, user_write_contrib, preprint_unpublished, url):
+        res = app.get('{}filter[is_published]=false'.format(url), auth=user_write_contrib.auth)
+        assert len(res.json['data']) == 0
+
+
+class TestReviewsPendingPreprintIsPublishedList(PreprintIsPublishedListMixin):
+
+    @pytest.fixture()
+    def user_admin_contrib(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def provider_one(self):
+        return PreprintProviderFactory(reviews_workflow='pre-moderation')
+
+    @pytest.fixture()
+    def provider_two(self, provider_one):
+        return provider_one
+
+    @pytest.fixture()
+    def project_public(self, user_admin_contrib, user_write_contrib):
+        project_public = ProjectFactory(creator=user_admin_contrib, is_public=True)
+        project_public.add_contributor(user_write_contrib, permissions=permissions.DEFAULT_CONTRIBUTOR_PERMISSIONS, save=True)
+        return project_public
+
+    @pytest.fixture()
+    def project_published(self, user_admin_contrib):
+        return ProjectFactory(creator=user_admin_contrib, is_public=True)
+
+    @pytest.fixture()
+    def url(self):
+        return '/{}preprints/?version=2.2&'.format(API_BASE)
+
+    @pytest.fixture()
+    def preprint_unpublished(self, user_admin_contrib, provider_one, project_public, subject):
+        return PreprintFactory(creator=user_admin_contrib, filename='mgla.pdf', provider=provider_one, subjects=[[subject._id]], project=project_public, is_published=False, reviews_state=States.PENDING.value)
+
+    def test_unpublished_visible_to_admins(self, app, user_admin_contrib, preprint_unpublished, preprint_published, url):
+        res = app.get(url, auth=user_admin_contrib.auth)
+        assert len(res.json['data']) == 2
+        assert preprint_unpublished._id in [d['id'] for d in res.json['data']]
+
+    def test_unpublished_visible_to_write_contribs(self, app, user_write_contrib, preprint_unpublished, preprint_published, url):
+        res = app.get(url, auth=user_write_contrib.auth)
+        assert len(res.json['data']) == 2
+        assert preprint_unpublished._id in [d['id'] for d in res.json['data']]
+
+    def test_filter_published_false_admin(self, app, user_admin_contrib, preprint_unpublished, preprint_published, url):
+        res = app.get('{}filter[is_published]=false'.format(url), auth=user_admin_contrib.auth)
+        assert len(res.json['data']) == 1
+        assert preprint_unpublished._id in [d['id'] for d in res.json['data']]
+
+    def test_filter_published_false_write_contrib(self, app, user_write_contrib, preprint_unpublished, url):
+        res = app.get('{}filter[is_published]=false'.format(url), auth=user_write_contrib.auth)
+        assert len(res.json['data']) == 1
+
+
+class TestReviewsInitialPreprintIsPublishedList(PreprintIsPublishedListMixin):
+
+    @pytest.fixture()
+    def user_admin_contrib(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def provider_one(self):
+        return PreprintProviderFactory(reviews_workflow='pre-moderation')
+
+    @pytest.fixture()
+    def provider_two(self, provider_one):
+        return provider_one
+
+    @pytest.fixture()
+    def project_public(self, user_admin_contrib, user_write_contrib):
+        project_public = ProjectFactory(creator=user_admin_contrib, is_public=True)
+        project_public.add_contributor(user_write_contrib, permissions=permissions.DEFAULT_CONTRIBUTOR_PERMISSIONS, save=True)
+        return project_public
+
+    @pytest.fixture()
+    def project_published(self, user_admin_contrib):
+        return ProjectFactory(creator=user_admin_contrib, is_public=True)
+
+    @pytest.fixture()
+    def url(self):
+        return '/{}preprints/?version=2.2&'.format(API_BASE)
+
+    @pytest.fixture()
+    def preprint_unpublished(self, user_admin_contrib, provider_one, project_public, subject):
+        return PreprintFactory(creator=user_admin_contrib, filename='mgla.pdf', provider=provider_one, subjects=[[subject._id]], project=project_public, is_published=False, reviews_state=States.INITIAL.value)
+
+    def test_unpublished_visible_to_admins(self, app, user_admin_contrib, preprint_unpublished, preprint_published, url):
+        res = app.get(url, auth=user_admin_contrib.auth)
+        assert len(res.json['data']) == 2
+        assert preprint_unpublished._id in [d['id'] for d in res.json['data']]
+
+    def test_unpublished_invisible_to_write_contribs(self, app, user_write_contrib, preprint_unpublished, preprint_published, url):
+        res = app.get(url, auth=user_write_contrib.auth)
+        assert len(res.json['data']) == 1
+        assert preprint_unpublished._id not in [d['id'] for d in res.json['data']]
+
+    def test_filter_published_false_admin(self, app, user_admin_contrib, preprint_unpublished, preprint_published, url):
+        res = app.get('{}filter[is_published]=false'.format(url), auth=user_admin_contrib.auth)
+        assert len(res.json['data']) == 1
+        assert preprint_unpublished._id in [d['id'] for d in res.json['data']]
+
+    def test_filter_published_false_write_contrib(self, app, user_write_contrib, preprint_unpublished, url):
+        res = app.get('{}filter[is_published]=false'.format(url), auth=user_write_contrib.auth)
+        assert len(res.json['data']) == 0
+
+
+class TestPreprintIsPublishedListMatchesDetail(PreprintListMatchesPreprintDetailMixin):
+
+    @pytest.fixture()
+    def user_admin_contrib(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def provider_one(self):
+        return PreprintProviderFactory()
+
+    @pytest.fixture()
+    def provider_two(self, provider_one):
+        return provider_one
+
+    @pytest.fixture()
+    def project_published(self, user_admin_contrib):
+        return ProjectFactory(creator=user_admin_contrib, is_public=True)
+
+    @pytest.fixture()
+    def project_public(self, user_admin_contrib, user_write_contrib):
+        project_public = ProjectFactory(creator=user_admin_contrib, is_public=True)
+        project_public.add_contributor(user_write_contrib, permissions=permissions.DEFAULT_CONTRIBUTOR_PERMISSIONS, save=True)
+        return project_public
+
+    @pytest.fixture()
+    def preprint_unpublished(self, user_admin_contrib, provider_one, project_public, subject):
+        return PreprintFactory(creator=user_admin_contrib, filename='mgla.pdf', provider=provider_one, subjects=[[subject._id]], project=project_public, is_published=False)
+
+    @pytest.fixture()
+    def list_url(self):
+        return '/{}preprints/?version=2.2&'.format(API_BASE)
+
+    @pytest.fixture()
+    def detail_url(self, preprint_unpublished):
+        return '/{}preprints/{}/'.format(API_BASE, preprint_unpublished._id)
+
+    def test_unpublished_visible_to_admins(self, app, user_admin_contrib, preprint_unpublished, preprint_published, list_url, detail_url):
+        res = app.get(list_url, auth=user_admin_contrib.auth)
+        assert len(res.json['data']) == 2
+        assert preprint_unpublished._id in [d['id'] for d in res.json['data']]
+
+        res = app.get(detail_url, auth=user_admin_contrib.auth)
+        assert res.json['data']['id'] == preprint_unpublished._id
+
+    def test_unpublished_invisible_to_write_contribs(self, app, user_write_contrib, preprint_unpublished, preprint_published, list_url, detail_url):
+        res = app.get(list_url, auth=user_write_contrib.auth)
+        assert len(res.json['data']) == 1
+        assert preprint_unpublished._id not in [d['id'] for d in res.json['data']]
+
+        res = app.get(detail_url, auth=user_write_contrib.auth, expect_errors=True)
+        assert res.status_code == 403
+
+
+class TestReviewsInitialPreprintIsPublishedListMatchesDetail(PreprintListMatchesPreprintDetailMixin):
+
+    @pytest.fixture()
+    def user_admin_contrib(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def provider_one(self):
+        return PreprintProviderFactory(reviews_workflow='pre-moderation')
+
+    @pytest.fixture()
+    def provider_two(self, provider_one):
+        return provider_one
+
+    @pytest.fixture()
+    def project_published(self, user_admin_contrib):
+        return ProjectFactory(creator=user_admin_contrib, is_public=True)
+
+    @pytest.fixture()
+    def project_public(self, user_admin_contrib, user_write_contrib):
+        project_public = ProjectFactory(creator=user_admin_contrib, is_public=True)
+        project_public.add_contributor(user_write_contrib, permissions=permissions.DEFAULT_CONTRIBUTOR_PERMISSIONS, save=True)
+        return project_public
+
+    @pytest.fixture()
+    def preprint_unpublished(self, user_admin_contrib, provider_one, project_public, subject):
+        return PreprintFactory(creator=user_admin_contrib, filename='mgla.pdf', provider=provider_one, subjects=[[subject._id]], project=project_public, is_published=False, reviews_state=States.INITIAL.value)
+
+    @pytest.fixture()
+    def list_url(self):
+        return '/{}preprints/?version=2.2&'.format(API_BASE)
+
+    @pytest.fixture()
+    def detail_url(self, preprint_unpublished):
+        return '/{}preprints/{}/'.format(API_BASE, preprint_unpublished._id)
+
+    def test_unpublished_visible_to_admins(self, app, user_admin_contrib, preprint_unpublished, preprint_published, list_url, detail_url):
+        res = app.get(list_url, auth=user_admin_contrib.auth)
+        assert len(res.json['data']) == 2
+        assert preprint_unpublished._id in [d['id'] for d in res.json['data']]
+
+        res = app.get(detail_url, auth=user_admin_contrib.auth)
+        assert res.json['data']['id'] == preprint_unpublished._id
+
+    def test_unpublished_invisible_to_write_contribs(self, app, user_write_contrib, preprint_unpublished, preprint_published, list_url, detail_url):
+        res = app.get(list_url, auth=user_write_contrib.auth)
+        assert len(res.json['data']) == 1
+        assert preprint_unpublished._id not in [d['id'] for d in res.json['data']]
+
+        res = app.get(detail_url, auth=user_write_contrib.auth, expect_errors=True)
+        assert res.status_code == 403
+
+
+class TestReviewsPendingPreprintIsPublishedListMatchesDetail(PreprintListMatchesPreprintDetailMixin):
+
+    @pytest.fixture()
+    def user_admin_contrib(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def provider_one(self):
+        return PreprintProviderFactory(reviews_workflow='pre-moderation')
+
+    @pytest.fixture()
+    def provider_two(self, provider_one):
+        return provider_one
+
+    @pytest.fixture()
+    def project_published(self, user_admin_contrib):
+        return ProjectFactory(creator=user_admin_contrib, is_public=True)
+
+    @pytest.fixture()
+    def project_public(self, user_admin_contrib, user_write_contrib):
+        project_public = ProjectFactory(creator=user_admin_contrib, is_public=True)
+        project_public.add_contributor(user_write_contrib, permissions=permissions.DEFAULT_CONTRIBUTOR_PERMISSIONS, save=True)
+        return project_public
+
+    @pytest.fixture()
+    def preprint_unpublished(self, user_admin_contrib, provider_one, project_public, subject):
+        return PreprintFactory(creator=user_admin_contrib, filename='mgla.pdf', provider=provider_one, subjects=[[subject._id]], project=project_public, is_published=False, reviews_state=States.PENDING.value)
+
+    @pytest.fixture()
+    def list_url(self):
+        return '/{}preprints/?version=2.2&'.format(API_BASE)
+
+    @pytest.fixture()
+    def detail_url(self, preprint_unpublished):
+        return '/{}preprints/{}/'.format(API_BASE, preprint_unpublished._id)
+
+    def test_unpublished_visible_to_admins(self, app, user_admin_contrib, preprint_unpublished, preprint_published, list_url, detail_url):
+        res = app.get(list_url, auth=user_admin_contrib.auth)
+        assert len(res.json['data']) == 2
+        assert preprint_unpublished._id in [d['id'] for d in res.json['data']]
+
+        res = app.get(detail_url, auth=user_admin_contrib.auth)
+        assert res.json['data']['id'] == preprint_unpublished._id
+
+    def test_unpublished_visible_to_write_contribs(self, app, user_write_contrib, preprint_unpublished, preprint_published, list_url, detail_url):
+        res = app.get(list_url, auth=user_write_contrib.auth)
+        assert len(res.json['data']) == 2
+        assert preprint_unpublished._id in [d['id'] for d in res.json['data']]
+
+        res = app.get(detail_url, auth=user_write_contrib.auth, expect_errors=True)
+        assert res.json['data']['id'] == preprint_unpublished._id
+
 
 class TestPreprintIsValidList(PreprintIsValidListMixin):
 

--- a/api_tests/preprints/views/test_preprint_list_mixin.py
+++ b/api_tests/preprints/views/test_preprint_list_mixin.py
@@ -160,6 +160,12 @@ class PreprintIsPublishedListMixin:
         res = app.get('{}filter[is_published]=false'.format(url))
         assert len(res.json['data']) == 0
 
+    def test_filter_published_false_admin(self, app, user_admin_contrib, preprint_unpublished, preprint_published, url):
+        res = app.get('{}filter[is_published]=false'.format(url), auth=user_admin_contrib.auth)
+        assert len(res.json['data']) == 1
+        assert preprint_unpublished._id in [d['id'] for d in res.json['data']]
+
+
 @pytest.mark.django_db
 class PreprintIsValidListMixin:
 

--- a/api_tests/preprints/views/test_preprint_list_mixin.py
+++ b/api_tests/preprints/views/test_preprint_list_mixin.py
@@ -12,6 +12,82 @@ from osf_tests.factories import (
 from website.util import permissions
 
 @pytest.mark.django_db
+class PreprintListMatchesPreprintDetailMixin:
+
+    @pytest.fixture()
+    def user_write_contrib(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def user_non_contrib(self):
+        return AuthUserFactory()
+
+    @pytest.fixture()
+    def user_admin_contrib(self):
+        raise NotImplementedError
+
+    @pytest.fixture()
+    def provider_one(self):
+        raise NotImplementedError
+
+    @pytest.fixture()
+    def provider_two(self):
+        raise NotImplementedError
+
+    @pytest.fixture()
+    def project_published(self):
+        raise NotImplementedError
+
+    @pytest.fixture()
+    def project_public(self):
+        raise NotImplementedError
+
+    @pytest.fixture()
+    def list_url(self):
+        raise NotImplementedError
+
+    @pytest.fixture()
+    def detail_url(self):
+        raise NotImplementedError
+
+    @pytest.fixture()
+    def subject(self):
+        return SubjectFactory()
+
+    @pytest.fixture()
+    def file_project_public(self, user_admin_contrib, project_public):
+        return test_utils.create_test_file(project_public, user_admin_contrib, 'mgla.pdf')
+
+    @pytest.fixture()
+    def file_project_published(self, user_admin_contrib, project_published):
+        return test_utils.create_test_file(project_published, user_admin_contrib, 'saor.pdf')
+
+    @pytest.fixture()
+    def preprint_unpublished(self, user_admin_contrib, provider_one, project_public, subject):
+        raise NotImplementedError
+
+    @pytest.fixture()
+    def preprint_published(self, user_admin_contrib, provider_two, project_published, subject):
+        return PreprintFactory(creator=user_admin_contrib, filename='saor.pdf', provider=provider_two, subjects=[[subject._id]], project=project_published, is_published=True)
+
+    def test_unpublished_invisible_to_non_contribs(self, app, user_non_contrib, preprint_unpublished, preprint_published, list_url, detail_url):
+        res = app.get(list_url, auth=user_non_contrib.auth)
+        assert len(res.json['data']) == 1
+        assert preprint_unpublished._id not in [d['id'] for d in res.json['data']]
+
+        res = app.get(detail_url, auth=user_non_contrib.auth, expect_errors=True)
+        assert res.status_code == 403
+
+    def test_unpublished_invisible_to_public(self, app, preprint_unpublished, preprint_published, list_url, detail_url):
+        res = app.get(list_url)
+        assert len(res.json['data']) == 1
+        assert preprint_unpublished._id not in [d['id'] for d in res.json['data']]
+
+        res = app.get(detail_url, expect_errors=True)
+        assert res.status_code == 401
+
+
+@pytest.mark.django_db
 class PreprintIsPublishedListMixin:
 
     @pytest.fixture()
@@ -60,21 +136,11 @@ class PreprintIsPublishedListMixin:
 
     @pytest.fixture()
     def preprint_unpublished(self, user_admin_contrib, provider_one, project_public, subject):
-        return PreprintFactory(creator=user_admin_contrib, filename='mgla.pdf', provider=provider_one, subjects=[[subject._id]], project=project_public, is_published=False)
+        raise NotImplementedError
 
     @pytest.fixture()
     def preprint_published(self, user_admin_contrib, provider_two, project_published, subject):
         return PreprintFactory(creator=user_admin_contrib, filename='saor.pdf', provider=provider_two, subjects=[[subject._id]], project=project_published, is_published=True)
-
-    def test_unpublished_visible_to_admins(self, app, user_admin_contrib, preprint_unpublished, preprint_published, url):
-        res = app.get(url, auth=user_admin_contrib.auth)
-        assert len(res.json['data']) == 2
-        assert preprint_unpublished._id in [d['id'] for d in res.json['data']]
-
-    def test_unpublished_invisible_to_write_contribs(self, app, user_write_contrib, preprint_unpublished, preprint_published, url):
-        res = app.get(url, auth=user_write_contrib.auth)
-        assert len(res.json['data']) == 1
-        assert preprint_unpublished._id not in [d['id'] for d in res.json['data']]
 
     def test_unpublished_invisible_to_non_contribs(self, app, user_non_contrib, preprint_unpublished, preprint_published, url):
         res = app.get(url, auth=user_non_contrib.auth)
@@ -85,15 +151,6 @@ class PreprintIsPublishedListMixin:
         res = app.get(url)
         assert len(res.json['data']) == 1
         assert preprint_unpublished._id not in [d['id'] for d in res.json['data']]
-
-    def test_filter_published_false_admin(self, app, user_admin_contrib, preprint_unpublished, preprint_published, url):
-        res = app.get('{}filter[is_published]=false'.format(url), auth=user_admin_contrib.auth)
-        assert len(res.json['data']) == 1
-        assert preprint_unpublished._id in [d['id'] for d in res.json['data']]
-
-    def test_filter_published_false_write_contrib(self, app, user_write_contrib, url):
-        res = app.get('{}filter[is_published]=false'.format(url), auth=user_write_contrib.auth)
-        assert len(res.json['data']) == 0
 
     def test_filter_published_false_non_contrib(self, app, user_non_contrib, url):
         res = app.get('{}filter[is_published]=false'.format(url), auth=user_non_contrib.auth)

--- a/api_tests/users/views/test_user_preprints_list.py
+++ b/api_tests/users/views/test_user_preprints_list.py
@@ -151,6 +151,24 @@ class TestUserPreprintIsPublishedList(PreprintIsPublishedListMixin):
     def url(self, user_admin_contrib):
         return '/{}users/{}/preprints/?version=2.2&'.format(API_BASE, user_admin_contrib._id)
 
+    @pytest.fixture()
+    def preprint_unpublished(self, user_admin_contrib, provider_one, project_public, subject):
+        return PreprintFactory(creator=user_admin_contrib, filename='mgla.pdf', provider=provider_one, subjects=[[subject._id]], project=project_public, is_published=False)
+
+    def test_unpublished_visible_to_admins(self, app, user_admin_contrib, preprint_unpublished, preprint_published, url):
+        res = app.get(url, auth=user_admin_contrib.auth)
+        assert len(res.json['data']) == 2
+        assert preprint_unpublished._id in [d['id'] for d in res.json['data']]
+
+    def test_unpublished_invisible_to_write_contribs(self, app, user_write_contrib, preprint_unpublished, preprint_published, url):
+        res = app.get(url, auth=user_write_contrib.auth)
+        assert len(res.json['data']) == 1
+        assert preprint_unpublished._id not in [d['id'] for d in res.json['data']]
+
+    def test_filter_published_false_write_contrib(self, app, user_write_contrib, preprint_unpublished, url):
+        res = app.get('{}filter[is_published]=false'.format(url), auth=user_write_contrib.auth)
+        assert len(res.json['data']) == 0
+
 class TestUserPreprintIsValidList(PreprintIsValidListMixin):
 
     @pytest.fixture()

--- a/osf_tests/factories.py
+++ b/osf_tests/factories.py
@@ -581,6 +581,8 @@ class PreprintFactory(DjangoModelFactory):
         subjects = kwargs.pop('subjects', None) or [[SubjectFactory()._id]]
         instance.node.preprint_article_doi = doi
 
+        instance.reviews_state = kwargs.pop('reviews_state', 'initial')
+
         user = kwargs.pop('creator', None) or instance.node.creator
         if not instance.node.is_contributor(user):
             instance.node.add_contributor(


### PR DESCRIPTION
## Purpose

Allow contributors to see unpublished preprints in the review process.

## Changes

* Contributors can see the preprint detail if provider uses reviews and the preprint is not in the initial state.
* Contributors can see preprint in preprint list if provider uses reviews and the preprint is not in the initial state. h/t @alexschiller
* Add tests

## Ticket

https://openscience.atlassian.net/browse/MOD-138
