### PR TITLE
[Feature] Disable click after maxlength hit [OSF-8870]

### DIFF
--- a/website/templates/include/comment_pane_template.mako
+++ b/website/templates/include/comment_pane_template.mako
@@ -30,7 +30,9 @@
                         <div class="clearfix">
                             <div class="pull-right">
                                 <a class="btn btn-default btn-sm" data-bind="click: cancelReply, css: {disabled: submittingReply}">Cancel</a>
-                                <a class="btn btn-success btn-sm" data-bind="click: submitReply, tooltip: {title: errorMessage(), placement: 'bottom', disabled: !validateReply()}, css: {disabled: !validateReply() || submittingReply()}, text: commentButtonText"></a>
+                                <span data-bind="tooltip: {title: errorMessage(), placement: 'bottom', disabled: !validateReply()}">
+                                    <a class="btn btn-success btn-sm" data-bind="click: submitReply, css: {disabled: !validateReply() || submittingReply()}, text: commentButtonText"></a>
+                                </span>
                                 <span data-bind="text: replyErrorMessage" class="text-danger"></span>
                             </div>
                         </div>

--- a/website/templates/include/comment_template.mako
+++ b/website/templates/include/comment_template.mako
@@ -89,7 +89,9 @@
                             <div class="clearfix">
                                 <div class="form-inline pull-right">
                                     <a class="btn btn-default btn-sm" data-bind="click: cancelEdit">Cancel</a>
-                                    <a class="btn btn-success btn-sm" data-bind="click: submitEdit, tooltip: {title: errorMessage(), placement: 'bottom', disabled: !validateEdit()}, css: {disabled: !validateEdit()}">Save</a>
+                                    <span data-bind="tooltip: {title: errorMessage(), placement: 'bottom', disabled: !validateEdit()}">
+                                        <a class="btn btn-success btn-sm" data-bind="click: submitEdit, css: {disabled: !validateEdit()}">Save</a>
+                                    </span>
                                     <span data-bind="text: editErrorMessage" class="text-danger"></span>
                                 </div>
                             </div>
@@ -166,7 +168,9 @@
                     <div class="clearfix">
                         <div class="pull-right">
                             <a class="btn btn-default btn-sm" data-bind="click: cancelReply, css: {disabled: submittingReply}"> Cancel</a>
-                            <a class="btn btn-success btn-sm" data-bind="click: submitReply, tooltip: {title: errorMessage(), placement: 'bottom', disabled: !validateReply()}, css: {disabled: !validateReply() || submittingReply()}, text: commentButtonText"></a>
+                            <span data-bind="tooltip: {title: errorMessage(), placement: 'bottom', disabled: !validateReply()}">
+                                <a class="btn btn-success btn-sm" data-bind="click: submitReply, css: {disabled: !validateReply() || submittingReply()}, text: commentButtonText"></a>
+                            </span>
                             <span data-bind="text: replyErrorMessage" class="text-danger"></span>
                         </div>
                     </div>


### PR DESCRIPTION
## Purpose

Fix the issue where submit/save button are greyed out
after maxlength hit but can still be clicked. 

Follow up PR https://github.com/CenterForOpenScience/osf.io/pull/7889

The cause: apply the tooltip binding on the same element that has
'disabled' binding sets 'pointer-events' to 'auto' which re-enables pointer-events. 

## Changes

Apply the binding to wrapping span element

## QA Notes

Test both three modes: edit, reply, comment. in all these place
make sure you cannot click after maxlength hit and that button is greyed out
and has the info tooltip.

## Ticket

[OSF-8870](https://openscience.atlassian.net/browse/OSF-8870)
