### PR TITLE
[EOSF-933] Raise GONE for deleted quick files view

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -38,7 +38,7 @@ from framework.transactions.handlers import no_auto_transaction
 from website import mailchimp_utils
 from website import mails, settings
 from addons.osfstorage import settings as osfstorage_settings
-from osf.models import AbstractNode, NodeLog
+from osf.models import AbstractNode, NodeLog, QuickFilesNode
 from website.profile.utils import add_contributor_json, serialize_unregistered
 from website.profile.views import fmt_date_or_none, update_osf_help_mails_subscription
 from website.project.decorators import check_can_access
@@ -4603,6 +4603,20 @@ class TestResolveGuid(OsfTestCase):
             '/{}/'.format(preprint._id)
         )
 
+    def test_deleted_quick_file_gone(self):
+        user = AuthUserFactory()
+        quickfiles = QuickFilesNode.objects.get(creator=user)
+        osfstorage = quickfiles.get_addon('osfstorage')
+        root = osfstorage.get_root()
+        test_file = root.append_file('soon_to_be_deleted.txt')
+        guid = test_file.get_guid(create=True)._id
+        test_file.delete()
+
+        url = web_url_for('resolve_guid', _guid=True, guid=guid)
+        res = self.app.get(url, expect_errors=True)
+
+        assert_equal(res.status_code, http.GONE)
+        assert_equal(res.request.path, '/{}/'.format(guid))
 
 class TestConfirmationViewBlockBingPreview(OsfTestCase):
 

--- a/website/views.py
+++ b/website/views.py
@@ -306,7 +306,7 @@ def resolve_guid(guid, suffix=None):
 
         if isinstance(referent, BaseFileNode) and referent.is_file and referent.node.is_quickfiles:
             if referent.is_deleted:
-                raise HTTPError(http.NOT_FOUND)
+                raise HTTPError(http.GONE)
             if PROXY_EMBER_APPS:
                 resp = requests.get(EXTERNAL_EMBER_APPS['ember_osf_web']['server'], stream=True)
                 return Response(stream_with_context(resp.iter_content()), resp.status_code)

--- a/website/views.py
+++ b/website/views.py
@@ -305,6 +305,8 @@ def resolve_guid(guid, suffix=None):
             return send_from_directory(preprints_dir, 'index.html')
 
         if isinstance(referent, BaseFileNode) and referent.is_file and referent.node.is_quickfiles:
+            if referent.is_deleted:
+                raise HTTPError(http.NOT_FOUND)
             if PROXY_EMBER_APPS:
                 resp = requests.get(EXTERNAL_EMBER_APPS['ember_osf_web']['server'], stream=True)
                 return Response(stream_with_context(resp.iter_content()), resp.status_code)


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

When a Quick File has been deleted, the OSF should return a page not found rather than routing to Ember.

## Changes

Add a condition to check if a Quick File is deleted and raise GONE if it is.

## Side effects

None

## Ticket

https://openscience.atlassian.net/browse/EOSF-933