### PR TITLE
[hotfix] Fix citations for nodes with disabled users [OSF-8831] 

### DIFF
--- a/api_tests/nodes/views/test_node_citations.py
+++ b/api_tests/nodes/views/test_node_citations.py
@@ -25,21 +25,34 @@ def non_contrib():
     return AuthUserFactory()
 
 @pytest.fixture()
+def disabled_contrib():
+    # disabled in the disable_user fixture so that they can be added as a contributor first
+    return AuthUserFactory()
+
+@pytest.fixture()
 def public_project(admin_contributor):
     return ProjectFactory(creator=admin_contributor, is_public=True)
 
 @pytest.fixture()
-def private_project(admin_contributor, write_contrib, read_contrib):
+def private_project(admin_contributor, write_contrib, read_contrib, disabled_contrib):
     private_project = ProjectFactory(creator=admin_contributor)
     private_project.add_contributor(write_contrib, permissions=['read','write'], auth=Auth(admin_contributor))
     private_project.add_contributor(read_contrib, permissions=['read'], auth=Auth(admin_contributor))
+    private_project.add_contributor(disabled_contrib, permissions=['read'], auth=Auth(admin_contributor))
     private_project.save()
     return private_project
+
+@pytest.fixture()
+def disable_user(disabled_contrib, private_project):
+    # pass private_project so that account is disabled after private_project is setup
+    disabled_contrib.disable_account()
+    disabled_contrib.is_registered = False
+    disabled_contrib.save()
 
 @pytest.mark.django_db
 class NodeCitationsMixin:
 
-    def test_node_citations(self, app, admin_contributor, write_contrib, read_contrib, non_contrib, private_url, public_url):
+    def test_node_citations(self, app, admin_contributor, write_contrib, read_contrib, non_contrib, disabled_contrib, private_url, public_url):
 
     #   test_admin_can_view_private_project_citations
         res = app.get(private_url, auth=admin_contributor.auth)

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -471,7 +471,8 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
         return utils.generate_csl_given_name(self.given_name, self.middle_names, self.suffix)
 
     def csl_name(self, node_id=None):
-        if self.is_registered:
+        # disabled users are set to is_registered = False but have a fullname
+        if self.is_registered or self.is_disabled:
             name = self.fullname
         else:
             name = self.get_unclaimed_record(node_id)['name']

--- a/tests/test_citations.py
+++ b/tests/test_citations.py
@@ -138,6 +138,21 @@ class CitationsUserTestCase(OsfTestCase):
             }
         )
 
+    def test_disabled_user_csl(self):
+        # Tests the csl name for a disabled user
+        user = UserFactory()
+        project = NodeFactory(creator=user)
+        user.disable_account()
+        user.is_registered = False
+        user.save()
+        assert bool(
+            user.csl_name() ==
+            {
+                'given': user.csl_given_name,
+                'family': user.family_name,
+            }
+        )
+
 
 class CitationsViewsTestCase(OsfTestCase):
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Any node with a disabled user will break citations on that node and any associated preprints

<!-- Describe the purpose of your changes -->

## Changes
1. Allow disabled users to use fullname instead of defaulting to checking for unclaimed records (e.g., acting like an unregistered contributor)
2. Add citations tests to confirm that this works properly
<!-- Briefly describe or list your changes  -->

## Side effects
Fewer sentry errors, the best side effect:
<img width="209" alt="screen shot 2017-10-19 at 3 57 14 pm" src="https://user-images.githubusercontent.com/1322421/31791344-4719c956-b4e6-11e7-90e2-fe306b510825.png">

<!--Any possible side effects? -->


## Ticket

https://openscience.atlassian.net/browse/OSF-8831

## QA Notes

Create a preprint with a user, Disable that user account and then confirm that the citations on the node and preprint work

Citations for unregistered contributors should also work (related but unlikely to break).