### PR TITLE
Feature/update FAQ link [OSF-8920]

### DIFF
--- a/website/templates/public/pages/support.mako
+++ b/website/templates/public/pages/support.mako
@@ -26,8 +26,8 @@
                     </div>
                     <div class="support-col-body clearfix">
                         <p> How can it be free? How will the OSF be useful to my research? What is a registration?
-                        Get your questions about the Open Science Framework answered on our <a href="http://help.osf.io/m/faqs"> FAQ page. </a></p>
-                        <a href="http://help.osf.io/m/faqs" class="btn btn-info m-t-lg pull-right" > Visit FAQ <i class="fa fa-angle-right"></i></a>
+                        Get your questions about the Open Science Framework answered on our <a href="http://help.osf.io/m/faqs/l/726460-faqs"> FAQ page. </a></p>
+                        <a href="http://help.osf.io/m/faqs/l/726460-faqs" class="btn btn-info m-t-lg pull-right" > Visit FAQ <i class="fa fa-angle-right"></i></a>
                     </div>
 
                </div>


### PR DESCRIPTION
## Purpose

Currently, it takes two clicks to actually get to frequently asked questions.

## Changes

Update "Visit FAQ" button  to link to actual questions.

## Side effects

None

## Tests

None needed: just link change.

## Ticket

https://openscience.atlassian.net/browse/OSF-8920

![faq button](https://user-images.githubusercontent.com/7839433/32804044-a965167a-c953-11e7-9339-1766c0ee1f7d.gif)

