### PR TITLE
[hotfix] Fix Glacier Audit Script [OSF-8891]

### DIFF
--- a/scripts/osfstorage/glacier_audit.py
+++ b/scripts/osfstorage/glacier_audit.py
@@ -67,8 +67,6 @@ def get_job(vault, job_id=None):
 def get_targets(date):
     return FileVersion.objects.filter(
         date_created__lt=date - DELTA_DATE, metadata__has_key='archive', location__isnull=False
-    ).exclude(
-        status='cached'
     ).iterator()
 
 


### PR DESCRIPTION
#### Purpose
- The glacier audit script makes references to a `FileVersion` field that doesn't exist (and which doesn't exist on the [develop-backup](https://github.com/CenterForOpenScience/osf.io/blob/develop-backup/website/files/models/base.py#L798) branch...)

#### Changes
- Remove the invalid reference.

#### Side effects
- None.

#### Ticket
- [OSF-8891](https://openscience.atlassian.net/browse/OSF-8891)
