### PR TITLE
Feature/Exclude prereg submitted without review from prereg reminder emails [OSF-8546]

### DIFF
--- a/osf_tests/test_remind_draft_preregistrations.py
+++ b/osf_tests/test_remind_draft_preregistrations.py
@@ -1,10 +1,13 @@
 import pytest
-from django.utils import timezone
 from website import settings
+from django.utils import timezone
+from framework.auth.core import Auth
+
+from website.prereg.utils import get_prereg_schema
 
 from .factories import UserFactory, DraftRegistrationFactory
 
-from osf.models import MetaSchema, DraftRegistrationApproval, QueuedMail
+from osf.models import QueuedMail
 from osf.models.queued_mail import PREREG_REMINDER_TYPE
 
 from scripts.remind_draft_preregistrations import main
@@ -15,7 +18,7 @@ def user():
 
 @pytest.fixture()
 def schema():
-    return MetaSchema.objects.get(name='Prereg Challenge')
+    return get_prereg_schema()
 
 @pytest.mark.django_db
 class TestPreregReminder:
@@ -54,14 +57,8 @@ class TestPreregReminder:
 
         assert QueuedMail.objects.filter(email_type=PREREG_REMINDER_TYPE).count() == 0
 
-    def test_dont_trigger_prereg_reminder_draft_submitted(self, draft):
-        approval = DraftRegistrationApproval(
-            meta={
-                'registration_choice': 'immediate'
-            }
-        )
-        approval.save()
-        draft.approval = approval
+    def test_dont_trigger_prereg_reminder_draft_submitted(self, user, draft):
+        draft.register(Auth(user))
         draft.save()
         main(dry_run=False)
 

--- a/scripts/remind_draft_preregistrations.py
+++ b/scripts/remind_draft_preregistrations.py
@@ -3,8 +3,10 @@ import logging
 from django.db import transaction
 from django.utils import timezone
 
+from website.prereg.utils import get_prereg_schema
+
 from framework.celery_tasks import app as celery_app
-from osf.models import DraftRegistration, MetaSchema, QueuedMail
+from osf.models import DraftRegistration, QueuedMail
 from osf.models.queued_mail import PREREG_REMINDER, PREREG_REMINDER_TYPE, queue_mail
 
 from website.app import init_app
@@ -47,10 +49,10 @@ def find_neglected_prereg_within_reminder_limit():
 
     return DraftRegistration.objects.filter(
         deleted__isnull=True,
-        approval__isnull=True,
-        registration_schema=MetaSchema.objects.get(name='Prereg Challenge'),
+        registered_node=None,
+        registration_schema=get_prereg_schema(),
         datetime_initiated__lte=timezone.now()-settings.PREREG_WAIT_TIME,
-        datetime_initiated__gte=timezone.now()-settings.PREREG_AGE_LIMIT
+        datetime_initiated__gte=timezone.now()-settings.PREREG_AGE_LIMIT,
     ).exclude(_id__in = already_queued)
 
 

--- a/website/mails/presends.py
+++ b/website/mails/presends.py
@@ -47,7 +47,7 @@ def prereg_reminder(email):
     draft = DraftRegistration.load(draft_id)
     reminders_sent = QueuedMail.objects.filter(data__draft_id=draft_id).exclude(sent_at=None).exists()
 
-    return draft and not draft.deleted and not reminders_sent and not draft.approval
+    return draft and not draft.deleted and not reminders_sent and not draft.registered_node
 
 def welcome_osf4m(email):
     """ presend has two functions. First is to make sure that the user has not


### PR DESCRIPTION
## Purpose

In my prereg reminder emails I was checking if the preregistrations had been submitted for review to check they were no longer drafts. Because you can start a preregistration challenge registration and register it without review, this was not an effective way of checking if the registrations were submitted.

## Changes

I now check if `registered_node` exists for a draft registration. This is what I should have been doing all along because this is the way to check if a registration draft has been submitted.

## QA Notes
One should go through the preregistration process and then "Register without review". If you wait 2 weeks (or about an hour on staging). You should not receive a prereg reminder email.

The same should continue to be true for registrations submitted for approval in the prereg challenge. You should not receive a prereg reminder email.

## Side Effects

I also changed the code to use the helper `get_prereg_schema` instead of grabbing the prereg schema myself. This should have no effect.

## Ticket

https://openscience.atlassian.net/browse/OSF-8546