### PR TITLE
[#OSF-7955]Templating a registration breaks and creates a malformed registration

### DIFF
--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -239,7 +239,7 @@ def project_before_template(auth, node, **kwargs):
             if addon.to_json(auth.user)['addon_full_name']:
                 prompts.append(addon.to_json(auth.user)['addon_full_name'])
 
-    return {'prompts': prompts}
+    return {'prompts': prompts, 'isRegistration': node.is_registration}
 
 
 @must_be_valid_project

--- a/website/static/js/project.js
+++ b/website/static/js/project.js
@@ -122,7 +122,7 @@ NodeActions.beforeTemplate = function(url, done) {
         var language = '<h4>Are you sure you want to create a new project using this project as a template?</h4>' +
                 '<p>Any add-ons configured for this project will not be authenticated in the new project.</p>';
         if(response.isRegistration){
-            language = '<h4>Are you sure you want to create a new registration using this project as a template?</h4>'
+            language = '<h4>Are you sure you want to create a new registration using this project as a template?</h4>';
         }
         bootbox.confirm({
             message: $osf.joinPrompts(response.prompts, (language)),

--- a/website/static/js/project.js
+++ b/website/static/js/project.js
@@ -122,7 +122,7 @@ NodeActions.beforeTemplate = function(url, done) {
         var language = '<h4>Are you sure you want to create a new project using this project as a template?</h4>' +
                 '<p>Any add-ons configured for this project will not be authenticated in the new project.</p>';
         if(response.isRegistration){
-            language = '<h4>Are you sure you want to create a new registration using this project as a template?</h4>';
+            language = '<h4>Are you sure you want to create a new project using this registration as a template?</h4>';
         }
         bootbox.confirm({
             message: $osf.joinPrompts(response.prompts, (language)),

--- a/website/static/js/project.js
+++ b/website/static/js/project.js
@@ -119,12 +119,13 @@ NodeActions.beforeTemplate = function(url, done) {
         url: url,
         contentType: 'application/json'
     }).done(function(response) {
+        var language = '<h4>Are you sure you want to create a new project using this project as a template?</h4>' +
+                '<p>Any add-ons configured for this project will not be authenticated in the new project.</p>';
+        if(response.isRegistration){
+            language = '<h4>Are you sure you want to create a new registration using this project as a template?</h4>'
+        }
         bootbox.confirm({
-            message: $osf.joinPrompts(response.prompts,
-                ('<h4>Are you sure you want to create a new project using this project as a template?</h4>' +
-                '<p>Any add-ons configured for this project will not be authenticated in the new project.</p>')),
-                //('Are you sure you want to create a new project using this project as a template? ' +
-                //  'Any add-ons configured for this project will not be authenticated in the new project.')),
+            message: $osf.joinPrompts(response.prompts, (language)),
             callback: function (result) {
                 if (result) {
                     done && done();


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Add language change when the templated node is a registration.
<!-- Describe the purpose of your changes -->

## Changes
After change: 
when the node is a project,
<img width="1289" alt="screen shot 2017-12-12 at 1 59 29 pm" src="https://user-images.githubusercontent.com/4974056/33902971-b22cee2a-df44-11e7-8de9-2a3440f02758.png">
when the node is a registration,
<img width="1322" alt="screen shot 2017-12-12 at 2 00 00 pm" src="https://user-images.githubusercontent.com/4974056/33903000-c4b7f9f4-df44-11e7-8b93-958b4aada1a6.png">

<!-- Briefly describe or list your changes  -->

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/OSF-7955
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
