### PR TITLE
[OSF-8247] Fix Fork completion failure email language 

### DIFF
--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1623,10 +1623,10 @@ class NodeForksList(JSONAPIBaseView, generics.ListCreateAPIView, NodeMixin, Node
         try:
             fork = serializer.save(node=node)
         except Exception as exc:
-            mails.send_mail(user.email, mails.FORK_FAILED, title=node.title, guid=node._id, mimetype='html')
+            mails.send_mail(user.email, mails.FORK_FAILED, title=node.title, guid=node._id, mimetype='html', can_change_preferences=False)
             raise exc
         else:
-            mails.send_mail(user.email, mails.FORK_COMPLETED, title=node.title, guid=fork._id, mimetype='html')
+            mails.send_mail(user.email, mails.FORK_COMPLETED, title=node.title, guid=fork._id, mimetype='html', can_change_preferences=False)
 
     # overrides ListCreateAPIView
     def get_parser_context(self, http_request):

--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1626,7 +1626,7 @@ class NodeForksList(JSONAPIBaseView, generics.ListCreateAPIView, NodeMixin, Node
             mails.send_mail(user.email, mails.FORK_FAILED, title=node.title, guid=node._id, mimetype='html')
             raise exc
         else:
-            mails.send_mail(user.email, mails.FORK_COMPLETED, title=fork.title, guid=fork._id, mimetype='html')
+            mails.send_mail(user.email, mails.FORK_COMPLETED, title=node.title, guid=fork._id, mimetype='html')
 
     # overrides ListCreateAPIView
     def get_parser_context(self, http_request):

--- a/api_tests/nodes/views/test_node_forks_list.py
+++ b/api_tests/nodes/views/test_node_forks_list.py
@@ -328,7 +328,12 @@ class TestNodeForkCreate:
             res = app.post_json_api(public_project_url, fork_data_with_title, auth=user.auth)
             assert res.status_code == 201
             assert res.json['data']['id'] == public_project.forks.first()._id
-            mock_send_mail.assert_called_with(user.email, mails.FORK_COMPLETED, title=res.json['data']['attributes']['title'], guid=res.json['data']['id'], mimetype='html')
+            mock_send_mail.assert_called_with(user.email,
+                                              mails.FORK_COMPLETED,
+                                              title=public_project.title,
+                                              guid=res.json['data']['id'],
+                                              mimetype='html',
+                                              can_change_preferences=False)
 
     def test_send_email_failed(self, app, user, public_project_url, fork_data_with_title, public_project):
 
@@ -336,4 +341,9 @@ class TestNodeForkCreate:
             with mock.patch.object(mails, 'send_mail', return_value=None) as mock_send_mail:
                 with pytest.raises(Exception):
                     app.post_json_api(public_project_url, fork_data_with_title, auth=user.auth)
-                    mock_send_mail.assert_called_with(user.email, mails.FORK_FAILED, title=public_project.title, guid=public_project._id, mimetype='html')
+                    mock_send_mail.assert_called_with(user.email,
+                                                      mails.FORK_FAILED,
+                                                      title=public_project.title,
+                                                      guid=public_project._id,
+                                                      mimetype='html',
+                                                      can_change_preferences=False)

--- a/website/mails/mails.py
+++ b/website/mails/mails.py
@@ -152,12 +152,12 @@ EXTERNAL_LOGIN_CONFIRM_EMAIL_CREATE = Mail(
 
 FORK_COMPLETED = Mail(
     'fork_completed',
-    subject='Your Fork has Completed'
+    subject='Your fork has completed'
 )
 
 FORK_FAILED = Mail(
     'fork_failed',
-    subject='Your Fork has Failed'
+    subject='Your fork has failed'
 )
 
 EXTERNAL_LOGIN_CONFIRM_EMAIL_LINK = Mail(

--- a/website/static/js/project.js
+++ b/website/static/js/project.js
@@ -80,7 +80,7 @@ NodeActions.forkNode = function() {
                 data: payload
             }
         );
-        $osf.growl('Fork status', 'Your fork is being forked you\'ll get an email when it\'s complete.', 'info');
+        $osf.growl('Fork status', 'Your fork is being created. You\'ll receive an email when it is complete.', 'info');
     });
 };
 

--- a/website/templates/emails/fork_completed.html.mako
+++ b/website/templates/emails/fork_completed.html.mako
@@ -9,10 +9,4 @@
     <h3 class="text-center" style="padding: 0;margin: 30px 0 0 0;border: none;list-style: none;font-weight: 300;text-align: center;">The fork of <b>${title}</b> has been successfully created: <a href="${settings.DOMAIN + guid}">here.</a></h3>
   </td>
 </tr>
-<tr>
-  <td style="border-collapse: collapse;">
-    The OSF Team
-    Center for Open Science
-  </td>
-</tr>
 </%def>

--- a/website/templates/emails/fork_completed.html.mako
+++ b/website/templates/emails/fork_completed.html.mako
@@ -6,12 +6,13 @@
 <tr>
   <td style="border-collapse: collapse;">
 
-    <h3 class="text-center" style="padding: 0;margin: 30px 0 0 0;border: none;list-style: none;font-weight: 300;text-align: center;">Your fork <b>${title}</b> has finished</h3>
+    <h3 class="text-center" style="padding: 0;margin: 30px 0 0 0;border: none;list-style: none;font-weight: 300;text-align: center;">The fork of <b>${title}</b> has been successfully created: <a href="${settings.DOMAIN + guid}">here.</a></h3>
   </td>
 </tr>
 <tr>
   <td style="border-collapse: collapse;">
-    You can view the fork here <a href="${settings.DOMAIN + guid}">here.</a>
+    The OSF Team
+    Center for Open Science
   </td>
 </tr>
 </%def>

--- a/website/templates/emails/fork_failed.html.mako
+++ b/website/templates/emails/fork_failed.html.mako
@@ -11,4 +11,9 @@
     </h3>
   </td>
 </tr>
+<tr>
+  <td style="border-collapse: collapse;">
+    You can view the project <a href="${settings.DOMAIN + guid}">here.</a>
+  </td>
+</tr>
 </%def>

--- a/website/templates/emails/fork_failed.html.mako
+++ b/website/templates/emails/fork_failed.html.mako
@@ -11,9 +11,4 @@
     </h3>
   </td>
 </tr>
-<tr>
-  <td style="border-collapse: collapse;">
-    You can view the fork here <a href="${settings.DOMAIN + guid}">here.</a>
-  </td>
-</tr>
 </%def>


### PR DESCRIPTION
## Purpose

Forking emails and error messages have bad, casing, grammar and language. This fixes that.

## Changes

Language and textual changes.
- Fork completed email should have the node title rather than the fork title;
- The line that says that they can opt-out of this type of email;
- Changed to sentence case from title case on the subject of the email;
- Used suggested wording for forking notification;
- Adjusted wording of body of success email based on suggestion and made it more compact;
- On failure email, re-worded so user sees that they can visit the original project, not the failed fork.

## QA Notes

This should now match the language described in the original ticket.

Please verify that at least one other HTML email still gives the unsubscribe option.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/OSF-8247
