### PR TITLE
[#OSF-8065]"Learn more" licenses link from create component modal should open in a new tab

### DIFF
--- a/website/static/js/addProjectPlugin.js
+++ b/website/static/js/addProjectPlugin.js
@@ -260,7 +260,7 @@ var AddProject = {
                                     m('i', ' This component will inherit the same license as ',
                                         m('b', options.parentTitle),
                                         '. ',
-                                        m('a[href="http://help.osf.io/m/sharing/l/524050-licenses?id=524050-licenses"]', 'Learn more.' )
+                                        m('a[target="_blank"][href="http://help.osf.io/m/sharing/l/524050-licenses?id=524050-licenses"]', 'Learn more.' )
                                     )
                                 )
                         ]): '',


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
"Learn more" licenses link from create component modal now opens in a new tab.
<!-- Describe the purpose of your changes -->

## Changes
After change:
When you lick the "Learn more" licenses link in create component modal, it will open the web pages in a new tab instead of the current tab.
<!-- Briefly describe or list your changes  -->

## Side effects

<!--Any possible side effects? -->


## Ticket
https://openscience.atlassian.net/browse/OSF-8065
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
