### PR TITLE
Feature/fix ampersands in project description (and then some) [OSF-8865]

### DIFF
--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -269,7 +269,7 @@ def format_result(result, parent_id=None):
         'is_pending_retraction': result['is_pending_retraction'],
         'embargo_end_date': result['embargo_end_date'],
         'is_pending_embargo': result['is_pending_embargo'],
-        'description': result['description'],
+        'description': sanitize.unescape_entities(result['description']),
         'category': result.get('category'),
         'date_created': result.get('date_created'),
         'date_registered': result.get('registered_date'),

--- a/website/static/js/components/publicNodes.js
+++ b/website/static/js/components/publicNodes.js
@@ -109,12 +109,12 @@ var PublicNode = {
                     m('span.component-overflow.f-w-lg', {style: 'line-height: 1.5;'}, [
                         m('span.project-statuses-lg'),
                         m('span', {class: ctrl.icon, style: 'padding-right: 5px;'}, ''),
-                        m('a', {'href': ctrl.node.links.html}, ctrl.node.attributes.title)
+                        m('a', {'href': ctrl.node.links.html}, $osf.decodeText(ctrl.node.attributes.title))
                     ])
                 ]),
                 ctrl.nodeType === 'components' ? m('div', {style: 'padding-bottom: 10px;'}, [
-                    ctrl.parent ? ctrl.parent.title + ' / ': m('em', '-- private project -- / '),
-                    m('b', ctrl.node.attributes.title)
+                    ctrl.parent ? $osf.decodeText(ctrl.parent.title) + ' / ': m('em', '-- private project -- / '),
+                    m('b', $osf.decodeText(ctrl.node.attributes.title))
                 ]) : '',
                 m('div.project-authors', {}, _formatContributors(ctrl.node)),
             ])

--- a/website/static/js/logTextParser.js
+++ b/website/static/js/logTextParser.js
@@ -92,6 +92,7 @@ var returnTextParams = function (param, text, logObject, view_url) {
         if (type === 'wiki_updated' && source === 'home') {
             source = 'Home';
         }
+        source = $osf.decodeText(source);
         return view_url ? m('a', {href: $osf.toRelativeUrl(view_url, window)}, source) : m('span', source);
     }
     return m('span', text);
@@ -238,23 +239,23 @@ var LogPieces = {
             // Log action is node_removed
             if (logObject.attributes.action === 'node_removed') {
                 if (logObject.attributes.params.params_node) {
-                    return m('span', logObject.attributes.params.params_node.title);
+                    return m('span', $osf.decodeText(logObject.attributes.params.params_node.title));
             }}
             else if(paramIsReturned(nodeObject, logObject) && nodeObject.data){
                 if (nodeObject.data.links && nodeObject.data.attributes) {
                     return m('a', {href: $osf.toRelativeUrl(nodeObject.data.links.html, window), onclick: function() {
                         $osf.trackClick(logObject.trackingCategory, logObject.trackingAction, 'navigate-to-project-from-logs');
-                    }}, nodeObject.data.attributes.title);
+                    }}, $osf.decodeText(nodeObject.data.attributes.title));
                 }
                 else if (nodeObject.data.attributes) {
-                    return m('span', nodeObject.data.attributes.title);
+                    return m('span', $osf.decodeText(nodeObject.data.attributes.title));
                 }
             }
             // Original node has been deleted
             else if (!paramIsReturned(nodeObject, logObject)) {
                 var deletedNode = logObject.attributes.params.params_node;
                 if (paramIsReturned(deletedNode, logObject)){
-                     return m('span', deletedNode.title);
+                     return m('span', $osf.decodeText(deletedNode.title));
                 }
             }
             return m('span', 'a project');
@@ -286,7 +287,7 @@ var LogPieces = {
         view: function(ctrl, logObject) {
             var forkedFrom = logObject.attributes.params.params_node;
             var id = forkedFrom.id;
-            var title = forkedFrom.title;
+            var title = $osf.decodeText(forkedFrom.title);
             if (paramIsReturned(forkedFrom, logObject) && title){
                 if (id) {
                     return m('a', {href: '/' + id + '/' }, title);
@@ -301,11 +302,11 @@ var LogPieces = {
         view: function (ctrl, logObject) {
             var linked_node = logObject.embeds.linked_node;
             if (linked_node && paramIsReturned(linked_node, logObject) && !linked_node.errors) {
-                return m('a', {href: $osf.toRelativeUrl(linked_node.data.links.html, window)}, linked_node.data.attributes.title);
+                return m('a', {href: $osf.toRelativeUrl(linked_node.data.links.html, window)}, $osf.decodeText(linked_node.data.attributes.title));
             }
             var linked_registration = logObject.embeds.linked_registration;
             if (linked_registration && paramIsReturned(linked_registration, logObject) && !linked_registration.errors) {
-                return m('a', {href: $osf.toRelativeUrl(linked_registration.data.links.html, window)}, linked_registration.data.attributes.title);
+                return m('a', {href: $osf.toRelativeUrl(linked_registration.data.links.html, window)}, $osf.decodeText(linked_registration.data.attributes.title));
             }
             return m('span', 'a project');
         }
@@ -337,12 +338,12 @@ var LogPieces = {
             var template_node = logObject.embeds.template_node;
 
             if(paramIsReturned(template_node, logObject)){
-                return m('a', {href: $osf.toRelativeUrl(template_node.data.links.html, window)}, template_node.data.attributes.title);
+                return m('a', {href: $osf.toRelativeUrl(template_node.data.links.html, window)}, $osf.decodeText(template_node.data.attributes.title));
             }
 
             var templateFromParams = logObject.attributes.params.template_node;
                 if (paramIsReturned(templateFromParams, logObject && templateFromParams.title)){
-                    return m('span', templateFromParams.title);
+                    return m('span', $osf.decodeText(templateFromParams.title));
                 }
             return m('span','a project' );
         }

--- a/website/static/js/myProjects.js
+++ b/website/static/js/myProjects.js
@@ -31,6 +31,7 @@ var sparseNodeFields = String([
     'contributors',
     'current_user_permissions',
     'date_modified',
+    'description',
     'parent',
     'public',
     'tags',

--- a/website/static/js/myProjects.js
+++ b/website/static/js/myProjects.js
@@ -1927,7 +1927,7 @@ var Information = {
                                 m('', 'Last Modified on: ' + (item.date ? item.date.local : ''))
                             ]),
                             m('p', [
-                                m('span', {style: 'white-space:pre-wrap'}, item.attributes.description)
+                                m('span', {style: 'white-space:pre-wrap'}, $osf.decodeText(item.attributes.description))
                             ]),
                             item.attributes.tags.length > 0 ?
                             m('p.m-t-md', [

--- a/website/static/js/nodeControl.js
+++ b/website/static/js/nodeControl.js
@@ -110,9 +110,9 @@ var ProjectViewModel = function(data, options) {
             title: 'Edit Description',
             emptytext: 'Add a brief description to your ' + project_or_component_label,
             emptyclass: 'text-muted',
-            value: self.description(),
+            value: $osf.decodeText(self.description()),
             success: function(response, newValue) {
-                newValue = response.newValue; // Update display to reflect changes, eg by sanitizer
+                newValue = $osf.decodeText(response.newValue); // Update display to reflect changes, eg by sanitizer
                 self.description(newValue);
                 return {newValue: newValue};
             }


### PR DESCRIPTION
## Purpose

Stop ampersands from showing up as &amp; in project descriptions, in titles on the profile page, and activity logs.

## Changes

Decode project descriptions on project, institutions dashboard, and search pages. (Am I missing other locations?)

Decode project titles on public projects and components user profile pages.

Decode project titles in activity logs.

## Side effects
Descriptions were not showing up on the my projects page because they were not included in `sparseNodeFields`. This PR also fixes that.

Not a side effect, but to keep this fix consistent, any time the project description is used people will need to make sure to decode the ampersands.

## Tests
None needed. Only changes ampersand visualization.

## Ticket

https://openscience.atlassian.net/browse/OSF-8865

<img width="534" alt="screen shot 2017-11-13 at 4 43 08 pm" src="https://user-images.githubusercontent.com/7839433/32750830-d80d860a-c891-11e7-9d47-0f914ed79f85.png">
<img width="380" alt="screen shot 2017-11-13 at 4 44 41 pm" src="https://user-images.githubusercontent.com/7839433/32750889-02873cc8-c892-11e7-82ef-3f0e04fa825e.png"><img width="329" alt="screen shot 2017-11-14 at 9 55 06 am" src="https://user-images.githubusercontent.com/7839433/32786449-fd9ec1be-c921-11e7-909e-6ce4f648479e.png">

<img width="1196" alt="screen shot 2017-11-14 at 4 18 09 pm" src="https://user-images.githubusercontent.com/7839433/32805520-b14d0f56-c957-11e7-80f1-d4463a48c3ce.png">

<img width="566" alt="screen shot 2017-11-21 at 11 59 25 am" src="https://user-images.githubusercontent.com/7839433/33085804-c6fae632-ceb3-11e7-8a93-dff37c74f2f1.png">
