### PR TITLE
Remove unused arg for archive_addon celery task [OSF-8987]

### DIFF
--- a/osf_tests/test_archiver.py
+++ b/osf_tests/test_archiver.py
@@ -444,8 +444,7 @@ class TestArchiverTasks(ArchiverTestCase):
             archive_node(results, self.archive_job._id)
         archive_osfstorage_signature = archive_addon.si(
             'osfstorage',
-            self.archive_job._id,
-            results
+            self.archive_job._id
         )
         assert(mock_group.called_with(archive_osfstorage_signature))
 
@@ -492,15 +491,13 @@ class TestArchiverTasks(ArchiverTestCase):
             archive_node(results, self.archive_job._id)
         archive_dropbox_signature = archive_addon.si(
             'dropbox',
-            self.archive_job._id,
-            results
+            self.archive_job._id
         )
         assert(mock_group.called_with(archive_dropbox_signature))
 
     @mock.patch('website.archiver.tasks.make_copy_request.delay')
     def test_archive_addon(self, mock_make_copy_request):
-        result = archiver_utils.aggregate_file_tree_metadata('osfstorage', FILE_TREE, self.user)
-        archive_addon('osfstorage', self.archive_job._id, result)
+        archive_addon('osfstorage', self.archive_job._id)
         assert_equal(self.archive_job.get_target('osfstorage').status, ARCHIVER_INITIATED)
         cookie = self.user.get_or_create_cookie()
         assert(mock_make_copy_request.called_with(

--- a/website/archiver/tasks.py
+++ b/website/archiver/tasks.py
@@ -175,7 +175,7 @@ def make_waterbutler_payload(dst_id, rename):
 
 @celery_app.task(base=ArchiverTask, ignore_result=False)
 @logged('archive_addon')
-def archive_addon(addon_short_name, job_pk, stat_result):
+def archive_addon(addon_short_name, job_pk):
     """Archive the contents of an addon by making a copy request to the
     WaterBulter API
 
@@ -243,8 +243,7 @@ def archive_node(stat_results, job_pk):
             else:
                 archive_addon.delay(
                     addon_short_name=result.target_name,
-                    job_pk=job_pk,
-                    stat_result=result,
+                    job_pk=job_pk
                 )
         project_signals.archive_callback.send(dst)
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Celery trying to pickle an `AggregateStatResult` object when passing to the `archive_addon` archiver task was causing celery to freak out, as it wasn't JSON serializable. Turns out `archive_addon` doens't even use that result sooooo

## Changes

- Remove the arg for `stat_result` from the `archive_addon` signature
- Don't pass the arg in the tests either

## Side effects

None anticipated


## Ticket
https://openscience.atlassian.net/browse/OSF-8987