### PR TITLE
[OSF-8055] Fix padding and responsiveness for analytics page metrics.

### DIFF
--- a/website/static/css/pages/statistics-page.css
+++ b/website/static/css/pages/statistics-page.css
@@ -4,6 +4,15 @@
     display: flex;
     display: -webkit-flex;
     flex-wrap: wrap;
+    padding-top: 40px;
+}
+
+@media (max-width: 768px) {
+    .col-sm-4.col-xs-12.panel.panel-default {
+        margin-left: 15px;
+        margin-right: 15px;
+    }
 }
 
 .no-analytics img { opacity: 0.5; }
+

--- a/website/templates/project/statistics.mako
+++ b/website/templates/project/statistics.mako
@@ -6,38 +6,36 @@
     <h2 class="text-300">Analytics</h2>
 </div>
 
- <div class="row equal-heighted-row">
-     <div class="col-md-4 panel panel-default">
-         <div class="">
-             <div class="panel-body">
-                 <div class="text-center">
-                     <h3>Forks</h3>
-                     <h2>${node['fork_count']}</h2>
-                     <a href='${node['url']}forks'><h4 >View all forks</h4></a>
-                 </div>
-             </div>
-         </div>
-     </div>
-     <div class="col-md-4">
-         <div class="panel panel-default">
-             <div class="panel-body">
-                 <div class="text-center">
-                     <h3>Links to Project</h3>
-                     <h2>${node['linked_nodes_count']}</h2>
-                     <a data-toggle="modal" data-target="#showLinks"><h4 >View all links</h4></a>
-                 </div>
-             </div>
-         </div>
-     </div>
-     <div class="col-md-4 panel panel-default">
-         <div class="panel-body">
-             <div class="text-center">
-                 <h3>Template Copies</h3>
-                 <h2>${node['templated_count']}</h2>
-             </div>
-         </div>
-     </div>
- </div>
+<div class="row equal-heighted-row">
+    <div class="col-sm-4 col-xs-12 panel panel-default">
+        <div class="panel-body">
+            <div class="text-center">
+                <h3>Forks</h3>
+                <h2>${node['fork_count']}</h2>
+                <a href='${node['url']}forks'><h4 >View all forks</h4></a>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-4 col-xs-12">
+        <div class="panel panel-default">
+            <div class="panel-body">
+                <div class="text-center">
+                    <h3>Links to Project</h3>
+                    <h2>${node['linked_nodes_count']}</h2>
+                    <a data-toggle="modal" data-target="#showLinks"><h4 >View all links</h4></a>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="col-sm-4 col-xs-12 panel panel-default">
+        <div class="panel-body">
+            <div class="text-center">
+                <h3>Template Copies</h3>
+                <h2>${node['templated_count']}</h2>
+            </div>
+        </div>
+    </div>
+</div>
 
 % if not node['is_public']:
     <div class="row m-lg">


### PR DESCRIPTION
## Purpose

Responsiveness for the newly added panels on the analytics tab is not very good, this fix addresses that and improves their padding.

## Changes

CSS changes to add better responsiveness and padding for the analytics panels.

## Before
![mobile_cards_should_be_centered](https://user-images.githubusercontent.com/9688518/33770235-df35eb62-dbfa-11e7-9dd5-0433370e7461.png)

## After
Chrome and Firefox look the same. 
<img width="336" alt="screen shot 2017-12-08 at 9 30 21 am" src="https://user-images.githubusercontent.com/9688518/33770161-a5bd1e6e-dbfa-11e7-9551-5563b0441bfb.png">
<img width="683" alt="screen shot 2017-12-08 at 9 30 08 am" src="https://user-images.githubusercontent.com/9688518/33770162-a5ca048a-dbfa-11e7-9555-9cba648a8412.png">
<img width="850" alt="screen shot 2017-12-08 at 9 29 49 am" src="https://user-images.githubusercontent.com/9688518/33770163-a5d52ba8-dbfa-11e7-8621-01713e180442.png">
<img width="1436" alt="screen shot 2017-12-08 at 9 29 34 am" src="https://user-images.githubusercontent.com/9688518/33770164-a5e2e158-dbfa-11e7-941a-d2ddc21b530b.png">


## QA Notes

There are still still issues with Safari that are documented in the ticket and will likely be resolved later.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/OSF-8055