### PR TITLE
Fix button layout and styling in Add contributor modals

### DIFF
--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -75,9 +75,9 @@ AddContributorViewModel = oop.extend(Paginator, {
         self.page = ko.observable('whom');
         self.pageTitle = ko.computed(function () {
             return {
-                whom: 'Add Contributors',
-                which: 'Select Components',
-                invite: 'Add Unregistered Contributor'
+                whom: 'Add contributors',
+                which: 'Select components',
+                invite: 'Add unregistered contributor'
             }[self.page()];
         });
         self.query = ko.observable();

--- a/website/templates/project/modal_add_contributor.mako
+++ b/website/templates/project/modal_add_contributor.mako
@@ -264,10 +264,17 @@
 
             <div class="modal-footer">
 
+                <span data-bind="if: page() == 'invite'">
+                  <button class="btn btn-link" data-bind="click:selectWhom">Back</button>
+                </span>
+
+                <span data-bind="if: page() == 'which'">
+                  <a class="btn btn-link" data-bind="click:selectWhom">Back</a>
+                </span>
+
                 <a href="#" class="btn btn-default" data-bind="click: clear" data-dismiss="modal">Cancel</a>
 
                 <span data-bind="if: page() === 'invite'">
-                    <button class="btn btn-primary" data-bind='click:selectWhom'>Back</button>
                     <button class='btn btn-success'
                          data-bind='click: postInvite, enable:canSubmit'
                                     type="submit">Add</button>
@@ -279,7 +286,6 @@
                 </span>
 
                 <span data-bind="if: page() == 'which'">
-                    <a class="btn btn-primary" data-bind="click:selectWhom">Back</a>
                     <a class="btn btn-success" data-bind="click:submit">Add</a>
                 </span>
 


### PR DESCRIPTION

## Purpose

<!-- Describe the purpose of your changes -->
Current button layout and style is error-prone (misleads users to click "Back" to submit the form). Also changes title to sentence case as per osf-style.

## Changes

<!-- Briefly describe or list your changes  -->

### Before

<img width="896" alt="osf small project contributors 2017-10-23 14-57-46" src="https://user-images.githubusercontent.com/2379650/31907695-9057ba96-b802-11e7-91e3-8ff76a8af483.png">

### After

<img width="895" alt="osf maximize rich portals contributors 2017-10-23 14-58-25" src="https://user-images.githubusercontent.com/2379650/31907724-a24c5356-b802-11e7-979e-03bd52d7ed19.png">
