### PR TITLE
[OSF-8228] Remove gray area from project navbar

### DIFF
--- a/website/templates/project/project_header.mako
+++ b/website/templates/project/project_header.mako
@@ -22,7 +22,7 @@
                     % if parent_node['id']:
 
                         % if parent_node['can_view'] or parent_node['is_public'] or parent_node['is_contributor']:
-                            <li><a href="${parent_node['url']}" data-toggle="tooltip" title="${parent_node['title']}" data-placement="bottom" style="padding: 12px 17px;"> <i class="fa fa-level-down fa-rotate-180"></i>  </a></li>
+                            <li><a href="${parent_node['url']}" data-toggle="tooltip" title="${parent_node['title']}" data-placement="bottom"> <i class="fa fa-level-down fa-rotate-180"></i>  </a></li>
 
                         % else:
                             <li><a href="#" data-toggle="tooltip" title="Parent project is private" data-placement="bottom" style="cursor: default"> <i class="fa fa-level-down fa-rotate-180 text-muted"></i>  </a></li>


### PR DESCRIPTION
## Purpose

There's a small gray area creeping out from under the blue highlighted area on project navbar, this PR fixes that.

## Before 
<img width="1424" alt="screen shot 2017-12-18 at 11 10 53 am" src="https://user-images.githubusercontent.com/9688518/34115636-386770ca-e3e4-11e7-8329-d462f26c8f11.png">

You can see the small strip of gray under the project name "Private ?"

## After
<img width="1407" alt="screen shot 2017-12-18 at 11 08 57 am" src="https://user-images.githubusercontent.com/9688518/34115628-31984b2a-e3e4-11e7-800d-87b86126f07c.png">
 Now it's gone.


## Changes

Fixes the gray strip by removing bad inline style.

## QA Notes

The navbar should appear like the after image.

## Side Effects

None that I know of.

## Ticket

https://openscience.atlassian.net/browse/OSF-8228