### PR TITLE
[hotfix] Update node identifiers when privacy changes or is deleted [#OSF-7229]

### DIFF
--- a/api_tests/nodes/views/test_node_detail.py
+++ b/api_tests/nodes/views/test_node_detail.py
@@ -22,6 +22,7 @@ from osf_tests.factories import (
     NodeLicenseRecordFactory,
     PrivateLinkFactory,
     PreprintFactory,
+    IdentifierFactory,
 )
 from rest_framework import exceptions
 from tests.base import fake
@@ -827,6 +828,25 @@ class TestNodeUpdate(NodeCRUDTestCase):
         )
         assert res.status_code == 200
 
+    @mock.patch('website.preprints.tasks.update_ezid_metadata_on_change.s')
+    def test_set_node_private_updates_ezid(self, mock_update_ezid_metadata, app, user, project_public, url_public, make_node_payload):
+        IdentifierFactory(referent=project_public, category='doi')
+        res = app.patch_json_api(url_public, make_node_payload(project_public, {'public': False}), auth=user.auth)
+        assert res.status_code == 200
+        project_public.reload()
+        assert not project_public.is_public
+        mock_update_ezid_metadata.assert_called_with(project_public, status='unavailable')
+
+    @mock.patch('website.preprints.tasks.update_ezid_metadata_on_change')
+    def test_set_node_with_preprint_private_updates_ezid(self, mock_update_ezid_metadata, app, user, project_public, url_public, make_node_payload):
+        target_object = PreprintFactory(project=project_public)
+
+        res = app.patch_json_api(url_public, make_node_payload(project_public, {'public': False}), auth=user.auth)
+        assert res.status_code == 200
+        project_public.reload()
+        assert not project_public.is_public
+        mock_update_ezid_metadata.assert_called_with(target_object, status='unavailable')
+
 
 @pytest.mark.django_db
 class TestNodeDelete(NodeCRUDTestCase):
@@ -900,6 +920,14 @@ class TestNodeDelete(NodeCRUDTestCase):
     @mock.patch('website.preprints.tasks.update_ezid_metadata_on_change.s')
     def test_delete_node_with_preprint_calls_preprint_update_status(self, mock_update_ezid_metadata_on_change, app, user, project_public, url_public):
         PreprintFactory(project=project_public)
+        app.delete_json_api(url_public, auth=user.auth, expect_errors=True)
+        project_public.reload()
+
+        assert mock_update_ezid_metadata_on_change.called
+
+    @mock.patch('website.preprints.tasks.update_ezid_metadata_on_change.s')
+    def test_delete_node_with_identifier_calls_preprint_update_status(self, mock_update_ezid_metadata_on_change, app, user, project_public, url_public):
+        IdentifierFactory(referent=project_public, category='doi')
         app.delete_json_api(url_public, auth=user.auth, expect_errors=True)
         project_public.reload()
 

--- a/api_tests/preprints/views/test_preprint_detail.py
+++ b/api_tests/preprints/views/test_preprint_detail.py
@@ -262,8 +262,8 @@ class TestPreprintUpdate:
         assert preprint.node.title == new_title
         assert mock_preprint_updated.called
 
-    @mock.patch('website.preprints.tasks.on_preprint_updated.s')
-    def test_update_tags(self, mock_preprint_updated, app, user, preprint, url):
+    @mock.patch('website.preprints.tasks.update_ezid_metadata_on_change')
+    def test_update_tags(self, mock_update_ezid, app, user, preprint, url):
         new_tags = ['hey', 'sup']
 
         for tag in new_tags:
@@ -281,10 +281,10 @@ class TestPreprintUpdate:
         preprint.node.reload()
 
         assert sorted(list(preprint.node.tags.all().values_list('name', flat=True))) == new_tags
-        assert mock_preprint_updated.called
+        assert mock_update_ezid.called
 
-    @mock.patch('website.preprints.tasks.on_preprint_updated.s')
-    def test_update_contributors(self, mock_preprint_updated, app, user, preprint, url):
+    @mock.patch('website.preprints.tasks.update_ezid_metadata_on_change')
+    def test_update_contributors(self, mock_update_ezid, app, user, preprint, url):
         new_user = AuthUserFactory()
         contributor_payload = {
             "data": {
@@ -311,7 +311,7 @@ class TestPreprintUpdate:
 
         assert res.status_code == 201
         assert new_user in preprint.node.contributors
-        assert mock_preprint_updated.called
+        assert mock_update_ezid.called
 
     def test_cannot_set_primary_file(self, app, user, preprint, url):
 
@@ -396,6 +396,7 @@ class TestPreprintUpdate:
         res = app.patch_json_api(url, payload, auth=user.auth)
         unpublished.reload()
         assert unpublished.is_published
+        assert mock_get_identifiers.called
 
     @mock.patch('website.preprints.tasks.get_and_set_preprint_identifiers.si')
     def test_update_published_makes_node_public(self, mock_get_identifiers, app, user):

--- a/api_tests/preprints/views/test_preprint_list_mixin.py
+++ b/api_tests/preprints/views/test_preprint_list_mixin.py
@@ -270,3 +270,5 @@ class PreprintIsValidListMixin:
         # admin
         res = app.get(url, auth=user_admin_contrib.auth)
         assert len(res.json['data']) == 0
+
+        assert mock_preprint_updated.called

--- a/website/identifiers/listeners.py
+++ b/website/identifiers/listeners.py
@@ -8,3 +8,6 @@ def update_status_on_delete(node):
 
     for preprint in node.preprints.all():
         enqueue_task(update_ezid_metadata_on_change.s(preprint, status='unavailable'))
+
+    if node.get_identifier('doi'):
+        enqueue_task(update_ezid_metadata_on_change.s(node, status='unavailable'))


### PR DESCRIPTION

## Purpose
When a DOI is created on a node, it's status in EZID should change to "unavailable" if that node is made private, or is deleted.

## Changes
- Add call to identifiers listener to also update a node's identifier on node delete, not just its preprint's identifiers
- Add call to `update_ezid_metadata_on_change` to update any existing DOIs on privacy change
- Modify tests for preprints to specifically check that `update_ezid_metadata_on_change` is being called
- Add new tests to check for that call when node privacy is updated or node is deleted

## Side effects
Shouldn't affect any existing tests, since none seem to create "doi" identifiers. If one is created in the future, one will have to mock the actual sending of EZID data in the tests

## Notes for QA!
To test:
1. Create a public project
2. Create a DOI/ARK for that project
3. Check out its status on https://ezid.cdlib.org/ by logging in with test creds (ask me if you don't have em!), the status for your new DOI should be "public"
4. Make that project private, status on EZID should shortly change to "unavailable"
5. Make it public again, status on EZID should switch back, too
6. Delete the project, status on EZID should switch back to "unavailable"


## Ticket
https://openscience.atlassian.net/browse/OSF-7229