### PR TITLE
[OSF-6477] Reset user's requested_deactivation status if they are reactivated

### DIFF
--- a/admin/users/views.py
+++ b/admin/users/views.py
@@ -68,6 +68,7 @@ class UserDeleteView(PermissionRequiredMixin, DeleteView):
                 flag = USER_REMOVED
                 message = 'User account {} disabled'.format(user.pk)
             else:
+                user.requested_deactivation = False
                 user.date_disabled = None
                 subscribe_on_confirm(user)
                 user.is_registered = True

--- a/admin_tests/users/test_views.py
+++ b/admin_tests/users/test_views.py
@@ -165,6 +165,7 @@ class TestDisableUser(AdminTestCase):
         self.view().delete(self.request)
         self.user.reload()
         nt.assert_false(self.user.is_disabled)
+        nt.assert_false(self.user.requested_deactivation)
         nt.assert_equal(AdminLogEntry.objects.count(), count + 1)
 
     def test_no_user(self):


### PR DESCRIPTION
## Purpose

The implementation of OSF-6477 has uncovered a small bug in user reactivation, if a user requests deactivation, is deactivated and then reactivated, their deactivation request still stands. This is more apparent now that the user can see if their deactivation request is pending. This PR clears any deactivation request when the account is reactivated.

## Changes

- One line change turns requested_deactivation to false when reactivated via view. 
- Corresponding change to unit tests

## QA Notes

1. Have a user request deactivation 
2. Deactivate them as an admin
3. Reactivate them as an admin
4. Log back in as the reactivated user.
5. Observe the red "Request Deactivation" button, showing that the user no long has a deactivation request pending.


## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/OSF-6477