### PR TITLE
[feature fix] Fix pointer logs for embargos and registrations [OSF-8607]

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -177,6 +177,33 @@ class HideIfWithdrawal(ConditionalField):
         return not isinstance(self.field, RelationshipField)
 
 
+class HideIfNotNodePointerLog(ConditionalField):
+    """
+    This field will not be shown if the log is not a pointer log for a node
+    """
+    def should_hide(self, instance):
+        pointer_param = instance.params.get('pointer', False)
+        if pointer_param:
+            node = AbstractNode.load(pointer_param['id'])
+            if node:
+                return node.type != 'osf.node'
+        return True
+
+
+class HideIfNotRegistrationPointerLog(ConditionalField):
+    """
+    This field will not be shown if the log is not a pointer log for a registration
+    """
+
+    def should_hide(self, instance):
+        pointer_param = instance.params.get('pointer', False)
+        if pointer_param:
+            node = AbstractNode.load(pointer_param['id'])
+            if node:
+                return node.type != 'osf.registration'
+        return True
+
+
 class HideIfProviderCommentsAnonymous(ConditionalField):
     """
     If the action's provider has anonymous comments and the user does not have `view_actions`

--- a/api/logs/serializers.py
+++ b/api/logs/serializers.py
@@ -7,6 +7,8 @@ from api.base.serializers import (
     LinksField,
     is_anonymized,
     DateByVersion,
+    HideIfNotNodePointerLog,
+    HideIfNotRegistrationPointerLog,
 )
 
 from osf.models import OSFUser, AbstractNode, PreprintService
@@ -200,10 +202,20 @@ class NodeLogSerializer(JSONAPISerializer):
     )
 
     # This would be a node_link, except that data isn't stored in the node log params
-    linked_node = RelationshipField(
-        related_view='nodes:node-detail',
-        related_view_kwargs={'node_id': '<params.pointer.id>'}
+    linked_node = HideIfNotNodePointerLog(
+        RelationshipField(
+            related_view='nodes:node-detail',
+            related_view_kwargs={'node_id': '<params.pointer.id>'}
+        )
     )
+
+    linked_registration = HideIfNotRegistrationPointerLog(
+        RelationshipField(
+            related_view='registrations:registration-detail',
+            related_view_kwargs={'node_id': '<params.pointer.id>'}
+        )
+    )
+
     template_node = RelationshipField(
         related_view='nodes:node-detail',
         related_view_kwargs={'node_id': '<params.template_node.id>'}

--- a/api_tests/nodes/views/test_node_logs.py
+++ b/api_tests/nodes/views/test_node_logs.py
@@ -7,10 +7,12 @@ from dateutil.parser import parse as parse_date
 
 from api.base.settings.defaults import API_BASE
 from framework.auth.core import Auth
-from osf.models import NodeLog
+from osf.models import NodeLog, Registration, Sanction
 from osf_tests.factories import (
-    ProjectFactory,
     AuthUserFactory,
+    ProjectFactory,
+    RegistrationFactory,
+    EmbargoFactory,
 )
 from tests.base import assert_datetime_equal
 from website.util import disconnected_from_listeners
@@ -31,7 +33,7 @@ class TestNodeLogList:
         return AuthUserFactory()
 
     @pytest.fixture()
-    def creator(self):
+    def non_contrib(self):
         return AuthUserFactory()
 
     @pytest.fixture()
@@ -45,6 +47,14 @@ class TestNodeLogList:
     @pytest.fixture()
     def pointer(self, user):
         return ProjectFactory(creator=user)
+
+    @pytest.fixture()
+    def pointer_registration(self, user):
+        return RegistrationFactory(creator=user, is_public=True)
+
+    @pytest.fixture()
+    def pointer_embargo(self, user):
+        return RegistrationFactory(creator=user, embargo=EmbargoFactory(user=user), is_public=False)
 
     @pytest.fixture()
     def private_project(self, user):
@@ -191,7 +201,80 @@ class TestNodeLogList:
         res = app.get(public_url, auth=contrib.auth)
         assert res.status_code == 200
         assert res.json['data'][API_LATEST]['attributes']['params']['pointer'] is None
+
+    def test_registration_pointers(self, app, user, user_auth, non_contrib, public_project, pointer_registration, public_url):
+        public_project.add_pointer(pointer_registration, auth=user_auth, save=True)
+        assert public_project.logs.latest().action == 'pointer_created'
+        res = app.get(public_url, auth=user.auth)
+        assert res.status_code == 200
+        assert len(res.json['data']) == public_project.logs.count()
+        assert res.json['data'][API_LATEST]['attributes']['action'] == 'pointer_created'
+        assert res.json['data'][API_LATEST]['relationships']['linked_registration']['data']['id'] == pointer_registration._id
+
+        # Confirm pointer contains correct data for various users
+        assert res.json['data'][API_LATEST]['attributes']['params']['pointer']['id'] == pointer_registration._id
+
+        res = app.get(public_url, auth=non_contrib.auth)
+        assert res.status_code == 200
+        assert res.json['data'][API_LATEST]['attributes']['params']['pointer']['id'] == pointer_registration._id
         
+        res = app.get(public_url)
+        assert res.status_code == 200
+        assert res.json['data'][API_LATEST]['attributes']['params']['pointer']['id'] == pointer_registration._id
+
+        # Delete pointer and make sure no data shown
+        pointer_registration.remove_node(Auth(user))
+        pointer_registration.save()
+
+        res = app.get(public_url, auth=user.auth)
+        assert res.status_code == 200
+        assert res.json['data'][API_LATEST]['attributes']['params']['pointer'] is None
+        
+        res = app.get(public_url)
+        assert res.status_code == 200
+        assert res.json['data'][API_LATEST]['attributes']['params']['pointer'] is None
+
+        res = app.get(public_url, auth=non_contrib.auth)
+        assert res.status_code == 200
+        assert res.json['data'][API_LATEST]['attributes']['params']['pointer'] is None
+
+    def test_embargo_pointers(self, app, user, user_auth, non_contrib, public_project, pointer_embargo, public_url):
+        public_project.add_pointer(pointer_embargo, auth=user_auth, save=True)
+        assert public_project.logs.latest().action == 'pointer_created'
+        res = app.get(public_url, auth=user.auth)
+        assert res.status_code == 200
+        assert len(res.json['data']) == public_project.logs.count()
+        assert res.json['data'][API_LATEST]['attributes']['action'] == 'pointer_created'
+        assert res.json['data'][API_LATEST]['relationships']['linked_registration']['data']['id'] == pointer_embargo._id
+
+        # Confirm pointer contains correct data for various users
+        assert res.json['data'][API_LATEST]['attributes']['params']['pointer']['id'] == pointer_embargo._id
+
+        res = app.get(public_url, auth=non_contrib.auth)
+        assert res.status_code == 200
+        assert res.json['data'][API_LATEST]['attributes']['params']['pointer'] is None
+        
+        res = app.get(public_url)
+        assert res.status_code == 200
+        assert res.json['data'][API_LATEST]['attributes']['params']['pointer'] is None
+
+        # Delete pointer and make sure no data shown
+        pointer_embargo.remove_node(Auth(user))
+        pointer_embargo.save()
+
+        res = app.get(public_url, auth=user.auth)
+        assert res.status_code == 200
+        assert res.json['data'][API_LATEST]['attributes']['params']['pointer'] is None
+        
+        res = app.get(public_url)
+        assert res.status_code == 200
+        assert res.json['data'][API_LATEST]['attributes']['params']['pointer'] is None
+
+        res = app.get(public_url, auth=non_contrib.auth)
+        assert res.status_code == 200
+        assert res.json['data'][API_LATEST]['attributes']['params']['pointer'] is None
+
+
 @pytest.mark.django_db
 class TestNodeLogFiltering(TestNodeLogList):
 

--- a/website/static/js/components/logFeed.js
+++ b/website/static/js/components/logFeed.js
@@ -17,7 +17,7 @@ var _buildLogUrl = function(node, page, limitLogs) {
     var logPage = page || 1;
     var urlPrefix = (node.isRegistration || node.is_registration) ? 'registrations' : 'nodes';
     var size = limitLogs ? LOG_PAGE_SIZE_LIMITED : LOG_PAGE_SIZE;
-    var query = { 'page[size]': size, 'page': logPage, 'embed': ['original_node', 'user', 'linked_node', 'template_node'], 'profile_image_size': PROFILE_IMAGE_SIZE};
+    var query = { 'page[size]': size, 'page': logPage, 'embed': ['original_node', 'user', 'linked_node', 'linked_registration', 'template_node'], 'profile_image_size': PROFILE_IMAGE_SIZE};
     var viewOnly = $osf.urlParams().view_only;
     if (viewOnly) {
         query.view_only = viewOnly;

--- a/website/static/js/logTextParser.js
+++ b/website/static/js/logTextParser.js
@@ -300,8 +300,12 @@ var LogPieces = {
     pointer: {
         view: function (ctrl, logObject) {
             var linked_node = logObject.embeds.linked_node;
-            if (paramIsReturned(linked_node, logObject) && !linked_node.errors) {
+            if (linked_node && paramIsReturned(linked_node, logObject) && !linked_node.errors) {
                 return m('a', {href: $osf.toRelativeUrl(linked_node.data.links.html, window)}, linked_node.data.attributes.title);
+            }
+            var linked_registration = logObject.embeds.linked_registration;
+            if (linked_registration && paramIsReturned(linked_registration, logObject) && !linked_registration.errors) {
+                return m('a', {href: $osf.toRelativeUrl(linked_registration.data.links.html, window)}, linked_registration.data.attributes.title);
             }
             return m('span', 'a project');
         }
@@ -310,10 +314,18 @@ var LogPieces = {
     pointer_category: {
         view: function (ctrl, logObject) {
             var linked_node = logObject.embeds.linked_node;
-            if (paramIsReturned(linked_node, logObject) && !linked_node.errors) {
-                var category = linked_node.data.attributes.category;
+            var category = '';
+            if (linked_node && paramIsReturned(linked_node, logObject) && !linked_node.errors) {
+                category = linked_node.data.attributes.category;
                 if (category !== '') {
                     return m('span', linked_node.data.attributes.category);
+                }
+            }
+            var linked_registration = logObject.embeds.linked_registration;
+            if (linked_registration && paramIsReturned(linked_registration, logObject) && !linked_registration.errors) {
+                category = linked_registration.data.attributes.category;
+                if (category !== '') {
+                    return m('span', linked_registration.data.attributes.category);
                 }
             }
             return m('span', '');

--- a/website/static/js/myProjects.js
+++ b/website/static/js/myProjects.js
@@ -505,7 +505,7 @@ var MyProjects = {
                 if(!item.data.attributes.retracted){
                     var urlPrefix = item.data.attributes.registration ? 'registrations' : 'nodes';
                     // TODO assess sparse field usage (some already implemented)
-                    var url = $osf.apiV2Url(urlPrefix + '/' + id + '/logs/', { query : { 'page[size]' : 6, 'embed' : ['original_node', 'user', 'linked_node', 'template_node'], 'profile_image_size': PROFILE_IMAGE_SIZE, 'fields[users]' : sparseUserFields}});
+                    var url = $osf.apiV2Url(urlPrefix + '/' + id + '/logs/', { query : { 'page[size]' : 6, 'embed' : ['original_node', 'user', 'linked_node', 'linked_registration', 'template_node'], 'profile_image_size': PROFILE_IMAGE_SIZE, 'fields[users]' : sparseUserFields}});
                     var promise = self.getLogs(url);
                     return promise;
                 }


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Follow-up to modify how registrations work. The `linked_node` field on logs did not return any data for registrations, which was further causing issues with how logs were being presented. 
<!-- Describe the purpose of your changes -->

## Changes
1. Add conditional to linked_nodes and linked_registrations so that they only show up if the pointer is a node or registration. This means data for registrations is now accessible and won't be `not found` like it is right now.
2. Add a bunch of permissions tests for the registrations and confirm that the proper linked_* shows up.
3. Add linked_registrations to the myprojects page node logs, so those logs render the same

BEFORE nodes/{guid}/logs/ linked_node for a registration
<img width="541" alt="screen shot 2017-11-08 at 11 43 11 am" src="https://user-images.githubusercontent.com/1322421/32561418-33d067c6-c47a-11e7-9535-02892c2e4d08.png">
NOTE: the nodes/qams8/ link goes to `Not Found`

AFTER nodes/{guid}/logs linked_node becomes `linked_registration`
<img width="569" alt="screen shot 2017-11-08 at 11 43 29 am" src="https://user-images.githubusercontent.com/1322421/32561480-556d6d66-c47a-11e7-9bb9-adfcafaca01f.png">
NOTE: the registrations/qams8/ link resolves properly!!
<!-- Briefly describe or list your changes  -->

## Side effects
None Known.
<!--Any possible side effects? -->


## Ticket

https://openscience.atlassian.net/browse/OSF-8607

## QA Notes
1. Glance at the myprojects page logs to confirm that they match the main logs
2. Registrations and Embargoes should only show their name if the person viewing has access. This means Embargoes are only shown for contributors until they are made public. When made public they will show the name as expected.
3. Check out a nodes logs api endpoint (e.g., staging-api.osf.io/v2/nodes/<guid>/logs/) and confirm that node pointers show a `linked_node` section and that registration pointers show a `linked_registration` section.