### PR TITLE
[Hotfix] Handle edge case when making registration public [#OSF-8899]

### DIFF
--- a/scripts/approve_registrations.py
+++ b/scripts/approve_registrations.py
@@ -37,10 +37,12 @@ def main(dry_run=True):
             .format(registration_approval._id, pending_registration._id)
         )
         if not dry_run:
-            if pending_registration.is_deleted or pending_registration.archiving:
+            if pending_registration.is_deleted:
                 # Clean up any registration failures during archiving
                 registration_approval.forcibly_reject()
                 registration_approval.save()
+                continue
+            if pending_registration.archiving:
                 continue
 
             with transaction.atomic():

--- a/website/static/js/nodesPrivacy.js
+++ b/website/static/js/nodesPrivacy.js
@@ -109,6 +109,7 @@ var NodesPrivacyViewModel = function(node, onSetPrivacy) {
     self.parentIsPublic = node.is_public;
     self.parentNodeType = node.node_type;
     self.isPreprint = node.is_preprint;
+    self.dataType = node.is_registration ? 'registrations' : 'nodes';
     self.treebeardUrl = window.contextVars.node.urls.api  + 'tree/';
     self.nodesOriginal = {};
     self.nodesChanged = ko.observable();
@@ -238,7 +239,7 @@ NodesPrivacyViewModel.prototype.confirmChanges =  function() {
     //The API's bulk limit is 100 nodes.  We catch the exception in nodes_privacy.mako.
     if (nodesChanged.length <= 100) {
         $osf.block('Updating Privacy');
-        patchNodesPrivacy(nodesChanged, 'nodes').then(function () {
+        patchNodesPrivacy(nodesChanged, self.dataType).then(function () {
             self.onSetPrivacy(nodesChanged);
 
             self.nodesChangedPublic([]);
@@ -309,7 +310,7 @@ NodesPrivacyViewModel.prototype.makeEmbargoPublic = function() {
 	return null;
     }).filter(Boolean);
     $osf.block('Submitting request to end embargo early ...');
-    patchNodesPrivacy(nodesChanged, 'registrations').then(function (res) {
+    patchNodesPrivacy(nodesChanged, self.dataType).then(function (res) {
         $osf.unblock();
         $('.modal').modal('hide');
         self.onSetPrivacy(nodesChanged, true);


### PR DESCRIPTION
## Purpose
Allow admins to make private/embargoed registrations public.

## Changes
* Don't `forcibly_reject` non-deleted registrations stuck in archiving
* `PATCH` `/v2/registrations/<registration_id>/` instead of `/v2/nodes/<registration_id>/`

## Side effects
None expected

## Ticket
[[#OSF-8899]](https://openscience.atlassian.net/browse/OSF-8899)
