### PR TITLE
Feature/Integrate nplusone [OSF-8863]

### DIFF
--- a/admin/base/settings/defaults.py
+++ b/admin/base/settings/defaults.py
@@ -248,3 +248,6 @@ if DEBUG:
             'debug_toolbar.panels.redirects.RedirectsPanel'
         }
     }
+
+# If set to True, automated tests with extra queries will fail.
+NPLUSONE_RAISE = False

--- a/admin/base/settings/defaults.py
+++ b/admin/base/settings/defaults.py
@@ -89,7 +89,6 @@ INSTALLED_APPS = (
     'django_nose',
     'password_reset',
     'guardian',
-    'nplusone.ext.django',
 
     # OSF
     'osf',
@@ -155,7 +154,6 @@ MIDDLEWARE_CLASSES = (
     # process_request to be skipped, e.g. when a trailing slash is omitted
     'api.base.middleware.DjangoGlobalMiddleware',
     'api.base.middleware.CeleryTaskMiddleware',
-    'nplusone.ext.django.NPlusOneMiddleware',
 
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
@@ -241,8 +239,8 @@ DESK_KEY_SECRET = ''
 TINYMCE_APIKEY = ''
 
 if DEBUG:
-    INSTALLED_APPS += ('debug_toolbar', )
-    MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware', )
+    INSTALLED_APPS += ('debug_toolbar', 'nplusone.ext.django',)
+    MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware', 'nplusone.ext.django.NPlusOneMiddleware',)
     DEBUG_TOOLBAR_CONFIG = {
         'SHOW_TOOLBAR_CALLBACK': lambda(_): True,
         'DISABLE_PANELS': {

--- a/admin/base/settings/defaults.py
+++ b/admin/base/settings/defaults.py
@@ -89,6 +89,7 @@ INSTALLED_APPS = (
     'django_nose',
     'password_reset',
     'guardian',
+    'nplusone.ext.django',
 
     # OSF
     'osf',
@@ -154,6 +155,7 @@ MIDDLEWARE_CLASSES = (
     # process_request to be skipped, e.g. when a trailing slash is omitted
     'api.base.middleware.DjangoGlobalMiddleware',
     'api.base.middleware.CeleryTaskMiddleware',
+    'nplusone.ext.django.NPlusOneMiddleware',
 
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',

--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -90,7 +90,6 @@ INSTALLED_APPS = (
     'raven.contrib.django.raven_compat',
     'django_extensions',
     'guardian',
-    'nplusone.ext.django',
 
     # OSF
     'osf',
@@ -205,7 +204,6 @@ MIDDLEWARE_CLASSES = (
     # 'api.base.middleware.ProfileMiddleware',
 
     # 'django.contrib.sessions.middleware.SessionMiddleware',
-    'nplusone.ext.django.NPlusOneMiddleware',
     'api.base.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -277,6 +275,10 @@ SELECT_FOR_UPDATE_ENABLED = True
 ANONYMOUS_USER_NAME = None
 
 CELERY_BEAT_SCHEDULER = 'django_celery_beat.schedulers:DatabaseScheduler'
+
+if DEBUG:
+    INSTALLED_APPS += ('nplusone.ext.django',)
+    MIDDLEWARE_CLASSES += ('nplusone.ext.django.NPlusOneMiddleware',)
 
 # If set to True, automated tests with extra queries will fail.
 NPLUSONE_RAISE = False

--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -90,6 +90,7 @@ INSTALLED_APPS = (
     'raven.contrib.django.raven_compat',
     'django_extensions',
     'guardian',
+    'nplusone.ext.django',
 
     # OSF
     'osf',
@@ -204,6 +205,7 @@ MIDDLEWARE_CLASSES = (
     # 'api.base.middleware.ProfileMiddleware',
 
     # 'django.contrib.sessions.middleware.SessionMiddleware',
+    'nplusone.ext.django.NPlusOneMiddleware',
     'api.base.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -275,3 +277,5 @@ SELECT_FOR_UPDATE_ENABLED = True
 ANONYMOUS_USER_NAME = None
 
 CELERY_BEAT_SCHEDULER = 'django_celery_beat.schedulers:DatabaseScheduler'
+
+NPLUSONE_RAISE = True

--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -277,3 +277,6 @@ SELECT_FOR_UPDATE_ENABLED = True
 ANONYMOUS_USER_NAME = None
 
 CELERY_BEAT_SCHEDULER = 'django_celery_beat.schedulers:DatabaseScheduler'
+
+# If set to True, automated tests with extra queries will fail.
+NPLUSONE_RAISE = False

--- a/api/base/settings/defaults.py
+++ b/api/base/settings/defaults.py
@@ -277,5 +277,3 @@ SELECT_FOR_UPDATE_ENABLED = True
 ANONYMOUS_USER_NAME = None
 
 CELERY_BEAT_SCHEDULER = 'django_celery_beat.schedulers:DatabaseScheduler'
-
-NPLUSONE_RAISE = True

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -33,3 +33,6 @@ ipdb==0.10.1
 
 # PyDevD (Remote Debugging)
 pydevd==0.0.6
+
+# n+1 query detection
+nplusone==0.8.2


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Catch slow queries before they go to production by integrating the [nplusone library](https://github.com/jmcarp/nplusone) into our development environment.

## Changes

- Add nplusone to dev requirements
- Add nplusone to INSTALLED_APPS and NPlusOneMiddleware to admin defaults and api default settings if debug mode
- Add NPLUSONE_RAISE with default value of False

 
## Side effects

In dev mode in admin app, and API, console prints out warnings.  No extra queries are addressed in this PR.  Locally, you can set NPLUSONE_RAISE to True, and all tests with extra queries will fail.
```
 | [nplusone]  DEBUG: Potential n+1 query detected on `AbstractNode.preprint_file`
api_1               | [nplusone]  DEBUG: Potential n+1 query detected on `Node.tags`
api_1               | [nplusone]  DEBUG: Potential n+1 query detected on `AbstractNode.node_license`
api_1               | [nplusone]  DEBUG: Potential n+1 query detected on `AbstractNode.contributor_set`
api_1               | [nplusone]  DEBUG: Potential n+1 query detected on `AbstractNode._parents`
api_1               | [nplusone]  DEBUG: Potential n+1 query detected on `AbstractNode.root`
api_1               | [nplusone]  DEBUG: Potential n+1 query detected on `AbstractNode.preprint_file`
api_1               | [nplusone]  DEBUG: Potential n+1 query detected on `Node.tags`
api_1               | [nplusone]  DEBUG: Potential n+1 query detected on `AbstractNode.node_license`
api_1               | [nplusone]  DEBUG: Potential n+1 query detected on `AbstractNode.contributor_set`
api_1               | [nplusone]  DEBUG: Potential n+1 query detected on `AbstractNode._parents`
api_1               | [nplusone]  DEBUG: Potential n+1 query detected on `AbstractNode.root`

```
## Ticket

https://openscience.atlassian.net/browse/OSF-8863