### PR TITLE
[Hotfix] Avoid 502-generating NoReverseMatch errors [No ticket]

### DIFF
--- a/admin/templates/nodes/node.html
+++ b/admin/templates/nodes/node.html
@@ -309,10 +309,12 @@
                                 <td>Embargo</td>
                                 <td>{{ node.embargo }}</td>
                             </tr>
+                            {% if node.registered_from is not None %}
                             <tr>
                                 <td>Registered From</td>
-                                <td><a href="{% url 'nodes:node' node.registered_from %}">{{ node.registered_from }}</a></td>
+                                <td><a href="{% url 'nodes:node' guid=node.registered_from %}">{{ node.registered_from }}</a></td>
                             </tr>
+                            {% endif %}
                         </tbody>
                         </table>
                     {% endif %}


### PR DESCRIPTION
## Purpose
Be better

## Changes
* Conditionally avoid a reverse lookup if it will fail

## QA Notes
Viewing registrations in the admin app should fail less often

## Side Effects
None expected

## Ticket
None known

Discovered while investigating [[OSF-8968]](https://openscience.atlassian.net/browse/OSF-8968)
