### PR TITLE
[feature] vol url param [OSF-8820]

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -980,7 +980,8 @@ class WaterbutlerLink(Link):
 
         if 'view_only' not in self.kwargs:
             view_only = request.query_params.get('view_only', False)
-            self.kwargs['view_only'] = view_only
+            if view_only:
+                self.kwargs['view_only'] = view_only
 
         url = website_utils.waterbutler_api_url_for(obj.node._id, obj.provider, obj.path, **self.kwargs)
         if not url:

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -977,6 +977,11 @@ class WaterbutlerLink(Link):
             raise SkipField
         if self.must_be_file is True and obj.path.endswith('/'):
             raise SkipField
+
+        if 'view_only' not in self.kwargs:
+            view_only = request.query_params.get('view_only', False)
+            self.kwargs['view_only'] = view_only
+
         url = website_utils.waterbutler_api_url_for(obj.node._id, obj.provider, obj.path, **self.kwargs)
         if not url:
             raise SkipField

--- a/api_tests/nodes/views/test_node_files_list.py
+++ b/api_tests/nodes/views/test_node_files_list.py
@@ -239,6 +239,10 @@ class TestNodeFilesList(ApiTestCase):
                                             })
         assert_equal(res.json['data'][0]['attributes']['name'], 'NewFile')
         assert_equal(res.json['data'][0]['attributes']['provider'], 'github')
+        assert_in(vol.key, res.json['data'][0]['links']['move'])
+        assert_in(vol.key, res.json['data'][0]['links']['upload'])
+        assert_in(vol.key, res.json['data'][0]['links']['download'])
+        assert_in(vol.key, res.json['data'][0]['links']['delete'])
 
     def test_returns_node_files_list(self):
         self._prepare_mock_wb_response(provider='github', files=[{'name': 'NewFile'}])


### PR DESCRIPTION
## Purpose

Add view_only param to node files list api endpoint

## Changes

Modify api.base.serializers to check for vol in params 
and add vol param to wb action links. 

## Ticket

[OSF-8820](https://openscience.atlassian.net/browse/OSF-8820)

## After

<img width="970" alt="screen shot 2017-11-10 at 11 15 15 am" src="https://user-images.githubusercontent.com/4511563/32667365-838aac74-c608-11e7-920c-5a24ebf707b5.png">

<img width="1066" alt="screen shot 2017-11-10 at 11 14 38 am" src="https://user-images.githubusercontent.com/4511563/32667366-839abfd8-c608-11e7-89fd-867df571aa89.png">
