### PR TITLE
[hotfix] Return 410 for a deleted file [OSF-8963]

### DIFF
--- a/api/files/views.py
+++ b/api/files/views.py
@@ -39,6 +39,8 @@ class FileMixin(object):
             obj = utils.get_object_or_error(BaseFileNode, self.kwargs[self.file_lookup_url_kwarg], self.request)
         except (NotFound, Gone):
             obj = utils.get_object_or_error(Guid, self.kwargs[self.file_lookup_url_kwarg], self.request).referent
+            if obj.is_deleted:
+                raise Gone(detail='The requested file is no longer available.')
             if not isinstance(obj, BaseFileNode):
                 raise NotFound
 

--- a/api_tests/files/views/test_file_detail.py
+++ b/api_tests/files/views/test_file_detail.py
@@ -60,11 +60,24 @@ class TestFileView:
         res = app.get(file_url, auth=non_contributor.auth, expect_errors=True)
         assert res.status_code == 403
 
+    def test_deleted_file_return_410(self, app, node, user):
+        deleted_file = api_utils.create_test_file(node, user, create_guid=True)
+        guid = deleted_file.get_guid()._id
+        assert guid
+
+        url = '/{}files/{}/'.format(API_BASE, guid)
+        res = app.get(url, auth=user.auth)
+        assert res.status_code == 200
+
+        deleted_file.delete(user=user, save=True)
+        res = app.get(url, auth=user.auth, expect_errors=True)
+        assert res.status_code == 410
+
     def test_file_guid_guid_status(self, app, user, file, file_url):
         # test_unvisited_file_has_no_guid
         res = app.get(file_url, auth=user.auth)
         assert res.status_code == 200
-        assert res.json['data']['attributes']['guid'] == None
+        assert res.json['data']['attributes']['guid'] is None
 
         # test_visited_file_has_guid
         guid = file.get_guid(create=True)
@@ -110,14 +123,14 @@ class TestFileView:
         assert attributes['kind'] == file.kind
         assert attributes['name'] == file.name
         assert attributes['materialized_path'] == file.materialized_path
-        assert attributes['last_touched'] == None
+        assert attributes['last_touched'] is None
         assert attributes['provider'] == file.provider
         assert attributes['size'] == file.versions.first().size
         assert attributes['current_version'] == len(file.history)
         assert attributes['date_modified'] == _dt_to_iso8601(file.versions.first().date_created.replace(tzinfo=pytz.utc))
         assert attributes['date_created'] == _dt_to_iso8601(file.versions.last().date_created.replace(tzinfo=pytz.utc))
-        assert attributes['extra']['hashes']['md5'] == None
-        assert attributes['extra']['hashes']['sha256'] == None
+        assert attributes['extra']['hashes']['md5'] is None
+        assert attributes['extra']['hashes']['sha256'] is None
         assert attributes['tags'] == []
 
     def test_file_has_rel_link_to_owning_project(self, app, user, file_url, node):
@@ -180,7 +193,7 @@ class TestFileView:
         assert can_comment is False
 
     def test_checkout(self, app, user, file, file_url, node):
-        assert file.checkout == None
+        assert file.checkout is None
         res = app.put_json_api(
             file_url,
             {'data': {'id': file._id, 'type': 'files', 'attributes': {'checkout': user._id}}},
@@ -210,7 +223,7 @@ class TestFileView:
         )
 
         file.reload()
-        assert file.checkout == None
+        assert file.checkout is None
         assert res.status_code == 200
 
     def test_checkout_file_error(self, app, user, file_url, file):
@@ -256,7 +269,7 @@ class TestFileView:
 
     def test_must_set_self(self, app, user, file, file_url):
         user_unauthorized = UserFactory()
-        assert file.checkout == None
+        assert file.checkout is None
         res = app.put_json_api(
             file_url,
             {'data': {'id': file._id, 'type': 'files', 'attributes': {'checkout': user_unauthorized._id}}},
@@ -265,7 +278,7 @@ class TestFileView:
         )
         file.reload()
         assert res.status_code == 400
-        assert file.checkout == None
+        assert file.checkout is None
 
     def test_must_be_self(self, app, file, file_url):
         user = AuthUserFactory()
@@ -295,7 +308,7 @@ class TestFileView:
         file.reload()
         node.reload()
         assert res.status_code == 200
-        assert file.checkout == None
+        assert file.checkout is None
         assert node.logs.latest().action == NodeLog.CHECKED_IN
         assert node.logs.latest().user == user
 
@@ -326,7 +339,7 @@ class TestFileView:
         node.reload()
         assert res.status_code == 200
         assert node.logs.count() == count
-        assert file.checkout == None
+        assert file.checkout is None
 
     def test_cannot_checkout_when_checked_out(self, app, user, node, file, file_url):
         user_unauthorized = UserFactory()
@@ -349,7 +362,7 @@ class TestFileView:
     def test_noncontrib_and_read_contrib_cannot_checkout(self, app, file, node, file_url):
         # test_noncontrib_cannot_checkout
         non_contrib = AuthUserFactory()
-        assert file.checkout == None
+        assert file.checkout is None
         assert not node.has_permission(non_contrib, 'read')
         res = app.put_json_api(
             file_url,
@@ -360,7 +373,7 @@ class TestFileView:
         file.reload()
         node.reload()
         assert res.status_code == 403
-        assert file.checkout == None
+        assert file.checkout is None
         assert node.logs.latest().action != NodeLog.CHECKED_OUT
 
         # test_read_contrib_cannot_checkout
@@ -376,7 +389,7 @@ class TestFileView:
         )
         file.reload()
         assert res.status_code == 403
-        assert file.checkout == None
+        assert file.checkout is None
         assert node.logs.latest().action != NodeLog.CHECKED_OUT
 
     def test_write_contrib_can_checkin(self, app, node, file, file_url):
@@ -393,7 +406,7 @@ class TestFileView:
         )
         file.reload()
         assert res.status_code == 200
-        assert file.checkout == None
+        assert file.checkout is None
 
     def test_removed_contrib_files_checked_in(self, app, node, file):
         write_contrib = AuthUserFactory()


### PR DESCRIPTION
## Purpose
Currently, looking up a deleted file via api file detail endpoint with **guid** returns 200 and the file object. 

## Changes

Add check for `is_deleted` on the returned file object

## Ticket

[OSF-8963](https://openscience.atlassian.net/browse/OSF-8963)

## After

<img width="1262" alt="screen shot 2017-11-24 at 9 21 47 am" src="https://user-images.githubusercontent.com/4511563/33214239-0efe53b4-d0f9-11e7-8f01-83ceafc0247e.png">

