### PR TITLE
[#OSF-8747]Add links to status page

### DIFF
--- a/website/templates/footer.mako
+++ b/website/templates/footer.mako
@@ -4,7 +4,7 @@
             <div class="col-sm-2 col-md-3 col-md-offset-1">
                 <h4>OSF</h4>
                 <ul>
-                    <li><a href="${domain}explore/activity/">Explore</a></li>
+                    <li><a href="https://status.cos.io/">Status</a></li>
                     <li><script type="text/javascript">document.write("<n uers=\"znvygb:pbagnpg@bfs.vb\" ery=\"absbyybj\">Pbagnpg</n>".replace(/[a-zA-Z]/g,function(e){return String.fromCharCode((e<="Z"?90:122)>=(e=e.charCodeAt(0)+13)?e:e-26)}));</script><noscript>Contact OSF: <span class="obfuscated-email-noscript"><strong><u>cont<span style="display:none;">null</span>act@<span style="display:none;">null</span>osf.<span style="display:none;">null</span>io</u></strong></span></noscript></li>
                     <li><a href="${domain}support">FAQ/Guides</a></li>
                     <li><a href="https://api.osf.io/v2/docs/">API</a></li>


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Remove 'Explore' and replace with 'Status' in footer
<!-- Describe the purpose of your changes -->

## Changes
before change:
<img width="856" alt="screen shot 2017-11-06 at 2 30 32 pm" src="https://user-images.githubusercontent.com/4974056/32459904-151c2b98-c2ff-11e7-802a-ddd6fe67e470.png">

after change:
<img width="623" alt="screen shot 2017-11-06 at 2 31 02 pm" src="https://user-images.githubusercontent.com/4974056/32459936-24267daa-c2ff-11e7-810a-66372f2d92d0.png">



<!-- Briefly describe or list your changes  -->

## Side effects
This pr doesn't remove or adjust the https://osf.io/activity/, even though it is not displaying properly and not something used recently. This page is still used in other places in osf:
https://github.com/CenterForOpenScience/osf.io/blob/develop/website/templates/landing.mako#L260
https://github.com/CenterForOpenScience/osf.io/blob/develop/website/templates/project/registrations.mako#L36
https://github.com/CenterForOpenScience/osf.io/blob/develop/website/language.py#L16
Unless there are some decisions made about the design and language change for those, cannot remove the code for the activity page.
<!--Any possible side effects? -->


## Ticket
https://openscience.atlassian.net/browse/OSF-8747
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
