### PR TITLE
[hotfix] embedding users on quickfile detail page [OSF-8874]

### DIFF
--- a/api/base/views.py
+++ b/api/base/views.py
@@ -145,7 +145,7 @@ class JSONAPIBaseView(generics.GenericAPIView):
         else:
             embeds = self.request.query_params.getlist('embed') or self.request.query_params.getlist('embed[]')
 
-        fields_check = self.serializer_class._declared_fields.copy()
+        fields_check = self.get_serializer_class()._declared_fields.copy()
         if 'fields[{}]'.format(self.serializer_class.Meta.type_) in self.request.query_params:
             # Check only requested and mandatory fields
             sparse_fields = self.request.query_params['fields[{}]'.format(self.serializer_class.Meta.type_)]

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -815,6 +815,7 @@ class NodeContributorsCreateSerializer(NodeContributorsSerializer):
     users = RelationshipField(
         related_view='users:user-detail',
         related_view_kwargs={'user_id': '<user._id>'},
+        always_embed=True,
         required=False
     )
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Allow embedding of the quickfile's node's owner's information, aka user in the serializer, in a quickfiles detail page

## Changes

- Use the `get_serializer` method when checking for fields that might have embeds instead of calling the property directly
- add tests

## Side effects

None anticipated


## Ticket
https://openscience.atlassian.net/browse/OSF-8874