### PR TITLE
Feature/Fix admin embargo update  [OSF-7846]

### DIFF
--- a/admin/static/js/nodes/registrations.js
+++ b/admin/static/js/nodes/registrations.js
@@ -14,7 +14,9 @@ $(document).ready(function() {
     $("#embargo-update-form").submit(function (event) {
         event.preventDefault();
         $('#update-embargo-modal').modal('show');
+    });
 
+    $("#embargo-update-modal").submit(function (event) {
         var data = $('#embargo-update-form').serialize();
         data["validation_only"]="False";
         $.ajax({

--- a/admin/static/js/nodes/registrations.js
+++ b/admin/static/js/nodes/registrations.js
@@ -36,7 +36,7 @@ $(document).ready(function() {
         startDate: "+0d"
     })
         .on("change", function (e) {
-            $("#embargo-update-submit").removeClass('disabled');
+            $("#embargo-update-submit").prop('disabled', false);
             $("#date-validation").text('');
             var data = $('#embargo-update-form').serialize();
             data["validation_only"]="True";
@@ -46,7 +46,7 @@ $(document).ready(function() {
                 data: data
             }).fail(function (jqXHR, textStatus, error) {
                 $("#date-validation").text(jqXHR.responseText);
-                $("#embargo-update-submit").addClass('disabled');
+                $("#embargo-update-submit").prop('disabled', true);
             });
         });
 });

--- a/admin/templates/nodes/node.html
+++ b/admin/templates/nodes/node.html
@@ -321,7 +321,7 @@
                                                 {{ node.embargo }}
                                             </span>
                                             <span class="form-view" style="display:none;">
-                                                <form id="embargo-update-form" action="{% url 'nodes:update_embargo' guid=node.id %}" method="post" class="row">
+                                                <form id="embargo-update-form" class="row">
                                                     {% csrf_token %}
                                                     <div class="col-md-6">
                                                         <input id='datepicker' type='datetime' name="date" class="form-control" value={{node.embargo_formatted}} />


### PR DESCRIPTION
## Purpose

When updating an embargo in the admin app, when you hit "Update embargo," a confirmation modal pops up. Currently, clicking that "Update embargo" button is submitting the form. The form should not be submitted until the user confirms using the modal.

## Changes

Form is now submitted on the "Confirm" button of the "Are you sure you want to update this embargo?" modal.

## QA Notes
Wait a couple of seconds before hitting "Confirm" to be sure that it is not submitting from clicking "Update embargo".

## Side Effects

I also noticed that the "update embargo" button was disabled, but still clickable when validation failed. This also fixes that.

## Ticket

https://openscience.atlassian.net/browse/OSF-7846
