### PR TITLE
Remove duped Node import

### DIFF
--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -16,7 +16,6 @@ from framework.utils import iso8601format
 from framework.auth.decorators import must_be_logged_in, collect_auth
 from framework.exceptions import HTTPError
 from osf.models.nodelog import NodeLog
-from osf.models.node import Node
 
 from website import language
 


### PR DESCRIPTION
Fixes https://travis-ci.org/CenterForOpenScience/osf.io/jobs/302083572

```
flake8 .
./website/project/views/node.py:40:1: F811 redefinition of unused 'Node' from line 19
```

`Node` is imported on LL19 and LL40