### PR TITLE
[OSF-8055] Fix relative link from forks to analyltics page

### DIFF
--- a/website/templates/project/forks.mako
+++ b/website/templates/project/forks.mako
@@ -8,7 +8,7 @@
 
 <div class="row">
         <div class="col-xs-9 col-sm-8">
-        <a href="analytics" class="padded strong">
+        <a href="${node['url']}analytics" class="padded strong">
             <span class="fa fa-arrow-left"></span> Back to Analytics
         </a>
 


### PR DESCRIPTION
## Purpose

Currently a bad relative link on the forks page send you a 404 if you come from the directly from the project overview. This fixes make the link absolute preventing the problem.

## Changes

Changed link to use node url instead of relative link.

## QA Notes

Go to the project overview page and click the fork icon, click View Forks then click Back to analytics, if you're now on the analytics page this fix worked. 

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/OSF-8055