### PR TITLE
[OSF-8056] Improve Add-on tab with new product considerations

### DIFF
--- a/website/static/js/pages/project-addons-page.js
+++ b/website/static/js/pages/project-addons-page.js
@@ -44,35 +44,19 @@ $('.addon-container').each(function(ind, elm) {
             var data = {};
             var name = elm.attr('name');
             data[name] = true;
+            var capabilities = $('#capabilities-' + name).html();
             bootbox.confirm({
-                title: 'Enable Add-on?',
-                message: 'Are you sure you want to enable this add-on?',
-                callback: function (result) {
+                message: capabilities,
+                callback: function(result) {
                     if (result) {
-                        var capabilities = $('#capabilities-' + name).html();
-                        if (capabilities) {
-                            bootbox.confirm({
-                                message: capabilities,
-                                callback: function(result) {
-                                    if (result) {
-                                        var request = $osf.postJSON(ctx.node.urls.api + 'settings/addons/', data);
-                                        request.done(changeAddonSettingsSuccess);
-                                        request.fail(changeAddonSettingsFailure);
-                                    }
-                                },
-                                buttons:{
-                                    confirm:{
-                                        label:'Confirm'
-                                    }
-                                }
-                            });
-                        }
+                        var request = $osf.postJSON(ctx.node.urls.api + 'settings/addons/', data);
+                        request.done(changeAddonSettingsSuccess);
+                        request.fail(changeAddonSettingsFailure);
                     }
                 },
-                buttons: {
-                    confirm: {
-                        label: 'Enable',
-                        className: 'btn-success'
+                buttons:{
+                    confirm:{
+                        label:'Confirm'
                     }
                 }
             });

--- a/website/templates/project/addons.mako
+++ b/website/templates/project/addons.mako
@@ -81,9 +81,9 @@
                                                                  % if addon.get('default'):
                                                                     <div class="text-muted">(This is a default addon)</div>
                                                                  % elif addon.get('enabled'):
-                                                                    <a class="text-muted">(already connected)</a>
+                                                                    <a class="text-danger">Disable</a>
                                                                  % else:
-                                                                     <a>connect</a>
+                                                                     <a>Enable</a>
                                                                  % endif
                                                              </div>
                                                          </div>


### PR DESCRIPTION
## Purpose

There were some things about the add-on tab which didn't make sense:

- There was an "Enable Add-on" modal that was made redundant by the the "Add-on Capabilities" modal, this fixes removes it so you go directly to "Add-on Capabilities" to confirm the add-on.
- The links for enabling/disabling the add-ons were labeled connect/disconnect, this relabels them enable/disable.

## Before 
![language_and_clickable_grayed_out_links](https://user-images.githubusercontent.com/9688518/34003203-b1f73f8a-e0c2-11e7-98ac-e6443786fd95.png)

## After

<img width="1355" alt="screen shot 2017-12-14 at 11 37 21 am" src="https://user-images.githubusercontent.com/9688518/34003403-36ae533a-e0c3-11e7-9a8e-dd40d664509a.png">


## Changes

- Changed link labels and styling
- Removed "Enable Add-on" modal, so it flows right into "Add-on Capabilities" modal.

## QA Notes

- Observe the link buttons in the "Select Add-ons" panel say "Enable/Disable" instead of "connect/disconnect"
- Enable an add-on and see that the "Add-on Capabilities" modal comes up immediately.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/OSF-8056