### PR TITLE
[feature] Fix my projects page gravatar in logs [OSF-8897]

### DIFF
--- a/website/static/css/log-feed.css
+++ b/website/static/css/log-feed.css
@@ -15,6 +15,9 @@
 
 .db-log-avatar {
     display: inline-block;
+}
+
+.db-log-avatar-project-overview {
     position: absolute;
 }
 

--- a/website/static/js/components/logFeed.js
+++ b/website/static/js/components/logFeed.js
@@ -216,7 +216,7 @@ var LogFeed = {
                     image = m('img', { src : item.embeds.user.errors[0].meta.profile_image});
                 }
                 return m('.db-activity-item', [
-                    m('', [m('.db-log-avatar.m-r-xs', image), m('span.p-l-sm.p-r-sm', ''), m.component(LogText.LogText, item)]),
+                    m('', [m('.db-log-avatar.db-log-avatar-project-overview.m-r-xs', image), m('span.p-l-sm.p-r-sm', ''), m.component(LogText.LogText, item)]),
                     m('.text-right', m('span.text-muted.m-r-xs', item.attributes.formattableDate.local))
                 ]);
             }) : '',


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Gravatar has a bit too much freedom.

<!-- Describe the purpose of your changes -->

## Changes
Imprison the gravatar.
Before (My Projects Page):
<img width="358" alt="screen shot 2017-11-13 at 12 50 40 pm" src="https://user-images.githubusercontent.com/1322421/32740579-5f392d58-c871-11e7-9a2f-6652d1c3fb4c.png">

After (My Projects Page):

<img width="359" alt="screen shot 2017-11-13 at 12 45 16 pm" src="https://user-images.githubusercontent.com/1322421/32740597-6a72cc4c-c871-11e7-954f-bdfb566ef16f.png">

<!-- Briefly describe or list your changes  -->

## Side effects
None
<!--Any possible side effects? -->


## Ticket

https://openscience.atlassian.net/browse/OSF-8897

## QA Notes
Check both the logs on the project overview page and the my projects page. The issue was some extra CSS added to the project overview page, which now should only be applied there.
