### PR TITLE
Feature/Rename DateByVersion [OSF-8979]

### DIFF
--- a/api/applications/serializers.py
+++ b/api/applications/serializers.py
@@ -3,7 +3,7 @@ from rest_framework import serializers as ser
 
 from osf.models import ApiOAuth2Application
 
-from api.base.serializers import JSONAPISerializer, LinksField, IDField, TypeField, DateByVersion
+from api.base.serializers import JSONAPISerializer, LinksField, IDField, TypeField, VersionedDateTimeField
 from api.base.utils import absolute_reverse
 
 
@@ -67,7 +67,7 @@ class ApiOAuth2ApplicationSerializer(ApiOAuthApplicationBaseSerializer):
                           read_only=True,  # Don't let user register an application in someone else's name
                           source='owner._id')
 
-    date_created = DateByVersion(source='created', help_text='The date this application was generated (automatically filled in)',
+    date_created = VersionedDateTimeField(source='created', help_text='The date this application was generated (automatically filled in)',
                                      read_only=True)
 
     def create(self, validated_data):

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -282,7 +282,7 @@ def _url_val(val, obj, serializer, request, **kwargs):
         return url
 
 
-class DateByVersion(ser.DateTimeField):
+class VersionedDateTimeField(ser.DateTimeField):
     """
     Custom DateTimeField that forces dates into the ISO-8601 format with timezone information in version 2.2.
     """
@@ -294,7 +294,7 @@ class DateByVersion(ser.DateTimeField):
                 self.format = '%Y-%m-%dT%H:%M:%S.%fZ'
             else:
                 self.format = '%Y-%m-%dT%H:%M:%S.%f' if value.microsecond else '%Y-%m-%dT%H:%M:%S'
-        return super(DateByVersion, self).to_representation(value)
+        return super(VersionedDateTimeField, self).to_representation(value)
 
 
 class IDField(ser.CharField):

--- a/api/citations/serializers.py
+++ b/api/citations/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers as ser
 
-from api.base.serializers import JSONAPISerializer, DateByVersion
+from api.base.serializers import JSONAPISerializer, VersionedDateTimeField
 
 
 class CitationSerializer(JSONAPISerializer):
@@ -12,7 +12,7 @@ class CitationSerializer(JSONAPISerializer):
     ])
     id = ser.CharField(source='_id', required=True)
     title = ser.CharField(max_length=200)
-    date_parsed = DateByVersion(read_only=True, help_text='Datetime the csl file was last parsed')
+    date_parsed = VersionedDateTimeField(read_only=True, help_text='Datetime the csl file was last parsed')
 
     short_title = ser.CharField(max_length=500)
     summary = ser.CharField(max_length=200)

--- a/api/collections/serializers.py
+++ b/api/collections/serializers.py
@@ -6,7 +6,7 @@ from framework.exceptions import PermissionsError
 from osf.models import AbstractNode, Collection
 from osf.exceptions import ValidationError
 from api.base.serializers import LinksField, RelationshipField
-from api.base.serializers import JSONAPISerializer, IDField, TypeField, DateByVersion
+from api.base.serializers import JSONAPISerializer, IDField, TypeField, VersionedDateTimeField
 from api.base.exceptions import InvalidModelValueError
 from api.base.utils import absolute_reverse, get_user_auth
 from api.nodes.serializers import NodeLinksSerializer
@@ -23,8 +23,8 @@ class CollectionSerializer(JSONAPISerializer):
     type = TypeField()
 
     title = ser.CharField(required=True)
-    date_created = DateByVersion(source='created', read_only=True)
-    date_modified = DateByVersion(source='modified', read_only=True)
+    date_created = VersionedDateTimeField(source='created', read_only=True)
+    date_modified = VersionedDateTimeField(source='modified', read_only=True)
     bookmarks = ser.BooleanField(read_only=False, default=False, source='is_bookmark_collection')
 
     links = LinksField({})

--- a/api/comments/serializers.py
+++ b/api/comments/serializers.py
@@ -14,7 +14,7 @@ from api.base.serializers import (JSONAPISerializer,
                                   RelationshipField,
                                   IDField, TypeField, LinksField,
                                   AnonymizedRegexField,
-                                  DateByVersion)
+                                  VersionedDateTimeField)
 
 
 class CommentReport(object):
@@ -43,8 +43,8 @@ class CommentSerializer(JSONAPISerializer):
     user = RelationshipField(related_view='users:user-detail', related_view_kwargs={'user_id': '<user._id>'})
     reports = RelationshipField(related_view='comments:comment-reports', related_view_kwargs={'comment_id': '<_id>'})
 
-    date_created = DateByVersion(source='created', read_only=True)
-    date_modified = DateByVersion(source='modified', read_only=True)
+    date_created = VersionedDateTimeField(source='created', read_only=True)
+    date_modified = VersionedDateTimeField(source='modified', read_only=True)
     modified = ser.BooleanField(source='edited', read_only=True, default=False)
     deleted = ser.BooleanField(read_only=True, source='is_deleted', default=False)
     is_abuse = ser.SerializerMethodField(help_text='If the comment has been reported or confirmed.')

--- a/api/files/serializers.py
+++ b/api/files/serializers.py
@@ -23,7 +23,7 @@ from api.base.serializers import (
     RelationshipField,
     TypeField,
     WaterbutlerLink,
-    DateByVersion,
+    VersionedDateTimeField,
 )
 from api.base.exceptions import Conflict
 from api.base.utils import absolute_reverse
@@ -156,7 +156,7 @@ class BaseFileSerializer(JSONAPISerializer):
     provider = ser.CharField(read_only=True, help_text='The Add-on service this file originates from')
     materialized_path = ser.CharField(
         read_only=True, help_text='The Unix-style path of this object relative to the provider root')
-    last_touched = DateByVersion(read_only=True, help_text='The last time this file had information fetched about it via the OSF')
+    last_touched = VersionedDateTimeField(read_only=True, help_text='The last time this file had information fetched about it via the OSF')
     date_modified = ser.SerializerMethodField(read_only=True, help_text='Timestamp when the file was last modified')
     date_created = ser.SerializerMethodField(read_only=True, help_text='Timestamp when the file was created')
     extra = ser.SerializerMethodField(read_only=True, help_text='Additional metadata about this file')
@@ -355,7 +355,7 @@ class FileVersionSerializer(JSONAPISerializer):
     id = ser.CharField(read_only=True, source='identifier')
     size = ser.IntegerField(read_only=True, help_text='The size of this file at this version')
     content_type = ser.CharField(read_only=True, help_text='The mime type of this file at this verison')
-    date_created = DateByVersion(source='created', read_only=True, help_text='The date that this version was created')
+    date_created = VersionedDateTimeField(source='created', read_only=True, help_text='The date that this version was created')
     links = LinksField({
         'self': 'self_url',
         'html': 'absolute_url'

--- a/api/logs/serializers.py
+++ b/api/logs/serializers.py
@@ -6,7 +6,7 @@ from api.base.serializers import (
     RestrictedDictSerializer,
     LinksField,
     is_anonymized,
-    DateByVersion,
+    VersionedDateTimeField,
     HideIfNotNodePointerLog,
     HideIfNotRegistrationPointerLog,
 )
@@ -180,7 +180,7 @@ class NodeLogSerializer(JSONAPISerializer):
     ]
 
     id = ser.CharField(read_only=True, source='_id')
-    date = DateByVersion(read_only=True)
+    date = VersionedDateTimeField(read_only=True)
     action = ser.CharField(read_only=True)
     params = ser.SerializerMethodField(read_only=True)
     links = LinksField({'self': 'get_absolute_url'})

--- a/api/nodes/serializers.py
+++ b/api/nodes/serializers.py
@@ -3,7 +3,7 @@ from django.db import connection
 from api.base.exceptions import (Conflict, EndpointNotImplementedError,
                                  InvalidModelValueError,
                                  RelationshipPostMakesNoChanges)
-from api.base.serializers import (DateByVersion, HideIfRegistration, IDField,
+from api.base.serializers import (VersionedDateTimeField, HideIfRegistration, IDField,
                                   JSONAPIListField,
                                   JSONAPIRelationshipSerializer,
                                   JSONAPISerializer, LinksField,
@@ -160,8 +160,8 @@ class NodeSerializer(JSONAPISerializer):
     title = ser.CharField(required=True)
     description = ser.CharField(required=False, allow_blank=True, allow_null=True)
     category = ser.ChoiceField(choices=category_choices, help_text='Choices: ' + category_choices_string)
-    date_created = DateByVersion(source='created', read_only=True)
-    date_modified = DateByVersion(source='last_logged', read_only=True)
+    date_created = VersionedDateTimeField(source='created', read_only=True)
+    date_modified = VersionedDateTimeField(source='last_logged', read_only=True)
     registration = ser.BooleanField(read_only=True, source='is_registration')
     preprint = ser.BooleanField(read_only=True, source='is_preprint')
     fork = ser.BooleanField(read_only=True, source='is_fork')
@@ -699,7 +699,7 @@ class NodeForksSerializer(NodeSerializer):
 
     title = ser.CharField(required=False)
     category = ser.ChoiceField(read_only=True, choices=category_choices, help_text='Choices: ' + category_choices_string)
-    forked_date = DateByVersion(read_only=True)
+    forked_date = VersionedDateTimeField(read_only=True)
 
     def create(self, validated_data):
         node = validated_data.pop('node')
@@ -1082,8 +1082,8 @@ class DraftRegistrationSerializer(JSONAPISerializer):
     type = TypeField()
     registration_supplement = ser.CharField(source='registration_schema._id', required=True)
     registration_metadata = ser.DictField(required=False)
-    datetime_initiated = DateByVersion(read_only=True)
-    datetime_updated = DateByVersion(read_only=True)
+    datetime_initiated = VersionedDateTimeField(read_only=True)
+    datetime_updated = VersionedDateTimeField(read_only=True)
 
     branched_from = RelationshipField(
         related_view='nodes:node-detail',
@@ -1181,7 +1181,7 @@ class NodeViewOnlyLinkSerializer(JSONAPISerializer):
 
     key = ser.CharField(read_only=True)
     id = IDField(source='_id', read_only=True)
-    date_created = DateByVersion(source='created', read_only=True)
+    date_created = VersionedDateTimeField(source='created', read_only=True)
     anonymous = ser.BooleanField(required=False, default=False)
     name = ser.CharField(required=False, default='Shared project link')
 

--- a/api/preprints/serializers.py
+++ b/api/preprints/serializers.py
@@ -5,7 +5,7 @@ from rest_framework import serializers as ser
 from api.base.exceptions import Conflict
 from api.base.serializers import (
     JSONAPISerializer, IDField,
-    LinksField, RelationshipField, DateByVersion, JSONAPIListField
+    LinksField, RelationshipField, VersionedDateTimeField, JSONAPIListField
 )
 from api.base.utils import absolute_reverse, get_user_auth
 from api.taxonomies.serializers import TaxonomyField
@@ -72,10 +72,10 @@ class PreprintSerializer(JSONAPISerializer):
 
     id = IDField(source='_id', read_only=True)
     subjects = ser.SerializerMethodField()
-    date_created = DateByVersion(source='created', read_only=True)
-    date_modified = DateByVersion(source='modified', read_only=True)
-    date_published = DateByVersion(read_only=True)
-    original_publication_date = DateByVersion(required=False)
+    date_created = VersionedDateTimeField(source='created', read_only=True)
+    date_modified = VersionedDateTimeField(source='modified', read_only=True)
+    date_published = VersionedDateTimeField(read_only=True)
+    original_publication_date = VersionedDateTimeField(required=False)
     doi = ser.CharField(source='article_doi', required=False, allow_null=True)
     is_published = ser.BooleanField(required=False)
     is_preprint_orphan = ser.BooleanField(read_only=True)
@@ -84,7 +84,7 @@ class PreprintSerializer(JSONAPISerializer):
     description = ser.CharField(required=False, allow_blank=True, allow_null=True, source='node.description')
     tags = JSONAPIListField(child=NodeTagField(), required=False, source='node.tags')
     node_is_public = ser.BooleanField(read_only=True, source='node__is_public')
-    preprint_doi_created = DateByVersion(read_only=True)
+    preprint_doi_created = VersionedDateTimeField(read_only=True)
 
     contributors = RelationshipField(
         related_view='nodes:node-contributors',
@@ -92,7 +92,7 @@ class PreprintSerializer(JSONAPISerializer):
     )
 
     reviews_state = ser.CharField(read_only=True, max_length=15)
-    date_last_transitioned = DateByVersion(read_only=True)
+    date_last_transitioned = VersionedDateTimeField(read_only=True)
 
     citation = RelationshipField(
         related_view='preprints:preprint-citation',

--- a/api/registrations/serializers.py
+++ b/api/registrations/serializers.py
@@ -17,7 +17,7 @@ from api.nodes.serializers import NodeLinksSerializer, NodeLicenseSerializer
 from api.nodes.serializers import NodeContributorsSerializer, NodeTagField
 from api.base.serializers import (IDField, RelationshipField, LinksField, HideIfWithdrawal,
                                   FileCommentRelationshipField, NodeFileHyperLinkField, HideIfRegistration,
-                                  JSONAPIListField, ShowIfVersion, DateByVersion,)
+                                  JSONAPIListField, ShowIfVersion, VersionedDateTimeField,)
 from framework.auth.core import Auth
 from osf.exceptions import ValidationValueError
 
@@ -29,7 +29,7 @@ class BaseRegistrationSerializer(NodeSerializer):
     category_choices = NodeSerializer.category_choices
     category_choices_string = NodeSerializer.category_choices_string
     category = HideIfWithdrawal(ser.ChoiceField(read_only=True, choices=category_choices, help_text='Choices: ' + category_choices_string))
-    date_modified = DateByVersion(source='last_logged', read_only=True)
+    date_modified = VersionedDateTimeField(source='last_logged', read_only=True)
     fork = HideIfWithdrawal(ser.BooleanField(read_only=True, source='is_fork'))
     collection = HideIfWithdrawal(ser.BooleanField(read_only=True, source='is_collection'))
     node_license = HideIfWithdrawal(NodeLicenseSerializer(read_only=True))
@@ -52,8 +52,8 @@ class BaseRegistrationSerializer(NodeSerializer):
     withdrawn = ser.BooleanField(source='is_retracted', read_only=True,
                                  help_text='The registration has been withdrawn.')
 
-    date_registered = DateByVersion(source='registered_date', read_only=True, help_text='Date time of registration.')
-    date_withdrawn = DateByVersion(source='retraction.date_retracted', read_only=True, help_text='Date time of when this registration was retracted.')
+    date_registered = VersionedDateTimeField(source='registered_date', read_only=True, help_text='Date time of registration.')
+    date_withdrawn = VersionedDateTimeField(source='retraction.date_retracted', read_only=True, help_text='Date time of when this registration was retracted.')
     embargo_end_date = HideIfWithdrawal(ser.SerializerMethodField(help_text='When the embargo on this registration will be lifted.'))
 
     withdrawal_justification = ser.CharField(source='retraction.justification', read_only=True)
@@ -309,7 +309,7 @@ class RegistrationSerializer(BaseRegistrationSerializer):
     """
     draft_registration = ser.CharField(write_only=True)
     registration_choice = ser.ChoiceField(write_only=True, choices=['immediate', 'embargo'])
-    lift_embargo = DateByVersion(write_only=True, default=None, input_formats=['%Y-%m-%dT%H:%M:%S'])
+    lift_embargo = VersionedDateTimeField(write_only=True, default=None, input_formats=['%Y-%m-%dT%H:%M:%S'])
 
 
 class RegistrationDetailSerializer(BaseRegistrationSerializer):

--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -5,7 +5,7 @@ from rest_framework import serializers as ser
 from api.base.exceptions import InvalidModelValueError
 from api.base.serializers import (
     BaseAPISerializer, JSONAPISerializer, JSONAPIRelationshipSerializer,
-    DateByVersion, HideIfDisabled, IDField,
+    VersionedDateTimeField, HideIfDisabled, IDField,
     Link, LinksField, ListDictField, TypeField, RelationshipField,
     WaterbutlerLink, ShowIfCurrentUser
 )
@@ -49,7 +49,7 @@ class UserSerializer(JSONAPISerializer):
     middle_names = ser.CharField(required=False, allow_blank=True, help_text='For bibliographic citations')
     family_name = ser.CharField(required=False, allow_blank=True, help_text='For bibliographic citations')
     suffix = HideIfDisabled(ser.CharField(required=False, allow_blank=True, help_text='For bibliographic citations'))
-    date_registered = HideIfDisabled(DateByVersion(read_only=True))
+    date_registered = HideIfDisabled(VersionedDateTimeField(read_only=True))
     active = HideIfDisabled(ser.BooleanField(read_only=True, source='is_active'))
     timezone = HideIfDisabled(ser.CharField(required=False, help_text="User's timezone, e.g. 'Etc/UTC"))
     locale = HideIfDisabled(ser.CharField(required=False, help_text="User's locale, e.g.  'en_US'"))

--- a/api/view_only_links/serializers.py
+++ b/api/view_only_links/serializers.py
@@ -5,7 +5,7 @@ from api.base.exceptions import RelationshipPostMakesNoChanges, NonDescendantNod
 from api.base.serializers import (
     JSONAPISerializer, IDField, RelationshipField,
     JSONAPIRelationshipSerializer, LinksField, relationship_diff,
-    DateByVersion,
+    VersionedDateTimeField,
     BaseAPISerializer)
 from api.base.utils import absolute_reverse
 
@@ -15,7 +15,7 @@ from osf.models import AbstractNode
 class ViewOnlyLinkDetailSerializer(JSONAPISerializer):
     key = ser.CharField(read_only=True)
     id = IDField(source='_id', read_only=True)
-    date_created = DateByVersion(source='created', read_only=True)
+    date_created = VersionedDateTimeField(source='created', read_only=True)
     anonymous = ser.BooleanField(required=False)
     name = ser.CharField(required=False)
 

--- a/api/wikis/serializers.py
+++ b/api/wikis/serializers.py
@@ -9,7 +9,7 @@ from api.base.serializers import (
     Link,
     LinksField,
     RelationshipField,
-    DateByVersion,
+    VersionedDateTimeField,
 )
 from api.base.utils import absolute_reverse
 
@@ -30,7 +30,7 @@ class WikiSerializer(JSONAPISerializer):
     size = ser.SerializerMethodField()
     path = ser.SerializerMethodField()
     materialized_path = ser.SerializerMethodField(method_name='get_path')
-    date_modified = DateByVersion(source='date')
+    date_modified = VersionedDateTimeField(source='date')
     content_type = ser.SerializerMethodField()
     current_user_can_comment = ser.SerializerMethodField(help_text='Whether the current user is allowed to post comments')
     extra = ser.SerializerMethodField(help_text='Additional metadata about this wiki')

--- a/api_tests/base/test_serializers.py
+++ b/api_tests/base/test_serializers.py
@@ -405,10 +405,10 @@ class TestShowIfVersion(ApiTestCase):
         assert_not_in('node_links', data['attributes'])
 
 
-class TestDateByVersion(DbTestCase):
+class VersionedDateTimeField(DbTestCase):
 
     def setUp(self):
-        super(TestDateByVersion, self).setUp()
+        super(VersionedDateTimeField, self).setUp()
         self.node = factories.NodeFactory()
         self.old_date = datetime.utcnow()   # naive dates before django-osf
         self.old_date_without_microseconds = self.old_date.replace(microsecond=0)


### PR DESCRIPTION
## Purpose

Make DateByVersion field name more consistent with DRF naming conventions

## Changes

Rename "DateByVersion" class to VersionedDateTimeField

## QA Notes

 If API tests are passing, should be good.  This is just a field name change behind the scenes.

## Side Effects

<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/OSF-8979