### PR TITLE
[feature/fix] Stop script from updating deleted registrations [OSF-8624]

### DIFF
--- a/scripts/fix_registration_unclaimed_records.py
+++ b/scripts/fix_registration_unclaimed_records.py
@@ -18,7 +18,7 @@ def main():
         # If we're not running in dry mode log everything to a file
         script_utils.add_file_logger(logger, __file__)
     with transaction.atomic():
-        qs = Registration.objects.filter(_contributors__is_registered=False)
+        qs = Registration.objects.filter(_contributors__is_registered=False, is_deleted=False)
         logger.info('Found {} registrations with unregistered contributors'.format(qs.count()))
         for registration in qs:
             registration_id = registration._id


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Deleted registrations break the fix registration unclaimed records script. When a registration is deleted the connection back to the originating node is severed, which breaks the script. This PR removes deleted reg from the queryset of registrations to update. Note this is different than a retraction, deletions occur when a registration is canceled.
<!-- Describe the purpose of your changes -->

## Changes
Don't update deleted registrations.
<!-- Briefly describe or list your changes  -->

## Side effects
any registration that is un-deleted may need to be updated, but unlikely.
<!--Any possible side effects? -->


## Ticket

https://openscience.atlassian.net/browse/OSF-8624
