### PR TITLE
[#OSF-8510]Search by contributor's profile information

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -683,7 +683,7 @@ function doItemOp(operation, to, from, rename, conflict) {
         } else if (xhr.status === 503) {
             message = textStatus;
         } else {
-            message = 'Please refresh the page or contact ' + $osf.osfSupportlink() + ' if the problem persists.';
+            message = 'Please refresh the page or contact ' + $osf.osfSupportLink() + ' if the problem persists.';
         }
 
         $osf.growl(operation.verb + ' failed.', message);

--- a/website/templates/project/modal_add_contributor.mako
+++ b/website/templates/project/modal_add_contributor.mako
@@ -98,63 +98,63 @@
                                                     </span><br>
                                                 </span>
                                                 <span data-bind="visible: contributor.social.personal">
-                                                    <a data-bind="attr: {href: contributor.social.personal}" data-toggle="tooltip" title="Personal Website">
+                                                    <a data-bind="attr: {href: contributor.social.personal}" data-toggle="tooltip" title="Personal Website"  target="_blank">
                                                         <i class="fa fa-globe social-icons fa-lg"></i>
                                                     </a>
                                                 </span>
 
                                                 <span data-bind="visible: contributor.social.twitter">
-                                                    <a data-bind="attr: {href: contributor.social.twitter}" data-toggle="tooltip" title="Twitter">
+                                                    <a data-bind="attr: {href: contributor.social.twitter}" data-toggle="tooltip" title="Twitter" target="_blank">
                                                         <i class="fa fa-twitter social-icons fa-lg"></i>
                                                     </a>
                                                 </span>
                                                 <span data-bind="visible: contributor.social.github">
-                                                    <a data-bind="attr: {href: contributor.social.github}" data-toggle="tooltip" title="Github">
+                                                    <a data-bind="attr: {href: contributor.social.github}" data-toggle="tooltip" title="Github" target="_blank">
                                                         <i class="fa fa-github-alt social-icons fa-lg"></i>
                                                     </a>
                                                 </span>
                                                 <span data-bind="visible: contributor.social.linkedIn" >
-                                                    <a data-bind="attr: {href: contributor.social.linkedIn}" data-toggle="tooltip" title="LinkedIn">
+                                                    <a data-bind="attr: {href: contributor.social.linkedIn}" data-toggle="tooltip" title="LinkedIn" target="_blank">
                                                         <i class="fa fa-linkedin social-icons fa-lg"></i>
                                                     </a>
                                                 </span>
                                                 <span data-bind="visible: contributor.social.scholar">
-                                                    <a data-bind="attr: {href: contributor.social.scholar}" data-toggle="tooltip" title="Google Scholar">
+                                                    <a data-bind="attr: {href: contributor.social.scholar}" data-toggle="tooltip" title="Google Scholar" target="_blank">
                                                         <img class="social-icons fa-lg" src="/static/img/googlescholar.png">
                                                     </a>
                                                 </span>
                                                 <span data-bind="visible: contributor.social.impactStory">
-                                                    <a data-bind="attr: {href: contributor.social.impactStory}" data-toggle="tooltip" title="ImpactStory">
+                                                    <a data-bind="attr: {href: contributor.social.impactStory}" data-toggle="tooltip" title="ImpactStory" target="_blank">
                                                         <i class="fa fa-info-circle social-icons fa-lg"></i>
                                                     </a>
                                                 </span>
                                                 <span data-bind="visible: contributor.social.orcid">
-                                                    <a data-bind="attr: {href: contributor.social.orcid}" data-toggle="tooltip" title="ORCiD">
+                                                    <a data-bind="attr: {href: contributor.social.orcid}" data-toggle="tooltip" title="ORCiD" target="_blank">
                                                         <i class="fa social-icons fa-lg">iD</i>
                                                     </a>
                                                 </span>
                                                 <span data-bind="visible: contributor.social.researcherId">
-                                                    <a data-bind="attr: {href: contributor.social.researcherId}" data-toggle="tooltip" title="ResearcherID">
+                                                    <a data-bind="attr: {href: contributor.social.researcherId}" data-toggle="tooltip" title="ResearcherID" target="_blank">
                                                         <i class="fa social-icons fa-lg">R</i>
                                                     </a>
                                                 </span>
                                                 <span data-bind="visible: contributor.social.researchGate">
-                                                    <a data-bind="attr: {href: contributor.social.researchGate}" data-toggle="tooltip" title="ResearchGate">
+                                                    <a data-bind="attr: {href: contributor.social.researchGate}" data-toggle="tooltip" title="ResearchGate" target="_blank">
                                                         <img class="social-icons p-b-xs" src="/static/img/researchgate.jpg"></i>
                                                     </a>
                                                 </span>
                                                 <span data-bind="visible: contributor.social.academiaInstitution + social.academiaProfileID">
-                                                    <a data-bind="attr: {href: contributor.social.academiaInstitution + social.academiaProfileID}" data-toggle="tooltip" title="Academia">
+                                                    <a data-bind="attr: {href: contributor.social.academiaInstitution + social.academiaProfileID}" data-toggle="tooltip" title="Academia" target="_blank">
                                                         <i class="fa social-icons fa-lg">A</i>
                                                     </a>
                                                 </span>
                                                 <span data-bind="visible: contributor.social.baiduScholar">
-                                                    <a data-bind="attr: {href: contributor.social.baiduScholar}" data-toggle="tooltip" title="Baidu Scholar">
+                                                    <a data-bind="attr: {href: contributor.social.baiduScholar}" data-toggle="tooltip" title="Baidu Scholar" target="_blank">
                                                         <img class="social-icons fa-lg" src="/static/img/baiduscholar.png">
                                                     </a>
                                                 </span>
                                                 <span data-bind="visible: contributor.social.ssrn">
-                                                    <a data-bind="attr: {href: contributor.social.ssrn}" data-toggle="tooltip" title="SSRN">
+                                                    <a data-bind="attr: {href: contributor.social.ssrn}" data-toggle="tooltip" title="SSRN" target="_blank">
                                                         <img class="social-icons fa-lg" src="/static/img/SSRN.png">
                                                     </a>
                                                 </span>


### PR DESCRIPTION

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Add the ability that when click on the profile info icon on add_contributor_modal will open a new tab instead of redirect the current tab. And fix a typo error for support email extract.
<!-- Describe the purpose of your changes -->

## Changes

<!-- Briefly describe or list your changes  -->

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/OSF-8510
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
