### PR TITLE
[Improvement][MOD-150] Use existing notify method for reviews

### DIFF
--- a/reviews/models/mixins.py
+++ b/reviews/models/mixins.py
@@ -236,7 +236,7 @@ class ReviewsMachine(Machine):
             'provider_support_email': self.reviewable.provider.email_support if self.reviewable.provider.email_support is not None else 'support@osf.io',
         }
 
-# Handle email notifications including: update comment, accept, and reject of submission.
+# Handle email notifications including: update comment, accept, and reject of submission. Uses existing OSF notify method.
 @reviews_signals.reviews_email.connect
 def reviews_notification(self, context, node):
     user = context['email_sender']

--- a/reviews/models/mixins.py
+++ b/reviews/models/mixins.py
@@ -21,7 +21,7 @@ from website import settings
 from osf.models import OSFUser
 
 from website.mails import mails
-from website.notifications.emails import notify
+from website.notifications import emails
 from website.reviews import signals as reviews_signals
 
 
@@ -246,7 +246,7 @@ def reviews_notification(self, context, node):
     email_recipients.remove(user._id)  # remove email sender
     for user_id in email_recipients:
         context['target_user'] = OSFUser.load(user_id)
-        notify(event='global_reviews', user=auth.user, node=node, timestamp=time_now, **context)
+        emails.notify(event='global_reviews', user=auth.user, node=node, timestamp=time_now, **context)
 
 # Handle email notifications for a new submission.
 @reviews_signals.reviews_email_submit.connect

--- a/website/notifications/emails.py
+++ b/website/notifications/emails.py
@@ -43,7 +43,8 @@ def notify(event, user, node, timestamp, **context):
         # If target, they get a reply email and are removed from the general email
         if target_user and target_user._id in subscriptions[notification_type]:
             subscriptions[notification_type].remove(target_user._id)
-            store_emails([target_user._id], notification_type, 'comment_replies', user, node, timestamp, **context)
+            event_name = 'global_reviews' if event_type == 'global_reviews' else 'comment_replies'
+            store_emails([target_user._id], notification_type, event_name, user, node, timestamp, **context)
             sent_users.append(target_user._id)
 
         if subscriptions[notification_type]:
@@ -87,7 +88,8 @@ def store_emails(recipient_ids, notification_type, event, user, node, timestamp,
     if notification_type == 'none':
         return
 
-    template = event + '.html.mako'
+    # Reviews has three email templates for the global_reviews event.
+    template = context['template'] + '.html.mako' if event == 'global_reviews' else event + '.html.mako'
     # user whose action triggered email sending
     context['user'] = user
     node_lineage_ids = get_node_lineage(node) if node else []


### PR DESCRIPTION
## Purpose

<!-- Describe the purpose of your changes -->
Use existing notify() for reviews notifications. We want reviews notifications to work the same way like OSF. notifications.

## Changes

- Update reviews model mixin
- Update notify method to handle global_reviews event from reviews.
- Update store method.
- Update test

<!-- Briefly describe or list your changes  -->

## Side effects

<!--Any possible side effects? -->


## Ticket
https://openscience.atlassian.net/browse/MOD-150
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
