### PR TITLE
[feature] Fix wbv0 uploads and archiving [OSF-8696]

### DIFF
--- a/addons/base/models.py
+++ b/addons/base/models.py
@@ -602,7 +602,7 @@ class BaseStorageAddon(object):
             'kind': 'folder',
             'name': self.root_node.name,
         }
-        if filenode.get('kind') == 'file' or 'size' in filenode:
+        if filenode.get('kind') == 'file':
             return filenode
 
         kwargs = {

--- a/osf_tests/test_archiver.py
+++ b/osf_tests/test_archiver.py
@@ -124,6 +124,7 @@ FILE_TREE = {
     'path': '/',
     'name': '',
     'kind': 'folder',
+    'size': '100',
     'children': [
         {
             'path': '/1234567',
@@ -152,6 +153,7 @@ WB_FILE_TREE = {
         'path': '/',
         'name': '',
         'kind': 'folder',
+        'size': '100',
         'children': [
             {
                 'attributes': {
@@ -436,6 +438,8 @@ class TestStorageAddonBase(ArchiverTestCase):
             'path': '/',
             'name': '',
             'kind': 'folder',
+            # Regression test for OSF-8696 confirming that size attr does not stop folders from recursing
+            'size': '100',
         }
         file_tree = addon._get_file_tree(root, self.user)
         assert_equal(FILE_TREE, file_tree)

--- a/tests/test_conferences.py
+++ b/tests/test_conferences.py
@@ -201,7 +201,7 @@ class TestProvisionNode(ContextTestCase):
             'osfstorage',
             _internal=True,
             cookie=self.user.get_or_create_cookie(),
-            name='/' + file_name
+            name=file_name
         )
         mock_put.assert_called_with(
             mock_get_url.return_value,
@@ -220,7 +220,7 @@ class TestProvisionNode(ContextTestCase):
             'osfstorage',
             _internal=True,
             cookie=self.user.get_or_create_cookie(),
-            name='/' + settings.MISSING_FILE_NAME,
+            name=settings.MISSING_FILE_NAME,
         )
         mock_put.assert_called_with(
             mock_get_url.return_value,

--- a/website/conferences/utils.py
+++ b/website/conferences/utils.py
@@ -57,8 +57,6 @@ def prepare_contributors(admins):
 def upload_attachment(user, node, attachment):
     attachment.seek(0)
     name = (attachment.filename or settings.MISSING_FILE_NAME)
-    if name[0] != '/':
-        name = '/' + name
     content = attachment.read()
     upload_url = util.waterbutler_api_url_for(node._id, 'osfstorage', name=name, cookie=user.get_or_create_cookie(), _internal=True)
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Fixes conference uploads and archiving
<!-- Describe the purpose of your changes -->

## Changes
Remove leading slash completely for file uploads
Remove size check for recursive folder stuff.
<!-- Briefly describe or list your changes  -->

## QA Notes
1. Check conference uploads, they should work now
2. Check archiving of a project with only a folder at the top level and containing a file. This is the broken edge case. 
<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Side Effects
NA
<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/OSF-8696
