### PR TITLE
Allow quickfiles to be copied and moved to a project [OSF-8841]

### DIFF
--- a/addons/osfstorage/models.py
+++ b/addons/osfstorage/models.py
@@ -144,19 +144,12 @@ class OsfStorageFileNode(BaseFileNode):
         self._materialized_path = self.materialized_path
         return super(OsfStorageFileNode, self).delete(user=user, parent=parent) if self._check_delete_allowed() else None
 
-    def copy_under(self, destination_parent, name=None):
-        if self.node.is_quickfiles:
-            raise exceptions.FileNodeIsQuickFilesNode()
-        return super(OsfStorageFileNode, self).copy_under(destination_parent, name)
-
     def move_under(self, destination_parent, name=None):
         if self.is_preprint_primary:
             if self.node != destination_parent.node or self.provider != destination_parent.provider:
                 raise exceptions.FileNodeIsPrimaryFile()
         if self.is_checked_out:
             raise exceptions.FileNodeCheckedOutError()
-        if self.node.is_quickfiles and self.node != destination_parent.node:
-            raise exceptions.FileNodeIsQuickFilesNode()
         return super(OsfStorageFileNode, self).move_under(destination_parent, name)
 
     def check_in_or_out(self, user, checkout, save=False):

--- a/addons/osfstorage/tests/test_views.py
+++ b/addons/osfstorage/tests/test_views.py
@@ -846,9 +846,9 @@ class TestMoveHook(HookTestCase):
         )
         assert_equal(res.status_code, 200)
 
-    def test_cannot_move_file_out_of_quickfiles_node(self):
+    def test_can_move_file_out_of_quickfiles_node(self):
         quickfiles_node = QuickFilesNode.objects.get_for_user(self.user)
-        quickfiles_file = create_test_file(quickfiles_node, self.user, filename='slippery.mp3')
+        create_test_file(quickfiles_node, self.user, filename='slippery.mp3')
         quickfiles_folder = OsfStorageFolder.objects.get(node=quickfiles_node)
         dest_folder = OsfStorageFolder.objects.get(node=self.project)
 
@@ -856,7 +856,7 @@ class TestMoveHook(HookTestCase):
             'osfstorage_move_hook',
             {'nid': quickfiles_node._id},
             payload={
-                'source': quickfiles_file._id,
+                'source': quickfiles_folder._id,
                 'node': quickfiles_node._id,
                 'user': self.user._id,
                 'destination': {
@@ -866,9 +866,8 @@ class TestMoveHook(HookTestCase):
                 }
             },
             method='post_json',
-            expect_errors=True,
         )
-        assert_equal(res.status_code, 400)
+        assert_equal(res.status_code, 200)
 
     def test_can_rename_file_in_quickfiles_node(self):
         quickfiles_node = QuickFilesNode.objects.get_for_user(self.user)
@@ -903,7 +902,7 @@ class TestMoveHook(HookTestCase):
 
 @pytest.mark.django_db
 class TestCopyHook(HookTestCase):
-    def test_cannot_copy_file_out_of_quickfiles_node(self):
+    def test_can_copy_file_out_of_quickfiles_node(self):
         quickfiles_node = QuickFilesNode.objects.get_for_user(self.user)
         create_test_file(quickfiles_node, self.user, filename='dont_copy_meeeeeeeee.mp3')
         quickfiles_folder = OsfStorageFolder.objects.get(node=quickfiles_node)
@@ -923,9 +922,8 @@ class TestCopyHook(HookTestCase):
                 }
             },
             method='post_json',
-            expect_errors=True,
         )
-        assert_equal(res.status_code, 400)
+        assert_equal(res.status_code, 201)
 
 
 @pytest.mark.django_db

--- a/addons/osfstorage/views.py
+++ b/addons/osfstorage/views.py
@@ -85,12 +85,7 @@ def osfstorage_get_revisions(file_node, node_addon, payload, **kwargs):
 
 @decorators.waterbutler_opt_hook
 def osfstorage_copy_hook(source, destination, name=None, **kwargs):
-    try:
-        return source.copy_under(destination, name=name).serialize(), httplib.CREATED
-    except exceptions.FileNodeIsQuickFilesNode:
-        raise HTTPError(httplib.BAD_REQUEST, data={
-            'message_long': 'Cannot copy file as it is in a quickfiles node'
-        })
+    return source.copy_under(destination, name=name).serialize(), httplib.CREATED
 
 
 @decorators.waterbutler_opt_hook
@@ -104,10 +99,6 @@ def osfstorage_move_hook(source, destination, name=None, **kwargs):
     except exceptions.FileNodeIsPrimaryFile:
         raise HTTPError(httplib.FORBIDDEN, data={
             'message_long': 'Cannot move file as it is the primary file of preprint.'
-        })
-    except exceptions.FileNodeIsQuickFilesNode:
-        raise HTTPError(httplib.BAD_REQUEST, data={
-            'message_long': 'Cannot move file as it is in a quickfiles node'
         })
 
 

--- a/website/files/exceptions.py
+++ b/website/files/exceptions.py
@@ -20,7 +20,3 @@ class FileNodeCheckedOutError(FileException):
 
 class FileNodeIsPrimaryFile(FileException):
     pass
-
-
-class FileNodeIsQuickFilesNode(FileException):
-    pass


### PR DESCRIPTION


[#OSF-8841]

This reverts commit 45faea194b1c39243ecb17508f1cfc4a77e3879f.

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Allow moving and copying of quickfiles into a project, reverse #7691 

## Changes

- Remove checks and exceptions raised when attempting to move or copy a quickfile
- Reverse tests to make sure that they can be moved and copied

## Side effects

none anticipated


## Ticket
https://openscience.atlassian.net/browse/OSF-8841