### PR TITLE
[Hotfix] Stop self merges [OSF-8852]

### DIFF
--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -564,6 +564,11 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
 
         :param user: A User object to be merged.
         """
+
+        # Attempt to prevent self merges which end up removing self as a contributor from all projects
+        if self == user:
+            raise ValueError('Cannot merge a user into itself')
+
         # Fail if the other user has conflicts.
         if not user.can_be_merged:
             raise MergeConflictError('Users cannot be merged')

--- a/osf_tests/test_user.py
+++ b/osf_tests/test_user.py
@@ -1231,6 +1231,10 @@ class TestMergingUsers:
 
         assert project.get_permissions(master) == ['read', 'write', 'admin']
 
+    def test_merge_user_into_self_fails(self, master):
+        with pytest.raises(ValueError):
+            master.merge_user(master)
+
 
 class TestDisablingUsers(OsfTestCase):
     def setUp(self):


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Currently it is possible to merge a user into itself which removes the user from all of their projects
<!-- Describe the purpose of your changes -->

## Changes
This adds a check to see if they are the same user and stops it. This is not a 100% confirmed fix, but all roads point to it being one route through which the main bug occurs.
<!-- Briefly describe or list your changes  -->

## Side effects
NA
<!--Any possible side effects? -->


## Ticket

https://openscience.atlassian.net/browse/OSF-8852

##  QA Notes
Just quickly make sure merges still work as expected, no testing of the actual functionality
