### PR TITLE
[hotfix] Make download button more easily discoverable

### DIFF
--- a/website/static/js/filepage/index.js
+++ b/website/static/js/filepage/index.js
@@ -49,7 +49,7 @@ var SharePopover =  {
         var fileLink = window.location.href;
 
         var mfrHost = renderLink.substring(0, renderLink.indexOf('render'));
-        return m('button#sharebutton.disabled.btn.btn-sm.btn-primary.file-share', {onclick: function popOverShow() {
+        return m('button#sharebutton.disabled.btn.btn-sm.btn-default.file-share', {onclick: function popOverShow() {
                 var pop = document.getElementById('popOver');
                 //This is bad, should only happen for Firefox, thanks @chrisseto
                 if (!pop){
@@ -501,6 +501,18 @@ var FileViewPage = {
         var height = $('iframe').attr('height') ? $('iframe').attr('height') : '0px';
 
         m.render(document.getElementById('toggleBar'), m('.btn-toolbar.m-t-md', [
+            m('.btn-group.m-t-xs', [
+                ctrl.isLatestVersion ? m('a.btn.btn-sm.btn-primary.file-download', {href: 'download'}, 'Download') : null
+            ]),
+            ctrl.context.currentUser.canEdit && (ctrl.file.provider !== 'bitbucket') && (!ctrl.canEdit()) && (ctrl.context.currentUser.isAdmin) ? m('.btn-group.m-l-xs.m-t-xs', [
+                ctrl.isLatestVersion ? m('.btn.btn-sm.btn-default', {onclick: $(document).trigger.bind($(document), 'fileviewpage:force_checkin')}, 'Force check in') : null
+            ]) : '',
+            ctrl.canEdit() && (!ctrl.file.checkoutUser) && (ctrl.file.provider === 'osfstorage') ? m('.btn-group.m-l-xs.m-t-xs', [
+                ctrl.isLatestVersion ? m('.btn.btn-sm.btn-default', {onclick: $(document).trigger.bind($(document), 'fileviewpage:checkout')}, 'Check out') : null
+            ]) : '',
+            (ctrl.canEdit() && (ctrl.file.checkoutUser === ctrl.context.currentUser.id) ) ? m('.btn-group.m-l-xs.m-t-xs', [
+                ctrl.isLatestVersion ? m('.btn.btn-sm.btn-warning', {onclick: $(document).trigger.bind($(document), 'fileviewpage:checkin')}, 'Check in') : null
+            ]) : '',
             // Special case whether or not to show the delete button for published Dataverse files
             // Special case to not show delete if file is preprint primary file
             // Special case to not show delete for public figshare files
@@ -512,23 +524,11 @@ var FileViewPage = {
                 (ctrl.file.provider !== 'osfstorage' || !ctrl.file.checkoutUser) &&
                 (document.URL.indexOf('version=latest-published') < 0)
             ) ? m('.btn-group.m-l-xs.m-t-xs', [
-                        ctrl.isLatestVersion ? m('button.btn.btn-sm.btn-danger.file-delete', {onclick: $(document).trigger.bind($(document), 'fileviewpage:delete') }, 'Delete') : null
-            ]) : '',
-            ctrl.context.currentUser.canEdit && (ctrl.file.provider !== 'bitbucket') && (!ctrl.canEdit()) && (ctrl.context.currentUser.isAdmin) ? m('.btn-group.m-l-xs.m-t-xs', [
-                ctrl.isLatestVersion ? m('.btn.btn-sm.btn-danger', {onclick: $(document).trigger.bind($(document), 'fileviewpage:force_checkin')}, 'Force check in') : null
-            ]) : '',
-            ctrl.canEdit() && (!ctrl.file.checkoutUser) && (ctrl.file.provider === 'osfstorage') ? m('.btn-group.m-l-xs.m-t-xs', [
-                ctrl.isLatestVersion ? m('.btn.btn-sm.btn-warning', {onclick: $(document).trigger.bind($(document), 'fileviewpage:checkout')}, 'Check out') : null
-            ]) : '',
-            (ctrl.canEdit() && (ctrl.file.checkoutUser === ctrl.context.currentUser.id) ) ? m('.btn-group.m-l-xs.m-t-xs', [
-                ctrl.isLatestVersion ? m('.btn.btn-sm.btn-warning', {onclick: $(document).trigger.bind($(document), 'fileviewpage:checkin')}, 'Check in') : null
+                ctrl.isLatestVersion ? m('button.btn.btn-sm.btn-default.file-delete', {onclick: $(document).trigger.bind($(document), 'fileviewpage:delete') }, 'Delete') : null
             ]) : '',
             window.contextVars.node.isPublic? m('.btn-group.m-t-xs', [
                 m.component(SharePopover, {link: link, height: height})
             ]) : '',
-            m('.btn-group.m-t-xs', [
-                ctrl.isLatestVersion ? m('a.btn.btn-sm.btn-primary.file-download', {href: 'download'}, 'Download') : null
-            ]),
             m('.btn-group.btn-group-sm.m-t-xs', [
                ctrl.editor ? m( '.btn.btn-default.disabled', 'Toggle view: ') : null
             ].concat(


### PR DESCRIPTION
## Purpose

<!-- Describe the purpose of your changes -->

Various users have had trouble finding how to download a file ([flowdock thread](https://www.flowdock.com/app/cos/osf-love/threads/VchTXUUhylTmg-36RMl0tVXH7LB)). 

## Changes

Change button styling and order to make "Download" the primary action.

### Before

<img width="303" alt="osf readme rst 2017-10-20 16-00-44" src="https://user-images.githubusercontent.com/2379650/31839626-efab2d0c-b5af-11e7-98cd-94c6341b7c70.png">

### After

<img width="310" alt="osf readme rst 2017-10-20 16-01-58" src="https://user-images.githubusercontent.com/2379650/31839818-b9bbcdf4-b5b0-11e7-8cae-5844462f2390.png">

## Side effects

<!--Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
