### PR TITLE
[hotfix] Files Page Fixes [OSF-9003]

### DIFF
--- a/tests/test_rubeus.py
+++ b/tests/test_rubeus.py
@@ -229,63 +229,6 @@ class TestRubeus(OsfTestCase):
             expected
         )
 
-    def test_serialize_private_node(self):
-        user = UserFactory()
-        auth = Auth(user=user)
-        public = ProjectFactory.create(is_public=True)
-        # Add contributor with write permissions to avoid admin permission cascade
-        public.add_contributor(user, permissions=['read', 'write'])
-        public.save()
-        private = ProjectFactory(parent=public, is_public=False)
-        NodeFactory(parent=private)
-        collector = rubeus.NodeFileCollector(node=public, auth=auth)
-
-        private_dummy = collector._serialize_node(private)
-        assert_false(private_dummy['permissions']['edit'])
-        assert_false(private_dummy['permissions']['view'])
-        assert_equal(private_dummy['name'], 'Private Component')
-        assert_equal(len(private_dummy['children']), 0)
-
-    def test_get_node_name(self):
-        user = UserFactory()
-        auth = Auth(user=user)
-        another_user = UserFactory()
-        another_auth = Auth(user=another_user)
-
-        # Public (Can View)
-        public_project = ProjectFactory(is_public=True)
-        collector = rubeus.NodeFileCollector(node=public_project, auth=another_auth)
-        node_name =  sanitize.unescape_entities(public_project.title)
-        assert_equal(collector._serialize_node(public_project)['name'], node_name)
-
-        # Private  (Can't View)
-        registration_private = RegistrationFactory(creator=user)
-        registration_private.is_public = False
-        registration_private.save()
-        collector = rubeus.NodeFileCollector(node=registration_private, auth=another_auth)
-        assert_equal(collector._serialize_node(registration_private)['name'], u'Private Registration')
-
-        content = ProjectFactory(creator=user)
-        node = ProjectFactory(creator=user, is_public=True)
-
-        forked_private = node.fork_node(auth=auth)
-        forked_private.is_public = False
-        forked_private.save()
-        collector = rubeus.NodeFileCollector(node=forked_private, auth=another_auth)
-        assert_equal(collector._serialize_node(forked_private)['name'], u'Private Fork')
-
-        node.add_pointer(content, auth=auth)
-        collector = rubeus.NodeFileCollector(node=node, auth=another_auth)
-        assert_equal(collector._get_nodes(node)['children'][1]['name'], u'Private Link')
-
-        private_project = ProjectFactory(is_public=False)
-        collector = rubeus.NodeFileCollector(node=private_project, auth=another_auth)
-        assert_equal(collector._serialize_node(private_project)['name'], u'Private Component')
-
-        private_node = NodeFactory(is_public=False)
-        collector = rubeus.NodeFileCollector(node=private_node, auth=another_auth)
-        assert_equal(collector._serialize_node(private_node)['name'], u'Private Component')
-
     def test_get_nodes_deleted_component(self):
         node = NodeFactory(creator=self.project.creator, parent=self.project)
         node.is_deleted = True
@@ -303,6 +246,54 @@ class TestRubeus(OsfTestCase):
         ret = serializer._get_nodes(project)
         child = ret['children'][1]  # first child is OSFStorage, second child is pointer
         assert_true(child['isPointer'])
+
+    def test_private_components_not_shown(self):
+        user = UserFactory()
+        public_project = ProjectFactory(creator=user, is_public=True)
+        private_child = NodeFactory(parent=public_project, creator=user, is_public=False)
+        public_grandchild = NodeFactory(parent=private_child, creator=user, is_public=True)
+        private_greatgrandchild = NodeFactory(parent=public_grandchild, creator=user, is_public=False)
+        public_greatgreatgranchild = NodeFactory(parent=private_greatgrandchild, creator=user, is_public=True)
+
+        serializer = rubeus.NodeFileCollector(node=public_project, auth=Auth(user=UserFactory()))
+        ret = serializer.to_hgrid()
+
+        children = ret[0]['children']
+
+        assert 'osfstorage' == children[0]['provider']
+
+        assert public_grandchild._id == children[1]['nodeID']
+        assert public_grandchild.title == children[1]['name']
+        assert False == children[1]['permissions']['edit']
+
+        assert public_greatgreatgranchild._id == children[1]['children'][1]['nodeID']
+        assert public_greatgreatgranchild.title == children[1]['children'][1]['name']
+        assert False == children[1]['children'][1]['permissions']['edit']
+
+        assert 'Private Component' not in ret
+
+    def test_private_components_shown(self):
+        user = UserFactory()
+        public_project = ProjectFactory(creator=user, is_public=True)
+        private_child = NodeFactory(parent=public_project, creator=user, is_public=False)
+        public_grandchild = NodeFactory(parent=private_child, creator=user, is_public=True)
+
+        serializer = rubeus.NodeFileCollector(node=public_project, auth=Auth(user))
+        ret = serializer.to_hgrid()
+
+        children = ret[0]['children']
+
+        assert 'osfstorage' == children[0]['provider']
+
+        assert private_child._id == children[1]['nodeID']
+        assert private_child.title == children[1]['name']
+        assert True == children[1]['permissions']['edit']
+
+        assert public_grandchild._id == children[1]['children'][1]['nodeID']
+        assert public_grandchild.title == children[1]['children'][1]['name']
+        assert True == children[1]['children'][1]['permissions']['edit']
+
+        assert 'Private Component' not in ret
 
 
 # TODO: Make this more reusable across test modules

--- a/website/util/rubeus.py
+++ b/website/util/rubeus.py
@@ -169,25 +169,36 @@ class NodeFileCollector(object):
         root = self._get_nodes(self.node, grid_root=self.node)
         return [root]
 
-    def _get_node_name(self, node, can_view, is_pointer=False):
-        """Input node object, return the project name to be display.
+    def find_readable_descendants(self, node):
         """
-        if can_view:
-            node_name = sanitize.unescape_entities(node.title)
-        elif node.is_registration:
-            node_name = u'Private Registration'
-        elif node.is_fork:
-            node_name = u'Private Fork'
-        elif is_pointer:
-            node_name = u'Private Link'
-        else:
-            node_name = u'Private Component'
+        Returns a generator of first descendant node(s) readable by <user>
+        in each descendant branch.
+        """
+        new_branches = []
+        Contributor = apps.get_model('osf.Contributor')
 
-        return node_name
+        linked_node_sqs = node.node_relations.filter(is_node_link=True, child=OuterRef('pk'))
+        has_write_perm_sqs = Contributor.objects.filter(node=OuterRef('pk'), write=True, user=self.auth.user)
+        descendants_qs = (
+            node._nodes
+            .filter(is_deleted=False)
+            .annotate(is_linked_node=Exists(linked_node_sqs))
+            .annotate(has_write_perm=Exists(has_write_perm_sqs))
+            .order_by('_parents')
+        )
+
+        for descendant in descendants_qs:
+            if descendant.can_view(self.auth):
+                yield descendant
+            else:
+                new_branches.append(descendant)
+
+        for bnode in new_branches:
+            for descendant in self.find_readable_descendants(bnode):
+                yield descendant
 
     def _serialize_node(self, node, parent=None, grid_root=None, children=[]):
         is_pointer = parent and node.is_linked_node
-        can_view = node.can_view(auth=self.auth)
         can_edit = node.has_write_perm if hasattr(node, 'has_write_perm') else node.can_edit(auth=self.auth)
 
         # Determines if `node` is within two levels of `grid_root`
@@ -197,12 +208,12 @@ class NodeFileCollector(object):
 
         return {
             # TODO: Remove safe_unescape_html when mako html safe comes in
-            'name': self._get_node_name(node, can_view, is_pointer),
+            'name': sanitize.unescape_entities(node.title),
             'category': node.category,
             'kind': FOLDER,
             'permissions': {
                 'edit': can_edit and not node.is_registration,
-                'view': can_view,
+                'view': True,
             },
             'urls': {
                 'upload': None,
@@ -216,20 +227,13 @@ class NodeFileCollector(object):
         }
 
     def _get_nodes(self, node, grid_root=None):
-        AbstractNode = apps.get_model('osf.AbstractNode')
-        Contributor = apps.get_model('osf.Contributor')
-
         data = []
         if node.can_view(auth=self.auth):
             serialized_addons = self._collect_addons(node)
-            linked_node_sqs = node.node_relations.filter(is_node_link=True, child=OuterRef('pk'))
-            has_write_perm_sqs = Contributor.objects.filter(node=OuterRef('pk'), write=True, user=self.auth.user)
-            children = (AbstractNode.objects
-                        .filter(is_deleted=False, _parents__parent=node)
-                        .annotate(is_linked_node=Exists(linked_node_sqs))
-                        .annotate(has_write_perm=Exists(has_write_perm_sqs))
-                        )
-            serialized_children = [self._serialize_node(child, parent=node, grid_root=grid_root) for child in children]
+            serialized_children = [
+                self._serialize_node(child, parent=node, grid_root=grid_root)
+                for child in self.find_readable_descendants(node)
+            ]
             data = serialized_addons + serialized_children
         return self._serialize_node(node, children=data)
 


### PR DESCRIPTION
#### Purpose
Fixes a few bugs introduced by [OSF-8677](https://openscience.atlassian.net/browse/OSF-8677) (PR #7824)
- Component ordering wasn't being respected by the files grid.
- Private components were being serialized in the files grid as an unclickable "Private Component" row. Prior to the 0.125.0 release, private components were simply omitted from the files grid. 
  - Note: this bug made it so that a public component nested within a private component wasn't accessible from the files grid.

#### Changes
- Makes use of `find_readable_descendants` so that nested private components will be serialized.
- Removes the `_get_node_name` method (after confirming it isn't used anywhere else) because non-viewable components are never serialized.
  - Removes related tests. 
- Adds tests to confirm nested projects (with public and private components) are serialized correctly.

#### Side Effects
- Not the DRYest code I've ever written. I copied the `find_readable_descendants` method from `AbstractNode` so that I could add the `is_linked_node` and `has_write_perm` annotations, as well as preserve component ordering. 

#### QA Notes
- Retest [OSF-8677](https://openscience.atlassian.net/browse/OSF-8677)
  - See ticket comments and "Purpose" above.
- API testing? Nope.
- Cross browser? Nope.

#### Ticket
- [OSF-9003](https://openscience.atlassian.net/browse/OSF-9003)

#### Before (in incognito)
![screen shot 2017-12-11 at 8 47 04 pm](https://user-images.githubusercontent.com/7913604/33863253-d174beba-deb4-11e7-9c47-427d456a41e4.png)

#### After (in incognito)
![screen shot 2017-12-11 at 8 49 22 pm](https://user-images.githubusercontent.com/7913604/33863258-d4aba116-deb4-11e7-9619-2fe91647860c.png)
