### PR TITLE
[OSF-8247] Remove unnecessary row from fork failure email

### DIFF
--- a/website/templates/emails/fork_failed.html.mako
+++ b/website/templates/emails/fork_failed.html.mako
@@ -11,9 +11,4 @@
     </h3>
   </td>
 </tr>
-<tr>
-  <td style="border-collapse: collapse;">
-    You can view the project here: <a href="${settings.DOMAIN + guid}">${settings.DOMAIN + guid}</a>
-  </td>
-</tr>
 </%def>


### PR DESCRIPTION
## Purpose

There's an extra row with some information in the fork failure email, this fix removes it.

## Changes

Remove the "View the fork here" row from the fork failure email.

## QA Notes

- Check the email, the line "View the fork here" should be gone.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/OSF-8247