### PR TITLE
[WIP][feature] Remove Logo Spinners [OSF-8821]

### DIFF
--- a/addons/wiki/templates/edit.mako
+++ b/addons/wiki/templates/edit.mako
@@ -46,9 +46,10 @@
                     </div>
                 </div>
                 <div id="grid">
-                    <div class="spinner-loading-wrapper">
-                        <div class="logo-spin logo-lg"></div>
-                        <p class="m-t-sm fg-load-message"> Loading wiki pages...  </p>
+                    <div class="ball-pulse ball-scale-blue text-center spinner-loading-wrapper">
+                      <div></div>
+                      <div></div>
+                      <div></div>
                     </div>
                 </div>
                 <div class="hidden text-danger" id="wikiErrorMessage" style="padding: 15px"></div>
@@ -259,10 +260,11 @@
 <div class="modal fade" id="renameModal">
     <div class="modal-dialog">
         <div class="modal-content">
-            <div class="spinner-loading-wrapper">
-                <div class="logo-spin logo-xl"></div>
-                 <p class="m-t-sm fg-load-message"> Renaming wiki...  </p>
-            </div>
+          <div class="ball-pulse ball-scale-blue text-center spinner-loading-wrapper">
+            <div></div>
+            <div></div>
+            <div></div>
+          </div>
         </div>
     </div>
 </div>

--- a/website/static/js/components/logFeed.js
+++ b/website/static/js/components/logFeed.js
@@ -203,8 +203,7 @@ var LogFeed = {
             ]) :
             // Show OSF spinner while there is a pending log request
             ctrl.logRequestPending() ?  m('.spinner-loading-wrapper', [
-                m('.logo-spin.logo-lg'),
-                m('p.m-t-sm.fg-load-message', 'Loading logs...')
+                m('.ball-pulse.ball-scale-blue.text-center', [m('div'), m('div'), m('div')]),
             ]) :
             // Display each log item (text and user image)
             [ctrl.activityLogs() ? ctrl.activityLogs().map(function(item) {

--- a/website/templates/profile/notifications.mako
+++ b/website/templates/profile/notifications.mako
@@ -55,9 +55,10 @@
                 </div>
                 <form id="selectNotifications" class="osf-treebeard-minimal">
                     <div id="grid">
-                        <div class="spinner-loading-wrapper">
-                            <div class="logo-spin logo-lg"></div>
-                            <p class="m-t-sm fg-load-message"> Loading notification settings... </p>
+                        <div class="ball-pulse ball-scale-blue text-center spinner-loading-wrapper">
+                          <div></div>
+                          <div></div>
+                          <div></div>
                         </div>
                     </div>
                     <div class="help-block" style="padding-left: 15px">

--- a/website/templates/project/files.mako
+++ b/website/templates/project/files.mako
@@ -9,10 +9,7 @@
 %endif
 
 <div id="treeGrid">
-	<div class="spinner-loading-wrapper">
-		<div class="logo-spin logo-lg"></div>
-		<p class="m-t-sm fg-load-message"> Loading files...  </p>
-	</div>
+    <div class="ball-scale ball-scale-blue text-center m-v-xl"><div></div></div>
 </div>
 
 

--- a/website/templates/project/nodes_privacy.mako
+++ b/website/templates/project/nodes_privacy.mako
@@ -36,9 +36,10 @@
                         </div>
                         <div class="osf-treebeard">
                             <div id="nodesPrivacyTreebeard">
-                                <div class="spinner-loading-wrapper">
-                                    <div class="logo-spin logo-md"></div>
-                                    <p class="m-t-sm fg-load-message"> Loading projects and components...  </p>
+                                <div class="ball-pulse ball-scale-blue text-center spinner-loading-wrapper">
+                                  <div></div>
+                                  <div></div>
+                                  <div></div>
                                 </div>
                             </div>
                             <div class="help-block" style="padding-left: 15px">

--- a/website/templates/project/project.mako
+++ b/website/templates/project/project.mako
@@ -324,9 +324,10 @@
                <div class="panel-body">
             %endif
                     <div id="treeGrid">
-                        <div class="spinner-loading-wrapper">
-                            <div class="logo-spin logo-lg"></div>
-                             <p class="m-t-sm fg-load-message"> Loading files...  </p>
+                        <div class="ball-pulse ball-scale-blue text-center spinner-loading-wrapper">
+                          <div></div>
+                          <div></div>
+                          <div></div>
                         </div>
                     </div>
                 </div><!-- end .panel-body -->
@@ -409,9 +410,10 @@
             </div>
             <div class="panel-body">
                 <div id="logFeed">
-                    <div class="spinner-loading-wrapper">
-                        <div class="logo-spin logo-lg"></div>
-                         <p class="m-t-sm fg-load-message"> Loading logs...  </p>
+                    <div class="ball-pulse ball-scale-blue text-center spinner-loading-wrapper">
+                      <div></div>
+                      <div></div>
+                      <div></div>
                     </div>
                 </div>
             </div>

--- a/website/templates/project/registrations.mako
+++ b/website/templates/project/registrations.mako
@@ -53,7 +53,7 @@
   <div role="tabpanel" class="tab-pane" id="drafts">
     <div id="draftRegistrationsScope" class="row scripted" style="min-height: 150px;padding-top:20px;">
       <div data-bind="visible: loadingDrafts" class="spinner-loading-wrapper">
-        <div class="logo-spin logo-lg"></div>
+        <div class="ball-scale ball-scale-blue text-center m-v-xl"><div></div></div>
       </div>
       <form id="newDraftRegistrationForm" method="POST" style="display:none">
         <!-- ko if: selectedSchema() -->

--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -255,9 +255,10 @@
 
                             <form id="wikiSettings" class="osf-treebeard-minimal">
                                 <div id="wgrid">
-                                    <div class="spinner-loading-wrapper">
-                                        <div class="logo-spin logo-lg"></div>
-                                        <p class="m-t-sm fg-load-message"> Loading wiki settings...  </p>
+                                    <div class="ball-pulse ball-scale-blue text-center spinner-loading-wrapper">
+                                      <div></div>
+                                      <div></div>
+                                      <div></div>
                                     </div>
                                 </div>
                                 <div class="help-block" style="padding-left: 15px">
@@ -397,9 +398,10 @@
                         </div>
                         <form id="notificationSettings" class="osf-treebeard-minimal">
                             <div id="grid">
-                                <div class="spinner-loading-wrapper">
-                                    <div class="logo-spin logo-lg"></div>
-                                    <p class="m-t-sm fg-load-message"> Loading notification settings...  </p>
+                                <div class="ball-pulse ball-scale-blue text-center spinner-loading-wrapper">
+                                  <div></div>
+                                  <div></div>
+                                  <div></div>
                                 </div>
                             </div>
                             <div class="help-block" style="padding-left: 15px">
@@ -582,7 +584,7 @@
     % if not node['is_registration']:
         <script type="text/javascript" src=${"/static/public/js/forward/node-cfg.js" | webpack_asset}></script>
     % endif
-    
+
     % for js_asset in addon_js:
         <script src="${js_asset | webpack_asset}"></script>
     % endfor

--- a/website/templates/project/view_file.mako
+++ b/website/templates/project/view_file.mako
@@ -48,10 +48,11 @@
     <div class="osf-panel panel panel-default osf-panel-hide osf-panel-flex reset-height">
       <div class="osf-panel-body-flex file-page reset-height">
         <div id="grid">
-          <div class="spinner-loading-wrapper">
-            <div class="logo-spin logo-lg"></div>
-            <p class="m-t-sm fg-load-message"> Loading files...  </p>
-          </div>
+            <div class="ball-pulse ball-scale-blue text-center spinner-loading-wrapper">
+              <div></div>
+              <div></div>
+              <div></div>
+            </div>
         </div>
       </div>
     </div>

--- a/website/templates/public/pages/meeting_landing.mako
+++ b/website/templates/public/pages/meeting_landing.mako
@@ -102,15 +102,6 @@
                             </p>
                             <div id="meetings-grid"></div>
                         </div>
-                        <div role="tabpanel" class="tab-pane" id="submissions">
-
-                            <div id="submissions-grid">
-                                <div id="allMeetingsLoader" class="spinner-loading-wrapper">
-                                    <div class="logo-spin logo-lg"></div>
-                                    <p class="m-t-sm fg-load-message"> Loading submissions...</p>
-                                </div>
-                            </div>
-                        </div>
                     </div>
                 </div>
 

--- a/website/templates/util/render_node.mako
+++ b/website/templates/util/render_node.mako
@@ -107,23 +107,6 @@
                 <span class="text-muted">${summary['nlogs']} contribution</span>
             % endif
         % endif
-        % if not summary['archiving']:
-            <div class="body hide" id="body-${summary['id']}" style="overflow:hidden;">
-            <hr />
-            % if summary['is_retracted']:
-                <h4>Recent activity information has been withdrawn.</h4>
-            % else:
-                <!-- Recent Activity (Logs) -->
-                Recent Activity
-                <div id="logFeed-${summary['primary_id'] if not summary['primary'] else summary['id']}">
-                    <div class="spinner-loading-wrapper">
-                        <div class="logo-spin logo-lg"></div>
-                         <p class="m-t-sm fg-load-message"> Loading logs...  </p>
-                    </div>
-                </div>
-            % endif
-        </div>
-        % endif
     </li>
 
 % else:


### PR DESCRIPTION
#### Purpose
- Removes the remaining logo spinners in favor of the loading indicators specified in [osf-style](https://centerforopenscience.github.io/osf-style/style.html#loader).

#### Side Effects
- Steve will be happier. 

#### Ticket
- [OSF-8821](https://openscience.atlassian.net/browse/OSF-8821)

#### GIFs
- Wiki Menu
![wiki grid](https://user-images.githubusercontent.com/7913604/32151048-17ae9324-bcf0-11e7-81d2-9b9bcbedc4bd.gif)

- Project Overview Page (files and logs widgets) 
![project page](https://user-images.githubusercontent.com/7913604/32151055-258487b0-bcf0-11e7-9b11-197de1067efe.gif)

- Files Page
![files page](https://user-images.githubusercontent.com/7913604/32151059-2d4b2df0-bcf0-11e7-8c7f-deda4832bed6.gif)

- Wiki Settings (project)
![wiki settings](https://user-images.githubusercontent.com/7913604/32151066-37b5e5be-bcf0-11e7-9c64-d14adfdf50c3.gif)

- Notification Settings (project)
![notification settings](https://user-images.githubusercontent.com/7913604/32151079-4642f3e2-bcf0-11e7-9c56-fdf66716b0c9.gif)

- Notification Settings (profile) 
![profile notification settings](https://user-images.githubusercontent.com/7913604/32151085-53a1f33a-bcf0-11e7-8e00-90543c3aab1a.gif)

- File Tree (file view page)
![file view](https://user-images.githubusercontent.com/7913604/32151087-5f4d16ba-bcf0-11e7-9f86-b41057f81e28.gif)

- Draft Registrations Tab 
![draft registrations](https://user-images.githubusercontent.com/7913604/32151093-67353d8a-bcf0-11e7-91ff-b534d07d3dd0.gif)


