### PR TITLE
[hotfix] Fix license lookup [OSF-8856]

### DIFF
--- a/website/static/js/search.js
+++ b/website/static/js/search.js
@@ -385,9 +385,12 @@ var ViewModel = function(params) {
             var nullLicenseCount = data.aggs.total || 0;
             if ((data.aggs || {}).licenses)  {
                 $.each(data.aggs.licenses, function(key, value) {
-                    licenseCounts.filter(function(l) {
+                    var licenseCount = licenseCounts.filter(function(l) {
                         return eqInsensitive(l.id, key);
-                    })[0].count(value);
+                    })[0];
+                    if (licenseCount) {
+                        licenseCount.count(value);
+                    }
                     nullLicenseCount -= value;
                 });
             }


### PR DESCRIPTION
## Purpose

Fix js error on search results page which makes loading appear infinite.

The main issue occurs because elastic search returns (depending on the query)
`AFL3` as part of the license aggregates. `AFL3` is removed from licenses gathered
from license list. https://github.com/CenterForOpenScience/osf.io/blob/45451c06bbd22cb64c139a8e2590ecce9925c99f/website/static/js/licenses.js#L4
With no `AFL3` key in the initial `licenseCounts` list (built from licenses list), the filter returns empty array which upon indexing causes error and the `loading` binding to stay `true`.
https://github.com/CenterForOpenScience/osf.io/blob/45451c06bbd22cb64c139a8e2590ecce9925c99f/website/static/js/search.js#L395-L402

## Changes

For now, just prevent JS error from happening using a simpler loop.

## Ticket
(OSF-8856)[https://openscience.atlassian.net/browse/OSF-8856]