### PR TITLE
[feature] Stop sending Adblock Keen errors to sentry [OSF-8935]

### DIFF
--- a/website/static/js/keen.js
+++ b/website/static/js/keen.js
@@ -104,9 +104,14 @@ var KeenTracker = (function() {
         }
         client.recordEvent(collection, eventData, function (err) {
             if (err) {
-                Raven.captureMessage('Error sending Keen data to ' + collection + ': <' + err + '>', {
-                    extra: {payload: eventData}
-                });
+                // If google analytics is inaccessible keen will throw errors
+                var adBlockError = document.getElementsByTagName('iframe').item(0) === null;
+                var uselessError = 'An error occurred!' === err;
+                if(!adBlockError || !uselessError) {
+                    Raven.captureMessage('Error sending Keen data to ' + collection + ': <' + err + '>', {
+                        extra: {payload: eventData}
+                    });
+                }
             }
         });
     }
@@ -117,9 +122,14 @@ var KeenTracker = (function() {
         }
         client.recordEvents(events, function (err, res) {
             if (err) {
-                Raven.captureMessage('Error sending Keen data for multiple events: <' + err + '>', {
-                    extra: {payload: events}
-                });
+                // If google analytics is inaccessible keen will throw errors
+                var adBlockError = document.getElementsByTagName('iframe').item(0) === null;
+                var uselessError = 'An error occurred!' === err;
+                if(!adBlockError || !uselessError) {
+                    Raven.captureMessage('Error sending Keen data for multiple events: <' + err + '>', {
+                        extra: {payload: events}
+                    });
+                }
             } else {
                 for (var collection in res) {
                     var results = res[collection];


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Keen fails when adblock is on and sends an error EVERY TIME.
<!-- Describe the purpose of your changes -->

## Changes
Check if google analytics iframe exists, if it does, no adblock and can send the error. If there is a useful error message also send it.
<!-- Briefly describe or list your changes  -->

## Side effects
None Known. Fewer sentry errors that are useless?
<!--Any possible side effects? -->


## Ticket

https://openscience.atlassian.net/browse/OSF-8935

## QA Notes
Check adblock on and off to see if sentry is still sending errors to staging. I can help you check if desirable. 
