### PR TITLE
[OSF-8710] Add growl message, remove reloading

### DIFF
--- a/website/static/js/pages/file-page.js
+++ b/website/static/js/pages/file-page.js
@@ -95,7 +95,7 @@ $(function() {
                 return JSON.stringify(payload);
             },
             success: function(response) {
-                window.location.reload();
+                $osf.growl('Success', 'Your file was successfully renamed. To view the new filename in the file tree below, refresh the page.', 'success');
             },
             error: function (response) {
                 var msg = response.responseJSON.message;


### PR DESCRIPTION
## Purpose

Currently, file detail page would reload upon successful rename, resulting in some other unintended problem. This PR remove the reload but add a growl box message instead.

## Changes

Remove reload and add growl box message that reads:
"Your file was successfully renamed. To view the new filename in the file tree below, refresh the page."

## QA Notes

So........ Now it should not reload after successful renaming, but shows a growl message that reads:
"Your file was successfully renamed. To view the new filename in the file tree below, refresh the page."

## Side Effects

None.

## Ticket

https://openscience.atlassian.net/browse/OSF-8710
