### PR TITLE
[hotfix] handle search error [OSF-8944]

### DIFF
--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -112,6 +112,8 @@ def requires_search(func):
             except NotFoundError as e:
                 raise exceptions.IndexNotFoundError(e.error)
             except RequestError as e:
+                if e.error == 'search_phase_execution_exception':
+                    raise exceptions.MalformedQueryError('Failed to parse query')
                 if 'ParseException' in e.error:  # ES 1.5
                     raise exceptions.MalformedQueryError(e.error)
                 if type(e.error) == dict:  # ES 2.0


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Query syntax errors from elasticsearch are raising an exception with 'search_phase_execution_exception' that is not caught properly. This is a hack-ish fix to get our builds passing and present a better error message via the api. Currently it is pasting the raw exception data on prod (which is enormous).

<!-- Describe the purpose of your changes -->


## Changes
Catch `search_phase_execution_exception` and reraise as a MalformedQueryException.
<!-- Briefly describe or list your changes  -->

## Side effects
Slightly less detail on error since the failed query is not passed back when this error is caught.
<!--Any possible side effects? -->


## Ticket

https://openscience.atlassian.net/browse/OSF-8944
