### PR TITLE
Resize user_profile_image OSF-4338

### DIFF
--- a/website/profile/utils.py
+++ b/website/profile/utils.py
@@ -8,13 +8,11 @@ from osf.models.contributor import get_contributor_permissions
 from website.util.permissions import reduce_permissions
 
 
-def get_profile_image_url(user, size=None):
-    if size is None:
-        size = settings.PROFILE_IMAGE_LARGE
+def get_profile_image_url(user, size=settings.PROFILE_IMAGE_MEDIUM):
     return profile_image_url(settings.PROFILE_IMAGE_PROVIDER,
                              user,
                              use_ssl=True,
-                             size=settings.PROFILE_IMAGE_MEDIUM)
+                             size=size)
 
 def serialize_user(user, node=None, admin=False, full=False, is_profile=False, include_node_counts=False):
     """


### PR DESCRIPTION
## Purpose

user_profile image was medium in nav bar. Should have been small.

## Changes

Resize user_profile_image

## QA Notes

Combine with testing for PR7629

## Side Effects

None

## Ticket
[OSF-4338](https://openscience.atlassian.net/browse/OSF-4338)
