### PR TITLE
[EOSF-878] Add 'move' link to quickfiles

### DIFF
--- a/api/users/serializers.py
+++ b/api/users/serializers.py
@@ -198,6 +198,7 @@ class UserQuickFilesSerializer(QuickFilesSerializer):
         'info': Link('files:file-detail', kwargs={'file_id': '<_id>'}),
         'upload': WaterbutlerLink(),
         'delete': WaterbutlerLink(),
+        'move': WaterbutlerLink(),
         'download': WaterbutlerLink(must_be_file=True),
     })
 

--- a/api_tests/users/views/test_user_files_list.py
+++ b/api_tests/users/views/test_user_files_list.py
@@ -5,6 +5,7 @@ from osf_tests.factories import AuthUserFactory
 from api.base.settings.defaults import API_BASE
 from osf.models import QuickFilesNode
 from addons.osfstorage.models import OsfStorageFile
+from website import util as website_utils
 
 
 @pytest.fixture()
@@ -97,3 +98,25 @@ class TestUserQuickFiles:
         assert 'user' in file_detail_json['relationships']
         assert 'node' not in file_detail_json['relationships']
         assert file_detail_json['relationships']['user']['links']['related']['href'].split('/')[-2] == user._id
+
+    def test_get_files_has_links(self, app, user, url):
+        res = app.get(url, auth=user.auth)
+        file_detail_json = res.json['data'][0]
+        quickfiles_node = quickfiles(user)
+        waterbutler_url = website_utils.waterbutler_api_url_for(quickfiles_node._id, 'osfstorage', file_detail_json['attributes']['path'])
+
+        assert 'delete' in file_detail_json['links']
+        assert file_detail_json['links']['delete'] == waterbutler_url
+
+        assert 'download' in file_detail_json['links']
+        assert file_detail_json['links']['download'] == waterbutler_url
+
+        assert 'info' in file_detail_json['links']
+
+        assert 'move' in file_detail_json['links']
+        assert file_detail_json['links']['move'] == waterbutler_url
+
+        assert 'self' in file_detail_json['links']
+
+        assert 'upload' in file_detail_json['links']
+        assert file_detail_json['links']['upload'] == waterbutler_url


### PR DESCRIPTION
## Purpose

When files are uploaded, they are automatically given a move link through waterbutler.  However, when files are loaded they are missing this link.  This adds a move link to the quick file serializer.

## Changes

- Add move link to the quick files serializer

## QA Notes

Before this fix, users were only able to move files that had just been uploaded.  With these changes, users should be able to have pre-uploaded files that can now be moved.  To test:

1. Upload a file
2. Move to project or component
3. Test that it works

4. Upload another file
5. Refresh the page
6. Move file to project or component
7. Test that it works 

## Ticket

https://openscience.atlassian.net/browse/EOSF-878