### PR TITLE
[OSF-7619] Make download as zip button visible to non-contribs

### DIFF
--- a/addons/github/static/githubFangornConfig.js
+++ b/addons/github/static/githubFangornConfig.js
@@ -238,7 +238,7 @@ var _githubItemButtons = {
                             },
                             icon: 'fa fa-download',
                             className: 'text-primary'
-                        }, 'Download'),
+                        }, 'Download as zip'),
                         m.component(Fangorn.Components.button, {
                             onclick: function (event) {
                                 window.open(item.data.urls.repo, '_blank');

--- a/addons/github/static/githubFangornConfig.js
+++ b/addons/github/static/githubFangornConfig.js
@@ -192,6 +192,14 @@ var _githubItemButtons = {
                         className: 'text-info'
                     }, branchArray)
                 );
+            } else {
+                buttons.push(
+                    m.component(Fangorn.Components.button, {
+                        onclick: function (event) { Fangorn.ButtonEvents._downloadZipEvent.call(tb, event, item); },
+                        icon: 'fa fa-download',
+                        className: 'text-primary'
+                    }, 'Download as zip')
+                );
             }
             if (tb.options.placement !== 'fileview') {
                 // If File and FileRead are not defined dropzone is not supported and neither is uploads
@@ -220,13 +228,6 @@ var _githubItemButtons = {
                             icon: 'fa fa-trash',
                             className: 'text-danger'
                         }, 'Delete Folder'));
-                        buttons.push(
-                            m.component(Fangorn.Components.button, {
-                                onclick: function (event) { Fangorn.ButtonEvents._downloadZipEvent.call(tb, event, item); },
-                                icon: 'fa fa-download',
-                                className: 'text-primary'
-                            }, 'Download as zip')
-                        );
                     }
                 }
                 if (item.data.addonFullname) {


### PR DESCRIPTION
## Purpose

Currently Github's Download-as-zip button only appears when the user is a contributor to that project. This fix makes the button visible and usable for all users.

## Changes

Changed js condition to apply more broadly to all folders.

## QA Notes

Look at a public project which has a Github addon, all folders in that addon should be downloadable as zip. Try as a contributor and non-contributor. 

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/OSF-7619