### PR TITLE
[hotfix] Fix Files Page Icons [OSF-9038]

### DIFF
--- a/website/util/rubeus.py
+++ b/website/util/rubeus.py
@@ -222,7 +222,7 @@ class NodeFileCollector(object):
         data = []
         if node.can_view(auth=self.auth):
             serialized_addons = self._collect_addons(node)
-            linked_node_sqs = node.node_relations.filter(is_node_link=True)
+            linked_node_sqs = node.node_relations.filter(is_node_link=True, child=OuterRef('pk'))
             has_write_perm_sqs = Contributor.objects.filter(node=OuterRef('pk'), write=True, user=self.auth.user)
             children = (AbstractNode.objects
                         .filter(is_deleted=False, _parents__parent=node)


### PR DESCRIPTION
#### Purpose
- Fixes incorrect icons on the files page.

#### Changes
- Fix linked node subquery so that only linked nodes are annotated as linked nodes, instead of every child being annotated as a linked node if a single linked node child exists.

#### QA Notes
- Cross browser not needed. 
- Confirm that what you see matches the "after" image below for links v. components.

#### Ticket
- [OSF-9038](https://openscience.atlassian.net/browse/OSF-9038)

#### Before
![screen shot 2017-12-06 at 4 06 17 pm](https://user-images.githubusercontent.com/7913604/33685555-00218464-daa0-11e7-8a71-0083d0c44f60.png)

#### After
![screen shot 2017-12-06 at 4 05 33 pm](https://user-images.githubusercontent.com/7913604/33685561-0481a7fa-daa0-11e7-9204-d2a997cfed0e.png)

