### PR TITLE
[Hotfix] Disable notifications for disabled users [OSF-8998]

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -567,7 +567,7 @@ def test_travis_else(ctx, numprocesses=None):
 def test_travis_api1_and_js(ctx, numprocesses=None):
     flake(ctx)
     jshint(ctx)
-    # TODO: Uncomment when https://github.com/travis-ci/travis-ci/issues/8836 is resolved 
+    # TODO: Uncomment when https://github.com/travis-ci/travis-ci/issues/8836 is resolved
     # karma(ctx)
     test_api1(ctx, numprocesses=numprocesses)
 

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1790,6 +1790,28 @@ class TestSendDigest(OsfTestCase):
         message = group_by_node(user_groups[last_user_index]['info'])
         assert_equal(kwargs['message'], message)
 
+    @mock.patch('website.mails.send_mail')
+    def test_send_users_email_ignores_disabled_users(self, mock_send_mail):
+        send_type = 'email_transactional'
+        d = factories.NotificationDigestFactory(
+            send_type=send_type,
+            event='comment_replies',
+            timestamp=timezone.now(),
+            message='Hello',
+            node_lineage=[factories.ProjectFactory()._id]
+        )
+        d.save()
+
+        user_groups = list(get_users_emails(send_type))
+        last_user_index = len(user_groups) - 1
+
+        user = OSFUser.load(user_groups[last_user_index]['user_id'])
+        user.is_disabled = True
+        user.save()
+
+        send_users_email(send_type)
+        assert_false(mock_send_mail.called)
+
     def test_remove_sent_digest_notifications(self):
         d = factories.NotificationDigestFactory(
             event='comment_replies',

--- a/website/notifications/tasks.py
+++ b/website/notifications/tasks.py
@@ -30,13 +30,14 @@ def send_users_email(send_type):
         notification_ids = [message['_id'] for message in info]
         sorted_messages = group_by_node(info)
         if sorted_messages:
-            mails.send_mail(
-                to_addr=user.username,
-                mimetype='html',
-                mail=mails.DIGEST,
-                name=user.fullname,
-                message=sorted_messages,
-            )
+            if not user.is_disabled:
+                mails.send_mail(
+                    to_addr=user.username,
+                    mimetype='html',
+                    mail=mails.DIGEST,
+                    name=user.fullname,
+                    message=sorted_messages,
+                )
             remove_notifications(email_notification_ids=notification_ids)
 
 


### PR DESCRIPTION
## Purpose
Don't send notification emails to disabled users. This seems like an obvious thing, but was an edge case that we didn't encounter for a long time. 

Rather than setting the user to receive `'none'` notifications upon disably, this keeps their old settings in case they are later restored, and checks to make sure that any user about to receive a notification email does not.

## Changes
* Ignore disabled users when calculating notifications
* Add test

## Side effects
Also fixes upstream flake8 error


## Ticket
[[OSF-8998]](https://openscience.atlassian.net/browse/OSF-8998)
