### PR TITLE
[OSF-8056] Fix Github/Gitlab on Add-ons Tab and improve filter

### DIFF
--- a/tests/test_addons.py
+++ b/tests/test_addons.py
@@ -1134,7 +1134,7 @@ class TestViewUtils(OsfTestCase):
         self.user_addon.save()
 
     def test_serialize_addons(self):
-        addon_dicts = serialize_addons(self.node)
+        addon_dicts = serialize_addons(self.node, self.auth_obj)
 
         enabled_addons = [addon for addon in addon_dicts if addon['enabled']]
         assert len(enabled_addons) == 2
@@ -1145,9 +1145,22 @@ class TestViewUtils(OsfTestCase):
         assert len(default_addons) == 1
         assert default_addons[0]['short_name'] == 'osfstorage'
 
+    def test_include_template_json(self):
+        """ Some addons (github, gitlab) need more specialized template infomation so we want to
+        ensure we get those extra variables that when the addon is enabled.
+        """
+        addon_dicts = serialize_addons(self.node, self.auth_obj)
+
+        enabled_addons = [addon for addon in addon_dicts if addon['enabled']]
+        assert len(enabled_addons) == 2
+        assert enabled_addons[1]['short_name'] == 'osfstorage'
+        assert enabled_addons[0]['short_name'] == 'github'
+        assert 'node_has_auth' in enabled_addons[0]
+        assert 'valid_credentials' in enabled_addons[0]
+
     def test_collect_node_config_js(self):
 
-        addon_dicts = serialize_addons(self.node)
+        addon_dicts = serialize_addons(self.node, self.auth_obj)
 
         asset_paths = collect_node_config_js(addon_dicts)
 

--- a/website/project/views/node.py
+++ b/website/project/views/node.py
@@ -288,7 +288,7 @@ def node_addons(auth, node, **kwargs):
 
     ret = _view_project(node, auth, primary=True)
 
-    addon_settings = serialize_addons(node)
+    addon_settings = serialize_addons(node, auth)
 
     ret['addon_capabilities'] = settings.ADDON_CAPABILITIES
 
@@ -304,7 +304,7 @@ def node_addons(auth, node, **kwargs):
     return ret
 
 
-def serialize_addons(node):
+def serialize_addons(node, auth):
 
     addon_settings = []
     addons_available = [addon for addon in settings.ADDONS_AVAILABLE
@@ -322,6 +322,11 @@ def serialize_addons(node):
         config['categories'] = addon.categories
         config['enabled'] = node.has_addon(addon.short_name)
         config['default'] = addon.short_name in settings.ADDONS_DEFAULT
+
+        if node.has_addon(addon.short_name):
+            node_json = node.get_addon(addon.short_name).to_json(auth.user)
+            config.update(node_json)
+
         addon_settings.append(config)
 
     addon_settings = sorted(addon_settings, key=lambda addon: addon['full_name'].lower())

--- a/website/static/js/pages/project-addons-page.js
+++ b/website/static/js/pages/project-addons-page.js
@@ -91,7 +91,7 @@ var filterAddons = function(event) {
         active_category = event.target.getAttribute('name');
     }
     for (var i = 0; i < containers.length; i++) {
-        if (containers[i].getAttribute('name').toUpperCase().indexOf(filter) > -1 &&
+        if (containers[i].getAttribute('full_name').toUpperCase().indexOf(filter) > -1 &&
                 (containers[i].getAttribute('categories').toUpperCase().indexOf(active_category.toUpperCase()) > -1 ||
                 active_category === 'All' ))
         {

--- a/website/templates/project/addons.mako
+++ b/website/templates/project/addons.mako
@@ -69,7 +69,7 @@
                                         <td>
                                             <div class="addon-list">
                                                 % for addon in addon_settings:
-                                                     <div name="${addon['short_name']}" status="${'enabled' if addon.get('enabled') else 'disabled'}" categories="${' '.join(addon['categories'])}" class="addon-container">
+                                                     <div name="${addon['short_name']}" full_name="${addon['full_name']}" status="${'enabled' if addon.get('enabled') else 'disabled'}" categories="${' '.join(addon['categories'])}" class="addon-container">
                                                          <div class="row ${'text-muted' if addon.get('enabled') else ''}">
                                                              <div class="col-md-1">
                                                                  <img class="addon-icon" src="${addon['addon_icon_url']}">


### PR DESCRIPTION
## Purpose

Currently Github/Gitlab panel allow a user to connect their node to Github/Gitlab, but when the page refreshes the "Connect Account" button is still present and the account appears to the user as unconnected. This fix passes more information to the Github/Gitlab templates that allow them to recognize they'd been connected and allow the user to configure.

Also the addon name filter was filtering by short name. Noticeably "Amazon S3" was being sorted as "s3", now addons will be filtered properly by their full name.

## Changes

- Reinstates the addon instances .to_json method, previously we had relied only on the AddonAppConfig's .to_json method. This allows Github/Gitlab to be used normally.
- The addon name filter now filters by the addons full name.
- Adds unit tests to ensure github/gitlab data is included.


## QA Notes

- Try enabling and connecting all 14 different addons. If they all can connect, this has worked.
- Filter addon names by full name, type "Amazon S3" instead of the short name 's3' and see if it recognizes the full name.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/OSF-8056