### PR TITLE
[OSF-8710] Rename file on file detail page: Fix for cross origin.

### DIFF
--- a/website/static/js/pages/file-page.js
+++ b/website/static/js/pages/file-page.js
@@ -77,7 +77,8 @@ $(function() {
                 type: 'post',
                 contentType: 'application/json',
                 dataType: 'json',
-                beforeSend: $osf.setXHRAuthorization
+                beforeSend: $osf.setXHRAuthorization,
+                crossOrigin: true,
             },
             validate: function(value) {
                 if($.trim(value) === ''){


### PR DESCRIPTION
## Purpose

Currently on staging, renaming a file on file detail page fails because of CORS issue. This PR should fix the issue.

## Changes

add `crossOrigin: true`.

## QA Notes

This should fix the issue discovered during QA testing.

## Ticket

https://openscience.atlassian.net/browse/OSF-8710