### PR TITLE
[hotfix] Fix skipped queued mail tests [OSF-9095] 

### DIFF
--- a/osf_tests/test_queued_mail.py
+++ b/osf_tests/test_queued_mail.py
@@ -20,7 +20,6 @@ def user():
     return UserFactory(is_registered=True)
 
 @pytest.mark.django_db
-@pytest.mark.skip  # Temp skip OSf-9095
 class TestQueuedMail:
 
     @pytest.fixture()
@@ -167,9 +166,9 @@ class TestQueuedMail:
         mail = self.queue_mail(mail=PREREG_REMINDER, user=user, draft_id=prereg._id)
         assert not mail.send_mail()
 
-
+    @mock.patch('website.archiver.tasks.archive')
     @mock.patch('osf.models.queued_mail.send_mail')
-    def test_remind_prereg_presend_submitted(self, mock_mail, user, prereg):
+    def test_remind_prereg_presend_submitted(self, mock_mail, mock_archive, user, prereg):
         prereg.register(Auth(user))
         prereg.save()
 
@@ -182,5 +181,3 @@ class TestQueuedMail:
         prereg.deleted = timezone.now()
         prereg.save()
         assert not mail.send_mail()
-
-

--- a/osf_tests/test_remind_draft_preregistrations.py
+++ b/osf_tests/test_remind_draft_preregistrations.py
@@ -1,3 +1,4 @@
+import mock
 import pytest
 from website import settings
 from django.utils import timezone
@@ -21,7 +22,6 @@ def schema():
     return get_prereg_schema()
 
 @pytest.mark.django_db
-@pytest.mark.skip  # Temp skip OSf-9095
 class TestPreregReminder:
 
     @pytest.fixture()
@@ -58,7 +58,8 @@ class TestPreregReminder:
 
         assert QueuedMail.objects.filter(email_type=PREREG_REMINDER_TYPE).count() == 0
 
-    def test_dont_trigger_prereg_reminder_draft_submitted(self, user, draft):
+    @mock.patch('website.archiver.tasks.archive')
+    def test_dont_trigger_prereg_reminder_draft_submitted(self, mock_archive, user, draft):
         draft.register(Auth(user))
         draft.save()
         main(dry_run=False)


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Two test classes were skipped due to a hanging test. 
<!-- Describe the purpose of your changes -->

## Changes
The tests were hanging due to archiver calls that were not mocked. These tests pass when run outside of docker, but fail inside docker (and subsequently on Travis). 
<!-- Briefly describe or list your changes  -->

## QA Notes
No QA
<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Side Effects
N/A
<!-- Any possible side effects? -->

## Ticket

https://openscience.atlassian.net/browse/OSF-9095
