### PR TITLE
[feature] Show settings for write users on registrations [OSF-9045]

### DIFF
--- a/website/templates/project/project_header.mako
+++ b/website/templates/project/project_header.mako
@@ -72,7 +72,7 @@
                             <li><a href="${node['url']}addons/">Add-ons</a></li>
                         % endif
 
-                        % if user['has_read_permissions'] and not node['is_registration'] or (node['is_registration'] and 'admin' in user['permissions']):
+                        % if user['has_read_permissions'] and not node['is_registration'] or (node['is_registration'] and 'write' in user['permissions']):
                             <li><a href="${node['url']}settings/">Settings</a></li>
                         % endif
                     % endif


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Write users can modify affiliations on registrations so actually should be able to see the settings page. In the past the only thing on the settings page was the withdraw button. 
<!-- Describe the purpose of your changes -->

## Changes
Show affiliations for write users on reg
<!-- Briefly describe or list your changes  -->

## QA Notes
Check that settings shows up for write contrib.
<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Side Effects
NA
<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/OSF-9045
