### PR TITLE
[feature] Speed Up Registration Contributors List Endpoint [OSF-9122]

### DIFF
--- a/api/registrations/views.py
+++ b/api/registrations/views.py
@@ -412,7 +412,7 @@ class RegistrationContributorsList(BaseContributorList, RegistrationMixin, UserM
 
     def get_default_queryset(self):
         node = self.get_node(check_object_permissions=False)
-        return node.contributor_set.all()
+        return node.contributor_set.all().include('user__guids')
 
 
 class RegistrationContributorDetail(BaseContributorDetail, RegistrationMixin, UserMixin):


### PR DESCRIPTION
#### Purpose
- According to NewRelic, the registration contributors list endpoint is one of our slowest. This PR speeds it up a bit.

#### Changes
- `.include(user___guids)` 
  - `BaseContributorsList` and `NodeContributorsList` use this same include -- registrations got left out of the party somehow.

#### Side Effects
- None

#### Ticket
- [OSF-9122](https://openscience.atlassian.net/browse/OSF-9122) (discovered while auditing slow endpoints in NewRelic for [OSF-8784](https://openscience.atlassian.net/browse/OSF-8784))

  