### PR TITLE
Downgrade drf to 3.6.3 for now to fix breaking Browsable API changes [OSF-8966]

### DIFF
--- a/api_tests/users/views/test_user_detail.py
+++ b/api_tests/users/views/test_user_detail.py
@@ -105,6 +105,12 @@ class TestUserDetail:
         res = app.get(url, auth=user_one)
         assert 'node' not in res.json['data']['relationships'].keys()
 
+    # Regression test for https://openscience.atlassian.net/browse/OSF-8966
+    def test_browsable_api_for_user_detail(self, app, user_one):
+        url = "/{}users/{}/?format=api".format(API_BASE, user_one._id)
+        res = app.get(url, auth=user_one.auth)
+        assert res.status_code == 200
+
 
 @pytest.mark.django_db
 class TestUserRoutesNodeRoutes:

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,7 +59,7 @@ raven==5.32.0
 
 # API requirements
 Django==1.11.7  # pyup: <2.0 # Remove this when we're on Py3
-djangorestframework==3.6.4
+djangorestframework==3.6.3
 django-cors-headers==1.3.1
 djangorestframework-bulk==0.2.1
 pyjwt==1.5.3


### PR DESCRIPTION
## Purpose

Our attempt to upgrade djangorestframework to version 3.6.4 revealed some breaking changes in that particular release, that were also noted by the django-rest-framework-gis team [in the PR for the change](https://github.com/encode/django-rest-framework/pull/5259), namely that while trying to filter for HiddenFields in the form renderers (which we don't actually use, and are filtered out after the forms are created),  filtering in the browsable API assumes that the keys in `serializer.data` will correspond to fields on the serializer, which they don't in our case.

That same team later [created a PR to fix it](https://github.com/encode/django-rest-framework/pull/5499) , that was merged for the [3.7.1 release](https://github.com/encode/django-rest-framework/milestone/58?closed=1) of drf.

Since the attempt to update drf to the current most recent 3.7.3 broke soooo many things on our end, I've made a [separate ticket to do the upgrade to the major version for real](https://openscience.atlassian.net/browse/OSF-8981) when the time comes.

## Changes

- downgrade djangorestframework to 3.6.3
- add a test that double checks that the browsable API for user detail can render properly

## Side effects

None anticipated


## Ticket
https://openscience.atlassian.net/browse/OSF-8966