### PR TITLE
[Feature] Expose metadata for missing files[PLAT-498]

### DIFF
--- a/addons/base/utils.py
+++ b/addons/base/utils.py
@@ -22,7 +22,7 @@ def get_addons_by_config_type(config_type, user):
     addons = [addon for addon in settings.ADDONS_AVAILABLE if config_type in addon.configs]
     return [serialize_addon_config(addon_config, user) for addon_config in sorted(addons, key=lambda cfg: cfg.full_name.lower())]
 
-def maybe_show_lost_file_metadata(auth, node, file, error_type):
+def format_last_known_metadata(auth, node, file, error_type):
     msg = """
     </div>"""  # None is default
     if error_type != 'FILE_SUSPENDED' and ((auth.user and node.is_contributor(auth.user)) or (auth.private_key and auth.private_key in node.private_link_keys_active)):
@@ -39,7 +39,7 @@ def maybe_show_lost_file_metadata(auth, node, file, error_type):
             """with a file size of {} bytes""".format(size) if size and (last_seen or path) else '',
             """last seen with a file size of {} bytes""".format(size) if size and not (last_seen or path) else '',
             """.</br></br>""" if last_seen or hashes or path or size else '',
-            """Hashes of last seen version:</br>{}""".format(
+            """Hashes of last seen version:</br><p>{}</p>""".format(
                 '</br>'.join(['{}: {}'.format(k, v) for k, v in hashes.items()])
             ) if hashes else '',  # TODO: Format better for UI
             msg

--- a/addons/base/utils.py
+++ b/addons/base/utils.py
@@ -20,3 +20,30 @@ def serialize_addon_config(config, user):
 def get_addons_by_config_type(config_type, user):
     addons = [addon for addon in settings.ADDONS_AVAILABLE if config_type in addon.configs]
     return [serialize_addon_config(addon_config, user) for addon_config in sorted(addons, key=lambda cfg: cfg.full_name.lower())]
+
+def maybe_show_lost_file_metadata(auth, node, file):
+    msg = """
+    </div>"""  # None is default
+    if (auth.user and node.is_contributor(auth.user)) or (auth.private_key and auth.private_key in node.private_link_keys_active):
+        last_meta = file.last_known_metadata
+        last_seen = last_meta.get('last_seen', None)
+        hashes = last_meta.get('hashes', None)
+        path = last_meta.get('path', None)
+        size = last_meta.get('size', None)
+        parts = [
+            """This file was """ if last_seen or hashes or path or size else '',
+            """last seen on {}""".format(last_seen) if last_seen else '',
+            """and found at path {}""".format(path) if last_seen and path else '',
+            """last found at path {}""".format(path) if not last_seen and path else '',
+            """with a file size of {}""".format(size) if size and (last_seen or path) else '',
+            """last seen with a file size of {}""".format(size) if size and not (last_seen or path) else '',
+            """.
+""" if last_seen or hashes or path or size else '',
+            """Hashes of last seen version:
+{}""".format(
+                '\n'.join(['{}: {}'.format(k, v) for k, v in hashes.items()])
+            ) if hashes else '',  # TODO: Format better for UI
+            msg
+        ]
+        return ''.join(parts)
+    return msg

--- a/addons/base/utils.py
+++ b/addons/base/utils.py
@@ -21,10 +21,10 @@ def get_addons_by_config_type(config_type, user):
     addons = [addon for addon in settings.ADDONS_AVAILABLE if config_type in addon.configs]
     return [serialize_addon_config(addon_config, user) for addon_config in sorted(addons, key=lambda cfg: cfg.full_name.lower())]
 
-def maybe_show_lost_file_metadata(auth, node, file):
+def maybe_show_lost_file_metadata(auth, node, file, error_type):
     msg = """
     </div>"""  # None is default
-    if (auth.user and node.is_contributor(auth.user)) or (auth.private_key and auth.private_key in node.private_link_keys_active):
+    if error_type != 'FILE_SUSPENDED' and ((auth.user and node.is_contributor(auth.user)) or (auth.private_key and auth.private_key in node.private_link_keys_active)):
         last_meta = file.last_known_metadata
         last_seen = last_meta.get('last_seen', None)
         hashes = last_meta.get('hashes', None)

--- a/addons/base/utils.py
+++ b/addons/base/utils.py
@@ -1,3 +1,4 @@
+import markupsafe
 from os.path import basename
 
 from website import settings
@@ -31,17 +32,15 @@ def maybe_show_lost_file_metadata(auth, node, file, error_type):
         path = last_meta.get('path', None)
         size = last_meta.get('size', None)
         parts = [
-            """This file was """ if last_seen or hashes or path or size else '',
-            """last seen on {}""".format(last_seen) if last_seen else '',
-            """and found at path {}""".format(path) if last_seen and path else '',
-            """last found at path {}""".format(path) if not last_seen and path else '',
-            """with a file size of {}""".format(size) if size and (last_seen or path) else '',
-            """last seen with a file size of {}""".format(size) if size and not (last_seen or path) else '',
-            """.
-""" if last_seen or hashes or path or size else '',
-            """Hashes of last seen version:
-{}""".format(
-                '\n'.join(['{}: {}'.format(k, v) for k, v in hashes.items()])
+            """</br>This file was """ if last_seen or hashes or path or size else '',
+            """last seen on {} UTC """.format(last_seen.strftime('%c')) if last_seen else '',
+            """and found at path {} """.format(markupsafe.escape(path)) if last_seen and path else '',
+            """last found at path {} """.format(markupsafe.escape(path)) if not last_seen and path else '',
+            """with a file size of {} bytes""".format(size) if size and (last_seen or path) else '',
+            """last seen with a file size of {} bytes""".format(size) if size and not (last_seen or path) else '',
+            """.</br></br>""" if last_seen or hashes or path or size else '',
+            """Hashes of last seen version:</br>{}""".format(
+                '</br>'.join(['{}: {}'.format(k, v) for k, v in hashes.items()])
             ) if hashes else '',  # TODO: Format better for UI
             msg
         ]

--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -32,7 +32,7 @@ from website import mails
 from website import settings
 from addons.base import exceptions
 from addons.base import signals as file_signals
-from addons.base.utils import maybe_show_lost_file_metadata
+from addons.base.utils import format_last_known_metadata
 from osf.models import (BaseFileNode, TrashedFileNode,
                         OSFUser, AbstractNode,
                         NodeLog, DraftRegistration, MetaSchema)
@@ -559,7 +559,7 @@ def addon_deleted_file(auth, node, error_type='BLAME_PROVIDER', **kwargs):
 
     error_msg = ''.join([
         ERROR_MESSAGES[error_type].format(**format_params),
-        maybe_show_lost_file_metadata(auth, node, file_node, error_type)
+        format_last_known_metadata(auth, node, file_node, error_type)
     ])
     ret = serialize_node(node, auth, primary=True)
     ret.update(rubeus.collect_addon_assets(node))

--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -550,7 +550,7 @@ def addon_deleted_file(auth, node, error_type='BLAME_PROVIDER', **kwargs):
 
     format_params = dict(
         file_name=markupsafe.escape(file_name),
-        deleted_by=markupsafe.escape(deleted_by),
+        deleted_by=markupsafe.escape(getattr(deleted_by, 'fullname', None)),
         deleted_on=markupsafe.escape(deleted_on),
         provider=markupsafe.escape(provider_full)
     )

--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -559,7 +559,7 @@ def addon_deleted_file(auth, node, error_type='BLAME_PROVIDER', **kwargs):
 
     error_msg = ''.join([
         ERROR_MESSAGES[error_type].format(**format_params),
-        maybe_show_lost_file_metadata(auth, node, file)
+        maybe_show_lost_file_metadata(auth, node, file_node, error_type)
     ])
     ret = serialize_node(node, auth, primary=True)
     ret.update(rubeus.collect_addon_assets(node))

--- a/addons/bitbucket/models.py
+++ b/addons/bitbucket/models.py
@@ -36,6 +36,13 @@ class BitbucketFile(BitbucketFileNode, File):
         revision = revision or commitSha or branch
         return super(BitbucketFile, self).touch(auth_header, revision=revision, **kwargs)
 
+    @property
+    def _hashes(self):
+        try:
+            return {'commit': self._history[-1]['extra']['commitSha']}
+        except (IndexError, KeyError):
+            return None
+
 class BitbucketProvider(ExternalProvider):
     """Provider to handler Bitbucket OAuth workflow
 

--- a/addons/box/models.py
+++ b/addons/box/models.py
@@ -31,7 +31,12 @@ class BoxFolder(BoxFileNode, Folder):
 
 
 class BoxFile(BoxFileNode, File):
-    pass
+    @property
+    def _hashes(self):
+        try:
+            return {'sha1': self._history[-1]['extra']['hashes']['sha1']}
+        except (IndexError, KeyError):
+            return None
 
 
 class Provider(ExternalProvider):

--- a/addons/dataverse/models.py
+++ b/addons/dataverse/models.py
@@ -24,6 +24,13 @@ class DataverseFolder(DataverseFileNode, Folder):
 class DataverseFile(DataverseFileNode, File):
     version_identifier = 'version'
 
+    @property
+    def _hashes(self):
+        try:
+            return self._history[-1]['extra']['hashes']
+        except (IndexError, KeyError):
+            return None
+
     def update(self, revision, data, save=True, user=None):
         """Note: Dataverse only has psuedo versions, pass None to not save them
         Call super to update _history and last_touched anyway.

--- a/addons/dropbox/models.py
+++ b/addons/dropbox/models.py
@@ -34,7 +34,12 @@ class DropboxFolder(DropboxFileNode, Folder):
 
 
 class DropboxFile(DropboxFileNode, File):
-    pass
+    @property
+    def _hashes(self):
+        try:
+            return {'Dropbox content_hash': self._history[-1]['extra']['hashes']['dropbox']}
+        except (IndexError, KeyError):
+            return None
 
 
 class Provider(ExternalProvider):

--- a/addons/figshare/models.py
+++ b/addons/figshare/models.py
@@ -25,6 +25,11 @@ class FigshareFolder(FigshareFileNode, Folder):
 class FigshareFile(FigshareFileNode, File):
     version_identifier = 'ref'
 
+    @property
+    def _hashes(self):
+        # figshare API doesn't provide this metadata
+        return None
+
     def update(self, revision, data, user=None, save=True):
         """Figshare does not support versioning.
         Always pass revision as None to avoid conflict.

--- a/addons/github/models.py
+++ b/addons/github/models.py
@@ -35,6 +35,13 @@ class GithubFolder(GithubFileNode, Folder):
 class GithubFile(GithubFileNode, File):
     version_identifier = 'ref'
 
+    @property
+    def _hashes(self):
+        try:
+            return {'fileSha': self.history[-1]['extra']['hashes']['git']}
+        except (IndexError, KeyError):
+            return None
+
     def touch(self, auth_header, revision=None, ref=None, branch=None, **kwargs):
         revision = revision or ref or branch
         return super(GithubFile, self).touch(auth_header, revision=revision, **kwargs)

--- a/addons/gitlab/models.py
+++ b/addons/gitlab/models.py
@@ -32,6 +32,13 @@ class GitLabFolder(GitLabFileNode, Folder):
 class GitLabFile(GitLabFileNode, File):
     version_identifier = 'commitSha'
 
+    @property
+    def _hashes(self):
+        try:
+            return {'commit': self._history[-1]['extra']['commitSha']}
+        except (IndexError, KeyError):
+            return None
+
     def touch(self, auth_header, revision=None, ref=None, branch=None, **kwargs):
         revision = revision or ref or branch
         return super(GitLabFile, self).touch(auth_header, revision=revision, **kwargs)

--- a/addons/googledrive/models.py
+++ b/addons/googledrive/models.py
@@ -35,7 +35,12 @@ class GoogleDriveFolder(GoogleDriveFileNode, Folder):
 
 
 class GoogleDriveFile(GoogleDriveFileNode, File):
-    pass
+    @property
+    def _hashes(self):
+        try:
+            return {'md5': self._history[-1]['extra']['hashes']['md5']}
+        except (IndexError, KeyError):
+            return None
 
 
 class GoogleDriveProvider(ExternalProvider):

--- a/addons/onedrive/models.py
+++ b/addons/onedrive/models.py
@@ -30,7 +30,12 @@ class OneDriveFolder(OneDriveFileNode, Folder):
 
 
 class OneDriveFile(OneDriveFileNode, File):
-    pass
+    @property
+    def _hashes(self):
+        try:
+            return {'md5': self._history[-1]['extra']['hashes']['md5']}
+        except (IndexError, KeyError):
+            return None
 
 
 class OneDriveProvider(ExternalProvider):

--- a/addons/osfstorage/models.py
+++ b/addons/osfstorage/models.py
@@ -204,6 +204,31 @@ class OsfStorageFileNode(BaseFileNode):
 
 class OsfStorageFile(OsfStorageFileNode, File):
 
+    @property
+    def _hashes(self):
+        last_version = self.versions.last()
+        if not last_version:
+            return None
+        return {
+            'sha1': last_version.metadata['sha1'],
+            'sha256': last_version.metadata['sha256'],
+            'md5': last_version.metadata['md5']
+        }
+
+    @property
+    def last_known_metadata(self):
+        last_version = self.versions.last()
+        if not last_version:
+            size = None
+        else:
+            size = last_version.size
+        return {
+            'path': self.materialized_path,
+            'hashes': self._hashes,
+            'size': size,
+            'last_seen': self.modified
+        }
+
     def touch(self, bearer, version=None, revision=None, **kwargs):
         try:
             return self.get_version(revision or version)

--- a/addons/owncloud/models.py
+++ b/addons/owncloud/models.py
@@ -25,7 +25,10 @@ class OwncloudFolder(OwncloudFileNode, Folder):
 
 
 class OwncloudFile(OwncloudFileNode, File):
-    pass
+    @property
+    def _hashes(self):
+        # ownCloud API doesn't provide this metadata
+        return None
 
 
 class OwnCloudProvider(BasicAuthProviderMixin):

--- a/addons/s3/models.py
+++ b/addons/s3/models.py
@@ -25,6 +25,13 @@ class S3Folder(S3FileNode, Folder):
 class S3File(S3FileNode, File):
     version_identifier = 'version'
 
+    @property
+    def _hashes(self):
+        try:
+            return self._history[-1]['extra']['hashes']
+        except (IndexError, KeyError):
+            return None
+
 
 class UserSettings(BaseOAuthUserSettings):
     oauth_provider = S3Provider

--- a/osf/models/files.py
+++ b/osf/models/files.py
@@ -487,6 +487,27 @@ class File(models.Model):
     def restore(self, recursive=True, parent=None, save=True, deleted_on=None):
         raise UnableToRestore('You cannot restore something that is not deleted.')
 
+    @property
+    def last_known_metadata(self):
+        try:
+            last_history = self._history[-1]
+        except IndexError:
+            size = None
+        else:
+            size = last_history.get('size', None)
+        return {
+            'path': self._materialized_path,
+            'hashes': self._hashes,
+            'size': size,
+            'last_seen': self.last_touched
+        }
+
+    @property
+    def _hashes(self):
+        """ Hook for sublasses to return file hashes, commit SHAs, etc.
+        Returns dict or None
+        """
+        return None
 
 class Folder(models.Model):
 

--- a/osf/models/files.py
+++ b/osf/models/files.py
@@ -601,6 +601,30 @@ class TrashedFile(TrashedFileNode):
     def kind(self):
         return 'file'
 
+    @property
+    def _hashes(self):
+        last_version = self.versions.last()
+        if not last_version:
+            return None
+        return {
+            'sha1': last_version.metadata['sha1'],
+            'sha256': last_version.metadata['sha256'],
+            'md5': last_version.metadata['md5']
+        }
+
+    @property
+    def last_known_metadata(self):
+        last_version = self.versions.last()
+        if not last_version:
+            size = None
+        else:
+            size = last_version.size
+        return {
+            'path': self.materialized_path,
+            'hashes': self._hashes,
+            'size': size,
+            'last_seen': self.modified
+        }
 
 class TrashedFolder(TrashedFileNode):
     @property


### PR DESCRIPTION
## Purpose
Expose the last known metadata for missing files to users that should be able to know it.

## Changes
* Conditionally extend pre-existing error message for this case
* Add base class methods to pre-parse some metadata
* Implement provider-specific hash hooks

## QA Notes
To test:
1. Connect addon and view file
2. Delete file through addon UI
3. Try to view file on OSF at same url
4. Confirm message includes more metadata

## Side Effects
None expected

## Ticket
[[#OSF-8636]](https://openscience.atlassian.net/browse/OSF-8636)
[[#OSF-8762]](https://openscience.atlassian.net/browse/OSF-8762)