### PR TITLE
[hotfix] External storage speed fix [OSF-8794]

### DIFF
--- a/addons/dataverse/models.py
+++ b/addons/dataverse/models.py
@@ -24,13 +24,14 @@ class DataverseFolder(DataverseFileNode, Folder):
 class DataverseFile(DataverseFileNode, File):
     version_identifier = 'version'
 
-    def update(self, revision, data, user=None):
+    def update(self, revision, data, save=True, user=None):
         """Note: Dataverse only has psuedo versions, don't save them
         Dataverse requires a user for the weird check below
         """
         self.name = data['name']
         self.materialized_path = data['materialized']
-        self.save()
+        if save:
+            self.save()
 
         version = FileVersion(identifier=revision)
         version.update_metadata(data, save=False)

--- a/addons/figshare/models.py
+++ b/addons/figshare/models.py
@@ -28,13 +28,14 @@ class FigshareFile(FigshareFileNode, File):
     def touch(self, bearer, revision=None, **kwargs):
         return super(FigshareFile, self).touch(bearer, revision=None, **kwargs)
 
-    def update(self, revision, data, user=None):
+    def update(self, revision, data, save=True, user=None):
         """Figshare does not support versioning.
         Always pass revision as None to avoid conflict.
         """
         self.name = data['name']
         self.materialized_path = data['materialized']
-        self.save()
+        if save:
+            self.save()
 
         version = FileVersion(identifier=None)
         version.update_metadata(data, save=False)

--- a/api/base/views.py
+++ b/api/base/views.py
@@ -908,14 +908,17 @@ class WaterButlerMixin(object):
                 # create method on BaseFileNode appends provider, bulk_create bypasses this step so it is added here
                 file_obj = base_class(node=node, _path='/' + attrs['path'].lstrip('/'), provider=base_class._provider)
                 objs_to_create[base_class].append(file_obj)
+            else:
+                file_objs.append(file_obj)
 
             file_obj.update(None, attrs, user=self.request.user, save=False)
-            file_objs.append(file_obj)
+
+        bulk_update(file_objs)
 
         for base_class in objs_to_create:
             base_class.objects.bulk_create(objs_to_create[base_class])
+            file_objs += objs_to_create[base_class] 
 
-        bulk_update(file_objs)
         return file_objs
 
     def get_file_node_from_wb_resp(self, item):

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1959,7 +1959,7 @@ class NodeFileDetail(JSONAPIBaseView, generics.RetrieveAPIView, WaterButlerMixin
         fobj = self.fetch_from_waterbutler()
         if isinstance(fobj, dict):
             # if dict it is a wb response, not file object yet
-            return self.get_file_node_from_wb_resp(fobj, self.get_node(check_object_permissions=False))
+            return self.get_file_node_from_wb_resp(fobj)
 
         if isinstance(fobj, list) or not isinstance(fobj, File):
             # We should not have gotten a folder here

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1925,9 +1925,8 @@ class NodeFilesList(JSONAPIBaseView, generics.ListAPIView, WaterButlerMixin, Lis
             # Resolve to a provider-specific subclass, so that
             # trashed file nodes are filtered out automatically
             ConcreteFileNode = BaseFileNode.resolve_class(provider, BaseFileNode.ANY)
-            return ConcreteFileNode.objects.filter(
-                id__in=[self.get_file_item(file).id for file in files_list],
-            )
+            file_ids = [f.id for f in self.bulk_get_file_nodes_from_wb_resp(files_list)]
+            return ConcreteFileNode.objects.filter(id__in=file_ids)
 
         if isinstance(files_list, list) or not isinstance(files_list, Folder):
             # We should not have gotten a file here
@@ -1959,7 +1958,8 @@ class NodeFileDetail(JSONAPIBaseView, generics.RetrieveAPIView, WaterButlerMixin
     def get_object(self):
         fobj = self.fetch_from_waterbutler()
         if isinstance(fobj, dict):
-            return self.get_file_item(fobj)
+            # if dict it is a wb response, not file object yet
+            return self.get_file_node_from_wb_resp(fobj, self.get_node(check_object_permissions=False))
 
         if isinstance(fobj, list) or not isinstance(fobj, File):
             # We should not have gotten a folder here

--- a/api_tests/nodes/views/test_node_files_list.py
+++ b/api_tests/nodes/views/test_node_files_list.py
@@ -244,6 +244,13 @@ class TestNodeFilesList(ApiTestCase):
         self._prepare_mock_wb_response(provider='github', files=[{'name': 'NewFile'}])
         self.add_github()
         url = '/{}nodes/{}/files/github/'.format(API_BASE, self.project._id)
+
+        # test create
+        res = self.app.get(url, auth=self.user.auth)
+        assert_equal(res.json['data'][0]['attributes']['name'], 'NewFile')
+        assert_equal(res.json['data'][0]['attributes']['provider'], 'github')
+
+        # test get
         res = self.app.get(url, auth=self.user.auth)
         assert_equal(res.json['data'][0]['attributes']['name'], 'NewFile')
         assert_equal(res.json['data'][0]['attributes']['provider'], 'github')
@@ -255,6 +262,12 @@ class TestNodeFilesList(ApiTestCase):
         res = self.app.get(url, auth=self.user.auth, headers={
             'COOKIE': 'foo=bar;'  # Webtests doesnt support cookies?
         })
+        # test create
+        assert_equal(res.status_code, 200)
+        assert_equal(res.json['data']['attributes']['name'], 'NewFile')
+        assert_equal(res.json['data']['attributes']['provider'], 'github')
+
+        # test get
         assert_equal(res.status_code, 200)
         assert_equal(res.json['data']['attributes']['name'], 'NewFile')
         assert_equal(res.json['data']['attributes']['provider'], 'github')
@@ -385,6 +398,14 @@ class TestNodeFilesListFiltering(ApiTestCase):
     def test_node_files_are_filterable_by_name(self):
         url = '/{}nodes/{}/files/github/?filter[name]=xyz'.format(API_BASE, self.project._id)
         self.add_github()
+
+        # test create
+        res = self.app.get(url, auth=self.user.auth)
+        assert_equal(res.status_code, 200)
+        assert_equal(len(res.json['data']), 1)  # filters out 'abc'
+        assert_equal(res.json['data'][0]['attributes']['name'], 'xyz')
+
+        # test get
         res = self.app.get(url, auth=self.user.auth)
         assert_equal(res.status_code, 200)
         assert_equal(len(res.json['data']), 1)  # filters out 'abc'
@@ -393,6 +414,14 @@ class TestNodeFilesListFiltering(ApiTestCase):
     def test_node_files_filter_by_name_case_insensitive(self):
         url = '/{}nodes/{}/files/github/?filter[name]=XYZ'.format(API_BASE, self.project._id)
         self.add_github()
+
+        # test create
+        res = self.app.get(url, auth=self.user.auth)
+        assert_equal(res.status_code, 200)
+        assert_equal(len(res.json['data']), 1)  # filters out 'abc', but finds 'xyz'
+        assert_equal(res.json['data'][0]['attributes']['name'], 'xyz')
+
+        # test get
         res = self.app.get(url, auth=self.user.auth)
         assert_equal(res.status_code, 200)
         assert_equal(len(res.json['data']), 1)  # filters out 'abc', but finds 'xyz'
@@ -401,6 +430,14 @@ class TestNodeFilesListFiltering(ApiTestCase):
     def test_node_files_are_filterable_by_path(self):
         url = '/{}nodes/{}/files/github/?filter[path]=abc'.format(API_BASE, self.project._id)
         self.add_github()
+
+        # test create
+        res = self.app.get(url, auth=self.user.auth)
+        assert_equal(res.status_code, 200)
+        assert_equal(len(res.json['data']), 1)  # filters out 'xyz'
+        assert_equal(res.json['data'][0]['attributes']['name'], 'abc')
+
+        # test get
         res = self.app.get(url, auth=self.user.auth)
         assert_equal(res.status_code, 200)
         assert_equal(len(res.json['data']), 1)  # filters out 'xyz'
@@ -409,6 +446,14 @@ class TestNodeFilesListFiltering(ApiTestCase):
     def test_node_files_are_filterable_by_kind(self):
         url = '/{}nodes/{}/files/github/?filter[kind]=folder'.format(API_BASE, self.project._id)
         self.add_github()
+
+        # test create
+        res = self.app.get(url, auth=self.user.auth)
+        assert_equal(res.status_code, 200)
+        assert_equal(len(res.json['data']), 1)  # filters out 'xyz'
+        assert_equal(res.json['data'][0]['attributes']['name'], 'abc')
+
+        # test get
         res = self.app.get(url, auth=self.user.auth)
         assert_equal(res.status_code, 200)
         assert_equal(len(res.json['data']), 1)  # filters out 'xyz'
@@ -420,6 +465,12 @@ class TestNodeFilesListFiltering(ApiTestCase):
         url = '/{}nodes/{}/files/github/?filter[last_touched][gt]={}'.format(API_BASE,
                                                                              self.project._id,
                                                                              yesterday_stamp.isoformat())
+        # test create
+        res = self.app.get(url, auth=self.user.auth)
+        assert_equal(res.status_code, 200)
+        assert_equal(len(res.json['data']), 2)
+
+        # test get
         res = self.app.get(url, auth=self.user.auth)
         assert_equal(res.status_code, 200)
         assert_equal(len(res.json['data']), 2)
@@ -431,6 +482,13 @@ class TestNodeFilesListFiltering(ApiTestCase):
         url = '/{}nodes/{}/files/osfstorage/?filter[last_touched][gt]={}'.format(API_BASE,
                                                                                  self.project._id,
                                                                                  yesterday_stamp.isoformat())
+
+        # test create
+        res = self.app.get(url, auth=self.user.auth, expect_errors=True)
+        assert_equal(res.status_code, 400)
+        assert_equal(len(res.json['errors']), 1)
+
+        # test get
         res = self.app.get(url, auth=self.user.auth, expect_errors=True)
         assert_equal(res.status_code, 400)
         assert_equal(len(res.json['errors']), 1)

--- a/osf/models/files.py
+++ b/osf/models/files.py
@@ -419,7 +419,7 @@ class File(models.Model):
     def kind(self):
         return 'file'
 
-    def update(self, revision, data, user=None):
+    def update(self, revision, data, user=None, save=True):
         """Using revision and data update all data pretaining to self
         :param str or None revision: The revision that data points to
         :param dict data: Metadata recieved from waterbutler
@@ -456,7 +456,8 @@ class File(models.Model):
         # Finally update last touched
         self.last_touched = timezone.now()
 
-        self.save()
+        if save:
+            self.save()
         return version
 
     def serialize(self):


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
External providers are super duper slow when there are lots of files. It scales linearly with the number of files because we update ALL files every time we hit a list endpoint. This PR makes it at least faster than it was before.
<!-- Describe the purpose of your changes -->

## Changes
<img width="679" alt="screen shot 2017-10-26 at 11 41 30 am" src="https://user-images.githubusercontent.com/1322421/32062484-a62c1924-ba42-11e7-9c1b-1c41d8853aa6.png">

1. Use bulk_update to save everything at one time
2. Use bulk_create to create all new objects at one time
3. Remove permission check on every file (permissions are already checked earlier)

<!-- Briefly describe or list your changes  -->

## Side effects
None Known
<!--Any possible side effects? -->


## Ticket

https://openscience.atlassian.net/browse/OSF-8794

## QA Notes
1. It is important to test files that have never been viewed and those that have been viewed once. I'll detail an example of how to test below. I'm most concerned about dataverse and figshare, since they had a small change special casing that I did not test locally.

2. Testing the speed improvements is not 100% necessary, mostly making sure that no views on the API fail is the most important part. Testing at least one folder with 200+ files may be worth doing. I can help you make a bunch of empty files very quickly if helpful.

3. Confirm that permissions are still handled properly (since a permissions check was removed)

So for each storage provider (not including osfstorage), here is a recommended workflow:
1. Connect an addon to a new private project and view a folder that contains multiple files via the API
2. Go to a list view for that provider
GitHub example: https://staging-api.osf.io/v2/nodes/f27hn/files/github/ten/

3. Confirm that the "last_touched" date is now
4. Refresh the page and confirm that it doesn't break and the "last_touched" date changes too
5. Open the same list view link in an incognito window and confirm permission error
6. Navigate to a file detail page
GitHub example: https://staging-api.osf.io/v2/nodes/f27hn/files/github/ten/1.txt

7. Confirm that "last_touched" date is now
8. Open the same detail page link in an incognito window and confirm permission error