### PR TITLE
Add ability to specify elasticsearch kwargs for SSL certs

### DIFF
--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -76,7 +76,8 @@ def client():
             CLIENT = Elasticsearch(
                 settings.ELASTIC_URI,
                 request_timeout=settings.ELASTIC_TIMEOUT,
-                retry_on_timeout=True
+                retry_on_timeout=True,
+                **settings.ELASIC_KWARGS
             )
             logging.getLogger('elasticsearch').setLevel(logging.WARN)
             logging.getLogger('elasticsearch.trace').setLevel(logging.WARN)

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -98,6 +98,13 @@ SEARCH_ENGINE = 'elastic'  # Can be 'elastic', or None
 ELASTIC_URI = 'localhost:9200'
 ELASTIC_TIMEOUT = 10
 ELASTIC_INDEX = 'website'
+ELASIC_KWARGS = {
+    # 'use_ssl': False,
+    # 'verify_certs': True,
+    # 'ca_certs': None,
+    # 'client_cert': None,
+    # 'client_key': None
+}
 
 # Sessions
 COOKIE_NAME = 'osf'


### PR DESCRIPTION
## Purpose

Needed for TLS/SSL connection for staging

## Changes

Add ELASTIC_KWARGS dictionary to defaults.py and use it in the elasticsearch client

## Side effects

N/A

## Notes for QA

No user-facing changes


## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
