### PR TITLE
[hotfix] Bump psycopg2 version to 2.7.3 [no ticket]

### DIFF
--- a/osf/models/external.py
+++ b/osf/models/external.py
@@ -364,7 +364,7 @@ class ExternalProvider(object):
         """
         pass
 
-    def refresh_oauth_key(self, force=False, extra={}, resp_auth_token_key='access_token',
+    def refresh_oauth_key(self, force=False, extra=None, resp_auth_token_key='access_token',
                           resp_refresh_token_key='refresh_token', resp_expiry_fn=None):
         """Handles the refreshing of an oauth_key for account associated with this provider.
            Not all addons need to use this, as some do not have oauth_keys that expire.
@@ -381,6 +381,7 @@ class ExternalProvider(object):
         datetime-formatted oauth_key expiry key, given a successful refresh response from
         `auto_refresh_url`. A default using 'expires_at' as a key is provided.
         """
+        extra = extra or {}
         # Ensure this is an authenticated Provider that uses token refreshing
         if not (self.account and self.auto_refresh_url):
             return False

--- a/osf/models/user.py
+++ b/osf/models/user.py
@@ -1013,11 +1013,11 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel, AbstractBaseUser, Permissi
         #       ref: https://tools.ietf.org/html/rfc822#section-6
         email = email.lower().strip()
 
-        if not external_identity and self.emails.filter(address=email).exists():
-            raise ValueError('Email already confirmed to this user.')
-
         with reraise_django_validation_errors():
             validate_email(email)
+
+        if not external_identity and self.emails.filter(address=email).exists():
+            raise ValueError('Email already confirmed to this user.')
 
         # If the unconfirmed email is already present, refresh the token
         if email in self.unconfirmed_emails:

--- a/requirements.txt
+++ b/requirements.txt
@@ -87,7 +87,7 @@ django-typed-models==0.7.0
 git+https://github.com/cos-forks/django-dirtyfields@develop
 git+https://github.com/cos-forks/django-extensions@master
 django-include==0.2.4
-psycopg2==2.6.2
+psycopg2==2.7.3
 ujson==1.35
 sqlparse==0.2.4
 psycogreen==1.0

--- a/website/util/rubeus.py
+++ b/website/util/rubeus.py
@@ -197,7 +197,8 @@ class NodeFileCollector(object):
             for descendant in self.find_readable_descendants(bnode):
                 yield descendant
 
-    def _serialize_node(self, node, parent=None, grid_root=None, children=[]):
+    def _serialize_node(self, node, parent=None, grid_root=None, children=None):
+        children = children or []
         is_pointer = parent and node.is_linked_node
         can_edit = node.has_write_perm if hasattr(node, 'has_write_perm') else node.can_edit(auth=self.auth)
 

--- a/website/util/sanitize.py
+++ b/website/util/sanitize.py
@@ -5,7 +5,7 @@ import json
 import bleach
 
 
-def strip_html(unclean, tags=[]):
+def strip_html(unclean, tags=None):
     """Sanitize a string, removing (as opposed to escaping) HTML tags
 
     :param unclean: A string to be stripped of HTML tags
@@ -15,6 +15,7 @@ def strip_html(unclean, tags=[]):
     """
     # We make this noop for non-string, non-collection inputs so this function can be used with higher-order
     # functions, such as rapply (recursively applies a function to collections)
+    tags = tags or []
     if not isinstance(unclean, basestring) and not is_iterable(unclean) and unclean is not None:
         return unclean
     return bleach.clean(unclean, strip=True, tags=tags, attributes=[], styles=[])


### PR DESCRIPTION
## Purpose
Related to travis-ci/travis-ci#8897 and psycopg/psycopg2#594

The new image that travis is using upgrades to Postgres 10.1, which psycopg2 version 2.6.1 does not like -- upgrade to latest 2.7.3 to fix this issue

## Changes
- upgrade psycopg2 to 2.7.3
- update a method to run validation and raise errors for null emails earlier before attempting a query
- also fix unrelated flake8 errors on master

## QA Notes
This change should not require QA, as it is solely backend dependency related!

## Side Effects

none anticipated

## Ticket
no ticket, gone rogue