### PR TITLE
[feature] Remove registrations of forks from forks endpoint [OSF-8422]

### DIFF
--- a/api/nodes/views.py
+++ b/api/nodes/views.py
@@ -1610,7 +1610,7 @@ class NodeForksList(JSONAPIBaseView, generics.ListCreateAPIView, NodeMixin, Node
 
     # overrides ListCreateAPIView
     def get_queryset(self):
-        all_forks = self.get_node().forks.order_by('-forked_date')
+        all_forks = self.get_node().forks.exclude(type='osf.registration').order_by('-forked_date')
         auth = get_user_auth(self.request)
 
         node_pks = [node.pk for node in all_forks if node.can_view(auth)]

--- a/api_tests/nodes/views/test_node_forks_list.py
+++ b/api_tests/nodes/views/test_node_forks_list.py
@@ -159,6 +159,16 @@ class TestNodeForksList:
         assert res.status_code == 403
         assert res.json['errors'][0]['detail'] == exceptions.PermissionDenied.default_detail
 
+    def test_forks_list_does_not_show_registrations_of_forks(self, app, public_project, public_fork, public_project_url):
+        reg = RegistrationFactory(project=public_fork, is_public=True)
+
+        # confirm registration shows up in node forks
+        assert reg in public_project.forks.all()
+        res = app.get(public_project_url)
+
+        # confirm registration of fork does not show up in public data
+        assert len(res.json['data']) == 0
+
 
 @pytest.mark.django_db
 class TestNodeForkCreate:


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Forks list in the UI does not include registrations of forks, but the api does. 
<!-- Describe the purpose of your changes -->

## Changes
Remove registrations of forks from the nodes/<guid>/forks endpoint
<!-- Briefly describe or list your changes  -->

## QA Notes
Check that the nodes/[guid]/forks/ endpoint does not include registrations of forks.
<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Side Effects
NA
<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/OSF-8422
