### PR TITLE
[Hotfix] Respect GitLab group permissions [#OSF-9077]

### DIFF
--- a/addons/gitlab/utils.py
+++ b/addons/gitlab/utils.py
@@ -95,7 +95,9 @@ def check_permissions(node_settings, auth, connection, branch, sha=None, repo=No
 
         has_access = (
             repo is not None and (
-                repo['permissions']['project_access']['access_level'] >= 30
+                # See https://docs.gitlab.com/ee/api/members.html
+                repo['permissions'].get('project_access', {}).get('access_level', 0) >= 30 or
+                repo['permissions'].get('group_access', {}).get('access_level', 0) >= 30
             )
         )
 


### PR DESCRIPTION
## Purpose
Prevent errors when linking a repo as a group owner / master / developer. 

## Changes
* Check for `group_access` in addition to `project_access`

## Side Effects
None expected

## Ticket
[[OSF-9077]](https://openscience.atlassian.net/browse/OSF-9077)
