### PR TITLE
Feature/Remove .remove() and .remove_one() methods [OSF-8921]

### DIFF
--- a/addons/base/testing/models.py
+++ b/addons/base/testing/models.py
@@ -164,11 +164,10 @@ class OAuthAddonNodeSettingsTestSuiteMixin(OAuthAddonModelTestSuiteMixinBase):
 
     def tearDown(self):
         super(OAuthAddonNodeSettingsTestSuiteMixin, self).tearDown()
-        self.user_settings.remove()
-        self.node_settings.remove()
-        self.external_account.remove()
-        self.node.remove()
-        self.user.remove()
+        self.user_settings.delete()
+        self.external_account.delete()
+        self.node.delete()
+        self.user.delete()
 
     def test_configured_true(self):
         assert_true(self.node_settings.has_auth)

--- a/addons/base/tests/models.py
+++ b/addons/base/tests/models.py
@@ -201,11 +201,10 @@ class OAuthAddonNodeSettingsTestSuiteMixin(OAuthAddonModelTestSuiteMixinBase):
 
     def tearDown(self):
         super(OAuthAddonNodeSettingsTestSuiteMixin, self).tearDown()
-        self.user_settings.remove()
-        self.node_settings.remove()
-        self.external_account.remove()
-        self.node.remove()
-        self.user.remove()
+        self.user_settings.delete()
+        self.external_account.delete()
+        self.node.delete()
+        self.user.delete()
 
     @pytest.mark.django_db
     def test_configured_true(self):

--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -458,7 +458,7 @@ def addon_delete_file_node(self, node, user, event_type, payload):
                 if item.kind == 'file' and not TrashedFileNode.load(item._id):
                     item.delete(user=user)
                 elif item.kind == 'folder':
-                    BaseFileNode.remove_one(item)
+                    BaseFileNode.delete(item)
         else:
             try:
                 file_node = BaseFileNode.resolve_class(provider, BaseFileNode.FILE).objects.get(

--- a/addons/osfstorage/tests/test_models.py
+++ b/addons/osfstorage/tests/test_models.py
@@ -677,7 +677,7 @@ class TestOsfStorageFileVersion(StorageTestCase):
         assert_equal(version2.archive, 'erchiv')
 
     def test_no_matching_archive(self):
-        models.FileVersion.remove()
+        models.FileVersion.objects.all().delete()
         assert_is(False, factories.FileVersionFactory(
             location={
                 'service': 'cloud',

--- a/addons/twofactor/tests/test_models.py
+++ b/addons/twofactor/tests/test_models.py
@@ -65,7 +65,7 @@ class TestUserSettingsModel(unittest.TestCase):
 
     def tearDown(self):
         super(TestUserSettingsModel, self).tearDown()
-        self.user.__class__.remove_one(self.user)
+        self.user.__class__.delete(self.user)
 
     def test_b32(self):
         assert_equal(self.user_settings.totp_secret_b32, self.TOTP_SECRET_B32)

--- a/admin_tests/meetings/test_views.py
+++ b/admin_tests/meetings/test_views.py
@@ -26,7 +26,7 @@ from admin.meetings.forms import MeetingForm
 class TestMeetingListView(AdminTestCase):
     def setUp(self):
         super(TestMeetingListView, self).setUp()
-        Conference.remove()
+        Conference.objects.all().delete()
         ConferenceFactory()
         ConferenceFactory()
         ConferenceFactory()
@@ -135,7 +135,7 @@ class TestMeetingFormView(AdminTestCase):
 class TestMeetingCreateFormView(AdminTestCase):
     def setUp(self):
         super(TestMeetingCreateFormView, self).setUp()
-        Conference.remove()
+        Conference.objects.all().delete()
         self.user = AuthUserFactory()
         self.request = RequestFactory().post('/fake_path')
         self.view = MeetingCreateFormView

--- a/admin_tests/pre_reg/utils.py
+++ b/admin_tests/pre_reg/utils.py
@@ -2,7 +2,7 @@ from osf.models import DraftRegistration, MetaSchema
 
 
 def draft_reg_util():
-    DraftRegistration.remove()
+    DraftRegistration.objects.all().delete()
     return MetaSchema.objects.get(name='Prereg Challenge', schema_version=2)
 
 

--- a/admin_tests/spam/test_views.py
+++ b/admin_tests/spam/test_views.py
@@ -25,7 +25,7 @@ from admin.spam.views import (
 class TestSpamListView(AdminTestCase):
     def setUp(self):
         super(TestSpamListView, self).setUp()
-        Comment.remove()
+        Comment.objects.all().delete()
         self.project = ProjectFactory(is_public=True)
         self.user_1 = AuthUserFactory()
         self.user_2 = AuthUserFactory()

--- a/api/preprints/views.py
+++ b/api/preprints/views.py
@@ -271,7 +271,7 @@ class PreprintDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView, Pre
     def perform_destroy(self, instance):
         if instance.is_published:
             raise Conflict('Published preprints cannot be deleted.')
-        PreprintService.remove_one(instance)
+        PreprintService.delete(instance)
 
 
 class PreprintCitationDetail(JSONAPIBaseView, generics.RetrieveAPIView, PreprintMixin):

--- a/framework/sessions/utils.py
+++ b/framework/sessions/utils.py
@@ -22,4 +22,4 @@ def remove_session(session):
     :return:
     """
     from osf.models import Session
-    Session.remove_one(session)
+    Session.objects.filter(id=session.id).delete()

--- a/osf/models/base.py
+++ b/osf/models/base.py
@@ -80,15 +80,6 @@ class BaseModel(TimeStampedModel):
         except cls.DoesNotExist:
             return None
 
-    @classmethod
-    def remove(cls, query=None):
-        return cls.objects.filter(query).delete() if query else cls.objects.all().delete()
-
-    @classmethod
-    def remove_one(cls, obj):
-        if obj.pk:
-            return obj.delete()
-
     @property
     def _primary_name(self):
         return '_id'

--- a/osf/models/queued_mail.py
+++ b/osf/models/queued_mail.py
@@ -58,7 +58,7 @@ class QueuedMail(ObjectIDMixin, BaseModel):
             self.save()
             return True
         else:
-            self.__class__.remove_one(self)
+            self.__class__.delete(self)
             return False
 
     def find_sent_of_same_type_and_user(self):

--- a/osf_tests/test_archiver.py
+++ b/osf_tests/test_archiver.py
@@ -1113,7 +1113,7 @@ class TestArchiverScripts(ArchiverTestCase):
             archive_job.datetime_initiated = timezone.now() - delta
             archive_job.save()
             reg.save()
-            ArchiveJob.remove_one(archive_job)
+            ArchiveJob.delete(archive_job)
             legacy.append(reg._id)
         for i in range(5):
             reg = factories.RegistrationFactory()

--- a/osf_tests/test_node.py
+++ b/osf_tests/test_node.py
@@ -545,14 +545,6 @@ class TestNodeMODMCompat:
             node.save()
         assert excinfo.value.message_dict == {'title': ['Title cannot exceed 200 characters.']}
 
-    def test_remove_one(self):
-        node = ProjectFactory()
-        node2 = ProjectFactory()
-        assert Node.objects.all().count() == 2  # sanity check
-        Node.remove_one(node)
-        assert Node.objects.all().count() == 1
-        assert node2 in Node.objects.all()
-
     def test_querying_on_guid_id(self):
         node = NodeFactory()
         assert len(node._id) == 5
@@ -3683,7 +3675,7 @@ class TestTemplateNode:
         registration = RegistrationFactory(project=project, is_deleted=True)
         new = registration.use_as_template(auth=auth)
         assert not new.nodes
-        
+
     @pytest.fixture()
     def pointee(self, project, user, auth):
         pointee = ProjectFactory(creator=user)

--- a/osf_tests/test_session.py
+++ b/osf_tests/test_session.py
@@ -40,8 +40,8 @@ class SessionUtilsTestCase(DbTestCase):
 
     def tearDown(self, *args, **kwargs):
         super(SessionUtilsTestCase, self).tearDown(*args, **kwargs)
-        OSFUser.remove()
-        Session.remove()
+        OSFUser.objects.all().delete()
+        Session.objects.all().delete()
 
     def test_remove_session_for_user(self):
         SessionFactory(user=self.user)

--- a/scripts/parse_citation_styles.py
+++ b/scripts/parse_citation_styles.py
@@ -31,7 +31,7 @@ from osf.models.citation import CitationStyle
 def main():
 
     # drop all styles
-    CitationStyle.remove()
+    CitationStyle.objects.all().delete()
 
     total = 0
 

--- a/scripts/register_oauth_scopes.py
+++ b/scripts/register_oauth_scopes.py
@@ -57,7 +57,7 @@ def do_populate(clear=False):
     scope_dict = oauth_scopes.public_scopes
 
     if clear:
-        ApiOAuth2Scope.remove()
+        ApiOAuth2Scope.objects.all().delete()
 
     for name, scope in scope_dict.iteritems():
         # Update a scope if it exists, else populate

--- a/scripts/tests/test_add_preprint_providers.py
+++ b/scripts/tests/test_add_preprint_providers.py
@@ -15,7 +15,7 @@ class TestAddPreprintProviders(OsfTestCase):
         taxonomy_main()
 
     def tearDown(self):
-        PreprintProvider.remove()
+        PreprintProvider.objects.all().delete()
 
     def test_add_prod_providers(self):
         populate_main('prod')

--- a/scripts/tests/test_glacier_audit.py
+++ b/scripts/tests/test_glacier_audit.py
@@ -30,7 +30,7 @@ class TestGlacierInventory(OsfTestCase):
 
     def tearDown(self):
         super(TestGlacierInventory, self).tearDown()
-        model.OsfStorageFileVersion.remove()
+        model.OsfStorageFileVersion.objects.all().delete()
 
     def test_inventory(self):
         version = FileVersionFactory(

--- a/scripts/tests/test_refresh_addon_tokens.py
+++ b/scripts/tests/test_refresh_addon_tokens.py
@@ -29,7 +29,7 @@ class TestRefreshTokens(OsfTestCase):
 
     def tearDown(self):
         super(TestRefreshTokens, self).tearDown()
-        ExternalAccount.remove()
+        ExternalAccount.objects.all().delete()
 
     def test_look_up_provider(self):
         for Provider in PROVIDER_CLASSES:

--- a/tests/base.py
+++ b/tests/base.py
@@ -290,14 +290,10 @@ class ApiAddonTestCase(ApiTestCase):
 
     def tearDown(self):
         super(ApiAddonTestCase, self).tearDown()
-        self.user.remove()
-        self.node.remove()
-        if self.node_settings:
-            self.node_settings.remove()
-        if self.user_settings:
-            self.user_settings.remove()
+        self.user.delete()
+        self.node.delete()
         if self.account:
-            self.account.remove()
+            self.account.delete()
 
 
 @override_settings(ROOT_URLCONF='admin.base.urls')

--- a/tests/test_citations.py
+++ b/tests/test_citations.py
@@ -39,8 +39,7 @@ class CitationsNodeTestCase(OsfTestCase):
 
     def tearDown(self):
         super(CitationsNodeTestCase, self).tearDown()
-        OSFUser.remove()
-        OSFUser.remove()
+        OSFUser.objects.all().delete()
 
     def test_csl_single_author(self):
         # Nodes with one contributor generate valid CSL-data

--- a/tests/test_conferences.py
+++ b/tests/test_conferences.py
@@ -372,7 +372,7 @@ class TestMessage(ContextTestCase):
             msg = message.ConferenceMessage()
             assert_equal(msg.conference_name, 'chocolate')
             assert_equal(msg.conference_category, 'data')
-        conf.__class__.remove_one(conf)
+        conf.__class__.delete(conf)
 
     def test_route_valid_b(self):
         recipient = '{0}conf-poster@osf.io'.format('test-' if settings.DEV_MODE else '')
@@ -421,7 +421,7 @@ class TestConferenceEmailViews(OsfTestCase):
         assert_equal(res.request.path, '/meetings/')
 
     def test_conference_submissions(self):
-        AbstractNode.remove()
+        AbstractNode.objects.all().delete()
         conference1 = ConferenceFactory()
         conference2 = ConferenceFactory()
         # Create conference nodes

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -19,7 +19,7 @@ class TestMetaData(OsfTestCase):
     def test_ensure_schemas(self):
 
         # Should be zero MetaSchema records to begin with
-        MetaSchema.remove()
+        MetaSchema.objects.all().delete()
         assert_equal(
             MetaSchema.objects.all().count(),
             0

--- a/tests/test_node_licenses.py
+++ b/tests/test_node_licenses.py
@@ -86,7 +86,7 @@ class TestNodeLicenses(OsfTestCase):
 
     def test_ensure_licenses_no_licenses(self):
         before_count = NodeLicense.objects.all().count()
-        NodeLicense.remove()
+        NodeLicense.objects.all().delete()
         assert_false(NodeLicense.objects.all().count())
 
         ensure_licenses()

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -213,7 +213,7 @@ class TestViewProject(OsfTestCase):
 
         assert_not_equal(result['node']['disapproval_link'], '')
         assert_in('/?token=', result['node']['disapproval_link'])
-        pending_reg.remove()
+        pending_reg.delete()
 
     def test_view_project_pending_registration_for_write_contributor_does_not_contain_cancel_link(self):
         write_user = UserFactory()
@@ -224,7 +224,7 @@ class TestViewProject(OsfTestCase):
         result = _view_project(pending_reg, Auth(write_user))
 
         assert_equal(result['node']['disapproval_link'], '')
-        pending_reg.remove()
+        pending_reg.delete()
 
     def test_view_project_child_exists(self):
         linked_node = ProjectFactory(creator=self.user)

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -100,7 +100,7 @@ class SanctionTokenHandlerBase(OsfTestCase):
             return
         approval_token = self.sanction.approval_state[self.user._id]['approval_token']
         handler = TokenHandler.from_string(approval_token)
-        self.Model.remove_one(self.sanction)
+        self.Model.delete(self.sanction)
         with mock_auth(self.user):
             try:
                 handler.to_response()

--- a/website/oauth/views.py
+++ b/website/oauth/views.py
@@ -27,7 +27,7 @@ def oauth_disconnect(external_account_id, auth):
             user_settings.revoke_oauth_access(account)
             user_settings.save()
 
-    # ExternalAccount.remove_one(account)
+    # ExternalAccount.delete(account)
     # # only after all addons have been dealt with can we remove it from the user
     user.external_accounts.remove(account)
     user.save()


### PR DESCRIPTION
## Purpose
These are unnecessary artifacts of MODM, and it's dangerous to have shortcuts for deleting things from the database (we don't want to do this any more).

## Changes

Removed the BaseModel.remove and BaseModel.remove_one methods and their usages.

## Side effects

<!--Any possible side effects? -->


## Ticket

https://openscience.atlassian.net/browse/OSF-8921

## QA Considerations
Shouldn't need QA testing, there shouldn't be any obvious changes on the front end