### PR TITLE
[hotfix] Fix auto_now context manager used in migrations [no ticket]

### DIFF
--- a/osf/utils/migrations.py
+++ b/osf/utils/migrations.py
@@ -17,13 +17,15 @@ def disable_auto_now_fields(model):
     Context manager to disable updates of all auto_now fields for a given model.
 
     """
+    changed = []
     for field in model._meta.get_fields():
         if hasattr(field, 'auto_now') and field.auto_now:
             field.auto_now = False
+            changed.append(field)
     try:
         yield
     finally:
-        for field in model._meta.get_fields():
+        for field in changed:
             if hasattr(field, 'auto_now') and not field.auto_now:
                 field.auto_now = True
 

--- a/osf_tests/test_utils.py
+++ b/osf_tests/test_utils.py
@@ -31,3 +31,14 @@ class TestDisableAutoNowContextManager:
         node.title = 'ABC'
         node.save()
         assert node.modified != new_date_modified
+
+    def test_auto_now_does_not_modify_non_auto_now_fields(self, node):
+        old_created = node.created
+        assert Node._meta.get_field('created').auto_now is False
+
+        with disable_auto_now_fields(Node):
+            node.description = 'new cool description!!'
+        node.save()
+
+        assert node.created == old_created
+        assert Node._meta.get_field('created').auto_now is False


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

The `disable_auto_now_fields` used in the `add_preprint_doi_created` migration was correctly disabling the auto_now fields, but not putting them back the way it found them. 

## Changes

- Keep track of updated auto_now add fields and only reset the ones you changed
- Add a test to check for this in the future

## QA Notes

This ticket does not need to be tested, as it's only for tests running on travis!

## Side Effects

none

## Ticket
none