### PR TITLE
[feature] Handle search_phase_execution_exception [OSF-8944]

### DIFF
--- a/website/search/elastic_search.py
+++ b/website/search/elastic_search.py
@@ -112,6 +112,8 @@ def requires_search(func):
             except NotFoundError as e:
                 raise exceptions.IndexNotFoundError(e.error)
             except RequestError as e:
+                if e.error == 'search_phase_execution_exception':
+                    raise exceptions.MalformedQueryError('Failed to parse query')
                 if 'ParseException' in e.error:  # ES 1.5
                     raise exceptions.MalformedQueryError(e.error)
                 if type(e.error) == dict:  # ES 2.0

--- a/website/search_migration/migrate.py
+++ b/website/search_migration/migrate.py
@@ -94,7 +94,7 @@ def set_up_index(idx):
         helpers.reindex(es_client(), idx, index)
         logger.info('Deleting {} index'.format(idx))
         es_client().indices.delete(index=idx)
-        es_client().indices.put_alias(idx, index)
+        es_client().indices.put_alias(index=index, name=idx)
     else:
         # Increment version
         version = int(alias.keys()[0].split('_v')[1]) + 1
@@ -111,7 +111,7 @@ def set_up_alias(old_index, index):
         logger.info('Removing old aliases to {}'.format(old_index))
         es_client().indices.delete_alias(index=old_index, name='_all', ignore=404)
     logger.info('Creating new alias from {0} to {1}'.format(old_index, index))
-    es_client().indices.put_alias(old_index, index)
+    es_client().indices.put_alias(index=index, name=old_index)
 
 
 def delete_old(index):


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Query syntax errors from elasticsearch are raising an exception with 'search_phase_execution_exception' that is not caught properly. This is a hack-ish fix to get our builds passing and present a better error message via the api. Currently it is pasting the raw exception data on prod (which is enormous).

<!-- Describe the purpose of your changes -->


## Changes
Catch `search_phase_execution_exception` and reraise as a MalformedQueryException.
Fix issue with variable name ordering (h/t @mfraezz)
https://github.com/elastic/elasticsearch-py/blob/1.3.0/elasticsearch/client/indices.py#L352
https://github.com/elastic/elasticsearch-py/blob/2.4.1/elasticsearch/client/indices.py#L337
<!-- Briefly describe or list your changes  -->

## Side effects
Slightly less detail on error since the failed query is not passed back when this error is caught.
<!--Any possible side effects? -->


## Ticket

https://openscience.atlassian.net/browse/OSF-8944
