### PR TITLE
Use native_osx strategy for docker-sync

### DIFF
--- a/README-docker-compose.md
+++ b/README-docker-compose.md
@@ -88,16 +88,13 @@
 
 ## Docker Sync
 
-Ubuntu: Skip install of docker-sync, fswatch, and unison. instead...
+Ubuntu: Skip install of docker-sync. instead...
         `cp docker-compose.linux.yml docker-compose.override.yml`
         Ignore future steps that start, stop, or wait for docker-sync
 
-1. Install Docker Sync 0.3.5
+1. Install Docker Sync
   - Mac: `$ gem install docker-sync`
   - [Instructions](http://docker-sync.io)
-
-1. Install fswatch and unison
-  - Mac: `$ brew install fswatch unison`
 
 1. Running Docker Sync
 
@@ -105,7 +102,7 @@ Ubuntu: Skip install of docker-sync, fswatch, and unison. instead...
 
     **IMPORTANT**: docker-sync may ask you to upgrade to a newer version. Type `n` to decline the upgrade then rerun the `start` command.
 
-  - `$ docker-sync start --daemon`
+  - `$ docker-sync start`
 
 1. OPTIONAL: If you have problems trying installing macfsevents
   - `$ sudo pip install macfsevents`
@@ -213,7 +210,7 @@ The OSF is supported by several services which function independently from the m
       wb-sync:
         src: '../waterbutler'
         dest: '/code'
-        sync_strategy: 'unison'
+        sync_strategy: 'native_osx'
         sync_excludes_type: 'Name'
         sync_excludes: ['.DS_Store', '*.pyc', '*.tmp', '.git', '.idea']
         watch_excludes: ['.*\.DS_Store', '.*\.pyc', '.*\.tmp', '.*/\.git', '.*/\.idea']

--- a/docker-sync.yml
+++ b/docker-sync.yml
@@ -10,7 +10,7 @@ syncs:
 
 #  wb-sync:
 #    src: '../waterbutler'
-#    sync_strategy: 'unison'
+#    sync_strategy: 'native_osx'
 #    sync_args: [ '-prefer newer' ]
 #    sync_excludes_type: 'Name'
 #    sync_excludes: ['.DS_Store', '*.pyc', '*.tmp', '.git', '.idea']
@@ -18,7 +18,7 @@ syncs:
 
 #  mfr-sync:
 #    src: '../modular-file-renderer'
-#    sync_strategy: 'unison'
+#    sync_strategy: 'native_osx'
 #    sync_args: [ '-prefer newer' ]
 #    sync_excludes_type: 'Name'
 #    sync_excludes: ['.DS_Store', '*.pyc', '*.tmp', '.git', '.idea']
@@ -26,7 +26,7 @@ syncs:
 
 #  preprints-sync:
 #    src: '../ember-preprints'
-#    sync_strategy: 'unison'
+#    sync_strategy: 'native_osx'
 #    sync_args: [ '-prefer newer' ]
 #    sync_excludes_type: 'Name'
 #    sync_excludes: ['.DS_Store', '*.map', '*.pyc', '*.tmp', '.git', '.idea', 'bower_components', 'node_modules', 'tmp', 'dist']
@@ -34,7 +34,7 @@ syncs:
 
 #  emberosf-sync:
 #    src: '../ember-osf/'
-#    sync_strategy: 'unison'
+#    sync_strategy: 'native_osx'
 #    sync_args: [ '-prefer newer' ]
 #    sync_excludes_type: 'Name'
 #    sync_excludes: ['.DS_Store', '*.map', '*.pyc', '*.tmp', '.git', '.idea', 'bower_components', 'node_modules', 'tmp', 'dist']
@@ -42,7 +42,7 @@ syncs:
 
 #  registries-sync:
 #    src: '../ember-osf-registries'
-#    sync_strategy: 'unison'
+#    sync_strategy: 'native_osx'
 #    sync_args: [ '-prefer newer' ]
 #    sync_excludes_type: 'Name'
 #    sync_excludes: ['.DS_Store', '*.map', '*.pyc', '*.tmp', '.git', '.idea', 'bower_components', 'node_modules', 'tmp', 'dist']
@@ -50,7 +50,7 @@ syncs:
 
   osf-sync:
     src: './'
-    sync_strategy: 'unison'
+    sync_strategy: 'native_osx'
     sync_excludes_type: 'Name'
     sync_prefer: 'default'
     sync_excludes: ['.DS_Store', '*.map', '*.pyc', '*.tmp', 'etree.py', '.git', '.idea', 'bower_components', 'node_modules', '.docker-sync']


### PR DESCRIPTION

## Purpose

<!-- Describe the purpose of your changes -->
`native_osx` is the new default strategy in docker-sync. It's quicker and more reliable than using unison on macOS: https://github.com/EugenMayer/docker-sync/wiki/8.-Strategies

## Changes

<!-- Briefly describe or list your changes  -->
- Change strategy to native_osx
- Update docs

## Side effects

<!--Any possible side effects? -->
Devs should be up to date with the latest docker-sync and restart their docker-sync containers

```
gem update docker-sync
docker-sync stop
docker-sync clean
docker-sync start
```


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
