### PR TITLE
[Hotfix] Balance TCI jobs [No Ticket]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,11 @@ env:
     # - VARNISH_DEB="varnish_4.1.0-1~trusty_amd64.deb"
     - OSF_DB_PORT="54321"
   matrix:
-    - TEST_BUILD="osf"
+    - TEST_BUILD="addons"
     - TEST_BUILD="else"
     - TEST_BUILD="api1_and_js"
     - TEST_BUILD="api2"
-    - TEST_BUILD="api3"
+    - TEST_BUILD="api3_and_osf"
     # - TEST_BUILD="varnish"
 
 before_install:

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -460,8 +460,8 @@ ADMIN_TESTS = [
 @task
 def test_osf(ctx, numprocesses=None):
     """Run the OSF test suite."""
-    print('Testing modules "{}"'.format(OSF_TESTS + ADDON_TESTS))
-    test_module(ctx, module=OSF_TESTS + ADDON_TESTS, numprocesses=numprocesses)
+    print('Testing modules "{}"'.format(OSF_TESTS))
+    test_module(ctx, module=OSF_TESTS, numprocesses=numprocesses)
 
 @task
 def test_else(ctx, numprocesses=None):
@@ -486,8 +486,8 @@ def test_api2(ctx, numprocesses=None):
 @task
 def test_api3(ctx, numprocesses=None):
     """Run the API test suite."""
-    print('Testing modules "{}"'.format(API_TESTS3))
-    test_module(ctx, module=API_TESTS3, numprocesses=numprocesses)
+    print('Testing modules "{}"'.format(API_TESTS3 + OSF_TESTS))
+    test_module(ctx, module=API_TESTS3 + OSF_TESTS, numprocesses=numprocesses)
 
 
 @task
@@ -525,10 +525,10 @@ def test(ctx, all=False, syntax=False):
         flake(ctx)
         jshint(ctx)
 
-    test_osf(ctx)
+    test_else(ctx)  # /tests
     test_api1(ctx)
     test_api2(ctx)
-    test_api3(ctx)
+    test_api3(ctx)  # also /osf_tests
 
     if all:
         test_addons(ctx)
@@ -543,13 +543,13 @@ def test_js(ctx):
     karma(ctx)
 
 @task
-def test_travis_osf(ctx, numprocesses=None):
+def test_travis_addons(ctx, numprocesses=None):
     """
     Run half of the tests to help travis go faster. Lints and Flakes happen everywhere to keep from wasting test time.
     """
     flake(ctx)
     jshint(ctx)
-    test_osf(ctx, numprocesses=numprocesses)
+    test_addons(ctx, numprocesses=numprocesses)
 
 
 @task
@@ -579,7 +579,7 @@ def test_travis_api2(ctx, numprocesses=None):
 
 
 @task
-def test_travis_api3(ctx, numprocesses=None):
+def test_travis_api3_and_osf(ctx, numprocesses=None):
     flake(ctx)
     jshint(ctx)
     test_api3(ctx, numprocesses=numprocesses)


### PR DESCRIPTION
## Purpose
The "osf" job has recently been timing out. Have each job run in about the same amount of time by balancing the number of tests per job. From a recent build:
```
osf: ========= 2454 passed, 32 skipped, 1 pytest-warnings in 2082.91 seconds =========
else: ======== 1295 passed, 17 skipped, 1 pytest-warnings in 1417.41 seconds =========
api1_and_js: = 1171 passed, 61 skipped, 1 pytest-warnings in 1526.10 seconds =========
api2: ============== 1127 passed, 1 pytest-warnings in 1279.63 seconds ===============
api3: ========== 515 passed, 8 skipped, 1 pytest-warnings in 564.43 seconds ==========
```
## Changes
* Move about 1k tests from job `osf` to `api3`
* Rename jobs appropriately
  * `osf`->`addons`
  * `api3`-> `api3_and_osf`

## QA Notes
None required

## Side Effects
None expected

## Ticket
None known