### PR TITLE
[hotfix] Slightly change permissions checks for permissions format [OSF-9088]

### DIFF
--- a/addons/gitlab/utils.py
+++ b/addons/gitlab/utils.py
@@ -93,11 +93,13 @@ def check_permissions(node_settings, auth, connection, branch, sha=None, repo=No
     if has_auth:
         repo = repo or connection.repo(node_settings.repo_id)
 
+        project_permissions = repo['permissions'].get('project_access') or {}
+        group_permissions = repo['permissions'].get('group_access') or {}
         has_access = (
             repo is not None and (
                 # See https://docs.gitlab.com/ee/api/members.html
-                repo['permissions'].get('project_access', {}).get('access_level', 0) >= 30 or
-                repo['permissions'].get('group_access', {}).get('access_level', 0) >= 30
+                project_permissions.get('access_level', 0) >= 30 or
+                group_permissions.get('access_level', 0) >= 30
             )
         )
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose

Slight tweak to permissions checks for gitlab.

Permissions are returned something like `{u'group_access': {u'notification_level': 3, u'access_level': 50}, u'project_access': None}`, or vice-versa.  Since the `project_access` and `group_access` keys are present but set to `None` if there aren't any, `.get(item, default)` will still return `None` instead of the default, as the key is there. Why, python?

Part 2 of #8048

## Changes

- slight permissions dict get tweak

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

To test!

- create a gitlab group
- create a new project inside that group
- add a file to that project
- connect that project to an OSF project
- ensure that the file tree for that project renders correctly

Also might make sense to doublecheck gitlab repos *not* in groups still connect/render (though this shouldn't touch that at all)

## Side Effects

none anticipated

## Ticket
https://openscience.atlassian.net/browse/OSF-9088