### PR TITLE
Feature/add name limits[OSF-8729]

### DIFF
--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -42,7 +42,7 @@ class UserSerializer(JSONAPISerializer):
     non_anonymized_fields = ['type']
     id = IDField(source='_id', read_only=True)
     type = TypeField()
-    full_name = ser.CharField(source='fullname', required=True, label='Full name', help_text='Display name used in the general user interface')
+    full_name = ser.CharField(source='fullname', required=True, label='Full name', help_text='Display name used in the general user interface', max_length=200)
     given_name = ser.CharField(required=False, allow_blank=True, help_text='For bibliographic citations')
     middle_names = ser.CharField(required=False, allow_blank=True, help_text='For bibliographic citations')
     family_name = ser.CharField(required=False, allow_blank=True, help_text='For bibliographic citations')

--- a/website/templates/include/profile/names.mako
+++ b/website/templates/include/profile/names.mako
@@ -4,7 +4,8 @@
 
         <div class="form-group">
             <label>Full name (e.g. Rosalind Elsie Franklin)</label>
-            <input class="form-control" data-bind="value: full" maxlength="255"/>
+            ## Maxlength for full names must be 200 - quickfile titles use fullname
+            <input class="form-control" data-bind="value: full" maxlength="200"/>
             <div data-bind="visible: showMessages, css:'text-danger'">
                 <p data-bind="validationMessage: full"></p>
             </div>

--- a/website/templates/include/profile/names.mako
+++ b/website/templates/include/profile/names.mako
@@ -4,7 +4,7 @@
 
         <div class="form-group">
             <label>Full name (e.g. Rosalind Elsie Franklin)</label>
-            <input class="form-control" data-bind="value: full" />
+            <input class="form-control" data-bind="value: full" maxlength="255"/>
             <div data-bind="visible: showMessages, css:'text-danger'">
                 <p data-bind="validationMessage: full"></p>
             </div>
@@ -23,22 +23,22 @@
 
         <div class="form-group">
             <label>Given name (e.g. Rosalind)</label>
-            <input class="form-control" data-bind="value: given" />
+            <input class="form-control" data-bind="value: given" maxlength="255"/>
         </div>
 
         <div class="form-group">
             <label>Middle name(s) (e.g. Elsie)</label>
-            <input class="form-control" data-bind="value: middle" />
+            <input class="form-control" data-bind="value: middle" maxlength="255"/>
         </div>
 
         <div class="form-group">
             <label>Family name (e.g. Franklin)</label>
-            <input class="form-control" data-bind="value: family" />
+            <input class="form-control" data-bind="value: family" maxlength="255"/>
         </div>
 
         <div class="form-group">
             <label>Suffix</label>
-            <input class="form-control" data-bind="value: suffix" />
+            <input class="form-control" data-bind="value: suffix" maxlength="255"/>
         </div>
 
         <hr />

--- a/website/templates/public/register.mako
+++ b/website/templates/public/register.mako
@@ -83,28 +83,28 @@
                 <div class="form-group" data-bind=" css: { 'has-error': fullName() && !fullName.isValid(), 'has-success': fullName() && fullName.isValid() }">
                     <label for="inputName" class="col-sm-4 control-label">Full Name</label>
                     <div class="col-sm-8">
-                        <input autofocus type="text" class="form-control" id="inputName" placeholder="Name" data-bind="value: fullName, disable: submitted(), event: { blur: trim.bind($data, fullName) }">
+                        <input autofocus type="text" class="form-control" id="inputName" placeholder="Name" data-bind="value: fullName, disable: submitted(), event: { blur: trim.bind($data, fullName) }" maxlength="255">
                         <p class="help-block" data-bind="validationMessage: fullName" style="display: none;"></p>
                     </div>
                 </div>
                 <div class="form-group" data-bind="css: { 'has-error': email1() && !email1.isValid(), 'has-success': email1() && email1.isValid() }" >
                     <label for="inputEmail" class="col-sm-4 control-label">Email</label>
                     <div class="col-sm-8">
-                        <input type="text" class="form-control" id="inputEmail" placeholder="Email" data-bind="value: email1, disable: submitted(), event: { blur: trim.bind($data, email1) }">
+                        <input type="text" class="form-control" id="inputEmail" placeholder="Email" data-bind="value: email1, disable: submitted(), event: { blur: trim.bind($data, email1) }" maxlength="255">
                         <p class="help-block" data-bind="validationMessage: email1" style="display: none;"></p>
                     </div>
                 </div>
                 <div class="form-group" data-bind="css: { 'has-error': email2() && !email2.isValid(), 'has-success': email2() && email2.isValid() }">
                     <label for="inputEmail2" class="col-sm-4 control-label">Confirm Email</label>
                     <div class="col-sm-8">
-                        <input type="text" class="form-control" id="inputEmail2" placeholder="Re-enter email" data-bind=" value: email2, disable: submitted(), event: { blur: trim.bind($data, email2) }">
+                        <input type="text" class="form-control" id="inputEmail2" placeholder="Re-enter email" data-bind=" value: email2, disable: submitted(), event: { blur: trim.bind($data, email2) }" maxlength="255">
                         <p class="help-block" data-bind="validationMessage: email2" style="display: none;"></p>
                     </div>
                 </div>
                 <div class="form-group" data-bind="css: { 'has-error': password() && !password.isValid(), 'has-success': password() && password.isValid() }">
                     <label for="inputPassword3" class="col-sm-4 control-label">Password</label>
                     <div class="col-sm-8">
-                        <input type="password" class="form-control" id="inputPassword3" placeholder="Password" data-bind="textInput: typedPassword, value: password, disable: submitted(), event: { blur: trim.bind($data, password) }">
+                        <input type="password" class="form-control" id="inputPassword3" placeholder="Password" data-bind="textInput: typedPassword, value: password, disable: submitted(), event: { blur: trim.bind($data, password) }" maxlength="255">
                         <div class="row" data-bind="visible: typedPassword().length > 0">
                             <div class="col-xs-8">
                                 <div class="progress create-password">

--- a/website/templates/public/register.mako
+++ b/website/templates/public/register.mako
@@ -83,7 +83,8 @@
                 <div class="form-group" data-bind=" css: { 'has-error': fullName() && !fullName.isValid(), 'has-success': fullName() && fullName.isValid() }">
                     <label for="inputName" class="col-sm-4 control-label">Full Name</label>
                     <div class="col-sm-8">
-                        <input autofocus type="text" class="form-control" id="inputName" placeholder="Name" data-bind="value: fullName, disable: submitted(), event: { blur: trim.bind($data, fullName) }" maxlength="255">
+                        ## Maxlength for full names must be 200 - quickfile titles use fullname
+                        <input autofocus type="text" class="form-control" id="inputName" placeholder="Name" data-bind="value: fullName, disable: submitted(), event: { blur: trim.bind($data, fullName) }" maxlength="200">
                         <p class="help-block" data-bind="validationMessage: fullName" style="display: none;"></p>
                     </div>
                 </div>
@@ -104,7 +105,7 @@
                 <div class="form-group" data-bind="css: { 'has-error': password() && !password.isValid(), 'has-success': password() && password.isValid() }">
                     <label for="inputPassword3" class="col-sm-4 control-label">Password</label>
                     <div class="col-sm-8">
-                        <input type="password" class="form-control" id="inputPassword3" placeholder="Password" data-bind="textInput: typedPassword, value: password, disable: submitted(), event: { blur: trim.bind($data, password) }" maxlength="255">
+                        <input type="password" class="form-control" id="inputPassword3" placeholder="Password" data-bind="textInput: typedPassword, value: password, disable: submitted(), event: { blur: trim.bind($data, password) }" maxlength="256">
                         <div class="row" data-bind="visible: typedPassword().length > 0">
                             <div class="col-xs-8">
                                 <div class="progress create-password">


### PR DESCRIPTION
## Purpose

It is possible to send us really large names through our profile settings page. This is possibly a security risk.

## Changes

Put character limits on the frontend inputs where name fields exist (profile settings and registration).

Put a character limit of 200 characters for fullnames in the api.

Note: Most of the fields were limited at 255 characters (the maxlength specified on the user model), but `fullname` was limited to 200 characters. It turns out quickfile nodes are named after the user's full name and stops the user from being able to create a full name that is longer than 200 characters.

## Side effects

Not a side effect of _this_ ticket, but fullnames can no longer be more than 200 characters.

## Tests
None needed because most purely frontend and the one api change is small.

## Ticket

https://openscience.atlassian.net/browse/OSF-8729
