### PR TITLE
[Hotfix] Make preprints with deleted nodes viewable via admin [OSF-8951]

### DIFF
--- a/admin/templates/preprints/preprint.html
+++ b/admin/templates/preprints/preprint.html
@@ -30,8 +30,7 @@
                         </div>
                     {% else %}
                         <span class="col-md-2">
-                        <form method="post">
-                              action="{% url 'nodes:restore' guid=node.id %}">
+                        <form method="post" action="{% url 'nodes:restore' guid=serialized_preprint.node.id %}">
                             {% csrf_token %}
                             <input class="btn btn-success" type="submit"
                                    value="Restore Preprint Node" />


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Deleted preprints be broke on admin. 

<!-- Describe the purpose of your changes -->

## Changes
There was a bit of django html gore that needed cleaning. 
<!-- Briefly describe or list your changes  -->

## Side effects
na
<!--Any possible side effects? -->


## Ticket

https://openscience.atlassian.net/browse/OSF-8951


## QA Notes
1. View a preprint with a deleted node and test the restore node button.
2. View a private preprint