### PR TITLE
[Hotfix] Stop quickfiles from moving with merges [OSF-8911]

### DIFF
--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -663,7 +663,7 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
         # - projects where the user was a contributor
         for node in user.contributed:
             # Skip bookmark collection node
-            if node.is_bookmark_collection:
+            if node.is_bookmark_collection or node.is_quickfiles:
                 continue
             # if both accounts are contributor of the same project
             if node.is_contributor(self) and node.is_contributor(user):

--- a/osf_tests/test_user.py
+++ b/osf_tests/test_user.py
@@ -1116,6 +1116,17 @@ class TestMergingUsers:
         merge_dupe()
         assert dashnode not in master.contributed
 
+    # Note the files are merged, but the actual node stays with the dupe user
+    def test_quickfiles_node_arent_merged(self, dupe, master, merge_dupe):
+        assert master.nodes.filter(type='osf.quickfilesnode').count() == 1
+        assert dupe.nodes.filter(type='osf.quickfilesnode').count() == 1
+
+        merge_dupe()
+        master.refresh_from_db()
+        dupe.refresh_from_db()
+        assert master.nodes.filter(type='osf.quickfilesnode').count() == 1
+        assert dupe.nodes.filter(type='osf.quickfilesnode').count() == 1
+
     def test_dupe_is_merged(self, dupe, master, merge_dupe):
         merge_dupe()
         assert dupe.is_merged

--- a/scripts/fix_merged_user_quickfiles.py
+++ b/scripts/fix_merged_user_quickfiles.py
@@ -6,7 +6,7 @@ from django.db.models import F
 
 from website.app import setup_django
 setup_django()
-from osf.models import AbstractNode
+from osf.models import QuickFilesNode
 from scripts import utils as script_utils
 
 
@@ -18,7 +18,7 @@ def main():
         # If we're not running in dry mode log everything to a file
         script_utils.add_file_logger(logger, __file__)
     with transaction.atomic():
-        qs = AbstractNode.objects.filter(type='osf.quickfilesnode').exclude(_contributors=F('creator'))
+        qs = QuickFilesNode.objects.exclude(_contributors=F('creator'))
         logger.info('Found {} quickfiles nodes with mismatched creator and _contributors'.format(qs.count()))
 
         for node in qs:

--- a/scripts/fix_merged_user_quickfiles.py
+++ b/scripts/fix_merged_user_quickfiles.py
@@ -1,0 +1,35 @@
+import logging
+import sys
+
+from django.db import transaction
+from django.db.models import F
+
+from website.app import setup_django
+setup_django()
+from osf.models import AbstractNode
+from scripts import utils as script_utils
+
+
+logger = logging.getLogger(__name__)
+
+def main():
+    dry = '--dry' in sys.argv
+    if not dry:
+        # If we're not running in dry mode log everything to a file
+        script_utils.add_file_logger(logger, __file__)
+    with transaction.atomic():
+        qs = AbstractNode.objects.filter(type='osf.quickfilesnode').exclude(_contributors=F('creator'))
+        logger.info('Found {} quickfiles nodes with mismatched creator and _contributors'.format(qs.count()))
+
+        for node in qs:
+            # There should only be one contributor, will error if this assumption is false
+            bad_contrib = node._contributors.get()
+            logger.info('Fixing {} (quickfiles node): Replacing {} (bad contributor) with {} (creator)'.format(node._id, bad_contrib._id, node.creator._id))
+            node.contributor_set.filter(user=bad_contrib).update(user=node.creator)
+            node.save()
+        if dry:
+            raise Exception('Abort Transaction - Dry Run')
+    print('Done')
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Merging users moves the quickfiles node. The files are moved properly away from the old quickfiles node, but the node itself also is moved. 
<!-- Describe the purpose of your changes -->

## Changes
Stop moving quickfiles nodes when transferring node contributor-ship. Add script to run to fix merged users.
<!-- Briefly describe or list your changes  -->

## Side effects
Stop potential bad things/weird things in the future.
<!--Any possible side effects? -->

## Deployment Instructions
Run the `fix_merged_user_quickfiles` script in --dry mode first to confirm everything works properly.

## Ticket

https://openscience.atlassian.net/browse/OSF-8911

## QA Notes
Just merge a user and make sure everything works properly. I'll confirm that things are working properly on the backend.
