### PR TITLE
[OSF-8319] Fix admin app logs to show information about components

### DIFF
--- a/admin/nodes/serializers.py
+++ b/admin/nodes/serializers.py
@@ -38,7 +38,7 @@ def serialize_node(node):
     }
 
 def serialize_log(log):
-    return log, log.params.iteritems()
+    return log, list(log.params.iteritems())
 
 
 def serialize_simple_user_and_node_permissions(node, user):

--- a/admin_tests/nodes/test_views.py
+++ b/admin_tests/nodes/test_views.py
@@ -354,7 +354,6 @@ class TestAdminNodeLogView(AdminTestCase):
         self.user = AuthUserFactory()
         self.auth = Auth(self.user)
         self.node = ProjectFactory(creator=self.user)
-        self.node.save()
 
     def test_get_object(self):
 
@@ -372,7 +371,7 @@ class TestAdminNodeLogView(AdminTestCase):
 
         logs = view.get_queryset()
 
-        log_entry = logs.all()[0]
+        log_entry = logs.first()
         nt.assert_true(log_entry.action == 'edit_title')
         nt.assert_true(log_entry.params['title_new'] == u'New Title')
 
@@ -392,8 +391,8 @@ class TestAdminNodeLogView(AdminTestCase):
 
     def test_get_logs_for_children(self):
         """ The "create component" action is actually logged as a create_project action
-        for it's child with a log parameter 'node' having it's guid as a value. We have to ensure
-        that all the components a parent has created appear in it's admin app logs, so we can't just
+        for its child with a log parameter 'node' having its guid as a value. We have to ensure
+        that all the components a parent has created appear in its admin app logs, so we can't just
          do node.logs.all(), that will leave out component creation.
         """
 

--- a/admin_tests/nodes/test_views.py
+++ b/admin_tests/nodes/test_views.py
@@ -10,7 +10,8 @@ from admin.nodes.views import (
     NodeFlaggedSpamList,
     NodeKnownSpamList,
     NodeKnownHamList,
-    NodeConfirmHamView
+    NodeConfirmHamView,
+    AdminNodeLogView
 )
 from admin_tests.utilities import setup_log_view, setup_view
 
@@ -19,6 +20,7 @@ from django.test import RequestFactory
 from django.core.urlresolvers import reverse
 from django.core.exceptions import PermissionDenied
 from django.contrib.auth.models import Permission
+from framework.auth.core import Auth
 
 from tests.base import AdminTestCase
 from osf_tests.factories import AuthUserFactory, ProjectFactory, RegistrationFactory
@@ -341,3 +343,70 @@ class TestNodeConfirmHamView(AdminTestCase):
 
         self.registration.refresh_from_db()
         nt.assert_true(self.registration.spam_status == 4)
+
+
+class TestAdminNodeLogView(AdminTestCase):
+
+    def setUp(self):
+        super(TestAdminNodeLogView, self).setUp()
+
+        self.request = RequestFactory().post('/fake_path')
+        self.user = AuthUserFactory()
+        self.auth = Auth(self.user)
+        self.node = ProjectFactory(creator=self.user)
+        self.node.save()
+
+    def test_get_object(self):
+
+        view = AdminNodeLogView()
+        view = setup_log_view(view, self.request, guid=self.node._id)
+
+        nt.assert_true(self.node, view.get_object())
+
+    def test_get_queryset(self):
+
+        self.node.set_title('New Title', auth=self.auth, save=True)
+
+        view = AdminNodeLogView()
+        view = setup_log_view(view, self.request, guid=self.node._id)
+
+        logs = view.get_queryset()
+
+        log_entry = logs.all()[0]
+        nt.assert_true(log_entry.action == 'edit_title')
+        nt.assert_true(log_entry.params['title_new'] == u'New Title')
+
+    def test_get_context_data(self):
+
+        self.node.set_title('New Title', auth=self.auth, save=True)
+
+        view = AdminNodeLogView()
+        view = setup_log_view(view, self.request, guid=self.node._id)
+
+        logs = view.get_context_data()['logs']
+        log_entry = logs[0][0]
+        log_params = logs[0][1]
+        nt.assert_true(log_entry.action == NodeLog.EDITED_TITLE)
+        nt.assert_true((u'title_new', u'New Title') in log_params)
+        nt.assert_true((u'node', self.node._id) in log_params)
+
+    def test_get_logs_for_children(self):
+        """ The "create component" action is actually logged as a create_project action
+        for it's child with a log parameter 'node' having it's guid as a value. We have to ensure
+        that all the components a parent has created appear in it's admin app logs, so we can't just
+         do node.logs.all(), that will leave out component creation.
+        """
+
+        component = ProjectFactory(creator=self.user, parent=self.node)
+        component.save()
+
+        view = AdminNodeLogView()
+        view = setup_log_view(view, self.request, guid=self.node._id)
+
+        logs = view.get_context_data()['logs']
+        log_entry = logs[0][0]
+        log_params = logs[0][1]
+
+        nt.assert_true(log_entry.action == NodeLog.PROJECT_CREATED)
+        nt.assert_true(log_entry.node._id == component._id)
+        nt.assert_true(('node', component._id) in log_params)


### PR DESCRIPTION
## Purpose

Currently the logs in the admin app only show information strictly dealing with the node being observed and not it's children, this is a bit different then the public node logs which show some info like component creation which only is associated with the child, but not the parent.

This fix makes the queries for the normal osf.io node logs and the private admin app logs match.

## Changes

 - Changes query for the admin app private logs to match the logs on the node overview page.
 - Adds unit tests for the admin node log view. 

## QA Notes

- Create some components and see if they're logged in the admin logs.
- The node overview logs should now match the admin logs entry-for-entry.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/OSF-8319