### PR TITLE
[Feature] Add vol param to 'info' link [OSF-8820]

### DIFF
--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -887,6 +887,9 @@ class LinksField(ser.Field):
         # not just the field attribute.
         return obj
 
+    def extend_absolute_info_url(self, obj):
+        return extend_querystring_if_key_exists(obj.get_absolute_info_url(), self.context['request'], 'view_only')
+
     def extend_absolute_url(self, obj):
         return extend_querystring_if_key_exists(obj.get_absolute_url(), self.context['request'], 'view_only')
 
@@ -900,10 +903,14 @@ class LinksField(ser.Field):
             else:
                 ret[name] = url
         if hasattr(obj, 'get_absolute_url') and 'self' not in self.links:
-            extended_url = self.extend_absolute_url(obj)
-            ret['self'] = extended_url
-            if 'info' in ret:
-                ret['info'] = extended_url
+            ret['self'] = self.extend_absolute_url(obj)
+
+        if 'info' in ret:
+            if hasattr(obj, 'get_absolute_info_url'):
+                ret['info'] = self.extend_absolute_info_url(obj)
+            else:
+                ret['info'] = extend_querystring_if_key_exists(ret['info'], self.context['request'], 'view_only')
+
         return ret
 
 

--- a/api/base/serializers.py
+++ b/api/base/serializers.py
@@ -900,7 +900,10 @@ class LinksField(ser.Field):
             else:
                 ret[name] = url
         if hasattr(obj, 'get_absolute_url') and 'self' not in self.links:
-            ret['self'] = self.extend_absolute_url(obj)
+            extended_url = self.extend_absolute_url(obj)
+            ret['self'] = extended_url
+            if 'info' in ret:
+                ret['info'] = extended_url
         return ret
 
 

--- a/api_tests/nodes/views/test_node_files_list.py
+++ b/api_tests/nodes/views/test_node_files_list.py
@@ -239,6 +239,7 @@ class TestNodeFilesList(ApiTestCase):
                                             })
         assert_equal(res.json['data'][0]['attributes']['name'], 'NewFile')
         assert_equal(res.json['data'][0]['attributes']['provider'], 'github')
+        assert_in(vol.key, res.json['data'][0]['links']['info'])
         assert_in(vol.key, res.json['data'][0]['links']['move'])
         assert_in(vol.key, res.json['data'][0]['links']['upload'])
         assert_in(vol.key, res.json['data'][0]['links']['download'])

--- a/osf/models/files.py
+++ b/osf/models/files.py
@@ -348,6 +348,9 @@ class BaseFileNode(TypedModel, CommentableMixin, OptionalGuidMixin, Taggable, Ob
     def get_absolute_url(self):
         return self.absolute_api_v2_url
 
+    def get_absolute_info_url(self):
+        return self.absolute_api_v2_url
+
     def _repoint_guids(self, updated):
         logger.warn('BaseFileNode._repoint_guids is deprecated.')
 


### PR DESCRIPTION
## Purpose

Add view_only url parameter to 'info' link for files endpoint

Follow up PR https://github.com/CenterForOpenScience/osf.io/pull/7871

## Changes

- Add vol url param to info link
- Update tests

## QA Notes

This is an API change. When looking up file detail say v2/nodes/jc3vf/files/github/?view_only=82b06ecfb70c448b95449c437a68ca0e Make sure the info has the view-only parameter as well.

## Ticket

[OSF-8820](https://openscience.atlassian.net/browse/OSF-8820)
