### PR TITLE
[SVCS-488] Improve docx rendering - OSF Part

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -732,6 +732,7 @@ def addon_view_file(auth, node, file_node, version):
             'direct': None,
             'mode': 'render',
             'action': 'download',
+            'public_file': node.is_public,
         })
     )
 


### PR DESCRIPTION
### Tickets and Related PRs

Service Ticket: https://openscience.atlassian.net/browse/SVCS-488
MFR PR: https://github.com/CenterForOpenScience/modular-file-renderer/pull/304

### Purpose

Let OSF expose whether a file is public to WB and MFR. For MFR can use an external rendering service provided by Microsoft to render public `.docx` files.

### Changes

Add `publice_file = node.is_public` as query parameter to the `download_url`,
  which is a query parameter for the  `render_url`,
    which is returned by `addon_view_file()`,
      which is called by route `addon_view_or_download_file()`.

This change is based on the discussion with @sloria and @AddisonSchiller a while ago.

### Side Effects

No

### QA Notes

Please refer to the [Service Ticket](https://openscience.atlassian.net/browse/SVCS-488) or the [Service PR](https://github.com/CenterForOpenScience/modular-file-renderer/pull/304).

### Deployments Notes

This PR must be merged before its MFR counterparts. The change won't take effect (nor cause any issues) until the MFR PR is merged.
