### PR TITLE
[MOD-172][Hotfix] Allow contributors to see private preprints for unmoderated services

### DIFF
--- a/api/preprints/permissions.py
+++ b/api/preprints/permissions.py
@@ -18,9 +18,11 @@ class PreprintPublishedOrAdmin(permissions.BasePermission):
             if auth.user is None:
                 return obj.verified_publishable
             else:
-                user_has_permissions = obj.verified_publishable or (node.is_public and auth.user.has_perm('view_submissions', obj.provider)) or node.has_permission(auth.user, osf_permissions.ADMIN)
-                if obj.provider.reviews_workflow:
-                    return user_has_permissions or (node.is_contributor(auth.user) and obj.reviews_state != States.INITIAL.value)
+                user_has_permissions = (obj.verified_publishable or
+                    (node.is_public and auth.user.has_perm('view_submissions', obj.provider)) or
+                    node.has_permission(auth.user, osf_permissions.ADMIN) or
+                    (node.is_contributor(auth.user) and obj.reviews_state != States.INITIAL.value)
+                )
                 return user_has_permissions
         else:
             if not node.has_permission(auth.user, osf_permissions.ADMIN):

--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -922,7 +922,7 @@ class TestPreprintDetailPermissions:
         assert res.json['data']['id'] == private_preprint._id
 
     #   test_private_visible_to_write_contribs
-        res = app.get(private_url, auth=write_contrib.auth, expect_errors=True)
+        res = app.get(private_url, auth=write_contrib.auth)
         assert res.status_code == 200
 
     #   test_private_invisible_to_non_contribs

--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -867,11 +867,27 @@ class TestPreprintDetailPermissions:
 
     @pytest.fixture()
     def unpublished_preprint(self, admin, provider, subject, public_project):
-        return PreprintFactory(creator=admin, filename='toe_socks_and_sunrises.pdf', provider=provider, subjects=[[subject._id]], project=public_project, is_published=False)
+        return PreprintFactory(creator=admin, filename='toe_socks_and_sunrises.pdf', provider=provider, subjects=[[subject._id]], project=public_project, is_published=False, reviews_state='initial')
 
     @pytest.fixture()
     def private_preprint(self, admin, provider, subject, private_project):
-        return PreprintFactory(creator=admin, filename='toe_socks_and_sunrises.pdf', provider=provider, subjects=[[subject._id]], project=private_project, is_published=False)
+        return PreprintFactory(creator=admin, filename='toe_socks_and_sunrises.pdf', provider=provider, subjects=[[subject._id]], project=private_project, is_published=False, reviews_state='accepted')
+
+    @pytest.fixture()
+    def abandoned_private_preprint(self, admin, provider, subject, private_project):
+        return PreprintFactory(creator=admin, filename='toe_socks_and_sunrises.pdf', provider=provider, subjects=[[subject._id]], project=private_project, is_published=False, reviews_state='initial')
+
+    @pytest.fixture()
+    def abandoned_public_preprint(self, admin, provider, subject, public_project):
+        return PreprintFactory(creator=admin, filename='toe_socks_and_sunrises.pdf', provider=provider, subjects=[[subject._id]], project=public_project, is_published=False, reviews_state='initial')
+
+    @pytest.fixture()
+    def abandoned_private_url(self, abandoned_private_preprint):
+        return '/{}preprints/{}/'.format(API_BASE, abandoned_private_preprint._id)
+
+    @pytest.fixture()
+    def abandoned_public_url(self, abandoned_public_preprint):
+        return '/{}preprints/{}/'.format(API_BASE, abandoned_public_preprint._id)
 
     @pytest.fixture()
     def unpublished_url(self, unpublished_preprint):
@@ -905,9 +921,9 @@ class TestPreprintDetailPermissions:
         res = app.get(private_url, auth=admin.auth)
         assert res.json['data']['id'] == private_preprint._id
 
-    #   test_private_invisible_to_write_contribs
+    #   test_private_visible_to_write_contribs
         res = app.get(private_url, auth=write_contrib.auth, expect_errors=True)
-        assert res.status_code == 403
+        assert res.status_code == 200
 
     #   test_private_invisible_to_non_contribs
         res = app.get(private_url, auth=non_contrib.auth, expect_errors=True)
@@ -915,6 +931,40 @@ class TestPreprintDetailPermissions:
 
     #   test_private_invisible_to_public
         res = app.get(private_url, expect_errors=True)
+        assert res.status_code == 401
+
+    def test_preprint_is_abandoned_detail(self, app, admin, write_contrib, non_contrib, abandoned_private_preprint, abandoned_public_preprint, abandoned_private_url, abandoned_public_url):
+
+    #   test_abandoned_private_visible_to_admins
+        res = app.get(abandoned_private_url, auth=admin.auth)
+        assert res.json['data']['id'] == abandoned_private_preprint._id
+
+    #   test_abandoned_private_invisible_to_write_contribs
+        res = app.get(abandoned_private_url, auth=write_contrib.auth, expect_errors=True)
+        assert res.status_code == 403
+
+    #   test_abandoned_private_invisible_to_non_contribs
+        res = app.get(abandoned_private_url, auth=non_contrib.auth, expect_errors=True)
+        assert res.status_code == 403
+
+    #   test_abandoned_private_invisible_to_public
+        res = app.get(abandoned_private_url, expect_errors=True)
+        assert res.status_code == 401
+
+    #   test_abandoned_public_visible_to_admins
+        res = app.get(abandoned_public_url, auth=admin.auth)
+        assert res.json['data']['id'] == abandoned_public_preprint._id
+
+    #   test_abandoned_public_invisible_to_write_contribs
+        res = app.get(abandoned_public_url, auth=write_contrib.auth, expect_errors=True)
+        assert res.status_code == 403
+
+    #   test_abandoned_public_invisible_to_non_contribs
+        res = app.get(abandoned_public_url, auth=non_contrib.auth, expect_errors=True)
+        assert res.status_code == 403
+
+    #   test_abandoned_public_invisible_to_public
+        res = app.get(abandoned_public_url, expect_errors=True)
         assert res.status_code == 401
 
 


### PR DESCRIPTION
## Purpose
Allow contributors to see private preprints for unmoderated services.

## Changes
Use the same permissions for moderated and unmoderated providers.

## Side effects
Contributors can now see preprints that were submitted to an unmoderated service and then made private.

## Ticket
https://openscience.atlassian.net/browse/MOD-172
