### PR TITLE
[OSF-8237] Change to use .done() for jQuery 3.

### DIFF
--- a/website/static/js/profile.js
+++ b/website/static/js/profile.js
@@ -446,7 +446,7 @@ var NameViewModel = function(urls, modes, preventUnsaved, fetchCallback) {
                 name: self.full()
             },
             dataType: 'json',
-        }).success(function (response) {
+        }).done(function (response) {
             self.imputedGiven(response.given);
             self.imputedMiddle(response.middle);
             self.imputedFamily(response.family);


### PR DESCRIPTION
## Purpose

Current on staging, auto fill button for profile citations are not working because jQuery 3 removed .success(). This fix the issue.
## Changes

.success() is changed to .done().

## Side Effects

None.

## Ticket

https://openscience.atlassian.net/browse/OSF-8237