### PR TITLE
[Feature] Use ondataload callback [OSF-8516]

### DIFF
--- a/website/static/js/nodesDeleteTreebeard.js
+++ b/website/static/js/nodesDeleteTreebeard.js
@@ -64,7 +64,7 @@ function NodesDeleteTreebeard(divID, data, nodesState, nodesOriginal) {
                 }
             ];
         },
-        onload : function () {
+        ondataload : function () {
             var tb = this;
             expandOnLoad.call(tb);
         },


### PR DESCRIPTION
## Purpose

Fix treebeard grid issue where tb.treeData is unavailable because http requests have not returned.

See [Fix treebeards](https://github.com/CenterForOpenScience/osf.io/pull/7694/commits/09c5c21696299ba577d9466a11fdec315109bb32)

## Changes

Use `ondataload` callback in `tbOptions`

## Ticket

[OSF-8516](https://openscience.atlassian.net/browse/OSF-8516)
