### PR TITLE
Fix custom taxonomy form in admin [OSF-8558]

### DIFF
--- a/admin/preprint_providers/forms.py
+++ b/admin/preprint_providers/forms.py
@@ -62,7 +62,8 @@ class PreprintProviderForm(forms.ModelForm):
 
 
 class PreprintProviderCustomTaxonomyForm(forms.Form):
-    custom_taxonomy_json = forms.CharField(widget=forms.Textarea, initial='{"include": [], "exclude": [], "custom": {}}', required=False)
+    add_missing = forms.BooleanField(required=False)
+    custom_taxonomy_json = forms.CharField(widget=forms.Textarea, initial='{"include": [], "exclude": [], "custom": {}, "merge": {}}', required=False)
     provider_id = forms.IntegerField(widget=forms.HiddenInput())
     include = forms.ChoiceField(choices=[], required=False)
     exclude = forms.ChoiceField(choices=[], required=False)
@@ -70,9 +71,12 @@ class PreprintProviderCustomTaxonomyForm(forms.Form):
     custom_parent = forms.CharField(required=False)
     bepress = forms.ChoiceField(choices=[], required=False)
 
+    merge_from = forms.ChoiceField(choices=[], required=False)
+    merge_into = forms.ChoiceField(choices=[], required=False)
+
     def __init__(self, *args, **kwargs):
         super(PreprintProviderCustomTaxonomyForm, self).__init__(*args, **kwargs)
-        subject_choices = [(x, x) for x in Subject.objects.all().values_list('text', flat=True)]
+        subject_choices = [(x, x) for x in Subject.objects.filter(bepress_subject__isnull=True).values_list('text', flat=True)]
         for name, field in self.fields.iteritems():
             if hasattr(field, 'choices'):
                 if field.choices == []:

--- a/admin/preprint_providers/views.py
+++ b/admin/preprint_providers/views.py
@@ -198,10 +198,9 @@ class ProcessCustomTaxonomy(PermissionRequiredMixin, View):
                     # Actually do the migration of the custom taxonomies
                     migrate(provider=provider._id, data=taxonomy_json, add_missing=provider_form.cleaned_data['add_missing'])
                     return redirect('preprint_providers:detail', preprint_provider_id=provider.id)
-
-            except ValueError as error:
+            except (ValueError, RuntimeError) as error:
                 response_data = {
-                    'message': 'There is an error with the submitted JSON. Here are some details: ' + error.message,
+                    'message': 'There is an error with the submitted JSON or the provider. Here are some details: ' + error.message,
                     'feedback_type': 'error'
                 }
         else:

--- a/admin/preprint_providers/views.py
+++ b/admin/preprint_providers/views.py
@@ -186,14 +186,17 @@ class ProcessCustomTaxonomy(PermissionRequiredMixin, View):
                 if request.is_ajax():
                     # An ajax request is for validation only, so run that validation!
                     try:
-                        response_data = validate_input(custom_provider=provider, data=taxonomy_json)
+                        response_data = validate_input(custom_provider=provider, data=taxonomy_json, add_missing=provider_form.cleaned_data['add_missing'])
+                        if response_data:
+                            added_subjects = [subject.text for subject in response_data]
+                            response_data = {'message': 'Custom taxonomy validated with added subjects: {}'.format(added_subjects), 'feedback_type': 'success'}
                     except (RuntimeError, AssertionError) as script_feedback:
                         response_data = {'message': script_feedback.message, 'feedback_type': 'error'}
                     if not response_data:
                         response_data = {'message': 'Custom taxonomy validated!', 'feedback_type': 'success'}
                 else:
                     # Actually do the migration of the custom taxonomies
-                    migrate(provider=provider._id, data=taxonomy_json)
+                    migrate(provider=provider._id, data=taxonomy_json, add_missing=provider_form.cleaned_data['add_missing'])
                     return redirect('preprint_providers:detail', preprint_provider_id=provider.id)
 
             except ValueError as error:
@@ -201,8 +204,13 @@ class ProcessCustomTaxonomy(PermissionRequiredMixin, View):
                     'message': 'There is an error with the submitted JSON. Here are some details: ' + error.message,
                     'feedback_type': 'error'
                 }
-            # Return a JsonResponse with the JSON error or the validation error if it's not doing an actual migration
-            return JsonResponse(response_data)
+        else:
+            response_data = {
+                'message': 'There is a problem with the form. Here are some details: ' + unicode(provider_form.errors),
+                'feedback_type': 'error'
+            }
+        # Return a JsonResponse with the JSON error or the validation error if it's not doing an actual migration
+        return JsonResponse(response_data)
 
 class ExportPreprintProvider(PermissionRequiredMixin, View):
     permission_required = 'osf.change_preprintprovider'

--- a/admin/static/js/preprint_providers/preprintProviders.js
+++ b/admin/static/js/preprint_providers/preprintProviders.js
@@ -160,9 +160,17 @@ $(document).ready(function() {
         });
     });
 
+    var getContent = function(taxonomyTextField) {
+        currentCustomTaxonomyContent = taxonomyTextField.val();
+        if (currentCustomTaxonomyContent === "") {
+            currentCustomTaxonomyContent = '{\"include\": [], \"exclude\": [], \"custom\": {}, \"merge\": {}}'
+        }
+        return JSON.parse(currentCustomTaxonomyContent);
+    };
+
     $( ".taxonomy-action-button" ).click(function() {
         var taxonomyTextField=$("#id_custom_taxonomy_json");
-        var content = JSON.parse(taxonomyTextField.val());
+        var content = getContent(taxonomyTextField);
         var value = $("#" + $(this).attr("value")).val();
         var subjects = content[$(this).attr("id")];
         if (subjects.indexOf(value) == -1) {
@@ -176,7 +184,7 @@ $(document).ready(function() {
         var name = $("#id_custom_name").val();
         var parent = $("#id_custom_parent").val();
         var bepress = $("#id_bepress").val();
-        var content = JSON.parse(taxonomyTextField.val());
+        var content = getContent(taxonomyTextField);
         if (content["custom"][name] === undefined) {
             content["custom"][name] = {
                 "parent": parent,
@@ -186,6 +194,21 @@ $(document).ready(function() {
 
         taxonomyTextField.val(JSON.stringify(content, undefined, 4));
     });
+
+
+    $( "#id-add-merge" ).click(function() {
+        var taxonomyTextField=$("#id_custom_taxonomy_json");
+        var merge_from = $("#id_merge_from").val();
+        var merge_into = $("#id_merge_into").val();
+        var content = getContent(taxonomyTextField);
+
+        if (content["merge"][merge_from] === undefined) {
+            content["merge"][merge_from] = merge_into
+        }
+
+        taxonomyTextField.val(JSON.stringify(content, undefined, 4));
+    });
+
 
     $("#id-validate-custom").on("click", function(event) {
        checkTaxonomy();
@@ -212,5 +235,7 @@ $(document).ready(function() {
     $("#id_include").select2();
     $("#id_exclude").select2();
     $("#id_bepress").select2();
+    $("#id_merge_from").select2();
+    $("#id_merge_into").select2();
 
 });

--- a/admin/templates/preprint_providers/enter_custom_taxonomy.html
+++ b/admin/templates/preprint_providers/enter_custom_taxonomy.html
@@ -22,6 +22,17 @@
 
             <div>
                 <div class="fieldWrapper">
+                    {{ taxonomy_form.add_missing.errors }}
+                    <div class="row">
+                        <div class="col-md-2">
+                            {{ taxonomy_form.add_missing.label_tag }}
+                        </div>
+                        <div class="col-md-10">
+                            {{ taxonomy_form.add_missing }}
+                        </div>
+                    </div>
+                </div>
+                <div class="fieldWrapper">
                     {{ taxonomy_form.include.errors }}
                     <div class="row">
                         <div class="col-md-2">
@@ -72,6 +83,29 @@
                     </div>
                 </div>
             </div>
+
+            <div>
+                <div><b>Merge:</b></div>
+                <div class="panel panel-default">
+                    <div class="panel-body">
+                        {{ taxonomy_form.merge_from.errors }}
+                        <p>
+                            {{ taxonomy_form.merge_from.label_tag }}
+                            {{ taxonomy_form.merge_from }}
+                        </p>
+                        {{ taxonomy_form.merge_into.errors }}
+                        <p>
+                            {{ taxonomy_form.merge_into.label_tag }}
+                            {{ taxonomy_form.merge_into }}
+                        </p>
+                        <div class="pull-right">
+                            <button type="button" id="id-add-merge">Add</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+
             <div>
                 <div class="fieldWrapper">
                     {{ taxonomy_form.custom_taxonomy_json.errors }}
@@ -109,6 +143,7 @@
             <div class="modal-body">
                 <div>
                     <ul>
+                        <li><b>add missing</b>: Choose "add missing" to automatically include subjects that are already in use on this preprint provider.
                         <li><b>include</b>: These subjects, and their children will be included in the custom taxonomy.
                             If a second level subject is included, that second level will become the top of the subject tree, and its parent will not be in the taxonomy.</li>
                         <li><b>exclude</b>: These subjects, and their children will *not* be included in the custom taxonomy. Useful to include a top level subject, but then specify
@@ -121,6 +156,14 @@
                                     bepress subject. See JSON below for an example.
                                 </li>
                                 <li>bepress: the existing subject that you would like to repalce with the subject listed in the custom name field.</li>
+                            </ul>
+                        </li>
+                        <li><b>merge</b>: The existing Bepress subjects you would like to "merge" together..
+                            <ul>
+                                <li>merge from: The subject to merge from</li>
+                                <li>merge into: The subject you would like the original subject to become, or merge into.
+                                *Note*: The subject you select for merge into must be included explicitly, and cannot just be implicitly via selecting "Add missing"
+                                </li>
                             </ul>
                         </li>
                     </ul>
@@ -159,6 +202,10 @@
             "parent": "",
             "bepress": "Engineering"
         }
+    },
+    merge: {
+        "Dance": "Arts and Humanities",
+        "Hydrology": "Climate"
     }
 }
                 </pre>

--- a/osf/management/commands/populate_custom_taxonomies.py
+++ b/osf/management/commands/populate_custom_taxonomies.py
@@ -15,6 +15,12 @@ logger = logging.getLogger(__name__)
 BEPRESS_PROVIDER = None
 
 def validate_input(custom_provider, data, copy=False, add_missing=False):
+
+    # This function may be run outside of this command (e.g. in the admin app) so we
+    # need to make sure that BEPRESS_PROVIDER is set
+    global BEPRESS_PROVIDER
+    BEPRESS_PROVIDER = PreprintProvider.objects.filter(_id='osf').first()
+
     logger.info('Validating data')
     includes = data.get('include', [])
     excludes = data.get('exclude', [])
@@ -50,7 +56,7 @@ def validate_input(custom_provider, data, copy=False, add_missing=False):
     included_subjects = included_subjects | Subject.objects.filter(text__in=merges.keys())
     missing_subjects = Subject.objects.filter(id__in=set([hier[-1].id for ps in PreprintService.objects.filter(provider=custom_provider) for hier in ps.subject_hierarchy])).exclude(id__in=included_subjects.values_list('id', flat=True))
     if not add_missing:
-        assert not missing_subjects.exists(), 'Incomplete mapping -- following subjects in use but not included:\n{}'.format(missing_subjects.all())
+        assert not missing_subjects.exists(), 'Incomplete mapping -- following subjects in use but not included:\n{}'.format(list(missing_subjects.values_list('text', flat=True)))
     logger.info('Successfully validated mapping completeness')
     return list(missing_subjects) if add_missing else None
 
@@ -154,7 +160,8 @@ def migrate(provider=None, share_title=None, data=None, dry_run=False, copy=Fals
     # This function may be run outside of this command (e.g. in the admin app) so we
     # need to make sure that BEPRESS_PROVIDER is set
     global BEPRESS_PROVIDER
-    BEPRESS_PROVIDER = PreprintProvider.objects.filter(_id='osf').first()
+    if not BEPRESS_PROVIDER:
+        BEPRESS_PROVIDER = PreprintProvider.objects.filter(_id='osf').first()
     custom_provider = PreprintProvider.objects.filter(_id=provider).first()
     assert custom_provider, 'Unable to find specified provider: {}'.format(provider)
     assert custom_provider.id != BEPRESS_PROVIDER.id, 'Cannot add custom mapping to BePress provider'

--- a/osf/management/commands/populate_custom_taxonomies.py
+++ b/osf/management/commands/populate_custom_taxonomies.py
@@ -57,6 +57,8 @@ def validate_input(custom_provider, data, copy=False, add_missing=False):
     missing_subjects = Subject.objects.filter(id__in=set([hier[-1].id for ps in PreprintService.objects.filter(provider=custom_provider) for hier in ps.subject_hierarchy])).exclude(id__in=included_subjects.values_list('id', flat=True))
     if not add_missing:
         assert not missing_subjects.exists(), 'Incomplete mapping -- following subjects in use but not included:\n{}'.format(list(missing_subjects.values_list('text', flat=True)))
+    assert custom_provider.share_title not in [None, '', 'bepress'], 'share title not set; please set the share title on this provider before creating a custom taxonomy.'
+
     logger.info('Successfully validated mapping completeness')
     return list(missing_subjects) if add_missing else None
 


### PR DESCRIPTION
## Purpose
The custom taxonomy script changed just a bit since this was written - let's fix it!

## Changes
- be sure to set `BEPRESS_PROVIDER` in the `validate` method as well, which is called seperately to check input
- add the `merge` form fields while we're at it, why not
- Parse out the error messages from the script into strings so that they can be rendered nicer
- Only show Bepress subjects in the dropdowns to make things faster

## Side effects

nope


## Ticket
https://openscience.atlassian.net/browse/OSF-8559