### PR TITLE
[OSF-8477] Import contributors in one click - fix pagination

### DIFF
--- a/website/static/js/contribAdder.js
+++ b/website/static/js/contribAdder.js
@@ -111,10 +111,6 @@ AddContributorViewModel = oop.extend(Paginator, {
             return self.query() && self.results().length && !self.parentImport();
         });
 
-        self.parentPagination = ko.pureComputed(function () {
-            return self.doneSearching() && self.parentImport();
-        });
-
         self.noResults = ko.pureComputed(function () {
             return self.query() && !self.results().length && self.doneSearching();
         });
@@ -295,10 +291,7 @@ AddContributorViewModel = oop.extend(Paginator, {
                     }
                 }
                 self.doneSearching(true);
-                self.selection(pageToShow);
-                self.currentPage(self.pageToGet());
-                self.numberOfPages(Math.ceil(contributors.length/5));
-                self.addNewPaginators(true);
+                self.selection(contributors);
             }
         );
     },

--- a/website/templates/project/modal_add_contributor.mako
+++ b/website/templates/project/modal_add_contributor.mako
@@ -120,11 +120,6 @@
                                         </div>
                                     </p>
                                 </div>
-                                <div data-bind="if: parentPagination">
-                                    <ul class="pagination pagination-sm" data-bind="foreach: paginators">
-                                        <li data-bind="css: style"><a href="#" data-bind="click: handler, text: text"></a></li>
-                                    </ul>
-                                </div>
                                 <div data-bind="if: showLoading">
                                     <p class="text-muted">Searching contributors...</p>
                                 </div>
@@ -216,7 +211,6 @@
                         </div>
 
                     </div>
-
                 </div>
                 <!-- Component selection page -->
                 <div data-bind="visible:page()=='which'">


### PR DESCRIPTION
## Purpose

There are a couple problems with the current import contributors feature.

- It doesn't import non-bibliographic contributors
- It doesn't import the contributors permissions
- You can't modify a contributors the bibliographic status before you add them, only their permissions.

This fix will set the permissions and bibliographic status on import so you can import everyone in one click.

## Changes

Changed the get_contributors_from_parent/ endpoint to get more info about the contributors permissions and bibliographic status, then modified the .mako and .js to display the new info without crowding the screen

## Before
![before_import_contributors](https://user-images.githubusercontent.com/9688518/29676552-5d3660ba-88c6-11e7-91de-1ed187ac78ff.gif)

## After
![import_contribs_demo](https://user-images.githubusercontent.com/9688518/29676570-675c72e6-88c6-11e7-9221-28872d04fad9.gif)


## Side effects

Modified some of the wrapping in that dialog, so make sure that works in a sane way with long names.

## Testing 

Nothing special

## Ticket

https://openscience.atlassian.net/browse/OSF-8477