### PR TITLE
[hotfix] Fix copy/conflict file tree [OSF-9071]

### DIFF
--- a/website/static/js/fangorn.js
+++ b/website/static/js/fangorn.js
@@ -55,7 +55,7 @@ var CONFLICT_INFO = {
         passed: 'Skipped'
     },
     replace: {
-        passed: 'Replaced old version'
+        passed: 'Moved or replaced old version'
     },
     keep: {
         passed: 'Kept both versions'
@@ -541,31 +541,39 @@ function checkConflictsRename(tb, item, name, cb) {
 
 function doItemOp(operation, to, from, rename, conflict) {
     var tb = this;
+    // dismiss old modal immediately to prevent button mashing
+    tb.modal.dismiss();
     var inReadyQueue;
     var filesRemaining;
-    var inConflictsQueue;
+    var inConflictsQueue = false;
     var syncMoves;
 
     var notRenameOp = typeof rename === 'undefined';
     if (notRenameOp) {
         filesRemaining = tb.syncFileMoveCache && tb.syncFileMoveCache[to.data.provider];
-        inConflictsQueue = filesRemaining.conflicts && filesRemaining.conflicts.length > 0;
         syncMoves = SYNC_UPLOAD_ADDONS.indexOf(from.data.provider) !== -1;
         if (syncMoves) {
             inReadyQueue = filesRemaining && filesRemaining.ready && filesRemaining.ready.length > 0;
         }
-        if (inConflictsQueue) {
-            var s = filesRemaining.conflicts.length > 1 ? 's' : '';
-            var mithrilContent = m('div', { className: 'text-center' }, [
-                m('p.h4', filesRemaining.conflicts.length + ' conflict' + s + ' left to resolve.'),
-                m('div', {className: 'ball-pulse ball-scale-blue text-center'}, [
-                    m('div',''),
-                    m('div',''),
-                    m('div',''),
-                ])
-            ]);
-            var header =  m('h3.break-word.modal-title', operation.action + ' "' + from.data.name +'"');
-            tb.modal.update(mithrilContent, m('', []), header);
+
+        if (filesRemaining.conflicts) {
+            inConflictsQueue = true;
+            if (filesRemaining.conflicts.length > 0) {
+                var s = filesRemaining.conflicts.length > 1 ? 's' : '';
+                var mithrilContent = m('div', { className: 'text-center' }, [
+                    m('p.h4', filesRemaining.conflicts.length + ' conflict' + s + ' left to resolve.'),
+                    m('div', {className: 'ball-pulse ball-scale-blue text-center'}, [
+                        m('div',''),
+                        m('div',''),
+                        m('div',''),
+                    ])
+                ]);
+                var header =  m('h3.break-word.modal-title', operation.action + ' "' + from.data.name +'"');
+                tb.modal.update(mithrilContent, m('', []), header);
+            } else {
+                // remove the empty queue to know there are no remaining conflicts next time
+                filesRemaining.conflicts = undefined;
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Some issues with copy/conflict.
<!-- Describe the purpose of your changes -->

## Changes
1. Rework conflict queue logic to properly clear out the queue when empty and to know when the queue is complete. 
2. Force dismiss modal on click actions to stop mashing
3. Change wording of 'Replaced old version' to 'Moved or replaced old version' to better match reality.
<!-- Briefly describe or list your changes  -->

## QA Notes
number 1: Make sure copy/moves don't lock up the modal indefinitely. 
number 2: Make sure the button cannot be mashed. It May in theory be possible to hit multiple times, but it should be really, really hard to do now.
number 3: Moves without conflicts were showing the "replaced" text even though it was just a move. The logic is a bit weird, so I just changed the language for now. A followup ticket may be created to separate these properly.
<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Side Effects
NA
<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/OSF-9071
