### PR TITLE
Check if asset path exists for addons

### DIFF
--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -318,8 +318,9 @@ def collect_node_config_js(addons):
     js_modules = []
     for addon in addons:
         js_path = os.path.join('/', 'static', 'public', 'js', addon['short_name'], 'node-cfg.js')
-        if js_path:
+        if os.path.exists(js_path):
             js_modules.append(js_path)
+
     return js_modules
 
 


### PR DESCRIPTION
## Purpose

Fixes bug where addon's page will fail to resolve because of missing assets.

## Changes

Adds check to so non-exsistent osfstorage/node-cfg isn't looked for.

## QA Notes

If addon page loaded, this worked

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/OSF-8056