### PR TITLE
[hotfix] No subjects_acceptable or _id when exporting preprint providers [OSF-9046]

### DIFF
--- a/admin/preprint_providers/views.py
+++ b/admin/preprint_providers/views.py
@@ -19,7 +19,7 @@ from osf.models.preprint_provider import rules_to_subjects
 
 # When preprint_providers exclusively use Subject relations for creation, set this to False
 SHOW_TAXONOMIES_IN_PREPRINT_PROVIDER_CREATE = True
-FIELDS_TO_NOT_IMPORT_EXPORT = ['access_token', 'share_source', 'subjects_acceptable']
+FIELDS_TO_NOT_IMPORT_EXPORT = ['access_token', 'share_source', 'subjects_acceptable', '_id']
 
 
 class PreprintProviderList(PermissionRequiredMixin, ListView):

--- a/admin/preprint_providers/views.py
+++ b/admin/preprint_providers/views.py
@@ -19,7 +19,7 @@ from osf.models.preprint_provider import rules_to_subjects
 
 # When preprint_providers exclusively use Subject relations for creation, set this to False
 SHOW_TAXONOMIES_IN_PREPRINT_PROVIDER_CREATE = True
-FIELDS_TO_NOT_IMPORT_EXPORT = ['access_token', 'share_source']
+FIELDS_TO_NOT_IMPORT_EXPORT = ['access_token', 'share_source', 'subjects_acceptable']
 
 
 class PreprintProviderList(PermissionRequiredMixin, ListView):

--- a/admin_tests/preprint_providers/test_views.py
+++ b/admin_tests/preprint_providers/test_views.py
@@ -239,7 +239,7 @@ class TestPreprintProviderExportImport(AdminTestCase):
         res = self.view.get(self.request)
         content_dict = json.loads(res.content)
 
-        content_dict['fields']['_id'] = 'new_id'
+        content_dict['fields']['name'] = 'Awesome New Name'
         data = StringIO(unicode(json.dumps(content_dict), 'utf-8'))
         self.import_request.FILES['file'] = InMemoryUploadedFile(data, None, 'data', 'application/json', 500, None, {})
 
@@ -249,7 +249,7 @@ class TestPreprintProviderExportImport(AdminTestCase):
         new_provider = PreprintProvider.objects.get(id=provider_id)
 
         nt.assert_equal(res.status_code, 302)
-        nt.assert_equal(new_provider._id, 'new_id')
+        nt.assert_equal(new_provider.name, 'Awesome New Name')
         nt.assert_equal(new_provider.subjects.all().count(), 1)
         nt.assert_equal(new_provider.licenses_acceptable.all().count(), 1)
         nt.assert_equal(new_provider.subjects.all()[0].text, self.subject.text)
@@ -261,7 +261,7 @@ class TestPreprintProviderExportImport(AdminTestCase):
         res = self.view.get(self.request)
         content_dict = json.loads(res.content)
 
-        content_dict['fields']['_id'] = 'new_id'
+        content_dict['fields']['name'] = 'Awesome New Name'
         content_dict['fields']['new_field'] = 'this is a new field, not in the model'
         del content_dict['fields']['description']  # this is a old field, removed from the model JSON
 
@@ -274,7 +274,7 @@ class TestPreprintProviderExportImport(AdminTestCase):
         new_provider = PreprintProvider.objects.get(id=provider_id)
 
         nt.assert_equal(res.status_code, 302)
-        nt.assert_equal(new_provider._id, 'new_id')
+        nt.assert_equal(new_provider.name, 'Awesome New Name')
 
     def test_update_provider_existing_subjects(self):
         # If there are existing subjects for a provider, imported subjects are ignored


### PR DESCRIPTION
[#OSF-9046]

<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

subjects_acceptable is less and less relevant now, and is causing all sorts of errors when importing into a new preprint provider without a custom taxonomy, as it uses _ids which don't match when moving between environments.

A quick thing is to just not export them, and instead rely on the actual Subjects (hopefully) set in the provider being exported. 

<!-- Describe the purpose of your changes -->

## Changes

- don't export subjects_acceptable, because the import is optimized for subject relationships (that really should exist anyhow before export)
- also don't export `_id` so that you can go back and change it later but still get all the same settings as another provider

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->
To test!
- Export a preprint provider with a custom taxonomy
- Import in the create section
- Make sure that the form imports correctly (it will be *very* slow as it creates a new custom taxonomy)

- Also try exporting a provider *without* a custom taxonomy
- Import that provider in the "create" section
- All subjects should be listed!

## Side Effects
none anticipated

## Ticket
https://openscience.atlassian.net/browse/OSF-9046