### PR TITLE
Fix PR7629 OSF-4338 - remove trailing comma

### DIFF
--- a/website/profile/utils.py
+++ b/website/profile/utils.py
@@ -14,7 +14,7 @@ def get_profile_image_url(user, size=None):
     return profile_image_url(settings.PROFILE_IMAGE_PROVIDER,
                              user,
                              use_ssl=True,
-                             size=settings.PROFILE_IMAGE_MEDIUM),
+                             size=settings.PROFILE_IMAGE_MEDIUM)
 
 def serialize_user(user, node=None, admin=False, full=False, is_profile=False, include_node_counts=False):
     """


### PR DESCRIPTION
## Purpose

PR 7629 resulted in bad URL for user profile image in nav bar.
This fixes it.

## Changes

Remove trailing comma

## QA Notes

Combine with testing for PR7629

## Side Effects

None

## Ticket
[OSF-4338](https://openscience.atlassian.net/browse/OSF-4338)
