### PR TITLE
[OSF-8691] Add alert for registration tags

### DIFF
--- a/website/static/js/registrationUtils.js
+++ b/website/static/js/registrationUtils.js
@@ -648,6 +648,7 @@ Draft.prototype.preRegisterPrompts = function(response, confirm) {
         };
     }
     var preRegisterPrompts = response.prompts || [];
+    preRegisterPrompts.push('Tags on a registration can be modified at any time to enhance discoverability.');
 
     var registrationModal = new RegistrationModal.ViewModel(
         confirm, preRegisterPrompts, validator


### PR DESCRIPTION
## Purpose

Add a prompt to alert users about tagging for registrations.

## Changes

In `registrationUtils.js`, a new message is appended to `preRegisterPrompts`.

![screen shot 2017-12-12 at 3 15 51 pm](https://user-images.githubusercontent.com/6599111/33907958-e1d82e0e-df54-11e7-8776-16a3b07c84fb.png)


## QA Notes

For OSF-8691, there are two things to note:
1. Refresh the page after adding/removing tags in the tag widget to make sure the addition/deletion of tags persists.
2. Make sure the message "Tags on a registration can be modified at any time to enhance discoverability." appears in the modal when user click the submit button to register.

## Side Effects

None

## Ticket

https://openscience.atlassian.net/browse/OSF-8691
