### PR TITLE
[HOTFIX][#OSF-9101]Error when subscribing to mailchimp: "Due to restrictions on your account, double opt-in is required for this list"

### DIFF
--- a/tests/test_mailchimp.py
+++ b/tests/test_mailchimp.py
@@ -52,7 +52,7 @@ class TestMailChimpHelpers(OsfTestCase):
                 'fname': user.given_name,
                 'lname': user.family_name,
             },
-            double_optin=False,
+            double_optin=True,
             update_existing=True,
         )
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1384,7 +1384,7 @@ class TestUserProfile(OsfTestCase):
                 'fname': self.user.given_name,
                 'lname': self.user.family_name,
             },
-            double_optin=False,
+            double_optin=True,
             update_existing=True
         )
         handlers.celery_teardown_request()
@@ -3879,7 +3879,7 @@ class TestConfigureMailingListViews(OsfTestCase):
                                                            'fname': user.given_name,
                                                            'lname': user.family_name,
                                                        },
-                                                       double_optin=False,
+                                                       double_optin=True,
                                                        update_existing=True)
 
     def test_get_mailchimp_get_endpoint_returns_200(self):

--- a/website/mailchimp_utils.py
+++ b/website/mailchimp_utils.py
@@ -50,7 +50,7 @@ def subscribe_mailchimp(list_name, user_id):
                 'fname': user.given_name,
                 'lname': user.family_name,
             },
-            double_optin=False,
+            double_optin=True,
             update_existing=True,
         )
 


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Fix the mailchimp double opt-in flag.

<!-- Describe the purpose of your changes -->

## Changes

<!-- Briefly describe or list your changes  -->

## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket
https://openscience.atlassian.net/browse/OSF-9101
<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
