### PR TITLE
[#OSF-8584]Trigger for wiki widget "Read More" does not match display field length

### DIFF
--- a/website/static/js/pages/project-dashboard-page.js
+++ b/website/static/js/pages/project-dashboard-page.js
@@ -332,7 +332,8 @@ $(document).ready(function () {
         request.done(function(resp) {
             var rawText = resp.wiki_content || '*Add important information, links, or images here to describe your project.*';
             var renderedText = ctx.renderedBeforeUpdate ? oldMd.render(rawText) : md.render(rawText);
-            var truncatedText = $.truncate(renderedText, {length: 400});
+            // don't truncate the text when length = 400
+            var truncatedText = $.truncate(renderedText, {length: 401});
             markdownElement.html(truncatedText);
             mathrender.mathjaxify(markdownElement);
             markdownElement.show();


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Fix the case when character.length == 400. Now doesn't truncate the text until character length hit 401.
<!-- Describe the purpose of your changes -->

## Changes
Before change:
when your wiki has 400 character,
<img width="576" alt="screen shot 2017-12-12 at 1 32 05 pm" src="https://user-images.githubusercontent.com/4974056/33901774-dec6e228-df40-11e7-92fb-a7abfd59456f.png">
After change:
when your wiki has 400 character,
<img width="1297" alt="screen shot 2017-12-12 at 1 32 43 pm" src="https://user-images.githubusercontent.com/4974056/33901797-f5a7f2de-df40-11e7-9c9c-8f4bb1f229af.png">

<!-- Briefly describe or list your changes  -->

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/OSF-8584#add-comment
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
