### PR TITLE
Feature/upgrade osf-style version to 1.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "mithril": "0.2.0",
     "moment": "^2.14.1",
     "object-assign": "^2.0.0",
-    "@centerforopenscience/osf-style": "^1.5.1",
+    "@centerforopenscience/osf-style": "^1.5.2",
     "pikaday": "^1.3.2",
     "pretty-data": "^0.40.0",
     "raw-loader": "^0.5.1",


### PR DESCRIPTION
## Purpose

Fix line height for project navbar.

## Changes

This points to the version of osf-style that has this fix.

## QA Notes
None

## Side Effects
Hopefully none

## Ticket
None
