### PR TITLE
[feature] Remove redundant query in UserNodes [OSF-9121]

### DIFF
--- a/api/users/views.py
+++ b/api/users/views.py
@@ -545,7 +545,7 @@ class UserNodes(JSONAPIBaseView, generics.ListAPIView, UserMixin, NodesFilterMix
     # overrides ListAPIView
     def get_queryset(self):
         return (
-            AbstractNode.objects.filter(id__in=set(self.get_queryset_from_request().values_list('id', flat=True)))
+            self.get_queryset_from_request()
             .select_related('node_license')
             .order_by('-modified', )
             .include('contributor__user__guids', 'root__guids', limit_includes=10)


### PR DESCRIPTION
#### Purpose
- Removes a redundant query in the UserNodes list endpoint. 

#### Side Effects
- (minor) Performance boost, woo! 

#### Ticket
- [OSF-9121](https://openscience.atlassian.net/browse/OSF-9121) (discovered while auditing slow endpoints in NewRelic for [OSF-8784](https://openscience.atlassian.net/browse/OSF-8784))

  