### PR TITLE
[OSF-8056] Fix language links and scrollspy for addons tab.

### DIFF
--- a/website/static/js/pages/project-addons-page.js
+++ b/website/static/js/pages/project-addons-page.js
@@ -5,7 +5,7 @@ var $osf = require('js/osfHelpers');
 var ctx = window.contextVars;
 
 var changeAddonSettingsSuccess = function () {
-    $osf.growl('Success', 'Your addon settings have been successfully changed.', 'success');
+    $osf.growl('Success', 'Your add-on settings have been successfully changed.', 'success');
     location.reload();
 };
 
@@ -23,7 +23,7 @@ $('.addon-container').each(function(ind, elm) {
             data[elm.attr('name')] = false;
             bootbox.confirm({
                 title: 'Disable Add-on?',
-                message: 'Are you sure you want to disable this addon?',
+                message: 'Are you sure you want to disable this add-on?',
                 callback: function (result) {
                     if (result) {
                         var request = $osf.postJSON(ctx.node.urls.api + 'settings/addons/', data);
@@ -46,7 +46,7 @@ $('.addon-container').each(function(ind, elm) {
             data[name] = true;
             bootbox.confirm({
                 title: 'Enable Add-on?',
-                message: 'Are you sure you want to enable this addon?',
+                message: 'Are you sure you want to enable this add-on?',
                 callback: function (result) {
                     if (result) {
                         var capabilities = $('#capabilities-' + name).html();

--- a/website/templates/project/addon/page.mako
+++ b/website/templates/project/addon/page.mako
@@ -20,7 +20,7 @@
     <div class='addon-config-error p-sm'>
         ${full_name} add-on is not configured properly.
         % if user['is_contributor']:
-            Configure this add-on on the <a href="${node['url']}settings/">settings</a> page.
+            Configure this add-on on the <a href="${node['url']}addons/">add-ons</a> page.
         % endif
     </div>
 

--- a/website/templates/project/addon/widget.mako
+++ b/website/templates/project/addon/widget.mako
@@ -16,7 +16,7 @@
             <div class='addon-config-error p-sm'>
                 ${full_name} add-on is not configured properly.
                 % if user['is_contributor']:
-                    Configure this add-on on the <a href="${node['url']}settings/">settings</a> page.
+                    Configure this add-on on the <a href="${node['url']}addons/">add-ons</a> page.
                 % endif
             </div>
 

--- a/website/templates/project/addons.mako
+++ b/website/templates/project/addons.mako
@@ -1,5 +1,5 @@
 <%inherit file="project/project_base.mako"/>
-<%def name="title()">${node['title']} Addons</%def>
+<%def name="title()">${node['title']} Add-ons</%def>
 
 <div class="row project-page">
     <span id="selectAddonsAnchor" class="anchor"></span>
@@ -11,8 +11,8 @@
 
                 <div class="panel panel-default osf-affix" data-spy="affix" data-offset-top="0" data-offset-bottom="263"><!-- Begin sidebar -->
                     <ul class="nav nav-stacked nav-pills">
-                        <li><a href="#selectAddon">Select Addon</a></li>
-                        <li><a href="#configureAddon">Configure Addon</a></li>
+                        <li><a href="#selectAddonsAnchor">Select Add-ons</a></li>
+                        <li><a href="#configureAddonsAnchor">Configure Add-ons</a></li>
                     </ul>
                 </div><!-- End sidebar -->
 

--- a/website/templates/util/render_addon_widget.mako
+++ b/website/templates/util/render_addon_widget.mako
@@ -139,7 +139,7 @@
                 <div class='addon-config-error p-sm'>
                     ${addon_data['full_name']} add-on is not configured properly.
                     % if user['is_contributor']:
-                        Configure this add-on on the <a href="${node['url']}settings/">settings</a> page.
+                        Configure this add-on on the <a href="${node['url']}addons/">add-ons</a> page.
                     % endif
                 </div>
 


### PR DESCRIPTION
## Purpose

On the Add-ons Tab the scroll spy (the navigation bar on the left hand side) is taking to use to the wrong elements of clicked and not highlighting correctly. This fixes that.

Also the "This addon is not configured properly" widgets on the node overview are still pointing to the settings page. This changes them the addon page.
**"This addon is not configured properly" pictured:** 
![screenshot-2](https://user-images.githubusercontent.com/9688518/33963447-f8b754d2-e022-11e7-8fbc-32ad1ac7bdc6.png)

Also there are several user facing refferences to "Addons" instead of "Add-ons", so I have changed to use the agreed upon spelling.

## Changes

- Scroll spy fixed
- "This addon is not configured properly" widget links changed
- "addons" spelling corrected to "Add-ons

## QA Notes

- Check the the scroll spy takes you the right part of the page and observe that it highlights when the correct part of the page is scrolled over.
- Note that all "This addon is not configured properly"  have links that point to the addons page.
- Proofread to the laguage and make sure "Add-on" is always used over "Addon."

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/OSF-8056