### PR TITLE
[Hotfix] Display all GL repos [No Ticket]

### DIFF
--- a/addons/gitlab/api.py
+++ b/addons/gitlab/api.py
@@ -47,10 +47,10 @@ class GitLabClient(object):
         raise NotFoundError
 
     def repos(self):
-        return self.gitlab.getprojects()
+        return list(self.gitlab.getall(self.gitlab.getprojects, per_page=100))
 
     def user_repos(self, user):
-        return self.gitlab.getprojectsowned()
+        return list(self.gitlab.getall(self.gitlab.getprojectsowned, per_page=100))
 
     def create_repo(self, repo, **kwargs):
         return self.gitlab.createproject(repo)


### PR DESCRIPTION
## Purpose
Display all GL repos, not just the default page size

## Changes
* Use client helpers to avoid front-end pagination

## QA Notes
1. Own more than 20
2. Make sure they all show up

## Side Effects
In the case where a user has far too many repos, loading them might take several extra seconds.

## Ticket
None known