### PR TITLE
[OSF-8056] Ensure Addon tab JS assets load properly 

### DIFF
--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -303,7 +303,7 @@ def node_addons(auth, node, **kwargs):
 
     ret['addon_capabilities'] = settings.ADDON_CAPABILITIES
     ret['addon_categories'] = set([item for addon in addon_settings for item in addon['categories']])
-    ret['addon_settings'] = addon_settings
+    ret['addon_settings'] = [addon for addon in addon_settings if not addon['default']]
     ret['addon_js'] = collect_node_config_js([addon for addon in addon_settings if addon['enabled']])
 
     return ret
@@ -318,7 +318,7 @@ def collect_node_config_js(addons):
     js_modules = []
     for addon in addons:
         js_path = os.path.join('/', 'static', 'public', 'js', addon['short_name'], 'node-cfg.js')
-        if os.path.exists(js_path):
+        if os.path.join(settings.ADDON_PATH, 'static', 'public', 'js', addon['short_name'], 'node-cfg.js'):
             js_modules.append(js_path)
 
     return js_modules


### PR DESCRIPTION
## Purpose

Previous checks only allowed certain assets which were not in the base addon directory to load, this fix checks correctly for all assets and removes the unsightly empty panel created by the absences of the default provider osfstorage.

## Changes

Checks proper directory of assets in settings.BASE_ASSETS and stops default provider js from rendering,

## QA Notes

All providers should enable properly and show there logo and connect account link, except osfstorage which should be totally gone from the bottom panel.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/OSF-8056