### PR TITLE
elasticsearch-py SSL/TLS update and fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ bleach==1.4.1
 html5lib==0.999999999
 blinker==1.4
 furl==0.4.92
-elasticsearch==1.3.0
+elasticsearch==2.4.0
 google-api-python-client==1.6.4
 Babel==2.5.1
 citeproc-py==0.4.0

--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -77,7 +77,7 @@ def client():
                 settings.ELASTIC_URI,
                 request_timeout=settings.ELASTIC_TIMEOUT,
                 retry_on_timeout=True,
-                **settings.ELASIC_KWARGS
+                **settings.ELASTIC_KWARGS
             )
             logging.getLogger('elasticsearch').setLevel(logging.WARN)
             logging.getLogger('elasticsearch.trace').setLevel(logging.WARN)

--- a/website/settings/defaults.py
+++ b/website/settings/defaults.py
@@ -98,7 +98,7 @@ SEARCH_ENGINE = 'elastic'  # Can be 'elastic', or None
 ELASTIC_URI = 'localhost:9200'
 ELASTIC_TIMEOUT = 10
 ELASTIC_INDEX = 'website'
-ELASIC_KWARGS = {
+ELASTIC_KWARGS = {
     # 'use_ssl': False,
     # 'verify_certs': True,
     # 'ca_certs': None,


### PR DESCRIPTION
## Purpose

Make elastic work with SSL/TLS (for real this time)

## Changes

* Updates elasticsearch-py dependency to 2.4.0 (from 1.3.0) to match what we're using
* Fix typo in settings

Related:
* https://github.com/elastic/elasticsearch-py/blob/2.4.0/elasticsearch/connection/http_urllib3.py
* floragunncom/search-guard#401
* http://urllib3.readthedocs.io/en/latest/reference/urllib3.contrib.html#module-urllib3.contrib.pyopenssl

## Ticket

N/A