### PR TITLE
[hotfix] Stop meetings from failing [OSF-8864]

### DIFF
--- a/tests/test_conferences.py
+++ b/tests/test_conferences.py
@@ -47,6 +47,18 @@ def create_fake_conference_nodes(n, endpoint):
         nodes.append(node)
     return nodes
 
+def create_fake_conference_nodes_bad_data(n, bad_n, endpoint):
+    nodes = []
+    for i in range(n):
+        node = ProjectFactory(is_public=True)
+        node.add_tag(endpoint, Auth(node.creator))
+        # inject bad data
+        if i < bad_n:
+            # Delete only contributor
+            node.contributor_set.filter(user=node.contributors.first()).delete()
+        node.save()
+        nodes.append(node)
+    return nodes
 
 class TestConferenceUtils(OsfTestCase):
 
@@ -448,6 +460,26 @@ class TestConferenceEmailViews(OsfTestCase):
         res = self.app.get(url)
         assert_equal(res.status_code, 200)
         assert_equal(len(res.json), n_conference_nodes)
+
+    # Regression for OSF-8864 to confirm bad project data does not make whole conference break
+    def test_conference_bad_data(self):
+        conference = ConferenceFactory()
+
+        # Create conference nodes
+        n_conference_nodes = 3
+        n_conference_nodes_bad = 1
+        create_fake_conference_nodes_bad_data(
+            n_conference_nodes,
+            n_conference_nodes_bad,
+            conference.endpoint,
+        )
+        # Create a non-conference node
+        ProjectFactory()
+
+        url = api_url_for('conference_data', meeting=conference.endpoint)
+        res = self.app.get(url)
+        assert_equal(res.status_code, 200)
+        assert_equal(len(res.json), n_conference_nodes - n_conference_nodes_bad)
 
     def test_conference_data_url_upper(self):
         conference = ConferenceFactory()

--- a/website/conferences/views.py
+++ b/website/conferences/views.py
@@ -10,6 +10,7 @@ from addons.osfstorage.models import OsfStorageFile
 from framework.auth import get_or_create_user
 from framework.exceptions import HTTPError
 from framework.flask import redirect
+from framework import sentry
 from framework.transactions.handlers import no_auto_transaction
 from osf.models import AbstractNode, Node, Conference, Tag
 from website import settings
@@ -187,11 +188,14 @@ def conference_data(meeting):
         raise HTTPError(httplib.NOT_FOUND)
 
     nodes = AbstractNode.objects.filter(tags__id__in=Tag.objects.filter(name__iexact=meeting, system=False).values_list('id', flat=True), is_public=True, is_deleted=False)
-
-    return [
-        _render_conference_node(each, idx, conf)
-        for idx, each in enumerate(nodes)
-    ]
+    ret = []
+    for idx, each in enumerate(nodes):
+        # To handle OSF-8864 where projects with no users caused meetings to be unable to resolve
+        try:
+            ret.append(_render_conference_node(each, idx, conf))
+        except IndexError:
+            sentry.log_exception()
+    return ret
 
 
 def redirect_to_meetings(**kwargs):


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
There is an issue with merged accounts that causes users to be removed from projects. These bad projects have caused a single meeting to be unable to resolve twice in the last couple days. The entire meeting should not fail, just that single project.
<!-- Describe the purpose of your changes -->

## Changes
Change was TDD'd since I don't have local meetings set up. 
1. Add a try-except and ignore nodes that cannot be rendered properly.
2. Raise a sentry error for nodes that fail and let the meeting still render.
3. Add test 


<!-- Briefly describe or list your changes  -->

## Side effects
Broken meeting nodes will not show up, but they will raise a sentry error. Next ticket will allow admin to fix this class of error.

<!--Any possible side effects? -->


## Ticket

https://openscience.atlassian.net/browse/OSF-8864

## QA Notes
1. Make sure meetings still render. 
2. Someone might be able to delete all the a contributor off a node on staging to test the explicit issue.
