### PR TITLE
[Feature] Improve metadata retention [OSF-8762][OSF-8636]

### DIFF
--- a/addons/dataverse/models.py
+++ b/addons/dataverse/models.py
@@ -6,7 +6,7 @@ from addons.base.models import (BaseOAuthNodeSettings, BaseOAuthUserSettings,
 from django.db import models
 from framework.auth.decorators import Auth
 from framework.exceptions import HTTPError
-from osf.models.files import File, Folder, FileVersion, BaseFileNode
+from osf.models.files import File, Folder, BaseFileNode
 from framework.auth.core import _get_current_user
 from addons.base import exceptions
 from addons.dataverse.client import connect_from_settings_or_401
@@ -25,16 +25,12 @@ class DataverseFile(DataverseFileNode, File):
     version_identifier = 'version'
 
     def update(self, revision, data, save=True, user=None):
-        """Note: Dataverse only has psuedo versions, don't save them
+        """Note: Dataverse only has psuedo versions, pass None to not save them
+        Call super to update _history and last_touched anyway.
         Dataverse requires a user for the weird check below
         """
-        self.name = data['name']
-        self.materialized_path = data['materialized']
-        if save:
-            self.save()
-
-        version = FileVersion(identifier=revision)
-        version.update_metadata(data, save=False)
+        version = super(DataverseFile, self).update(None, data, user=user, save=save)
+        version.identifier = revision
 
         user = user or _get_current_user()
         if not user or not self.node.can_edit(user=user):

--- a/addons/figshare/models.py
+++ b/addons/figshare/models.py
@@ -7,7 +7,7 @@ from django.db import models
 from framework.auth import Auth
 from framework.exceptions import HTTPError
 from osf.models.external import ExternalProvider
-from osf.models.files import File, Folder, FileVersion, BaseFileNode
+from osf.models.files import File, Folder, BaseFileNode
 from addons.base import exceptions
 from addons.figshare import settings as figshare_settings
 from addons.figshare import messages
@@ -25,20 +25,12 @@ class FigshareFolder(FigshareFileNode, Folder):
 class FigshareFile(FigshareFileNode, File):
     version_identifier = 'ref'
 
-    def touch(self, bearer, revision=None, **kwargs):
-        return super(FigshareFile, self).touch(bearer, revision=None, **kwargs)
-
-    def update(self, revision, data, save=True, user=None):
+    def update(self, revision, data, user=None, save=True):
         """Figshare does not support versioning.
         Always pass revision as None to avoid conflict.
+        Call super to update _history and last_touched anyway.
         """
-        self.name = data['name']
-        self.materialized_path = data['materialized']
-        if save:
-            self.save()
-
-        version = FileVersion(identifier=None)
-        version.update_metadata(data, save=False)
+        version = super(FigshareFile, self).update(None, data, user=user, save=save)
 
         # Draft files are not renderable
         if data['extra']['status'] == 'drafts':


### PR DESCRIPTION
## Purpose
Store metadata about touched addon files

## Changes
* Use `super` to update `_history` and `last_touched`

## QA Notes
Test that looking at Figshare/Dataverse files still work

## Side Effects
None expected

## Ticket
[[OSF-8762]](https://openscience.atlassian.net/browse/OSF-8762)
[[OSF-8636]](https://openscience.atlassian.net/browse/OSF-8636)