### PR TITLE
fix serialization for  StatResult and AggregateStatResult [OSF-8987]

### DIFF
--- a/website/archiver/__init__.py
+++ b/website/archiver/__init__.py
@@ -24,7 +24,10 @@ ARCHIVER_FAILURE_STATUSES = {
 
 NO_ARCHIVE_LIMIT = 'high_upload_limit'
 
-class StatResult(object):
+# StatResult and AggregateStatResult are dict subclasses because they are used
+# in celery tasks, and celery serializes to JSON by default
+
+class StatResult(dict):
     """
     Helper class to collect metadata about a single file
     """
@@ -35,18 +38,15 @@ class StatResult(object):
         self.target_name = target_name
         self.disk_usage = float(disk_usage)
 
-    def __str__(self):
-        return str(self._to_dict())
-
-    def _to_dict(self):
-        return {
+        self.update({
             'target_id': self.target_id,
             'target_name': self.target_name,
             'disk_usage': self.disk_usage,
-        }
+            'num_files': self.num_files
+        })
 
 
-class AggregateStatResult(object):
+class AggregateStatResult(dict):
     """
     Helper class to collect metadata about arbitrary depth file/addon/node file trees
     """
@@ -56,25 +56,21 @@ class AggregateStatResult(object):
         targets = targets or []
         self.targets = [target for target in targets if target]
 
-    def __str__(self):
-        return str(self._to_dict())
-
-    def _to_dict(self):
-        return {
+        self.update({
             'target_id': self.target_id,
             'target_name': self.target_name,
             'targets': [
-                target._to_dict()
+                target
                 for target in self.targets
             ],
             'num_files': self.num_files,
             'disk_usage': self.disk_usage,
-        }
+        })
 
     @property
     def num_files(self):
-        return sum([value.num_files for value in self.targets])
+        return sum([value['num_files'] for value in self.targets])
 
     @property
     def disk_usage(self):
-        return sum([value.disk_usage for value in self.targets])
+        return sum([value['disk_usage'] for value in self.targets])

--- a/website/archiver/tasks.py
+++ b/website/archiver/tasks.py
@@ -238,11 +238,11 @@ def archive_node(stat_results, job_pk):
             job.status = ARCHIVER_SUCCESS
             job.save()
         for result in stat_result.targets:
-            if not result.num_files:
-                job.update_target(result.target_name, ARCHIVER_SUCCESS)
+            if not result['num_files']:
+                job.update_target(result['target_name'], ARCHIVER_SUCCESS)
             else:
                 archive_addon.delay(
-                    addon_short_name=result.target_name,
+                    addon_short_name=result['target_name'],
                     job_pk=job_pk
                 )
         project_signals.archive_callback.send(dst)


### PR DESCRIPTION


<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Take 2!

These are used in celery tasks, which serialize things to JSON. Before, we were passing around the raw objects, which was breaking in the upgraded celery - hence making them JSON serializable by subclassing dict!

## Changes

- change access of serialized objects to dict access after passing around by tasks
- make StatResult and AggregateStatResult subclassses of dict

## Side effects

hope not 


## Ticket
https://openscience.atlassian.net/browse/OSF-8987