### PR TITLE
[hotfix] preprint es query, get roots for metrics and noteworthy

### DIFF
--- a/scripts/analytics/institution_summary.py
+++ b/scripts/analytics/institution_summary.py
@@ -50,7 +50,7 @@ class InstitutionSummary(SummaryAnalytics):
                     'name': ensure_bytes(institution.name),
                 },
                 'users': {
-                    'total': institution.osfuser_set.count(),
+                    'total': institution.osfuser_set.filter(is_active=True).count(),
                 },
                 'nodes': {
                     'total': institution.nodes.filter(node_query).exclude(type='osf.registration').count(),

--- a/scripts/analytics/institution_summary.py
+++ b/scripts/analytics/institution_summary.py
@@ -37,7 +37,7 @@ class InstitutionSummary(SummaryAnalytics):
                 Q(date_created__lt=query_datetime)
             )
 
-            project_query = node_query & Q(parent_nodes__isnull=True)
+            project_query = node_query
             public_query = Q(is_public=True)
             private_query = Q(is_public=False)
             node_public_query = node_query & public_query
@@ -58,9 +58,9 @@ class InstitutionSummary(SummaryAnalytics):
                     'private': institution.nodes.filter(node_private_query).exclude(type='osf.registration').count(),
                 },
                 'projects': {
-                    'total': institution.nodes.filter(project_query).exclude(type='osf.registration').count(),
-                    'public': institution.nodes.filter(project_public_query).exclude(type='osf.registration').count(),
-                    'private': institution.nodes.filter(project_private_query).exclude(type='osf.registration').count(),
+                    'total': institution.nodes.filter(project_query).exclude(type='osf.registration').get_roots().count(),
+                    'public': institution.nodes.filter(project_public_query).exclude(type='osf.registration').get_roots().count(),
+                    'private': institution.nodes.filter(project_private_query).exclude(type='osf.registration').get_roots().count(),
                 },
                 'registered_nodes': {
                     'total': institution.nodes.filter(node_query).filter(type='osf.registration').count(),
@@ -68,9 +68,9 @@ class InstitutionSummary(SummaryAnalytics):
                     'embargoed': institution.nodes.filter(node_private_query).filter(type='osf.registration').count(),
                 },
                 'registered_projects': {
-                    'total': institution.nodes.filter(project_query).filter(type='osf.registration').count(),
-                    'public': institution.nodes.filter(project_public_query).filter(type='osf.registration').count(),
-                    'embargoed': institution.nodes.filter(project_private_query).filter(type='osf.registration').count(),
+                    'total': institution.nodes.filter(project_query).filter(type='osf.registration').get_roots().count(),
+                    'public': institution.nodes.filter(project_public_query).filter(type='osf.registration').get_roots().count(),
+                    'embargoed': institution.nodes.filter(project_private_query).filter(type='osf.registration').get_roots().count(),
                 },
                 'keen': {
                     'timestamp': timestamp_datetime.isoformat()

--- a/scripts/analytics/node_summary.py
+++ b/scripts/analytics/node_summary.py
@@ -28,7 +28,7 @@ class NodeSummary(SummaryAnalytics):
         query_datetime = timestamp_datetime + timedelta(1)
 
         node_query = {'is_deleted': False, 'date_created__lte': query_datetime}
-        project_query = dict(chain(node_query.iteritems(), {'parent_nodes__isnull': True}.iteritems()))
+        project_query = node_query
 
         public_query = {'is_public': True}
         private_query = {'is_public': False}
@@ -53,9 +53,9 @@ class NodeSummary(SummaryAnalytics):
             },
             # Projects - the number of top-level only projects
             'projects': {
-                'total': Node.objects.filter(**project_query).count(),
-                'public': Node.objects.filter(**project_public_query).count(),
-                'private': Node.objects.filter(**project_private_query).count(),
+                'total': Node.objects.filter(**project_query).get_roots().count(),
+                'public': Node.objects.filter(**project_public_query).get_roots().count(),
+                'private': Node.objects.filter(**project_private_query).get_roots().count(),
             },
             # Registered Nodes - the number of registered projects and components
             'registered_nodes': {
@@ -66,10 +66,10 @@ class NodeSummary(SummaryAnalytics):
             },
             # Registered Projects - the number of registered top level projects
             'registered_projects': {
-                'total': Registration.objects.filter(**project_query).count(),
-                'public': Registration.objects.filter(**project_public_query).count(),
-                'embargoed': Registration.objects.filter(**project_private_query).count(),
-                'withdrawn': Registration.objects.filter(**project_retracted_query).count(),
+                'total': Registration.objects.filter(**project_query).get_roots().count(),
+                'public': Registration.objects.filter(**project_public_query).get_roots().count(),
+                'embargoed': Registration.objects.filter(**project_private_query).get_roots().count(),
+                'withdrawn': Registration.objects.filter(**project_retracted_query).get_roots().count(),
             }
         }
 

--- a/scripts/analytics/preprint_summary.py
+++ b/scripts/analytics/preprint_summary.py
@@ -59,7 +59,7 @@ class PreprintSummary(SummaryAnalytics):
         counts = []
         for preprint_provider in PreprintProvider.objects.all():
             name = preprint_provider.name if preprint_provider.name != 'Open Science Framework' else 'OSF'
-            elastic_query['query']['bool']['must']['match'][1]['sources'] = name
+            elastic_query['query']['bool']['must'][1]['match']['sources'] = name
             resp = requests.post('https://share.osf.io/api/v2/search/creativeworks/_search', json=elastic_query).json()
             counts.append({
                 'keen': {

--- a/scripts/analytics/preprint_summary.py
+++ b/scripts/analytics/preprint_summary.py
@@ -31,14 +31,18 @@ class PreprintSummary(SummaryAnalytics):
         elastic_query = {
             "query": {
                 "bool": {
-                    "must": {
-                        "match": {
-                            "type": "preprints"
+                    "must": [
+                        {
+                            "match": {
+                                "type": "preprint"
+                            }
                         },
-                        "match": {
-                            "sources": None
+                        {
+                            "match": {
+                                "sources": None
+                            }
                         }
-                    },
+                    ],
                     'filter': [
                         {
                             "range": {
@@ -55,7 +59,7 @@ class PreprintSummary(SummaryAnalytics):
         counts = []
         for preprint_provider in PreprintProvider.objects.all():
             name = preprint_provider.name if preprint_provider.name != 'Open Science Framework' else 'OSF'
-            elastic_query['query']['bool']['must']['match']['sources'] = name
+            elastic_query['query']['bool']['must']['match'][1]['sources'] = name
             resp = requests.post('https://share.osf.io/api/v2/search/creativeworks/_search', json=elastic_query).json()
             counts.append({
                 'keen': {

--- a/scripts/populate_new_and_noteworthy_projects.py
+++ b/scripts/populate_new_and_noteworthy_projects.py
@@ -56,7 +56,7 @@ def get_new_and_noteworthy_nodes(noteworthy_links_node):
     """
     today = timezone.now()
     last_month = (today - dateutil.relativedelta.relativedelta(months=1))
-    data = Node.objects.filter(Q(date_created__gte=last_month) & Q(is_public=True) & Q(is_deleted=False) & (Q(parent_nodes__isnull=True) | Q(parent_nodes=noteworthy_links_node)))
+    data = Node.objects.filter(Q(date_created__gte=last_month) & Q(is_public=True) & Q(is_deleted=False)).get_roots()
     nodes = []
     for node in data:
         unique_actions = NodeLog.objects.filter(node=node.pk).order_by('action').distinct('action').count()


### PR DESCRIPTION
Fixes for Node, Institution, and Preprint metric analytics.
Fixes to new and noteworthy root project query.

## Additional Steps:

Node, Institution and Preprint metrics need to be re-indexed to keen.io for all historical dates.
