### PR TITLE
[OSF-8710] IE fix for file rename on detail page.

### DIFF
--- a/website/static/js/pages/file-page.js
+++ b/website/static/js/pages/file-page.js
@@ -59,9 +59,9 @@ $(function() {
     }
 
     var titleEditable = function () {
-        var readOnlyProviders = ['bitbucket', 'figshare', 'dataverse'];
+        var readOnlyProviders = ['bitbucket', 'figshare', 'dataverse', 'gitlab', 'onedrive'];
         var ctx = window.contextVars;
-        if (readOnlyProviders.includes(ctx.file.provider) || ctx.file.checkoutUser || !ctx.currentUser.canEdit || ctx.node.isRegistration)
+        if (readOnlyProviders.indexOf(ctx.file.provider) >= 0 || ctx.file.checkoutUser || !ctx.currentUser.canEdit || ctx.node.isRegistration)
             return false;
         else
             return true;


### PR DESCRIPTION
## Purpose

Fix support for IE. Add GitLab and OneDrive as read only providers.

## Changes

1. Change `includes()` to `indexOf()` to support IE 11.
2. Add two more read only providers.

## QA Notes

None

## Side Effects

None

## Ticket

https://openscience.atlassian.net/browse/OSF-8710
