### PR TITLE
[OSF-8269] Fix typo in wiki config

### DIFF
--- a/website/static/js/wikiSettingsTreebeard.js
+++ b/website/static/js/wikiSettingsTreebeard.js
@@ -110,7 +110,7 @@ function ProjectWiki(data) {
                         if(!item.parent().data.permissions.admin){
                             return 'Only admins may change permissions of this wiki.';
                         } else {
-                            return item.parent().data.node.is_public ? 'Select who can edit' : 'This feature disabled for wikis of private '  + item.parent().data.nodeType + 's.';
+                            return item.parent().data.node.is_public ? 'Select who can edit' : 'This feature is disabled for wikis of private '  + item.parent().data.nodeType + 's.';
                         }
                     }
                 },


### PR DESCRIPTION
## Purpose

When you try configure a private wiki it gives you the message "This feature disabled for wikis of private project/components", this should be "This feature **is** disabled for wikis of private project/components"

## Changes

- Changes text to read "This feature is disabled for wikis of private project/components"

## QA Notes

Create a project and go to configure the wiki, if it is private and enabled you should see the message, "This feature is disabled for wikis of private project/components"

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/OSF-8269