### PR TITLE
[feature] Fix Failing Forks and Registrations [OSF-8941]

### DIFF
--- a/api/caching/listeners.py
+++ b/api/caching/listeners.py
@@ -1,11 +1,10 @@
-from django.dispatch import receiver
-from django.db.models.signals import post_save
-
 from api.caching.tasks import ban_url
 from framework.postcommit_tasks.handlers import enqueue_postcommit_task
 
-
-@receiver(post_save)
-def ban_object_from_cache(sender, instance, created, **kwargs):
+# unused for now
+# from django.dispatch import receiver
+# from django.db.models.signals import post_save
+# @receiver(post_save)
+def ban_object_from_cache(sender, instance, **kwargs):
     if hasattr(instance, 'absolute_api_v2_url'):
         enqueue_postcommit_task(ban_url, (instance, ), {}, celery=False, once_per_request=True)


### PR DESCRIPTION
#### Purpose
- Fixes a caching issue that was causing forks and registrations to not work properly.

#### Changes
- Remove signal calling `ban_object_from_cache` 

#### Side effects
- None expected, `ban_object_from_cache` was never called prior to #7801 
- Alternatively, this file could've been deleted, decided with @sloria to leave it in just in case. 

#### Ticket
- [OSF-8941](https://openscience.atlassian.net/browse/OSF-8941)
