### PR TITLE
Feature/Change full name length to 186 to account for quickfiles [OSF-8729]

### DIFF
--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -44,7 +44,7 @@ class UserSerializer(JSONAPISerializer):
     non_anonymized_fields = ['type']
     id = IDField(source='_id', read_only=True)
     type = TypeField()
-    full_name = ser.CharField(source='fullname', required=True, label='Full name', help_text='Display name used in the general user interface', max_length=200)
+    full_name = ser.CharField(source='fullname', required=True, label='Full name', help_text='Display name used in the general user interface', max_length=186)
     given_name = ser.CharField(required=False, allow_blank=True, help_text='For bibliographic citations')
     middle_names = ser.CharField(required=False, allow_blank=True, help_text='For bibliographic citations')
     family_name = ser.CharField(required=False, allow_blank=True, help_text='For bibliographic citations')

--- a/website/templates/include/profile/names.mako
+++ b/website/templates/include/profile/names.mako
@@ -4,8 +4,8 @@
 
         <div class="form-group">
             <label>Full name (e.g. Rosalind Elsie Franklin)</label>
-            ## Maxlength for full names must be 200 - quickfile titles use fullname
-            <input class="form-control" data-bind="value: full" maxlength="200"/>
+            ## Maxlength for full names must be 186 - quickfile titles use fullname + 's Quick Files
+            <input class="form-control" data-bind="value: full" maxlength="186"/>
             <div data-bind="visible: showMessages, css:'text-danger'">
                 <p data-bind="validationMessage: full"></p>
             </div>

--- a/website/templates/public/register.mako
+++ b/website/templates/public/register.mako
@@ -83,8 +83,8 @@
                 <div class="form-group" data-bind=" css: { 'has-error': fullName() && !fullName.isValid(), 'has-success': fullName() && fullName.isValid() }">
                     <label for="inputName" class="col-sm-4 control-label">Full Name</label>
                     <div class="col-sm-8">
-                        ## Maxlength for full names must be 200 - quickfile titles use fullname
-                        <input autofocus type="text" class="form-control" id="inputName" placeholder="Name" data-bind="value: fullName, disable: submitted(), event: { blur: trim.bind($data, fullName) }" maxlength="200">
+                        ## Maxlength for full names must be 186 - quickfile titles use fullname + 's Quick Files
+                        <input autofocus type="text" class="form-control" id="inputName" placeholder="Name" data-bind="value: fullName, disable: submitted(), event: { blur: trim.bind($data, fullName) }" maxlength="186">
                         <p class="help-block" data-bind="validationMessage: fullName" style="display: none;"></p>
                     </div>
                 </div>


### PR DESCRIPTION
## Purpose

I didn't realize that quickfiles add " 's quickfiles" to the end of a user's `fullname` when creating the quickfiles node. Since currently nodes can only have titles 200 characters in length, fullnames can only be 186 max. 

This will be fixed in [OSF-8994](https://openscience.atlassian.net/browse/OSF-8994?jql=text%20~%20%22node%20title%20limit%22) because node title limit will be increased. At that point, the limit for fullnames can go back to 256.

## Changes

Change limits from the erroneous 200 to 184.

## QA Notes

Make sure that changing fullname to have 186 characters does not fail on profile settings page. Make sure to wait to see the green "Settings updated"

Make sure creating a user with a 186 character name works

## Side Effects

None

## Ticket

https://openscience.atlassian.net/browse/OSF-8729