### PR TITLE
[feature] Fix fangorn conflicts queue check [OSF-6466]

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -709,7 +709,7 @@ function doItemOp(operation, to, from, rename, conflict) {
         orderFolder.call(tb, from.parent());
     }).always(function(){
         from.inProgress = false;
-        if (notRenameOp && (typeof inConflictsQueue !== 'undefined' || syncMoves)) {
+        if (notRenameOp && (inConflictsQueue || syncMoves)) {
             doSyncMove(tb, to.data.provider);
         }
     });


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Prior to any conflicts, the queue resolved to undefined. After conflicts it resolves to false. 
Fun fact: 
`undefined && true` returns undefined not false.
`false && true` returns false

<!-- Describe the purpose of your changes -->

## Changes
Remove typeof check to just existence. 
<!-- Briefly describe or list your changes  -->

## QA Notes
Previously, if no conflict had occurred yet, moving a file from one folder to another would not show a modal. After a conflict the same file movement would show a modal. After a conflict, moving two files (one that has a conflict and one that does not) would initially show the conflict dialogue, but then immediately show the inaccurate moved modal. I can demo if this is confusing.

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Side Effects
None Known
<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/OSF-6466
