### PR TITLE
Stop fangorn copies for read-only providers and add docs for local OD configuration

### DIFF
--- a/addons/onedrive/README.md
+++ b/addons/onedrive/README.md
@@ -3,5 +3,6 @@
 Enabling the addon for development
 
 1. If `addons/onedrive/settings/local.py` does not yet exist, create a local onedrive settings file with `cp addons/onedrive/settings/local-dist.py addons/onedrive/settings/local.py`
-2. Register the addon with Microsoft (https://account.live.com/developers/applications/index) and enter http://localhost:5000/oauth/callback/onedrive/ as the Redirect URL.
-3. Enter your OneDrive `client_id` and `client_secret` as `ONEDRIVE_KEY` and `ONEDRIVE_SECRET` in `addons/onedrive/settings/local.py`.
+2. Register the addon with Microsoft at https://account.live.com/developers/applications/index it should be a 'Web' platform, not 'Web API'
+3. Enter the Redirect URL as http://localhost:5000/oauth/callback/onedrive/
+4. Click 'Generate New Password' and put that string as the `ONEDRIVE_SECRET` in `addons/onedrive/settings/local.py` and put the Application Id as `ONEDRIVE_KEY`

--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -2519,6 +2519,9 @@ function isInvalidDropFolder(folder) {
         // must have a provider
         !folder.data.provider ||
         folder.data.status ||
+        // The following are read-only providers
+        folder.data.provider === 'onedrive' ||
+        folder.data.provider === 'gitlab' ||
         // cannot add to published dataverse
         (folder.data.provider === 'dataverse' && folder.data.dataverseIsPublished)
     ) {


### PR DESCRIPTION
## Purpose

Currently you can drag a file or folder into a read-only provider and it will attempt to copy and when fail, this fix grey out the upload option stopping the copy from failing.

Also adds docs for configuring One Drive locally.

## Changes

Small JS change to fangorn ensures uploads to Read-onlys Gitlab and One Drive are blocked.

## Side effects

None that I know of.

## Ticket

Discovered testing: https://openscience.atlassian.net/browse/OSF-8573
This does not have it's own ticket.