### PR TITLE
[Hotfix] Escape fullname rather than complex object

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -553,7 +553,7 @@ def addon_deleted_file(auth, node, error_type='BLAME_PROVIDER', **kwargs):
 
     format_params = dict(
         file_name=markupsafe.escape(file_name),
-        deleted_by=markupsafe.escape(deleted_by),
+        deleted_by=markupsafe.escape(getattr(deleted_by, 'fullname', None)),
         deleted_on=markupsafe.escape(deleted_on),
         provider=markupsafe.escape(provider_full)
     )


### PR DESCRIPTION
## Purpose
Escape string, not object

## Changes
* `escape` string.
  * Use `getattr` due to possible Nonetype object

## QA Notes
None required

## Side Effects
None expected

## Ticket
None known