### PR TITLE
[OSF-8247] Change fork emails to use raw link instead of text

### DIFF
--- a/website/templates/emails/fork_completed.html.mako
+++ b/website/templates/emails/fork_completed.html.mako
@@ -6,7 +6,7 @@
 <tr>
   <td style="border-collapse: collapse;">
 
-    <h3 class="text-center" style="padding: 0;margin: 30px 0 0 0;border: none;list-style: none;font-weight: 300;text-align: center;">The fork of <b>${title}</b> has been successfully created: <a href="${settings.DOMAIN + guid}">here.</a></h3>
+    <h3 class="text-center" style="padding: 0;margin: 30px 0 0 0;border: none;list-style: none;font-weight: 300;text-align: center;">The fork of <b>${title}</b> has been successfully created here: ${settings.DOMAIN + guid}</h3>
   </td>
 </tr>
 </%def>

--- a/website/templates/emails/fork_completed.html.mako
+++ b/website/templates/emails/fork_completed.html.mako
@@ -6,7 +6,7 @@
 <tr>
   <td style="border-collapse: collapse;">
 
-    <h3 class="text-center" style="padding: 0;margin: 30px 0 0 0;border: none;list-style: none;font-weight: 300;text-align: center;">The fork of <b>${title}</b> has been successfully created here: ${settings.DOMAIN + guid}</h3>
+    <h3 class="text-center" style="padding: 0;margin: 30px 0 0 0;border: none;list-style: none;font-weight: 300;text-align: center;">The fork of <b>${title}</b> has been successfully created here: <a href="${settings.DOMAIN + guid}">${settings.DOMAIN + guid}</a> </h3>
   </td>
 </tr>
 </%def>

--- a/website/templates/emails/fork_failed.html.mako
+++ b/website/templates/emails/fork_failed.html.mako
@@ -13,7 +13,7 @@
 </tr>
 <tr>
   <td style="border-collapse: collapse;">
-    You can view the project <a href="${settings.DOMAIN + guid}">here.</a>
+    You can view the project here: ${settings.DOMAIN + guid}
   </td>
 </tr>
 </%def>

--- a/website/templates/emails/fork_failed.html.mako
+++ b/website/templates/emails/fork_failed.html.mako
@@ -13,7 +13,7 @@
 </tr>
 <tr>
   <td style="border-collapse: collapse;">
-    You can view the project here: ${settings.DOMAIN + guid}
+    You can view the project here: <a href="${settings.DOMAIN + guid}">${settings.DOMAIN + guid}</a>
   </td>
 </tr>
 </%def>


### PR DESCRIPTION
## Purpose

Currently the fork sucess/failure emails use text labels on links instead of raw links, this fix makes things more consistent other emails by using the raw links.

## Changes

- Fork success email now uses a raw link (osf.io/...) instead of label text ("here.")
- Fork failure email now uses a raw link (osf.io/...) instead of label text ("here.")

## QA Notes

- You should know be able to see the full text of a link instead of the label, "here."

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/OSF-8247