### PR TITLE
[OSF-8055] Clean up forks page

### DIFF
--- a/website/templates/project/forks.mako
+++ b/website/templates/project/forks.mako
@@ -6,11 +6,13 @@
     <h2 class="text-300">Forks</h2>
 </div>
 
+<div class="row m-md">
+    <a href="${node['url']}analytics" class="padded strong">
+        <span class="fa fa-arrow-left"></span> Back to Analytics
+    </a>
+</div>
 <div class="row">
-        <div class="col-xs-9 col-sm-8">
-        <a href="${node['url']}analytics" class="padded strong">
-            <span class="fa fa-arrow-left"></span> Back to Analytics
-        </a>
+    <div class="col-xs-9 col-sm-8">
 
         % if node['fork_count']:
             ${render_nodes.render_nodes(nodes=node['forks'], sortable=False, user=user, pluralized_node_type='forks', show_path=False, include_js=True)}
@@ -18,14 +20,14 @@
                 <p class="m-md">This project has no forks. A fork is a copy of a project that you can change without
                 affecting the original project.</p>
         % endif
+    </div>
+    <div class="col-xs-3 col-sm-4">
+        <div class="m-md">
+            % if user_name and (user['is_contributor'] or node['is_public']) and not disk_saving_mode:
+                <a class="btn btn-success" type="button" onclick="NodeActions.forkNode();">New fork</a>
+            % endif
         </div>
-        <div class="col-xs-3 col-sm-4">
-                <div class="m-md">
-                    % if user_name and (user['is_contributor'] or node['is_public']) and not disk_saving_mode:
-                        <a class="btn btn-success" type="button" onclick="NodeActions.forkNode();">New fork</a>
-                    % endif
-                </div>
-        </div>
+    </div>
 </div>
 
 <%def name="javascript_bottom()">


### PR DESCRIPTION
## Purpose

After some changes were made on the forks page to accommodate changes to the analytics page things were a bit funky. The "Back to Analytics" button had no top padding and the "New Forks" button was out on alignment.

## Before
![forks_page](https://user-images.githubusercontent.com/9688518/33806513-52b38854-dd97-11e7-9534-cf5a61583f10.png)

## After
<img width="1440" alt="screen shot 2017-12-10 at 10 48 27 am" src="https://user-images.githubusercontent.com/9688518/33806539-b55a43a8-dd97-11e7-9624-e83608485820.png">


## Changes

- Added some margin to the "back to analytics" link button.
- Brings the "New Forks" button back into alignment with forks panel.

## QA Notes

Check for responsiveness on multiple browsers.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/OSF-8055