### PR TITLE
[OSF-8269] Changes to allow for enabling/disabling of wikis.

### DIFF
--- a/addons/wiki/tests/test_wiki.py
+++ b/addons/wiki/tests/test_wiki.py
@@ -1259,11 +1259,22 @@ class TestPublicWiki(OsfTestCase):
 
         assert_equal(data, expected)
 
-    def test_serialize_wiki_settings_no_wiki(self):
+    def test_serialize_wiki_settings_disabled_wiki(self):
         node = NodeFactory(parent=self.project, creator=self.user)
         node.delete_addon('wiki', self.consolidate_auth)
         data = serialize_wiki_settings(self.user, [node])
-        expected = []
+        expected = [{'node':
+                        {'url': node.url,
+                         'is_public': False,
+                         'id': node._id,
+                         'title': node.title},
+                    'category': 'hypothesis',
+                    'kind': 'folder',
+                    'nodeType': 'component',
+                    'children': [],
+                    'permissions': {'admin': True,
+                                    'view': True}
+                    }]
 
         assert_equal(data, expected)
 

--- a/addons/wiki/utils.py
+++ b/addons/wiki/utils.py
@@ -202,25 +202,25 @@ def serialize_wiki_settings(user, nodes):
                 },
             })
 
-            children_tree.extend(serialize_wiki_settings(user, children))
+        children_tree.extend(serialize_wiki_settings(user, children))
 
-            item = {
-                'node': {
-                    'id': node._id,
-                    'url': node.url if can_read else '',
-                    'title': node.title if can_read else 'Private Project',
-                    'is_public': node.is_public
-                },
-                'children': children_tree,
-                'kind': 'folder' if not node.parent_node or not node.parent_node.has_permission(user, 'read') else 'node',
-                'nodeType': node.project_or_component,
-                'category': node.category,
-                'permissions': {
-                    'view': can_read,
-                    'admin': is_admin,
-                },
-            }
+        item = {
+            'node': {
+                'id': node._id,
+                'url': node.url if can_read else '',
+                'title': node.title if can_read else 'Private Project',
+                'is_public': node.is_public
+            },
+            'children': children_tree,
+            'kind': 'folder' if not node.parent_node or not node.parent_node.has_permission(user, 'read') else 'node',
+            'nodeType': node.project_or_component,
+            'category': node.category,
+            'permissions': {
+                'view': can_read,
+                'admin': is_admin,
+            },
+        }
 
-            items.append(item)
+        items.append(item)
 
     return items

--- a/website/templates/project/settings.mako
+++ b/website/templates/project/settings.mako
@@ -144,13 +144,12 @@
                     </div>
 
                 <div class="panel-body">
-                    %if wiki:
                         <form id="selectWikiForm">
                             <div>
                                 <label class="break-word">
                                     <input
                                             type="checkbox"
-                                            name="${wiki.short_name}"
+                                            name="wiki"
                                             class="wiki-select"
                                             data-bind="checked: enabled"
                                     />
@@ -165,11 +164,11 @@
                                 </div>
                             </div>
                         </form>
-                    %endif
 
+                        %if wiki_enabled:
                             <h3>Configure</h3>
                             <div style="padding-left: 15px">
-                                %if  node['is_public']:
+                                %if node['is_public']:
                                     <p class="text">Control who can edit the wiki of <b>${node['title']}</b></p>
                                 %else:
                                     <p class="text">Control who can edit your wiki. To allow all OSF users to edit the wiki, <b>${node['title']}</b> must be public.</p>
@@ -187,6 +186,7 @@
                                     <p id="configureWikiMessage"></p>
                                 </div>
                             </form>
+                        %endif
                     </div>
                 </div>
             %endif


### PR DESCRIPTION
## Purpose

The wiki disable button got lost in the shuffle of changing view attributes, this fix restores it and makes disabled wikis appear in the wiki configure panel.

## Changes

HTML changes to make button visible and JS changes to allow disabled wiki nodes to still appear (This needed because their children may be configurable, even though they are not.)

## QA Notes

Try complex branching hierarchies with both enabled and disabled wikis.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/OSF-8269